### PR TITLE
Add fieldAlert to va_form

### DIFF
--- a/src/site/stages/build/process-cms-exports/schemas/input/node-va_form.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/node-va_form.js
@@ -13,6 +13,11 @@ module.exports = {
       maxItems: 1,
       items: { $ref: 'EntityReference' },
     },
+    field_alert: {
+      type: 'array',
+      maxItems: 1,
+      items: { $ref: 'EntityReference' },
+    },
     field_benefit_categories: { $ref: 'EntityReferenceArray' },
     field_va_form_administration: {
       type: 'array',
@@ -58,6 +63,7 @@ module.exports = {
     'metatag',
     'path',
     'field_administration',
+    'field_alert',
     'field_benefit_categories',
     'field_va_form_administration',
     'field_va_form_issue_date',

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-va_form.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-va_form.js
@@ -60,6 +60,7 @@ module.exports = {
       },
     },
     fieldVaFormAdministration: { $ref: 'output/taxonomy_term-administration' },
+    fieldAlert: { $ref: 'BlockContent' },
     fieldVaFormIssueDate: dateSchema,
     fieldVaFormLinkTeasers: {
       type: 'array',
@@ -96,6 +97,7 @@ module.exports = {
     'entityMetatags',
     'entityPublished',
     'fieldAdministration',
+    'fieldAlert',
     'fieldBenefitCategories',
     'fieldVaFormAdministration',
     'fieldVaFormIssueDate',

--- a/src/site/stages/build/process-cms-exports/transformers/node-va_form.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-va_form.js
@@ -14,6 +14,7 @@ const transform = (entity, { ancestors }) => ({
   entityMetatags: createMetaTagArray(entity.metatag.value),
   entityPublished: isPublished(getDrupalValue(entity.status)),
   fieldAdministration: entity.fieldAdministration[0],
+  fieldAlert: entity.fieldAlert.length ? entity.fieldAlert[0] : null,
   fieldBenefitCategories: entity.fieldBenefitCategories.map(
     ({ fieldHomePageHubLabel }) => ({
       entity: { fieldHomePageHubLabel },
@@ -57,6 +58,7 @@ module.exports = {
     'metatag',
     'status',
     'field_administration',
+    'field_alert',
     'field_benefit_categories',
     'field_va_form_administration',
     'field_va_form_issue_date',


### PR DESCRIPTION
## Description
Multiple forms are missing alerts.

Based on the [liquid template](https://github.com/department-of-veterans-affairs/vets-website/blob/09f8a9c6cbc511092c54d51600de0d8a857ac9b6/src/site/layouts/va_form.drupal.liquid#L95-L105), `field_alert` is required to display the alert.

```
        {% if fieldAlert.length %}
          {% for alert in fieldAlert %}
            {% if alert.entity != empty %}
              {% include "src/site/blocks/alert.drupal.liquid" with alert = alert.entity %}
            {% endif %}
          {% endfor %}
        {% else %}
          {% if fieldAlert.entity != empty %}
            {% include "src/site/blocks/alert.drupal.liquid" with alert = fieldAlert.entity %}
          {% endif %}
        {% endif %}
```

The `va_form` transformer is missing the `field_alert` field.

## Testing done
Locally

## Screenshots
![Screen Shot 2020-10-27 at 12.56.05 PM.png](https://images.zenhubusercontent.com/5d89589c3ac3440001d19c89/6c7a9281-590f-4ae3-b875-0a89d977165c)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
