### PR TITLE
VACMS-12970 consume menus from endpoint b

### DIFF
--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -38,7 +38,7 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
   const clientOptions = { ...defaultClientOptions, ...clientOptionsArg };
   // Set up debug logging
   // eslint-disable-next-line no-console
-  const say = clientOptions.verbose ? console.log : () => {};
+  const say = clientOptions.verbose ? console.log : () => { };
 
   const envConfig = DRUPALS[buildOptions.buildtype];
   const drupalConfig = Object.assign({}, envConfig, buildArgs);
@@ -225,6 +225,16 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
         variables: {
           id: nodeId,
           today: moment().format('YYYY-MM-DD'),
+          onlyPublishedContent: false,
+        },
+      });
+    },
+
+    // Sets up the CMS SideNav Menus list.
+    async getSideNavigations() {
+      return this.query({
+        query: getQuery(queries.GET_HEALTH_SYSTEM_NAVS),
+        variables: {
           onlyPublishedContent: false,
         },
       });

--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -38,7 +38,7 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
   const clientOptions = { ...defaultClientOptions, ...clientOptionsArg };
   // Set up debug logging
   // eslint-disable-next-line no-console
-  const say = clientOptions.verbose ? console.log : () => { };
+  const say = clientOptions.verbose ? console.log : () => {};
 
   const envConfig = DRUPALS[buildOptions.buildtype];
   const drupalConfig = Object.assign({}, envConfig, buildArgs);

--- a/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
+++ b/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
@@ -6,7 +6,7 @@
 // String Helpers
 const { camelize } = require('./../../../../../utilities/stringHelpers');
 
-const { getsideNavsViaGraphQL } = require('../../metalsmith-drupal');
+const { getSideNavsViaGraphQL } = require('../../metalsmith-drupal');
 
 const FACILITY_SIDEBAR_QUERY = `
     name
@@ -63,14 +63,16 @@ const FACILITY_SIDEBAR_QUERY = `
 
 let compiledQuery = '';
 
-getsideNavsViaGraphQL.forEach(facilityMenuName => {
-  compiledQuery += `
+getSideNavsViaGraphQL().then(sideNavs => {
+  sideNavs.forEach(facilityMenuName => {
+    compiledQuery += `
          ${camelize(
-    facilityMenuName,
-  )}FacilitySidebarQuery: menuByName(name: "${facilityMenuName}") {
+           facilityMenuName,
+         )}FacilitySidebarQuery: menuByName(name: "${facilityMenuName}") {
             ${FACILITY_SIDEBAR_QUERY}
          }
         `;
+  });
 });
 
-module.exports = compiledQuery;*/
+module.exports = compiledQuery;

--- a/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
+++ b/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
@@ -5,26 +5,8 @@
 
 // String Helpers
 const { camelize } = require('./../../../../../utilities/stringHelpers');
-
-const FACILITY_MENU_NAMES = [
-  'pittsburgh-health-care',
-  'va-altoona-health-care',
-  'va-butler-health-care',
-  'va-cheyenne-health-care',
-  'va-coatesville-health-care',
-  'va-eastern-colorado-health-care',
-  'va-eastern-oklahoma-health-care',
-  'va-erie-health-care',
-  'va-lebanon',
-  'va-montana-health-care',
-  'va-oklahoma-health-care',
-  'va-philadelphia-health-care',
-  'va-salt-lake-city-health-care',
-  'va-sheridan-health-care',
-  'va-western-colorado-health-care',
-  'va-wilkes-barre-health-care',
-  'va-wilmington-health-care',
-];
+/* eslint-disable no-undef */
+const FACILITY_MENU_NAMES = cmsSideNavs;
 
 const FACILITY_SIDEBAR_QUERY = `
     name

--- a/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
+++ b/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
@@ -5,8 +5,8 @@
 
 // String Helpers
 const { camelize } = require('./../../../../../utilities/stringHelpers');
-/* eslint-disable no-undef */
-const FACILITY_MENU_NAMES = cmsSideNavs;
+
+const { getsideNavsViaGraphQL } = require('../../metalsmith-drupal');
 
 const FACILITY_SIDEBAR_QUERY = `
     name
@@ -63,14 +63,14 @@ const FACILITY_SIDEBAR_QUERY = `
 
 let compiledQuery = '';
 
-FACILITY_MENU_NAMES.forEach(facilityMenuName => {
+getsideNavsViaGraphQL.forEach(facilityMenuName => {
   compiledQuery += `
          ${camelize(
-           facilityMenuName,
-         )}FacilitySidebarQuery: menuByName(name: "${facilityMenuName}") {
+    facilityMenuName,
+  )}FacilitySidebarQuery: menuByName(name: "${facilityMenuName}") {
             ${FACILITY_SIDEBAR_QUERY}
          }
         `;
 });
 
-module.exports = compiledQuery;
+module.exports = compiledQuery;*/

--- a/src/site/stages/build/drupal/graphql/sideNavMenus.graphql.js
+++ b/src/site/stages/build/drupal/graphql/sideNavMenus.graphql.js
@@ -1,0 +1,3 @@
+module.exports = `{
+  sideNavMenus
+}`;

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -140,9 +140,9 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
  * @param {Object} buildOptions
  * @return {Object} - The result of the GraphQL query
  */
-async function getsideNavsViaGraphQL(buildOptions) {
+async function getSideNavsViaGraphQL(buildOptions = global.buildOptions) {
   global.buildtype = buildOptions.buildtype;
-  let SideNavs;
+  let sideNavs;
 
   const sideNavFile = path.join(
     buildOptions.cacheDirectory,
@@ -153,22 +153,22 @@ async function getsideNavsViaGraphQL(buildOptions) {
   if (shouldPullDrupal(buildOptions)) {
     const contentApi = getApiClient(buildOptions);
     log('Pulling side nav menus from Drupal...');
-    SideNavs = await contentApi.getSideNavigations();
+    sideNavs = await contentApi.getSideNavigations();
 
     // Write them to .cache/{buildtype}/drupal/side-nav-menus.json
     fs.ensureDirSync(buildOptions.cacheDirectory);
     fs.emptyDirSync(path.dirname(sideNavFile));
-    fs.writeJsonSync(sideNavFile, SideNavs, { spaces: 2 });
+    fs.writeJsonSync(sideNavFile, sideNavs, { spaces: 2 });
   } else {
     log('Using cached side navs');
-    SideNavs = fs.existsSync(sideNavFile) ? fs.readJsonSync(sideNavFile) : {};
+    sideNavs = fs.existsSync(sideNavFile) ? fs.readJsonSync(sideNavFile) : {};
   }
 
   if (global.verbose) {
-    log(`Drupal side navs:\n${JSON.stringify(SideNavs, null, 2)}`);
+    log(`Drupal side navs:\n${JSON.stringify(sideNavs, null, 2)}`);
   }
 
-  return SideNavs;
+  return sideNavs.sideNavMenus || [];
 }
 
 /**
@@ -296,7 +296,7 @@ async function loadCachedDrupalFiles(buildOptions, files) {
 function getDrupalContent(buildOptions) {
   if (!ENABLED_ENVIRONMENTS.has(buildOptions.buildtype)) {
     log(`Drupal integration disabled for buildtype ${buildOptions.buildtype}`);
-    return () => { };
+    return () => {};
   }
 
   return async (files, metalsmith, done) => {
@@ -330,4 +330,4 @@ function getDrupalContent(buildOptions) {
   };
 }
 
-module.exports = { getsideNavsViaGraphQL, getDrupalContent, shouldPullDrupal };
+module.exports = { getSideNavsViaGraphQL, getDrupalContent, shouldPullDrupal };

--- a/src/site/stages/build/drupal/queries.js
+++ b/src/site/stages/build/drupal/queries.js
@@ -1,6 +1,7 @@
 const queries = {
   GET_ALL_PAGES: './graphql/GetAllPages.graphql',
   GET_LATEST_PAGE_BY_ID: './graphql/GetLatestPageById.graphql',
+  GET_HEALTH_SYSTEM_NAVS: './graphql/sideNavMenus.graphql',
 };
 
 function getQuery(query, { useTomeSync } = {}) {

--- a/src/site/stages/build/index.js
+++ b/src/site/stages/build/index.js
@@ -94,6 +94,7 @@ function preserveWebpackOutput(metalsmithDestination, buildType) {
 }
 
 function build(BUILD_OPTIONS) {
+  global.buildOptions = BUILD_OPTIONS;
   const smith = silverSmith();
 
   registerLiquidFilters();

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -19,7 +19,6 @@ const { shouldPullDrupal } = require('./drupal/metalsmith-drupal');
 const { defaultCMSExportContentDir } = require('./process-cms-exports/helpers');
 const { logDrupal } = require('./drupal/utilities-drupal');
 const { useFlags } = require('./drupal/load-saved-flags');
-const DRUPALS = require('../../constants/drupals');
 
 const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'buildtype', type: String, defaultValue: defaultBuildtype },

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -19,6 +19,7 @@ const { shouldPullDrupal } = require('./drupal/metalsmith-drupal');
 const { defaultCMSExportContentDir } = require('./process-cms-exports/helpers');
 const { logDrupal } = require('./drupal/utilities-drupal');
 const { useFlags } = require('./drupal/load-saved-flags');
+const DRUPALS = require('../../constants/drupals');
 
 const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'buildtype', type: String, defaultValue: defaultBuildtype },
@@ -221,6 +222,69 @@ async function setUpFeatureFlags(options) {
   });
 }
 
+/**
+ * Sets up the CMS SideNav Menus list.
+ */
+async function setUpSideNavMenuList(options) {
+  global.buildtype = options.buildtype;
+  let SideNavs;
+
+  const sideNavFile = path.join(
+    options.cacheDirectory,
+    'drupal',
+    'side-nav-menus.json',
+  );
+
+  if (shouldPullDrupal(options)) {
+    logDrupal('Pulling side nav menus from Drupal...');
+    const apiClient = getDrupalClient(options);
+    const envConfig = DRUPALS[global.buildtype];
+    const drupalConfig = Object.assign({}, envConfig);
+    const { user, password } = drupalConfig;
+
+    const encodedCredentials = Buffer.from(`${user}:${password}`).toString(
+      'base64',
+    );
+    const result = await apiClient.proxyFetch(
+      `${apiClient.getSiteUri()}/graphql/`,
+      {
+        headers: {
+          Authorization: `Basic ${encodedCredentials}`,
+          'Content-Type': 'application/json',
+        },
+        method: 'post',
+        body: JSON.stringify({
+          query: `{
+         sideNavMenus
+       }`,
+        }),
+      },
+    );
+
+    const responseBody = await result.text();
+    try {
+      SideNavs = JSON.parse(responseBody).data.sideNavMenus;
+    } catch (e) {
+      throw new TypeError(
+        `Could not parse Drupal side nav menus. Response:\n${responseBody}`,
+      );
+    }
+
+    // Write them to .cache/{buildtype}/drupal/side-nav-menus.json
+    fs.ensureDirSync(options.cacheDirectory);
+    fs.emptyDirSync(path.dirname(sideNavFile));
+    fs.writeJsonSync(sideNavFile, SideNavs, { spaces: 2 });
+  } else {
+    logDrupal('Using cached side navs');
+    SideNavs = fs.existsSync(sideNavFile) ? fs.readJsonSync(sideNavFile) : {};
+  }
+
+  if (global.verbose) {
+    logDrupal(`Drupal side navs:\n${JSON.stringify(SideNavs, null, 2)}`);
+  }
+  global.cmsSideNavs = SideNavs;
+}
+
 async function getOptions(commandLineOptions) {
   const options = commandLineOptions || gatherFromCommandLine();
 
@@ -228,6 +292,7 @@ async function getOptions(commandLineOptions) {
   applyEnvironmentOverrides(options);
   deriveHostUrl(options);
   await setUpFeatureFlags(options);
+  await setUpSideNavMenuList(options);
 
   // Setting verbosity for the whole content build process as global so we don't
   // have to pass the buildOptions around for just that.


### PR DESCRIPTION
## Description
Currently, array of drupal system menus fed into graphql query is hardcoded. This pr adds logic to grab system menu names from graphql endpoint

This pr attempts to refactor https://github.com/department-of-veterans-affairs/vets-website/pull/14488 per @ncksllvn 's suggestions.

The backend piece for this is complete, so merging this pr and releasing to prod will be able to consume drupal menu data, sans hardcode method.

cc: @mmiddaugh 