### PR TITLE
updated hover styling

### DIFF
--- a/src/applications/gi/components/profile/SchoolCategoryRating.jsx
+++ b/src/applications/gi/components/profile/SchoolCategoryRating.jsx
@@ -42,7 +42,7 @@ export default function SchoolCategoryRating({
       <div className="rating vads-u-border-bottom--1px vads-u-border-color--gray-lighter">
         <button
           aria-expanded={open}
-          className="usa-accordion-button"
+          className="usa-accordion-button-ratings"
           onClick={() => openHandler(categoryRating.categoryName)}
         >
           <div className="vads-l-row medium-screen:vads-u-padding-left--1">

--- a/src/applications/gi/components/profile/SchoolRatings.jsx
+++ b/src/applications/gi/components/profile/SchoolRatings.jsx
@@ -61,7 +61,7 @@ export default function SchoolRatings({
 
       <div className="vads-l-row">
         <div className="medium-screen:vads-l-col--6 small-screen:vads-l-col--12 xsmall-screen:vads-l-col--12">
-          <div className="vads-u-font-weight--bold vads-u-font-size--lg vads-u-font-family--serif vads-u-padding-top--3">
+          <div className="vads-u-font-weight--bold vads-u-font-size--lg vads-u-font-family--serif vads-u-padding-top--3 school-ratings-accordion-headings">
             Education ratings
           </div>
 
@@ -94,7 +94,7 @@ export default function SchoolRatings({
         </div>
 
         <div className="medium-screen:vads-l-col--6 small-screen:vads-l-col--12 xsmall-screen:vads-l-col--12 ">
-          <div className="vads-u-font-weight--bold vads-u-font-size--lg vads-u-font-family--serif vads-u-padding-top--3">
+          <div className="vads-u-font-weight--bold vads-u-font-size--lg vads-u-font-family--serif vads-u-padding-top--3 school-ratings-accordion-headings">
             Veteran friendliness
           </div>
           <div className="vads-u-padding-left--0">

--- a/src/applications/gi/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi/sass/partials/_gi-profile-page.scss
@@ -171,6 +171,20 @@
     margin-top: 0.208em;
     margin-bottom: 0.208em;
   }
+  button.usa-accordion-button-ratings {
+    text-align: left;
+    margin-top: 0.208em;
+    margin-bottom: 0.208em;
+    margin-bottom: 1px;
+    margin-top: 1px;
+  }
+  .school-ratings-accordion-headings{
+    margin-bottom: 9px;
+  }
+
+  button.usa-accordion-button-ratings:hover {
+    background-color: #f1f1f1;
+  }
 
   .calculate-your-benefits {
     div.eligibility-details h2 {


### PR DESCRIPTION
## Description
Adding on hover effect

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/15514

## Testing done
local testing

## Screenshots

![Screen Shot 2020-11-02 at 9 46 48 AM](https://user-images.githubusercontent.com/50601724/97881432-63619380-1cf0-11eb-8cec-fc3b7041a6b2.png)

## Acceptance criteria
- [x] On the institution profile page within the "School ratings" section, if a rating subcategory (mini accordion) is hovered over, clicked, or tapped then the background color of the mini accordion button should update to #F1F1F1 as seen in SA1.
- [x] The section separators between rating subcategories (i.e., GI Bill support, Veteran community) are lengthened in accordance with SA1.
- [x] 20px between accordion and content to allow for breathing room with the added hover state (AC1) in accordance with SA1.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
