### PR TITLE
VACMS-3256: Add breadcrumb handling for lc types.

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -416,6 +416,27 @@ module.exports = function registerFilters() {
     return breadcrumbs;
   };
 
+  liquid.filters.deriveLcBreadcrumbs = (
+    breadcrumbs,
+    string,
+    currentPath,
+    pageTitle,
+  ) => {
+    breadcrumbs.push({
+      url: { path: '/resources', routed: false },
+      text: 'Resources and support',
+    });
+
+    if (pageTitle) {
+      breadcrumbs.push({
+        url: { path: currentPath, routed: true },
+        text: string,
+      });
+    }
+
+    return breadcrumbs;
+  };
+
   // used to get a base url path of a health care region from entityUrl.path
   liquid.filters.regionBasePath = path => path.split('/')[1];
 

--- a/src/site/includes/breadcrumbs.drupal.liquid
+++ b/src/site/includes/breadcrumbs.drupal.liquid
@@ -4,6 +4,11 @@
     {% if deriveBreadcrumbsFromUrl == true %}
     {% assign crumbs = entityUrl.breadcrumb | deriveLastBreadcrumbFromPath: title, entityUrl.path %}
     {% endif %}
+
+    {% if constructLcBreadcrumbs == true %}
+    {% assign crumbs = entityUrl.breadcrumb | deriveLcBreadcrumbs: title, entityUrl.path, titleInclude %}
+    {% endif %}
+
     {% for crumb in crumbs %}
       {% if forloop.last == true %}
         <li><a aria-current="page" href="/{{ path }}">{{ crumb.text }}</a></li>

--- a/src/site/layouts/checklist.drupal.liquid
+++ b/src/site/layouts/checklist.drupal.liquid
@@ -1,7 +1,7 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with constructLcBreadcrumbs = true titleInclude = true %}
 
 {% assign listchecklistItemIndex = 0 %}
 

--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -2,7 +2,7 @@
 
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with constructLcBreadcrumbs = true titleInclude = true %}
 
 <div id="content" class="interior">
   <main class="va-l-detail-page">

--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -1,7 +1,7 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with constructLcBreadcrumbs = true titleInclude = false %}
 <div id="content" class="interior">
   <main>
     <div class="usa-grid usa-grid-full">

--- a/src/site/layouts/media_list_images.drupal.liquid
+++ b/src/site/layouts/media_list_images.drupal.liquid
@@ -2,7 +2,7 @@
 
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with constructLcBreadcrumbs = true titleInclude = true %}
 
 <div id="content" class="interior">
   <main class="va-l-detail-page">

--- a/src/site/layouts/media_list_videos.drupal.liquid
+++ b/src/site/layouts/media_list_videos.drupal.liquid
@@ -2,7 +2,7 @@
 
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with constructLcBreadcrumbs = true titleInclude = true %}
 
 <div id="content" class="interior">
   <main class="va-l-detail-page">

--- a/src/site/layouts/q_a.drupal.liquid
+++ b/src/site/layouts/q_a.drupal.liquid
@@ -2,7 +2,7 @@
 
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with constructLcBreadcrumbs = true titleInclude = true %}
 
 <div id="content" class="interior">
   <main class="va-l-detail-page">

--- a/src/site/layouts/step_by_step.drupal.liquid
+++ b/src/site/layouts/step_by_step.drupal.liquid
@@ -2,7 +2,7 @@
 
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with constructLcBreadcrumbs = true titleInclude = true %}
 
 <div id="content" class="interior">
   <main class="va-l-detail-page">


### PR DESCRIPTION
## Description
Adds learning center breadcrumb handling to all lc content types. This logic is extensible / can be added to term pages when term page layouts are complete.

## How to
In template for content type or term, add breadcrumb include like this:
`{% include "src/site/includes/breadcrumbs.drupal.liquid" with constructLcBreadcrumbs = true titleInclude = true %}`
To construct an Lc crumb trail, add `constructLcBreadcrumbs = true` and to add the page title (e.g., for a content type page as opposed to a term landing page) set titleInclude to true: `titleInclude = true`

## Testing done
Visual / build

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/96933489-88533c80-148e-11eb-99b0-05bf51aa990c.png)

## Acceptance criteria
- [ ] Visiting any lc content type page (checklist, qa, etc.) has breadcrumb structure like this: Home  > Resources and support > Page title

cc: @oksana-c @kevwalsh 