### PR TITLE
[14166] Add form data checks to cypress test

### DIFF
--- a/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
@@ -1,4 +1,5 @@
 import { initCommunityCareMock } from './vaos-cypress-helpers';
+import moment from 'moment';
 
 describe('Create new community care appointment', () => {
   beforeEach(() => {
@@ -158,6 +159,55 @@ describe('Create new community care appointment', () => {
     cy.axeCheck();
     // Click continue button
     cy.get('.usa-button').click();
+
+    // Check form requestBody is as expected
+    cy.wait('@appointmentRequests').should(xhr => {
+      expect(xhr.status).to.eq(200);
+      expect(xhr.url, 'post url').to.contain(
+        '/vaos/v0/appointment_requests?type=cc',
+      );
+
+      const request = xhr.requestBody;
+      expect(request)
+        .to.have.property('optionDate1')
+        .to.equal(
+          moment()
+            .add(5, 'days')
+            .format('MM/DD/YYYY'),
+        );
+      expect(request)
+        .to.have.property('optionDate2')
+        .to.equal('No Date Selected');
+      expect(request)
+        .to.have.property('optionDate3')
+        .to.equal('No Date Selected');
+      expect(Cypress._.values(request.preferredProviders)).to.deep.eq([
+        {
+          address: {
+            city: 'city',
+            state: 'IL',
+            street: 'address1, address2',
+            zipCode: '60613',
+          },
+          firstName: 'firstname',
+          lastName: 'lastname',
+          practiceName: 'practice name',
+          providerCity: 'city',
+          providerState: 'IL',
+          providerStreet: 'address1, address2',
+          providerZipCode1: '60613',
+        },
+      ]);
+      expect(request).to.have.property(
+        'newMessage',
+        'This is a very good reason.',
+      );
+      expect(request).to.have.property('optionTime1', 'AM');
+      expect(request).to.have.property('optionTime2', 'No Time Selected');
+      expect(request).to.have.property('optionTime3', 'No Time Selected');
+      expect(request).to.have.property('email', 'veteran@gmail.com');
+      expect(request).to.have.property('phoneNumber', '5035551234');
+    });
 
     // Your appointment request has been submitted step
     cy.url().should(

--- a/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
@@ -164,18 +164,13 @@ describe('Create new community care appointment', () => {
     cy.wait('@appointmentRequests').should(xhr => {
       let date = moment().add(5, 'days');
 
+      // Check for weekend and select following Monday if true
       if (date.weekday() === 0) {
-        date = date
-          .add(7, 'days')
-          .day(1)
-          .format('MM/DD/YYYY');
+        date = date.add(1, 'days').format('MM/DD/YYYY');
       } else if (date.weekday() === 6) {
-        date = date
-          .add(1, 'days')
-          .day(1)
-          .format('MM/DD/YYYY');
+        date = date.add(2, 'days').format('MM/DD/YYYY');
       } else {
-        date = date.day(1).format('MM/DD/YYYY');
+        date = date.format('MM/DD/YYYY');
       }
 
       expect(xhr.status).to.eq(200);

--- a/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
@@ -165,9 +165,17 @@ describe('Create new community care appointment', () => {
       let date = moment().add(5, 'days');
 
       if (date.weekday() === 0) {
-        date = moment().add(7, 'days');
+        date = date
+          .add(7, 'days')
+          .day(1)
+          .format('MM/DD/YYYY');
       } else if (date.weekday() === 6) {
-        date = moment().add(6, 'days');
+        date = date
+          .add(1, 'days')
+          .day(1)
+          .format('MM/DD/YYYY');
+      } else {
+        date = date.day(1).format('MM/DD/YYYY');
       }
 
       expect(xhr.status).to.eq(200);
@@ -177,7 +185,7 @@ describe('Create new community care appointment', () => {
       const request = xhr.requestBody;
       expect(request)
         .to.have.property('optionDate1')
-        .to.equal(date.day(1).format('MM/DD/YYYY'));
+        .to.equal(date);
       expect(request)
         .to.have.property('optionDate2')
         .to.equal('No Date Selected');

--- a/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
@@ -173,7 +173,8 @@ describe('Create new community care appointment', () => {
         .to.equal(
           moment()
             .add(5, 'days')
-            .format('MM/DD/YYYY'),
+            .format('MM/DD/YYYY')
+            .day(1),
         );
       expect(request)
         .to.have.property('optionDate2')

--- a/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
@@ -162,20 +162,22 @@ describe('Create new community care appointment', () => {
 
     // Check form requestBody is as expected
     cy.wait('@appointmentRequests').should(xhr => {
+      let date = moment().add(5, 'days');
+
+      if (date.weekday() === 0) {
+        date = moment().add(7, 'days');
+      } else if (date.weekday() === 6) {
+        date = moment().add(6, 'days');
+      }
+
       expect(xhr.status).to.eq(200);
       expect(xhr.url, 'post url').to.contain(
         '/vaos/v0/appointment_requests?type=cc',
       );
-
       const request = xhr.requestBody;
       expect(request)
         .to.have.property('optionDate1')
-        .to.equal(
-          moment()
-            .add(5, 'days')
-            .format('MM/DD/YYYY')
-            .day(1),
-        );
+        .to.equal(date.day(1).format('MM/DD/YYYY'));
       expect(request)
         .to.have.property('optionDate2')
         .to.equal('No Date Selected');

--- a/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
@@ -423,7 +423,7 @@ export function initCommunityCareMock() {
         attributes: {},
       },
     },
-  });
+  }).as('appointmentRequests');
 
   cy.route({
     method: 'POST',


### PR DESCRIPTION
## Description
For the Cypress tests we've written that go through the form flow, we should be able to inspect the submit request data at the end of the flow and verify that the data matches what we expect. This would be a big step up for our e2e tests, as previously we've only been able to test that it called the right endpoint.

## Testing done
local and cypress

## Screenshots


## Acceptance criteria
- [x] Cypress test verifies that all data entered in the form is contained in the body of the form submit POST request in the correct spot.
- [x] Focus on community care flow only for this ticket

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
