### PR TITLE
14420: Correct text wrapping

### DIFF
--- a/src/applications/gi/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi/sass/partials/_gi-profile-page.scss
@@ -442,6 +442,13 @@
       .location-cell,
       .estimated-housing-cell {
         margin-left: -1px;
+        display: flex;
+      }
+
+      .location-cell dfn,
+      .estimated-housing-cell dfn {
+        padding-right: 0.2em;
+        white-space: nowrap;
       }
 
       .extension-row {


### PR DESCRIPTION
## Description
Styling update from UX review to correct wrapping of text wrapping in the location field of the responsive table on mobile views.

[Originating Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/14420)

## Testing done
Testing passes locally

## Screenshots
<img width="314" alt="Screen Shot 2020-10-30 at 10 20 58 AM" src="https://user-images.githubusercontent.com/48804834/97724469-54d26c80-1aa3-11eb-9375-03555fce62f7.png">


## Acceptance criteria
- [x] Text no longer wraps

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
