### PR TITLE
Ensure related information doesn't render when there's only 1 empty one

### DIFF
--- a/src/site/includes/related-information.drupal.liquid
+++ b/src/site/includes/related-information.drupal.liquid
@@ -1,4 +1,4 @@
-{% if fieldRelatedInformation != empty %}
+{% if fieldRelatedInformation != empty and fieldRelatedInformation[0].entity.fieldLink %}
   <div class="row">
     <div class="usa-content columns">
       <aside class="va-nav-linkslist va-nav-linkslist--related">


### PR DESCRIPTION
## Description

This PR fixes Related Information showing up when there aren't any related information links.

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] Update Related Information to not render when there are empty related information links.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
