### PR TITLE
CT - Update school ratings mobile styling

### DIFF
--- a/src/applications/gi/components/profile/SchoolCategoryRating.jsx
+++ b/src/applications/gi/components/profile/SchoolCategoryRating.jsx
@@ -45,7 +45,7 @@ export default function SchoolCategoryRating({
           className="usa-accordion-button-ratings"
           onClick={() => openHandler(categoryRating.categoryName)}
         >
-          <div className="vads-l-row medium-screen:vads-u-padding-left--1">
+          <div className="category-main vads-l-row medium-screen:vads-u-padding-left--1">
             <div className="vads-l-col--6 vads-u-font-size--sm">{title}</div>
             {categoryRating.averageRating && (
               <div className="vads-l-col--6 vads-u-font-size--sm">

--- a/src/applications/gi/components/profile/SchoolRatings.jsx
+++ b/src/applications/gi/components/profile/SchoolRatings.jsx
@@ -45,7 +45,7 @@ export default function SchoolRatings({
   return (
     <div className="school-ratings vads-l-grid-container vads-u-padding--0">
       <div className="ratings-heading">
-        <div className="vads-u-font-weight--bold vads-u-font-size--lg vads-u-font-family--serif">
+        <div className="vads-u-font-weight--bolßd vads-u-font-size--lg vads-u-font-family--serif">
           {ratingCount} Veterans rated this institution:
         </div>
         <div className="vads-l-row">
@@ -120,7 +120,7 @@ export default function SchoolRatings({
             )}
           </div>
         </div>
-        <div className="vads-u-padding-top--4">
+        <div className="vads-u-padding-top--4 about-ratings">
           <span className="vads-u-font-size--h3 vads-u-font-weight--bold vads-u-font-family--serif">
             About ratings
           </span>

--- a/src/applications/gi/components/profile/SchoolRatings.jsx
+++ b/src/applications/gi/components/profile/SchoolRatings.jsx
@@ -44,24 +44,26 @@ export default function SchoolRatings({
 
   return (
     <div className="school-ratings vads-l-grid-container vads-u-padding--0">
-      <div className="vads-u-font-weight--bold vads-u-font-size--lg vads-u-font-family--serif">
-        {ratingCount} Veterans rated this institution:
-      </div>
-      <div className="vads-l-row">
-        <div className="vads-u-display--inline-block vads-u-text-align--center main-rating">
-          <div className="vads-u-font-weight--bold vads-u-font-size--2xl">
-            {stars.display}
-          </div>
-          <div>out of a possible 5 stars</div>
-          <div className="vads-u-font-size--lg">
-            {renderStars(ratingAverage)}
+      <div className="ratings-heading">
+        <div className="vads-u-font-weight--bold vads-u-font-size--lg vads-u-font-family--serif">
+          {ratingCount} Veterans rated this institution:
+        </div>
+        <div className="vads-l-row">
+          <div className="vads-u-display--inline-block vads-u-text-align--center main-rating">
+            <div className="vads-u-font-weight--bold vads-u-font-size--2xl">
+              {stars.display}
+            </div>
+            <div>out of a possible 5 stars</div>
+            <div className="vads-u-font-size--lg">
+              {renderStars(ratingAverage)}
+            </div>
           </div>
         </div>
       </div>
 
       <div className="vads-l-row">
         <div className="medium-screen:vads-l-col--6 small-screen:vads-l-col--12 xsmall-screen:vads-l-col--12">
-          <div className="vads-u-font-weight--bold vads-u-font-size--lg vads-u-font-family--serif vads-u-padding-top--3 school-ratings-accordion-headings">
+          <div className="vads-u-font-weight--bold vads-u-font-size--lg vads-u-font-family--serif category-ratings-accordion-headings">
             Education ratings
           </div>
 
@@ -94,7 +96,7 @@ export default function SchoolRatings({
         </div>
 
         <div className="medium-screen:vads-l-col--6 small-screen:vads-l-col--12 xsmall-screen:vads-l-col--12 ">
-          <div className="vads-u-font-weight--bold vads-u-font-size--lg vads-u-font-family--serif vads-u-padding-top--3 school-ratings-accordion-headings">
+          <div className="vads-u-font-weight--bold vads-u-font-size--lg vads-u-font-family--serif category-ratings-accordion-headings">
             Veteran friendliness
           </div>
           <div className="vads-u-padding-left--0">

--- a/src/applications/gi/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi/sass/partials/_gi-profile-page.scss
@@ -42,11 +42,17 @@
     position: relative;
     top: 2em;
   }
+  @include media-maxwidth($medium-screen - 1) {
+    .ratings-heading {
+      padding-left: 1rem;
+      padding-right: 1rem;
+    }
+  }
 
   #school-ratings-accordion-content {
     @include media-maxwidth($medium-screen - 1) {
-      padding-left: 1rem;
-      padding-right: 1rem;
+      padding-left: 0rem;
+      padding-right: 0rem;
     }
   }
 
@@ -60,6 +66,14 @@
       @include media-maxwidth($medium-screen - 1) {
         max-width: none;
       }
+    }
+
+    .category-main {
+      padding-left: 10px;
+      padding-right: 10px;
+      //@include media-maxwidth($small-screen - 1) {
+      //  width: 100px;
+      //}
     }
 
     .bar-outer {
@@ -83,7 +97,7 @@
       background-position: right 1rem center;
 
       @include media-maxwidth($medium-screen - 1) {
-        background-position: right 0rem center;
+        background-position: right 1rem center;
       }
     }
   }
@@ -168,15 +182,24 @@
 
   button.usa-accordion-button {
     text-align: left;
-    height: 57px;
   }
+
   button.usa-accordion-button-ratings {
     text-align: left;
     margin-bottom: 1px;
     margin-top: 1px;
   }
-  .school-ratings-accordion-headings{
+
+  .category-ratings-accordion-headings{
     margin-bottom: 9px;
+    padding-top: 2rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
+
+    @include media-maxwidth($medium-screen - 1) {
+      padding-left: 1rem;
+      padding-right: 1rem;
+    }
   }
 
   button.usa-accordion-button-ratings:hover {

--- a/src/applications/gi/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi/sass/partials/_gi-profile-page.scss
@@ -60,6 +60,13 @@
     width: 160px;
   }
 
+  @include media-maxwidth($medium-screen - 1) {
+    .about-ratings {
+      padding-left: 1rem;
+      padding-right: 1rem;
+    }
+  }
+
   .category-rating {
     .rating {
       max-width: 320px;


### PR DESCRIPTION
## Description
Update the padding of institution category rating titles for small screen sizes.

## Testing done
Tested locally and QA reviewed

## Screenshots
![image](https://user-images.githubusercontent.com/41960449/98557647-7802d600-2272-11eb-8eca-d5aa8a637499.png)

## Acceptance criteria
- [x] "The width of the mobile view has been updated so that the expand (+) and collapse (-) icons are not cut off on the screen (10px padding). Note this is true in both the "hover" and "select" state."

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
