### PR TITLE
Imported vets-json-schema schema

### DIFF
--- a/src/applications/disability-benefits/686c-674/config/chapters/household-income/householdIncome.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/household-income/householdIncome.js
@@ -1,13 +1,7 @@
 import { netWorthCalculation, netWorthTitle } from './helpers';
+import { householdIncome } from '../../utilities';
 
-export const schema = {
-  type: 'object',
-  properties: {
-    householdIncome: {
-      type: 'boolean',
-    },
-  },
-};
+export const schema = householdIncome;
 
 export const uiSchema = {
   householdIncome: {

--- a/src/applications/disability-benefits/686c-674/config/utilities.js
+++ b/src/applications/disability-benefits/686c-674/config/utilities.js
@@ -79,6 +79,7 @@ const {
   reportChildStoppedAttendingSchool,
   reportStepchildNotInHousehold,
   report674,
+  householdIncome,
 } = fullSchema.properties;
 
 export {
@@ -93,6 +94,7 @@ export {
   reportChildStoppedAttendingSchool,
   reportStepchildNotInHousehold,
   report674,
+  householdIncome,
   isServerError,
   isClientError,
 };


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/15788)

This PR is to import the `vets-json-schema` properties for `householdIncome` and use that inside the form 686c instead of static properties.

## Testing done
Existing tests still pass


## Acceptance criteria
- [x] vets-website is now using the pension questions from vets-json-schema
- [x] PRs have been submitted for review

