### PR TITLE
Update yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -18243,9 +18243,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema#10047a793c01b7119fc418545b3e7bad05059736":
-  version "17.0.2"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema#10047a793c01b7119fc418545b3e7bad05059736"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema#5fe60907a8b6b228d9c5e8ba3d459cc7e841c4c1":
+  version "17.1.0"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema#5fe60907a8b6b228d9c5e8ba3d459cc7e841c4c1"
 
 vinyl-file@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description

Seeing `additional-linting` & `test_and_build` failures from an outdated `yarn.lock` file

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] `yarn.lock` updated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
