### PR TITLE
Revert "Remove friendly facility name display (#14537)"

### DIFF
--- a/src/applications/vaos/appointment-list/components/cards/pending/AppointmentRequestListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/cards/pending/AppointmentRequestListItem.jsx
@@ -6,6 +6,7 @@ import moment from 'moment';
 import ListBestTimeToCall from './ListBestTimeToCall';
 import { sentenceCase } from '../../../../utils/formatters';
 import {
+  getVAAppointmentLocationName,
   getPatientTelecom,
   isVideoAppointment,
 } from '../../../../services/appointment';
@@ -99,12 +100,12 @@ export default class AppointmentRequestListItem extends React.Component {
                 appointment={appointment}
               />
             )}
-            {isExpressCare && facility?.name}
+            {isExpressCare && getVAAppointmentLocationName(appointment)}
             {!isCC &&
               !isExpressCare && (
                 <VAFacilityLocation
                   facility={facility}
-                  facilityName={facility?.name}
+                  facilityName={getVAAppointmentLocationName(appointment)}
                   facilityId={parseFakeFHIRId(facilityId)}
                 />
               )}

--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -204,6 +204,19 @@ export function getVAAppointmentLocationId(appointment) {
 }
 
 /**
+ * Returns the location name of a VA appointment
+ *
+ * @export
+ * @param {Object} appointment A FHIR appointment resource
+ * @returns The location name where the VA appointment is located
+ */
+export function getVAAppointmentLocationName(appointment) {
+  return appointment.participant?.find(p =>
+    p.actor.reference?.startsWith('Location'),
+  )?.actor?.display;
+}
+
+/**
  * Returns the patient telecom info in a VA appointment
  *
  * @export

--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -321,6 +321,7 @@ function setParticipant(appt) {
           {
             actor: {
               reference: `Location/var${appt.facility.facilityCode}`,
+              display: appt.friendlyLocationName || appt.facility?.name,
             },
           },
         ];

--- a/src/applications/vaos/tests/appointment-list/components/ExpressCareList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ExpressCareList.unit.spec.jsx
@@ -8,8 +8,8 @@ import {
   setFetchJSONResponse,
 } from 'platform/testing/unit/helpers';
 import backendServices from 'platform/user/profile/constants/backendServices';
-import { getVAFacilityMock, getVARequestMock } from '../../mocks/v0';
-import { mockAppointmentInfo, mockFacilitiesFetch } from '../../mocks/helpers';
+import { getVARequestMock } from '../../mocks/v0';
+import { mockAppointmentInfo } from '../../mocks/helpers';
 import { renderFromRoutes } from '../../mocks/setup';
 
 describe('VAOS integration: express care requests', () => {
@@ -59,31 +59,10 @@ describe('VAOS integration: express care requests', () => {
       appointment.id = '1234';
       mockAppointmentInfo({ requests: [appointment] });
 
-      const facility = {
-        id: 'vha_442GC',
-        attributes: {
-          ...getVAFacilityMock().attributes,
-          uniqueId: '442GC',
-          name: 'Cheyenne VA Medical Center',
-          address: {
-            physical: {
-              zip: '82001-5356',
-              city: 'Cheyenne',
-              state: 'WY',
-              address1: '2360 East Pershing Boulevard',
-            },
-          },
-          phone: {
-            main: '307-778-7550',
-          },
-        },
-      };
-      mockFacilitiesFetch('vha_442GC', [facility]);
-
       const { baseElement, findByText, getByText } = renderFromRoutes({
         initialState,
       });
-      await findByText(/Cheyenne VA Medical Center/i);
+      await findByText(/Some VA medical center/i);
       expect(baseElement).to.contain.text('Express care appointment');
       expect(baseElement).not.to.contain.text('Preferred date and time');
       expect(baseElement).not.to.contain.text('in the morning');
@@ -116,27 +95,6 @@ describe('VAOS integration: express care requests', () => {
       appointment.id = '1234';
       mockAppointmentInfo({ requests: [appointment] });
 
-      const facility = {
-        id: 'vha_442GC',
-        attributes: {
-          ...getVAFacilityMock().attributes,
-          uniqueId: '442GC',
-          name: 'Cheyenne VA Medical Center',
-          address: {
-            physical: {
-              zip: '82001-5356',
-              city: 'Cheyenne',
-              state: 'WY',
-              address1: '2360 East Pershing Boulevard',
-            },
-          },
-          phone: {
-            main: '307-778-7550',
-          },
-        },
-      };
-      mockFacilitiesFetch('vha_442GC', [facility]);
-
       const {
         baseElement,
         findByText,
@@ -146,7 +104,7 @@ describe('VAOS integration: express care requests', () => {
         initialState,
       });
 
-      await findByText(/Cheyenne VA Medical Center/i);
+      await findByText(/Some VA medical center/i);
       expect(baseElement).not.to.contain.text('Back pain');
       expect(queryByText(/cancel appointment/i)).to.not.be.ok;
 

--- a/src/applications/vaos/tests/appointment-list/components/FutureAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/FutureAppointmentsList.unit.spec.jsx
@@ -65,6 +65,7 @@ describe('VAOS integration: pending appointments', () => {
       expect(baseElement).to.contain('.fa-exclamation-triangle');
       expect(dateHeader).to.have.tagName('h3');
 
+      expect(baseElement).to.contain.text('Some facility name');
       expect(getByText(/view facility information/i)).to.have.attribute(
         'href',
         '/find-locations/facility/vha_442GC',
@@ -147,7 +148,7 @@ describe('VAOS integration: pending appointments', () => {
         'href',
         'https://maps.google.com?saddr=Current+Location&daddr=2360 East Pershing Boulevard, Cheyenne, WY 82001-5356',
       );
-      expect(baseElement).to.contain.text('Cheyenne VA Medical Center');
+      expect(baseElement).to.contain.text('Some facility name');
       expect(baseElement).to.contain.text('2360 East Pershing Boulevard');
       expect(baseElement).to.contain.text('Cheyenne, WY 82001-5356');
       expect(baseElement).to.contain.text('307-778-7550');
@@ -333,6 +334,7 @@ describe('VAOS integration: pending appointments', () => {
       expect(baseElement).to.contain('.fa-exclamation-triangle');
       expect(dateHeader).to.have.tagName('h3');
 
+      expect(baseElement).to.contain.text('Some facility name');
       expect(getByText(/view facility information/i)).to.have.attribute(
         'href',
         '/find-locations/facility/vha_442GC',

--- a/src/applications/vaos/tests/services/appointment/transformers.unit.spec.js
+++ b/src/applications/vaos/tests/services/appointment/transformers.unit.spec.js
@@ -517,6 +517,9 @@ describe('VAOS Appointment transformer', () => {
           p.actor.reference.includes('Location'),
         )[0];
         expect(locationActor.actor.reference).to.equal('Location/var983');
+        expect(locationActor.actor.display).to.equal(
+          'CHYSHR-Cheyenne VA Medical Center',
+        );
       });
 
       it('should set patient info in participants', () => {


### PR DESCRIPTION
# Description

This reverts commit 4062dfd7fb611f357162986438996e6667f4d1f3, because there's a weird DB constraint around the facility name that is used for requests. Hopefully we can re-do this change later.

Related to https://issues.mobilehealth.va.gov/browse/VAOSR-1010

## Acceptance criteria
- [ ] facility.name is used again

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
