### PR TITLE
Update connected apps FAQ

### DIFF
--- a/src/applications/personalization/profile-2/components/connected-apps/ConnectedApps.jsx
+++ b/src/applications/personalization/profile-2/components/connected-apps/ConnectedApps.jsx
@@ -165,7 +165,7 @@ export class ConnectedApps extends Component {
                   'profile-section': 'vets-faqs',
                 })
               }
-              href="/sign-in-faq/#connecting-third-party-(non-VA"
+              href="/sign-in-faq/#connecting-third-party-non-va-"
             >
               Go to FAQs about signing in to VA.gov
             </a>


### PR DESCRIPTION
## Description
The URL linking to the FAQ in the connected apps section /profile/connected-apps should link to the correct anchor. The current URL is broken and should be replaced with `/sign-in-faq/#connecting-third-party-non-va-`.

## Acceptance criteria
- [x] Update connected apps FAQ link

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
