### PR TITLE
BDD: Hide Disability Follow Up Descriptions

### DIFF
--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -154,16 +154,14 @@ export const specialIssueTypes = {
 };
 
 export const defaultDisabilityDescriptions = {
-  primaryDescription:
-    'This disability/symptom is related to my military service.',
+  primaryDescription: 'This disability is related to my military service.',
   causedByDisabilityDescription:
-    'This disability/symptom was caused by another condition.',
-  worsenedDescription:
-    'This pre-existing disability/symptom was worsened by military service.',
+    'This disability was caused by another condition.',
+  worsenedDescription: 'This disability was worsened by military service.',
   worsenedEffects:
-    'This pre-existing disability/symptom was worsened by military service.',
+    'This pre-existing disability was worsened by military service.',
   vaMistreatmentDescription:
-    'This disability/symptom was caused by an injury or event that happened while I was receiving VA care.',
+    'This disability was caused by an injury or event that happened while I was receiving VA care.',
 };
 
 export const PTSD_CHANGE_LABELS = {

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -153,6 +153,19 @@ export const specialIssueTypes = {
   POW: 'POW',
 };
 
+export const defaultDisabilityDescriptions = {
+  primaryDescription:
+    'This disability/symptom is related to my military service.',
+  causedByDisabilityDescription:
+    'This disability/symptom was caused by another condition.',
+  worsenedDescription:
+    'This pre-existing disability/symptom was worsened by military service.',
+  worsenedEffects:
+    'This pre-existing disability/symptom was worsened by military service.',
+  vaMistreatmentDescription:
+    'This disability/symptom was caused by an injury or event that happened while I was receiving VA care.',
+};
+
 export const PTSD_CHANGE_LABELS = {
   changeAssignment:
     'Sudden requests for a change in occupational series or duty assignment',

--- a/src/applications/disability-benefits/all-claims/pages/newDisabilityFollowUp.js
+++ b/src/applications/disability-benefits/all-claims/pages/newDisabilityFollowUp.js
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 
-import { capitalizeEachWord } from '../utils';
+import { capitalizeEachWord, isBDD } from '../utils';
 import disabilityLabels from '../content/disabilityLabels';
 
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
@@ -86,10 +86,11 @@ export const uiSchema = {
           'Please briefly describe the injury or exposure that caused your condition. For example, I operated loud machinery while in the service, and this caused me to lose my hearing. (400 characters maximum)',
         'ui:widget': 'textarea',
         'ui:required': (formData, index) =>
-          formData.newDisabilities[index].cause === 'NEW',
+          !isBDD(formData) && formData.newDisabilities[index].cause === 'NEW',
         'ui:options': {
           expandUnder: 'cause',
           expandUnderCondition: 'NEW',
+          hideIf: isBDD,
         },
         'ui:validations': [validateLength(400)],
       },
@@ -124,8 +125,12 @@ export const uiSchema = {
             'Please briefly describe how the disability you selected caused your new disability. (400 characters maximum)',
           'ui:widget': 'textarea',
           'ui:required': (formData, index) =>
+            !isBDD(formData) &&
             formData.newDisabilities[index].cause === 'SECONDARY' &&
             getDisabilitiesList(formData, index).length > 0,
+          'ui:options': {
+            hideIf: isBDD,
+          },
           'ui:validations': [validateLength(400)],
         },
       },
@@ -133,11 +138,13 @@ export const uiSchema = {
         'ui:options': {
           expandUnder: 'cause',
           expandUnderCondition: 'WORSENED',
+          hideIf: isBDD,
         },
         worsenedDescription: {
           'ui:title':
             'Please briefly describe the injury or exposure during your military service that caused your existing disability to get worse. (50 characters maximum)',
           'ui:required': (formData, index) =>
+            !isBDD(formData) &&
             formData.newDisabilities[index].cause === 'WORSENED' &&
             getDisabilitiesList(formData, index).length > 0,
           'ui:validations': [validateLength(50)],
@@ -147,6 +154,7 @@ export const uiSchema = {
             'Please tell us how the disability affected you before your service, and how it affects you now after your service. (350 characters maximum)',
           'ui:widget': 'textarea',
           'ui:required': (formData, index) =>
+            !isBDD(formData) &&
             formData.newDisabilities[index].cause === 'WORSENED' &&
             getDisabilitiesList(formData, index).length > 0,
           'ui:validations': [validateLength(350)],
@@ -162,8 +170,12 @@ export const uiSchema = {
             'Please briefly describe the injury or event while you were under VA care that caused your disability. (350 characters maximum)',
           'ui:widget': 'textarea',
           'ui:required': (formData, index) =>
+            !isBDD(formData) &&
             formData.newDisabilities[index].cause === 'VA' &&
             getDisabilitiesList(formData, index).length > 0,
+          'ui:options': {
+            hideIf: isBDD,
+          },
           'ui:validations': [validateLength(350)],
         },
         vaMistreatmentLocation: {

--- a/src/applications/disability-benefits/all-claims/submit-transformer.js
+++ b/src/applications/disability-benefits/all-claims/submit-transformer.js
@@ -13,6 +13,7 @@ import {
   PTSD_CHANGE_LABELS,
   ATTACHMENT_KEYS,
   disabilityActionTypes,
+  defaultDisabilityDescriptions,
 } from './constants';
 
 import { disabilityIsSelected, hasGuardOrReservePeriod, isBDD } from './utils';
@@ -370,21 +371,21 @@ export function transform(formConfig, form) {
         switch (disability.cause) {
           case causeTypes.NEW:
             disabilityDescription.primaryDescription =
-              'This disability/symptom is related to my military service.';
+              defaultDisabilityDescriptions.primaryDescription;
             break;
           case causeTypes.SECONDARY:
             disabilityDescription.causedByDisabilityDescription =
-              'This disability/symptom was caused by another condition.';
+              defaultDisabilityDescriptions.causedByDisabilityDescription;
             break;
           case causeTypes.WORSENED:
             disabilityDescription.worsenedDescription =
-              'This pre-existing disability/symptom was worsened by military service.';
+              defaultDisabilityDescriptions.worsenedDescription;
             disabilityDescription.worsenedEffects =
-              'This pre-existing disability/symptom was worsened by military service.';
+              defaultDisabilityDescriptions.worsenedEffects;
             break;
           case causeTypes.VA:
             disabilityDescription.vaMistreatmentDescription =
-              'This disability/symptom was caused by an injury or event that happened while I was receiving VA care.';
+              defaultDisabilityDescriptions.vaMistreatmentDescription;
             break;
           default:
         }

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-bdd-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-bdd-test.json
@@ -160,32 +160,25 @@
       "newDisabilities": [
         {
           "cause": "NEW",
-          "primaryDescription": "It makes no sense for this particular condition, but hey, this is only test data.",
           "condition": "asthma",
           "view:descriptionInfo": {}
         },
         {
           "cause": "SECONDARY",
           "view:secondaryFollowUp": {
-            "causedByDisability": "Asthma",
-            "causedByDisabilityDescription": "Again, this doesn't really make sense."
+            "causedByDisability": "Asthma"
           },
           "condition": "phlebitis",
           "view:descriptionInfo": {}
         },
         {
           "cause": "WORSENED",
-          "view:worsenedFollowUp": {
-            "worsenedDescription": "My knee was strained in the service",
-            "worsenedEffects": "It wasn't great before, but it got bad enough I needed a replacement. Now I have to take medication for it. I think. That makes sense, right?"
-          },
           "condition": "knee replacement",
           "view:descriptionInfo": {}
         },
         {
           "cause": "VA",
           "view:vaFollowUp": {
-            "vaMistreatmentDescription": "A thing happened.",
             "vaMistreatmentLocation": "Somewhereville",
             "vaMistreatmentDate": "A while ago"
           },

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/minimal-bdd-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/minimal-bdd-test.json
@@ -59,7 +59,6 @@
       "newDisabilities": [
         {
           "cause": "NEW",
-          "primaryDescription": "It makes no sense for this particular condition, but hey, this is only test data.",
           "condition": "asthma",
           "view:descriptionInfo": {}
         }

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/maximal-bdd-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/maximal-bdd-test.json
@@ -52,20 +52,20 @@
       "newPrimaryDisabilities": [
         {
           "cause": "NEW",
-          "primaryDescription": "It makes no sense for this particular condition, but hey, this is only test data.",
+          "primaryDescription": "This disability is related to my military service.",
           "condition": "asthma",
           "classificationCode": "540"
         },
         {
           "cause": "WORSENED",
-          "worsenedDescription": "My knee was strained in the service",
-          "worsenedEffects": "It wasn't great before, but it got bad enough I needed a replacement. Now I have to take medication for it. I think. That makes sense, right?",
+          "worsenedDescription": "This disability was worsened by military service.",
+          "worsenedEffects": "This pre-existing disability was worsened by military service.",
           "condition": "knee replacement",
           "classificationCode": "8919"
         },
         {
           "cause": "VA",
-          "vaMistreatmentDescription": "A thing happened.",
+          "vaMistreatmentDescription": "This disability was caused by an injury or event that happened while I was receiving VA care.",
           "vaMistreatmentLocation": "Somewhereville",
           "vaMistreatmentDate": "A while ago",
           "condition": "myocardial infarction (MI)",
@@ -73,7 +73,7 @@
         },
         {
           "cause": "NEW",
-          "primaryDescription": "Secondary to Asthma\nAgain, this doesn't really make sense.",
+          "primaryDescription": "Secondary to Asthma\nThis disability was caused by another condition.",
           "condition": "phlebitis",
           "classificationCode": "5300"
         }

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/minimal-bdd-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/minimal-bdd-test.json
@@ -35,7 +35,7 @@
       "newPrimaryDisabilities": [
         {
           "cause": "NEW",
-          "primaryDescription": "It makes no sense for this particular condition, but hey, this is only test data.",
+          "primaryDescription": "This disability is related to my military service.",
           "condition": "asthma",
           "classificationCode": "540"
         }


### PR DESCRIPTION
## Description
In the BDD flow for all-claims, we want to hide the description fields on the new disability follow up page. These fields are still required though, so we need to add default values in the submit transformer.

## Acceptance criteria
- [ ] In BDD flow, description fields on disability follow up page are hidden and not required