### PR TITLE
Get typeOfCareId properly when toggling sort method

### DIFF
--- a/src/applications/vaos/new-appointment/redux/reducer.js
+++ b/src/applications/vaos/new-appointment/redux/reducer.js
@@ -412,14 +412,14 @@ export default function formReducer(state = initialState, action) {
     }
     case FORM_PAGE_FACILITY_SORT_METHOD_UPDATED: {
       const formData = state.data;
-      const typeOfCareId = formData.typeOfCareId;
+      const typeOfCareId = getTypeOfCare(formData).id;
       const sortMethod = action.sortMethod;
       const location = action.location;
       let typeOfCareFacilities = state.facilities[typeOfCareId];
       let newSchema = state.pages.vaFacilityV2;
       let requestLocationStatus = state.requestLocationStatus;
 
-      if (location) {
+      if (location && typeOfCareFacilities?.length) {
         const { coords } = location;
         const { latitude, longitude } = coords;
 


### PR DESCRIPTION
## Description
Fixes an issue when the user switches sort methods and has eye care, audiology, or sleep care selected as type of care.

Related Sentry issue: http://sentry10.vfs.va.gov/organizations/vsp/issues/4094/?environment=production&project=4&query=is%3Aunresolved+url%3Ahttps%3A%2F%2Fwww.va.gov%2Fhealth-care%2Fschedule-view-va-appointments%2Fappointments%2Fnew-appointment%2Fva-facility-2&statsPeriod=24h

## Testing done
Local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
