### PR TITLE
Show covid banner on VAMC health services pages

### DIFF
--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -149,6 +149,7 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
       facilitySidebar: sidebar,
       entityUrl: hsEntityUrl,
       alert: page.alert,
+      bannerAlert: page.bannerAlert,
       title: page.title,
       regionNickname: page.fieldNicknameForThisFacility,
       clinicalHealthServices,

--- a/src/site/stages/build/drupal/load-saved-flags.js
+++ b/src/site/stages/build/drupal/load-saved-flags.js
@@ -12,7 +12,7 @@ const fs = require('fs-extra');
  * @return {Proxy} - A Proxy containing all the feature flags; throws
  *                   an error if a flag is called without existing
  */
-function useFlags(rawFlags, shouldLog = false) {
+function useFlags(rawFlags, shouldLog = true) {
   // eslint-disable-next-line fp/no-proxy
   const p = new Proxy(rawFlags, {
     get(obj, prop) {
@@ -30,6 +30,9 @@ function useFlags(rawFlags, shouldLog = false) {
         'Symbol(Symbol.iterator)',
       ];
       if (!ignoreList.includes(prop.toString()) && shouldLog) {
+        // TODO: make this error message more helpful and less noisy, i.e.
+        // - only log once rather than 100's of times
+        // - indicate the solution may be to pass the --pull-drupal flag to the build.
         // eslint-disable-next-line no-console
         console.error(
           `Could not find query flag ${prop.toString()}. This could be a typo or the feature flag wasn't returned from Drupal.`,

--- a/src/site/stages/build/drupal/load-saved-flags.js
+++ b/src/site/stages/build/drupal/load-saved-flags.js
@@ -12,7 +12,7 @@ const fs = require('fs-extra');
  * @return {Proxy} - A Proxy containing all the feature flags; throws
  *                   an error if a flag is called without existing
  */
-function useFlags(rawFlags, shouldLog = true) {
+function useFlags(rawFlags, shouldLog = false) {
   // eslint-disable-next-line fp/no-proxy
   const p = new Proxy(rawFlags, {
     get(obj, prop) {


### PR DESCRIPTION
## Description
The covid banner was missing from VAMC health services pages. This fixes that bug.


## Testing done
Manual

## Screenshots
![VA_Pittsburgh_Health_Care___Patient_And_Health_Services___Veterans_Affairs](https://user-images.githubusercontent.com/80267/98608616-97712180-22b9-11eb-9e41-4aa5680aac7d.png)


## Acceptance criteria
- [x] The covid banner is visible

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
