### PR TITLE
Sanlouise 14012 hide profile error

### DIFF
--- a/src/applications/personalization/profile-2/components/Profile2Wrapper.jsx
+++ b/src/applications/personalization/profile-2/components/Profile2Wrapper.jsx
@@ -5,6 +5,7 @@ import { Link, useLocation } from 'react-router-dom';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import Breadcrumbs from '@department-of-veterans-affairs/formation-react/Breadcrumbs';
 import { isWideScreen } from 'platform/utilities/accessibility/index';
+import { selectProfile } from 'platform/user/selectors';
 
 import {
   directDepositLoadError,
@@ -106,14 +107,20 @@ const Profile2Wrapper = ({
   );
 };
 
-const mapStateToProps = state => ({
-  hero: state.vaProfile?.hero,
-  showNotAllDataAvailableError:
-    !!directDepositLoadError(state) ||
-    !!fullNameLoadError(state) ||
-    !!personalInformationLoadError(state) ||
-    !!militaryInformationLoadError(state),
-});
+const mapStateToProps = state => {
+  const veteranStatus = selectProfile(state)?.veteranStatus;
+  const invalidVeteranStatus =
+    !veteranStatus || veteranStatus === 'NOT_AUTHORIZED';
+
+  return {
+    hero: state.vaProfile?.hero,
+    showNotAllDataAvailableError:
+      !!directDepositLoadError(state) ||
+      !!fullNameLoadError(state) ||
+      !!personalInformationLoadError(state) ||
+      (!!militaryInformationLoadError(state) && !invalidVeteranStatus),
+  };
+};
 
 Profile2Wrapper.propTypes = {
   children: PropTypes.node.isRequired,

--- a/src/applications/personalization/profile-2/tests/components/Profile.data-unavailable-error.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/components/Profile.data-unavailable-error.unit.spec.js
@@ -110,12 +110,12 @@ async function hideErrorNonVet(
   const spinner = view.queryByRole('progressbar');
   await waitForElementToBeRemoved(spinner);
 
-  const alert = await view.queryByTestId(ALERT_ID);
+  const alert = view.queryByTestId(ALERT_ID);
   expect(alert).not.to.exist;
 
   pageNames.forEach(pageName => {
     userEvent.click(view.getByRole('link', { name: pageName }));
-    expect(alert).to.be.null;
+    expect(view.queryByTestId(ALERT_ID)).to.not.exist;
   });
 }
 

--- a/src/applications/personalization/profile-2/tests/components/Profile.data-unavailable-error.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/components/Profile.data-unavailable-error.unit.spec.js
@@ -93,6 +93,32 @@ async function errorAppearsOnAllPages(
   });
 }
 
+async function hideErrorNonVet(
+  pageNames = [
+    PROFILE_PATH_NAMES.MILITARY_INFORMATION,
+    PROFILE_PATH_NAMES.DIRECT_DEPOSIT,
+    PROFILE_PATH_NAMES.ACCOUNT_SECURITY,
+    PROFILE_PATH_NAMES.CONNECTED_APPLICATIONS,
+  ],
+) {
+  const initialState = createBasicInitialState();
+  initialState.user.profile.veteranStatus = null;
+
+  const view = render(<Profile2Router isLOA3 isInMVI />, {
+    initialState,
+  });
+  const spinner = view.queryByRole('progressbar');
+  await waitForElementToBeRemoved(spinner);
+
+  const alert = await view.queryByTestId(ALERT_ID);
+  expect(alert).not.to.exist;
+
+  pageNames.forEach(pageName => {
+    userEvent.click(view.getByRole('link', { name: pageName }));
+    expect(alert).to.be.null;
+  });
+}
+
 describe('Profile "Not all data available" error', () => {
   let server;
 
@@ -115,6 +141,18 @@ describe('Profile "Not all data available" error', () => {
     const spinner = view.queryByRole('progressbar');
     await waitForElementToBeRemoved(spinner);
     expect(view.queryByTestId(ALERT_ID)).not.to.exist;
+  });
+
+  it('should not be shown if there is a 500 error with the `GET service_history` endpoint and the user is not a vet', async () => {
+    server.use(...mocks.getServiceHistory500);
+
+    await hideErrorNonVet();
+  });
+
+  it('should not be shown if there is a 401 error with the `GET service_history` endpoint and the user is not a vet', async () => {
+    server.use(...mocks.getServiceHistory401);
+
+    await hideErrorNonVet();
   });
 
   it('should be shown on all pages if there is an error with the `GET full_name` endpoint', async () => {


### PR DESCRIPTION
## Description
We should not show the global profile error when the call to `/service_history` fails and the user is a non-veteran. The call fails expectedly with a 403, so this should not be treated as an error.

## Testing done
Works locally, added unit tests.

## Acceptance criteria
- [x] Hide error when the call to `/service_history` fails and the user is a non-veteran

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
