### PR TITLE
Update Medallia-specific  styles

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-medallia.scss
+++ b/src/platform/site-wide/sass/modules/_m-medallia.scss
@@ -16,16 +16,6 @@ Source: https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity#A_Overridin
   font-family: "Source Sans Pro", sans-serif !important;
 }
 
-/* Add padding to the bottom of the Medallia form */
-#liveForm .panel-footer-web {
-  padding-bottom: 1rem;
-}
-
-/* Remove 'Powered by Medallia' */
-#liveForm .kpl-form-footer.ng-scope {
-  display: none;
-}
-
 /* Radio buttons background color */
 .neb-content md-radio-group div.radio md-radio-button ._md-on {
   background-color: #0071bc !important;
@@ -49,20 +39,34 @@ Source: https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity#A_Overridin
 }
 
 /* 150px-wide container div for "Very Dissatisfied" and "Very Satisfied" spans */
-#liveForm .edge-labels {
+.ng-scope .edge-labels {
   display: flex;
   justify-content: space-between;
 }
 
 /* "Very Dissatisfied" label below "1 of 5" rating element */
-#leftEdge {
+.ng-scope #leftEdge {
   padding-right: 25px;
   text-align: left;
   width: 75px;
 }
 
 /* "Very Satisfied" label below "5 of 5" rating element */
-#rightEdge {
+.ng-scope #rightEdge {
   text-align: right;
   width: 50px;
+}
+
+/* Hide Powered By Medallia and/or footer containing Powered By Medallia */
+/* Intro page of Medallia survey visible on https://staging.va.gov/find-locations/facility/vha_691 */
+/* `.ng-scope .kpl-form-footer` is common to multiple Medallia forms and form pages */
+.ng-scope .kpl-form-footer,
+.ng-scope .footerCls {
+  display: none;
+}
+
+/* Add padding to the bottom of the Medallia form */
+/* `.ng-scope .panel-footer-web` is common to multiple Medallia forms and form pages */
+.ng-scope .panel-footer-web {
+  padding-bottom: 1rem;
 }

--- a/src/platform/site-wide/sass/modules/_m-medallia.scss
+++ b/src/platform/site-wide/sass/modules/_m-medallia.scss
@@ -4,18 +4,8 @@
 #liveForm textarea,
 /* https://css-tricks.com/override-inline-styles-with-css/ */
 .ng-scope span[style],
-.ng-scope textarea,
-/* 
-Even with `!important`, #thankYouPageText > div > span wasn't specific enough to overcome the inline style.
-"Inline styles added to an element always overwrite any styles in external stylesheets, 
-and thus can be thought of as having the highest specificity."
-Source: https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity#Selector_Types
-
-"Both inline styles and !important are considered very bad practice,
-but sometimes you need the latter to override the former."
-Source: https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity#A_Overriding_inline_styles
-*/
-.ng-scope #thankYouPageText > div > p > span {
+.ng-scope span,
+.ng-scope textarea {
   font-family: "Source Sans Pro", sans-serif !important;
 }
 

--- a/src/platform/site-wide/sass/modules/_m-medallia.scss
+++ b/src/platform/site-wide/sass/modules/_m-medallia.scss
@@ -1,6 +1,7 @@
 /* Fonts */
 #liveForm .ng-binding,
 #liveForm div > span,
+#liveForm textarea,
 /* 
 Even with `!important`, #thankYouPageText > div > span wasn't specific enough to overcome the inline style.
 "Inline styles added to an element always overwrite any styles in external stylesheets, 

--- a/src/platform/site-wide/sass/modules/_m-medallia.scss
+++ b/src/platform/site-wide/sass/modules/_m-medallia.scss
@@ -12,7 +12,8 @@ Source: https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity#Selector_Ty
 but sometimes you need the latter to override the former."
 Source: https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity#A_Overriding_inline_styles
 */
-#thankYouPageText > div > p > span > span > span {
+.ng-scope #thankYouPageText > div > p > span > span > span,
+.ng-scope span {
   font-family: "Source Sans Pro", sans-serif !important;
 }
 

--- a/src/platform/site-wide/sass/modules/_m-medallia.scss
+++ b/src/platform/site-wide/sass/modules/_m-medallia.scss
@@ -2,7 +2,8 @@
 #liveForm .ng-binding,
 #liveForm div > span,
 #liveForm textarea,
-.ng-scope span,
+/* https://css-tricks.com/override-inline-styles-with-css/ */
+.ng-scope span[style],
 .ng-scope textarea,
 /* 
 Even with `!important`, #thankYouPageText > div > span wasn't specific enough to overcome the inline style.

--- a/src/platform/site-wide/sass/modules/_m-medallia.scss
+++ b/src/platform/site-wide/sass/modules/_m-medallia.scss
@@ -1,6 +1,17 @@
 /* Fonts */
 #liveForm .ng-binding,
-#liveForm div > span {
+#liveForm div > span,
+/* 
+Even with `!important`, #thankYouPageText > div > span wasn't specific enough to overcome the inline style.
+"Inline styles added to an element always overwrite any styles in external stylesheets, 
+and thus can be thought of as having the highest specificity."
+Source: https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity#Selector_Types
+
+"Both inline styles and !important are considered very bad practice,
+but sometimes you need the latter to override the former."
+Source: https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity#A_Overriding_inline_styles
+*/
+#thankYouPageText > div > p > span > span > span {
   font-family: "Source Sans Pro", sans-serif !important;
 }
 

--- a/src/platform/site-wide/sass/modules/_m-medallia.scss
+++ b/src/platform/site-wide/sass/modules/_m-medallia.scss
@@ -2,6 +2,8 @@
 #liveForm .ng-binding,
 #liveForm div > span,
 #liveForm textarea,
+.ng-scope span,
+.ng-scope textarea,
 /* 
 Even with `!important`, #thankYouPageText > div > span wasn't specific enough to overcome the inline style.
 "Inline styles added to an element always overwrite any styles in external stylesheets, 
@@ -12,8 +14,7 @@ Source: https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity#Selector_Ty
 but sometimes you need the latter to override the former."
 Source: https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity#A_Overriding_inline_styles
 */
-.ng-scope #thankYouPageText > div > p > span > span > span,
-.ng-scope span {
+.ng-scope #thankYouPageText > div > p > span {
   font-family: "Source Sans Pro", sans-serif !important;
 }
 


### PR DESCRIPTION
## GitHub Issue

https://github.com/department-of-veterans-affairs/va.gov-team/issues/13287

## Description

The **Thank You** page of the Medallia survey was using inline styles, and the style rules from our [less-specific CSS selectors](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/site-wide/sass/modules/_m-medallia.scss#L3) weren't being applied. This PR adds a more specific selector coupled with `!important` to override the inline styles, and successfully apply the correct font to the **Thank You** page. 

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/6130520/95500043-d2ef9780-096b-11eb-8763-2248ec0dccfd.png)

### After

![image](https://user-images.githubusercontent.com/6130520/95500013-c9fec600-096b-11eb-8a1d-d203296fa5e2.png)

## Demos

![highly-specific-selector-plus-important](https://user-images.githubusercontent.com/6130520/95499867-873cee00-096b-11eb-95d9-661b94111cf1.gif)

![medallia-textarea-font-update](https://user-images.githubusercontent.com/6130520/95630398-6053ea00-0a47-11eb-8dba-a6e7d57355bc.gif)

### Relevant Conversation/Comments

> **Joanne**: [also, it doesn't look like the Intro & Thank You pages are inheriting the Font style](https://github.com/department-of-veterans-affairs/va.gov-team/issues/13287#issuecomment-705654982)
> **Bill**: [I see what you're talking about on the Thank You page. But I'm not seeing an Intro page on staging.](https://github.com/department-of-veterans-affairs/va.gov-team/issues/13287#issuecomment-705725810)

## Acceptance criteria
- [x] Font is updated on Medallia **Thank You** page

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)

## Related Links

- https://github.com/department-of-veterans-affairs/vets-website/pull/14483
- https://github.com/department-of-veterans-affairs/vets-website/pull/14516
- [Overriding Inline Styles](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity#A_Overriding_inline_styles)
- [CSS specificity by selector](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity#Selector_Types)