### PR TITLE
Corrected facility sorting in health_care_region_page transformer.

### DIFF
--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
@@ -183,9 +183,10 @@ const transform = ({
             reverseField =>
               reverseField.fieldMainLocation && reverseField.entityPublished,
           )
-          .sort(
-            (a, b) =>
-              a.fieldNicknameForThisFacility - b.fieldNicknameForThisFacility,
+          .sort((a, b) =>
+            a.fieldNicknameForThisFacility.localeCompare(
+              b.fieldNicknameForThisFacility,
+            ),
           )
           .map(r => ({
             entityUrl: r.entityUrl,
@@ -214,9 +215,10 @@ const transform = ({
             reverseField =>
               !reverseField.fieldMainLocation && reverseField.entityPublished,
           )
-          .sort(
-            (a, b) =>
-              a.fieldNicknameForThisFacility - b.fieldNicknameForThisFacility,
+          .sort((a, b) =>
+            a.fieldNicknameForThisFacility.localeCompare(
+              b.fieldNicknameForThisFacility,
+            ),
           )
           .map(r => ({
             entityUrl: r.entityUrl,


### PR DESCRIPTION
## Description
Fixed the transformer's sorting of facilities by nickname so that the content shows up in the expected order.

## Testing done
Re-ran the content build with the changes and saw that there were no more differences in the order of facilities.

## Acceptance criteria
- [ ] The transformer should result in the same content for the affected pages.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
