### PR TITLE
Dont show 'is vet deceased' or 'date of death' fields when relationship=veteran

### DIFF
--- a/src/applications/ask-a-question/form/inquiry/status/veteranStatusUI.js
+++ b/src/applications/ask-a-question/form/inquiry/status/veteranStatusUI.js
@@ -20,11 +20,18 @@ const requireVetRelationship = selectedVeteranStatus =>
   selectedVeteranStatus === 'behalf of vet' ||
   selectedVeteranStatus === 'dependent';
 
+const requireDeathInfo = formData => {
+  const { veteranStatus, relationshipToVeteran } = formData.veteranStatus;
+
+  if (relationshipToVeteran === 'Veteran') {
+    return false;
+  }
+
+  return veteranStatus === 'dependent' || veteranStatus === 'behalf of vet';
+};
+
 export const requireServiceInfo = selectedVeteranStatus =>
   selectedVeteranStatus && selectedVeteranStatus !== 'general';
-
-const hideDateOfDeath = selectedVeteranStatus =>
-  selectedVeteranStatus === 'vet' || selectedVeteranStatus === 'general';
 
 export const veteranStatusUI = {
   'ui:description': veteranStatusSectionDescription,
@@ -53,11 +60,12 @@ export const veteranStatusUI = {
   [formFields.veteranIsDeceased]: {
     'ui:title': isDeceasedTitle,
     'ui:widget': 'yesNo',
-    'ui:required': formData =>
-      requireVetRelationship(formData.veteranStatus.veteranStatus),
+    'ui:required': requireDeathInfo,
     'ui:options': {
       expandUnder: 'veteranStatus',
-      expandUnderCondition: requireVetRelationship,
+      hideIf: formData => {
+        return !requireDeathInfo(formData);
+      },
     },
   },
   [formFields.dateOfDeath]: {
@@ -66,10 +74,11 @@ export const veteranStatusUI = {
       'ui:options': {
         expandUnder: 'veteranStatus',
         hideIf: formData => {
-          return !!(
-            hideDateOfDeath(formData.veteranStatus.veteranStatus) ||
-            !formData.veteranStatus.veteranIsDeceased
-          );
+          const showDateOfDeath =
+            formData.veteranStatus.veteranIsDeceased &&
+            requireDeathInfo(formData);
+
+          return !showDateOfDeath;
         },
       },
     },


### PR DESCRIPTION
## Description
[department-of-veterans-affairs/orchid#136] 

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
