### PR TITLE
App directory unit tests

### DIFF
--- a/src/applications/third-party-app-directory/actions/index.unit.spec.js
+++ b/src/applications/third-party-app-directory/actions/index.unit.spec.js
@@ -1,0 +1,132 @@
+// Node modules.
+import { expect } from 'chai';
+import sinon from 'sinon';
+// Relative imports.
+import {
+  fetchResultsAction,
+  fetchResultsFailure,
+  fetchResultsSuccess,
+  fetchResultsThunk,
+} from './index';
+import {
+  FETCH_RESULTS,
+  FETCH_RESULTS_FAILURE,
+  FETCH_RESULTS_SUCCESS,
+} from '../constants';
+
+describe('Actions', () => {
+  describe('fetchResultsAction', () => {
+    it('should return an action in the shape we expect', () => {
+      const options = {
+        category: 'Health',
+        hideFetchingState: true,
+        platform: 'iOS',
+      };
+      const action = fetchResultsAction(options);
+
+      expect(action).to.be.deep.equal({
+        options,
+        type: FETCH_RESULTS,
+      });
+    });
+  });
+
+  describe('fetchResultsFailure', () => {
+    it('should return an action in the shape we expect', () => {
+      const action = fetchResultsFailure('test');
+
+      expect(action).to.be.deep.equal({
+        error: 'test',
+        type: FETCH_RESULTS_FAILURE,
+      });
+    });
+  });
+
+  describe('fetchResultsSuccess', () => {
+    it('should return an action in the shape we expect', () => {
+      const response = {
+        results: [],
+        totalResults: 0,
+      };
+      const action = fetchResultsSuccess(response);
+
+      expect(action).to.be.deep.equal({
+        response,
+        type: FETCH_RESULTS_SUCCESS,
+      });
+    });
+  });
+
+  describe('fetchResultsThunk', () => {
+    let mockedLocation;
+    let mockedHistory;
+
+    beforeEach(() => {
+      mockedLocation = {
+        search: '',
+        pathname: '',
+      };
+
+      mockedHistory = {
+        replaceState: sinon.stub(),
+      };
+    });
+
+    it('updates search params', async () => {
+      const dispatch = () => {};
+      const thunk = fetchResultsThunk({
+        category: 'Health',
+        platform: 'iOS',
+        hideFetchingState: false,
+        history: mockedHistory,
+        location: mockedLocation,
+        mockRequest: true,
+        page: 1,
+        perPage: 10,
+      });
+
+      await thunk(dispatch);
+
+      const replaceStateStub = mockedHistory.replaceState;
+
+      expect(replaceStateStub.calledOnce).to.be.true;
+      expect(replaceStateStub.firstCall.args[2]).to.be.equal(
+        '?category=Health&platform=iOS',
+      );
+    });
+
+    it('calls dispatch', async () => {
+      const dispatch = sinon.stub();
+      const thunk = fetchResultsThunk({
+        category: 'Health',
+        platform: 'iOS',
+        hideFetchingState: false,
+        history: mockedHistory,
+        location: mockedLocation,
+        mockRequest: true,
+        page: 1,
+        perPage: 10,
+      });
+
+      await thunk(dispatch);
+
+      expect(
+        dispatch.firstCall.calledWith({
+          options: {
+            category: 'Health',
+            platform: 'iOS',
+            hideFetchingState: false,
+            page: 1,
+          },
+          type: FETCH_RESULTS,
+        }),
+      ).to.be.true;
+
+      const secondCallAction = dispatch.secondCall.args[0];
+      expect(secondCallAction.type).to.be.oneOf([
+        FETCH_RESULTS_SUCCESS,
+        FETCH_RESULTS_FAILURE,
+      ]);
+    });
+  });
+});

--- a/src/applications/third-party-app-directory/actions/index.unit.spec.js
+++ b/src/applications/third-party-app-directory/actions/index.unit.spec.js
@@ -72,29 +72,6 @@ describe('Actions', () => {
       };
     });
 
-    it('updates search params', async () => {
-      const dispatch = () => {};
-      const thunk = fetchResultsThunk({
-        category: 'Health',
-        platform: 'iOS',
-        hideFetchingState: false,
-        history: mockedHistory,
-        location: mockedLocation,
-        mockRequest: true,
-        page: 1,
-        perPage: 10,
-      });
-
-      await thunk(dispatch);
-
-      const replaceStateStub = mockedHistory.replaceState;
-
-      expect(replaceStateStub.calledOnce).to.be.true;
-      expect(replaceStateStub.firstCall.args[2]).to.be.equal(
-        '?category=Health&platform=iOS',
-      );
-    });
-
     it('calls dispatch', async () => {
       const dispatch = sinon.stub();
       const thunk = fetchResultsThunk({
@@ -113,8 +90,6 @@ describe('Actions', () => {
       expect(
         dispatch.firstCall.calledWith({
           options: {
-            category: 'Health',
-            platform: 'iOS',
             hideFetchingState: false,
             page: 1,
           },

--- a/src/applications/third-party-app-directory/api/index.unit.spec.js
+++ b/src/applications/third-party-app-directory/api/index.unit.spec.js
@@ -1,0 +1,13 @@
+// Node modules.
+import { expect } from 'chai';
+// Relative imports.
+import { fetchResultsApi } from './index';
+
+describe('api functions', () => {
+  describe('fetchResultsApi', () => {
+    it('should return a normalized API response', async () => {
+      const apiCall = await fetchResultsApi({ mockRequest: true });
+      expect(apiCall).to.be.an('object');
+    });
+  });
+});

--- a/src/applications/third-party-app-directory/api/index.unit.spec.js
+++ b/src/applications/third-party-app-directory/api/index.unit.spec.js
@@ -4,10 +4,19 @@ import { expect } from 'chai';
 import { fetchResultsApi } from './index';
 
 describe('api functions', () => {
-  describe('fetchResultsApi', () => {
+  describe('fetchResults', () => {
     it('should return a normalized API response', async () => {
       const apiCall = await fetchResultsApi({ mockRequest: true });
       expect(apiCall).to.be.an('object');
     });
   });
+
+  // TODO: update when scopes are updated
+  // describe('fetchScopes', () => {
+  //   it('should return an array of data permissions', async () => {
+  //     const {data} = await fetchScopes();
+  //     expect(data).to.be.an('object');
+  //     expect(data.scopes).to.be.an('array');
+  //   });
+  // });
 });

--- a/src/applications/third-party-app-directory/components/SearchResult/index.unit.spec.js
+++ b/src/applications/third-party-app-directory/components/SearchResult/index.unit.spec.js
@@ -6,42 +6,42 @@ import { shallow } from 'enzyme';
 import { SearchResult } from './index';
 
 describe('<SearchResult>', () => {
+  const props = {
+    item: {
+      name: 'Apple Health',
+      iconURL:
+        'https://www.apple.com/v/ios/health/c/images/overview/icon_health__c9yeoina5qaa_large_2x.png',
+      categories: ['Health'],
+      platforms: ['iOS'],
+      appURL: 'https://www.apple.com/ios/health/',
+      description:
+        'With the Apple Health app, you can see all your health records — such as medications, immunizations, lab results, and more — in one place. The Health app continually updates these records giving you access to a single, integrated snapshot of your health profile whenever you want, quickly and privately. All Health Records data is encrypted and protected with the user’s iPhone passcode, Touch ID or Face ID.',
+      privacyPolicyURL: 'https://support.apple.com/en-us/HT209519',
+      termsOfServiceURL: 'https://www.apple.com/legal/sla/',
+      id: '1',
+      type: 'third-party-app',
+    },
+  };
   it('should render', () => {
-    const props = {
-      item: {
-        name: 'Apple Health',
-        iconURL:
-          'https://www.apple.com/v/ios/health/c/images/overview/icon_health__c9yeoina5qaa_large_2x.png',
-        categories: ['Health'],
-        platforms: ['iOS'],
-        appURL: 'https://www.apple.com/ios/health/',
-        description:
-          'With the Apple Health app, you can see all your health records — such as medications, immunizations, lab results, and more — in one place. The Health app continually updates these records giving you access to a single, integrated snapshot of your health profile whenever you want, quickly and privately. All Health Records data is encrypted and protected with the user’s iPhone passcode, Touch ID or Face ID.',
-        permissions: [
-          '[Placeholder copy - scopes from OAuth listed here]',
-          '[Placeholder copy - scopes from OAuth listed here]',
-          '[Placeholder copy - scopes from OAuth listed here]',
-          '[Placeholder copy - scopes from OAuth listed here]',
-          '[Placeholder copy - scopes from OAuth listed here]',
-        ],
-        privacyPolicyURL: 'https://support.apple.com/en-us/HT209519',
-        termsOfServiceURL: 'https://www.apple.com/legal/sla/',
-        id: '1',
-        type: 'third-party-app',
-      },
-    };
-
     const wrapper = shallow(<SearchResult {...props} />);
-    const firstText = wrapper.text();
+    const initialText = wrapper.text();
 
-    expect(firstText).to.include(props.item.name);
-    expect(firstText).to.not.include(props.item.description);
+    expect(initialText).to.include(props.item.name);
+    expect(initialText).to.not.include(props.item.description);
 
-    wrapper.setState({ show: true });
-    const secondText = wrapper.text();
+    wrapper.unmount();
+  });
 
-    expect(secondText).to.include(props.item.name);
-    expect(secondText).to.include(props.item.description);
+  it('should toggle to display additional app information', () => {
+    const wrapper = shallow(<SearchResult {...props} />);
+
+    expect(wrapper.find('.fa-chevron-down')).to.have.lengthOf(1);
+
+    wrapper.find('button').simulate('click');
+    const additionalText = wrapper.text();
+
+    expect(wrapper.find('.fa-chevron-up')).to.have.lengthOf(1);
+    expect(additionalText).to.include(props.item.description);
 
     wrapper.unmount();
   });

--- a/src/applications/third-party-app-directory/components/SearchResult/index.unit.spec.js
+++ b/src/applications/third-party-app-directory/components/SearchResult/index.unit.spec.js
@@ -1,0 +1,48 @@
+// Node modules.
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+// Relative imports.
+import { SearchResult } from './index';
+
+describe('<SearchResult>', () => {
+  it('should render', () => {
+    const props = {
+      item: {
+        name: 'Apple Health',
+        iconURL:
+          'https://www.apple.com/v/ios/health/c/images/overview/icon_health__c9yeoina5qaa_large_2x.png',
+        categories: ['Health'],
+        platforms: ['iOS'],
+        appURL: 'https://www.apple.com/ios/health/',
+        description:
+          'With the Apple Health app, you can see all your health records — such as medications, immunizations, lab results, and more — in one place. The Health app continually updates these records giving you access to a single, integrated snapshot of your health profile whenever you want, quickly and privately. All Health Records data is encrypted and protected with the user’s iPhone passcode, Touch ID or Face ID.',
+        permissions: [
+          '[Placeholder copy - scopes from OAuth listed here]',
+          '[Placeholder copy - scopes from OAuth listed here]',
+          '[Placeholder copy - scopes from OAuth listed here]',
+          '[Placeholder copy - scopes from OAuth listed here]',
+          '[Placeholder copy - scopes from OAuth listed here]',
+        ],
+        privacyPolicyURL: 'https://support.apple.com/en-us/HT209519',
+        termsOfServiceURL: 'https://www.apple.com/legal/sla/',
+        id: '1',
+        type: 'third-party-app',
+      },
+    };
+
+    const wrapper = shallow(<SearchResult {...props} />);
+    const firstText = wrapper.text();
+
+    expect(firstText).to.include(props.item.name);
+    expect(firstText).to.not.include(props.item.description);
+
+    wrapper.setState({ show: true });
+    const secondText = wrapper.text();
+
+    expect(secondText).to.include(props.item.name);
+    expect(secondText).to.include(props.item.description);
+
+    wrapper.unmount();
+  });
+});

--- a/src/applications/third-party-app-directory/helpers/index.unit.spec.js
+++ b/src/applications/third-party-app-directory/helpers/index.unit.spec.js
@@ -1,0 +1,34 @@
+// Node modules.
+import { expect } from 'chai';
+// Relative imports.
+import { normalizeResponse } from './index';
+
+describe('helpers', () => {
+  describe('`normalizeResponse`', () => {
+    it('should return what we expect', () => {
+      const response = {
+        data: [
+          {
+            id: '1',
+            attributes: { name: 'some name' },
+            type: 'some type',
+          },
+        ],
+        meta: {
+          count: 227,
+        },
+      };
+
+      expect(normalizeResponse(response)).to.deep.equal({
+        results: [
+          {
+            id: '1',
+            name: 'some name',
+            type: 'some type',
+          },
+        ],
+        totalResults: 227,
+      });
+    });
+  });
+});

--- a/src/applications/third-party-app-directory/reducers/index.unit.spec.js
+++ b/src/applications/third-party-app-directory/reducers/index.unit.spec.js
@@ -1,0 +1,54 @@
+// Node modules.
+import { expect } from 'chai';
+// Relative imports.
+import { FETCH_RESULTS, FETCH_RESULTS_SUCCESS } from '../constants';
+import { thirdPartyAppsReducer } from './index';
+
+describe('reducer', () => {
+  it('returns the default state', () => {
+    const emptyAction = {};
+    const result = thirdPartyAppsReducer(undefined, emptyAction);
+
+    expect(result).to.be.deep.equal({
+      error: '',
+      fetching: false,
+      page: 1,
+      perPage: 10,
+      results: undefined,
+      totalResults: undefined,
+    });
+  });
+
+  it('fetches results', () => {
+    const action = {
+      type: FETCH_RESULTS,
+      options: {
+        category: 'health',
+        hideFetchingState: true,
+        platform: 'ios',
+      },
+    };
+    const state = thirdPartyAppsReducer(undefined, action);
+
+    expect(state).to.be.deep.equal({
+      error: '',
+      fetching: false,
+      page: 1,
+      perPage: 10,
+      results: undefined,
+      totalResults: undefined,
+    });
+  });
+
+  it('receives results', () => {
+    const initialState = {
+      fetching: true,
+      results: undefined,
+    };
+    const action = { type: FETCH_RESULTS_SUCCESS, response: { results: [] } };
+    const state = thirdPartyAppsReducer(initialState, action);
+
+    expect(state.fetching).to.be.false;
+    expect(state.results).to.be.instanceOf(Array);
+  });
+});


### PR DESCRIPTION
## Description
This PR sets up unit tests for the app directory widget.

Ticket: https://vajira.max.gov/browse/API-2410

## Testing done
- Ran tests locally

## Acceptance criteria
- [x] Unit tests passing

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
