### PR TITLE
Remove array from field_alert_block_reference

### DIFF
--- a/src/site/stages/build/process-cms-exports/schemas/input/paragraph-alert.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/paragraph-alert.js
@@ -3,7 +3,11 @@
 module.exports = {
   type: 'object',
   properties: {
-    field_alert_block_reference: { $ref: 'EntityReferenceArray' },
+    field_alert_block_reference: {
+      type: 'array',
+      maxItems: 1,
+      items: { $ref: 'EntityReference' },
+    },
     field_alert_heading: { $ref: 'GenericNestedString' },
     field_alert_type: { $ref: 'GenericNestedString' },
     field_va_paragraphs: { $ref: 'EntityReferenceArray' },

--- a/src/site/stages/build/process-cms-exports/schemas/output/paragraph-alert.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/paragraph-alert.js
@@ -13,12 +13,7 @@ module.exports = {
           type: ['array', 'null'],
           items: { $ref: 'Paragraph' },
         },
-        fieldAlertBlockReference: {
-          type: ['array', 'null'],
-          items: {
-            $ref: 'BlockContent',
-          },
-        },
+        fieldAlertBlockReference: { $ref: 'BlockContent' },
       },
       required: [
         'entityType',

--- a/src/site/stages/build/process-cms-exports/transformers/paragraph-alert.js
+++ b/src/site/stages/build/process-cms-exports/transformers/paragraph-alert.js
@@ -16,7 +16,7 @@ const transform = entity => {
       fieldAlertHeading: getDrupalValue(fieldAlertHeading),
       fieldVaParagraphs: fieldVaParagraphs.length ? fieldVaParagraphs : null,
       fieldAlertBlockReference: fieldAlertBlockReference.length
-        ? fieldAlertBlockReference
+        ? fieldAlertBlockReference[0]
         : null,
     },
   };


### PR DESCRIPTION
## Description
There is a wrong section being displayed.

Based on the [liquid template](https://github.com/department-of-veterans-affairs/vets-website/blob/71d243c6e0b84c74ebbd30adec81c9a41b15cf13/src/site/paragraphs/alert.drupal.liquid#L31-L34), it is expecting an object and not an array.

The transformer is returning an array of objects and the raw node only shows an array of 1 object

```
    "field_alert_block_reference": [
        {
            "target_type": "block_content",
            "target_uuid": "4e43f3ca-7301-4f22-826a-67c9470c31d6"
        }
    ],
```

The solution is to change it to return only an object

## Testing done
Locally

## Screenshots
![Screen Shot 2020-10-29 at 1.49.51 PM.png](https://images.zenhubusercontent.com/5d89589c3ac3440001d19c89/6d67aea6-eae8-48b9-8b17-b2f4d0655b4c)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
