### PR TITLE
Update Applicant information labels to match new standards

### DIFF
--- a/src/platform/forms/definitions/fullName.js
+++ b/src/platform/forms/definitions/fullName.js
@@ -9,19 +9,19 @@ export function validateName(errors, pageData) {
 const uiSchema = {
   'ui:validations': [validateName],
   first: {
-    'ui:title': 'First name',
+    'ui:title': 'Your first name',
     'ui:errorMessages': {
       required: 'Please enter a first name',
     },
   },
   last: {
-    'ui:title': 'Last name',
+    'ui:title': 'Your last name',
     'ui:errorMessages': {
       required: 'Please enter a last name',
     },
   },
   middle: {
-    'ui:title': 'Middle name',
+    'ui:title': 'Your middle name',
   },
   suffix: {
     'ui:title': 'Suffix',

--- a/src/platform/forms/pages/applicantInformation.jsx
+++ b/src/platform/forms/pages/applicantInformation.jsx
@@ -51,7 +51,7 @@ export default function applicantInformation(schema, options) {
         [`${prefix}FullName`]: fullNameUI,
         [`${prefix}DateOfBirth`]: Object.assign(
           {},
-          currentOrPastDateUI('Date of birth'),
+          currentOrPastDateUI('Your date of birth'),
           {
             'ui:errorMessages': {
               pattern: 'Please provide a valid date',


### PR DESCRIPTION
## Description
https://design.va.gov/patterns/form-labels has been updated with new labels 

https://github.com/department-of-veterans-affairs/va.gov-team/issues/13965 is for updating the 1995 form, since these labels come from platform code this PR is to update the labels for all forms using Applicant information

## Testing done


## Screenshots
![Screen Shot 2020-10-02 at 12 52 09 PM](https://user-images.githubusercontent.com/1094999/94948908-18b0e980-04ae-11eb-81c4-8388f6eccd72.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
