### PR TITLE
Updated maxLength value to 255 on additionalInformation text-area on …

### DIFF
--- a/src/applications/vaos/express-care/components/ExpressCareDetailsPage.jsx
+++ b/src/applications/vaos/express-care/components/ExpressCareDetailsPage.jsx
@@ -29,7 +29,7 @@ const initialSchema = {
         </span>
       ),
       type: 'string',
-      maxLength: 256,
+      maxLength: 255,
     },
     contactInfo: {
       type: 'object',


### PR DESCRIPTION
Updated maxLength value to 255 on additionalInformation text-area on the Express Care Details page.

## Description
The purpose of this story was to ensure that client and server-side validation match for the maximum length response in the additional info field on the Express Care details page.  The solution was to update the value to 255 to match the back-end value (it was originally set to 256).

## Testing done
Unit tests were ran and all passed

## Screenshots


## Acceptance criteria
- No more than 255 characters can be entered into the additional info field on the Express Care details page.

## Definition of done
https://github.com/department-of-veterans-affairs/va.gov-team/issues/15902
