### PR TITLE
Sort the reverse fields in node-event_listing

### DIFF
--- a/src/site/stages/build/process-cms-exports/transformers/node-event_listing.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-event_listing.js
@@ -12,6 +12,7 @@ const reverseFields = reverseFieldListing => ({
           reverseField =>
             reverseField.entityBundle === 'event' && reverseField.status,
         )
+        .sort((a, b) => b.changed - a.changed)
         .map(reverseField => ({
           title: reverseField.title,
           entityUrl: reverseField.entityUrl,


### PR DESCRIPTION
## Description
The reverse field in `node-event_listing` needs to be sorted in descending order by the `changed` field to match the [graphql query](https://github.com/department-of-veterans-affairs/vets-website/blob/4013102de6fa5970ef9c38f92836b6d7e8c177a3/src/site/stages/build/drupal/graphql/eventListingPage.graphql.js#L14).

## Testing done
Ran the `diff` of `/outreach-and-events/events/past-events/page-2/index.html` for both builds.

## Screenshots


## Acceptance criteria
- [ ] `/outreach-and-events/events/past-events/page-2/index.html` has consistent information in both the cms export and graphql builds.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
