### PR TITLE
[Development] Edit new service period when missing data

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
@@ -20,6 +20,8 @@ import { errorSchemaIsValid } from 'platform/forms-system/src/js/validation';
 const Element = Scroll.Element;
 const scroller = Scroll.scroller;
 
+const isUndefined = value => (value || '') === '';
+
 /* Non-review growable table (array) field */
 // Mostly copied from USFS with a few additions/modifications:
 // Addition of 'Save' button, handleSave action, modifications to handleRemove
@@ -40,10 +42,14 @@ export default class ArrayField extends React.Component {
      * manage and doesn’t need to persist from page to page
      */
     this.state = {
-      // force edit mode for valid BDD separation date; empty serviceBranch,
-      // but includes valid "to" entry
+      // force edit mode for any empty service period data
       editing: props.formData
-        ? props.formData.map(data => data?.serviceBranch === '')
+        ? props.formData.map(
+            data =>
+              isUndefined(data?.serviceBranch) ||
+              isUndefined(data?.dateRange?.from) ||
+              isUndefined(data?.dateRange?.to),
+          )
         : [true],
     };
   }


### PR DESCRIPTION
## Description

In Form 526, if a service period is missing the branch, it will automatically open in edit mode. But if the data is missing the start and/or end date, the card is not made editable and shows "Unknown" to the user.

<details><summary>Screenshots</summary>

<!-- leave a blank line above -->
![](https://user-images.githubusercontent.com/136959/95210163-d2f76800-07b0-11eb-8a36-da1792aa5a19.png)
![](https://user-images.githubusercontent.com/136959/95210165-d2f76800-07b0-11eb-81f2-b3886a4cabb7.png)
</details>

This PR checks if any of the data fields - branch name, start or end dates - are empty, then it opens the service period card in edit mode.

<details><summary>Missing "end" date</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-10-06 at 10 32 26 AM](https://user-images.githubusercontent.com/136959/95223832-a4cd5480-07bf-11eb-8d03-7e28bfd9e10c.png)
</details>

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/14444

## Testing done

None (tech debt, missing modified ArrayField unit tests)

## Screenshots

See description

## Acceptance criteria
- [x] Service period blocks open in edit mode when missing any data

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
