### PR TITLE
VACMS-12970: Remove hardcoded menus list and replace with dynamic drupal endpoint

### DIFF
--- a/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
+++ b/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
@@ -5,26 +5,8 @@
 
 // String Helpers
 const { camelize } = require('./../../../../../utilities/stringHelpers');
-
-const FACILITY_MENU_NAMES = [
-  'pittsburgh-health-care',
-  'va-altoona-health-care',
-  'va-butler-health-care',
-  'va-cheyenne-health-care',
-  'va-coatesville-health-care',
-  'va-eastern-colorado-health-care',
-  'va-eastern-oklahoma-health-care',
-  'va-erie-health-care',
-  'va-lebanon',
-  'va-montana-health-care',
-  'va-oklahoma-health-care',
-  'va-philadelphia-health-care',
-  'va-salt-lake-city-health-care',
-  'va-sheridan-health-care',
-  'va-western-colorado-health-care',
-  'va-wilkes-barre-health-care',
-  'va-wilmington-health-care',
-];
+/* eslint-disable no-undef */
+const FACILITY_MENU_NAMES = cmsSideNavs;
 
 const FACILITY_SIDEBAR_QUERY = `
     name

--- a/src/site/stages/build/drupal/graphql/sideNavMenus.graphql.js
+++ b/src/site/stages/build/drupal/graphql/sideNavMenus.graphql.js
@@ -1,0 +1,3 @@
+module.exports = `{
+  sideNavMenus
+}`;

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -19,6 +19,7 @@ const { shouldPullDrupal } = require('./drupal/metalsmith-drupal');
 const { defaultCMSExportContentDir } = require('./process-cms-exports/helpers');
 const { logDrupal } = require('./drupal/utilities-drupal');
 const { useFlags } = require('./drupal/load-saved-flags');
+const DRUPALS = require('../../constants/drupals');
 
 const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'buildtype', type: String, defaultValue: defaultBuildtype },
@@ -221,6 +222,69 @@ async function setUpFeatureFlags(options) {
   });
 }
 
+/**
+ * Sets up the CMS SideNav Menus list.
+ */
+async function setUpSideNavMenuList(options) {
+  global.buildtype = options.buildtype;
+  let SideNavs;
+
+  const sideNavFile = path.join(
+    options.cacheDirectory,
+    'drupal',
+    'side-nav-menus.json',
+  );
+
+  if (shouldPullDrupal(options)) {
+    logDrupal('Pulling side nav menus from Drupal...');
+    const apiClient = getDrupalClient(options);
+    const envConfig = DRUPALS[global.buildtype];
+    const drupalConfig = Object.assign({}, envConfig);
+    const { user, password } = drupalConfig;
+
+    const encodedCredentials = Buffer.from(`${user}:${password}`).toString(
+      'base64',
+    );
+    const result = await apiClient.proxyFetch(
+      `${apiClient.getSiteUri()}/graphql/`,
+      {
+        headers: {
+          Authorization: `Basic ${encodedCredentials}`,
+          'Content-Type': 'application/json',
+        },
+        method: 'post',
+        body: JSON.stringify({
+          query: `{
+         sideNavMenus
+       }`,
+        }),
+      },
+    );
+
+    const responseBody = await result.text();
+    try {
+      SideNavs = JSON.parse(responseBody).data.sideNavMenus;
+    } catch (e) {
+      throw new TypeError(
+        `Could not parse Drupal side nav menus. Response:\n${responseBody}`,
+      );
+    }
+
+    // Write them to .cache/{buildtype}/drupal/side-nav-menus.json
+    fs.ensureDirSync(options.cacheDirectory);
+    fs.emptyDirSync(path.dirname(sideNavFile));
+    fs.writeJsonSync(sideNavFile, SideNavs, { spaces: 2 });
+  } else {
+    logDrupal('Using cached side navs');
+    SideNavs = fs.existsSync(sideNavFile) ? fs.readJsonSync(sideNavFile) : {};
+  }
+
+  if (global.verbose) {
+    logDrupal(`Drupal side navs:\n${JSON.stringify(SideNavs, null, 2)}`);
+  }
+  global.cmsSideNavs = SideNavs;
+}
+
 async function getOptions(commandLineOptions) {
   const options = commandLineOptions || gatherFromCommandLine();
 
@@ -228,6 +292,7 @@ async function getOptions(commandLineOptions) {
   applyEnvironmentOverrides(options);
   deriveHostUrl(options);
   await setUpFeatureFlags(options);
+  await setUpSideNavMenuList(options);
 
   // Setting verbosity for the whole content build process as global so we don't
   // have to pass the buildOptions around for just that.


### PR DESCRIPTION
## Description
Currently, array of drupal system menus fed into graphql query is hardcoded. This pr adds logic to grab system menu names from graphql endpoint.
Can not be merged until https://github.com/department-of-veterans-affairs/va.gov-cms/pull/3110 is on prod.

cc: @mpelzsherman 

## Testing done
Visual, build.