### PR TITLE
Clinic based video appointments don't have provider names

### DIFF
--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -287,7 +287,9 @@ function setParticipant(appt) {
         });
       }
 
-      const providers = appt.vvsAppointments?.[0]?.providers;
+      const providers = appt.vvsAppointments?.[0]?.providers?.filter(
+        provider => !!provider.name,
+      );
       if (providers?.length) {
         participant = participant.concat(
           providers.map(provider => ({

--- a/src/applications/vaos/services/mocks/var/confirmed_va.json
+++ b/src/applications/vaos/services/mocks/var/confirmed_va.json
@@ -55,89 +55,83 @@
       }
     },
     {
-      "id": "c3e3e32701223fdf389c06eae00fcb24",
+      "id": "a784f714fa1606e39dee11e3bdbb7901",
       "type": "va_appointments",
       "attributes": {
-        "startDate": "2020-09-24T20:00:00Z",
-        "sta6aid": "983GC",
-        "clinicId": "1234",
-        "clinicFriendlyName": "Video visit clinic",
+        "startDate": "2020-11-14T12:52:00Z",
+        "sta6aid": "983",
+        "clinicId": "848",
+        "clinicFriendlyName": "CHY PC VAR2",
         "facilityId": "983",
-        "communityCare": null,
+        "communityCare": false,
         "vdsAppointments": [],
         "vvsAppointments": [
           {
-            "id": "465f0120-e268-2f66-bdbf-96f44d9ad3a9",
+            "id": "CB2349303442341141231a",
             "appointmentKind": "CLINIC_BASED",
             "sourceSystem": "TMP",
-            "dateTime": "2020-09-24T20:00:00Z",
-            "desiredDate": "2020-09-24T20:00:00Z",
-            "duration": 30,
+            "dateTime": "2020-11-14T12:52:00Z",
+            "desiredDate": "2020-10-10T17:40:00Z",
+            "duration": 20,
             "status": {
               "description": "F",
               "code": "FUTURE"
             },
             "schedulingRequestType": "NEXT_AVAILABLE_APPT",
             "type": "REGULAR",
-            "instructionsOther": false,
+            "bookingNotes": "Test",
+            "instruction": "this is a test of instruction",
+            "instructionsOther": true,
             "patients": [
               {
                 "name": {
-                  "firstName": "JUDY",
-                  "lastName": "MORRISON"
+                  "firstName": "John",
+                  "lastName": "Morrison"
                 },
                 "contactInformation": {
-                  "mobile": "8888888888",
-                  "preferredEmail": "test@va.gov",
-                  "timeZone": "10"
+                  "mobile": "1234567890",
+                  "preferredEmail": "fake@email.gov",
+                  "timeZone": "10",
+                  "timeZoneName": "America/Denver"
                 },
                 "location": {
                   "type": "VA",
                   "facility": {
                     "name": "CHEYENNE VAMC",
                     "siteCode": "983",
-                    "timeZone": "10"
+                    "timeZone": "10",
+                    "timeZoneName": "America/Denver"
                   },
                   "clinic": {
-                    "ien": "1234",
-                    "name": "VVC CLINIC"
+                    "ien": "848",
+                    "name": "CHY PC VAR2"
                   }
                 },
-                "patientAppointment": true,
-                "virtualMeetingRoom": {
-                  "conference": "patientConference",
-                  "pin": "12345",
-                  "url": "http://patientConference.com"
-                }
+                "patientAppointment": true
               }
             ],
             "providers": [
               {
-                "name": {
-                  "firstName": "Meg",
-                  "lastName": "Smith"
-                },
                 "contactInformation": {
-                  "preferredEmail": "test@va.gov",
-                  "timeZone": "10"
+                  "mobile": "9912567890",
+                  "preferredEmail": "fake@email.gov",
+                  "timeZone": "10",
+                  "timeZoneName": "America/Denver"
                 },
                 "location": {
                   "type": "VA",
                   "facility": {
                     "name": "CHEYENNE VAMC",
                     "siteCode": "983",
-                    "timeZone": "10"
+                    "timeZone": "10",
+                    "timeZoneName": "America/Denver"
                   },
                   "clinic": {
-                    "ien": "1234",
-                    "name": "VVC CLINIC"
+                    "ien": "848",
+                    "name": "CHY PC VAR2"
                   }
                 },
-                "virtualMeetingRoom": {
-                  "conference": "patientConference",
-                  "pin": "12345",
-                  "url": "http://patientConference.com"
-                }
+                "vistaDateTime": "2019-12-10T17:45:00Z"
               }
             ]
           }

--- a/src/applications/vaos/tests/appointment-list/components/FutureAppointmentsList.video.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/FutureAppointmentsList.video.unit.spec.jsx
@@ -487,6 +487,14 @@ describe('VAOS integration: upcoming video appointments', () => {
       bookingNotes: 'Some random note',
       appointmentKind: 'CLINIC_BASED',
       status: { description: 'F', code: 'FUTURE' },
+      providers: [
+        {
+          clinic: {
+            ien: '455',
+            name: 'Testing',
+          },
+        },
+      ],
     };
     mockAppointmentInfo({ va: [appointment] });
     const facility = {


### PR DESCRIPTION
## Description
Clinic based video appointments don't have a `name` property in the items in the `providers` array, which is causing an error because we always assume it exists. This shows up in staging because john.morrison@id.me now has one of those appointments in past appointments.

## Testing done
Local and unit testing

## Acceptance criteria
- [ ] Clinic based appointments are rendered correctly

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
