### PR TITLE
[Development] Claim status tool upload fixes

### DIFF
--- a/src/applications/claims-status/components/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/AddFilesForm.jsx
@@ -154,7 +154,7 @@ class AddFilesForm extends React.Component {
           <p className="file-requirement-header">Accepted file types:</p>
           <p className="file-requirement-text">{displayTypes}</p>
           <p className="file-requirement-header">Maximum file size:</p>
-          <p className="file-requirement-text">25MB</p>
+          <p className="file-requirement-text">50MB</p>
         </div>
         {this.props.files.map(({ file, docType }, index) => (
           <div key={index} className="document-item-container">

--- a/src/applications/claims-status/tests/components/AddFilesForm.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/AddFilesForm.unit.spec.jsx
@@ -176,7 +176,41 @@ describe('<AddFilesForm>', () => {
       },
     ]);
     expect(onAddFile.called).to.be.false;
-    expect(tree.getMountedInstance().state.errorMessage).not.to.be.empty;
+    expect(tree.getMountedInstance().state.errorMessage).to.contain(
+      'accepted types',
+    );
+  });
+
+  it('should not add file of zero size', () => {
+    const files = [];
+    const field = { value: '', dirty: false };
+    const onSubmit = sinon.spy();
+    const onAddFile = sinon.spy();
+    const onRemoveFile = sinon.spy();
+    const onFieldChange = sinon.spy();
+    const onCancel = sinon.spy();
+    const onDirtyFields = sinon.spy();
+
+    const tree = SkinDeep.shallowRender(
+      <AddFilesForm
+        files={files}
+        field={field}
+        onSubmit={onSubmit}
+        onAddFile={onAddFile}
+        onRemoveFile={onRemoveFile}
+        onFieldChange={onFieldChange}
+        onCancel={onCancel}
+        onDirtyFields={onDirtyFields}
+      />,
+    );
+    tree.getMountedInstance().add([
+      {
+        name: 'something.txt',
+        size: 0,
+      },
+    ]);
+    expect(onAddFile.called).to.be.false;
+    expect(tree.getMountedInstance().state.errorMessage).to.contain('is empty');
   });
 
   it('should not add an invalid file size', () => {
@@ -203,12 +237,14 @@ describe('<AddFilesForm>', () => {
     );
     tree.getMountedInstance().add([
       {
-        name: 'something.exe',
+        name: 'something.txt',
         size: 999999999999,
       },
     ]);
     expect(onAddFile.called).to.be.false;
-    expect(tree.getMountedInstance().state.errorMessage).not.to.be.empty;
+    expect(tree.getMountedInstance().state.errorMessage).to.contain(
+      'maximum file size',
+    );
   });
 
   it('should add a valid file', () => {

--- a/src/applications/claims-status/utils/validations.js
+++ b/src/applications/claims-status/utils/validations.js
@@ -26,7 +26,12 @@ export function isValidFileType(file) {
 }
 
 export function isValidFile(file) {
-  return !!file && isValidFileSize(file) && isValidFileType(file);
+  return (
+    !!file &&
+    isValidFileSize(file) &&
+    !isEmptyFileSize(file) &&
+    isValidFileType(file)
+  );
 }
 
 export function isValidDocument({ file, docType }) {


### PR DESCRIPTION
## Description

When attempting to upload a zero-byte empty file, an error should be displayed to the user. This was not happening and has been fixed in this PR.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/14889
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/13187

## Testing done

Updated unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Zero-byte size files must show an error to the user

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
