### PR TITLE
Contact Us confirmation page styling fixes

### DIFF
--- a/src/applications/ask-a-question/containers/ConfirmationPage.jsx
+++ b/src/applications/ask-a-question/containers/ConfirmationPage.jsx
@@ -41,9 +41,7 @@ export class ConfirmationPage extends React.Component {
           <i>Please print this page for your records.</i>
         </p>
         <div className="inset">
-          <h4>
-            Contact us form <span className="additional">(Form 0873)</span>
-          </h4>
+          <h3 className="confirmation-page-inset-title">Your message</h3>
           <span>
             for {name.first} {name.middle} {name.last} {name.suffix}
           </span>

--- a/src/applications/ask-a-question/sass/ask-a-question.scss
+++ b/src/applications/ask-a-question/sass/ask-a-question.scss
@@ -18,3 +18,10 @@
 textarea#root_query {
   height: 40rem;
 }
+
+ul.claim-list {
+  margin-bottom: 0;
+  & li:last-child {
+    margin-bottom: 0;
+  }
+}


### PR DESCRIPTION
## Description
[department-of-veterans-affairs/orchid#76]
- updates h4 to be an h3, title is now 'Your message'
- removes excess space on top/bottom of blue inset box

## Testing done


## Screenshots
<img width="679" alt="Screen Shot 2020-10-13 at 17 54 06" src="https://user-images.githubusercontent.com/19177102/95920574-a5e12180-0d7d-11eb-8cf7-7bc5b467330a.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
