### PR TITLE
Contact Us - Change customText appType to 'inquiry' and update errorText within FormSaveErrorMessage

### DIFF
--- a/src/applications/ask-a-question/form/form.js
+++ b/src/applications/ask-a-question/form/form.js
@@ -3,6 +3,7 @@ import fullSchema from './0873-schema.json';
 // In a real app this would be imported from `vets-json-schema`:
 // import fullSchema from 'vets-json-schema/dist/0873-schema.json';
 
+import React from 'react';
 import IntroductionPage from './introduction/IntroductionPage';
 import ConfirmationPage from './confirmation/ConfirmationPage';
 import VeteranInformationPage from './veteran/veteranInformationPage';
@@ -27,6 +28,7 @@ import {
 } from '../constants/labels';
 
 import manifest from '../manifest.json';
+import CallMyVA311 from './review/error/CallMyVA311';
 
 const {
   fullName,
@@ -75,6 +77,11 @@ const formConfig = {
       // saved: 'Your [benefitType] [appType] has been saved.',
     },
   },
+  errorText: () => (
+    <p>
+      If it still doesn’t work, please <CallMyVA311 />
+    </p>
+  ),
   version: 0,
   prefillEnabled: true,
   savedFormMessages: {
@@ -86,6 +93,7 @@ const formConfig = {
   customText: {
     submitButtonText,
     reviewPageTitle,
+    appType: 'inquiry',
   },
   defaultDefinitions: {
     address,

--- a/src/applications/ask-a-question/form/review/error/CallMyVA311.js
+++ b/src/applications/ask-a-question/form/review/error/CallMyVA311.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import Telephone, {
+  CONTACTS,
+  PATTERNS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
+
+export default function CallMyVA311({ startSentence }) {
+  return (
+    <span>
+      {startSentence ? 'Call' : 'call'} us at{' '}
+      <a href="tel:18446982311">844-698-2311</a>.<br />
+      If you have hearing loss, call TTY:{' '}
+      <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
+    </span>
+  );
+}


### PR DESCRIPTION
## Description
[department-of-veterans-affairs/orchid#113]
When the user attempts to submit an inquiry on the Ask-A-Question flow for vets-website and the API returns a 503 for their POSTed inquiry, then the form should display an error message saying the inquiry could not be submitted and to reach out to the MyVA311 help number.

## Testing done
- Manual testing
- We did not see a need for unit testing since (a) there was no additional logic or complexity added and (b) most of the code is simply configuration or render components to be passed to platform form config.

## Screenshots
<img width="737" alt="Screen Shot 2020-10-20 at 10 07 52 AM" src="https://user-images.githubusercontent.com/7305450/96642655-4f269b00-12db-11eb-8fd3-07f345762605.png">

## Acceptance criteria
GIVEN that a user is submitting an inquiry on the Ask-A-Question form
WHEN the API returns a 503 from an attempt to POST the inquiry
THEN the user remains on the review page and an error message should be displayed with inquiry-specific text and a help number for MyVA311

## Definition of done
- The error is showing on 503
- The info in the error has the MyVA311 number for help (i.e. 1-844-698-2311)
- The text in the generic submission error should show 'inquiry' instead of the default 'application'