### PR TITLE
Rename the "usePartialSchema" to just "partialSchema" so the linter d…

### DIFF
--- a/src/site/stages/build/process-cms-exports/schemas/output/node-event_listing.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-event_listing.js
@@ -1,4 +1,4 @@
-const { usePartialSchema } = require('../../transformers/helpers');
+const { partialSchema } = require('../../transformers/helpers');
 const eventSchema = require('./node-event');
 
 const reverseFieldSchema = {
@@ -7,8 +7,7 @@ const reverseFieldSchema = {
     entities: {
       type: 'array',
       items: {
-        /* eslint-disable react-hooks/rules-of-hooks */
-        entity: usePartialSchema(eventSchema, [
+        entity: partialSchema(eventSchema, [
           'title',
           'entityUrl',
           'fieldDate',

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-full_width_banner_alert.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-full_width_banner_alert.js
@@ -1,4 +1,4 @@
-const { usePartialSchema } = require('../../transformers/helpers');
+const { partialSchema } = require('../../transformers/helpers');
 const alertsSchema = require('./node-vamc_operating_status_and_alerts');
 
 module.exports = {
@@ -24,8 +24,7 @@ module.exports = {
     fieldBannerAlertVamcs: {
       type: 'array',
       items: {
-        /* eslint-disable react-hooks/rules-of-hooks */
-        entity: usePartialSchema(alertsSchema, ['fieldOffice', 'entityUrl']),
+        entity: partialSchema(alertsSchema, ['fieldOffice', 'entityUrl']),
       },
     },
     fieldBody: { type: 'string' },

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
@@ -1,4 +1,4 @@
-const { usePartialSchema } = require('../../transformers/helpers');
+const { partialSchema } = require('../../transformers/helpers');
 const personProfileSchema = require('./node-person_profile');
 const healthCareLocalFacilitySchema = require('./node-health_care_local_facility');
 const newsStorySchema = require('./node-news_story');
@@ -26,8 +26,7 @@ const facilitiesSchema = {
     entities: {
       type: 'array',
       items: {
-        /* eslint-disable react-hooks/rules-of-hooks */
-        entity: usePartialSchema(healthCareLocalFacilitySchema, [
+        entity: partialSchema(healthCareLocalFacilitySchema, [
           'entityUrl',
           'entityBundle',
           'title',
@@ -56,7 +55,7 @@ const eventTeasersSchema = max => ({
       type: 'array',
       maxItems: max,
       items: {
-        entity: usePartialSchema(eventSchema, [
+        entity: partialSchema(eventSchema, [
           'title',
           'fieldDate',
           'fieldDescription',
@@ -76,7 +75,7 @@ const newsTeasersSchema = max => ({
       type: 'array',
       maxItems: max,
       items: {
-        entity: usePartialSchema(newsStorySchema, [
+        entity: partialSchema(newsStorySchema, [
           'title',
           'fieldFeatured',
           'fieldIntroText',
@@ -124,8 +123,7 @@ module.exports = {
     fieldLeadership: {
       type: 'array',
       items: {
-        /* eslint-disable react-hooks/rules-of-hooks */
-        entity: usePartialSchema(personProfileSchema, [
+        entity: partialSchema(personProfileSchema, [
           'entityPublished',
           'title',
           'fieldNameFirst',
@@ -150,7 +148,7 @@ module.exports = {
         entities: {
           type: 'array',
           items: {
-            entity: usePartialSchema(healthCareLocalFacilitySchema, [
+            entity: partialSchema(healthCareLocalFacilitySchema, [
               'title',
               'fieldOperatingStatusFacility',
             ]),
@@ -169,7 +167,7 @@ module.exports = {
           type: 'array',
           maxItems: 100,
           items: {
-            entity: usePartialSchema(pressRelease, [
+            entity: partialSchema(pressRelease, [
               'title',
               'fieldReleaseDate',
               'entityUrl',

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-press_releases_listing.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-press_releases_listing.js
@@ -1,4 +1,4 @@
-const { usePartialSchema } = require('../../transformers/helpers');
+const { partialSchema } = require('../../transformers/helpers');
 const pressReleaseSchema = require('./node-press_release');
 
 module.exports = {
@@ -27,8 +27,7 @@ module.exports = {
         entities: {
           type: 'array',
           items: {
-            /* eslint-disable react-hooks/rules-of-hooks */
-            entity: usePartialSchema(pressReleaseSchema, [
+            entity: partialSchema(pressReleaseSchema, [
               'title',
               'fieldReleaseDate',
               'entityUrl',

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-story_listing.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-story_listing.js
@@ -1,4 +1,4 @@
-const { usePartialSchema } = require('../../transformers/helpers');
+const { partialSchema } = require('../../transformers/helpers');
 const newsStorySchema = require('./node-news_story');
 
 module.exports = {
@@ -27,8 +27,7 @@ module.exports = {
         entities: {
           type: 'array',
           items: {
-            /* eslint-disable react-hooks/rules-of-hooks */
-            entity: usePartialSchema(newsStorySchema, [
+            entity: partialSchema(newsStorySchema, [
               'title',
               'fieldFeatured',
               'entityUrl',

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-va_form.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-va_form.js
@@ -1,4 +1,4 @@
-const { usePartialSchema } = require('../../transformers/helpers');
+const { partialSchema } = require('../../transformers/helpers');
 
 const dateSchema = {
   oneOf: [
@@ -71,8 +71,7 @@ module.exports = {
     fieldVaFormRelatedForms: {
       type: 'array',
       items: {
-        /* eslint-disable react-hooks/rules-of-hooks */
-        entity: usePartialSchema(vaFormSchema, [
+        entity: partialSchema(vaFormSchema, [
           'fieldVaFormName',
           'fieldVaFormNumber',
           'fieldVaFormUsage',

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-vamc_operating_status_and_alerts.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-vamc_operating_status_and_alerts.js
@@ -1,4 +1,4 @@
-const { usePartialSchema } = require('../../transformers/helpers');
+const { partialSchema } = require('../../transformers/helpers');
 const localFacilitySchema = require('./node-health_care_local_facility');
 
 module.exports = {
@@ -21,8 +21,7 @@ module.exports = {
       type: 'array',
       items: {
         // Yes, it's wrapped in entity here, but not in the originating schema
-        /* eslint-disable react-hooks/rules-of-hooks */
-        entity: usePartialSchema(localFacilitySchema, [
+        entity: partialSchema(localFacilitySchema, [
           'title',
           'entityUrl',
           'fieldOperatingStatusFacility',

--- a/src/site/stages/build/process-cms-exports/tests/transformer-helpers.unit.spec.js
+++ b/src/site/stages/build/process-cms-exports/tests/transformer-helpers.unit.spec.js
@@ -7,7 +7,7 @@ const {
   getWysiwygString,
   unescapeUnicode,
   createMetaTagArray,
-  usePartialSchema,
+  partialSchema,
   findMatchingEntities,
 } = require('../transformers/helpers');
 
@@ -233,25 +233,25 @@ describe('CMS export transformer helpers', () => {
 
   describe('usePartialSchema', () => {
     it('Should throw an error when a non-object schema is passed', () => {
-      expect(() => usePartialSchema({ type: 'array' })).to.throw();
-      expect(() => usePartialSchema(['invalid schema'])).to.throw();
+      expect(() => partialSchema({ type: 'array' })).to.throw();
+      expect(() => partialSchema(['invalid schema'])).to.throw();
     });
 
     it('Should throw an error when properties is not an array', () => {
       expect(() =>
-        usePartialSchema({ type: 'object' }, { foo: 'invalid properties' }),
+        partialSchema({ type: 'object' }, { foo: 'invalid properties' }),
       ).to.throw();
     });
 
     it('Should throw an error when properties contains non-strings', () => {
       expect(() =>
-        usePartialSchema({ type: 'object' }, [{ invalid: 'prop name' }]),
+        partialSchema({ type: 'object' }, [{ invalid: 'prop name' }]),
       ).to.throw();
     });
 
     it('Should throw an error when a property specified is missing from the schema', () => {
       expect(() =>
-        usePartialSchema(
+        partialSchema(
           { type: 'object', properties: { stuff: { type: 'string' } } },
           ['thingy'],
         ),
@@ -266,7 +266,7 @@ describe('CMS export transformer helpers', () => {
           foo: { type: 'string' },
         },
       };
-      expect(usePartialSchema(schema, ['foo'])).to.deep.equal({
+      expect(partialSchema(schema, ['foo'])).to.deep.equal({
         type: 'object',
         properties: {
           foo: { type: 'string' },
@@ -283,7 +283,7 @@ describe('CMS export transformer helpers', () => {
           var: { type: 'string' },
         },
       };
-      expect(usePartialSchema(schema, ['foo'])).to.deep.equal({
+      expect(partialSchema(schema, ['foo'])).to.deep.equal({
         type: 'object',
         properties: {
           foo: { type: 'string' },
@@ -301,7 +301,7 @@ describe('CMS export transformer helpers', () => {
         },
         required: ['foo', 'bar'],
       };
-      expect(usePartialSchema(schema, ['foo'])).to.deep.equal({
+      expect(partialSchema(schema, ['foo'])).to.deep.equal({
         type: 'object',
         properties: {
           foo: { type: 'string' },

--- a/src/site/stages/build/process-cms-exports/transformers/helpers.js
+++ b/src/site/stages/build/process-cms-exports/transformers/helpers.js
@@ -259,7 +259,7 @@ module.exports = {
    *                                     that we want to use
    * @return {Object} The new schema
    */
-  usePartialSchema(schema, properties) {
+  partialSchema(schema, properties) {
     // Some sanity checking before we start
     assert(
       schema.type === 'object' ||


### PR DESCRIPTION
Rename the "usePartialSchema" to just "partialSchema" so the linter doesn't think it's a hook!

## Description
eslint throws an error if any function starting with the string "use" isn't used correctly.

Renaming the function is a simple workaround, so we don't have to disable the rule every time.