### PR TITLE
Added gold outline to EYB link

### DIFF
--- a/src/applications/gi/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi/sass/partials/_gi-profile-page.scss
@@ -505,7 +505,6 @@
       line-height: 50px;
       margin-bottom: 1em;
       position: relative;
-      outline : none;
     }
   }
 }


### PR DESCRIPTION
## Description
As a touch screen user, I want to be able to click or press the Skip to your estimated benefits link without accidentally bumping the Update benefits button.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/14409

## Testing done

local
## Screenshots

![Screen Shot 2020-10-13 at 2 34 59 PM](https://user-images.githubusercontent.com/50601724/95901419-4c6af980-0d61-11eb-9a8f-1539fd4e4fe0.png)

## Acceptance criteria
- [x] added link outline

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
