### PR TITLE
Clear local storage before SSOe tests

### DIFF
--- a/src/platform/utilities/tests/sso.unit.spec.js
+++ b/src/platform/utilities/tests/sso.unit.spec.js
@@ -293,6 +293,10 @@ describe('checkAutoSession', () => {
 });
 
 describe('checkAndUpdateSSOeSession', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it('should should do nothing if there is not SSO session active', () => {
     expect(localStorage.getItem('sessionExpirationSSO')).to.be.null;
     checkAndUpdateSSOeSession();


### PR DESCRIPTION
## Description
Sometimes there's already a value in `sessionExpirationSSO` (ex: http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fvets-website/detail/remove-dashboard-dependency-cv/11/tests) when the tests run, which breaks one of them. This specifically clears local storage before the test runs.

## Testing done
Unit testing

## Acceptance criteria
- [ ] Tests pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
