### PR TITLE
Remove renderErrorMessage branching

### DIFF
--- a/src/platform/forms-system/src/js/review/ReviewPage.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewPage.jsx
@@ -37,7 +37,6 @@ class ReviewPage extends React.Component {
           formConfig={formConfig}
           pageList={pageList}
           path={path}
-          renderErrorMessage
         />
       </div>
     );

--- a/src/platform/forms-system/src/js/review/ReviewPage.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewPage.jsx
@@ -37,6 +37,7 @@ class ReviewPage extends React.Component {
           formConfig={formConfig}
           pageList={pageList}
           path={path}
+          renderErrorMessage
         />
       </div>
     );

--- a/src/platform/forms-system/src/js/review/SubmitButtons.jsx
+++ b/src/platform/forms-system/src/js/review/SubmitButtons.jsx
@@ -15,13 +15,7 @@ import ThrottledError from './submit-states/ThrottledError';
 import ValidationError from './submit-states/ValidationError';
 
 export default function SubmitButtons(props) {
-  const {
-    onBack,
-    onSubmit,
-    renderErrorMessage,
-    submission,
-    formConfig,
-  } = props;
+  const { onBack, onSubmit, submission, formConfig } = props;
 
   const appType = formConfig?.customText?.appType || APP_TYPE_DEFAULT;
   const buttonText =
@@ -78,7 +72,6 @@ export default function SubmitButtons(props) {
       <GenericError
         appType={appType}
         formConfig={formConfig}
-        renderErrorMessage={renderErrorMessage}
         onBack={onBack}
         onSubmit={onSubmit}
       />
@@ -89,7 +82,6 @@ export default function SubmitButtons(props) {
 SubmitButtons.propTypes = {
   onBack: PropTypes.func,
   onSubmit: PropTypes.func,
-  renderErrorMessage: PropTypes.bool,
   submission: PropTypes.object,
   formConfig: PropTypes.shape({
     customText: PropTypes.shape({

--- a/src/platform/forms-system/src/js/review/SubmitController.jsx
+++ b/src/platform/forms-system/src/js/review/SubmitController.jsx
@@ -83,7 +83,7 @@ class SubmitController extends Component {
   };
 
   render() {
-    const { form, formConfig, renderErrorMessage } = this.props;
+    const { form, formConfig } = this.props;
 
     return (
       <SubmitButtons
@@ -91,14 +91,13 @@ class SubmitController extends Component {
         onBack={this.goBack}
         onSubmit={this.handleSubmit}
         submission={form.submission}
-        renderErrorMessage={renderErrorMessage}
       />
     );
   }
 }
 
 function mapStateToProps(state, ownProps) {
-  const { formConfig, pageList, renderErrorMessage } = ownProps;
+  const { formConfig, pageList } = ownProps;
   const router = ownProps.router;
 
   const form = state.form;
@@ -113,7 +112,6 @@ function mapStateToProps(state, ownProps) {
     formConfig,
     pagesByChapter,
     pageList,
-    renderErrorMessage,
     router,
     submission,
     showPreSubmitError,
@@ -133,7 +131,6 @@ SubmitController.propTypes = {
   formConfig: PropTypes.object.isRequired,
   pagesByChapter: PropTypes.object.isRequired,
   pageList: PropTypes.array.isRequired,
-  renderErrorMessage: PropTypes.bool,
   router: PropTypes.object.isRequired,
   setPreSubmit: PropTypes.func.isRequired,
   setSubmission: PropTypes.func.isRequired,

--- a/src/platform/forms-system/src/js/review/submit-states/GenericError.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/GenericError.jsx
@@ -3,28 +3,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 // components
-import ErrorMessage from 'platform/forms/components/common/alerts/ErrorMessage';
 import PreSubmitSection from 'platform/forms/components/review/PreSubmitSection';
 import FormSaveErrorMessage from 'platform/forms/components/review/FormSaveErrorMessage';
 import { Column, Row } from 'platform/forms/components/common/grid';
 // const FormSaveErrorMessage = props => props?.children;
 export default function GenericError(props) {
-  const { appType, formConfig, renderErrorMessage, onSubmit, testId } = props;
+  const { formConfig, onSubmit, testId } = props;
   let submitButton;
-  let submitMessage;
 
-  if (renderErrorMessage) {
-    submitMessage = <FormSaveErrorMessage formConfig={formConfig} />;
-  } else {
-    submitMessage = (
-      <ErrorMessage
-        active
-        title={`We’re sorry, the ${appType} didn’t go through.`}
-        message="You’ll have to start over. We suggest you wait 1 day while we fix
-        this problem."
-      />
-    );
-  }
+  const submitMessage = <FormSaveErrorMessage formConfig={formConfig} />;
 
   if (process.env.NODE_ENV !== 'production') {
     submitButton = (
@@ -57,6 +44,5 @@ export default function GenericError(props) {
 GenericError.propTypes = {
   appType: PropTypes.string,
   formConfig: PropTypes.object,
-  renderErrorMessage: PropTypes.bool,
   onSubmit: PropTypes.func,
 };

--- a/src/platform/forms-system/src/js/review/submit-states/GenericError.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/GenericError.jsx
@@ -15,6 +15,10 @@ export default function GenericError(props) {
 
   if (!formConfig.disableSave) {
     submitMessage = <FormSaveErrorMessage formConfig={formConfig} />;
+  } else if (formConfig.submissionError) {
+    const SubmissionError = formConfig.submissionError;
+
+    submitMessage = <SubmissionError form={formConfig} />;
   } else {
     submitMessage = (
       <ErrorMessage

--- a/src/platform/forms-system/src/js/review/submit-states/GenericError.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/GenericError.jsx
@@ -3,15 +3,28 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 // components
+import ErrorMessage from 'platform/forms/components/common/alerts/ErrorMessage';
 import PreSubmitSection from 'platform/forms/components/review/PreSubmitSection';
 import FormSaveErrorMessage from 'platform/forms/components/review/FormSaveErrorMessage';
 import { Column, Row } from 'platform/forms/components/common/grid';
 // const FormSaveErrorMessage = props => props?.children;
 export default function GenericError(props) {
-  const { formConfig, onSubmit, testId } = props;
+  const { appType, formConfig, onSubmit, testId } = props;
   let submitButton;
+  let submitMessage;
 
-  const submitMessage = <FormSaveErrorMessage formConfig={formConfig} />;
+  if (!formConfig.disableSave) {
+    submitMessage = <FormSaveErrorMessage formConfig={formConfig} />;
+  } else {
+    submitMessage = (
+      <ErrorMessage
+        active
+        title={`We’re sorry, the ${appType} didn’t go through.`}
+        message="You’ll have to start over. We suggest you wait 1 day while we fix
+        this problem."
+      />
+    );
+  }
 
   if (process.env.NODE_ENV !== 'production') {
     submitButton = (

--- a/src/platform/forms-system/test/js/review/SubmitButtons.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/SubmitButtons.unit.spec.jsx
@@ -54,26 +54,15 @@ describe('Schemaform review: <SubmitButtons>', () => {
   });
 
   it('renders generic error', () => {
-    const renderErrorMessage = () => {
-      return <span className="message">Error message</span>;
-    };
-
     const submission = {
       status: 'error',
     };
 
     const tree = SkinDeep.shallowRender(
-      <SubmitButtons
-        renderErrorMessage={renderErrorMessage}
-        submission={submission}
-        formConfig={formConfig}
-      />,
+      <SubmitButtons submission={submission} formConfig={formConfig} />,
     );
 
     expect(tree.everySubTree('GenericError')[0].type).to.equal(GenericError);
-    expect(
-      tree.everySubTree('GenericError')[0].props.renderErrorMessage,
-    ).to.equal(renderErrorMessage);
   });
 
   it('renders validation error', () => {

--- a/src/platform/forms-system/test/js/review/submit-states/GenericError.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/submit-states/GenericError.unit.spec.jsx
@@ -136,11 +136,6 @@ describe('Schemaform review: <GenericError />', () => {
     expect(submitButton).to.not.be.null;
     fireEvent.click(submitButton);
     expect(onSubmit.called).to.be.true;
-    expect(
-      tree.getByText(
-        'You’ll have to start over. We suggest you wait 1 day while we fix this problem.',
-      ),
-    ).to.not.be.null;
 
     tree.unmount();
   });
@@ -205,7 +200,6 @@ describe('Schemaform review: <GenericError />', () => {
           appType="test"
           formConfig={formConfig}
           onSubmit={onSubmit}
-          renderErrorMessage
           testId="12345"
         />
       </Provider>,

--- a/src/platform/forms-system/test/js/review/submit-states/GenericError.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/submit-states/GenericError.unit.spec.jsx
@@ -205,7 +205,7 @@ describe('Schemaform review: <GenericError />', () => {
     tree.unmount();
   });
 
-  it('renders non save-in-progress error', () => {
+  it('renders default non save-in-progress error', () => {
     const onSubmit = sinon.spy();
 
     const form = createForm();
@@ -230,6 +230,37 @@ describe('Schemaform review: <GenericError />', () => {
 
     expect(tree.getByText('We’re sorry, the test didn’t go through.')).to.not.be
       .null;
+
+    tree.unmount();
+  });
+
+  it('renders custom non save-in-progress error', () => {
+    const onSubmit = sinon.spy();
+
+    const form = createForm();
+    const formConfig = getFormConfig({
+      disableSave: true,
+      submissionError: () => <div>Custom Error Message</div>,
+    });
+
+    const formReducer = createformReducer({
+      formConfig: form,
+    });
+
+    const store = createStore();
+    store.injectReducer('form', formReducer);
+
+    const tree = render(
+      <Provider store={store}>
+        <GenericError
+          appType="test"
+          formConfig={formConfig}
+          onSubmit={onSubmit}
+        />
+      </Provider>,
+    );
+
+    expect(tree.getByText('Custom Error Message')).to.not.be.null;
 
     tree.unmount();
   });

--- a/src/platform/forms-system/test/js/review/submit-states/GenericError.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/submit-states/GenericError.unit.spec.jsx
@@ -104,7 +104,7 @@ describe('Schemaform review: <GenericError />', () => {
     tree.unmount();
   });
 
-  it('has the expected error in dev mode', () => {
+  it('the "submit again" button appears in dev mode', () => {
     const onSubmit = sinon.spy();
 
     const form = createForm();
@@ -129,13 +129,6 @@ describe('Schemaform review: <GenericError />', () => {
     );
 
     const submitButton = tree.getByText('Submit again');
-    expect(
-      tree.getByText(
-        'We’re sorry. We can’t submit your application right now.',
-      ),
-    ).to.not.be.null;
-    expect(tree.getByTestId('12345')).to.have.attribute('role', 'alert');
-    expect(tree.getByText('Go Back to VA.gov')).to.not.be.null;
     expect(submitButton).to.not.be.null;
     fireEvent.click(submitButton);
     expect(onSubmit.called).to.be.true;
@@ -208,6 +201,35 @@ describe('Schemaform review: <GenericError />', () => {
         'We’re sorry. We can’t submit your application right now.',
       ),
     ).to.not.be.null;
+
+    tree.unmount();
+  });
+
+  it('renders non save-in-progress error', () => {
+    const onSubmit = sinon.spy();
+
+    const form = createForm();
+    const formConfig = getFormConfig({ disableSave: true });
+
+    const formReducer = createformReducer({
+      formConfig: form,
+    });
+
+    const store = createStore();
+    store.injectReducer('form', formReducer);
+
+    const tree = render(
+      <Provider store={store}>
+        <GenericError
+          appType="test"
+          formConfig={formConfig}
+          onSubmit={onSubmit}
+        />
+      </Provider>,
+    );
+
+    expect(tree.getByText('We’re sorry, the test didn’t go through.')).to.not.be
+      .null;
 
     tree.unmount();
   });

--- a/src/platform/forms-system/test/js/review/submit-states/GenericError.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/submit-states/GenericError.unit.spec.jsx
@@ -129,8 +129,11 @@ describe('Schemaform review: <GenericError />', () => {
     );
 
     const submitButton = tree.getByText('Submit again');
-    expect(tree.getByText('We’re sorry, the test didn’t go through.')).to.not.be
-      .null;
+    expect(
+      tree.getByText(
+        'We’re sorry, we can’t submit your application right now.',
+      ),
+    ).to.not.be.null;
     expect(tree.getByTestId('12345')).to.have.attribute('role', 'alert');
     expect(tree.getByText('Go Back to VA.gov')).to.not.be.null;
     expect(submitButton).to.not.be.null;

--- a/src/platform/forms-system/test/js/review/submit-states/GenericError.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/submit-states/GenericError.unit.spec.jsx
@@ -131,7 +131,7 @@ describe('Schemaform review: <GenericError />', () => {
     const submitButton = tree.getByText('Submit again');
     expect(
       tree.getByText(
-        'We’re sorry, we can’t submit your application right now.',
+        'We’re sorry. We can’t submit your application right now.',
       ),
     ).to.not.be.null;
     expect(tree.getByTestId('12345')).to.have.attribute('role', 'alert');

--- a/src/platform/forms-system/test/js/review/submit-states/GenericError.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/submit-states/GenericError.unit.spec.jsx
@@ -167,11 +167,6 @@ describe('Schemaform review: <GenericError />', () => {
       </Provider>,
     );
 
-    expect(
-      tree.getByText(
-        'You’ll have to start over. We suggest you wait 1 day while we fix this problem.',
-      ),
-    ).to.not.be.null;
     expect(tree.getByTestId('12345')).to.have.attribute('role', 'alert');
     expect(tree.getByText('Go Back to VA.gov')).to.not.be.null;
 

--- a/src/platform/forms/save-in-progress/RoutedSavableReviewPage.jsx
+++ b/src/platform/forms/save-in-progress/RoutedSavableReviewPage.jsx
@@ -97,7 +97,6 @@ class RoutedSavableReviewPage extends React.Component {
             formConfig={formConfig}
             pageList={pageList}
             path={path}
-            renderErrorMessage
           />
         </DowntimeNotification>
         <SaveStatus


### PR DESCRIPTION
## Description

In #14141 we came across a situation where a team elected not to use save-in-progress functionality, and since this hasn't been done before it led to issues regarding how error messages are rendered. This change should make it so that non-SiP forms won't use the default SiP error messaging, but they can also use custom error messaging.

### Background

Currently, the `ReviewPage` component is only used in the `createRoutes` helper:

https://github.com/department-of-veterans-affairs/vets-website/blob/de5230a256a8c5262fe352e9fb3ff7755454ab9b/src/platform/forms-system/src/js/routing.js#L75-L80

This `createRoutes` helper is only used in the `createSaveInProgressRoutes` helper, where the `ReviewPage` component is immediately overwritten by `RoutedSavableReviewPage`:

https://github.com/department-of-veterans-affairs/vets-website/blob/de5230a256a8c5262fe352e9fb3ff7755454ab9b/src/platform/forms/save-in-progress/helpers.js#L41-L47

This means that as of now, the `ReviewPage` component is not used in any production code. So, since _that_ means that the only production occurrence of `SubmitController` is in the `RoutedSavableReviewPage`component, where `renderErrorMessage` is set to true, we can effectively remove `renderErrorMessage` and the branching that its absence would cause since that is dead code.

## Testing done

Unit testing


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
