### PR TITLE
Fix all instances of entityMetaTags

### DIFF
--- a/src/site/stages/build/process-cms-exports/schemas/output/node-event.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-event.js
@@ -6,34 +6,8 @@ module.exports = {
     entityBundle: { enum: ['event'] },
     title: { type: 'string' },
     entityUrl: { $ref: 'EntityUrl' },
-    entityMetaTags: {
-      // Probably should be a common schema...except it's got
-      // __typename instead of type, so it's different.
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: {
-          __typename: { type: 'string' },
-          key: { type: 'string' },
-          value: { type: 'string' },
-        },
-      },
-    },
     entityPublished: { type: 'boolean' },
     changed: { type: 'number' },
-    // uid: {
-    //   type: 'object',
-    //   properties: {
-    //     targetId: { type: 'number' },
-    //     entity: {
-    //       type: 'object',
-    //       properties: {
-    //         name: { type: 'string' },
-    //         timezone: { type: ['null'] }, // All the exmaples are null
-    //       },
-    //     },
-    //   },
-    // },
     fieldAdditionalInformationAbo: {
       oneOf: [{ $ref: 'ProcessedString' }, { type: 'null' }],
     },

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
@@ -121,7 +121,6 @@ module.exports = {
       $ref: 'output/paragraph-list_of_link_teasers',
     },
     fieldPressReleaseBlurb: { $ref: 'ProcessedString' },
-    entityMetaTags: { $ref: 'MetaTags' },
     fieldLeadership: {
       type: 'array',
       items: {

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-page.js
@@ -40,7 +40,7 @@ module.exports = {
       },
       required: ['date'],
     },
-    entityMetaTags: {
+    entityMetatags: {
       $ref: 'MetaTags',
     },
     entityPublished: { type: 'boolean' },

--- a/src/site/stages/build/process-cms-exports/transformers/node-page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-page.js
@@ -39,7 +39,7 @@ function pageTransform(entity) {
     // ).toUTCString(),
 
     entityPublished: isPublished(getDrupalValue(status)),
-    entityMetaTags: createMetaTagArray(metaTags, 'type'),
+    entityMetatags: createMetaTagArray(metaTags),
   });
 
   transformed.fieldAlert = !isEmpty(flatten(fieldAlert)) ? fieldAlert[0] : null;


### PR DESCRIPTION
## Description

`entityMetaTags` has been misspelled in the `node-page` transformer causing the liquid template to miss the information and display different data. This PR will fix the misspelling as well as the removal of the unnecessary `entityMetaTags` since it's already being injected somewhere else in the process.

## Testing done
`node script/cms/test-bundle-transformers.js --bundle "node-health_care_local_facility" --entity node.0b968788-cfb0-41aa-8206-2577105072fa.json` 
and 
`diff -ur graphql-localhost/burials-memorials/eligibility/burial-at-sea/index.html localhost/burials-memorials/eligibility/burial-at-sea/index.html | delta`

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
