### PR TITLE
add error handling for createCacheFile

### DIFF
--- a/script/drupal-aws-cache.js
+++ b/script/drupal-aws-cache.js
@@ -119,7 +119,10 @@ async function createCacheFile() {
 }
 
 if (options.fetch) {
-  fetchCache();
+  fetchCache().catch(error => {
+    console.error(`Error in fetchCache: ${error}`);
+    process.exit(1);
+  });
 } else {
   createCacheFile().catch(error => {
     console.error(`Error in createCacheFile: ${error}`);

--- a/script/drupal-aws-cache.js
+++ b/script/drupal-aws-cache.js
@@ -121,5 +121,8 @@ async function createCacheFile() {
 if (options.fetch) {
   fetchCache();
 } else {
-  createCacheFile();
+  createCacheFile().catch(error => {
+    console.error(`Error in createCacheFile: ${error}`);
+    process.exit(1);
+  });
 }


### PR DESCRIPTION
## Description
- add error handling to async function in drupal-aws-cache 

## Testing done
- verified that throwing an error in async function causes non-zero exit status 


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
