### PR TITLE
Fix mocking of global window across unit tests

### DIFF
--- a/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
@@ -54,7 +54,8 @@ describe('IntroductionPage', () => {
   let oldWindow;
   beforeEach(() => {
     oldWindow = global.window;
-    global.window = globalWin;
+    global.window = Object.create(global.window);
+    Object.assign(global.window, globalWin);
   });
   afterEach(() => {
     global.window = oldWindow;

--- a/src/applications/disability-benefits/all-claims/tests/components/UpdateMilitaryHistory.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/UpdateMilitaryHistory.unit.spec.jsx
@@ -16,8 +16,7 @@ const inRangeBddDate2 = moment()
 
 describe('UpdateMilitaryHistory', () => {
   let wrapper;
-  let oldSessionStorage;
-  let storage = {};
+
   const servicePeriods = (to = inRangeBddDate2) => [
     {
       serviceBranch: 'Army',
@@ -40,17 +39,11 @@ describe('UpdateMilitaryHistory', () => {
     const setFormData = data => {
       form.data = data;
     };
-    oldSessionStorage = window.sessionStorage;
-    delete window.sessionStorage;
-    window.sessionStorage = {
-      getItem: key => storage[key] || null,
-      setItem: (key, value) => {
-        storage[key] = value;
-      },
-      removeItem: key => delete storage[key],
-    };
     if (separationDate) {
-      window.sessionStorage.setItem(SAVED_SEPARATION_DATE, separationDate);
+      global.window.sessionStorage.setItem(
+        SAVED_SEPARATION_DATE,
+        separationDate,
+      );
     }
     wrapper = mount(
       <UpdateMilitaryHistory form={form} setFormData={setFormData} />,
@@ -59,8 +52,7 @@ describe('UpdateMilitaryHistory', () => {
   }
 
   afterEach(() => {
-    window.sessionStorage = oldSessionStorage;
-    storage = {};
+    global.window.sessionStorage.removeItem(SAVED_SEPARATION_DATE);
     wrapper.unmount();
     form.data.serviceInformation.servicePeriods = [];
   });

--- a/src/applications/edu-benefits/10203/tests/actions/post-911-gib-status.unit.spec.js
+++ b/src/applications/edu-benefits/10203/tests/actions/post-911-gib-status.unit.spec.js
@@ -17,11 +17,14 @@ const setup = () => {
       json: () => Promise.resolve({}),
     }),
   );
-  global.window.dataLayer = [];
-  global.window.URL = {
-    createObjectURL: () => {},
-    revokeObjectURL: () => {},
-  };
+  global.window = Object.create(global.window);
+  Object.assign(global.window, {
+    dataLayer: [],
+    URL: {
+      createObjectURL: () => {},
+      revokeObjectURL: () => {},
+    },
+  });
 };
 
 const teardown = () => {

--- a/src/applications/post-911-gib-status/tests/actions/post-911-gib-status.unit.spec.js
+++ b/src/applications/post-911-gib-status/tests/actions/post-911-gib-status.unit.spec.js
@@ -26,11 +26,14 @@ const setup = () => {
       json: () => Promise.resolve({}),
     }),
   );
-  global.window.dataLayer = [];
-  global.window.URL = {
-    createObjectURL: () => {},
-    revokeObjectURL: () => {},
-  };
+  global.window = Object.create(global.window);
+  Object.assign(global.window, {
+    dataLayer: [],
+    URL: {
+      createObjectURL: () => {},
+      revokeObjectURL: () => {},
+    },
+  });
 };
 
 const teardown = () => {

--- a/src/platform/forms/tests/save-in-progress/FormSignInModal.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/FormSignInModal.unit.spec.jsx
@@ -12,10 +12,12 @@ describe('<FormSignInModal>', () => {
     visible: false,
   };
 
-  const oldWindow = global.window;
+  let oldWindow = null;
 
   beforeEach(() => {
-    global.window = { dataLayer: [] };
+    oldWindow = global.window;
+    global.window = Object.create(global.window);
+    Object.assign(global.window, { dataLayer: [] });
   });
 
   afterEach(() => {

--- a/src/platform/monitoring/tests/record-event.unit.spec.js
+++ b/src/platform/monitoring/tests/record-event.unit.spec.js
@@ -4,12 +4,14 @@ import { expect } from 'chai';
 import recordEvent, { recordEventOnce } from '../record-event';
 
 describe('recordEvent', () => {
-  const oldWindow = global.window;
+  let oldWindow = null;
 
   beforeEach(() => {
-    global.window = {
+    oldWindow = global.window;
+    global.window = Object.create(global.window);
+    Object.assign(global.window, {
       dataLayer: [],
-    };
+    });
   });
 
   afterEach(() => {

--- a/src/platform/site-wide/user-nav/tests/components/HelpMenu.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/components/HelpMenu.unit.spec.jsx
@@ -10,16 +10,18 @@ describe('<HelpMenu>', () => {
     clickHandler: f => f,
   };
 
-  const oldWindow = global.window;
+  let oldWindow = null;
 
   beforeEach(() => {
-    global.window = {
+    oldWindow = global.window;
+    global.window = Object.create(global.window);
+    Object.assign(global.window, {
       location: {
         hostname: 'www.va.gov',
         replace: () => {},
         pathname: '/',
       },
-    };
+    });
   });
 
   afterEach(() => {

--- a/src/platform/site-wide/user-nav/tests/components/PersonalizationDropdown.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/components/PersonalizationDropdown.unit.spec.jsx
@@ -5,12 +5,14 @@ import { shallow } from 'enzyme';
 import { PersonalizationDropdown } from '../../components/PersonalizationDropdown';
 
 describe('<PersonalizationDropdown>', () => {
-  const oldWindow = global.window;
+  let oldWindow = null;
 
   beforeEach(() => {
-    global.window = {
+    oldWindow = global.window;
+    global.window = Object.create(global.window);
+    Object.assign(global.window, {
       dataLayer: [],
-    };
+    });
   });
 
   afterEach(() => {

--- a/src/platform/site-wide/user-nav/tests/components/SearchHelpSignIn.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/components/SearchHelpSignIn.unit.spec.jsx
@@ -20,16 +20,18 @@ describe('<SearchHelpSignIn>', () => {
     userGreeting: 'test@vets.gov',
   };
 
-  const oldWindow = global.window;
+  let oldWindow = null;
 
   beforeEach(() => {
-    global.window = {
+    oldWindow = global.window;
+    global.window = Object.create(global.window);
+    Object.assign(global.window, {
       location: {
         hostname: 'www.va.gov',
         replace: () => {},
         pathname: '/',
       },
-    };
+    });
   });
 
   afterEach(() => {

--- a/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
@@ -30,12 +30,17 @@ describe('<Main>', () => {
     initializeProfile: sinon.spy(),
   };
 
-  const oldWindow = global.window;
+  let oldWindow = null;
 
   beforeEach(() => {
-    global.window = mockEventListeners({
-      location: { pathname: '/' },
-    });
+    oldWindow = global.window;
+    global.window = Object.create(global.window);
+    Object.assign(
+      global.window,
+      mockEventListeners({
+        location: { pathname: '/' },
+      }),
+    );
   });
 
   afterEach(() => {

--- a/src/platform/user/tests/authorization/components/RequiredLoginView.unit.spec.jsx
+++ b/src/platform/user/tests/authorization/components/RequiredLoginView.unit.spec.jsx
@@ -14,13 +14,13 @@ describe('<RequiredLoginView>', () => {
   const initialSetup = () => {
     localStorage.setItem('hasSession', true);
     oldWindow = global.window;
-
-    global.window = {
+    global.window = Object.create(global.window);
+    Object.assign(global.window, {
       pathname: '',
       location: {
         replace: redirectFunc,
       },
-    };
+    });
   };
 
   const teardown = () => {

--- a/src/platform/utilities/tests/environment/va-subdomain.unit.spec.jsx
+++ b/src/platform/utilities/tests/environment/va-subdomain.unit.spec.jsx
@@ -3,30 +3,36 @@ import { expect } from 'chai';
 import isVATeamSiteSubdomain from '../../environment/va-subdomain';
 
 describe('brand-consolidation/va-subdomain', () => {
-  const oldWindow = window;
+  let oldWindow = null;
 
-  after(() => {
+  beforeEach(() => {
+    oldWindow = global.window;
+    global.window = Object.create(global.window);
+  });
+
+  afterEach(() => {
+    global.window = oldWindow;
     window = oldWindow; // eslint-disable-line no-global-assign
   });
 
   it('returns false if is not a VA subdomain', () => {
     // eslint-disable-next-line no-global-assign
-    window = {
+    Object.assign(global.window, {
       location: {
         hostname: 'www.va.gov',
       },
-    };
+    });
 
     expect(isVATeamSiteSubdomain()).to.be.false;
   });
 
   it('returns true if is a VA subdomain', () => {
     // eslint-disable-next-line no-global-assign
-    window = {
+    Object.assign(global.window, {
       location: {
         hostname: 'www.BENEFITS.va.gov',
       },
-    };
+    });
 
     expect(isVATeamSiteSubdomain()).to.be.true;
   });

--- a/src/platform/utilities/tests/sso.unit.spec.js
+++ b/src/platform/utilities/tests/sso.unit.spec.js
@@ -31,7 +31,8 @@ let oldWindow;
 
 const fakeWindow = () => {
   oldWindow = global.window;
-  global.window = {
+  global.window = Object.create(global.window);
+  Object.assign(global.window, {
     dataLayer: [],
     location: {
       get: () => global.window.location,
@@ -41,7 +42,7 @@ const fakeWindow = () => {
       pathname: '',
       search: '',
     },
-  };
+  });
 };
 
 describe('checkAutoSession', () => {


### PR DESCRIPTION
## Description
This PR attempts to fix unit tests in our CI by replacing instances of mocking `global.window` with a more comprehensive mock via `Object.create`.

## Testing done
Ran several `yarn test:unit` with `CHOMA_SEED`s that were failing on other branches

## Screenshots
N/A

## Acceptance criteria
- [ ] Unit tests are more stable in CI

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
