### PR TITLE
Update Redux store: `profile.vet360` => `profile.vapContactInfo`

### DIFF
--- a/src/applications/healthcare/questionnaire/components/veteran-info/AppointmentInfoBox.jsx
+++ b/src/applications/healthcare/questionnaire/components/veteran-info/AppointmentInfoBox.jsx
@@ -6,7 +6,7 @@ import AddressView from './AddressView';
 import PhoneNumberView from './PhoneNumberView';
 import AppointmentDisplay from './AppointmentDisplay';
 import { setData } from 'platform/forms-system/src/js/actions';
-import { selectProfile, selectVet360 } from 'platform/user/selectors';
+import { selectProfile, selectVAPContactInfo } from 'platform/user/selectors';
 
 const AppointmentInfoBox = ({
   userFullName,
@@ -126,20 +126,20 @@ const AppointmentInfoBox = ({
 
 const mapStateToProps = state => {
   const profile = selectProfile(state);
-  const vet360 = selectVet360(state);
+  const vapContactInfo = selectVAPContactInfo(state);
   return {
     userFullName: profile.userFullName,
     dateOfBirth: profile.dob,
     gender: profile.gender,
     addresses: {
-      residential: vet360?.residentialAddress,
-      mailing: vet360?.mailingAddress,
+      residential: vapContactInfo?.residentialAddress,
+      mailing: vapContactInfo?.mailingAddress,
     },
     phoneNumbers: [
-      { label: 'Home', data: vet360?.homePhone },
-      { label: 'Mobile', data: vet360?.mobilePhone },
-      { label: 'Work', data: vet360?.workPhone },
-      { label: 'Temporary', data: vet360?.temporaryPhone },
+      { label: 'Home', data: vapContactInfo?.homePhone },
+      { label: 'Mobile', data: vapContactInfo?.mobilePhone },
+      { label: 'Work', data: vapContactInfo?.workPhone },
+      { label: 'Temporary', data: vapContactInfo?.temporaryPhone },
     ],
     appointment: state.questionnaireData?.context?.appointment,
   };

--- a/src/applications/healthcare/questionnaire/components/veteran-info/AppointmentInfoBox.jsx
+++ b/src/applications/healthcare/questionnaire/components/veteran-info/AppointmentInfoBox.jsx
@@ -6,6 +6,7 @@ import AddressView from './AddressView';
 import PhoneNumberView from './PhoneNumberView';
 import AppointmentDisplay from './AppointmentDisplay';
 import { setData } from 'platform/forms-system/src/js/actions';
+import { selectProfile, selectVet360 } from 'platform/user/selectors';
 
 const AppointmentInfoBox = ({
   userFullName,
@@ -123,22 +124,26 @@ const AppointmentInfoBox = ({
   );
 };
 
-const mapStateToProps = state => ({
-  userFullName: state.user?.profile?.userFullName,
-  dateOfBirth: state.user?.profile?.dob,
-  gender: state.user?.profile?.gender,
-  addresses: {
-    residential: state.user?.profile?.vet360?.residentialAddress,
-    mailing: state.user?.profile?.vet360?.mailingAddress,
-  },
-  phoneNumbers: [
-    { label: 'Home', data: state.user?.profile?.vet360?.homePhone },
-    { label: 'Mobile', data: state.user?.profile?.vet360?.mobilePhone },
-    { label: 'Work', data: state.user?.profile?.vet360?.workPhone },
-    { label: 'Temporary', data: state.user?.profile?.vet360?.temporaryPhone },
-  ],
-  appointment: state.questionnaireData?.context?.appointment,
-});
+const mapStateToProps = state => {
+  const profile = selectProfile(state);
+  const vet360 = selectVet360(state);
+  return {
+    userFullName: profile.userFullName,
+    dateOfBirth: profile.dob,
+    gender: profile.gender,
+    addresses: {
+      residential: vet360?.residentialAddress,
+      mailing: vet360?.mailingAddress,
+    },
+    phoneNumbers: [
+      { label: 'Home', data: vet360?.homePhone },
+      { label: 'Mobile', data: vet360?.mobilePhone },
+      { label: 'Work', data: vet360?.workPhone },
+      { label: 'Temporary', data: vet360?.temporaryPhone },
+    ],
+    appointment: state.questionnaireData?.context?.appointment,
+  };
+};
 
 const mapDispatchToProps = {
   setFormData: setData,

--- a/src/applications/healthcare/questionnaire/tests/unit/utils/createFakeStores.js
+++ b/src/applications/healthcare/questionnaire/tests/unit/utils/createFakeStores.js
@@ -20,7 +20,7 @@ const createFakeUserStore = (
           },
           dob: '1924-12-19',
           gender,
-          vet360: {
+          vapContactInfo: {
             mobilePhone: phones.hasMobile
               ? {
                   areaCode: '503',

--- a/src/applications/letters/containers/AddressSection.jsx
+++ b/src/applications/letters/containers/AddressSection.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { focusElement } from 'platform/utilities/ui';
+import { selectVet360 } from 'platform/user/selectors';
 
 import { isAddressEmpty } from '../utils/helpers';
 import noAddressBanner from '../components/NoAddressBanner';
@@ -76,7 +77,7 @@ export class AddressSection extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    savedAddress: state.user.profile.vet360.mailingAddress,
+    savedAddress: selectVet360(state)?.mailingAddress,
   };
 }
 

--- a/src/applications/letters/containers/AddressSection.jsx
+++ b/src/applications/letters/containers/AddressSection.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { focusElement } from 'platform/utilities/ui';
-import { selectVet360 } from 'platform/user/selectors';
+import { selectVAPContactInfo } from 'platform/user/selectors';
 
 import { isAddressEmpty } from '../utils/helpers';
 import noAddressBanner from '../components/NoAddressBanner';
@@ -77,7 +77,7 @@ export class AddressSection extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    savedAddress: selectVet360(state)?.mailingAddress,
+    savedAddress: selectVAPContactInfo(state)?.mailingAddress,
   };
 }
 

--- a/src/applications/letters/containers/Main.jsx
+++ b/src/applications/letters/containers/Main.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import { systemDownMessage } from 'platform/static-data/error-messages';
-import { selectVet360 } from 'platform/user/selectors';
+import { selectVAPContactInfo } from 'platform/user/selectors';
 import { AVAILABILITY_STATUSES } from '../utils/constants';
 import { recordsNotFound, isAddressEmpty } from '../utils/helpers';
 import noAddressBanner from '../components/NoAddressBanner';
@@ -79,7 +79,7 @@ function mapStateToProps(state) {
       serviceInfo: letterState.serviceInfo,
     },
     optionsAvailable: letterState.optionsAvailable,
-    emptyAddress: isAddressEmpty(selectVet360(state)?.mailingAddress),
+    emptyAddress: isAddressEmpty(selectVAPContactInfo(state)?.mailingAddress),
   };
 }
 

--- a/src/applications/letters/containers/Main.jsx
+++ b/src/applications/letters/containers/Main.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import { systemDownMessage } from 'platform/static-data/error-messages';
+import { selectVet360 } from 'platform/user/selectors';
 import { AVAILABILITY_STATUSES } from '../utils/constants';
 import { recordsNotFound, isAddressEmpty } from '../utils/helpers';
 import noAddressBanner from '../components/NoAddressBanner';
@@ -78,7 +79,7 @@ function mapStateToProps(state) {
       serviceInfo: letterState.serviceInfo,
     },
     optionsAvailable: letterState.optionsAvailable,
-    emptyAddress: isAddressEmpty(state.user.profile.vet360.mailingAddress),
+    emptyAddress: isAddressEmpty(selectVet360(state)?.mailingAddress),
   };
 }
 

--- a/src/applications/personalization/profile/components/personal-information/VAPProfileField.jsx
+++ b/src/applications/personalization/profile/components/personal-information/VAPProfileField.jsx
@@ -454,7 +454,7 @@ const mapDispatchToProps = {
 
 /**
  * Container used to easily create components for VA Profile-backed contact information.
- * @property {string} fieldName The name of the property as it appears in the user.profile.vet360 object.
+ * @property {string} fieldName The name of the property as it appears in the user.profile.vapContactInfo object.
  * @property {func} ContentView The component used to render the read-display of the field.
  * @property {func} EditView The component used to render the edit mode of the field.
  * @property {func} ValidationView The component used to render validation mode the field.

--- a/src/applications/personalization/profile/tests/components/VAPProfileField.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/VAPProfileField.unit.spec.jsx
@@ -166,7 +166,7 @@ describe('mapStateToProps', () => {
   const getBasicState = () => ({
     user: {
       profile: {
-        vet360: {
+        vapContactInfo: {
           mobilePhone: '',
         },
       },
@@ -226,7 +226,7 @@ describe('mapStateToProps', () => {
     const showValidationModalState = () => ({
       user: {
         profile: {
-          vet360: {
+          vapContactInfo: {
             mailingAddress: '',
           },
         },

--- a/src/applications/personalization/profile/tests/components/alerts/Profile.data-unavailable-error.unit.spec.js
+++ b/src/applications/personalization/profile/tests/components/alerts/Profile.data-unavailable-error.unit.spec.js
@@ -38,7 +38,7 @@ function createBasicInitialState() {
           current: 3,
           highest: 3,
         },
-        vet360: {},
+        vapContactInfo: {},
         multifactor: true,
         services: ['evss-claims', 'user-profile', 'vet360'],
         veteranStatus: {

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.delete-email-address.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.delete-email-address.unit.spec.jsx
@@ -65,7 +65,7 @@ describe('Deleting email address', () => {
   beforeEach(() => {
     window.VetsGov = { pollTimeout: 1 };
     const initialState = createBasicInitialState();
-    emailAddress = initialState.user.profile.vet360.email.emailAddress;
+    emailAddress = initialState.user.profile.vapContactInfo.email.emailAddress;
 
     view = renderWithProfileReducers(ui, {
       initialState,

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.edit-email-address.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.edit-email-address.unit.spec.jsx
@@ -198,7 +198,7 @@ describe('Editing email address', () => {
   describe('when an address does not exist yet', () => {
     beforeEach(() => {
       const initialState = createBasicInitialState();
-      initialState.user.profile.vet360.email = null;
+      initialState.user.profile.vapContactInfo.email = null;
 
       view = renderWithProfileReducers(ui, {
         initialState,

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.unit.spec.jsx
@@ -53,7 +53,7 @@ describe('PersonalInformation', () => {
     const {
       residentialAddress,
       mailingAddress,
-    } = initialState.user.profile.vet360;
+    } = initialState.user.profile.vapContactInfo;
 
     const view = renderWithProfileReducers(ui, { initialState });
 

--- a/src/applications/personalization/profile/tests/unit-test-helpers.js
+++ b/src/applications/personalization/profile/tests/unit-test-helpers.js
@@ -26,7 +26,7 @@ export function renderWithProfileReducers(
   });
 }
 
-// Creates a good baseline value for the user.profile.vet360 part of Redux
+// Creates a good baseline value for the user.profile.vapContactInfo part of Redux
 export function getBasicContactInfoState() {
   return {
     email: {
@@ -187,7 +187,7 @@ export function createBasicInitialState() {
     },
     user: {
       profile: {
-        vet360: getBasicContactInfoState(),
+        vapContactInfo: getBasicContactInfoState(),
       },
     },
   };

--- a/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/index.unit.spec.jsx
@@ -503,7 +503,7 @@ describe('VAOS integration: appointment list', () => {
       user: {
         profile: {
           ...userState.profile,
-          vet360: {
+          vapContactInfo: {
             residentialAddress: {
               // Northampton, MA
               latitude: 42.3495,

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfCarePage.unit.spec.jsx
@@ -30,7 +30,7 @@ const initialState = {
   user: {
     profile: {
       facilities: [{ facilityId: '983', isCerner: false }],
-      vet360: {
+      vapContactInfo: {
         residentialAddress: {
           addressLine1: '123 big sky st',
         },
@@ -200,7 +200,7 @@ describe('VAOS <TypeOfCarePage>', () => {
 
   it('should display alert message when residential address is missing', async () => {
     const stateWithoutAddress = set(
-      'user.profile.vet360.residentialAddress',
+      'user.profile.vapContactInfo.residentialAddress',
       null,
       initialState,
     );
@@ -232,7 +232,7 @@ describe('VAOS <TypeOfCarePage>', () => {
 
   it('should display alert message when residental address is a PO Box', async () => {
     const stateWithPOBox = set(
-      'user.profile.vet360.residentialAddress',
+      'user.profile.vapContactInfo.residentialAddress',
       {
         addressLine1: 'PO Box 123',
       },
@@ -250,7 +250,7 @@ describe('VAOS <TypeOfCarePage>', () => {
 
   it('should save adress modal dismissal after page change', async () => {
     const stateWithoutAddress = set(
-      'user.profile.vet360.residentialAddress',
+      'user.profile.vapContactInfo.residentialAddress',
       null,
       initialState,
     );

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfCarePage.unit.spec.jsx
@@ -198,7 +198,7 @@ describe('VAOS <TypeOfCarePage>', () => {
     );
   });
 
-  it('should display alert message when residental address is missing', async () => {
+  it('should display alert message when residential address is missing', async () => {
     const stateWithoutAddress = set(
       'user.profile.vet360.residentialAddress',
       null,

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.multi.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.multi.unit.spec.jsx
@@ -215,7 +215,7 @@ describe('VAOS integration: VA flat facility page - multiple facilities', () => 
         ...initialState.user,
         profile: {
           ...initialState.user.profile,
-          vet360: {
+          vapContactInfo: {
             residentialAddress: {
               addressLine1: '290 Ludlow Ave',
               city: 'Cincinatti',
@@ -275,7 +275,7 @@ describe('VAOS integration: VA flat facility page - multiple facilities', () => 
         ...initialState.user,
         profile: {
           ...initialState.user.profile,
-          vet360: {
+          vapContactInfo: {
             residentialAddress: {
               addressLine1: '290 Ludlow Ave',
               city: 'Cincinatti',
@@ -326,7 +326,7 @@ describe('VAOS integration: VA flat facility page - multiple facilities', () => 
         ...initialState.user,
         profile: {
           ...initialState.user.profile,
-          vet360: {
+          vapContactInfo: {
             residentialAddress: {
               addressLine1: '290 Ludlow Ave',
               city: 'Cincinatti',

--- a/src/applications/vaos/tests/new-appointment/redux/actions.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/redux/actions.unit.spec.js
@@ -1058,7 +1058,7 @@ describe('VAOS newAppointment actions', () => {
       const state = {
         user: {
           profile: {
-            vet360: {
+            vapContactInfo: {
               email: {
                 emailAddress: 'test@va.gov',
               },

--- a/src/applications/vaos/tests/new-appointment/redux/helpers/formSubmitTransformers.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/redux/helpers/formSubmitTransformers.unit.spec.js
@@ -211,7 +211,7 @@ describe('VAOS data transformation', () => {
     const state = {
       user: {
         profile: {
-          vet360: {},
+          vapContactInfo: {},
         },
       },
       newAppointment: {
@@ -352,7 +352,7 @@ describe('VAOS data transformation', () => {
     const state = {
       user: {
         profile: {
-          vet360: {},
+          vapContactInfo: {},
         },
       },
       newAppointment: {
@@ -494,7 +494,7 @@ describe('VAOS data transformation', () => {
     const state = {
       user: {
         profile: {
-          vet360: {},
+          vapContactInfo: {},
         },
       },
       newAppointment: {

--- a/src/platform/user/profile/reducers/index.js
+++ b/src/platform/user/profile/reducers/index.js
@@ -42,7 +42,7 @@ const initialState = {
     loading: false,
     termsAndConditionsAccepted: false,
   },
-  vet360: {},
+  vapContactInfo: {},
   savedForms: [],
   prefillsAvailable: [],
   loading: true,

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -84,7 +84,7 @@ export function mapRawUserDataToState(json) {
       last,
     },
     verified,
-    vet360: isVAProfileServiceConfigured()
+    vapContactInfo: isVAProfileServiceConfigured()
       ? vet360ContactInformation
       : mockContactInformation,
     session,
@@ -116,11 +116,11 @@ export function mapRawUserDataToState(json) {
 
   // This one is checking userState because there's no extra mapping and it's
   // easier to leave the mocking code the way it is
-  if (meta && userState.vet360 === null) {
+  if (meta && userState.vapContactInfo === null) {
     const errorStatus = meta.errors.find(
       error => error.externalService === commonServices.Vet360,
     ).status;
-    userState.vet360 = { status: getErrorStatusDesc(errorStatus) };
+    userState.vapContactInfo = { status: getErrorStatusDesc(errorStatus) };
   }
 
   return userState;

--- a/src/platform/user/profile/vap-svc/containers/ReceiveTextMessages.jsx
+++ b/src/platform/user/profile/vap-svc/containers/ReceiveTextMessages.jsx
@@ -47,7 +47,7 @@ class ReceiveTextMessages extends React.Component {
       completedTransaction: false,
       lastTransaction: null,
     });
-    const payload = this.props.profile.vet360.mobilePhone;
+    const payload = this.props.profile.vapContactInfo.mobilePhone;
     payload.isTextPermitted = event;
     const method = payload.id ? 'PUT' : 'POST';
     const smsAction = payload.isTextPermitted ? 'smsOptin' : 'smsOptout';
@@ -90,7 +90,9 @@ class ReceiveTextMessages extends React.Component {
       <div className="receive-text-messages">
         <div className="form-checkbox-buttons">
           <ErrorableCheckbox
-            checked={!!this.props.profile.vet360.mobilePhone.isTextPermitted}
+            checked={
+              !!this.props.profile.vapContactInfo.mobilePhone.isTextPermitted
+            }
             label={
               <span>
                 We’ll send VA health care appointment text reminders to this

--- a/src/platform/user/profile/vap-svc/containers/Vet360ProfileField.jsx
+++ b/src/platform/user/profile/vap-svc/containers/Vet360ProfileField.jsx
@@ -303,7 +303,7 @@ const mapDispatchToProps = {
 
 /**
  * Container used to easily create components for Vet360 contact information.
- * @property {string} fieldName The name of the property as it appears in the user.profile.vet360 object.
+ * @property {string} fieldName The name of the property as it appears in the user.profile.vapContactInfo object.
  * @property {func} Content The component used to render the read-display of the field.
  * @property {func} EditModal The component used to render the contents of the field's edit-modal.
  * @property {string} title The field name converted to a visible display, such as for labels, modal titles, etc. Example: "mailingAddress" passes "Mailing address" as the title.

--- a/src/platform/user/profile/vap-svc/selectors.js
+++ b/src/platform/user/profile/vap-svc/selectors.js
@@ -1,7 +1,7 @@
 import backendServices from '~/platform/user/profile/constants/backendServices';
 import {
   selectAvailableServices,
-  selectVet360,
+  selectVAPContactInfo,
 } from '~/platform/user/selectors';
 
 import { VET360_INITIALIZATION_STATUS, INIT_VET360_ID } from './constants';
@@ -16,7 +16,7 @@ export function selectIsVet360AvailableForUser(state) {
 }
 
 export function selectVet360Field(state, fieldName) {
-  return selectVet360(state)[fieldName];
+  return selectVAPContactInfo(state)[fieldName];
 }
 
 export function selectVet360Transaction(state, fieldName) {

--- a/src/platform/user/profile/vap-svc/tests/containers/CopyMailingAddress.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/containers/CopyMailingAddress.unit.spec.jsx
@@ -17,7 +17,7 @@ describe('<CopyMailingAddress/>', () => {
       state = {
         user: {
           profile: {
-            vet360: {
+            vapContactInfo: {
               [FIELD_NAMES.MAILING_ADDRESS]: null,
             },
           },
@@ -33,7 +33,9 @@ describe('<CopyMailingAddress/>', () => {
     it('returns the required props', () => {
       const mailingAddress = { city: 'some city' };
 
-      state.user.profile.vet360[FIELD_NAMES.MAILING_ADDRESS] = mailingAddress;
+      state.user.profile.vapContactInfo[
+        FIELD_NAMES.MAILING_ADDRESS
+      ] = mailingAddress;
       state.vet360.formFields[FIELD_NAMES.RESIDENTIAL_ADDRESS] = {
         city: 'some other city',
       };
@@ -48,7 +50,7 @@ describe('<CopyMailingAddress/>', () => {
     describe('checked prop', () => {
       beforeEach(() => {
         // this is real data from staging
-        state.user.profile.vet360[FIELD_NAMES.MAILING_ADDRESS] = {
+        state.user.profile.vapContactInfo[FIELD_NAMES.MAILING_ADDRESS] = {
           addressLine1: '36320 Coronado Dr',
           addressLine2: null,
           addressLine3: null,

--- a/src/platform/user/profile/vap-svc/tests/containers/ReceiveTextMessages.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/containers/ReceiveTextMessages.unit.spec.jsx
@@ -25,7 +25,7 @@ describe('<ReceiveTextMessages/>', () => {
       isSuccessVisible() {},
       profile: {
         verified: true,
-        vet360: { mobilePhone: { isTextPermitted: false } },
+        vapContactInfo: { mobilePhone: { isTextPermitted: false } },
       },
       hideCheckbox: false,
       transaction: {},
@@ -84,7 +84,7 @@ describe('<ReceiveTextMessages/>', () => {
         },
         user: {
           profile: {
-            vet360: { mobilePhone: { mobilePhone } },
+            vapContactInfo: { mobilePhone: { mobilePhone } },
           },
         },
         vet360: {
@@ -96,9 +96,11 @@ describe('<ReceiveTextMessages/>', () => {
     });
 
     it('returns the required props', () => {
-      state.user.profile.vet360[FIELD_NAMES.MOBILE_PHONE] = mobilePhone;
+      state.user.profile.vapContactInfo[FIELD_NAMES.MOBILE_PHONE] = mobilePhone;
       const result = mapStateToProps(state, ownProps);
-      expect(result.profile.vet360.mobilePhone).to.be.equal(mobilePhone);
+      expect(result.profile.vapContactInfo.mobilePhone).to.be.equal(
+        mobilePhone,
+      );
       expect(result.profile).to.be.equal(state.user.profile);
       expect(result.hideCheckbox).not.to.be.null;
       expect(result.transaction).to.be.null;
@@ -111,12 +113,12 @@ describe('<ReceiveTextMessages/>', () => {
       expect(result.hideCheckbox).to.be.true;
     });
     it('returns hideCheckbox as true when user does not have a mobile phone', () => {
-      state.user.profile.vet360.mobilePhone = null;
+      state.user.profile.vapContactInfo.mobilePhone = null;
       const result = mapStateToProps(state, ownProps);
       expect(result.hideCheckbox).to.be.true;
     });
     it('returns hideCheckbox as true when users mobile phone is not textable', () => {
-      state.user.profile.vet360.mobilePhone.isTextPermitted = false;
+      state.user.profile.vapContactInfo.mobilePhone.isTextPermitted = false;
       const result = mapStateToProps(state, ownProps);
       expect(result.hideCheckbox).to.be.true;
     });

--- a/src/platform/user/profile/vap-svc/tests/containers/Vet360ProfileField.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/containers/Vet360ProfileField.unit.spec.jsx
@@ -161,7 +161,7 @@ describe('mapStateToProps', () => {
     featureToggles: { vaProfileAddressValidation: true },
     user: {
       profile: {
-        vet360: {
+        vapContactInfo: {
           mailingAddress: '',
         },
       },

--- a/src/platform/user/profile/vap-svc/tests/selectors.unit.spec.js
+++ b/src/platform/user/profile/vap-svc/tests/selectors.unit.spec.js
@@ -17,7 +17,7 @@ const hooks = {
     const user = {
       profile: {
         services: [backendServices.VET360],
-        vet360: {},
+        vapContactInfo: {},
       },
     };
 
@@ -76,7 +76,7 @@ describe('selectors', () => {
   describe('selectVet360Field', () => {
     beforeEach(hooks.beforeEach);
     it('looks up a field from the user vet360 data', () => {
-      state.user.profile.vet360 = { someField: 'data' };
+      state.user.profile.vapContactInfo = { someField: 'data' };
       expect(selectors.selectVet360Field(state, 'someField')).to.equal('data');
     });
   });

--- a/src/platform/user/selectors.js
+++ b/src/platform/user/selectors.js
@@ -56,9 +56,10 @@ export const selectPatientFacilities = state =>
 
     return facility;
   }) || null;
-export const selectVet360 = state => selectProfile(state).vapContactInfo;
+export const selectVAPContactInfo = state =>
+  selectProfile(state).vapContactInfo;
 export const selectVet360EmailAddress = state =>
-  selectVet360(state)?.email?.emailAddress;
+  selectVAPContactInfo(state)?.email?.emailAddress;
 const createPhoneNumberStringFromData = phoneNumberData => {
   const data = phoneNumberData || {};
   const areaCode = data.areaCode || '';
@@ -69,14 +70,15 @@ const createPhoneNumberStringFromData = phoneNumberData => {
   return `${areaCode}${phoneNumber}${extension ? `x${extension}` : ''}`;
 };
 export const selectVet360MobilePhone = state =>
-  selectVet360(state)?.mobilePhone;
+  selectVAPContactInfo(state)?.mobilePhone;
 export const selectVet360MobilePhoneString = state =>
   createPhoneNumberStringFromData(selectVet360MobilePhone(state));
-export const selectVet360HomePhone = state => selectVet360(state)?.homePhone;
+export const selectVet360HomePhone = state =>
+  selectVAPContactInfo(state)?.homePhone;
 export const selectVet360HomePhoneString = state =>
   createPhoneNumberStringFromData(selectVet360HomePhone(state));
 export const selectVet360ResidentialAddress = state =>
-  selectVet360(state)?.residentialAddress;
+  selectVAPContactInfo(state)?.residentialAddress;
 
 export function createIsServiceAvailableSelector(service) {
   return state => selectAvailableServices(state).includes(service);

--- a/src/platform/user/selectors.js
+++ b/src/platform/user/selectors.js
@@ -56,7 +56,7 @@ export const selectPatientFacilities = state =>
 
     return facility;
   }) || null;
-export const selectVet360 = state => selectProfile(state).vet360;
+export const selectVet360 = state => selectProfile(state).vapContactInfo;
 export const selectVet360EmailAddress = state =>
   selectVet360(state)?.email?.emailAddress;
 const createPhoneNumberStringFromData = phoneNumberData => {

--- a/src/platform/user/tests/profile/utilities/index.unit.spec.js
+++ b/src/platform/user/tests/profile/utilities/index.unit.spec.js
@@ -112,7 +112,7 @@ describe('Profile utilities', () => {
         },
       });
 
-      expect(mappedData.vet360).to.deep.equal(
+      expect(mappedData.vapContactInfo).to.deep.equal(
         data.attributes.vet360_contact_information,
       );
     });
@@ -195,7 +195,7 @@ describe('Profile utilities', () => {
         },
       });
 
-      expect(mappedData.vet360.status).to.equal('SERVER_ERROR');
+      expect(mappedData.vapContactInfo.status).to.equal('SERVER_ERROR');
     });
   });
 });

--- a/src/platform/user/tests/selectors.unit.spec.js
+++ b/src/platform/user/tests/selectors.unit.spec.js
@@ -3,11 +3,11 @@ import * as selectors from '../selectors';
 
 describe('user selectors', () => {
   describe('selectVet360', () => {
-    it('pulls out the state.profile.vet360 data', () => {
+    it('pulls out the state.profile.vapContactInfo data', () => {
       const state = {
         user: {
           profile: {
-            vet360: {
+            vapContactInfo: {
               email: {
                 emailAddress: '123@va.com',
               },
@@ -16,7 +16,7 @@ describe('user selectors', () => {
         },
       };
       expect(selectors.selectVet360(state)).to.deep.equal(
-        state.user.profile.vet360,
+        state.user.profile.vapContactInfo,
       );
     });
     it('returns undefined if there is no vet360 on the profile', () => {
@@ -30,11 +30,11 @@ describe('user selectors', () => {
   });
 
   describe('selectVet360EmailAddress', () => {
-    it('pulls out the state.profile.vet360.emailAddress', () => {
+    it('pulls out the state.profile.vapContactInfo.emailAddress', () => {
       const state = {
         user: {
           profile: {
-            vet360: {
+            vapContactInfo: {
               email: {
                 createdAt: '2019-10-11T12:42:14.000Z',
                 emailAddress: 'testertester2@mail.com',
@@ -52,7 +52,7 @@ describe('user selectors', () => {
         },
       };
       expect(selectors.selectVet360EmailAddress(state)).to.equal(
-        state.user.profile.vet360.email.emailAddress,
+        state.user.profile.vapContactInfo.email.emailAddress,
       );
     });
     it('returns undefined if there is no vet360 on the profile', () => {
@@ -67,7 +67,7 @@ describe('user selectors', () => {
       const state = {
         user: {
           profile: {
-            vet360: {},
+            vapContactInfo: {},
           },
         },
       };
@@ -99,18 +99,18 @@ describe('user selectors', () => {
     };
 
     describe('selectVet360MobilePhone', () => {
-      it('pulls out the state.profile.vet360.mobilePhone data object', () => {
+      it('pulls out the state.profile.vapContactInfo.mobilePhone data object', () => {
         const state = {
           user: {
             profile: {
-              vet360: {
+              vapContactInfo: {
                 mobilePhone: phoneNumberData,
               },
             },
           },
         };
         expect(selectors.selectVet360MobilePhone(state)).to.deep.equal(
-          state.user.profile.vet360.mobilePhone,
+          state.user.profile.vapContactInfo.mobilePhone,
         );
       });
       it('returns undefined if there is no vet360 on the profile', () => {
@@ -125,7 +125,7 @@ describe('user selectors', () => {
         const state = {
           user: {
             profile: {
-              vet360: {},
+              vapContactInfo: {},
             },
           },
         };
@@ -138,7 +138,7 @@ describe('user selectors', () => {
         const state = {
           user: {
             profile: {
-              vet360: {
+              vapContactInfo: {
                 mobilePhone: phoneNumberData,
               },
             },
@@ -152,7 +152,7 @@ describe('user selectors', () => {
         const state = {
           user: {
             profile: {
-              vet360: {
+              vapContactInfo: {
                 mobilePhone: { ...phoneNumberData, extension: '1234' },
               },
             },
@@ -166,7 +166,7 @@ describe('user selectors', () => {
         const state = {
           user: {
             profile: {
-              vet360: {
+              vapContactInfo: {
                 mobilePhone: { ...phoneNumberData, extension: '0000' },
               },
             },
@@ -179,18 +179,18 @@ describe('user selectors', () => {
     });
 
     describe('selectVet360HomePhone', () => {
-      it('pulls out the state.profile.vet360.homePhone data object', () => {
+      it('pulls out the state.profile.vapContactInfo.homePhone data object', () => {
         const state = {
           user: {
             profile: {
-              vet360: {
+              vapContactInfo: {
                 homePhone: phoneNumberData,
               },
             },
           },
         };
         expect(selectors.selectVet360HomePhone(state)).to.deep.equal(
-          state.user.profile.vet360.homePhone,
+          state.user.profile.vapContactInfo.homePhone,
         );
       });
       it('returns undefined if there is no vet360 on the profile', () => {
@@ -205,7 +205,7 @@ describe('user selectors', () => {
         const state = {
           user: {
             profile: {
-              vet360: {},
+              vapContactInfo: {},
             },
           },
         };
@@ -218,7 +218,7 @@ describe('user selectors', () => {
         const state = {
           user: {
             profile: {
-              vet360: {
+              vapContactInfo: {
                 homePhone: phoneNumberData,
               },
             },
@@ -232,7 +232,7 @@ describe('user selectors', () => {
         const state = {
           user: {
             profile: {
-              vet360: {
+              vapContactInfo: {
                 homePhone: { ...phoneNumberData, extension: '1234' },
               },
             },

--- a/src/platform/user/tests/selectors.unit.spec.js
+++ b/src/platform/user/tests/selectors.unit.spec.js
@@ -15,7 +15,7 @@ describe('user selectors', () => {
           },
         },
       };
-      expect(selectors.selectVet360(state)).to.deep.equal(
+      expect(selectors.selectVAPContactInfo(state)).to.deep.equal(
         state.user.profile.vapContactInfo,
       );
     });
@@ -25,7 +25,7 @@ describe('user selectors', () => {
           profile: {},
         },
       };
-      expect(selectors.selectVet360(state)).to.be.undefined;
+      expect(selectors.selectVAPContactInfo(state)).to.be.undefined;
     });
   });
 


### PR DESCRIPTION
## Description
This PR is the fourth in a handful to remove mentions of vet360 from our frontend code.

[PR 1 renamed the `vet360` folder to `vap-svc`](https://github.com/department-of-veterans-affairs/vets-website/pull/14798)
[PR 2 renamed the `vet360` Babel alias to `@@vap-svc`](https://github.com/department-of-veterans-affairs/vets-website/pull/14811)
[PR 3 renamed the `isVet360Configured` helper to `isVAProfileServiceConfigured`](https://github.com/department-of-veterans-affairs/vets-website/pull/14834)

This PR is focused on:
- Renaming Redux's `profile.vet360` data to `profile.vapContactInfo`

## Testing done
Local + existing tests

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs