### PR TITLE
[Development] HLR: Fix veteran ssn/va file no prefill

### DIFF
--- a/src/applications/disability-benefits/996/content/veteranInformation.jsx
+++ b/src/applications/disability-benefits/996/content/veteranInformation.jsx
@@ -82,7 +82,7 @@ VeteranInfoView.propTypes = {
 
 const mapStateToProps = state => {
   const profile = selectProfile(state);
-  const veteran = state.form?.veteran;
+  const veteran = state.form?.data.veteran;
   return {
     profile,
     veteran,


### PR DESCRIPTION
## Description

Prefill data includes the last 4 of a Veteran's SSN & VA File number, but was not properly extracted from the data when being displayed on the Veteran information page.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/14124

## Testing done

N/A

## Screenshots

<details><summary>Before</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-10-05 at 3 40 25 PM](https://user-images.githubusercontent.com/136959/95129995-8284f980-0721-11eb-830d-eb2644608c33.png)</details>

<details><summary>After</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-10-05 at 3 42 29 PM](https://user-images.githubusercontent.com/136959/95130018-8ca6f800-0721-11eb-9c96-2d1449382dd3.png)</details>

## Acceptance criteria
- [ ] Last 4 of Vetern's SSN and/or VA file number are displayed on the Veteran info page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
