### PR TITLE
[package.json] Bump Formation to 6.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -276,7 +276,7 @@
   },
   "private": true,
   "dependencies": {
-    "@department-of-veterans-affairs/formation": "6.9.5",
+    "@department-of-veterans-affairs/formation": "6.10.1",
     "@department-of-veterans-affairs/formation-react": "5.7.6",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "@fortawesome/fontawesome-free": "^5.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1266,10 +1266,10 @@
     react-focus-lock "^2.4.0"
     react-transition-group "1"
 
-"@department-of-veterans-affairs/formation@6.9.5":
-  version "6.9.5"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-6.9.5.tgz#65b13afec4a3f6a5368670f6f63f93e2c6cb170c"
-  integrity sha512-IbaxZwETnyyHPOjsOXa+dvV8pJw5zJfVeGdjrl3tbTjyL7gAzuo8/ZCNNvFlRajI9gJ5pIewtgJsrr09dDs2lQ==
+"@department-of-veterans-affairs/formation@6.10.1":
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-6.10.1.tgz#299bf553fbf3c722ca43af0c13ab838611601cd7"
+  integrity sha512-2JVyiIDtk5Mm6iSFRMMOBeyJb8P53NNdcrteM6WeiLdjGtDWPC5mkJl3hdrq9p5MX6DSsVlfzZiN+aZmZ25QrA==
   dependencies:
     "@fortawesome/fontawesome-free" "^5.6.3"
     domready "^1.0.8"


### PR DESCRIPTION
## Description
This PR bumps Formation to fix an issue with the `flex-basis` property being outputted without a unit specified - a flat `0` would be outputted, breaking the display for IE. Other browsers accept the zero value.

https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/commit/5d9fda60b1f54ad7a36d30d23912e2651fa743f8

https://github.com/department-of-veterans-affairs/va.gov-team/issues/15610

## Testing done
Via developer tools, inspected the element with the erroneous rule

## Screenshots

### Issue in IE
![image.png](https://images.zenhubusercontent.com/59cb9de1b0222d5de47953d8/f838f584-3e82-422b-be6c-4bbf5d28b7a4)

### Fixed
![image](https://user-images.githubusercontent.com/1915775/98041645-47ddb200-1df0-11eb-8c62-1f4111e79dc3.png)

## Acceptance criteria
- [ ] Visual issue is fixed in IE

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
