### PR TITLE
VACMS-3256: Remove duplicate resources crumb.

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -422,19 +422,27 @@ module.exports = function registerFilters() {
     currentPath,
     pageTitle,
   ) => {
-    breadcrumbs.push({
+    const filteredCrumbs = [];
+    breadcrumbs.forEach(crumb => {
+      // Remove any resources crumb - we don't want the drupal page title.
+      if (crumb.url.path !== '/resources') {
+        filteredCrumbs.push(crumb);
+      }
+    });
+    // Add the resources crumb with the correct crumb title.
+    filteredCrumbs.push({
       url: { path: '/resources', routed: false },
       text: 'Resources and support',
     });
 
     if (pageTitle) {
-      breadcrumbs.push({
+      filteredCrumbs.push({
         url: { path: currentPath, routed: true },
         text: string,
       });
     }
 
-    return breadcrumbs;
+    return filteredCrumbs;
   };
 
   // used to get a base url path of a health care region from entityUrl.path

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -422,13 +422,10 @@ module.exports = function registerFilters() {
     currentPath,
     pageTitle,
   ) => {
-    const filteredCrumbs = [];
-    breadcrumbs.forEach(crumb => {
-      // Remove any resources crumb - we don't want the drupal page title.
-      if (crumb.url.path !== '/resources') {
-        filteredCrumbs.push(crumb);
-      }
-    });
+    // Remove any resources crumb - we don't want the drupal page title.
+    const filteredCrumbs = breadcrumbs.filter(
+      crumb => crumb.url.path !== '/resources',
+    );
     // Add the resources crumb with the correct crumb title.
     filteredCrumbs.push({
       url: { path: '/resources', routed: false },

--- a/src/site/layouts/basic_landing_page.drupal.liquid
+++ b/src/site/layouts/basic_landing_page.drupal.liquid
@@ -1,7 +1,7 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with constructLcBreadcrumbs = true titleInclude = false %}
 
 <div id="content" class="interior">
   <main class="va-l-detail-page">

--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -1,7 +1,7 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" with constructLcBreadcrumbs = true titleInclude = false %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
 <div id="content" class="interior">
   <main>
     <div class="usa-grid usa-grid-full">


### PR DESCRIPTION
## Description
Removes duplicate crumb being added by drupal page title & moves new bc pattern to basic_landing_page.

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/97444591-b5767380-1902-11eb-90ea-fb65de3673c2.png)
![image](https://user-images.githubusercontent.com/2404547/97635215-55b8bf00-1a0d-11eb-9590-4faaee23807f.png)

## Acceptance criteria
- [ ] Visit preview page for `resources/what-if-im-having-trouble-opening-a-pdf/` and visually verify that breadcrumb looks like screenshot.
- [ ] Visit `housing-assistance/` and visually verify breadcrumb appears as in second screenshot.
