### PR TITLE
rename vet360 selectors to VAP

### DIFF
--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import * as Sentry from '@sentry/browser';
 import recordEvent from 'platform/monitoring/record-event';
-import { selectVet360ResidentialAddress } from 'platform/user/selectors';
+import { selectVAPResidentialAddress } from 'platform/user/selectors';
 import {
   GA_PREFIX,
   APPOINTMENT_TYPES,
@@ -461,7 +461,7 @@ export function fetchExpressCareWindows() {
 
     const initialState = getState();
     const userSiteIds = selectSystemIds(initialState);
-    const address = selectVet360ResidentialAddress(initialState);
+    const address = selectVAPResidentialAddress(initialState);
 
     try {
       const settings = await getRequestEligibilityCriteria(userSiteIds);

--- a/src/applications/vaos/express-care/redux/actions.js
+++ b/src/applications/vaos/express-care/redux/actions.js
@@ -2,9 +2,9 @@ import moment from 'moment';
 import recordEvent from 'platform/monitoring/record-event';
 
 import {
-  selectVet360EmailAddress,
-  selectVet360HomePhoneString,
-  selectVet360MobilePhoneString,
+  selectVAPEmailAddress,
+  selectVAPHomePhoneString,
+  selectVAPMobilePhoneString,
 } from 'platform/user/selectors';
 import newExpressCareRequestFlow from '../newExpressCareRequestFlow';
 import {
@@ -74,9 +74,9 @@ export function updateFormData(page, uiSchema, data) {
 export function openAdditionalDetailsPage(page, uiSchema, schema) {
   return (dispatch, getState) => {
     const state = getState();
-    const email = selectVet360EmailAddress(state);
-    const homePhone = selectVet360HomePhoneString(state);
-    const mobilePhone = selectVet360MobilePhoneString(state);
+    const email = selectVAPEmailAddress(state);
+    const homePhone = selectVAPHomePhoneString(state);
+    const mobilePhone = selectVAPMobilePhoneString(state);
     const phoneNumber = mobilePhone || homePhone;
     dispatch({
       type: FORM_ADDITIONAL_DETAILS_PAGE_OPENED,

--- a/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
@@ -24,7 +24,7 @@ import {
 } from '../../../utils/selectors';
 import { resetDataLayer } from '../../../utils/events';
 
-import { selectVet360ResidentialAddress } from 'platform/user/selectors';
+import { selectVAPResidentialAddress } from 'platform/user/selectors';
 
 const initialSchema = {
   type: 'object',
@@ -144,7 +144,7 @@ export class TypeOfCarePage extends React.Component {
 function mapStateToProps(state) {
   const formInfo = getFormPageInfo(state, pageKey);
   const newAppointment = getNewAppointment(state);
-  const address = selectVet360ResidentialAddress(state);
+  const address = selectVAPResidentialAddress(state);
   return {
     ...formInfo,
     ...address,

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -4,10 +4,10 @@ import * as Sentry from '@sentry/browser';
 import recordEvent from 'platform/monitoring/record-event';
 
 import {
-  selectVet360EmailAddress,
-  selectVet360HomePhoneString,
-  selectVet360MobilePhoneString,
-  selectVet360ResidentialAddress,
+  selectVAPEmailAddress,
+  selectVAPHomePhoneString,
+  selectVAPMobilePhoneString,
+  selectVAPResidentialAddress,
 } from 'platform/user/selectors';
 import newAppointmentFlow from '../newAppointmentFlow';
 import {
@@ -251,9 +251,9 @@ export function startRequestAppointmentFlow(isCommunityCare) {
 export function openTypeOfCarePage(page, uiSchema, schema) {
   return (dispatch, getState) => {
     const state = getState();
-    const email = selectVet360EmailAddress(state);
-    const homePhone = selectVet360HomePhoneString(state);
-    const mobilePhone = selectVet360MobilePhoneString(state);
+    const email = selectVAPEmailAddress(state);
+    const homePhone = selectVAPHomePhoneString(state);
+    const mobilePhone = selectVAPMobilePhoneString(state);
     const showCommunityCare = vaosCommunityCare(state);
 
     const phoneNumber = mobilePhone || homePhone;
@@ -394,7 +394,7 @@ export function openFacilityPageV2(page, uiSchema, schema) {
           typeOfCareId,
           schema,
           uiSchema,
-          address: selectVet360ResidentialAddress(initialState),
+          address: selectVAPResidentialAddress(initialState),
         });
 
         // If we have an already selected location or only have a single location
@@ -504,7 +504,7 @@ export function hideEligibilityModal() {
  * 2. A user has only one parent, so we also need to fetch facilities
  * 3. A user might only have one parent and facility available, so we need to also
  *    do eligibility checks
- * 4. A user might already have been on this page, in which case we may have some 
+ * 4. A user might already have been on this page, in which case we may have some
  *    of the above data already and don't want to make another api call
 */
 export function openFacilityPage(page, uiSchema, schema) {

--- a/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.js
@@ -4,7 +4,7 @@ import titleCase from 'platform/utilities/data/titleCase';
 import { getTimezoneBySystemId } from '../../../utils/timezone';
 import { getFacilityIdFromLocation } from '../../../services/location';
 import { getSiteIdFromOrganization } from '../../../services/organization';
-import { selectVet360ResidentialAddress } from 'platform/user/selectors';
+import { selectVAPResidentialAddress } from 'platform/user/selectors';
 import {
   PURPOSE_TEXT,
   TYPE_OF_VISIT,
@@ -152,7 +152,7 @@ export function transformFormToCCRequest(state) {
     ];
   }
 
-  const residentialAddress = selectVet360ResidentialAddress(state);
+  const residentialAddress = selectVAPResidentialAddress(state);
   const organization = getChosenCCSystemId(state);
   const parentFacilityId = getSiteIdFromOrganization(organization);
   let cityState;

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -3,7 +3,7 @@ import { createSelector } from 'reselect';
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import {
   selectPatientFacilities,
-  selectVet360ResidentialAddress,
+  selectVAPResidentialAddress,
   selectCernerAppointmentsFacilities,
 } from 'platform/user/selectors';
 import { titleCase } from './formatters';
@@ -346,7 +346,7 @@ export function getFacilityPageV2Info(state) {
 
   return {
     ...formInfo,
-    address: selectVet360ResidentialAddress(state),
+    address: selectVAPResidentialAddress(state),
     canScheduleAtChosenFacility:
       eligibilityStatus.direct || eligibilityStatus.request,
     childFacilitiesStatus,
@@ -630,7 +630,7 @@ export function selectActiveExpressCareWindows(state, nowMoment) {
 /*
  * Gets the formatted hours string of the current window, chosen based on the
  * provided time.
- * 
+ *
  * Note: we're picking the first active window, there could be more than one
  */
 export function selectLocalExpressCareWindowString(state, nowMoment) {
@@ -648,7 +648,7 @@ export function selectLocalExpressCareWindowString(state, nowMoment) {
 /*
  * Gets the facility info for the current window, chosen based on the
  * provided time.
- * 
+ *
  * Note: we're picking the first active window, there could be more than one
  */
 export function selectActiveExpressCareFacility(state, nowMoment) {

--- a/src/platform/user/profile/vap-svc/containers/ReceiveTextMessages.jsx
+++ b/src/platform/user/profile/vap-svc/containers/ReceiveTextMessages.jsx
@@ -6,8 +6,8 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import {
   isVAPatient,
   selectProfile,
-  selectVet360MobilePhone,
-} from 'platform/user/selectors';
+  selectVAPMobilePhone,
+} from '~/platform/user/selectors';
 
 import * as VAP_SERVICE from '../constants';
 import { createTransaction, clearTransactionStatus } from '../actions';
@@ -119,7 +119,7 @@ export function mapStateToProps(state, ownProps) {
   const hasError = !!isFailedTransaction(transaction);
   const isPending = !!isPendingTransaction(transaction);
   const profileState = selectProfile(state);
-  const mobilePhone = selectVet360MobilePhone(state);
+  const mobilePhone = selectVAPMobilePhone(state);
   const isTextable =
     mobilePhone?.phoneType === VAP_SERVICE.PHONE_TYPE.mobilePhone;
   const hideCheckbox =

--- a/src/platform/user/selectors.js
+++ b/src/platform/user/selectors.js
@@ -58,7 +58,7 @@ export const selectPatientFacilities = state =>
   }) || null;
 export const selectVAPContactInfo = state =>
   selectProfile(state).vapContactInfo;
-export const selectVet360EmailAddress = state =>
+export const selectVAPEmailAddress = state =>
   selectVAPContactInfo(state)?.email?.emailAddress;
 const createPhoneNumberStringFromData = phoneNumberData => {
   const data = phoneNumberData || {};
@@ -69,15 +69,15 @@ const createPhoneNumberStringFromData = phoneNumberData => {
   const extension = data.extension === '0000' ? undefined : data.extension;
   return `${areaCode}${phoneNumber}${extension ? `x${extension}` : ''}`;
 };
-export const selectVet360MobilePhone = state =>
+export const selectVAPMobilePhone = state =>
   selectVAPContactInfo(state)?.mobilePhone;
-export const selectVet360MobilePhoneString = state =>
-  createPhoneNumberStringFromData(selectVet360MobilePhone(state));
-export const selectVet360HomePhone = state =>
+export const selectVAPMobilePhoneString = state =>
+  createPhoneNumberStringFromData(selectVAPMobilePhone(state));
+export const selectVAPHomePhone = state =>
   selectVAPContactInfo(state)?.homePhone;
-export const selectVet360HomePhoneString = state =>
-  createPhoneNumberStringFromData(selectVet360HomePhone(state));
-export const selectVet360ResidentialAddress = state =>
+export const selectVAPHomePhoneString = state =>
+  createPhoneNumberStringFromData(selectVAPHomePhone(state));
+export const selectVAPResidentialAddress = state =>
   selectVAPContactInfo(state)?.residentialAddress;
 
 export function createIsServiceAvailableSelector(service) {

--- a/src/platform/user/tests/selectors.unit.spec.js
+++ b/src/platform/user/tests/selectors.unit.spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import * as selectors from '../selectors';
 
 describe('user selectors', () => {
-  describe('selectVet360', () => {
+  describe('selectVAPContactInfo', () => {
     it('pulls out the state.profile.vapContactInfo data', () => {
       const state = {
         user: {
@@ -19,7 +19,7 @@ describe('user selectors', () => {
         state.user.profile.vapContactInfo,
       );
     });
-    it('returns undefined if there is no vet360 on the profile', () => {
+    it('returns undefined if there is no vapContactInfo on the profile', () => {
       const state = {
         user: {
           profile: {},
@@ -29,7 +29,7 @@ describe('user selectors', () => {
     });
   });
 
-  describe('selectVet360EmailAddress', () => {
+  describe('selectVAPEmailAddress', () => {
     it('pulls out the state.profile.vapContactInfo.emailAddress', () => {
       const state = {
         user: {
@@ -51,17 +51,17 @@ describe('user selectors', () => {
           },
         },
       };
-      expect(selectors.selectVet360EmailAddress(state)).to.equal(
+      expect(selectors.selectVAPEmailAddress(state)).to.equal(
         state.user.profile.vapContactInfo.email.emailAddress,
       );
     });
-    it('returns undefined if there is no vet360 on the profile', () => {
+    it('returns undefined if there is no vapContactInfo on the profile', () => {
       const state = {
         user: {
           profile: {},
         },
       };
-      expect(selectors.selectVet360EmailAddress(state)).to.be.undefined;
+      expect(selectors.selectVAPEmailAddress(state)).to.be.undefined;
     });
     it('returns undefined if there is no email', () => {
       const state = {
@@ -71,7 +71,7 @@ describe('user selectors', () => {
           },
         },
       };
-      expect(selectors.selectVet360EmailAddress(state)).to.be.undefined;
+      expect(selectors.selectVAPEmailAddress(state)).to.be.undefined;
     });
   });
 
@@ -98,7 +98,7 @@ describe('user selectors', () => {
       vet360Id: '139281',
     };
 
-    describe('selectVet360MobilePhone', () => {
+    describe('selectVAPMobilePhone', () => {
       it('pulls out the state.profile.vapContactInfo.mobilePhone data object', () => {
         const state = {
           user: {
@@ -109,17 +109,17 @@ describe('user selectors', () => {
             },
           },
         };
-        expect(selectors.selectVet360MobilePhone(state)).to.deep.equal(
+        expect(selectors.selectVAPMobilePhone(state)).to.deep.equal(
           state.user.profile.vapContactInfo.mobilePhone,
         );
       });
-      it('returns undefined if there is no vet360 on the profile', () => {
+      it('returns undefined if there is no vapContactInfo on the profile', () => {
         const state = {
           user: {
             profile: {},
           },
         };
-        expect(selectors.selectVet360MobilePhone(state)).to.be.undefined;
+        expect(selectors.selectVAPMobilePhone(state)).to.be.undefined;
       });
       it('returns undefined if there is no mobile phone', () => {
         const state = {
@@ -129,11 +129,11 @@ describe('user selectors', () => {
             },
           },
         };
-        expect(selectors.selectVet360MobilePhone(state)).to.be.undefined;
+        expect(selectors.selectVAPMobilePhone(state)).to.be.undefined;
       });
     });
 
-    describe('selectVet360MobilePhoneString', () => {
+    describe('selectVAPMobilePhoneString', () => {
       it('pulls out the mobile phone number as a single string if it exists', () => {
         const state = {
           user: {
@@ -144,7 +144,7 @@ describe('user selectors', () => {
             },
           },
         };
-        expect(selectors.selectVet360MobilePhoneString(state)).to.equal(
+        expect(selectors.selectVAPMobilePhoneString(state)).to.equal(
           '4158453210',
         );
       });
@@ -158,7 +158,7 @@ describe('user selectors', () => {
             },
           },
         };
-        expect(selectors.selectVet360MobilePhoneString(state)).to.equal(
+        expect(selectors.selectVAPMobilePhoneString(state)).to.equal(
           '4158453210x1234',
         );
       });
@@ -172,13 +172,13 @@ describe('user selectors', () => {
             },
           },
         };
-        expect(selectors.selectVet360MobilePhoneString(state)).to.equal(
+        expect(selectors.selectVAPMobilePhoneString(state)).to.equal(
           '4158453210',
         );
       });
     });
 
-    describe('selectVet360HomePhone', () => {
+    describe('selectVAPHomePhone', () => {
       it('pulls out the state.profile.vapContactInfo.homePhone data object', () => {
         const state = {
           user: {
@@ -189,17 +189,17 @@ describe('user selectors', () => {
             },
           },
         };
-        expect(selectors.selectVet360HomePhone(state)).to.deep.equal(
+        expect(selectors.selectVAPHomePhone(state)).to.deep.equal(
           state.user.profile.vapContactInfo.homePhone,
         );
       });
-      it('returns undefined if there is no vet360 on the profile', () => {
+      it('returns undefined if there is no vapContactInfo on the profile', () => {
         const state = {
           user: {
             profile: {},
           },
         };
-        expect(selectors.selectVet360HomePhone(state)).to.be.undefined;
+        expect(selectors.selectVAPHomePhone(state)).to.be.undefined;
       });
       it('returns undefined if there is no mobile phone', () => {
         const state = {
@@ -209,11 +209,11 @@ describe('user selectors', () => {
             },
           },
         };
-        expect(selectors.selectVet360HomePhone(state)).to.be.undefined;
+        expect(selectors.selectVAPHomePhone(state)).to.be.undefined;
       });
     });
 
-    describe('selectVet360HomePhoneString', () => {
+    describe('selectVAPHomePhoneString', () => {
       it('pulls out the home phone number as a single string if it exists', () => {
         const state = {
           user: {
@@ -224,7 +224,7 @@ describe('user selectors', () => {
             },
           },
         };
-        expect(selectors.selectVet360HomePhoneString(state)).to.equal(
+        expect(selectors.selectVAPHomePhoneString(state)).to.equal(
           '4158453210',
         );
       });
@@ -238,7 +238,7 @@ describe('user selectors', () => {
             },
           },
         };
-        expect(selectors.selectVet360HomePhoneString(state)).to.equal(
+        expect(selectors.selectVAPHomePhoneString(state)).to.equal(
           '4158453210x1234',
         );
       });


### PR DESCRIPTION
## Description
This PR is the seventh in a handful to remove mentions of vet360 from our frontend code.

[PR 1 renamed the `vet360` folder to `vap-svc`](https://github.com/department-of-veterans-affairs/vets-website/pull/14798)
[PR 2 renamed the `vet360` Babel alias to `@@vap-svc`](https://github.com/department-of-veterans-affairs/vets-website/pull/14811)
[PR 3 renamed the `isVet360Configured` helper to `isVAProfileServiceConfigured`](https://github.com/department-of-veterans-affairs/vets-website/pull/14834)
[PR 4 renamed Redux's `profile.vet360` data to `profile.vapContactInfo`](https://github.com/department-of-veterans-affairs/vets-website/issues/14866)
[PR 5 renamed some `VET360` constants, actions and selectors](https://github.com/department-of-veterans-affairs/vets-website/pull/14888)
[PR 6 renamed more `VET360` constants to `VAP_SERVICE`](https://github.com/department-of-veterans-affairs/vets-website/pull/14899)

This PR is focused on:
- Renaming some contact info selectors

## Testing done
Local + existing tests

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs