### PR TITLE
Report Pact test failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,10 @@ jobs:
             - ~/.cache/yarn
       - run: mkdir -p ./test-results
       - run: mkdir -p ./pacts
-      - run: yarn test:contract
+      - run:
+          command: yarn test:contract
+          environment:
+            MOCHA_FILE: ./test-results/test-results.xml
       - run: yarn pact:publish
       - persist_to_workspace:
           root: .

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "test:accessibility": "./script/run-nightwatch.sh --env accessibility",
     "test:accessibility:docker": "docker-compose -p accessibility up -d && docker-compose -p accessibility run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run nightwatch:docker -- --env=accessibility && docker-compose -p accessibility stop",
     "test:best-practice": "./script/run-nightwatch.sh --env bestpractice",
-    "test:contract": "BUILDTYPE=localhost npm run test:unit 'src/**/tests/**/*.pact.spec.js'",
+    "test:contract": "BUILDTYPE=localhost npm run test:unit -- --reporter mocha-junit-reporter 'src/**/tests/**/*.pact.spec.js'",
     "test:coverage": "npm run test:unit -- --coverage",
     "test:coverage-apps": "npm run test:coverage && node script/app-coverage-report.js",
     "test:puppeteer": "./script/run-puppeteer-tests.sh",

--- a/script/run-unit-test.js
+++ b/script/run-unit-test.js
@@ -49,12 +49,10 @@ const testRunner = options.coverage ? coveragePath : mochaPath;
 const mochaOpts =
   'src/platform/testing/unit/mocha.opts src/platform/testing/unit/helper.js';
 
-// Otherwise, run the command
 runCommand(
   `LOG_LEVEL=${options[
     'log-level'
   ].toLowerCase()} ${testRunner} --max-old-space-size=4096 --opts ${mochaOpts} --recursive ${options.path
     .map(p => `'${p}'`)
     .join(' ')}`,
-  options.coverage ? null : 0,
 );

--- a/script/run-unit-test.js
+++ b/script/run-unit-test.js
@@ -5,10 +5,12 @@ const { runCommand } = require('./utils');
 // For usage instructions see https://github.com/department-of-veterans-affairs/vets-website#unit-tests
 
 const defaultPath = './src/**/*.unit.spec.js?(x)';
+
 const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'log-level', type: String, defaultValue: 'log' },
   { name: 'app-folder', type: String, defaultValue: null },
   { name: 'coverage', type: Boolean, defaultValue: false },
+  { name: 'reporter', type: String, defaultValue: null },
   { name: 'help', alias: 'h', type: Boolean, defaultValue: false },
   {
     name: 'path',
@@ -18,6 +20,7 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
     defaultValue: [defaultPath],
   },
 ];
+
 const options = commandLineArgs(COMMAND_LINE_OPTIONS_DEFINITIONS);
 let coverageInclude = '';
 
@@ -33,12 +36,14 @@ if (
   coverageInclude = `--include 'src/applications/${options['app-folder']}/**'`;
 }
 
+const reporterOption = options.reporter ? `--reporter ${options.reporter}` : '';
+
 if (options.help) {
   printUnitTestHelp();
   process.exit(0);
 }
 
-const mochaPath = 'BABEL_ENV=test mocha';
+const mochaPath = `BABEL_ENV=test mocha ${reporterOption}`;
 const coveragePath = `NODE_ENV=test nyc --all ${coverageInclude} --reporter=lcov --reporter=text --reporter=json-summary mocha --reporter mocha-junit-reporter --no-color`;
 const testRunner = options.coverage ? coveragePath : mochaPath;
 const mochaOpts =


### PR DESCRIPTION
## Description
Previously, failed Pact tests would report success due to the following reasons:
- They ran as unit tests without the coverage option.
- The non-coverage path of the unit test script (as in just running `mocha`) suppressed error exit codes.

This fix exposes the error code from the unit test script so that it exits as a failure instead of success. Fixes department-of-veterans-affairs/va.gov-team#14641.

Also made a change to have the Pact tests output the JUnit test results for Circle to report them in the test results tab.

## Testing done
Forced a contract test failure to confirm that it would report a failure in the Circle build.

## Acceptance criteria
- [ ] Pact test failures should also result in a build failure.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
