### PR TITLE
Attempt to fix inconsistent Wizard unit test

### DIFF
--- a/src/applications/edu-benefits/wizard/pages/ApplyNow.jsx
+++ b/src/applications/edu-benefits/wizard/pages/ApplyNow.jsx
@@ -43,8 +43,8 @@ const ApplyNow = ({ getPageStateFromPageName, setWizardStatus }) => {
     receivingSponsorBenefitsAnswer = transferredBenefitsAnswer;
   }
   useEffect(() => {
-    const updateUrl = async () => {
-      const updatedBenefit = await getReferredBenefit();
+    const updateUrl = () => {
+      const updatedBenefit = getReferredBenefit();
       const { FORM_ID_0994, FORM_ID_10203 } = formIdSuffixes;
       setReferredBenefit(updatedBenefit);
       if (updatedBenefit) {

--- a/src/applications/static-pages/wizard/index.js
+++ b/src/applications/static-pages/wizard/index.js
@@ -24,11 +24,11 @@ export const formIdSuffixes = {
   FORM_ID_1990N: '1990N',
 };
 
-export const getReferredBenefit = async () =>
-  (await sessionStorage.getItem('benefitReferred')) || NO_BENEFIT_REFERRED;
+export const getReferredBenefit = () =>
+  sessionStorage.getItem('benefitReferred') || NO_BENEFIT_REFERRED;
 
-export const getWizardStatus = async () =>
-  (await sessionStorage.getItem('wizardStatus')) || WIZARD_STATUS_NOT_STARTED;
+export const getWizardStatus = () =>
+  sessionStorage.getItem('wizardStatus') || WIZARD_STATUS_NOT_STARTED;
 
 export class Wizard extends React.Component {
   constructor(props) {


### PR DESCRIPTION
## Description
This build failed during unit tests, and I think it can be traced back to the sessionStorage logic. http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fvets-website/detail/master/8725/tests

![image](https://user-images.githubusercontent.com/1915775/96515671-b9840080-1233-11eb-96fa-a3b8236eb7bc.png)


## Testing done
Cannot recreate even with CHOMA seed

## Screenshots
Screenshot of error pasted above

## Acceptance criteria
- [ ] CI is more stable

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
