### PR TITLE
Updated skip to E.Y.B. link on profile page.

### DIFF
--- a/src/applications/gi/components/profile/EstimateYourBenefitsForm.jsx
+++ b/src/applications/gi/components/profile/EstimateYourBenefitsForm.jsx
@@ -1041,9 +1041,9 @@ class EstimateYourBenefitsForm extends React.Component {
 
   renderEYBSkipLink = () => {
     return (
-      <div className="vads-u-padding-bottom--2p5">
+      <div className="vads-u-padding-top--1 ">
         <a
-          className="va-button-link learn-more-button eyb-skip-link"
+          className="va-button-link learn-more-button eyb-skip-link vads-u-display--block"
           aria-label="Skip to your estimated benefits"
           href="#estimated-benefits"
         >

--- a/src/applications/gi/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi/sass/partials/_gi-profile-page.scss
@@ -502,6 +502,10 @@
 
     &:focus {
       top: auto;
+      line-height: 50px;
+      margin-bottom: 1em;
+      position: relative;
+      outline : none;
     }
   }
 }


### PR DESCRIPTION
## Description
As a touch screen user, I want to be able to click or press the Skip to your estimated benefits link without accidentally bumping the Update benefits button.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/14409
## Testing done
local testing

## Screenshots
![Screen Shot 2020-10-13 at 8 48 50 AM](https://user-images.githubusercontent.com/50601724/95862524-0a29c400-0d31-11eb-9af1-b0f605a7dde0.png)
## Acceptance criteria
- [x] Skip to your estimated benefits link is at least 44px tall on all devices
- [x] Skip to your estimated benefits link has 12-14px of clear space above and below it

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
