### PR TITLE
Move Dashboard CSS from entry point to the top-level app itself

### DIFF
--- a/src/applications/personalization/dashboard/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard/components/Dashboard.jsx
@@ -2,6 +2,13 @@ import React from 'react';
 import { Router, useRouterHistory } from 'react-router';
 import { createHistory } from 'history';
 
+import '../../../claims-status/sass/claims-status.scss';
+import '../sass/dashboard.scss';
+import '../sass/dashboard-alert.scss';
+import '../sass/messaging/messaging.scss';
+import '../sass/user-profile.scss';
+import '../../preferences/sass/preferences.scss';
+
 import routes from '../routes';
 
 function Dashboard({ rootUrl }) {

--- a/src/applications/personalization/dashboard/dashboard-entry.jsx
+++ b/src/applications/personalization/dashboard/dashboard-entry.jsx
@@ -1,12 +1,6 @@
 import React from 'react';
 
 import 'platform/polyfills';
-import '../../claims-status/sass/claims-status.scss';
-import './sass/dashboard.scss';
-import './sass/dashboard-alert.scss';
-import './sass/messaging/messaging.scss';
-import './sass/user-profile.scss';
-import '../preferences/sass/preferences.scss';
 
 import DashboardWrapper from '../dashboard-2/components/DashboardWrapper';
 


### PR DESCRIPTION
## Description
Doing this ensures that the CSS for Dashboard v1 does is only added to _that_ app's bundle. There is no reason to load all of the CSS for Dashboard v1 if the DashboardWrapper decides to load and show Dashboard v2.

## Testing done
Confirmed that Dashboard v1 still looks fine

## Screenshots
![dashboard-css](https://user-images.githubusercontent.com/20728956/98271139-78cefb80-1f44-11eb-8bce-d79776a0e981.gif)

## Acceptance criteria
- [x] Dashboard v1 still appears as intended

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs