### PR TITLE
Checked tuition values for NaN value updated to N/A

### DIFF
--- a/src/applications/gi/components/search/RatedSearchResult.jsx
+++ b/src/applications/gi/components/search/RatedSearchResult.jsx
@@ -48,6 +48,7 @@ export function RatedSearchResult({
   };
 
   const tuition = estimate(estimated.tuition);
+  const NaNCheck = tuition.props.children[0] === '$NaN' ? 'N/A' : tuition;
   const housing = estimate(estimated.housing);
   const books = estimate(estimated.books);
   const version = queryParams.get('version');
@@ -100,7 +101,7 @@ export function RatedSearchResult({
                 <div className="vads-u-font-weight--bold columns small-4 medium-3">
                   Tuition:
                 </div>
-                <div className="columns small-8 medium-9">{tuition}</div>
+                <div className="columns small-8 medium-9">{NaNCheck}</div>
               </div>
               <div className="row">
                 <div className="vads-u-font-weight--bold columns small-4 medium-3">

--- a/src/applications/gi/components/search/RatedSearchResult.jsx
+++ b/src/applications/gi/components/search/RatedSearchResult.jsx
@@ -39,16 +39,19 @@ export function RatedSearchResult({
 }) {
   const queryParams = useQueryParams();
   const estimate = ({ ratedQualifier, value }) => {
-    return (
-      <span>
-        {formatCurrency(value)}
-        {ratedQualifier}
-      </span>
-    );
+    if (value === 'N/A') {
+      return 'N/A';
+    } else {
+      return (
+        <span>
+          {formatCurrency(value)}
+          {ratedQualifier}
+        </span>
+      );
+    }
   };
 
   const tuition = estimate(estimated.tuition);
-  const NaNCheck = tuition.props.children[0] === '$NaN' ? 'N/A' : tuition;
   const housing = estimate(estimated.housing);
   const books = estimate(estimated.books);
   const version = queryParams.get('version');
@@ -101,7 +104,7 @@ export function RatedSearchResult({
                 <div className="vads-u-font-weight--bold columns small-4 medium-3">
                   Tuition:
                 </div>
-                <div className="columns small-8 medium-9">{NaNCheck}</div>
+                <div className="columns small-8 medium-9">{tuition}</div>
               </div>
               <div className="row">
                 <div className="vads-u-font-weight--bold columns small-4 medium-3">

--- a/src/applications/gi/components/search/RatedSearchResult.jsx
+++ b/src/applications/gi/components/search/RatedSearchResult.jsx
@@ -39,16 +39,12 @@ export function RatedSearchResult({
 }) {
   const queryParams = useQueryParams();
   const estimate = ({ ratedQualifier, value }) => {
-    if (value === 'N/A') {
-      return 'N/A';
-    } else {
-      return (
-        <span>
-          {formatCurrency(value)}
-          {ratedQualifier}
-        </span>
-      );
-    }
+    return (
+      <span>
+        {formatCurrency(value)}
+        {ratedQualifier}
+      </span>
+    );
   };
 
   const tuition = estimate(estimated.tuition);

--- a/src/applications/gi/utils/helpers.js
+++ b/src/applications/gi/utils/helpers.js
@@ -9,7 +9,12 @@ export const formatNumber = value => {
   return `${str.replace(/\d(?=(\d{3})+$)/g, '$&,')}`;
 };
 
-export const formatCurrency = value => `$${formatNumber(Math.round(+value))}`;
+export const formatCurrency = value => {
+  if (isNaN(value)) {
+    return value;
+  }
+  return `$${formatNumber(Math.round(+value))}`;
+};
 
 export const isVetTecSelected = filters => filters.category === 'vettec';
 


### PR DESCRIPTION
## Description
All OJT facilities are displaying NaN as the value for Tuition on the search results page in the Comparison Tool. The tuition value should be displayed. For institutions with no value, "N/A" should be displayed. This will apply to most, if not all, OJT facilities.
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/14850
## Testing done
local

## Screenshots
![Screen Shot 2020-10-19 at 12 06 18 PM](https://user-images.githubusercontent.com/50601724/96476766-a22d1f00-1203-11eb-83dd-db10bc1cfefa.png)

## Acceptance criteria
- [x] N/A is displayed 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
