### PR TITLE
Redirect users registered to Sacramento to v1 facility page

### DIFF
--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
@@ -91,12 +91,10 @@ function VAFacilityPageV2({
     const facility = facilities.find(f => f.id === newData.vaFacility);
     const vaParent = getParentOfLocation(parentFacilities, facility)?.id;
 
-    if (!!facility && !!vaParent) {
-      updateFormData(pageKey, uiSchema, {
-        ...newData,
-        vaParent,
-      });
-    }
+    updateFormData(pageKey, uiSchema, {
+      ...newData,
+      vaParent,
+    });
   };
 
   const title = (

--- a/src/applications/vaos/tests/utils/selectors.unit.spec.js
+++ b/src/applications/vaos/tests/utils/selectors.unit.spec.js
@@ -929,4 +929,26 @@ describe('VAOS selectors', () => {
       expect(selectUseFlatFacilityPage(state)).to.be.false;
     });
   });
+
+  it('should return false if feature toggle is on and user is registered to Sacramento VA and has cerner facilities', () => {
+    const state = {
+      featureToggles: {
+        vaOnlineSchedulingFlatFacilityPage: true,
+      },
+      user: {
+        profile: {
+          facilities: [
+            {
+              facilityId: '668',
+              isCerner: true,
+              usesCernerAppointments: true,
+            },
+            { facilityId: '612', isCerner: false },
+          ],
+        },
+      },
+    };
+
+    expect(selectUseFlatFacilityPage(state)).to.be.false;
+  });
 });

--- a/src/applications/vaos/tests/utils/selectors.unit.spec.js
+++ b/src/applications/vaos/tests/utils/selectors.unit.spec.js
@@ -21,6 +21,7 @@ import {
   selectLocalExpressCareWindowString,
   selectNextAvailableExpressCareWindowString,
   selectIsCernerOnlyPatient,
+  selectUseFlatFacilityPage,
 } from '../../utils/selectors';
 
 import { VHA_FHIR_ID, APPOINTMENT_TYPES } from '../../utils/constants';
@@ -859,6 +860,73 @@ describe('VAOS selectors', () => {
           'h:mm a',
         )} to ${endTime.format('h:mm a')} MT`,
       );
+    });
+  });
+
+  describe('selectUseFlatFacilityPage', () => {
+    it('should return true if feature toggle is on and user is not cerner patient', () => {
+      const state = {
+        featureToggles: {
+          vaOnlineSchedulingFlatFacilityPage: true,
+        },
+      };
+
+      expect(selectUseFlatFacilityPage(state)).to.be.true;
+    });
+
+    it('should return false if feature toggle is off', () => {
+      const state = {
+        featureToggles: {
+          vaOnlineSchedulingFlatFacilityPage: false,
+        },
+        user: {
+          profile: {
+            facilities: [{ facilityId: '124', isCerner: false }],
+          },
+        },
+      };
+
+      expect(selectUseFlatFacilityPage(state)).to.be.false;
+    });
+
+    it('should return false if feature toggle is on and user has cerner facilities', () => {
+      const state = {
+        featureToggles: {
+          vaOnlineSchedulingFlatFacilityPage: true,
+        },
+        user: {
+          profile: {
+            facilities: [
+              {
+                facilityId: '668',
+                isCerner: true,
+                usesCernerAppointments: true,
+              },
+              { facilityId: '124', isCerner: false },
+            ],
+          },
+        },
+      };
+
+      expect(selectUseFlatFacilityPage(state)).to.be.false;
+    });
+
+    it('should return false if feature toggle is on and user is registered to Sacramento VA', () => {
+      const state = {
+        featureToggles: {
+          vaOnlineSchedulingFlatFacilityPage: true,
+        },
+        user: {
+          profile: {
+            facilities: [
+              { facilityId: '983', isCerner: false },
+              { facilityId: '612', isCerner: false },
+            ],
+          },
+        },
+      };
+
+      expect(selectUseFlatFacilityPage(state)).to.be.false;
     });
   });
 });

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -49,6 +49,9 @@ export const selectIsCernerPatient = state =>
     f => f.isCerner && f.usesCernerAppointments,
   );
 
+export const selectHasSacramentoVAFacility = state =>
+  selectPatientFacilities(state)?.some(f => f.facilityId === '612');
+
 export const vaosApplication = state => toggleValues(state).vaOnlineScheduling;
 export const vaosCancel = state => toggleValues(state).vaOnlineSchedulingCancel;
 export const vaosRequests = state =>
@@ -69,7 +72,9 @@ export const selectFeatureToggleLoading = state => toggleValues(state).loading;
 const vaosFlatFacilityPage = state =>
   toggleValues(state).vaOnlineSchedulingFlatFacilityPage;
 export const selectUseFlatFacilityPage = state =>
-  vaosFlatFacilityPage(state) && !selectIsCernerPatient(state);
+  vaosFlatFacilityPage(state) &&
+  !selectIsCernerPatient(state) &&
+  !selectHasSacramentoVAFacility(state);
 
 export function getNewAppointment(state) {
   return state.newAppointment;

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -49,7 +49,7 @@ export const selectIsCernerPatient = state =>
     f => f.isCerner && f.usesCernerAppointments,
   );
 
-export const selectHasSacramentoVAFacility = state =>
+export const selectIsRegisteredToSacramentoVA = state =>
   selectPatientFacilities(state)?.some(f => f.facilityId === '612');
 
 export const vaosApplication = state => toggleValues(state).vaOnlineScheduling;
@@ -74,7 +74,7 @@ const vaosFlatFacilityPage = state =>
 export const selectUseFlatFacilityPage = state =>
   vaosFlatFacilityPage(state) &&
   !selectIsCernerPatient(state) &&
-  !selectHasSacramentoVAFacility(state);
+  !selectIsRegisteredToSacramentoVA(state);
 
 export function getNewAppointment(state) {
   return state.newAppointment;


### PR DESCRIPTION
## Description
Sacramento VA has a unique situation where its root facility (id: 612) is not an actual facility, which is causing radio buttons to be un-selectable on the new facility page.

This PR updates the `selectUseFlatFacilityPage` selector to temporarily redirect users registered to Sacremento to the v1 page while we work on a fix.

## Testing done
Local and unit


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
