### PR TITLE
[15046] Accessibility Telephone Numbers

### DIFF
--- a/src/applications/vaos/appointment-list/components/cards/express-care/ExpressCareCard.jsx
+++ b/src/applications/vaos/appointment-list/components/cards/express-care/ExpressCareCard.jsx
@@ -5,6 +5,7 @@ import { sentenceCase } from '../../../../utils/formatters';
 import { getPatientTelecom } from '../../../../services/appointment';
 import { APPOINTMENT_STATUS } from '../../../../utils/constants';
 import ExpressCareStatus from './ExpressCareStatus';
+import Telephone from '@department-of-veterans-affairs/formation-react/Telephone';
 
 export default function ExpressCareCard({
   appointment,
@@ -47,7 +48,7 @@ export default function ExpressCareCard({
               Your contact details
             </dt>
             <dd>
-              {getPatientTelecom(appointment, 'phone')}
+              <Telephone contact={getPatientTelecom(appointment, 'phone')} />
               <br />
               {getPatientTelecom(appointment, 'email')}
             </dd>

--- a/src/applications/vaos/components/FacilityAddress.jsx
+++ b/src/applications/vaos/components/FacilityAddress.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import FacilityDirectionsLink from '../components/FacilityDirectionsLink';
+import Telephone from '@department-of-veterans-affairs/formation-react/Telephone';
 
 export default function FacilityAddress({
   name,
@@ -41,7 +42,8 @@ export default function FacilityAddress({
             <strong>Main phone:</strong>
           </dt>{' '}
           <dd className="vads-u-display--inline">
-            <a href={`tel:${phone.replace(/[^0-9]/g, '')}`}>{phone}</a>
+            <br />
+            <Telephone contact={phone} />
           </dd>
         </dl>
       )}

--- a/src/applications/vaos/express-care/components/ExpressCareInfoPage.jsx
+++ b/src/applications/vaos/express-care/components/ExpressCareInfoPage.jsx
@@ -11,6 +11,9 @@ import {
   selectExpressCareNewRequest,
 } from '../../utils/selectors';
 import { scrollAndFocus } from '../../utils/scrollAndFocus';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 const pageKey = 'info';
 const pageTitle = 'How Express Care works';
@@ -69,8 +72,8 @@ function ExpressCareInfoPage({
       >
         <p id="vaos-ecip-call-911" data-testid="p_vaos-ecip-call-911">
           <strong>
-            Call <a href="tel:911">911</a> or go to the nearest emergency room
-            now if you have any of these symptoms:
+            Call <Telephone contact={CONTACTS['911']} /> or go to the nearest
+            emergency room now if you have any of these symptoms:
           </strong>
         </p>
         <ul
@@ -95,7 +98,7 @@ function ExpressCareInfoPage({
         <ul aria-labelledby="vaos-ecip-talk" data-testid="ul_vaos-ecip-talk">
           <li>
             Call our Veterans Crisis Line at{' '}
-            <a href="tel:800-273-8255">800-273-8255</a> and select 1.
+            <Telephone contact="800-273-8255" extension="1" />.
           </li>
         </ul>
       </AlertBox>

--- a/src/applications/vaos/tests/appointment-list/components/ExpressCareList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ExpressCareList.unit.spec.jsx
@@ -204,7 +204,7 @@ describe('VAOS integration: express care requests', () => {
       expect(getByText(/cancel appointment/i)).to.have.tagName('button');
 
       expect(baseElement).to.contain.text('Your contact details');
-      expect(baseElement).to.contain.text('5555555566');
+      expect(baseElement).to.contain.text('866-651-3180');
       expect(baseElement).to.contain.text('patient.test@va.gov');
 
       expect(baseElement).to.contain.text(

--- a/src/applications/vaos/tests/appointment-list/components/FutureAppointmentsList.cc.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/FutureAppointmentsList.cc.unit.spec.jsx
@@ -64,7 +64,7 @@ describe('VAOS integration: upcoming CC appointments', () => {
     expect(baseElement).to.contain.text('Big sky medical');
     expect(baseElement).to.contain.text('123 Big Sky st');
     expect(baseElement).to.contain.text('Bozeman, MT 59715');
-    expect(baseElement).to.contain.text('4065555555');
+    expect(baseElement).to.contain.text('406-555-5555');
     expect(baseElement).to.contain.text('Special instructions');
     expect(baseElement).to.contain.text('Bring your glasses');
     expect(getByText(/add to calendar/i)).to.have.tagName('a');

--- a/src/applications/vaos/tests/components/FacilityAddress.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/FacilityAddress.unit.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { expect } from 'chai';
 
 import FacilityAddress from '../../components/FacilityAddress';
@@ -24,7 +24,7 @@ const facility = {
 describe('VAOS <FacilityAddress>', () => {
   it('should render address for va facility', () => {
     const address = facility.address;
-    const tree = shallow(<FacilityAddress facility={facility} />);
+    const tree = mount(<FacilityAddress facility={facility} />);
     expect(tree.text()).to.contain(address.line[0]);
     expect(tree.text()).to.contain(address.city);
     expect(tree.text()).to.contain(address.state);

--- a/src/applications/vaos/tests/express-care/components/ExpressCareConfirmationPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/express-care/components/ExpressCareConfirmationPage.unit.spec.jsx
@@ -163,7 +163,7 @@ describe('VAOS integration: Express Care form submission', () => {
     );
 
     expect(screen.baseElement).to.contain.text('Your contact details');
-    expect(screen.baseElement).to.contain.text('5555555555');
+    expect(screen.baseElement).to.contain.text('555-555-5555');
     expect(screen.baseElement).to.contain.text('test@va.gov');
 
     expect(screen.baseElement).to.contain.text(


### PR DESCRIPTION
## Description
Some of our telephone numbers (Express Care) are coming through as long strings of text without dash separators. Our content guidelines indicate we should be separating phone numbers with dashes for easier pattern recognition.

> Use hyphens between numbers, and don’t use parentheses to set off the area code: 212-123-1234.

I'd also like to consider using the Telephone design system component because it offers a better experience for screen readers by reading each number aloud individually.

As a screen reader user, I want to hear telephone numbers read aloud in a steady cadence so I can understand them better.
As a user who has a hard time "chunking" phone numbers when there are no dashes or separations, I want to see phone numbers with well-formatted blocks so I can recognize them as phone numbers easier.

- [x] https://staging.va.gov/health-care/schedule-view-va-appointments/appointments/
- [x] https://staging.va.gov/health-care/schedule-view-va-appointments/appointments/past
- [x] https://staging.va.gov/health-care/schedule-view-va-appointments/appointments/express-care
- [x] https://staging.va.gov/health-care/schedule-view-va-appointments/appointments/new-express-care-request
- [x] https://staging.va.gov/health-care/schedule-view-va-appointments/appointments/new-express-care-request/confirmation

## Testing done


## Screenshots
![image](https://user-images.githubusercontent.com/8315447/98255153-1c230f00-1f4b-11eb-89ce-17023ccf2132.png)
![image](https://user-images.githubusercontent.com/8315447/98255273-3c52ce00-1f4b-11eb-95ff-51b6467a2c31.png)
![image](https://user-images.githubusercontent.com/8315447/98254186-fb0dee80-1f49-11eb-843b-a34ff3dcb4b2.png)
![image](https://user-images.githubusercontent.com/8315447/98255398-5ee4e700-1f4b-11eb-870f-1fc582b9ef63.png)
![image](https://user-images.githubusercontent.com/8315447/98255462-6e643000-1f4b-11eb-8920-90c742f8616e.png)

## Acceptance criteria
- [x] Phone numbers are formatted correctly
- [x] Team has implemented the Telephone design system component for appointment cards OR
- [ ] Team decides against using the Telephone component and documents the decision

## Definition of done
- [ ] Review and acknowledge feedback.
- [ ] Fix and/or document decisions made.
- [ ] Accessibility specialist will close ticket after reviewing documented decisions / validating fix.

- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
