### PR TITLE
only trust keepalive response if session-alive is present

### DIFF
--- a/src/platform/utilities/sso/keepAliveSSO.js
+++ b/src/platform/utilities/sso/keepAliveSSO.js
@@ -17,9 +17,17 @@ export default async function keepAlive() {
       credentials: 'include',
       cache: 'no-store',
     });
-    const alive = resp.headers.get('session-alive') === 'true';
+    const alive = resp.headers.get('session-alive');
+    if (alive === null) {
+      // session-alive response header is missing, possibly because the
+      // browser failed to send the "Origin" request header.  with missing
+      // response headers, we can't determine if the user is logged in or
+      // logged out, so just return back an empty response (the same that
+      // would be returned in the event of an error)
+      return {};
+    }
     return {
-      ttl: alive ? Number(resp.headers.get('session-timeout')) : 0,
+      ttl: alive === 'true' ? Number(resp.headers.get('session-timeout')) : 0,
       transactionid: resp.headers.get('va_eauth_transactionid'),
       // for DSLogon or mhv, use a mapped authn context value, however for
       // idme, we need to use the provided authncontextclassref as it could be

--- a/src/platform/utilities/tests/sso.unit.spec.js
+++ b/src/platform/utilities/tests/sso.unit.spec.js
@@ -384,14 +384,16 @@ describe('keepAlive', () => {
   });
 
   it('should return active dslogon session', async () => {
+    /* eslint-disable prettier/prettier */
     const resp = new Response('{}', {
       headers: {
         'session-alive': 'true',
         'session-timeout': '900',
-        va_eauth_transactionid: 'X',
-        va_eauth_csid: 'DSLogon',
+        'va_eauth_transactionid': 'X',
+        'va_eauth_csid': 'DSLogon',
       },
     });
+    /* eslint-enable prettier/prettier */
     stubFetch.resolves(resp);
     const res = await keepAlive();
     expect(res).to.eql({
@@ -402,14 +404,16 @@ describe('keepAlive', () => {
   });
 
   it('should return active mhv session', async () => {
+    /* eslint-disable prettier/prettier */
     const resp = new Response('{}', {
       headers: {
         'session-alive': 'true',
         'session-timeout': '900',
-        va_eauth_transactionid: 'X',
-        va_eauth_csid: 'mhv',
+        'va_eauth_transactionid': 'X',
+        'va_eauth_csid': 'mhv',
       },
     });
+    /* eslint-enable prettier/prettier */
     stubFetch.resolves(resp);
     const res = await keepAlive();
     expect(res).to.eql({
@@ -420,15 +424,17 @@ describe('keepAlive', () => {
   });
 
   it('should return active idme session', async () => {
+    /* eslint-disable prettier/prettier */
     const resp = new Response('{}', {
       headers: {
         'session-alive': 'true',
         'session-timeout': '900',
-        va_eauth_transactionid: 'X',
-        va_eauth_csid: 'idme',
-        va_eauth_authncontextclassref: '/loa1',
+        'va_eauth_transactionid': 'X',
+        'va_eauth_csid': 'idme',
+        'va_eauth_authncontextclassref': '/loa1',
       },
     });
+    /* eslint-enable prettier/prettier */
     stubFetch.resolves(resp);
     const res = await keepAlive();
     expect(res).to.eql({

--- a/src/platform/utilities/tests/sso.unit.spec.js
+++ b/src/platform/utilities/tests/sso.unit.spec.js
@@ -383,16 +383,16 @@ describe('keepAlive', () => {
   });
 
   it('should return active dslogon session', () => {
-    /* eslint-disable prettier/prettier */
+    /* eslint-disable camelcase */
     const resp = new Response('{}', {
       headers: {
         'session-alive': 'true',
         'session-timeout': '900',
-        'va_eauth_transactionid': 'X',
-        'va_eauth_csid': 'DSLogon',
+        va_eauth_transactionid: 'X',
+        va_eauth_csid: 'DSLogon',
       },
     });
-    /* eslint-enable prettier/prettier */
+    /* eslint-enable camelcase */
     stubFetch.resolves(resp);
     return keepAlive().then(res => {
       expect(res).to.eql({
@@ -404,16 +404,16 @@ describe('keepAlive', () => {
   });
 
   it('should return active mhv session', () => {
-    /* eslint-disable prettier/prettier */
+    /* eslint-disable camelcase */
     const resp = new Response('{}', {
       headers: {
         'session-alive': 'true',
         'session-timeout': '900',
-        'va_eauth_transactionid': 'X',
-        'va_eauth_csid': 'mhv',
+        va_eauth_transactionid: 'X',
+        va_eauth_csid: 'mhv',
       },
     });
-    /* eslint-enable prettier/prettier */
+    /* eslint-enable camelcase */
     stubFetch.resolves(resp);
     return keepAlive().then(res => {
       expect(res).to.eql({
@@ -425,17 +425,17 @@ describe('keepAlive', () => {
   });
 
   it('should return active idme session', () => {
-    /* eslint-disable prettier/prettier */
+    /* eslint-disable camelcase */
     const resp = new Response('{}', {
       headers: {
         'session-alive': 'true',
         'session-timeout': '900',
-        'va_eauth_transactionid': 'X',
-        'va_eauth_csid': 'idme',
-        'va_eauth_authncontextclassref': '/loa1',
+        va_eauth_transactionid: 'X',
+        va_eauth_csid: 'idme',
+        va_eauth_authncontextclassref: '/loa1',
       },
     });
-    /* eslint-enable prettier/prettier */
+    /* eslint-enable camelcase */
     stubFetch.resolves(resp);
     return keepAlive().then(res => {
       expect(res).to.eql({

--- a/src/platform/utilities/tests/sso.unit.spec.js
+++ b/src/platform/utilities/tests/sso.unit.spec.js
@@ -8,6 +8,7 @@ import * as keepAliveMod from 'platform/utilities/sso/keepAliveSSO';
 
 import { checkAutoSession, checkAndUpdateSSOeSession } from '../sso';
 import * as loginAttempted from '../sso/loginAttempted';
+import { keepAlive } from '../sso/keepAliveSSO';
 
 function setKeepAliveResponse(stub, sessionTimeout = 0, csid = null) {
   const response = new Response();
@@ -335,5 +336,105 @@ describe('checkAndUpdateSSOeSession', () => {
 
   afterEach(() => {
     localStorage.clear();
+  });
+});
+
+describe('keepAlive', () => {
+  let sandbox;
+  let stubFetch;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    stubFetch = sandbox.stub(global, 'fetch');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should return an empty object on a type error', async () => {
+    stubFetch.rejects('TypeError');
+    const res = await keepAlive();
+    expect(res).to.eql({});
+  });
+
+  it('should return an empty object when missing session-alive', async () => {
+    const resp = new Response('{}', {
+      headers: {},
+    });
+    stubFetch.resolves(resp);
+    const res = await keepAlive();
+    expect(res).to.eql({});
+  });
+
+  it('should return ttl 0 when not alive', async () => {
+    const resp = new Response('{}', {
+      headers: {
+        'session-alive': 'false',
+        'session-timeout': '900',
+      },
+    });
+    stubFetch.resolves(resp);
+    const res = await keepAlive();
+    expect(res).to.eql({
+      ttl: 0,
+      transactionid: null,
+      authn: undefined,
+    });
+  });
+
+  it('should return active dslogon session', async () => {
+    const resp = new Response('{}', {
+      headers: {
+        'session-alive': 'true',
+        'session-timeout': '900',
+        va_eauth_transactionid: 'X',
+        va_eauth_csid: 'DSLogon',
+      },
+    });
+    stubFetch.resolves(resp);
+    const res = await keepAlive();
+    expect(res).to.eql({
+      ttl: 900,
+      transactionid: 'X',
+      authn: 'dslogon',
+    });
+  });
+
+  it('should return active mhv session', async () => {
+    const resp = new Response('{}', {
+      headers: {
+        'session-alive': 'true',
+        'session-timeout': '900',
+        va_eauth_transactionid: 'X',
+        va_eauth_csid: 'mhv',
+      },
+    });
+    stubFetch.resolves(resp);
+    const res = await keepAlive();
+    expect(res).to.eql({
+      ttl: 900,
+      transactionid: 'X',
+      authn: 'myhealthevet',
+    });
+  });
+
+  it('should return active idme session', async () => {
+    const resp = new Response('{}', {
+      headers: {
+        'session-alive': 'true',
+        'session-timeout': '900',
+        va_eauth_transactionid: 'X',
+        va_eauth_csid: 'idme',
+        va_eauth_authncontextclassref: '/loa1',
+      },
+    });
+    stubFetch.resolves(resp);
+    const res = await keepAlive();
+    expect(res).to.eql({
+      ttl: 900,
+      transactionid: 'X',
+      authn: '/loa1',
+    });
   });
 });

--- a/src/platform/utilities/tests/sso.unit.spec.js
+++ b/src/platform/utilities/tests/sso.unit.spec.js
@@ -343,31 +343,29 @@ describe('keepAlive', () => {
   let sandbox;
   let stubFetch;
 
-  beforeEach(() => {
+  before(() => {
     sandbox = sinon.createSandbox();
     stubFetch = sandbox.stub(global, 'fetch');
   });
 
-  afterEach(() => {
+  after(() => {
     sandbox.restore();
   });
 
-  it('should return an empty object on a type error', async () => {
+  it('should return an empty object on a type error', () => {
     stubFetch.rejects('TypeError');
-    const res = await keepAlive();
-    expect(res).to.eql({});
+    return keepAlive().then(res => expect(res).to.eql({}));
   });
 
-  it('should return an empty object when missing session-alive', async () => {
+  it('should return an empty object when missing session-alive', () => {
     const resp = new Response('{}', {
       headers: {},
     });
     stubFetch.resolves(resp);
-    const res = await keepAlive();
-    expect(res).to.eql({});
+    return keepAlive().then(res => expect(res).to.eql({}));
   });
 
-  it('should return ttl 0 when not alive', async () => {
+  it('should return ttl 0 when not alive', () => {
     const resp = new Response('{}', {
       headers: {
         'session-alive': 'false',
@@ -375,15 +373,16 @@ describe('keepAlive', () => {
       },
     });
     stubFetch.resolves(resp);
-    const res = await keepAlive();
-    expect(res).to.eql({
-      ttl: 0,
-      transactionid: null,
-      authn: undefined,
+    return keepAlive().then(res => {
+      expect(res).to.eql({
+        ttl: 0,
+        transactionid: null,
+        authn: undefined,
+      });
     });
   });
 
-  it('should return active dslogon session', async () => {
+  it('should return active dslogon session', () => {
     /* eslint-disable prettier/prettier */
     const resp = new Response('{}', {
       headers: {
@@ -395,15 +394,16 @@ describe('keepAlive', () => {
     });
     /* eslint-enable prettier/prettier */
     stubFetch.resolves(resp);
-    const res = await keepAlive();
-    expect(res).to.eql({
-      ttl: 900,
-      transactionid: 'X',
-      authn: 'dslogon',
+    return keepAlive().then(res => {
+      expect(res).to.eql({
+        ttl: 900,
+        transactionid: 'X',
+        authn: 'dslogon',
+      });
     });
   });
 
-  it('should return active mhv session', async () => {
+  it('should return active mhv session', () => {
     /* eslint-disable prettier/prettier */
     const resp = new Response('{}', {
       headers: {
@@ -415,15 +415,16 @@ describe('keepAlive', () => {
     });
     /* eslint-enable prettier/prettier */
     stubFetch.resolves(resp);
-    const res = await keepAlive();
-    expect(res).to.eql({
-      ttl: 900,
-      transactionid: 'X',
-      authn: 'myhealthevet',
+    return keepAlive().then(res => {
+      expect(res).to.eql({
+        ttl: 900,
+        transactionid: 'X',
+        authn: 'myhealthevet',
+      });
     });
   });
 
-  it('should return active idme session', async () => {
+  it('should return active idme session', () => {
     /* eslint-disable prettier/prettier */
     const resp = new Response('{}', {
       headers: {
@@ -436,11 +437,12 @@ describe('keepAlive', () => {
     });
     /* eslint-enable prettier/prettier */
     stubFetch.resolves(resp);
-    const res = await keepAlive();
-    expect(res).to.eql({
-      ttl: 900,
-      transactionid: 'X',
-      authn: '/loa1',
+    return keepAlive().then(res => {
+      expect(res).to.eql({
+        ttl: 900,
+        transactionid: 'X',
+        authn: '/loa1',
+      });
     });
   });
 });


### PR DESCRIPTION
In some cases, the response returned to us from the `/keepalive` endpoint
won't have valid response headers.  One such case is when the browser
fails to submit an "Origin" request header.  When that happens, the
"session-alive" response header will be absent, so we shouldn't assume
that the user is logged out.  When missing we should assert that we can't
determine a user's SSOe status and therefore shouldn't try to keep it "in
sync" with their www.va.gov session.

fixes https://github.com/department-of-veterans-affairs/va.gov-team/issues/15709

### testing
- [x] wrote unit tests for the keepAlive() function
