### PR TITLE
FL: Fix state after failed search

### DIFF
--- a/src/applications/facility-locator/reducers/searchQuery.js
+++ b/src/applications/facility-locator/reducers/searchQuery.js
@@ -84,6 +84,7 @@ export const SearchQueryReducer = (state = INITIAL_STATE, action) => {
         ...state,
         error: true,
         inProgress: false,
+        searchBoundsInProgress: false,
       };
     case SEARCH_QUERY_UPDATED:
       return {

--- a/src/applications/facility-locator/tests/reducers/searchQuery.unit.spec.js
+++ b/src/applications/facility-locator/tests/reducers/searchQuery.unit.spec.js
@@ -83,6 +83,7 @@ describe('search query reducer', () => {
 
     expect(state.error).to.eql(true);
     expect(state.inProgress).to.eql(false);
+    expect(state.searchBoundsInProgress).to.eql(false);
   });
 
   it('should handle search query updated', () => {


### PR DESCRIPTION
## Description
Issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/13368

## Testing done
Unit

## Screenshots(gif)

![resetSearch](https://user-images.githubusercontent.com/100468/95242526-ea484c80-07d4-11eb-8163-a44f980348f2.gif)


## Acceptance criteria
- [x] Unit test has been added
- [x] The state is cleared after a failed search

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
