### PR TITLE
added accessibility tags for express care exclusions

### DIFF
--- a/src/applications/vaos/express-care/components/ExpressCareInfoPage.jsx
+++ b/src/applications/vaos/express-care/components/ExpressCareInfoPage.jsx
@@ -67,13 +67,16 @@ function ExpressCareInfoPage({
         className="vads-u-margin-top--0p5 vads-u-margin-bottom--4"
         isVisible
       >
-        <p>
+        <p id="vaos-ecip-call-911" data-testid="p_vaos-ecip-call-911">
           <strong>
             Call <a href="tel:911">911</a> or go to the nearest emergency room
             now if you have any of these symptoms:
           </strong>
         </p>
-        <ul>
+        <ul
+          aria-labelledby="vaos-ecip-call-911"
+          data-testid="ul_vaos-ecip-call-911"
+        >
           <li>Major bleeding or trauma</li>
           <li>Chest pain with shortness of breath</li>
           <li>Sudden inability to speak or walk</li>
@@ -86,10 +89,10 @@ function ExpressCareInfoPage({
           For emergencies, you don’t need a VA referral or approval to go a
           non-VA ER in your community.
         </p>
-        <p>
+        <p id="vaos-ecip-talk" data-testid="p_vaos-ecip-talk">
           <strong>If you need to talk to someone right now:</strong>
         </p>
-        <ul>
+        <ul aria-labelledby="vaos-ecip-talk" data-testid="ul_vaos-ecip-talk">
           <li>
             Call our Veterans Crisis Line at{' '}
             <a href="tel:800-273-8255">800-273-8255</a> and select 1.

--- a/src/applications/vaos/tests/express-care/components/ExpressCareInfoPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/express-care/components/ExpressCareInfoPage.unit.spec.jsx
@@ -52,6 +52,21 @@ describe('VAOS integration: Express Care info page', () => {
 
     expect(await screen.findByText(/How Express Care Works/i)).to.exist;
     expect(
+      await screen.findByText(/Express Care can’t provide emergency help/i),
+    ).to.exist;
+    expect(screen.getByTestId('p_vaos-ecip-call-911')).to.have.id(
+      'vaos-ecip-call-911',
+    );
+    expect(screen.getByTestId('ul_vaos-ecip-call-911')).to.have.attr(
+      'aria-labelledby',
+      'vaos-ecip-call-911',
+    );
+    expect(screen.getByTestId('p_vaos-ecip-talk')).to.have.id('vaos-ecip-talk');
+    expect(screen.getByTestId('ul_vaos-ecip-talk')).to.have.attr(
+      'aria-labelledby',
+      'vaos-ecip-talk',
+    );
+    expect(
       screen.getByText(
         new RegExp(
           `You can request Express Care today between ${startTime.format(


### PR DESCRIPTION
## Description
Accessible attributes `aria-labelledby` were added to the Express Care information page to ensure screen readers would be able to read the list of symptoms not appropriate for an Express Care appointment, but instead require immediate action (i.e. phoning 911).

*Note* There were six Axe issues found that are unrelated to this change.

## Testing done
Unit tests were updated to reflect this change.
The Axe (v4.6.1 core 4.0.2) browser tool was used to scan the associated page (http://.../health-care/schedule-view-va-appointments/appointments/new-express-care-request)

## Acceptance criteria
Lists are read aloud by the <p> tag text by screen readers
Zero axe-core violations detected

## Definition of done
https://github.com/department-of-veterans-affairs/va.gov-team/issues/15102

