### PR TITLE
14426 adjust alert

### DIFF
--- a/src/applications/disability-benefits/view-payments/components/view-payments-lists/ViewPaymentsLists.jsx
+++ b/src/applications/disability-benefits/view-payments/components/view-payments-lists/ViewPaymentsLists.jsx
@@ -77,7 +77,7 @@ class ViewPaymentsLists extends Component {
       const reformattedPayments = reformatPaymentDates(filteredPayments);
       paymentsReceivedTable.content = (
         <Payments
-          tableVersion="recieved"
+          tableVersion="received"
           fields={paymentsReceivedFields}
           data={reformattedPayments}
           textContent={paymentsReceivedContent}

--- a/src/applications/disability-benefits/view-payments/components/view-payments-lists/ViewPaymentsLists.jsx
+++ b/src/applications/disability-benefits/view-payments/components/view-payments-lists/ViewPaymentsLists.jsx
@@ -5,7 +5,7 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation-react/Lo
 import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
-import moment from 'moment';
+
 import Payments from './payments/Payments.jsx';
 import ViewPaymentsHeader from '../../components/view-payments-header/ViewPaymentsHeader.jsx';
 import {
@@ -13,6 +13,9 @@ import {
   paymentsReceivedFields,
   paymentsReceivedContent,
   paymentsReturnedContent,
+  filterReturnPayments,
+  reformatReturnPaymentDates,
+  reformatPaymentDates,
 } from './helpers';
 import { getAllPayments } from '../../actions';
 import {
@@ -23,27 +26,115 @@ import {
 } from '../../utils';
 
 class ViewPaymentsLists extends Component {
+  state = {
+    returnPayments: [],
+    paymentsRecieved: [],
+  };
+
   componentDidMount() {
     this.props.getAllPayments();
   }
 
-  render() {
-    let paymentsReceivedTableContent = '';
-    let paymentsReturnedTableContent = '';
-    let content;
+  buildReturnedPaymentListContent = returnPayments => {
+    // If there are returned payments, set paymentsReturnedTable to a Payments component
+    // If there are NO returned payments, set paymentsReturnedTable to AlertBox
+    const paymentsReturnedTable = {};
 
+    if (returnPayments.length > 0) {
+      // remove all entries with all null property values
+      let filteredReturnPayments = filterReturnPayments(returnPayments);
+      // convert date to more friendly format
+      filteredReturnPayments = reformatReturnPaymentDates(
+        filteredReturnPayments,
+      );
+
+      paymentsReturnedTable.content = (
+        <Payments
+          tableVersion="returned"
+          fields={paymentsReturnedFields}
+          data={filteredReturnPayments}
+          textContent={paymentsReturnedContent}
+        />
+      );
+    } else {
+      paymentsReturnedTable.content = (
+        <AlertBox
+          content={
+            <p>
+              We can’t find any returned VA payments. If you think this is an
+              error, or if you have questions about your payment history, please
+              call <Telephone contact={CONTACTS.VA_BENEFITS} />.
+            </p>
+          }
+          headline="We don’t have a record of returned payments"
+          status="info"
+          backgroundOnly="true"
+          className="vads-u-background-color--gray-lightest"
+        />
+      );
+    }
+    return paymentsReturnedTable;
+  };
+
+  buildPaymentListContent = payments => {
+    // If there are recieved payments, set paymentsReceivedTable to a Payments component
+    // If there are NO recieved payments, set paymentsReceivedTable to AlertBox
+    const paymentsReceivedTable = {};
+    if (payments.length > 0) {
+      const reformattedPayments = reformatPaymentDates(payments);
+      paymentsReceivedTable.content = (
+        <Payments
+          tableVersion="recieved"
+          fields={paymentsReceivedFields}
+          data={reformattedPayments}
+          textContent={paymentsReceivedContent}
+        />
+      );
+    } else {
+      paymentsReceivedTable.content = (
+        <AlertBox
+          content={
+            <p>
+              We can’t find any VA payments made to you. If you think this is an
+              error, or if you have questions about your payment history, please
+              call <Telephone contact={CONTACTS.VA_BENEFITS} />.
+            </p>
+          }
+          headline="We don’t have a record of VA payments made to you"
+          status="info"
+          backgroundOnly="true"
+          className="vads-u-background-color--gray-lightest"
+        />
+      );
+    }
+    return paymentsReceivedTable;
+  };
+
+  render() {
+    let paymentsReceivedTable = '';
+    let paymentsReturnedTable = '';
+    let content;
+    // If the app is loading, show a loading LoadingIndicator
+    // if there is an error show an AlertBox
+    // If the app is NOT loading
     if (this.props.isLoading) {
       content = <LoadingIndicator message="Loading payment information..." />;
-    } else if (this.props.error) {
+    }
+
+    if (this.props.error) {
       const status = isClientError(this.props.error.code) ? 'info' : 'error';
       const alertContent = isClientError(this.props.error.code)
         ? ClientErrorAlertContent
         : ServerErrorAlertContent;
       content = <AlertBox content={alertContent} status={status} isVisible />;
-    } else if (!this.props.isLoading && this.props.payments) {
-      const { returnPayments } = this.props.payments;
-      let { payments } = this.props.payments;
-      // handle no payments for both arrays
+    }
+
+    if (!this.props.isLoading && this.props.payments) {
+      // Deconstruct payments props object
+      // If there are no payments AND no payments returned, render an Alertbox
+      // If there are either payments OR payments returned, run payment list builders
+      const { returnPayments, payments } = this.props.payments;
+
       if (returnPayments.length === 0 && payments.length === 0) {
         content = (
           <AlertBox
@@ -54,85 +145,18 @@ class ViewPaymentsLists extends Component {
           />
         );
       } else {
-        // handle no payments returned
-        if (returnPayments.length > 0) {
-          // remove all entries with all null property values
-          let filteredReturnPayments = returnPayments.filter(payment => {
-            for (const [key] of Object.entries(payment)) {
-              if (payment[key] !== null) {
-                return true;
-              }
-            }
-            return false;
-          });
-          // convert date to more friendly format
-          filteredReturnPayments = filteredReturnPayments.map(payment => {
-            return {
-              ...payment,
-              returnedCheckCancelDt: payment.returnedCheckCancelDt
-                ? moment(payment.returnedCheckCancelDt).format('MMM D, YYYY')
-                : null,
-              returnedCheckIssueDt: payment.returnedCheckIssueDt
-                ? moment(payment.returnedCheckIssueDt).format('MMM D, YYYY')
-                : null,
-            };
-          });
-          paymentsReturnedTableContent = (
-            <Payments
-              tableVersion="returned"
-              fields={paymentsReturnedFields}
-              data={filteredReturnPayments}
-              textContent={paymentsReturnedContent}
-            />
-          );
-        } else {
-          paymentsReturnedTableContent = (
-            <div className="vads-u-margin-y--2 vads-u-padding-y--2 vads-u-padding-x--3 vads-u-background-color--gray-lightest">
-              <h3 className="vads-u-margin-top--0">
-                We don’t have a record of returned payments
-              </h3>
-              <p className="vads-u-margin-bottom--0p5">
-                We can’t find any returned VA payments. If you think this is an
-                error, or if you have questions about your payment history,
-                please call <Telephone contact={CONTACTS.VA_BENEFITS} />.
-              </p>
-            </div>
-          );
-        }
-        // handle no payments received
-        if (payments.length > 0) {
-          payments = payments.map(payment => {
-            return {
-              ...payment,
-              payCheckDt: moment(payment.payCheckDt).format('MMM D, YYYY'),
-            };
-          });
-          paymentsReceivedTableContent = (
-            <Payments
-              tableVersion="recieved"
-              fields={paymentsReceivedFields}
-              data={payments}
-              textContent={paymentsReceivedContent}
-            />
-          );
-        } else {
-          paymentsReceivedTableContent = (
-            <div className="vads-u-margin-y--2 vads-u-padding-y--2 vads-u-padding-x--3 vads-u-background-color--gray-lightest">
-              <h3 className="vads-u-margin-top--0">
-                We don’t have a record of VA payments made to you
-              </h3>
-              <p className="vads-u-margin-bottom--0p5">
-                We can’t find any VA payments made to you. If you think this is
-                an error, or if you have questions about your payment history,
-                please call <Telephone contact={CONTACTS.VA_BENEFITS} />.
-              </p>
-            </div>
-          );
-        }
+        // run payments returned list builder
+        paymentsReturnedTable = this.buildReturnedPaymentListContent(
+          returnPayments,
+        );
+
+        // Run payments recieved list builder
+        paymentsReceivedTable = this.buildPaymentListContent(payments);
+
         content = (
           <>
             <ViewPaymentsHeader />
-            {paymentsReceivedTableContent}
+            {paymentsReceivedTable.content}
             <strong>Note:</strong> Some payment details might not be available
             online. For example, direct-deposit payments less than $1 or check
             payments less than $5, won’t show in your online payment history.
@@ -140,7 +164,7 @@ class ViewPaymentsLists extends Component {
             recurring and irregular compensation payments. If you have questions
             about payments made by VA, please call the VA Help Desk at{' '}
             <Telephone contact={CONTACTS.VA_BENEFITS} />
-            {paymentsReturnedTableContent}
+            {paymentsReturnedTable.content}
             <h3>What if I find a check that I reported missing?</h3>
             <p>
               If you reported a check missing and found it later, you must
@@ -154,6 +178,7 @@ class ViewPaymentsLists extends Component {
         );
       }
     }
+
     return content;
   }
 }

--- a/src/applications/disability-benefits/view-payments/components/view-payments-lists/ViewPaymentsLists.jsx
+++ b/src/applications/disability-benefits/view-payments/components/view-payments-lists/ViewPaymentsLists.jsx
@@ -36,13 +36,8 @@ class ViewPaymentsLists extends Component {
     const paymentsReturnedTable = {};
 
     if (returnPayments.length > 0) {
-      // remove all entries with all null property values
-      let filteredReturnPayments = filterReturnPayments(returnPayments);
-
       // convert date to more friendly format
-      filteredReturnPayments = reformatReturnPaymentDates(
-        filteredReturnPayments,
-      );
+      const filteredReturnPayments = reformatReturnPaymentDates(returnPayments);
 
       paymentsReturnedTable.content = (
         <Payments
@@ -77,7 +72,9 @@ class ViewPaymentsLists extends Component {
     // If there are NO recieved payments, set paymentsReceivedTable to AlertBox
     const paymentsReceivedTable = {};
     if (payments.length > 0) {
-      const reformattedPayments = reformatPaymentDates(payments);
+      // remove all entries with all null property values
+      const filteredPayments = filterReturnPayments(payments);
+      const reformattedPayments = reformatPaymentDates(filteredPayments);
       paymentsReceivedTable.content = (
         <Payments
           tableVersion="recieved"

--- a/src/applications/disability-benefits/view-payments/components/view-payments-lists/ViewPaymentsLists.jsx
+++ b/src/applications/disability-benefits/view-payments/components/view-payments-lists/ViewPaymentsLists.jsx
@@ -33,13 +33,13 @@ class ViewPaymentsLists extends Component {
   buildReturnedPaymentListContent = returnPayments => {
     // If there are returned payments, set paymentsReturnedTable to a Payments component
     // If there are NO returned payments, set paymentsReturnedTable to AlertBox
-    const paymentsReturnedTable = {};
+    let paymentsReturnedTable = {};
 
     if (returnPayments.length > 0) {
       // convert date to more friendly format
       const filteredReturnPayments = reformatReturnPaymentDates(returnPayments);
 
-      paymentsReturnedTable.content = (
+      paymentsReturnedTable = (
         <Payments
           tableVersion="returned"
           fields={paymentsReturnedFields}
@@ -48,7 +48,7 @@ class ViewPaymentsLists extends Component {
         />
       );
     } else {
-      paymentsReturnedTable.content = (
+      paymentsReturnedTable = (
         <AlertBox
           content={
             <p>
@@ -70,12 +70,12 @@ class ViewPaymentsLists extends Component {
   buildPaymentListContent = payments => {
     // If there are recieved payments, set paymentsReceivedTable to a Payments component
     // If there are NO recieved payments, set paymentsReceivedTable to AlertBox
-    const paymentsReceivedTable = {};
+    let paymentsReceivedTable = {};
     if (payments.length > 0) {
       // remove all entries with all null property values
       const filteredPayments = filterReturnPayments(payments);
       const reformattedPayments = reformatPaymentDates(filteredPayments);
-      paymentsReceivedTable.content = (
+      paymentsReceivedTable = (
         <Payments
           tableVersion="received"
           fields={paymentsReceivedFields}
@@ -84,7 +84,7 @@ class ViewPaymentsLists extends Component {
         />
       );
     } else {
-      paymentsReceivedTable.content = (
+      paymentsReceivedTable = (
         <AlertBox
           content={
             <p>
@@ -148,7 +148,7 @@ class ViewPaymentsLists extends Component {
         content = (
           <>
             <ViewPaymentsHeader />
-            {paymentsReceivedTable.content}
+            {paymentsReceivedTable}
             <strong>Note:</strong> Some payment details might not be available
             online. For example, direct-deposit payments less than $1 or check
             payments less than $5, won’t show in your online payment history.
@@ -156,7 +156,7 @@ class ViewPaymentsLists extends Component {
             recurring and irregular compensation payments. If you have questions
             about payments made by VA, please call the VA Help Desk at{' '}
             <Telephone contact={CONTACTS.VA_BENEFITS} />
-            {paymentsReturnedTable.content}
+            {paymentsReturnedTable}
             <h3>What if I find a check that I reported missing?</h3>
             <p>
               If you reported a check missing and found it later, you must

--- a/src/applications/disability-benefits/view-payments/components/view-payments-lists/ViewPaymentsLists.jsx
+++ b/src/applications/disability-benefits/view-payments/components/view-payments-lists/ViewPaymentsLists.jsx
@@ -26,11 +26,6 @@ import {
 } from '../../utils';
 
 class ViewPaymentsLists extends Component {
-  state = {
-    returnPayments: [],
-    paymentsRecieved: [],
-  };
-
   componentDidMount() {
     this.props.getAllPayments();
   }
@@ -43,6 +38,7 @@ class ViewPaymentsLists extends Component {
     if (returnPayments.length > 0) {
       // remove all entries with all null property values
       let filteredReturnPayments = filterReturnPayments(returnPayments);
+
       // convert date to more friendly format
       filteredReturnPayments = reformatReturnPaymentDates(
         filteredReturnPayments,
@@ -134,7 +130,6 @@ class ViewPaymentsLists extends Component {
       // If there are no payments AND no payments returned, render an Alertbox
       // If there are either payments OR payments returned, run payment list builders
       const { returnPayments, payments } = this.props.payments;
-
       if (returnPayments.length === 0 && payments.length === 0) {
         content = (
           <AlertBox

--- a/src/applications/disability-benefits/view-payments/components/view-payments-lists/helpers.js
+++ b/src/applications/disability-benefits/view-payments/components/view-payments-lists/helpers.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import moment from 'moment';
 
 export const paymentsReceivedFields = [
   {
@@ -86,3 +87,37 @@ export const paymentsReturnedContent = (
     </p>
   </>
 );
+
+export const filterReturnPayments = payments => {
+  return payments.filter(payment => {
+    for (const [key] of Object.entries(payment)) {
+      if (payment[key] !== null) {
+        return true;
+      }
+    }
+    return false;
+  });
+};
+
+export const reformatReturnPaymentDates = payments => {
+  return payments.map(payment => {
+    return {
+      ...payment,
+      returnedCheckCancelDt: payment.returnedCheckCancelDt
+        ? moment(payment.returnedCheckCancelDt).format('MMM D, YYYY')
+        : null,
+      returnedCheckIssueDt: payment.returnedCheckIssueDt
+        ? moment(payment.returnedCheckIssueDt).format('MMM D, YYYY')
+        : null,
+    };
+  });
+};
+
+export const reformatPaymentDates = payments => {
+  return payments.map(payment => {
+    return {
+      ...payment,
+      payCheckDt: moment(payment.payCheckDt).format('MMM D, YYYY'),
+    };
+  });
+};

--- a/src/applications/disability-benefits/view-payments/components/view-payments-lists/payments/Payments.jsx
+++ b/src/applications/disability-benefits/view-payments/components/view-payments-lists/payments/Payments.jsx
@@ -5,9 +5,6 @@ import ResponsiveTable from '../../responsive-table/ResponsiveTable';
 import { clientServerErrorContent } from '../helpers';
 import { chunk } from 'lodash';
 
-const alertClasses =
-  'vads-u-padding-y--2p5 vads-u-padding-right--4 vads-u-padding-left--2';
-
 class Payments extends Component {
   state = {
     page: 1,
@@ -102,10 +99,10 @@ class Payments extends Component {
     } else {
       tableContent = (
         <AlertBox
-          className={alertClasses}
           content={clientServerErrorContent('Received')}
           status="info"
-          isVisible
+          backgroundOnly="true"
+          className="vads-u-background-color--gray-lightest"
         />
       );
     }

--- a/src/applications/disability-benefits/view-payments/components/view-payments-lists/payments/Payments.jsx
+++ b/src/applications/disability-benefits/view-payments/components/view-payments-lists/payments/Payments.jsx
@@ -99,7 +99,7 @@ class Payments extends Component {
     } else {
       tableContent = (
         <AlertBox
-          content={clientServerErrorContent('Received')}
+          content={clientServerErrorContent(this.props.tableVersion)}
           status="info"
           backgroundOnly="true"
           className="vads-u-background-color--gray-lightest"

--- a/src/applications/disability-benefits/view-payments/tests/components/view-payments-lists/Payments/Payments.unit.spec.jsx
+++ b/src/applications/disability-benefits/view-payments/tests/components/view-payments-lists/Payments/Payments.unit.spec.jsx
@@ -29,15 +29,14 @@ describe('<Payments />', () => {
     const mockEmptyPayments = [];
     const screen = render(
       <Payments
+        tableVersion="received"
         fields={paymentsReceivedFields}
         data={mockEmptyPayments}
         textContent={paymentsReceivedContent}
       />,
     );
 
-    expect(
-      await screen.findByText(/We don’t have a record of returned payments/),
-    ).to.exist;
+    expect(await screen.findByText(/No received payments/)).to.exist;
   });
 
   it('should update the display numbers when paginating', async () => {

--- a/src/applications/disability-benefits/view-payments/tests/components/view-payments-lists/Payments/Payments.unit.spec.jsx
+++ b/src/applications/disability-benefits/view-payments/tests/components/view-payments-lists/Payments/Payments.unit.spec.jsx
@@ -35,7 +35,9 @@ describe('<Payments />', () => {
       />,
     );
 
-    expect(await screen.findByText(/No Received payments/)).to.exist;
+    expect(
+      await screen.findByText(/We don’t have a record of returned payments/),
+    ).to.exist;
   });
 
   it('should update the display numbers when paginating', async () => {


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/14426)

This PR is to change the style of the error message we show when there are no returned payments. I also decided to do a refactor of the payment lists component to make the logic more readable and more maintainable.

## Testing done
All existing unit tests still pass

## Screenshots
![Screen Shot 2020-10-15 at 10 04 16 AM](https://user-images.githubusercontent.com/1899695/96162785-ce783100-0ecd-11eb-9bc5-bec9a2cc5d45.png)


## Acceptance criteria
- [x] The logic that renders the no payments Alertbox for a table has been moved to the component
- [x] The Alertbox that is shown when a table has no payments does not have the blue line on the left-hand side
- [x] A PR has been submitted for review

