### PR TITLE
[Templates] Add an ID to accordion items

### DIFF
--- a/src/site/paragraphs/collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/collapsible_panel.drupal.liquid
@@ -30,7 +30,7 @@
     <ul class="usa-unstyled-list">
         {% for accordionItem in entity.fieldVaParagraphs %}
             {% assign item = accordionItem.entity %}
-            <li data-entity-id="{{ item.entityId }}">
+            <li id="{{ item.fieldTitle | truncate: 30 | handleize }}--{{ item.entityId }}" data-entity-id="{{ item.entityId }}">
                 <button
                         class="usa-accordion-button usa-button-unstyled"
                         aria-expanded="{{ entity.fieldCollapsiblePanelExpand }}"

--- a/src/site/paragraphs/collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/collapsible_panel.drupal.liquid
@@ -30,7 +30,7 @@
     <ul class="usa-unstyled-list">
         {% for accordionItem in entity.fieldVaParagraphs %}
             {% assign item = accordionItem.entity %}
-            <li id="{{ item.fieldTitle | truncate: 30 | handleize }}--{{ item.entityId }}" data-entity-id="{{ item.entityId }}">
+            <li id="{{ item.entityId }}" data-entity-id="{{ item.entityId }}">
                 <button
                         class="usa-accordion-button usa-button-unstyled"
                         aria-expanded="{{ entity.fieldCollapsiblePanelExpand }}"

--- a/src/site/paragraphs/q_a.collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/q_a.collapsible_panel.drupal.liquid
@@ -21,7 +21,7 @@
     <ul class="usa-unstyled-list">
         {% for accordionItem in questions %}
           {% assign item = accordionItem.entity %}
-          <li>
+          <li id="{{ item.fieldQuestion | truncate: 30 | handleize }}--{{ item.entityId }}">
           <div itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
             <button class="usa-accordion-button usa-button-unstyled" aria-controls="{{ item.entityBundle }}-{{ item.entityId }}">
               <span itemprop="name">{{ item.fieldQuestion }}</span>

--- a/src/site/paragraphs/q_a.collapsible_panel.drupal.liquid
+++ b/src/site/paragraphs/q_a.collapsible_panel.drupal.liquid
@@ -21,7 +21,7 @@
     <ul class="usa-unstyled-list">
         {% for accordionItem in questions %}
           {% assign item = accordionItem.entity %}
-          <li id="{{ item.fieldQuestion | truncate: 30 | handleize }}--{{ item.entityId }}">
+          <li id="{{ item.entityId }}">
           <div itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
             <button class="usa-accordion-button usa-button-unstyled" aria-controls="{{ item.entityBundle }}-{{ item.entityId }}">
               <span itemprop="name">{{ item.fieldQuestion }}</span>


### PR DESCRIPTION
## Description
This PR adds IDs to the `<li>` elements in accordions, so that we can link to certain accordion items. Later, we should update the accordion's JS to auto-expand the item by the URL's hash.

## Testing done
I inspected the DOM across various pages to confirm IDs were added 

## Screenshots
### http://localhost:3001/decision-reviews/higher-level-review/
![image](https://user-images.githubusercontent.com/1915775/98047604-339eb280-1dfa-11eb-837b-df94860c8d8c.png)


### http://localhost:3001/health-care/about-va-health-benefits/
![image](https://user-images.githubusercontent.com/1915775/98047918-c8091500-1dfa-11eb-99d1-71be153cd4cf.png)


## Acceptance criteria
- [ ] Accordion items are linkable 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
