### PR TITLE
Handle "not in MPI" and "can't connect to MPI" errors differently

### DIFF
--- a/src/applications/hca/helpers.jsx
+++ b/src/applications/hca/helpers.jsx
@@ -16,14 +16,14 @@ import {
 } from 'platform/forms-system/src/js/helpers';
 import { getInactivePages } from 'platform/forms/helpers';
 import { isValidDate } from 'platform/forms/validations';
-import { isInMVI } from 'platform/user/selectors';
+import { isInMPI } from 'platform/user/selectors';
 
 import facilityLocator from '../facility-locator/manifest.json';
 
 export function prefillTransformer(pages, formData, metadata, state) {
   let newData = formData;
 
-  if (isInMVI(state)) {
+  if (isInMPI(state)) {
     newData = { ...newData, 'view:isUserInMvi': true };
   }
 

--- a/src/applications/personalization/profile-2/components/AccountSecurityContent.jsx
+++ b/src/applications/personalization/profile-2/components/AccountSecurityContent.jsx
@@ -6,7 +6,7 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import recordEvent from 'platform/monitoring/record-event';
 import {
   isLOA3 as isLOA3Selector,
-  isInMPI as isInMVISelector,
+  isInMPI as isInMPISelector,
   hasMPIConnectionError as hasMPIConnectionErrorSelector,
   isMultifactorEnabled as isMultifactorEnabledSelector,
   selectProfile,
@@ -106,7 +106,7 @@ export const AccountSecurityContent = ({
 
 AccountSecurityContent.propTypes = {
   isIdentityVerified: PropTypes.bool.isRequired,
-  isInMVI: PropTypes.bool.isRequired,
+  isInMPI: PropTypes.bool.isRequired,
   isMultifactorEnabled: PropTypes.bool.isRequired,
   mhvAccount: PropTypes.shape({
     accountLevel: PropTypes.string,
@@ -125,13 +125,13 @@ export const mapStateToProps = state => {
   const { verified, mhvAccount } = profile;
   const showMHVTermsAndConditions =
     verified && MHVTermsAndConditionsStatus.willRenderContent(mhvAccount);
-  const isInMVI = isInMVISelector(state);
+  const isInMPI = isInMPISelector(state);
   const isIdentityVerified = isLOA3Selector(state);
   const hasMPIConnectionError = hasMPIConnectionErrorSelector(state);
   const showMPIConnectionError = isIdentityVerified && hasMPIConnectionError;
   const showNotInMPIError =
-    isIdentityVerified && !hasMPIConnectionError && !isInMVI;
-  const showWeHaveVerifiedYourID = isInMVI && isIdentityVerified;
+    isIdentityVerified && !hasMPIConnectionError && !isInMPI;
+  const showWeHaveVerifiedYourID = isInMPI && isIdentityVerified;
 
   return {
     isIdentityVerified,

--- a/src/applications/personalization/profile-2/components/AccountSecurityContent.jsx
+++ b/src/applications/personalization/profile-2/components/AccountSecurityContent.jsx
@@ -6,7 +6,8 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import recordEvent from 'platform/monitoring/record-event';
 import {
   isLOA3 as isLOA3Selector,
-  isInMVI as isInMVISelector,
+  isInMPI as isInMVISelector,
+  hasMPIConnectionError as hasMPIConnectionErrorSelector,
   isMultifactorEnabled as isMultifactorEnabledSelector,
   selectProfile,
 } from 'platform/user/selectors';
@@ -18,7 +19,8 @@ import {
 import ProfileInfoTable from './ProfileInfoTable';
 import TwoFactorAuthorizationStatus from './TwoFactorAuthorizationStatus';
 import IdentityNotVerified from './IdentityNotVerified';
-import NotInMVI from './NotInMVI';
+import NotInMPIError from './NotInMPIError';
+import MPIConnectionError from './MPIConnectionError';
 import MHVTermsAndConditionsStatus from './MHVTermsAndConditionsStatus';
 import EmailAddressNotification from './EmailAddressNotification';
 import Verified from './Verified';
@@ -28,9 +30,11 @@ export const AccountSecurityContent = ({
   isMultifactorEnabled,
   mhvAccount,
   showMHVTermsAndConditions,
+  showWeHaveVerifiedYourID,
+  showMPIConnectionError,
+  showNotInMPIError,
   isAuthenticatedWithSSOe,
   signInServiceName,
-  isInMVI,
 }) => {
   const securitySections = [
     {
@@ -45,7 +49,7 @@ export const AccountSecurityContent = ({
     },
   ];
 
-  if (isIdentityVerified && isInMVI) {
+  if (showWeHaveVerifiedYourID) {
     securitySections.unshift({
       title: 'Identity verification',
       verified: true,
@@ -69,7 +73,8 @@ export const AccountSecurityContent = ({
   return (
     <>
       {!isIdentityVerified && <IdentityNotVerified />}
-      {!isInMVI && isIdentityVerified && <NotInMVI />}
+      {showMPIConnectionError && <MPIConnectionError />}
+      {showNotInMPIError && <NotInMPIError />}
       <ProfileInfoTable data={securitySections} fieldName="accountSecurity" />
       <AlertBox
         status="info"
@@ -120,12 +125,21 @@ export const mapStateToProps = state => {
   const { verified, mhvAccount } = profile;
   const showMHVTermsAndConditions =
     verified && MHVTermsAndConditionsStatus.willRenderContent(mhvAccount);
+  const isInMVI = isInMVISelector(state);
+  const isIdentityVerified = isLOA3Selector(state);
+  const hasMPIConnectionError = hasMPIConnectionErrorSelector(state);
+  const showMPIConnectionError = isIdentityVerified && hasMPIConnectionError;
+  const showNotInMPIError =
+    isIdentityVerified && !hasMPIConnectionError && !isInMVI;
+  const showWeHaveVerifiedYourID = isInMVI && isIdentityVerified;
 
   return {
-    isIdentityVerified: isLOA3Selector(state),
-    isInMVI: isInMVISelector(state),
+    isIdentityVerified,
     isMultifactorEnabled: isMultifactorEnabledSelector(state),
     mhvAccount,
+    showWeHaveVerifiedYourID,
+    showMPIConnectionError,
+    showNotInMPIError,
     showMHVTermsAndConditions,
     signInServiceName: signInServiceNameSelector(state),
     isAuthenticatedWithSSOe: authenticatedWithSSOeSelector(state),

--- a/src/applications/personalization/profile-2/components/MPIConnectionError.jsx
+++ b/src/applications/personalization/profile-2/components/MPIConnectionError.jsx
@@ -3,12 +3,10 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 const MPIConnectionError = () => {
   const content = (
-    <>
-      <p>
-        We’re sorry. Something went wrong when we tried to connect to your
-        Veteran records. Please refresh this page to try again.
-      </p>
-    </>
+    <p>
+      We’re sorry. Something went wrong when we tried to connect to your Veteran
+      records. Please refresh this page to try again.
+    </p>
   );
 
   return (

--- a/src/applications/personalization/profile-2/components/MPIConnectionError.jsx
+++ b/src/applications/personalization/profile-2/components/MPIConnectionError.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+
+const MPIConnectionError = () => {
+  const content = (
+    <>
+      <p>
+        We’re sorry. Something went wrong when we tried to connect to your
+        Veteran records. Please refresh this page to try again.
+      </p>
+    </>
+  );
+
+  return (
+    <div className="vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4">
+      <AlertBox
+        headline="We can’t access your Veteran records"
+        content={content}
+        status="warning"
+      />
+    </div>
+  );
+};
+
+export default MPIConnectionError;

--- a/src/applications/personalization/profile-2/components/NotInMPIError.jsx
+++ b/src/applications/personalization/profile-2/components/NotInMPIError.jsx
@@ -4,7 +4,7 @@ import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
-const NotInMVI = () => {
+const NotInMPIError = () => {
   const content = (
     <>
       <p>
@@ -32,4 +32,4 @@ const NotInMVI = () => {
   );
 };
 
-export default NotInMVI;
+export default NotInMPIError;

--- a/src/applications/personalization/profile-2/tests/components/AccountSecurityContent.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/AccountSecurityContent.unit.spec.jsx
@@ -23,7 +23,7 @@ describe('AccountSecurityContent', () => {
     mhvAccount: { termsAndConditionsAccepted: true },
     showMHVTermsAndConditions: true,
     useSSOe: true,
-    isInMVI: true,
+    showWeHaveVerifiedYourID: true,
   });
 
   it('should render a ProfileInfoTable as its first child', () => {
@@ -102,6 +102,7 @@ describe('AccountSecurityContent', () => {
       it('should pass in three rows of data', () => {
         props = makeDefaultProps();
         props.isIdentityVerified = false;
+        props.showWeHaveVerifiedYourID = false;
         wrapper = shallow(<AccountSecurityContent {...props} />);
         infoTableData = wrapper.find('ProfileInfoTable').prop('data');
         expect(infoTableData.length).to.equal(3);
@@ -155,35 +156,6 @@ describe('mapStateToProps', () => {
         },
       });
       expect(mappedProps.isIdentityVerified).to.be.false;
-    });
-  });
-
-  describe('isInMVI', () => {
-    it('should be `true` if the user can be found in the MVI/MPI', () => {
-      const mappedProps = mapStateToProps({
-        user: {
-          profile: {
-            loa: {
-              current: 3,
-            },
-            status: 'OK',
-          },
-        },
-      });
-      expect(mappedProps.isInMVI).to.be.true;
-    });
-    it('should be `false` if the user cannot be found in the MVI/MPI', () => {
-      const mappedProps = mapStateToProps({
-        user: {
-          profile: {
-            loa: {
-              current: 3,
-            },
-            status: null,
-          },
-        },
-      });
-      expect(mappedProps.isInMVI).to.be.false;
     });
   });
 

--- a/src/applications/personalization/profile-2/tests/components/NotInMPIError.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/NotInMPIError.unit.spec.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { expect } from 'chai';
 
-import NotInMVI from '../../components/NotInMPIError';
+import NotInMPI from '../../components/NotInMPIError';
 
-describe('NotInMVI', () => {
+describe('NotInMPI', () => {
   let wrapper;
   beforeEach(() => {
-    wrapper = mount(<NotInMVI />);
+    wrapper = mount(<NotInMPI />);
   });
 
   it('should render the correct text', () => {

--- a/src/applications/personalization/profile-2/tests/components/NotInMVI.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/NotInMVI.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { expect } from 'chai';
 
-import NotInMVI from '../../components/NotInMVI';
+import NotInMVI from '../../components/NotInMPIError';
 
 describe('NotInMVI', () => {
   let wrapper;

--- a/src/applications/personalization/profile-2/tests/e2e/profile.mpi-error.cypress.spec.js
+++ b/src/applications/personalization/profile-2/tests/e2e/profile.mpi-error.cypress.spec.js
@@ -28,7 +28,6 @@ function test(mobile = false) {
   );
 
   // Should show an error alert about not being able to connect to MPI
-  // TODO: We might show a different error message in this particular case since in this case we can't connect to MPI.
   cy.findByText(/We can’t access your Veteran records/i)
     .should('exist')
     .closest('.usa-alert-warning')

--- a/src/applications/personalization/profile-2/tests/e2e/profile.not-in-mpi-error.cypress.spec.js
+++ b/src/applications/personalization/profile-2/tests/e2e/profile.not-in-mpi-error.cypress.spec.js
@@ -1,6 +1,6 @@
 import { PROFILE_PATHS } from '../../constants';
 
-import mockMPIErrorUser from '../fixtures/users/user-mpi-error.json';
+import mockUserNotInMPI from '../fixtures/users/user-not-in-mpi.json';
 import mockFeatureToggles from '../fixtures/feature-toggles.json';
 
 /**
@@ -27,14 +27,13 @@ function test(mobile = false) {
     `${Cypress.config().baseUrl}${PROFILE_PATHS.ACCOUNT_SECURITY}`,
   );
 
-  // Should show an error alert about not being able to connect to MPI
-  // TODO: We might show a different error message in this particular case since in this case we can't connect to MPI.
-  cy.findByText(/We can’t access your Veteran records/i)
+  // Should show a "not in MPI" error
+  cy.findByText(/We can’t match your information to our Veteran records/i)
     .should('exist')
     .closest('.usa-alert-warning')
     .should('exist');
   cy.findByText(
-    /something went wrong when we tried to connect to your veteran records/i,
+    /We can’t give you access to your profile or account information/i,
   )
     .should('exist')
     .closest('.usa-alert-warning')
@@ -83,7 +82,7 @@ describe('When user is LOA3 with 2FA turned on but we cannot connect to MPI', ()
       'DISMISSED_ANNOUNCEMENTS',
       JSON.stringify(['single-sign-on-intro']),
     );
-    cy.login(mockMPIErrorUser);
+    cy.login(mockUserNotInMPI);
     // login() calls cy.server() so we can now mock routes
     cy.route('GET', '/v0/feature_toggles*', mockFeatureToggles);
   });

--- a/src/applications/personalization/profile-2/tests/fixtures/users/user-not-in-mpi.json
+++ b/src/applications/personalization/profile-2/tests/fixtures/users/user-not-in-mpi.json
@@ -1,0 +1,92 @@
+{
+  "data": {
+    "id": "",
+    "type": "users_scaffolds",
+    "attributes": {
+      "services": [
+        "facilities",
+        "hca",
+        "edu-benefits",
+        "form-save-in-progress",
+        "form-prefill",
+        "user-profile",
+        "appeals-status",
+        "identity-proofed",
+        "evss_common_client",
+        "claim_increase"
+      ],
+      "account": { "accountUuid": "c049d895-ecdf-40a4-ac0f-7947a06ea0c2" },
+      "profile": {
+        "email": "vets.gov.user+36@gmail.com",
+        "firstName": "WESLEY",
+        "middleName": "Watson",
+        "lastName": "FORD",
+        "birthDate": "1986-05-06",
+        "gender": "M",
+        "zip": "22182",
+        "lastSignedIn": "2020-08-21T22:13:08.801Z",
+        "loa": { "current": 3, "highest": 3 },
+        "multifactor": true,
+        "verified": true,
+        "signIn": { "serviceName": "idme", "accountType": "N/A" },
+        "authnContext": "http://idmanagement.gov/ns/assurance/loa/3/vets"
+      },
+      "vaProfile": null,
+      "veteranStatus": null,
+      "inProgressForms": [
+        {
+          "form": "22-10203",
+          "metadata": {
+            "version": 1,
+            "returnUrl": "/benefits/stem-eligibility",
+            "savedAt": 1597089200404,
+            "expiresAt": 1602273198,
+            "lastUpdated": 1597089198
+          },
+          "lastUpdated": 1597089198
+        }
+      ],
+      "prefillsAvailable": [
+        "21-686C",
+        "40-10007",
+        "22-1990",
+        "22-1990N",
+        "22-1990E",
+        "22-1995",
+        "22-1995S",
+        "22-5490",
+        "22-5495",
+        "22-0993",
+        "22-0994",
+        "FEEDBACK-TOOL",
+        "22-10203",
+        "21-526EZ",
+        "21-526EZ-BDD",
+        "1010ez",
+        "21P-530",
+        "21P-527EZ",
+        "686C-674",
+        "20-0996",
+        "MDOT"
+      ],
+      "vet360ContactInformation": {}
+    }
+  },
+  "meta": {
+    "errors": [
+      {
+        "externalService": "MVI",
+        "startTime": "2020-08-21T22:17:28Z",
+        "endTime": null,
+        "status": 404
+      },
+      {
+        "externalService": "EMIS",
+        "startTime": "2020-08-21T22:17:28Z",
+        "endTime": null,
+        "description": "EMISRedis::VeteranStatus::NotAuthorized, NOT_AUTHORIZED",
+        "status": 401
+      }
+    ]
+  }
+}

--- a/src/applications/personalization/profiles-wrapper/ProfilesWrapper.jsx
+++ b/src/applications/personalization/profiles-wrapper/ProfilesWrapper.jsx
@@ -6,7 +6,7 @@ import ProfileOneWrapper from 'applications/personalization/profile360/container
 import { PROFILE_VERSION } from 'applications/personalization/profile-2/constants';
 
 import {
-  isInMVI as isInMVISelector,
+  isInMPI as isInMVISelector,
   isLOA1 as isLOA1Selector,
   isLOA3 as isLOA3Selector,
   isLoggedIn,

--- a/src/platform/user/selectors.js
+++ b/src/platform/user/selectors.js
@@ -5,8 +5,10 @@ import { CERNER_FACILITY_IDS } from '../utilities/cerner';
 
 export const selectUser = state => state.user;
 export const isLoggedIn = state => selectUser(state).login.currentlyLoggedIn;
-export const selectProfile = state => selectUser(state)?.profile;
-export const isInMVI = state => selectProfile(state).status === 'OK';
+export const selectProfile = state => selectUser(state)?.profile || {};
+export const isInMPI = state => selectProfile(state).status === 'OK';
+export const hasMPIConnectionError = state =>
+  selectProfile(state).status === 'SERVER_ERROR';
 export const isProfileLoading = state => selectProfile(state).loading;
 export const isLOA3 = state => selectProfile(state).loa.current === 3;
 export const isLOA1 = state => selectProfile(state).loa.current === 1;

--- a/src/platform/user/tests/selectors.unit.spec.js
+++ b/src/platform/user/tests/selectors.unit.spec.js
@@ -360,4 +360,54 @@ describe('user selectors', () => {
       expect(selectors.selectIsCernerPatient(state)).to.be.false;
     });
   });
+
+  describe('isInMPI', () => {
+    it('returns `true` if the profile.status is `OK`', () => {
+      const state = {
+        user: {
+          profile: {
+            status: 'OK',
+          },
+        },
+      };
+      expect(selectors.isInMPI(state)).to.be.true;
+    });
+    it('returns `false` if the profile.status is anything other than `OK`', () => {
+      const state = {
+        user: {
+          profile: {
+            status: 'blah',
+          },
+        },
+      };
+      expect(selectors.isInMPI(state)).to.be.false;
+      delete state.user.profile;
+      expect(selectors.isInMPI(state)).to.be.false;
+    });
+  });
+
+  describe('hasMPIConnectionError', () => {
+    it('returns `true` if the profile.status is `SERVER_ERROR`', () => {
+      const state = {
+        user: {
+          profile: {
+            status: 'SERVER_ERROR',
+          },
+        },
+      };
+      expect(selectors.hasMPIConnectionError(state)).to.be.true;
+    });
+    it('returns `false` if the profile.status is anything other than `SERVER_ERROR`', () => {
+      const state = {
+        user: {
+          profile: {
+            status: 'ERROR',
+          },
+        },
+      };
+      expect(selectors.isInMPI(state)).to.be.false;
+      delete state.user.profile;
+      expect(selectors.isInMPI(state)).to.be.false;
+    });
+  });
 });


### PR DESCRIPTION
## Description
Previous to this PR we were showing users a message saying that they were not in MPI if we couldn't even connect to MPI. With this PR we show different messages for these two scenarios:
- we cannot connect to MPI
- we could connect to MPI and the user is not in MPI

## Testing done
Local + unit tests + Cypress tests

## Screenshots
<details>
  <summary>cannot connect to MPI error</summary>
  
<img width="756" alt="MPI error" src="https://user-images.githubusercontent.com/20728956/95610554-5e713300-0a15-11eb-9c19-0a50c2e2cc11.png">

</details>

<details>
  <summary>not in MPI error</summary>
  
![image](https://user-images.githubusercontent.com/20728956/95610602-6a5cf500-0a15-11eb-9843-8a7111bcd1d0.png)

</details>

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs