### PR TITLE
Fixed issues with command line arg definitions.

### DIFF
--- a/script/drupal-aws-cache.js
+++ b/script/drupal-aws-cache.js
@@ -24,7 +24,6 @@ const defaultBuildtype = ENVIRONMENTS.LOCALHOST;
 const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'fetch', type: Boolean, defaultValue: false },
   { name: 'buildtype', type: String, defaultValue: defaultBuildtype },
-  { name: 'unexpected', type: String, multiple: true, defaultOption: true },
 ];
 const cacheUrl = `https://s3-us-gov-west-1.amazonaws.com/vetsgov-website-builds-s3-upload/content`;
 const options = commandLineArgs(COMMAND_LINE_OPTIONS_DEFINITIONS);

--- a/script/drupal-aws-cache.js
+++ b/script/drupal-aws-cache.js
@@ -72,7 +72,7 @@ async function fetchCache() {
     options.buildtype === ENVIRONMENTS.LOCALHOST
       ? ENVIRONMENTS.VAGOVDEV
       : options.buildtype;
-  const cacheKey = getDrupalCacheKey(cacheEnv);
+  const cacheKey = await getDrupalCacheKey(cacheEnv);
   const fullCacheUrl = `${cacheUrl}/${cacheKey}.tar.bz2`;
   const downloadPath = path.join(cacheDirectory, `${cacheKey}.tar.bz2`);
 

--- a/script/drupal-aws-cache.js
+++ b/script/drupal-aws-cache.js
@@ -24,7 +24,7 @@ const defaultBuildtype = ENVIRONMENTS.LOCALHOST;
 const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'fetch', type: Boolean, defaultValue: false },
   { name: 'buildtype', type: String, defaultValue: defaultBuildtype },
-  { name: 'unexpected', type: String, multile: true, defaultOption: true },
+  { name: 'unexpected', type: String, multiple: true, defaultOption: true },
 ];
 const cacheUrl = `https://s3-us-gov-west-1.amazonaws.com/vetsgov-website-builds-s3-upload/content`;
 const options = commandLineArgs(COMMAND_LINE_OPTIONS_DEFINITIONS);

--- a/script/preview.js
+++ b/script/preview.js
@@ -51,7 +51,6 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
     type: String,
     defaultValue: process.env.DRUPAL_PASSWORD,
   },
-  { name: 'unexpected', type: String, multiple: true, defaultOption: true },
 ];
 
 if (process.env.SENTRY_DSN) {
@@ -59,10 +58,6 @@ if (process.env.SENTRY_DSN) {
 }
 
 const options = commandLineArgs(COMMAND_LINE_OPTIONS_DEFINITIONS);
-
-if (options.unexpected && options.unexpected.length !== 0) {
-  throw new Error(`Unexpected arguments: '${options.unexpected}'`);
-}
 
 if (options.buildpath === null) {
   options.buildpath = `build/${options.buildtype}`;

--- a/script/preview.js
+++ b/script/preview.js
@@ -51,7 +51,7 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
     type: String,
     defaultValue: process.env.DRUPAL_PASSWORD,
   },
-  { name: 'unexpected', type: String, multile: true, defaultOption: true },
+  { name: 'unexpected', type: String, multiple: true, defaultOption: true },
 ];
 
 if (process.env.SENTRY_DSN) {

--- a/src/platform/testing/e2e/mockapi.js
+++ b/src/platform/testing/e2e/mockapi.js
@@ -24,7 +24,7 @@ const optionDefinitions = [
   { name: 'responses', type: String },
 
   // Catch-all for bad arguments.
-  { name: 'unexpected', type: String, multile: true, defaultOption: true },
+  { name: 'unexpected', type: String, multiple: true, defaultOption: true },
 ];
 const options = commandLineArgs(optionDefinitions);
 

--- a/src/platform/testing/e2e/mockapi.js
+++ b/src/platform/testing/e2e/mockapi.js
@@ -22,15 +22,8 @@ const optionDefinitions = [
   { name: 'port', type: Number, defaultValue: +(process.env.API_PORT || 3000) },
   { name: 'host', type: String, defaultValue: 'localhost' },
   { name: 'responses', type: String },
-
-  // Catch-all for bad arguments.
-  { name: 'unexpected', type: String, multiple: true, defaultOption: true },
 ];
 const options = commandLineArgs(optionDefinitions);
-
-if (options.unexpected && options.unexpected.length !== 0) {
-  throw new Error(`Unexpected arguments: '${options.unexpected}'`);
-}
 
 function stripTrailingSlash(path) {
   return path.substr(-1) === '/' ? path.slice(0, -1) : path;

--- a/src/platform/testing/e2e/test-server.js
+++ b/src/platform/testing/e2e/test-server.js
@@ -18,15 +18,8 @@ const optionDefinitions = [
   { name: 'buildtype', type: String, defaultValue: ENVIRONMENTS.VAGOVDEV },
   { name: 'port', type: Number, defaultValue: +(process.env.WEB_PORT || 3333) },
   { name: 'host', type: String, defaultValue: 'localhost' },
-
-  // Catch-all for bad arguments.
-  { name: 'unexpected', type: String, multiple: true, defaultOption: true },
 ];
 const options = commandLineArgs(optionDefinitions);
-
-if (options.unexpected && options.unexpected.length !== 0) {
-  throw new Error(`Unexpected arguments: '${options.unexpected}'`);
-}
 
 const app = express();
 

--- a/src/platform/testing/e2e/test-server.js
+++ b/src/platform/testing/e2e/test-server.js
@@ -20,7 +20,7 @@ const optionDefinitions = [
   { name: 'host', type: String, defaultValue: 'localhost' },
 
   // Catch-all for bad arguments.
-  { name: 'unexpected', type: String, multile: true, defaultOption: true },
+  { name: 'unexpected', type: String, multiple: true, defaultOption: true },
 ];
 const options = commandLineArgs(optionDefinitions);
 

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -58,7 +58,7 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'accessibility', type: Boolean, defaultValue: false },
   { name: 'lint-plain-language', type: Boolean, defaultValue: false },
   { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false },
-  { name: 'unexpected', type: String, multile: true, defaultOption: true },
+  { name: 'unexpected', type: String, multiple: true, defaultOption: true },
 ];
 
 function gatherFromCommandLine() {

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -64,8 +64,6 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   // isn't actually a part of this list of options, but an error would be thrown
   // without it. Remove this when getOptions is decoupled from the cache script.
   { name: 'fetch', type: Boolean, defaultValue: false },
-
-  { name: 'unexpected', type: String, multiple: true, defaultOption: true },
 ];
 
 function gatherFromCommandLine() {
@@ -74,10 +72,6 @@ function gatherFromCommandLine() {
   // Set defaults which require the value of other options
   options['cms-export-dir'] =
     options['cms-export-dir'] || defaultCMSExportContentDir(options.buildtype);
-
-  if (options.unexpected && options.unexpected.length !== 0) {
-    throw new Error(`Unexpected arguments: '${options.unexpected}'`);
-  }
 
   return options;
 }

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -58,6 +58,13 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'accessibility', type: Boolean, defaultValue: false },
   { name: 'lint-plain-language', type: Boolean, defaultValue: false },
   { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false },
+
+  // HACK: The drupal-aws-cache script ends up here while trying to cache
+  // the query for getting all pages. The 'fetch' option from that cache script
+  // isn't actually a part of this list of options, but an error would be thrown
+  // without it. Remove this when getOptions is decoupled from the cache script.
+  { name: 'fetch', type: Boolean, defaultValue: false },
+
   { name: 'unexpected', type: String, multiple: true, defaultOption: true },
 ];
 


### PR DESCRIPTION
## Description
This is mainly a fix for the Drupal cache script. Running that script with `--fetch` (or just `yarn fetch-drupal-cache`) ultimately ends up in `getOptions` for the content build, and not including it in the definition list for those options threw an error.
1. To get the cache key, it queries for all pages.
2. The query for all pages queries for sidenavs.
3. The query for sidenavs pulls the build options.
4. The build options don't include `fetch` as an option, so an error is thrown.

This also fixes misspellings of `multiple` in definitions command line options and removes unnecessary `unexpected` arg definitions.

## Testing done
Ran script locally and passed. Without the fix, the script threw an unhandled promise rejection.

## Acceptance criteria
- [ ] The `drupal-aws-cache.js` script should run successfully.
- [ ] The `drupal-aws-cache.js` script should properly handle (log) errors.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
