### PR TITLE
Add support for facility exceptions to render Cerner content

### DIFF
--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
@@ -9,8 +9,8 @@ import UnauthContent from '../UnauthContent';
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
 import { hasFacilityException } from '../../../utils';
 import {
-  selectIsCernerPatient,
   selectFacilityIDs,
+  selectIsCernerPatient,
 } from 'platform/user/selectors';
 
 export const App = ({

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
@@ -7,9 +7,10 @@ import AuthContent from '../AuthContent';
 import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
-import { selectIsCernerPatient } from 'platform/user/selectors';
+import { hasFacilityException } from '../../../utils';
+import { selectIsCernerPatient, selectFacilityIDs } from 'platform/user/selectors';
 
-export const App = ({ isCernerPatient, showNewGetMedicalRecordsPage }) => {
+export const App = ({ facilityIDs, isCernerPatient, showAuthFacilityIDExceptions, showNewGetMedicalRecordsPage }) => {
   if (!showNewGetMedicalRecordsPage) {
     return <LegacyContent />;
   }
@@ -18,16 +19,23 @@ export const App = ({ isCernerPatient, showNewGetMedicalRecordsPage }) => {
     return <AuthContent />;
   }
 
+  if (hasFacilityException(facilityIDs, showAuthFacilityIDExceptions)) {
+    return <AuthContent />;
+  }
+
   return <UnauthContent />;
 };
 
 App.propTypes = {
+  showAuthFacilityIDExceptions: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
   // From mapStateToProps.
+  facilityIDs: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
   isCernerPatient: PropTypes.bool,
   showNewGetMedicalRecordsPage: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = state => ({
+  facilityIDs: selectFacilityIDs(state),
   isCernerPatient: selectIsCernerPatient(state),
   showNewGetMedicalRecordsPage:
     state?.featureToggles?.[featureFlagNames.showNewGetMedicalRecordsPage],

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
@@ -8,9 +8,17 @@ import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
 import { hasFacilityException } from '../../../utils';
-import { selectIsCernerPatient, selectFacilityIDs } from 'platform/user/selectors';
+import {
+  selectIsCernerPatient,
+  selectFacilityIDs,
+} from 'platform/user/selectors';
 
-export const App = ({ facilityIDs, isCernerPatient, showAuthFacilityIDExceptions, showNewGetMedicalRecordsPage }) => {
+export const App = ({
+  facilityIDs,
+  isCernerPatient,
+  showAuthFacilityIDExceptions,
+  showNewGetMedicalRecordsPage,
+}) => {
   if (!showNewGetMedicalRecordsPage) {
     return <LegacyContent />;
   }
@@ -27,7 +35,8 @@ export const App = ({ facilityIDs, isCernerPatient, showAuthFacilityIDExceptions
 };
 
 App.propTypes = {
-  showAuthFacilityIDExceptions: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+  showAuthFacilityIDExceptions: PropTypes.arrayOf(PropTypes.string.isRequired)
+    .isRequired,
   // From mapStateToProps.
   facilityIDs: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
   isCernerPatient: PropTypes.bool,

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.unit.spec.js
@@ -10,9 +10,7 @@ import { App } from './index';
 
 describe('Get Medical Records Page <App>', () => {
   it('renders what we expect when the feature toggle is turned off', () => {
-    const wrapper = shallow(
-      <App showNewGetMedicalRecordsPage={false} />,
-    );
+    const wrapper = shallow(<App showNewGetMedicalRecordsPage={false} />);
     expect(wrapper.find(LegacyContent)).to.have.lengthOf(1);
   });
 

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.unit.spec.js
@@ -12,6 +12,7 @@ describe('Get Medical Records Page <App>', () => {
   it('renders what we expect when the feature toggle is turned off', () => {
     const wrapper = shallow(<App showNewGetMedicalRecordsPage={false} />);
     expect(wrapper.find(LegacyContent)).to.have.lengthOf(1);
+    wrapper.unmount();
   });
 
   it('renders what we expect when there is a Cerner facility exception', () => {

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.unit.spec.js
@@ -4,16 +4,28 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 // Relative imports.
 import AuthContent from '../AuthContent';
+import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import { App } from './index';
 
 describe('Get Medical Records Page <App>', () => {
-  it('renders what we expect when not a Cerner patient', () => {
+  it('renders what we expect when the feature toggle is turned off', () => {
     const wrapper = shallow(
-      <App showNewGetMedicalRecordsPage isCernerPatient={false} />,
+      <App showNewGetMedicalRecordsPage={false} />,
     );
-    expect(wrapper.find(UnauthContent)).to.have.lengthOf(1);
-    expect(wrapper.find(AuthContent)).to.have.lengthOf(0);
+    expect(wrapper.find(LegacyContent)).to.have.lengthOf(1);
+  });
+
+  it('renders what we expect when there is a Cerner facility exception', () => {
+    const wrapper = shallow(
+      <App
+        facilityIDs={['1']}
+        isCernerPatient={false}
+        showAuthFacilityIDExceptions={['1']}
+        showNewGetMedicalRecordsPage
+      />,
+    );
+    expect(wrapper.find(AuthContent)).to.have.lengthOf(1);
     wrapper.unmount();
   });
 
@@ -21,8 +33,15 @@ describe('Get Medical Records Page <App>', () => {
     const wrapper = shallow(
       <App showNewGetMedicalRecordsPage isCernerPatient />,
     );
-    expect(wrapper.find(UnauthContent)).to.have.lengthOf(0);
     expect(wrapper.find(AuthContent)).to.have.lengthOf(1);
+    wrapper.unmount();
+  });
+
+  it('renders what we expect when not a Cerner patient', () => {
+    const wrapper = shallow(
+      <App showNewGetMedicalRecordsPage isCernerPatient={false} />,
+    );
+    expect(wrapper.find(UnauthContent)).to.have.lengthOf(1);
     wrapper.unmount();
   });
 });

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/constants/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/constants/index.js
@@ -1,0 +1,2 @@
+// @NOTE: This is used for Cerner facilities whose key-value pair `isCerner: false` is false, but still need to show on some of the Cerner pages.
+export const showAuthFacilityIDExceptions = [];

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/index.js
@@ -2,6 +2,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
+// Relative imports.
+import { showAuthFacilityIDExceptions } from './constants';
 
 export default (store, widgetType) => {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
@@ -11,7 +13,7 @@ export default (store, widgetType) => {
       const App = module.default;
       ReactDOM.render(
         <Provider store={store}>
-          <App />
+          <App showAuthFacilityIDExceptions={showAuthFacilityIDExceptions} />
         </Provider>,
         root,
       );

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.js
@@ -7,7 +7,10 @@ import AuthContent from '../AuthContent';
 import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
-import { selectIsCernerPatient, selectFacilityIDs } from 'platform/user/selectors';
+import {
+  selectFacilityIDs,
+  selectIsCernerPatient,
+} from 'platform/user/selectors';
 import { hasFacilityException } from '../../../utils';
 
 export const App = ({

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.js
@@ -8,9 +8,12 @@ import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
 import { selectIsCernerPatient } from 'platform/user/selectors';
+import { hasFacilityException } from '../../../utils';
 
 export const App = ({
+  facilityIDs,
   isCernerPatient,
+  showAuthFacilityIDExceptions,
   showNewRefillTrackPrescriptionsPage,
 }) => {
   if (!showNewRefillTrackPrescriptionsPage) {
@@ -21,16 +24,23 @@ export const App = ({
     return <AuthContent />;
   }
 
+  if (hasFacilityException(facilityIDs, showAuthFacilityIDExceptions)) {
+    return <AuthContent />;
+  }
+
   return <UnauthContent />;
 };
 
 App.propTypes = {
+  showAuthFacilityIDExceptions: PropTypes.array.isRequired,
   // From mapStateToProps.
+  facilityIDs: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
   isCernerPatient: PropTypes.bool,
   showNewRefillTrackPrescriptionsPage: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = state => ({
+  facilityIDs: selectFacilityIDs(state),
   isCernerPatient: selectIsCernerPatient(state),
   showNewRefillTrackPrescriptionsPage:
     state?.featureToggles?.[

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.js
@@ -7,7 +7,7 @@ import AuthContent from '../AuthContent';
 import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
-import { selectIsCernerPatient } from 'platform/user/selectors';
+import { selectIsCernerPatient, selectFacilityIDs } from 'platform/user/selectors';
 import { hasFacilityException } from '../../../utils';
 
 export const App = ({

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.unit.spec.js
@@ -14,6 +14,7 @@ describe('Get Medical Records Page <App>', () => {
       <App showNewRefillTrackPrescriptionsPage={false} />,
     );
     expect(wrapper.find(LegacyContent)).to.have.lengthOf(1);
+    wrapper.unmount();
   });
 
   it('renders what we expect when there is a Cerner facility exception', () => {

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.unit.spec.js
@@ -4,16 +4,28 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 // Relative imports.
 import AuthContent from '../AuthContent';
+import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import { App } from './index';
 
 describe('Get Medical Records Page <App>', () => {
-  it('renders what we expect when not a Cerner patient', () => {
+  it('renders what we expect when the feature toggle is turned off', () => {
     const wrapper = shallow(
-      <App showNewRefillTrackPrescriptionsPage isCernerPatient={false} />,
+      <App showNewRefillTrackPrescriptionsPage={false} />,
     );
-    expect(wrapper.find(UnauthContent)).to.have.lengthOf(1);
-    expect(wrapper.find(AuthContent)).to.have.lengthOf(0);
+    expect(wrapper.find(LegacyContent)).to.have.lengthOf(1);
+  });
+
+  it('renders what we expect when there is a Cerner facility exception', () => {
+    const wrapper = shallow(
+      <App
+        facilityIDs={['1']}
+        isCernerPatient={false}
+        showAuthFacilityIDExceptions={['1']}
+        showNewRefillTrackPrescriptionsPage
+      />,
+    );
+    expect(wrapper.find(AuthContent)).to.have.lengthOf(1);
     wrapper.unmount();
   });
 
@@ -21,8 +33,15 @@ describe('Get Medical Records Page <App>', () => {
     const wrapper = shallow(
       <App showNewRefillTrackPrescriptionsPage isCernerPatient />,
     );
-    expect(wrapper.find(UnauthContent)).to.have.lengthOf(0);
     expect(wrapper.find(AuthContent)).to.have.lengthOf(1);
+    wrapper.unmount();
+  });
+
+  it('renders what we expect when not a Cerner patient', () => {
+    const wrapper = shallow(
+      <App showNewRefillTrackPrescriptionsPage isCernerPatient={false} />,
+    );
+    expect(wrapper.find(UnauthContent)).to.have.lengthOf(1);
     wrapper.unmount();
   });
 });

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/constants/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/constants/index.js
@@ -1,0 +1,2 @@
+// @NOTE: This is used for Cerner facilities whose key-value pair `isCerner: false` is false, but still need to show on some of the Cerner pages.
+export const showAuthFacilityIDExceptions = [];

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/index.js
@@ -2,6 +2,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
+// Relative imports.
+import { showAuthFacilityIDExceptions } from './constants';
 
 export default (store, widgetType) => {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
@@ -11,7 +13,7 @@ export default (store, widgetType) => {
       const App = module.default;
       ReactDOM.render(
         <Provider store={store}>
-          <App />
+          <App showAuthFacilityIDExceptions={showAuthFacilityIDExceptions} />
         </Provider>,
         root,
       );

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/App/index.js
@@ -32,7 +32,8 @@ export const App = ({
 };
 
 App.propTypes = {
-  showAuthFacilityIDExceptions: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+  showAuthFacilityIDExceptions: PropTypes.arrayOf(PropTypes.string.isRequired)
+    .isRequired,
   // From mapStateToProps.
   facilityIDs: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
   isCernerPatient: PropTypes.bool,

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/App/index.js
@@ -7,7 +7,10 @@ import AuthContent from '../AuthContent';
 import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
-import { selectIsCernerPatient, selectFacilityIDs } from 'platform/user/selectors';
+import {
+  selectFacilityIDs,
+  selectIsCernerPatient,
+} from 'platform/user/selectors';
 import { hasFacilityException } from '../../../utils';
 
 export const App = ({

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/App/index.js
@@ -7,7 +7,7 @@ import AuthContent from '../AuthContent';
 import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
-import { selectIsCernerPatient } from 'platform/user/selectors';
+import { selectIsCernerPatient, selectFacilityIDs } from 'platform/user/selectors';
 import { hasFacilityException } from '../../../utils';
 
 export const App = ({

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/App/index.js
@@ -8,9 +8,12 @@ import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
 import { selectIsCernerPatient } from 'platform/user/selectors';
+import { hasFacilityException } from '../../../utils';
 
 export const App = ({
+  facilityIDs,
   isCernerPatient,
+  showAuthFacilityIDExceptions,
   showNewScheduleViewAppointmentsPage,
 }) => {
   if (!showNewScheduleViewAppointmentsPage) {
@@ -21,16 +24,23 @@ export const App = ({
     return <AuthContent />;
   }
 
+  if (hasFacilityException(facilityIDs, showAuthFacilityIDExceptions)) {
+    return <AuthContent />;
+  }
+
   return <UnauthContent />;
 };
 
 App.propTypes = {
+  showAuthFacilityIDExceptions: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
   // From mapStateToProps.
+  facilityIDs: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
   isCernerPatient: PropTypes.bool,
   showNewScheduleViewAppointmentsPage: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = state => ({
+  facilityIDs: selectFacilityIDs(state),
   isCernerPatient: selectIsCernerPatient(state),
   showNewScheduleViewAppointmentsPage:
     state?.featureToggles?.[

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/App/index.unit.spec.js
@@ -14,6 +14,7 @@ describe('Get Medical Records Page <App>', () => {
       <App showNewScheduleViewAppointmentsPage={false} />,
     );
     expect(wrapper.find(LegacyContent)).to.have.lengthOf(1);
+    wrapper.unmount();
   });
 
   it('renders what we expect when there is a Cerner facility exception', () => {

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/App/index.unit.spec.js
@@ -4,16 +4,28 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 // Relative imports.
 import AuthContent from '../AuthContent';
+import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import { App } from './index';
 
 describe('Get Medical Records Page <App>', () => {
-  it('renders what we expect when not a Cerner patient', () => {
+  it('renders what we expect when the feature toggle is turned off', () => {
     const wrapper = shallow(
-      <App showNewScheduleViewAppointmentsPage isCernerPatient={false} />,
+      <App showNewScheduleViewAppointmentsPage={false} />,
     );
-    expect(wrapper.find(UnauthContent)).to.have.lengthOf(1);
-    expect(wrapper.find(AuthContent)).to.have.lengthOf(0);
+    expect(wrapper.find(LegacyContent)).to.have.lengthOf(1);
+  });
+
+  it('renders what we expect when there is a Cerner facility exception', () => {
+    const wrapper = shallow(
+      <App
+        facilityIDs={['1']}
+        isCernerPatient={false}
+        showAuthFacilityIDExceptions={['1']}
+        showNewScheduleViewAppointmentsPage
+      />,
+    );
+    expect(wrapper.find(AuthContent)).to.have.lengthOf(1);
     wrapper.unmount();
   });
 
@@ -21,8 +33,15 @@ describe('Get Medical Records Page <App>', () => {
     const wrapper = shallow(
       <App showNewScheduleViewAppointmentsPage isCernerPatient />,
     );
-    expect(wrapper.find(UnauthContent)).to.have.lengthOf(0);
     expect(wrapper.find(AuthContent)).to.have.lengthOf(1);
+    wrapper.unmount();
+  });
+
+  it('renders what we expect when not a Cerner patient', () => {
+    const wrapper = shallow(
+      <App showNewScheduleViewAppointmentsPage isCernerPatient={false} />,
+    );
+    expect(wrapper.find(UnauthContent)).to.have.lengthOf(1);
     wrapper.unmount();
   });
 });

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/constants/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/constants/index.js
@@ -1,2 +1,2 @@
 // @NOTE: This is used for Cerner facilities whose key-value pair `isCerner: false` is false, but still need to show on some of the Cerner pages.
-export const showAuthFacilityIDExceptions = [];
+export const showAuthFacilityIDExceptions = ['757'];

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/constants/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/constants/index.js
@@ -1,0 +1,2 @@
+// @NOTE: This is used for Cerner facilities whose key-value pair `isCerner: false` is false, but still need to show on some of the Cerner pages.
+export const showAuthFacilityIDExceptions = [];

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/index.js
@@ -2,6 +2,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
+// Relative imports.
+import { showAuthFacilityIDExceptions } from './constants';
 
 export default (store, widgetType) => {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
@@ -11,7 +13,7 @@ export default (store, widgetType) => {
       const App = module.default;
       ReactDOM.render(
         <Provider store={store}>
-          <App />
+          <App showAuthFacilityIDExceptions={showAuthFacilityIDExceptions} />
         </Provider>,
         root,
       );

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.js
@@ -8,8 +8,14 @@ import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
 import { selectIsCernerPatient } from 'platform/user/selectors';
+import { hasFacilityException } from '../../../utils';
 
-export const App = ({ isCernerPatient, showNewSecureMessagingPage }) => {
+export const App = ({
+  facilityIDs,
+  isCernerPatient,
+  showAuthFacilityIDExceptions,
+  showNewSecureMessagingPage,
+}) => {
   if (!showNewSecureMessagingPage) {
     return <LegacyContent />;
   }
@@ -18,16 +24,24 @@ export const App = ({ isCernerPatient, showNewSecureMessagingPage }) => {
     return <AuthContent />;
   }
 
+  if (hasFacilityException(facilityIDs, showAuthFacilityIDExceptions)) {
+    return <AuthContent />;
+  }
+
   return <UnauthContent />;
 };
 
 App.propTypes = {
+  showAuthFacilityIDExceptions: PropTypes.arrayOf(PropTypes.string.isRequired)
+    .isRequired,
   // From mapStateToProps.
+  facilityIDs: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
   isCernerPatient: PropTypes.bool,
   showNewSecureMessagingPage: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = state => ({
+  facilityIDs: selectFacilityIDs(state),
   isCernerPatient: selectIsCernerPatient(state),
   showNewSecureMessagingPage:
     state?.featureToggles?.[featureFlagNames.showNewSecureMessagingPage],

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.js
@@ -7,7 +7,10 @@ import AuthContent from '../AuthContent';
 import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
-import { selectIsCernerPatient, selectFacilityIDs } from 'platform/user/selectors';
+import {
+  selectFacilityIDs,
+  selectIsCernerPatient,
+} from 'platform/user/selectors';
 import { hasFacilityException } from '../../../utils';
 
 export const App = ({

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.js
@@ -7,7 +7,7 @@ import AuthContent from '../AuthContent';
 import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
-import { selectIsCernerPatient } from 'platform/user/selectors';
+import { selectIsCernerPatient, selectFacilityIDs } from 'platform/user/selectors';
 import { hasFacilityException } from '../../../utils';
 
 export const App = ({

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.unit.spec.js
@@ -12,6 +12,7 @@ describe('Get Medical Records Page <App>', () => {
   it('renders what we expect when the feature toggle is turned off', () => {
     const wrapper = shallow(<App showNewSecureMessagingPage={false} />);
     expect(wrapper.find(LegacyContent)).to.have.lengthOf(1);
+    wrapper.unmount();
   });
 
   it('renders what we expect when there is a Cerner facility exception', () => {

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.unit.spec.js
@@ -4,23 +4,44 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 // Relative imports.
 import AuthContent from '../AuthContent';
+import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import { App } from './index';
 
 describe('Get Medical Records Page <App>', () => {
+  it('renders what we expect when the feature toggle is turned off', () => {
+    const wrapper = shallow(
+      <App showNewSecureMessagingPage={false} />,
+    );
+    expect(wrapper.find(LegacyContent)).to.have.lengthOf(1);
+  });
+
+  it('renders what we expect when there is a Cerner facility exception', () => {
+    const wrapper = shallow(
+      <App
+        facilityIDs={['1']}
+        isCernerPatient={false}
+        showAuthFacilityIDExceptions={['1']}
+        showNewSecureMessagingPage
+      />,
+    );
+    expect(wrapper.find(AuthContent)).to.have.lengthOf(1);
+    wrapper.unmount();
+  });
+
+  it('renders what we expect when a Cerner patient', () => {
+    const wrapper = shallow(
+      <App showNewSecureMessagingPage isCernerPatient />,
+    );
+    expect(wrapper.find(AuthContent)).to.have.lengthOf(1);
+    wrapper.unmount();
+  });
+
   it('renders what we expect when not a Cerner patient', () => {
     const wrapper = shallow(
       <App showNewSecureMessagingPage isCernerPatient={false} />,
     );
     expect(wrapper.find(UnauthContent)).to.have.lengthOf(1);
-    expect(wrapper.find(AuthContent)).to.have.lengthOf(0);
-    wrapper.unmount();
-  });
-
-  it('renders what we expect when a Cerner patient', () => {
-    const wrapper = shallow(<App showNewSecureMessagingPage isCernerPatient />);
-    expect(wrapper.find(UnauthContent)).to.have.lengthOf(0);
-    expect(wrapper.find(AuthContent)).to.have.lengthOf(1);
     wrapper.unmount();
   });
 });

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.unit.spec.js
@@ -10,9 +10,7 @@ import { App } from './index';
 
 describe('Get Medical Records Page <App>', () => {
   it('renders what we expect when the feature toggle is turned off', () => {
-    const wrapper = shallow(
-      <App showNewSecureMessagingPage={false} />,
-    );
+    const wrapper = shallow(<App showNewSecureMessagingPage={false} />);
     expect(wrapper.find(LegacyContent)).to.have.lengthOf(1);
   });
 
@@ -30,9 +28,7 @@ describe('Get Medical Records Page <App>', () => {
   });
 
   it('renders what we expect when a Cerner patient', () => {
-    const wrapper = shallow(
-      <App showNewSecureMessagingPage isCernerPatient />,
-    );
+    const wrapper = shallow(<App showNewSecureMessagingPage isCernerPatient />);
     expect(wrapper.find(AuthContent)).to.have.lengthOf(1);
     wrapper.unmount();
   });

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/constants/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/constants/index.js
@@ -1,0 +1,2 @@
+// @NOTE: This is used for Cerner facilities whose key-value pair `isCerner: false` is false, but still need to show on some of the Cerner pages.
+export const showAuthFacilityIDExceptions = [];

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/index.js
@@ -2,6 +2,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
+// Relative imports.
+import { showAuthFacilityIDExceptions } from '../../constants';
 
 export default (store, widgetType) => {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
@@ -11,7 +13,7 @@ export default (store, widgetType) => {
       const App = module.default;
       ReactDOM.render(
         <Provider store={store}>
-          <App />
+          <App showAuthFacilityIDExceptions={showAuthFacilityIDExceptions} />
         </Provider>,
         root,
       );

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/index.js
@@ -3,7 +3,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 // Relative imports.
-import { showAuthFacilityIDExceptions } from '../../constants';
+import { showAuthFacilityIDExceptions } from './constants';
 
 export default (store, widgetType) => {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);

--- a/src/applications/static-pages/health-care-manage-benefits/utils/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/utils/index.js
@@ -3,7 +3,10 @@ import { isEmpty, intersection } from 'lodash';
 
 export const hasFacilityException = (facilityIDs, facilityIDExceptions) => {
   // Derive the facility exceptions that were found.
-  const facilityExceptionsFound = intersection(facilityIDs, facilityIDExceptions);
+  const facilityExceptionsFound = intersection(
+    facilityIDs,
+    facilityIDExceptions,
+  );
 
   // Return false if there are none.
   if (isEmpty(facilityExceptionsFound)) {
@@ -11,5 +14,5 @@ export const hasFacilityException = (facilityIDs, facilityIDExceptions) => {
   }
 
   // Return true if there are some.
-return true;
-}
+  return true;
+};

--- a/src/applications/static-pages/health-care-manage-benefits/utils/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/utils/index.js
@@ -1,0 +1,15 @@
+// Node modules.
+import { isEmpty, intersection } from 'lodash';
+
+export const hasFacilityException = (facilityIDs, facilityIDExceptions) => {
+  // Derive the facility exceptions that were found.
+  const facilityExceptionsFound = intersection(facilityIDs, facilityIDExceptions);
+
+  // Return false if there are none.
+  if (isEmpty(facilityExceptionsFound)) {
+    return false;
+  }
+
+  // Return true if there are some.
+return true;
+}

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.js
@@ -7,7 +7,7 @@ import AuthContent from '../AuthContent';
 import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
-import { selectIsCernerPatient } from 'platform/user/selectors';
+import { selectIsCernerPatientm, selectFacilityIDs } from 'platform/user/selectors';
 import { hasFacilityException } from '../../../utils';
 
 export const App = ({

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.js
@@ -7,7 +7,10 @@ import AuthContent from '../AuthContent';
 import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
-import { selectIsCernerPatientm, selectFacilityIDs } from 'platform/user/selectors';
+import {
+  selectFacilityIDs,
+  selectIsCernerPatient,
+} from 'platform/user/selectors';
 import { hasFacilityException } from '../../../utils';
 
 export const App = ({

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.js
@@ -8,8 +8,14 @@ import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
 import { selectIsCernerPatient } from 'platform/user/selectors';
+import { hasFacilityException } from '../../../utils';
 
-export const App = ({ isCernerPatient, showNewViewTestLabResultsPage }) => {
+export const App = ({
+  facilityIDs,
+  isCernerPatient,
+  showAuthFacilityIDExceptions,
+  showNewViewTestLabResultsPage,
+}) => {
   if (!showNewViewTestLabResultsPage) {
     return <LegacyContent />;
   }
@@ -18,16 +24,24 @@ export const App = ({ isCernerPatient, showNewViewTestLabResultsPage }) => {
     return <AuthContent />;
   }
 
+  if (hasFacilityException(facilityIDs, showAuthFacilityIDExceptions)) {
+    return <AuthContent />;
+  }
+
   return <UnauthContent />;
 };
 
 App.propTypes = {
+  showAuthFacilityIDExceptions: PropTypes.arrayOf(PropTypes.string.isRequired)
+    .isRequired,
   // From mapStateToProps.
+  facilityIDs: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
   isCernerPatient: PropTypes.bool,
   showNewViewTestLabResultsPage: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = state => ({
+  facilityIDs: selectFacilityIDs(state),
   isCernerPatient: selectIsCernerPatient(state),
   showNewViewTestLabResultsPage:
     state?.featureToggles?.[featureFlagNames.showNewViewTestLabResultsPage],

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.unit.spec.js
@@ -10,9 +10,7 @@ import { App } from './index';
 
 describe('Get Medical Records Page <App>', () => {
   it('renders what we expect when the feature toggle is turned off', () => {
-    const wrapper = shallow(
-      <App showNewViewTestLabResultsPage={false} />,
-    );
+    const wrapper = shallow(<App showNewViewTestLabResultsPage={false} />);
     expect(wrapper.find(LegacyContent)).to.have.lengthOf(1);
   });
 

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.unit.spec.js
@@ -4,16 +4,28 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 // Relative imports.
 import AuthContent from '../AuthContent';
+import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import { App } from './index';
 
 describe('Get Medical Records Page <App>', () => {
-  it('renders what we expect when not a Cerner patient', () => {
+  it('renders what we expect when the feature toggle is turned off', () => {
     const wrapper = shallow(
-      <App showNewViewTestLabResultsPage isCernerPatient={false} />,
+      <App showNewViewTestLabResultsPage={false} />,
     );
-    expect(wrapper.find(UnauthContent)).to.have.lengthOf(1);
-    expect(wrapper.find(AuthContent)).to.have.lengthOf(0);
+    expect(wrapper.find(LegacyContent)).to.have.lengthOf(1);
+  });
+
+  it('renders what we expect when there is a Cerner facility exception', () => {
+    const wrapper = shallow(
+      <App
+        facilityIDs={['1']}
+        isCernerPatient={false}
+        showAuthFacilityIDExceptions={['1']}
+        showNewViewTestLabResultsPage
+      />,
+    );
+    expect(wrapper.find(AuthContent)).to.have.lengthOf(1);
     wrapper.unmount();
   });
 
@@ -21,8 +33,15 @@ describe('Get Medical Records Page <App>', () => {
     const wrapper = shallow(
       <App showNewViewTestLabResultsPage isCernerPatient />,
     );
-    expect(wrapper.find(UnauthContent)).to.have.lengthOf(0);
     expect(wrapper.find(AuthContent)).to.have.lengthOf(1);
+    wrapper.unmount();
+  });
+
+  it('renders what we expect when not a Cerner patient', () => {
+    const wrapper = shallow(
+      <App showNewViewTestLabResultsPage isCernerPatient={false} />,
+    );
+    expect(wrapper.find(UnauthContent)).to.have.lengthOf(1);
     wrapper.unmount();
   });
 });

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.unit.spec.js
@@ -12,6 +12,7 @@ describe('Get Medical Records Page <App>', () => {
   it('renders what we expect when the feature toggle is turned off', () => {
     const wrapper = shallow(<App showNewViewTestLabResultsPage={false} />);
     expect(wrapper.find(LegacyContent)).to.have.lengthOf(1);
+    wrapper.unmount();
   });
 
   it('renders what we expect when there is a Cerner facility exception', () => {

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/constants/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/constants/index.js
@@ -1,0 +1,2 @@
+// @NOTE: This is used for Cerner facilities whose key-value pair `isCerner: false` is false, but still need to show on some of the Cerner pages.
+export const showAuthFacilityIDExceptions = [];

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/index.js
@@ -2,6 +2,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
+// Relative imports.
+import { showAuthFacilityIDExceptions } from './constants';
 
 export default (store, widgetType) => {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
@@ -11,7 +13,7 @@ export default (store, widgetType) => {
       const App = module.default;
       ReactDOM.render(
         <Provider store={store}>
-          <App />
+          <App showAuthFacilityIDExceptions={showAuthFacilityIDExceptions} />
         </Provider>,
         root,
       );

--- a/src/platform/user/selectors.js
+++ b/src/platform/user/selectors.js
@@ -14,6 +14,8 @@ export const isLOA3 = state => selectProfile(state).loa.current === 3;
 export const isLOA1 = state => selectProfile(state).loa.current === 1;
 export const isMultifactorEnabled = state => selectProfile(state).multifactor;
 export const selectAvailableServices = state => selectProfile(state)?.services;
+export const selectFacilityIDs = state =>
+  selectProfile(state)?.facilities?.map(f => f.facilityId) || [];
 export const selectPatientFacilities = state =>
   selectProfile(state)?.facilities?.map(({ facilityId, isCerner }) => {
     // Derive if the user belongs to a Cerner facility in the FE maintained list.

--- a/src/platform/utilities/cerner/index.js
+++ b/src/platform/utilities/cerner/index.js
@@ -1,7 +1,7 @@
 // Relative imports.
 import environment from 'platform/utilities/environment';
 
-export const CERNER_FACILITY_IDS = ['757'];
+export const CERNER_FACILITY_IDS = ['757', '668'];
 export const isCernerLive = !environment.isProduction();
 
 export const getCernerURL = path => {


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/14203

This PR adds support for Cerner facility exceptions that should only render on one page.

## Testing done
Updated unit tests

## Screenshots
N/A

## Acceptance criteria

```
# /health-care/appointments (authenticated user)

1. Is the Flipper feature flag `show_new_schedule_view_appointments_page` set to true?
    -> Yes
        -> Do any facilities have `isCerner=true`?
            -> Yes - Show the Cerner portal
            -> No 
                -> Do any facilities have an ID listed in the lookup table, `facilitiesEnabledForCernerScheduleViewApptsOnly`
                    -> Yes - Show the Cerner portal (this will be the case for Columbus facility)
                    -> No - Don't show the Cerner portal 
    -> No - Show the legacy content of this health care page
```

- [x] Change logic to reflect the above ^^

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
