### PR TITLE
[Bug] Fix edit mode on new conditions page

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
@@ -20,8 +20,6 @@ import { errorSchemaIsValid } from 'platform/forms-system/src/js/validation';
 const Element = Scroll.Element;
 const scroller = Scroll.scroller;
 
-const isUndefined = value => (value || '') === '';
-
 /* Non-review growable table (array) field */
 // Mostly copied from USFS with a few additions/modifications:
 // Addition of 'Save' button, handleSave action, modifications to handleRemove
@@ -43,14 +41,7 @@ export default class ArrayField extends React.Component {
      */
     this.state = {
       // force edit mode for any empty service period data
-      editing: props.formData
-        ? props.formData.map(
-            data =>
-              isUndefined(data?.serviceBranch) ||
-              isUndefined(data?.dateRange?.from) ||
-              isUndefined(data?.dateRange?.to),
-          )
-        : [true],
+      editing: this.setInitialState(),
     };
   }
 
@@ -76,6 +67,16 @@ export default class ArrayField extends React.Component {
   shouldComponentUpdate(nextProps, nextState) {
     return !deepEquals(this.props, nextProps) || nextState !== this.state;
   }
+
+  setInitialState = () => {
+    const { formData, uiSchema } = this.props;
+    if (formData) {
+      return uiSchema['ui:options']?.setEditState
+        ? uiSchema['ui:options']?.setEditState(formData)
+        : formData.map(() => false);
+    }
+    return [true];
+  };
 
   onItemChange = (indexToChange, value) => {
     const newItems = _.set(indexToChange, value, this.props.formData || []);

--- a/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
+++ b/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
@@ -4,6 +4,7 @@ import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 
 import ValidatedServicePeriodView from '../components/ValidatedServicePeriodView';
 import ArrayField from '../components/ArrayField';
+import { isUndefined } from '../utils';
 
 const dateRangeUISchema = dateRangeUI(
   'Service start date',
@@ -60,6 +61,13 @@ export const uiSchema = {
         viewField: ValidatedServicePeriodView,
         reviewMode: true,
         showSave: true,
+        setEditState: formData =>
+          formData.map(
+            data =>
+              isUndefined(data?.serviceBranch) ||
+              isUndefined(data?.dateRange?.from) ||
+              isUndefined(data?.dateRange?.to),
+          ),
       },
       items: {
         serviceBranch: {

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -35,6 +35,7 @@ import {
   formatDateRange,
   isBDD,
   show526Wizard,
+  isUndefined,
 } from '../utils.jsx';
 
 describe('526 helpers', () => {
@@ -628,6 +629,21 @@ describe('526 helpers', () => {
       };
 
       expect(activeServicePeriods(formData)).to.eql([futurePeriod, noToDate]);
+    });
+  });
+
+  describe('isUndefined', () => {
+    it('should detect undefined (falsy) values', () => {
+      let undef;
+      expect(isUndefined()).to.be.true;
+      expect(isUndefined(false)).to.be.true;
+      expect(isUndefined('')).to.be.true;
+      expect(isUndefined(0)).to.be.true;
+      expect(isUndefined(undef)).to.be.true;
+      expect(isUndefined('0')).to.be.false;
+      expect(isUndefined(' ')).to.be.false;
+      expect(isUndefined(1)).to.be.false;
+      expect(isUndefined(true)).to.be.false;
     });
   });
 });

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -76,6 +76,8 @@ export const srSubstitute = (srIgnored, substitutionText) => (
   </span>
 );
 
+export const isUndefined = value => (value || '') === '';
+
 export const formatDate = (date, format = DATE_FORMAT) => {
   const m = moment(date);
   return date && m.isValid() ? m.format(format) : 'Unknown';


### PR DESCRIPTION
## Description

The `ArrayField` specific to form 526 was made to detect empty military service periods/branch name and place the entry into edit mode. The new conditions page was recently made to also use the ArrayField and thus incorrectly places all entries into edit mode when the page becomes visible. This update fixes that problem

Related:
- https://github.com/department-of-veterans-affairs/vets-website/pull/14491
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/14444

## Testing done

Added basic unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Military service history entries correctly enter edit mode as needed
- [x] New conditions entries correctly enter edit mode as needed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
