### PR TITLE
[Development] Fix post-HLR wizard focus management

### DIFF
--- a/src/applications/disability-benefits/996/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/components/IntroductionPage.jsx
@@ -118,14 +118,14 @@ export class IntroductionPage extends React.Component {
 
   render() {
     const callToActionContent = this.getCallToActionContent();
-    const show = this.state.status !== WIZARD_STATUS_COMPLETE;
+    const showWizard = this.state.status !== WIZARD_STATUS_COMPLETE;
 
     return (
       <article className="schemaform-intro">
         <FormTitle title="Request a Higher-Level Review" />
         <p>Equal to VA Form 20-0996 (Higher-Level Review).</p>
 
-        {show ? (
+        {showWizard ? (
           <WizardContainer setWizardStatus={this.setWizardStatus} />
         ) : (
           <>

--- a/src/applications/disability-benefits/996/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/components/IntroductionPage.jsx
@@ -38,10 +38,16 @@ export class IntroductionPage extends React.Component {
   };
 
   componentDidMount() {
-    focusElement('.va-nav-breadcrumbs-list');
+    // focus on h1 if wizard has completed
+    // focus on breadcrumb nav when wizard is visible
+    const focusTarget =
+      this.state.status === WIZARD_STATUS_COMPLETE
+        ? 'h1'
+        : '.va-nav-breadcrumbs-list';
+    focusElement(focusTarget);
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps, prevState) {
     const {
       contestableIssues = {},
       getContestableIssues,
@@ -63,6 +69,13 @@ export class IntroductionPage extends React.Component {
           benefitType,
           contestedIssues: contestableIssues.issues,
         });
+      }
+
+      // set focus on h1 only after wizard completes
+      if (prevState.status !== WIZARD_STATUS_COMPLETE) {
+        setTimeout(() => {
+          focusElement('h1');
+        }, 100);
       }
     }
   }

--- a/src/applications/disability-benefits/996/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/components/IntroductionPage.jsx
@@ -18,7 +18,7 @@ import {
   FETCH_CONTESTABLE_ISSUES_INIT,
 } from '../actions';
 
-import { higherLevelReviewFeature } from '../helpers';
+import { higherLevelReviewFeature, scrollToTop } from '../helpers';
 import {
   noContestableIssuesFound,
   showContestableIssueError,
@@ -45,6 +45,7 @@ export class IntroductionPage extends React.Component {
         ? 'h1'
         : '.va-nav-breadcrumbs-list';
     focusElement(focusTarget);
+    scrollToTop();
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -74,6 +75,7 @@ export class IntroductionPage extends React.Component {
       // set focus on h1 only after wizard completes
       if (prevState.status !== WIZARD_STATUS_COMPLETE) {
         setTimeout(() => {
+          scrollToTop();
           focusElement('h1');
         }, 100);
       }

--- a/src/applications/disability-benefits/996/content/contestedIssues.jsx
+++ b/src/applications/disability-benefits/996/content/contestedIssues.jsx
@@ -80,7 +80,7 @@ const disabilitiesList = (
       </li>
       <li>
         You’re requesting a review of another Higher-Level Review. You can
-        either submit a supplmental claim or appeal to the Board of Veterans’
+        either submit a supplemental claim or appeal to the Board of Veterans’
         Appeals.
       </li>
     </ul>

--- a/src/applications/disability-benefits/996/helpers.js
+++ b/src/applications/disability-benefits/996/helpers.js
@@ -1,3 +1,5 @@
+import Scroll from 'react-scroll';
+
 // import the toggleValues helper
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
@@ -8,3 +10,11 @@ export const higherLevelReviewFeature = state =>
 // testing
 export const $ = (selector, DOM) => DOM.querySelector(selector);
 export const $$ = (selector, DOM) => DOM.querySelectorAll(selector);
+
+export const scrollToTop = () => {
+  Scroll.scroller.scrollTo('topScrollElement', {
+    duration: 500,
+    delay: 0,
+    smooth: true,
+  });
+};


### PR DESCRIPTION
## Description

After the user completes the Higher-Level Review (HLR) wizard, focus is lost and the page does not scroll to the top. This PR moves focus to the `H1` and scrolls the page to the top focus element (not the absolute top of the page).

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/15150

## Testing done

Local unit tests - no new tests

## Screenshots

N/A

## Acceptance criteria
- [x] If wizard has completed, focus on `h1` initially
- [x] On initial wizard visibility, focus on the navigation breadcrumbs
- [x] Once the wizard is completed, shift focus to the `h1` and scroll to the top of the page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
