### PR TITLE
Make satisfaction labels wrap to two lines so they aren't smushed together

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-medallia.scss
+++ b/src/platform/site-wide/sass/modules/_m-medallia.scss
@@ -35,3 +35,22 @@
   label.rating-label {
   border-radius: 10px !important;
 }
+
+/* 150px-wide container div for "Very Dissatisfied" and "Very Satisfied" spans */
+#liveForm .edge-labels {
+  display: flex;
+  justify-content: space-between;
+}
+
+/* "Very Dissatisfied" label below "1 of 5" rating element */
+#leftEdge {
+  padding-right: 25px;
+  text-align: left;
+  width: 75px;
+}
+
+/* "Very Satisfied" label below "5 of 5" rating element */
+#rightEdge {
+  text-align: right;
+  width: 50px;
+}


### PR DESCRIPTION
## GitHub Issue

https://github.com/department-of-veterans-affairs/va.gov-team/issues/13287

## Description

Update **Very Dissatisfied** and **Very Satisfied** labels to wrap to two lines so they aren't scrunched together

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/6130520/95473291-927f2200-0949-11eb-88f4-1a64c2d37c76.png)

### After

![image](https://user-images.githubusercontent.com/6130520/95473232-81ceac00-0949-11eb-9cd6-6c416056d1b6.png)

## Demo

![wrapping-satisfaction-labels](https://user-images.githubusercontent.com/6130520/95472494-bc841480-0948-11eb-982b-b2b2fdb35770.gif)

### Relevant Conversation/Comments

>**Joanne**: [What would the label wrapping for 2 lines look like?](https://github.com/department-of-veterans-affairs/va.gov-team/issues/13287#issuecomment-705123388)
>**Bill**: [here is what the wrapping text would look like with two different text-alignment options; left/right or centered](https://github.com/department-of-veterans-affairs/va.gov-team/issues/13287#issuecomment-705167036)
>**Joanne**: [Left- & right-aligned look more usable to me than center or no alignment.](https://github.com/department-of-veterans-affairs/va.gov-team/issues/13287#issuecomment-705179355)
>**Crystabel**: [I agree with left and right aligned looks more usable](https://github.com/department-of-veterans-affairs/va.gov-team/issues/13287#issuecomment-705184338)

## Acceptance criteria
- [x] Very Dissatisfied label wraps to two lines
- [x] Very Dissatisfied label is left-aligned
- [x] Very Satisfied label wraps to two lines
- [x] Very Satisfied label is right-aligned

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)

## Related Links

- https://github.com/department-of-veterans-affairs/vets-website/pull/14483