### PR TITLE
[Development] Change HLR same office wording

### DIFF
--- a/src/applications/disability-benefits/996/content/OfficeForReview.jsx
+++ b/src/applications/disability-benefits/996/content/OfficeForReview.jsx
@@ -7,17 +7,10 @@ export const OfficeForReviewAlert = (
     headline="We will try to fulfill your request"
     className="vads-u-margin-left--3 vads-u-margin-top--0 vads-u-font-weight--normal"
     content={
-      <>
-        <p>
-          Some issues can only be processed at the office that issued your prior
-          decision. And some decisions are only processed at one VA office or
-          facility.
-        </p>
-        <p>
-          If we cannot fulfill your request, we will notify you at the time the
-          Higher-Level Review decision is made.
-        </p>
-      </>
+      <p>
+        If we cannot fulfill your request, we will notify you at the time the
+        Higher-Level Review decision is made.
+      </p>
     }
   />
 );
@@ -31,6 +24,8 @@ export const OfficeForReviewTitle = (
 export const OfficeForReviewDescription = (
   <p className="vads-u-margin-left--3">
     You have the right to request the same office conduct the review. VA may be
-    unable to grant this request.
+    unable to grant this request. In either scenario, your case will be looked
+    at by a different individual and considered separately from your original
+    decision.
   </p>
 );

--- a/src/applications/disability-benefits/996/content/OfficeForReview.jsx
+++ b/src/applications/disability-benefits/996/content/OfficeForReview.jsx
@@ -10,7 +10,7 @@ export const OfficeForReviewAlert = (
       <>
         <p>
           Some issues can only be processed at the office that issued your prior
-          decision. And some decisions are only processed at on VA office or
+          decision. And some decisions are only processed at one VA office or
           facility.
         </p>
         <p>
@@ -24,13 +24,13 @@ export const OfficeForReviewAlert = (
 
 export const OfficeForReviewTitle = (
   <strong className="normal-weight-in-review">
-    If possible, I would like to have a different office conduct this review.
+    If possible, I would like the same office conduct this review.
   </strong>
 );
 
 export const OfficeForReviewDescription = (
   <p className="vads-u-margin-left--3">
-    You have the right to request another office (different from the office that
-    issued your prior decision) to conduct the review.
+    You have the right to request the same office conduct the review. VA may be
+    unable to grant this request.
   </p>
 );


### PR DESCRIPTION
## Description

Our stakeholder requested we change the same office wording to more closely match the form description. We also included an additional sentence to ensure the Veteran doesn't get confused by this wording change.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/15829

## Testing done

N/A - content updated

## Screenshots

![Screen Shot 2020-11-05 at 8 49 21 AM](https://user-images.githubusercontent.com/136959/98256773-943a0680-1f44-11eb-88b8-8bf04210e66a.png)

## Acceptance criteria
- [x] Same office checkbox content has been updated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
