### PR TITLE
address WAVE warning

### DIFF
--- a/src/applications/vre/28-1900/config/chapters/communication-preferences/communicationPreferences.js
+++ b/src/applications/vre/28-1900/config/chapters/communication-preferences/communicationPreferences.js
@@ -82,7 +82,7 @@ export const uiSchema = {
   },
   appointmentTimePreferences: {
     'ui:title': (
-      <p className="vads-u-margin--0 vads-u-margin-top--3 vads-u-display--inline-block vads-u-font-weight--normal vads-u-color--base vads-u-font-family--sans vads-u-font-size--base">
+      <p className="vads-u-margin--0 vads-u-display--inline-block vads-u-font-weight--normal vads-u-color--base vads-u-font-family--sans vads-u-font-size--base">
         When are the best times to meet with your VR&E counselor?{' '}
         <span className="schemaform-required-span vads-u-display--block">
           (*At lease one required)
@@ -91,9 +91,9 @@ export const uiSchema = {
     ),
     'ui:validations': [validateAtLeastOneSelected],
     'ui:options': {
-      // this needed because ObjectField adds the schemaform-block class to this, which creates a huge top margin.
-      classNames: 'vads-u-margin-top--neg2',
-      showFieldLabel: true,
+      // negative margin is needed because ObjectField adds the schemaform-block class to this, which creates a huge top margin.
+      classNames: 'vads-u-margin-top--neg3',
+      showFieldLabel: false,
     },
     morning: {
       'ui:title': 'Mornings 6:00 to 10:00 a.m.',

--- a/src/applications/vre/28-1900/config/chapters/communication-preferences/communicationPreferences.js
+++ b/src/applications/vre/28-1900/config/chapters/communication-preferences/communicationPreferences.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import fullSchema from 'vets-json-schema/dist/28-1900-schema.json';
+import { validateBooleanGroup } from 'platform/forms-system/src/js/validation';
 import {
   AppointmentPreferencesInformation,
   TeleCounselingInformation,
   VreCommunicationInformation,
-  validateAtLeastOneSelected,
 } from './helpers';
 
 const titleClasses = 'vads-u-display--inline-block vads-u-margin--0';
@@ -82,18 +82,18 @@ export const uiSchema = {
   },
   appointmentTimePreferences: {
     'ui:title': (
-      <p className="vads-u-margin--0 vads-u-display--inline-block vads-u-font-weight--normal vads-u-color--base vads-u-font-family--sans vads-u-font-size--base">
+      <p className="schemaform-block-title vads-u-margin--0 vads-u-margin-top--2 vads-u-display--inline-block vads-u-font-weight--normal vads-u-color--base vads-u-font-family--sans vads-u-font-size--base">
         When are the best times to meet with your VR&E counselor?{' '}
         <span className="schemaform-required-span vads-u-display--block">
           (*At lease one required)
         </span>
       </p>
     ),
-    'ui:validations': [validateAtLeastOneSelected],
+    'ui:validations': [validateBooleanGroup],
     'ui:options': {
       // negative margin is needed because ObjectField adds the schemaform-block class to this, which creates a huge top margin.
-      classNames: 'vads-u-margin-top--neg3',
-      showFieldLabel: false,
+      classNames: 'vads-u-margin-top--neg2',
+      showFieldLabel: true,
     },
     morning: {
       'ui:title': 'Mornings 6:00 to 10:00 a.m.',


### PR DESCRIPTION
## Description
This pull request addresses a warning thrown by WAVE regarding a fieldset missing a corresponding legend. 

## Testing done
- local

## Screenshots
<details><summary>WAVE warning</summary>

<img width="734" alt="Screen Shot 2020-10-28 at 11 30 37 AM" src="https://user-images.githubusercontent.com/15097156/97609023-7d962b80-19e9-11eb-99cd-ede3053a87bb.png">
</details>

<details><summary>Negative Margin fix</summary>

<img width="681" alt="Screen Shot 2020-10-29 at 1 12 42 PM" src="https://user-images.githubusercontent.com/15097156/97608930-5e979980-19e9-11eb-95c9-7ffe97db519b.png">
</details>

## Acceptance criteria
- [x] form works locally
- [x] WAVE warning has been resolved

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
