### PR TITLE
Add CSP_NONCE to script elements in src/site/includes/header.html

### DIFF
--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -30,7 +30,7 @@
   {% include "src/site/includes/metatags.liquid" %}
   {% endif %}
 
-  <script>
+  <script nonce="**CSP_NONCE**">
     {% include "src/site/assets/js/record-event.js" %}
   </script>
 
@@ -67,9 +67,9 @@
     <script nonce="**CSP_NONCE**" src="{{ botframework_cdn }}"></script>
   {% endif %}
 
-  <script defer nomodule data-entry-name="polyfills.js"></script>
-  <script defer data-entry-name="vendor.js"></script>
-  <script defer data-entry-name="{{ entryname | default: 'static-pages' }}.js"></script>
+  <script nonce="**CSP_NONCE**" defer nomodule data-entry-name="polyfills.js"></script>
+  <script nonce="**CSP_NONCE**" defer data-entry-name="vendor.js"></script>
+  <script nonce="**CSP_NONCE**" defer data-entry-name="{{ entryname | default: 'static-pages' }}.js"></script>
 
   <!--
   We participate in the US government’s analytics program. See the data at analytics.usa.gov.
@@ -78,7 +78,7 @@
   <script async type="text/javascript" nonce="**CSP_NONCE**" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=VA"
     id="_fed_an_ua_tag"></script>
 
-  <script type="text/javascript">
+  <script nonce="**CSP_NONCE**" type="text/javascript">
     window.VetsGov = window.VetsGov || {};
     window.VetsGov.headerFooter = {{ headerFooterData }};
   </script>
@@ -103,7 +103,7 @@
     data-homepage-banner-visible="{{ homepage_banner.visible }}"
   ></div>
 
-  <script type="text/javascript">
+  <script nonce="**CSP_NONCE**" type="text/javascript">
   (function() {
     var module = {};
     {% include "src/site/assets/js/incompatible-browser.js" %}


### PR DESCRIPTION
## Description

Add `nonce="**CSP_NONCE**"` to `<script>` elements in [`src/site/includes/header.html`](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/site/includes/header.html) to fix CSP Sentry errors, specifically http://sentry-legacy.vfs.va.gov/share/issue/09d46ac5316e4a048fdd32b48502986b/.

## Page with error

https://staging.va.gov/pittsburgh-health-care/

![image](https://user-images.githubusercontent.com/6130520/96773639-739d7880-13aa-11eb-8ff4-766a67068f15.png)

## Questions

- Should we default to adding `nonce="**CSP_NONCE**"` to every `<script>` element? If so, could/should we have a linting rule for that?