### PR TITLE
[Resources and support] Launch

### DIFF
--- a/src/site/stages/build/plugins/create-resources-and-support-section.js
+++ b/src/site/stages/build/plugins/create-resources-and-support-section.js
@@ -3,7 +3,6 @@
 const _ = require('lodash');
 const liquid = require('tinyliquid');
 
-const ENVIRONMENTS = require('../../../constants/environments');
 const { ENTITY_BUNDLES } = require('../../../constants/content-modeling');
 
 const { logDrupal } = require('../drupal/utilities-drupal');
@@ -335,11 +334,7 @@ function createSearchResults(files) {
   };
 }
 
-function createResourcesAndSupportWebsiteSection(buildOptions) {
-  if (buildOptions.buildtype === ENVIRONMENTS.VAGOVPROD) {
-    return () => {};
-  }
-
+function createResourcesAndSupportWebsiteSection() {
   return files => {
     excludeQaNodesThatAreNotStandalonePages(files);
     createArticleListingsPages(files);

--- a/src/site/stages/build/plugins/create-resources-and-support-section.js
+++ b/src/site/stages/build/plugins/create-resources-and-support-section.js
@@ -197,6 +197,7 @@ function createPaginatedArticleListings({
           });
 
           const page = {
+            private: true, // @todo remove this to enable indexing
             articleTypesByEntityBundle,
             contents: Buffer.from(''),
             path: pageOfArticles.uri,
@@ -334,11 +335,21 @@ function createSearchResults(files) {
   };
 }
 
+// @todo remove this to enable indexing
+function excludeFromSiteMap(files) {
+  const allArticles = getArticlesBelongingToResourcesAndSupportSection(files);
+
+  allArticles.forEach(article => {
+    article.private = true;
+  });
+}
+
 function createResourcesAndSupportWebsiteSection() {
   return files => {
     excludeQaNodesThatAreNotStandalonePages(files);
     createArticleListingsPages(files);
     createSearchResults(files);
+    excludeFromSiteMap(files);
   };
 }
 


### PR DESCRIPTION
## Description
This PR removes the prod flag from the build step for generating some Resources and Support pages - the article listings and the search. 

## Testing done
This will just apply the same behavior to prod that we already have in local/dev/staging

## Screenshots
N/A

## Acceptance criteria
- [ ] Resources and support is prepared to launch

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
