### PR TITLE
do not log to sentry for review instance

### DIFF
--- a/src/platform/monitoring/sentry.js
+++ b/src/platform/monitoring/sentry.js
@@ -7,9 +7,10 @@ import * as Sentry from '@sentry/browser';
 import environment from '../utilities/environment';
 
 // url check is necessary for e2e tests and local environments
-const trackErrors = environment.BASE_URL.indexOf('localhost') < 0;
+const isLocalhost      = environment.BASE_URL.includes('localhost')
+const isReviewInstance = environment.BASE_URL.includes('.review.');
 
-if (trackErrors) {
+if (!(isLocalhost || isReviewInstance)) {
   const url = `${environment.BASE_URL}/js-report/0`.replace('//', '//faker@');
   Sentry.init({
     dsn: url,


### PR DESCRIPTION
## Description
Prevent tracking sentry errors when on review instances.

[Related slack thread](https://dsva.slack.com/archives/CBU0KDSB1/p1602098456245800)

## Testing done
Teste in local chrome dev tools console.

## Screenshots
![image](https://user-images.githubusercontent.com/3077884/96180430-68f16800-0f00-11eb-93e7-7a3bc306443c.png)


## Acceptance criteria
- [ ]

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub) - N/A, no ticket exists but slack thread in support channel linked
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
