### PR TITLE
14420: Correct HR styling

### DIFF
--- a/src/applications/gi/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi/sass/partials/_gi-profile-page.scss
@@ -403,10 +403,6 @@
       }
     }
 
-    .responsive-table-row-separator {
-      display: none;
-    }
-
     .extension-row {
       padding-left: 16px;
       .extension-cell-label {
@@ -440,8 +436,7 @@
 
       .responsive-table-row-separator {
         display: block;
-        margin-top: 0.7em;
-        margin-bottom: 0.5em;
+        margin: 0.7em 1em 0.5em;
       }
 
       .location-cell,


### PR DESCRIPTION
## Description
Update to the margins of the the horizontal rule separator in between the rows of the responsive table.

[Originating Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/14420)

## Testing done
Testing Passes Locally

## Screenshots
<img width="288" alt="Screen Shot 2020-10-28 at 5 16 45 PM" src="https://user-images.githubusercontent.com/48804834/97574565-ccc86600-19c1-11eb-8d34-e69044cf1d21.png">


## Acceptance criteria
- [x] Margins adjusted per UX review

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
