### PR TITLE
Fix missing sections for health_care_local_facility

### DIFF
--- a/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
@@ -24,43 +24,6 @@ module.exports = `
         }
       }
     }
-    fieldRegionPage {
-      entity {
-        ... on NodeHealthCareRegionPage {
-          fieldFacebook {
-            title
-            url {
-              path
-            }
-          }
-          fieldTwitter {
-            title
-            url {
-              path
-            }
-          }
-          fieldFlickr {
-            title
-            url {
-              path
-            }
-          }
-          fieldInstagram {
-            title
-            url {
-              path
-            }
-          }
-          fieldGovdeliveryIdEmerg
-          fieldGovdeliveryIdNews
-          fieldOperatingStatus {
-            url {
-              path
-            }
-          }
-        }
-      }
-    }
     fieldAddress {
       addressLine1
       locality
@@ -99,6 +62,37 @@ module.exports = `
           fieldRelatedLinks {
             entity {
               ... listOfLinkTeasers
+            }
+          }
+          fieldFacebook {
+            title
+            url {
+              path
+            }
+          }
+          fieldTwitter {
+            title
+            url {
+              path
+            }
+          }
+          fieldFlickr {
+            title
+            url {
+              path
+            }
+          }
+          fieldInstagram {
+            title
+            url {
+              path
+            }
+          }
+          fieldGovdeliveryIdEmerg
+          fieldGovdeliveryIdNews
+          fieldOperatingStatus {
+            url {
+              path
             }
           }
         }

--- a/src/site/stages/build/process-cms-exports/schemas/input/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/node-health_care_region_page.js
@@ -1,5 +1,17 @@
 /* eslint-disable camelcase */
 
+const socialMediaLinkSchema = {
+  type: 'array',
+  items: {
+    type: 'object',
+    properties: {
+      uri: { type: 'string' },
+      title: { type: 'string' },
+    },
+    required: ['uri', 'title'],
+  },
+};
+
 module.exports = {
   type: 'object',
   properties: {
@@ -22,6 +34,13 @@ module.exports = {
       },
     },
     field_leadership: { $ref: 'EntityReferenceArray' },
+    field_govdelivery_id_emerg: { $ref: 'GenericNestedString' },
+    field_govdelivery_id_news: { $ref: 'GenericNestedString' },
+    field_facebook: socialMediaLinkSchema,
+    field_flickr: socialMediaLinkSchema,
+    field_instagram: socialMediaLinkSchema,
+    field_twitter: socialMediaLinkSchema,
+    field_operating_status: socialMediaLinkSchema,
     reverse_field_region_page: { $ref: 'EntityReferenceArray' },
     reverse_field_office: { $ref: 'EntityReferenceArray' },
   },
@@ -34,6 +53,13 @@ module.exports = {
     // 'field_link_facility_emerg_list',
     'field_nickname_for_this_facility',
     'field_leadership',
+    'field_govdelivery_id_emerg',
+    'field_govdelivery_id_news',
+    'field_operating_status',
+    'field_facebook',
+    'field_flickr',
+    'field_instagram',
+    'field_twitter',
     'reverse_field_region_page',
     'reverse_field_office',
   ],

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
@@ -100,19 +100,7 @@ module.exports = {
     fieldGovdeliveryIdEmerg: { type: 'string' },
     fieldGovdeliveryIdNews: { type: 'string' },
     fieldOperatingStatus: socialMediaSchema,
-    // fieldFacebook: socialMediaSchema,
-    fieldFacebook: {
-      type: ['object', 'null'],
-      properties: {
-        url: {
-          type: 'object',
-          properties: {
-            path: { type: 'string' },
-          },
-        },
-      },
-      required: ['url'],
-    },
+    fieldFacebook: socialMediaSchema,
     fieldFlickr: socialMediaSchema,
     fieldInstagram: socialMediaSchema,
     fieldTwitter: socialMediaSchema,

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
@@ -5,6 +5,21 @@ const newsStorySchema = require('./node-news_story');
 const eventSchema = require('./node-event');
 const pressRelease = require('./node-press_release');
 
+const socialMediaSchema = {
+  type: ['object', 'null'],
+  properties: {
+    url: {
+      type: 'object',
+      properties: {
+        path: { type: 'string' },
+      },
+      required: ['path'],
+    },
+    title: { type: 'string' },
+  },
+  required: ['url', 'title'],
+};
+
 const facilitiesSchema = {
   type: 'object',
   properties: {
@@ -82,6 +97,25 @@ module.exports = {
     entityBundle: { enum: ['health_care_region_page'] },
     title: { type: 'string' },
     entityUrl: { $ref: 'EntityUrl' },
+    fieldGovdeliveryIdEmerg: { type: 'string' },
+    fieldGovdeliveryIdNews: { type: 'string' },
+    fieldOperatingStatus: socialMediaSchema,
+    // fieldFacebook: socialMediaSchema,
+    fieldFacebook: {
+      type: ['object', 'null'],
+      properties: {
+        url: {
+          type: 'object',
+          properties: {
+            path: { type: 'string' },
+          },
+        },
+      },
+      required: ['url'],
+    },
+    fieldFlickr: socialMediaSchema,
+    fieldInstagram: socialMediaSchema,
+    fieldTwitter: socialMediaSchema,
     fieldNicknameForThisFacility: { type: ['string', 'null'] },
     fieldLinkFacilityEmergList: {
       type: ['object', 'null'],
@@ -165,6 +199,13 @@ module.exports = {
   },
   required: [
     'title',
+    'fieldGovdeliveryIdEmerg',
+    'fieldGovdeliveryIdNews',
+    'fieldOperatingStatus',
+    'fieldFacebook',
+    'fieldFlickr',
+    'fieldInstagram',
+    'fieldTwitter',
     'fieldNicknameForThisFacility',
     'fieldLinkFacilityEmergList',
     'fieldPressReleaseBlurb',

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
@@ -1,9 +1,12 @@
+/* eslint-disable camelcase */
+
 const {
   getDrupalValue,
   isPublished,
   createMetaTagArray,
   combineItemsInIndexedObject,
   utcToEpochTime,
+  getImageCrop,
 } = require('./helpers');
 const { mapKeys, camelCase } = require('lodash');
 
@@ -12,6 +15,41 @@ const getSocialMediaObject = ({ uri, title }) =>
     ? {
         url: { path: uri },
         title,
+      }
+    : null;
+
+const getFieldRegionObject = ({
+  title,
+  field_related_links,
+  field_govdelivery_id_emerg,
+  field_govdelivery_id_news,
+  field_operating_status,
+  field_facebook,
+  field_flickr,
+  field_instagram,
+  field_twitter,
+}) =>
+  title
+    ? {
+        title: getDrupalValue(title),
+        fieldRelatedLinks: field_related_links[0],
+        fieldGovdeliveryIdEmerg: getDrupalValue(field_govdelivery_id_emerg),
+        fieldGovdeliveryIdNews: getDrupalValue(field_govdelivery_id_news),
+        fieldOperatingStatus: field_operating_status[0]
+          ? getSocialMediaObject(field_operating_status[0])
+          : null,
+        fieldFacebook: field_facebook[0]
+          ? getSocialMediaObject(field_facebook[0])
+          : null,
+        fieldFlickr: field_flickr[0]
+          ? getSocialMediaObject(field_flickr[0])
+          : null,
+        fieldInstagram: field_instagram[0]
+          ? getSocialMediaObject(field_instagram[0])
+          : null,
+        fieldTwitter: field_twitter[0]
+          ? getSocialMediaObject(field_twitter[0])
+          : null,
       }
     : null;
 
@@ -44,7 +82,7 @@ const transform = (entity, { ancestors }) => ({
   fieldMainLocation: getDrupalValue(entity.fieldMainLocation),
   fieldMedia:
     entity.fieldMedia && entity.fieldMedia.length
-      ? { entity: entity.fieldMedia[0] }
+      ? { entity: getImageCrop(entity.fieldMedia[0], '_32MEDIUMTHUMBNAIL') }
       : null,
   fieldMentalHealthPhone: getDrupalValue(entity.fieldMentalHealthPhone),
   fieldNicknameForThisFacility: getDrupalValue(
@@ -63,7 +101,8 @@ const transform = (entity, { ancestors }) => ({
           r => r.entity.uuid === entity.fieldRegionPage[0].uuid,
         )
           ? entity.fieldRegionPage[0]
-          : { title: getDrupalValue(entity.fieldRegionPage[0].title) },
+          : // : getDrupalValue(entity.fieldRegionPage[0].title),
+            getFieldRegionObject(entity.fieldRegionPage[0]),
       }
     : null,
   fieldTwitter: getSocialMediaObject(entity.fieldTwitter),

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
@@ -101,8 +101,7 @@ const transform = (entity, { ancestors }) => ({
           r => r.entity.uuid === entity.fieldRegionPage[0].uuid,
         )
           ? entity.fieldRegionPage[0]
-          : // : getDrupalValue(entity.fieldRegionPage[0].title),
-            getFieldRegionObject(entity.fieldRegionPage[0]),
+          : getFieldRegionObject(entity.fieldRegionPage[0]),
       }
     : null,
   fieldTwitter: getSocialMediaObject(entity.fieldTwitter),

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
@@ -7,10 +7,25 @@ const {
   isPublished,
 } = require('./helpers');
 
+const getSocialMediaObject = ({ uri, title }) =>
+  uri
+    ? {
+        url: { path: uri },
+        title,
+      }
+    : null;
+
 const transform = ({
   title,
   status,
   metatag: { value: metaTags },
+  fieldGovdeliveryIdEmerg,
+  fieldGovdeliveryIdNews,
+  fieldOperatingStatus,
+  fieldFacebook,
+  fieldFlickr,
+  fieldInstagram,
+  fieldTwitter,
   fieldNicknameForThisFacility,
   fieldRelatedLinks,
   fieldPressReleaseBlurb,
@@ -24,6 +39,19 @@ const transform = ({
   entityPublished: isPublished(getDrupalValue(status)),
   entityLabel: getDrupalValue(title),
   title: getDrupalValue(title),
+  fieldGovdeliveryIdEmerg: getDrupalValue(fieldGovdeliveryIdEmerg),
+  fieldGovdeliveryIdNews: getDrupalValue(fieldGovdeliveryIdNews),
+  fieldOperatingStatus: fieldOperatingStatus[0]
+    ? getSocialMediaObject(fieldOperatingStatus[0])
+    : null,
+  fieldFacebook: fieldFacebook[0]
+    ? getSocialMediaObject(fieldFacebook[0])
+    : null,
+  fieldFlickr: fieldFlickr[0] ? getSocialMediaObject(fieldFlickr[0]) : null,
+  fieldInstagram: fieldInstagram[0]
+    ? getSocialMediaObject(fieldInstagram[0])
+    : null,
+  fieldTwitter: fieldTwitter[0] ? getSocialMediaObject(fieldTwitter[0]) : null,
   fieldNicknameForThisFacility: getDrupalValue(fieldNicknameForThisFacility),
   fieldLinkFacilityEmergList:
     fieldLinkFacilityEmergList && fieldLinkFacilityEmergList[0]
@@ -339,12 +367,19 @@ module.exports = {
     'title',
     'status',
     'path',
-    'field_nickname_for_this_facility',
-    'field_link_facility_emerg_list',
-    'field_related_links',
-    'field_press_release_blurb',
-    'metatag',
+    'field_govdelivery_id_emerg',
+    'field_govdelivery_id_news',
+    'field_facebook',
+    'field_flickr',
+    'field_instagram',
+    'field_twitter',
     'field_leadership',
+    'field_link_facility_emerg_list',
+    'field_nickname_for_this_facility',
+    'field_operating_status',
+    'field_press_release_blurb',
+    'field_related_links',
+    'metatag',
     'reverse_field_region_page',
     'reverse_field_office',
   ],


### PR DESCRIPTION
## Description
This PR fixes 5 different issues from ticket [13240](https://github.com/department-of-veterans-affairs/va.gov-team/issues/13240)

Most issues were related to the `fieldRegionPage` field in the [liquid template](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/site/layouts/health_care_local_facility.drupal.liquid#L380)

## Testing done
```
diff -ur graphql-localhost/pittsburgh-health-care/locations/pittsburgh-va-medical-center-university-drive/index.html localhost/pittsburgh-health-care/locations/pittsburgh-va-medical-center-university-drive/index.html | delta
```

## Screenshots


## Acceptance criteria
- [x] Fix missing section for `list_of_link_teasers_facility`
- [x] Fix missing section for `facility_social_links`
- [x] Fix wrong href for images
- [x] Fix GraphQL query with `fieldRegionPage` duplicate
- [x] Add new fields in the transformer from the GraphQL query


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
