### PR TITLE
Added outreach links to both link maps

### DIFF
--- a/src/platform/landing-pages/header-footer-data.json
+++ b/src/platform/landing-pages/header-footer-data.json
@@ -46,8 +46,15 @@
     },
     {
       "column": 1,
-      "href": "https://www.nrd.gov",
+      "href": "https://www.va.gov/outreach-and-events/events/",
       "order": 7,
+      "target": null,
+      "title": "VA Outreach Events"
+    },
+    {
+      "column": 1,
+      "href": "https://www.nrd.gov",
+      "order": 8,
       "target": "_blank",
       "title": "National Resource Directory",
       "rel": "noopener noreferrer"
@@ -112,8 +119,15 @@
     },
     {
       "column": 2,
-      "href": "https://www.va.gov/welcome-kit/",
+      "href": "https://www.va.gov/outreach-and-events/outreach-materials/",
       "order": 9,
+      "target": null,
+      "title": "VA Outreach Materials"
+    },
+    {
+      "column": 2,
+      "href": "https://www.va.gov/welcome-kit/",
+      "order": 10,
       "target": null,
       "title": "Print your VA welcome kit"
     },

--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -45,8 +45,15 @@
   },
   {
     "column": 1,
-    "href": "https://www.nrd.gov",
+    "href": "https://www.va.gov/outreach-and-events/events/",
     "order": 7,
+    "target": null,
+    "title": "VA Outreach Events"
+  },
+  {
+    "column": 1,
+    "href": "https://www.nrd.gov",
+    "order": 8,
     "target": "_blank",
     "title": "National Resource Directory",
     "rel": "noopener noreferrer"
@@ -111,8 +118,15 @@
   },
   {
     "column": 2,
-    "href": "https://www.va.gov/welcome-kit/",
+    "href": "https://www.va.gov/outreach-and-events/outreach-materials/",
     "order": 9,
+    "target": null,
+    "title": "VA Outreach Materials"
+  },
+  {
+    "column": 2,
+    "href": "https://www.va.gov/welcome-kit/",
+    "order": 10,
     "target": null,
     "title": "Print your VA welcome kit"
   },


### PR DESCRIPTION
## Issue: [15384](https://github.com/department-of-veterans-affairs/va.gov-team/issues/15384)

## Description
Added to new links on footer for outreach pages. 

## Screenshots
![Screen Shot 2020-11-05 at 9 40 33 AM](https://user-images.githubusercontent.com/26075258/98255804-d0bd3080-1f4b-11eb-8b8a-66455a7c3930.png)

## Acceptance criteria
- [x] Add a link for "VA outreach events" that links to https://www.va.gov/outreach-and-events/events/ in the first column of the footer (Veteran programs and services).
- [x] Add al ink to "VA outreach materials" that links to https://www.va.gov/outreach-and-events/outreach-materials/ in the second column of the footer (More VA resources)

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
