### PR TITLE
[14111] Adjust VAOS Footer

### DIFF
--- a/src/applications/vaos/components/NeedHelp.jsx
+++ b/src/applications/vaos/components/NeedHelp.jsx
@@ -15,18 +15,28 @@ export default function NeedHelp() {
         className="vads-u-margin-y--1p5 vads-u-border-color--primary"
       />
       <p className="vads-u-margin-top--0">
-        For help scheduling a VA or community care appointment, please call{' '}
-        <a href="tel:8774705947">877-470-5947</a> (if you have hearing loss,
-        call TTY:{' '}
+        If you need help scheduling a VA or community care appointment, please
+        call your VA or community care facility.{' '}
+        <a href="tel:8774705947">877-470-5947</a> (TTY:{' '}
         <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
-        ). We’re here Monday &ndash; Friday, 8:00 a.m. to 8:00 p.m. ET.
+        ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+      </p>
+      <p className="vads-u-margin-top--0">
+        If you need help scheduling a VA or community care appointment, please
+        call your VA or community care facility.{' '}
+        <a
+          href="https://www.va.gov/find-locations/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Find your health facility’s phone number.
+        </a>
       </p>
       <p className="vads-u-margin-top--0">
         For questions about joining a VA Video Connect appointment, please call{' '}
-        <a href="tel:8666513180">866-651-3180</a> (if you have hearing loss,
-        call TTY:{' '}
+        <a href="tel:8666513180">866-651-3180</a> (TTY:{' '}
         <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
-        ). We’re here Monday &ndash; Saturday, 7:00 a.m. to 11:00 p.m. ET.
+        ). We’re here Monday through Saturday, 7:00 a.m. to 11:00 p.m. ET.
       </p>
       <p className="vads-u-margin-top--0">
         <a

--- a/src/applications/vaos/tests/components/NeedHelp.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/NeedHelp.unit.spec.jsx
@@ -12,15 +12,21 @@ describe('VAOS <NeedHelp>', () => {
     expect(tree.hasClass('vads-u-margin-top--9')).be.true;
 
     const links = tree.find('a');
-    expect(links.length).to.equal(3);
+    expect(links.length).to.equal(4);
     expect(links.at(0).props().href).to.equal('tel:8774705947');
     expect(links.at(0).text()).to.equal('877-470-5947');
-    expect(links.at(1).props().href).to.equal('tel:8666513180');
-    expect(links.at(1).text()).to.equal('866-651-3180');
-    expect(links.at(2).props().href).to.equal(
+    expect(links.at(1).props().href).to.equal(
+      'https://www.va.gov/find-locations/',
+    );
+    expect(links.at(1).text()).to.equal(
+      'Find your health facility’s phone number.',
+    );
+    expect(links.at(2).props().href).to.equal('tel:8666513180');
+    expect(links.at(2).text()).to.equal('866-651-3180');
+    expect(links.at(3).props().href).to.equal(
       'https://veteran.apps.va.gov/feedback-web/v1/?appId=85870ADC-CC55-405E-9AC3-976A92BBBBEE',
     );
-    expect(links.at(2).text()).to.equal(
+    expect(links.at(3).text()).to.equal(
       'Leave feedback about this application',
     );
 


### PR DESCRIPTION
## Description
We have received feedback from the help desk that Veterans are calling them to get help with their VA appointment. The help desk is only available to triage issues with the app itself, not specific appointment issues.

## Testing done
Local and Unit

## Screenshots
![image](https://user-images.githubusercontent.com/8315447/96023976-2f95fb00-0e21-11eb-8df9-98e7d5c6efb7.png)

## Acceptance criteria
- [x] all phone numbers should be hyperlinked.
- [x] update footer to following:

> Need help?
> If you have questions about using the VA appointments tool, or if the tool isn’t working right, please call 877-470-5947 (TTY: 711). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
> 
> If you need help scheduling a VA or community care appointment, please call your VA or community care facility. Find your health facility’s phone number.
> 
> For questions about joining a VA Video Connect appointment, please call 866-651-3180 (TTY: 711). We’re here Monday through Saturday, 7:00 a.m. to 11:00 p.m. ET.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
