### PR TITLE
526/BDD: Move servedInCombatZone Immediately After Military History

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -208,6 +208,13 @@ const formConfig = {
           uiSchema: separationLocation.uiSchema,
           schema: separationLocation.schema,
         },
+        servedInCombatZone: {
+          title: 'Combat status',
+          path: 'review-veteran-details/combat-status',
+          depends: servedAfter911,
+          uiSchema: servedInCombatZone.uiSchema,
+          schema: servedInCombatZone.schema,
+        },
         claimType: {
           title: 'Claim type',
           path: 'claim-type',
@@ -216,13 +223,6 @@ const formConfig = {
           uiSchema: claimType.uiSchema,
           schema: claimType.schema,
           onContinue: captureEvents.claimType,
-        },
-        servedInCombatZone: {
-          title: 'Combat status',
-          path: 'review-veteran-details/combat-status',
-          depends: servedAfter911,
-          uiSchema: servedInCombatZone.uiSchema,
-          schema: servedInCombatZone.schema,
         },
         reservesNationalGuardService: {
           title: 'Reserves and National Guard service',

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -236,11 +236,8 @@ export function queryForFacilities(input = '') {
 
 export function getSeparationLocations() {
   return apiRequest('/disability_compensation_form/separation_locations')
-    .then((
-      { separation_locations }, // eslint-disable-line camelcase
-    ) =>
-      // eslint-disable-next-line camelcase
-      separation_locations.map(separationLocation => ({
+    .then(({ separationLocations }) =>
+      separationLocations.map(separationLocation => ({
         id: separationLocation.code,
         label: separationLocation.description,
       })),


### PR DESCRIPTION
## Description
This moves the `servedInCombatZone` page to be immediately after the military history/separation location pages.

## Acceptance criteria
- [ ] `servedInCombatZone` page is immediately after the military history/separation location page in the 526/BDD flow