### PR TITLE
[Resources and support] Remove prod feature flag

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -900,7 +900,6 @@
     "template": {
       "title:": "Search results",
       "layout": "page-react.html",
-      "vagovprod": false,
       "includeBreadcrumbs": true,
       "breadcrumbs_override": [
         {


### PR DESCRIPTION
## Description
I forgot to remove this feature flag from the registry for launching the search results part of R&S...

## Testing done


## Screenshots


## Acceptance criteria
- [ ] App will go to prod

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
