### PR TITLE
ATLAS location and confirmation code are now mapped into FHIR format

### DIFF
--- a/src/applications/vaos/appointment-list/components/cards/confirmed/AtlasLocation.jsx
+++ b/src/applications/vaos/appointment-list/components/cards/confirmed/AtlasLocation.jsx
@@ -1,24 +1,26 @@
 import React from 'react';
 import FacilityAddress from '../../../../components/FacilityAddress';
+import {
+  getATLASConfirmationCode,
+  getATLASLocation,
+} from '../../../../services/appointment';
 
 export default function AtlasLocation({ appointment }) {
-  const vvsAppointment = appointment.legacyVAR.apiData.vvsAppointments[0];
-  const address = vvsAppointment.tasInfo.address;
-  const name = `ATLAS facility in ${address.city}, ${address.state}`;
+  const { address } = getATLASLocation(appointment);
+  const { city, state } = address;
+  const confirmationCode = getATLASConfirmationCode(appointment);
+
+  const name = `ATLAS facility in ${city}, ${state}`;
   const facility = {
     name,
-    address: {
-      ...address,
-      line: [address.streetAddress],
-      postalCode: address.zipCode,
-    },
+    address,
   };
 
   return (
     <div>
       <FacilityAddress facility={facility} showDirectionsLink />
       <div className="vads-u-font-weight--bold vads-u-margin-top--2">
-        Appointment code: {vvsAppointment.tasInfo.confirmationCode}
+        Appointment code: {confirmationCode}
       </div>
       <span>
         You will use this code to find your appointment using the computer

--- a/src/applications/vaos/appointment-list/components/cards/confirmed/ConfirmedAppointmentListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/cards/confirmed/ConfirmedAppointmentListItem.jsx
@@ -16,6 +16,7 @@ import CommunityCareInstructions from './CommunityCareInstructions';
 import AppointmentStatus from '../AppointmentStatus';
 import ConfirmedCommunityCareLocation from './ConfirmedCommunityCareLocation';
 import {
+  getATLASLocation,
   getVARFacilityId,
   getVAAppointmentLocationId,
   isVideoAppointment,
@@ -96,8 +97,7 @@ export default function ConfirmedAppointmentListItem({
   if (isAtlas) {
     header = 'VA Video Connect';
     vvcHeader = ' at an ATLAS location';
-    const address =
-      appointment.legacyVAR.apiData.vvsAppointments[0].tasInfo.address;
+    const { address } = getATLASLocation(appointment);
     if (address) {
       location = `${address.streetAddress}, ${address.city}, ${address.state} ${
         address.zipCode

--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -122,6 +122,32 @@ export function isVideoGFE(appointment) {
 }
 
 /**
+ * Gets legacy VAR ATLAS location from HealthcareService reference
+ *
+ * @param {Object} appointment VAR Appointment in FHIR schema
+ * @returns {Object} the address from legacy VAR tasInfo.address
+ */
+export function getATLASLocation(appointment) {
+  return appointment?.contained.find(res => res.resourceType === 'Location');
+}
+
+/**
+ * Gets legacy VAR ATLAS confirmation code from HealthcareService reference
+ *
+ * @param {Object} appointment VAR Appointment in FHIR schema
+ * @returns {Object} the confirmation code from legacy VAR tasInfo.confirmationCode
+ */
+export function getATLASConfirmationCode(appointment) {
+  const characteristic = appointment.contained
+    ?.find(contained => contained.resourceType === 'HealthcareService')
+    ?.characteristic?.find(c =>
+      c.coding?.find(code => code.system === 'ATLAS_CC'),
+    );
+
+  return characteristic?.coding[0].code;
+}
+
+/**
  * Gets legacy VAR facility id from HealthcareService reference
  *
  * @param {Object} appointment VAR Appointment in FHIR schema

--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -11,6 +11,7 @@ import {
   UNABLE_TO_REACH_VETERAN_DETCODE,
 } from '../../utils/constants';
 import { getTimezoneBySystemId } from '../../utils/timezone';
+import { transformATLASLocation } from '../location/transformers';
 
 /**
  * Determines what type of appointment a VAR appointment object is depending on
@@ -370,6 +371,7 @@ function setContained(appt) {
     case APPOINTMENT_TYPES.vaAppointment: {
       if (isVideoVisit(appt)) {
         const contained = [];
+        const { tasInfo } = appt.vvsAppointments[0];
         const service = {
           resourceType: 'HealthcareService',
           id: `HealthcareService/var${appt.vvsAppointments[0].id}`,
@@ -402,7 +404,20 @@ function setContained(appt) {
           ],
         };
 
-        if (appt.sta6aid) {
+        if (tasInfo) {
+          service.characteristic = [
+            ...service.characteristic,
+            {
+              coding: [
+                {
+                  system: 'ATLAS_CC',
+                  code: tasInfo.confirmationCode,
+                },
+              ],
+            },
+          ];
+          contained.push(transformATLASLocation(tasInfo));
+        } else if (appt.sta6aid) {
           service.location = {
             reference: `Location/var${appt.sta6aid}`,
           };

--- a/src/applications/vaos/services/location/transformers.js
+++ b/src/applications/vaos/services/location/transformers.js
@@ -214,6 +214,38 @@ export function transformFacility(facility) {
 }
 
 /**
+ * Transform an ATLAS facility from LegacyVAR to a FHIR location resource
+ * @export
+ * @param {Object} tasInfo The tasInfo object from legacyVAR
+ * @returns {Object} A FHIR Location resource
+ */
+export function transformATLASLocation(tasInfo) {
+  const { address, siteCode } = tasInfo;
+  const {
+    city,
+    longitude,
+    latitude,
+    state,
+    streetAddress,
+    zipCode: postalCode,
+  } = address;
+  return {
+    resourceType: 'Location',
+    id: `var${siteCode}`,
+    address: {
+      line: [streetAddress],
+      city,
+      state,
+      postalCode,
+    },
+    position: {
+      longitude,
+      latitude,
+    },
+  };
+}
+
+/**
  * Sets requestSupported and directSchedulingSupported in legacyVAR
  * for locations that are retrieved from the v1 facilities API.  This
  * also replaces the ids when running locally or on staging since there

--- a/src/applications/vaos/services/mocks/var/confirmed_va.json
+++ b/src/applications/vaos/services/mocks/var/confirmed_va.json
@@ -242,8 +242,8 @@
                 "state": "MT",
                 "zipCode": "59917",
                 "country": "USA",
-                "longitude": null,
-                "latitude": null,
+                "longitude": -115.1,
+                "latitude": 48.8,
                 "additionalDetails": ""
               },
               "contacts": [

--- a/src/applications/vaos/tests/services/appointment/index.unit.spec.js
+++ b/src/applications/vaos/tests/services/appointment/index.unit.spec.js
@@ -9,6 +9,8 @@ import {
 import {
   isUpcomingAppointmentOrRequest,
   isValidPastAppointment,
+  getATLASConfirmationCode,
+  getATLASLocation,
   getBookedAppointments,
   getAppointmentRequests,
   isVideoAppointment,
@@ -18,6 +20,7 @@ import {
   transformConfirmedAppointments,
   transformPendingAppointments,
 } from '../../../services/appointment/transformers';
+import { transformATLASLocation } from '../../../services/location/transformers';
 import {
   getVAAppointmentMock,
   getVideoAppointmentMock,
@@ -170,6 +173,77 @@ describe('VAOS Appointment service', () => {
       ])[0];
 
       expect(isVideoGFE(gfe)).to.equal(true);
+    });
+  });
+
+  describe('getATLASLocation', () => {
+    it('should return the ATLAS address', () => {
+      const mock = getVideoAppointmentMock();
+      const tasInfo = {
+        confirmationCode: '7VBBCA',
+        address: {
+          streetAddress: '114 Dewey Ave',
+          city: 'Eureka',
+          state: 'MT',
+          zipCode: '59917',
+          country: 'USA',
+          longitude: -115.1,
+          latitude: 48.8,
+          additionalDetails: '',
+        },
+        siteCode: 9931,
+      };
+
+      const confirmedVA = transformConfirmedAppointments([
+        {
+          ...mock.attributes,
+          vvsAppointments: [
+            {
+              ...mock.attributes.vvsAppointments[0],
+              tasInfo,
+            },
+          ],
+        },
+      ])[0];
+
+      expect(getATLASLocation(confirmedVA)).to.eql(
+        transformATLASLocation(tasInfo),
+      );
+    });
+  });
+
+  describe('getATLASConfirmationCode', () => {
+    it('should return the ATLAS confirmation code', () => {
+      const mock = getVideoAppointmentMock();
+      const tasInfo = {
+        confirmationCode: '7VBBCA',
+        address: {
+          streetAddress: '114 Dewey Ave',
+          city: 'Eureka',
+          state: 'MT',
+          zipCode: '59917',
+          country: 'USA',
+          longitude: null,
+          latitude: null,
+          additionalDetails: '',
+        },
+      };
+
+      const confirmedVA = transformConfirmedAppointments([
+        {
+          ...mock.attributes,
+          vvsAppointments: [
+            {
+              ...mock.attributes.vvsAppointments[0],
+              tasInfo,
+            },
+          ],
+        },
+      ])[0];
+
+      expect(getATLASConfirmationCode(confirmedVA)).to.eql(
+        tasInfo.confirmationCode,
+      );
     });
   });
 

--- a/src/applications/vaos/tests/services/appointment/transformers.unit.spec.js
+++ b/src/applications/vaos/tests/services/appointment/transformers.unit.spec.js
@@ -12,6 +12,7 @@ import {
   transformConfirmedAppointments,
   transformPendingAppointments,
 } from '../../../services/appointment/transformers';
+import { transformATLASLocation } from '../../../services/location/transformers';
 
 const now = moment();
 const tomorrow = moment().add(1, 'days');
@@ -207,6 +208,20 @@ const videoAppt = {
           },
         },
       ],
+      tasInfo: {
+        confirmationCode: '7VBBCA',
+        address: {
+          streetAddress: '114 Dewey Ave',
+          city: 'Eureka',
+          state: 'MT',
+          zipCode: '59917',
+          country: 'USA',
+          longitude: -115.1,
+          latitude: 48.8,
+          additionalDetails: '',
+        },
+        siteCode: 9931,
+      },
       providers: [
         {
           name: { firstName: 'Test T+90', lastName: 'Test' },
@@ -435,16 +450,15 @@ describe('VAOS Appointment transformer', () => {
 
       it('should set video url in HealthcareService.telecom', () => {
         expect('contained' in data).to.equal(true);
-        expect(data.contained[0].resourceType).to.equal('HealthcareService');
-        expect(data.contained[0].id).to.contain(
+        expect(data.contained[1].resourceType).to.equal('HealthcareService');
+        expect(data.contained[1].id).to.contain(
           `var${videoAppt.vvsAppointments[0].id}`,
         );
-        expect(data.contained[0].telecom[0].value).to.equal(
+        expect(data.contained[1].telecom[0].value).to.equal(
           'https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VVC8275247@care2.evn.va.gov&pin=3242949390#',
         );
-        expect(data.contained[0].telecom[0].period.start).to.equal(data.start);
-        expect(data.contained[0].resourceType).to.equal('HealthcareService');
-        expect(data.contained[0].characteristic[0].coding[0].system).to.equal(
+        expect(data.contained[1].telecom[0].period.start).to.equal(data.start);
+        expect(data.contained[1].characteristic[0].coding[0].system).to.equal(
           'VVS',
         );
       });
@@ -478,9 +492,24 @@ describe('VAOS Appointment transformer', () => {
           },
         ])[0];
 
-        expect(gfeData.contained[0].resourceType).to.equal('HealthcareService');
-        expect(gfeData.contained[0].characteristic[0].coding[0].code).to.equal(
+        expect(gfeData.contained[1].resourceType).to.equal('HealthcareService');
+        expect(gfeData.contained[1].characteristic[0].coding[0].code).to.equal(
           VIDEO_TYPES.gfe,
+        );
+      });
+      it('should return ATLAS location', () => {
+        const { address } = transformATLASLocation(
+          videoAppt.vvsAppointments[0].tasInfo,
+        );
+
+        expect(data.contained[0].address).to.eql(address);
+      });
+      it('should return confirmation code', () => {
+        expect(data.contained[1].characteristic[1].coding[0].code).to.equal(
+          '7VBBCA',
+        );
+        expect(data.contained[1].characteristic[1].coding[0].system).to.equal(
+          'ATLAS_CC',
         );
       });
     });

--- a/src/applications/vaos/tests/services/location/transformers.unit.spec.js
+++ b/src/applications/vaos/tests/services/location/transformers.unit.spec.js
@@ -6,6 +6,7 @@ import {
   transformDSFacilities,
   transformFacility,
   transformFacilities,
+  transformATLASLocation,
 } from '../../../services/location/transformers';
 
 const facilitiesParsed = facilities983.data.map(f => ({
@@ -149,6 +150,53 @@ describe('VAOS Location transformer', () => {
       const data = transformFacilities(facilityDetailsParsed);
       expect(data.length).to.equal(facilityDetailsParsed.length);
       expect(data[0].identifier[0].value).to.equal('urn:va:division:442:442');
+    });
+  });
+
+  describe('transformATLASLocation', () => {
+    it('should transform ATLAS Location', () => {
+      const tasInfo = {
+        confirmationCode: '7VBBCA',
+        address: {
+          streetAddress: '114 Dewey Ave',
+          city: 'Eureka',
+          state: 'MT',
+          zipCode: '59917',
+          country: 'USA',
+          longitude: -115.1,
+          latitude: 48.8,
+          additionalDetails: '',
+        },
+        siteCode: 9931,
+      };
+
+      const {
+        streetAddress,
+        city,
+        state,
+        zipCode: postalCode,
+        latitude,
+        longitude,
+      } = tasInfo.address;
+
+      const location = {
+        resourceType: 'Location',
+        id: `var${tasInfo.siteCode}`,
+        address: {
+          line: [streetAddress],
+          city,
+          state,
+          postalCode,
+        },
+        position: {
+          longitude,
+          latitude,
+        },
+      };
+
+      const result = transformATLASLocation(tasInfo);
+
+      expect(result).to.eql(location);
     });
   });
 });


### PR DESCRIPTION
## Description
The purpose of this ticket was to continue mapping data from `legacyVAR` into the FHIR format.  In particular, the work here maps an ATLAS location and confirmation code into the FHIR format.

## Testing done
Unit tests were added to account for this change.

## Acceptance criteria
- [ATLAS location should be mapped to a Location resource in the contained array]
- [ATLAS confirmation code should be added to HealthcareService resource created for video appointments (maybe as a characteristic or identifier?)]

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/14082
