### PR TITLE
Update va311 numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -277,7 +277,7 @@
   "private": true,
   "dependencies": {
     "@department-of-veterans-affairs/formation": "6.9.5",
-    "@department-of-veterans-affairs/formation-react": "5.7.1",
+    "@department-of-veterans-affairs/formation-react": "5.7.2",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "@fortawesome/fontawesome-free": "^5.6.3",
     "@mapbox/mapbox-sdk": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -277,7 +277,7 @@
   "private": true,
   "dependencies": {
     "@department-of-veterans-affairs/formation": "6.9.5",
-    "@department-of-veterans-affairs/formation-react": "5.7.6",
+    "@department-of-veterans-affairs/formation-react": "5.7.5",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "@fortawesome/fontawesome-free": "^5.6.3",
     "@mapbox/mapbox-sdk": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -277,7 +277,7 @@
   "private": true,
   "dependencies": {
     "@department-of-veterans-affairs/formation": "6.9.5",
-    "@department-of-veterans-affairs/formation-react": "5.7.2",
+    "@department-of-veterans-affairs/formation-react": "5.7.3",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "@fortawesome/fontawesome-free": "^5.6.3",
     "@mapbox/mapbox-sdk": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -277,7 +277,7 @@
   "private": true,
   "dependencies": {
     "@department-of-veterans-affairs/formation": "6.9.5",
-    "@department-of-veterans-affairs/formation-react": "5.7.3",
+    "@department-of-veterans-affairs/formation-react": "5.7.6",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "@fortawesome/fontawesome-free": "^5.6.3",
     "@mapbox/mapbox-sdk": "^0.10.0",

--- a/src/applications/ask-a-question/form/review/error/CallMyVA311.js
+++ b/src/applications/ask-a-question/form/review/error/CallMyVA311.js
@@ -8,7 +8,7 @@ export default function CallMyVA311({ startSentence }) {
   return (
     <span>
       {startSentence ? 'Call' : 'call'} us at{' '}
-      <a href="tel:18006982411">800-698-2411</a>.<br />
+      <Telephone contact={CONTACTS.VA_311} />.<br />
       If you have hearing loss, call TTY:{' '}
       <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
     </span>

--- a/src/applications/ask-a-question/form/review/error/CallMyVA311.js
+++ b/src/applications/ask-a-question/form/review/error/CallMyVA311.js
@@ -8,7 +8,7 @@ export default function CallMyVA311({ startSentence }) {
   return (
     <span>
       {startSentence ? 'Call' : 'call'} us at{' '}
-      <a href="tel:18446982311">844-698-2311</a>.<br />
+      <a href="tel:18006982411">800-698-2411</a>.<br />
       If you have hearing loss, call TTY:{' '}
       <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
     </span>

--- a/src/applications/caregivers/tests/e2e/1010cg.cypress.spec.js
+++ b/src/applications/caregivers/tests/e2e/1010cg.cypress.spec.js
@@ -12,6 +12,7 @@ const secondaryTwoLabel = `Secondary Family Caregiver (2) applicant\u2019s`;
 
 const testSecondaryTwo = createTestConfig(
   {
+    skip: true,
     dataPrefix: 'data',
     dataSets: [
       'requiredOnly',

--- a/src/applications/disability-benefits/686c-674/config/helpers.js
+++ b/src/applications/disability-benefits/686c-674/config/helpers.js
@@ -52,7 +52,7 @@ export const ServerErrorAlert = (
     </p>
     <p>
       If you get this error again, please call the VA.gov help desk at{' '}
-      <Telephone contact="8006982411">800-698-2411</Telephone> (TTY:{' '}
+      <Telephone contact={CONTACTS.VA_311} /> (TTY:{' '}
       <Telephone contact={CONTACTS['711']} pattern={PATTERNS['3_DIGIT']} />
       ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
     </p>

--- a/src/applications/disability-benefits/view-payments/utils.js
+++ b/src/applications/disability-benefits/view-payments/utils.js
@@ -39,7 +39,7 @@ export const ServerErrorAlertContent = (
     </p>
     <p>
       If you get this error again, please call the VA.gov help desk at{' '}
-      <Telephone contact={8446982311} />
+      <Telephone contact={8006982411} />
       (TTY: <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
       ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET
     </p>

--- a/src/applications/disability-benefits/view-payments/utils.js
+++ b/src/applications/disability-benefits/view-payments/utils.js
@@ -39,7 +39,7 @@ export const ServerErrorAlertContent = (
     </p>
     <p>
       If you get this error again, please call the VA.gov help desk at{' '}
-      <Telephone contact={8006982411} />
+      <Telephone contact={CONTACTS.VA_311} />
       (TTY: <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
       ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET
     </p>

--- a/src/applications/personalization/profile/components/connected-apps/AdditionalInfoSections.jsx
+++ b/src/applications/personalization/profile/components/connected-apps/AdditionalInfoSections.jsx
@@ -108,8 +108,8 @@ export const AdditionalInfoSections = ({ activeApps }) => {
                 or contact your VA health care team.
               </li>
               <li className="vads-u-padding-left--1">
-                <strong>If your information isn’t accurate:</strong> Call us
-                at <Telephone contact={CONTACTS.VA_311} />. If you have hearing
+                <strong>If your information isn’t accurate:</strong> Call us at{' '}
+                <Telephone contact={CONTACTS.VA_311} />. If you have hearing
                 loss, call{' '}
                 <Telephone
                   contact={CONTACTS['711']}

--- a/src/applications/personalization/profile/components/connected-apps/AdditionalInfoSections.jsx
+++ b/src/applications/personalization/profile/components/connected-apps/AdditionalInfoSections.jsx
@@ -108,7 +108,7 @@ export const AdditionalInfoSections = ({ activeApps }) => {
                 or contact your VA health care team.
               </li>
               <li className="vads-u-padding-left--1">
-                <strong>If your information isn’t accurate:</strong> Call VA311
+                <strong>If your information isn’t accurate:</strong> Call us
                 at <Telephone contact={CONTACTS.VA_311} />. If you have hearing
                 loss, call{' '}
                 <Telephone

--- a/src/applications/personalization/profile/tests/components/alerts/NotInMPIError.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/alerts/NotInMPIError.unit.spec.jsx
@@ -27,7 +27,7 @@ describe('NotInMPI', () => {
       wrapper
         .text()
         .includes(
-          'If you’d like to access these tools, please contact the VA.gov help desk at 844-698-2311 (TTY: 711) to verify and update your records.',
+          'If you’d like to access these tools, please contact the VA.gov help desk at 800-698-2411 (TTY: 711) to verify and update your records.',
         ),
     ).to.be.true;
     wrapper.unmount();

--- a/src/applications/personalization/rated-disabilities/components/RatedDisabilityList.jsx
+++ b/src/applications/personalization/rated-disabilities/components/RatedDisabilityList.jsx
@@ -38,7 +38,7 @@ class RatedDisabilityList extends React.Component {
           </p>
           <p>
             If you get this error again, please call the VA.gov help desk at{' '}
-            <Telephone contact="8006982411">800-698-2411</Telephone> (TTY:{' '}
+            <Telephone contact={CONTACTS.VA_311} /> (TTY:{' '}
             <Telephone
               contact={CONTACTS['711']}
               pattern={PATTERNS['3_DIGIT']}

--- a/src/applications/personalization/rated-disabilities/components/TotalRatingStates.jsx
+++ b/src/applications/personalization/rated-disabilities/components/TotalRatingStates.jsx
@@ -18,7 +18,7 @@ export const errorMessage = () => {
       </p>
       <p>
         If you get this error again, please call the VA.gov help desk at{' '}
-        <Telephone contact="8006982411">800-698-2411</Telephone> (TTY:{' '}
+        <Telephone contact={CONTACTS.VA_311} /> (TTY:{' '}
         <Telephone contact={CONTACTS['711']} pattern={PATTERNS['3_DIGIT']} />
         ). We’re here Monday-Friday, 8:00 a.m.-8:00 p.m. ET.
       </p>

--- a/src/applications/personalization/view-dependents/layouts/helpers.jsx
+++ b/src/applications/personalization/view-dependents/layouts/helpers.jsx
@@ -13,7 +13,7 @@ export const errorFragment = (
     </p>
     <p>
       If you get this error again, please call the VA.gov help desk at
-      <Telephone contact="8006982411">800-698-2411</Telephone>{' '}
+      <Telephone contact={CONTACTS.VA_311} />{' '}
       <Telephone contact={CONTACTS['711']} pattern={PATTERNS['3_DIGIT']} />
       ). We're here Monday-Friday, 8:00a.m.-8:00p.m. ET.
     </p>

--- a/src/applications/validate-mhv-account/components/errors/NeedsVAPatient.jsx
+++ b/src/applications/validate-mhv-account/components/errors/NeedsVAPatient.jsx
@@ -24,7 +24,7 @@ const NeedsVAPatient = () => {
         </p>
         <p>
           Call our MyVA411 main information line at (
-          <a href="tel:800-698-2411">800-698-2411</a>
+            <Telephone contact={CONTACTS.VA_311} />
           ), and select 3 to reach your nearest VA medical center. If you have
           hearing loss, call TTY:{' '}
           <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
@@ -41,7 +41,7 @@ const NeedsVAPatient = () => {
           </strong>
         </p>
         <p>
-          Call <a href="tel:800-698-2411">800-698-2411</a>, and select 3 to
+          Call <Telephone contact={CONTACTS.VA_311} />, and select 3 to
           reach your nearest VA medical center. If you have hearing loss, call
           TTY: <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
           .

--- a/src/applications/validate-mhv-account/components/errors/NeedsVAPatient.jsx
+++ b/src/applications/validate-mhv-account/components/errors/NeedsVAPatient.jsx
@@ -23,7 +23,8 @@ const NeedsVAPatient = () => {
           </strong>
         </p>
         <p>
-          Call our MyVA411 main information line at (<a href="tel:800-698-2411">800-698-2411</a>
+          Call our MyVA411 main information line at (
+          <a href="tel:800-698-2411">800-698-2411</a>
           ), and select 3 to reach your nearest VA medical center. If you have
           hearing loss, call TTY:{' '}
           <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.

--- a/src/applications/validate-mhv-account/components/errors/NeedsVAPatient.jsx
+++ b/src/applications/validate-mhv-account/components/errors/NeedsVAPatient.jsx
@@ -23,7 +23,7 @@ const NeedsVAPatient = () => {
           </strong>
         </p>
         <p>
-          Call VA311 (<a href="tel:800-698-2411">800-698-2411</a>
+          Call our MyVA411 main information line at (<a href="tel:800-698-2411">800-698-2411</a>
           ), and select 3 to reach your nearest VA medical center. If you have
           hearing loss, call TTY:{' '}
           <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.

--- a/src/applications/validate-mhv-account/components/errors/NeedsVAPatient.jsx
+++ b/src/applications/validate-mhv-account/components/errors/NeedsVAPatient.jsx
@@ -24,7 +24,7 @@ const NeedsVAPatient = () => {
         </p>
         <p>
           Call our MyVA411 main information line at (
-            <Telephone contact={CONTACTS.VA_311} />
+          <Telephone contact={CONTACTS.VA_311} />
           ), and select 3 to reach your nearest VA medical center. If you have
           hearing loss, call TTY:{' '}
           <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
@@ -41,10 +41,9 @@ const NeedsVAPatient = () => {
           </strong>
         </p>
         <p>
-          Call <Telephone contact={CONTACTS.VA_311} />, and select 3 to
-          reach your nearest VA medical center. If you have hearing loss, call
-          TTY: <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
-          .
+          Call <Telephone contact={CONTACTS.VA_311} />, and select 3 to reach
+          your nearest VA medical center. If you have hearing loss, call TTY:{' '}
+          <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
         </p>
         <p>
           Tell the representative that you’re enrolled in VA health care and

--- a/src/applications/validate-mhv-account/components/errors/NeedsVAPatient.jsx
+++ b/src/applications/validate-mhv-account/components/errors/NeedsVAPatient.jsx
@@ -23,7 +23,7 @@ const NeedsVAPatient = () => {
           </strong>
         </p>
         <p>
-          Call VA311 (<a href="tel:844-698-2311">844-698-2311</a>
+          Call VA311 (<a href="tel:800-698-2411">800-698-2411</a>
           ), and select 3 to reach your nearest VA medical center. If you have
           hearing loss, call TTY:{' '}
           <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
@@ -40,7 +40,7 @@ const NeedsVAPatient = () => {
           </strong>
         </p>
         <p>
-          Call <a href="tel:844-698-2311">844-698-2311</a>, and select 3 to
+          Call <a href="tel:800-698-2411">800-698-2411</a>, and select 3 to
           reach your nearest VA medical center. If you have hearing loss, call
           TTY: <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
           .

--- a/src/platform/landing-pages/header-footer-data.json
+++ b/src/platform/landing-pages/header-footer-data.json
@@ -197,7 +197,7 @@
     },
     {
       "column": 4,
-      "label": "Call VA311:",
+      "label": "Call us:",
       "href": "tel:18006982411",
       "order": 3,
       "target": null,
@@ -347,7 +347,7 @@
                 "text": "Coronavirus FAQs",
                 "href": "https://www.va.gov/coronavirus-veteran-frequently-asked-questions/"
               },
-              "description": "Get answers to frequently asked questions about COVID-19 and VA health care. You can also call VA311 at 800-698-2411."
+              "description": "Get answers to frequently asked questions about COVID-19 and VA health care. You can also call our MyVA411 main information line at at 800-698-2411."
             }
           }
         },

--- a/src/platform/landing-pages/header-footer-data.json
+++ b/src/platform/landing-pages/header-footer-data.json
@@ -198,10 +198,10 @@
     {
       "column": 4,
       "label": "Call VA311:",
-      "href": "tel:18446982311",
+      "href": "tel:18006982411",
       "order": 3,
       "target": null,
-      "title": "844-698-2311"
+      "title": "800-698-2411"
     },
     {
       "column": 4,
@@ -347,7 +347,7 @@
                 "text": "Coronavirus FAQs",
                 "href": "https://www.va.gov/coronavirus-veteran-frequently-asked-questions/"
               },
-              "description": "Get answers to frequently asked questions about COVID-19 and VA health care. You can also call VA311 at 844-698-2311."
+              "description": "Get answers to frequently asked questions about COVID-19 and VA health care. You can also call VA311 at 800-698-2411."
             }
           }
         },

--- a/src/platform/site-wide/cta-widget/components/messages/NeedsVAPatient.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/NeedsVAPatient.jsx
@@ -21,7 +21,7 @@ const NeedsVAPatient = () => {
           </strong>
         </p>
         <p>
-          Call VA311 (<a href="tel:800-698-2411">800-698-2411</a>
+          Call our MyVA411 main information line at (<a href="tel:800-698-2411">800-698-2411</a>
           ), and select 3 to reach your nearest VA medical center. If you have
           hearing loss, call TTY:{' '}
           <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.

--- a/src/platform/site-wide/cta-widget/components/messages/NeedsVAPatient.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/NeedsVAPatient.jsx
@@ -39,10 +39,9 @@ const NeedsVAPatient = () => {
           </strong>
         </p>
         <p>
-          Call <Telephone contact={CONTACTS.VA_311} />, and select 3 to
-          reach your nearest VA medical center. If you have hearing loss, call
-          TTY: <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
-          .
+          Call <Telephone contact={CONTACTS.VA_311} />, and select 3 to reach
+          your nearest VA medical center. If you have hearing loss, call TTY:{' '}
+          <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
         </p>
         <p>
           Tell the representative that you’re enrolled in VA health care and

--- a/src/platform/site-wide/cta-widget/components/messages/NeedsVAPatient.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/NeedsVAPatient.jsx
@@ -21,7 +21,8 @@ const NeedsVAPatient = () => {
           </strong>
         </p>
         <p>
-          Call our MyVA411 main information line at (<a href="tel:800-698-2411">800-698-2411</a>
+          Call our MyVA411 main information line at (
+          <a href="tel:800-698-2411">800-698-2411</a>
           ), and select 3 to reach your nearest VA medical center. If you have
           hearing loss, call TTY:{' '}
           <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.

--- a/src/platform/site-wide/cta-widget/components/messages/NeedsVAPatient.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/NeedsVAPatient.jsx
@@ -21,7 +21,7 @@ const NeedsVAPatient = () => {
           </strong>
         </p>
         <p>
-          Call VA311 (<a href="tel:844-698-2311">844-698-2311</a>
+          Call VA311 (<a href="tel:800-698-2411">800-698-2411</a>
           ), and select 3 to reach your nearest VA medical center. If you have
           hearing loss, call TTY:{' '}
           <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
@@ -38,7 +38,7 @@ const NeedsVAPatient = () => {
           </strong>
         </p>
         <p>
-          Call <a href="tel:844-698-2311">844-698-2311</a>, and select 3 to
+          Call <a href="tel:800-698-2411">800-698-2411</a>, and select 3 to
           reach your nearest VA medical center. If you have hearing loss, call
           TTY: <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
           .

--- a/src/platform/site-wide/cta-widget/components/messages/NeedsVAPatient.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/NeedsVAPatient.jsx
@@ -22,7 +22,7 @@ const NeedsVAPatient = () => {
         </p>
         <p>
           Call our MyVA411 main information line at (
-          <a href="tel:800-698-2411">800-698-2411</a>
+          <Telephone contact={CONTACTS.VA_311} />
           ), and select 3 to reach your nearest VA medical center. If you have
           hearing loss, call TTY:{' '}
           <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
@@ -39,7 +39,7 @@ const NeedsVAPatient = () => {
           </strong>
         </p>
         <p>
-          Call <a href="tel:800-698-2411">800-698-2411</a>, and select 3 to
+          Call <Telephone contact={CONTACTS.VA_311} />, and select 3 to
           reach your nearest VA medical center. If you have hearing loss, call
           TTY: <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
           .

--- a/src/platform/site-wide/user-nav/components/HelpMenu.jsx
+++ b/src/platform/site-wide/user-nav/components/HelpMenu.jsx
@@ -29,7 +29,7 @@ function HelpMenu({ clickHandler, cssClass, isOpen }) {
         <a href="https://iris.custhelp.va.gov/app/ask">Ask a Question</a>
       </p>
       <p>
-        <a href="tel:18006982411">Call VA311: 800-698-2411</a>
+        <a href="tel:18006982411">Call us: 800-698-2411</a>
       </p>
       <p>
         TTY: <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />

--- a/src/platform/site-wide/user-nav/components/HelpMenu.jsx
+++ b/src/platform/site-wide/user-nav/components/HelpMenu.jsx
@@ -29,7 +29,7 @@ function HelpMenu({ clickHandler, cssClass, isOpen }) {
         <a href="https://iris.custhelp.va.gov/app/ask">Ask a Question</a>
       </p>
       <p>
-        <a href="tel:18006982411">Call us: 800-698-2411</a>
+        Call us: <Telephone contact={CONTACTS.VA_311} />
       </p>
       <p>
         TTY: <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />

--- a/src/platform/site-wide/user-nav/components/HelpMenu.jsx
+++ b/src/platform/site-wide/user-nav/components/HelpMenu.jsx
@@ -29,7 +29,7 @@ function HelpMenu({ clickHandler, cssClass, isOpen }) {
         <a href="https://iris.custhelp.va.gov/app/ask">Ask a Question</a>
       </p>
       <p>
-        <a href="tel:18446982311">Call VA311: 844-698-2311</a>
+        <a href="tel:18006982411">Call VA311: 800-698-2411</a>
       </p>
       <p>
         TTY: <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />

--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -196,7 +196,7 @@
   },
   {
     "column": 4,
-    "label": "Call VA311:",
+    "label": "Call us:",
     "href": "tel:18006982411",
     "order": 3,
     "target": null,

--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -197,10 +197,10 @@
   {
     "column": 4,
     "label": "Call VA311:",
-    "href": "tel:18446982311",
+    "href": "tel:18006982411",
     "order": 3,
     "target": null,
-    "title": "844-698-2311"
+    "title": "800-698-2411"
   },
   {
     "column": 4,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1254,10 +1254,10 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@department-of-veterans-affairs/formation-react@5.7.1":
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation-react/-/formation-react-5.7.1.tgz#b3dcb3aa94d4b8e62c7757f8cdfd118339cc81e7"
-  integrity sha512-yZAarpySAIylMNN56K4i862RFUjzz/vQloBHEYcl/2FKJdLwf3QeUSTe3FudMbdaPn5MKWg1u4+jdenrX9nq0w==
+"@department-of-veterans-affairs/formation-react@5.7.5":
+  version "5.7.5"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation-react/-/formation-react-5.7.5.tgz#029fba9d3ccd49cffe44b398babcbbc5d9b6bf60"
+  integrity sha512-TgUqLK4XK2xMWSSpw3AGOSCySTSg3LvZ9VmM9ewLDWWx9BT4WiSvN78Zd4V2iYLETBwjQ6ywsqShpRbwW+pUYA==
   dependencies:
     classnames "^2.2.6"
     lodash "^4.17.15"


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/14609

This PR bumps formation-react for the update in the `<Telephone />` component and updates all VA311 numbers. If I missed any, please lmk asap!! 🙂 

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Update VA311 numbers from 844-698-2311 to 800-698-2411

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
