### PR TITLE
Add transformer for paragraph-audience_topics

### DIFF
--- a/src/site/stages/build/process-cms-exports/schemas/input/paragraph-audience_topics.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/paragraph-audience_topics.js
@@ -1,0 +1,20 @@
+/* eslint-disable camelcase */
+
+module.exports = {
+  type: 'object',
+  properties: {
+    field_audience_beneficiares: {
+      type: 'array',
+      items: {
+        oneOf: [{ $ref: 'EntityReference' }, { type: 'array', maxItems: 0 }],
+      },
+    },
+    field_topics: {
+      type: 'array',
+      items: {
+        oneOf: [{ $ref: 'EntityReference' }, { type: 'array', maxItems: 0 }],
+      },
+    },
+  },
+  required: ['field_audience_beneficiares', 'field_topics'],
+};

--- a/src/site/stages/build/process-cms-exports/schemas/input/taxonomy_term-audience_beneficiaries.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/taxonomy_term-audience_beneficiaries.js
@@ -1,0 +1,9 @@
+/* eslint-disable camelcase */
+
+module.exports = {
+  type: 'object',
+  properties: {
+    name: { $ref: 'GenericNestedString' },
+  },
+  required: ['name'],
+};

--- a/src/site/stages/build/process-cms-exports/schemas/input/taxonomy_term-topics.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/taxonomy_term-topics.js
@@ -1,0 +1,9 @@
+/* eslint-disable camelcase */
+
+module.exports = {
+  type: 'object',
+  properties: {
+    name: { $ref: 'GenericNestedString' },
+  },
+  required: ['name'],
+};

--- a/src/site/stages/build/process-cms-exports/schemas/output/paragraph-audience_topics.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/paragraph-audience_topics.js
@@ -1,0 +1,20 @@
+module.exports = {
+  type: 'object',
+  properties: {
+    entityType: { type: 'string', enum: ['paragraph'] },
+    entityBundle: { type: 'string', enum: ['audience_topics'] },
+    fieldAudienceBeneficiares: {
+      oneOf: [
+        { $ref: 'output/taxonomy_term-audience_beneficiaries' },
+        { type: 'null' },
+      ],
+    },
+    fieldTopics: {
+      oneOf: [
+        { $ref: 'output/taxonomy_term-topics' },
+        { type: 'array', maxItems: 0 },
+      ],
+    },
+  },
+  required: ['fieldAudienceBeneficiares', 'fieldTopics'],
+};

--- a/src/site/stages/build/process-cms-exports/schemas/output/taxonomy_term-audience_beneficiaries.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/taxonomy_term-audience_beneficiaries.js
@@ -1,0 +1,15 @@
+module.exports = {
+  type: 'object',
+  properties: {
+    entity: {
+      type: 'object',
+      properties: {
+        entityType: { type: 'string', enum: ['taxonomy_term'] },
+        entityBundle: { type: 'string', enum: ['audience_beneficiaries'] },
+        name: { type: 'string' },
+      },
+      required: ['name'],
+    },
+  },
+  required: ['entity'],
+};

--- a/src/site/stages/build/process-cms-exports/schemas/output/taxonomy_term-topics.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/taxonomy_term-topics.js
@@ -1,0 +1,15 @@
+module.exports = {
+  type: 'object',
+  properties: {
+    entity: {
+      type: 'object',
+      properties: {
+        entityType: { type: 'string', enum: ['taxonomy_term'] },
+        entityBundle: { type: 'string', enum: ['topics'] },
+        name: { type: 'string' },
+      },
+      required: ['name'],
+    },
+  },
+  required: ['entity'],
+};

--- a/src/site/stages/build/process-cms-exports/transformers/node-basic_landing_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-basic_landing_page.js
@@ -1,0 +1,14 @@
+// Remove eslint-disable when transformer is complete
+/* eslint-disable no-unused-vars */
+const { getDrupalValue } = require('./helpers');
+
+const transform = entity => ({
+  entityType: 'node',
+  entityBundle: 'basic_landing_page',
+  fieldIntroTextLimitedHtml: {},
+});
+
+module.exports = {
+  filter: [''],
+  transform,
+};

--- a/src/site/stages/build/process-cms-exports/transformers/node-checklist.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-checklist.js
@@ -1,0 +1,14 @@
+// Remove eslint-disable when transformer is complete
+/* eslint-disable no-unused-vars */
+const { getDrupalValue } = require('./helpers');
+
+const transform = entity => ({
+  entityType: 'node',
+  entityBundle: 'checklist',
+  fieldIntroTextLimitedHtml: {},
+});
+
+module.exports = {
+  filter: [''],
+  transform,
+};

--- a/src/site/stages/build/process-cms-exports/transformers/node-faq_multiple_q_a.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-faq_multiple_q_a.js
@@ -1,0 +1,14 @@
+// Remove eslint-disable when transformer is complete
+/* eslint-disable no-unused-vars */
+const { getDrupalValue } = require('./helpers');
+
+const transform = entity => ({
+  entityType: 'node',
+  entityBundle: 'faq_multiple_q_a',
+  fieldIntroTextLimitedHtml: {},
+});
+
+module.exports = {
+  filter: [''],
+  transform,
+};

--- a/src/site/stages/build/process-cms-exports/transformers/node-media_list_images.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-media_list_images.js
@@ -1,0 +1,14 @@
+// Remove eslint-disable when transformer is complete
+/* eslint-disable no-unused-vars */
+const { getDrupalValue } = require('./helpers');
+
+const transform = entity => ({
+  entityType: 'node',
+  entityBundle: 'media_list_images',
+  fieldIntroTextLimitedHtml: {},
+});
+
+module.exports = {
+  filter: [''],
+  transform,
+};

--- a/src/site/stages/build/process-cms-exports/transformers/node-media_list_videos.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-media_list_videos.js
@@ -1,0 +1,14 @@
+// Remove eslint-disable when transformer is complete
+/* eslint-disable no-unused-vars */
+const { getDrupalValue } = require('./helpers');
+
+const transform = entity => ({
+  entityType: 'node',
+  entityBundle: 'media_list_videos',
+  fieldIntroTextLimitedHtml: {},
+});
+
+module.exports = {
+  filter: [''],
+  transform,
+};

--- a/src/site/stages/build/process-cms-exports/transformers/node-q_a.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-q_a.js
@@ -1,0 +1,13 @@
+const { getDrupalValue } = require('./helpers');
+
+const transform = entity => ({
+  entityType: 'node',
+  entityBundle: 'q_a',
+  title: getDrupalValue(entity.title),
+  fieldTags: entity.fieldTags[0],
+});
+
+module.exports = {
+  filter: ['title', 'field_tags'],
+  transform,
+};

--- a/src/site/stages/build/process-cms-exports/transformers/node-step_by_step.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-step_by_step.js
@@ -1,0 +1,14 @@
+// Remove eslint-disable when transformer is complete
+/* eslint-disable no-unused-vars */
+const { getDrupalValue } = require('./helpers');
+
+const transform = entity => ({
+  entityType: 'node',
+  entityBundle: 'step_by_step',
+  fieldIntroTextLimitedHtml: {},
+});
+
+module.exports = {
+  filter: [''],
+  transform,
+};

--- a/src/site/stages/build/process-cms-exports/transformers/node-support_resources_detail_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-support_resources_detail_page.js
@@ -1,0 +1,14 @@
+// Remove eslint-disable when transformer is complete
+/* eslint-disable no-unused-vars */
+const { getDrupalValue } = require('./helpers');
+
+const transform = entity => ({
+  entityType: 'node',
+  entityBundle: 'support_resources_detail_page',
+  fieldIntroTextLimitedHtml: {},
+});
+
+module.exports = {
+  filter: [''],
+  transform,
+};

--- a/src/site/stages/build/process-cms-exports/transformers/paragraph-alert_single.js
+++ b/src/site/stages/build/process-cms-exports/transformers/paragraph-alert_single.js
@@ -1,0 +1,13 @@
+// Remove eslint-disable when transformer is complete
+/* eslint-disable no-unused-vars */
+const { getDrupalValue } = require('./helpers');
+
+const transform = entity => ({
+  entityType: 'paragraph',
+  entityBundle: 'alert_single',
+});
+
+module.exports = {
+  filter: [''],
+  transform,
+};

--- a/src/site/stages/build/process-cms-exports/transformers/paragraph-audience_topics.js
+++ b/src/site/stages/build/process-cms-exports/transformers/paragraph-audience_topics.js
@@ -1,0 +1,13 @@
+const transform = entity => ({
+  entityType: 'paragraph',
+  entityBundle: 'audience_topics',
+  fieldAudienceBeneficiares: entity.fieldAudienceBeneficiares[0]
+    ? entity.fieldAudienceBeneficiares[0]
+    : null,
+  fieldTopics: entity.fieldTopics[0] ? entity.fieldTopics[0] : [],
+});
+
+module.exports = {
+  filter: ['field_audience_beneficiares', 'field_topics'],
+  transform,
+};

--- a/src/site/stages/build/process-cms-exports/transformers/paragraph-button.js
+++ b/src/site/stages/build/process-cms-exports/transformers/paragraph-button.js
@@ -1,0 +1,13 @@
+// Remove eslint-disable when transformer is complete
+/* eslint-disable no-unused-vars */
+const { getDrupalValue } = require('./helpers');
+
+const transform = entity => ({
+  entityType: 'paragraph',
+  entityBundle: 'button',
+});
+
+module.exports = {
+  filter: [''],
+  transform,
+};

--- a/src/site/stages/build/process-cms-exports/transformers/paragraph-contact_information.js
+++ b/src/site/stages/build/process-cms-exports/transformers/paragraph-contact_information.js
@@ -1,0 +1,13 @@
+// Remove eslint-disable when transformer is complete
+/* eslint-disable no-unused-vars */
+const { getDrupalValue } = require('./helpers');
+
+const transform = entity => ({
+  entityType: 'paragraph',
+  entityBundle: 'contact_information',
+});
+
+module.exports = {
+  filter: [''],
+  transform,
+};

--- a/src/site/stages/build/process-cms-exports/transformers/paragraph-lists_of_links.js
+++ b/src/site/stages/build/process-cms-exports/transformers/paragraph-lists_of_links.js
@@ -1,0 +1,13 @@
+// Remove eslint-disable when transformer is complete
+/* eslint-disable no-unused-vars */
+const { getDrupalValue } = require('./helpers');
+
+const transform = entity => ({
+  entityType: 'paragraph',
+  entityBundle: 'lists_of_links',
+});
+
+module.exports = {
+  filter: [''],
+  transform,
+};

--- a/src/site/stages/build/process-cms-exports/transformers/paragraph-q_a_group.js
+++ b/src/site/stages/build/process-cms-exports/transformers/paragraph-q_a_group.js
@@ -1,0 +1,13 @@
+// Remove eslint-disable when transformer is complete
+/* eslint-disable no-unused-vars */
+const { getDrupalValue } = require('./helpers');
+
+const transform = entity => ({
+  entityType: 'paragraph',
+  entityBundle: 'q_a_group',
+});
+
+module.exports = {
+  filter: [''],
+  transform,
+};

--- a/src/site/stages/build/process-cms-exports/transformers/paragraph-rich_text_char_limit_1000.js
+++ b/src/site/stages/build/process-cms-exports/transformers/paragraph-rich_text_char_limit_1000.js
@@ -1,0 +1,13 @@
+// Remove eslint-disable when transformer is complete
+/* eslint-disable no-unused-vars */
+const { getDrupalValue } = require('./helpers');
+
+const transform = entity => ({
+  entityType: 'paragraph',
+  entityBundle: 'rich_text_char_limit_1000',
+});
+
+module.exports = {
+  filter: [''],
+  transform,
+};

--- a/src/site/stages/build/process-cms-exports/transformers/paragraph-step.js
+++ b/src/site/stages/build/process-cms-exports/transformers/paragraph-step.js
@@ -1,0 +1,13 @@
+// Remove eslint-disable when transformer is complete
+/* eslint-disable no-unused-vars */
+const { getDrupalValue } = require('./helpers');
+
+const transform = entity => ({
+  entityType: 'paragraph',
+  entityBundle: 'step',
+});
+
+module.exports = {
+  filter: [''],
+  transform,
+};

--- a/src/site/stages/build/process-cms-exports/transformers/paragraph-step_by_step.js
+++ b/src/site/stages/build/process-cms-exports/transformers/paragraph-step_by_step.js
@@ -1,0 +1,13 @@
+// Remove eslint-disable when transformer is complete
+/* eslint-disable no-unused-vars */
+const { getDrupalValue } = require('./helpers');
+
+const transform = entity => ({
+  entityType: 'paragraph',
+  entityBundle: 'step_by_step',
+});
+
+module.exports = {
+  filter: [''],
+  transform,
+};

--- a/src/site/stages/build/process-cms-exports/transformers/taxonomy_term-audience_beneficiaries.js
+++ b/src/site/stages/build/process-cms-exports/transformers/taxonomy_term-audience_beneficiaries.js
@@ -1,0 +1,14 @@
+const { getDrupalValue } = require('./helpers');
+
+const transform = entity => ({
+  entity: {
+    entityType: 'taxonomy_term',
+    entityBundle: 'audience_beneficiaries',
+    name: getDrupalValue(entity.name),
+  },
+});
+
+module.exports = {
+  filter: ['name'],
+  transform,
+};

--- a/src/site/stages/build/process-cms-exports/transformers/taxonomy_term-lc_categories.js
+++ b/src/site/stages/build/process-cms-exports/transformers/taxonomy_term-lc_categories.js
@@ -1,0 +1,13 @@
+// Remove eslint-disable when transformer is complete
+/* eslint-disable no-unused-vars */
+const { getDrupalValue } = require('./helpers');
+
+const transform = entity => ({
+  entityType: 'taxonomy_term',
+  entityBundle: 'lc_categories',
+});
+
+module.exports = {
+  filter: [''],
+  transform,
+};

--- a/src/site/stages/build/process-cms-exports/transformers/taxonomy_term-products.js
+++ b/src/site/stages/build/process-cms-exports/transformers/taxonomy_term-products.js
@@ -1,0 +1,13 @@
+// Remove eslint-disable when transformer is complete
+/* eslint-disable no-unused-vars */
+const { getDrupalValue } = require('./helpers');
+
+const transform = entity => ({
+  entityType: 'taxonomy_term',
+  entityBundle: 'products',
+});
+
+module.exports = {
+  filter: [''],
+  transform,
+};

--- a/src/site/stages/build/process-cms-exports/transformers/taxonomy_term-topics.js
+++ b/src/site/stages/build/process-cms-exports/transformers/taxonomy_term-topics.js
@@ -1,0 +1,14 @@
+const { getDrupalValue } = require('./helpers');
+
+const transform = entity => ({
+  entity: {
+    entityType: 'taxonomy_term',
+    entityBundle: 'topics',
+    name: getDrupalValue(entity.name),
+  },
+});
+
+module.exports = {
+  filter: ['name'],
+  transform,
+};


### PR DESCRIPTION
## Description
This PR adds empty templates for the transformers needed to fix the `cms-export` build.

The list of the transformers that will need to be completed can be found [here](https://github.com/department-of-veterans-affairs/va.gov-team/issues/15861#issuecomment-722590115).

## Testing done
Ran the cms export build and verified it was successful.

## Screenshots


## Acceptance criteria
- [ ] The cms export build works.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
