### PR TITLE
Add events for current location requests on new appointment page

### DIFF
--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -432,15 +432,23 @@ export function requestCurrentLocation(uiSchema) {
     dispatch({
       type: FORM_REQUEST_CURRENT_LOCATION,
     });
+    recordEvent({
+      event: `${GA_PREFIX}-request-current-location-clicked`,
+    });
     try {
       const location = await getPreciseLocation();
+      recordEvent({
+        event: `${GA_PREFIX}-request-current-location-allowed`,
+      });
       dispatch({
         type: FORM_REQUEST_CURRENT_LOCATION_SUCCEEDED,
         location,
         uiSchema,
       });
     } catch (e) {
-      captureError(e, false, 'facility page');
+      recordEvent({
+        event: `${GA_PREFIX}-request-current-location-blocked`,
+      });
       dispatch({
         type: FORM_REQUEST_CURRENT_LOCATION_FAILED,
       });


### PR DESCRIPTION
## Description
Adds events around selecting current location for facility sorting on new facility page

## Testing done
Unit testing

## Acceptance criteria
- [ ] Events are correct

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
