### PR TITLE
Disable flaky datetime select test

### DIFF
--- a/src/applications/vaos/tests/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
@@ -69,7 +69,7 @@ const availableSlots = getAppointmentTimeSlots(
 );
 
 describe('VAOS <DateTimeSelectPage>', () => {
-  it('should allow user to select date and time for a VA appointment', async () => {
+  xit('should allow user to select date and time for a VA appointment', async () => {
     const store = createTestStore({
       newAppointment: {
         availableSlots,


### PR DESCRIPTION
## Description
Disables a test that is flaky on Jenkins

http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fvets-website/detail/master/8774/tests

## Testing done
Unit testing

## Acceptance criteria
- [ ] Test doesn't run

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
