### PR TITLE
[Development] Build HLR in prod

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -299,7 +299,7 @@
       "layout": "page-react.html",
       "description": "Apply online to request a Higher-Level Review.",
       "includeBreadcrumbs": true,
-      "vagovprod": false,
+      "vagovprod": true,
       "breadcrumbs_override": [
         {
           "name": "VA decision review and appeals",


### PR DESCRIPTION
## Description

We're starting Higher-Level Review (HLR) UAT soon... we need to get HLR built for production. It is disabled using a feature flag, so it won't be seen or discoverable in production.

## Testing done

None for this PR

## Screenshots

N/A

## Acceptance criteria
- [ ] HLR is built in production

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
