### PR TITLE
Check direct schedule feature flag in getLocationsByTypeOfCareAndSiteIds

### DIFF
--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -346,6 +346,7 @@ export function openFacilityPageV2(page, uiSchema, schema) {
     try {
       const initialState = getState();
       const newAppointment = initialState.newAppointment;
+      const directSchedulingEnabled = vaosDirectScheduling(initialState);
       const typeOfCare = getTypeOfCare(newAppointment.data);
       const typeOfCareId = typeOfCare?.id;
       if (typeOfCareId) {
@@ -374,6 +375,7 @@ export function openFacilityPageV2(page, uiSchema, schema) {
           typeOfCareFacilities = await getLocationsByTypeOfCareAndSiteIds({
             typeOfCareId,
             siteIds,
+            directSchedulingEnabled,
           });
         }
 

--- a/src/applications/vaos/services/location/index.js
+++ b/src/applications/vaos/services/location/index.js
@@ -112,26 +112,18 @@ export async function getLocation({ facilityId }) {
 export async function getLocationsByTypeOfCareAndSiteIds({
   typeOfCareId,
   siteIds,
+  directSchedulingEnabled,
 }) {
   try {
     let locations = [];
 
-    const criteria = await Promise.all([
-      getDirectBookingEligibilityCriteria(siteIds),
-      getRequestEligibilityCriteria(siteIds),
-    ]);
+    const promises = [getRequestEligibilityCriteria(siteIds)];
 
-    // Fetch facilities that support direct scheduling and filter
-    // only those that support the selected type of care
-    const directFacilityIds =
-      criteria[0]
-        ?.filter(facility =>
-          facility?.coreSettings?.some(
-            setting =>
-              setting.id === typeOfCareId && !!setting.patientHistoryRequired,
-          ),
-        )
-        ?.map(facility => facility.id) || [];
+    if (directSchedulingEnabled) {
+      promises.push(getDirectBookingEligibilityCriteria(siteIds));
+    }
+
+    const criteria = await Promise.all(promises);
 
     // If patientHistoryRequired is blank or null, the scheduling method is
     // disabled for that type of care.  If "No", it is enabled, but doesn't require
@@ -140,7 +132,7 @@ export async function getLocationsByTypeOfCareAndSiteIds({
     // Fetch facilities that support requests and filter
     // only those that support the selected type of care
     const requestFacilityIds =
-      criteria[1]
+      criteria[0]
         ?.filter(facility =>
           facility?.requestSettings?.some(
             setting =>
@@ -148,6 +140,19 @@ export async function getLocationsByTypeOfCareAndSiteIds({
           ),
         )
         ?.map(facility => facility.id) || [];
+
+    // Fetch facilities that support direct scheduling and filter
+    // only those that support the selected type of care
+    const directFacilityIds = directSchedulingEnabled
+      ? criteria[1]
+          ?.filter(facility =>
+            facility?.coreSettings?.some(
+              setting =>
+                setting.id === typeOfCareId && !!setting.patientHistoryRequired,
+            ),
+          )
+          ?.map(facility => facility.id) || []
+      : [];
 
     const uniqueIds = Array.from(
       new Set([...directFacilityIds, ...requestFacilityIds]),

--- a/src/applications/vaos/tests/services/location/index.unit.spec.js
+++ b/src/applications/vaos/tests/services/location/index.unit.spec.js
@@ -186,7 +186,7 @@ describe('VAOS Location service', () => {
       expect('directSchedulingSupported' in data[0].legacyVAR).to.equal(true);
     });
 
-    it('should make skip direct booking fetch if direct scheduling disabled', async () => {
+    it('should skip direct booking fetch if direct scheduling disabled', async () => {
       mockFetch();
       setFetchJSONResponse(global.fetch, requestEligbilityCriteria);
       setFetchJSONResponse(global.fetch.onCall(1), facilityDetails);

--- a/src/applications/vaos/tests/services/location/index.unit.spec.js
+++ b/src/applications/vaos/tests/services/location/index.unit.spec.js
@@ -6,14 +6,17 @@ import {
 } from 'platform/testing/unit/helpers';
 
 import {
-  getLocations,
-  getLocation,
-  getSupportedLocationsByTypeOfCare,
-  getParentOfLocation,
   getFacilityIdFromLocation,
+  getLocation,
+  getLocations,
+  getLocationsByTypeOfCareAndSiteIds,
+  getParentOfLocation,
+  getSupportedLocationsByTypeOfCare,
 } from '../../../services/location';
 import facilities983 from '../../../services/mocks/var/facilities_983.json';
 import facilityDetails from '../../../services/mocks/var/facility_data.json';
+import requestEligbilityCriteria from '../../../services/mocks/var/request_eligibility_criteria.json';
+import directBookingEligbilityCriteria from '../../../services/mocks/var/direct_booking_eligibility_criteria.json';
 import { VHA_FHIR_ID } from '../../../utils/constants';
 
 describe('VAOS Location service', () => {
@@ -145,6 +148,85 @@ describe('VAOS Location service', () => {
 
       expect(global.fetch.firstCall.args[0]).to.contain(
         '/facilities/va/vha_442',
+      );
+      expect(error?.resourceType).to.equal('OperationOutcome');
+    });
+  });
+
+  describe('getLocationsByTypeOfCareAndSiteIds', () => {
+    let data;
+
+    it('should make 3 successful requests', async () => {
+      mockFetch();
+      setFetchJSONResponse(global.fetch, requestEligbilityCriteria);
+      setFetchJSONResponse(
+        global.fetch.onCall(1),
+        directBookingEligbilityCriteria,
+      );
+      setFetchJSONResponse(global.fetch.onCall(2), facilityDetails);
+
+      data = await getLocationsByTypeOfCareAndSiteIds({
+        typeOfCareId: '323',
+        siteIds: ['983', '984'],
+        directSchedulingEnabled: true,
+      });
+
+      expect(global.fetch.firstCall.args[0]).to.contain(
+        '/request_eligibility_criteria?parent_sites[]=983&parent_sites[]=984',
+      );
+      expect(global.fetch.secondCall.args[0]).to.contain(
+        '/direct_booking_eligibility_criteria?parent_sites[]=983&parent_sites[]=984',
+      );
+      expect(global.fetch.thirdCall.args[0]).to.contain(
+        '/v1/facilities/va?ids=vha_442GD,vha_442GC,vha_442HK,vha_442,vha_442GB,vha_552,vha_552GA,vha_552GB',
+      );
+      expect(data[0].resourceType).to.equal('Location');
+      expect(data[0].name).to.equal('Cheyenne VA Medical Center');
+      expect('requestSupported' in data[0].legacyVAR).to.equal(true);
+      expect('directSchedulingSupported' in data[0].legacyVAR).to.equal(true);
+    });
+
+    it('should make skip direct booking fetch if direct scheduling disabled', async () => {
+      mockFetch();
+      setFetchJSONResponse(global.fetch, requestEligbilityCriteria);
+      setFetchJSONResponse(global.fetch.onCall(1), facilityDetails);
+
+      data = await getLocationsByTypeOfCareAndSiteIds({
+        typeOfCareId: '323',
+        siteIds: ['983', '984'],
+        directSchedulingEnabled: false,
+      });
+
+      expect(global.fetch.firstCall.args[0]).to.contain(
+        '/request_eligibility_criteria?parent_sites[]=983&parent_sites[]=984',
+      );
+      expect(global.fetch.secondCall.args[0]).to.contain(
+        '/v1/facilities/va?ids=',
+      );
+      expect(data[0].resourceType).to.equal('Location');
+      expect('requestSupported' in data[0].legacyVAR).to.equal(true);
+      expect('directSchedulingSupported' in data[0].legacyVAR).to.equal(true);
+    });
+
+    it('should return OperationOutcome error', async () => {
+      mockFetch();
+      setFetchJSONFailure(global.fetch, {
+        errors: [],
+      });
+
+      let error;
+      try {
+        data = await getLocationsByTypeOfCareAndSiteIds({
+          typeOfCareId: '323',
+          siteIds: ['983', '984'],
+          directSchedulingEnabled: true,
+        });
+      } catch (e) {
+        error = e;
+      }
+
+      expect(global.fetch.firstCall.args[0]).to.contain(
+        '/request_eligibility_criteria?parent_sites[]=983&parent_sites[]=984',
       );
       expect(error?.resourceType).to.equal('OperationOutcome');
     });


### PR DESCRIPTION
## Description
This PR checks the direct scheduling enabled feature toggle and skips the call to `/direct_booking_eligibility_criteria` if the toggle is disabled.

## Testing done
Local and unit tests


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
