### PR TITLE
Modify the url in the media-document transformer

### DIFF
--- a/src/site/stages/build/process-cms-exports/transformers/media-document.js
+++ b/src/site/stages/build/process-cms-exports/transformers/media-document.js
@@ -4,7 +4,7 @@ const transform = entity => ({
   fieldDocument: {
     entity: {
       filename: entity.fieldDocument[0].filename,
-      url: entity.fieldDocument[0].url,
+      url: entity.fieldDocument[0].url.replace('public:/', '/files'),
     },
   },
 });


### PR DESCRIPTION
## Description
This PR updates the `fieldDocument.entity.url` field in the `media-document` transformer to have the correct file path.

## Testing done
Verified there are no instances of documents with the prefix of `public://` in the build.

Also tested a few pages to make sure downloads worked as expected. One of them being: 
http://localhost:3001/pittsburgh-health-care/research/safety-security/animal-research/

## Screenshots


## Acceptance criteria
- [ ] The `public://` prefix is not in the url of any document files, and has been replaced with the `/files` prefix.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
