### PR TITLE
Add padding to bottom of Medallia form

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-medallia.scss
+++ b/src/platform/site-wide/sass/modules/_m-medallia.scss
@@ -1,7 +1,12 @@
 /* Fonts */
 #liveForm .ng-binding,
 #liveForm div > span {
-  font-family: "Source Sans Pro" !important;
+  font-family: "Source Sans Pro", sans-serif !important;
+}
+
+/* Add padding to the bottom of the Medallia form */
+#liveForm .panel-footer-web {
+  padding-bottom: 1rem;
 }
 
 /* Remove 'Powered by Medallia' */


### PR DESCRIPTION
## GitHub Issue

https://github.com/department-of-veterans-affairs/va.gov-team/issues/13287

## Description

**Primary Goal**: add `padding-bottom` to the Medallia form. 

**Secondary Goal**:  Update the `font-family` declaration to see if it will start applying now

### Context

Some styles are successfully being applied, like the [`display: none` to hide the Powered by Medallia line](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/site-wide/sass/modules/_m-medallia.scss#L9). 

However, the [`font-family`](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/site-wide/sass/modules/_m-medallia.scss#L4) CSS is being loaded, but not applied. 🤔 

## Screenshots

![add-padding-bottom-to-medallia-form](https://user-images.githubusercontent.com/6130520/95131206-48b4f280-0723-11eb-875b-ecd36bce0c51.gif)

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
