### PR TITLE
Add entityLabel to term-administration

### DIFF
--- a/src/site/stages/build/process-cms-exports/schemas/output/taxonomy_term-administration.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/taxonomy_term-administration.js
@@ -11,6 +11,7 @@ module.exports = {
       properties: {
         entityType: { enum: ['taxonomy_term'] },
         entityBundle: { enum: ['administration'] },
+        entityLabel: { type: 'string' },
         name: { type: 'string' },
         fieldAcronym: nullableString,
         fieldDescription: nullableString,

--- a/src/site/stages/build/process-cms-exports/transformers/taxonomy_term-administration.js
+++ b/src/site/stages/build/process-cms-exports/transformers/taxonomy_term-administration.js
@@ -7,6 +7,7 @@ const transform = entity => {
     entity: {
       entityType: 'taxonomy_term',
       entityBundle: 'administration',
+      entityLabel: getDrupalValue(entity.name),
       name: getDrupalValue(entity.name),
       fieldAcronym: getDrupalValue(entity.fieldAcronym),
       fieldDescription: getDrupalValue(entity.fieldDescription),


### PR DESCRIPTION
## Description
There is a label missing in the `term-administration` transformer

Based on [liquid template](https://github.com/department-of-veterans-affairs/vets-website/blob/09f8a9c6cbc511092c54d51600de0d8a857ac9b6/src/site/layouts/va_form.drupal.liquid#L49) `entityLabel` is missing from the transformer
```
{% if fieldBenefitCategories.length > 0 %}
   {{ fieldBenefitCategories | map: "entity" | map: "fieldHomePageHubLabel" | join: ', ' }}
{% else %}
   {{ fieldVaFormAdministration.entity.entityLabel }}
{% endif %}
```

## Testing done
Locally

## Screenshots
![Screen Shot 2020-10-27 at 12.44.23 PM.png](https://images.zenhubusercontent.com/5d89589c3ac3440001d19c89/59cdf206-bf14-4c5d-adde-76e62d4be61f)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
