### PR TITLE
Updated URL for stubbed API endpoint in Cypress test for 1995 form.

### DIFF
--- a/src/applications/edu-benefits/1995/tests/e2e/edu-1995.cypress.spec.js
+++ b/src/applications/edu-benefits/1995/tests/e2e/edu-1995.cypress.spec.js
@@ -27,7 +27,7 @@ const form = createTestConfig(
         },
       });
       cy.get('@testData').then(testData => {
-        cy.route('GET', '/v0/in_progress_forms/1995', testData);
+        cy.route('GET', '/v0/in_progress_forms/22-1995', testData);
       });
     },
     pageHooks: {


### PR DESCRIPTION
## Description
It seems like the API endpoints for the 1995 form were changed at some point, and maybe the stub for this test got overlooked. This changes the stub to use the new URL and so that the test doesn't time out and fail when run locally.

## Testing done
Ran test locally, which passed.

## Acceptance criteria
- [ ] Tests should also pass when run locally.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
