### PR TITLE
Filter out facilities using patientHistoryRequired

### DIFF
--- a/src/applications/vaos/services/location/index.js
+++ b/src/applications/vaos/services/location/index.js
@@ -109,19 +109,6 @@ export async function getLocation({ facilityId }) {
   }
 }
 
-function supportsSchedulingTypeOfCareFilter(typeOfCareId, setting) {
-  const patientHistoryRequired = setting.patientHistoryRequired;
-
-  // If patientHistoryRequired is blank or null, the scheduling method is
-  // disabled for that type of care.  If "No", it is enabled, but doesn't require
-  // a previous appointment.  If "Yes", it is enabled and requires a previous appt
-  return (
-    setting.id === typeOfCareId &&
-    Object.prototype.hasOwnProperty.call(setting, 'patientHistoryRequired') &&
-    (patientHistoryRequired === 'Yes' || patientHistoryRequired === 'No')
-  );
-}
-
 export async function getLocationsByTypeOfCareAndSiteIds({
   typeOfCareId,
   siteIds,
@@ -139,19 +126,25 @@ export async function getLocationsByTypeOfCareAndSiteIds({
     const directFacilityIds =
       criteria[0]
         ?.filter(facility =>
-          facility?.coreSettings?.some(setting =>
-            supportsSchedulingTypeOfCareFilter(typeOfCareId, setting),
+          facility?.coreSettings?.some(
+            setting =>
+              setting.id === typeOfCareId && !!setting.patientHistoryRequired,
           ),
         )
         ?.map(facility => facility.id) || [];
+
+    // If patientHistoryRequired is blank or null, the scheduling method is
+    // disabled for that type of care.  If "No", it is enabled, but doesn't require
+    // a previous appointment.  If "Yes", it is enabled and requires a previous appt
 
     // Fetch facilities that support requests and filter
     // only those that support the selected type of care
     const requestFacilityIds =
       criteria[1]
         ?.filter(facility =>
-          facility?.requestSettings?.some(setting =>
-            supportsSchedulingTypeOfCareFilter(typeOfCareId, setting),
+          facility?.requestSettings?.some(
+            setting =>
+              setting.id === typeOfCareId && !!setting.patientHistoryRequired,
           ),
         )
         ?.map(facility => facility.id) || [];

--- a/src/applications/vaos/services/location/index.js
+++ b/src/applications/vaos/services/location/index.js
@@ -109,6 +109,19 @@ export async function getLocation({ facilityId }) {
   }
 }
 
+function supportsSchedulingTypeOfCareFilter(typeOfCareId, setting) {
+  const patientHistoryRequired = setting.patientHistoryRequired;
+
+  // If patientHistoryRequired is blank or null, the scheduling method is
+  // disabled for that type of care.  If "No", it is enabled, but doesn't require
+  // a previous appointment.  If "Yes", it is enabled and requires a previous appt
+  return (
+    setting.id === typeOfCareId &&
+    Object.prototype.hasOwnProperty.call(setting, 'patientHistoryRequired') &&
+    (patientHistoryRequired === 'Yes' || patientHistoryRequired === 'No')
+  );
+}
+
 export async function getLocationsByTypeOfCareAndSiteIds({
   typeOfCareId,
   siteIds,
@@ -126,7 +139,9 @@ export async function getLocationsByTypeOfCareAndSiteIds({
     const directFacilityIds =
       criteria[0]
         ?.filter(facility =>
-          facility?.coreSettings?.some(setting => setting.id === typeOfCareId),
+          facility?.coreSettings?.some(setting =>
+            supportsSchedulingTypeOfCareFilter(typeOfCareId, setting),
+          ),
         )
         ?.map(facility => facility.id) || [];
 
@@ -135,8 +150,8 @@ export async function getLocationsByTypeOfCareAndSiteIds({
     const requestFacilityIds =
       criteria[1]
         ?.filter(facility =>
-          facility?.requestSettings?.some(
-            setting => setting.id === typeOfCareId,
+          facility?.requestSettings?.some(setting =>
+            supportsSchedulingTypeOfCareFilter(typeOfCareId, setting),
           ),
         )
         ?.map(facility => facility.id) || [];


### PR DESCRIPTION
## Description
Updates direct booking and request eligibility calls to filter based on `patientHistoryRequired` field.  For each type of care in the `requestSettings` or `coreSettings` array,  if the `patientHistoryRequired` equals `"Yes"` or `"No"`, scheduling is enabled for that type of care.  If it is blank, missing, or null, scheduling is disabled for that type of care.

I was writing some unit tests for these in `FacilityPageV2.multi.unit.spec.jsx`, but realized that since the radios show up based on the mocks facility details call (not the direct/request eligibility calls), there isn't a very good way to test this.

I could possible export the `supportsSchedulingTypeOfCareFilter()` function I created and write a unit test for that though.

## Testing done
Local testing

## Screenshots


## Acceptance criteria
- [ ] Facilities settings with `patientHistoryRequired` that are blank or null should be filtered out

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
