### PR TITLE
Update vet360 Babel alias

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -51,7 +51,7 @@
       {
         "root": "./src",
         "alias": {
-          "vet360": "./src/platform/user/profile/vet360",
+          "@@vet360": "./src/platform/user/profile/vet360",
           "@@profile": "./src/applications/personalization/profile"
         }
       }

--- a/.eslintrc
+++ b/.eslintrc
@@ -56,7 +56,7 @@
     "va/use-resolved-path": [
       2,
       {
-        "aliases": ["applications", "platform", "site", "vet360", "@@profile"]
+        "aliases": ["applications", "platform", "site", "@@vet360", "@@profile"]
       }
     ],
 

--- a/src/applications/letters/containers/AddressSection.jsx
+++ b/src/applications/letters/containers/AddressSection.jsx
@@ -6,11 +6,11 @@ import { focusElement } from 'platform/utilities/ui';
 import { isAddressEmpty } from '../utils/helpers';
 import noAddressBanner from '../components/NoAddressBanner';
 
-import { TRANSACTION_CATEGORY_TYPES } from 'vet360/constants';
+import { TRANSACTION_CATEGORY_TYPES } from '@@vet360/constants';
 
-import Vet360InitializeID from 'vet360/containers/InitializeVet360ID';
-import Vet360PendingTransactionCategory from 'vet360/containers/Vet360PendingTransactionCategory';
-import MailingAddress from 'vet360/components/MailingAddress';
+import Vet360InitializeID from '@@vet360/containers/InitializeVet360ID';
+import Vet360PendingTransactionCategory from '@@vet360/containers/Vet360PendingTransactionCategory';
+import MailingAddress from '@@vet360/components/MailingAddress';
 
 export class AddressSection extends React.Component {
   componentDidMount() {

--- a/src/applications/letters/reducers/index.js
+++ b/src/applications/letters/reducers/index.js
@@ -1,4 +1,4 @@
-import vet360 from 'vet360/reducers';
+import vet360 from '@@vet360/reducers';
 
 import _ from 'lodash/fp';
 import {

--- a/src/applications/personalization/profile/components/personal-information/ContactInformation.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformation.jsx
@@ -5,18 +5,18 @@ import DowntimeNotification, {
 } from 'platform/monitoring/DowntimeNotification';
 import recordEvent from 'platform/monitoring/record-event';
 
-import { TRANSACTION_CATEGORY_TYPES } from 'vet360/constants';
+import { TRANSACTION_CATEGORY_TYPES } from '@@vet360/constants';
 
-import Vet360InitializeID from 'vet360/containers/InitializeVet360ID';
-import Vet360PendingTransactionCategory from 'vet360/containers/Vet360PendingTransactionCategory';
+import Vet360InitializeID from '@@vet360/containers/InitializeVet360ID';
+import Vet360PendingTransactionCategory from '@@vet360/containers/Vet360PendingTransactionCategory';
 
-import MailingAddress from 'vet360/components/MailingAddress';
-import ResidentialAddress from 'vet360/components/ResidentialAddress';
-import HomePhone from 'vet360/components/HomePhone';
-import MobilePhone from 'vet360/components/MobilePhone';
-import WorkPhone from 'vet360/components/WorkPhone';
-import FaxNumber from 'vet360/components/FaxNumber';
-import Email from 'vet360/components/Email';
+import MailingAddress from '@@vet360/components/MailingAddress';
+import ResidentialAddress from '@@vet360/components/ResidentialAddress';
+import HomePhone from '@@vet360/components/HomePhone';
+import MobilePhone from '@@vet360/components/MobilePhone';
+import WorkPhone from '@@vet360/components/WorkPhone';
+import FaxNumber from '@@vet360/components/FaxNumber';
+import Email from '@@vet360/components/Email';
 
 import { handleDowntimeForSection } from '../alerts/DowntimeBanner';
 import ContactInformationExplanation from './ContactInformationExplanation';

--- a/src/applications/personalization/profile/components/personal-information/VAPEditView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/VAPEditView.jsx
@@ -5,7 +5,7 @@ import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
 import {
   isFailedTransaction,
   isPendingTransaction,
-} from 'vet360/util/transactions';
+} from '@@vet360/util/transactions';
 import VAPEditModalActionButtons from './VAPEditModalActionButtons';
 import Vet360EditModalErrorMessage from 'platform/user/profile/vet360/components/base/Vet360EditModalErrorMessage';
 

--- a/src/applications/personalization/profile/components/personal-information/addresses/AddressEditView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/addresses/AddressEditView.jsx
@@ -4,9 +4,9 @@ import pickBy from 'lodash/pickBy';
 import ADDRESS_DATA from 'platform/forms/address/data';
 import { focusElement } from 'platform/utilities/ui';
 
-import { ADDRESS_POU, FIELD_NAMES, USA } from 'vet360/constants';
+import { ADDRESS_POU, FIELD_NAMES, USA } from '@@vet360/constants';
 import VAPEditView from '../VAPEditView';
-import CopyMailingAddress from 'vet360/containers/CopyMailingAddress';
+import CopyMailingAddress from '@@vet360/containers/CopyMailingAddress';
 import ContactInfoForm from 'platform/user/profile/vet360/components/ContactInfoForm';
 
 class AddressEditView extends React.Component {

--- a/src/applications/personalization/profile/components/personal-information/addresses/VAPAddressField.jsx
+++ b/src/applications/personalization/profile/components/personal-information/addresses/VAPAddressField.jsx
@@ -9,7 +9,7 @@ import {
   ADDRESS_TYPES,
   ADDRESS_POU,
   USA,
-} from 'vet360/constants';
+} from '@@vet360/constants';
 
 import VAPProfileField from '../VAPProfileField';
 

--- a/src/applications/personalization/profile/components/personal-information/email-addresses/VAPEmailField.jsx
+++ b/src/applications/personalization/profile/components/personal-information/email-addresses/VAPEmailField.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { API_ROUTES, FIELD_NAMES } from 'vet360/constants';
+import { API_ROUTES, FIELD_NAMES } from '@@vet360/constants';
 
 import VAPProfileField from '../VAPProfileField';
 

--- a/src/applications/personalization/profile/components/personal-information/phone-numbers/PhoneEditView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/phone-numbers/PhoneEditView.jsx
@@ -5,7 +5,7 @@ import VAPEditView from '@@profile/components/personal-information/VAPEditView';
 
 import { isVAPatient } from 'platform/user/selectors';
 
-import { FIELD_NAMES } from 'vet360/constants';
+import { FIELD_NAMES } from '@@vet360/constants';
 
 import ContactInfoForm from 'platform/user/profile/vet360/components/ContactInfoForm';
 

--- a/src/applications/personalization/profile/components/personal-information/phone-numbers/VAPPhoneField.jsx
+++ b/src/applications/personalization/profile/components/personal-information/phone-numbers/VAPPhoneField.jsx
@@ -4,12 +4,12 @@ import pickBy from 'lodash/pickBy';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import Telephone from '@department-of-veterans-affairs/formation-react/Telephone';
 
-import { API_ROUTES, FIELD_NAMES, PHONE_TYPE, USA } from 'vet360/constants';
+import { API_ROUTES, FIELD_NAMES, PHONE_TYPE, USA } from '@@vet360/constants';
 
 import PhoneNumberWidget from 'platform/forms-system/src/js/widgets/PhoneNumberWidget';
 
 import VAPProfileField from '../VAPProfileField';
-import ReceiveTextMessages from 'vet360/containers/ReceiveTextMessages';
+import ReceiveTextMessages from '@@vet360/containers/ReceiveTextMessages';
 
 import PhoneEditView from './PhoneEditView';
 

--- a/src/applications/personalization/profile/reducers/index.js
+++ b/src/applications/personalization/profile/reducers/index.js
@@ -1,5 +1,5 @@
 import set from 'platform/utilities/data/set';
-import vet360 from 'vet360/reducers';
+import vet360 from '@@vet360/reducers';
 import { hcaEnrollmentStatus } from 'applications/hca/reducer';
 
 import {

--- a/src/applications/personalization/profile/tests/components/VAPProfileField.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/VAPProfileField.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   VAPProfileField,
   mapStateToProps,
 } from '@@profile/components/personal-information/VAPProfileField';
-import { FIELD_NAMES, TRANSACTION_STATUS } from 'vet360/constants';
+import { FIELD_NAMES, TRANSACTION_STATUS } from '@@vet360/constants';
 
 function ContentView() {
   return <h1>Content</h1>;

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.delete-address.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.delete-address.unit.spec.jsx
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import { setupServer } from 'msw/node';
 
 import { resetFetch } from 'platform/testing/unit/helpers';
-import { FIELD_TITLES, FIELD_NAMES } from 'vet360/constants';
+import { FIELD_TITLES, FIELD_NAMES } from '@@vet360/constants';
 
 import * as mocks from '@@profile/msw-mocks';
 import PersonalInformation from '@@profile/components/personal-information/PersonalInformation';

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.delete-telephone.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.delete-telephone.unit.spec.jsx
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import { setupServer } from 'msw/node';
 
 import { resetFetch } from 'platform/testing/unit/helpers';
-import { FIELD_TITLES, FIELD_NAMES } from 'vet360/constants';
+import { FIELD_TITLES, FIELD_NAMES } from '@@vet360/constants';
 
 import * as mocks from '@@profile/msw-mocks';
 import PersonalInformation from '@@profile/components/personal-information/PersonalInformation';

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.edit-telephone.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.edit-telephone.unit.spec.jsx
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 import { setupServer } from 'msw/node';
 
 import { resetFetch } from 'platform/testing/unit/helpers';
-import { FIELD_TITLES, FIELD_NAMES } from 'vet360/constants';
+import { FIELD_TITLES, FIELD_NAMES } from '@@vet360/constants';
 
 import * as mocks from '@@profile/msw-mocks';
 import PersonalInformation from '@@profile/components/personal-information/PersonalInformation';

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.update-address.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.update-address.unit.spec.jsx
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 import { setupServer } from 'msw/node';
 
 import { resetFetch } from 'platform/testing/unit/helpers';
-import { FIELD_TITLES, FIELD_NAMES } from 'vet360/constants';
+import { FIELD_TITLES, FIELD_NAMES } from '@@vet360/constants';
 
 import * as mocks from '@@profile/msw-mocks';
 import PersonalInformation from '@@profile/components/personal-information/PersonalInformation';

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -18,7 +18,7 @@ import {
 import {
   isVet360Configured,
   mockContactInformation,
-} from 'vet360/util/local-vet360';
+} from '@@vet360/util/local-vet360';
 
 const commonServices = {
   EMIS: 'EMIS',

--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -10,7 +10,7 @@ import {
   isSuccessfulTransaction,
   isFailedTransaction,
 } from '../util/transactions';
-import { FIELD_NAMES, ADDRESS_POU } from 'vet360/constants';
+import { FIELD_NAMES, ADDRESS_POU } from '@@vet360/constants';
 
 export const VET360_TRANSACTIONS_FETCH_SUCCESS =
   'VET360_TRANSACTIONS_FETCH_SUCCESS';

--- a/src/platform/user/profile/vet360/components/AddressField/AddressEditModal.jsx
+++ b/src/platform/user/profile/vet360/components/AddressField/AddressEditModal.jsx
@@ -4,9 +4,9 @@ import pickBy from 'lodash/pickBy';
 import ADDRESS_DATA from 'platform/forms/address/data';
 import { focusElement } from 'platform/utilities/ui';
 
-import { ADDRESS_POU, FIELD_NAMES, USA } from 'vet360/constants';
+import { ADDRESS_POU, FIELD_NAMES, USA } from '@@vet360/constants';
 import Vet360EditModal from '../base/Vet360EditModal';
-import CopyMailingAddress from 'vet360/containers/CopyMailingAddress';
+import CopyMailingAddress from '@@vet360/containers/CopyMailingAddress';
 import ContactInfoForm from '../ContactInfoForm';
 
 class AddressEditModal extends React.Component {

--- a/src/platform/user/profile/vet360/components/AddressField/AddressField.jsx
+++ b/src/platform/user/profile/vet360/components/AddressField/AddressField.jsx
@@ -9,9 +9,9 @@ import {
   ADDRESS_TYPES,
   ADDRESS_POU,
   USA,
-} from 'vet360/constants';
+} from '@@vet360/constants';
 
-import Vet360ProfileField from 'vet360/containers/Vet360ProfileField';
+import Vet360ProfileField from '@@vet360/containers/Vet360ProfileField';
 
 import AddressEditModal from './AddressEditModal';
 import AddressValidationModal from '../../containers/AddressValidationModal';

--- a/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
+++ b/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
@@ -3,7 +3,7 @@ import React from 'react';
 import ADDRESS_DATA from 'platform/forms/address/data';
 import cloneDeep from 'platform/utilities/data/cloneDeep';
 
-import { ADDRESS_FORM_VALUES, USA } from 'vet360/constants';
+import { ADDRESS_FORM_VALUES, USA } from '@@vet360/constants';
 
 // Regex that uses a negative lookahead to check that a string does NOT contain
 // things like `http`, `www.`, or a few common TLDs. Let's cross our fingers and

--- a/src/platform/user/profile/vet360/components/EmailField/EmailField.jsx
+++ b/src/platform/user/profile/vet360/components/EmailField/EmailField.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { API_ROUTES, FIELD_NAMES } from 'vet360/constants';
+import { API_ROUTES, FIELD_NAMES } from '@@vet360/constants';
 
-import Vet360ProfileField from 'vet360/containers/Vet360ProfileField';
+import Vet360ProfileField from '@@vet360/containers/Vet360ProfileField';
 
 import EmailEditModal from './EmailEditModal';
 import EmailView from './EmailView';

--- a/src/platform/user/profile/vet360/components/PhoneField/PhoneEditModal.jsx
+++ b/src/platform/user/profile/vet360/components/PhoneField/PhoneEditModal.jsx
@@ -5,7 +5,7 @@ import Vet360EditModal from '../base/Vet360EditModal';
 
 import { isVAPatient } from 'platform/user/selectors';
 
-import { FIELD_NAMES } from 'vet360/constants';
+import { FIELD_NAMES } from '@@vet360/constants';
 
 import ContactInfoForm from '../ContactInfoForm';
 

--- a/src/platform/user/profile/vet360/components/PhoneField/PhoneField.jsx
+++ b/src/platform/user/profile/vet360/components/PhoneField/PhoneField.jsx
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 import pickBy from 'lodash/pickBy';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
-import { API_ROUTES, FIELD_NAMES, PHONE_TYPE, USA } from 'vet360/constants';
+import { API_ROUTES, FIELD_NAMES, PHONE_TYPE, USA } from '@@vet360/constants';
 
 import PhoneNumberWidget from 'platform/forms-system/src/js/widgets/PhoneNumberWidget';
 
-import Vet360ProfileField from 'vet360/containers/Vet360ProfileField';
+import Vet360ProfileField from '@@vet360/containers/Vet360ProfileField';
 
 import PhoneEditModal from './PhoneEditModal';
 import PhoneView from './PhoneView';

--- a/src/platform/user/profile/vet360/components/base/Vet360EditModal.jsx
+++ b/src/platform/user/profile/vet360/components/base/Vet360EditModal.jsx
@@ -7,7 +7,7 @@ import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
 import {
   isFailedTransaction,
   isPendingTransaction,
-} from 'vet360/util/transactions';
+} from '@@vet360/util/transactions';
 import Vet360EditModalActionButtons from './Vet360EditModalActionButtons';
 import Vet360EditModalErrorMessage from './Vet360EditModalErrorMessage';
 

--- a/src/platform/user/profile/vet360/components/base/Vet360EditModalErrorMessage.jsx
+++ b/src/platform/user/profile/vet360/components/base/Vet360EditModalErrorMessage.jsx
@@ -8,7 +8,7 @@ import {
   DECEASED_ERROR_CODES,
   INVALID_EMAIL_ADDRESS_ERROR_CODES,
   LOW_CONFIDENCE_ADDRESS_ERROR_CODES,
-} from 'vet360/util/transactions';
+} from '@@vet360/util/transactions';
 
 function hasError(codes, errors) {
   return errors.some(error => codes.has(error.code));

--- a/src/platform/user/profile/vet360/components/base/Vet360Transaction.jsx
+++ b/src/platform/user/profile/vet360/components/base/Vet360Transaction.jsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import {
   isPendingTransaction,
   isFailedTransaction,
-} from 'vet360/util/transactions';
+} from '@@vet360/util/transactions';
 
 import Vet360TransactionInlineErrorMessage from './Vet360TransactionInlineErrorMessage';
 import Vet360TransactionPending from './Vet360TransactionPending';

--- a/src/platform/user/profile/vet360/components/base/Vet360TransactionErrorBanner.jsx
+++ b/src/platform/user/profile/vet360/components/base/Vet360TransactionErrorBanner.jsx
@@ -10,7 +10,7 @@ import {
   hasMVIError,
   hasMVINotFoundError,
   hasVAProfileInitError,
-} from 'vet360/util/transactions';
+} from '@@vet360/util/transactions';
 
 export function GenericUpdateError(props) {
   return (

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -24,9 +24,9 @@ import * as VET360 from '../constants';
 import {
   isFailedTransaction,
   isPendingTransaction,
-} from 'vet360/util/transactions';
+} from '@@vet360/util/transactions';
 
-import Vet360EditModalErrorMessage from 'vet360/components/base/Vet360EditModalErrorMessage';
+import Vet360EditModalErrorMessage from '@@vet360/components/base/Vet360EditModalErrorMessage';
 
 class AddressValidationModal extends React.Component {
   componentWillUnmount() {

--- a/src/platform/user/profile/vet360/containers/AddressValidationView.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationView.jsx
@@ -10,10 +10,10 @@ import { focusElement } from 'platform/utilities/ui';
 import {
   isFailedTransaction,
   isPendingTransaction,
-} from 'vet360/util/transactions';
-import { selectAddressValidation } from 'vet360/selectors';
+} from '@@vet360/util/transactions';
+import { selectAddressValidation } from '@@vet360/selectors';
 
-import Vet360EditModalErrorMessage from 'vet360/components/base/Vet360EditModalErrorMessage';
+import Vet360EditModalErrorMessage from '@@vet360/components/base/Vet360EditModalErrorMessage';
 
 import * as VET360 from '../constants';
 import {

--- a/src/platform/user/profile/vet360/tests/containers/CopyMailingAddress.unit.spec.jsx
+++ b/src/platform/user/profile/vet360/tests/containers/CopyMailingAddress.unit.spec.jsx
@@ -1,10 +1,10 @@
 import { expect } from 'chai';
 
-import { FIELD_NAMES } from 'vet360/constants';
+import { FIELD_NAMES } from '@@vet360/constants';
 
-import { mapStateToProps } from 'vet360/containers/CopyMailingAddress';
+import { mapStateToProps } from '@@vet360/containers/CopyMailingAddress';
 
-import { convertNextValueToCleanData } from 'vet360/components/AddressField/AddressField';
+import { convertNextValueToCleanData } from '@@vet360/components/AddressField/AddressField';
 
 describe('<CopyMailingAddress/>', () => {
   describe('mapStateToProps', () => {

--- a/src/platform/user/profile/vet360/tests/util/transactions.unit.spec.js
+++ b/src/platform/user/profile/vet360/tests/util/transactions.unit.spec.js
@@ -4,7 +4,7 @@ import {
   isFailedTransaction,
   isPendingTransaction,
   isSuccessfulTransaction,
-} from 'vet360/util/transactions';
+} from '@@vet360/util/transactions';
 
 describe('isPendingTransaction', () => {
   it('returns `false` if passed nothing', () => {


### PR DESCRIPTION
## Description
This PR updates the name of the `vet360` Babel alias to be in line with our new naming convention that uses a `@@` prefix.

## Testing done
Local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs