### PR TITLE
add test for communication preferences

### DIFF
--- a/src/applications/vre/28-1900/tests/config/communicationPreferences.unit.spec.js
+++ b/src/applications/vre/28-1900/tests/config/communicationPreferences.unit.spec.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import sinon from 'sinon';
+import {
+  DefinitionTester,
+  selectRadio,
+  selectCheckbox,
+} from 'platform/testing/unit/schemaform-utils.jsx';
+
+import formConfig from '../../config/form';
+
+const {
+  schema,
+  uiSchema,
+} = formConfig.chapters.communicationPreferences.pages.communicationPreferences;
+
+describe('Chapter 31 communication preferences', () => {
+  it('should render', () => {
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        definitions={formConfig.defaultDefinitions}
+      />,
+    );
+    expect(form.find('input').length).to.equal(8);
+    form.unmount();
+  });
+  it('should not submit with unfilled fields', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        definitions={formConfig.defaultDefinitions}
+        onSubmit={onSubmit}
+      />,
+    );
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error').length).to.equal(3);
+    expect(onSubmit.called).to.be.false;
+    form.unmount();
+  });
+  it('should submit with all required fields', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        definitions={formConfig.defaultDefinitions}
+        onSubmit={onSubmit}
+      />,
+    );
+    selectRadio(form, 'root_useEva', 'Y');
+    selectRadio(form, 'root_useTelecounseling', 'Y');
+    selectCheckbox(form, 'root_appointmentTimePreferences_morning', true);
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+    form.unmount();
+  });
+});


### PR DESCRIPTION
## Description
This pull request adds unit tests for the communication preferences page in the Chapter 31 form application.

## Testing done
- local, all unit tests pass

## Screenshots
![Screen Shot 2020-10-14 at 12 52 17 PM](https://user-images.githubusercontent.com/15097156/96020555-38d09900-0e1c-11eb-9c53-a42e41002218.png)


## Acceptance criteria
- [x] all unit tests pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
