### PR TITLE
Fix repeated showing of eligibility modal

### DIFF
--- a/src/applications/vaos/new-appointment/newAppointmentFlow.js
+++ b/src/applications/vaos/new-appointment/newAppointmentFlow.js
@@ -74,7 +74,6 @@ async function vaFacilityNext(state, dispatch) {
         checkEligibility({
           location,
           siteId,
-          showModal: true,
         }),
       );
     }

--- a/src/applications/vaos/new-appointment/newAppointmentFlow.js
+++ b/src/applications/vaos/new-appointment/newAppointmentFlow.js
@@ -10,6 +10,7 @@ import { FACILITY_TYPES, FLOW_TYPES, TYPES_OF_CARE } from '../utils/constants';
 import { getSiteIdFromFakeFHIRId } from '../services/location';
 import {
   checkEligibility,
+  showEligibilityModal,
   showPodiatryAppointmentUnavailableModal,
   startDirectScheduleFlow,
   startRequestAppointmentFlow,
@@ -79,6 +80,7 @@ async function vaFacilityNext(state, dispatch) {
     }
 
     if (!eligibility.direct && !eligibility.request) {
+      dispatch(showEligibilityModal());
       return VA_FACILITY_V2_KEY;
     }
   }

--- a/src/applications/vaos/new-appointment/newAppointmentFlow.js
+++ b/src/applications/vaos/new-appointment/newAppointmentFlow.js
@@ -74,6 +74,7 @@ async function vaFacilityNext(state, dispatch) {
         checkEligibility({
           location,
           siteId,
+          showModal: true,
         }),
       );
     }

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -158,6 +158,8 @@ export const FORM_SHOW_PODIATRY_APPOINTMENT_UNAVAILABLE_MODAL =
   'newAppointment/FORM_SHOW_PODIATRY_APPOINTMENT_UNAVAILABLE_MODAL';
 export const FORM_HIDE_PODIATRY_APPOINTMENT_UNAVAILABLE_MODAL =
   'newAppointment/FORM_HIDE_PODIATRY_APPOINTMENT_UNAVAILABLE_MODAL';
+export const FORM_SHOW_ELIGIBILITY_MODAL =
+  'newAppointment/FORM_SHOW_ELIGIBILITY_MODAL';
 export const FORM_HIDE_ELIGIBILITY_MODAL =
   'newAppointment/FORM_HIDE_ELIGIBILITY_MODAL';
 export const FORM_REASON_FOR_APPOINTMENT_PAGE_OPENED =
@@ -479,6 +481,12 @@ export function updateFacilitySortMethod(sortMethod, uiSchema) {
     } else {
       dispatch(action);
     }
+  };
+}
+
+export function showEligibilityModal() {
+  return {
+    type: FORM_SHOW_ELIGIBILITY_MODAL,
   };
 }
 

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -292,7 +292,7 @@ export function fetchFacilityDetails(facilityId) {
   };
 }
 
-export function checkEligibility({ location, siteId, showModal }) {
+export function checkEligibility({ location, siteId }) {
   return async (dispatch, getState) => {
     const state = getState();
     const useVSP = vaosVSPAppointmentNew(state);
@@ -320,7 +320,6 @@ export function checkEligibility({ location, siteId, showModal }) {
         typeOfCareId,
         eligibilityData,
         facilityId: location.id,
-        showModal,
       });
 
       try {

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -292,7 +292,7 @@ export function fetchFacilityDetails(facilityId) {
   };
 }
 
-export function checkEligibility({ location, siteId }) {
+export function checkEligibility({ location, siteId, showModal }) {
   return async (dispatch, getState) => {
     const state = getState();
     const useVSP = vaosVSPAppointmentNew(state);
@@ -320,6 +320,7 @@ export function checkEligibility({ location, siteId }) {
         typeOfCareId,
         eligibilityData,
         facilityId: location.id,
+        showModal,
       });
 
       try {

--- a/src/applications/vaos/new-appointment/redux/reducer.js
+++ b/src/applications/vaos/new-appointment/redux/reducer.js
@@ -10,7 +10,7 @@ import {
 } from 'platform/forms-system/src/js/state/helpers';
 
 import { getParentOfLocation } from '../../services/location';
-import { getEligibilityChecks, isEligible } from './helpers/eligibility';
+import { getEligibilityChecks } from './helpers/eligibility';
 
 import {
   FORM_DATA_UPDATED,
@@ -41,6 +41,7 @@ import {
   FORM_ELIGIBILITY_CHECKS,
   FORM_ELIGIBILITY_CHECKS_SUCCEEDED,
   FORM_ELIGIBILITY_CHECKS_FAILED,
+  FORM_SHOW_ELIGIBILITY_MODAL,
   FORM_HIDE_ELIGIBILITY_MODAL,
   START_DIRECT_SCHEDULE_FLOW,
   START_REQUEST_APPOINTMENT_FLOW,
@@ -411,6 +412,7 @@ export default function formReducer(state = initialState, action) {
         parentFacilities,
         childFacilitiesStatus: FETCH_STATUS.succeeded,
         facilityPageSortMethod: sortMethod,
+        showEligibilityModal: false,
       };
     }
     case FORM_REQUEST_CURRENT_LOCATION: {
@@ -700,7 +702,6 @@ export default function formReducer(state = initialState, action) {
     }
     case FORM_ELIGIBILITY_CHECKS_SUCCEEDED: {
       const eligibility = getEligibilityChecks(action.eligibilityData);
-      const canSchedule = isEligible(eligibility);
       const facilityId = action.facilityId || state.data.vaFacility;
 
       let clinics = state.clinics;
@@ -722,14 +723,18 @@ export default function formReducer(state = initialState, action) {
         },
         eligibilityStatus: FETCH_STATUS.succeeded,
         pastAppointments: action.eligibilityData.pastAppointments,
-        showEligibilityModal:
-          action.showModal && !canSchedule.direct && !canSchedule.request,
       };
     }
     case FORM_ELIGIBILITY_CHECKS_FAILED: {
       return {
         ...state,
         eligibilityStatus: FETCH_STATUS.failed,
+      };
+    }
+    case FORM_SHOW_ELIGIBILITY_MODAL: {
+      return {
+        ...state,
+        showEligibilityModal: true,
       };
     }
     case FORM_HIDE_ELIGIBILITY_MODAL: {

--- a/src/applications/vaos/new-appointment/redux/reducer.js
+++ b/src/applications/vaos/new-appointment/redux/reducer.js
@@ -10,7 +10,7 @@ import {
 } from 'platform/forms-system/src/js/state/helpers';
 
 import { getParentOfLocation } from '../../services/location';
-import { getEligibilityChecks } from './helpers/eligibility';
+import { getEligibilityChecks, isEligible } from './helpers/eligibility';
 
 import {
   FORM_DATA_UPDATED,
@@ -702,6 +702,7 @@ export default function formReducer(state = initialState, action) {
     }
     case FORM_ELIGIBILITY_CHECKS_SUCCEEDED: {
       const eligibility = getEligibilityChecks(action.eligibilityData);
+      const canSchedule = isEligible(eligibility);
       const facilityId = action.facilityId || state.data.vaFacility;
 
       let clinics = state.clinics;
@@ -723,7 +724,8 @@ export default function formReducer(state = initialState, action) {
         },
         eligibilityStatus: FETCH_STATUS.succeeded,
         pastAppointments: action.eligibilityData.pastAppointments,
-        showEligibilityModal: action.showModal,
+        showEligibilityModal:
+          action.showModal && !canSchedule.direct && !canSchedule.request,
       };
     }
     case FORM_ELIGIBILITY_CHECKS_FAILED: {

--- a/src/applications/vaos/new-appointment/redux/reducer.js
+++ b/src/applications/vaos/new-appointment/redux/reducer.js
@@ -723,6 +723,7 @@ export default function formReducer(state = initialState, action) {
         },
         eligibilityStatus: FETCH_STATUS.succeeded,
         pastAppointments: action.eligibilityData.pastAppointments,
+        showEligibilityModal: action.showModal,
       };
     }
     case FORM_ELIGIBILITY_CHECKS_FAILED: {

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.multi.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.multi.unit.spec.jsx
@@ -485,7 +485,7 @@ describe('VAOS integration: VA flat facility page - multiple facilities', () => 
     );
   });
 
-  it('should show eligibility modal again if user closed out eligibility modal and clicked continue', async () => {
+  it('should show eligibility modal again if user closes it out and hits continue again with the same facility selected', async () => {
     mockParentSites(parentSiteIds, [parentSite983, parentSite984]);
     mockDirectBookingEligibilityCriteria(
       parentSiteIds,

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.multi.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.multi.unit.spec.jsx
@@ -485,6 +485,48 @@ describe('VAOS integration: VA flat facility page - multiple facilities', () => 
     );
   });
 
+  it('should show eligibility modal again if user closed out eligibility modal and clicked continue', async () => {
+    mockParentSites(parentSiteIds, [parentSite983, parentSite984]);
+    mockDirectBookingEligibilityCriteria(
+      parentSiteIds,
+      directFacilities.slice(0, 5),
+    );
+    mockRequestEligibilityCriteria(
+      parentSiteIds,
+      requestFacilities.slice(0, 4),
+    );
+    mockFacilitiesFetch(vhaIds.slice(0, 5).join(','), facilities.slice(0, 5));
+    mockEligibilityFetches({
+      siteId: '983',
+      facilityId: '983QA',
+      typeOfCareId: '323',
+    });
+    const store = createTestStore(initialState);
+    await setTypeOfCare(store, /primary care/i);
+
+    const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
+      store,
+    });
+
+    await screen.findByText(/below is a list of VA locations/i);
+
+    fireEvent.click(await screen.findByLabelText(/Fake facility name 5/i));
+    fireEvent.click(screen.getByText(/Continue/));
+    await screen.findByText(
+      /This facility does not allow scheduling requests/i,
+    );
+    const closeButton = screen.container.querySelector('.va-modal-close');
+    fireEvent.click(closeButton);
+    screen.debug();
+    expect(screen.baseElement).not.to.contain.text(
+      /This facility does not allow scheduling requests/,
+    );
+    fireEvent.click(screen.getByText(/Continue/));
+    await screen.findByText(
+      /This facility does not allow scheduling requests/i,
+    );
+  });
+
   it('should display an error message when eligibility calls fail', async () => {
     mockParentSites(parentSiteIds, [parentSite983, parentSite984]);
     mockDirectBookingEligibilityCriteria(parentSiteIds, directFacilities);

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.multi.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.multi.unit.spec.jsx
@@ -517,7 +517,6 @@ describe('VAOS integration: VA flat facility page - multiple facilities', () => 
     );
     const closeButton = screen.container.querySelector('.va-modal-close');
     fireEvent.click(closeButton);
-    screen.debug();
     expect(screen.baseElement).not.to.contain.text(
       /This facility does not allow scheduling requests/,
     );


### PR DESCRIPTION
## Description
The last PR introduced a bug where the eligibility modal would only show the first time a user hits continue if we have already fetched eligibility data for that facility.  This PR separates the showing of the modal into a separate action so that we can show the eligibility modal without fetching eligibility data again if we have it already.

## Testing done
Local and unit


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
