### PR TITLE
Combine character count into single string

### DIFF
--- a/src/applications/vaos/components/TextareaWidget.jsx
+++ b/src/applications/vaos/components/TextareaWidget.jsx
@@ -43,8 +43,9 @@ function TextareaWidget({
       />
       {!!schema.maxLength && (
         <div className={characterLimitClasses}>
-          {Math.abs(remainingCharacters)}{' '}
-          {isOverLimit ? 'characters over the limit' : 'characters remaining'}
+          {`${Math.abs(remainingCharacters)} ${
+            isOverLimit ? 'characters over the limit' : 'characters remaining'
+          }`}
         </div>
       )}
     </>


### PR DESCRIPTION
## Description
This combines the character count text into one single string instead of multiple text nodes (I think?) inside an element. Hopefully this fixes the JAWS issue reading the count

## Testing done
Local testing

## Acceptance criteria
- [ ] Text reads out correctly in JAWS

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
