### PR TITLE
Add page config option for Exit button

### DIFF
--- a/src/applications/edu-benefits/10203/config/chapters.js
+++ b/src/applications/edu-benefits/10203/config/chapters.js
@@ -47,6 +47,7 @@ export const chapters = {
         pageClass: 'vads-u-max-width--100 vads-u-vads-u-width--full',
         uiSchema: initialConfirmEligibility.uiSchema,
         schema: initialConfirmEligibility.schema,
+        exitTo: '/education/',
       },
     },
   },
@@ -67,6 +68,7 @@ export const chapters = {
         uiSchema: confirmEligibility.uiSchema,
         schema: confirmEligibility.schema,
         hideHeaderRow: true,
+        exitTo: '/education/',
       },
       programDetails: {
         title: 'STEM degree and school details',

--- a/src/applications/edu-benefits/10203/containers/ConfirmEligibilityView.jsx
+++ b/src/applications/edu-benefits/10203/containers/ConfirmEligibilityView.jsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import { isChapter33 } from '../helpers';
 import captureEvents from '../analytics-functions';
 import { ExitApplicationButton } from '../components/ExitApplicationButton';
+import environment from 'platform/utilities/environment';
 
 export class ConfirmEligibilityView extends React.Component {
   onChange = property => {
@@ -160,12 +161,14 @@ export class ConfirmEligibilityView extends React.Component {
         </div>
 
         <div>
-          <div className="vads-u-margin-top--neg2">
-            <ExitApplicationButton
-              formId={this.props.formId}
-              isLoggedIn={this.props.isLoggedIn}
-            />
-          </div>
+          {environment.isProduction() && (
+            <div className="vads-u-margin-top--neg2">
+              <ExitApplicationButton
+                formId={this.props.formId}
+                isLoggedIn={this.props.isLoggedIn}
+              />
+            </div>
+          )}
 
           <div>
             <p>

--- a/src/applications/edu-benefits/10203/containers/ConfirmEligibilityView.jsx
+++ b/src/applications/edu-benefits/10203/containers/ConfirmEligibilityView.jsx
@@ -160,8 +160,8 @@ export class ConfirmEligibilityView extends React.Component {
           <b>
             You must meet the above requirements to qualify for the scholarship.
           </b>{' '}
-          Please consider that ineligible applications delay the processing of
-          benefits for eligible applicants.
+          {environment.isProduction() &&
+            'Please consider that ineligible applications delay the processing of benefits for eligible applicants.'}
         </div>
         {environment.isProduction() && (
           <div>

--- a/src/applications/edu-benefits/10203/containers/ConfirmEligibilityView.jsx
+++ b/src/applications/edu-benefits/10203/containers/ConfirmEligibilityView.jsx
@@ -152,7 +152,11 @@ export class ConfirmEligibilityView extends React.Component {
           {this.renderChecks()}
           {this.renderConfirmEligibility()}
         </div>
-        <div className="vads-u-padding-top--4">
+        <div
+          className={`vads-u-padding-${
+            environment.isProduction() ? 'y' : 'top'
+          }--4`}
+        >
           <b>
             You must meet the above requirements to qualify for the scholarship.
           </b>{' '}

--- a/src/applications/edu-benefits/10203/containers/ConfirmEligibilityView.jsx
+++ b/src/applications/edu-benefits/10203/containers/ConfirmEligibilityView.jsx
@@ -152,31 +152,30 @@ export class ConfirmEligibilityView extends React.Component {
           {this.renderChecks()}
           {this.renderConfirmEligibility()}
         </div>
-        <div className="vads-u-padding-y--4">
+        <div className="vads-u-padding-top--4">
           <b>
             You must meet the above requirements to qualify for the scholarship.
           </b>{' '}
           Please consider that ineligible applications delay the processing of
           benefits for eligible applicants.
         </div>
-
-        <div>
-          {environment.isProduction() && (
+        {environment.isProduction() && (
+          <div>
             <div className="vads-u-margin-top--neg2">
               <ExitApplicationButton
                 formId={this.props.formId}
                 isLoggedIn={this.props.isLoggedIn}
               />
             </div>
-          )}
 
-          <div>
-            <p>
-              If you'd still like to apply, you can continue with your
-              application.
-            </p>
+            <div>
+              <p>
+                If you'd still like to apply, you can continue with your
+                application.
+              </p>
+            </div>
           </div>
-        </div>
+        )}
       </div>
     );
   }

--- a/src/applications/edu-benefits/10203/containers/InitialConfirmEligibilityView.jsx
+++ b/src/applications/edu-benefits/10203/containers/InitialConfirmEligibilityView.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import captureEvents from '../analytics-functions';
 import { isChapter33 } from '../helpers';
 import { ExitApplicationButton } from '../components/ExitApplicationButton';
+import environment from 'platform/utilities/environment';
 
 function InitialConfirmEligibilityView(props) {
   if (props.onReviewPage) {
@@ -31,13 +32,17 @@ function InitialConfirmEligibilityView(props) {
           </div>
         </div>
       </div>
-      <br />
-      <div>
-        <ExitApplicationButton
-          formId={props.formId}
-          isLoggedIn={props.isLoggedIn}
-        />
-      </div>
+      {environment.isProduction() && (
+        <>
+          <br />
+          <div>
+            <ExitApplicationButton
+              formId={props.formId}
+              isLoggedIn={props.isLoggedIn}
+            />
+          </div>
+        </>
+      )}
       <br />
       <span>
         If you'd still like to apply, you can continue with your application.

--- a/src/applications/edu-benefits/10203/containers/InitialConfirmEligibilityView.jsx
+++ b/src/applications/edu-benefits/10203/containers/InitialConfirmEligibilityView.jsx
@@ -41,12 +41,13 @@ function InitialConfirmEligibilityView(props) {
               isLoggedIn={props.isLoggedIn}
             />
           </div>
+          <br />
+          <span>
+            If you'd still like to apply, you can continue with your
+            application.
+          </span>
         </>
       )}
-      <br />
-      <span>
-        If you'd still like to apply, you can continue with your application.
-      </span>
     </div>
   );
 }

--- a/src/applications/edu-benefits/10203/containers/InitialConfirmEligibilityView.jsx
+++ b/src/applications/edu-benefits/10203/containers/InitialConfirmEligibilityView.jsx
@@ -25,8 +25,8 @@ function InitialConfirmEligibilityView(props) {
                   You must be a Post-9/11 GI Bill or Fry Scholarship beneficiary
                   to qualify for the scholarship.
                 </strong>{' '}
-                Please consider that ineligible applications delay the
-                processing of benefits for eligible applicants.
+                {environment.isProduction() &&
+                  'Please consider that ineligible applications delay the processing of benefits for eligible applicants.'}
               </p>
             </div>
           </div>

--- a/src/platform/forms-system/src/js/containers/FormPage.jsx
+++ b/src/platform/forms-system/src/js/containers/FormPage.jsx
@@ -14,6 +14,7 @@ import { focusElement } from '../utilities/ui';
 import recordEvent from 'platform/monitoring/record-event';
 import { removeFormApi } from 'platform/forms/save-in-progress/api';
 import environment from 'platform/utilities/environment';
+import { APP_TYPE_DEFAULT } from '../constants';
 
 function focusForm() {
   focusElement('.nav-header > h2');
@@ -203,7 +204,8 @@ class FormPage extends React.Component {
                   href={route.pageConfig.exitTo}
                   onClick={this.onExit}
                 >
-                  Exit application
+                  Exit{' '}
+                  {route.formConfig?.customText?.appType || APP_TYPE_DEFAULT}
                 </a>
               )}
             </div>


### PR DESCRIPTION
## Description

This adds the property `exitTo` to page config which if a `href` string is provided renders an exit `a` tag.
When this `a` tag is clicked the current form in progress is deleted if the user is logged in.

Using prod flag as this will need testing.

## Testing done
- Navigate to `/education/other-va-education-benefits/stem-scholarship/apply-for-scholarship-form-22-10203`
1. Path 1
    - Reach "Step 2 of 6: Education benefit", 
    - Select any option other than first 2
    - Click Continue
    - Observe Exit application button
    - Clicking "Exit application" should redirect to `/education`
1. Path 2
    - Reach "Step 2 of 6: Education benefit", 
    - Select either of the first 2 options
    - Click Continue
    - On "Step 3 of 6: Program details": Select No, No, "More than 6 months"
    - Click Continue
    - Observe Exit application button
    - Clicking "Exit application" should redirect to `/education`

If logged in as user the form should no longer show up in their profile as in progress.

## Screenshots
Path 1
![Screen Shot 2020-10-09 at 1 57 11 PM](https://user-images.githubusercontent.com/1094999/95616168-604bee00-0a37-11eb-8731-4111ee878f7f.png)

Path 2
![Screen Shot 2020-10-09 at 1 57 51 PM](https://user-images.githubusercontent.com/1094999/95616203-6e9a0a00-0a37-11eb-897f-0be0ada5f56a.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
