### PR TITLE
Use more granular selector to show/hide Cerner appt widget

### DIFF
--- a/src/applications/personalization/dashboard/components/ManageYourVAHealthCare.jsx
+++ b/src/applications/personalization/dashboard/components/ManageYourVAHealthCare.jsx
@@ -13,7 +13,7 @@ import {
   renderWidgetDowntimeNotification,
 } from '../helpers';
 
-import { selectIsCernerPatient } from 'platform/user/selectors';
+import { selectCernerAppointmentsFacilities } from 'platform/user/selectors';
 
 import MessagingWidget from '../containers/MessagingWidget';
 import PrescriptionsWidget from '../containers/PrescriptionsWidget';
@@ -97,7 +97,7 @@ const ManageYourVAHealthCare = ({
   isEnrolledInHealthCare,
   preferredFacility,
   showServerError,
-  showCernerWidget,
+  showCernerAppointmentWidget,
 }) => (
   <>
     <h2>Manage your VA health care</h2>
@@ -157,9 +157,9 @@ const ManageYourVAHealthCare = ({
       <PrescriptionsWidget />
     </DowntimeNotification>
     {isEnrolledInHealthCare &&
-      !showCernerWidget && <ScheduleAnAppointmentWidget />}
+      !showCernerAppointmentWidget && <ScheduleAnAppointmentWidget />}
     {isEnrolledInHealthCare &&
-      showCernerWidget && <ScheduleAnAppointmentCernerWidget />}
+      showCernerAppointmentWidget && <ScheduleAnAppointmentCernerWidget />}
   </>
 );
 
@@ -167,7 +167,9 @@ const mapStateToProps = state => {
   const isEnrolledInHealthCare = isEnrolledInVAHealthCare(state);
   const hcaEnrollmentStatus = selectEnrollmentStatus(state);
   const showServerError = hasESRServerError(state);
-  const showCernerWidget = selectIsCernerPatient(state);
+  const showCernerAppointmentWidget = !!selectCernerAppointmentsFacilities(
+    state,
+  )?.length;
   const {
     applicationDate,
     enrollmentDate,
@@ -180,7 +182,7 @@ const mapStateToProps = state => {
     isEnrolledInHealthCare,
     preferredFacility,
     showServerError,
-    showCernerWidget,
+    showCernerAppointmentWidget,
   };
 };
 

--- a/src/platform/user/selectors.js
+++ b/src/platform/user/selectors.js
@@ -1,7 +1,12 @@
 // TODO: perhaps make these selectors fail gracefully if state.user, or any of
 // the properties on the user object are not defined
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
-import { CERNER_FACILITY_IDS } from '../utilities/cerner';
+import {
+  CERNER_APPOINTMENTS_BLOCKLIST,
+  CERNER_FACILITY_IDS,
+  CERNER_MESSAGING_BLOCKLIST,
+  CERNER_RX_BLOCKLIST,
+} from '../utilities/cerner';
 
 export const selectUser = state => state.user;
 export const isLoggedIn = state => selectUser(state).login.currentlyLoggedIn;
@@ -70,3 +75,21 @@ export const selectIsCernerOnlyPatient = state =>
 
 export const selectIsCernerPatient = state =>
   selectPatientFacilities(state)?.some(f => f.isCerner);
+
+// return the Cerner facilities that are _not_ blocked from Cerner's RX features
+export const selectCernerRxFacilities = state =>
+  selectPatientFacilities(state)?.filter(
+    f => f.isCerner && !CERNER_RX_BLOCKLIST.includes(f.facilityId),
+  );
+
+// return the Cerner facilities that are _not_ blocked from Cerner's secure messaging features
+export const selectCernerMessagingFacilities = state =>
+  selectPatientFacilities(state)?.filter(
+    f => f.isCerner && !CERNER_MESSAGING_BLOCKLIST.includes(f.facilityId),
+  );
+
+// return the Cerner facilities that are _not_ blocked from Cerner's appointments features
+export const selectCernerAppointmentsFacilities = state =>
+  selectPatientFacilities(state)?.filter(
+    f => f.isCerner && !CERNER_APPOINTMENTS_BLOCKLIST.includes(f.facilityId),
+  );

--- a/src/platform/user/selectors.js
+++ b/src/platform/user/selectors.js
@@ -4,8 +4,10 @@ import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagName
 import {
   CERNER_APPOINTMENTS_BLOCKLIST,
   CERNER_FACILITY_IDS,
+  CERNER_MEDICAL_RECORDS_BLOCKLIST,
   CERNER_MESSAGING_BLOCKLIST,
   CERNER_RX_BLOCKLIST,
+  CERNER_TEST_RESULTS_BLOCKLIST,
 } from '../utilities/cerner';
 
 export const selectUser = state => state.user;
@@ -21,10 +23,15 @@ export const isMultifactorEnabled = state => selectProfile(state).multifactor;
 export const selectAvailableServices = state => selectProfile(state)?.services;
 export const selectPatientFacilities = state =>
   selectProfile(state)?.facilities?.map(({ facilityId, isCerner }) => {
+    // TODO: The work in this selector to override the `isCerner` values will be
+    // removed after the override logic gets moved to vets-api. ie, we will be
+    // able to trust the `isCerner` flags that come directly from vets-api.
+
     // Derive if the user belongs to a Cerner facility in the FE maintained list.
     const hasCernerFacilityID = CERNER_FACILITY_IDS.includes(facilityId);
 
     // Derive if the feature toggle is on.
+    // TODO: can this feature toggle check be removed since it should always be true now?
     const showNewScheduleViewAppointmentsPage =
       state?.featureToggles?.[
         featureFlagNames.showNewScheduleViewAppointmentsPage
@@ -82,14 +89,30 @@ export const selectCernerRxFacilities = state =>
     f => f.isCerner && !CERNER_RX_BLOCKLIST.includes(f.facilityId),
   );
 
-// return the Cerner facilities that are _not_ blocked from Cerner's secure messaging features
+// return the Cerner facilities that are _not_ blocked from Cerner's secure
+// messaging features
 export const selectCernerMessagingFacilities = state =>
   selectPatientFacilities(state)?.filter(
     f => f.isCerner && !CERNER_MESSAGING_BLOCKLIST.includes(f.facilityId),
   );
 
-// return the Cerner facilities that are _not_ blocked from Cerner's appointments features
+// return the Cerner facilities that are _not_ blocked from Cerner's
+// appointments features
 export const selectCernerAppointmentsFacilities = state =>
   selectPatientFacilities(state)?.filter(
     f => f.isCerner && !CERNER_APPOINTMENTS_BLOCKLIST.includes(f.facilityId),
+  );
+
+// return the Cerner facilities that are _not_ blocked from Cerner's medical
+// records features
+export const selectCernerMedicalRecordsFacilities = state =>
+  selectPatientFacilities(state)?.filter(
+    f => f.isCerner && !CERNER_MEDICAL_RECORDS_BLOCKLIST.includes(f.facilityId),
+  );
+
+// return the Cerner facilities that are _not_ blocked from Cerner's test and
+// lab results features
+export const selectCernerTestResultsFacilities = state =>
+  selectPatientFacilities(state)?.filter(
+    f => f.isCerner && !CERNER_TEST_RESULTS_BLOCKLIST.includes(f.facilityId),
   );

--- a/src/platform/user/selectors.js
+++ b/src/platform/user/selectors.js
@@ -45,11 +45,29 @@ export const selectPatientFacilities = state =>
       showNewScheduleViewAppointmentsPage &&
       (isCerner || (isCernerPatient && hasCernerFacilityID));
 
-    return {
+    const facility = {
       facilityId,
       // This overrides the MPI isCerner flag in favor of the feature toggle.
       isCerner: passesCernerChecks,
     };
+
+    if (passesCernerChecks) {
+      facility.usesCernerAppointments = !CERNER_APPOINTMENTS_BLOCKLIST.includes(
+        facilityId,
+      );
+      facility.usesCernerMedicalRecords = !CERNER_MEDICAL_RECORDS_BLOCKLIST.includes(
+        facilityId,
+      );
+      facility.usesCernerMessaging = !CERNER_MESSAGING_BLOCKLIST.includes(
+        facilityId,
+      );
+      facility.usesCernerRx = !CERNER_RX_BLOCKLIST.includes(facilityId);
+      facility.usesCernerTestResults = !CERNER_TEST_RESULTS_BLOCKLIST.includes(
+        facilityId,
+      );
+    }
+
+    return facility;
   }) || null;
 export const selectVet360 = state => selectProfile(state).vet360;
 export const selectVet360EmailAddress = state =>

--- a/src/platform/user/selectors.js
+++ b/src/platform/user/selectors.js
@@ -103,34 +103,32 @@ export const selectIsCernerPatient = state =>
 
 // return the Cerner facilities that are _not_ blocked from Cerner's RX features
 export const selectCernerRxFacilities = state =>
-  selectPatientFacilities(state)?.filter(
-    f => f.isCerner && !CERNER_RX_BLOCKLIST.includes(f.facilityId),
-  );
+  selectPatientFacilities(state)?.filter(f => f.isCerner && f.usesCernerRx);
 
 // return the Cerner facilities that are _not_ blocked from Cerner's secure
 // messaging features
 export const selectCernerMessagingFacilities = state =>
   selectPatientFacilities(state)?.filter(
-    f => f.isCerner && !CERNER_MESSAGING_BLOCKLIST.includes(f.facilityId),
+    f => f.isCerner && f.usesCernerMessaging,
   );
 
 // return the Cerner facilities that are _not_ blocked from Cerner's
 // appointments features
 export const selectCernerAppointmentsFacilities = state =>
   selectPatientFacilities(state)?.filter(
-    f => f.isCerner && !CERNER_APPOINTMENTS_BLOCKLIST.includes(f.facilityId),
+    f => f.isCerner && f.usesCernerAppointments,
   );
 
 // return the Cerner facilities that are _not_ blocked from Cerner's medical
 // records features
 export const selectCernerMedicalRecordsFacilities = state =>
   selectPatientFacilities(state)?.filter(
-    f => f.isCerner && !CERNER_MEDICAL_RECORDS_BLOCKLIST.includes(f.facilityId),
+    f => f.isCerner && f.usesCernerMedicalRecords,
   );
 
 // return the Cerner facilities that are _not_ blocked from Cerner's test and
 // lab results features
 export const selectCernerTestResultsFacilities = state =>
   selectPatientFacilities(state)?.filter(
-    f => f.isCerner && !CERNER_TEST_RESULTS_BLOCKLIST.includes(f.facilityId),
+    f => f.isCerner && f.usesCernerTestResults,
   );

--- a/src/platform/user/tests/selectors.unit.spec.js
+++ b/src/platform/user/tests/selectors.unit.spec.js
@@ -410,4 +410,80 @@ describe('user selectors', () => {
       expect(selectors.isInMPI(state)).to.be.false;
     });
   });
+
+  describe('selectCernerRxFacilities', () => {
+    it('returns the Cerner facilities that are not in the RX blocklist', () => {
+      const state = {
+        featureToggles: {
+          // eslint-disable-next-line camelcase
+          show_new_schedule_view_appointments_page: true,
+        },
+        user: {
+          profile: {
+            facilities: [
+              { facilityId: '983', isCerner: false }, // not cerner
+              { facilityId: '757', isCerner: false }, // cerner, but blocked from RX
+              { facilityId: '668', isCerner: true }, // cerner, not blocked from RX
+            ],
+            isCernerPatient: true,
+          },
+        },
+      };
+      const expected = [{ facilityId: '668', isCerner: true }];
+      expect(selectors.selectCernerRxFacilities(state)).to.deep.equal(expected);
+    });
+  });
+
+  describe('selectCernerMessagingFacilities', () => {
+    it('returns the Cerner facilities that are not in the messaging blocklist', () => {
+      const state = {
+        featureToggles: {
+          // eslint-disable-next-line camelcase
+          show_new_schedule_view_appointments_page: true,
+        },
+        user: {
+          profile: {
+            facilities: [
+              { facilityId: '983', isCerner: false }, // not cerner
+              { facilityId: '757', isCerner: false }, // cerner, but blocked from messaging
+              { facilityId: '668', isCerner: true }, // cerner, not blocked from messaging
+            ],
+            isCernerPatient: true,
+          },
+        },
+      };
+      const expected = [{ facilityId: '668', isCerner: true }];
+      expect(selectors.selectCernerMessagingFacilities(state)).to.deep.equal(
+        expected,
+      );
+    });
+  });
+
+  describe('selectCernerAppointmentsFacilities', () => {
+    it('returns the Cerner facilities that are not in the appointments blocklist', () => {
+      const state = {
+        featureToggles: {
+          // eslint-disable-next-line camelcase
+          show_new_schedule_view_appointments_page: true,
+        },
+        user: {
+          profile: {
+            facilities: [
+              { facilityId: '983', isCerner: false }, // not cerner
+              { facilityId: '757', isCerner: false }, // cerner, not blocked from appointments
+              { facilityId: '668', isCerner: true }, // cerner, not blocked from appointments
+            ],
+            isCernerPatient: true,
+          },
+        },
+      };
+      const expected = [
+        { facilityId: '757', isCerner: true },
+        { facilityId: '668', isCerner: true },
+      ];
+      expect(selectors.selectCernerAppointmentsFacilities(state)).to.deep.equal(
+        expected,
+      );
+    });
+  });
 });

--- a/src/platform/user/tests/selectors.unit.spec.js
+++ b/src/platform/user/tests/selectors.unit.spec.js
@@ -266,6 +266,46 @@ describe('user selectors', () => {
         state.user.profile.facilities,
       );
     });
+    it('pulls out the state.profile.facilities array and adds Cerner capability flags to Cerner facilities', () => {
+      const state = {
+        featureToggles: {
+          // eslint-disable-next-line camelcase
+          show_new_schedule_view_appointments_page: true,
+        },
+        user: {
+          profile: {
+            facilities: [
+              { facilityId: '757', isCerner: false },
+              { facilityId: '668', isCerner: true },
+              { facilityId: '984', isCerner: false },
+            ],
+            isCernerPatient: false,
+          },
+        },
+      };
+      const expected = [
+        { facilityId: '984', isCerner: false },
+        {
+          facilityId: '668',
+          isCerner: true,
+          usesCernerAppointments: true,
+          usesCernerMedicalRecords: true,
+          usesCernerMessaging: true,
+          usesCernerRx: true,
+          usesCernerTestResults: true,
+        },
+        {
+          facilityId: '757',
+          isCerner: true,
+          usesCernerAppointments: true,
+          usesCernerMedicalRecords: false,
+          usesCernerMessaging: false,
+          usesCernerRx: false,
+          usesCernerTestResults: false,
+        },
+      ];
+      expect(selectors.selectPatientFacilities(state)).to.deep.equal(expected);
+    });
     it('returns undefined if there is no facilities on the profile', () => {
       const state = {
         user: {

--- a/src/platform/user/tests/selectors.unit.spec.js
+++ b/src/platform/user/tests/selectors.unit.spec.js
@@ -275,11 +275,11 @@ describe('user selectors', () => {
         user: {
           profile: {
             facilities: [
-              { facilityId: '757', isCerner: false },
-              { facilityId: '668', isCerner: true },
               { facilityId: '984', isCerner: false },
+              { facilityId: '668', isCerner: true },
+              { facilityId: '757', isCerner: false },
             ],
-            isCernerPatient: false,
+            isCernerPatient: true,
           },
         },
       };
@@ -469,7 +469,17 @@ describe('user selectors', () => {
           },
         },
       };
-      const expected = [{ facilityId: '668', isCerner: true }];
+      const expected = [
+        {
+          facilityId: '668',
+          isCerner: true,
+          usesCernerAppointments: true,
+          usesCernerMedicalRecords: true,
+          usesCernerMessaging: true,
+          usesCernerRx: true,
+          usesCernerTestResults: true,
+        },
+      ];
       expect(selectors.selectCernerRxFacilities(state)).to.deep.equal(expected);
     });
   });
@@ -492,7 +502,17 @@ describe('user selectors', () => {
           },
         },
       };
-      const expected = [{ facilityId: '668', isCerner: true }];
+      const expected = [
+        {
+          facilityId: '668',
+          isCerner: true,
+          usesCernerAppointments: true,
+          usesCernerMedicalRecords: true,
+          usesCernerMessaging: true,
+          usesCernerRx: true,
+          usesCernerTestResults: true,
+        },
+      ];
       expect(selectors.selectCernerMessagingFacilities(state)).to.deep.equal(
         expected,
       );
@@ -518,8 +538,24 @@ describe('user selectors', () => {
         },
       };
       const expected = [
-        { facilityId: '757', isCerner: true },
-        { facilityId: '668', isCerner: true },
+        {
+          facilityId: '757',
+          isCerner: true,
+          usesCernerAppointments: true,
+          usesCernerMedicalRecords: false,
+          usesCernerMessaging: false,
+          usesCernerRx: false,
+          usesCernerTestResults: false,
+        },
+        {
+          facilityId: '668',
+          isCerner: true,
+          usesCernerAppointments: true,
+          usesCernerMedicalRecords: true,
+          usesCernerMessaging: true,
+          usesCernerRx: true,
+          usesCernerTestResults: true,
+        },
       ];
       expect(selectors.selectCernerAppointmentsFacilities(state)).to.deep.equal(
         expected,
@@ -545,7 +581,17 @@ describe('user selectors', () => {
           },
         },
       };
-      const expected = [{ facilityId: '668', isCerner: true }];
+      const expected = [
+        {
+          facilityId: '668',
+          isCerner: true,
+          usesCernerAppointments: true,
+          usesCernerMedicalRecords: true,
+          usesCernerMessaging: true,
+          usesCernerRx: true,
+          usesCernerTestResults: true,
+        },
+      ];
       expect(
         selectors.selectCernerMedicalRecordsFacilities(state),
       ).to.deep.equal(expected);
@@ -570,7 +616,17 @@ describe('user selectors', () => {
           },
         },
       };
-      const expected = [{ facilityId: '668', isCerner: true }];
+      const expected = [
+        {
+          facilityId: '668',
+          isCerner: true,
+          usesCernerAppointments: true,
+          usesCernerMedicalRecords: true,
+          usesCernerMessaging: true,
+          usesCernerRx: true,
+          usesCernerTestResults: true,
+        },
+      ];
       expect(selectors.selectCernerTestResultsFacilities(state)).to.deep.equal(
         expected,
       );

--- a/src/platform/user/tests/selectors.unit.spec.js
+++ b/src/platform/user/tests/selectors.unit.spec.js
@@ -486,4 +486,54 @@ describe('user selectors', () => {
       );
     });
   });
+
+  describe('selectCernerMedicalRecordsFacilities', () => {
+    it('returns the Cerner facilities that are not in the medical records blocklist', () => {
+      const state = {
+        featureToggles: {
+          // eslint-disable-next-line camelcase
+          show_new_schedule_view_appointments_page: true,
+        },
+        user: {
+          profile: {
+            facilities: [
+              { facilityId: '983', isCerner: false }, // not cerner
+              { facilityId: '757', isCerner: false }, // cerner, blocked from medical records
+              { facilityId: '668', isCerner: true }, // cerner, not blocked from medical records
+            ],
+            isCernerPatient: true,
+          },
+        },
+      };
+      const expected = [{ facilityId: '668', isCerner: true }];
+      expect(
+        selectors.selectCernerMedicalRecordsFacilities(state),
+      ).to.deep.equal(expected);
+    });
+  });
+
+  describe('selectCernerTestResultsFacilities', () => {
+    it('returns the Cerner facilities that are not in the test results blocklist', () => {
+      const state = {
+        featureToggles: {
+          // eslint-disable-next-line camelcase
+          show_new_schedule_view_appointments_page: true,
+        },
+        user: {
+          profile: {
+            facilities: [
+              { facilityId: '983', isCerner: false }, // not cerner
+              { facilityId: '757', isCerner: false }, // cerner, blocked from test results
+              { facilityId: '668', isCerner: true }, // cerner, not blocked from test results
+            ],
+            isCernerPatient: true,
+          },
+        },
+      };
+      const expected = [{ facilityId: '668', isCerner: true }];
+      expect(selectors.selectCernerTestResultsFacilities(state)).to.deep.equal(
+        expected,
+      );
+    });
+  });
 });

--- a/src/platform/utilities/cerner/index.js
+++ b/src/platform/utilities/cerner/index.js
@@ -13,6 +13,11 @@ export const CERNER_RX_BLOCKLIST = ['757'];
 export const CERNER_MESSAGING_BLOCKLIST = ['757'];
 // Facilities that are Cerner but do not have Cerner appointment features:
 export const CERNER_APPOINTMENTS_BLOCKLIST = [];
+// Facilities that are Cerner but do not have Cerner medical records features:
+export const CERNER_MEDICAL_RECORDS_BLOCKLIST = ['757'];
+// Facilities that are Cerner but do not have Cerner test and lab results
+// features:
+export const CERNER_TEST_RESULTS_BLOCKLIST = ['757'];
 
 export const getCernerURL = path => {
   const host = environment.isProduction()

--- a/src/platform/utilities/cerner/index.js
+++ b/src/platform/utilities/cerner/index.js
@@ -1,15 +1,17 @@
 // Relative imports.
 import environment from 'platform/utilities/environment';
 
+// Cerner facilities that do not have the `isCerner` flag set to true
+// 757: Chalmers P. Wylie Veterans Outpatient Clinic
 export const CERNER_FACILITY_IDS = ['757'];
 
-// Not at Cerner facilities have the same capabilities. These blocklists are
+// Not all Cerner facilities have the same capabilities. These blocklists are
 // used to determine which facilities lack certain capabilities.
-// Facilities that are Cerner but do not have Cerner prescription features
+// Facilities that are Cerner but do not have Cerner prescription features:
 export const CERNER_RX_BLOCKLIST = ['757'];
-// Facilities that are Cerner but do not have Cerner secure messaging features
+// Facilities that are Cerner but do not have Cerner secure messaging features:
 export const CERNER_MESSAGING_BLOCKLIST = ['757'];
-// Facilities that are Cerner but do not have Cerner appointment features
+// Facilities that are Cerner but do not have Cerner appointment features:
 export const CERNER_APPOINTMENTS_BLOCKLIST = [];
 
 export const getCernerURL = path => {

--- a/src/platform/utilities/cerner/index.js
+++ b/src/platform/utilities/cerner/index.js
@@ -2,7 +2,15 @@
 import environment from 'platform/utilities/environment';
 
 export const CERNER_FACILITY_IDS = ['757'];
-export const isCernerLive = !environment.isProduction();
+
+// Not at Cerner facilities have the same capabilities. These blocklists are
+// used to determine which facilities lack certain capabilities.
+// Facilities that are Cerner but do not have Cerner prescription features
+export const CERNER_RX_BLOCKLIST = ['757'];
+// Facilities that are Cerner but do not have Cerner secure messaging features
+export const CERNER_MESSAGING_BLOCKLIST = ['757'];
+// Facilities that are Cerner but do not have Cerner appointment features
+export const CERNER_APPOINTMENTS_BLOCKLIST = [];
 
 export const getCernerURL = path => {
   const host = environment.isProduction()


### PR DESCRIPTION
## Description
Currently the My VA Dashboard shows a different Appointment widget if the user is a patient at a Cerner system.

Soon we will need to:
- show a different Rx widget if the user is a patient at a Cerner system that supports prescriptions
- show a different Messaging widget if the user is a patient at a Cerner system that supports secure messaging

The bottom line is that not all Cerner system have the same capabilities. This is what we know now:
- patients in system ID 757 (Chalmers P. Wylie) should only be shown the appointment widget
- patients in system ID 668 (Spokane Mann-Grandstaff) should be shown all three widgets

The logic to determine which systems support which capabilities should live in the front end. The PR makes an important assumption that truly is just an assumption at this point: **_Most_ Cerner systems will support appointments, messaging, and Rx.** In other words, system 757 is an exception. Working with that assumption in mind, this PR sets up blocklists that can be used to track which facilities do NOT support certain features. It also sets up more granular selectors to get only the facilities that support certain facilities.

A follow up PR will:
- [ ] make the new Rx and Messaging widgets
- [ ] use the new selectors to determine if those widgets should be shown

## Testing done
Unit tests

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs