### PR TITLE
Add abstract metatag to createMetaTagArray and raw-metatag schema

### DIFF
--- a/src/site/stages/build/process-cms-exports/schemas/common/raw-metatag.js
+++ b/src/site/stages/build/process-cms-exports/schemas/common/raw-metatag.js
@@ -14,6 +14,7 @@ module.exports = {
         description: { type: 'string' },
         twitter_cards_title: { type: 'string' },
         twitter_cards_site: { type: 'string' },
+        abstract: { type: 'string' },
         image_src: { type: 'string' },
         og_title: { type: 'string' },
         keywords: { type: 'string' },

--- a/src/site/stages/build/process-cms-exports/transformers/helpers.js
+++ b/src/site/stages/build/process-cms-exports/transformers/helpers.js
@@ -222,6 +222,7 @@ module.exports = {
       createMetaTag('MetaValue', 'description', metaTags.description),
       createMetaTag('MetaValue', 'twitter:title', metaTags.twitter_cards_title),
       createMetaTag('MetaValue', 'twitter:site', metaTags.twitter_cards_site),
+      createMetaTag('MetaValue', 'abstract', metaTags.abstract),
       createMetaTag('MetaLink', 'image_src', metaTags.image_src),
       createMetaTag('MetaProperty', 'og:title', metaTags.og_title),
       createMetaTag('MetaValue', 'keywords', metaTags.keywords),


### PR DESCRIPTION
## Description
This PR adds the `abstract` meta tag to the `createMetaTagArray` function. This resolves the missing `abstract` metatag in the cms export build.

## Testing done
Ran the `diff` of the cms export and graphql build for `/health-care/about-va-health-benefits/dental-care/dental-insurance/` to make sure there were no differences in the metatags.

## Screenshots


## Acceptance criteria
- [ ] `/health-care/about-va-health-benefits/dental-care/dental-insurance/` has the same metatags in the cms export build as the graphql build.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
