### PR TITLE
Only show uniq support services

### DIFF
--- a/src/site/includes/related-benefit-hubs.drupal.liquid
+++ b/src/site/includes/related-benefit-hubs.drupal.liquid
@@ -3,12 +3,23 @@
     <h2 class="vads-u-margin-top--0">Need more help?</h2>
 
     <ul class="usa-unstyled-list">
+      <!-- Create empty list of IDs -->
+      {% assign supportServiceIDs = "" %}
+
       {% for relatedBenefitHub in fieldRelatedBenefitHubs %}
         {% for supportService in relatedBenefitHub.entity.fieldSupportServices %}
-          <li>
-            <p class="vads-u-margin-top--0"><strong>{{ supportService.entity.title }}</strong> <a href="{{ supportService.entity.fieldLink.url.path }}"
-                rel="noreferrer noopener">{{ supportService.entity.fieldPhoneNumber }}</a></p>
-          </li>
+          <script>console.log("{{ supportServiceIDs }}")</script>
+          <!-- Show the link if it hasn't been rendered yet -->
+          {% unless supportServiceIDs contains supportService.entity.entityId %}
+            <li>
+              <p class="vads-u-margin-top--0"><strong>{{ supportService.entity.title }}</strong> <a href="{{ supportService.entity.fieldLink.url.path }}"
+                  rel="noreferrer noopener">{{ supportService.entity.fieldPhoneNumber }}</a></p>
+            </li>
+          {% endunless %}
+
+          <!-- Add the entity ID to our list of IDs -->
+          {% assign supportServiceIDs = supportServiceIDs | append: supportService.entity.entityId %}
+          {% assign supportServiceIDs = supportServiceIDs | append: "," %}
         {% endfor %}
       {% endfor %}
     </ul>

--- a/src/site/stages/build/drupal/graphql/supportService.graphql.js
+++ b/src/site/stages/build/drupal/graphql/supportService.graphql.js
@@ -1,5 +1,6 @@
 module.exports = `
   fragment supportService on NodeSupportService {
+    entityId
     title
     fieldLink {
       title


### PR DESCRIPTION
## Description
**Issue:** #1 here: https://dsva.slack.com/archives/C52CL1PKQ/p1603376884433300

This PR filters duplicate support services for `Need more help`.

## Testing done
N/A

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/12773166/96928230-803ad300-1475-11eb-8114-69f94d0929ae.png)

### After

![image](https://user-images.githubusercontent.com/12773166/96928102-51246180-1475-11eb-9426-8d55cd72a75b.png)

## Acceptance criteria
- [x] Filter duplicate support service links

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
