### PR TITLE
Flat facility page bugs

### DIFF
--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/EligibilityModal.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/EligibilityModal.jsx
@@ -75,7 +75,7 @@ export default function EligibilityModal({
 
   return (
     <Modal
-      id="cancelAppt"
+      id="eligibilityModal"
       status="warning"
       visible
       onClose={onClose}

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
@@ -72,7 +72,9 @@ function VAFacilityPageV2({
   const history = useHistory();
   const loadingEligibility = loadingEligibilityStatus === FETCH_STATUS.loading;
   const loadingParents = parentFacilitiesStatus === FETCH_STATUS.loading;
-  const loadingFacilities = childFacilitiesStatus === FETCH_STATUS.loading;
+  const loadingFacilities =
+    childFacilitiesStatus === FETCH_STATUS.loading ||
+    childFacilitiesStatus === FETCH_STATUS.notStarted;
 
   useEffect(
     () => {

--- a/src/applications/vaos/new-appointment/newAppointmentFlow.js
+++ b/src/applications/vaos/new-appointment/newAppointmentFlow.js
@@ -4,7 +4,6 @@ import {
   getFormData,
   getNewAppointment,
   getTypeOfCare,
-  getTypeOfCareFacilities,
   selectUseFlatFacilityPage,
 } from '../utils/selectors';
 import { FACILITY_TYPES, FLOW_TYPES, TYPES_OF_CARE } from '../utils/constants';
@@ -62,24 +61,26 @@ function getFacilityPageKey(state) {
 }
 
 async function vaFacilityNext(state, dispatch) {
-  let eligibility;
+  let eligibility = getEligibilityStatus(state);
 
   if (selectUseFlatFacilityPage(state)) {
-    const location = getChosenFacilityInfo(state);
-    const siteId = getSiteIdFromFakeFHIRId(location.id);
+    // Fetch eligibility if we haven't already
+    if (eligibility.direct === null && eligibility.request === null) {
+      const location = getChosenFacilityInfo(state);
+      const siteId = getSiteIdFromFakeFHIRId(location.id);
 
-    eligibility = await dispatch(
-      checkEligibility({
-        location,
-        siteId,
-        showModal: getTypeOfCareFacilities(state)?.length > 1,
-      }),
-    );
+      eligibility = await dispatch(
+        checkEligibility({
+          location,
+          siteId,
+          showModal: true,
+        }),
+      );
+    }
+
     if (!eligibility.direct && !eligibility.request) {
       return VA_FACILITY_V2_KEY;
     }
-  } else {
-    eligibility = getEligibilityStatus(state);
   }
 
   if (eligibility.direct) {

--- a/src/applications/vaos/new-appointment/newAppointmentFlow.js
+++ b/src/applications/vaos/new-appointment/newAppointmentFlow.js
@@ -1,9 +1,10 @@
 import {
+  getChosenFacilityInfo,
+  getEligibilityStatus,
   getFormData,
   getNewAppointment,
-  getEligibilityStatus,
   getTypeOfCare,
-  getChosenFacilityInfo,
+  getTypeOfCareFacilities,
   selectUseFlatFacilityPage,
 } from '../utils/selectors';
 import { FACILITY_TYPES, FLOW_TYPES, TYPES_OF_CARE } from '../utils/constants';
@@ -64,9 +65,16 @@ async function vaFacilityNext(state, dispatch) {
   let eligibility;
 
   if (selectUseFlatFacilityPage(state)) {
-    const facility = getChosenFacilityInfo(state);
-    const siteId = getSiteIdFromFakeFHIRId(facility.id);
-    eligibility = await dispatch(checkEligibility(facility, siteId));
+    const location = getChosenFacilityInfo(state);
+    const siteId = getSiteIdFromFakeFHIRId(location.id);
+
+    eligibility = await dispatch(
+      checkEligibility({
+        location,
+        siteId,
+        showModal: getTypeOfCareFacilities(state)?.length > 1,
+      }),
+    );
     if (!eligibility.direct && !eligibility.request) {
       return VA_FACILITY_V2_KEY;
     }

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -392,10 +392,8 @@ export function openFacilityPageV2(page, uiSchema, schema) {
           address: selectVet360ResidentialAddress(initialState),
         });
 
-        // If we have an already selected location or only have a single location
-        // fetch eligbility data immediately
-        const eligibilityDataNeeded =
-          !!facilityId || typeOfCareFacilities?.length === 1;
+        // If we have only have a single location fetch eligbility data immediately
+        const eligibilityDataNeeded = typeOfCareFacilities?.length === 1;
 
         if (!typeOfCareFacilities.length) {
           recordEligibilityFailure(

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -290,7 +290,7 @@ export function fetchFacilityDetails(facilityId) {
   };
 }
 
-export function checkEligibility(location, siteId) {
+export function checkEligibility({ location, siteId, showModal }) {
   return async (dispatch, getState) => {
     const state = getState();
     const useVSP = vaosVSPAppointmentNew(state);
@@ -318,6 +318,7 @@ export function checkEligibility(location, siteId) {
         typeOfCareId,
         eligibilityData,
         facilityId: location.id,
+        showModal,
       });
 
       try {
@@ -393,7 +394,8 @@ export function openFacilityPageV2(page, uiSchema, schema) {
         });
 
         // If we have only have a single location fetch eligbility data immediately
-        const eligibilityDataNeeded = typeOfCareFacilities?.length === 1;
+        const eligibilityDataNeeded =
+          !!facilityId || typeOfCareFacilities?.length === 1;
 
         if (!typeOfCareFacilities.length) {
           recordEligibilityFailure(
@@ -411,13 +413,13 @@ export function openFacilityPageV2(page, uiSchema, schema) {
           newAppointment.eligibility[`${facilityId}_${typeOfCareId}`] || null;
 
         if (eligibilityDataNeeded && !eligibilityChecks) {
-          const selectedFacility = typeOfCareFacilities[0];
+          const location = typeOfCareFacilities.find(f => f.id === facilityId);
 
           if (!siteId) {
-            siteId = getSiteIdFromFakeFHIRId(selectedFacility.id);
+            siteId = getSiteIdFromFakeFHIRId(location.id);
           }
 
-          dispatch(checkEligibility(selectedFacility, siteId));
+          dispatch(checkEligibility({ location, siteId, showModal: false }));
         }
       }
     } catch (e) {

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -19,7 +19,7 @@ import {
   selectSystemIds,
   getEligibilityStatus,
   getRootIdForChosenFacility,
-  getSelectedTypeOfCareFacilities,
+  getTypeOfCareFacilities,
   getSiteIdForChosenFacility,
   vaosVSPAppointmentNew,
   getCCEType,
@@ -352,7 +352,7 @@ export function openFacilityPageV2(page, uiSchema, schema) {
       if (typeOfCareId) {
         const siteIds = selectSystemIds(initialState);
         const useVSP = vaosVSPAppointmentNew(initialState);
-        let typeOfCareFacilities = newAppointment.facilities[typeOfCareId];
+        let typeOfCareFacilities = getTypeOfCareFacilities(initialState);
         let siteId = null;
         let facilityId = newAppointment.data.vaFacility;
         let parentFacilities = newAppointment.parentFacilities;
@@ -434,7 +434,7 @@ export function openFacilityPageV2(page, uiSchema, schema) {
 export function updateFacilitySortMethod(sortMethod, uiSchema) {
   return async (dispatch, getState) => {
     let location = null;
-    const facilities = getSelectedTypeOfCareFacilities(getState());
+    const facilities = getTypeOfCareFacilities(getState());
     const calculatedDistanceFromCurrentLocation = facilities.some(
       f => !!f.legacyVAR?.distancefromCurrentLocation,
     );

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -393,7 +393,8 @@ export function openFacilityPageV2(page, uiSchema, schema) {
           address: selectVet360ResidentialAddress(initialState),
         });
 
-        // If we have only have a single location fetch eligbility data immediately
+        // If we have an already selected location or only have a single location
+        // fetch eligbility data immediately
         const eligibilityDataNeeded =
           !!facilityId || typeOfCareFacilities?.length === 1;
 

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -419,7 +419,7 @@ export function openFacilityPageV2(page, uiSchema, schema) {
             siteId = getSiteIdFromFakeFHIRId(location.id);
           }
 
-          dispatch(checkEligibility({ location, siteId, showModal: false }));
+          dispatch(checkEligibility({ location, siteId }));
         }
       }
     } catch (e) {

--- a/src/applications/vaos/new-appointment/redux/reducer.js
+++ b/src/applications/vaos/new-appointment/redux/reducer.js
@@ -722,7 +722,8 @@ export default function formReducer(state = initialState, action) {
         },
         eligibilityStatus: FETCH_STATUS.succeeded,
         pastAppointments: action.eligibilityData.pastAppointments,
-        showEligibilityModal: !canSchedule.direct && !canSchedule.request,
+        showEligibilityModal:
+          action.showModal && !canSchedule.direct && !canSchedule.request,
       };
     }
     case FORM_ELIGIBILITY_CHECKS_FAILED: {

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.multi.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.multi.unit.spec.jsx
@@ -404,11 +404,6 @@ describe('VAOS integration: VA flat facility page - multiple facilities', () => 
       facilityId: '983',
       typeOfCareId: '323',
     });
-    mockEligibilityFetches({
-      siteId: '983',
-      facilityId: '983GB',
-      typeOfCareId: '323',
-    });
     const store = createTestStore(initialState);
     await setTypeOfCare(store, /primary care/i);
 
@@ -431,6 +426,12 @@ describe('VAOS integration: VA flat facility page - multiple facilities', () => 
     expect(
       await screen.findByLabelText(/Fake facility name 1/i),
     ).to.have.attribute('checked');
+
+    expect(
+      await screen.queryByText(
+        /You’ve reached the limit for appointment request/i,
+      ),
+    ).to.be.null;
   });
 
   it('should show unsupported facilities alert with facility locator tool link', async () => {
@@ -592,6 +593,7 @@ describe('VAOS integration: VA flat facility page - multiple facilities', () => 
     await screen.findByText(
       /We couldn’t find a recent appointment at this location/i,
     );
+    screen.getByRole('alertdialog');
   });
 
   // TODO: should use correct eligibility info after a split type of care is changed

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.multi.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.multi.unit.spec.jsx
@@ -593,7 +593,7 @@ describe('VAOS integration: VA flat facility page - multiple facilities', () => 
     await screen.findByText(
       /We couldn’t find a recent appointment at this location/i,
     );
-    screen.getByRole('alertdialog');
+    expect(screen.getByRole('alertdialog')).to.be.ok;
   });
 
   // TODO: should use correct eligibility info after a split type of care is changed

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.multi.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.multi.unit.spec.jsx
@@ -404,6 +404,11 @@ describe('VAOS integration: VA flat facility page - multiple facilities', () => 
       facilityId: '983',
       typeOfCareId: '323',
     });
+    mockEligibilityFetches({
+      siteId: '983',
+      facilityId: '983GB',
+      typeOfCareId: '323',
+    });
     const store = createTestStore(initialState);
     await setTypeOfCare(store, /primary care/i);
 

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -143,17 +143,20 @@ export function getParentFacilities(state) {
   return getNewAppointment(state).parentFacilities;
 }
 
-export function getChosenFacilityInfo(state) {
+export function getTypeOfCareFacilities(state) {
   const data = getFormData(state);
   const facilities = getNewAppointment(state).facilities;
   const typeOfCareId = getTypeOfCare(data)?.id;
-  const selectedTypeOfCareFacilities = selectUseFlatFacilityPage(state)
+
+  return selectUseFlatFacilityPage(state)
     ? facilities[`${typeOfCareId}`]
     : facilities[`${typeOfCareId}_${data.vaParent}`];
+}
 
+export function getChosenFacilityInfo(state) {
   return (
-    selectedTypeOfCareFacilities?.find(
-      facility => facility.id === data.vaFacility,
+    getTypeOfCareFacilities(state)?.find(
+      facility => facility.id === getFormData(state).vaFacility,
     ) || null
   );
 }
@@ -244,6 +247,7 @@ export function getEligibilityChecks(state) {
   const data = getFormData(state);
   const newAppointment = getNewAppointment(state);
   const typeOfCareId = getTypeOfCare(data)?.id;
+
   return (
     newAppointment.eligibility[`${data.vaFacility}_${typeOfCareId}`] || null
   );
@@ -367,7 +371,7 @@ export function getFacilityPageV2Info(state) {
     requestLocationStatus,
     selectedFacility: getChosenFacilityInfo(state),
     singleValidVALocation: facilities?.length === 1 && !!data.vaFacility,
-    showEligibilityModal: facilities?.length > 1 && showEligibilityModal,
+    showEligibilityModal,
     sortMethod: facilityPageSortMethod,
     typeOfCare: typeOfCare?.name,
   };

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -132,13 +132,6 @@ export function getCCEType(state) {
   return typeOfCare?.cceType;
 }
 
-export function getSelectedTypeOfCareFacilities(state) {
-  const data = getFormData(state);
-  const newAppointment = getNewAppointment(state);
-  const typeOfCare = getTypeOfCare(data);
-  return newAppointment.facilities[(typeOfCare?.id)];
-}
-
 export function getParentFacilities(state) {
   return getNewAppointment(state).parentFacilities;
 }

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -366,7 +366,7 @@ export function getFacilityPageV2Info(state) {
     parentFacilitiesStatus,
     requestLocationStatus,
     selectedFacility: getChosenFacilityInfo(state),
-    singleValidVALocation: facilities?.length === 1,
+    singleValidVALocation: facilities?.length === 1 && !!data.vaFacility,
     showEligibilityModal: facilities?.length > 1 && showEligibilityModal,
     sortMethod: facilityPageSortMethod,
     typeOfCare: typeOfCare?.name,


### PR DESCRIPTION
## Description
This PR addresses 2 bugs:

### Cannot read property 'requestFailed' of null
http://sentry.vfs.va.gov/organizations/vsp/issues/4083/?environment=production&project=4&query=is%3Aunresolved+url%3Ahttps%3A%2F%2Fwww.va.gov%2Fhealth-care%2Fschedule-view-va-appointments%2Fappointments%2Fnew-appointment%2Fva-facility-2&statsPeriod=7d

This is occurring for a small number of people who choose a facility, hit continue, and then return to the facility page.  When returning to the page with a facility already selected, we were performing an eligibility check on the wrong facility id, and then unintentionally trying to display the eligibility modal with an empty eligibility result.

This PR prevents the eligibility modal from displaying on load when returning to the page, and makes sure we are checking for the correct eligibility info.

### null is not an object (evaluating 'n.name')
http://sentry.vfs.va.gov/organizations/vsp/issues/5883/?project=4&query=url%3Ahttps%3A%2F%2Fwww.va.gov%2Fhealth-care%2Fschedule-view-va-appointments%2Fappointments%2Fnew-appointment%2Fva-facility-2+url%3Ahttps%3A%2F%2Fwww.va.gov%2Fhealth-care%2Fschedule-view-va-appointments%2Fappointments%2Fnew-appointment%2Fva-facility-2&statsPeriod=24h

I believe this is occurring because the `<VAFacilityInfoMessage>` component is rendering before we have any facilities

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
