### PR TITLE
Fixed gibctBenefitFilterEnhancement flag

### DIFF
--- a/src/applications/gi/components/profile/BenefitsForm.jsx
+++ b/src/applications/gi/components/profile/BenefitsForm.jsx
@@ -20,6 +20,7 @@ export class BenefitsForm extends React.Component {
     handleInputFocus: PropTypes.func,
     giBillChapterOpen: PropTypes.arrayOf(PropTypes.bool),
     yourMilitaryDetails: PropTypes.bool,
+    gibctBenefitFilterEnhancement: PropTypes.bool,
   };
 
   static defaultProps = {

--- a/src/applications/gi/components/search/InstitutionSearchForm.jsx
+++ b/src/applications/gi/components/search/InstitutionSearchForm.jsx
@@ -18,6 +18,7 @@ function InstitutionSearchForm({
   fetchAutocompleteSuggestions,
   filters,
   filtersClass,
+  gibctBenefitFilterEnhancement,
   handleFilterChange,
   hideModal,
   location,
@@ -74,12 +75,14 @@ function InstitutionSearchForm({
             showModal={showModal}
             showHeader
             handleInputFocus={handleInstitutionSearchInputFocus}
+            gibctBenefitFilterEnhancement={gibctBenefitFilterEnhancement}
           />
           <OnlineClassesFilter
             onlineClasses={eligibility.onlineClasses}
             onChange={eligibilityChange}
             showModal={showModal}
             handleInputFocus={handleInstitutionSearchInputFocus}
+            gibctBenefitFilterEnhancement={gibctBenefitFilterEnhancement}
           />
         </div>
         <div id="see-results-button" className="results-button">

--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -48,6 +48,7 @@ export function SearchPage({
   dispatchUpdateAutocompleteSearchTerm,
   eligibility,
   filters,
+  gibctBenefitFilterEnhancement,
   gibctSearchEnhancements,
   gibctSchoolRatings,
   search,
@@ -273,6 +274,7 @@ export function SearchPage({
           showModal={dispatchShowModal}
           eligibilityChange={dispatchEligibilityChange}
           hideModal={dispatchHideModal}
+          gibctBenefitFilterEnhancement={gibctBenefitFilterEnhancement}
         />
       </div>
     );
@@ -299,6 +301,9 @@ const mapStateToProps = state => ({
   ],
   gibctSchoolRatings: toggleValues(state)[
     FEATURE_FLAG_NAMES.gibctSchoolRatings
+  ],
+  gibctBenefitFilterEnhancement: toggleValues(state)[
+    FEATURE_FLAG_NAMES.gibctBenefitFilterEnhancement
   ],
 });
 

--- a/src/applications/gi/tests/components/search/RatedSearchResult.unit.spec.jsx
+++ b/src/applications/gi/tests/components/search/RatedSearchResult.unit.spec.jsx
@@ -45,21 +45,4 @@ describe('<SearchResult>', () => {
     expect(vdom).to.not.be.undefined;
     tree.unmount();
   });
-
-  it('should render with gibctFilterEnhancement feature flag', () => {
-    const tree = mount(
-      <MemoryRouter>
-        <RatedSearchResult
-          estimated={estimated}
-          womenOnly={result.womenonly}
-          menOnly={result.menonly}
-          {...result}
-          gibctFilterEnhancement
-        />
-      </MemoryRouter>,
-    );
-    const vdom = tree.html();
-    expect(vdom).to.not.be.undefined;
-    tree.unmount();
-  });
 });


### PR DESCRIPTION
## Description
`gibct_benefit_filter_enhancement` feature flag fixes missing filter fields

[ZenHub Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/14901)

## Testing done
Tested locally and QA reviewed

## Screenshots
![image](https://user-images.githubusercontent.com/41960449/96146181-05e9dc00-0ed4-11eb-987d-3ea48381e6ee.png)

## Acceptance criteria
- [x] "Your military details" additional details is displayed when the `gibct_benefit_filter_enhancement` feature flag is on.
- [x] "Your housing allowance" additional details is displayed when the `gibct_benefit_filter_enhancement` feature flag is on.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
