### PR TITLE
Fix fieldDate on node-event

### DIFF
--- a/src/site/stages/build/process-cms-exports/transformers/node-event.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-event.js
@@ -11,22 +11,16 @@ const { mapKeys, camelCase } = require('lodash');
 const assert = require('assert');
 const moment = require('moment');
 
-function toUtc(timeString) {
+function toUtc(timeString, withExplicitUtc = true) {
   const time = moment.utc(timeString);
   assert(
     time.isValid(),
     `Expected timeString to be a moment-parsable string. Found ${timeString}`,
   );
-  return time.format('YYYY-MM-DD kk:mm:ss [UTC]');
-}
-
-function toUtcTz(timeString) {
-  const time = moment.utc(timeString);
-  assert(
-    time.isValid(),
-    `Expected timeString to be a moment-parsable string. Found ${timeString}`,
-  );
-  return time.format('YYYY-MM-DDTkk:mm:ss');
+  const formatString = withExplicitUtc
+    ? 'YYYY-MM-DD kk:mm:ss [UTC]'
+    : 'YYYY-MM-DD[T]kk:mm:ss';
+  return time.format(formatString);
 }
 
 const transform = entity => ({
@@ -55,9 +49,9 @@ const transform = entity => ({
   },
   fieldDate: {
     startDate: toUtc(entity.fieldDate[0].value),
-    value: toUtcTz(entity.fieldDate[0].value),
+    value: toUtc(entity.fieldDate[0].value, false),
     endDate: toUtc(entity.fieldDate[0].end_value),
-    endValue: toUtcTz(entity.fieldDate[0].end_value),
+    endValue: toUtc(entity.fieldDate[0].end_value, false),
   },
   fieldDescription: getDrupalValue(entity.fieldDescription),
   fieldEventCost: getDrupalValue(entity.fieldEventCost),

--- a/src/site/stages/build/process-cms-exports/transformers/node-event.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-event.js
@@ -5,6 +5,7 @@ const {
   createLink,
   createMetaTagArray,
   isPublished,
+  getImageCrop,
 } = require('./helpers');
 const { mapKeys, camelCase } = require('lodash');
 const assert = require('assert');
@@ -17,6 +18,15 @@ function toUtc(timeString) {
     `Expected timeString to be a moment-parsable string. Found ${timeString}`,
   );
   return time.format('YYYY-MM-DD kk:mm:ss [UTC]');
+}
+
+function toUtcTz(timeString) {
+  const time = moment.utc(timeString);
+  assert(
+    time.isValid(),
+    `Expected timeString to be a moment-parsable string. Found ${timeString}`,
+  );
+  return time.format('YYYY-MM-DDTkk:mm:ss');
 }
 
 const transform = entity => ({
@@ -45,9 +55,9 @@ const transform = entity => ({
   },
   fieldDate: {
     startDate: toUtc(entity.fieldDate[0].value),
-    value: entity.fieldDate[0].value,
+    value: toUtcTz(entity.fieldDate[0].value),
     endDate: toUtc(entity.fieldDate[0].end_value),
-    endValue: entity.fieldDate[0].end_value,
+    endValue: toUtcTz(entity.fieldDate[0].end_value),
   },
   fieldDescription: getDrupalValue(entity.fieldDescription),
   fieldEventCost: getDrupalValue(entity.fieldEventCost),
@@ -60,7 +70,7 @@ const transform = entity => ({
   fieldLocationHumanreadable: getDrupalValue(entity.fieldLocationHumanreadable),
   fieldMedia:
     entity.fieldMedia && entity.fieldMedia.length
-      ? { entity: entity.fieldMedia[0] }
+      ? { entity: getImageCrop(entity.fieldMedia[0], '_72MEDIUMTHUMBNAIL') }
       : null,
   status: getDrupalValue(entity.status),
 });


### PR DESCRIPTION
## Description
There are output discrepancies in the fieldDate and image url.

This PR will fix 2 tickets [13168](https://github.com/department-of-veterans-affairs/va.gov-team/issues/13168) and [13169](https://github.com/department-of-veterans-affairs/va.gov-team/issues/13169)

## Testing done
Locally

## Screenshots

![Screen Shot 2020-10-16 at 3 16 19 PM](https://user-images.githubusercontent.com/55560129/96598344-c39e1180-12bc-11eb-9fc3-9e5d1a9eb2ac.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
