### PR TITLE
[Resources and support] Remove page number from breadcrumbs in article listings

### DIFF
--- a/src/site/stages/build/plugins/create-resources-and-support-section.js
+++ b/src/site/stages/build/plugins/create-resources-and-support-section.js
@@ -215,15 +215,6 @@ function createPaginatedArticleListings({
             },
           };
 
-          if (index > 0) {
-            page.entityUrl.breadcrumb.push({
-              url: {
-                path: `/${pageOfArticles.uri}/`,
-              },
-              text: index + 1,
-            });
-          }
-
           page.debug = JSON.stringify(page);
 
           return page;


### PR DESCRIPTION
## Description
This PR removes the page number from the breadrcrumbs on the article listings pages of the new resources and support section. 

https://github.com/department-of-veterans-affairs/va.gov-team/issues/15730
## Testing done
Visually confirmed breadcrumb is gone

## Screenshots

### the problem
![image](https://user-images.githubusercontent.com/43381063/98017225-f53ece80-1dcc-11eb-8bb1-68b3f185494d.png)


## Acceptance criteria
- [ ] Page number is not a breadcrumb

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
