### PR TITLE
[Templates] Add 'article type' field into article listings

### DIFF
--- a/src/applications/resources-and-support/components/SearchResult.jsx
+++ b/src/applications/resources-and-support/components/SearchResult.jsx
@@ -11,7 +11,7 @@ const articleTypes = {
   [ENTITY_BUNDLES.MEDIA_LIST_VIDEOS]: 'Media list',
   [ENTITY_BUNDLES.SUPPORT_RESOURCES_DETAIL_PAGE]: 'About',
   [ENTITY_BUNDLES.FAQ_MULTIPLE_Q_A]: 'FAQs',
-  [ENTITY_BUNDLES.STEP_BY_STEP]: 'Step by step',
+  [ENTITY_BUNDLES.STEP_BY_STEP]: 'Step-by-step',
 };
 
 export default function SearchResult({ article }) {

--- a/src/site/layouts/support_resources_article_listing.drupal.liquid
+++ b/src/site/layouts/support_resources_article_listing.drupal.liquid
@@ -20,6 +20,10 @@
           {% for article in articles %}
             <li>
               <div class="vads-u-padding-y--3 vads-u-border-top--1px vads-u-border-color--gray-lighter">
+                <div>
+                  <dfn class="vads-u-visibility--screen-reader">Article type: </dfn>
+                  {{ articleTypesByEntityBundle | get: article.entityBundle }}
+                </div>
                 <h2 class="vads-u-font-size--h3 vads-u-margin-top--0">
                   <a href="{{ article.entityUrl.path }}">{{ article.title }}</a>
                 </h2>

--- a/src/site/stages/build/plugins/create-resources-and-support-section.js
+++ b/src/site/stages/build/plugins/create-resources-and-support-section.js
@@ -25,15 +25,19 @@ const BREADCRUMB_BASE_PATH = [
   },
 ];
 
-const entityBundlesForResourcesAndSupport = new Set([
-  ENTITY_BUNDLES.STEP_BY_STEP,
-  ENTITY_BUNDLES.FAQ_MULTIPLE_Q_A,
-  ENTITY_BUNDLES.Q_A,
-  ENTITY_BUNDLES.CHECKLIST,
-  ENTITY_BUNDLES.MEDIA_LIST_IMAGES,
-  ENTITY_BUNDLES.MEDIA_LIST_VIDEOS,
-  ENTITY_BUNDLES.SUPPORT_RESOURCES_DETAIL_PAGE,
-]);
+const articleTypesByEntityBundle = {
+  [ENTITY_BUNDLES.Q_A]: 'Question and answer',
+  [ENTITY_BUNDLES.CHECKLIST]: 'Checklist',
+  [ENTITY_BUNDLES.MEDIA_LIST_IMAGES]: 'Media list',
+  [ENTITY_BUNDLES.MEDIA_LIST_VIDEOS]: 'Media list',
+  [ENTITY_BUNDLES.SUPPORT_RESOURCES_DETAIL_PAGE]: 'About',
+  [ENTITY_BUNDLES.FAQ_MULTIPLE_Q_A]: 'FAQs',
+  [ENTITY_BUNDLES.STEP_BY_STEP]: 'Step by step',
+};
+
+const entityBundlesForResourcesAndSupport = new Set(
+  Object.keys(articleTypesByEntityBundle),
+);
 
 function getArticlesBelongingToResourcesAndSupportSection(files) {
   return Object.entries(files)
@@ -194,6 +198,7 @@ function createPaginatedArticleListings({
           });
 
           const page = {
+            articleTypesByEntityBundle,
             contents: Buffer.from(''),
             path: pageOfArticles.uri,
             entityUrl: {

--- a/src/site/stages/build/plugins/create-resources-and-support-section.js
+++ b/src/site/stages/build/plugins/create-resources-and-support-section.js
@@ -32,7 +32,7 @@ const articleTypesByEntityBundle = {
   [ENTITY_BUNDLES.MEDIA_LIST_VIDEOS]: 'Media list',
   [ENTITY_BUNDLES.SUPPORT_RESOURCES_DETAIL_PAGE]: 'About',
   [ENTITY_BUNDLES.FAQ_MULTIPLE_Q_A]: 'FAQs',
-  [ENTITY_BUNDLES.STEP_BY_STEP]: 'Step by step',
+  [ENTITY_BUNDLES.STEP_BY_STEP]: 'Step-by-step',
 };
 
 const entityBundlesForResourcesAndSupport = new Set(

--- a/src/site/stages/build/plugins/download-drupal-assets.js
+++ b/src/site/stages/build/plugins/download-drupal-assets.js
@@ -74,6 +74,7 @@ async function downloadFile(
 
 function downloadDrupalAssets(options) {
   const client = getDrupalClient(options);
+  return () => {};
   return async (files, metalsmith, done) => {
     const assetsToDownload = Object.entries(files)
       .filter(entry => entry[1].isDrupalAsset && !entry[1].contents)

--- a/src/site/stages/build/plugins/download-drupal-assets.js
+++ b/src/site/stages/build/plugins/download-drupal-assets.js
@@ -74,7 +74,6 @@ async function downloadFile(
 
 function downloadDrupalAssets(options) {
   const client = getDrupalClient(options);
-  return () => {};
   return async (files, metalsmith, done) => {
     const assetsToDownload = Object.entries(files)
       .filter(entry => entry[1].isDrupalAsset && !entry[1].contents)


### PR DESCRIPTION
## Description
This PR adds the "article type" field into article listings pages, which are generated during the build by cycling through certain types of nodes.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/15607

## Testing done
Verified the field renders via local preview

## Screenshots
See the highlighted text

![image](https://user-images.githubusercontent.com/1915775/97714244-4c743480-1a97-11eb-8f71-847c0561a6a2.png)


## Acceptance criteria
- [ ] Article type is visible

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
