### PR TITLE
rename top-level Redux `vet360` slice to `vapService`

### DIFF
--- a/src/applications/letters/reducers/index.js
+++ b/src/applications/letters/reducers/index.js
@@ -1,4 +1,4 @@
-import vet360 from '@@vap-svc/reducers';
+import vapService from '@@vap-svc/reducers';
 
 import _ from 'lodash/fp';
 import {
@@ -157,5 +157,5 @@ function letters(state = initialState, action) {
 
 export default {
   letters,
-  vet360,
+  vapService,
 };

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
@@ -420,7 +420,7 @@ export const mapStateToProps = (state, ownProps) => {
     activeEditView === 'addressValidation';
 
   return {
-    hasUnsavedEdits: state.vet360.hasUnsavedEdits,
+    hasUnsavedEdits: state.vapService.hasUnsavedEdits,
     analyticsSectionName: VAP_SERVICE.ANALYTICS_FIELD_MAP[fieldName],
     blockEditMode: !!activeEditView,
     /*

--- a/src/applications/personalization/profile/components/personal-information/PersonalInformation.jsx
+++ b/src/applications/personalization/profile/components/personal-information/PersonalInformation.jsx
@@ -85,7 +85,7 @@ PersonalInformation.propTypes = {
 
 const mapStateToProps = state => ({
   showDirectDepositBlockedError: !!directDepositIsBlocked(state),
-  hasUnsavedEdits: state.vet360.hasUnsavedEdits,
+  hasUnsavedEdits: state.vapService.hasUnsavedEdits,
 });
 
 export default connect(

--- a/src/applications/personalization/profile/components/personal-information/addresses/AddressEditView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/addresses/AddressEditView.jsx
@@ -106,7 +106,7 @@ class AddressEditView extends React.Component {
 }
 
 const mapStateToProps = state => ({
-  modalData: state.vet360?.modalData,
+  modalData: state.vapService?.modalData,
 });
 
 export default connect(mapStateToProps)(AddressEditView);

--- a/src/applications/personalization/profile/reducers/index.js
+++ b/src/applications/personalization/profile/reducers/index.js
@@ -1,95 +1,9 @@
-import set from 'platform/utilities/data/set';
-import vet360 from '@@vap-svc/reducers';
+import vapService from '@@vap-svc/reducers';
 import { hcaEnrollmentStatus } from 'applications/hca/reducer';
-
-import {
-  FETCH_HERO_SUCCESS,
-  FETCH_HERO_FAILED,
-  FETCH_PERSONAL_INFORMATION_SUCCESS,
-  FETCH_PERSONAL_INFORMATION_FAILED,
-  FETCH_MILITARY_INFORMATION_SUCCESS,
-  FETCH_MILITARY_INFORMATION_FAILED,
-} from '../actions';
-
-import {
-  PAYMENT_INFORMATION_FETCH_SUCCEEDED,
-  PAYMENT_INFORMATION_FETCH_FAILED,
-  PAYMENT_INFORMATION_SAVE_STARTED,
-  PAYMENT_INFORMATION_SAVE_SUCCEEDED,
-  PAYMENT_INFORMATION_SAVE_FAILED,
-  PAYMENT_INFORMATION_EDIT_MODAL_TOGGLED,
-} from '../actions/paymentInformation';
-
-const initialState = {
-  hero: null,
-  personalInformation: null,
-  militaryInformation: null,
-  paymentInformation: null,
-  paymentInformationUiState: {
-    isEditing: false,
-    isSaving: false,
-    responseError: null,
-  },
-};
-
-function vaProfile(state = initialState, action) {
-  switch (action.type) {
-    case FETCH_HERO_SUCCESS:
-    case FETCH_HERO_FAILED:
-      return set('hero', action.hero, state);
-
-    case FETCH_PERSONAL_INFORMATION_SUCCESS:
-    case FETCH_PERSONAL_INFORMATION_FAILED:
-      return set('personalInformation', action.personalInformation, state);
-
-    case FETCH_MILITARY_INFORMATION_SUCCESS:
-    case FETCH_MILITARY_INFORMATION_FAILED:
-      return set('militaryInformation', action.militaryInformation, state);
-
-    case PAYMENT_INFORMATION_FETCH_SUCCEEDED:
-    case PAYMENT_INFORMATION_SAVE_SUCCEEDED: {
-      let newState = set('paymentInformation', action.response, state);
-      newState = set('paymentInformationUiState.isEditing', false, newState);
-      return set('paymentInformationUiState.isSaving', false, newState);
-    }
-
-    case PAYMENT_INFORMATION_EDIT_MODAL_TOGGLED: {
-      const newState = set(
-        'paymentInformationUiState.isEditing',
-        !state.paymentInformationUiState.isEditing,
-        state,
-      );
-
-      return set('paymentInformationUiState.responseError', null, newState);
-    }
-
-    case PAYMENT_INFORMATION_SAVE_STARTED:
-      return set('paymentInformationUiState.isSaving', true, state);
-
-    case PAYMENT_INFORMATION_FETCH_FAILED: {
-      return set(
-        'paymentInformation',
-        { error: action.response.error || true },
-        state,
-      );
-    }
-
-    case PAYMENT_INFORMATION_SAVE_FAILED: {
-      const newState = set('paymentInformationUiState.isSaving', false, state);
-      return set(
-        'paymentInformationUiState.responseError',
-        action.response,
-        newState,
-      );
-    }
-
-    default:
-      return state;
-  }
-}
+import vaProfile from './vaProfile';
 
 export default {
   vaProfile,
-  vet360,
+  vapService,
   hcaEnrollmentStatus,
 };

--- a/src/applications/personalization/profile/reducers/vaProfile.js
+++ b/src/applications/personalization/profile/reducers/vaProfile.js
@@ -1,0 +1,89 @@
+import set from 'platform/utilities/data/set';
+
+import {
+  FETCH_HERO_SUCCESS,
+  FETCH_HERO_FAILED,
+  FETCH_PERSONAL_INFORMATION_SUCCESS,
+  FETCH_PERSONAL_INFORMATION_FAILED,
+  FETCH_MILITARY_INFORMATION_SUCCESS,
+  FETCH_MILITARY_INFORMATION_FAILED,
+} from '../actions';
+
+import {
+  PAYMENT_INFORMATION_FETCH_SUCCEEDED,
+  PAYMENT_INFORMATION_FETCH_FAILED,
+  PAYMENT_INFORMATION_SAVE_STARTED,
+  PAYMENT_INFORMATION_SAVE_SUCCEEDED,
+  PAYMENT_INFORMATION_SAVE_FAILED,
+  PAYMENT_INFORMATION_EDIT_MODAL_TOGGLED,
+} from '../actions/paymentInformation';
+
+const initialState = {
+  hero: null,
+  personalInformation: null,
+  militaryInformation: null,
+  paymentInformation: null,
+  paymentInformationUiState: {
+    isEditing: false,
+    isSaving: false,
+    responseError: null,
+  },
+};
+
+function vaProfile(state = initialState, action) {
+  switch (action.type) {
+    case FETCH_HERO_SUCCESS:
+    case FETCH_HERO_FAILED:
+      return set('hero', action.hero, state);
+
+    case FETCH_PERSONAL_INFORMATION_SUCCESS:
+    case FETCH_PERSONAL_INFORMATION_FAILED:
+      return set('personalInformation', action.personalInformation, state);
+
+    case FETCH_MILITARY_INFORMATION_SUCCESS:
+    case FETCH_MILITARY_INFORMATION_FAILED:
+      return set('militaryInformation', action.militaryInformation, state);
+
+    case PAYMENT_INFORMATION_FETCH_SUCCEEDED:
+    case PAYMENT_INFORMATION_SAVE_SUCCEEDED: {
+      let newState = set('paymentInformation', action.response, state);
+      newState = set('paymentInformationUiState.isEditing', false, newState);
+      return set('paymentInformationUiState.isSaving', false, newState);
+    }
+
+    case PAYMENT_INFORMATION_EDIT_MODAL_TOGGLED: {
+      const newState = set(
+        'paymentInformationUiState.isEditing',
+        !state.paymentInformationUiState.isEditing,
+        state,
+      );
+
+      return set('paymentInformationUiState.responseError', null, newState);
+    }
+
+    case PAYMENT_INFORMATION_SAVE_STARTED:
+      return set('paymentInformationUiState.isSaving', true, state);
+
+    case PAYMENT_INFORMATION_FETCH_FAILED: {
+      return set(
+        'paymentInformation',
+        { error: action.response.error || true },
+        state,
+      );
+    }
+
+    case PAYMENT_INFORMATION_SAVE_FAILED: {
+      const newState = set('paymentInformationUiState.isSaving', false, state);
+      return set(
+        'paymentInformationUiState.responseError',
+        action.response,
+        newState,
+      );
+    }
+
+    default:
+      return state;
+  }
+}
+
+export default vaProfile;

--- a/src/applications/personalization/profile/tests/components/ContactInformationField.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/ContactInformationField.unit.spec.jsx
@@ -171,7 +171,7 @@ describe('mapStateToProps', () => {
         },
       },
     },
-    vet360: {
+    vapService: {
       addressValidation: {},
       formFields: {
         mobilePhone: {},
@@ -191,7 +191,7 @@ describe('mapStateToProps', () => {
     });
     it('should be true if currently editing another field', () => {
       const state = getBasicState();
-      state.vet360.modal = 'homePhone';
+      state.vapService.modal = 'homePhone';
       const mappedProps = mapStateToProps(state, {
         fieldName: FIELD_NAMES.MOBILE_PHONE,
       });
@@ -201,7 +201,7 @@ describe('mapStateToProps', () => {
   describe('#activeEditView', () => {
     it('should be the field name of the field that is being edited', () => {
       const state = getBasicState();
-      state.vet360.modal = FIELD_NAMES.RESIDENTIAL_ADDRESS;
+      state.vapService.modal = FIELD_NAMES.RESIDENTIAL_ADDRESS;
       const mappedProps = mapStateToProps(state, {
         fieldName: FIELD_NAMES.MOBILE_PHONE,
       });
@@ -211,8 +211,8 @@ describe('mapStateToProps', () => {
     });
     it('should be the field name of the address field that is being validated', () => {
       const state = getBasicState();
-      state.vet360.modal = 'addressValidation';
-      state.vet360.addressValidation.addressValidationType =
+      state.vapService.modal = 'addressValidation';
+      state.vapService.addressValidation.addressValidationType =
         FIELD_NAMES.RESIDENTIAL_ADDRESS;
       const mappedProps = mapStateToProps(state, {
         fieldName: FIELD_NAMES.MOBILE_PHONE,
@@ -231,7 +231,7 @@ describe('mapStateToProps', () => {
           },
         },
       },
-      vet360: {
+      vapService: {
         addressValidation: {
           addressValidationType: FIELD_NAMES.MAILING_ADDRESS,
         },
@@ -256,7 +256,7 @@ describe('mapStateToProps', () => {
     describe('when the address validation modal is not open', () => {
       it('sets `showValidationView` to `false`', () => {
         const state = showValidationModalState();
-        state.vet360.modal = 'notTheValidationModal';
+        state.vapService.modal = 'notTheValidationModal';
         const mappedProps = mapStateToProps(state, {
           fieldName: FIELD_NAMES.MAILING_ADDRESS,
           ValidationView: () => {},

--- a/src/platform/user/profile/vap-svc/actions/transactions.js
+++ b/src/platform/user/profile/vap-svc/actions/transactions.js
@@ -92,7 +92,7 @@ export function refreshTransaction(
     try {
       const { transactionId } = transaction.data.attributes;
       const state = getState();
-      const isAlreadyAwaitingUpdate = state.vet360.transactionsAwaitingUpdate.includes(
+      const isAlreadyAwaitingUpdate = state.vapService.transactionsAwaitingUpdate.includes(
         transactionId,
       );
 

--- a/src/platform/user/profile/vap-svc/components/AddressField/AddressEditModal.jsx
+++ b/src/platform/user/profile/vap-svc/components/AddressField/AddressEditModal.jsx
@@ -126,7 +126,7 @@ class AddressEditModal extends React.Component {
 }
 
 const mapStateToProps = state => ({
-  modalData: state.vet360?.modalData,
+  modalData: state.vapService?.modalData,
 });
 
 export default connect(mapStateToProps)(AddressEditModal);

--- a/src/platform/user/profile/vap-svc/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vap-svc/containers/AddressValidationModal.jsx
@@ -280,23 +280,24 @@ class AddressValidationModal extends React.Component {
 const mapStateToProps = (state, ownProps) => {
   const { transaction } = ownProps;
   const addressValidationType =
-    state.vet360.addressValidation.addressValidationType;
+    state.vapService.addressValidation.addressValidationType;
 
   return {
     analyticsSectionName:
       VAP_SERVICE.ANALYTICS_FIELD_MAP[addressValidationType],
     isLoading:
-      state.vet360.fieldTransactionMap[addressValidationType]?.isPending ||
+      state.vapService.fieldTransactionMap[addressValidationType]?.isPending ||
       isPendingTransaction(transaction),
     addressValidationError:
-      state.vet360.addressValidation.addressValidationError,
-    suggestedAddresses: state.vet360.addressValidation.suggestedAddresses,
-    confirmedSuggestions: state.vet360.addressValidation.confirmedSuggestions,
+      state.vapService.addressValidation.addressValidationError,
+    suggestedAddresses: state.vapService.addressValidation.suggestedAddresses,
+    confirmedSuggestions:
+      state.vapService.addressValidation.confirmedSuggestions,
     addressValidationType,
-    validationKey: state.vet360.addressValidation.validationKey,
-    addressFromUser: state.vet360.addressValidation.addressFromUser,
-    selectedAddress: state.vet360.addressValidation.selectedAddress,
-    selectedAddressId: state.vet360.addressValidation.selectedAddressId,
+    validationKey: state.vapService.addressValidation.validationKey,
+    addressFromUser: state.vapService.addressValidation.addressFromUser,
+    selectedAddress: state.vapService.addressValidation.selectedAddress,
+    selectedAddressId: state.vapService.addressValidation.selectedAddressId,
   };
 };
 

--- a/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
+++ b/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
@@ -305,7 +305,7 @@ const mapStateToProps = (state, ownProps) => {
     analyticsSectionName:
       VAP_SERVICE.ANALYTICS_FIELD_MAP[addressValidationType],
     isLoading:
-      state.vet360.fieldTransactionMap[addressValidationType]?.isPending ||
+      state.vapService.fieldTransactionMap[addressValidationType]?.isPending ||
       isPendingTransaction(transaction),
     addressFromUser,
     addressValidationError,

--- a/src/platform/user/profile/vap-svc/containers/ReceiveTextMessages.jsx
+++ b/src/platform/user/profile/vap-svc/containers/ReceiveTextMessages.jsx
@@ -125,7 +125,7 @@ export function mapStateToProps(state, ownProps) {
   const hideCheckbox =
     !isTextable || !isVAPatient(state) || hasError || isPending;
   const transactionSuccess =
-    state.vet360.transactionStatus ===
+    state.vapService.transactionStatus ===
     VAP_SERVICE.TRANSACTION_STATUS.COMPLETED_SUCCESS;
   return {
     profile: profileState,

--- a/src/platform/user/profile/vap-svc/containers/Vet360PendingTransactionCategory.jsx
+++ b/src/platform/user/profile/vap-svc/containers/Vet360PendingTransactionCategory.jsx
@@ -7,7 +7,7 @@ import { refreshTransaction } from '../actions';
 import Vet360TransactionPending from '../components/base/Vet360TransactionPending';
 
 import { TRANSACTION_CATEGORY_TYPES } from '../constants';
-import { selectVet360PendingCategoryTransactions } from '../selectors';
+import { selectVAPServicePendingCategoryTransactions } from '../selectors';
 
 function Vet360PendingTransactionCategory({
   refreshTransaction: dispatchRefreshTransaction,
@@ -46,7 +46,7 @@ function Vet360PendingTransactionCategory({
 
 const mapStateToProps = (state, ownProps) => {
   const { categoryType } = ownProps;
-  const pendingTransactions = selectVet360PendingCategoryTransactions(
+  const pendingTransactions = selectVAPServicePendingCategoryTransactions(
     state,
     categoryType,
   );

--- a/src/platform/user/profile/vap-svc/containers/Vet360ProfileField.jsx
+++ b/src/platform/user/profile/vap-svc/containers/Vet360ProfileField.jsx
@@ -273,7 +273,7 @@ export const mapStateToProps = (state, ownProps) => {
   const data = selectVAPContactInfoField(state, fieldName);
   const isEmpty = !data;
   const addressValidationType =
-    state.vet360.addressValidation.addressValidationType;
+    state.vapService.addressValidation.addressValidationType;
   const showValidationModal =
     ownProps.ValidationModal &&
     addressValidationType === fieldName &&

--- a/src/platform/user/profile/vap-svc/containers/Vet360TransactionReporter.jsx
+++ b/src/platform/user/profile/vap-svc/containers/Vet360TransactionReporter.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 // import scrollToTop from 'platform/utilities/ui/scrollToTop';
 
 import {
-  selectVet360FailedTransactions,
+  selectVAPServiceFailedTransactions,
   selectMostRecentErroredTransaction,
 } from '../selectors';
 
@@ -52,7 +52,7 @@ class Vet360TransactionReporter extends React.Component {
 
 const mapStateToProps = state => ({
   mostRecentErroredTransaction: selectMostRecentErroredTransaction(state),
-  erroredTransactions: selectVet360FailedTransactions(state),
+  erroredTransactions: selectVAPServiceFailedTransactions(state),
 });
 
 const mapDispatchToProps = {

--- a/src/platform/user/profile/vap-svc/selectors.js
+++ b/src/platform/user/profile/vap-svc/selectors.js
@@ -24,7 +24,7 @@ export function selectVAPContactInfoField(state, fieldName) {
 
 export function selectVAPServiceTransaction(state, fieldName) {
   const {
-    vet360: {
+    vapService: {
       transactions,
       fieldTransactionMap: { [fieldName]: transactionRequest = null },
     },
@@ -44,13 +44,13 @@ export function selectVAPServiceTransaction(state, fieldName) {
   };
 }
 
-export function selectVet360FailedTransactions(state) {
-  return state.vet360.transactions.filter(isFailedTransaction);
+export function selectVAPServiceFailedTransactions(state) {
+  return state.vapService.transactions.filter(isFailedTransaction);
 }
 
 export function selectMostRecentErroredTransaction(state) {
   const {
-    vet360: {
+    vapService: {
       transactions,
       metadata: { mostRecentErroredTransactionId },
     },
@@ -65,9 +65,9 @@ export function selectMostRecentErroredTransaction(state) {
   return transaction;
 }
 
-export function selectVet360PendingCategoryTransactions(state, type) {
+export function selectVAPServicePendingCategoryTransactions(state, type) {
   const {
-    vet360: { transactions, fieldTransactionMap },
+    vapService: { transactions, fieldTransactionMap },
   } = state;
 
   const existsWithinFieldTransactionMap = transaction => {
@@ -99,15 +99,15 @@ export function selectVet360PendingCategoryTransactions(state, type) {
 }
 
 export function selectEditedFormField(state, fieldName) {
-  return state.vet360.formFields[fieldName];
+  return state.vapService.formFields[fieldName];
 }
 
 export function selectCurrentlyOpenEditModal(state) {
-  return state.vet360.modal;
+  return state.vapService.modal;
 }
 
 export function selectAddressValidation(state) {
-  return state.vet360?.addressValidation || {};
+  return state.vapService?.addressValidation || {};
 }
 
 export function selectAddressValidationType(state) {

--- a/src/platform/user/profile/vap-svc/tests/containers/AddressValidationModal.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/containers/AddressValidationModal.unit.spec.jsx
@@ -6,7 +6,7 @@ import AddressValidationModal from '../../containers/AddressValidationModal';
 describe('<AddressValidationModal/>', () => {
   const fakeStore = {
     getState: () => ({
-      vet360: {
+      vapService: {
         fieldTransactionMap: {
           mailingAddress: {
             isPending: false,
@@ -98,7 +98,7 @@ describe('<AddressValidationModal/>', () => {
   it('renders correct buttons', () => {
     const newFakeStore = {
       getState: () => ({
-        vet360: {
+        vapService: {
           fieldTransactionMap: {
             mailingAddress: {
               isPending: false,
@@ -142,7 +142,7 @@ describe('<AddressValidationModal/>', () => {
   it('renders multiple suggestion button text', () => {
     const newFakeStore = {
       getState: () => ({
-        vet360: {
+        vapService: {
           fieldTransactionMap: {
             mailingAddress: {
               isPending: false,
@@ -242,7 +242,7 @@ describe('<AddressValidationModal/>', () => {
   it('renders use suggested button text', () => {
     const newFakeStore = {
       getState: () => ({
-        vet360: {
+        vapService: {
           fieldTransactionMap: {
             mailingAddress: {
               isPending: false,
@@ -330,7 +330,7 @@ describe('<AddressValidationModal/>', () => {
   it('validates inputs', () => {
     const newFakeStore = {
       getState: () => ({
-        vet360: {
+        vapService: {
           fieldTransactionMap: {
             mailingAddress: {
               isPending: false,

--- a/src/platform/user/profile/vap-svc/tests/containers/AddressValidationView.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/containers/AddressValidationView.unit.spec.jsx
@@ -6,7 +6,7 @@ import AddressValidationView from '../../containers/AddressValidationView';
 describe('<AddressValidationView/>', () => {
   const fakeStore = {
     getState: () => ({
-      vet360: {
+      vapService: {
         fieldTransactionMap: {
           mailingAddress: {
             isPending: false,
@@ -91,7 +91,7 @@ describe('<AddressValidationView/>', () => {
   it('renders correct buttons', () => {
     const newFakeStore = {
       getState: () => ({
-        vet360: {
+        vapService: {
           fieldTransactionMap: {
             mailingAddress: {
               isPending: false,
@@ -135,7 +135,7 @@ describe('<AddressValidationView/>', () => {
   it('does not render cancel button while pending transaction', () => {
     const newFakeStore = {
       getState: () => ({
-        vet360: {
+        vapService: {
           fieldTransactionMap: {
             mailingAddress: {
               isPending: true,
@@ -175,7 +175,7 @@ describe('<AddressValidationView/>', () => {
   it('renders multiple suggestion button text', () => {
     const newFakeStore = {
       getState: () => ({
-        vet360: {
+        vapService: {
           fieldTransactionMap: {
             mailingAddress: {
               isPending: false,
@@ -275,7 +275,7 @@ describe('<AddressValidationView/>', () => {
   it('renders use suggested button text', () => {
     const newFakeStore = {
       getState: () => ({
-        vet360: {
+        vapService: {
           fieldTransactionMap: {
             mailingAddress: {
               isPending: false,
@@ -363,7 +363,7 @@ describe('<AddressValidationView/>', () => {
   it('validates inputs', () => {
     const newFakeStore = {
       getState: () => ({
-        vet360: {
+        vapService: {
           fieldTransactionMap: {
             mailingAddress: {
               isPending: false,

--- a/src/platform/user/profile/vap-svc/tests/containers/CopyMailingAddress.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/containers/CopyMailingAddress.unit.spec.jsx
@@ -22,7 +22,7 @@ describe('<CopyMailingAddress/>', () => {
             },
           },
         },
-        vet360: {
+        vapService: {
           formFields: {
             [FIELD_NAMES.MAILING_ADDRESS]: null,
           },
@@ -36,7 +36,7 @@ describe('<CopyMailingAddress/>', () => {
       state.user.profile.vapContactInfo[
         FIELD_NAMES.MAILING_ADDRESS
       ] = mailingAddress;
-      state.vet360.formFields[FIELD_NAMES.RESIDENTIAL_ADDRESS] = {
+      state.vapService.formFields[FIELD_NAMES.RESIDENTIAL_ADDRESS] = {
         city: 'some other city',
       };
 
@@ -83,7 +83,7 @@ describe('<CopyMailingAddress/>', () => {
 
       it('is `true` when addresses are equal', () => {
         // This is real data from staging
-        state.vet360.formFields[FIELD_NAMES.RESIDENTIAL_ADDRESS] = {
+        state.vapService.formFields[FIELD_NAMES.RESIDENTIAL_ADDRESS] = {
           value: {
             id: 145184,
             addressLine1: '36320 Coronado Dr',
@@ -101,7 +101,7 @@ describe('<CopyMailingAddress/>', () => {
       });
 
       it('is `false` when addresses are not equal', () => {
-        state.vet360.formFields[FIELD_NAMES.RESIDENTIAL_ADDRESS] = {
+        state.vapService.formFields[FIELD_NAMES.RESIDENTIAL_ADDRESS] = {
           value: {
             id: 145184,
             addressLine1: '123 Main St.',

--- a/src/platform/user/profile/vap-svc/tests/containers/ReceiveTextMessages.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/containers/ReceiveTextMessages.unit.spec.jsx
@@ -87,7 +87,7 @@ describe('<ReceiveTextMessages/>', () => {
             vapContactInfo: { mobilePhone: { mobilePhone } },
           },
         },
-        vet360: {
+        vapService: {
           transactions: null,
           fieldTransactionMap: { mobilePhone: transactionRequest },
           transactionStatus: '',
@@ -123,7 +123,7 @@ describe('<ReceiveTextMessages/>', () => {
       expect(result.hideCheckbox).to.be.true;
     });
     it('returns transactionSuccess as true when transactionStatus equals COMPLETED_SUCCESS', () => {
-      state.vet360.transactionStatus = 'COMPLETED_SUCCESS';
+      state.vapService.transactionStatus = 'COMPLETED_SUCCESS';
       const result = mapStateToProps(state, ownProps);
       expect(result.transactionSuccess).to.be.true;
     });

--- a/src/platform/user/profile/vap-svc/tests/containers/Vet360ProfileField.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/containers/Vet360ProfileField.unit.spec.jsx
@@ -166,7 +166,7 @@ describe('mapStateToProps', () => {
         },
       },
     },
-    vet360: {
+    vapService: {
       addressValidation: {
         addressValidationType: 'mailingAddress',
       },
@@ -192,7 +192,7 @@ describe('mapStateToProps', () => {
     describe('when the address validation modal is not open', () => {
       it('sets `showValidationModal` to `false`', () => {
         const state = showValidationModalState();
-        state.vet360.modal = 'notTheValidationModal';
+        state.vapService.modal = 'notTheValidationModal';
         const mappedProps = mapStateToProps(state, {
           fieldName: 'mailingAddress',
           ValidationModal: () => {},

--- a/src/platform/user/profile/vap-svc/tests/selectors.unit.spec.js
+++ b/src/platform/user/profile/vap-svc/tests/selectors.unit.spec.js
@@ -21,7 +21,7 @@ const hooks = {
       },
     };
 
-    const vet360 = {
+    const vapService = {
       modal: null,
       formFields: {},
       transactions: [],
@@ -33,7 +33,7 @@ const hooks = {
 
     state = {
       user,
-      vet360,
+      vapService,
     };
   },
 };
@@ -101,7 +101,7 @@ describe('selectors', () => {
         [fieldName]: transactionRequest,
       };
 
-      state.vet360 = { transactions, fieldTransactionMap };
+      state.vapService = { transactions, fieldTransactionMap };
 
       let result = selectors.selectVAPServiceTransaction(state, fieldName);
       expect(result).to.deep.equal({ transaction, transactionRequest });
@@ -135,7 +135,7 @@ describe('selectors', () => {
         },
       ];
 
-      state.vet360.transactions = [
+      state.vapService.transactions = [
         ...failed,
         {
           data: {
@@ -159,7 +159,7 @@ describe('selectors', () => {
         },
       ];
 
-      const result = selectors.selectVet360FailedTransactions(state);
+      const result = selectors.selectVAPServiceFailedTransactions(state);
 
       expect(result).to.include(failed[0]);
       expect(result).to.include(failed[1]);
@@ -171,8 +171,8 @@ describe('selectors', () => {
     it('selects the transaction of the ID stored in the metadata mostRecentErroredTransactionId', () => {
       const transactionId = 'transaction_id';
       const transaction = { data: { attributes: { transactionId } } };
-      state.vet360.transactions = [transaction];
-      state.vet360.metadata.mostRecentErroredTransactionId = transactionId;
+      state.vapService.transactions = [transaction];
+      state.vapService.metadata.mostRecentErroredTransactionId = transactionId;
       expect(selectors.selectMostRecentErroredTransaction(state)).to.be.equal(
         transaction,
       );
@@ -235,9 +235,9 @@ describe('selectors', () => {
         },
       ];
 
-      state.vet360.transactions = transactions;
+      state.vapService.transactions = transactions;
 
-      const result = selectors.selectVet360PendingCategoryTransactions(
+      const result = selectors.selectVAPServicePendingCategoryTransactions(
         state,
         type,
       );
@@ -252,7 +252,7 @@ describe('selectors', () => {
     it('looks up the form value in state for a given field name', () => {
       const fieldName = 'someField';
       const fieldValue = 'someFieldValue';
-      state.vet360.formFields[fieldName] = fieldValue;
+      state.vapService.formFields[fieldName] = fieldValue;
 
       expect(selectors.selectEditedFormField(state, fieldName)).to.be.equal(
         fieldValue,
@@ -264,7 +264,7 @@ describe('selectors', () => {
     beforeEach(hooks.beforeEach);
     it('looks up the form value in state for a given field name', () => {
       const currentlyOpenModal = 'someField';
-      state.vet360.modal = currentlyOpenModal;
+      state.vapService.modal = currentlyOpenModal;
 
       expect(selectors.selectCurrentlyOpenEditModal(state)).to.be.equal(
         currentlyOpenModal,
@@ -280,7 +280,7 @@ describe('selectors', () => {
         validationKey: '123',
         addressValidationError: null,
       };
-      state.vet360.addressValidation = addressValidation;
+      state.vapService.addressValidation = addressValidation;
 
       expect(selectors.selectAddressValidation(state)).to.deep.equal(
         addressValidation,
@@ -292,7 +292,7 @@ describe('selectors', () => {
     beforeEach(hooks.beforeEach);
     it('should return the current address validation type', () => {
       const addressValidationType = 'home';
-      state.vet360.addressValidation = {
+      state.vapService.addressValidation = {
         addressValidationType,
       };
 
@@ -337,7 +337,7 @@ describe('selectVAPServiceInitializationStatus', () => {
   it('returns INITIALIZING if there is an ongoing transaction', () => {
     const transactionId = 'transaction_1';
     state.user.profile.services = [];
-    state.vet360.transactions = [
+    state.vapService.transactions = [
       {
         data: {
           attributes: {
@@ -347,7 +347,9 @@ describe('selectVAPServiceInitializationStatus', () => {
         },
       },
     ];
-    state.vet360.fieldTransactionMap[INIT_VAP_SERVICE_ID] = { transactionId };
+    state.vapService.fieldTransactionMap[INIT_VAP_SERVICE_ID] = {
+      transactionId,
+    };
     const result = selectors.selectVAPServiceInitializationStatus(state);
     expect(result.status).to.be.equal(
       VAP_SERVICE_INITIALIZATION_STATUS.INITIALIZING,
@@ -357,7 +359,7 @@ describe('selectVAPServiceInitializationStatus', () => {
   it('returns INITIALIZATION_FAILURE if there is a failed transaction', () => {
     const transactionId = 'transaction_1';
     state.user.profile.services = [];
-    state.vet360.transactions = [
+    state.vapService.transactions = [
       {
         data: {
           attributes: {
@@ -367,7 +369,9 @@ describe('selectVAPServiceInitializationStatus', () => {
         },
       },
     ];
-    state.vet360.fieldTransactionMap[INIT_VAP_SERVICE_ID] = { transactionId };
+    state.vapService.fieldTransactionMap[INIT_VAP_SERVICE_ID] = {
+      transactionId,
+    };
     const result = selectors.selectVAPServiceInitializationStatus(state);
     expect(result.status).to.be.equal(
       VAP_SERVICE_INITIALIZATION_STATUS.INITIALIZATION_FAILURE,


### PR DESCRIPTION
## Description
This PR is the eighth in a handful to remove mentions of vet360 from our frontend code.

[PR 1 renamed the `vet360` folder to `vap-svc`](https://github.com/department-of-veterans-affairs/vets-website/pull/14798)
[PR 2 renamed the `vet360` Babel alias to `@@vap-svc`](https://github.com/department-of-veterans-affairs/vets-website/pull/14811)
[PR 3 renamed the `isVet360Configured` helper to `isVAProfileServiceConfigured`](https://github.com/department-of-veterans-affairs/vets-website/pull/14834)
[PR 4 renamed Redux's `profile.vet360` data to `profile.vapContactInfo`](https://github.com/department-of-veterans-affairs/vets-website/issues/14866)
[PR 5 renamed some `VET360` constants, actions and selectors](https://github.com/department-of-veterans-affairs/vets-website/pull/14888)
[PR 6 renamed more `VET360` constants to `VAP_SERVICE`](https://github.com/department-of-veterans-affairs/vets-website/pull/14899)
[PR 7 renamed some contact information selectors](https://github.com/department-of-veterans-affairs/vets-website/pull/14912)

This PR is focused on:
- Renaming the top-level `vet360` slice in Redux to `vapService`

## Testing done
Local + existing tests

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs