### PR TITLE
[Development] Validate BDD flow

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/UpdateMilitaryHistory.jsx
+++ b/src/applications/disability-benefits/all-claims/components/UpdateMilitaryHistory.jsx
@@ -2,12 +2,16 @@ import { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { setData } from 'platform/forms-system/src/js/actions';
 
+import { isBDD } from '../utils';
 import { SAVED_SEPARATION_DATE } from '../constants';
 
 export const addServicePeriod = (formData, separationDate, setFormData) => {
   const updateData = newData => {
     window.sessionStorage.removeItem(SAVED_SEPARATION_DATE);
-    setFormData(newData);
+    setFormData({
+      ...newData,
+      'view:isBddData': true,
+    });
   };
 
   const data = formData;
@@ -47,7 +51,7 @@ export const UpdateMilitaryHistory = ({ form = {}, setFormData }) => {
   // Get date from Wizard if user entered a valid BDD separation date
   const separationDate = window.sessionStorage.getItem(SAVED_SEPARATION_DATE);
   useEffect(() => {
-    if (form.data && separationDate) {
+    if (form.data && isBDD(form.data) && separationDate) {
       addServicePeriod(form.data, separationDate, setFormData);
     }
   });

--- a/src/applications/disability-benefits/all-claims/tests/components/UpdateMilitaryHistory.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/UpdateMilitaryHistory.unit.spec.jsx
@@ -1,15 +1,24 @@
 import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
+import moment from 'moment';
 
 import { SAVED_SEPARATION_DATE } from '../../constants';
 import { UpdateMilitaryHistory } from '../../components/UpdateMilitaryHistory';
+
+const inRangeBddDate = moment()
+  .add(120, 'days')
+  .format('YYYY-MM-DD');
+
+const inRangeBddDate2 = moment()
+  .add(100, 'days')
+  .format('YYYY-MM-DD');
 
 describe('UpdateMilitaryHistory', () => {
   let wrapper;
   let oldSessionStorage;
   let storage = {};
-  const servicePeriods = (to = '2020-12-31') => [
+  const servicePeriods = (to = inRangeBddDate2) => [
     {
       serviceBranch: 'Army',
       dateRange: {
@@ -68,7 +77,7 @@ describe('UpdateMilitaryHistory', () => {
   });
   it('should update the form data', () => {
     setUp({
-      separationDate: '2021-01-30',
+      separationDate: inRangeBddDate,
       callback: () => {
         expect(form.data.serviceInformation.servicePeriods).to.deep.equal([
           ...servicePeriods(),
@@ -76,37 +85,38 @@ describe('UpdateMilitaryHistory', () => {
             serviceBranch: '',
             dateRange: {
               from: '',
-              to: '2021-01-30',
+              to: inRangeBddDate,
             },
           },
         ]);
         expect(form.data.serviceInformation.servicePeriods).to.have.lengthOf(2);
+        expect(form.data['view:isBddData']).to.be.true;
       },
     });
   });
   it('should add separation date to an existing "empty" entry', () => {
-    const separationDate = '2021-01-30';
     setUp({
-      separationDate,
+      separationDate: inRangeBddDate,
       to: '', // Add empty "to" date in prefill
       callback: () => {
         expect(form.data.serviceInformation.servicePeriods).to.deep.equal(
-          servicePeriods(separationDate),
+          servicePeriods(inRangeBddDate),
         );
         expect(form.data.serviceInformation.servicePeriods).to.have.lengthOf(1);
+        expect(form.data['view:isBddData']).to.be.true;
       },
     });
   });
   it('should not add a duplicate separation date', () => {
-    const separationDate = '2021-01-30';
     setUp({
-      separationDate,
-      to: separationDate, // Separation date already in prefill
+      separationDate: inRangeBddDate,
+      to: inRangeBddDate, // Separation date already in prefill
       callback: () => {
         expect(form.data.serviceInformation.servicePeriods).to.deep.equal(
-          servicePeriods(separationDate),
+          servicePeriods(inRangeBddDate),
         );
         expect(form.data.serviceInformation.servicePeriods).to.have.lengthOf(1);
+        expect(form.data['view:isBddData']).to.be.true;
       },
     });
   });

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -915,6 +915,7 @@ describe('526 v2 depends functions', () => {
     },
   };
   const isBDDTrueData = {
+    'view:isBddData': true,
     serviceInformation: {
       servicePeriods: [
         {
@@ -933,6 +934,7 @@ describe('526 v2 depends functions', () => {
     },
   };
   const isBDDLessThan90Data = {
+    'view:isBddData': true,
     serviceInformation: {
       servicePeriods: [
         {
@@ -1023,6 +1025,9 @@ describe('526 v2 depends functions', () => {
     it('should return false if no service period is provided with a separation date', () => {
       expect(isBDD(null)).to.be.false;
     });
+    it('should return false if no service period is provided with a separation date', () => {
+      expect(isBDD({ 'view:isBddData': true })).to.be.false;
+    });
     it('should return true if a valid date is added to session storage from the wizard', () => {
       sessionStorage.setItem(
         SAVED_SEPARATION_DATE,
@@ -1032,6 +1037,15 @@ describe('526 v2 depends functions', () => {
       );
       expect(isBDD(null)).to.be.true;
     });
+    it('should return true if a valid date is added to session storage from the wizard even if active duty flag is false', () => {
+      sessionStorage.setItem(
+        SAVED_SEPARATION_DATE,
+        moment()
+          .add(90, 'days')
+          .format('YYYY-MM-DD'),
+      );
+      expect(isBDD({ 'view:isBddData': true })).to.be.true;
+    });
     it('should return false for invalid dates in session storage from the wizard', () => {
       sessionStorage.setItem(
         SAVED_SEPARATION_DATE,
@@ -1040,6 +1054,18 @@ describe('526 v2 depends functions', () => {
           .format('YYYY-MM-DD'),
       );
       expect(isBDD(null)).to.be.false;
+    });
+    it('should return false for invalid dates in session storage from the wizard even if active duty flag is true', () => {
+      sessionStorage.setItem(
+        SAVED_SEPARATION_DATE,
+        moment()
+          .add(200, 'days')
+          .format('YYYY-MM-DD'),
+      );
+      expect(isBDD({ 'view:isBddData': true })).to.be.false;
+    });
+    it('should ignore in range service periods if not on active duty', () => {
+      expect(isBDD({ ...isBDDTrueData, 'view:isBddData': false })).to.be.false;
     });
   });
 

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -863,14 +863,25 @@ export const DISABILITY_SHARED_CONFIG = {
 
 export const isBDD = formData => {
   const servicePeriods = formData?.serviceInformation?.servicePeriods;
+
   // separation date entered in the wizard
   const separationDate = window.sessionStorage.getItem(SAVED_SEPARATION_DATE);
+
   // this flag helps maintain the correct form title within a session
   window.sessionStorage.removeItem(FORM_STATUS_BDD);
 
+  // User hasn't started the form or the wizard
   if ((!servicePeriods || !Array.isArray(servicePeriods)) && !separationDate) {
     return false;
   }
+
+  // isActiveDuty is true when the user selects that option in the wizard & then
+  // enters a separation date - based on the session storage value; we then
+  // set this flag in the formData.
+  // If the user doesn't choose the active duty wizard option, but enters a
+  // future date in their service history, this may be associated with reserves
+  // and therefor should not open the BDD flow
+  const isActiveDuty = Boolean(formData?.['view:isBddData'] || separationDate);
 
   const mostRecentDate = separationDate
     ? moment(separationDate)
@@ -884,6 +895,7 @@ export const isBDD = formData => {
   }
 
   const result =
+    isActiveDuty &&
     mostRecentDate.isAfter(moment().add(89, 'days')) &&
     !mostRecentDate.isAfter(moment().add(180, 'days'));
   if (result) {


### PR DESCRIPTION
## Description

To ensure that a service member is properly entering the BDD (Benefits Delivery at Discharge) flow, this PR uses the member entered separation date from the wizard as an indicator that they are on active duty - given that they answered the first wizard question that they are on active duty.

Previously, if a member entered a future date in the service history that is within the 90 to 180 day timeframe for BDD, they would enter the flow regardless if they selected active duty in the wizard, or not.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/13773

## Testing done

Updated BDD specific unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] BDD flow is followed _only_ if the user chooses "active duty" in the wizard
- [x] Entering a valid date between 90 to 180 days in the future in the service history will not automatically enter the member into the BDD flow unless they made the "active duty" selection in the wizard

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
