### PR TITLE
VACMS-2972: Remove unused field_description from lc types.

### DIFF
--- a/src/site/stages/build/drupal/graphql/nodeChecklist.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeChecklist.graphql.js
@@ -7,7 +7,6 @@ fragment nodeChecklist on NodeChecklist {
 
   changed
   title
-  fieldDescription
   fieldIntroTextLimitedHtml {
     processed
   }

--- a/src/site/stages/build/drupal/graphql/nodeMediaListImages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeMediaListImages.graphql.js
@@ -7,7 +7,6 @@ fragment nodeMediaListImages on NodeMediaListImages {
 
   changed
   title
-  fieldDescription
   fieldIntroTextLimitedHtml {
     processed
   }

--- a/src/site/stages/build/drupal/graphql/nodeMediaListVideos.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeMediaListVideos.graphql.js
@@ -7,7 +7,6 @@ fragment nodeMediaListVideos on NodeMediaListVideos {
 
   changed
   title
-  fieldDescription
   fieldIntroTextLimitedHtml {
     processed
   }


### PR DESCRIPTION
## Description
See https://github.com/department-of-veterans-affairs/va.gov-cms/issues/2972
We need to remove these instances in graphQL before removing in cms. That's what I am doing here.

## Testing done
Build

## Screenshots
N/A

## Acceptance criteria
- [ ] Successful build
