### PR TITLE
remove 'gibct_filter_enhancement' flag usage

### DIFF
--- a/src/applications/caregivers/tests/e2e/fixtures/mocks/feature-toggles.json
+++ b/src/applications/caregivers/tests/e2e/fixtures/mocks/feature-toggles.json
@@ -135,10 +135,6 @@
         "value": true
       },
       {
-        "name": "gibctFilterEnhancement",
-        "value": true
-      },
-      {
         "name": "debtLettersShowLetters",
         "value": true
       },

--- a/src/applications/debt-letters/tests/e2e/fixtures/mocks/feature-toggles.json
+++ b/src/applications/debt-letters/tests/e2e/fixtures/mocks/feature-toggles.json
@@ -35,7 +35,6 @@
       { "name": "gibctEybBottomSheet", "value": true },
       { "name": "gibctSearchEnhancements", "value": true },
       { "name": "form996HigherLevelReview", "value": true },
-      { "name": "gibctFilterEnhancement", "value": true },
       { "name": "debtLettersShowLetters", "value": true },
       { "name": "gibctCh33BenefitRateUpdate", "value": true }
     ]

--- a/src/applications/gi/components/profile/HeadingSummary.jsx
+++ b/src/applications/gi/components/profile/HeadingSummary.jsx
@@ -153,20 +153,18 @@ class HeadingSummary extends React.Component {
               </IconWithInfo>
             </div>
           </div>
-          {this.props.gibctFilterEnhancement && (
-            <div className="row vads-u-padding-top--1p5">
-              <div className="view-details columns vads-u-display--inline-block">
-                <ScorecardTags
-                  styling={'info-flag'}
-                  it={this.props.institution}
-                  menOnly={this.props.institution.menOnly}
-                  womenOnly={this.props.institution.womenOnly}
-                  hbcu={this.props.institution.hbcu}
-                  relAffil={this.props.institution.relAffil}
-                />
-              </div>
+          <div className="row vads-u-padding-top--1p5">
+            <div className="view-details columns vads-u-display--inline-block">
+              <ScorecardTags
+                styling={'info-flag'}
+                it={this.props.institution}
+                menOnly={this.props.institution.menOnly}
+                womenOnly={this.props.institution.womenOnly}
+                hbcu={this.props.institution.hbcu}
+                relAffil={this.props.institution.relAffil}
+              />
             </div>
-          )}
+          </div>
         </div>
         <AdditionalResources />
       </div>

--- a/src/applications/gi/components/profile/HeadingSummary.jsx
+++ b/src/applications/gi/components/profile/HeadingSummary.jsx
@@ -156,7 +156,7 @@ class HeadingSummary extends React.Component {
           <div className="row vads-u-padding-top--1p5">
             <div className="view-details columns vads-u-display--inline-block">
               <ScorecardTags
-                styling={'info-flag'}
+                styling="info-flag"
                 it={this.props.institution}
                 menOnly={this.props.institution.menOnly}
                 womenOnly={this.props.institution.womenOnly}

--- a/src/applications/gi/components/profile/InstitutionProfile.jsx
+++ b/src/applications/gi/components/profile/InstitutionProfile.jsx
@@ -40,7 +40,6 @@ export class InstitutionProfile extends React.Component {
       constants,
       showModal,
       gibctEybBottomSheet,
-      gibctFilterEnhancement,
       gibctSchoolRatings,
     } = this.props;
 
@@ -55,7 +54,6 @@ export class InstitutionProfile extends React.Component {
         <HeadingSummary
           institution={profile.attributes}
           onLearnMore={showModal.bind(this, 'gibillstudents')}
-          gibctFilterEnhancement={gibctFilterEnhancement}
           gibctSchoolRatings={gibctSchoolRatings}
         />
         <div className="usa-accordion vads-u-margin-top--4">

--- a/src/applications/gi/components/search/InstitutionFilterForm.jsx
+++ b/src/applications/gi/components/search/InstitutionFilterForm.jsx
@@ -28,7 +28,6 @@ class InstitutionFilterForm extends React.Component {
       onChange={this.handleDropdownChange}
       handleInputFocus={this.props.handleInputFocus}
       displayAllOption
-      gibctFilterEnhancement={this.props.gibctFilterEnhancement}
     />
   );
 
@@ -142,11 +141,7 @@ class InstitutionFilterForm extends React.Component {
 
     return (
       <Dropdown
-        label={
-          this.props.gibctFilterEnhancement
-            ? 'Institution categories'
-            : 'Institution type'
-        }
+        label={'Institution categories'}
         name="type"
         options={options}
         value={this.props.filters.type}
@@ -159,33 +154,11 @@ class InstitutionFilterForm extends React.Component {
   };
 
   render() {
-    if (this.props.gibctFilterEnhancement) {
-      return (
-        <div className="institution-filter-form">
-          {this.renderCountryFilter()}
-          {this.renderStateFilter()}
-
-          {
-            <CautionaryWarningsFilter
-              excludeCautionFlags={this.props.filters.excludeCautionFlags}
-              excludeWarnings={this.props.filters.excludeWarnings}
-              onChange={this.handleCheckboxChange}
-              showModal={this.props.showModal}
-              handleInputFocus={this.props.handleInputFocus}
-            />
-          }
-          {this.renderCategoryFilter()}
-          {this.renderTypeFilter()}
-          {this.renderProgramFilters()}
-        </div>
-      );
-    }
     return (
       <div className="institution-filter-form">
-        <h2>Institution details</h2>
-        {this.renderCategoryFilter()}
         {this.renderCountryFilter()}
         {this.renderStateFilter()}
+
         {
           <CautionaryWarningsFilter
             excludeCautionFlags={this.props.filters.excludeCautionFlags}
@@ -195,8 +168,9 @@ class InstitutionFilterForm extends React.Component {
             handleInputFocus={this.props.handleInputFocus}
           />
         }
-        {this.renderProgramFilters()}
+        {this.renderCategoryFilter()}
         {this.renderTypeFilter()}
+        {this.renderProgramFilters()}
       </div>
     );
   }

--- a/src/applications/gi/components/search/InstitutionFilterForm.jsx
+++ b/src/applications/gi/components/search/InstitutionFilterForm.jsx
@@ -141,7 +141,7 @@ class InstitutionFilterForm extends React.Component {
 
     return (
       <Dropdown
-        label={'Institution categories'}
+        label="Institution categories"
         name="type"
         options={options}
         value={this.props.filters.type}

--- a/src/applications/gi/components/search/InstitutionSearchForm.jsx
+++ b/src/applications/gi/components/search/InstitutionSearchForm.jsx
@@ -53,7 +53,7 @@ function InstitutionSearchForm({
           <h2>Refine search</h2>
           <KeywordSearch
             autocomplete={autocomplete}
-            label={'Enter a school, location, or employer name'}
+            label="Enter a school, location, or employer name"
             location={location}
             onClearAutocompleteSuggestions={clearAutocompleteSuggestions}
             onFetchAutocompleteSuggestions={fetchAutocompleteSuggestions}

--- a/src/applications/gi/components/search/InstitutionSearchForm.jsx
+++ b/src/applications/gi/components/search/InstitutionSearchForm.jsx
@@ -18,7 +18,6 @@ function InstitutionSearchForm({
   fetchAutocompleteSuggestions,
   filters,
   filtersClass,
-  gibctFilterEnhancement,
   handleFilterChange,
   hideModal,
   location,
@@ -46,20 +45,15 @@ function InstitutionSearchForm({
     }
   }
 
-  const header = gibctFilterEnhancement ? 'Refine search' : 'Keywords';
-  const keywordSearchLabel = gibctFilterEnhancement
-    ? 'Enter a school, location, or employer name'
-    : 'City, school, or employer';
-
   return (
     <div className="row">
       <div id="institution-search" className={filtersClass}>
         <div className="filters-sidebar-inner vads-u-margin-left--1p5">
           {search.filterOpened && <h1>Filter your search</h1>}
-          <h2>{header}</h2>
+          <h2>''Refine search''</h2>
           <KeywordSearch
             autocomplete={autocomplete}
-            label={keywordSearchLabel}
+            label={'Enter a school, location, or employer name'}
             location={location}
             onClearAutocompleteSuggestions={clearAutocompleteSuggestions}
             onFetchAutocompleteSuggestions={fetchAutocompleteSuggestions}
@@ -72,7 +66,6 @@ function InstitutionSearchForm({
             handleFilterChange={handleFilterChange}
             showModal={showModal}
             handleInputFocus={handleInstitutionSearchInputFocus}
-            gibctFilterEnhancement={gibctFilterEnhancement}
           />
           <BenefitsForm
             eligibilityChange={eligibilityChange}
@@ -81,14 +74,12 @@ function InstitutionSearchForm({
             showModal={showModal}
             showHeader
             handleInputFocus={handleInstitutionSearchInputFocus}
-            gibctFilterEnhancement={gibctFilterEnhancement}
           />
           <OnlineClassesFilter
             onlineClasses={eligibility.onlineClasses}
             onChange={eligibilityChange}
             showModal={showModal}
             handleInputFocus={handleInstitutionSearchInputFocus}
-            gibctFilterEnhancement={gibctFilterEnhancement}
           />
         </div>
         <div id="see-results-button" className="results-button">

--- a/src/applications/gi/components/search/InstitutionSearchForm.jsx
+++ b/src/applications/gi/components/search/InstitutionSearchForm.jsx
@@ -50,7 +50,7 @@ function InstitutionSearchForm({
       <div id="institution-search" className={filtersClass}>
         <div className="filters-sidebar-inner vads-u-margin-left--1p5">
           {search.filterOpened && <h1>Filter your search</h1>}
-          <h2>''Refine search''</h2>
+          <h2>Refine search</h2>
           <KeywordSearch
             autocomplete={autocomplete}
             label={'Enter a school, location, or employer name'}

--- a/src/applications/gi/components/search/RatedSearchResult.jsx
+++ b/src/applications/gi/components/search/RatedSearchResult.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import appendQuery from 'append-query';
 import { Link } from 'react-router-dom';
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import { estimatedBenefits } from '../../selectors/estimator';
 import {
   convertRatingToStars,
@@ -20,7 +18,6 @@ import {
 import ScorecardTags from '../../components/ScorecardTags';
 
 export function RatedSearchResult({
-  gibctFilterEnhancement,
   schoolClosing,
   schoolClosingOn,
   estimated,
@@ -150,17 +147,15 @@ export function RatedSearchResult({
               </div>
             )}
 
-            {gibctFilterEnhancement && (
-              <div className="small-12  medium-5 columns">
-                <ScorecardTags
-                  styling="search-result-tag"
-                  menOnly={menOnly}
-                  womenOnly={womenOnly}
-                  hbcu={hbcu}
-                  relAffil={relAffil}
-                />
-              </div>
-            )}
+            <div className="small-12  medium-5 columns">
+              <ScorecardTags
+                styling="search-result-tag"
+                menOnly={menOnly}
+                womenOnly={womenOnly}
+                hbcu={hbcu}
+                relAffil={relAffil}
+              />
+            </div>
           </div>
           <div className="row">
             <div className="columns">
@@ -175,9 +170,6 @@ export function RatedSearchResult({
 
 const mapStateToProps = (state, props) => ({
   estimated: estimatedBenefits(state, props),
-  gibctFilterEnhancement: toggleValues(state)[
-    FEATURE_FLAG_NAMES.gibctFilterEnhancement
-  ],
 });
 
 export default connect(mapStateToProps)(RatedSearchResult);

--- a/src/applications/gi/components/search/SearchResult.jsx
+++ b/src/applications/gi/components/search/SearchResult.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import appendQuery from 'append-query';
 import { Link } from 'react-router-dom';
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import { estimatedBenefits } from '../../selectors/estimator';
 import {
   formatCurrency,
@@ -18,7 +16,6 @@ import {
 import ScorecardTags from '../../components/ScorecardTags';
 
 export function SearchResult({
-  gibctFilterEnhancement,
   schoolClosing,
   schoolClosingOn,
   estimated,
@@ -125,17 +122,15 @@ export function SearchResult({
               </div>
             </div>
           </div>
-          {gibctFilterEnhancement && (
-            <div className="tag-container">
-              <ScorecardTags
-                styling="search-result-tag"
-                menOnly={menOnly}
-                womenOnly={womenOnly}
-                hbcu={hbcu}
-                relAffil={relAffil}
-              />
-            </div>
-          )}
+          <div className="tag-container">
+            <ScorecardTags
+              styling="search-result-tag"
+              menOnly={menOnly}
+              womenOnly={womenOnly}
+              hbcu={hbcu}
+              relAffil={relAffil}
+            />
+          </div>
           <div className="row">
             <div className="view-details columns">
               <Link to={profileLink}>View details ›</Link>
@@ -149,9 +144,6 @@ export function SearchResult({
 
 const mapStateToProps = (state, props) => ({
   estimated: estimatedBenefits(state, props),
-  gibctFilterEnhancement: toggleValues(state)[
-    FEATURE_FLAG_NAMES.gibctFilterEnhancement
-  ],
 });
 
 export default connect(mapStateToProps)(SearchResult);

--- a/src/applications/gi/components/search/SearchResultTypeOfInstitutionFilter.jsx
+++ b/src/applications/gi/components/search/SearchResultTypeOfInstitutionFilter.jsx
@@ -6,7 +6,6 @@ function SearchResultTypeOfInstitutionFilter({
   category,
   onChange,
   handleInputFocus,
-  gibctFilterEnhancement,
 }) {
   const options = [
     {
@@ -25,11 +24,7 @@ function SearchResultTypeOfInstitutionFilter({
 
   return (
     <RadioButtons
-      label={
-        gibctFilterEnhancement
-          ? 'Select an institution type'
-          : 'Type of institution'
-      }
+      label={'Select an institution type'}
       name="category"
       options={options}
       value={category}

--- a/src/applications/gi/components/search/SearchResultTypeOfInstitutionFilter.jsx
+++ b/src/applications/gi/components/search/SearchResultTypeOfInstitutionFilter.jsx
@@ -24,7 +24,7 @@ function SearchResultTypeOfInstitutionFilter({
 
   return (
     <RadioButtons
-      label={'Select an institution type'}
+      label="Select an institution type"
       name="category"
       options={options}
       value={category}

--- a/src/applications/gi/containers/ProfilePage.jsx
+++ b/src/applications/gi/containers/ProfilePage.jsx
@@ -25,7 +25,6 @@ export function ProfilePage({
   dispatchHideModal,
   eligibility,
   gibctEybBottomSheet,
-  gibctFilterEnhancement,
   gibctSchoolRatings,
   match,
 }) {
@@ -89,7 +88,6 @@ export function ProfilePage({
           eligibility={eligibility}
           version={version}
           gibctEybBottomSheet={gibctEybBottomSheet}
-          gibctFilterEnhancement={gibctFilterEnhancement}
           gibctSchoolRatings={gibctSchoolRatings}
         />
       );
@@ -120,9 +118,6 @@ const mapStateToProps = state => {
     eligibility,
     gibctEybBottomSheet: toggleValues(state)[
       FEATURE_FLAG_NAMES.gibctEybBottomSheet
-    ],
-    gibctFilterEnhancement: toggleValues(state)[
-      FEATURE_FLAG_NAMES.gibctFilterEnhancement
     ],
     gibctSchoolRatings: toggleValues(state)[
       FEATURE_FLAG_NAMES.gibctSchoolRatings

--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -48,7 +48,6 @@ export function SearchPage({
   dispatchUpdateAutocompleteSearchTerm,
   eligibility,
   filters,
-  gibctFilterEnhancement,
   gibctSearchEnhancements,
   gibctSchoolRatings,
   search,
@@ -274,7 +273,6 @@ export function SearchPage({
           showModal={dispatchShowModal}
           eligibilityChange={dispatchEligibilityChange}
           hideModal={dispatchHideModal}
-          gibctFilterEnhancement={gibctFilterEnhancement}
         />
       </div>
     );
@@ -298,9 +296,6 @@ const mapStateToProps = state => ({
   eligibility: state.eligibility,
   gibctSearchEnhancements: toggleValues(state)[
     FEATURE_FLAG_NAMES.gibctSearchEnhancements
-  ],
-  gibctFilterEnhancement: toggleValues(state)[
-    FEATURE_FLAG_NAMES.gibctFilterEnhancement
   ],
   gibctSchoolRatings: toggleValues(state)[
     FEATURE_FLAG_NAMES.gibctSchoolRatings

--- a/src/applications/gi/tests/components/search/InstitutionSearchForm.unit.spec.jsx
+++ b/src/applications/gi/tests/components/search/InstitutionSearchForm.unit.spec.jsx
@@ -20,7 +20,6 @@ describe('<InstitutionSearchForm>', () => {
         filtersClass={filtersClass}
         search={search}
         eligibility={eligibility}
-        gibctFilterEnhancement
       />,
     );
     expect(wrapper).to.not.be.undefined;

--- a/src/applications/gi/tests/components/search/SearchResult.unit.spec.jsx
+++ b/src/applications/gi/tests/components/search/SearchResult.unit.spec.jsx
@@ -45,21 +45,4 @@ describe('<SearchResult>', () => {
     expect(vdom).to.not.be.undefined;
     tree.unmount();
   });
-
-  it('should render with gibctFilterEnhancement feature flag', () => {
-    const tree = mount(
-      <MemoryRouter>
-        <SearchResult
-          estimated={estimated}
-          womenOnly={result.womenonly}
-          menOnly={result.menonly}
-          {...result}
-          gibctFilterEnhancement
-        />
-      </MemoryRouter>,
-    );
-    const vdom = tree.html();
-    expect(vdom).to.not.be.undefined;
-    tree.unmount();
-  });
 });

--- a/src/applications/healthcare/questionnaire/tests/e2e/fixtures/mocks/feature-toggles.disabled.json
+++ b/src/applications/healthcare/questionnaire/tests/e2e/fixtures/mocks/feature-toggles.disabled.json
@@ -131,10 +131,6 @@
            "value":true
         },
         {
-           "name":"gibctFilterEnhancement",
-           "value":true
-        },
-        {
            "name":"debtLettersShowLetters",
            "value":true
         },

--- a/src/applications/healthcare/questionnaire/tests/e2e/fixtures/mocks/feature-toggles.enabled.json
+++ b/src/applications/healthcare/questionnaire/tests/e2e/fixtures/mocks/feature-toggles.enabled.json
@@ -131,10 +131,6 @@
            "value":true
         },
         {
-           "name":"gibctFilterEnhancement",
-           "value":true
-        },
-        {
            "name":"debtLettersShowLetters",
            "value":true
         },

--- a/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/disabled.json
+++ b/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/disabled.json
@@ -127,10 +127,6 @@
         "value": false
       },
       {
-        "name": "gibctFilterEnhancement",
-        "value": false
-      },
-      {
         "name": "debtLettersShowLetters",
         "value": false
       },

--- a/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/enabled.json
+++ b/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/enabled.json
@@ -127,10 +127,6 @@
         "value": true
       },
       {
-        "name": "gibctFilterEnhancement",
-        "value": true
-      },
-      {
         "name": "debtLettersShowLetters",
         "value": true
       },

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -33,7 +33,6 @@ export default Object.freeze({
   allowOnline1010cgSubmissions: 'allow_online_10_10cg_submissions',
   gibctEybBottomSheet: 'gibctEybBottomSheet',
   gibctSearchEnhancements: 'gibctSearchEnhancements',
-  gibctFilterEnhancement: 'gibctFilterEnhancement',
   gibctBenefitFilterEnhancement: 'gibctBenefitFilterEnhancement',
   gibctSchoolRatings: 'gibctSchoolRatings',
   form996HigherLevelReview: 'form996HigherLevelReview',


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/13363


## Testing done
dev tested

## Screenshots


## Acceptance criteria
- [x] The feature flag 'gibct_filter_enhancement' is removed.
- [x] The feature flag is not displayed here: https://[environment]-api.va.gov/flipper/features.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
