### PR TITLE
Add new Cerner-specific health care widgets for My VA Dashboard

### DIFF
--- a/src/applications/personalization/dashboard/components/ManageYourVAHealthCare.jsx
+++ b/src/applications/personalization/dashboard/components/ManageYourVAHealthCare.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import environment from 'platform/utilities/environment';
@@ -7,13 +7,20 @@ import {
   DowntimeNotification,
   externalServices,
 } from 'platform/monitoring/DowntimeNotification';
+import { getMedicalCenterNameByID } from 'platform/utilities/medical-centers/medical-centers';
+import { mhvUrl } from 'platform/site-wide/mhv/utilities';
+import backendServices from 'platform/user/profile/constants/backendServices';
+import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
+import {
+  selectCernerAppointmentsFacilities,
+  selectCernerMessagingFacilities,
+  selectCernerRxFacilities,
+} from 'platform/user/selectors';
 
 import {
   recordDashboardClick,
   renderWidgetDowntimeNotification,
 } from '../helpers';
-
-import { selectCernerAppointmentsFacilities } from 'platform/user/selectors';
 
 import MessagingWidget from '../containers/MessagingWidget';
 import PrescriptionsWidget from '../containers/PrescriptionsWidget';
@@ -25,6 +32,84 @@ import {
   selectEnrollmentStatus,
 } from 'applications/hca/selectors';
 import { getEnrollmentDetails } from 'applications/hca/enrollment-status-helpers';
+
+// Returns an AlertBox to present the user with info about working with the
+// Cerner facility they are enrolled at. Props allow you to edit a small amount
+// of the content that is rendered in the AlertBox.
+const CernerAlertBox = ({
+  ctaButtonText,
+  ctaButtonUrl,
+  ctaText,
+  facilityNames,
+}) => {
+  // Helper component that takes an array of facility names and a separator string and returns some JSX to style the list of facility names.
+  const FacilityList = ({ facilities, separator }) => {
+    const newArray = [];
+    // first make an array that alternates between a facility name and the
+    // separator word wrapped in a <span> for styling purposes
+    facilities.forEach(el => {
+      newArray.push(el);
+      newArray.push(
+        <span className="vads-u-font-weight--normal vads-u-font-size--base">
+          {separator}
+        </span>,
+      );
+    });
+    // we don't need the last separator in the array
+    newArray.pop();
+    // Then map over the array we just made, converting it to JSX
+    return (
+      <>
+        {newArray.map((el, i) => {
+          return <Fragment key={i}>{el}</Fragment>;
+        })}
+      </>
+    );
+  };
+
+  return (
+    <AlertBox
+      status="warning"
+      headline="Your VA health care team may be using our new My VA Health portal"
+    >
+      <h3>Our records show you’re registered at:</h3>
+      <h4>
+        <FacilityList facilities={facilityNames} separator=" and " />
+        <span className="vads-u-font-weight--normal vads-u-font-size--base">
+          {' '}
+          (Using My VA Health)
+        </span>
+      </h4>
+      <p>
+        Please choose a health management portal below, depending on the
+        facility for your appointment. You may need to disable your browser’s
+        pop-up blocker to open the portal. If you’re prompted to sign in again,
+        use the same account you used to sign in on VA.gov.
+      </p>
+      <h3>{ctaText}</h3>
+      <h4>
+        <FacilityList facilities={facilityNames} separator=" or " />
+      </h4>
+      <a
+        href={
+          environment.isProduction()
+            ? 'https://patientportal.myhealth.va.gov/'
+            : 'https://ehrm-va-test.patientportal.us.healtheintent.com/'
+        }
+        type="button"
+        className="usa-button-primary"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Go to My VA Health
+      </a>
+      <h4>Another VA health facility</h4>
+      <a href={ctaButtonUrl} type="button" className="usa-button-secondary">
+        {ctaButtonText}
+      </a>
+    </AlertBox>
+  );
+};
 
 const ScheduleAnAppointmentWidget = () => (
   <div id="rx-widget">
@@ -44,60 +129,64 @@ const ScheduleAnAppointmentWidget = () => (
   </div>
 );
 
-const ScheduleAnAppointmentCernerWidget = () => (
+const CernerScheduleAnAppointmentWidget = ({ facilityNames }) => (
   <>
-    <h3>Schedule an appointment</h3>
-    <AlertBox
-      status="warning"
-      headline="Your VA health care team may be using our new My VA Health portal"
-    >
-      <h3>Our records show you’re registered at:</h3>
-      <h4>
-        Chalmers P. Wylie Veteran Outpatient Clinic{' '}
-        <span className="vads-u-font-weight--normal vads-u-font-size--base">
-          (Now using My VA Health)
-        </span>
-      </h4>
-      <p>
-        Please choose a health management portal below, depending on the
-        facility for your appointment. You may need to disable your browser’s
-        pop-up blocker to open the portal. If you’re prompted to sign in again,
-        use the same account you used to sign in on VA.gov.
-      </p>
-      <h3>Manage appointments at:</h3>
-      <h4>Chalmers P. Wylie Veteran Outpatient Clinic</h4>
-      <a
-        href={
-          environment.isProduction()
-            ? 'https://patientportal.myhealth.va.gov/'
-            : 'https://ehrm-va-test.patientportal.us.healtheintent.com/'
-        }
-        type="button"
-        className="usa-button-primary"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        Go to My VA Health
-      </a>
-      <h4>Another VA health facility</h4>
-      <a
-        href="/health-care/schedule-view-va-appointments/"
-        type="button"
-        className="usa-button-secondary"
-      >
-        Go to the VA appointments tool
-      </a>
-    </AlertBox>
+    <h3>View, schedule, or cancel an appointment</h3>
+    <CernerAlertBox
+      ctaText="Manage appointments at:"
+      ctaButtonText="Go to the VA appointments tool"
+      ctaButtonUrl="/health-care/schedule-view-va-appointments/"
+      facilityNames={facilityNames}
+    />
+  </>
+);
+
+const CernerSecureMessagingWidget = ({
+  facilityNames,
+  authenticatedWithSSOe,
+}) => (
+  <>
+    <h3>Send or receive a secure message</h3>
+    <CernerAlertBox
+      ctaText="Send a secure message to a provider at:"
+      ctaButtonText="Go to My HealtheVet"
+      ctaButtonUrl={mhvUrl(authenticatedWithSSOe, 'secure-messaging')}
+      facilityNames={facilityNames}
+    />
+  </>
+);
+
+const CernerPrescriptionsWidget = ({
+  facilityNames,
+  authenticatedWithSSOe,
+}) => (
+  <>
+    <h3>Refill and track prescriptions</h3>
+    <CernerAlertBox
+      ctaText="Refill prescriptions from:"
+      ctaButtonText="Go to My HealtheVet"
+      ctaButtonUrl={mhvUrl(
+        authenticatedWithSSOe,
+        'web/myhealthevet/refill-prescriptions',
+      )}
+      facilityNames={facilityNames}
+    />
   </>
 );
 
 const ManageYourVAHealthCare = ({
   applicationDate,
+  appointmentFacilityNames,
+  messagingFacilityNames,
+  prescriptionFacilityNames,
+  authenticatedWithSSOe,
   enrollmentDate,
   isEnrolledInHealthCare,
   preferredFacility,
   showServerError,
   showCernerAppointmentWidget,
+  showCernerMessagingWidget,
+  showCernerPrescriptionWidget,
 }) => (
   <>
     <h2>Manage your VA health care</h2>
@@ -135,41 +224,82 @@ const ManageYourVAHealthCare = ({
       isVisible={isEnrolledInHealthCare}
       className="background-color-only"
     />
-    <DowntimeNotification
-      appTitle="messaging"
-      dependencies={[externalServices.mvi, externalServices.mhv]}
-      render={renderWidgetDowntimeNotification(
-        'Secure messaging',
-        'Track Secure Messages',
-      )}
-    >
-      <MessagingWidget />
-    </DowntimeNotification>
 
-    <DowntimeNotification
-      appTitle="rx"
-      dependencies={[externalServices.mvi, externalServices.mhv]}
-      render={renderWidgetDowntimeNotification(
-        'prescription refill',
-        'Refill Prescriptions',
-      )}
-    >
-      <PrescriptionsWidget />
-    </DowntimeNotification>
+    {!showCernerMessagingWidget && (
+      <DowntimeNotification
+        appTitle="messaging"
+        dependencies={[externalServices.mvi, externalServices.mhv]}
+        render={renderWidgetDowntimeNotification(
+          'Secure messaging',
+          'Track Secure Messages',
+        )}
+      >
+        <MessagingWidget />
+      </DowntimeNotification>
+    )}
+    {showCernerMessagingWidget && (
+      <CernerSecureMessagingWidget
+        facilityNames={messagingFacilityNames}
+        authenticatedWithSSOe={authenticatedWithSSOe}
+      />
+    )}
+
+    {!showCernerPrescriptionWidget && (
+      <DowntimeNotification
+        appTitle="rx"
+        dependencies={[externalServices.mvi, externalServices.mhv]}
+        render={renderWidgetDowntimeNotification(
+          'prescription refill',
+          'Refill Prescriptions',
+        )}
+      >
+        <PrescriptionsWidget />
+      </DowntimeNotification>
+    )}
+    {showCernerPrescriptionWidget && (
+      <CernerPrescriptionsWidget
+        facilityNames={prescriptionFacilityNames}
+        authenticatedWithSSOe={authenticatedWithSSOe}
+      />
+    )}
+
     {isEnrolledInHealthCare &&
       !showCernerAppointmentWidget && <ScheduleAnAppointmentWidget />}
-    {isEnrolledInHealthCare &&
-      showCernerAppointmentWidget && <ScheduleAnAppointmentCernerWidget />}
+    {showCernerAppointmentWidget && (
+      <CernerScheduleAnAppointmentWidget
+        facilityNames={appointmentFacilityNames}
+      />
+    )}
   </>
 );
 
 const mapStateToProps = state => {
   const isEnrolledInHealthCare = isEnrolledInVAHealthCare(state);
   const hcaEnrollmentStatus = selectEnrollmentStatus(state);
+
   const showServerError = hasESRServerError(state);
-  const showCernerAppointmentWidget = !!selectCernerAppointmentsFacilities(
-    state,
-  )?.length;
+  const profileState = state.user.profile;
+  const canAccessMessaging = profileState.services.includes(
+    backendServices.MESSAGING,
+  );
+  const canAccessPrescriptions = profileState.services.includes(
+    backendServices.RX,
+  );
+
+  const cernerAppointmentFacilities = selectCernerAppointmentsFacilities(state);
+  const cernerMessagingFacilities = selectCernerMessagingFacilities(state);
+  const cernerPrescriptionFacilities = selectCernerRxFacilities(state);
+
+  const appointmentFacilityNames = cernerAppointmentFacilities?.map(facility =>
+    getMedicalCenterNameByID(facility.facilityId),
+  );
+  const messagingFacilityNames = cernerMessagingFacilities?.map(facility =>
+    getMedicalCenterNameByID(facility.facilityId),
+  );
+  const prescriptionFacilityNames = cernerPrescriptionFacilities?.map(
+    facility => getMedicalCenterNameByID(facility.facilityId),
+  );
+
   const {
     applicationDate,
     enrollmentDate,
@@ -182,7 +312,16 @@ const mapStateToProps = state => {
     isEnrolledInHealthCare,
     preferredFacility,
     showServerError,
-    showCernerAppointmentWidget,
+    showCernerAppointmentWidget:
+      isEnrolledInHealthCare && !!cernerAppointmentFacilities.length,
+    showCernerMessagingWidget:
+      canAccessMessaging && !!cernerMessagingFacilities.length,
+    showCernerPrescriptionWidget:
+      canAccessPrescriptions && !!cernerPrescriptionFacilities.length,
+    appointmentFacilityNames,
+    messagingFacilityNames,
+    prescriptionFacilityNames,
+    authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
   };
 };
 

--- a/src/applications/personalization/dashboard/components/ManageYourVAHealthCare.jsx
+++ b/src/applications/personalization/dashboard/components/ManageYourVAHealthCare.jsx
@@ -112,7 +112,7 @@ const CernerAlertBox = ({
 };
 
 const ScheduleAnAppointmentWidget = () => (
-  <div id="rx-widget">
+  <div id="rx-widget" data-testid="non-cerner-appointment-widget">
     <h3>Schedule an appointment</h3>
     <p>
       Find out how to make a doctor’s appointment with a member of your VA
@@ -130,7 +130,7 @@ const ScheduleAnAppointmentWidget = () => (
 );
 
 const CernerScheduleAnAppointmentWidget = ({ facilityNames }) => (
-  <>
+  <div data-testid="cerner-appointment-widget">
     <h3>View, schedule, or cancel an appointment</h3>
     <CernerAlertBox
       ctaText="Manage appointments at:"
@@ -138,14 +138,14 @@ const CernerScheduleAnAppointmentWidget = ({ facilityNames }) => (
       ctaButtonUrl="/health-care/schedule-view-va-appointments/"
       facilityNames={facilityNames}
     />
-  </>
+  </div>
 );
 
 const CernerSecureMessagingWidget = ({
   facilityNames,
   authenticatedWithSSOe,
 }) => (
-  <>
+  <div data-testid="cerner-messaging-widget">
     <h3>Send or receive a secure message</h3>
     <CernerAlertBox
       ctaText="Send a secure message to a provider at:"
@@ -153,14 +153,14 @@ const CernerSecureMessagingWidget = ({
       ctaButtonUrl={mhvUrl(authenticatedWithSSOe, 'secure-messaging')}
       facilityNames={facilityNames}
     />
-  </>
+  </div>
 );
 
 const CernerPrescriptionsWidget = ({
   facilityNames,
   authenticatedWithSSOe,
 }) => (
-  <>
+  <div data-testid="cerner-prescription-widget">
     <h3>Refill and track prescriptions</h3>
     <CernerAlertBox
       ctaText="Refill prescriptions from:"
@@ -171,7 +171,7 @@ const CernerPrescriptionsWidget = ({
       )}
       facilityNames={facilityNames}
     />
-  </>
+  </div>
 );
 
 const ManageYourVAHealthCare = ({

--- a/src/applications/personalization/dashboard/components/ManageYourVAHealthCare.jsx
+++ b/src/applications/personalization/dashboard/components/ManageYourVAHealthCare.jsx
@@ -1,14 +1,12 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
-import environment from 'platform/utilities/environment';
 
 import {
   DowntimeNotification,
   externalServices,
 } from 'platform/monitoring/DowntimeNotification';
 import { getMedicalCenterNameByID } from 'platform/utilities/medical-centers/medical-centers';
-import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 import backendServices from 'platform/user/profile/constants/backendServices';
 import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 import {
@@ -18,6 +16,13 @@ import {
 } from 'platform/user/selectors';
 
 import {
+  hasServerError as hasESRServerError,
+  isEnrolledInVAHealthCare,
+  selectEnrollmentStatus,
+} from 'applications/hca/selectors';
+import { getEnrollmentDetails } from 'applications/hca/enrollment-status-helpers';
+
+import {
   recordDashboardClick,
   renderWidgetDowntimeNotification,
 } from '../helpers';
@@ -25,91 +30,11 @@ import {
 import MessagingWidget from '../containers/MessagingWidget';
 import PrescriptionsWidget from '../containers/PrescriptionsWidget';
 import ESRError, { ESR_ERROR_TYPES } from './ESRError';
-
 import {
-  hasServerError as hasESRServerError,
-  isEnrolledInVAHealthCare,
-  selectEnrollmentStatus,
-} from 'applications/hca/selectors';
-import { getEnrollmentDetails } from 'applications/hca/enrollment-status-helpers';
-
-// Returns an AlertBox to present the user with info about working with the
-// Cerner facility they are enrolled at. Props allow you to edit a small amount
-// of the content that is rendered in the AlertBox.
-const CernerAlertBox = ({
-  ctaButtonText,
-  ctaButtonUrl,
-  ctaText,
-  facilityNames,
-}) => {
-  // Helper component that takes an array of facility names and a separator string and returns some JSX to style the list of facility names.
-  const FacilityList = ({ facilities, separator }) => {
-    const newArray = [];
-    // first make an array that alternates between a facility name and the
-    // separator word wrapped in a <span> for styling purposes
-    facilities.forEach(el => {
-      newArray.push(el);
-      newArray.push(
-        <span className="vads-u-font-weight--normal vads-u-font-size--base">
-          {separator}
-        </span>,
-      );
-    });
-    // we don't need the last separator in the array
-    newArray.pop();
-    // Then map over the array we just made, converting it to JSX
-    return (
-      <>
-        {newArray.map((el, i) => {
-          return <Fragment key={i}>{el}</Fragment>;
-        })}
-      </>
-    );
-  };
-
-  return (
-    <AlertBox
-      status="warning"
-      headline="Your VA health care team may be using our new My VA Health portal"
-    >
-      <h3>Our records show you’re registered at:</h3>
-      <h4>
-        <FacilityList facilities={facilityNames} separator=" and " />
-        <span className="vads-u-font-weight--normal vads-u-font-size--base">
-          {' '}
-          (Using My VA Health)
-        </span>
-      </h4>
-      <p>
-        Please choose a health management portal below, depending on the
-        facility for your appointment. You may need to disable your browser’s
-        pop-up blocker to open the portal. If you’re prompted to sign in again,
-        use the same account you used to sign in on VA.gov.
-      </p>
-      <h3>{ctaText}</h3>
-      <h4>
-        <FacilityList facilities={facilityNames} separator=" or " />
-      </h4>
-      <a
-        href={
-          environment.isProduction()
-            ? 'https://patientportal.myhealth.va.gov/'
-            : 'https://ehrm-va-test.patientportal.us.healtheintent.com/'
-        }
-        type="button"
-        className="usa-button-primary"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        Go to My VA Health
-      </a>
-      <h4>Another VA health facility</h4>
-      <a href={ctaButtonUrl} type="button" className="usa-button-secondary">
-        {ctaButtonText}
-      </a>
-    </AlertBox>
-  );
-};
+  CernerPrescriptionsWidget,
+  CernerScheduleAnAppointmentWidget,
+  CernerSecureMessagingWidget,
+} from './cerner-widgets';
 
 const ScheduleAnAppointmentWidget = () => (
   <div id="rx-widget" data-testid="non-cerner-appointment-widget">
@@ -126,51 +51,6 @@ const ScheduleAnAppointmentWidget = () => (
         Schedule an appointment
       </a>
     </p>
-  </div>
-);
-
-const CernerScheduleAnAppointmentWidget = ({ facilityNames }) => (
-  <div data-testid="cerner-appointment-widget">
-    <h3>View, schedule, or cancel an appointment</h3>
-    <CernerAlertBox
-      ctaText="Manage appointments at:"
-      ctaButtonText="Go to the VA appointments tool"
-      ctaButtonUrl="/health-care/schedule-view-va-appointments/"
-      facilityNames={facilityNames}
-    />
-  </div>
-);
-
-const CernerSecureMessagingWidget = ({
-  facilityNames,
-  authenticatedWithSSOe,
-}) => (
-  <div data-testid="cerner-messaging-widget">
-    <h3>Send or receive a secure message</h3>
-    <CernerAlertBox
-      ctaText="Send a secure message to a provider at:"
-      ctaButtonText="Go to My HealtheVet"
-      ctaButtonUrl={mhvUrl(authenticatedWithSSOe, 'secure-messaging')}
-      facilityNames={facilityNames}
-    />
-  </div>
-);
-
-const CernerPrescriptionsWidget = ({
-  facilityNames,
-  authenticatedWithSSOe,
-}) => (
-  <div data-testid="cerner-prescription-widget">
-    <h3>Refill and track prescriptions</h3>
-    <CernerAlertBox
-      ctaText="Refill prescriptions from:"
-      ctaButtonText="Go to My HealtheVet"
-      ctaButtonUrl={mhvUrl(
-        authenticatedWithSSOe,
-        'web/myhealthevet/refill-prescriptions',
-      )}
-      facilityNames={facilityNames}
-    />
   </div>
 );
 

--- a/src/applications/personalization/dashboard/components/ManageYourVAHealthCare.jsx
+++ b/src/applications/personalization/dashboard/components/ManageYourVAHealthCare.jsx
@@ -193,11 +193,11 @@ const mapStateToProps = state => {
     preferredFacility,
     showServerError,
     showCernerAppointmentWidget:
-      isEnrolledInHealthCare && !!cernerAppointmentFacilities.length,
+      isEnrolledInHealthCare && !!cernerAppointmentFacilities?.length,
     showCernerMessagingWidget:
-      canAccessMessaging && !!cernerMessagingFacilities.length,
+      canAccessMessaging && !!cernerMessagingFacilities?.length,
     showCernerPrescriptionWidget:
-      canAccessPrescriptions && !!cernerPrescriptionFacilities.length,
+      canAccessPrescriptions && !!cernerPrescriptionFacilities?.length,
     appointmentFacilityNames,
     messagingFacilityNames,
     prescriptionFacilityNames,

--- a/src/applications/personalization/dashboard/components/cerner-widgets.js
+++ b/src/applications/personalization/dashboard/components/cerner-widgets.js
@@ -1,0 +1,128 @@
+import React, { Fragment } from 'react';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+
+import environment from 'platform/utilities/environment';
+import { mhvUrl } from 'platform/site-wide/mhv/utilities';
+
+// Returns an AlertBox to present the user with info about working with the
+// Cerner facility they are enrolled at. Props allow you to edit a small amount
+// of the content that is rendered in the AlertBox.
+const CernerAlertBox = ({
+  ctaButtonText,
+  ctaButtonUrl,
+  ctaText,
+  facilityNames,
+}) => {
+  // Helper component that takes an array of facility names and a separator string and returns some JSX to style the list of facility names.
+  const FacilityList = ({ facilities, separator }) => {
+    const newArray = [];
+    // first make an array that alternates between a facility name and the
+    // separator word wrapped in a <span> for styling purposes
+    facilities.forEach(el => {
+      newArray.push(el);
+      newArray.push(
+        <span className="vads-u-font-weight--normal vads-u-font-size--base">
+          {separator}
+        </span>,
+      );
+    });
+    // we don't need the last separator in the array
+    newArray.pop();
+    // Then map over the array we just made, converting it to JSX
+    return (
+      <>
+        {newArray.map((el, i) => {
+          return <Fragment key={i}>{el}</Fragment>;
+        })}
+      </>
+    );
+  };
+
+  return (
+    <AlertBox
+      status="warning"
+      headline="Your VA health care team may be using our new My VA Health portal"
+    >
+      <h3>Our records show you’re registered at:</h3>
+      <h4>
+        <FacilityList facilities={facilityNames} separator=" and " />
+        <span className="vads-u-font-weight--normal vads-u-font-size--base">
+          {' '}
+          (Using My VA Health)
+        </span>
+      </h4>
+      <p>
+        Please choose a health management portal below, depending on the
+        facility for your appointment. You may need to disable your browser’s
+        pop-up blocker to open the portal. If you’re prompted to sign in again,
+        use the same account you used to sign in on VA.gov.
+      </p>
+      <h3>{ctaText}</h3>
+      <h4>
+        <FacilityList facilities={facilityNames} separator=" or " />
+      </h4>
+      <a
+        href={
+          environment.isProduction()
+            ? 'https://patientportal.myhealth.va.gov/'
+            : 'https://ehrm-va-test.patientportal.us.healtheintent.com/'
+        }
+        type="button"
+        className="usa-button-primary"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Go to My VA Health
+      </a>
+      <h4>Another VA health facility</h4>
+      <a href={ctaButtonUrl} type="button" className="usa-button-secondary">
+        {ctaButtonText}
+      </a>
+    </AlertBox>
+  );
+};
+
+export const CernerScheduleAnAppointmentWidget = ({ facilityNames }) => (
+  <div data-testid="cerner-appointment-widget">
+    <h3>View, schedule, or cancel an appointment</h3>
+    <CernerAlertBox
+      ctaText="Manage appointments at:"
+      ctaButtonText="Go to the VA appointments tool"
+      ctaButtonUrl="/health-care/schedule-view-va-appointments/"
+      facilityNames={facilityNames}
+    />
+  </div>
+);
+
+export const CernerSecureMessagingWidget = ({
+  facilityNames,
+  authenticatedWithSSOe,
+}) => (
+  <div data-testid="cerner-messaging-widget">
+    <h3>Send or receive a secure message</h3>
+    <CernerAlertBox
+      ctaText="Send a secure message to a provider at:"
+      ctaButtonText="Go to My HealtheVet"
+      ctaButtonUrl={mhvUrl(authenticatedWithSSOe, 'secure-messaging')}
+      facilityNames={facilityNames}
+    />
+  </div>
+);
+
+export const CernerPrescriptionsWidget = ({
+  facilityNames,
+  authenticatedWithSSOe,
+}) => (
+  <div data-testid="cerner-prescription-widget">
+    <h3>Refill and track prescriptions</h3>
+    <CernerAlertBox
+      ctaText="Refill prescriptions from:"
+      ctaButtonText="Go to My HealtheVet"
+      ctaButtonUrl={mhvUrl(
+        authenticatedWithSSOe,
+        'web/myhealthevet/refill-prescriptions',
+      )}
+      facilityNames={facilityNames}
+    />
+  </div>
+);

--- a/src/applications/personalization/dashboard/components/cerner-widgets.js
+++ b/src/applications/personalization/dashboard/components/cerner-widgets.js
@@ -44,7 +44,7 @@ const CernerAlertBox = ({
       headline="Your VA health care team may be using our new My VA Health portal"
     >
       <h3>Our records show you’re registered at:</h3>
-      <h4>
+      <h4 className="vads-u-font-family--sans">
         <FacilityList facilities={facilityNames} separator=" and " />
         <span className="vads-u-font-weight--normal vads-u-font-size--base">
           {' '}
@@ -58,7 +58,7 @@ const CernerAlertBox = ({
         use the same account you used to sign in on VA.gov.
       </p>
       <h3>{ctaText}</h3>
-      <h4>
+      <h4 className="vads-u-font-family--sans">
         <FacilityList facilities={facilityNames} separator=" or " />
       </h4>
       <a
@@ -74,7 +74,7 @@ const CernerAlertBox = ({
       >
         Go to My VA Health
       </a>
-      <h4>Another VA health facility</h4>
+      <h4 className="vads-u-font-family--sans">Another VA health facility</h4>
       <a href={ctaButtonUrl} type="button" className="usa-button-secondary">
         {ctaButtonText}
       </a>

--- a/src/applications/personalization/dashboard/containers/MessagingWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/MessagingWidget.jsx
@@ -91,7 +91,7 @@ class MessagingWidget extends React.Component {
     }
 
     return (
-      <div id="msg-widget">
+      <div id="msg-widget" data-testid="non-cerner-messaging-widget">
         <h3>Check secure messages</h3>
         {content}
         <p>

--- a/src/applications/personalization/dashboard/containers/PrescriptionsWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/PrescriptionsWidget.jsx
@@ -62,7 +62,7 @@ class PrescriptionsWidget extends React.Component {
     }
 
     return (
-      <div id="rx-widget">
+      <div id="rx-widget" data-testid="non-cerner-prescription-widget">
         <h3>Refill prescriptions</h3>
         <div>{content}</div>
         <p>

--- a/src/applications/personalization/dashboard/tests/components/cerner-widgets.unit.spec.js
+++ b/src/applications/personalization/dashboard/tests/components/cerner-widgets.unit.spec.js
@@ -1,0 +1,134 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+
+import {
+  CernerPrescriptionsWidget,
+  CernerScheduleAnAppointmentWidget,
+  CernerSecureMessagingWidget,
+} from '../../components/cerner-widgets';
+
+describe('Prescriptions Widget', () => {
+  const facilityNames = ['Facility Name'];
+  let view;
+  beforeEach(() => {
+    view = render(<CernerPrescriptionsWidget facilityNames={facilityNames} />);
+  });
+  it('renders the correct text, including the facility names', () => {
+    expect(
+      view.getByRole('heading', {
+        name: /Refill and track prescriptions/i,
+      }),
+    ).to.exist;
+    expect(
+      view.getByRole('heading', {
+        name: /Refill prescriptions from:/i,
+      }),
+    ).to.exist;
+    expect(
+      view.getAllByRole('heading', { name: new RegExp(facilityNames[0], 'i') })
+        .length,
+    ).to.equal(2);
+  });
+  it('renders the correct primary CTA button', () => {
+    const myVAHealthButton = view.getByRole('link', {
+      name: /Go to My VA Health/i,
+    });
+    expect(myVAHealthButton.href).to.equal(
+      'https://ehrm-va-test.patientportal.us.healtheintent.com/',
+    );
+  });
+  it('renders the correct alternate CTA button', () => {
+    const ctaButton = view.getByRole('link', {
+      name: /Go to My HealtheVet/i,
+    });
+    expect(ctaButton.href).to.contain(
+      'https://mhv-syst.myhealth.va.gov/mhv-portal-web/web/myhealthevet/refill-prescription',
+    );
+  });
+});
+
+describe('Appointment Widget', () => {
+  const facilityNames = ['Facility Name', 'Another Facility Name'];
+  let view;
+  beforeEach(() => {
+    view = render(
+      <CernerScheduleAnAppointmentWidget facilityNames={facilityNames} />,
+    );
+  });
+  it('renders the correct text, including the facility names', () => {
+    expect(
+      view.getByRole('heading', {
+        name: /View, schedule, or cancel an appointment/i,
+      }),
+    ).to.exist;
+    expect(view.getByRole('heading', { name: /manage appointments at:/i })).to
+      .exist;
+    expect(
+      view.getAllByRole('heading', { name: new RegExp(facilityNames[0], 'i') })
+        .length,
+    ).to.equal(2);
+    expect(
+      view.getAllByRole('heading', { name: new RegExp(facilityNames[1], 'i') })
+        .length,
+    ).to.equal(2);
+  });
+  it('renders the correct primary CTA button', () => {
+    const myVAHealthButton = view.getByRole('link', {
+      name: /Go to My VA Health/i,
+    });
+    expect(myVAHealthButton.href).to.equal(
+      'https://ehrm-va-test.patientportal.us.healtheintent.com/',
+    );
+  });
+  it('renders the correct alternate CTA button', () => {
+    const ctaButton = view.getByRole('link', {
+      name: /Go to the VA appointments tool/i,
+    });
+    expect(ctaButton.href).to.contain(
+      '/health-care/schedule-view-va-appointments/',
+    );
+  });
+});
+
+describe('Secure Messaging Widget', () => {
+  const facilityNames = ['Facility Name'];
+  let view;
+  beforeEach(() => {
+    view = render(
+      <CernerSecureMessagingWidget facilityNames={facilityNames} />,
+    );
+  });
+  it('renders the correct text, including the facility names', () => {
+    expect(
+      view.getByRole('heading', {
+        name: /Send or receive a secure message/i,
+      }),
+    ).to.exist;
+    expect(
+      view.getByRole('heading', {
+        name: /Send a secure message to a provider at:/i,
+      }),
+    ).to.exist;
+    expect(
+      view.getAllByRole('heading', { name: new RegExp(facilityNames[0], 'i') })
+        .length,
+    ).to.equal(2);
+  });
+  it('renders the correct primary CTA button', () => {
+    const myVAHealthButton = view.getByRole('link', {
+      name: /Go to My VA Health/i,
+    });
+    expect(myVAHealthButton.href).to.equal(
+      'https://ehrm-va-test.patientportal.us.healtheintent.com/',
+    );
+  });
+  it('renders the correct alternate CTA button', () => {
+    const ctaButton = view.getByRole('link', {
+      name: /Go to My HealtheVet/i,
+    });
+    expect(ctaButton.href).to.contain(
+      'https://mhv-syst.myhealth.va.gov/mhv-portal-web/secure-messaging',
+    );
+  });
+});

--- a/src/applications/personalization/dashboard/tests/e2e/dashboard.health-care-widgets.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/dashboard.health-care-widgets.cypress.spec.js
@@ -1,0 +1,266 @@
+const enrollmentStatusEnrolled = {
+  applicationDate: '2006-01-30T00:00:00.000-06:00',
+  enrollmentDate: '2006-03-20T00:00:00.000-06:00',
+  preferredFacility: '626A4 - ALVIN C. YORK VAMC',
+  effectiveDate: '2018-04-28T18:21:56.000-05:00',
+  parsedStatus: 'enrolled',
+};
+
+function mockLocalStorage() {
+  // make sure no first-time UX modals are in the way
+  window.localStorage.setItem(
+    'DISMISSED_ANNOUNCEMENTS',
+    JSON.stringify(['single-sign-on-intro', 'find-benefits-intro']),
+  );
+}
+
+function mockFeatureFlags() {
+  cy.route('GET', '/v0/feature_toggles*', {
+    data: {
+      type: 'feature_toggles',
+      features: [
+        {
+          // This feature flag is required to enable Cerner alerts
+          name: 'show_new_schedule_view_appointments_page',
+          value: true,
+        },
+      ],
+    },
+  });
+}
+
+function makeUserObject(
+  options = {
+    isCerner: true,
+    rx: true,
+    messaging: true,
+    facilities: [
+      { facilityId: '668', isCerner: true },
+      { facilityId: '757', isCerner: true },
+    ],
+  },
+) {
+  const services = [];
+  if (options.rx) {
+    services.push('rx');
+  }
+  if (options.messaging) {
+    services.push('messaging');
+  }
+  return {
+    data: {
+      id: '',
+      type: 'users_scaffolds',
+      attributes: {
+        services,
+        account: { accountUuid: 'c049d895-ecdf-40a4-ac0f-7947a06ea0c2' },
+        profile: {
+          email: 'vets.gov.user+36@gmail.com',
+          firstName: 'WESLEY',
+          middleName: 'WATSON',
+          lastName: 'FORD',
+          birthDate: '1986-05-06',
+          gender: 'M',
+          zip: '21122-6706',
+          lastSignedIn: '2020-07-21T00:04:51.589Z',
+          loa: { current: 3, highest: 3 },
+          multifactor: true,
+          verified: true,
+          signIn: { serviceName: 'idme', accountType: 'N/A', ssoe: true },
+          authnContext: 'http://idmanagement.gov/ns/assurance/loa/3',
+        },
+        vaProfile: {
+          status: 'OK',
+          birthDate: '19860506',
+          familyName: 'Ford',
+          gender: 'M',
+          givenNames: ['Wesley', 'Watson'],
+          isCernerPatient: options.isCerner,
+          facilities: options.facilities,
+          vaPatient: true,
+          mhvAccountState: 'NONE',
+        },
+        veteranStatus: {
+          status: 'OK',
+          isVeteran: true,
+          servedInMilitary: true,
+        },
+        inProgressForms: [],
+        prefillsAvailable: [],
+        vet360ContactInformation: {},
+      },
+    },
+    meta: { errors: null },
+  };
+}
+
+describe('MyVA Dashboard - Health Care Widgets', () => {
+  describe('when user is enrolled at Cerner facility with all features', () => {
+    beforeEach(() => {
+      mockLocalStorage();
+      const mockUser = makeUserObject({
+        isCerner: true,
+        messaging: true,
+        rx: true,
+        facilities: [{ facilityId: '688', isCerner: true }],
+      });
+      cy.login(mockUser);
+      // login() calls cy.server() so we can now mock routes
+      cy.route(
+        'GET',
+        '/v0/health_care_applications/enrollment_status',
+        enrollmentStatusEnrolled,
+      );
+      mockFeatureFlags();
+    });
+    it('should show the correct widgets', () => {
+      cy.visit('my-va/');
+      cy.findByTestId('cerner-appointment-widget').should('exist');
+      cy.findByTestId('cerner-messaging-widget').should('exist');
+      cy.findByTestId('cerner-prescription-widget').should('exist');
+      cy.findByTestId('non-cerner-appointment-widget').should('not.exist');
+      cy.findByTestId('non-cerner-messaging-widget').should('not.exist');
+      cy.findByTestId('non-cerner-prescription-widget').should('not.exist');
+    });
+  });
+  describe('when user is enrolled at Cerner facility that only supports appointments', () => {
+    beforeEach(() => {
+      mockLocalStorage();
+      const mockUser = makeUserObject({
+        isCerner: true,
+        messaging: true,
+        rx: true,
+        facilities: [{ facilityId: '757', isCerner: true }],
+      });
+      cy.login(mockUser);
+      // login() calls cy.server() so we can now mock routes
+      cy.route(
+        'GET',
+        '/v0/health_care_applications/enrollment_status',
+        enrollmentStatusEnrolled,
+      );
+      mockFeatureFlags();
+    });
+    it('should show the correct widgets', () => {
+      cy.visit('my-va/');
+      cy.findByTestId('cerner-appointment-widget').should('exist');
+      cy.findByTestId('cerner-messaging-widget').should('not.exist');
+      cy.findByTestId('cerner-prescription-widget').should('not.exist');
+      cy.findByTestId('non-cerner-appointment-widget').should('not.exist');
+      cy.findByTestId('non-cerner-messaging-widget').should('exist');
+      cy.findByTestId('non-cerner-prescription-widget').should('exist');
+    });
+  });
+  describe('when user is enrolled at Cerner facility and lacks the prescription and messaging features', () => {
+    beforeEach(() => {
+      mockLocalStorage();
+      const mockUser = makeUserObject({
+        isCerner: true,
+        messaging: false,
+        rx: false,
+        facilities: [{ facilityId: '757', isCerner: true }],
+      });
+      cy.login(mockUser);
+      // login() calls cy.server() so we can now mock routes
+      cy.route(
+        'GET',
+        '/v0/health_care_applications/enrollment_status',
+        enrollmentStatusEnrolled,
+      );
+      mockFeatureFlags();
+    });
+    it('should show the correct widgets', () => {
+      cy.visit('my-va/');
+      cy.findByTestId('cerner-appointment-widget').should('exist');
+      cy.findByTestId('cerner-messaging-widget').should('not.exist');
+      cy.findByTestId('cerner-prescription-widget').should('not.exist');
+      cy.findByTestId('non-cerner-appointment-widget').should('not.exist');
+      cy.findByTestId('non-cerner-messaging-widget').should('not.exist');
+      cy.findByTestId('non-cerner-prescription-widget').should('not.exist');
+    });
+  });
+  describe('when user is enrolled in a non-Cerner facility', () => {
+    beforeEach(() => {
+      mockLocalStorage();
+      const mockUser = makeUserObject({
+        isCerner: false,
+        messaging: true,
+        rx: true,
+        facilities: [{ facilityId: '686', isCerner: false }],
+      });
+      cy.login(mockUser);
+      // login() calls cy.server() so we can now mock routes
+      cy.route(
+        'GET',
+        '/v0/health_care_applications/enrollment_status',
+        enrollmentStatusEnrolled,
+      );
+      mockFeatureFlags();
+    });
+    it('should show the correct widgets', () => {
+      cy.visit('my-va/');
+      cy.findByTestId('cerner-appointment-widget').should('not.exist');
+      cy.findByTestId('cerner-messaging-widget').should('not.exist');
+      cy.findByTestId('cerner-prescription-widget').should('not.exist');
+      cy.findByTestId('non-cerner-appointment-widget').should('exist');
+      cy.findByTestId('non-cerner-messaging-widget').should('exist');
+      cy.findByTestId('non-cerner-prescription-widget').should('exist');
+    });
+  });
+  describe('when user is enrolled in a non-Cerner facility and lacks the messaging service', () => {
+    beforeEach(() => {
+      mockLocalStorage();
+      const mockUser = makeUserObject({
+        isCerner: false,
+        messaging: false,
+        rx: true,
+        facilities: [{ facilityId: '686', isCerner: false }],
+      });
+      cy.login(mockUser);
+      // login() calls cy.server() so we can now mock routes
+      cy.route(
+        'GET',
+        '/v0/health_care_applications/enrollment_status',
+        enrollmentStatusEnrolled,
+      );
+      mockFeatureFlags();
+    });
+    it('should show the correct widgets', () => {
+      cy.visit('my-va/');
+      cy.findByTestId('cerner-appointment-widget').should('not.exist');
+      cy.findByTestId('cerner-messaging-widget').should('not.exist');
+      cy.findByTestId('cerner-prescription-widget').should('not.exist');
+      cy.findByTestId('non-cerner-appointment-widget').should('exist');
+      cy.findByTestId('non-cerner-messaging-widget').should('not.exist');
+      cy.findByTestId('non-cerner-prescription-widget').should('exist');
+    });
+  });
+  describe('when user is enrolled in a non-Cerner facility and lacks the prescriptions service', () => {
+    beforeEach(() => {
+      mockLocalStorage();
+      const mockUser = makeUserObject({
+        isCerner: false,
+        messaging: true,
+        rx: false,
+        facilities: [{ facilityId: '686', isCerner: false }],
+      });
+      cy.login(mockUser);
+      // login() calls cy.server() so we can now mock routes
+      cy.route(
+        'GET',
+        '/v0/health_care_applications/enrollment_status',
+        enrollmentStatusEnrolled,
+      );
+      mockFeatureFlags();
+    });
+    it('should show the correct widgets', () => {
+      cy.visit('my-va/');
+      cy.findByTestId('cerner-appointment-widget').should('not.exist');
+      cy.findByTestId('cerner-messaging-widget').should('not.exist');
+      cy.findByTestId('cerner-prescription-widget').should('not.exist');
+      cy.findByTestId('non-cerner-appointment-widget').should('exist');
+      cy.findByTestId('non-cerner-messaging-widget').should('exist');
+      cy.findByTestId('non-cerner-prescription-widget').should('not.exist');
+    });
+  });
+});

--- a/src/applications/personalization/dashboard/tests/e2e/dashboard.health-care-widgets.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/dashboard.health-care-widgets.cypress.spec.js
@@ -102,7 +102,7 @@ describe('MyVA Dashboard - Health Care Widgets', () => {
         isCerner: true,
         messaging: true,
         rx: true,
-        facilities: [{ facilityId: '688', isCerner: true }],
+        facilities: [{ facilityId: '668', isCerner: true }],
       });
       cy.login(mockUser);
       // login() calls cy.server() so we can now mock routes


### PR DESCRIPTION
## Description
Adds new widgets to show on the My VA Dashboard's "Manager Your Heath Care" section when a user is a patient at a Cerner facility.

## Testing done
- local
- RTL tests for the new widgets
- Cypress tests to confirm the correct widgets are shown depending on different `GET user/` responses

## Screenshots
<details>
  <summary>Appointment widget with one facility name:</summary>

<img width="650" alt="appt - 1 facility" src="https://user-images.githubusercontent.com/20728956/96523670-25ae3680-122b-11eb-8cc0-83535309b314.png">
  
</details>

<details>
  <summary>Appointment widget with two facility names:</summary>

<img width="646" alt="appt - 2 facilities" src="https://user-images.githubusercontent.com/20728956/96523706-44acc880-122b-11eb-9018-b1fc0a06f3a7.png">
  
</details>

<details>
  <summary>Secure messaging widget:</summary>

<img width="648" alt="messaging" src="https://user-images.githubusercontent.com/20728956/96523708-48404f80-122b-11eb-9a5e-33647792fd44.png">
  
</details>

<details>
  <summary>Prescriptions widget:</summary>

<img width="652" alt="prescriptions" src="https://user-images.githubusercontent.com/20728956/96523712-4d9d9a00-122b-11eb-8c9f-9f92bc38d48f.png">
  
</details>

## Acceptance criteria
- [ ] Show the correct Cerner widgets when a user is enrolled in a Cerner facility that supports those services
- [ ] Show the non-Cerner widgets when a user has access to a particular service but it not enrolled in a Cerner facility

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs