### PR TITLE
Add page break for print view 1995 confirmation page

### DIFF
--- a/src/applications/edu-benefits/1995/containers/ConfirmationPage.jsx
+++ b/src/applications/edu-benefits/1995/containers/ConfirmationPage.jsx
@@ -260,7 +260,9 @@ class ConfirmationPage extends React.Component {
                 Learn more about what happens after you apply:
               </a>
             </p>
-            <h4 className="confirmation-guidance-heading">Need help?</h4>
+            <h4 className="confirmation-guidance-heading pagebreak">
+              Need help?
+            </h4>
             <p className="confirmation-guidance-message">
               If you have questions, call 888-GI-BILL-1 (
               <a href="tel:+18884424551">888-442-4551</a>

--- a/src/applications/edu-benefits/sass/edu-benefits.scss
+++ b/src/applications/edu-benefits/sass/edu-benefits.scss
@@ -157,6 +157,7 @@
   .schemaform-subtitle {
     display: none;
   }
+  .pagebreak { page-break-before: always; }
 }
 
 div[data-chapter="benefitSelection"]{


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/14358

We want the printed pages to be divided at the "Need Help?" section on the 1995 confirmation page. 

## Testing done


## Screenshots
![image](https://user-images.githubusercontent.com/48804654/96628044-b3e3f480-12df-11eb-83d2-7d24da99c3f3.png)



## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
