### PR TITLE
send keepalive request without a pre-flight

### DIFF
--- a/src/platform/utilities/sso/keepAliveSSO.js
+++ b/src/platform/utilities/sso/keepAliveSSO.js
@@ -16,9 +16,6 @@ export default async function keepAlive() {
       method: 'GET',
       credentials: 'include',
       cache: 'no-store',
-      headers: {
-        'Content-Type': 'text/plain',
-      },
     });
     const alive = resp.headers.get('session-alive') === 'true';
     return {

--- a/src/platform/utilities/sso/keepAliveSSO.js
+++ b/src/platform/utilities/sso/keepAliveSSO.js
@@ -17,7 +17,7 @@ export default async function keepAlive() {
       credentials: 'include',
       cache: 'no-store',
       headers: {
-        'Content-Type': 'application/json',
+        'Content-Type': 'text/plain',
       },
     });
     const alive = resp.headers.get('session-alive') === 'true';


### PR DESCRIPTION
simple cross origin requests don't require a pre-flight.  the keepalive
request could be simple if we changed the Content-Type from
application/json to text/plain.  Its unknown whether eauth.va.gov will
accept a request of this type, but its worth testing out.

we're hoping that this might eliminate the problems arising for some
users outlined in https://github.com/department-of-veterans-affairs/va.gov-team/issues/15351

https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Simple_requests

## Description


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
