### PR TITLE
[Development] Fix BDD Cypress tests

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
@@ -68,6 +68,9 @@ export const uiSchema = {
     },
     'view:acknowledgement': {
       'ui:title': 'Patient Acknowledgment',
+      'ui:options': {
+        useDlWrap: true,
+      },
     },
     'ui:validations': [
       (errors, item) => {

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/mocks/feature-toggles.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/mocks/feature-toggles.json
@@ -1,7 +1,20 @@
 {
   "data": {
     "type": "feature_toggles",
-    "features": []
+    "features": [
+      {
+        "name": "form526OriginalClaims",
+        "value": true
+      },
+      {
+        "name": "form526BenefitsDeliveryAtDischarge",
+        "value": true
+      },
+      {
+        "name": "show526Wizard",
+        "value": true
+      }
+    ]
   }
 }
 

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/mocks/separation-locations.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/mocks/separation-locations.json
@@ -1,0 +1,8 @@
+{
+  "separationLocations": [
+    {
+      "code": "98283",
+      "description": "AF Academy"
+    }
+  ]
+}

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -832,18 +832,15 @@ export const activeServicePeriods = formData =>
   );
 
 export const isBDD = formData => {
-  const servicePeriods = formData?.serviceInformation?.servicePeriods;
+  const isBddDataFlag = Boolean(formData?.['view:isBddData']);
+  const servicePeriods = formData?.serviceInformation?.servicePeriods || [];
 
   // separation date entered in the wizard
   const separationDate = window.sessionStorage.getItem(SAVED_SEPARATION_DATE);
 
   // this flag helps maintain the correct form title within a session
-  window.sessionStorage.removeItem(FORM_STATUS_BDD);
-
-  // User hasn't started the form or the wizard
-  if ((!servicePeriods || !Array.isArray(servicePeriods)) && !separationDate) {
-    return false;
-  }
+  // Removed because of Cypress e2e tests don't have access to 'view:isBddData'
+  // window.sessionStorage.removeItem(FORM_STATUS_BDD);
 
   // isActiveDuty is true when the user selects that option in the wizard & then
   // enters a separation date - based on the session storage value; we then
@@ -851,13 +848,21 @@ export const isBDD = formData => {
   // If the user doesn't choose the active duty wizard option, but enters a
   // future date in their service history, this may be associated with reserves
   // and therefor should not open the BDD flow
-  const isActiveDuty = Boolean(formData?.['view:isBddData'] || separationDate);
+  const isActiveDuty = isBddDataFlag || separationDate;
+
+  if (
+    !isActiveDuty ||
+    // User hasn't started the form or the wizard
+    (servicePeriods.length === 0 && !separationDate)
+  ) {
+    return false;
+  }
 
   const mostRecentDate = separationDate
     ? moment(separationDate)
     : servicePeriods
         .filter(({ dateRange }) => dateRange?.to)
-        .map(({ dateRange }) => moment(dateRange.to))
+        .map(({ dateRange }) => moment(dateRange?.to))
         .sort((dateA, dateB) => dateB - dateA)[0];
 
   if (!mostRecentDate) {
@@ -872,7 +877,7 @@ export const isBDD = formData => {
     // this flag helps maintain the correct form title within a session
     window.sessionStorage.setItem(FORM_STATUS_BDD, 'true');
   }
-  return result;
+  return Boolean(result);
 };
 
 export const DISABILITY_SHARED_CONFIG = {


### PR DESCRIPTION
## Description

This PR started out as checking color contrast issues reported in the BDD form, but since the Cypress tests specific for BDD were disabled. Upon re-enabling these tests, a few issues were found that needed to be addressed:

- Include feature flags
- Step through 526 wizard
- Ensure e2e tests can properly determine if it's in normal vs BDD flow
- Add separation location mock data
- Fix found accessibility errors

The actual accessibility color issues were manually checked and determined to be false positive reported issues by axe

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/14013
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/13647

## Testing done

Unit tests
Cypress e2e tests

## Screenshots

N/A

## Acceptance criteria
- [x] Newly enabled Cypress e2e tests for BDD pass
- [x] Cypress tests the wizard
- [x] Fix reported accessibility issues
- [x] Color contrast issues determined to not be an issue

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
