### PR TITLE
Render an h3 only if there's a fieldSectionHeader, otherwise h2

### DIFF
--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -82,7 +82,11 @@
                 </div>
               {% else %}
                   {% for fieldQA in fieldQAGroup.entity.fieldQAs %}
-                    <h3>{{ fieldQA.entity.title }}</h3>
+                    {% if fieldQAGroup.entity.fieldSectionHeader %}
+                      <h3>{{ fieldQA.entity.title }}</h3>
+                    {% else %}
+                      <h2>{{ fieldQA.entity.title }}</h2>
+                    {% endif %}
                     {% if fieldQA.entity %}
                       {% assign fieldAnswer = fieldQA.entity.fieldAnswer %}
                       {% assign bundleComponent = "src/site/paragraphs/" | append: fieldAnswer.entity.entityBundle %}


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/15797

This PR makes it so that `fieldQA.entity.title` is an h2 tag unless `fieldQAGroup.entity.fieldSectionHeader` is present, then it's an h3 tag.

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Update `fieldQA.entity.title` h2/h3 tags logic.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
