### PR TITLE
14365: Update breadcrumb title and links along with page and form titles

### DIFF
--- a/src/applications/edu-benefits/1995/config/form.js
+++ b/src/applications/edu-benefits/1995/config/form.js
@@ -49,7 +49,7 @@ const formConfig = {
     date,
     dateRange,
   },
-  title: 'Update your education benefits',
+  title: 'Change your education benefits',
   subTitle: 'Form 22-1995',
   preSubmitInfo,
   footerContent: FormFooter,

--- a/src/applications/edu-benefits/1995/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/1995/containers/IntroductionPage.jsx
@@ -56,7 +56,7 @@ export class IntroductionPage extends React.Component {
         itemScope
         itemType="http://schema.org/HowTo"
       >
-        <FormTitle title="Manage your education benefits" />
+        <FormTitle title="Change your education benefits" />
         <p itemProp="description">
           Equal to VA Form 22-1995 (Request for Change of Program or Place of
           Training).

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -647,12 +647,12 @@
           "path": "education/"
         },
         {
-          "name": "How to apply",
-          "path": "education/how-to-apply/"
+          "name": "Change your GI Bill school or program",
+          "path": "education/change-gi-bill-benefits/"
         },
         {
-          "name": "Apply for education benefits",
-          "path": "education/apply-for-education-benefits/application/1995"
+          "name": "Change your benefits VA Form 22-1995",
+          "path": "education/apply-for-education-benefits/application/1995/introduction"
         }
       ]
     }


### PR DESCRIPTION
## Description
As a developer, I need to update the 1995 title and breadcrumbs so that it matches DEPO patterns and practices to provide the veteran with a consistent user experience.

[Originating Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/14365)

## Testing done
Testing Passes locally

## Screenshots
<img width="652" alt="Screen Shot 2020-10-14 at 2 33 30 PM" src="https://user-images.githubusercontent.com/48804834/96031170-01b5b400-0e2b-11eb-838a-e4171b2fd64e.png">
<img width="649" alt="Screen Shot 2020-10-14 at 2 33 46 PM" src="https://user-images.githubusercontent.com/48804834/96031173-02e6e100-0e2b-11eb-96d0-7f7b188d0b27.png">


## Acceptance criteria
- [x] On the introduction page the "Manage your education benefits" header is replaced with "Change your education benefits".
- [x] On the form pages the "Update your education benefits" header is replaced with "Change your education benefits".
- [x] The breadcrumb of the 1995 is: Home > Education and training > Change your GI Bill school or program > Change your benefits VA Form 22-1995
a. "Home" url: https://www.va.gov/
b. "Education and training" url: https://www.va.gov/education/
c. "Change your GI Bill school or program" url: https://www.va.gov/education/change-gi-bill-benefits/
d. "Change your benefits VA Form 22-1995" url: https://www.va.gov/education/apply-for-education-benefits/application/1995/introduction

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
