### PR TITLE
[Development] 526 wizard updates

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -19,7 +19,7 @@ import { BDD_INFO_URL } from '../constants';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {
-    focusElement('.va-nav-breadcrumbs-list');
+    focusElement('h1');
   }
 
   render() {

--- a/src/applications/disability-benefits/wizard/pages/start.jsx
+++ b/src/applications/disability-benefits/wizard/pages/start.jsx
@@ -3,14 +3,14 @@ import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-rea
 import { pageNames } from './pageList';
 
 const options = [
-  { value: pageNames.appeals, label: 'Yes' },
-  { value: pageNames.bdd, label: 'No' },
+  { value: pageNames.bdd, label: 'Yes' },
+  { value: pageNames.appeals, label: 'No' },
 ];
 
 const StartPage = ({ setPageState, state = {} }) => (
   <ErrorableRadioButtons
     name={`${pageNames.start}-option`}
-    label="Have you separated from your military or uniformed service?"
+    label="Are you currently on active duty?"
     id={`${pageNames.start}-option`}
     options={options}
     onValueChange={({ value }) => setPageState({ selected: value }, value)}


### PR DESCRIPTION
## Description

Benefits Delivery at Discharge can only be filed by active duty members, so we're changing the first wizard question to ask if they are on active duty.

<details><summary>Active duty wizard question update</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-10-06 at 9 52 06 AM](https://user-images.githubusercontent.com/136959/95219736-5a49d900-07bb-11eb-81c8-e926e20652eb.png)</details>

Additionally, once the wizard has completed, we need to move the focus to the introduction page `H1`.

Related
- Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/14070
- Design: https://vsateams.invisionapp.com/share/8GXOG91ZWNJ#/screens/421391042
- Slack discussion: https://dsva.slack.com/archives/C0113MPTGH5/p1601995961022700?thread_ts=1601923906.011400&cid=C0113MPTGH5

## Testing done

N/A - content & focus change

## Screenshots

See description

## Acceptance criteria
- [x] Wizard initial question asks if the user is currently on active duty
- [x] Focus is shifted to `H1` on wizard completion

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
