### PR TITLE
Sanlouise 14881 add cypress tests profile

### DIFF
--- a/src/applications/personalization/profile-2/tests/e2e/profile.personal-and-contact-information-address-validation.cypress.spec.js
+++ b/src/applications/personalization/profile-2/tests/e2e/profile.personal-and-contact-information-address-validation.cypress.spec.js
@@ -1,0 +1,60 @@
+import { PROFILE_PATHS } from '../../constants';
+
+import mockUser from '../fixtures/users/user-36.json';
+import mockPersonalInformation from '../fixtures/personal-information-success.json';
+import mockServiceHistory from '../fixtures/service-history-success.json';
+import mockFullName from '../fixtures/full-name-success.json';
+
+const setup = () => {
+  window.localStorage.setItem(
+    'DISMISSED_ANNOUNCEMENTS',
+    JSON.stringify(['single-sign-on-intro']),
+  );
+
+  cy.login(mockUser);
+  cy.route('GET', 'v0/profile/personal_information', mockPersonalInformation);
+  cy.route('GET', 'v0/profile/service_history', mockServiceHistory);
+  cy.route('GET', 'v0/profile/full_name', mockFullName);
+  cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+
+  // should show a loading indicator
+  cy.findByRole('progressbar').should('exist');
+  cy.findByText(/loading your information/i).should('exist');
+
+  // and then the loading indicator should be removed
+  cy.findByText(/loading your information/i).should('not.exist');
+  cy.findByRole('progressbar').should('not.exist');
+};
+
+describe('Addresses in the address validation modal on the profile', () => {
+  it('should render as expected', () => {
+    setup();
+
+    // Open edit view
+    cy.findByRole('button', {
+      name: new RegExp(`edit mailing address`, 'i'),
+    }).click({
+      force: true,
+    });
+
+    // Update address
+    cy.get(`#root_addressLine3`)
+      .click()
+      .type('Addition to Address');
+
+    cy.findAllByText(/Update/)
+      .first()
+      .click();
+
+    // Ensure correct addresses show up
+    cy.findByText(
+      /1493 Martin Luther King Rd, Apt 1, Addition to Address/i,
+    ).should('exist');
+
+    cy.findByText(/400 NW 65th St/i).should('exist');
+
+    cy.findAllByText(/Update/)
+      .first()
+      .click();
+  });
+});

--- a/src/applications/personalization/profile-2/tests/e2e/profile.personal-and-contact-information-address-validation.cypress.spec.js
+++ b/src/applications/personalization/profile-2/tests/e2e/profile.personal-and-contact-information-address-validation.cypress.spec.js
@@ -42,9 +42,9 @@ describe('Addresses in the address validation modal on the profile', () => {
       .click()
       .type('Addition to Address');
 
-    cy.findAllByText(/Update/)
-      .first()
-      .click();
+    cy.findByRole('button', { name: 'Update' }).click({
+      force: true,
+    });
 
     // Ensure correct addresses show up
     cy.findByText(
@@ -53,8 +53,6 @@ describe('Addresses in the address validation modal on the profile', () => {
 
     cy.findByText(/400 NW 65th St/i).should('exist');
 
-    cy.findAllByText(/Update/)
-      .first()
-      .click();
+    cy.findByRole('button', { name: 'Update' }).should('exist');
   });
 });

--- a/src/applications/personalization/profile-2/tests/e2e/profile.personal-and-contact-information-fields-check.cypress.spec.js
+++ b/src/applications/personalization/profile-2/tests/e2e/profile.personal-and-contact-information-fields-check.cypress.spec.js
@@ -41,7 +41,7 @@ describe('Content on the personal information section in the profile', () => {
     // Check gender
     cy.findByText(/Male/i).should('exist');
 
-    // Check home address
+    // Check mailing address
     cy.get('div[data-field-name="mailingAddress"]')
       .contains(/1493 Martin Luther King Rd, Apt 1/i)
       .should('exist');

--- a/src/applications/personalization/profile-2/tests/e2e/profile.personal-and-contact-information-fields-check.cypress.spec.js
+++ b/src/applications/personalization/profile-2/tests/e2e/profile.personal-and-contact-information-fields-check.cypress.spec.js
@@ -1,0 +1,60 @@
+import { PROFILE_PATHS } from '../../constants';
+
+import mockUser from '../fixtures/users/user-36.json';
+import mockPersonalInformation from '../fixtures/personal-information-success.json';
+import mockServiceHistory from '../fixtures/service-history-success.json';
+import mockFullName from '../fixtures/full-name-success.json';
+
+const setup = () => {
+  window.localStorage.setItem(
+    'DISMISSED_ANNOUNCEMENTS',
+    JSON.stringify(['single-sign-on-intro']),
+  );
+
+  cy.login(mockUser);
+  cy.route('GET', 'v0/profile/personal_information', mockPersonalInformation);
+  cy.route('GET', 'v0/profile/service_history', mockServiceHistory);
+  cy.route('GET', 'v0/profile/full_name', mockFullName);
+  cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+
+  // should show a loading indicator
+  cy.findByRole('progressbar').should('exist');
+  cy.findByText(/loading your information/i).should('exist');
+
+  // and then the loading indicator should be removed
+  cy.findByText(/loading your information/i).should('not.exist');
+  cy.findByRole('progressbar').should('not.exist');
+};
+
+describe('Content on the personal information section in the profile', () => {
+  it('should render as expected', () => {
+    setup();
+    // Check full name
+    cy.findByText(/Wesley Watson Ford/i).should('exist');
+
+    // Check service branch
+    cy.findByText(/United States Air Force/i).should('exist');
+
+    // Check date of birth
+    cy.findByText(/May 6, 1986/i).should('exist');
+
+    // Check gender
+    cy.findByText(/Male/i).should('exist');
+
+    // Check home address
+    cy.findByText(/1493 Martin Luther King Rd, Apt 1/i).should('exist');
+    cy.findByText(/Fulton, NY 97062/i).should('exist');
+
+    // Check military address
+    cy.findByText(/PSC 808 Box 37/i).should('exist');
+
+    // Check home phone number
+    cy.findByText(/503-222-2222, ext. 0000/i).should('exist');
+
+    // Check mobile phone number
+    cy.findByText(/503-555-1234, ext. 0000/i).should('exist');
+
+    // Check email
+    cy.findByText(/veteran@gmail.com/i).should('exist');
+  });
+});

--- a/src/applications/personalization/profile-2/tests/e2e/profile.personal-and-contact-information-fields-check.cypress.spec.js
+++ b/src/applications/personalization/profile-2/tests/e2e/profile.personal-and-contact-information-fields-check.cypress.spec.js
@@ -42,19 +42,32 @@ describe('Content on the personal information section in the profile', () => {
     cy.findByText(/Male/i).should('exist');
 
     // Check home address
-    cy.findByText(/1493 Martin Luther King Rd, Apt 1/i).should('exist');
-    cy.findByText(/Fulton, NY 97062/i).should('exist');
+    cy.get('div[data-field-name="mailingAddress"]')
+      .contains(/1493 Martin Luther King Rd, Apt 1/i)
+      .should('exist');
 
-    // Check military address
-    cy.findByText(/PSC 808 Box 37/i).should('exist');
+    cy.get('div[data-field-name="mailingAddress"]')
+      .contains(/Fulton, NY 97062/i)
+      .should('exist');
+
+    // Check home address
+    cy.get('div[data-field-name="residentialAddress"]')
+      .contains(/PSC 808 Box 37/i)
+      .should('exist');
 
     // Check home phone number
-    cy.findByText(/503-222-2222, ext. 0000/i).should('exist');
+    cy.get('div[data-field-name="homePhone"]')
+      .contains(/503-222-2222, ext. 0000/i)
+      .should('exist');
 
     // Check mobile phone number
-    cy.findByText(/503-555-1234, ext. 0000/i).should('exist');
+    cy.get('div[data-field-name="mobilePhone"]')
+      .contains(/503-555-1234, ext. 0000/i)
+      .should('exist');
 
     // Check email
-    cy.findByText(/veteran@gmail.com/i).should('exist');
+    cy.get('div[data-field-name="email"]')
+      .contains(/veteran@gmail.com/i)
+      .should('exist');
   });
 });


### PR DESCRIPTION
## Description
This PR replaces the following 2 test files:

1. https://github.com/department-of-veterans-affairs/vets-website/blob/d1f7243257c92e37acb0b1dabfaa10dceb29519d/src/platform/user/profile/vet360/tests/e2e/addressValidation.e2e.spec.js
2. https://github.com/department-of-veterans-affairs/vets-website/blob/d1f7243257c92e37acb0b1dabfaa10dceb29519d/src/applications/personalization/profile360/tests/e2e/profile-360.e2e.spec.js

I left out editing the email address from the profile test because it should be a separate test if it hasn't already been covered.

This PR merely replaces deleted functionality and is not intended to provide better coverage for address validation. [This ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/14987) will be responsible for adding good e2e coverage for address validation and verifying that we have enough coverage for updating the email address.

## Testing done
Tests pass locally

## Acceptance criteria
- [x] Create cypress tests

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
