### PR TITLE
Add new Dashboard wrapper to load the correct Dashboard version

### DIFF
--- a/src/applications/personalization/dashboard-2/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard-2/components/Dashboard.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function Dashboard() {
+  return <h2>Dashboard Two!</h2>;
+}
+
+export default Dashboard;

--- a/src/applications/personalization/dashboard-2/components/DashboardWrapper.jsx
+++ b/src/applications/personalization/dashboard-2/components/DashboardWrapper.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import localStorage from 'platform/utilities/storage/localStorage';
+import { selectShowDashboard2 } from '../selectors';
+
+import DashboardOne from 'applications/personalization/dashboard/components/Dashboard';
+import DashboardTwo from './Dashboard';
+
+// The root component for the My VA Dashboard app that lives at /my-va
+//
+// Its only responsibility is to determine if the user should see Dashboard v1
+// or Dashboard v2 based on the value of the Dashboard v2 feature flag and/or
+// the value of  'DASHBOARD_VERSION' in the browser's local storage.
+//
+// The 'DASHBOARD_VERSION' local storage value will override the value of the
+// feature flag.
+function DashboardWrapper({ showDashboard2, rootUrl }) {
+  let dashboard;
+  if (showDashboard2) {
+    dashboard = <DashboardTwo />;
+  } else {
+    dashboard = <DashboardOne rootUrl={rootUrl} />;
+  }
+  return dashboard;
+}
+
+const mapStateToProps = state => {
+  const LSDashboardVersion = localStorage.getItem('DASHBOARD_VERSION');
+  const LSDashboard1 = LSDashboardVersion === '1';
+  const LSDashboard2 = LSDashboardVersion === '2';
+  const FFDashboard2 = selectShowDashboard2(state);
+  return {
+    showDashboard2: LSDashboard2 || (FFDashboard2 && !LSDashboard1),
+  };
+};
+
+export default connect(mapStateToProps)(DashboardWrapper);

--- a/src/applications/personalization/dashboard-2/components/DashboardWrapper.jsx
+++ b/src/applications/personalization/dashboard-2/components/DashboardWrapper.jsx
@@ -1,11 +1,16 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { connect } from 'react-redux';
+import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 
 import localStorage from 'platform/utilities/storage/localStorage';
 import { selectShowDashboard2 } from '../selectors';
 
-import DashboardOne from 'applications/personalization/dashboard/components/Dashboard';
-import DashboardTwo from './Dashboard';
+const DashboardV1 = React.lazy(() => {
+  return import('../../dashboard/components/Dashboard');
+});
+const DashboardV2 = React.lazy(() => {
+  return import('./Dashboard');
+});
 
 // The root component for the My VA Dashboard app that lives at /my-va
 //
@@ -16,13 +21,22 @@ import DashboardTwo from './Dashboard';
 // The 'DASHBOARD_VERSION' local storage value will override the value of the
 // feature flag.
 function DashboardWrapper({ showDashboard2, rootUrl }) {
-  let dashboard;
+  const loader = (
+    <div className="vads-u-margin-y--4 vads-u-padding-y--0p5">
+      <LoadingIndicator message="Please wait while we load the application for you." />
+    </div>
+  );
+  let content;
   if (showDashboard2) {
-    dashboard = <DashboardTwo />;
+    content = <DashboardV2 />;
   } else {
-    dashboard = <DashboardOne rootUrl={rootUrl} />;
+    content = <DashboardV1 rootUrl={rootUrl} />;
   }
-  return dashboard;
+  return (
+    <div>
+      <Suspense fallback={loader}>{content}</Suspense>
+    </div>
+  );
 }
 
 const mapStateToProps = state => {

--- a/src/applications/personalization/dashboard-2/components/DashboardWrapper.jsx
+++ b/src/applications/personalization/dashboard-2/components/DashboardWrapper.jsx
@@ -26,17 +26,12 @@ function DashboardWrapper({ showDashboard2, rootUrl }) {
       <LoadingIndicator message="Please wait while we load the application for you." />
     </div>
   );
-  let content;
-  if (showDashboard2) {
-    content = <DashboardV2 />;
-  } else {
-    content = <DashboardV1 rootUrl={rootUrl} />;
-  }
-  return (
-    <div>
-      <Suspense fallback={loader}>{content}</Suspense>
-    </div>
+  const content = showDashboard2 ? (
+    <DashboardV2 />
+  ) : (
+    <DashboardV1 rootUrl={rootUrl} />
   );
+  return <Suspense fallback={loader}>{content}</Suspense>;
 }
 
 const mapStateToProps = state => {

--- a/src/applications/personalization/dashboard-2/selectors.js
+++ b/src/applications/personalization/dashboard-2/selectors.js
@@ -1,0 +1,5 @@
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+
+export const selectShowDashboard2 = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.dashboardShowDashboard2];

--- a/src/applications/personalization/dashboard/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard/components/Dashboard.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Router, useRouterHistory } from 'react-router';
+import { createHistory } from 'history';
+
+import routes from '../routes';
+
+function Dashboard({ rootUrl }) {
+  // This Dashboard app used to be created by startApp in `dashboard-entry.jsx`.
+  // So this React Router setup code is pulled from the `startApp` helper
+  // function.
+  const history = useRouterHistory(createHistory)({
+    basename: rootUrl,
+  });
+  return <Router history={history}>{routes}</Router>;
+}
+
+export default Dashboard;

--- a/src/applications/personalization/dashboard/dashboard-entry.jsx
+++ b/src/applications/personalization/dashboard/dashboard-entry.jsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import 'platform/polyfills';
 import '../profile/sass/user-profile.scss';
 import '../../claims-status/sass/claims-status.scss';
@@ -6,15 +8,18 @@ import './sass/dashboard-alert.scss';
 import './sass/messaging/messaging.scss';
 import '../preferences/sass/preferences.scss';
 
+import DashboardWrapper from '../dashboard-2/components/DashboardWrapper';
+
 import startApp from 'platform/startup';
 
-import routes from './routes';
 import reducer from './reducers';
 import manifest from './manifest.json';
 
+const url = manifest.rootUrl;
+
 startApp({
-  url: manifest.rootUrl,
+  component: <DashboardWrapper version="1" rootUrl={url} />,
+  url,
   reducer,
-  routes,
   entryName: manifest.entryName,
 });


### PR DESCRIPTION
## Description
Replaces the existing My VA Dashboard app with a new wrapper app that loads either the old/existing Dashboard v1 or the new Dashboard v2 app depending on the value of the feature flag (`'dashboard_show_dashboard_2'`) and/or the local storage override prop (`'DASHBOARD_VERSION'`).

## Testing done
Local

## Screenshots
This GIFs shows the new wrapper resolving to first show Dashboard v1 (due to the local storage prop being set to `'1'`) then it shows changing the local storage prop to load Dashboard v2.

![dashboard-loader](https://user-images.githubusercontent.com/20728956/97239503-007c7380-17a9-11eb-8703-95e72ab6ae0a.gif)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs