### PR TITLE
Add encodeURI to image URL

### DIFF
--- a/src/site/stages/build/process-cms-exports/transformers/helpers.js
+++ b/src/site/stages/build/process-cms-exports/transformers/helpers.js
@@ -168,17 +168,6 @@ module.exports = {
   },
 
   /**
-   * Takes a string and applies the following:
-   * - Encodes special characters
-   *
-   * @param {string}
-   * @return {string}
-   */
-  setEncodedString(value) {
-    return encodeURI(value);
-  },
-
-  /**
    * Takes an array meant to contain only one object.
    * If this object exists, an object will be returned matching what is expected for "fieldLink" objects,
    * otherwise null is returned.

--- a/src/site/stages/build/process-cms-exports/transformers/helpers.js
+++ b/src/site/stages/build/process-cms-exports/transformers/helpers.js
@@ -168,6 +168,17 @@ module.exports = {
   },
 
   /**
+   * Takes a string and applies the following:
+   * - Encodes special characters
+   *
+   * @param {string}
+   * @return {string}
+   */
+  setEncodedString(value) {
+    return encodeURI(value);
+  },
+
+  /**
    * Takes an array meant to contain only one object.
    * If this object exists, an object will be returned matching what is expected for "fieldLink" objects,
    * otherwise null is returned.

--- a/src/site/stages/build/process-cms-exports/transformers/media-image.js
+++ b/src/site/stages/build/process-cms-exports/transformers/media-image.js
@@ -1,8 +1,4 @@
-const {
-  createMetaTagArray,
-  getDrupalValue,
-  setEncodedString,
-} = require('./helpers');
+const { createMetaTagArray, getDrupalValue } = require('./helpers');
 
 const transform = entity => ({
   entityType: 'media',
@@ -15,9 +11,9 @@ const transform = entity => ({
   image: {
     alt: entity.image[0].alt || '',
     title: entity.image[0].title || '',
-    url: setEncodedString(entity.thumbnail[0].url),
+    url: encodeURI(entity.thumbnail[0].url),
     derivative: {
-      url: setEncodedString(entity.thumbnail[0].url),
+      url: encodeURI(entity.thumbnail[0].url),
       width: entity.image[0].width,
       height: entity.image[0].height,
     },

--- a/src/site/stages/build/process-cms-exports/transformers/media-image.js
+++ b/src/site/stages/build/process-cms-exports/transformers/media-image.js
@@ -1,4 +1,8 @@
-const { createMetaTagArray, getDrupalValue } = require('./helpers');
+const {
+  createMetaTagArray,
+  getDrupalValue,
+  setEncodedString,
+} = require('./helpers');
 
 const transform = entity => ({
   entityType: 'media',
@@ -11,9 +15,9 @@ const transform = entity => ({
   image: {
     alt: entity.image[0].alt || '',
     title: entity.image[0].title || '',
-    url: entity.thumbnail[0].url,
+    url: setEncodedString(entity.thumbnail[0].url),
     derivative: {
-      url: entity.thumbnail[0].url,
+      url: setEncodedString(entity.thumbnail[0].url),
       width: entity.image[0].width,
       height: entity.image[0].height,
     },


### PR DESCRIPTION
## Description
When comparing HTML builds you can see white spaces in the image URLs. This PR will fixed this issue by encoding the URL

## Testing done
Running `diff -ur graphql-localhost/pittsburgh-health-care/leadership/index.html localhost/pittsburgh-health-care/leadership/index.html | delta`

## Screenshots

![Screen Shot 2020-10-12 at 11 28 19 AM](https://user-images.githubusercontent.com/55560129/95776394-3b9f8280-0c92-11eb-8abe-31b4afbd7f5c.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
