### PR TITLE
1995/10203: Missing the blue line under ‘Need Help?’ on confirmation page/UX updates #15172

### DIFF
--- a/src/applications/edu-benefits/10203/containers/ConfirmationPage.jsx
+++ b/src/applications/edu-benefits/10203/containers/ConfirmationPage.jsx
@@ -116,7 +116,9 @@ class ConfirmationPage extends React.Component {
               Learn more about what happens after you apply
             </a>
           </p>
-          <h4 className="confirmation-guidance-heading">Need help?</h4>
+          <h4 className="confirmation-guidance-heading vads-u-border-bottom--3px vads-u-border-color--primary vads-u-line-height--4">
+            Need help?
+          </h4>
 
           <p className="confirmation-guidance-message">
             If you have questions, call 1-888-GI-BILL-1 (

--- a/src/applications/edu-benefits/10203/containers/ConfirmationPage.jsx
+++ b/src/applications/edu-benefits/10203/containers/ConfirmationPage.jsx
@@ -126,12 +126,10 @@ class ConfirmationPage extends React.Component {
             ), Monday &#8211; Friday, 8:00 a.m. &#8211; 7:00 p.m. ET.
           </p>
         </div>
-        <div className="row form-progress-buttons schemaform-back-buttons">
-          <div className="small-6 usa-width-one-half medium-6 columns">
-            <a href="/">
-              <button className="usa-button-primary">Go back to VA.gov</button>
-            </a>
-          </div>
+        <div className="form-progress-buttons schemaform-back-buttons">
+          <a href="/">
+            <button className="usa-button-primary">Go back to VA.gov</button>
+          </a>
         </div>
       </div>
     );

--- a/src/applications/edu-benefits/1995/containers/ConfirmationPage.jsx
+++ b/src/applications/edu-benefits/1995/containers/ConfirmationPage.jsx
@@ -161,7 +161,7 @@ class ConfirmationPage extends React.Component {
               Learn more about what happens after you apply:
             </a>
           </p>
-          <h4 className="confirmation-guidance-heading pagebreak">
+          <h4 className="confirmation-guidance-heading pagebreak vads-u-border-bottom--3px vads-u-border-color--primary vads-u-line-height--4">
             Need help?
           </h4>
           <p className="confirmation-guidance-message">

--- a/src/applications/edu-benefits/1995/containers/ConfirmationPage.jsx
+++ b/src/applications/edu-benefits/1995/containers/ConfirmationPage.jsx
@@ -170,12 +170,10 @@ class ConfirmationPage extends React.Component {
             ), Monday &#8211; Friday, 8:00 a.m. &#8211; 7:00 p.m. ET.
           </p>
         </div>
-        <div className="row form-progress-buttons schemaform-back-buttons">
-          <div className="small-6 usa-width-one-half medium-6 columns">
-            <a href="/">
-              <button className="usa-button-primary">Go back to VA.gov</button>
-            </a>
-          </div>
+        <div className="form-progress-buttons schemaform-back-buttons">
+          <a href="/">
+            <button className="usa-button-primary">Go back to VA.gov</button>
+          </a>
         </div>
       </div>
     );


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/15172

## Testing done


## Screenshots
![Screen Shot 2020-11-06 at 1 55 57 PM](https://user-images.githubusercontent.com/1094999/98403983-ced09b80-2037-11eb-9516-66e4b9f9ba07.png)
![Screen Shot 2020-11-06 at 1 56 15 PM](https://user-images.githubusercontent.com/1094999/98404005-d7c16d00-2037-11eb-886d-b161f9c22f4a.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

