### PR TITLE
Addlevel 2 prop to alertbox

### DIFF
--- a/src/applications/personalization/profile/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile/components/ProfileWrapper.jsx
@@ -24,6 +24,7 @@ import { isEmpty } from 'lodash';
 const NotAllDataAvailableError = () => (
   <div data-testid="not-all-data-available-error">
     <AlertBox
+      level={2}
       status="warning"
       headline="We can’t load all of your information"
       className="vads-u-margin-bottom--4"


### PR DESCRIPTION
## Description
This PR changes the h level from h3 to h2 on the AlertBox in the ProfileWrapper. 

## Testing done
Works well locally. Axe best practice suggestion no longer there.

## Screenshots
BEFORE
![image](https://user-images.githubusercontent.com/14869324/98410298-a04fc200-2031-11eb-93c7-cad0f90230b4.png)

AFTER
![image](https://user-images.githubusercontent.com/14869324/98410322-b067a180-2031-11eb-85ad-9eb91d8f42a1.png)


## Acceptance criteria
- [x] Add level 2 prop to AlertBox

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
