### PR TITLE
[CI] Execute a separate Mocha command for each app directory

### DIFF
--- a/script/run-unit-test.js
+++ b/script/run-unit-test.js
@@ -53,14 +53,14 @@ const logLevel = options['log-level'].toLowerCase();
 const forcedExitCode = options.coverage ? null : 0;
 const testDirectories = options.path;
 
-// run all unit tests else run only the test provided as a command line argument 
+// run all unit tests else run only the test provided as a command line argument
 if (testDirectories[0] === defaultPath) {
-  // array of unit test paths 
+  // array of unit test paths
   const allUnitTestPaths = glob.sync(defaultPath);
 
   // Group unit tests into suites by directories by creating a list of all unit test containing directories from the list of allUnitTestPaths
   const unitTestDirectories = new Set(
-    allUnitTests.map(unitTest => {
+    allUnitTestPaths.map(unitTest => {
       // Start with './src/applications/burials/tests/config/benefitsSelection.unit.spec.js'
       const directory = path.dirname(unitTest);
       const directoryPathArray = directory.split(path.sep);

--- a/script/run-unit-test.js
+++ b/script/run-unit-test.js
@@ -71,6 +71,10 @@ if (testDirectories[0] === defaultPath) {
 
       if (directoryPathArray[2] === 'applications') {
         subdirectoryDepth = 4;
+
+        if (directoryPathArray[3] === 'personalization') {
+          subdirectoryDepth = 5;
+        }
       }
 
       // Reduce to 'src/applications/burials/'
@@ -114,9 +118,11 @@ if (testDirectories[0] === defaultPath) {
       );
 
       if (junitReportForAllTestRuns) {
-        junitReportForAllTestRuns('testsuites').append(
-          junitReport('testsuites').children(),
-        );
+        junitReport('testsuites').each((index, testSuitesRootNode) => {
+          junitReportForAllTestRuns('testsuites').append(
+            testSuitesRootNode.children,
+          );
+        });
         fs.writeFileSync(junitReportFilePath, junitReportForAllTestRuns.html());
       } else {
         junitReportForAllTestRuns = junitReport;

--- a/script/run-unit-test.js
+++ b/script/run-unit-test.js
@@ -118,11 +118,8 @@ if (testDirectories[0] === defaultPath) {
       );
 
       if (junitReportForAllTestRuns) {
-        junitReport('testsuites').each((index, testSuitesRootNode) => {
-          junitReportForAllTestRuns('testsuites').append(
-            testSuitesRootNode.children,
-          );
-        });
+        const testsuites = junitReport('testsuite');
+        junitReportForAllTestRuns('testsuites').append(testsuites);
         fs.writeFileSync(junitReportFilePath, junitReportForAllTestRuns.html());
       } else {
         junitReportForAllTestRuns = junitReport;

--- a/script/run-unit-test.js
+++ b/script/run-unit-test.js
@@ -53,6 +53,7 @@ const logLevel = options['log-level'].toLowerCase();
 const forcedExitCode = options.coverage ? null : 0;
 const testDirectories = options.path;
 
+// run all unit tests else run only the test provided as a command line argument 
 if (testDirectories[0] === defaultPath) {
   const allUnitTests = glob.sync(defaultPath);
 

--- a/script/run-unit-test.js
+++ b/script/run-unit-test.js
@@ -79,10 +79,14 @@ if (testDirectories[0] === defaultPath) {
     // eslint-disable-next-line no-console
     console.log(chalk.blue(`Test suite: ${unitTestDirectory}`));
 
-    const mocha = `NODE_ENV=test nyc --include "${unitTestDirectory}/**" --reporter=lcov --reporter=text --reporter=json-summary mocha --reporter mocha-junit-reporter --no-color`;
-    const command = `LOG_LEVEL=${logLevel} ${mocha} --opts ${mochaOpts} --recursive ".${
-      path.sep
-    }${unitTestDirectory}${wildCard}"`;
+    let executeMocha = 'BABEL_ENV=test mocha';
+
+    if (options.coverage) {
+      executeMocha = `NODE_ENV=test nyc --include "${unitTestDirectory}/**" --reporter=lcov --reporter=text --reporter=json-summary mocha --reporter mocha-junit-reporter --no-color`;
+    }
+
+    const findUnitTestsInDir = `".${path.sep}${unitTestDirectory}${wildCard}"`;
+    const command = `LOG_LEVEL=${logLevel} ${executeMocha} --opts ${mochaOpts} --recursive ${findUnitTestsInDir}`;
     const exitStatus = runCommandSync(command);
 
     if (exitStatus !== 0) {

--- a/script/run-unit-test.js
+++ b/script/run-unit-test.js
@@ -86,6 +86,8 @@ if (testDirectories[0] === defaultPath) {
     const exitStatus = runCommandSync(command);
 
     if (exitStatus !== 0) {
+      // eslint-disable-next-line no-console
+      console.log(chalk.red(`${unitTestDirectory} failed!`));
       failures.push(unitTestDirectory);
     }
   });

--- a/script/run-unit-test.js
+++ b/script/run-unit-test.js
@@ -73,8 +73,7 @@ if (testDirectories[0] === defaultPath) {
   );
 
   const wildCard = `${path.sep}**${path.sep}*.unit.spec.js?(x)`;
-
-  let isPassing = true;
+  const failures = [];
 
   unitTestDirectories.forEach(unitTestDirectory => {
     // eslint-disable-next-line no-console
@@ -87,11 +86,15 @@ if (testDirectories[0] === defaultPath) {
     const exitStatus = runCommandSync(command);
 
     if (exitStatus !== 0) {
-      isPassing = false;
+      failures.push(unitTestDirectory);
     }
   });
 
-  if (!isPassing) process.exitCode = 1;
+  if (failures.length > 0) {
+    // eslint-disable-next-line no-console
+    failures.forEach(failure => console.log(chalk.red(`${failure} failed!`)));
+    process.exitCode = 1;
+  }
 } else {
   const testDirectoriesEscaped = options.path.map(p => `'${p}'`).join(' ');
 

--- a/script/run-unit-test.js
+++ b/script/run-unit-test.js
@@ -55,7 +55,8 @@ const testDirectories = options.path;
 
 // run all unit tests else run only the test provided as a command line argument 
 if (testDirectories[0] === defaultPath) {
-  const allUnitTests = glob.sync(defaultPath);
+  // array of unit test paths 
+  const allUnitTestPaths = glob.sync(defaultPath);
 
   const unitTestDirectories = new Set(
     allUnitTests.map(unitTest => {

--- a/script/run-unit-test.js
+++ b/script/run-unit-test.js
@@ -58,6 +58,7 @@ if (testDirectories[0] === defaultPath) {
   // array of unit test paths 
   const allUnitTestPaths = glob.sync(defaultPath);
 
+  // Group unit tests into suites by directories by creating a list of all unit test containing directories from the list of allUnitTestPaths
   const unitTestDirectories = new Set(
     allUnitTests.map(unitTest => {
       // Start with './src/applications/burials/tests/config/benefitsSelection.unit.spec.js'

--- a/script/run-unit-test.js
+++ b/script/run-unit-test.js
@@ -9,8 +9,6 @@ const { runCommand, runCommandSync } = require('./utils');
 
 const defaultPath = './src/**/*.unit.spec.js?(x)';
 
-// const allUnitTests = glob.sync('{src,test}/**/*.unit.spec.js?(x)');
-
 const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'log-level', type: String, defaultValue: 'log' },
   { name: 'app-folder', type: String, defaultValue: null },

--- a/script/run-unit-test.js
+++ b/script/run-unit-test.js
@@ -1,10 +1,16 @@
+const path = require('path');
+const chalk = require('chalk');
+const glob = require('glob');
 const printUnitTestHelp = require('./run-unit-test-help.js');
 const commandLineArgs = require('command-line-args');
-const { runCommand } = require('./utils');
+const { runCommand, runCommandSync } = require('./utils');
 
 // For usage instructions see https://github.com/department-of-veterans-affairs/vets-website#unit-tests
 
 const defaultPath = './src/**/*.unit.spec.js?(x)';
+
+// const allUnitTests = glob.sync('{src,test}/**/*.unit.spec.js?(x)');
+
 const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'log-level', type: String, defaultValue: 'log' },
   { name: 'app-folder', type: String, defaultValue: null },
@@ -44,12 +50,52 @@ const testRunner = options.coverage ? coveragePath : mochaPath;
 const mochaOpts =
   'src/platform/testing/unit/mocha.opts src/platform/testing/unit/helper.js';
 
-// Otherwise, run the command
-runCommand(
-  `LOG_LEVEL=${options[
-    'log-level'
-  ].toLowerCase()} ${testRunner} --max-old-space-size=4096 --opts ${mochaOpts} --recursive ${options.path
-    .map(p => `'${p}'`)
-    .join(' ')}`,
-  options.coverage ? null : 0,
-);
+const logLevel = options['log-level'].toLowerCase();
+const forcedExitCode = options.coverage ? null : 0;
+const testDirectories = options.path;
+
+if (testDirectories[0] === defaultPath) {
+  const allUnitTests = glob.sync(defaultPath);
+
+  const unitTestDirectories = new Set(
+    allUnitTests.map(unitTest => {
+      // Start with './src/applications/tests/config/benefitsSelection.unit.spec.js'
+      const directory = path.dirname(unitTest);
+      const directoryPathArray = directory.split(path.sep);
+
+      let subdirectoryDepth = 3;
+
+      if (directoryPathArray[2] === 'applications') {
+        subdirectoryDepth = 4;
+      }
+
+      // Reduce to './src/applications//'
+      return directoryPathArray.slice(0, subdirectoryDepth).join(path.sep);
+    }),
+  );
+
+  const wildCard = `${path.sep}**${path.sep}*.unit.spec.js?(x)`;
+
+  let isPassing = true;
+
+  unitTestDirectories.forEach(unitTestDirectory => {
+    // eslint-disable-next-line no-console
+    console.log(chalk.blue(`Test suite: ${unitTestDirectory}`));
+
+    const command = `LOG_LEVEL=${logLevel} ${testRunner} --max-old-space-size=4096 --opts ${mochaOpts} --recursive "${unitTestDirectory}${wildCard}"`;
+    const exitStatus = runCommandSync(command);
+
+    if (exitStatus !== 0) {
+      isPassing = false;
+    }
+  });
+
+  if (!isPassing) process.exitCode = 1;
+} else {
+  const testDirectoriesEscaped = options.path.map(p => `'${p}'`).join(' ');
+
+  const command = `LOG_LEVEL=${logLevel} ${testRunner} --max-old-space-size=4096 --opts ${mochaOpts} --recursive ${testDirectoriesEscaped}`;
+
+  // Otherwise, run the command
+  runCommand(command, forcedExitCode);
+}

--- a/script/run-unit-test.js
+++ b/script/run-unit-test.js
@@ -57,7 +57,7 @@ if (testDirectories[0] === defaultPath) {
 
   const unitTestDirectories = new Set(
     allUnitTests.map(unitTest => {
-      // Start with './src/applications/tests/config/benefitsSelection.unit.spec.js'
+      // Start with './src/applications/burials/tests/config/benefitsSelection.unit.spec.js'
       const directory = path.dirname(unitTest);
       const directoryPathArray = directory.split(path.sep);
 
@@ -67,7 +67,7 @@ if (testDirectories[0] === defaultPath) {
         subdirectoryDepth = 4;
       }
 
-      // Reduce to './src/applications//'
+      // Reduce to 'src/applications/burials/'
       return directoryPathArray.slice(1, subdirectoryDepth).join(path.sep);
     }),
   );

--- a/script/run-unit-test.js
+++ b/script/run-unit-test.js
@@ -70,7 +70,7 @@ if (testDirectories[0] === defaultPath) {
       }
 
       // Reduce to './src/applications//'
-      return directoryPathArray.slice(0, subdirectoryDepth).join(path.sep);
+      return directoryPathArray.slice(1, subdirectoryDepth).join(path.sep);
     }),
   );
 
@@ -82,7 +82,10 @@ if (testDirectories[0] === defaultPath) {
     // eslint-disable-next-line no-console
     console.log(chalk.blue(`Test suite: ${unitTestDirectory}`));
 
-    const command = `LOG_LEVEL=${logLevel} ${testRunner} --max-old-space-size=4096 --opts ${mochaOpts} --recursive "${unitTestDirectory}${wildCard}"`;
+    const mocha = `NODE_ENV=test nyc --include "${unitTestDirectory}/**" --reporter=lcov --reporter=text --reporter=json-summary mocha --reporter mocha-junit-reporter --no-color`;
+    const command = `LOG_LEVEL=${logLevel} ${mocha} --opts ${mochaOpts} --recursive ".${
+      path.sep
+    }${unitTestDirectory}${wildCard}"`;
     const exitStatus = runCommandSync(command);
 
     if (exitStatus !== 0) {

--- a/src/applications/burials/tests/helpers.unit.spec.jsx
+++ b/src/applications/burials/tests/helpers.unit.spec.jsx
@@ -26,6 +26,12 @@ describe('Burials helpers', () => {
         data: {},
       };
 
+      const justTesting = true;
+
+      if (justTesting) {
+        throw new Error('This string should be visible in Jenkins');
+      }
+
       return submit(form, formConfig).then(
         () => {
           expect.fail();

--- a/src/applications/burials/tests/helpers.unit.spec.jsx
+++ b/src/applications/burials/tests/helpers.unit.spec.jsx
@@ -26,12 +26,6 @@ describe('Burials helpers', () => {
         data: {},
       };
 
-      const justTesting = true;
-
-      if (justTesting) {
-        throw new Error('This string should be visible in Jenkins');
-      }
-
       return submit(form, formConfig).then(
         () => {
           expect.fail();


### PR DESCRIPTION
## Description
This PR restructures the startup script for unit tests by breaking down a single global execution into smaller directories. This means that running `yarn test:unit` will do -

```
mocha src/site/***.unit.spec.jsx?
mocha src/platform/***.unit.spec.jsx?
mocha src/applications/app1/***.unit.spec.jsx?
mocha src/applications/app2/***.unit.spec.jsx?
mocha src/applications/app3/***.unit.spec.jsx?
etc
```

This effectively creates a more-isolated environment for each app's test suite to execute, thereby limiting the amount of "fluke" test failures and when a fluke does occur, the error will be more isolated (since only a subset of tests was run.)

## Testing done
Ran `yarn test:unit` a lot locally and have been monitoring CI

## Screenshots
N/A - See output in CI of "unit" step. Example - http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fvets-website/detail/fix-unit-tests---isolate/4/pipeline

## Acceptance criteria
- [x] Unit tests pass consistently or fail less often due to a "fluke"

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
