### PR TITLE
14407: Removal of id causing mismatch in label and the content

### DIFF
--- a/src/applications/gi/components/profile/EstimateYourBenefitsForm.jsx
+++ b/src/applications/gi/components/profile/EstimateYourBenefitsForm.jsx
@@ -890,7 +890,6 @@ class EstimateYourBenefitsForm extends React.Component {
           onChange={this.handleHasClassesOutsideUSChange}
           checked={inputs.classesOutsideUS}
           name={'classesOutsideUS'}
-          id={'classesOutsideUS'}
         />
       );
     }


### PR DESCRIPTION
## Description
When I select Other Location and enter a valid zip code, the checkbox label "I'll be taking classes outside of the U.S. and U.S. territories" is showing an axe-core critical violation. This means I won't be able to hear the label read when the checkbox receives focus. Screenshot attached below.

[Originating Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/14407)

## Testing done
Testing passes locally, Axe issue is no longer present as described in the originating issue and has been testing using voiceover in chrome on MacOS, using JAWS with internet explorer on Windows 10, and using voiceover on safari on iOS

## Screenshots
N/A no visual changes

## Acceptance criteria
- [x] Zero axe-core violations are shown on future scans
- [x] Input label is read aloud when the checkbox has screen reader focus

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
