### PR TITLE
Category ratings group update

### DIFF
--- a/src/applications/gi/components/profile/SchoolRatings.jsx
+++ b/src/applications/gi/components/profile/SchoolRatings.jsx
@@ -8,10 +8,18 @@ export default function SchoolRatings({
   ratingCount,
   institutionCategoryRatings = [],
 }) {
-  const [openName, setOpenName] = useState('');
+  const [openName, setOpenName] = useState({
+    educationRatings: '',
+    veteranFriendliness: '',
+  });
   const stars = convertRatingToStars(ratingAverage);
 
-  const renderSchoolCategoryRating = (title, categoryName, description) => {
+  const renderSchoolCategoryRating = (
+    title,
+    categoryName,
+    description,
+    groupName,
+  ) => {
     const categoryRating = institutionCategoryRatings.find(
       category => category.categoryName === categoryName,
     );
@@ -19,9 +27,15 @@ export default function SchoolRatings({
       <SchoolCategoryRating
         title={title}
         openHandler={() => {
-          setOpenName(openName === categoryName ? '' : categoryName);
+          const newOpenNames = {
+            ...openName,
+            [groupName]:
+              openName[groupName] === categoryName ? '' : categoryName,
+          };
+
+          setOpenName(newOpenNames);
         }}
-        open={openName === categoryName}
+        open={openName[groupName] === categoryName}
         categoryRating={categoryRating}
         description={description}
       />
@@ -56,21 +70,25 @@ export default function SchoolRatings({
               'Overall experience',
               'overall_experience',
               'How was the overall experience at this school? Would Veterans recommend this school to other Veterans or military family members?',
+              'educationRatings',
             )}
             {renderSchoolCategoryRating(
               'Quality of classes',
               'quality_of_classes',
               'Classes, academic programs, and instruction meet Veteran expectations for a high quality education.',
+              'educationRatings',
             )}
             {renderSchoolCategoryRating(
               'Online instruction',
               'online_instruction',
               'Online classes are comparable quality to in-person instruction. Technology for virtual classes is easy to use. The school offers helpful tech support for online students.',
+              'educationRatings',
             )}
             {renderSchoolCategoryRating(
               'Job preparation',
               'job_preparation',
               'Coursework prepares Veterans for the job market. Instructors and school support systems help them find work in their desired fields.',
+              'educationRatings',
             )}
           </div>
         </div>
@@ -84,16 +102,19 @@ export default function SchoolRatings({
               'GI Bill support',
               'gi_bill_support',
               'It’s easy to use GI Bill education benefits at this school. School officials are helpful if there are challenges processing VA benefits.',
+              'veteranFriendliness',
             )}
             {renderSchoolCategoryRating(
               'Veteran community',
               'veteran_community',
               'There’s a robust community at the school for Veterans and military-connected students. The school supports and engages Veterans.',
+              'veteranFriendliness',
             )}
             {renderSchoolCategoryRating(
               'True to expectations',
               'marketing_practices',
               'The school provides clear and detailed explanations of admissions requirements, academic programs, and all the associated costs.',
+              'veteranFriendliness',
             )}
           </div>
         </div>

--- a/src/applications/gi/components/profile/SchoolRatings.jsx
+++ b/src/applications/gi/components/profile/SchoolRatings.jsx
@@ -8,7 +8,7 @@ export default function SchoolRatings({
   ratingCount,
   institutionCategoryRatings = [],
 }) {
-  const [openName, setOpenName] = useState({
+  const [openNames, setOpenNames] = useState({
     educationRatings: '',
     veteranFriendliness: '',
   });
@@ -28,14 +28,14 @@ export default function SchoolRatings({
         title={title}
         openHandler={() => {
           const newOpenNames = {
-            ...openName,
+            ...openNames,
             [groupName]:
-              openName[groupName] === categoryName ? '' : categoryName,
+              openNames[groupName] === categoryName ? '' : categoryName,
           };
 
-          setOpenName(newOpenNames);
+          setOpenNames(newOpenNames);
         }}
-        open={openName[groupName] === categoryName}
+        open={openNames[groupName] === categoryName}
         categoryRating={categoryRating}
         description={description}
       />

--- a/src/applications/gi/tests/components/profile/SchoolRatings.unit.spec.jsx
+++ b/src/applications/gi/tests/components/profile/SchoolRatings.unit.spec.jsx
@@ -178,7 +178,7 @@ describe('<SchoolRatings>', () => {
     wrapper.unmount();
   });
 
-  it('should only allow 1 open SchoolCategoryRating', () => {
+  it('should only allow 1 open SchoolCategoryRating per group', () => {
     const wrapper = mount(
       <SchoolRatings
         ratingAverage={3}
@@ -197,9 +197,17 @@ describe('<SchoolRatings>', () => {
       .find('button')
       .at(1)
       .simulate('click');
+    wrapper
+      .find('button')
+      .at(4)
+      .simulate('click');
+    wrapper
+      .find('button')
+      .at(5)
+      .simulate('click');
 
-    expect(wrapper.find('button[aria-expanded=true]').length).to.eq(1);
-    expect(wrapper.find('button[aria-expanded=false]').length).to.eq(6);
+    expect(wrapper.find('button[aria-expanded=true]').length).to.eq(2);
+    expect(wrapper.find('button[aria-expanded=false]').length).to.eq(5);
 
     wrapper.unmount();
   });


### PR DESCRIPTION
## Description
Only one category per group can be open at the same time.

[ZenHub Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/13635)

## Testing done
Tested locally and QA reviewed

## Screenshots
![image](https://user-images.githubusercontent.com/41960449/96589587-fd6a1a80-12b2-11eb-8a67-7c37ed179068.png)

## Acceptance criteria
- [x] Only one rating category per group (Education ratings, Veteran friendliness) can be expanded at a time

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
