### PR TITLE
Add field_table_of_contents_boolean field

### DIFF
--- a/src/site/stages/build/process-cms-exports/schemas/input/node-page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/node-page.js
@@ -44,6 +44,7 @@ module.exports = {
         },
       },
     },
+    field_table_of_contents_boolean: { $ref: 'GenericNestedBoolean' },
     metatag: {
       type: 'object',
     },

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-page.js
@@ -12,6 +12,7 @@ module.exports = {
     fieldDescription: {
       type: ['string', 'null'],
     },
+    fieldTableOfContentsBoolean: { type: ['boolean', 'null'] },
     fieldFeaturedContent: {
       type: 'array',
       items: {

--- a/src/site/stages/build/process-cms-exports/transformers/node-page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-page.js
@@ -16,6 +16,7 @@ function pageTransform(entity) {
     fieldPageLastBuilt,
     fieldAlert,
     fieldDescription,
+    fieldTableOfContentsBoolean,
     status,
     metatag: { value: metaTags },
   } = entity;
@@ -27,6 +28,7 @@ function pageTransform(entity) {
     fieldRelatedLinks: entity.fieldRelatedLinks[0],
     fieldIntroText: getDrupalValue(fieldIntroText),
     fieldDescription: getDrupalValue(fieldDescription),
+    fieldTableOfContentsBoolean: getDrupalValue(fieldTableOfContentsBoolean),
     changed: utcToEpochTime(getDrupalValue(changed)),
     fieldPageLastBuilt: {
       // Assume the raw data is in UTC
@@ -55,6 +57,7 @@ module.exports = {
   filter: [
     'field_intro_text',
     'field_description',
+    'field_table_of_contents_boolean',
     'field_featured_content',
     'field_content_block',
     'field_alert',


### PR DESCRIPTION
## Description
There is a section missing.

Based on the [liquid template](https://github.com/department-of-veterans-affairs/vets-website/blob/09f8a9c6cbc511092c54d51600de0d8a857ac9b6/src/site/layouts/page.drupal.liquid#L45-L50) the `fieldTableOfContentsBoolean` field is needed.

```
{% if fieldTableOfContentsBoolean != empty and fieldTableOfContentsBoolean %}
   <section id="table-of-contents">
      <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
      <ul class="usa-unstyled-list"></ul>
   </section>
{% endif %}
```

## Testing done
Locally

## Screenshots
![Screen Shot 2020-10-22 at 4.47.04 PM.png](https://images.zenhubusercontent.com/5d89589c3ac3440001d19c89/8a5c659d-4551-4b72-885e-d8eca05ce852)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
