### PR TITLE
Set a consistent error title for VAOS server errors

### DIFF
--- a/src/applications/vaos/utils/error.js
+++ b/src/applications/vaos/utils/error.js
@@ -13,7 +13,7 @@ export function captureError(
   if (err instanceof Error) {
     Sentry.captureException(err);
     eventErrorKey = err.message;
-  } else {
+  } else if (err?.issue || err?.errors) {
     Sentry.withScope(scope => {
       scope.setExtra('error', err);
       if (extraData) {
@@ -27,6 +27,19 @@ export function captureError(
         err?.issue?.[0]?.code ||
         err;
       const message = `vaos_server_error${errorTitle ? `: ${errorTitle}` : ''}`;
+      eventErrorKey = message;
+      // the apiRequest helper returns the errors array, instead of an exception
+      Sentry.captureMessage(message);
+    });
+  } else {
+    Sentry.withScope(scope => {
+      scope.setExtra('error', err);
+      if (extraData) {
+        scope.setExtra('extraData', extraData);
+      }
+      const message = `vaos_client_error${
+        customTitle ? `: ${customTitle}` : ''
+      }`;
       eventErrorKey = message;
       // the apiRequest helper returns the errors array, instead of an exception
       Sentry.captureMessage(message);

--- a/src/applications/vaos/utils/error.js
+++ b/src/applications/vaos/utils/error.js
@@ -20,7 +20,12 @@ export function captureError(
         scope.setExtra('extraData', extraData);
       }
       const errorTitle =
-        customTitle || err?.errors?.[0]?.title || err?.issue?.[0]?.code || err;
+        customTitle ||
+        err?.errors?.[0]?.title ||
+        err?.issue?.[0]?.diagnostics ||
+        err?.errors?.[0]?.code ||
+        err?.issue?.[0]?.code ||
+        err;
       const message = `vaos_server_error${errorTitle ? `: ${errorTitle}` : ''}`;
       eventErrorKey = message;
       // the apiRequest helper returns the errors array, instead of an exception


### PR DESCRIPTION
## Description
This updates our error function to use title first for both regular errors and errors converted to FHIR. 

I've also added another category of error, for errors that aren't an instance of Error and are also not server errors. This should help us keep the other categories more consistent and give us an error message to search for in Sentry to find errors we need to adjust the output for.

## Testing done
Unit testing

## Acceptance criteria
- [ ] Errors are more consistently named

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
