### PR TITLE
Remove "Download" string from Downloadable file component template (#15972)

### DIFF
--- a/src/site/paragraphs/downloadable_file.drupal.liquid
+++ b/src/site/paragraphs/downloadable_file.drupal.liquid
@@ -27,8 +27,8 @@
 
         <a class="file-download-with-icon" target="_blank"
            href="{{url}}" download="{{url}}">
-            <i class="fas fa-download vads-u-margin--0p5" aria-hidden="true" role="img"></i>
-            Download {{entity.fieldTitle}} ({{url | fileExt | upcase}})
+            <i class="fas fa-download vads-u-margin--0p5" aria-label="Download"></i>
+            {{entity.fieldTitle}} ({{url | fileExt | upcase}})
         </a>
     {% endif %}
 
@@ -36,8 +36,8 @@
         {% assign url = entity.fieldMedia.entity.fieldDocument.entity.url %}
         <a class="file-download-with-icon" target="_blank"
            href="{{url}}" download="{{url}}">
-            <i class="fas fa-download vads-u-margin--0p5" aria-hidden="true" role="img"></i>
-            Download {{entity.fieldTitle}} ({{url | fileExt | upcase}})
+            <i class="fas fa-download vads-u-margin--0p5" aria-label="Download"></i>
+            {{entity.fieldTitle}} ({{url | fileExt | upcase}})
         </a>
     {% endif %}
 


### PR DESCRIPTION
## Description

See https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/15972

This roles back the change from https://github.com/department-of-veterans-affairs/vets-website/pull/14451  and fulfills the needs of https://github.com/department-of-veterans-affairs/va.gov-team/issues/14614 and https://github.com/department-of-veterans-affairs/va.gov-team/issues/5473

Code was provided by @jenstrickland as a followup to [a #cms-support channel request](https://dsva.slack.com/archives/CDHBKAL9W/p1604864028473700) from @bethpottsVADEPO

 

## Testing done


## Screenshots

### Previous

Undesired "Download" string on https://www.va.gov/welcome-kit

![Digital_Service___VA___Slack](https://user-images.githubusercontent.com/643678/98584502-f7ed6800-2293-11eb-9cea-0a66434bce1f.jpg)

Double "Download" string on https://www.va.gov/pittsburgh-health-care/university-drive-campus-map/
![VA_Pittsburgh_Health_Care___University_Drive_campus_map](https://user-images.githubusercontent.com/643678/98584934-85c95300-2294-11eb-9d85-f97b63908c35.jpg)



## Acceptance criteria
- [ ] No "Download " string is prepended to the link text provided by editors. 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
