### PR TITLE
Fixes for news_story transformer

### DIFF
--- a/src/site/stages/build/process-cms-exports/schemas/input/node-news_story.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/node-news_story.js
@@ -16,6 +16,11 @@ module.exports = {
     field_full_story: { $ref: 'GenericNestedString' },
     field_image_caption: { $ref: 'GenericNestedString' },
     field_intro_text: { $ref: 'GenericNestedString' },
+    field_listing: {
+      type: 'array',
+      items: { $ref: 'EntityReference' },
+      maxItems: 1,
+    },
     field_media: {
       type: 'array',
       items: { $ref: 'EntityReference' },
@@ -47,6 +52,7 @@ module.exports = {
     'field_full_story',
     'field_image_caption',
     'field_intro_text',
+    'field_listing',
     'field_media',
     'status',
     'field_featured',

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-news_story.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-news_story.js
@@ -25,6 +25,17 @@ module.exports = {
     fieldFullStory: { $ref: 'ProcessedString' },
     fieldImageCaption: { type: ['string', 'null'] },
     fieldIntroText: { type: 'string' },
+    fieldListing: {
+      type: 'object',
+      properties: {
+        entity: {
+          type: 'object',
+          properties: {
+            entityUrl: { $ref: 'EntityUrl' },
+          },
+        },
+      },
+    },
     fieldMedia: { oneOf: [{ $ref: 'Media' }, { type: 'null' }] },
     fieldOffice: {
       oneOf: [

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-news_story.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-news_story.js
@@ -11,7 +11,16 @@ module.exports = {
     entityMetatags: { $ref: 'MetaTags' },
     entityUrl: { $ref: 'EntityUrl' },
     fieldAuthor: {
-      oneOf: [{ $ref: 'output/node-person_profile' }, { type: 'null' }],
+      oneOf: [
+        {
+          type: 'object',
+          properties: {
+            title: { type: 'string' },
+            fieldDescription: { type: ['string', 'null'] },
+          },
+        },
+        { type: 'null' },
+      ],
     },
     fieldFullStory: { $ref: 'ProcessedString' },
     fieldImageCaption: { type: ['string', 'null'] },

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-story_listing.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-story_listing.js
@@ -11,6 +11,7 @@ module.exports = {
     changed: { type: 'number' },
     entityPublished: { type: 'boolean' },
     entityMetatags: { $ref: 'MetaTags' },
+    entityUrl: { $ref: 'EntityUrl' },
     fieldAdministration: { $ref: 'output/taxonomy_term-administration' },
     fieldDescription: { type: 'string' },
     fieldIntroText: { type: 'string' },

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-story_listing.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-story_listing.js
@@ -11,7 +11,6 @@ module.exports = {
     changed: { type: 'number' },
     entityPublished: { type: 'boolean' },
     entityMetatags: { $ref: 'MetaTags' },
-    entityUrl: { $ref: 'EntityUrl' },
     fieldAdministration: { $ref: 'output/taxonomy_term-administration' },
     fieldDescription: { type: 'string' },
     fieldIntroText: { type: 'string' },

--- a/src/site/stages/build/process-cms-exports/transformers/node-news_story.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-news_story.js
@@ -11,8 +11,6 @@ const transform = (entity, { ancestors }) => ({
   entityType: 'node',
   entityBundle: 'news_story',
   title: getDrupalValue(entity.title),
-  // Ignoring this for now as uid is causing issues
-  // uid: entity.uid[0],
   created: utcToEpochTime(getDrupalValue(entity.created)),
   promote: getDrupalValue(entity.promote),
   entityMetatags: createMetaTagArray(entity.metatag.value),
@@ -23,6 +21,11 @@ const transform = (entity, { ancestors }) => ({
   },
   fieldImageCaption: getDrupalValue(entity.fieldImageCaption),
   fieldIntroText: getDrupalValue(entity.fieldIntroText),
+  fieldListing: entity.fieldListing[0]
+    ? {
+        entity: { entityUrl: entity.fieldListing[0].entityUrl },
+      }
+    : null,
   fieldMedia:
     entity.fieldMedia && entity.fieldMedia.length
       ? { entity: getImageCrop(entity.fieldMedia[0], '_21MEDIUMTHUMBNAIL') }
@@ -49,6 +52,7 @@ module.exports = {
     'field_full_story',
     'field_image_caption',
     'field_intro_text',
+    'field_listing',
     'field_media',
     'field_office',
     'status',


### PR DESCRIPTION
## Description

1. Fixed failing output schema validation for `news_story` by paring down the attributes expected from `fieldAuthor`.

2. Fixed missing `href` values in `news_story` pages. Fixes department-of-veterans-affairs/va.gov-team#13197.

    The `news_story.drupal.liquid` template was setting the value to `fieldListing.entity.entityUrl.path`, but the `news_story` transformer was not including `fieldListing` in the output.

## Testing done
Compared local builds. Ran transformer validation on the affected transformers.

## Acceptance criteria
- [ ] Links on `news_story` pages should have values for their `href` attributes.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
