### PR TITLE
[WIP] Make COVID screener available in Spanish

### DIFF
--- a/src/applications/coronavirus-screener/components/FormQuestion.jsx
+++ b/src/applications/coronavirus-screener/components/FormQuestion.jsx
@@ -9,6 +9,7 @@ export default function FormQuestion({
   optionsConfig,
   setQuestionValue,
   clearQuestionValues,
+  selectedLanguage,
 }) {
   const scrollElementName = `multi-question-form-${question.id}-scroll-element`;
 
@@ -41,14 +42,14 @@ export default function FormQuestion({
       onClick={handleClick}
       value={option.optionValue}
     >
-      {option.optionText}
+      {option.optionText[selectedLanguage]}
     </button>
   ));
-
+  const questionText = question.text[selectedLanguage];
   return (
     <div className="feature" id={`question-${question.id}`}>
       <Element name={scrollElementName} />
-      <h2>{question.text}</h2>
+      <h2>{questionText}</h2>
       {options}
     </div>
   );

--- a/src/applications/coronavirus-screener/components/FormQuestion.jsx
+++ b/src/applications/coronavirus-screener/components/FormQuestion.jsx
@@ -45,11 +45,11 @@ export default function FormQuestion({
       {option.optionText[selectedLanguage]}
     </button>
   ));
-  const questionText = question.text[selectedLanguage];
+
   return (
     <div className="feature" id={`question-${question.id}`}>
       <Element name={scrollElementName} />
-      <h2>{questionText}</h2>
+      <h2>{question.text[selectedLanguage]}</h2>
       {options}
     </div>
   );

--- a/src/applications/coronavirus-screener/components/FormQuestion.unit.spec.jsx
+++ b/src/applications/coronavirus-screener/components/FormQuestion.unit.spec.jsx
@@ -8,20 +8,37 @@ let mockQuestion;
 let mockRecordStart;
 let mockOptionsConfig;
 let mockSetQuestionValue;
-let mockclearQuestionValues;
+let mockClearQuestionValues;
+let mockSelectedLanguage;
 
 beforeEach(() => {
   mockQuestion = {
     id: 'sample1',
-    text: 'this is question sample1 text',
+    text: {
+      en: 'this is question sample1 text',
+      es: 'este es el texto de la pregunta sample1',
+    },
   };
   mockRecordStart = () => {};
   mockOptionsConfig = [
-    { optionValue: 'yes', optionText: 'Yes' },
-    { optionValue: 'no', optionText: 'No' },
+    {
+      optionValue: 'yes',
+      optionText: {
+        en: 'Yes',
+        es: 'Sí',
+      },
+    },
+    {
+      optionValue: 'no',
+      optionText: {
+        en: 'No',
+        es: 'No',
+      },
+    },
   ];
   mockSetQuestionValue = () => {};
-  mockclearQuestionValues = () => {};
+  mockClearQuestionValues = () => {};
+  mockSelectedLanguage = 'es';
 });
 
 describe('coronavirus-screener', () => {
@@ -33,10 +50,13 @@ describe('coronavirus-screener', () => {
           recordStart={mockRecordStart}
           optionsConfig={mockOptionsConfig}
           setQuestionValue={mockSetQuestionValue}
-          clearQuestionValues={mockclearQuestionValues}
+          clearQuestionValues={mockClearQuestionValues}
+          selectedLanguage={mockSelectedLanguage}
         />,
       );
-      expect(wrapper.find('h2').text()).to.equal(mockQuestion.text);
+      expect(wrapper.find('h2').text()).to.equal(
+        mockQuestion.text[mockSelectedLanguage],
+      );
       wrapper.unmount();
     });
     it('sets button class when no option is selected', () => {
@@ -46,7 +66,7 @@ describe('coronavirus-screener', () => {
           recordStart={mockRecordStart}
           optionsConfig={mockOptionsConfig}
           setQuestionValue={mockSetQuestionValue}
-          clearQuestionValues={mockclearQuestionValues}
+          clearQuestionValues={mockClearQuestionValues}
         />,
       );
       expect(wrapper.find('.usa-button-secondary')).to.have.lengthOf(2);
@@ -64,7 +84,7 @@ describe('coronavirus-screener', () => {
           recordStart={mockRecordStart}
           optionsConfig={mockOptionsConfig}
           setQuestionValue={mockSetQuestionValue}
-          clearQuestionValues={mockclearQuestionValues}
+          clearQuestionValues={mockClearQuestionValues}
         />,
       );
       expect(wrapper.find('.usa-button')).to.have.lengthOf(1);
@@ -90,7 +110,7 @@ describe('coronavirus-screener', () => {
           recordStart={mockRecordStart}
           optionsConfig={mockOptionsConfig}
           setQuestionValue={setQuestionValueSpy}
-          clearQuestionValues={mockclearQuestionValues}
+          clearQuestionValues={mockClearQuestionValues}
         />,
       );
 

--- a/src/applications/coronavirus-screener/components/FormResult.jsx
+++ b/src/applications/coronavirus-screener/components/FormResult.jsx
@@ -3,44 +3,48 @@ import { Element } from 'react-scroll';
 import moment from 'moment';
 import classnames from 'classnames';
 import { scrollerTo } from '../lib';
+import { resultText } from '../config/text';
 
-const Incomplete = () => <div>Please answer all the questions above.</div>;
-
-function Complete({ children }) {
+function Complete({ children, selectedLanguage }) {
   return (
     <div>
       {children}
       <div className="covid-screener-date vads-u-font-weight--bold">
-        <div className="vads-u-font-size--xl">Valid for</div>
+        <div className="vads-u-font-size--xl">
+          {resultText.validtext[selectedLanguage]}
+        </div>
         <div className="covid-screener-400">{moment().format('dddd')}</div>
         <div className="covid-screener-500">{moment().format('MMM D')}</div>
         <div className="vads-u-font-size--xl">{moment().format('h:mm a')}</div>
       </div>
-      <div className="vads-u-font-size--lg">
-        <p>
-          Please show this screen to the staff member at the facility entrance.
-        </p>
-        <p>Thank you for helping us protect you and others during this time.</p>
-      </div>
+      {resultText.completetext[selectedLanguage]}
     </div>
   );
 }
 
-const Pass = () => (
-  <Complete>
-    <i aria-hidden="true" role="presentation" className="fas fa-check" />
-    <h2 className="vads-u-font-size--2xl">OK to proceed</h2>
-  </Complete>
-);
-
-const MoreScreening = () => (
-  <Complete>
-    <h2 className="vads-u-font-size--2xl">More screening needed</h2>
-  </Complete>
-);
-
-export default function FormResult({ formState }) {
+export default function FormResult({ formState, selectedLanguage }) {
   const scrollElementName = 'multi-question-form-result-scroll-element';
+
+  const Incomplete = () => (
+    <div>{resultText.incompletetext[selectedLanguage]}</div>
+  );
+
+  const Pass = () => (
+    <Complete selectedLanguage={selectedLanguage}>
+      <i aria-hidden="true" role="presentation" className="fas fa-check" />
+      <h2 className="vads-u-font-size--2xl">
+        {resultText.passtext[selectedLanguage]}
+      </h2>
+    </Complete>
+  );
+
+  const MoreScreening = () => (
+    <Complete selectedLanguage={selectedLanguage}>
+      <h2 className="vads-u-font-size--2xl">
+        {resultText.morescreeningtext[selectedLanguage]}
+      </h2>
+    </Complete>
+  );
 
   useEffect(() => {
     // only scroll when form is complete

--- a/src/applications/coronavirus-screener/components/FormResult.jsx
+++ b/src/applications/coronavirus-screener/components/FormResult.jsx
@@ -17,7 +17,7 @@ function Complete({ children, selectedLanguage }) {
         <div className="covid-screener-500">{moment().format('MMM D')}</div>
         <div className="vads-u-font-size--xl">{moment().format('h:mm a')}</div>
       </div>
-      {resultText.completetext[selectedLanguage]}
+      {resultText.completeText[selectedLanguage]}
     </div>
   );
 }
@@ -26,14 +26,14 @@ export default function FormResult({ formState, selectedLanguage }) {
   const scrollElementName = 'multi-question-form-result-scroll-element';
 
   const Incomplete = () => (
-    <div>{resultText.incompletetext[selectedLanguage]}</div>
+    <div>{resultText.incompleteText[selectedLanguage]}</div>
   );
 
   const Pass = () => (
     <Complete selectedLanguage={selectedLanguage}>
       <i aria-hidden="true" role="presentation" className="fas fa-check" />
       <h2 className="vads-u-font-size--2xl">
-        {resultText.passtext[selectedLanguage]}
+        {resultText.passText[selectedLanguage]}
       </h2>
     </Complete>
   );
@@ -41,7 +41,7 @@ export default function FormResult({ formState, selectedLanguage }) {
   const MoreScreening = () => (
     <Complete selectedLanguage={selectedLanguage}>
       <h2 className="vads-u-font-size--2xl">
-        {resultText.morescreeningtext[selectedLanguage]}
+        {resultText.moreScreeningText[selectedLanguage]}
       </h2>
     </Complete>
   );

--- a/src/applications/coronavirus-screener/components/MultiQuestionForm.jsx
+++ b/src/applications/coronavirus-screener/components/MultiQuestionForm.jsx
@@ -124,6 +124,8 @@ export default function MultiQuestionForm({
   );
 
   return (
+    // TODO: Rather than pass selectedLanguage around as a prop, write it to
+    // state and then use it where it is needed.
     <div>
       {formQuestions}
       <FormResult formState={formState} selectedLanguage={selectedLanguage} />

--- a/src/applications/coronavirus-screener/components/MultiQuestionForm.jsx
+++ b/src/applications/coronavirus-screener/components/MultiQuestionForm.jsx
@@ -15,6 +15,7 @@ export default function MultiQuestionForm({
   questions,
   defaultOptions,
   customId,
+  selectedLanguage,
 }) {
   const [formState, setFormState] = useState({
     status: 'incomplete',
@@ -106,7 +107,6 @@ export default function MultiQuestionForm({
   }
 
   const enabledQuestions = getEnabledQuestions({ questionState, customId });
-
   const formQuestions = enabledQuestions.map(
     (question, index) =>
       (index === 0 ||
@@ -118,6 +118,7 @@ export default function MultiQuestionForm({
           setQuestionValue={setQuestionValue}
           clearQuestionValues={clearQuestionValues}
           key={`question-${question.id}`}
+          selectedLanguage={selectedLanguage}
         />
       ),
   );
@@ -125,7 +126,7 @@ export default function MultiQuestionForm({
   return (
     <div>
       {formQuestions}
-      <FormResult formState={formState} />
+      <FormResult formState={formState} selectedLanguage={selectedLanguage} />
     </div>
   );
 }

--- a/src/applications/coronavirus-screener/components/MultiQuestionForm.unit.spec.jsx
+++ b/src/applications/coronavirus-screener/components/MultiQuestionForm.unit.spec.jsx
@@ -10,17 +10,35 @@ beforeEach(() => {
   mockQuestions = [
     {
       id: 'myFirstQuestion',
-      text: 'This is the first question text',
+      text: {
+        en: 'This is the first question text',
+        es: 'Este es el primer texto de la pregunta',
+      },
       startQuestion: true,
     },
     {
       id: 'mySecondQuestion',
-      text: 'This is the second question text',
+      text: {
+        en: 'This is the second question text',
+        es: 'Este es el texto de la segunda pregunta',
+      },
     },
   ];
   mockDefaultOptions = [
-    { optionValue: 'yes', optionText: 'Yes' },
-    { optionValue: 'no', optionText: 'No' },
+    {
+      optionValue: 'yes',
+      optionText: {
+        en: 'Yes',
+        es: 'Sí',
+      },
+    },
+    {
+      optionValue: 'no',
+      optionText: {
+        en: 'No',
+        es: 'No',
+      },
+    },
   ];
 });
 

--- a/src/applications/coronavirus-screener/components/MultiQuestionForm.unit.spec.jsx
+++ b/src/applications/coronavirus-screener/components/MultiQuestionForm.unit.spec.jsx
@@ -5,6 +5,7 @@ import MultiQuestionForm from './MultiQuestionForm';
 
 let mockQuestions;
 let mockDefaultOptions;
+let mockSelectedLanguage;
 
 beforeEach(() => {
   mockQuestions = [
@@ -40,6 +41,7 @@ beforeEach(() => {
       },
     },
   ];
+  mockSelectedLanguage = 'es';
 });
 
 describe('coronavirus-screener', () => {
@@ -49,19 +51,28 @@ describe('coronavirus-screener', () => {
         <MultiQuestionForm
           questions={mockQuestions}
           defaultOptions={mockDefaultOptions}
+          selectedLanguage={mockSelectedLanguage}
         />,
       );
 
       const firstQuestionId = `#question-${mockQuestions[0].id}`;
-      const firstQuestionText = mockQuestions[0].text;
+      const firstQuestionText = mockQuestions[0].text[mockSelectedLanguage];
+      const firstQuestionFirstButtonText =
+        mockDefaultOptions[0].optionText[mockSelectedLanguage];
 
       const firstQuestion = wrapper
         .children()
         .first()
         .dive()
         .find(firstQuestionId);
-
       expect(firstQuestion.find('h2').text()).to.equal(firstQuestionText);
+      expect(
+        firstQuestion
+          .find('button')
+          .children()
+          .first()
+          .text(),
+      ).to.equal(firstQuestionFirstButtonText);
 
       wrapper.unmount();
     });

--- a/src/applications/coronavirus-screener/config/questions.jsx
+++ b/src/applications/coronavirus-screener/config/questions.jsx
@@ -3,57 +3,97 @@ import React from 'react';
 export const questions = [
   {
     id: 'isStaff',
-    text: 'Are you a VA employee or contractor?',
+    text: {
+      en: 'Are you a VA employee or contractor?',
+      es:
+        '¿Es usted un empleado/a o contratista del Departamento de Asuntos de Veteranos?',
+    },
     passValues: ['yes', 'no'],
     clearValues: true,
     startQuestion: true,
   },
   {
     id: 'test-results-hi',
-    text: 'Are you waiting for COVID-19 test results?',
+    text: {
+      en: 'Are you waiting for COVID-19 test results?',
+      es: '',
+    },
     customId: ['459', '459GE', '459GF', '459GH'],
   },
   {
     id: 'fever',
-    text: 'In the past 24 hours, have you had a fever?',
+    text: {
+      en: 'In the past 24 hours, have you had a fever?',
+      es: 'En las últimas 24 horas, ¿ha tenido fiebre?',
+    },
   },
   {
     id: 'cough',
-    text:
-      "In the past 7 days, have you had a cough, shortness of breath, or difficulty breathing that's new or getting worse?",
+    text: {
+      en:
+        "In the past 7 days, have you had a cough, shortness of breath, or difficulty breathing that's new or getting worse?",
+      es:
+        'En los últimos 7 días, ¿ha tenido tos, le ha faltado el aire o ha experimentado dificultad para respirar (malestar nuevo o que ha empeorado)?',
+    },
   },
   {
     id: 'flu',
-    text: (
-      <div>
-        In the past 3 days, have you had any of these symptoms?
-        <ul>
-          <li>Fever or feeling feverish (chills, sweating)</li>
-          <li>Fatigue (feeling tired all the time)</li>
-          <li>Muscle or body aches</li>
-          <li>Headache</li>
-          <li>New loss of smell or taste</li>
-          <li>Sore throat</li>
-          <li>Nausea, vomiting, or diarrhea</li>
-        </ul>
-      </div>
-    ),
+    text: {
+      en: (
+        <div>
+          In the past 3 days, have you had any of these symptoms?
+          <ul>
+            <li>Fever or feeling feverish (chills, sweating)</li>
+            <li>Fatigue (feeling tired all the time)</li>
+            <li>Muscle or body aches</li>
+            <li>Headache</li>
+            <li>New loss of smell or taste</li>
+            <li>Sore throat</li>
+            <li>Nausea, vomiting, or diarrhea</li>
+          </ul>
+        </div>
+      ),
+      es: (
+        <div>
+          En los últimos 3 días, ¿ha tenido alguno de estos síntomas?
+          <ul>
+            <li>Fiebre o se sintió afiebrado/a (escalofríos, sudoración)</li>
+            <li>Fatiga (se sintió cansado/a todo el tiempo)</li>
+            <li>Dolores musculares o corporales</li>
+            <li>Dolor de cabeza</li>
+            <li>Pérdida reciente de olfato o gusto</li>
+            <li>Dolor de garganta</li>
+            <li>Náuseas, vómitos o diarrea</li>
+          </ul>
+        </div>
+      ),
+    },
   },
   {
     id: 'household-exposure-526',
-    text:
-      "Has anyone who lives with you had any of the above symptoms that aren't clearly caused by another condition?",
+    text: {
+      en:
+        "Has anyone who lives with you had any of the above symptoms that aren't clearly caused by another condition?",
+      es: '',
+    },
     customId: ['526'],
   },
   {
     id: 'congestion',
-    text:
-      "Do you currently have a runny nose or congestion that's new and not related to allergies?",
+    text: {
+      en:
+        "Do you currently have a runny nose or congestion that's new and not related to allergies?",
+      es: '¿Actualmente tiene secreción o congestión nasal?',
+    },
   },
   {
     id: 'exposure',
-    text:
-      'In the past 14 days, have you had close contact with someone who you know was diagnosed with COVID-19 or was waiting for COVID-19 test results?',
+    text: {
+      en:
+        'In the past 14 days, have you had close contact with someone who you know was diagnosed with COVID-19 or was waiting for COVID-19 test results?',
+      es:
+        'En los últimos 14 días, ¿ha tenido contacto cercano con alguien que usted sabe que recibió un diagnóstico positivo de COVID-19?',
+    },
     dependsOn: {
       id: 'isStaff',
       value: 'no',
@@ -61,8 +101,12 @@ export const questions = [
   },
   {
     id: 'exposure-staff',
-    text:
-      "Have you had contact with someone you know was diagnosed with COVID-19 or was waiting for COVID-19 test results that you haven't already reported to VA occupational health?",
+    text: {
+      en:
+        "Have you had contact with someone you know was diagnosed with COVID-19 or was waiting for COVID-19 test results that you haven't already reported to VA occupational health?",
+      es:
+        '¿Ha tenido contacto con alguien que recibió un diagnóstico positivo de COVID-19 que aún no ha sido informado al departamento de salud ocupacional del Departamento de Asuntos de Veteranos?',
+    },
     dependsOn: {
       id: 'isStaff',
       value: 'yes',
@@ -70,72 +114,111 @@ export const questions = [
   },
   {
     id: 'travel-459',
-    text: 'In the past 14 days, have you traveled outside of Hawaii?',
+    text: {
+      en: 'In the past 14 days, have you traveled outside of Hawaii?',
+      es: '',
+    },
     customId: ['459'],
   },
   {
     id: 'travel-459GE',
-    text: 'In the past 14 days, have you traveled outside of Guam?',
+    text: {
+      en: 'In the past 14 days, have you traveled outside of Guam?',
+      es: '',
+    },
     customId: ['459GE'],
   },
   {
     id: 'travel-459GF',
-    text: 'In the past 14 days, have you traveled outside of American Samoa?',
+    text: {
+      en: 'In the past 14 days, have you traveled outside of American Samoa?',
+      es: '',
+    },
     customId: ['459GF'],
   },
   {
     id: 'travel-459GH',
-    text:
-      'In the past 14 days, have you traveled outside of the Northern Mariana Islands?',
+    text: {
+      en:
+        'In the past 14 days, have you traveled outside of the Northern Mariana Islands?',
+      es: '',
+    },
     customId: ['459GH'],
   },
   {
     id: 'travel-new-england-ma-ct-ri',
-    text: 'In the past 14 days, have you traveled outside of New England?',
+    text: {
+      en: 'In the past 14 days, have you traveled outside of New England?',
+      es: '',
+    },
     customId: ['523', '650', '689', '402', '405', '631', '518', '608', '478'],
   },
   {
     id: 'travel-ny',
-    text:
-      'In the past 14 days, have you traveled outside of New York and its surrounding states?',
+    text: {
+      en:
+        'In the past 14 days, have you traveled outside of New York and its surrounding states?',
+      es: '',
+    },
     customId: ['526', '528', '620', '630', '632'],
   },
   {
     id: 'travel-self-pr',
-    text: 'Have you traveled outside of Puerto Rico within the last 14 days?',
+    text: {
+      en: 'Have you traveled outside of Puerto Rico within the last 14 days?',
+      es: 'En los últimos 14 días, ¿ha viajado fuera de Puerto Rico?',
+    },
     customId: ['672'],
   },
   {
     id: 'travel-other-pr',
-    text:
-      'Have you had contact with someone who has traveled outside of Puerto Rico within the last 14 days?',
+    text: {
+      en:
+        'Have you had contact with someone who has traveled outside of Puerto Rico within the last 14 days?',
+      es:
+        '¿Ha tenido contacto con alguien que haya viajado fuera de Puerto Rico en los últimos 14 días?',
+    },
     customId: ['672'],
   },
   {
     id: 'travel-self-stvi',
-    text: 'Have you traveled outside of St. Thomas within the last 14 days?',
+    text: {
+      en: 'Have you traveled outside of St. Thomas within the last 14 days?',
+      es: 'En los últimos 14 días, ¿ha viajado fuera de St. Thomas?',
+    },
     customId: ['672GB'],
   },
   {
     id: 'travel-other-stvi',
-    text:
-      'Have you had contact with someone who has traveled outside of St. Thomas within the last 14 days?',
+    text: {
+      en:
+        'Have you had contact with someone who has traveled outside of St. Thomas within the last 14 days?',
+      es:
+        '¿Ha tenido contacto con alguien que haya viajado fuera de St. Thomas en los últimos 14 días?',
+    },
     customId: ['672GB'],
   },
   {
     id: 'travel-self-scvi',
-    text: 'Have you traveled outside of St. Croix within the last 14 days?',
+    text: {
+      en: 'Have you traveled outside of St. Croix within the last 14 days?',
+      es: 'En los últimos 14 días, ¿ha viajado fuera de St. Croix?',
+    },
     customId: ['672GA'],
   },
   {
     id: 'travel-other-scvi',
-    text:
-      'Have you had contact with someone who has traveled outside of St. Croix within the last 14 days?',
+    text: {
+      en:
+        'Have you had contact with someone who has traveled outside of St. Croix within the last 14 days?',
+      es:
+        '¿Ha tenido contacto con alguien que haya viajado fuera de St. Croix en los últimos 14 días?',
+    },
     customId: ['672GA'],
   },
 ];
 
 export const defaultOptions = [
-  { optionValue: 'yes', optionText: 'Yes' },
-  { optionValue: 'no', optionText: 'No' },
+  { optionValue: 'yes', optionText: { en: 'Yes', es: 'Sí' } },
+  { optionValue: 'no', optionText: { en: 'No', es: 'No' } },
 ];

--- a/src/applications/coronavirus-screener/config/questions.jsx
+++ b/src/applications/coronavirus-screener/config/questions.jsx
@@ -16,7 +16,7 @@ export const questions = [
     id: 'test-results-hi',
     text: {
       en: 'Are you waiting for COVID-19 test results?',
-      es: '',
+      es: '¿Está esperando los resultados de la prueba de COVID-19?',
     },
     customId: ['459', '459GE', '459GF', '459GH'],
   },
@@ -74,7 +74,8 @@ export const questions = [
     text: {
       en:
         "Has anyone who lives with you had any of the above symptoms that aren't clearly caused by another condition?",
-      es: '',
+      es:
+        '¿Alguien que vive contigo ha tenido alguno de los síntomas anteriores que no son claramente causados por otra condición?',
     },
     customId: ['526'],
   },
@@ -83,7 +84,8 @@ export const questions = [
     text: {
       en:
         "Do you currently have a runny nose or congestion that's new and not related to allergies?",
-      es: '¿Actualmente tiene secreción o congestión nasal?',
+      es:
+        '¿Tienes actualmente una secreción nasal o congestión que es nueva y no está relacionada con alergias?',
     },
   },
   {
@@ -92,7 +94,7 @@ export const questions = [
       en:
         'In the past 14 days, have you had close contact with someone who you know was diagnosed with COVID-19 or was waiting for COVID-19 test results?',
       es:
-        'En los últimos 14 días, ¿ha tenido contacto cercano con alguien que usted sabe que recibió un diagnóstico positivo de COVID-19?',
+        'En los últimos 14 días, ¿ha tenido contacto cercano con alguien que sabe que fue diagnosticado con COVID-19 o estaba esperando los resultados de la prueba de COVID-19?',
     },
     dependsOn: {
       id: 'isStaff',
@@ -105,7 +107,7 @@ export const questions = [
       en:
         "Have you had contact with someone you know was diagnosed with COVID-19 or was waiting for COVID-19 test results that you haven't already reported to VA occupational health?",
       es:
-        '¿Ha tenido contacto con alguien que recibió un diagnóstico positivo de COVID-19 que aún no ha sido informado al departamento de salud ocupacional del Departamento de Asuntos de Veteranos?',
+        '¿Ha tenido contacto con alguien que conoce que fue diagnosticado con COVID-19 o estaba esperando los resultados de la prueba de COVID-19 que aún no ha reportado a Salud Ocupacional de VA?',
     },
     dependsOn: {
       id: 'isStaff',
@@ -116,7 +118,7 @@ export const questions = [
     id: 'travel-459',
     text: {
       en: 'In the past 14 days, have you traveled outside of Hawaii?',
-      es: '',
+      es: 'En los últimos 14 días, ¿ha viajado fuera de Hawái?',
     },
     customId: ['459'],
   },
@@ -124,7 +126,7 @@ export const questions = [
     id: 'travel-459GE',
     text: {
       en: 'In the past 14 days, have you traveled outside of Guam?',
-      es: '',
+      es: 'En los últimos 14 días, ¿ha viajado fuera de Guam?',
     },
     customId: ['459GE'],
   },
@@ -132,7 +134,7 @@ export const questions = [
     id: 'travel-459GF',
     text: {
       en: 'In the past 14 days, have you traveled outside of American Samoa?',
-      es: '',
+      es: 'En los últimos 14 días, ¿ha viajado fuera de Samoa Americana?',
     },
     customId: ['459GF'],
   },
@@ -141,7 +143,8 @@ export const questions = [
     text: {
       en:
         'In the past 14 days, have you traveled outside of the Northern Mariana Islands?',
-      es: '',
+      es:
+        'En los últimos 14 días, ¿ha viajado fuera de las Islas Marianas de Norte?',
     },
     customId: ['459GH'],
   },
@@ -149,7 +152,7 @@ export const questions = [
     id: 'travel-new-england-ma-ct-ri',
     text: {
       en: 'In the past 14 days, have you traveled outside of New England?',
-      es: '',
+      es: 'En los últimos 14 días, ¿ha viajado fuera de Nueva Inglaterra?',
     },
     customId: ['523', '650', '689', '402', '405', '631', '518', '608', '478'],
   },
@@ -158,7 +161,8 @@ export const questions = [
     text: {
       en:
         'In the past 14 days, have you traveled outside of New York and its surrounding states?',
-      es: '',
+      es:
+        'En los últimos 14 días, ¿ha viajado fuera de Nueva York y sus estados circundantes?',
     },
     customId: ['526', '528', '620', '630', '632'],
   },

--- a/src/applications/coronavirus-screener/config/text.jsx
+++ b/src/applications/coronavirus-screener/config/text.jsx
@@ -5,36 +5,36 @@ export const introText = {
     en: 'COVID-19 screening tool',
     es: 'Herramienta de evaluación para COVID-19',
   },
-  vaintrotext: {
+  vaIntroText: {
     en:
       'Please answer the questions listed below. Share your results with the staff member at the facility entrance.',
     es:
       'Por favor, responda las preguntas que se enumeran a continuación. Comparta sus resultados con el miembro del personal que se encuentra en la entrada del establecimiento.',
   },
-  privacytext: {
+  privacyText: {
     en: "We won't store or share your data.",
     es: 'No guardaremos ni compartiremos sus datos.',
   },
-  languageselecttext: {
+  languageSelectText: {
     es: 'Change to English',
     en: 'Cambiar al español',
   },
 };
 
 export const resultText = {
-  incompletetext: {
+  incompleteText: {
     en: 'Please answer all the questions above',
     es: 'Por favor, conteste todas las preguntas anteriores.',
   },
-  passtext: {
+  passText: {
     en: 'OK to proceed',
     es: 'Puede proceder',
   },
-  morescreeningtext: {
+  moreScreeningText: {
     en: 'More screening needed',
     es: 'Se necesita más evaluación',
   },
-  completetext: {
+  completeText: {
     en: (
       <div className="vads-u-font-size--lg">
         <p>

--- a/src/applications/coronavirus-screener/config/text.jsx
+++ b/src/applications/coronavirus-screener/config/text.jsx
@@ -16,8 +16,8 @@ export const introText = {
     es: 'No guardaremos ni compartiremos sus datos.',
   },
   languageselecttext: {
-    es: 'Prefer English?',
-    en: '¿Prefieres español?',
+    es: 'Change to English',
+    en: 'Cambiar al español',
   },
 };
 

--- a/src/applications/coronavirus-screener/config/text.jsx
+++ b/src/applications/coronavirus-screener/config/text.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+export const introText = {
+  h1: {
+    en: 'COVID-19 screening tool',
+    es: 'Herramienta de evaluación para COVID-19',
+  },
+  vaintrotext: {
+    en:
+      'Please answer the questions listed below. Share your results with the staff member at the facility entrance.',
+    es:
+      'Por favor, responda las preguntas que se enumeran a continuación. Comparta sus resultados con el miembro del personal que se encuentra en la entrada del establecimiento.',
+  },
+  privacytext: {
+    en: "We won't store or share your data.",
+    es: 'No guardaremos ni compartiremos sus datos.',
+  },
+  languageselecttext: {
+    es: 'Prefer English?',
+    en: '¿Prefieres español?',
+  },
+};
+
+export const resultText = {
+  incompletetext: {
+    en: 'Please answer all the questions above',
+    es: 'Por favor, conteste todas las preguntas anteriores.',
+  },
+  passtext: {
+    en: 'OK to proceed',
+    es: 'Puede proceder',
+  },
+  morescreeningtext: {
+    en: 'More screening needed',
+    es: 'Se necesita más evaluación',
+  },
+  completetext: {
+    en: (
+      <div className="vads-u-font-size--lg">
+        <p>
+          Please show this screen to the staff member at the facility entrance.
+        </p>
+        <p>Thank you for helping us protect you and others during this time.</p>
+      </div>
+    ),
+    es: (
+      <div className="vads-u-font-size--lg">
+        <p>
+          Muestre esta pantalla al miembro del personal en la entrada del
+          establecimiento.
+        </p>
+        <p>
+          Gracias por ayudarnos a mantenerlo a usted y a los demás protegidos
+          durante este tiempo.
+        </p>
+      </div>
+    ),
+  },
+  validtext: {
+    en: 'Valid for',
+    es: 'Válido para',
+  },
+};

--- a/src/applications/coronavirus-screener/containers/App.jsx
+++ b/src/applications/coronavirus-screener/containers/App.jsx
@@ -2,26 +2,53 @@ import React from 'react';
 import MetaTags from 'react-meta-tags';
 import MultiQuestionForm from '../components/MultiQuestionForm';
 import { questions, defaultOptions } from '../config/questions';
+import { introText } from '../config/text';
 
 export default function App({ params }) {
+  let selectedLanguage = 'en';
+  let alternateLangauge = 'es';
+  let alternateRefBase = '/covid19screen/';
+  let customId = params.id;
+
+  // If the first value is not a number, then there is no custom site id.
+  if (isNaN(params.id)) {
+    customId = undefined;
+  } else {
+    // If the first value is a number, then there is a custom site id.
+    alternateRefBase = `/covid19screen/${customId}/`;
+  }
+  //  If the first or second value is ES, then change the langauge to Spanish.
+  if (
+    params.id?.toUpperCase() === 'ES' ||
+    params.languageId?.toUpperCase() === 'ES'
+  ) {
+    selectedLanguage = 'es';
+    alternateLangauge = 'en';
+  }
+
+  const alternateRef = `${alternateRefBase}${alternateLangauge}`;
+
   return (
     <div className="covid-screener">
       <MetaTags>
         <meta name="robots" content="noindex" />
       </MetaTags>
       <div className="vads-l-grid-container">
-        <h1>COVID-19 screening tool</h1>
+        <h1>{introText.h1[selectedLanguage]}</h1>
         <div className="va-introtext">
+          <p>{introText.vaintrotext[selectedLanguage]}</p>
+          <p>{introText.privacytext[selectedLanguage]}</p>
           <p>
-            Please answer the questions listed below. Share your results with
-            the staff member at the facility entrance.
+            <a href={alternateRef}>
+              {introText.languageselecttext[selectedLanguage]}
+            </a>
           </p>
-          <p>We won't store or share your data.</p>
         </div>
         <MultiQuestionForm
           questions={questions}
           defaultOptions={defaultOptions}
-          customId={params.id?.toUpperCase()}
+          customId={customId?.toUpperCase()}
+          selectedLanguage={selectedLanguage}
         />
       </div>
     </div>

--- a/src/applications/coronavirus-screener/containers/App.jsx
+++ b/src/applications/coronavirus-screener/containers/App.jsx
@@ -8,16 +8,19 @@ export default function App({ params }) {
   let selectedLanguage = 'en';
   let alternateLangauge = 'es';
   let alternateRefBase = '/covid19screen/';
-  let customId = params.id;
+  // Control for facility ids that have letters in them e.g. 459GE.
+  let customId = params.id?.slice(0, 3);
 
   // If the first value is not a number, then there is no custom site id.
-  if (isNaN(params.id)) {
+  if (isNaN(customId)) {
     customId = undefined;
   } else {
-    // If the first value is a number, then there is a custom site id.
-    alternateRefBase = `/covid19screen/${customId}/`;
+    // If the first three chars of the first value is a number,
+    // then there is a custom site id.
+    alternateRefBase = `/covid19screen/${params.id}/`;
   }
-  //  If the first or second value is ES, then change the langauge to Spanish.
+  // If the last two chars of the first or second value is ES,
+  // then change the langauge to Spanish.
   if (
     params.id?.toUpperCase() === 'ES' ||
     params.languageId?.toUpperCase() === 'ES'
@@ -36,11 +39,11 @@ export default function App({ params }) {
       <div className="vads-l-grid-container">
         <h1>{introText.h1[selectedLanguage]}</h1>
         <div className="va-introtext">
-          <p>{introText.vaintrotext[selectedLanguage]}</p>
-          <p>{introText.privacytext[selectedLanguage]}</p>
+          <p>{introText.vaIntroText[selectedLanguage]}</p>
+          <p>{introText.privacyText[selectedLanguage]}</p>
           <p>
             <a href={alternateRef}>
-              <strong>{introText.languageselecttext[selectedLanguage]}</strong>
+              <strong>{introText.languageSelectText[selectedLanguage]}</strong>
             </a>
           </p>
         </div>

--- a/src/applications/coronavirus-screener/containers/App.jsx
+++ b/src/applications/coronavirus-screener/containers/App.jsx
@@ -40,7 +40,7 @@ export default function App({ params }) {
           <p>{introText.privacytext[selectedLanguage]}</p>
           <p>
             <a href={alternateRef}>
-              {introText.languageselecttext[selectedLanguage]}
+              <strong>{introText.languageselecttext[selectedLanguage]}</strong>
             </a>
           </p>
         </div>

--- a/src/applications/coronavirus-screener/routes.jsx
+++ b/src/applications/coronavirus-screener/routes.jsx
@@ -5,6 +5,7 @@ import App from './containers/App.jsx';
 const routes = [
   <Route path="/" key="/" component={App} />,
   <Route path="/:id" key="/:id" component={App} />,
+  <Route path="/:id/:languageId" key="/:id/:languageId" component={App} />,
 ];
 
 export default routes;

--- a/src/applications/coronavirus-screener/sass/coronavirus-screener.scss
+++ b/src/applications/coronavirus-screener/sass/coronavirus-screener.scss
@@ -4,6 +4,9 @@
   *:not(.fas) {
     font-family: Source Sans Pro, Helvetica Neue, Helvetica, Roboto, Arial,
       sans-serif;
+    h1 {
+      margin-top: 10px;
+    }
   }
   .covid-screener-date {
     margin: 2em 0 2em 0;

--- a/src/applications/coronavirus-screener/tests/00.coronavirus-screener.e2e.spec.js
+++ b/src/applications/coronavirus-screener/tests/00.coronavirus-screener.e2e.spec.js
@@ -22,10 +22,12 @@ export default createE2eTest(client => {
   routeOptions.forEach(routeOption => {
     client
       .url(`${baseUrl}/covid19screen${routeOption.route}`)
+      .pause(1000)
       .waitForElementVisible('body', normal)
       .assert.containsText(
         'div[class*=vads-l-grid-container]',
         `${routeOption.expectedText}`,
+        routeOption.title,
       );
   });
 
@@ -33,15 +35,31 @@ export default createE2eTest(client => {
     client.url(`${baseUrl}/covid19screen${routeOption}`);
 
     // visitor passing answers
-    testQuestionScenario({ scenario: visitorPass, client });
+    testQuestionScenario({
+      scenario: visitorPass,
+      routeOption,
+      client,
+    });
 
     // visitor needs more screening
-    testQuestionScenario({ scenario: visitorScreening, client });
+    testQuestionScenario({
+      scenario: visitorScreening,
+      routeOption,
+      client,
+    });
 
     // staff passing answers
-    testQuestionScenario({ scenario: staffPass, client });
+    testQuestionScenario({
+      scenario: staffPass,
+      routeOption,
+      client,
+    });
 
     // staff needs more screening
-    testQuestionScenario({ scenario: staffScreening, client });
+    testQuestionScenario({
+      scenario: staffScreening,
+      routeOption,
+      client,
+    });
   });
 });

--- a/src/applications/coronavirus-screener/tests/00.coronavirus-screener.e2e.spec.js
+++ b/src/applications/coronavirus-screener/tests/00.coronavirus-screener.e2e.spec.js
@@ -8,7 +8,6 @@ import {
   staffScreening,
   fullTestRouteOptions,
   routeOptions,
-  expectTextbyLanguage,
 } from './question-scenario-helper';
 
 // test scenarios for visitors and staff

--- a/src/applications/coronavirus-screener/tests/00.coronavirus-screener.e2e.spec.js
+++ b/src/applications/coronavirus-screener/tests/00.coronavirus-screener.e2e.spec.js
@@ -6,6 +6,9 @@ import {
   visitorScreening,
   staffPass,
   staffScreening,
+  fullTestRouteOptions,
+  routeOptions,
+  expectTextbyLanguage,
 } from './question-scenario-helper';
 
 // test scenarios for visitors and staff
@@ -17,15 +20,29 @@ export default createE2eTest(client => {
     .assert.visible('div[class*=covid-screener-results-incomplete]')
     .axeCheck('.main');
 
-  // visitor passing answers
-  testQuestionScenario({ scenario: visitorPass, client });
+  routeOptions.forEach(routeOption => {
+    client
+      .url(`${baseUrl}/covid19screen${routeOption.route}`)
+      .waitForElementVisible('body', normal)
+      .assert.containsText(
+        'div[class*=vads-l-grid-container]',
+        `${routeOption.expectedText}`,
+      );
+  });
 
-  // visitor needs more screening
-  testQuestionScenario({ scenario: visitorScreening, client });
+  fullTestRouteOptions.forEach(routeOption => {
+    client.url(`${baseUrl}/covid19screen${routeOption}`);
 
-  // staff passing answers
-  testQuestionScenario({ scenario: staffPass, client });
+    // visitor passing answers
+    testQuestionScenario({ scenario: visitorPass, client });
 
-  // staff needs more screening
-  testQuestionScenario({ scenario: staffScreening, client });
+    // visitor needs more screening
+    testQuestionScenario({ scenario: visitorScreening, client });
+
+    // staff passing answers
+    testQuestionScenario({ scenario: staffPass, client });
+
+    // staff needs more screening
+    testQuestionScenario({ scenario: staffScreening, client });
+  });
 });

--- a/src/applications/coronavirus-screener/tests/question-scenario-helper.js
+++ b/src/applications/coronavirus-screener/tests/question-scenario-helper.js
@@ -3,7 +3,7 @@ import { normal, slow } from 'platform/testing/e2e/timeouts';
 // wait time before clicking
 const pause = 1000;
 
-export function testQuestionScenario({ scenario, client }) {
+export function testQuestionScenario({ scenario, routeOption, client }) {
   client.refresh().waitForElementVisible('body', normal);
   scenario.questions.forEach(question => {
     client
@@ -15,7 +15,10 @@ export function testQuestionScenario({ scenario, client }) {
   });
   client
     .waitForElementVisible(`div[class*=${scenario.result.class}]`, slow)
-    .assert.visible(`div[class*=${scenario.result.class}]`, scenario.title);
+    .assert.visible(
+      `div[class*=${scenario.result.class}]`,
+      `${scenario.title} on route: ${routeOption}`,
+    );
 }
 
 export const visitorPass = {
@@ -86,9 +89,29 @@ export const expectTextbyLanguage = {
 };
 
 export const routeOptions = [
-  { route: '/es', expectedText: `${expectTextbyLanguage.es}` },
-  { route: '/123', expectedText: `${expectTextbyLanguage.en}` },
-  { route: '/123/es', expectedText: `${expectTextbyLanguage.es}` },
-  { route: '/', expectedText: `${expectTextbyLanguage.en}` },
-  { route: 'fr', expectedText: `${expectTextbyLanguage.en}` },
+  {
+    route: '/es',
+    expectedText: `${expectTextbyLanguage.es}`,
+    title: 'Route /es (expect Spanish)',
+  },
+  {
+    route: '/123',
+    expectedText: `${expectTextbyLanguage.en}`,
+    title: 'Route /123 (expect English)',
+  },
+  {
+    route: '/123/es',
+    expectedText: `${expectTextbyLanguage.es}`,
+    title: 'Route /123/es (expect Spanish)',
+  },
+  {
+    route: '/',
+    expectedText: `${expectTextbyLanguage.en}`,
+    title: 'Route / (expect English)',
+  },
+  {
+    route: '/fr',
+    expectedText: `${expectTextbyLanguage.en}`,
+    title: 'Route /fr (expect English)',
+  },
 ];

--- a/src/applications/coronavirus-screener/tests/question-scenario-helper.js
+++ b/src/applications/coronavirus-screener/tests/question-scenario-helper.js
@@ -1,7 +1,7 @@
 import { normal, slow } from 'platform/testing/e2e/timeouts';
 
 // wait time before clicking
-const pause = 1000;
+const pause = 2000;
 
 export function testQuestionScenario({ scenario, routeOption, client }) {
   client.refresh().waitForElementVisible('body', normal);

--- a/src/applications/coronavirus-screener/tests/question-scenario-helper.js
+++ b/src/applications/coronavirus-screener/tests/question-scenario-helper.js
@@ -1,7 +1,7 @@
 import { normal, slow } from 'platform/testing/e2e/timeouts';
 
 // wait time before clicking
-const pause = 2000;
+const pause = 1000;
 
 export function testQuestionScenario({ scenario, routeOption, client }) {
   client.refresh().waitForElementVisible('body', normal);
@@ -111,6 +111,21 @@ export const routeOptions = [
   },
   {
     route: '/fr',
+    expectedText: `${expectTextbyLanguage.en}`,
+    title: 'Route /fr (expect English)',
+  },
+  {
+    route: '/459gh',
+    expectedText: `${expectTextbyLanguage.en}`,
+    title: 'Route /459gh (expect English)',
+  },
+  {
+    route: '/459gh/es',
+    expectedText: `${expectTextbyLanguage.es}`,
+    title: 'Route /fr (expect Spanish)',
+  },
+  {
+    route: '/459gh/en',
     expectedText: `${expectTextbyLanguage.en}`,
     title: 'Route /fr (expect English)',
   },

--- a/src/applications/coronavirus-screener/tests/question-scenario-helper.js
+++ b/src/applications/coronavirus-screener/tests/question-scenario-helper.js
@@ -77,3 +77,18 @@ export const staffScreening = {
     class: 'covid-screener-results-more-screening',
   },
 };
+
+export const fullTestRouteOptions = ['/', '/es'];
+
+export const expectTextbyLanguage = {
+  en: 'COVID-19 screening tool',
+  es: 'Herramienta de evaluación para COVID-19',
+};
+
+export const routeOptions = [
+  { route: '/es', expectedText: `${expectTextbyLanguage.es}` },
+  { route: '/123', expectedText: `${expectTextbyLanguage.en}` },
+  { route: '/123/es', expectedText: `${expectTextbyLanguage.es}` },
+  { route: '/', expectedText: `${expectTextbyLanguage.en}` },
+  { route: 'fr', expectedText: `${expectTextbyLanguage.en}` },
+];


### PR DESCRIPTION
## To do
- [x] Get updated translations for all content in /config/
- [x] Update/write tests
- [ ] User test with fluent / native Spanish speakers
- [x] Design review

## Description


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
