### PR TITLE
Inprogress message fix

### DIFF
--- a/src/platform/forms-system/src/js/utilities/save-in-progress-messages.js
+++ b/src/platform/forms-system/src/js/utilities/save-in-progress-messages.js
@@ -5,7 +5,9 @@ const appType = formConfig =>
 
 export function inProgressMessage(formConfig) {
   const defaultMessage = `Your ${appType(formConfig)} is in progress.`;
-  return formConfig.saveInProgress?.messages?.inProgress || defaultMessage;
+  const message = formConfig.saveInProgress?.messages?.inProgress;
+
+  return typeof message === 'string' ? message : defaultMessage;
 }
 
 export function expiredMessage(formConfig) {

--- a/src/platform/forms-system/test/js/utilities/save-in-progress-messages.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/save-in-progress-messages.unit.spec.js
@@ -27,7 +27,7 @@ describe('inProgressMessage()', () => {
     expect(inProgressMessage(formConfig)).to.eql('Bippity boppity boo!');
   });
 
-  it('should allow the message to be null if an empty string is used', () => {
+  it('should not override an empty string with the default message', () => {
     const formConfig = {
       saveInProgress: {
         messages: {

--- a/src/platform/forms-system/test/js/utilities/save-in-progress-messages.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/save-in-progress-messages.unit.spec.js
@@ -1,0 +1,29 @@
+import { expect } from 'chai';
+
+import { inProgressMessage } from '../../../src/js/utilities/save-in-progress-messages';
+
+describe('inProgressMessage()', () => {
+  it('should return a default message when the message is not set', () => {
+    const formConfig = {
+      saveInProgress: {
+        messages: {},
+      },
+    };
+
+    expect(inProgressMessage(formConfig)).to.eql(
+      'Your application is in progress.',
+    );
+  });
+
+  it('should return a message from the formConfig when properly set', () => {
+    const formConfig = {
+      saveInProgress: {
+        messages: {
+          inProgress: 'Bippity boppity boo!',
+        },
+      },
+    };
+
+    expect(inProgressMessage(formConfig)).to.eql('Bippity boppity boo!');
+  });
+});

--- a/src/platform/forms-system/test/js/utilities/save-in-progress-messages.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/save-in-progress-messages.unit.spec.js
@@ -26,4 +26,16 @@ describe('inProgressMessage()', () => {
 
     expect(inProgressMessage(formConfig)).to.eql('Bippity boppity boo!');
   });
+
+  it('should allow the message to be null if an empty string is used', () => {
+    const formConfig = {
+      saveInProgress: {
+        messages: {
+          inProgress: '',
+        },
+      },
+    };
+
+    expect(inProgressMessage(formConfig)).to.eql('');
+  });
 });

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -8,7 +8,7 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation-react/Lo
 import { getNextPagePath } from 'platform/forms-system/src/js/routing';
 import {
   expiredMessage,
-  inProgressMessage,
+  inProgressMessage as getInProgressMessage,
 } from 'platform/forms-system/src/js/utilities/save-in-progress-messages';
 import recordEvent from 'platform/monitoring/record-event';
 import _ from 'platform/utilities/data';
@@ -56,6 +56,7 @@ class SaveInProgressIntro extends React.Component {
         const expiresAt = moment.unix(savedForm.metadata.expiresAt);
         const expirationDate = expiresAt.format('MMM D, YYYY');
         const isExpired = expiresAt.isBefore();
+        const inProgressMessage = getInProgressMessage(formConfig);
 
         if (!isExpired) {
           const lastSavedDateTime = savedAt.format('M/D/YYYY [at] h:mm a');
@@ -67,10 +68,14 @@ class SaveInProgressIntro extends React.Component {
                   <strong>Your {appType} is in progress</strong>
                 </div>
                 <div className="saved-form-metadata-container">
-                  <span className="saved-form-item-metadata">
-                    {inProgressMessage(formConfig)}
-                  </span>
-                  <br />
+                  {inProgressMessage && (
+                    <>
+                      <span className="saved-form-item-metadata">
+                        {inProgressMessage}
+                      </span>
+                      <br />
+                    </>
+                  )}
                   <span className="saved-form-item-metadata">
                     Your {appType} was last saved on {lastSavedDateTime}
                   </span>

--- a/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
@@ -602,4 +602,58 @@ describe('Schemaform <SaveInProgressIntro>', () => {
     );
     tree.unmount();
   });
+
+  it('should not render an inProgress message', () => {
+    const user = {
+      profile: {
+        savedForms: [
+          {
+            form: VA_FORM_IDS.FORM_10_10EZ,
+            metadata: {
+              lastUpdated: 946684800,
+              expiresAt: moment().unix() + 2000,
+            },
+          },
+        ],
+        prefillsAvailable: [],
+      },
+      login: {
+        currentlyLoggedIn: true,
+        loginUrls: {
+          idme: '/mockLoginUrl',
+        },
+      },
+    };
+
+    const emptyMessageConfig = {
+      saveInProgress: {
+        messages: {
+          inProgress: '',
+        },
+      },
+    };
+
+    const tree = shallow(
+      <SaveInProgressIntro
+        saveInProgress={{ formData: {} }}
+        pageList={pageList}
+        formId="1010ez"
+        user={user}
+        prefillEnabled
+        hideUnauthedStartLink
+        fetchInProgressForm={fetchInProgressForm}
+        removeInProgressForm={removeInProgressForm}
+        toggleLoginModal={toggleLoginModal}
+        startMessageOnly
+        unauthStartText="Custom message displayed to non-signed-in users"
+        formConfig={emptyMessageConfig}
+      />,
+    );
+    expect(tree.find('.saved-form-item-metadata')).to.have.lengthOf(1);
+    expect(tree.find('.saved-form-metadata-container').text()).to.not.contain(
+      'Your application is in progress',
+    );
+
+    tree.unmount();
+  });
 });


### PR DESCRIPTION
## Description

### Fixes department-of-veterans-affairs/va.gov-team/issues/15735

This allows the "in progress" part of the save-in-progress messaging to be disabled. This can be done by setting `formConfig.saveInProgress.messages.inProgress` to the empty string.


## Testing done

Unit tests added


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
