### PR TITLE
Modified to display warning notification when pager duty notification…

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/index.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/index.jsx
@@ -29,6 +29,10 @@ import FutureAppointmentsList from '../FutureAppointmentsList';
 import PastAppointmentsList from '../PastAppointmentsList';
 import ExpressCareList from '../ExpressCareList';
 import PageLayout from './PageLayout';
+import DowntimeNotification, {
+  externalServices,
+} from 'platform/monitoring/DowntimeNotification';
+import WarningNotification from '../../../components/WarningNotification';
 
 const pageTitle = 'VA appointments';
 
@@ -104,6 +108,15 @@ function AppointmentsPage({
   return (
     <PageLayout>
       <h1 className="vads-u-flex--1">{pageTitle}</h1>
+      <DowntimeNotification
+        appTitle="VA online scheduling tool"
+        isReady
+        dependencies={[externalServices.vaosWarning]}
+        render={(props, childContent) => (
+          <WarningNotification {...props}>{childContent}</WarningNotification>
+        )}
+      />
+
       {showScheduleButton && (
         <ScheduleNewAppointment
           isCernerOnlyPatient={isCernerOnlyPatient}

--- a/src/applications/vaos/components/WarningNotification.jsx
+++ b/src/applications/vaos/components/WarningNotification.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import externalServiceStatus from 'platform/monitoring/DowntimeNotification/config/externalServiceStatus';
+
+export default function WarningNotification({ status }) {
+  if (status === externalServiceStatus.down) {
+    return (
+      <AlertBox
+        className="vads-u-margin-bottom--4"
+        headline={`You may have trouble using the VA appointments tool right now.`}
+        isVisible
+        status="warning"
+      >
+        <p>
+          Some Veterans have reported problems with viewing, scheduling, or
+          canceling their appointments. We’re working to fix the issue now.
+        </p>
+        <p>
+          {' '}
+          If you have trouble using this tool, call your VA health facility or
+          community care provider.{' '}
+          <a href="/find-locations">
+            Find your health facility or provider’s phone number
+          </a>
+        </p>
+      </AlertBox>
+    );
+  }
+  return null;
+}

--- a/src/applications/vaos/express-care/components/FormLayout.jsx
+++ b/src/applications/vaos/express-care/components/FormLayout.jsx
@@ -1,15 +1,30 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import NeedHelp from '../../components/NeedHelp';
 import ErrorBoundary from '../../components/ErrorBoundary';
+import DowntimeNotification, {
+  externalServices,
+} from 'platform/monitoring/DowntimeNotification';
+import WarningNotification from '../../components/WarningNotification';
 
 export default function FormLayout({ children }) {
+  const location = useLocation();
   return (
     <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--8">
       <Breadcrumbs>
         <Link to="new-express-care-request">Express Care request</Link>
       </Breadcrumbs>
+      {location.pathname.endsWith('new-express-care-request') && (
+        <DowntimeNotification
+          appTitle="VA online scheduling tool"
+          isReady
+          dependencies={[externalServices.vaosWarning]}
+          render={(props, childContent) => (
+            <WarningNotification {...props}>{childContent}</WarningNotification>
+          )}
+        />
+      )}
       <div className="vads-l-row">
         <div className="vads-l-col--12 medium-screen:vads-l-col--8">
           <span className="vaos-form__title vaos-u-margin-bottom--1 vads-u-font-size--sm vads-u-font-weight--normal vads-u-font-family--sans">

--- a/src/applications/vaos/new-appointment/components/FormLayout.jsx
+++ b/src/applications/vaos/new-appointment/components/FormLayout.jsx
@@ -1,15 +1,29 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import Breadcrumbs from '../../components/Breadcrumbs';
 import NeedHelp from '../../components/NeedHelp';
 import ErrorBoundary from '../../components/ErrorBoundary';
+import DowntimeNotification, {
+  externalServices,
+} from 'platform/monitoring/DowntimeNotification';
+import WarningNotification from '../../components/WarningNotification';
 
 export default function FormLayout({ children, isReviewPage }) {
+  const location = useLocation();
   return (
     <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2">
       <Breadcrumbs>
         <Link to="new-appointment">New appointment</Link>
       </Breadcrumbs>
+      {location.pathname.endsWith('new-appointment') && (
+        <DowntimeNotification
+          appTitle="VA online scheduling tool"
+          dependencies={[externalServices.vaosWarning]}
+          render={(props, childContent) => (
+            <WarningNotification {...props}>{childContent}</WarningNotification>
+          )}
+        />
+      )}
       <div className="vads-l-row">
         <div className="vads-l-col--12 medium-screen:vads-l-col--8">
           {!isReviewPage && (

--- a/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/index.unit.spec.jsx
@@ -8,6 +8,7 @@ import {
   setFetchJSONFailure,
   mockFetch,
   resetFetch,
+  setFetchJSONResponse,
 } from 'platform/testing/unit/helpers';
 import {
   getVARequestMock,
@@ -22,7 +23,10 @@ import {
   mockFacilitiesFetch,
   mockRequestEligibilityCriteria,
 } from '../../../mocks/helpers';
-import { renderWithStoreAndRouter } from '../../../mocks/setup';
+import {
+  createTestStore,
+  renderWithStoreAndRouter,
+} from '../../../mocks/setup';
 
 import reducers from '../../../../redux/reducer';
 import FutureAppointmentsList from '../../../../appointment-list/components/FutureAppointmentsList';
@@ -588,5 +592,36 @@ describe('VAOS integration: appointment list', () => {
         selected: false,
       }),
     ).to.have.attribute('tabindex', '-1');
+  });
+
+  it('should render warning message', async () => {
+    setFetchJSONResponse(
+      global.fetch.withArgs(`${environment.API_URL}/v0/maintenance_windows/`),
+      {
+        data: [
+          {
+            id: '139',
+            type: 'maintenance_windows',
+            attributes: {
+              externalService: 'vaosWarning',
+              description: 'My description',
+              startTime: moment.utc().subtract('1', 'days'),
+              endTime: moment.utc().add('1', 'days'),
+            },
+          },
+        ],
+      },
+    );
+    const store = createTestStore(initialState);
+    const screen = renderWithStoreAndRouter(<AppointmentsPage />, {
+      store,
+    });
+
+    expect(
+      await screen.findByRole('heading', {
+        level: '3',
+        name: /You may have trouble using the VA appointments tool right now/,
+      }),
+    ).to.exist;
   });
 });

--- a/src/applications/vaos/tests/express-care/components/ExpressCareInfoPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/express-care/components/ExpressCareInfoPage.unit.spec.jsx
@@ -7,6 +7,7 @@ import {
   mockFetch,
   resetFetch,
   setFetchJSONFailure,
+  setFetchJSONResponse,
 } from 'platform/testing/unit/helpers';
 import { setupExpressCareMocks } from '../../mocks/helpers';
 import ExpressCareInfoPage from '../../../express-care/components/ExpressCareInfoPage';
@@ -129,5 +130,36 @@ describe('VAOS integration: Express Care info page', () => {
 
     await waitFor(() => expect(screen.history.push.called).to.be.true);
     expect(screen.history.push.firstCall.args[0]).to.equal('/');
+  });
+
+  it('should render warning message', async () => {
+    setFetchJSONResponse(
+      global.fetch.withArgs(`${environment.API_URL}/v0/maintenance_windows/`),
+      {
+        data: [
+          {
+            id: '139',
+            type: 'maintenance_windows',
+            attributes: {
+              externalService: 'vaosWarning',
+              description: 'My description',
+              startTime: moment.utc().subtract('1', 'days'),
+              endTime: moment.utc().add('1', 'days'),
+            },
+          },
+        ],
+      },
+    );
+    const store = createTestStore(initialState);
+    const screen = renderWithStoreAndRouter(<NewExpressCareRequest />, {
+      store,
+    });
+
+    expect(
+      await screen.findByRole('heading', {
+        level: '3',
+        name: /You may have trouble using the VA appointments tool right now/,
+      }),
+    ).to.exist;
   });
 });

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfCarePage.unit.spec.jsx
@@ -5,7 +5,11 @@ import { fireEvent, waitFor } from '@testing-library/dom';
 import { cleanup } from '@testing-library/react';
 
 import set from 'platform/utilities/data/set';
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import {
+  mockFetch,
+  resetFetch,
+  setFetchJSONResponse,
+} from 'platform/testing/unit/helpers';
 
 import { getParentSiteMock } from '../../mocks/v0';
 import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
@@ -15,6 +19,9 @@ import {
 } from '../../mocks/helpers';
 
 import TypeOfCarePage from '../../../new-appointment/components/TypeOfCarePage';
+import { NewAppointment } from '../../../new-appointment';
+import moment from 'moment';
+import environment from 'platform/utilities/environment';
 
 const initialState = {
   featureToggles: {
@@ -268,5 +275,36 @@ describe('VAOS <TypeOfCarePage>', () => {
     });
 
     expect(screen.queryByText(/You need to have a home address/i)).to.not.exist;
+  });
+
+  it('should render warning message', async () => {
+    setFetchJSONResponse(
+      global.fetch.withArgs(`${environment.API_URL}/v0/maintenance_windows/`),
+      {
+        data: [
+          {
+            id: '139',
+            type: 'maintenance_windows',
+            attributes: {
+              externalService: 'vaosWarning',
+              description: 'My description',
+              startTime: moment.utc().subtract('1', 'days'),
+              endTime: moment.utc().add('1', 'days'),
+            },
+          },
+        ],
+      },
+    );
+    const store = createTestStore(initialState);
+    const screen = renderWithStoreAndRouter(<NewAppointment />, {
+      store,
+    });
+
+    expect(
+      await screen.findByRole('heading', {
+        level: '3',
+        name: /You may have trouble using the VA appointments tool right now/,
+      }),
+    ).to.exist;
   });
 });

--- a/src/platform/monitoring/DowntimeNotification/config/externalServices.js
+++ b/src/platform/monitoring/DowntimeNotification/config/externalServices.js
@@ -32,4 +32,6 @@ export default {
   search: 'search',
   // Online appointment scheduling
   vaos: 'vaos',
+  // Online appointment scheduling warning message
+  vaosWarning: 'vaosWarning',
 };


### PR DESCRIPTION
## Description
This change displays a warning notification to the end user when a Page Duty notification is received as opposed to displaying a downtime notification which shuts down the app. The warning notification are displayed on the main entry points only. i.e Appointment List, New Appointment (type of care), and Express Care pages.

## Testing done
Unit testing

## Screenshots
![Screen Shot 2020-11-03 at 5 38 07 PM](https://user-images.githubusercontent.com/3587066/98052406-c724b300-1dfb-11eb-8551-c4cc1b499059.png)
---
![Screen Shot 2020-11-03 at 5 37 52 PM](https://user-images.githubusercontent.com/3587066/98052414-cab83a00-1dfb-11eb-9f40-1bd775142526.png)
---
![Screen Shot 2020-11-03 at 5 37 32 PM](https://user-images.githubusercontent.com/3587066/98052421-ce4bc100-1dfb-11eb-966d-922ecee60e92.png)


## Acceptance criteria
- [ ] All unit test pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
