### PR TITLE
CCP services typeahead validation errors

### DIFF
--- a/src/applications/facility-locator/components/ServiceTypeAhead.jsx
+++ b/src/applications/facility-locator/components/ServiceTypeAhead.jsx
@@ -17,18 +17,38 @@ class ServiceTypeAhead extends Component {
       error: false,
       optionsFound: false,
       validationMessage: '',
+      selectedService: null,
     };
+    this.onSearch = this.onSearch.bind(this);
   }
 
   componentDidMount() {
     this.getServices();
+    document
+      .getElementById('facility-search-controls')
+      .addEventListener('submit', this.onSearch);
+  }
+
+  componentWillUnmount() {
+    document
+      .getElementById('facility-search-controls')
+      .addEventListener('submit', this.onSearch);
+  }
+
+  onSearch() {
+    if (!this.state.selectedService) {
+      this.setState({
+        error: true,
+        validationMessage: Error.SERVICE_NOT_FOUND,
+      });
+    }
   }
 
   validateService(inputValue, event, selectedItem) {
     const servicesFound = Array.from(
       document.querySelectorAll('[id ^= "downshift-"]'),
     );
-    if (event.key === 'Enter') {
+    if (event && event.key === 'Enter') {
       if (!inputValue || inputValue.length === 0) {
         this.setState({
           error: true,
@@ -75,6 +95,9 @@ class ServiceTypeAhead extends Component {
     const value = selectedItem ? selectedItem.specialtyCode.trim() : null;
     this.props.onSelect({
       target: { value },
+    });
+    this.setState({
+      selectedService: value,
     });
   };
 

--- a/src/applications/facility-locator/components/ServiceTypeAhead.jsx
+++ b/src/applications/facility-locator/components/ServiceTypeAhead.jsx
@@ -91,7 +91,6 @@ class ServiceTypeAhead extends Component {
   };
 
   handleOnSelect = selectedItem => {
-    if (selectedItem && selectedItem === 'not-found') return;
     const value = selectedItem ? selectedItem.specialtyCode.trim() : null;
     this.props.onSelect({
       target: { value },

--- a/src/applications/facility-locator/components/ServiceTypeAhead.jsx
+++ b/src/applications/facility-locator/components/ServiceTypeAhead.jsx
@@ -154,7 +154,7 @@ class ServiceTypeAhead extends Component {
               <span className="vads-u-color--secondary-dark">(*Required)</span>
               {this.state.error && (
                 <span
-                  className="validation-message"
+                  className="usa-input-error-message"
                   role="alert"
                   id="text-service-error"
                 >

--- a/src/applications/facility-locator/components/ServiceTypeAhead.jsx
+++ b/src/applications/facility-locator/components/ServiceTypeAhead.jsx
@@ -165,7 +165,7 @@ class ServiceTypeAhead extends Component {
             </label>
             <span id="service-typeahead">
               <input
-                className={this.state.error ? 'validation-error' : null}
+                className={this.state.error ? 'validation-service-error' : null}
                 {...getInputProps({
                   onKeyDown: event => {
                     this.validateService(inputValue, event, selectedItem);

--- a/src/applications/facility-locator/constants/index.js
+++ b/src/applications/facility-locator/constants/index.js
@@ -89,7 +89,7 @@ export const Error = {
   DEFAULT: 'We’re sorry. Something went wrong on our end. Please try again.',
   LOCATION:
     'Something’s not quite right. Please enter a valid or different location and try your search again.',
-  INVALID_SERVICE: 'Please enter a valid Service type.',
-  SERVICE_NOT_FOUND: 'This service type was not found.',
+  INVALID_SERVICE: 'Please enter a valid service type.',
+  SERVICE_NOT_FOUND: 'We’re sorry. This service type was not found.',
   SELECT_SERVICE: 'Please select an item from the list',
 };

--- a/src/applications/facility-locator/constants/index.js
+++ b/src/applications/facility-locator/constants/index.js
@@ -89,4 +89,7 @@ export const Error = {
   DEFAULT: 'We’re sorry. Something went wrong on our end. Please try again.',
   LOCATION:
     'Something’s not quite right. Please enter a valid or different location and try your search again.',
+  INVALID_SERVICE: 'Please enter a valid Service type.',
+  SERVICE_NOT_FOUND: 'This service type was not found.',
+  SELECT_SERVICE: 'Please select an item from the list',
 };

--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -511,6 +511,19 @@ $facility-locator-color-gray: #ccc;
   flex-direction: column;
 }
 
+.validation-message {
+  color: #cd2026;
+  font-size: 1.6rem;
+  font-weight: 700;
+  padding-bottom: 3px;
+  padding-top: 3px;
+}
+
+.validation-error {
+  border: 4px solid #cd2026;
+}
+
+
 #other-tools {
   text-align: center;
   margin: 22px auto;
@@ -520,4 +533,5 @@ $facility-locator-color-gray: #ccc;
     width: 260px;
     white-space: pre-line;
   }
+
 }

--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -511,10 +511,9 @@ $facility-locator-color-gray: #ccc;
   flex-direction: column;
 }
 
-.validation-error {
+.validation-service-error {
   border: 4px solid #cd2026;
 }
-
 
 #other-tools {
   text-align: center;
@@ -525,5 +524,4 @@ $facility-locator-color-gray: #ccc;
     width: 260px;
     white-space: pre-line;
   }
-
 }

--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -511,14 +511,6 @@ $facility-locator-color-gray: #ccc;
   flex-direction: column;
 }
 
-.validation-message {
-  color: #cd2026;
-  font-size: 1.6rem;
-  font-weight: 700;
-  padding-bottom: 3px;
-  padding-top: 3px;
-}
-
 .validation-error {
   border: 4px solid #cd2026;
 }


### PR DESCRIPTION
## Description
issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/5287

## Testing done


## Screenshots


## Acceptance criteria
- [x] When the Veteran has not entered a value into the Service typeahead field, a search cannot be triggered and the user is presented with a clearly marked error message. [Please enter a valid Service type.](https://design.va.gov/patterns/messaging-dictionary)
- [x] If the Service type field resets to default (empty), a search cannot be triggered and the user is presented with a clearly marked error message. [Please enter a valid Service type.](https://design.va.gov/patterns/messaging-dictionary)
- [x] If the Veteran enters parameters which do not match a possible result for any reason, a search cannot be triggered and the user is presented with a clearly marked error message. [We're sorry. This service type was not found.](https://design.va.gov/patterns/messaging-dictionary)
- [x] If the Veteran does not select a result from the displayed list, a search cannot be triggered and the user is presented with a clearly marked error message. `Please select an item from the list`
- [x] When the Veteran selects a result from the displayed list, that item is displayed in the form field. 

## Definition of done

- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
