### PR TITLE
Add the "retries" flag into Mocha command

### DIFF
--- a/script/run-unit-test.js
+++ b/script/run-unit-test.js
@@ -44,7 +44,7 @@ if (options.help) {
 }
 
 const mochaPath = `BABEL_ENV=test mocha ${reporterOption}`;
-const coveragePath = `NODE_ENV=test nyc --all ${coverageInclude} --reporter=lcov --reporter=text --reporter=json-summary mocha --reporter mocha-junit-reporter --no-color`;
+const coveragePath = `NODE_ENV=test nyc --all ${coverageInclude} --reporter=lcov --reporter=text --reporter=json-summary mocha --reporter mocha-junit-reporter --no-color --retries=3`;
 const testRunner = options.coverage ? coveragePath : mochaPath;
 const mochaOpts =
   'src/platform/testing/unit/mocha.opts src/platform/testing/unit/helper.js';

--- a/script/run-unit-test.js
+++ b/script/run-unit-test.js
@@ -44,7 +44,7 @@ if (options.help) {
 }
 
 const mochaPath = `BABEL_ENV=test mocha ${reporterOption}`;
-const coveragePath = `NODE_ENV=test nyc --all ${coverageInclude} --reporter=lcov --reporter=text --reporter=json-summary mocha --reporter mocha-junit-reporter --no-color --retries=3`;
+const coveragePath = `NODE_ENV=test nyc --all ${coverageInclude} --reporter=lcov --reporter=text --reporter=json-summary mocha --reporter mocha-junit-reporter --no-color --retries 3`;
 const testRunner = options.coverage ? coveragePath : mochaPath;
 const mochaOpts =
   'src/platform/testing/unit/mocha.opts src/platform/testing/unit/helper.js';

--- a/src/platform/testing/unit/mocha.opts
+++ b/src/platform/testing/unit/mocha.opts
@@ -9,3 +9,4 @@
 --prof
 --reporter progress
 --timeout 10000
+--retries 3

--- a/src/platform/testing/unit/mocha.opts
+++ b/src/platform/testing/unit/mocha.opts
@@ -9,4 +9,3 @@
 --prof
 --reporter progress
 --timeout 10000
---retries 3


### PR DESCRIPTION
## Description
Add the `retries` argument to Mocha command

Per https://mochajs.org/api/mocha

> retries | number | <optional> | Number of times to retry failed tests.

## Testing done
CI is the test

## Screenshots
N/A

## Acceptance criteria
- [ ] Unit tests don't fail as often in CI

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
