### PR TITLE
Update img src from va.gov to www.va.gov

### DIFF
--- a/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
@@ -41,7 +41,7 @@ export class ConfirmationPage extends React.Component {
       <div>
         <div className="print-only">
           <img
-            src="https://va.gov/img/design/logo/logo-black-and-white.png"
+            src="https://www.va.gov/img/design/logo/logo-black-and-white.png"
             alt="VA logo"
             width="300"
           />


### PR DESCRIPTION
## Description

Update `img` `src` from `va.gov` to `www.va.gov` to fix Sentry [error](http://sentry.vfs.va.gov/share/issue/5b11fedb535c47d0beffb8533470d1a2/)

## Relevant Links

- Sentry error: http://sentry.vfs.va.gov/share/issue/5b11fedb535c47d0beffb8533470d1a2/
- Initial report of bug: https://dsva.slack.com/archives/CQH357ZTP/p1602626937141100
- Slack conversation: https://dsva.slack.com/archives/CQH357ZTP/p1603217005221200?thread_ts=1603204106.213900&cid=CQH357ZTP
