### PR TITLE
[Development] Add description to submitted HLR contestable issues

### DIFF
--- a/src/applications/disability-benefits/996/config/submit-transformer.js
+++ b/src/applications/disability-benefits/996/config/submit-transformer.js
@@ -40,18 +40,26 @@ export function transform(formConfig, form) {
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/resolvedOptions
     Intl.DateTimeFormat().resolvedOptions().timeZone;
 
-  const getIssueName = ({ attributes }) => {
-    const hasPercentage = attributes?.ratingIssuePercentNumber
-      ? ` - ${attributes.ratingIssuePercentNumber}%`
-      : '';
-    return `${attributes.ratingIssueSubjectText}${hasPercentage}`;
+  const getIssueName = ({ attributes } = {}) => {
+    const {
+      ratingIssueSubjectText,
+      ratingIssuePercentNumber,
+      description,
+    } = attributes;
+    return [
+      ratingIssueSubjectText,
+      `${ratingIssuePercentNumber || '0'}%`,
+      description,
+    ]
+      .filter(part => part)
+      .join(' - ');
   };
 
   /* submitted contested issue format
   [{
     "type": "contestableIssue",
     "attributes": {
-      "issue": "tinnitus - 10",
+      "issue": "tinnitus - 10% - some longer description",
       "decisionDate": "1900-01-01",
       "decisionIssueId": 1,
       "ratingIssueReferenceId": "2",

--- a/src/applications/disability-benefits/996/config/submit-transformer.js
+++ b/src/applications/disability-benefits/996/config/submit-transformer.js
@@ -52,7 +52,8 @@ export function transform(formConfig, form) {
       description,
     ]
       .filter(part => part)
-      .join(' - ');
+      .join(' - ')
+      .substring(0, 140);
   };
 
   /* submitted contested issue format

--- a/src/applications/disability-benefits/996/tests/fixtures/data/transformed-maximal-test.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/data/transformed-maximal-test.json
@@ -26,7 +26,7 @@
     {
       "type": "contestableIssue",
       "attributes": {
-        "issue": "Headaches - 20%",
+        "issue": "Headaches - 20% - Acute chronic head pain",
         "decisionDate": "2011-01-02",
         "decisionIssueId": 44,
         "ratingIssueReferenceId": "66"
@@ -35,7 +35,7 @@
     {
       "type": "contestableIssue",
       "attributes": {
-        "issue": "Being green - 50%",
+        "issue": "Being green - 50% - Chronic greenness",
         "decisionDate": "2011-01-01",
         "decisionIssueId": 42,
         "ratingIssueReferenceId": "52",


### PR DESCRIPTION
## Description

Currently, when submitting Higher-Level Review contestable issue data, we include the issue name along with the rating percentage, e.g. `Emphysema - 100%`.

We have been requested to also include the issue description text, e.g. `Emphysema - 100% - Service connection for Emphysema is granted with an evaluation of 100 percent effective June 1, 2013.` - this may or may not include the decision date; but that will be included along with the submitted data.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/15597

## Testing done

Updated submit transformer unit test

## Screenshots

<details><summary>Resulting transformed data</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-11-04 at 2 40 10 PM](https://user-images.githubusercontent.com/136959/98166432-0101c200-1ead-11eb-9be2-932e35855548.png)</details>

## Acceptance criteria
- [x] submitted `issue` includes contestable issue description

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
