### PR TITLE
[Development] HLR updates

### DIFF
--- a/src/applications/disability-benefits/996/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/components/IntroductionPage.jsx
@@ -95,11 +95,8 @@ export class IntroductionPage extends React.Component {
   };
 
   getCallToActionContent = () => {
-    const { route, contestableIssues, allowHlr, testHlr } = this.props;
-    // check feature flag
-    if (!(allowHlr || testHlr)) {
-      return showWorkInProgress;
-    }
+    const { route, contestableIssues } = this.props;
+
     if (contestableIssues?.error) {
       return showContestableIssueError(contestableIssues.error);
     }
@@ -134,6 +131,17 @@ export class IntroductionPage extends React.Component {
   render() {
     const callToActionContent = this.getCallToActionContent();
     const showWizard = this.state.status !== WIZARD_STATUS_COMPLETE;
+
+    // check feature flag
+    if (!this.props.allowHlr) {
+      return (
+        <article className="schemaform-intro">
+          <FormTitle title="Request a Higher-Level Review" />
+          <p>Equal to VA Form 20-0996 (Higher-Level Review).</p>
+          <p>{showWorkInProgress}</p>
+        </article>
+      );
+    }
 
     return (
       <article className="schemaform-intro">

--- a/src/applications/disability-benefits/996/components/createHLRApplicationStatus.jsx
+++ b/src/applications/disability-benefits/996/components/createHLRApplicationStatus.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { VA_FORM_IDS } from 'platform/forms/constants';
+import { connectFeatureToggle } from 'platform/utilities/feature-toggles';
 
 const formIds = new Set([VA_FORM_IDS.FORM_20_0996]);
 
@@ -15,6 +16,8 @@ export default function createHigherLevelReviewApplicationStatus(
     import(/* webpackChunkName: "higher-level-review-application-status" */
     '../utils').then(module => {
       const { ApplicationStatus, WizardLink } = module.default;
+      connectFeatureToggle(store.dispatch);
+
       ReactDOM.render(
         <Provider store={store}>
           <ApplicationStatus

--- a/src/applications/disability-benefits/996/content/contestableIssueAlerts.jsx
+++ b/src/applications/disability-benefits/996/content/contestableIssueAlerts.jsx
@@ -48,7 +48,21 @@ export const showWorkInProgress = (
   <AlertBox
     status="info"
     headline="We’re still working on this feature"
-    content={`We’re rolling out the Higher-Level Review form in stages. It’s
-      not quite ready yet, so please check back again soon.`}
+    content={
+      <>
+        <p>
+          We’re rolling out the Higher-Level Review form in stages. It’s not
+          quite ready yet. Please check back again soon.
+        </p>
+        <p>
+          <a
+            href="/decision-reviews/higher-level-review/"
+            className="u-vads-display--block u-vads-margin-top--2"
+          >
+            Return to Higher-Level Review information page
+          </a>
+        </p>
+      </>
+    }
   />
 );

--- a/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
@@ -15,7 +15,7 @@ import {
 
 const defaultProps = {
   getContestableIssues: () => {},
-  testHlr: true,
+  allowHlr: true,
   user: {
     profile: {
       // need to have a saved form or else form will redirect to v2
@@ -60,6 +60,17 @@ describe('IntroductionPage', () => {
   afterEach(() => {
     global.window = oldWindow;
     sessionStorage.removeItem(WIZARD_STATUS);
+  });
+
+  it('should render a work in progress message', () => {
+    const tree = shallow(
+      <IntroductionPage {...defaultProps} allowHlr={false} />,
+    );
+
+    const AlertBox = tree.find('AlertBox');
+    expect(AlertBox.length).to.equal(1);
+    expect(AlertBox.props().headline).to.contain('working on this feature');
+    tree.unmount();
   });
 
   it('should render CallToActionWidget', () => {

--- a/src/applications/disability-benefits/996/wizard/WizardLink.jsx
+++ b/src/applications/disability-benefits/996/wizard/WizardLink.jsx
@@ -4,7 +4,7 @@ import { BASE_URL } from '../constants';
 
 const WizardLink = (
   <>
-    <h4>Online</h4>
+    <h3 className="vads-u-font-size--h4">Online</h3>
     <p>
       To request a Higher-Level Review for compensation claims, you can use our
       online request tool. This online option is only available for disability


### PR DESCRIPTION
## Description

Higher-Level Review form updates

- Only show a work-in-progress alert when the feature flag is disabled; previously the introduction page content was shown with no start form buttons
- Ensure link button, to be added to HLR info page, includes feature flag access

Related issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/15733

## Testing done

Updated unit tests

## Screenshots

<details><summary>WIP alert</summary>

<!-- leave a blank line above -->
This is only see when the HLR feature flag is disabled and the user somehow accesses the HLR page:

![Screen Shot 2020-11-03 at 10 54 46 AM](https://user-images.githubusercontent.com/136959/98019570-890d9c00-1dc7-11eb-9c23-d4e87cf5d6c1.png)</details>

## Acceptance criteria
- [x] Update content shown when feature flag is disabled
- [x] Add feature flag data to link to be added to HLR info page (Drupal content page)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
