### PR TITLE
Add inProgressFormId to Sentry requests

### DIFF
--- a/src/applications/letters/tests/actions/letters.unit.spec.js
+++ b/src/applications/letters/tests/actions/letters.unit.spec.js
@@ -1,9 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import * as Sentry from '@sentry/browser';
-import sentryTestkit from 'sentry-testkit';
 
-const { testkit, sentryTransport } = sentryTestkit();
+import { testkit } from 'platform/testing/unit/sentry';
 
 import {
   BACKEND_SERVICE_ERROR,
@@ -25,11 +23,6 @@ import {
   getBenefitSummaryOptions,
   getLetterPdf,
 } from '../../actions/letters';
-
-Sentry.init({
-  dsn: 'http://one@fake/dsn',
-  transport: sentryTransport,
-});
 
 /**
  * Setup() for each test requires stubbing global fetch() and setting userToken.

--- a/src/platform/forms-system/src/js/actions.js
+++ b/src/platform/forms-system/src/js/actions.js
@@ -139,11 +139,13 @@ export function submitToUrl(body, submitUrl, trackingPrefix, eventData) {
 }
 
 export function submitForm(formConfig, form) {
+  const inProgressFormId = form.loadedData?.metadata?.inProgressFormId;
   const captureError = (error, errorType) => {
     Sentry.withScope(scope => {
       scope.setFingerprint([formConfig.trackingPrefix]);
       scope.setExtra('errorType', errorType);
       scope.setExtra('statusText', error.statusText);
+      scope.setExtra('inProgressFormId', inProgressFormId);
       Sentry.captureException(error);
     });
     recordEvent({

--- a/src/platform/forms-system/src/js/review/SubmitController.jsx
+++ b/src/platform/forms-system/src/js/review/SubmitController.jsx
@@ -44,13 +44,7 @@ class SubmitController extends Component {
   };
 
   handleSubmit = () => {
-    const {
-      form,
-      formConfig,
-      pageList,
-      trackingPrefix,
-      inProgressFormId,
-    } = this.props;
+    const { form, formConfig, pageList, trackingPrefix } = this.props;
 
     // If a pre-submit agreement is required, make sure it was accepted
     const preSubmit = this.getPreSubmit(formConfig);
@@ -64,6 +58,7 @@ class SubmitController extends Component {
     // like to know if they’re common
     const { isValid, errors } = isValidForm(form, pageList);
     if (!isValid) {
+      const inProgressFormId = form.loadedData?.metadata?.inProgressFormId;
       recordEvent({
         event: `${trackingPrefix}-validation-failed`,
       });
@@ -105,7 +100,6 @@ function mapStateToProps(state, ownProps) {
   const trackingPrefix = formConfig.trackingPrefix;
   const submission = form.submission;
   const showPreSubmitError = submission.hasAttemptedSubmit;
-  const inProgressFormId = form.loadedData?.metadata?.inProgressFormId;
 
   return {
     form,
@@ -116,7 +110,6 @@ function mapStateToProps(state, ownProps) {
     submission,
     showPreSubmitError,
     trackingPrefix,
-    inProgressFormId,
   };
 }
 

--- a/src/platform/forms-system/test/js/actions.unit.spec.js
+++ b/src/platform/forms-system/test/js/actions.unit.spec.js
@@ -191,6 +191,7 @@ describe('Schemaform actions:', () => {
 
       const promise = thunk(dispatch).then(() => {
         const sentryReports = testkit.reports();
+        expect(sentryReports.length).to.equal(1);
         expect(sentryReports[0].extra.inProgressFormId).to.equal('123');
         expect(sentryReports[0].extra.errorType).to.equal('serverError');
         expect(sentryReports[0].extra.statusText).to.equal('Bad Request');

--- a/src/platform/forms-system/test/js/review/SubmitController.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/SubmitController.unit.spec.jsx
@@ -209,7 +209,6 @@ describe('Schemaform review: SubmitController', () => {
           },
         },
       },
-      data: { privacyAgreementAccepted: true },
     });
     const pageList = [
       { path: 'page-1', pageKey: 'page1', schema: page.schema },

--- a/src/platform/forms-system/test/js/review/SubmitController.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/SubmitController.unit.spec.jsx
@@ -185,29 +185,35 @@ describe('Schemaform review: SubmitController', () => {
     tree.unmount();
   });
 
-  it('should not submit when invalid', () => {
-    const form = createForm();
+  it('should not submit when invalid data is entered', () => {
     // Form with missing rquired field
+    const page = {
+      title: 'Missing stuff',
+      schema: {
+        type: 'object',
+        required: ['stuff'],
+        properties: {
+          stuff: { type: 'string' },
+        },
+      },
+    };
+    const form = createForm({
+      data: { privacyAgreementAccepted: true },
+      pages: { page1: { schema: page.schema } },
+    });
     const formConfig = createFormConfig({
       chapters: {
         chapter1: {
           pages: {
-            page1: {
-              title: 'Missing stuff',
-              schema: {
-                type: 'object',
-                required: ['stuff'],
-                properties: {
-                  stuff: { type: 'string' },
-                },
-              },
-            },
+            page1: page,
           },
         },
       },
       data: { privacyAgreementAccepted: true },
     });
-    const pageList = createPageList();
+    const pageList = [
+      { path: 'page-1', pageKey: 'page1', schema: page.schema },
+    ];
     const setPreSubmit = sinon.spy();
     const setSubmission = sinon.spy();
     const submitForm = sinon.spy();
@@ -236,6 +242,7 @@ describe('Schemaform review: SubmitController', () => {
 
     expect(submitForm.called).to.be.false;
     expect(setSubmission.calledWith('hasAttemptedSubmit')).to.be.true;
+    expect(setSubmission.calledWith('status', 'validationError')).to.be.true;
     tree.unmount();
   });
 

--- a/src/platform/forms-system/test/js/review/SubmitController.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/SubmitController.unit.spec.jsx
@@ -186,7 +186,7 @@ describe('Schemaform review: SubmitController', () => {
   });
 
   it('should not submit when invalid data is entered', () => {
-    // Form with missing rquired field
+    // Form with missing required field
     const page = {
       title: 'Missing stuff',
       schema: {

--- a/src/platform/forms-system/test/js/review/SubmitController.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/SubmitController.unit.spec.jsx
@@ -5,6 +5,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import createCommonStore from 'platform/startup/store';
+import { testkit } from 'platform/testing/unit/sentry';
 
 import { SubmitController } from '../../../src/js/review/SubmitController';
 
@@ -71,6 +72,7 @@ const createForm = options => ({
     },
   },
   data: {},
+  loadedData: { metadata: { inProgressFormId: '123' } },
   ...options,
 });
 
@@ -97,6 +99,12 @@ const createStore = (options = {}) => {
 };
 
 describe('Schemaform review: SubmitController', () => {
+  beforeEach(() => {
+    testkit.reset();
+  });
+  afterEach(() => {
+    testkit.reset();
+  });
   it('should route to confirmation page after submit', () => {
     const form = createForm();
     const formConfig = createFormConfig();
@@ -242,6 +250,73 @@ describe('Schemaform review: SubmitController', () => {
     expect(submitForm.called).to.be.false;
     expect(setSubmission.calledWith('hasAttemptedSubmit')).to.be.true;
     expect(setSubmission.calledWith('status', 'validationError')).to.be.true;
+    tree.unmount();
+  });
+
+  it('should submit submission error data to Sentry', () => {
+    // Form with missing required field
+    const page = {
+      title: 'Missing stuff',
+      schema: {
+        type: 'object',
+        required: ['stuff'],
+        properties: {
+          stuff: { type: 'string' },
+        },
+      },
+    };
+    const form = createForm({
+      data: { privacyAgreementAccepted: true },
+      pages: { page1: { schema: page.schema } },
+    });
+    const formConfig = createFormConfig({
+      chapters: {
+        chapter1: {
+          pages: {
+            page1: page,
+          },
+        },
+      },
+    });
+    const pageList = [
+      { path: 'page-1', pageKey: 'page1', schema: page.schema },
+    ];
+    const setPreSubmit = sinon.spy();
+    const setSubmission = sinon.spy();
+    const submitForm = sinon.spy();
+
+    const store = createStore({
+      form,
+    });
+
+    const tree = render(
+      <Provider store={store}>
+        <SubmitController
+          form={form}
+          formConfig={formConfig}
+          pageList={pageList}
+          route={{ formConfig, pageList }}
+          setPreSubmit={setPreSubmit}
+          setSubmission={setSubmission}
+          submitForm={submitForm}
+          trackingPrefix={formConfig.trackingPrefix}
+        />
+      </Provider>,
+    );
+
+    const submitButton = tree.getByText('Submit application');
+    fireEvent.click(submitButton);
+
+    expect(submitForm.called).to.be.false;
+
+    const sentryReports = testkit.reports();
+    expect(sentryReports.length).to.equal(1);
+    expect(sentryReports[0].extra.inProgressFormId).to.equal('123');
+    expect(sentryReports[0].extra.prefix).to.equal('test-');
+    expect(sentryReports[0].extra.errors)
+      .to.be.an('array')
+      .with.length('1');
+
     tree.unmount();
   });
 

--- a/src/platform/testing/unit/mocha-setup.js
+++ b/src/platform/testing/unit/mocha-setup.js
@@ -11,6 +11,14 @@ import chaiDOM from 'chai-dom';
 import { JSDOM } from 'jsdom';
 import '../../site-wide/moment-setup';
 import ENVIRONMENTS from 'site/constants/environments';
+import * as Sentry from '@sentry/browser';
+
+import { sentryTransport } from './sentry';
+
+Sentry.init({
+  dsn: 'http://one@fake/dsn',
+  transport: sentryTransport,
+});
 
 global.__BUILDTYPE__ = process.env.BUILDTYPE || ENVIRONMENTS.VAGOVDEV;
 global.__API__ = null;

--- a/src/platform/testing/unit/sentry.js
+++ b/src/platform/testing/unit/sentry.js
@@ -1,0 +1,3 @@
+import sentryTestkit from 'sentry-testkit';
+
+export const { testkit, sentryTransport } = sentryTestkit();


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/15060

Just for kicks, I tried out narrated diffs to group my changes together: https://narrated-diffs.thomasbroadley.com/8a060846-3a4d-41f8-bbf1-e1510636e904

## Testing done
I fixed an existing test and added two unit tests to ensure the requests to Sentry were made with the expected parameters.

## Screenshots
N/A

## Acceptance criteria
- [ ] `inProgressFormId` is sent along with the Sentry requests