### PR TITLE
Remove trailing comma for IE compatibility

### DIFF
--- a/src/site/assets/js/incompatible-browser.js
+++ b/src/site/assets/js/incompatible-browser.js
@@ -9,7 +9,7 @@ function checkBrowserCompatibility() {
     // check whether browser is IE10 and older
     if (window.navigator.userAgent.indexOf('MSIE ') > 0) {
       var browserWarning = document.getElementsByClassName(
-        'incompatible-browser-warning',
+        'incompatible-browser-warning'
       )[0];
 
       if (browserWarning) {


### PR DESCRIPTION
## Description
IE doesn't support trailing commas in functions, https://caniuse.com/?search=trailing, so this is causing a runtime error.

https://dsva.slack.com/archives/C0190MTGNUE/p1604002872039000?thread_ts=1603998977.030500&cid=C0190MTGNUE

https://github.com/department-of-veterans-affairs/va.gov-team/issues/15615

## Testing done
I haven't tested this yet bc I don't have IE, but I will.

## Screenshots
todo

## Acceptance criteria
- [ ] Runtime error is resolved in IE

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
