### PR TITLE
Adjustment in data layer for FL map-move event

### DIFF
--- a/src/applications/facility-locator/tests/e2e/gaEvents.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/gaEvents.cypress.spec.js
@@ -35,6 +35,7 @@ describe('Google Analytics FL Events', () => {
           assertEventAndAttributes(win, 'fl-map-pin-click', [
             'event',
             'fl-facility-type',
+            'fl-facility-id',
             'fl-facility-classification',
             'fl-facility-name',
             'fl-facility-distance-from-search',

--- a/src/applications/facility-locator/utils/analytics.js
+++ b/src/applications/facility-locator/utils/analytics.js
@@ -5,16 +5,17 @@ import { distBetween } from './facilityDistance';
  * Helper fn to record Markers events for GA
  */
 export const recordMarkerEvents = r => {
-  const { classification, name, facilityType } = r.attributes;
+  const { classification, name, facilityType, id } = r.attributes;
   const distance = r.distance;
 
-  if (classification && name && facilityType && distance) {
+  if (classification && name && facilityType && distance && id) {
     recordEvent({
       event: 'fl-map-pin-click',
       'fl-facility-type': facilityType,
       'fl-facility-classification': classification,
       'fl-facility-name': name,
       'fl-facility-distance-from-search': distance,
+      'fl-facility-id': id,
     });
   }
 };

--- a/src/applications/facility-locator/utils/analytics.js
+++ b/src/applications/facility-locator/utils/analytics.js
@@ -42,6 +42,9 @@ export const recordZoomPanEvents = (e, searchCoords, currentZoomLevel) => {
         event: 'fl-search',
         'fl-map-miles-moved': distanceMoved,
       });
+      recordEvent({
+        'fl-map-miles-moved': undefined,
+      });
     }
   }
 };


### PR DESCRIPTION
## Description
Issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/14453

## Testing done


## Screenshots

## Tasks
- [x] Clear the fl-map-miles-moved dataLayer variable after it is set `window.dataLayer.push({'fl-map-miles-moved': undefined});`

## Acceptance Criteria
- [x] Analytics can differentiate between the regular search and the map move from the dataLayer alone

## Definition of done

- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
