### PR TITLE
Contact us form - always show veteran service section

### DIFF
--- a/src/applications/ask-a-question/form/veteran/veteranInformationPage.js
+++ b/src/applications/ask-a-question/form/veteran/veteranInformationPage.js
@@ -4,7 +4,6 @@ import _ from 'lodash';
 import { schema } from 'platform/forms/definitions/address';
 import fullSchema from '../0873-schema.json';
 import { veteranInformationUI } from './veteranInformationUI';
-import { requireServiceInfo } from '../inquiry/status/veteranStatusUI';
 
 const {
   dependentInformation,
@@ -59,13 +58,7 @@ const veteranInformationPage = {
         hideIf: formData => hideVeteranInformation(formData),
       },
     },
-    [formFields.veteranServiceInformation]: {
-      ...veteranServiceInformationUI,
-      'ui:options': {
-        hideIf: formData =>
-          !requireServiceInfo(formData.veteranStatus.veteranStatus),
-      },
-    },
+    [formFields.veteranServiceInformation]: veteranServiceInformationUI,
   },
   schema: {
     type: 'object',

--- a/src/applications/ask-a-question/tests/unit/form/veteran/veteranInformationPage.unit.spec.js
+++ b/src/applications/ask-a-question/tests/unit/form/veteran/veteranInformationPage.unit.spec.js
@@ -15,14 +15,6 @@ import {
   veteranInformationHeader,
 } from '../../../../constants/labels';
 
-function expectBranchOfServiceNotToExist(wrapper) {
-  getLabelText(
-    wrapper,
-    veteranServiceInformationUI.branchOfService['ui:title'],
-    'veteranServiceInformation',
-  ).shouldNotExist();
-}
-
 function expectBranchOfServiceToBeRequired(wrapper) {
   getLabelText(
     wrapper,
@@ -145,13 +137,13 @@ describe('Veteran Information Page', () => {
     ).shouldExist();
   });
 
-  describe('when a general question', () => {
+  describe('when on behalf of veteran', () => {
     beforeEach(() => {
-      renderWithVeteranStatus('general');
+      renderWithVeteranStatus({ veteranStatus: 'behalf of vet' });
     });
 
-    it('should not require any other fields when veteran status is general question', () => {
-      expectBranchOfServiceNotToExist(wrapper);
+    it('should require branch of service', () => {
+      expectBranchOfServiceToBeRequired(wrapper);
     });
 
     it('should not show veteran information if veteran status is not myself as a veteran', () => {
@@ -163,16 +155,6 @@ describe('Veteran Information Page', () => {
         'veteranInformation',
       ).shouldNotExist();
       getLabelText(wrapper, emailTitle, 'veteranInformation').shouldNotExist();
-    });
-  });
-
-  describe('when on behalf of veteran', () => {
-    beforeEach(() => {
-      renderWithVeteranStatus({ veteranStatus: 'behalf of vet' });
-    });
-
-    it('should require branch of service', () => {
-      expectBranchOfServiceToBeRequired(wrapper);
     });
 
     it('should not show veteran information when relationship to veteran is veteran', () => {


### PR DESCRIPTION
## Description
[department-of-veterans-affairs/orchid#129] 


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
