### PR TITLE
[Form Details] Allow pages in sitemap.xml

### DIFF
--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -6,7 +6,7 @@ const set = require('lodash/fp/set');
 // Creates the file object to add to the file list using the page and layout
 function createFileObj(page, layout) {
   // Exclude some types from sitemap.
-  const privateTypes = ['outreach_asset', 'support_service', 'va_form'];
+  const privateTypes = ['outreach_asset', 'support_service'];
   let privStatus = false;
   if (privateTypes.indexOf(page.entityBundle) > -1) {
     privStatus = true;


### PR DESCRIPTION
## Description
This PR allows pages under the `va_form` node-type to be included in the sitemap. 

https://github.com/department-of-veterans-affairs/va.gov-team/issues/12242

Sister DevOps PR - https://github.com/department-of-veterans-affairs/devops/pull/7709

## Testing done
Observed form detail pages are included in sitemap.xml

## Screenshots
N/A

## Acceptance criteria
- [ ] Form detail pages can be indexed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
