### PR TITLE
Remove unused bread layers

### DIFF
--- a/src/site/layouts/basic_landing_page.drupal.liquid
+++ b/src/site/layouts/basic_landing_page.drupal.liquid
@@ -67,15 +67,6 @@
           {% endif %}
         </article>
 
-        <!-- Tags -->
-        {% include "src/site/includes/tags.drupal.liquid" with fieldTags = fieldTags %}
-
-        <!-- Need more help -->
-        {% include "src/site/includes/related-benefit-hubs.drupal.liquid" with fieldRelatedBenefitHubs = fieldRelatedBenefitHubs %}
-
-        <!-- Related information -->
-        {% include "src/site/includes/related-information.drupal.liquid" with fieldRelatedInformation = fieldRelatedInformation %}
-
         <!-- Last Updated -->
         <div class="last-updated usa-content">
           Last updated: <time


### PR DESCRIPTION
## Description

This PR fixes a bug with the basic landing page LC template.

## Testing done
N/A

## Screenshots
![localhost_3001_preview_nodeId=8296](https://user-images.githubusercontent.com/12773166/97332098-aed2f800-183f-11eb-9946-c74e81f2bddb.png)

## Acceptance criteria
- [x] Fix basic landing page bug and remove unused bread layers

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
