### PR TITLE
wip: 14619-Mobile-Table-Template

### DIFF
--- a/src/applications/static-pages/sass/modules/_m-facilities.scss
+++ b/src/applications/static-pages/sass/modules/_m-facilities.scss
@@ -11,6 +11,68 @@ $duo-tone-lighten: #000;
 .lighten::after {
   background-color: $duo-tone-lighten;
 }
+@media screen and (max-width: 509px) {
+  .rwd thead {
+    display: none;
+  }
+  .rwd tr {
+    border-top: 2px solid #999;
+  }
+  .rwd td,
+  .rwd th {
+    border: none;
+    display: block;
+  }
+  .rwd td {
+    display: grid;
+    // grid-template-columns: 85px 1fr;
+    margin: 0;
+    padding: 0.5rem;
+  }
+
+  .rwd caption {
+    display: flex;
+    justify-content: space-between;
+  }
+  .rwd td div{
+    display: flex;
+
+  }
+  .rwd td div strong{
+    padding-right: 2px;
+    font-weight: normal;
+  }
+  .rwd .col-header{
+    font-weight: bold;
+  }
+  .rwd dfn {
+    display: block;
+    font-style: normal;
+    font-weight: 800;
+    margin: 0;
+    padding: 0;
+  }
+  span {
+    text-align: right;
+  }
+  .rwd tr td:nth-child(3) {
+    display: block;
+  }
+  tr td:nth-child(3) dfn {
+    display: block;
+  }
+}
+@media screen and (min-width: 510px) {
+  .rwd tr {
+    border: none;
+  }
+  .rwd td {
+    display: table-cell;
+  }
+  .rwd dfn {
+    display: none;
+  }
+}
 
 /* Duo-tone effect */
 .duotone {

--- a/src/applications/static-pages/sass/modules/_m-facilities.scss
+++ b/src/applications/static-pages/sass/modules/_m-facilities.scss
@@ -15,6 +15,10 @@ $duo-tone-lighten: #000;
   .rwd thead {
     display: none;
   }
+
+  .rwd .column-value {
+    display: none;
+  }
   .rwd tr {
     border-top: 2px solid #999;
   }

--- a/src/site/paragraphs/table.drupal.liquid
+++ b/src/site/paragraphs/table.drupal.liquid
@@ -78,7 +78,7 @@ Row 3 Column 2 Row 3 Column 3",
 					either that, or make a PR to the formation/js repo to handle displaying/hiding sibling nodes rather than expecting additional-info-content to always be a child of  additional-info-container
 					to accomplish this we could use a query selecotr by data-entity-id in formation/js/additional-info.js, and add that attribute to the div below.
 					-->
-						{{column}}
+					<div class="column-value"> {{column}} </div>	
 				<div class="additional-info-content">
 					<!-- this is how every other single drupal template displays additional content: -->
 					{{ entity.fieldWysiwyg.processed }}

--- a/src/site/paragraphs/table.drupal.liquid
+++ b/src/site/paragraphs/table.drupal.liquid
@@ -78,10 +78,11 @@ Row 3 Column 2 Row 3 Column 3",
 					either that, or make a PR to the formation/js repo to handle displaying/hiding sibling nodes rather than expecting additional-info-content to always be a child of  additional-info-container
 					to accomplish this we could use a query selecotr by data-entity-id in formation/js/additional-info.js, and add that attribute to the div below.
 					-->
+						{{column}}
 				<div class="additional-info-content">
 					<!-- this is how every other single drupal template displays additional content: -->
 					{{ entity.fieldWysiwyg.processed }}
-					<!-- {{column}} -->
+				
 				</div>
 			</td>
 			{% endif %}

--- a/src/site/paragraphs/table.drupal.liquid
+++ b/src/site/paragraphs/table.drupal.liquid
@@ -66,17 +66,18 @@ Row 3 Column 2 Row 3 Column 3",
 			{% else %}
 			<td>
 				<!-- formation.js?c106:1 Uncaught TypeError: Cannot read property 'innerHTML' of null
-    at eval (formation.js?c106:1)
-    at Array.forEach (<anonymous>)
-    at u (formation.js?c106:1)
-	at eval (formation.js?c106:1)
-https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/master/packages/formation/js/additional-info.js#L30
-this error is coming from the fact that we are in an else and the additonal info conent isn't a child to the container
- one solution is to move this div inside the if above
-and just like below, make a change to the entity to return the necessary processed nodes for the correct columns to show up
-either that, or make a PR to the formation/js repo to handle displaying/hiding sibling nodes rather than expecting additional-info-content to always be a child of  additional-info-container
-as an alternative we could use a query selecotr by data-entity id, and add that attribbute below.
--->
+					at eval (formation.js?c106:1)
+					at Array.forEach (<anonymous>)
+					at u (formation.js?c106:1)
+					at eval (formation.js?c106:1)
+					where this error is coming from:
+					https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/master/packages/formation/js/additional-info.js#L30
+					this error is coming from the fact that the class additional-info-content isn't a child to the additional-info-container
+					one solution is to move the additional-info-container div inside the if above
+					and just like below, make a change to the entity to return the necessary processed nodes for the correct columns to show up
+					either that, or make a PR to the formation/js repo to handle displaying/hiding sibling nodes rather than expecting additional-info-content to always be a child of  additional-info-container
+					to accomplish this we could use a query selecotr by data-entity-id in formation/js/additional-info.js, and add that attribute to the div below.
+					-->
 				<div class="additional-info-content">
 					<!-- this is how every other single drupal template displays additional content: -->
 					{{ entity.fieldWysiwyg.processed }}

--- a/src/site/paragraphs/table.drupal.liquid
+++ b/src/site/paragraphs/table.drupal.liquid
@@ -1,57 +1,93 @@
 {% comment %}
-    Example data:
-    entity: {
-        "entityId": "3944",
-        "fieldTable": {
-            "tableValue": "Row 1 Column 1 Row 1 Column 2 Row 1 Column 3 Row 2 Column 1 Row 2 Column 2 Row 2 Column 3 Row 3 Column 1 Row 3 Column 2 Row 3 Column 3",
-            "value": {
-                "0": [
-                "Row 1 Column 1",
-                "Row 1 Column 2",
-                "Row 1 Column 3"
-                ],
-                "1": [
-                "Row 2 Column 1",
-                "Row 2 Column 2",
-                "Row 2 Column 3"
-                ],
-                "2": [
-                "Row 3 Column 1",
-                "Row 3 Column 2",
-                "Row 3 Column 3"
-                ],
-            }
-            "format": "rich_text",
-            "caption": "Test Table"
-        }
-    }
+Example data:
+entity: {
+"entityId": "3944",
+"fieldTable": {
+"tableValue": "Row 1 Column 1 Row 1 Column 2 Row 1 Column 3 Row 2 Column 1 Row 2 Column 2 Row 2 Column 3 Row 3 Column 1
+Row 3 Column 2 Row 3 Column 3",
+"value": {
+"0": [
+"Row 1 Column 1",
+"Row 1 Column 2",
+"Row 1 Column 3"
+],
+"1": [
+"Row 2 Column 1",
+"Row 2 Column 2",
+"Row 2 Column 3"
+],
+"2": [
+"Row 3 Column 1",
+"Row 3 Column 2",
+"Row 3 Column 3"
+],
+}
+"format": "rich_text",
+"caption": "Test Table"
+}
+}
 {% endcomment %}
 
 
-<table data-template="paragraphs/table" data-entity-id="{{ entity.entityId }}" class="va-table">
+<table data-template="paragraphs/table" data-entity-id="{{ entity.entityId }}" class="va-table rwd">
 
-    {% if entity.fieldTable.caption %}
-        <caption>{{ entity.fieldTable.caption }}</caption>
-    {% endif %}
+	{% if entity.fieldTable.caption %}
+	<caption>{{ entity.fieldTable.caption }} <a class="small-screen:vads-u-display--none">Show All</a></caption>
+	{% endif %}
 
-    {% for value in entity.fieldTable.value %}
-        {% if forloop.first == true %}
-            <thead>
-                <tr>
-                    {% for column in value %}
-                        <th>{{ column }}</th>
-                    {% endfor %}
-                </tr>
-            </thead>
-        {% elsif forloop.last == false %}
-            <tbody>
-                <tr class="class">
-                    {% for column in value %}
-                        <td>{{ column }}</td>
-                    {% endfor %}
-                </tr>
-            </tbody>
-        {% endif %}
-    {% endfor %}
+	{% for value in entity.fieldTable.value %}
+	{% if forloop.first == true %}
+	<thead>
+		<tr>
+			{% for column in value %}
+			{% if forloop.first == true %}
+			{% assign col_header = column %}
+			{% endif %}
+
+			<th>{{ column }}</th>
+			{% endfor %}
+		</tr>
+	</thead>
+	{% elsif forloop.last == false %}
+
+	<tbody>
+
+		<tr class="class">
+			{% for column in value %}
+			{% if forloop.first == true %}
+			<td>
+				<div class="col-header small-screen:vads-u-display--none"> {{col_header}}</div>
+				<div> {{ column }} </div>
+				<div data-template="paragraphs/expandable_text" data-entity-id="{{ entity.entityId }}"
+					class="form-expanding-group borderless-alert additional-info-container small-screen:vads-u-display--none">
+					<div class="additional-info-title">Show details...</div>
+				</div>
+			</td>
+			{% else %}
+			<td>
+				<!-- formation.js?c106:1 Uncaught TypeError: Cannot read property 'innerHTML' of null
+    at eval (formation.js?c106:1)
+    at Array.forEach (<anonymous>)
+    at u (formation.js?c106:1)
+	at eval (formation.js?c106:1)
+https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/master/packages/formation/js/additional-info.js#L30
+this error is coming from the fact that we are in an else and the additonal info conent isn't a child to the container
+ one solution is to move this div inside the if above
+and just like below, make a change to the entity to return the necessary processed nodes for the correct columns to show up
+either that, or make a PR to the formation/js repo to handle displaying/hiding sibling nodes rather than expecting additional-info-content to always be a child of  additional-info-container
+as an alternative we could use a query selecotr by data-entity id, and add that attribbute below.
+-->
+				<div class="additional-info-content">
+					<!-- this is how every other single drupal template displays additional content: -->
+					{{ entity.fieldWysiwyg.processed }}
+					<!-- {{column}} -->
+				</div>
+			</td>
+			{% endif %}
+			{% endfor %}
+		</tr>
+	</tbody>
+	{% endif %}
+	{% endfor %}
 
 </table>


### PR DESCRIPTION
## Description

this is a wip pr.
known issues:
-css is in the wrong place. @kelsonic @ncksllvn looking for your guidance on where to put it
-additional spacing beneath the "Show Details..." component. this is from the error referenced on line 73 in `table.drupal.liquid`
-I think the cleanest solution would be changing the structure of the entity itself to match how other drupal templates use the additional-info component, or, submitting a PR to the additional-info component in formation to handle sibling content
-the link font sizing is off for "Show All"
## Testing done


## Screenshots
<img width="499" alt="Screen Shot 2020-10-21 at 4 22 42 PM" src="https://user-images.githubusercontent.com/46791771/96800213-a864fc00-13b9-11eb-98ad-eb313362a36e.png">
mock:
<img width="396" alt="Screen Shot 2020-10-21 at 4 24 50 PM" src="https://user-images.githubusercontent.com/46791771/96800360-fe39a400-13b9-11eb-8f9e-4e00f2c310e3.png">

[](https://preview.uxpin.com/e7717d3fa019146277f28d799d247b820140d1b5#/pages/132642759/documentation/no-panels?mode=i)

