### PR TITLE
Make new isVAPatient selector

### DIFF
--- a/src/applications/hca/selectors.js
+++ b/src/applications/hca/selectors.js
@@ -31,7 +31,7 @@ export const hasApplicationInESR = state => {
   const status = selectEnrollmentStatus(state).enrollmentStatus;
   return nonActiveInESRStatuses.has(status) === false;
 };
-export const isEnrolledInVAHealthCare = state =>
+export const isEnrolledInESR = state =>
   selectEnrollmentStatus(state).enrollmentStatus ===
   HCA_ENROLLMENT_STATUSES.enrolled;
 export const dismissedHCANotificationDate = state =>

--- a/src/applications/hca/tests/selectors.unit.spec.js
+++ b/src/applications/hca/tests/selectors.unit.spec.js
@@ -158,15 +158,13 @@ describe('simple top-level selectors', () => {
     });
   });
 
-  describe('isEnrolledInVAHealthCare', () => {
+  describe('isEnrolledInESR', () => {
     it('returns `false` if the enrollmentStatus is not set', () => {
       const state = {
         hcaEnrollmentStatus: { ...basicEnrollmentStatusState },
       };
-      const isEnrolledInVAHealthCare = selectors.isEnrolledInVAHealthCare(
-        state,
-      );
-      expect(isEnrolledInVAHealthCare).to.be.false;
+      const isEnrolledInESR = selectors.isEnrolledInESR(state);
+      expect(isEnrolledInESR).to.be.false;
     });
     it('returns `false` if the enrollmentStatus is not enrolled', () => {
       const state = {
@@ -175,10 +173,8 @@ describe('simple top-level selectors', () => {
           enrollmentStatus: HCA_ENROLLMENT_STATUSES.pendingOther,
         },
       };
-      const isEnrolledInVAHealthCare = selectors.isEnrolledInVAHealthCare(
-        state,
-      );
-      expect(isEnrolledInVAHealthCare).to.be.false;
+      const isEnrolledInESR = selectors.isEnrolledInESR(state);
+      expect(isEnrolledInESR).to.be.false;
     });
     it('returns `true` if the enrollmentStatus is enrolled', () => {
       const state = {
@@ -187,10 +183,8 @@ describe('simple top-level selectors', () => {
           enrollmentStatus: HCA_ENROLLMENT_STATUSES.enrolled,
         },
       };
-      const isEnrolledInVAHealthCare = selectors.isEnrolledInVAHealthCare(
-        state,
-      );
-      expect(isEnrolledInVAHealthCare).to.be.true;
+      const isEnrolledInESR = selectors.isEnrolledInESR(state);
+      expect(isEnrolledInESR).to.be.true;
     });
   });
 

--- a/src/applications/personalization/dashboard/components/ManageYourVAHealthCare.jsx
+++ b/src/applications/personalization/dashboard/components/ManageYourVAHealthCare.jsx
@@ -10,6 +10,7 @@ import { getMedicalCenterNameByID } from 'platform/utilities/medical-centers/med
 import backendServices from 'platform/user/profile/constants/backendServices';
 import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 import {
+  isVAPatient as isVAPatientSelector,
   selectCernerAppointmentsFacilities,
   selectCernerMessagingFacilities,
   selectCernerRxFacilities,
@@ -17,7 +18,7 @@ import {
 
 import {
   hasServerError as hasESRServerError,
-  isEnrolledInVAHealthCare,
+  isEnrolledInESR,
   selectEnrollmentStatus,
 } from 'applications/hca/selectors';
 import { getEnrollmentDetails } from 'applications/hca/enrollment-status-helpers';
@@ -61,9 +62,10 @@ const ManageYourVAHealthCare = ({
   prescriptionFacilityNames,
   authenticatedWithSSOe,
   enrollmentDate,
-  isEnrolledInHealthCare,
+  isInESR,
   preferredFacility,
   showServerError,
+  showNonCernerAppointmentWidget,
   showCernerAppointmentWidget,
   showCernerMessagingWidget,
   showCernerPrescriptionWidget,
@@ -101,7 +103,7 @@ const ManageYourVAHealthCare = ({
         </div>
       }
       status="info"
-      isVisible={isEnrolledInHealthCare}
+      isVisible={isInESR}
       className="background-color-only"
     />
 
@@ -143,8 +145,7 @@ const ManageYourVAHealthCare = ({
       />
     )}
 
-    {isEnrolledInHealthCare &&
-      !showCernerAppointmentWidget && <ScheduleAnAppointmentWidget />}
+    {showNonCernerAppointmentWidget && <ScheduleAnAppointmentWidget />}
     {showCernerAppointmentWidget && (
       <CernerScheduleAnAppointmentWidget
         facilityNames={appointmentFacilityNames}
@@ -154,7 +155,10 @@ const ManageYourVAHealthCare = ({
 );
 
 const mapStateToProps = state => {
-  const isEnrolledInHealthCare = isEnrolledInVAHealthCare(state);
+  // used to decided if an appointment widget is shown
+  const isVAPatient = isVAPatientSelector(state);
+  // used to decided if the "You Are Enrolled In VA Health Care" alert is shown
+  const isInESR = isEnrolledInESR(state);
   const hcaEnrollmentStatus = selectEnrollmentStatus(state);
 
   const showServerError = hasESRServerError(state);
@@ -189,11 +193,13 @@ const mapStateToProps = state => {
   return {
     applicationDate,
     enrollmentDate,
-    isEnrolledInHealthCare,
+    isInESR,
     preferredFacility,
     showServerError,
+    showNonCernerAppointmentWidget:
+      isVAPatient && !cernerAppointmentFacilities?.length,
     showCernerAppointmentWidget:
-      isEnrolledInHealthCare && !!cernerAppointmentFacilities?.length,
+      isVAPatient && !!cernerAppointmentFacilities?.length,
     showCernerMessagingWidget:
       canAccessMessaging && !!cernerMessagingFacilities?.length,
     showCernerPrescriptionWidget:

--- a/src/applications/personalization/dashboard/containers/DashboardApp.jsx
+++ b/src/applications/personalization/dashboard/containers/DashboardApp.jsx
@@ -7,6 +7,7 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 import backendServices from 'platform/user/profile/constants/backendServices';
 import {
+  isVAPatient,
   selectProfile,
   selectPatientFacilities,
 } from 'platform/user/selectors';
@@ -16,10 +17,7 @@ import { focusElement } from 'platform/utilities/ui';
 
 import { removeSavedForm as removeSavedFormAction } from '../actions';
 import { getEnrollmentStatus as getEnrollmentStatusAction } from 'applications/hca/actions';
-import {
-  hasServerError as hasESRServerError,
-  isEnrolledInVAHealthCare,
-} from 'applications/hca/selectors';
+import { hasServerError as hasESRServerError } from 'applications/hca/selectors';
 
 import { recordDashboardClick } from '../helpers';
 import {
@@ -380,7 +378,7 @@ export const mapStateToProps = state => {
     canAccessClaims,
     profile: profileState,
     showManageYourVAHealthCare:
-      isEnrolledInVAHealthCare(state) || canAccessRx || canAccessMessaging,
+      isVAPatient(state) || canAccessRx || canAccessMessaging,
     showServerError,
     showCOVID19Alert,
     vaHealthChatEligibleSystemId,

--- a/src/applications/personalization/profile/components/personal-information/phone-numbers/PhoneEditView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/phone-numbers/PhoneEditView.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 
 import VAPEditView from 'applications/personalization/profile/components/personal-information/VAPEditView';
 
-import { isEnrolledInVAHealthCare as isEnrolledInVAHealthCareSelector } from 'applications/hca/selectors';
+import { isVAPatient } from 'platform/user/selectors';
 
 import { FIELD_NAMES } from 'vet360/constants';
 
@@ -62,7 +62,7 @@ class PhoneEditView extends React.Component {
 }
 
 export function mapStateToProps(state, ownProps) {
-  const isEnrolledInVAHealthCare = isEnrolledInVAHealthCareSelector(state);
+  const isEnrolledInVAHealthCare = isVAPatient(state);
   const showSMSCheckbox =
     ownProps.fieldName === FIELD_NAMES.MOBILE_PHONE && isEnrolledInVAHealthCare;
   return { showSMSCheckbox };

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.sms-checkbox.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.sms-checkbox.unit.spec.jsx
@@ -65,21 +65,7 @@ describe('When enrolled in health care', () => {
   beforeEach(() => {
     window.VetsGov = { pollTimeout: 1 };
     const initialState = createBasicInitialState();
-    initialState.hcaEnrollmentStatus = {
-      applicationDate: '2006-01-30T00:00:00.000-06:00',
-      enrollmentDate: '2006-03-20T00:00:00.000-06:00',
-      preferredFacility: '626A4 - ALVIN C. YORK VAMC',
-      enrollmentStatus: 'enrolled',
-      enrollmentStatusEffectiveDate: '2018-04-28T18:21:56.000-05:00',
-      dismissedNotificationDate: null,
-      hasServerError: false,
-      isLoadingApplicationStatus: false,
-      isLoadingDismissedNotification: false,
-      isUserInMVI: true,
-      loginRequired: true,
-      noESRRecordFound: false,
-      showHCAReapplyContent: false,
-    };
+    initialState.user.profile.vaPatient = true;
     view = renderWithProfileReducers(ui, {
       initialState,
     });

--- a/src/platform/user/profile/vet360/components/PhoneField/PhoneEditModal.jsx
+++ b/src/platform/user/profile/vet360/components/PhoneField/PhoneEditModal.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 
 import Vet360EditModal from '../base/Vet360EditModal';
 
-import { isEnrolledInVAHealthCare as isEnrolledInVAHealthCareSelector } from 'applications/hca/selectors';
+import { isVAPatient } from 'platform/user/selectors';
 
 import { FIELD_NAMES } from 'vet360/constants';
 
@@ -63,11 +63,10 @@ class PhoneEditModal extends React.Component {
 }
 
 export function mapStateToProps(state, ownProps) {
-  const isEnrolledInVAHealthCare = isEnrolledInVAHealthCareSelector(state);
+  const isEnrolledInVAHealthCare = isVAPatient(state);
   const showSMSCheckbox =
     ownProps.fieldName === FIELD_NAMES.MOBILE_PHONE && isEnrolledInVAHealthCare;
   return {
-    isEnrolledInVAHealthCare,
     showSMSCheckbox,
   };
 }

--- a/src/platform/user/profile/vet360/containers/ReceiveTextMessages.jsx
+++ b/src/platform/user/profile/vet360/containers/ReceiveTextMessages.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import ErrorableCheckbox from '@department-of-veterans-affairs/formation-react/ErrorableCheckbox';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import {
+  isVAPatient,
   selectProfile,
   selectVet360MobilePhone,
 } from 'platform/user/selectors';
@@ -17,21 +18,12 @@ import {
   isFailedTransaction,
 } from '../util/transactions';
 
-import { getEnrollmentStatus as getEnrollmentStatusAction } from 'applications/hca/actions';
-import { isEnrolledInVAHealthCare } from 'applications/hca/selectors';
-
 class ReceiveTextMessages extends React.Component {
   state = {
     startedTransaction: false,
     completedTransaction: false,
     lastTransaction: null,
   };
-
-  componentDidMount() {
-    if (this.props.isVerified) {
-      this.props.getEnrollmentStatus();
-    }
-  }
 
   /* eslint-disable camelcase */
   UNSAFE_componentWillReceiveProps(nextProps) {
@@ -127,16 +119,14 @@ export function mapStateToProps(state, ownProps) {
   const profileState = selectProfile(state);
   const mobilePhone = selectVet360MobilePhone(state);
   const isTextable = mobilePhone?.phoneType === VET360.PHONE_TYPE.mobilePhone;
-  const isVerified = profileState.verified;
   const hideCheckbox =
-    !isTextable || !isEnrolledInVAHealthCare(state) || hasError || isPending;
+    !isTextable || !isVAPatient(state) || hasError || isPending;
   const transactionSuccess =
     state.vet360.transactionStatus ===
     VET360.TRANSACTION_STATUS.COMPLETED_SUCCESS;
   return {
     profile: profileState,
     hideCheckbox,
-    isVerified,
     transaction,
     transactionSuccess,
     apiRoute: VET360.API_ROUTES.TELEPHONES,
@@ -144,7 +134,6 @@ export function mapStateToProps(state, ownProps) {
 }
 
 const mapDispatchToProps = {
-  getEnrollmentStatus: getEnrollmentStatusAction,
   createTransaction,
   clearTransactionStatus,
 };

--- a/src/platform/user/selectors.js
+++ b/src/platform/user/selectors.js
@@ -10,6 +10,7 @@ import {
 export const selectUser = state => state.user;
 export const isLoggedIn = state => selectUser(state).login.currentlyLoggedIn;
 export const selectProfile = state => selectUser(state)?.profile || {};
+export const isVAPatient = state => selectProfile(state).vaPatient === true;
 export const isInMPI = state => selectProfile(state).status === 'OK';
 export const hasMPIConnectionError = state =>
   selectProfile(state).status === 'SERVER_ERROR';

--- a/src/platform/user/tests/selectors.unit.spec.js
+++ b/src/platform/user/tests/selectors.unit.spec.js
@@ -401,6 +401,35 @@ describe('user selectors', () => {
     });
   });
 
+  describe('isVAPatient', () => {
+    it('returns `true` if the profile.vaPatient is `true`', () => {
+      const state = {
+        user: {
+          profile: {
+            vaPatient: true,
+          },
+        },
+      };
+      expect(selectors.isVAPatient(state)).to.be.true;
+    });
+    it('returns `false` if the profile.vaPatient is anything other than `true`', () => {
+      const state = {
+        user: {
+          profile: {
+            vaPatient: 'blah',
+          },
+        },
+      };
+      expect(selectors.isVAPatient(state)).to.be.false;
+      delete state.user.profile.vaPatient;
+      expect(selectors.isVAPatient(state)).to.be.false;
+      delete state.user.profile;
+      expect(selectors.isVAPatient(state)).to.be.false;
+      delete state.user;
+      expect(selectors.isVAPatient(state)).to.be.false;
+    });
+  });
+
   describe('isInMPI', () => {
     it('returns `true` if the profile.status is `OK`', () => {
       const state = {


### PR DESCRIPTION
## Description
This is an alternate way to see if a user has VA health care. It uses data that already exists on the user model so it does not require making a separate call to ESR to check enrollment status.

This PR also renames the existing selector: `isEnrolledInVAHealthCare` => `isEnrolledInESR`

## Testing done
Local + updated existing tests that check for the functionality of the SMS appointment reminders checkbox.

## Screenshots
NA

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs