### PR TITLE
[Development] Add Decision date to HLR contestable issue

### DIFF
--- a/src/applications/disability-benefits/996/content/contestedIssues.jsx
+++ b/src/applications/disability-benefits/996/content/contestedIssues.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import moment from 'moment';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import { COVID_FAQ_URL, NULL_CONDITION_STRING } from '../constants';
@@ -25,6 +26,7 @@ export const disabilityOption = ({ attributes }) => {
     ratingIssueSubjectText,
     description,
     ratingIssuePercentNumber,
+    approxDecisionDate,
   } = attributes;
   // May need to throw an error to Sentry if any of these doesn't exist
   // A valid rated disability *can* have a rating percentage of 0%
@@ -32,15 +34,23 @@ export const disabilityOption = ({ attributes }) => {
 
   return (
     <div className="widget-content">
-      <h3 className="vads-u-margin-top--0 vads-u-font-size--h4">
+      <h3 className="vads-u-margin-y--0 vads-u-font-size--h4">
         {typeof ratingIssueSubjectText === 'string'
           ? ratingIssueSubjectText
           : NULL_CONDITION_STRING}
       </h3>
-      <span>{description || ''}</span>
+      {description && (
+        <p className="vads-u-margin-bottom--0">{description || ''}</p>
+      )}
       {showPercentNumber && (
-        <p>
+        <p className="vads-u-margin-bottom--0">
           Current rating: <strong>{ratingIssuePercentNumber}%</strong>
+        </p>
+      )}
+      {approxDecisionDate && (
+        <p>
+          Decision date:{' '}
+          <strong>{moment(approxDecisionDate).format('MMM D, YYYY')}</strong>
         </p>
       )}
     </div>

--- a/src/applications/disability-benefits/996/tests/components/contestedIssues.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/components/contestedIssues.unit.spec.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import moment from 'moment';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import ReactTestUtils from 'react-dom/test-utils';
@@ -84,9 +85,15 @@ describe('Higher-Level Review 0996 choose contested issues', () => {
     $$('.widget-outline label', formDOM).forEach((label, index) => {
       const data = issues[index].attributes;
       expect($('h3', label).textContent).to.equal(data.ratingIssueSubjectText);
-      expect($('span', label).textContent).to.equal(data.description || '');
-      expect($('.widget-content p', label).textContent).to.equal(
+      const content = $('.widget-content', label).textContent;
+      expect(content).to.contain(data.description || '');
+      expect(content).to.contain(
         `Current rating: ${data.ratingIssuePercentNumber}%`,
+      );
+      expect(content).to.contain(
+        `Decision date: ${moment(data.approxDecisionDate).format(
+          'MMM D, YYYY',
+        )}`,
       );
     });
   });


### PR DESCRIPTION
## Description

A user may appear to have duplicate contestable issues with different decision dates. This PR adds the decision date to allow the user to better differentiate and determine the correct issue to select.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/15579

## Testing done

Updated unit tests

## Screenshots

<details><summary>Decision date added to contestable issues card</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-11-04 at 3 16 25 PM](https://user-images.githubusercontent.com/136959/98172282-b422e900-1eb6-11eb-9b1b-cc114517910c.png)</details>

## Acceptance criteria
- [x] HLR contestable issues include a decision date

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
