### PR TITLE
Update the check for fieldAdditionalInformationAbo in node-event

### DIFF
--- a/src/site/stages/build/process-cms-exports/transformers/node-event.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-event.js
@@ -33,7 +33,7 @@ const transform = entity => ({
   entityMetatags: createMetaTagArray(entity.metatag.value),
   // TODO: Verify this is how to derive the entityPublished state
   entityPublished: isPublished(getDrupalValue(entity.status)),
-  fieldAdditionalInformationAbo: entity.fieldAdditionalInformationAbo.value
+  fieldAdditionalInformationAbo: entity.fieldAdditionalInformationAbo[0]
     ? {
         processed: getWysiwygString(
           getDrupalValue(entity.fieldAdditionalInformationAbo),


### PR DESCRIPTION
## Description
This PR fixes the missing section on `/outreach-and-events/events/webcast-veterans-benefits-performance-and-results-for-fy-2020-fourth/index.html` by updating the check for `fieldAdditionalInformationAbo` in the `node-event` transformer. Previously, the check was not accessing the field correctly, resulting in a `null` value.

This PR fixes https://github.com/department-of-veterans-affairs/va.gov-team/issues/15366 & https://github.com/department-of-veterans-affairs/va.gov-team/issues/15369.

## Testing done
Ran the `diff` for the cms export and graphql build on `/outreach-and-events/events/webcast-veterans-benefits-performance-and-results-for-fy-2020-fourth/index.html` and `/outreach-and-events/events/pave-connect-employer-session-windstream-communications/index.html`.

## Screenshots


## Acceptance criteria
- [ ] `/outreach-and-events/events/webcast-veterans-benefits-performance-and-results-for-fy-2020-fourth/index.html` is consistent in the cms export and graphql builds.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
