### PR TITLE
Tag all published pacts

### DIFF
--- a/script/publish-pacts.js
+++ b/script/publish-pacts.js
@@ -9,11 +9,13 @@ const fs = require('fs');
 const path = require('path');
 const pact = require('@pact-foundation/pact-node');
 
-const pactsFolder = path.resolve(__dirname, '../pacts');
+let pactFilesOrDirs = [];
 
 try {
+  const pactsFolder = path.resolve(__dirname, '../pacts');
   const pactFiles = fs.readdirSync(pactsFolder);
   if (!pactFiles.length) throw new Error('No pacts found.');
+  pactFilesOrDirs = pactFiles.map(pactFile => path.join(pactsFolder, pactFile));
 } catch (e) {
   console.warn(e.message);
   console.log('Skipping pact publishing.');
@@ -32,7 +34,7 @@ const opts = {
   pactBroker: process.env.PACT_BROKER_URL,
   pactBrokerUsername: process.env.PACT_BROKER_BASIC_AUTH_USERNAME,
   pactBrokerPassword: process.env.PACT_BROKER_BASIC_AUTH_PASSWORD,
-  pactFilesOrDirs: [pactsFolder],
+  pactFilesOrDirs,
   consumerVersion,
   tags: [branchName],
 };

--- a/script/publish-pacts.js
+++ b/script/publish-pacts.js
@@ -9,13 +9,13 @@ const fs = require('fs');
 const path = require('path');
 const pact = require('@pact-foundation/pact-node');
 
-let pactFilesOrDirs = [];
+let pactPaths = [];
 
 try {
   const pactsFolder = path.resolve(__dirname, '../pacts');
   const pactFiles = fs.readdirSync(pactsFolder);
   if (!pactFiles.length) throw new Error('No pacts found.');
-  pactFilesOrDirs = pactFiles.map(pactFile => path.join(pactsFolder, pactFile));
+  pactPaths = pactFiles.map(pactFile => path.join(pactsFolder, pactFile));
 } catch (e) {
   console.warn(e.message);
   console.log('Skipping pact publishing.');
@@ -34,16 +34,23 @@ const opts = {
   pactBroker: process.env.PACT_BROKER_URL,
   pactBrokerUsername: process.env.PACT_BROKER_BASIC_AUTH_USERNAME,
   pactBrokerPassword: process.env.PACT_BROKER_BASIC_AUTH_PASSWORD,
-  pactFilesOrDirs,
   consumerVersion,
   tags: [branchName],
 };
 
-pact
-  .publishPacts(opts)
-  .then(() => {
+// Individually publish each pact instead of the whole directory in order
+// to properly tag them all. The Pact client was not originally meant to
+// publish multiple pacts at once but is able to anyway. But as a result,
+// tagging multiple pacts at once is not supported until a future release.
+// https://github.com/pact-foundation/pact-js/issues/289
+const publishPact = async pactPath => {
+  try {
+    await pact.publishPacts({ ...opts, pactFilesOrDirs: [pactPath] });
     console.log('Pact successfully published!');
-  })
-  .catch(e => {
-    console.log(`Pact failed to publish: ${e}`);
-  });
+  } catch (e) {
+    console.log(`Pact at ${pactPath} failed to publish: ${e}`);
+    process.exit(1);
+  }
+};
+
+pactPaths.forEach(publishPact);


### PR DESCRIPTION
## Description
Even though all pacts have been getting published, only one of them has been getting tagged. This is a fix to make sure all pacts are tagged when they get published. Fixes department-of-veterans-affairs/va.gov-team#14667.

In the comments, I've linked the relevant official Pact issue which explains that the client wasn't intended to publish pacts for multiple consumers. Even though it is actually able to do that, it isn't officially supported, so it makes sense that tagging pacts for multiple consumers isn't officially supported either. It's expected to be fixed in an upcoming release, but that versison is not officially out yet.

## Testing done
Ran the build to see to the results of the pact publishing job. All pacts are getting tagged now.

## Acceptance criteria
- [ ] All published pacts should be tagged.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
