### PR TITLE
14634 chp31 adjustments

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -819,7 +819,22 @@
     "rootUrl": "/careers-employment/vocational-rehabilitation/apply",
     "template": {
       "vagovprod": false,
-      "layout": "page-react.html"
+      "layout": "page-react.html",
+      "includeBreadcrumbs": true,
+      "breadcrumbs_override": [
+        {
+          "path": "careers-employment",
+          "name": "Careers and employment"
+        },
+        {
+          "path": "careers-employment/vocational-rehabilitation",
+          "name": "Veteran Readiness and Employment"
+        },
+        {
+          "path": "careers-employment/vocational-rehabilitation/apply",
+          "name": "Apply for VR&E Form 28-1900"
+        }
+      ]
     }
   },
   {

--- a/src/applications/vre/28-1900/components/PreSubmitInfo.js
+++ b/src/applications/vre/28-1900/components/PreSubmitInfo.js
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export default {
+  required: true,
+  notice: (
+    <>
+      <div className="vads-u-margin-y--2p5">
+        <strong>By submitting this form</strong> you certify that you are the
+        claimant and the information you gave above is true and correct to the
+        best of your knowledge and belief.
+      </div>
+      <div className="vads-u-margin-y--1p5">
+        <strong>Note:</strong> According to federal law, there are criminal
+        penalties, including a fine and/or imprisonment for up to 5 years, for
+        withholding information or for providing incorrect information. (See 18
+        U.S.C. 1001)
+      </div>
+    </>
+  ),
+  field: 'privacyAgreementAccepted',
+  label: (
+    <span>
+      I have read and accept the{' '}
+      <a target="_blank" href="/privacy-policy/">
+        privacy policy
+      </a>
+    </span>
+  ),
+  error: 'You must accept the privacy policy before continuing',
+};

--- a/src/applications/vre/28-1900/config/chapters/veteran/veteran-address/veteranAddress.js
+++ b/src/applications/vre/28-1900/config/chapters/veteran/veteran-address/veteranAddress.js
@@ -15,6 +15,7 @@ export const schema = {
       type: 'string',
     },
   },
+  required: ['email'],
 };
 
 export const uiSchema = {
@@ -41,7 +42,7 @@ export const uiSchema = {
   'view:confirmEmail': {
     ...emailUI(),
     'ui:title': 'Confirm email address',
-    'ui:required': formData => typeof formData.email === 'string',
+    'ui:required': () => true,
     'ui:validations': [
       {
         validator: (errors, fieldData, formData) => {

--- a/src/applications/vre/28-1900/config/form.js
+++ b/src/applications/vre/28-1900/config/form.js
@@ -2,6 +2,7 @@ import fullSchema from 'vets-json-schema/dist/28-1900-schema.json';
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import { hasSession } from 'platform/user/profile/utilities';
+import PreSubmitInfo from 'applications/vre/28-1900/components/PreSubmitInfo';
 import VeteranInformationViewComponent from '../components/VeteranInformationViewComponent';
 import { additionalInformation } from './chapters/additional-information';
 import { communicationPreferences } from './chapters/communication-preferences';
@@ -17,6 +18,7 @@ const formConfig = {
   trackingPrefix: '28-1900-chapter-31-',
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
+  preSubmitInfo: PreSubmitInfo,
   formId: '28-1900',
   saveInProgress: {
     messages: {
@@ -37,7 +39,7 @@ const formConfig = {
     noAuth:
       'Please sign in again to continue your application for Vocational Readiness and Employment.',
   },
-  title: '28-1900 Vocational Readiness and Employment',
+  title: 'Apply for Veteran Readiness and Employment',
   defaultDefinitions: { ...fullSchema.definitions },
   chapters: {
     veteranInformation: {

--- a/src/applications/vre/28-1900/containers/IntroductionPage.jsx
+++ b/src/applications/vre/28-1900/containers/IntroductionPage.jsx
@@ -25,7 +25,7 @@ const IntroductionPage = props => {
 
   return (
     <div className="schemaform-intro">
-      <FormTitle title="28-1900 Veteran Readiness and Employment" />
+      <FormTitle title="Apply for Veteran Readiness and Employment" />
       <p>
         Equal to VA Form 21-1900 (28-1900 Veteran Readiness and Employment).
       </p>

--- a/src/applications/vre/28-1900/tests/config/veteranContactInformation.unit.spec.js
+++ b/src/applications/vre/28-1900/tests/config/veteranContactInformation.unit.spec.js
@@ -1,0 +1,97 @@
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import sinon from 'sinon';
+import {
+  DefinitionTester,
+  fillData,
+} from 'platform/testing/unit/schemaform-utils.jsx';
+import { changeDropdown } from '../helpers';
+
+import formConfig from '../../config/form';
+
+const {
+  schema,
+  uiSchema,
+} = formConfig.chapters.veteranInformation.pages.contactInformation;
+
+describe('Chapter 31 veteran contact information', () => {
+  it('should render', () => {
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        definitions={formConfig.defaultDefinitions}
+      />,
+    );
+    expect(form.find('input').length).to.equal(10);
+    form.unmount();
+  });
+  it('should require address and email', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        definitions={formConfig.defaultDefinitions}
+        onSubmit={onSubmit}
+      />,
+    );
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error').length).to.equal(5);
+    expect(onSubmit.called).to.be.false;
+    form.unmount();
+  });
+  it('should require emails to match', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        definitions={formConfig.defaultDefinitions}
+        onSubmit={onSubmit}
+      />,
+    );
+    fillData(form, 'select#root_veteranAddress_countryName', 'USA');
+    fillData(form, 'input#root_veteranAddress_addressLine1', 'Some road');
+    fillData(form, 'input#root_veteranAddress_city', 'Some city');
+    changeDropdown(form, 'select#root_veteranAddress_stateCode', 'DC');
+    fillData(form, 'input#root_veteranAddress_zipCode', '12345');
+    fillData(form, 'input#root_email', 'me2@home.com');
+    form.find('input[name="root_view:confirmEmail"]').simulate('change', {
+      target: {
+        value: 'test@test.com',
+      },
+    });
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error').length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
+    form.unmount();
+  });
+  it('should submit with valid fields', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        definitions={formConfig.defaultDefinitions}
+        onSubmit={onSubmit}
+      />,
+    );
+    fillData(form, 'select#root_veteranAddress_countryName', 'USA');
+    fillData(form, 'input#root_veteranAddress_addressLine1', 'Some road');
+    fillData(form, 'input#root_veteranAddress_city', 'Some city');
+    changeDropdown(form, 'select#root_veteranAddress_stateCode', 'DC');
+    fillData(form, 'input#root_veteranAddress_zipCode', '12345');
+    fillData(form, 'input#root_email', 'test@test.com');
+    form.find('input[name="root_view:confirmEmail"]').simulate('change', {
+      target: {
+        value: 'test@test.com',
+      },
+    });
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+    form.unmount();
+  });
+});


### PR DESCRIPTION
## Description
This pull request adjust several things on the chapter 31 form including:
- the addition of breadcrumbs
- updating the `h1` tag to align with mockups
- adding privacy agreement section to the review page
- adding unit tests for veteran contact information
- making email and confirm email fields required

## Testing done
- local, all tests pass

## Screenshots
<details><summary>breadcrumbs and h1</summary>

<img width="777" alt="Screen Shot 2020-10-15 at 11 49 53 AM" src="https://user-images.githubusercontent.com/15097156/96154940-5ca7e380-0edd-11eb-92c3-b8491971c669.png">
</details>

<details><summary>tests</summary>

![Screen Shot 2020-10-15 at 11 45 24 AM](https://user-images.githubusercontent.com/15097156/96155046-7b0ddf00-0edd-11eb-979a-59130a3d2711.png)
</details>

<details><summary>email fields</summary>

<img width="617" alt="Screen Shot 2020-10-15 at 10 37 51 AM" src="https://user-images.githubusercontent.com/15097156/96155102-8b25be80-0edd-11eb-8315-813939a02211.png">
<img width="706" alt="Screen Shot 2020-10-15 at 10 38 00 AM" src="https://user-images.githubusercontent.com/15097156/96155105-8bbe5500-0edd-11eb-9a9c-b3ee8a236f45.png">
</details>

<details><summary>privacy agreement</summary>

<img width="591" alt="Screen Shot 2020-10-15 at 11 58 03 AM" src="https://user-images.githubusercontent.com/15097156/96155263-bdcfb700-0edd-11eb-8a32-959dbc406896.png">
</details>


## Acceptance criteria
- [x] adjustments made
- [x] tests pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
