### PR TITLE
Fix date format in node-event

### DIFF
--- a/src/site/stages/build/process-cms-exports/transformers/node-event.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-event.js
@@ -18,7 +18,7 @@ function toUtc(timeString, withExplicitUtc = true) {
     `Expected timeString to be a moment-parsable string. Found ${timeString}`,
   );
   const formatString = withExplicitUtc
-    ? 'YYYY-MM-DD kk:mm:ss [UTC]'
+    ? 'YYYY-MM-DD HH:mm:ss [UTC]'
     : 'YYYY-MM-DD[T]kk:mm:ss';
   return time.format(formatString);
 }


### PR DESCRIPTION
## Description
Another one liner. This PR updates the date format in the `toUtc` function in `node-event`. The `/outreach-and-events/` pages now show the correct dates.

## Testing done
Verified the `diff` for the following pages didn't include differences related to dates:

`/outreach-and-events/events/leesburg-virginia-community-veterans-engagement-board/index.html`
`/outreach-and-events/events/mst-ptsd-survivor-hear-me-see-me-empowered-advocate/index.html`
`/outreach-and-events/events/past-events/page-10/index.html`

## Screenshots


## Acceptance criteria
- [ ] `/outreach-and-events/events/` pages have the correct dates.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
