### PR TITLE
[Resources and support] Implement "fieldAudienceBeneficiares" into search results and article listings

### DIFF
--- a/src/applications/resources-and-support/components/SearchResult.jsx
+++ b/src/applications/resources-and-support/components/SearchResult.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+import { Article } from '../prop-types';
+import { ENTITY_BUNDLES } from '../constants';
+
+import Tag from './Tag';
+
+const articleTypes = {
+  [ENTITY_BUNDLES.Q_A]: 'Question and answer',
+  [ENTITY_BUNDLES.CHECKLIST]: 'Checklist',
+  [ENTITY_BUNDLES.MEDIA_LIST_IMAGES]: 'Media list',
+  [ENTITY_BUNDLES.MEDIA_LIST_VIDEOS]: 'Media list',
+  [ENTITY_BUNDLES.SUPPORT_RESOURCES_DETAIL_PAGE]: 'About',
+  [ENTITY_BUNDLES.FAQ_MULTIPLE_Q_A]: 'FAQs',
+  [ENTITY_BUNDLES.STEP_BY_STEP]: 'Step by step',
+};
+
+export default function SearchResult({ article }) {
+  const hasTopics =
+    article.fieldPrimaryCategory?.entity?.entityUrl ||
+    article.fieldOtherCategories?.length > 0;
+
+  return (
+    <div className="vads-u-padding-y--3 vads-u-border-top--1px vads-u-border-color--gray-lighter">
+      <div>
+        <dfn className="sr-only">Article type: </dfn>
+        {articleTypes[article.entityBundle]}
+      </div>
+      <h2 className="vads-u-font-size--h3 vads-u-margin-top--0">
+        <a href={article.entityUrl.path}>{article.title}</a>
+      </h2>
+      <p
+        className="vads-u-margin-bottom--0"
+        // the article descriptions contain HTML entities
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: article.description }}
+      />
+      {hasTopics && (
+        <div className="vads-u-margin-top--1">
+          <dfn className="vads-u-font-weight--bold">Topics </dfn>
+          {article.fieldPrimaryCategory?.entity?.entityUrl && (
+            <Tag term={article.fieldPrimaryCategory?.entity} />
+          )}
+          {article.fieldOtherCategories?.map((otherCategory, index) => {
+            return (
+              <Tag key={`category-${index}`} term={otherCategory.entity} />
+            );
+          })}
+        </div>
+      )}
+      {article.fieldTags?.entity?.fieldAudienceBeneficiares?.entity?.name && (
+        <div className="vads-u-margin-top--1">
+          <dfn className="vads-u-font-weight--bold">Audience </dfn>
+          <Tag
+            term={article.fieldTags.entity.fieldAudienceBeneficiares.entity}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+SearchResult.propTypes = {
+  article: Article
+};

--- a/src/applications/resources-and-support/components/SearchResult.jsx
+++ b/src/applications/resources-and-support/components/SearchResult.jsx
@@ -61,5 +61,5 @@ export default function SearchResult({ article }) {
 }
 
 SearchResult.propTypes = {
-  article: Article
+  article: Article,
 };

--- a/src/applications/resources-and-support/components/SearchResultList.jsx
+++ b/src/applications/resources-and-support/components/SearchResultList.jsx
@@ -16,51 +16,58 @@ const articleTypes = {
   [ENTITY_BUNDLES.STEP_BY_STEP]: 'Step by step',
 };
 
+function SearchResult({ article }) {
+  const hasTopics =
+    article.fieldPrimaryCategory?.entity?.entityUrl ||
+    article.fieldOtherCategories?.length > 0;
+
+  return (
+    <div className="vads-u-padding-y--3 vads-u-border-top--1px vads-u-border-color--gray-lighter">
+      <div>
+        <dfn className="sr-only">Article type: </dfn>
+        {articleTypes[article.entityBundle]}
+      </div>
+      <h2 className="vads-u-font-size--h3 vads-u-margin-top--0">
+        <a href={article.entityUrl.path}>{article.title}</a>
+      </h2>
+      <p
+        className="vads-u-margin-bottom--0"
+        // the article descriptions contain HTML entities
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: article.description }}
+      />
+      {hasTopics && (
+        <div className="vads-u-margin-top--1">
+          <dfn className="vads-u-font-weight--bold">Topics </dfn>
+          {article.fieldPrimaryCategory?.entity?.entityUrl && (
+            <Tag term={article.fieldPrimaryCategory?.entity} />
+          )}
+          {article.fieldOtherCategories?.map((otherCategory, index) => {
+            return (
+              <Tag key={`category-${index}`} term={otherCategory.entity} />
+            );
+          })}
+        </div>
+      )}
+      {article.fieldTags?.entity?.fieldAudienceBeneficiares?.entity?.name && (
+        <div className="vads-u-margin-top--1">
+          <dfn className="vads-u-font-weight--bold">Audience </dfn>
+          <Tag
+            term={article.fieldTags.entity.fieldAudienceBeneficiares.entity}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function SearchResultList({ results }) {
   return (
     <ul className="usa-unstyled-list">
       {results.map((article, articleIndex) => {
         return (
           <li key={`article-${articleIndex}`}>
-            <div className="vads-u-padding-y--3 vads-u-border-top--1px vads-u-border-color--gray-lighter">
-              <div>
-                <dfn className="sr-only">Article type: </dfn>
-                {articleTypes[article.entityBundle]}
-              </div>
-              <h2 className="vads-u-font-size--h3 vads-u-margin-top--0">
-                <a href={article.entityUrl.path}>{article.title}</a>
-              </h2>
-              <p
-                className="vads-u-margin-bottom--0"
-                // the article descriptions contain HTML entities
-                // eslint-disable-next-line react/no-danger
-                dangerouslySetInnerHTML={{ __html: article.description }}
-              />
-              <div className="vads-u-margin-top--1">
-                <dfn className="vads-u-font-weight--bold">Topics </dfn>
-                <Tag term={article.fieldPrimaryCategory?.entity} />
-                {article.fieldOtherCategories?.map((otherCategory, index) => {
-                  return (
-                    <Tag
-                      key={`category-${index}`}
-                      term={otherCategory.entity}
-                    />
-                  );
-                })}
-              </div>
-              {article.fieldTags?.entity?.fieldTopics?.length > 0 && (
-                <div className="vads-u-margin-top--1">
-                  <dfn className="vads-u-font-weight--bold">Audience </dfn>
-                  {article.fieldTags?.entity?.fieldTopics?.map(
-                    (fieldTopic, index) => {
-                      return (
-                        <Tag key={`topic-${index}`} term={fieldTopic.entity} />
-                      );
-                    },
-                  )}
-                </div>
-              )}
-            </div>
+            <SearchResult article={article} />
           </li>
         );
       })}

--- a/src/applications/resources-and-support/components/SearchResultList.jsx
+++ b/src/applications/resources-and-support/components/SearchResultList.jsx
@@ -2,64 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Article } from '../prop-types';
-import { ENTITY_BUNDLES } from '../constants';
 
-import Tag from './Tag';
-
-const articleTypes = {
-  [ENTITY_BUNDLES.Q_A]: 'Question and answer',
-  [ENTITY_BUNDLES.CHECKLIST]: 'Checklist',
-  [ENTITY_BUNDLES.MEDIA_LIST_IMAGES]: 'Media list',
-  [ENTITY_BUNDLES.MEDIA_LIST_VIDEOS]: 'Media list',
-  [ENTITY_BUNDLES.SUPPORT_RESOURCES_DETAIL_PAGE]: 'About',
-  [ENTITY_BUNDLES.FAQ_MULTIPLE_Q_A]: 'FAQs',
-  [ENTITY_BUNDLES.STEP_BY_STEP]: 'Step by step',
-};
-
-function SearchResult({ article }) {
-  const hasTopics =
-    article.fieldPrimaryCategory?.entity?.entityUrl ||
-    article.fieldOtherCategories?.length > 0;
-
-  return (
-    <div className="vads-u-padding-y--3 vads-u-border-top--1px vads-u-border-color--gray-lighter">
-      <div>
-        <dfn className="sr-only">Article type: </dfn>
-        {articleTypes[article.entityBundle]}
-      </div>
-      <h2 className="vads-u-font-size--h3 vads-u-margin-top--0">
-        <a href={article.entityUrl.path}>{article.title}</a>
-      </h2>
-      <p
-        className="vads-u-margin-bottom--0"
-        // the article descriptions contain HTML entities
-        // eslint-disable-next-line react/no-danger
-        dangerouslySetInnerHTML={{ __html: article.description }}
-      />
-      {hasTopics && (
-        <div className="vads-u-margin-top--1">
-          <dfn className="vads-u-font-weight--bold">Topics </dfn>
-          {article.fieldPrimaryCategory?.entity?.entityUrl && (
-            <Tag term={article.fieldPrimaryCategory?.entity} />
-          )}
-          {article.fieldOtherCategories?.map((otherCategory, index) => {
-            return (
-              <Tag key={`category-${index}`} term={otherCategory.entity} />
-            );
-          })}
-        </div>
-      )}
-      {article.fieldTags?.entity?.fieldAudienceBeneficiares?.entity?.name && (
-        <div className="vads-u-margin-top--1">
-          <dfn className="vads-u-font-weight--bold">Audience </dfn>
-          <Tag
-            term={article.fieldTags.entity.fieldAudienceBeneficiares.entity}
-          />
-        </div>
-      )}
-    </div>
-  );
-}
+import SearchResult from './SearchResult';
 
 export default function SearchResultList({ results }) {
   return (

--- a/src/applications/resources-and-support/prop-types.js
+++ b/src/applications/resources-and-support/prop-types.js
@@ -26,6 +26,9 @@ export const Article = PropTypes.shape({
   ),
   fieldTags: PropTypes.shape({
     entity: PropTypes.shape({
+      fieldAudienceBeneficiares: PropTypes.shape({
+        entity: TaxonomyTerm,
+      }),
       fieldTopics: PropTypes.arrayOf(
         PropTypes.shape({
           entity: TaxonomyTerm,

--- a/src/site/stages/build/plugins/create-resources-and-support-section.js
+++ b/src/site/stages/build/plugins/create-resources-and-support-section.js
@@ -46,11 +46,17 @@ function groupByTags(allArticles) {
   for (const article of allTaggedArticles) {
     const {
       fieldTags: {
-        entity: { fieldTopics },
+        entity: { fieldTopics, fieldAudienceBeneficiares },
       },
     } = article;
 
-    fieldTopics.map(fieldTopic => fieldTopic.entity).forEach(fieldTopic => {
+    const terms = [...fieldTopics];
+
+    if (fieldAudienceBeneficiares) {
+      terms.push(fieldAudienceBeneficiares);
+    }
+
+    terms.map(fieldTopic => fieldTopic.entity).forEach(fieldTopic => {
       const articleListing = articleListingsByTag[fieldTopic.name];
 
       if (!articleListing) {


### PR DESCRIPTION
## Description
This PR begins generating article listings pages using the `fieldAudienceBeneficiares` property. It also implements that field into the search results React app.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/14288
https://github.com/department-of-veterans-affairs/va.gov-team/issues/14841

## Testing done
Used the search results locally and confirmed the listings are being generated

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/97250809-11df7300-17dd-11eb-8560-9db5c1d2599c.png)


## Acceptance criteria
- [ ] `fieldAudienceBeneficiares` is implemented into search results
- [ ] Article listings are generated for `fieldAudienceBeneficiares` property

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
