### PR TITLE
Sanlouise 14741 cleanup veteranstatus

### DIFF
--- a/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -190,7 +190,7 @@ function mapStateToProps(state) {
       serviceInfo: letterState.serviceInfo,
     },
     // default isVeteran to true for now - please see vets.gov-team issue #6250
-    // isVeteran: (state.user.profile.veteranStatus === 'OK' ? state.user.profile.isVeteran : true),
+    // isVeteran: (state.user.profile.veteranStatus.status === 'OK' ? state.user.profile.veteranStatus.isVeteran : true),
     isVeteran: true,
     optionsAvailable: letterState.optionsAvailable,
     requestOptions: letterState.requestOptions,

--- a/src/applications/personalization/profile/components/military-information/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile/components/military-information/MilitaryInformation.jsx
@@ -15,7 +15,7 @@ import DowntimeNotification, {
   externalServices,
 } from 'platform/monitoring/DowntimeNotification';
 import { focusElement } from 'platform/utilities/ui';
-import { selectProfile } from 'platform/user/selectors';
+import { selectVeteranStatus } from 'platform/user/selectors';
 import LoadFail from '../alerts/LoadFail';
 import { handleDowntimeForSection } from '../alerts/DowntimeBanner';
 import facilityLocator from 'applications/facility-locator/manifest.json';
@@ -122,7 +122,7 @@ const MilitaryInformationContent = ({ militaryInformation, veteranStatus }) => {
   }, []);
 
   const invalidVeteranStatus =
-    !veteranStatus || veteranStatus === 'NOT_AUTHORIZED';
+    !veteranStatus?.status || veteranStatus?.status === 'NOT_AUTHORIZED';
 
   // When the user is not authorized, militaryInformation.serviceHistory is populated with .error
   if (
@@ -232,12 +232,16 @@ MilitaryInformation.propTypes = {
       ),
     }).isRequired,
   }).isRequired,
-  veteranStatus: PropTypes.string,
+  veteranStatus: PropTypes.shape({
+    isVeteran: PropTypes.bool,
+    status: PropTypes.string,
+    servedInMilitary: PropTypes.bool,
+  }).isRequired,
 };
 
 const mapStateToProps = state => ({
   militaryInformation: state.vaProfile?.militaryInformation,
-  veteranStatus: selectProfile(state)?.veteranStatus,
+  veteranStatus: selectVeteranStatus(state),
 });
 
 export default connect(mapStateToProps)(MilitaryInformation);

--- a/src/applications/personalization/profile/msw-mocks.js
+++ b/src/applications/personalization/profile/msw-mocks.js
@@ -1629,6 +1629,11 @@ export const toggleSMSNotificationsSuccess = (enrolled = true) => {
                 loa: { current: 3, highest: 3 },
                 multifactor: true,
                 verified: true,
+                veteranStatus: {
+                  status: 'OK',
+                  isVeteran: true,
+                  servedInMilitary: true,
+                },
                 signIn: {
                   serviceName: 'idme',
                   accountType: 'N/A',
@@ -1647,11 +1652,6 @@ export const toggleSMSNotificationsSuccess = (enrolled = true) => {
                 facilities: [{ facilityId: '983', isCerner: false }],
                 vaPatient: true,
                 mhvAccountState: 'NONE',
-              },
-              veteranStatus: {
-                status: 'OK',
-                isVeteran: true,
-                servedInMilitary: true,
               },
               inProgressForms: [],
               prefillsAvailable: [],

--- a/src/applications/personalization/profile/tests/components/MilitaryInformation.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/MilitaryInformation.unit.spec.jsx
@@ -18,7 +18,9 @@ function createBasicInitialState() {
     },
     user: {
       profile: {
-        veteranStatus: 'OK',
+        veteranStatus: {
+          status: 'OK',
+        },
       },
     },
     vaProfile: {
@@ -207,7 +209,7 @@ describe('MilitaryInformation', () => {
   describe('when the veteranStatus is null and militaryInformation is empty', () => {
     it('should show the correct error', () => {
       initialState = createBasicInitialState();
-      initialState.user.profile.veteranStatus = null;
+      initialState.user.profile.veteranStatus.status = null;
       initialState.vaProfile.militaryInformation = null;
       view = renderWithProfileReducers(<MilitaryInformation />, {
         initialState,

--- a/src/applications/personalization/profile/tests/components/alerts/Profile.data-unavailable-error.unit.spec.js
+++ b/src/applications/personalization/profile/tests/components/alerts/Profile.data-unavailable-error.unit.spec.js
@@ -33,6 +33,7 @@ function createBasicInitialState() {
         hasCheckedKeepAlive: true,
       },
       profile: {
+        status: 'OK',
         loa: {
           current: 3,
           highest: 3,
@@ -40,18 +41,12 @@ function createBasicInitialState() {
         vet360: {},
         multifactor: true,
         services: ['evss-claims', 'user-profile', 'vet360'],
-        isVeteran: true,
         veteranStatus: {
+          status: 'OK',
           isVeteran: true,
-          veteranStatus: {
-            status: 'OK',
-            isVeteran: true,
-            servedInMilitary: true,
-          },
           servedInMilitary: true,
         },
         verified: true,
-        status: 'OK',
       },
     },
   };

--- a/src/applications/personalization/rated-disabilities/tests/components/RatedDisabilityView.unit.spec.jsx
+++ b/src/applications/personalization/rated-disabilities/tests/components/RatedDisabilityView.unit.spec.jsx
@@ -8,7 +8,9 @@ describe('<RatedDisabilityView/>', () => {
   const user = {
     profile: {
       verified: true,
-      status: 'OK',
+      veteranStatus: {
+        status: 'OK',
+      },
     },
   };
   const ratedDisabilities = { ratedDisabilities: [] };

--- a/src/applications/personalization/rated-disabilities/tests/components/RatedDisabilityView.unit.spec.jsx
+++ b/src/applications/personalization/rated-disabilities/tests/components/RatedDisabilityView.unit.spec.jsx
@@ -7,10 +7,8 @@ import RatedDisabilityView from '../../components/RatedDisabilityView';
 describe('<RatedDisabilityView/>', () => {
   const user = {
     profile: {
+      status: 'OK',
       verified: true,
-      veteranStatus: {
-        status: 'OK',
-      },
     },
   };
   const ratedDisabilities = { ratedDisabilities: [] };

--- a/src/applications/veteran-id-card/components/RequiredVeteranView.jsx
+++ b/src/applications/veteran-id-card/components/RequiredVeteranView.jsx
@@ -8,7 +8,7 @@ import EmailVICHelp from 'platform/static-data/EmailVICHelp';
 function RequiredVeteranView({ userProfile, children }) {
   let view;
 
-  if (userProfile.veteranStatus === 'SERVER_ERROR') {
+  if (userProfile.veteranStatus?.status === 'SERVER_ERROR') {
     // If eMIS status is null, show a system down message.
     view = (
       <SystemDownView

--- a/src/applications/veteran-id-card/containers/VeteranIDCard.jsx
+++ b/src/applications/veteran-id-card/containers/VeteranIDCard.jsx
@@ -40,9 +40,9 @@ class VeteranIDCard extends React.Component {
         if (serviceRateLimitedAuthed) {
           recordEvent({ event: 'vic-authenticated-ratelimited' });
           this.renderEmailCapture = true;
-          if (userProfile.veteranStatus.status === 'NOT_FOUND') {
+          if (userProfile.veteranStatus?.status === 'NOT_FOUND') {
             recordEvent({ events: 'vic-emis-lookup-failed' });
-          } else if (userProfile.veteranStatus.status === 'SERVER_ERROR') {
+          } else if (userProfile.veteranStatus?.status === 'SERVER_ERROR') {
             recordEvent({ events: 'vic-emis-error' });
           }
         } else {

--- a/src/applications/veteran-id-card/containers/VeteranIDCard.jsx
+++ b/src/applications/veteran-id-card/containers/VeteranIDCard.jsx
@@ -40,9 +40,9 @@ class VeteranIDCard extends React.Component {
         if (serviceRateLimitedAuthed) {
           recordEvent({ event: 'vic-authenticated-ratelimited' });
           this.renderEmailCapture = true;
-          if (userProfile.veteranStatus === 'NOT_FOUND') {
+          if (userProfile.veteranStatus.status === 'NOT_FOUND') {
             recordEvent({ events: 'vic-emis-lookup-failed' });
-          } else if (userProfile.veteranStatus === 'SERVER_ERROR') {
+          } else if (userProfile.veteranStatus.status === 'SERVER_ERROR') {
             recordEvent({ events: 'vic-emis-error' });
           }
         } else {

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -88,20 +88,16 @@ export function mapRawUserDataToState(json) {
       ? vet360ContactInformation
       : mockContactInformation,
     session,
+    veteranStatus: {},
   };
 
   if (meta && veteranStatus === null) {
     const errorStatus = meta.errors.find(
       error => error.externalService === commonServices.EMIS,
     ).status;
-    userState.veteranStatus = getErrorStatusDesc(errorStatus);
+    userState.veteranStatus.status = getErrorStatusDesc(errorStatus);
   } else {
-    userState.isVeteran = veteranStatus.isVeteran;
-    userState.veteranStatus = {
-      isVeteran: veteranStatus.isVeteran,
-      veteranStatus,
-      servedInMilitary: veteranStatus.servedInMilitary,
-    };
+    userState.veteranStatus = { ...veteranStatus };
   }
 
   if (meta && vaProfile === null) {

--- a/src/platform/user/selectors.js
+++ b/src/platform/user/selectors.js
@@ -11,9 +11,10 @@ export const selectUser = state => state.user;
 export const isLoggedIn = state => selectUser(state).login.currentlyLoggedIn;
 export const selectProfile = state => selectUser(state)?.profile || {};
 export const isVAPatient = state => selectProfile(state).vaPatient === true;
-export const isInMPI = state => selectProfile(state).status === 'OK';
+export const selectVeteranStatus = state => selectProfile(state).veteranStatus;
+export const isInMPI = state => selectProfile(state)?.status === 'OK';
 export const hasMPIConnectionError = state =>
-  selectProfile(state).status === 'SERVER_ERROR';
+  selectProfile(state)?.status === 'SERVER_ERROR';
 export const isProfileLoading = state => selectProfile(state).loading;
 export const isLOA3 = state => selectProfile(state).loa.current === 3;
 export const isLOA1 = state => selectProfile(state).loa.current === 1;

--- a/src/platform/user/tests/profile/utilities/index.unit.spec.js
+++ b/src/platform/user/tests/profile/utilities/index.unit.spec.js
@@ -96,16 +96,9 @@ describe('Profile utilities', () => {
         },
       });
 
-      expect(mappedData.isVeteran).to.equal(
-        data.attributes.veteran_status.is_veteran,
-      );
       expect(mappedData.veteranStatus).to.deep.equal({
+        status: data.attributes.veteran_status.status,
         isVeteran: data.attributes.veteran_status.is_veteran,
-        veteranStatus: {
-          status: data.attributes.veteran_status.status,
-          isVeteran: data.attributes.veteran_status.is_veteran,
-          servedInMilitary: data.attributes.veteran_status.served_in_military,
-        },
         servedInMilitary: data.attributes.veteran_status.served_in_military,
       });
     });
@@ -184,7 +177,7 @@ describe('Profile utilities', () => {
         },
       });
 
-      expect(mappedData.veteranStatus).to.equal('NOT_FOUND');
+      expect(mappedData.veteranStatus.status).to.equal('NOT_FOUND');
     });
 
     it('should handle vet 360 error', () => {

--- a/src/platform/user/tests/selectors.unit.spec.js
+++ b/src/platform/user/tests/selectors.unit.spec.js
@@ -245,6 +245,28 @@ describe('user selectors', () => {
     });
   });
 
+  describe('selectVeteranStatus', () => {
+    it('pulls out the veteranStatus object', () => {
+      const state = {
+        user: {
+          profile: {
+            veteranStatus: {
+              status: 'OK',
+              isVeteran: true,
+              servedInMilitary: true,
+            },
+          },
+        },
+      };
+      const expected = {
+        status: 'OK',
+        isVeteran: true,
+        servedInMilitary: true,
+      };
+      expect(selectors.selectVeteranStatus(state)).to.deep.equal(expected);
+    });
+  });
+
   describe('selectPatientFacilities', () => {
     it('pulls out the state.profile.facilities array', () => {
       const state = {
@@ -460,7 +482,9 @@ describe('user selectors', () => {
       const state = {
         user: {
           profile: {
-            status: 'SERVER_ERROR',
+            veteranStatus: {
+              status: 'SERVER_ERROR',
+            },
           },
         },
       };
@@ -470,7 +494,9 @@ describe('user selectors', () => {
       const state = {
         user: {
           profile: {
-            status: 'ERROR',
+            veteranStatus: {
+              status: 'ERROR',
+            },
           },
         },
       };

--- a/src/platform/user/tests/selectors.unit.spec.js
+++ b/src/platform/user/tests/selectors.unit.spec.js
@@ -482,9 +482,7 @@ describe('user selectors', () => {
       const state = {
         user: {
           profile: {
-            veteranStatus: {
-              status: 'SERVER_ERROR',
-            },
+            status: 'SERVER_ERROR',
           },
         },
       };


### PR DESCRIPTION
## Description
At some point, `isVeteran` was duplicated thrice in the redux store and these duplications have been around for a very long time. Applications have become dependent on those duplicated properties, and those duplications and dependencies are cleaned up by this PR. I realize this is touching integral logic to our application and code that has not been touched in years. However, I could not at least give it a try to clean up this little mess. This update should be tested very thoroughly before merging.

To see the structure below, log into staging with user +36.

![image](https://user-images.githubusercontent.com/14869324/97360514-ed7aa980-1863-11eb-9139-c0df9b2d47e7.png)


I believe we want the `veteranStatus` object (and the 'status' on the profile which indicated whether the user in in `MVI`) in our redux store to look like:

```
 veteranStatus {
   status: "OK",
   isVeteran: true,
   servedInMilitary: true,
 }
status: "OK",
```

and no longer like:

```
 isVeteran: true,
 veteranStatus {
   isVeteran: true,
   veteranStatus {
     status: "OK",
     isVeteran: true,
     servedInMilitary: true,
   },
   servedInMilitary: true,
 }
 status: "OK",
```

## Screenshots
### Redux store AFTER (local, user +1)
![image](https://user-images.githubusercontent.com/14869324/97907124-066ed900-1d02-11eb-8141-0e7354271611.png)


## Testing done
All works well locally, updated tests where needed.

## Acceptance criteria
- [x] Clean up `veteranStatus` in the redux store 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
