### PR TITLE
PW-14347 Up to Top Button

### DIFF
--- a/src/applications/static-pages/sass/static-pages.scss
+++ b/src/applications/static-pages/sass/static-pages.scss
@@ -84,3 +84,40 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
     }
   }
 }
+
+//=============================
+// Up To Top Button Styles 
+//=============================
+.vsa-top-button-container {
+  bottom: 0;
+  left: 0;
+  pointer-events: none;
+  position: fixed;
+  width: 100%;
+
+  .usa-content {
+    position: relative;
+  }
+
+  .vsa-top-button {
+    bottom: 0;
+    margin: 0;
+    opacity: 0;
+    pointer-events: none;
+    position: absolute;
+    transition: opacity 200ms ease-in;
+    right: 0;
+  }
+
+  .vsa-top-button.vsa-top-button-transition-in {
+    pointer-events: all;
+    opacity: 1;
+    transform: translateY(-12px);
+  }
+
+  .vsa-top-button.vsa-top-button-transition-out {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+
+}

--- a/src/applications/static-pages/sass/static-pages.scss
+++ b/src/applications/static-pages/sass/static-pages.scss
@@ -94,6 +94,13 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
   pointer-events: none;
   position: fixed;
   width: 100%;
+  &.vsa-top-button-container-relative {
+    position: relative;
+  }
+
+  .usa-width-three-fourths.vsa-top-button-container-relative { 
+    width: 100%;
+  }
 
   .usa-content {
     position: relative;
@@ -105,19 +112,20 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
     opacity: 0;
     pointer-events: none;
     position: absolute;
-    transition: opacity 200ms ease-in;
+    transition: all 250ms ease-in;
     right: 0;
+    width: auto;
+    &.vsa-top-button-transition-in {
+      pointer-events: all;
+      opacity: 1;
+      transform: translateY(-12px);
+    }
+    &.vsa-top-button-transition-out {
+      opacity: 0;
+      transform: translateY(2px);
+    }
+    &.vsa-top-button-transition-reset {
+      transform: translateY(0px);
+    }
   }
-
-  .vsa-top-button.vsa-top-button-transition-in {
-    pointer-events: all;
-    opacity: 1;
-    transform: translateY(-12px);
-  }
-
-  .vsa-top-button.vsa-top-button-transition-out {
-    opacity: 0;
-    transform: translateY(24px);
-  }
-
 }

--- a/src/applications/static-pages/sass/static-pages.scss
+++ b/src/applications/static-pages/sass/static-pages.scss
@@ -86,7 +86,7 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
 }
 
 //=============================
-// Up To Top Button Styles 
+// Up To Top Button Styles
 //=============================
 .vsa-top-button-container {
   bottom: 0;
@@ -94,11 +94,11 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
   pointer-events: none;
   position: fixed;
   width: 100%;
-  &.vsa-top-button-container-relative {
+  &.va-top-button-container-relative {
     position: relative;
   }
 
-  .usa-width-three-fourths.vsa-top-button-container-relative { 
+  .usa-width-three-fourths.va-top-button-container-relative {
     width: 100%;
   }
 
@@ -115,16 +115,16 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
     transition: all 250ms ease-in;
     right: 0;
     width: auto;
-    &.vsa-top-button-transition-in {
+    &.va-top-button-transition-in {
       pointer-events: all;
       opacity: 1;
       transform: translateY(-12px);
     }
-    &.vsa-top-button-transition-out {
+    &.va-top-button-transition-out {
       opacity: 0;
       transform: translateY(2px);
     }
-    &.vsa-top-button-transition-reset {
+    &.va-top-button-transition-reset {
       transform: translateY(0px);
     }
   }

--- a/src/applications/static-pages/scroll-top-button.js
+++ b/src/applications/static-pages/scroll-top-button.js
@@ -5,48 +5,31 @@
  * html is located in src/site/components/up_to_top_button.html
  */
 
-let upToTopButton = '';
-let footer = '';
 let threeFourthsContainer = '';
+let footer = '';
 const container = document.querySelector('.vsa-top-button-container');
-
-function initVars() {
-  threeFourthsContainer = container.querySelector('.usa-width-three-fourths');
-  upToTopButton = container.querySelector('.vsa-top-button');
-  footer = document.querySelector('.footer-inner');
-  // NOTE: Guarded Return so button does not show at all with errors
-  if (!threeFourthsContainer || !upToTopButton || !footer)
-    return 'NODE_MISSING_CLASS';
-
-  return 'SUCCESS';
-}
+const distanceOfScrollingBeforeAppearing = 600;
+const BUTTON_CLASSES = {
+  TRANSITION_IN: 'vsa-top-button-transition-in',
+  TRANSITION_OUT: 'vsa-top-button-transition-out',
+  CONTAINER_RELATIVE: 'vsa-top-button-container-relative',
+  TRANSITION_RESET: 'vsa-top-button-transition-reset',
+};
 
 function navigateToTop() {
   return window.scrollTo(0, 0);
 }
 
-function assignClickHandlerButtonToDom() {
-  const button = container.querySelector('.usa-button.vsa-top-button');
-  if (button) button.onclick = navigateToTop();
-  // eslint-disable-next-line no-console
-  if (!button) console.warn('MISSING_UP_TO_TOP_BUTTON');
-}
-
-function scrollListener() {
+function scrollListener(button) {
   // Responsible for toggling animation classes
   const scrollFromTop =
     window.pageYOffset !== undefined
       ? window.pageYOffset
       : (document.documentElement || document.body.parentNode || document.body)
           .scrollTop;
-  const distanceOfScrollingBeforeAppearing = 600;
-  const buttonTransitionIn = 'vsa-top-button-transition-in';
-  const buttonTransitionOut = 'vsa-top-button-transition-out';
-  const buttonContainerRelative = 'vsa-top-button-container-relative';
-  const buttonTransitionReset = 'vsa-top-button-transition-reset';
 
   function doesElHaveClass(el, className) {
-    return el.classList.value.indexOf(className) > -1;
+    return el.classList.contains(className);
   }
 
   function isScrolledIntoView(el) {
@@ -56,39 +39,53 @@ function scrollListener() {
     return elemTop >= 0 && elemTop <= window.innerHeight;
   }
 
+  const {
+    TRANSITION_IN,
+    TRANSITION_OUT,
+    TRANSITION_RESET,
+    CONTAINER_RELATIVE,
+  } = BUTTON_CLASSES;
+
   if (
     scrollFromTop > distanceOfScrollingBeforeAppearing &&
-    !doesElHaveClass(upToTopButton, buttonTransitionIn)
+    !doesElHaveClass(button, TRANSITION_IN)
   ) {
-    upToTopButton.classList.add(buttonTransitionIn);
-    upToTopButton.classList.remove(buttonTransitionOut);
+    button.classList.add(TRANSITION_IN);
+    button.classList.remove(TRANSITION_OUT);
   } else if (
     scrollFromTop < distanceOfScrollingBeforeAppearing &&
-    doesElHaveClass(upToTopButton, buttonTransitionIn)
+    doesElHaveClass(button, TRANSITION_IN)
   ) {
-    upToTopButton.classList.add(buttonTransitionOut);
-    upToTopButton.classList.remove(buttonTransitionIn);
+    button.classList.add(TRANSITION_OUT);
+    button.classList.remove(TRANSITION_IN);
   }
   if (isScrolledIntoView(footer)) {
-    container.classList.add(buttonContainerRelative);
-    threeFourthsContainer.classList.add(buttonContainerRelative);
-    upToTopButton.classList.add(buttonTransitionReset);
-  } else if (doesElHaveClass(container, buttonContainerRelative)) {
-    container.classList.remove(buttonContainerRelative);
-    threeFourthsContainer.classList.remove(buttonContainerRelative);
-    upToTopButton.classList.remove(buttonTransitionReset);
+    container.classList.add(CONTAINER_RELATIVE);
+    threeFourthsContainer.classList.add(CONTAINER_RELATIVE);
+    button.classList.add(TRANSITION_RESET);
+  } else if (doesElHaveClass(container, CONTAINER_RELATIVE)) {
+    container.classList.remove(CONTAINER_RELATIVE);
+    threeFourthsContainer.classList.remove(CONTAINER_RELATIVE);
+    button.classList.remove(TRANSITION_RESET);
   }
 }
 
-function runScripts() {
-  if (!container) return;
-  if (initVars() === 'NODE_MISSING_CLASS') return;
+function setup() {
+  const upToTopButton = container.querySelector('.vsa-top-button');
 
-  window.addEventListener('scroll', scrollListener);
-  assignClickHandlerButtonToDom();
+  if (!upToTopButton) {
+    // The current page likely does not contain a "Back to top" button in its layout.
+    return;
+  }
+
+  // ... Grab other DOM refs
+  threeFourthsContainer = container.querySelector('.usa-width-three-fourths');
+  footer = document.querySelector('.footer-inner');
+  if (!threeFourthsContainer || !footer) return;
+
+  // Attach listeners
+  upToTopButton.addEventListener('click', navigateToTop);
+  window.addEventListener('scroll', () => scrollListener(upToTopButton));
 }
 
-const initScrollToTopButton = () =>
-  window.addEventListener('DOMContentLoaded', runScripts);
-
-export default initScrollToTopButton;
+export default () => document.addEventListener('DOMContentLoaded', setup);

--- a/src/applications/static-pages/scroll-top-button.js
+++ b/src/applications/static-pages/scroll-top-button.js
@@ -30,9 +30,9 @@ function getScrolledDistanceFromTopOfScreen() {
 // Responsible for toggling animation classes
 function scrollListener(
   button,
-  container,
+  buttonContainer,
   footer,
-  threeFourthsContainer,
+  layoutContainer,
   buttonClasses,
 ) {
   const distanceOfScrollingBeforeAppearing = 600;
@@ -53,44 +53,45 @@ function scrollListener(
   }
 
   if (isScrolledIntoView(footer)) {
-    container.classList.add(buttonClasses.containerRelative);
-    threeFourthsContainer.classList.add(buttonClasses.containerRelative);
+    buttonContainer.classList.add(buttonClasses.containerRelative);
+    layoutContainer.classList.add(buttonClasses.containerRelative);
     button.classList.add(buttonClasses.transitionReset);
-  } else if (doesElHaveClass(container, buttonClasses.containerRelative)) {
-    container.classList.remove(buttonClasses.containerRelative);
-    threeFourthsContainer.classList.remove(buttonClasses.containerRelative);
+  } else if (
+    doesElHaveClass(buttonContainer, buttonClasses.containerRelative)
+  ) {
+    buttonContainer.classList.remove(buttonClasses.containerRelative);
+    layoutContainer.classList.remove(buttonClasses.containerRelative);
     button.classList.remove(buttonClasses.transitionReset);
   }
 }
 
 function setup() {
-  const container = document.querySelector('.vsa-top-button-container');
-  if (!container) return;
+  const buttonContainer = document.getElementById('top-button-container');
+  if (!buttonContainer) return;
 
-  const upToTopButton = container.querySelector('.vsa-top-button');
+  const upToTopButton = document.querySelector('.vsa-top-button');
   if (!upToTopButton) return;
   // The current page likely does not contain a "Back to top" button in its layout.
 
-  const threeFourthsContainer = container.querySelector(
-    '.usa-width-three-fourths',
-  );
-  const footer = document.querySelector('.footer-inner');
+  const layoutContainer = document.getElementById('usa-width-container');
+  const footer = document.getElementById('footerNav');
+
   const buttonClasses = {
-    transitionIn: 'vsa-top-button-transition-in',
-    transitionOut: 'vsa-top-button-transition-out',
-    containerRelative: 'vsa-top-button-container-relative',
-    transitionReset: 'vsa-top-button-transition-reset',
+    transitionIn: 'va-top-button-transition-in',
+    transitionOut: 'va-top-button-transition-out',
+    containerRelative: 'va-top-button-container-relative',
+    transitionReset: 'va-top-button-transition-reset',
   };
 
-  if (!threeFourthsContainer || !footer) return;
+  if (!layoutContainer || !footer) return;
   // Attach listeners
   upToTopButton.addEventListener('click', navigateToTop);
   window.addEventListener('scroll', () =>
     scrollListener(
       upToTopButton,
-      container,
+      buttonContainer,
       footer,
-      threeFourthsContainer,
+      layoutContainer,
       buttonClasses,
     ),
   );

--- a/src/applications/static-pages/scroll-top-button.js
+++ b/src/applications/static-pages/scroll-top-button.js
@@ -1,3 +1,10 @@
+/**
+ * This button is used for navigating the user back to the top of the page.
+ * It's to be used on long article pages.
+ * There is some complexity in the animation toggling function "scrollListener"
+ * html is located in src/site/components/up_to_top_button.html
+ */
+
 export default function initScrollToTopButton() {
   const container = document.querySelector('.vsa-top-button-container');
   let upToTopButton = '';

--- a/src/applications/static-pages/scroll-top-button.js
+++ b/src/applications/static-pages/scroll-top-button.js
@@ -1,0 +1,89 @@
+export default function initScrollToTopButton() {
+  const container = document.querySelector('.vsa-top-button-container');
+  let upToTopButton = '';
+  let footer = '';
+  let threeFourthsContainer = '';
+
+  function initVars() {
+    threeFourthsContainer = container.querySelector('.usa-width-three-fourths');
+    upToTopButton = container.querySelector('.vsa-top-button');
+    footer = document.querySelector('.footer-inner');
+    // NOTE: Guarded Return so button does not show at all with errors
+    if (!threeFourthsContainer || !upToTopButton || !footer)
+      return 'NODE_MISSING_CLASS';
+
+    return 'SUCCESS';
+  }
+
+  function scrollListener() {
+    // Responsible for toggling animation classes
+    const scrollTop =
+      window.pageYOffset !== undefined
+        ? window.pageYOffset
+        : (
+            document.documentElement ||
+            document.body.parentNode ||
+            document.body
+          ).scrollTop;
+    const distanceOfScrollingBeforeAppearing = 600;
+    const buttonTransitionIn = 'vsa-top-button-transition-in';
+    const buttonTransitionOut = 'vsa-top-button-transition-out';
+    const buttonContainerRelative = 'vsa-top-button-container-relative';
+    const buttonTransitionReset = 'vsa-top-button-transition-reset';
+
+    function doesElHaveClass(el, className) {
+      return el.classList.value.indexOf(className) > -1;
+    }
+
+    function isScrolledIntoView(el) {
+      const rect = el.getBoundingClientRect();
+      const elemTop = rect.top;
+      // Only partially || completely visible elements return true
+      return elemTop >= 0 && elemTop <= window.innerHeight;
+    }
+
+    if (
+      scrollTop > distanceOfScrollingBeforeAppearing &&
+      !doesElHaveClass(upToTopButton, buttonTransitionIn)
+    ) {
+      upToTopButton.classList.add(buttonTransitionIn);
+      upToTopButton.classList.remove(buttonTransitionOut);
+    } else if (
+      scrollTop < distanceOfScrollingBeforeAppearing &&
+      doesElHaveClass(upToTopButton, buttonTransitionIn)
+    ) {
+      upToTopButton.classList.add(buttonTransitionOut);
+      upToTopButton.classList.remove(buttonTransitionIn);
+    }
+    if (isScrolledIntoView(footer)) {
+      container.classList.add(buttonContainerRelative);
+      threeFourthsContainer.classList.add(buttonContainerRelative);
+      upToTopButton.classList.add(buttonTransitionReset);
+    } else if (doesElHaveClass(container, buttonContainerRelative)) {
+      container.classList.remove(buttonContainerRelative);
+      threeFourthsContainer.classList.remove(buttonContainerRelative);
+      upToTopButton.classList.remove(buttonTransitionReset);
+    }
+  }
+
+  function navigateToTop() {
+    return window.scrollTo(0, 0);
+  }
+
+  function assignClickHandlerButtonToDom() {
+    const button = container.querySelector('.usa-button.vsa-top-button');
+    if (button) button.onclick = navigateToTop();
+    // eslint-disable-next-line no-console
+    if (!button) console.warn('MISSING_UP_TO_TOP_BUTTON');
+  }
+
+  function runScripts() {
+    if (!container) return;
+    if (initVars() === 'NODE_MISSING_CLASS') return;
+
+    window.addEventListener('scroll', scrollListener);
+    assignClickHandlerButtonToDom();
+  }
+
+  window.addEventListener('load', runScripts);
+}

--- a/src/applications/static-pages/scroll-top-button.js
+++ b/src/applications/static-pages/scroll-top-button.js
@@ -5,92 +5,90 @@
  * html is located in src/site/components/up_to_top_button.html
  */
 
-export default function initScrollToTopButton() {
-  const container = document.querySelector('.vsa-top-button-container');
-  let upToTopButton = '';
-  let footer = '';
-  let threeFourthsContainer = '';
+let upToTopButton = '';
+let footer = '';
+let threeFourthsContainer = '';
+const container = document.querySelector('.vsa-top-button-container');
 
-  function initVars() {
-    threeFourthsContainer = container.querySelector('.usa-width-three-fourths');
-    upToTopButton = container.querySelector('.vsa-top-button');
-    footer = document.querySelector('.footer-inner');
-    // NOTE: Guarded Return so button does not show at all with errors
-    if (!threeFourthsContainer || !upToTopButton || !footer)
-      return 'NODE_MISSING_CLASS';
+function initVars() {
+  threeFourthsContainer = container.querySelector('.usa-width-three-fourths');
+  upToTopButton = container.querySelector('.vsa-top-button');
+  footer = document.querySelector('.footer-inner');
+  // NOTE: Guarded Return so button does not show at all with errors
+  if (!threeFourthsContainer || !upToTopButton || !footer)
+    return 'NODE_MISSING_CLASS';
 
-    return 'SUCCESS';
-  }
-
-  function scrollListener() {
-    // Responsible for toggling animation classes
-    const scrollTop =
-      window.pageYOffset !== undefined
-        ? window.pageYOffset
-        : (
-            document.documentElement ||
-            document.body.parentNode ||
-            document.body
-          ).scrollTop;
-    const distanceOfScrollingBeforeAppearing = 600;
-    const buttonTransitionIn = 'vsa-top-button-transition-in';
-    const buttonTransitionOut = 'vsa-top-button-transition-out';
-    const buttonContainerRelative = 'vsa-top-button-container-relative';
-    const buttonTransitionReset = 'vsa-top-button-transition-reset';
-
-    function doesElHaveClass(el, className) {
-      return el.classList.value.indexOf(className) > -1;
-    }
-
-    function isScrolledIntoView(el) {
-      const rect = el.getBoundingClientRect();
-      const elemTop = rect.top;
-      // Only partially || completely visible elements return true
-      return elemTop >= 0 && elemTop <= window.innerHeight;
-    }
-
-    if (
-      scrollTop > distanceOfScrollingBeforeAppearing &&
-      !doesElHaveClass(upToTopButton, buttonTransitionIn)
-    ) {
-      upToTopButton.classList.add(buttonTransitionIn);
-      upToTopButton.classList.remove(buttonTransitionOut);
-    } else if (
-      scrollTop < distanceOfScrollingBeforeAppearing &&
-      doesElHaveClass(upToTopButton, buttonTransitionIn)
-    ) {
-      upToTopButton.classList.add(buttonTransitionOut);
-      upToTopButton.classList.remove(buttonTransitionIn);
-    }
-    if (isScrolledIntoView(footer)) {
-      container.classList.add(buttonContainerRelative);
-      threeFourthsContainer.classList.add(buttonContainerRelative);
-      upToTopButton.classList.add(buttonTransitionReset);
-    } else if (doesElHaveClass(container, buttonContainerRelative)) {
-      container.classList.remove(buttonContainerRelative);
-      threeFourthsContainer.classList.remove(buttonContainerRelative);
-      upToTopButton.classList.remove(buttonTransitionReset);
-    }
-  }
-
-  function navigateToTop() {
-    return window.scrollTo(0, 0);
-  }
-
-  function assignClickHandlerButtonToDom() {
-    const button = container.querySelector('.usa-button.vsa-top-button');
-    if (button) button.onclick = navigateToTop();
-    // eslint-disable-next-line no-console
-    if (!button) console.warn('MISSING_UP_TO_TOP_BUTTON');
-  }
-
-  function runScripts() {
-    if (!container) return;
-    if (initVars() === 'NODE_MISSING_CLASS') return;
-
-    window.addEventListener('scroll', scrollListener);
-    assignClickHandlerButtonToDom();
-  }
-
-  window.addEventListener('load', runScripts);
+  return 'SUCCESS';
 }
+
+function navigateToTop() {
+  return window.scrollTo(0, 0);
+}
+
+function assignClickHandlerButtonToDom() {
+  const button = container.querySelector('.usa-button.vsa-top-button');
+  if (button) button.onclick = navigateToTop();
+  // eslint-disable-next-line no-console
+  if (!button) console.warn('MISSING_UP_TO_TOP_BUTTON');
+}
+
+function scrollListener() {
+  // Responsible for toggling animation classes
+  const scrollFromTop =
+    window.pageYOffset !== undefined
+      ? window.pageYOffset
+      : (document.documentElement || document.body.parentNode || document.body)
+          .scrollTop;
+  const distanceOfScrollingBeforeAppearing = 600;
+  const buttonTransitionIn = 'vsa-top-button-transition-in';
+  const buttonTransitionOut = 'vsa-top-button-transition-out';
+  const buttonContainerRelative = 'vsa-top-button-container-relative';
+  const buttonTransitionReset = 'vsa-top-button-transition-reset';
+
+  function doesElHaveClass(el, className) {
+    return el.classList.value.indexOf(className) > -1;
+  }
+
+  function isScrolledIntoView(el) {
+    const rect = el.getBoundingClientRect();
+    const elemTop = rect.top;
+    // Only partially || completely visible elements return true
+    return elemTop >= 0 && elemTop <= window.innerHeight;
+  }
+
+  if (
+    scrollFromTop > distanceOfScrollingBeforeAppearing &&
+    !doesElHaveClass(upToTopButton, buttonTransitionIn)
+  ) {
+    upToTopButton.classList.add(buttonTransitionIn);
+    upToTopButton.classList.remove(buttonTransitionOut);
+  } else if (
+    scrollFromTop < distanceOfScrollingBeforeAppearing &&
+    doesElHaveClass(upToTopButton, buttonTransitionIn)
+  ) {
+    upToTopButton.classList.add(buttonTransitionOut);
+    upToTopButton.classList.remove(buttonTransitionIn);
+  }
+  if (isScrolledIntoView(footer)) {
+    container.classList.add(buttonContainerRelative);
+    threeFourthsContainer.classList.add(buttonContainerRelative);
+    upToTopButton.classList.add(buttonTransitionReset);
+  } else if (doesElHaveClass(container, buttonContainerRelative)) {
+    container.classList.remove(buttonContainerRelative);
+    threeFourthsContainer.classList.remove(buttonContainerRelative);
+    upToTopButton.classList.remove(buttonTransitionReset);
+  }
+}
+
+function runScripts() {
+  if (!container) return;
+  if (initVars() === 'NODE_MISSING_CLASS') return;
+
+  window.addEventListener('scroll', scrollListener);
+  assignClickHandlerButtonToDom();
+}
+
+const initScrollToTopButton = () =>
+  window.addEventListener('DOMContentLoaded', runScripts);
+
+export default initScrollToTopButton;

--- a/src/applications/static-pages/scroll-top-button.js
+++ b/src/applications/static-pages/scroll-top-button.js
@@ -5,87 +5,95 @@
  * html is located in src/site/components/up_to_top_button.html
  */
 
-let threeFourthsContainer = '';
-let footer = '';
-const container = document.querySelector('.vsa-top-button-container');
-const distanceOfScrollingBeforeAppearing = 600;
-const BUTTON_CLASSES = {
-  TRANSITION_IN: 'vsa-top-button-transition-in',
-  TRANSITION_OUT: 'vsa-top-button-transition-out',
-  CONTAINER_RELATIVE: 'vsa-top-button-container-relative',
-  TRANSITION_RESET: 'vsa-top-button-transition-reset',
-};
-
 function navigateToTop() {
   return window.scrollTo(0, 0);
 }
 
-function scrollListener(button) {
-  // Responsible for toggling animation classes
-  const scrollFromTop =
-    window.pageYOffset !== undefined
-      ? window.pageYOffset
-      : (document.documentElement || document.body.parentNode || document.body)
-          .scrollTop;
+function doesElHaveClass(el, className) {
+  return el.classList.contains(className);
+}
 
-  function doesElHaveClass(el, className) {
-    return el.classList.contains(className);
-  }
+function isScrolledIntoView(el) {
+  const rect = el.getBoundingClientRect();
+  const elemTop = rect.top;
+  // Only partially || completely visible elements return true
+  return elemTop >= 0 && elemTop <= window.innerHeight;
+}
 
-  function isScrolledIntoView(el) {
-    const rect = el.getBoundingClientRect();
-    const elemTop = rect.top;
-    // Only partially || completely visible elements return true
-    return elemTop >= 0 && elemTop <= window.innerHeight;
-  }
+function getScrolledDistanceFromTopOfScreen() {
+  return window.pageYOffset !== undefined
+    ? window.pageYOffset
+    : (document.documentElement || document.body.parentNode || document.body)
+        .scrollTop;
+}
 
-  const {
-    TRANSITION_IN,
-    TRANSITION_OUT,
-    TRANSITION_RESET,
-    CONTAINER_RELATIVE,
-  } = BUTTON_CLASSES;
+// Responsible for toggling animation classes
+function scrollListener(
+  button,
+  container,
+  footer,
+  threeFourthsContainer,
+  buttonClasses,
+) {
+  const distanceOfScrollingBeforeAppearing = 600;
+  const scrollFromTop = getScrolledDistanceFromTopOfScreen();
 
   if (
     scrollFromTop > distanceOfScrollingBeforeAppearing &&
-    !doesElHaveClass(button, TRANSITION_IN)
+    !doesElHaveClass(button, buttonClasses.transitionIn)
   ) {
-    button.classList.add(TRANSITION_IN);
-    button.classList.remove(TRANSITION_OUT);
+    button.classList.add(buttonClasses.transitionIn);
+    button.classList.remove(buttonClasses.transitionOut);
   } else if (
     scrollFromTop < distanceOfScrollingBeforeAppearing &&
-    doesElHaveClass(button, TRANSITION_IN)
+    doesElHaveClass(button, buttonClasses.transitionIn)
   ) {
-    button.classList.add(TRANSITION_OUT);
-    button.classList.remove(TRANSITION_IN);
+    button.classList.add(buttonClasses.transitionOut);
+    button.classList.remove(buttonClasses.transitionIn);
   }
+
   if (isScrolledIntoView(footer)) {
-    container.classList.add(CONTAINER_RELATIVE);
-    threeFourthsContainer.classList.add(CONTAINER_RELATIVE);
-    button.classList.add(TRANSITION_RESET);
-  } else if (doesElHaveClass(container, CONTAINER_RELATIVE)) {
-    container.classList.remove(CONTAINER_RELATIVE);
-    threeFourthsContainer.classList.remove(CONTAINER_RELATIVE);
-    button.classList.remove(TRANSITION_RESET);
+    container.classList.add(buttonClasses.containerRelative);
+    threeFourthsContainer.classList.add(buttonClasses.containerRelative);
+    button.classList.add(buttonClasses.transitionReset);
+  } else if (doesElHaveClass(container, buttonClasses.containerRelative)) {
+    container.classList.remove(buttonClasses.containerRelative);
+    threeFourthsContainer.classList.remove(buttonClasses.containerRelative);
+    button.classList.remove(buttonClasses.transitionReset);
   }
 }
 
 function setup() {
+  const container = document.querySelector('.vsa-top-button-container');
+  if (!container) return;
+
   const upToTopButton = container.querySelector('.vsa-top-button');
+  if (!upToTopButton) return;
+  // The current page likely does not contain a "Back to top" button in its layout.
 
-  if (!upToTopButton) {
-    // The current page likely does not contain a "Back to top" button in its layout.
-    return;
-  }
+  const threeFourthsContainer = container.querySelector(
+    '.usa-width-three-fourths',
+  );
+  const footer = document.querySelector('.footer-inner');
+  const buttonClasses = {
+    transitionIn: 'vsa-top-button-transition-in',
+    transitionOut: 'vsa-top-button-transition-out',
+    containerRelative: 'vsa-top-button-container-relative',
+    transitionReset: 'vsa-top-button-transition-reset',
+  };
 
-  // ... Grab other DOM refs
-  threeFourthsContainer = container.querySelector('.usa-width-three-fourths');
-  footer = document.querySelector('.footer-inner');
   if (!threeFourthsContainer || !footer) return;
-
   // Attach listeners
   upToTopButton.addEventListener('click', navigateToTop);
-  window.addEventListener('scroll', () => scrollListener(upToTopButton));
+  window.addEventListener('scroll', () =>
+    scrollListener(
+      upToTopButton,
+      container,
+      footer,
+      threeFourthsContainer,
+      buttonClasses,
+    ),
+  );
 }
 
 export default () => document.addEventListener('DOMContentLoaded', setup);

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -29,6 +29,7 @@ import createHigherLevelReviewApplicationStatus from 'applications/disability-be
 import createPost911GiBillStatusWidget, {
   post911GIBillStatusReducer,
 } from '../post-911-gib-status/createPost911GiBillStatusWidget';
+import initScrollToTopButton from './scroll-top-button';
 
 import form686CTA from './view-modify-dependent/686-cta/form686CTA';
 import createCaregiverContentToggle from './caregiver-content-toggle/createCaregiverContentToggle';
@@ -180,6 +181,9 @@ createChapter36CTA(store, widgetTypes.CHAPTER_36_CTA);
 if (location.pathname === '/') {
   createMyVALoginWidget(store);
 }
+
+// Up to top button for Article Pages
+initScrollToTopButton();
 
 /* eslint-disable no-unused-vars,camelcase */
 const lazyLoad = new LazyLoad({

--- a/src/site/components/up_to_top_button.html
+++ b/src/site/components/up_to_top_button.html
@@ -1,7 +1,7 @@
 {% comment %}
 
 =====================
- Up To Top Button
+Up To Top Button
 =====================
 
 Used as quick navigate back to top for long article pages.
@@ -15,81 +15,14 @@ Used as quick navigate back to top for long article pages.
     <div class="usa-grid usa-grid-full">
         <div class="usa-width-three-fourths">
             <div class="usa-content">
-                <button class="usa-button vads-u-background-color--gray-dark vsa-top-button vads-u-display--flex vads-u-align-items--center" onclick="navigateToTop()">
-                    <i class="fas fa-arrow-up vads-u-font-size--lg vads-u-margin-right--0 small-desktop-screen:vads-u-margin-right--1p5 small-desktop-screen:vads-u-font-size--sm"></i>
-                    <p class="vads-u-display--none vads-u-color--white vads-u-margin--0 small-desktop-screen:vads-u-display--block">Back to top</p>
+                <button
+                    class="usa-button vads-u-background-color--gray-dark vsa-top-button vads-u-display--flex vads-u-align-items--center">
+                    <i
+                        class="fas fa-arrow-up vads-u-font-size--lg vads-u-margin-right--0 small-desktop-screen:vads-u-margin-right--1p5 small-desktop-screen:vads-u-font-size--sm"></i>
+                    <p
+                        class="vads-u-display--none vads-u-color--white vads-u-margin--0 small-desktop-screen:vads-u-display--block">
+                        Back to top</p>
                 </button>
-                <script nonce="**CSP_NONCE**" type="text/javascript">
-                    var container = document.querySelector('.vsa-top-button-container')
-                    var upToTopButton = '',
-                    footer = '',
-                    threeFourthsContainer = '';
-
-                    window.addEventListener('load', runScripts)
-
-
-                    function runScripts() {
-                        if(!container) return 
-                        
-                        if(initVars() === 'NODE_MISSING_CLASS') return 
-                        else window.addEventListener('scroll', scrollListener)
-                    }
-
-                    function initVars() {
-                        threeFourthsContainer = container.querySelector('.usa-width-three-fourths')
-                        upToTopButton = container.querySelector('.vsa-top-button')
-                        footer = document.querySelector('.footer-inner')
-                        // NOTE: Guarded Return so button does not show at all with errors 
-                        if(!threeFourthsContainer || !upToTopButton || !footer) return 'NODE_MISSING_CLASS' 
-                    }
-
-                    function scrollListener() {
-                        // Responsible for toggling animation classes 
-                        var scrollTop = (window.pageYOffset !== undefined) ? window.pageYOffset : (document.documentElement || document.body.parentNode || document.body).scrollTop;
-                        var buttonTransitionIn = 'vsa-top-button-transition-in'
-                        var buttonTransitionOut = 'vsa-top-button-transition-out'
-                        var buttonContainerRelative = 'vsa-top-button-container-relative'
-                        var buttonTransitionReset = 'vsa-top-button-transition-reset'
-                        
-                        
-                        if(scrollTop > 600 && !doesElHaveClass(upToTopButton, buttonTransitionIn)) {
-                            upToTopButton.classList.add(buttonTransitionIn)
-                            upToTopButton.classList.remove(buttonTransitionOut)
-                        } else if (scrollTop < 600 && doesElHaveClass(upToTopButton, buttonTransitionIn)) {
-                            upToTopButton.classList.add(buttonTransitionOut)
-                            upToTopButton.classList.remove(buttonTransitionIn)
-                        }
-
-                        if(isScrolledIntoView(footer)) {
-                            container.classList.add(buttonContainerRelative)
-                            threeFourthsContainer.classList.add(buttonContainerRelative)
-                            upToTopButton.classList.add(buttonTransitionReset)
-                        }
-                        else if(doesElHaveClass(container, buttonContainerRelative)) {
-                            container.classList.remove(buttonContainerRelative)
-                            threeFourthsContainer.classList.remove(buttonContainerRelative)
-                            upToTopButton.classList.remove(buttonTransitionReset)
-                        }
-
-                        function doesElHaveClass(el, className) {
-                            var hasClass = el.classList.value.indexOf(className) > -1
-                            return hasClass
-                        }
-
-                        function isScrolledIntoView(el) {
-                            var rect = el.getBoundingClientRect();
-                            var elemTop = rect.top;
-
-                            // Only partially || completely visible elements return true
-                            var isVisible = (elemTop >= 0) && (elemTop <= window.innerHeight);
-                            return isVisible;
-                        }
-                    }
-                    
-                    function navigateToTop() {
-                        return window.scrollTo(0,0)
-                    }
-                </script>
             </div>
         </div>
     </div>

--- a/src/site/components/up_to_top_button.html
+++ b/src/site/components/up_to_top_button.html
@@ -12,7 +12,7 @@ Used as quick navigate back to top for long article pages.
 
 {% endcomment %}
 
-<div class="vsa-top-button-container">
+<div data-template="components/up_to_top_button" class="vsa-top-button-container">
     <div class="usa-grid usa-grid-full">
         <div class="usa-width-three-fourths">
             <div class="usa-content">

--- a/src/site/components/up_to_top_button.html
+++ b/src/site/components/up_to_top_button.html
@@ -7,13 +7,53 @@
 Used as quick navigate back to top for long article pages.
 
 1. To import button, use {% include "src/site/components/up_to_top_button.html" %}.
+2. The button needs to be absolutely positioned to w/e container 
 
 {% endcomment %}
 
-<button class="usa-button vads-u-background-color--gray-dark vads-u-display--flex vads-u-align-items--center">
-    <i class="fas fa-arrow-up vads-u-font-size--lg vads-u-margin-right--0 small-desktop-screen:vads-u-margin-right--1p5 small-desktop-screen:vads-u-font-size--sm"></i>
-    <p class="vads-u-display--none vads-u-color--white vads-u-margin--0 small-desktop-screen:vads-u-display--block">Back to top</p>
-</button>
-<script nonce="**CSP_NONCE**" type="text/javascript">
+<div class="vsa-top-button-container">
+    <div class="usa-grid usa-grid-full">
+        <div class="usa-width-three-fourths">
+            <div class="usa-content">
+                <button class="usa-button vads-u-background-color--gray-dark vsa-top-button vads-u-display--flex vads-u-align-items--center">
+                    <i class="fas fa-arrow-up vads-u-font-size--lg vads-u-margin-right--0 small-desktop-screen:vads-u-margin-right--1p5 small-desktop-screen:vads-u-font-size--sm"></i>
+                    <p class="vads-u-display--none vads-u-color--white vads-u-margin--0 small-desktop-screen:vads-u-display--block">Back to top</p>
+                </button>
+                <script nonce="**CSP_NONCE**" type="text/javascript">
+                    var container = document.querySelector('.vsa-top-button-container')
+                    var upToTopButton = "",
+                    threeFourthsContainer = "";
 
-</script>
+                    window.addEventListener('load', runScripts)
+
+
+                    function runScripts() {
+                        if(!container) return 
+                        
+                        initVars()
+                        window.addEventListener('scroll', scrollListener)
+                    }
+
+                    function initVars() {
+                        threeFourthsContainer = container.querySelector(".usa-width-three-fourths")
+                        upToTopButton = container.querySelector(".vsa-top-button")
+                    }
+
+                    function scrollListener() {
+                        var scrollTop = (window.pageYOffset !== undefined) ? window.pageYOffset : (document.documentElement || document.body.parentNode || document.body).scrollTop;
+                        
+                        if(scrollTop > 600 && upToTopButton.classList.value.indexOf('vsa-top-button-transition-in') === -1) {
+                            upToTopButton.classList.add('vsa-top-button-transition-in')
+                            upToTopButton.classList.remove('vsa-top-button-transition-out')
+                        } else if (scrollTop < 600 && upToTopButton.classList.value.indexOf('vsa-top-button-transition-in') > -1) {
+                            upToTopButton.classList.add('vsa-top-button-transition-out')
+                            upToTopButton.classList.remove('vsa-top-button-transition-in')
+                        }
+
+                    }
+
+                </script>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/site/components/up_to_top_button.html
+++ b/src/site/components/up_to_top_button.html
@@ -1,0 +1,19 @@
+{% comment %}
+
+=====================
+ Up To Top Button
+=====================
+
+Used as quick navigate back to top for long article pages.
+
+1. To import button, use {% include "src/site/components/up_to_top_button.html" %}.
+
+{% endcomment %}
+
+<button class="usa-button vads-u-background-color--gray-dark vads-u-display--flex vads-u-align-items--center">
+    <i class="fas fa-arrow-up vads-u-font-size--lg vads-u-margin-right--0 small-desktop-screen:vads-u-margin-right--1p5 small-desktop-screen:vads-u-font-size--sm"></i>
+    <p class="vads-u-display--none vads-u-color--white vads-u-margin--0 small-desktop-screen:vads-u-display--block">Back to top</p>
+</button>
+<script nonce="**CSP_NONCE**" type="text/javascript">
+
+</script>

--- a/src/site/components/up_to_top_button.html
+++ b/src/site/components/up_to_top_button.html
@@ -12,9 +12,9 @@ Used as quick navigate back to top for long article pages.
 
 {% endcomment %}
 
-<div data-template="components/up_to_top_button" class="vsa-top-button-container">
+<div data-template="components/up_to_top_button" id="top-button-container" class="vsa-top-button-container">
     <div class="usa-grid usa-grid-full">
-        <div class="usa-width-three-fourths">
+        <div id="usa-width-container" class="usa-width-three-fourths">
             <div class="usa-content">
                 <button
                     class="usa-button vads-u-background-color--gray-dark vsa-top-button vads-u-display--flex vads-u-align-items--center">

--- a/src/site/components/up_to_top_button.html
+++ b/src/site/components/up_to_top_button.html
@@ -7,7 +7,7 @@
 Used as quick navigate back to top for long article pages.
 
 1. To import button, use {% include "src/site/components/up_to_top_button.html" %}.
-2. The button needs to be absolutely positioned to w/e container 
+2. It needs to be imported as the last component within the div with the "usa-content" class.
 
 {% endcomment %}
 
@@ -15,14 +15,15 @@ Used as quick navigate back to top for long article pages.
     <div class="usa-grid usa-grid-full">
         <div class="usa-width-three-fourths">
             <div class="usa-content">
-                <button class="usa-button vads-u-background-color--gray-dark vsa-top-button vads-u-display--flex vads-u-align-items--center">
+                <button class="usa-button vads-u-background-color--gray-dark vsa-top-button vads-u-display--flex vads-u-align-items--center" onclick="navigateToTop()">
                     <i class="fas fa-arrow-up vads-u-font-size--lg vads-u-margin-right--0 small-desktop-screen:vads-u-margin-right--1p5 small-desktop-screen:vads-u-font-size--sm"></i>
                     <p class="vads-u-display--none vads-u-color--white vads-u-margin--0 small-desktop-screen:vads-u-display--block">Back to top</p>
                 </button>
                 <script nonce="**CSP_NONCE**" type="text/javascript">
                     var container = document.querySelector('.vsa-top-button-container')
-                    var upToTopButton = "",
-                    threeFourthsContainer = "";
+                    var upToTopButton = '',
+                    footer = '',
+                    threeFourthsContainer = '';
 
                     window.addEventListener('load', runScripts)
 
@@ -30,28 +31,64 @@ Used as quick navigate back to top for long article pages.
                     function runScripts() {
                         if(!container) return 
                         
-                        initVars()
-                        window.addEventListener('scroll', scrollListener)
+                        if(initVars() === 'NODE_MISSING_CLASS') return 
+                        else window.addEventListener('scroll', scrollListener)
                     }
 
                     function initVars() {
-                        threeFourthsContainer = container.querySelector(".usa-width-three-fourths")
-                        upToTopButton = container.querySelector(".vsa-top-button")
+                        threeFourthsContainer = container.querySelector('.usa-width-three-fourths')
+                        upToTopButton = container.querySelector('.vsa-top-button')
+                        footer = document.querySelector('.footer-inner')
+                        // NOTE: Guarded Return so button does not show at all with errors 
+                        if(!threeFourthsContainer || !upToTopButton || !footer) return 'NODE_MISSING_CLASS' 
                     }
 
                     function scrollListener() {
+                        // Responsible for toggling animation classes 
                         var scrollTop = (window.pageYOffset !== undefined) ? window.pageYOffset : (document.documentElement || document.body.parentNode || document.body).scrollTop;
+                        var buttonTransitionIn = 'vsa-top-button-transition-in'
+                        var buttonTransitionOut = 'vsa-top-button-transition-out'
+                        var buttonContainerRelative = 'vsa-top-button-container-relative'
+                        var buttonTransitionReset = 'vsa-top-button-transition-reset'
                         
-                        if(scrollTop > 600 && upToTopButton.classList.value.indexOf('vsa-top-button-transition-in') === -1) {
-                            upToTopButton.classList.add('vsa-top-button-transition-in')
-                            upToTopButton.classList.remove('vsa-top-button-transition-out')
-                        } else if (scrollTop < 600 && upToTopButton.classList.value.indexOf('vsa-top-button-transition-in') > -1) {
-                            upToTopButton.classList.add('vsa-top-button-transition-out')
-                            upToTopButton.classList.remove('vsa-top-button-transition-in')
+                        
+                        if(scrollTop > 600 && !doesElHaveClass(upToTopButton, buttonTransitionIn)) {
+                            upToTopButton.classList.add(buttonTransitionIn)
+                            upToTopButton.classList.remove(buttonTransitionOut)
+                        } else if (scrollTop < 600 && doesElHaveClass(upToTopButton, buttonTransitionIn)) {
+                            upToTopButton.classList.add(buttonTransitionOut)
+                            upToTopButton.classList.remove(buttonTransitionIn)
                         }
 
-                    }
+                        if(isScrolledIntoView(footer)) {
+                            container.classList.add(buttonContainerRelative)
+                            threeFourthsContainer.classList.add(buttonContainerRelative)
+                            upToTopButton.classList.add(buttonTransitionReset)
+                        }
+                        else if(doesElHaveClass(container, buttonContainerRelative)) {
+                            container.classList.remove(buttonContainerRelative)
+                            threeFourthsContainer.classList.remove(buttonContainerRelative)
+                            upToTopButton.classList.remove(buttonTransitionReset)
+                        }
 
+                        function doesElHaveClass(el, className) {
+                            var hasClass = el.classList.value.indexOf(className) > -1
+                            return hasClass
+                        }
+
+                        function isScrolledIntoView(el) {
+                            var rect = el.getBoundingClientRect();
+                            var elemTop = rect.top;
+
+                            // Only partially || completely visible elements return true
+                            var isVisible = (elemTop >= 0) && (elemTop <= window.innerHeight);
+                            return isVisible;
+                        }
+                    }
+                    
+                    function navigateToTop() {
+                        return window.scrollTo(0,0)
+                    }
                 </script>
             </div>
         </div>

--- a/src/site/components/up_to_top_button.html
+++ b/src/site/components/up_to_top_button.html
@@ -8,6 +8,7 @@ Used as quick navigate back to top for long article pages.
 
 1. To import button, use {% include "src/site/components/up_to_top_button.html" %}.
 2. It needs to be imported as the last component within the div with the "usa-content" class.
+3. JS is located in src/applications/static-pages/scroll-top-button.js
 
 {% endcomment %}
 

--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -124,9 +124,6 @@
             Last updated: <time
               datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
           </div>
-
-          <!-- Up to Top Button -->
-          {% include "src/site/components/up_to_top_button.html" %}
         </div>
       </div>
     </div>

--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -104,9 +104,6 @@
             {% endif %}
           </article>
 
-          <!-- Up to Top Button -->
-          {% include "src/site/components/up_to_top_button.html" %}
-
           <!-- Tags -->
           {% include "src/site/includes/tags.drupal.liquid" with fieldTags = fieldTags %}
 
@@ -127,6 +124,9 @@
             Last updated: <time
               datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
           </div>
+
+          <!-- Up to Top Button -->
+          {% include "src/site/components/up_to_top_button.html" %}
         </div>
       </div>
     </div>

--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -104,6 +104,9 @@
             {% endif %}
           </article>
 
+          <!-- Up to Top Button -->
+          {% include "src/site/components/up_to_top_button.html" %}
+
           <!-- Tags -->
           {% include "src/site/includes/tags.drupal.liquid" with fieldTags = fieldTags %}
 

--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -124,6 +124,9 @@
             Last updated: <time
               datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
           </div>
+
+          <!-- Up To Top Button -->
+          {% include "src/site/components/up_to_top_button.html" %}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Issue: [Back up to Top](https://github.com/department-of-veterans-affairs/va.gov-team/issues/14347)

## Screenshots
Desktop:
![Screen Shot 2020-11-04 at 11 40 53 AM](https://user-images.githubusercontent.com/26075258/98143410-0b18c600-1e97-11eb-80a0-f960c734fc39.png)

Desktop Footer:
![Screen Shot 2020-11-04 at 11 49 13 AM](https://user-images.githubusercontent.com/26075258/98143550-3bf8fb00-1e97-11eb-970a-badf930130ac.png)

Tablet: 
![Screen Shot 2020-11-04 at 11 44 08 AM](https://user-images.githubusercontent.com/26075258/98143457-1ec42c80-1e97-11eb-8acb-c781af656225.png)

Mobile:
![Screen Shot 2020-11-04 at 11 43 20 AM](https://user-images.githubusercontent.com/26075258/98143478-25eb3a80-1e97-11eb-9616-5f5c6f270e8a.png)

Template Import use:
<img width="878" alt="Screen Shot 2020-11-04 at 11 58 38 AM" src="https://user-images.githubusercontent.com/26075258/98143514-326f9300-1e97-11eb-893f-3ca96315015b.png">


## Acceptance criteria
- [x] Add "Up to Top" Button which navigates the consumer up to top if the page when pressed.  

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
