### PR TITLE
rename some old VET360 constants, actions, and selectors

### DIFF
--- a/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
@@ -28,8 +28,8 @@ import {
   selectAddressValidationType,
   selectCurrentlyOpenEditModal,
   selectEditedFormField,
-  selectVet360Field,
-  selectVet360Transaction,
+  selectVAPContactInfoField,
+  selectVAPServiceTransaction,
 } from '@@vap-svc/selectors';
 
 import ContactInformationEditButton from './ContactInformationEditButton';
@@ -405,11 +405,11 @@ class ContactInformationField extends React.Component {
 
 export const mapStateToProps = (state, ownProps) => {
   const { fieldName } = ownProps;
-  const { transaction, transactionRequest } = selectVet360Transaction(
+  const { transaction, transactionRequest } = selectVAPServiceTransaction(
     state,
     fieldName,
   );
-  const data = selectVet360Field(state, fieldName);
+  const data = selectVAPContactInfoField(state, fieldName);
   const isEmpty = !data;
   const addressValidationType = selectAddressValidationType(state);
   const activeEditView = selectCurrentlyOpenEditModal(state);

--- a/src/platform/user/profile/vap-svc/actions/transactions.js
+++ b/src/platform/user/profile/vap-svc/actions/transactions.js
@@ -7,7 +7,7 @@ import { FIELD_NAMES, ADDRESS_POU } from '@@vap-svc/constants';
 
 import { showAddressValidationModal } from '../../utilities';
 
-import localVet360, {
+import localVAProfileService, {
   isVAProfileServiceConfigured,
 } from '../util/local-vapsvc';
 import { CONFIRMED } from '../../constants/addressValidationMessages';
@@ -16,23 +16,26 @@ import {
   isFailedTransaction,
 } from '../util/transactions';
 
-export const VET360_TRANSACTIONS_FETCH_SUCCESS =
-  'VET360_TRANSACTIONS_FETCH_SUCCESS';
-export const VET360_TRANSACTION_REQUESTED = 'VET360_TRANSACTION_REQUESTED';
-export const VET360_TRANSACTION_REQUEST_FAILED =
-  'VET360_TRANSACTION_REQUEST_FAILED';
-export const VET360_TRANSACTION_REQUEST_SUCCEEDED =
-  'VET360_TRANSACTION_REQUEST_SUCCEEDED';
-export const VET360_TRANSACTION_REQUEST_CLEARED =
-  'VET360_TRANSACTION_REQUEST_CLEARED';
-export const VET360_TRANSACTION_UPDATE_REQUESTED =
-  'VET360_TRANSACTION_UPDATE_REQUESTED';
-export const VET360_TRANSACTION_UPDATED = 'VET360_TRANSACTION_UPDATED';
-export const VET360_TRANSACTION_UPDATE_FAILED =
-  'VET360_TRANSACTION_UPDATE_FAILED';
-export const VET360_TRANSACTION_CLEARED = 'VET360_TRANSACTION_CLEARED';
-export const VET360_CLEAR_TRANSACTION_STATUS =
-  'VET360_CLEAR_TRANSACTION_STATUS';
+export const VAP_SERVICE_TRANSACTIONS_FETCH_SUCCESS =
+  'VAP_SERVICE_TRANSACTIONS_FETCH_SUCCESS';
+export const VAP_SERVICE_TRANSACTION_REQUESTED =
+  'VAP_SERVICE_TRANSACTION_REQUESTED';
+export const VAP_SERVICE_TRANSACTION_REQUEST_FAILED =
+  'VAP_SERVICE_TRANSACTION_REQUEST_FAILED';
+export const VAP_SERVICE_TRANSACTION_REQUEST_SUCCEEDED =
+  'VAP_SERVICE_TRANSACTION_REQUEST_SUCCEEDED';
+export const VAP_SERVICE_TRANSACTION_REQUEST_CLEARED =
+  'VAP_SERVICE_TRANSACTION_REQUEST_CLEARED';
+export const VAP_SERVICE_TRANSACTION_UPDATE_REQUESTED =
+  'VAP_SERVICE_TRANSACTION_UPDATE_REQUESTED';
+export const VAP_SERVICE_TRANSACTION_UPDATED =
+  'VAP_SERVICE_TRANSACTION_UPDATED';
+export const VAP_SERVICE_TRANSACTION_UPDATE_FAILED =
+  'VAP_SERVICE_TRANSACTION_UPDATE_FAILED';
+export const VAP_SERVICE_TRANSACTION_CLEARED =
+  'VAP_SERVICE_TRANSACTION_CLEARED';
+export const VAP_SERVICE_CLEAR_TRANSACTION_STATUS =
+  'VAP_SERVICE_CLEAR_TRANSACTION_STATUS';
 export const ADDRESS_VALIDATION_CONFIRM = 'ADDRESS_VALIDATION_CONFIRM';
 export const ADDRESS_VALIDATION_ERROR = 'ADDRESS_VALIDATION_ERROR';
 export const ADDRESS_VALIDATION_RESET = 'ADDRESS_VALIDATION_RESET';
@@ -41,7 +44,7 @@ export const ADDRESS_VALIDATION_UPDATE = 'ADDRESS_VALIDATION_UPDATE';
 
 export function clearTransactionStatus() {
   return {
-    type: VET360_CLEAR_TRANSACTION_STATUS,
+    type: VAP_SERVICE_CLEAR_TRANSACTION_STATUS,
   };
 }
 
@@ -57,7 +60,7 @@ export function fetchTransactions() {
         // response = localVet360.getUserTransactions();
       }
       dispatch({
-        type: VET360_TRANSACTIONS_FETCH_SUCCESS,
+        type: VAP_SERVICE_TRANSACTIONS_FETCH_SUCCESS,
         data: response.data,
       });
     } catch (err) {
@@ -68,14 +71,14 @@ export function fetchTransactions() {
 
 export function clearTransaction(transaction) {
   return {
-    type: VET360_TRANSACTION_CLEARED,
+    type: VAP_SERVICE_TRANSACTION_CLEARED,
     transaction,
   };
 }
 
 export function clearTransactionRequest(fieldName) {
   return {
-    type: VET360_TRANSACTION_REQUEST_CLEARED,
+    type: VAP_SERVICE_TRANSACTION_REQUEST_CLEARED,
     fieldName,
   };
 }
@@ -98,14 +101,14 @@ export function refreshTransaction(
       }
 
       dispatch({
-        type: VET360_TRANSACTION_UPDATE_REQUESTED,
+        type: VAP_SERVICE_TRANSACTION_UPDATE_REQUESTED,
         transaction,
       });
 
       const route = _route || `/profile/status/${transactionId}`;
       const transactionRefreshed = isVAProfileServiceConfigured()
         ? await apiRequest(route)
-        : await localVet360.updateTransaction(transactionId);
+        : await localVAProfileService.updateTransaction(transactionId);
 
       if (isSuccessfulTransaction(transactionRefreshed)) {
         const forceCacheClear = true;
@@ -118,7 +121,7 @@ export function refreshTransaction(
         });
       } else {
         dispatch({
-          type: VET360_TRANSACTION_UPDATED,
+          type: VAP_SERVICE_TRANSACTION_UPDATED,
           transaction: transactionRefreshed,
         });
 
@@ -132,7 +135,7 @@ export function refreshTransaction(
       }
     } catch (err) {
       dispatch({
-        type: VET360_TRANSACTION_UPDATE_FAILED,
+        type: VAP_SERVICE_TRANSACTION_UPDATE_FAILED,
         transaction,
         err,
       });
@@ -157,14 +160,14 @@ export function createTransaction(
     };
     try {
       dispatch({
-        type: VET360_TRANSACTION_REQUESTED,
+        type: VAP_SERVICE_TRANSACTION_REQUESTED,
         fieldName,
         method,
       });
 
       const transaction = isVAProfileServiceConfigured()
         ? await apiRequest(route, options)
-        : await localVet360.createTransaction();
+        : await localVAProfileService.createTransaction();
 
       if (transaction?.errors) {
         const error = new Error();
@@ -182,13 +185,13 @@ export function createTransaction(
       }
 
       dispatch({
-        type: VET360_TRANSACTION_REQUEST_SUCCEEDED,
+        type: VAP_SERVICE_TRANSACTION_REQUEST_SUCCEEDED,
         fieldName,
         transaction,
       });
     } catch (error) {
       dispatch({
-        type: VET360_TRANSACTION_REQUEST_FAILED,
+        type: VAP_SERVICE_TRANSACTION_REQUEST_FAILED,
         error,
         fieldName,
       });
@@ -219,7 +222,7 @@ export const validateAddress = (
   try {
     const response = isVAProfileServiceConfigured()
       ? await apiRequest('/profile/address_validation', options)
-      : await localVet360.addressValidationSuccess();
+      : await localVAProfileService.addressValidationSuccess();
     const { addresses, validationKey } = response;
     const suggestedAddresses = addresses
       // sort highest confidence score to lowest confidence score
@@ -343,7 +346,7 @@ export const updateValidationKeyAndSave = (
     };
     const response = isVAProfileServiceConfigured()
       ? await apiRequest('/profile/address_validation', options)
-      : await localVet360.addressValidationSuccess();
+      : await localVAProfileService.addressValidationSuccess();
     const { validationKey } = response;
 
     return dispatch(

--- a/src/platform/user/profile/vap-svc/constants/index.js
+++ b/src/platform/user/profile/vap-svc/constants/index.js
@@ -43,7 +43,7 @@ export const TRANSACTION_STATUS = {
   COMPLETED_FAILURE: 'COMPLETED_FAILURE',
 };
 
-export const INIT_VET360_ID = 'initializeVet360ID';
+export const INIT_VAP_SERVICE_ID = 'initializeVAProfileServiceID';
 
 export const FIELD_NAMES = {
   HOME_PHONE: 'homePhone',
@@ -97,7 +97,7 @@ export const API_ROUTES = {
   ADDRESSES: '/profile/addresses',
 };
 
-export const VET360_INITIALIZATION_STATUS = {
+export const VAP_SERVICE_INITIALIZATION_STATUS = {
   INITIALIZED: 'INITIALIZED',
   INITIALIZING: 'INITIALIZING',
   INITIALIZATION_FAILURE: 'INITIALIZATION_FAILURE',

--- a/src/platform/user/profile/vap-svc/containers/CopyMailingAddress.jsx
+++ b/src/platform/user/profile/vap-svc/containers/CopyMailingAddress.jsx
@@ -8,7 +8,7 @@ import { isEmptyAddress } from 'platform/forms/address/helpers';
 
 import { FIELD_NAMES } from '../constants';
 
-import { selectVet360Field, selectEditedFormField } from '../selectors';
+import { selectVAPContactInfoField, selectEditedFormField } from '../selectors';
 
 const ADDRESS_PROPS = [
   'addressLine1',
@@ -54,7 +54,10 @@ class CopyMailingAddress extends React.Component {
 }
 
 export function mapStateToProps(state) {
-  const mailingAddress = selectVet360Field(state, FIELD_NAMES.MAILING_ADDRESS);
+  const mailingAddress = selectVAPContactInfoField(
+    state,
+    FIELD_NAMES.MAILING_ADDRESS,
+  );
   const hasEmptyMailingAddress = isEmptyAddress(mailingAddress);
 
   const residentialAddress = selectEditedFormField(

--- a/src/platform/user/profile/vap-svc/containers/InitializeVet360ID.jsx
+++ b/src/platform/user/profile/vap-svc/containers/InitializeVet360ID.jsx
@@ -4,10 +4,10 @@ import { connect } from 'react-redux';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 import {
-  INIT_VET360_ID,
+  INIT_VAP_SERVICE_ID,
   ANALYTICS_FIELD_MAP,
   API_ROUTES,
-  VET360_INITIALIZATION_STATUS,
+  VAP_SERVICE_INITIALIZATION_STATUS,
 } from '../constants';
 
 import {
@@ -16,13 +16,13 @@ import {
   refreshTransaction,
 } from '../actions';
 
-import { selectVet360InitializationStatus } from '../selectors';
+import { selectVAPServiceInitializationStatus } from '../selectors';
 
 import TransactionPending from '../components/base/Vet360TransactionPending';
 
 class InitializeVet360ID extends React.Component {
   componentDidMount() {
-    if (this.props.status === VET360_INITIALIZATION_STATUS.INITIALIZED) {
+    if (this.props.status === VAP_SERVICE_INITIALIZATION_STATUS.INITIALIZED) {
       this.props.fetchTransactions();
     } else {
       this.initializeVet360ID();
@@ -31,7 +31,7 @@ class InitializeVet360ID extends React.Component {
 
   initializeVet360ID() {
     const route = API_ROUTES.INIT_VET360_ID;
-    const fieldName = INIT_VET360_ID;
+    const fieldName = INIT_VAP_SERVICE_ID;
     const method = 'POST';
     const body = null;
     const analytics = ANALYTICS_FIELD_MAP.INIT_VET360_ID;
@@ -61,10 +61,10 @@ class InitializeVet360ID extends React.Component {
 
   render() {
     switch (this.props.status) {
-      case VET360_INITIALIZATION_STATUS.INITIALIZED:
+      case VAP_SERVICE_INITIALIZATION_STATUS.INITIALIZED:
         return <>{this.props.children}</>;
 
-      case VET360_INITIALIZATION_STATUS.INITIALIZATION_FAILURE:
+      case VAP_SERVICE_INITIALIZATION_STATUS.INITIALIZATION_FAILURE:
         return (
           <AlertBox
             isVisible
@@ -78,14 +78,14 @@ class InitializeVet360ID extends React.Component {
           />
         );
 
-      case VET360_INITIALIZATION_STATUS.INITIALIZING:
+      case VAP_SERVICE_INITIALIZATION_STATUS.INITIALIZING:
         return (
           <TransactionPending refreshTransaction={this.refreshTransaction}>
             Initialization in progress...
           </TransactionPending>
         );
 
-      case VET360_INITIALIZATION_STATUS.UNINITIALIZED:
+      case VAP_SERVICE_INITIALIZATION_STATUS.UNINITIALIZED:
       default:
         return <div />;
     }
@@ -97,7 +97,7 @@ const mapStateToProps = state => {
     status,
     transaction,
     transactionRequest,
-  } = selectVet360InitializationStatus(state);
+  } = selectVAPServiceInitializationStatus(state);
   return {
     status,
     transaction,

--- a/src/platform/user/profile/vap-svc/containers/ReceiveTextMessages.jsx
+++ b/src/platform/user/profile/vap-svc/containers/ReceiveTextMessages.jsx
@@ -11,7 +11,7 @@ import {
 
 import * as VET360 from '../constants';
 import { createTransaction, clearTransactionStatus } from '../actions';
-import { selectVet360Transaction } from '@@vap-svc/selectors';
+import { selectVAPServiceTransaction } from '@@vap-svc/selectors';
 
 import {
   isPendingTransaction,
@@ -115,7 +115,7 @@ class ReceiveTextMessages extends React.Component {
 
 export function mapStateToProps(state, ownProps) {
   const { fieldName } = ownProps;
-  const { transaction } = selectVet360Transaction(state, fieldName);
+  const { transaction } = selectVAPServiceTransaction(state, fieldName);
   const hasError = !!isFailedTransaction(transaction);
   const isPending = !!isPendingTransaction(transaction);
   const profileState = selectProfile(state);

--- a/src/platform/user/profile/vap-svc/containers/Vet360ProfileField.jsx
+++ b/src/platform/user/profile/vap-svc/containers/Vet360ProfileField.jsx
@@ -19,8 +19,8 @@ import {
 } from '../actions';
 
 import {
-  selectVet360Field,
-  selectVet360Transaction,
+  selectVAPContactInfoField,
+  selectVAPServiceTransaction,
   selectCurrentlyOpenEditModal,
   selectEditedFormField,
 } from '../selectors';
@@ -266,11 +266,11 @@ class Vet360ProfileField extends React.Component {
 
 export const mapStateToProps = (state, ownProps) => {
   const { fieldName } = ownProps;
-  const { transaction, transactionRequest } = selectVet360Transaction(
+  const { transaction, transactionRequest } = selectVAPServiceTransaction(
     state,
     fieldName,
   );
-  const data = selectVet360Field(state, fieldName);
+  const data = selectVAPContactInfoField(state, fieldName);
   const isEmpty = !data;
   const addressValidationType =
     state.vet360.addressValidation.addressValidationType;

--- a/src/platform/user/profile/vap-svc/reducers/index.js
+++ b/src/platform/user/profile/vap-svc/reducers/index.js
@@ -1,16 +1,16 @@
 import {
   UPDATE_PROFILE_FORM_FIELD,
   OPEN_MODAL,
-  VET360_TRANSACTIONS_FETCH_SUCCESS,
-  VET360_TRANSACTION_REQUESTED,
-  VET360_TRANSACTION_REQUEST_SUCCEEDED,
-  VET360_TRANSACTION_REQUEST_FAILED,
-  VET360_TRANSACTION_UPDATED,
-  VET360_TRANSACTION_CLEARED,
-  VET360_TRANSACTION_REQUEST_CLEARED,
-  VET360_TRANSACTION_UPDATE_REQUESTED,
-  VET360_TRANSACTION_UPDATE_FAILED,
-  VET360_CLEAR_TRANSACTION_STATUS,
+  VAP_SERVICE_TRANSACTIONS_FETCH_SUCCESS,
+  VAP_SERVICE_TRANSACTION_REQUESTED,
+  VAP_SERVICE_TRANSACTION_REQUEST_SUCCEEDED,
+  VAP_SERVICE_TRANSACTION_REQUEST_FAILED,
+  VAP_SERVICE_TRANSACTION_UPDATED,
+  VAP_SERVICE_TRANSACTION_CLEARED,
+  VAP_SERVICE_TRANSACTION_REQUEST_CLEARED,
+  VAP_SERVICE_TRANSACTION_UPDATE_REQUESTED,
+  VAP_SERVICE_TRANSACTION_UPDATE_FAILED,
+  VAP_SERVICE_CLEAR_TRANSACTION_STATUS,
   ADDRESS_VALIDATION_CONFIRM,
   ADDRESS_VALIDATION_ERROR,
   ADDRESS_VALIDATION_RESET,
@@ -62,14 +62,14 @@ const initialState = {
 
 export default function vet360(state = initialState, action) {
   switch (action.type) {
-    case VET360_CLEAR_TRANSACTION_STATUS: {
+    case VAP_SERVICE_CLEAR_TRANSACTION_STATUS: {
       return {
         ...state,
         transactionStatus: '',
       };
     }
 
-    case VET360_TRANSACTIONS_FETCH_SUCCESS: {
+    case VAP_SERVICE_TRANSACTIONS_FETCH_SUCCESS: {
       const transactions = action.data.map(transactionData =>
         // Wrap in a "data" property to imitate the API response for a single transaction
         ({ data: transactionData }),
@@ -80,7 +80,7 @@ export default function vet360(state = initialState, action) {
       };
     }
 
-    case VET360_TRANSACTION_REQUESTED:
+    case VAP_SERVICE_TRANSACTION_REQUESTED:
       return {
         ...state,
         fieldTransactionMap: {
@@ -89,7 +89,7 @@ export default function vet360(state = initialState, action) {
         },
       };
 
-    case VET360_TRANSACTION_REQUEST_FAILED:
+    case VAP_SERVICE_TRANSACTION_REQUEST_FAILED:
       return {
         ...state,
         fieldTransactionMap: {
@@ -103,7 +103,7 @@ export default function vet360(state = initialState, action) {
         },
       };
 
-    case VET360_TRANSACTION_REQUEST_SUCCEEDED: {
+    case VAP_SERVICE_TRANSACTION_REQUEST_SUCCEEDED: {
       return {
         ...state,
         transactions: state.transactions.concat(action.transaction),
@@ -120,7 +120,7 @@ export default function vet360(state = initialState, action) {
       };
     }
 
-    case VET360_TRANSACTION_UPDATE_REQUESTED: {
+    case VAP_SERVICE_TRANSACTION_UPDATE_REQUESTED: {
       const { transactionId } = action.transaction.data.attributes;
       return {
         ...state,
@@ -130,7 +130,7 @@ export default function vet360(state = initialState, action) {
       };
     }
 
-    case VET360_TRANSACTION_UPDATED: {
+    case VAP_SERVICE_TRANSACTION_UPDATED: {
       const { transaction } = action;
       const {
         transactionId: updatedTransactionId,
@@ -156,7 +156,7 @@ export default function vet360(state = initialState, action) {
       };
     }
 
-    case VET360_TRANSACTION_UPDATE_FAILED: {
+    case VAP_SERVICE_TRANSACTION_UPDATE_FAILED: {
       const { transactionId } = action.transaction.data.attributes;
       return {
         ...state,
@@ -166,7 +166,7 @@ export default function vet360(state = initialState, action) {
       };
     }
 
-    case VET360_TRANSACTION_CLEARED: {
+    case VAP_SERVICE_TRANSACTION_CLEARED: {
       const finishedTransactionId =
         action.transaction.data.attributes.transactionId;
       const fieldTransactionMap = { ...state.fieldTransactionMap };
@@ -198,7 +198,7 @@ export default function vet360(state = initialState, action) {
       };
     }
 
-    case VET360_TRANSACTION_REQUEST_CLEARED: {
+    case VAP_SERVICE_TRANSACTION_REQUEST_CLEARED: {
       const fieldTransactionMap = { ...state.fieldTransactionMap };
       delete fieldTransactionMap[action.fieldName];
 

--- a/src/platform/user/profile/vap-svc/selectors.js
+++ b/src/platform/user/profile/vap-svc/selectors.js
@@ -4,22 +4,25 @@ import {
   selectVAPContactInfo,
 } from '~/platform/user/selectors';
 
-import { VET360_INITIALIZATION_STATUS, INIT_VET360_ID } from './constants';
+import {
+  VAP_SERVICE_INITIALIZATION_STATUS,
+  INIT_VAP_SERVICE_ID,
+} from './constants';
 
 import { isVAProfileServiceConfigured } from './util/local-vapsvc';
 
 import { isFailedTransaction, isPendingTransaction } from './util/transactions';
 
-export function selectIsVet360AvailableForUser(state) {
+export function selectIsVAProfileServiceAvailableForUser(state) {
   if (!isVAProfileServiceConfigured()) return true; // returns true if on localhost
   return selectAvailableServices(state).includes(backendServices.VET360);
 }
 
-export function selectVet360Field(state, fieldName) {
+export function selectVAPContactInfoField(state, fieldName) {
   return selectVAPContactInfo(state)[fieldName];
 }
 
-export function selectVet360Transaction(state, fieldName) {
+export function selectVAPServiceTransaction(state, fieldName) {
   const {
     vet360: {
       transactions,
@@ -111,14 +114,14 @@ export function selectAddressValidationType(state) {
   return selectAddressValidation(state).addressValidationType;
 }
 
-export function selectVet360InitializationStatus(state) {
-  let status = VET360_INITIALIZATION_STATUS.UNINITIALIZED;
+export function selectVAPServiceInitializationStatus(state) {
+  let status = VAP_SERVICE_INITIALIZATION_STATUS.UNINITIALIZED;
 
-  const { transaction, transactionRequest } = selectVet360Transaction(
+  const { transaction, transactionRequest } = selectVAPServiceTransaction(
     state,
-    INIT_VET360_ID,
+    INIT_VAP_SERVICE_ID,
   );
-  const isReady = selectIsVet360AvailableForUser(state);
+  const isReady = selectIsVAProfileServiceAvailableForUser(state);
   let isPending = false;
   let isFailure = false;
 
@@ -129,11 +132,11 @@ export function selectVet360InitializationStatus(state) {
   }
 
   if (isReady) {
-    status = VET360_INITIALIZATION_STATUS.INITIALIZED;
+    status = VAP_SERVICE_INITIALIZATION_STATUS.INITIALIZED;
   } else if (isPending) {
-    status = VET360_INITIALIZATION_STATUS.INITIALIZING;
+    status = VAP_SERVICE_INITIALIZATION_STATUS.INITIALIZING;
   } else if (isFailure) {
-    status = VET360_INITIALIZATION_STATUS.INITIALIZATION_FAILURE;
+    status = VAP_SERVICE_INITIALIZATION_STATUS.INITIALIZATION_FAILURE;
   }
 
   return {

--- a/src/platform/user/profile/vap-svc/tests/reducers/index.unit.spec.js
+++ b/src/platform/user/profile/vap-svc/tests/reducers/index.unit.spec.js
@@ -14,7 +14,7 @@ describe('vet360 reducer', () => {
     const state = vet360(
       {},
       {
-        type: 'VET360_TRANSACTIONS_FETCH_SUCCESS',
+        type: 'VAP_SERVICE_TRANSACTIONS_FETCH_SUCCESS',
         data: [1, 2, 3],
       },
     );
@@ -27,7 +27,7 @@ describe('vet360 reducer', () => {
     const state = vet360(
       {},
       {
-        type: 'VET360_TRANSACTION_REQUESTED',
+        type: 'VAP_SERVICE_TRANSACTION_REQUESTED',
         fieldName: 'fieldName',
         method: 'POST',
       },
@@ -51,7 +51,7 @@ describe('vet360 reducer', () => {
         },
       },
       {
-        type: 'VET360_TRANSACTION_REQUEST_FAILED',
+        type: 'VAP_SERVICE_TRANSACTION_REQUEST_FAILED',
         fieldName: 'fieldName',
         error: 'errorMessage',
       },
@@ -78,7 +78,7 @@ describe('vet360 reducer', () => {
         transactions: [],
       },
       {
-        type: 'VET360_TRANSACTION_REQUEST_SUCCEEDED',
+        type: 'VAP_SERVICE_TRANSACTION_REQUEST_SUCCEEDED',
         fieldName: 'fieldName',
         transaction: {
           data: {
@@ -106,7 +106,7 @@ describe('vet360 reducer', () => {
     const state = vet360(
       { transactionsAwaitingUpdate: [] },
       {
-        type: 'VET360_TRANSACTION_UPDATE_REQUESTED',
+        type: 'VAP_SERVICE_TRANSACTION_UPDATE_REQUESTED',
         transaction: {
           data: {
             attributes: {
@@ -138,7 +138,7 @@ describe('vet360 reducer', () => {
         metadata: {},
       },
       {
-        type: 'VET360_TRANSACTION_UPDATED',
+        type: 'VAP_SERVICE_TRANSACTION_UPDATED',
         transaction: {
           data: {
             attributes: {
@@ -171,7 +171,7 @@ describe('vet360 reducer', () => {
         metadata: {},
       },
       {
-        type: 'VET360_TRANSACTION_UPDATED',
+        type: 'VAP_SERVICE_TRANSACTION_UPDATED',
         transaction: {
           data: {
             attributes: {
@@ -192,7 +192,7 @@ describe('vet360 reducer', () => {
     const state = vet360(
       { transactionsAwaitingUpdate: [111] },
       {
-        type: 'VET360_TRANSACTION_UPDATE_FAILED',
+        type: 'VAP_SERVICE_TRANSACTION_UPDATE_FAILED',
         transaction: {
           data: {
             attributes: {
@@ -207,7 +207,7 @@ describe('vet360 reducer', () => {
   });
 
   it('should set transaction status cleared', () => {
-    const state = vet360({}, { type: 'VET360_CLEAR_TRANSACTION_STATUS' });
+    const state = vet360({}, { type: 'VAP_SERVICE_CLEAR_TRANSACTION_STATUS' });
     expect(state.transactionStatus.length).to.eql(0);
   });
 
@@ -228,7 +228,7 @@ describe('vet360 reducer', () => {
         },
       },
       {
-        type: 'VET360_TRANSACTION_CLEARED',
+        type: 'VAP_SERVICE_TRANSACTION_CLEARED',
         transaction: {
           data: {
             attributes: {
@@ -252,7 +252,7 @@ describe('vet360 reducer', () => {
         },
       },
       {
-        type: 'VET360_TRANSACTION_REQUEST_CLEARED',
+        type: 'VAP_SERVICE_TRANSACTION_REQUEST_CLEARED',
         fieldName: 'name',
       },
     );

--- a/src/platform/user/profile/vap-svc/tests/selectors.unit.spec.js
+++ b/src/platform/user/profile/vap-svc/tests/selectors.unit.spec.js
@@ -4,8 +4,8 @@ import backendServices from '~/platform/user/profile/constants/backendServices';
 import {
   TRANSACTION_STATUS,
   TRANSACTION_CATEGORY_TYPES,
-  INIT_VET360_ID,
-  VET360_INITIALIZATION_STATUS,
+  INIT_VAP_SERVICE_ID,
+  VAP_SERVICE_INITIALIZATION_STATUS,
 } from '../constants';
 
 import * as selectors from '../selectors';
@@ -39,7 +39,7 @@ const hooks = {
 };
 
 describe('selectors', () => {
-  describe('selectIsVet360AvailableForUser', () => {
+  describe('selectIsVAProfileServiceAvailableForUser', () => {
     beforeEach(hooks.beforeEach);
     it('returns true if vet360 is found in the profile.services list or when the environment is localhost', () => {
       const old = { document: global.document };
@@ -49,21 +49,21 @@ describe('selectors', () => {
         },
       };
 
-      let result = selectors.selectIsVet360AvailableForUser(state);
+      let result = selectors.selectIsVAProfileServiceAvailableForUser(state);
       expect(
         result,
-        'returns true when on localhost so the local mock Vet360 will run',
+        'returns true when on localhost so the local VA Profile Service mock will run',
       ).to.be.true;
 
       global.document.location.hostname = 'staging.va.gov';
-      result = selectors.selectIsVet360AvailableForUser(state);
+      result = selectors.selectIsVAProfileServiceAvailableForUser(state);
       expect(
         result,
         'returns true when the environment is not localhost but Vet360 is in the profile services array',
       ).to.be.true;
 
       state.user.profile.services = [];
-      result = selectors.selectIsVet360AvailableForUser(state);
+      result = selectors.selectIsVAProfileServiceAvailableForUser(state);
       expect(
         result,
         'returns false when the environment is not localhost and Vet360 is not in the services array',
@@ -73,15 +73,17 @@ describe('selectors', () => {
     });
   });
 
-  describe('selectVet360Field', () => {
+  describe('selectVAPContactInfoField', () => {
     beforeEach(hooks.beforeEach);
-    it('looks up a field from the user vet360 data', () => {
+    it('looks up a field from the user VAP contact info data', () => {
       state.user.profile.vapContactInfo = { someField: 'data' };
-      expect(selectors.selectVet360Field(state, 'someField')).to.equal('data');
+      expect(selectors.selectVAPContactInfoField(state, 'someField')).to.equal(
+        'data',
+      );
     });
   });
 
-  describe('selectVet360Transaction', () => {
+  describe('selectVAPServiceTransaction', () => {
     beforeEach(hooks.beforeEach);
     it('accepts a field name to look up a transaction and transaction request using the field-transaction map', () => {
       const fieldName = 'someField';
@@ -101,10 +103,10 @@ describe('selectors', () => {
 
       state.vet360 = { transactions, fieldTransactionMap };
 
-      let result = selectors.selectVet360Transaction(state, fieldName);
+      let result = selectors.selectVAPServiceTransaction(state, fieldName);
       expect(result).to.deep.equal({ transaction, transactionRequest });
 
-      result = selectors.selectVet360Transaction(state, 'someOtherField');
+      result = selectors.selectVAPServiceTransaction(state, 'someOtherField');
       expect(
         result,
         'returns a null transaction for a field that has no data in the field-transaction map',
@@ -301,7 +303,7 @@ describe('selectors', () => {
   });
 });
 
-describe('selectVet360InitializationStatus', () => {
+describe('selectVAPServiceInitializationStatus', () => {
   const old = { document: global.document };
 
   beforeEach(() => {
@@ -319,15 +321,17 @@ describe('selectVet360InitializationStatus', () => {
 
   it('returns UNINITIALIZED if Vet360 is not found in the services array and there is not an associated transaction', () => {
     state.user.profile.services = [];
-    const result = selectors.selectVet360InitializationStatus(state);
+    const result = selectors.selectVAPServiceInitializationStatus(state);
     expect(result.status).to.be.equal(
-      VET360_INITIALIZATION_STATUS.UNINITIALIZED,
+      VAP_SERVICE_INITIALIZATION_STATUS.UNINITIALIZED,
     );
   });
 
   it('returns INITIALIZED if Vet360 is found in the services array', () => {
-    const result = selectors.selectVet360InitializationStatus(state);
-    expect(result.status).to.be.equal(VET360_INITIALIZATION_STATUS.INITIALIZED);
+    const result = selectors.selectVAPServiceInitializationStatus(state);
+    expect(result.status).to.be.equal(
+      VAP_SERVICE_INITIALIZATION_STATUS.INITIALIZED,
+    );
   });
 
   it('returns INITIALIZING if there is an ongoing transaction', () => {
@@ -343,10 +347,10 @@ describe('selectVet360InitializationStatus', () => {
         },
       },
     ];
-    state.vet360.fieldTransactionMap[INIT_VET360_ID] = { transactionId };
-    const result = selectors.selectVet360InitializationStatus(state);
+    state.vet360.fieldTransactionMap[INIT_VAP_SERVICE_ID] = { transactionId };
+    const result = selectors.selectVAPServiceInitializationStatus(state);
     expect(result.status).to.be.equal(
-      VET360_INITIALIZATION_STATUS.INITIALIZING,
+      VAP_SERVICE_INITIALIZATION_STATUS.INITIALIZING,
     );
   });
 
@@ -363,10 +367,10 @@ describe('selectVet360InitializationStatus', () => {
         },
       },
     ];
-    state.vet360.fieldTransactionMap[INIT_VET360_ID] = { transactionId };
-    const result = selectors.selectVet360InitializationStatus(state);
+    state.vet360.fieldTransactionMap[INIT_VAP_SERVICE_ID] = { transactionId };
+    const result = selectors.selectVAPServiceInitializationStatus(state);
     expect(result.status).to.be.equal(
-      VET360_INITIALIZATION_STATUS.INITIALIZATION_FAILURE,
+      VAP_SERVICE_INITIALIZATION_STATUS.INITIALIZATION_FAILURE,
     );
   });
 });


### PR DESCRIPTION
## Description
This PR is the fifth in a handful to remove mentions of vet360 from our frontend code.

[PR 1 renamed the `vet360` folder to `vap-svc`](https://github.com/department-of-veterans-affairs/vets-website/pull/14798)
[PR 2 renamed the `vet360` Babel alias to `@@vap-svc`](https://github.com/department-of-veterans-affairs/vets-website/pull/14811)
[PR 3 renamed the `isVet360Configured` helper to `isVAProfileServiceConfigured`](https://github.com/department-of-veterans-affairs/vets-website/pull/14834)
[PR 4 renamed Redux's `profile.vet360` data to `profile.vapContactInfo`](https://github.com/department-of-veterans-affairs/vets-website/issues/14866)

This PR is focused on:
- Renaming some VET360 constants, actions and selectors.

## Testing done
Local + existing tests

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs