### PR TITLE
Comment out Digital Analytics Program script that should only be on public pages

### DIFF
--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -21,7 +21,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
   {% if buildtype != 'vagovprod' %}
-    <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex">
   {% endif %}
 
   {% if drupalTags %}
@@ -64,7 +64,7 @@
 <![endif]-->
 
   {% if botframework_cdn %}
-    <script nonce="**CSP_NONCE**" src="{{ botframework_cdn }}"></script>
+  <script nonce="**CSP_NONCE**" src="{{ botframework_cdn }}"></script>
   {% endif %}
 
   <script nonce="**CSP_NONCE**" defer nomodule data-entry-name="polyfills.js"></script>
@@ -74,9 +74,14 @@
   <!--
   We participate in the US government’s analytics program. See the data at analytics.usa.gov.
   https://github.com/digital-analytics-program/gov-wide-code
--->
+
+  Commenting out the Universal-Federated-Analytics-Min.js script because it's only supposed to be on public-facing pages.
+  Related links: 
+  - https://github.com/digital-analytics-program/gov-wide-code#appropriate-placement
+  - https://github.com/department-of-veterans-affairs/devops/pull/7814/files#r511980455
   <script async type="text/javascript" nonce="**CSP_NONCE**" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=VA"
-    id="_fed_an_ua_tag"></script>
+  id="_fed_an_ua_tag"></script>
+  -->
 
   <script nonce="**CSP_NONCE**" type="text/javascript">
     window.VetsGov = window.VetsGov || {};
@@ -90,23 +95,20 @@
   <a class="show-on-focus" href="#content">Skip to Content</a>
 
   {% if !noHeader %}
-    {% include "src/site/includes/top-nav.html" %}
+  {% include "src/site/includes/top-nav.html" %}
   {% endif %}
 
   {% include "src/site/components/fullwidth_banner_alerts.drupal.liquid" %}
 
-  <div
-    data-widget-type="banners"
-    data-homepage-banner-content="{{ homepage_banner.content | escape }}"
+  <div data-widget-type="banners" data-homepage-banner-content="{{ homepage_banner.content | escape }}"
     data-homepage-banner-title="{{ homepage_banner.title | escape }}"
-    data-homepage-banner-type="{{ homepage_banner.type }}"
-    data-homepage-banner-visible="{{ homepage_banner.visible }}"
-  ></div>
+    data-homepage-banner-type="{{ homepage_banner.type }}" data-homepage-banner-visible="{{ homepage_banner.visible }}">
+  </div>
 
   <script nonce="**CSP_NONCE**" type="text/javascript">
-  (function() {
-    var module = {};
-    {% include "src/site/assets/js/incompatible-browser.js" %}
-    checkBrowserCompatibility();
-  })();
+    (function () {
+      var module = {};
+      {% include "src/site/assets/js/incompatible-browser.js" %}
+      checkBrowserCompatibility();
+    })();
   </script>


### PR DESCRIPTION
## Description

According to the [Appropriate Placement section of the `digital-analytics-program/gov-wide-code` repo README](https://github.com/digital-analytics-program/gov-wide-code#appropriate-placement):

>The Digital Analytics Program Javascript code is intended to be implemented on "public-facing" federal government webpages.

## Acceptance criteria
- [x] the DAP script tag should not be placed on pages visited during logged-in sessions/"privileged sessions" (password reset)

## Relevant Links

- https://github.com/digital-analytics-program/gov-wide-code#appropriate-placement
- Comment on a PR related to the content security policy: https://github.com/department-of-veterans-affairs/devops/pull/7814/files#r511980455
- Thread in #platform-team: https://dsva.slack.com/archives/CJRQ85PQB/p1603727410414400