### PR TITLE
Add get image crop#13718

### DIFF
--- a/src/site/stages/build/process-cms-exports/transformers/paragraph-media.js
+++ b/src/site/stages/build/process-cms-exports/transformers/paragraph-media.js
@@ -1,4 +1,4 @@
-const { getDrupalValue, getImageCrop  } = require('./helpers');
+const { getDrupalValue, getImageCrop } = require('./helpers');
 
 const transform = entity => ({
   entity: {

--- a/src/site/stages/build/process-cms-exports/transformers/paragraph-media.js
+++ b/src/site/stages/build/process-cms-exports/transformers/paragraph-media.js
@@ -1,4 +1,4 @@
-const { getDrupalValue } = require('./helpers');
+const { getDrupalValue, getImageCrop  } = require('./helpers');
 
 const transform = entity => ({
   entity: {
@@ -9,7 +9,7 @@ const transform = entity => ({
       getDrupalValue(entity.fieldAllowClicksOnThisImage) || false,
     fieldMedia:
       entity.fieldMedia && entity.fieldMedia.length
-        ? { entity: entity.fieldMedia[0] }
+        ? { entity: getImageCrop(entity.fieldMedia[0], '_21MEDIUMTHUMBNAIL') }
         : null,
   },
 });


### PR DESCRIPTION
## Description
Add `getImageCrop` to `paragraph-media` transformer.

## Testing done
Compared images src in both builds were the same. 

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
