### PR TITLE
Fix flat list facility id in submit and missing facility details for old version

### DIFF
--- a/src/applications/vaos/new-appointment/components/ConfirmationPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/ConfirmationPage/index.jsx
@@ -59,7 +59,7 @@ export class ConfirmationPage extends React.Component {
       data.facilityType !== FACILITY_TYPES.COMMUNITY_CARE
     ) {
       // Remove parse function when converting this call to FHIR service
-      this.props.fetchFacilityDetails(parseFakeFHIRId(data.vaFacility));
+      this.props.fetchFacilityDetails(data.vaFacility);
     }
     scrollAndFocus();
   }

--- a/src/applications/vaos/new-appointment/components/ConfirmationPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/ConfirmationPage/index.jsx
@@ -25,12 +25,6 @@ import {
 import ConfirmationDirectScheduleInfo from './ConfirmationDirectScheduleInfo';
 import ConfirmationRequestInfo from './ConfirmationRequestInfo';
 
-// Only use this when we need to pass data that comes back from one of our
-// services files to one of the older api functions
-function parseFakeFHIRId(id) {
-  return id.replace('var', '');
-}
-
 export class ConfirmationPage extends React.Component {
   constructor(props) {
     super(props);

--- a/src/applications/vaos/utils/data.js
+++ b/src/applications/vaos/utils/data.js
@@ -61,7 +61,7 @@ export function transformFormToVARequest(state) {
   const siteId = getSiteIdForChosenFacility(state);
   const isFacilityV2Page = vaosFlatFacilityPage(state);
   const facilityId = isFacilityV2Page
-    ? facility.id
+    ? facility.id.replace('var', '')
     : getFacilityIdFromLocation(facility);
 
   return {


### PR DESCRIPTION
## Description
This fixes 2 issues:
1. When using the flat list, we were passing an unparsed ID in the POST body (e.g. `var983` instead of `983`), which was causing some submit failures
1. I think this might have been an existing bug, but the facility details were not showing on the Confirmation page with the old facility list page

## Testing done
Local testing

## Screenshots
![image](https://user-images.githubusercontent.com/786704/95133598-66c82600-0716-11eb-8748-28f0883d8ba2.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
