### PR TITLE
Rename `isVet360Configured` to `isVAProfileServiceConfigured`

### DIFF
--- a/src/applications/debt-letters/actions/index.js
+++ b/src/applications/debt-letters/actions/index.js
@@ -1,6 +1,6 @@
 import { apiRequest } from 'platform/utilities/api';
 import environment from 'platform/utilities/environment';
-import { isVet360Configured } from '@@vap-svc/util/local-vet360';
+import { isVAProfileServiceConfigured } from '@@vap-svc/util/local-vapsvc';
 import recordEvent from 'platform/monitoring/record-event';
 
 import {
@@ -54,7 +54,7 @@ export const fetchDebtLettersVBMS = () => async dispatch => {
         'Source-App-Name': window.appName,
       },
     };
-    const response = isVet360Configured()
+    const response = isVAProfileServiceConfigured()
       ? await apiRequest(`${environment.API_URL}/v0/debt_letters`, options)
       : await debtLettersSuccessVBMS();
 
@@ -89,7 +89,7 @@ export const fetchDebtLetters = () => async dispatch => {
         'Source-App-Name': window.appName,
       },
     };
-    const response = isVet360Configured()
+    const response = isVAProfileServiceConfigured()
       ? await apiRequest(`${environment.API_URL}/v0/debts`, options)
       : await debtLettersSuccess();
 

--- a/src/applications/debt-letters/actions/index.js
+++ b/src/applications/debt-letters/actions/index.js
@@ -1,7 +1,7 @@
-import { apiRequest } from 'platform/utilities/api';
-import environment from 'platform/utilities/environment';
+import recordEvent from '~/platform/monitoring/record-event';
+import { apiRequest } from '~/platform/utilities/api';
+import environment from '~/platform/utilities/environment';
 import { isVAProfileServiceConfigured } from '@@vap-svc/util/local-vapsvc';
-import recordEvent from 'platform/monitoring/record-event';
 
 import {
   debtLettersSuccess,

--- a/src/applications/financial-status-report/actions/index.js
+++ b/src/applications/financial-status-report/actions/index.js
@@ -8,7 +8,7 @@ import {
   FSR_RESET_ERRORS,
   FSR_API_CALL_INITIATED,
 } from '../constants';
-import { isVet360Configured } from '@@vap-svc/util/local-vet360';
+import { isVAProfileServiceConfigured } from '@@vap-svc/util/local-vapsvc';
 import moment from 'moment';
 import head from 'lodash/head';
 import localStorage from 'platform/utilities/storage/localStorage';
@@ -79,7 +79,7 @@ export const fetchDebts = () => async dispatch => {
         'Source-App-Name': window.appName,
       },
     };
-    const response = isVet360Configured()
+    const response = isVAProfileServiceConfigured()
       ? await apiRequest(`${environment.API_URL}/v0/debts`, options)
       : await debtLettersSuccess();
 

--- a/src/applications/personalization/profile/README.md
+++ b/src/applications/personalization/profile/README.md
@@ -8,7 +8,7 @@ Staging test users for all sections are laid out in [this spreadsheet](https://d
 
 ## Contact info and the VA Profile service
 
-Contact info is powered by the VA Profile service (Slack Channel #va-profile) formerly known as Vet 360. You'll still see references to Vet 360 or just 360 in the code. It is not possible to connect to VA Profile through `vets-api` when running locally. All calls to update contact info are mocked entirely in the front end by short-circuiting API requests at the Redux action-creator level by making a call to the `isVet360Configured()` helper. `local-vet360.js` provides a lot of helper functions you can call from action creators to simulate different scenarios such as a failure.
+Contact info is powered by the VA Profile service (Slack Channel #va-profile) formerly known as Vet 360. You'll still see references to Vet 360 or just 360 in the code. It is not possible to connect to VA Profile through `vets-api` when running locally. All calls to update contact info are mocked entirely in the front end by short-circuiting API requests at the Redux action-creator level by making a call to the `isVAProfileServiceConfigured()` helper. `local-vapsvc.js` provides a lot of helper functions you can call from action creators to simulate different scenarios such as a failure.
 
 VA Profile is an asynchronous, transaction-based service. Making updates is a two step process. First, you create a transaction ("Please update the phone number to 555-123-1234") and get back a transaction ID. Then you check on the status of that transaction ("Have you finished with transaction ID ABC-123?") until it has resolved or failed.
 

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -4,9 +4,9 @@ import {
   setSentryLoginType,
   clearSentryLoginType,
 } from '../../authentication/utilities';
-import localStorage from 'platform/utilities/storage/localStorage';
+import localStorage from '~/platform/utilities/storage/localStorage';
 
-import { ssoKeepAliveSession } from 'platform/utilities/sso';
+import { ssoKeepAliveSession } from '~/platform/utilities/sso';
 
 import {
   ADDRESS_VALIDATION_TYPES,

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -16,9 +16,9 @@ import {
 } from '../constants/addressValidationMessages';
 
 import {
-  isVet360Configured,
+  isVAProfileServiceConfigured,
   mockContactInformation,
-} from '@@vap-svc/util/local-vet360';
+} from '@@vap-svc/util/local-vapsvc';
 
 const commonServices = {
   EMIS: 'EMIS',
@@ -84,7 +84,7 @@ export function mapRawUserDataToState(json) {
       last,
     },
     verified,
-    vet360: isVet360Configured()
+    vet360: isVAProfileServiceConfigured()
       ? vet360ContactInformation
       : mockContactInformation,
     session,

--- a/src/platform/user/profile/vap-svc/actions/transactions.js
+++ b/src/platform/user/profile/vap-svc/actions/transactions.js
@@ -4,7 +4,9 @@ import recordEvent from 'platform/monitoring/record-event';
 import { inferAddressType } from 'applications/letters/utils/helpers';
 import { showAddressValidationModal } from '../../utilities';
 
-import localVet360, { isVet360Configured } from '../util/local-vet360';
+import localVet360, {
+  isVAProfileServiceConfigured,
+} from '../util/local-vapsvc';
 import { CONFIRMED } from '../../constants/addressValidationMessages';
 import {
   isSuccessfulTransaction,
@@ -45,7 +47,7 @@ export function fetchTransactions() {
   return async dispatch => {
     try {
       let response;
-      if (isVet360Configured()) {
+      if (isVAProfileServiceConfigured()) {
         response = await apiRequest('/profile/status/');
       } else {
         response = { data: [] };
@@ -99,7 +101,7 @@ export function refreshTransaction(
       });
 
       const route = _route || `/profile/status/${transactionId}`;
-      const transactionRefreshed = isVet360Configured()
+      const transactionRefreshed = isVAProfileServiceConfigured()
         ? await apiRequest(route)
         : await localVet360.updateTransaction(transactionId);
 
@@ -158,7 +160,7 @@ export function createTransaction(
         method,
       });
 
-      const transaction = isVet360Configured()
+      const transaction = isVAProfileServiceConfigured()
         ? await apiRequest(route, options)
         : await localVet360.createTransaction();
 
@@ -213,7 +215,7 @@ export const validateAddress = (
   };
 
   try {
-    const response = isVet360Configured()
+    const response = isVAProfileServiceConfigured()
       ? await apiRequest('/profile/address_validation', options)
       : await localVet360.addressValidationSuccess();
     const { addresses, validationKey } = response;
@@ -337,7 +339,7 @@ export const updateValidationKeyAndSave = (
         'Content-Type': 'application/json',
       },
     };
-    const response = isVet360Configured()
+    const response = isVAProfileServiceConfigured()
       ? await apiRequest('/profile/address_validation', options)
       : await localVet360.addressValidationSuccess();
     const { validationKey } = response;

--- a/src/platform/user/profile/vap-svc/actions/transactions.js
+++ b/src/platform/user/profile/vap-svc/actions/transactions.js
@@ -1,7 +1,10 @@
-import { apiRequest } from 'platform/utilities/api';
-import { refreshProfile } from 'platform/user/profile/actions';
-import recordEvent from 'platform/monitoring/record-event';
-import { inferAddressType } from 'applications/letters/utils/helpers';
+import { apiRequest } from '~/platform/utilities/api';
+import { refreshProfile } from '~/platform/user/profile/actions';
+import recordEvent from '~/platform/monitoring/record-event';
+import { inferAddressType } from '~/applications/letters/utils/helpers';
+
+import { FIELD_NAMES, ADDRESS_POU } from '@@vap-svc/constants';
+
 import { showAddressValidationModal } from '../../utilities';
 
 import localVet360, {
@@ -12,7 +15,6 @@ import {
   isSuccessfulTransaction,
   isFailedTransaction,
 } from '../util/transactions';
-import { FIELD_NAMES, ADDRESS_POU } from '@@vap-svc/constants';
 
 export const VET360_TRANSACTIONS_FETCH_SUCCESS =
   'VET360_TRANSACTIONS_FETCH_SUCCESS';

--- a/src/platform/user/profile/vap-svc/selectors.js
+++ b/src/platform/user/profile/vap-svc/selectors.js
@@ -3,12 +3,12 @@ import backendServices from 'platform/user/profile/constants/backendServices';
 import { selectAvailableServices, selectVet360 } from 'platform/user/selectors';
 import { VET360_INITIALIZATION_STATUS, INIT_VET360_ID } from './constants';
 
-import { isVet360Configured } from './util/local-vet360';
+import { isVAProfileServiceConfigured } from './util/local-vapsvc';
 
 import { isFailedTransaction, isPendingTransaction } from './util/transactions';
 
 export function selectIsVet360AvailableForUser(state) {
-  if (!isVet360Configured()) return true; // returns true if on localhost
+  if (!isVAProfileServiceConfigured()) return true; // returns true if on localhost
   return selectAvailableServices(state).includes(backendServices.VET360);
 }
 

--- a/src/platform/user/profile/vap-svc/selectors.js
+++ b/src/platform/user/profile/vap-svc/selectors.js
@@ -1,6 +1,9 @@
-import backendServices from 'platform/user/profile/constants/backendServices';
+import backendServices from '~/platform/user/profile/constants/backendServices';
+import {
+  selectAvailableServices,
+  selectVet360,
+} from '~/platform/user/selectors';
 
-import { selectAvailableServices, selectVet360 } from 'platform/user/selectors';
 import { VET360_INITIALIZATION_STATUS, INIT_VET360_ID } from './constants';
 
 import { isVAProfileServiceConfigured } from './util/local-vapsvc';

--- a/src/platform/user/profile/vap-svc/tests/selectors.unit.spec.js
+++ b/src/platform/user/profile/vap-svc/tests/selectors.unit.spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import backendServices from 'platform/user/profile/constants/backendServices';
+import backendServices from '~/platform/user/profile/constants/backendServices';
 
 import {
   TRANSACTION_STATUS,

--- a/src/platform/user/profile/vap-svc/tests/selectors.unit.spec.js
+++ b/src/platform/user/profile/vap-svc/tests/selectors.unit.spec.js
@@ -41,7 +41,7 @@ const hooks = {
 describe('selectors', () => {
   describe('selectIsVet360AvailableForUser', () => {
     beforeEach(hooks.beforeEach);
-    it('returns true if vet660 is found in the profile.services list or when the environment is localhost', () => {
+    it('returns true if vet360 is found in the profile.services list or when the environment is localhost', () => {
       const old = { document: global.document };
       global.document = {
         location: {
@@ -55,7 +55,7 @@ describe('selectors', () => {
         'returns true when on localhost so the local mock Vet360 will run',
       ).to.be.true;
 
-      global.document.location.hostname = 'staging.vets.gov';
+      global.document.location.hostname = 'staging.va.gov';
       result = selectors.selectIsVet360AvailableForUser(state);
       expect(
         result,
@@ -308,7 +308,7 @@ describe('selectVet360InitializationStatus', () => {
     hooks.beforeEach();
     global.document = {
       location: {
-        hostname: 'staging.vets.gov',
+        hostname: 'staging.va.gov',
       },
     };
   });

--- a/src/platform/user/profile/vap-svc/util/local-vapsvc.js
+++ b/src/platform/user/profile/vap-svc/util/local-vapsvc.js
@@ -1,14 +1,12 @@
 import { uniqueId } from 'lodash';
 import * as VET360_CONSTANTS from '../constants';
 
-export function isVet360Configured() {
+export function isVAProfileServiceConfigured() {
   return (
     // using the existence of VetsGov.pollTimeout as an indicator that we are
     // running unit tests and therefore _do_ want the FE to make real API calls
     window.VetsGov.pollTimeout ||
     [
-      'staging.vets.gov',
-      'www.vets.gov',
       'dev.va.gov',
       'preview.va.gov',
       'staging.va.gov',


### PR DESCRIPTION
## Description
This PR is the third in a handful to remove mentions of vet360 in our code.

[PR 1 renamed the `vet360` folder to `vap-svc`](https://github.com/department-of-veterans-affairs/vets-website/pull/14798)
[PR 2 renamed the `vet360` Babel alias to `@@vap-svc`](https://github.com/department-of-veterans-affairs/vets-website/pull/14811)

This PR is focused on:
- renaming the `isVet360Configured` helper to `isVAProfileServiceConfigured`
- it also renames the `local-vet360.js` file to `local-vapsvc.js`

## Testing done
Local + existing tests

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs