### PR TITLE
Handle email address error codes

### DIFF
--- a/src/applications/personalization/profile-2/msw-mocks.js
+++ b/src/applications/personalization/profile-2/msw-mocks.js
@@ -97,10 +97,10 @@ const createTransactionRequestSuccessBody = {
 // couple of places but for testing purposes I'm reusing this body for _all_
 // transaction creation requests.
 const createTransactionRequestFailedError = {
-  title: 'Check Email Domain',
-  code: 'VET360_EMAIL304',
-  detail: 'AlphaNumeric ToplevelDomainName must be <= 63 Characters.',
+  code: 'VET360_EMAIL206',
+  detail: 'Confirmation Date can not be greater than sourceDate',
   status: '400',
+  title: 'Confirmation Date can not be greater than sourceDate',
 };
 
 export const validateAddressFailure = [

--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -162,6 +162,12 @@ export function createTransaction(
         ? await apiRequest(route, options)
         : await localVet360.createTransaction();
 
+      if (transaction?.errors) {
+        const error = new Error();
+        error.errors = transaction?.errors;
+        throw error;
+      }
+
       // We want the validateAddresses method handling dataLayer events for saving / updating addresses.
       if (!fieldName.toLowerCase().includes('address')) {
         recordEvent({

--- a/src/platform/user/profile/vet360/components/base/Vet360EditModalErrorMessage.jsx
+++ b/src/platform/user/profile/vet360/components/base/Vet360EditModalErrorMessage.jsx
@@ -5,8 +5,9 @@ import AlertBox, {
 import facilityLocator from 'applications/facility-locator/manifest.json';
 
 import {
-  LOW_CONFIDENCE_ADDRESS_ERROR_CODES,
   DECEASED_ERROR_CODES,
+  INVALID_EMAIL_ADDRESS_ERROR_CODES,
+  LOW_CONFIDENCE_ADDRESS_ERROR_CODES,
 } from 'vet360/util/transactions';
 
 function hasError(codes, errors) {
@@ -42,6 +43,15 @@ export default function Vet360EditModalErrorMessage({
             Find your nearest VA medical center
           </a>
         </div>
+      );
+      break;
+
+    case hasError(INVALID_EMAIL_ADDRESS_ERROR_CODES, errors):
+      content = (
+        <p>
+          It looks like the email you entered isn’t valid. Please enter your
+          email address again.
+        </p>
       );
       break;
 

--- a/src/platform/user/profile/vet360/tests/components/Vet360EditModalErrorMessage.unit.spec.jsx
+++ b/src/platform/user/profile/vet360/tests/components/Vet360EditModalErrorMessage.unit.spec.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import Vet360EditModalErrorMessage from '../../components/base/Vet360EditModalErrorMessage';
+
+describe('<Vet360EditModalErrorMessage />', () => {
+  it('shows the correct error message when there is an invalid email', () => {
+    const invalidEmailError = {
+      errors: [
+        {
+          title: 'Check Email Address',
+          detail:
+            "Email address cannot have 2 @ symbols, must have at least one period '.' after the @ character, and cannot have '.%' or '%.' or '%..%' or \" ( ) , : ; < > @ [ ] or space unless in a quoted string in the local part.",
+          code: 'VET360_EMAIL305',
+          source: 'Vet360::ContactInformation::Service',
+          status: '400',
+        },
+      ],
+    };
+    const wrapper = shallow(
+      <Vet360EditModalErrorMessage
+        clearErrors={() => {}}
+        error={invalidEmailError}
+        title=""
+      />,
+    );
+    const alert = wrapper.find('AlertBox');
+    const alertContentText = alert?.prop('content')?.props?.children?.props
+      ?.children;
+    expect(alertContentText).to.include(
+      'It looks like the email you entered isn’t valid. Please enter your email address again.',
+    );
+    wrapper.unmount();
+  });
+});

--- a/src/platform/user/profile/vet360/util/transactions.js
+++ b/src/platform/user/profile/vet360/util/transactions.js
@@ -57,6 +57,13 @@ export const LOW_CONFIDENCE_ADDRESS_ERROR_CODES = new Set([
 
 export const DECEASED_ERROR_CODES = new Set(['MVI300']);
 
+export const INVALID_EMAIL_ADDRESS_ERROR_CODES = new Set([
+  'EMAIL304',
+  'EMAIL305',
+  'VET360_EMAIL304',
+  'VET360_EMAIL305',
+]);
+
 export function isPendingTransaction(transaction) {
   return PENDING_STATUSES.has(transaction?.data.attributes.transactionStatus);
 }


### PR DESCRIPTION
## Description
When entering an email address with an invalid TLD, the server handles it correctly and provides proper errors, but we only show a generic error message to the user. We should show a more specific error message to the user.

## Testing done


## Screenshots


## Acceptance criteria
- [x] Update copy in AlertBox when the user gets an invalid email error

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
