### PR TITLE
Attempt to fix flaky VAOS Cypress tests

### DIFF
--- a/src/applications/vaos/tests/e2e/va-appointment.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/va-appointment.cypress.spec.js
@@ -14,6 +14,7 @@ describe('VAOS direct schedule flow', () => {
     cy.visit('health-care/schedule-view-va-appointments/appointments/');
     cy.injectAxe();
     cy.get('.va-modal-body button').click();
+    cy.findAllByRole('tab').should('exist');
 
     // Start flow
     cy.findByText('Schedule an appointment').click();
@@ -80,6 +81,7 @@ describe('VAOS direct schedule flow', () => {
     cy.visit('health-care/schedule-view-va-appointments/appointments/');
     cy.injectAxe();
     cy.get('.va-modal-body button').click();
+    cy.findAllByRole('tab').should('exist');
 
     // Start flow
     cy.findByText('Schedule an appointment').click();
@@ -146,6 +148,7 @@ describe('VAOS direct schedule flow', () => {
     cy.visit('health-care/schedule-view-va-appointments/appointments/');
     cy.injectAxe();
     cy.get('.va-modal-body button').click();
+    cy.findAllByRole('tab').should('exist');
 
     // Start flow
     cy.findByText('Schedule an appointment').click();

--- a/src/applications/vaos/tests/e2e/va-appointment.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/va-appointment.cypress.spec.js
@@ -70,6 +70,10 @@ describe('VAOS direct schedule flow', () => {
       );
       expect(request).to.have.property('preferredEmail', 'veteran@gmail.com');
     });
+    cy.wait('@appointmentPreferences').should(xhr => {
+      const request = xhr.requestBody;
+      expect(request.emailAddress).to.eq('veteran@gmail.com');
+    });
 
     // Confirmation page
     newApptTests.confirmationPageTest(additionalInfo);

--- a/src/applications/vaos/tests/e2e/va-request.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/va-request.cypress.spec.js
@@ -11,6 +11,7 @@ function fillOutForm(facilitySelection) {
   cy.visit('health-care/schedule-view-va-appointments/appointments/');
   cy.injectAxe();
   cy.get('.va-modal-body button').click();
+  cy.findAllByRole('tab').should('exist');
 
   // Start flow
   cy.findByText('Schedule an appointment').click();

--- a/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
@@ -263,11 +263,37 @@ function mockDirectScheduleSlots() {
 }
 
 export function initAppointmentListMock() {
-  cy.server();
-  cy.login();
-  mockFeatureToggles();
-  mockSupportedSites();
+  setupSchedulingMocks();
 
+  const today = moment();
+  cy.route({
+    method: 'GET',
+    url: '/vaos/v0/request_eligibility_criteria*',
+    response: {
+      data: [
+        getExpressCareRequestCriteriaMock('983', [
+          {
+            day: today
+              .clone()
+              .tz('America/Denver')
+              .format('dddd')
+              .toUpperCase(),
+            canSchedule: true,
+            startTime: today
+              .clone()
+              .subtract('2', 'minutes')
+              .tz('America/Denver')
+              .format('HH:mm'),
+            endTime: today
+              .clone()
+              .add('2', 'minutes')
+              .tz('America/Denver')
+              .format('HH:mm'),
+          },
+        ]),
+      ],
+    },
+  }).as('getRequestEligibilityCriteria');
   cy.route({
     method: 'GET',
     url: '/vaos/v0/appointment_requests*',
@@ -324,38 +350,7 @@ export function initAppointmentListMock() {
 }
 
 export function initExpressCareMocks() {
-  const today = moment();
   initAppointmentListMock();
-
-  cy.route({
-    method: 'GET',
-    url: '/vaos/v0/request_eligibility_criteria*',
-    response: {
-      data: [
-        getExpressCareRequestCriteriaMock('983', [
-          {
-            day: today
-              .clone()
-              .tz('America/Denver')
-              .format('dddd')
-              .toUpperCase(),
-            canSchedule: true,
-            startTime: today
-              .clone()
-              .subtract('2', 'minutes')
-              .tz('America/Denver')
-              .format('HH:mm'),
-            endTime: today
-              .clone()
-              .add('2', 'minutes')
-              .tz('America/Denver')
-              .format('HH:mm'),
-          },
-        ]),
-      ],
-    },
-  }).as('getRequestEligibilityCriteria');
-
   mockRequestLimits();
 
   cy.route({

--- a/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
@@ -7,6 +7,7 @@ import requests from '../../services/mocks/var/requests.json';
 import cancelReasons from '../../services/mocks/var/cancel_reasons.json';
 import supportedSites from '../../services/mocks/var/sites-supporting-var.json';
 import facilities from '../../services/mocks/var/facilities.json';
+import facilityData from '../../services/mocks/var/facility_data.json';
 import facilities983 from '../../services/mocks/var/facilities_983.json';
 import clinicList983 from '../../services/mocks/var/clinicList983.json';
 import slots from '../../services/mocks/var/slots.json';
@@ -201,6 +202,16 @@ function mockSubmitVAAppointment() {
     url: '/vaos/v0/appointments',
     response: { data: {} },
   }).as('appointmentSubmission');
+  cy.route({
+    method: 'GET',
+    url: '/vaos/v0/preferences',
+    response: { data: {} },
+  });
+  cy.route({
+    method: 'PUT',
+    url: '/vaos/v0/preferences',
+    response: { data: {} },
+  }).as('appointmentPreferences');
 }
 
 function setupSchedulingMocks() {
@@ -393,6 +404,21 @@ export function initExpressCareMocks() {
 
 export function initVAAppointmentMock() {
   setupSchedulingMocks();
+  cy.route({
+    method: 'GET',
+    url: '/v1/facilities/va/vha_442',
+    response: { data: facilityData.data[0] },
+  });
+  cy.route({
+    method: 'GET',
+    url: '/v1/facilities/va?ids=*',
+    response: facilityData,
+  });
+  cy.route({
+    method: 'GET',
+    url: '/vaos/v0/community_care/eligibility/Optometry',
+    response: { data: { eligible: false } },
+  });
   mockPrimaryCareClinics();
   mockRequestLimits();
   mockVisits();

--- a/src/applications/vaos/tests/e2e/vaos-cypress-schedule-appointment-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-cypress-schedule-appointment-helpers.js
@@ -12,7 +12,7 @@ export function chooseTypeOfCareTest(label) {
 export function chooseVAFacilityTest() {
   cy.url().should('include', '/va-facility');
   cy.axeCheck();
-  cy.findByLabelText(/CHYSHR/).click();
+  cy.findByLabelText(/CHYSHR/).check();
   cy.findByLabelText(
     'CHYSHR-Cheyenne VA Medical Center (Cheyenne, WY)',
   ).click();
@@ -22,7 +22,10 @@ export function chooseVAFacilityTest() {
 export function chooseClinicTest() {
   cy.url().should('include', '/clinics');
   cy.axeCheck();
-  cy.findByLabelText('CHY PC CASSIDY').click();
+  cy.findByText(/You can choose a clinic where you’ve been seen/i);
+  cy.get('#root_clinicId_0')
+    .focus()
+    .click();
   cy.findByText(/Continue/).click();
 }
 


### PR DESCRIPTION
## Description
Some of our tests are failing for unclear reasons in Cypress, this tries to address that by waiting longer on the appointment list. One guess I have is that the schedule button is clicked before the modal overlay is removed.

## Testing done
Local Cypress testing

## Acceptance criteria
- [ ] Tests pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
