### PR TITLE
Fixed profile service history Pact test.

### DIFF
--- a/src/applications/personalization/profile360/tests/service-history.pact.spec.js
+++ b/src/applications/personalization/profile360/tests/service-history.pact.spec.js
@@ -16,7 +16,7 @@ contractTest('VA Profile', 'VA.gov API', mockApi => {
         uponReceiving: 'a GET request',
         withRequest: {
           method: 'GET',
-          path: '/v0/service_history',
+          path: '/v0/profile/service_history',
           headers: {
             'X-Key-Inflection': 'camel',
           },
@@ -53,7 +53,7 @@ contractTest('VA Profile', 'VA.gov API', mockApi => {
         uponReceiving: 'a GET request',
         withRequest: {
           method: 'GET',
-          path: '/v0/service_history',
+          path: '/v0/profile/service_history',
           headers: {
             'X-Key-Inflection': 'camel',
           },
@@ -86,7 +86,7 @@ contractTest('VA Profile', 'VA.gov API', mockApi => {
         uponReceiving: 'a GET request',
         withRequest: {
           method: 'GET',
-          path: '/v0/service_history',
+          path: '/v0/profile/service_history',
           headers: {
             'X-Key-Inflection': 'camel',
           },


### PR DESCRIPTION
## Description
Corrected the endpoints called in the test so that the pacts can be generated and published to the broker.

When I ran the test individually at first, the following errors in `logs/pact.log` pointed out the issue.

```
 156   │ E, [2020-10-08T13:14:45.931369 #9934] ERROR -- : No matching interaction found for GET /v0/profile/service_history
 157   │ E, [2020-10-08T13:14:45.931386 #9934] ERROR -- : Interaction diffs for that route:
 158   │ E, [2020-10-08T13:14:45.931400 #9934] ERROR -- :
 159   │ W, [2020-10-08T13:14:45.935920 #9934]  WARN -- : Verifying - actual interactions do not match expected interactions.
 160   │ Missing requests:
 161   │     GET /v0/service_history
 162   │
 163   │ Unexpected requests:
 164   │     GET /v0/profile/service_history
 165   │
 166   │
 167   │ W, [2020-10-08T13:14:45.935970 #9934]  WARN -- : Missing requests:
 168   │     GET /v0/service_history
 169   │
 170   │ Unexpected requests:
 171   │     GET /v0/profile/service_history
```

## Testing done
Ran the individual test locally:
```sh
BUILDTYPE=localhost yarn test:unit src/applications/personalization/profile360/tests/service-history.pact.spec.js
```

## Acceptance criteria
- [ ] Profile pact tests should pass so that the pacts may get published to the broker for the backend to verify.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
