### PR TITLE
14639: 1995: Update button and question content

### DIFF
--- a/src/applications/edu-benefits/definitions/serviceBefore1977.jsx
+++ b/src/applications/edu-benefits/definitions/serviceBefore1977.jsx
@@ -23,7 +23,7 @@ const uiSchema = {
   },
   parentDependent: {
     'ui:title':
-      'Do you have a parent who is dependent on your financial support?',
+      'Do you have a parent who depends on you for financial support?',
     'ui:widget': 'yesNo',
   },
 };

--- a/src/applications/edu-benefits/definitions/toursOfDuty.jsx
+++ b/src/applications/edu-benefits/definitions/toursOfDuty.jsx
@@ -64,7 +64,7 @@ export function schema(currentSchema, userOptions) {
 export const uiSchema = {
   'ui:title': 'Service periods',
   'ui:options': {
-    itemName: 'Service Period',
+    itemName: 'service period',
     viewField: ServicePeriodView,
     hideTitle: true,
   },

--- a/src/platform/forms-system/src/js/fields/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/fields/ArrayField.jsx
@@ -372,7 +372,7 @@ export default class ArrayField extends React.Component {
             disabled={!this.props.formData || addAnotherDisabled}
             onClick={this.handleAdd}
           >
-            Add Another {uiOptions.itemName}
+            Add another {uiOptions.itemName}
           </button>
           <p>
             {addAnotherDisabled &&

--- a/src/platform/forms-system/src/js/fields/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/fields/ArrayField.jsx
@@ -145,7 +145,7 @@ export default class ArrayField extends React.Component {
   }
 
   /*
-   * Clicking Add Another
+   * Clicking Add another
    */
   handleAdd() {
     const lastIndex = this.props.formData.length - 1;

--- a/src/platform/forms-system/src/js/review/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/review/ArrayField.jsx
@@ -335,8 +335,8 @@ class ArrayField extends React.Component {
                   onClick={() => this.handleAdd()}
                 >
                   {uiOptions.itemName
-                    ? `Add Another ${uiOptions.itemName}`
-                    : 'Add Another'}
+                    ? `Add another ${uiOptions.itemName}`
+                    : 'Add another'}
                 </button>
                 <div>
                   {addAnotherDisabled &&

--- a/src/platform/forms-system/test/js/fields/ArrayField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/fields/ArrayField.unit.spec.jsx
@@ -141,7 +141,7 @@ describe('Schemaform <ArrayField>', () => {
     // no remove button
     expect(button.length).to.equal(2);
     expect(button[0].text()).to.equal('Save');
-    expect(button[1].text()).to.contain('Add Another');
+    expect(button[1].text()).to.contain('Add another');
   });
   it('should render save button with showSave option', () => {
     const idSchema = {
@@ -188,7 +188,7 @@ describe('Schemaform <ArrayField>', () => {
     expect(button[0].text()).to.equal('Edit');
     expect(button[1].text()).to.equal('Update');
     expect(button[2].text()).to.equal('Remove');
-    expect(button[3].text()).to.contain('Add Another');
+    expect(button[3].text()).to.contain('Add another');
   });
 
   it('should render invalid items', () => {

--- a/src/platform/forms-system/test/js/review/ArrayField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ArrayField.unit.spec.jsx
@@ -133,7 +133,7 @@ describe('Schemaform review <ArrayField>', () => {
       items: {},
       'ui:options': {
         viewField: f => f,
-        itemName: 'Item name',
+        itemName: 'item name',
       },
     };
     const arrayData = [{}, {}];
@@ -153,9 +153,9 @@ describe('Schemaform review <ArrayField>', () => {
     );
 
     tree.getMountedInstance().handleAdd();
-    expect(tree.everySubTree('h5')[0].text()).to.equal('New Item name');
+    expect(tree.everySubTree('h5')[0].text()).to.equal('New item name');
     expect(tree.everySubTree('button')[2].text()).to.equal(
-      'Add another Item name',
+      'Add another item name',
     );
   });
   it('should render array warning', () => {

--- a/src/platform/forms-system/test/js/review/ArrayField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ArrayField.unit.spec.jsx
@@ -155,7 +155,7 @@ describe('Schemaform review <ArrayField>', () => {
     tree.getMountedInstance().handleAdd();
     expect(tree.everySubTree('h5')[0].text()).to.equal('New Item name');
     expect(tree.everySubTree('button')[2].text()).to.equal(
-      'Add Another Item name',
+      'Add another Item name',
     );
   });
   it('should render array warning', () => {


### PR DESCRIPTION
## Description
As a developer, I need to update the 1995 so that it is up to date with the current DEPO patterns and practices.

[Originating Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/14639)

## Testing done


## Screenshots
<img width="172" alt="Screen Shot 2020-10-15 at 3 53 37 PM" src="https://user-images.githubusercontent.com/48804834/96181094-74915e80-0f01-11eb-97e0-637d98243b69.png">
<img width="363" alt="Screen Shot 2020-10-15 at 3 54 56 PM" src="https://user-images.githubusercontent.com/48804834/96181097-75c28b80-0f01-11eb-9b38-8bbc935a4286.png">


## Acceptance criteria
- [x] In chapter 3, the "Add Another Service Period" button is replaced with "Add another service period"
- [x] In chapter 5, the "Do you have a parent who is dependent on your financial support?" question is replaced with "Do you have a parent who depends on you for financial support?"

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
