### PR TITLE
Add new ~ Babel alias

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -51,6 +51,7 @@
       {
         "root": "./src",
         "alias": {
+          "~": "./src",
           "@@vap-svc": "./src/platform/user/profile/vap-svc",
           "@@profile": "./src/applications/personalization/profile"
         }

--- a/jsconfig-example.json
+++ b/jsconfig-example.json
@@ -5,7 +5,9 @@
     "baseUrl": ".",
     "paths": {
       "*": ["*", "src/*"],
-      "vet360/*": ["./src/platform/user/profile/vet360/*"]
+      "~/*": ["./src/*"],
+      "@@profile/*": ["./src/applications/personalization/profile/*"],
+      "@@vap-svc/*": ["./src/platform/user/profile/vap-svc/*"]
     },
     // adding this line allows you to ⌘click JSX imports to open the source
     "jsx": "react",

--- a/src/applications/personalization/profile/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile/components/ProfileWrapper.jsx
@@ -4,8 +4,9 @@ import PropTypes from 'prop-types';
 import { Link, useLocation } from 'react-router-dom';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import Breadcrumbs from '@department-of-veterans-affairs/formation-react/Breadcrumbs';
-import { isWideScreen } from 'platform/utilities/accessibility/index';
-import { selectProfile } from 'platform/user/selectors';
+
+import { isWideScreen } from '~/platform/utilities/accessibility/index';
+import { selectProfile } from '~/platform/user/selectors';
 
 import {
   directDepositLoadError,


### PR DESCRIPTION
## Description
Based on [the conversation in this PR](https://github.com/department-of-veterans-affairs/va.gov-team/pull/15591) we decided to add a new `~` Babel alias that stands in for `./src` to make our imports from `applications/`, `platform/`, and `site/` a little clearer.

## Testing done
Existing tests

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs