### PR TITLE
[Development] Add form submission details to SiP data

### DIFF
--- a/src/platform/forms-system/src/js/actions.js
+++ b/src/platform/forms-system/src/js/actions.js
@@ -47,11 +47,12 @@ export function setEditMode(page, edit, index = null) {
 
 // extra is used to pass other information (from a submission error or anything else)
 // into the submission state object
-export function setSubmission(field, value, extra = null) {
+export function setSubmission(field, value, errorMessage = null, extra = null) {
   return {
     type: SET_SUBMISSION,
     field,
     value,
+    errorMessage, // include errorMessage in form.submission
     extra,
   };
 }
@@ -192,7 +193,7 @@ export function submitForm(formConfig, form) {
           errorType = 'serverError';
         }
         captureError(error, errorType);
-        dispatch(setSubmission('status', errorType, error.extra));
+        dispatch(setSubmission('status', errorType, errorMessage, error.extra));
       });
   };
 }

--- a/src/platform/forms-system/src/js/review/SubmitController.jsx
+++ b/src/platform/forms-system/src/js/review/SubmitController.jsx
@@ -9,6 +9,7 @@ import { isValidForm } from '../validation';
 import { createPageListByChapter, getActiveExpandedPages } from '../helpers';
 import recordEvent from 'platform/monitoring/record-event';
 import { setPreSubmit, setSubmission, submitForm } from '../actions';
+import { autoSaveForm } from 'platform/forms/save-in-progress/actions';
 
 class SubmitController extends Component {
   /* eslint-disable-next-line camelcase */
@@ -45,11 +46,14 @@ class SubmitController extends Component {
 
   handleSubmit = () => {
     const { form, formConfig, pageList, trackingPrefix } = this.props;
+    const { formId, data, submission } = form;
+    const now = new Date().getTime();
 
     // If a pre-submit agreement is required, make sure it was accepted
     const preSubmit = this.getPreSubmit(formConfig);
     if (preSubmit.required && !form.data[preSubmit.field]) {
       this.props.setSubmission('hasAttemptedSubmit', true);
+      this.props.setSubmission('timestamp', now);
       // <PreSubmitSection/> is displaying an error for this case
       return;
     }
@@ -57,8 +61,14 @@ class SubmitController extends Component {
     // Validation errors in this situation are not visible, so we’d
     // like to know if they’re common
     const { isValid, errors } = isValidForm(form, pageList);
+    const { inProgressFormId, version, returnUrl } = form.loadedData?.metadata;
+    const submissionData = {
+      ...submission,
+      hasAttemptedSubmit: true,
+      timestamp: now,
+    };
+
     if (!isValid) {
-      const inProgressFormId = form.loadedData?.metadata?.inProgressFormId;
       recordEvent({
         event: `${trackingPrefix}-validation-failed`,
       });
@@ -70,8 +80,16 @@ class SubmitController extends Component {
       });
       this.props.setSubmission('status', 'validationError');
       this.props.setSubmission('hasAttemptedSubmit', true);
+
+      // Update save-in-progress with failed submit
+      submissionData.errors = errors;
+      this.props.autoSaveForm(formId, data, version, returnUrl, submissionData);
       return;
     }
+
+    // Update save-in-progress after attempted submit; if successful, SiP data
+    // will be erased
+    this.props.autoSaveForm(formId, data, version, returnUrl, submissionData);
 
     // User accepted if required, and no errors, so submit
     this.props.submitForm(formConfig, form);
@@ -117,6 +135,7 @@ const mapDispatchToProps = {
   setPreSubmit,
   setSubmission,
   submitForm,
+  autoSaveForm,
 };
 
 SubmitController.propTypes = {
@@ -130,6 +149,7 @@ SubmitController.propTypes = {
   submitForm: PropTypes.func.isRequired,
   submission: PropTypes.object.isRequired,
   trackingPrefix: PropTypes.string.isRequired,
+  autoSaveForm: PropTypes.func.isRequired,
 };
 
 export default withRouter(

--- a/src/platform/forms-system/src/js/state/reducers.js
+++ b/src/platform/forms-system/src/js/state/reducers.js
@@ -55,18 +55,27 @@ export default {
   }),
   [SET_SUBMISSION]: (state, action) => {
     const newState = _.set(['submission', action.field], action.value, state);
-    if (action.extra) {
-      newState.submission.extra = action.extra;
+    const { extra, errorMessage } = action;
+    const submission = {
+      ...newState.submission,
+      timestamp: new Date().getTime(),
+      hasAttemptedSubmit: true,
+    };
+    if (errorMessage) {
+      submission.errorMessage = errorMessage;
     }
-
+    if (extra) {
+      submission.extra = extra;
+    }
+    newState.submission = submission;
     return newState;
   },
   [SET_SUBMITTED]: (state, action) => {
     const submission = _.assign(state.submission, {
       response: action.response,
       status: 'applicationSubmitted',
+      timestamp: new Date(),
     });
-
     return _.set('submission', submission, state);
   },
   [SET_VIEWED_PAGES]: (state, action) => {

--- a/src/platform/forms-system/test/js/actions.unit.spec.js
+++ b/src/platform/forms-system/test/js/actions.unit.spec.js
@@ -121,6 +121,7 @@ describe('Schemaform actions:', () => {
           field: 'status',
           value: 'submitPending',
           extra: null,
+          errorMessage: null,
         });
         expect(dispatch.secondCall.args[0]).to.eql({
           type: SET_SUBMITTED,
@@ -154,12 +155,14 @@ describe('Schemaform actions:', () => {
           field: 'status',
           value: 'submitPending',
           extra: null,
+          errorMessage: null,
         });
         expect(dispatch.secondCall.args[0]).to.eql({
           type: SET_SUBMISSION,
           field: 'status',
           value: 'serverError',
           extra: null,
+          errorMessage: 'vets_server_error: Bad Request',
         });
       });
 
@@ -223,12 +226,14 @@ describe('Schemaform actions:', () => {
           field: 'status',
           value: 'submitPending',
           extra: null,
+          errorMessage: null,
         });
         expect(dispatch.secondCall.args[0]).to.eql({
           type: SET_SUBMISSION,
           field: 'status',
           value: 'throttledError',
           extra: 2000,
+          errorMessage: 'vets_throttled_error: undefined',
         });
       });
 
@@ -265,6 +270,7 @@ describe('Schemaform actions:', () => {
           field: 'status',
           value: 'submitPending',
           extra: null,
+          errorMessage: null,
         });
         expect(formConfig.submit.called).to.be.true;
         expect(requests).to.be.empty;

--- a/src/platform/forms-system/test/js/review/SubmitController.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/SubmitController.unit.spec.jsx
@@ -329,6 +329,7 @@ describe('Schemaform review: SubmitController', () => {
     const setPreSubmit = sinon.spy();
     const setSubmission = sinon.spy();
     const submitForm = sinon.spy();
+    const autoSaveForm = sinon.spy();
 
     const store = createStore({
       form,
@@ -344,6 +345,7 @@ describe('Schemaform review: SubmitController', () => {
           setPreSubmit={setPreSubmit}
           setSubmission={setSubmission}
           submitForm={submitForm}
+          autoSaveForm={autoSaveForm}
           trackingPrefix={formConfig.trackingPrefix}
         />
       </Provider>,
@@ -366,6 +368,7 @@ describe('Schemaform review: SubmitController', () => {
     const setPreSubmit = sinon.spy();
     const setSubmission = sinon.spy();
     const submitForm = sinon.spy();
+    const autoSaveForm = sinon.spy();
 
     const store = createStore({
       form,
@@ -381,6 +384,7 @@ describe('Schemaform review: SubmitController', () => {
           setPreSubmit={setPreSubmit}
           setSubmission={setSubmission}
           submitForm={submitForm}
+          autoSaveForm={autoSaveForm}
           trackingPrefix={formConfig.trackingPrefix}
         />
       </Provider>,
@@ -405,6 +409,7 @@ describe('Schemaform review: SubmitController', () => {
     const setPreSubmit = sinon.spy();
     const setSubmission = sinon.spy();
     const submitForm = sinon.spy();
+    const autoSaveForm = sinon.spy();
 
     const store = createStore({
       form,
@@ -420,6 +425,7 @@ describe('Schemaform review: SubmitController', () => {
           setPreSubmit={setPreSubmit}
           setSubmission={setSubmission}
           submitForm={submitForm}
+          autoSaveForm={autoSaveForm}
           trackingPrefix={formConfig.trackingPrefix}
         />
       </Provider>,

--- a/src/platform/forms-system/test/js/state/index.unit.spec.js
+++ b/src/platform/forms-system/test/js/state/index.unit.spec.js
@@ -215,6 +215,7 @@ describe('schemaform createSchemaFormReducer', () => {
       );
 
       expect(state.submission.hasAttemptedSubmit).to.be.true;
+      expect(state.submission.timestamp).to.exist;
     });
     it('should set submitted', () => {
       const state = reducer(

--- a/src/platform/forms/save-in-progress/RoutedSavablePage.jsx
+++ b/src/platform/forms/save-in-progress/RoutedSavablePage.jsx
@@ -34,10 +34,9 @@ class RoutedSavablePage extends React.Component {
     const { form, user } = this.props;
     if (user.login.currentlyLoggedIn) {
       const data = form.data;
-      const { formId, version } = form;
+      const { formId, version, submission } = form;
       const returnUrl = this.props.location.pathname;
-
-      this.props.autoSaveForm(formId, data, version, returnUrl);
+      this.props.autoSaveForm(formId, data, version, returnUrl, submission);
     }
   }
 

--- a/src/platform/forms/save-in-progress/RoutedSavableReviewPage.jsx
+++ b/src/platform/forms/save-in-progress/RoutedSavableReviewPage.jsx
@@ -48,10 +48,10 @@ class RoutedSavableReviewPage extends React.Component {
     const { form, user } = this.props;
     if (user.login.currentlyLoggedIn) {
       const data = form.data;
-      const { formId, version } = form;
+      const { formId, version, submission } = form;
       const returnUrl = this.props.location.pathname;
 
-      this.props.autoSaveForm(formId, data, version, returnUrl);
+      this.props.autoSaveForm(formId, data, version, returnUrl, submission);
     }
   };
 

--- a/src/platform/forms/save-in-progress/SaveFormLink.jsx
+++ b/src/platform/forms/save-in-progress/SaveFormLink.jsx
@@ -29,9 +29,15 @@ class SaveFormLink extends React.Component {
   }
 
   handleSave = () => {
-    const { formId, version, data } = this.props.form;
+    const { formId, version, data, submission } = this.props.form;
     const returnUrl = this.props.locationPathname;
-    this.props.saveAndRedirectToReturnUrl(formId, data, version, returnUrl);
+    this.props.saveAndRedirectToReturnUrl(
+      formId,
+      data,
+      version,
+      returnUrl,
+      submission,
+    );
   };
 
   openLoginModal = () => {

--- a/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
@@ -44,7 +44,7 @@ const SipsDevModal = props => {
 
   const saveData = (event, type) => {
     event.preventDefault();
-    const { formId, version, data } = props.form;
+    const { formId, version, data, submission } = props.form;
     const parsedData = JSON.parse(sipsData);
 
     // maximal-data.json is wrapped in `{ "data": {...} }
@@ -56,7 +56,13 @@ const SipsDevModal = props => {
     const newData =
       type === 'merge' ? Object.assign({}, data, resultingData) : resultingData;
     setError('');
-    props.saveAndRedirectToReturnUrl(formId, newData, version, sipsUrl);
+    props.saveAndRedirectToReturnUrl(
+      formId,
+      newData,
+      version,
+      sipsUrl,
+      submission,
+    );
     toggleModal(false);
   };
 

--- a/src/platform/forms/save-in-progress/actions.js
+++ b/src/platform/forms/save-in-progress/actions.js
@@ -150,14 +150,34 @@ export function migrateFormData(savedData, migrations) {
 }
 
 /**
+ * @typedef Form~submission - copy of `form.submission` object which stores the
+ *   state of the form last submission attempt
+ * @type {Object}
+ * @property {Boolean|String} status - initialized as `false`, and may end up as
+ *   a string: 'submitPending', 'applicationSubmitted', 'validationError',
+ *  'clientError', 'throttledError', 'serverError', etc.
+ * @property {Boolean|String} errorMessage - initialized as `false`; Returns
+ *   actual server errorMessage
+ * @property {Boolean} id - initialized as `false`; never altered. A submit ID
+ *   would not be available as the SiPs data is cleared after submission
+ * @property {Boolean|Number} timestamp - initialized as `false`; or contains
+ *   the number of milliseconds* since the Unix Epoch of the submission attempt
+ * @property {Boolean} hasAttemptedSubmit - flag indicating if the user had
+ *   attempted to submit a form
+ * @property {Number} extra - extra 'x-ratelimit-reset' data returned from a
+ *   rate limit ('throttledError) error (see submitToUrl function in the
+ *   forms-system actions file)
+ */
+/**
  * Saves the form data to the back end
  * @param  {String}  saveType  The type of save that's happening, auto or save and redirect
  * @param  {String}  formId    The form’s formId
  * @param  {Object}  formData  The data the user has entered so far
  * @param  {Ingeter} version   The form’s version
  * @param  {String}  returnUrl The last URL the user was at before saving
+ * @param  {Form~submission} submission Form submission data
  */
-function saveForm(saveType, formId, formData, version, returnUrl) {
+function saveForm(saveType, formId, formData, version, returnUrl, submission) {
   const savedAt = Date.now();
 
   return (dispatch, getState) => {
@@ -172,6 +192,7 @@ function saveForm(saveType, formId, formData, version, returnUrl) {
       returnUrl,
       savedAt,
       trackingPrefix,
+      submission,
     )
       .then(json => {
         dispatch(

--- a/src/platform/forms/save-in-progress/actions.js
+++ b/src/platform/forms/save-in-progress/actions.js
@@ -158,6 +158,9 @@ export function migrateFormData(savedData, migrations) {
  *  'clientError', 'throttledError', 'serverError', etc.
  * @property {Boolean|String} errorMessage - initialized as `false`; Returns
  *   actual server errorMessage
+ * @property {Object} errors - The errors object provided by the jsonschema
+ *   validation library; only available when there are form validation errors
+ *   prior to actual form submission to the server
  * @property {Boolean} id - initialized as `false`; never altered. A submit ID
  *   would not be available as the SiPs data is cleared after submission
  * @property {Boolean|Number} timestamp - initialized as `false`; or contains

--- a/src/platform/forms/save-in-progress/api.js
+++ b/src/platform/forms/save-in-progress/api.js
@@ -44,12 +44,14 @@ export function saveFormApi(
   returnUrl,
   savedAt,
   trackingPrefix,
+  submission,
 ) {
   const body = JSON.stringify({
     metadata: {
       version,
       returnUrl,
       savedAt,
+      submission,
     },
     formData,
   });


### PR DESCRIPTION
## Description

While exploring form 526 metrics, Anna discovered that many users would stop mid-form. We can't easily tell if they had previously attempted to submit the form. To obtain better metrics, we need to determine if the user had attempted to submit the form and decided to navigation back through the form before giving up, or if they had just given up at a particular step.

The save-in-progress (SiP) data includes a return url within its metadata, which is how this problem was discovered, but we are missing this crucial information.

- Initially the plan was to include the `hasAttemptedSubmit` value from `form.submission`
- After examining the other `form.submission` data values, it seemed to be more valuable to include the entire object. Initial Redux state of `form.submission`
  ![](https://user-images.githubusercontent.com/136959/97902107-b8a6a080-1d02-11eb-9737-b6c6e9cae699.png)
- While working on the update, I discovered that the `errorMessage`, `id` and `timestamp` were never updated

In this PR:
- The `errorMessage` value is now updated after any server error with the provided error message.
- The `timestamp` is now updated _after_ all submission attempts
- The `id` is **not** updated as the submission ID would not be available in failed submission attempts, and the save-in-progress data is removed after a successful submission.
- Validation form `errors` have also been included within the submission data to provide us with better details.
- Code was added to update the save-in-progress data _after_ form submission; previously it was only saved when form data was altered (I'm not 100% confident this is accurate).

Related:
- https://dsva.slack.com/archives/C5AGLBNRK/p1604004676290200?thread_ts=1603999885.288700&cid=C5AGLBNRK
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/15642
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/15680
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/15689

## Testing done

Updated unit tests

## Screenshots

<details><summary>Metrics evaluation</summary>

<!-- leave a blank line above -->
![sankeymatic_2200x1600](https://user-images.githubusercontent.com/136959/97928564-edc7e880-1d2c-11eb-816c-93ebefdadc0a.png)</details>

## Acceptance criteria
- [x] Save-in-progress metrics include submission data, which includes any error message, last submission timestamp and if the user had or had not attempted to submit the form.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
