### PR TITLE
Update node-va_form's output schema

### DIFF
--- a/src/site/stages/build/process-cms-exports/schemas/output/node-va_form.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-va_form.js
@@ -60,7 +60,9 @@ module.exports = {
       },
     },
     fieldVaFormAdministration: { $ref: 'output/taxonomy_term-administration' },
-    fieldAlert: { $ref: 'BlockContent' },
+    fieldAlert: {
+      oneOf: [{ $ref: 'BlockContent' }, { type: 'null' }],
+    },
     fieldVaFormIssueDate: dateSchema,
     fieldVaFormLinkTeasers: {
       type: 'array',


### PR DESCRIPTION
## Description
This PR updates `fieldAlert` to include type `null` in the `node-va_form` output schema. This was causing an error when building the cms export.

## Testing done
Ran the bundle script for `node-va_form` and verified the cms export build finished successfully.

## Screenshots


## Acceptance criteria
- [ ] The `node-va_form` transformer throws no errors when running the bunlde.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
