### PR TITLE
[Templates] Fix screenreader error in reading form name

### DIFF
--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -19,14 +19,12 @@
       {% endif %}
 
       <article class="usa-content">
-        <h1 class="vads-u-margin-bottom--0">{{ title }}</h1>
+        <h1 class="vads-u-margin-bottom--0">
+          {{ title }}
+          <span class="vads-u-display--block va-introtext">{{ fieldVaFormName }}</span>
+        </h1>
 
         <dl>
-          <div class="vads-u-margin-bottom--4">
-            <dt class="vads-u-visibility--screen-reader">Form name:</dt>
-            <dd class="va-introtext">{{ fieldVaFormName }}</dd>
-          </div>
-
           <div class="vads-u-margin-y--1">
             <dt class="vads-u-font-weight--bold vads-u-display--inline">
               Related to:

--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -21,15 +21,19 @@
       <article class="usa-content">
         <h1 class="vads-u-margin-bottom--0">
           {{ title }}
-          <span class="vads-u-display--block va-introtext">{{ fieldVaFormName }}</span>
         </h1>
 
         <dl>
+          <div class="vads-u-margin-bottom--4">
+            <dt class="va-introtext">
+              <dfn class="vads-u-visibility--screen-reader">Form name:</dfn>
+              {{ fieldVaFormName }}
+            </dt>
+          </div>
+
           <div class="vads-u-margin-y--1">
-            <dt class="vads-u-font-weight--bold vads-u-display--inline">
-              Related to:
-            </dd>
-            <dd class="vads-u-display--inline">
+            <dd>
+              <dfn class="vads-u-font-weight--bold vads-u-display--inline">Related to:</dfn>
               {% case fieldVaFormType %}
                 {% when 'employment' %}
                   Employment or jobs at VA
@@ -50,10 +54,8 @@
 
           {% if fieldVaFormRevisionDate or fieldVaFormIssueDate %}
             <div>
-              <dt class="vads-u-font-weight--bold vads-u-display--inline">
-                Form last updated:
-              </dt>
-              <dd class="vads-u-display--inline">
+              <dd>
+                <dfn class="vads-u-font-weight--bold vads-u-display--inline">Form last updated:</dfn>
                 {% assign revisionDateIsLatestUpdate = fieldVaFormRevisionDate.value | isLaterThan: fieldVaFormIssueDate.value %}
                 {% if revisionDateIsLatestUpdate %}
                   {{ fieldVaFormRevisionDate.value | humanizeDate }}


### PR DESCRIPTION
## Description
This PR fixes a screenreader issue where Voiceover would starting beeping when trying to read the form name. The issue is described in https://dsva.slack.com/archives/C52CL1PKQ/p1601938682219700.


https://github.com/department-of-veterans-affairs/va.gov-team/issues/14440

## Testing done
Ran VoiceOver on http://localhost:3001/preview?nodeId=5776

## Screenshots
N/A (audio issue)

## Acceptance criteria
- [ ] VoiceOver reads the page properly

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
