### PR TITLE
Prefix name for test facilities in VAOS

### DIFF
--- a/src/applications/vaos/utils/data.js
+++ b/src/applications/vaos/utils/data.js
@@ -61,6 +61,8 @@ function getTestFacilityName(id, name) {
   }
 
   if (!environment.isProduction() && id.startsWith('984')) {
+    // The extra space here is intentional, that appears to be how it is named
+    // in CDW
     return `DAYTSHR -${name}`;
   }
 

--- a/src/applications/vaos/utils/data.js
+++ b/src/applications/vaos/utils/data.js
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import titleCase from 'platform/utilities/data/titleCase';
+import environment from 'platform/utilities/environment';
 import {
   PURPOSE_TEXT,
   CC_PURPOSE,
@@ -54,6 +55,18 @@ function getUserMessage(data) {
   return `${label}: ${data.reasonAdditionalInfo}`;
 }
 
+function getTestFacilityName(id, name) {
+  if (!environment.isProduction() && id.startsWith('983')) {
+    return `CHYSHR-${name}`;
+  }
+
+  if (!environment.isProduction() && id.startsWith('984')) {
+    return `DAYTSHR -${name}`;
+  }
+
+  return name;
+}
+
 export function transformFormToVARequest(state) {
   const facility = getChosenFacilityInfo(state);
   const data = getFormData(state);
@@ -63,13 +76,16 @@ export function transformFormToVARequest(state) {
   const facilityId = isFacilityV2Page
     ? facility.id.replace('var', '')
     : getFacilityIdFromLocation(facility);
+  const facilityName = isFacilityV2Page
+    ? getTestFacilityName(facilityId, facility.name)
+    : facility.name;
 
   return {
     typeOfCare: typeOfCare.id,
     typeOfCareId: typeOfCare.id,
     appointmentType: typeOfCare.name,
     facility: {
-      name: facility.name,
+      name: facilityName,
       facilityCode: facilityId,
       parentSiteCode: siteId,
     },


### PR DESCRIPTION
## Description
The new facility page has the same issue that EC has, in that we have problems on the backend when sending the Lighthouse facility name instead of the CDW name.

I'm attempting to fix that by prefixing the name when not in prod so that it matches the CDW name. If this doesn't work, we'll need to port over EC's helpers for calling the services to get the name.

## Testing done
Unit testing

## Acceptance criteria
- [ ] Requests can be submitted

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
