### PR TITLE
[Bug] Check login status before calling autoSaveForm

### DIFF
--- a/src/platform/forms-system/src/js/review/SubmitController.jsx
+++ b/src/platform/forms-system/src/js/review/SubmitController.jsx
@@ -47,7 +47,7 @@ class SubmitController extends Component {
   handleSubmit = () => {
     const { form, formConfig, pageList, trackingPrefix, user } = this.props;
     const { formId, data, submission } = form;
-    const isLoggedIn = user.login?.currentlyLoggedIn;
+    const isLoggedIn = user?.login?.currentlyLoggedIn;
     const now = new Date().getTime();
 
     // If a pre-submit agreement is required, make sure it was accepted

--- a/src/platform/forms-system/src/js/review/SubmitController.jsx
+++ b/src/platform/forms-system/src/js/review/SubmitController.jsx
@@ -82,7 +82,7 @@ class SubmitController extends Component {
       this.props.setSubmission('status', 'validationError');
       this.props.setSubmission('hasAttemptedSubmit', true);
 
-      if (isLoggedIn) {
+      if (isLoggedIn && formConfig.prefillEnabled) {
         // Update save-in-progress with failed submit
         submissionData.errors = errors;
         this.props.autoSaveForm(
@@ -96,7 +96,7 @@ class SubmitController extends Component {
       return;
     }
 
-    if (isLoggedIn) {
+    if (isLoggedIn && formConfig.prefillEnabled) {
       // Update save-in-progress after attempted submit; if successful, SiP data
       // will be erased
       this.props.autoSaveForm(formId, data, version, returnUrl, submissionData);

--- a/src/platform/forms-system/test/js/review/SubmitController.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/SubmitController.unit.spec.jsx
@@ -26,6 +26,7 @@ const createformReducer = (options = {}) =>
 const createFormConfig = options => ({
   urlPrefix: '/',
   trackingPrefix: 'test-',
+  prefillEnabled: true,
   preSubmitInfo: {
     required: true,
     field: 'privacyAgreementAccepted',

--- a/src/platform/forms-system/test/js/review/SubmitController.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/SubmitController.unit.spec.jsx
@@ -91,6 +91,12 @@ const createPageList = () => [
   },
 ];
 
+const createUserLogIn = (status = true) => ({
+  login: {
+    currentlyLoggedIn: status,
+  },
+});
+
 const createStore = (options = {}) => {
   return createCommonStore({
     form: createForm(options?.form || {}),
@@ -109,6 +115,7 @@ describe('Schemaform review: SubmitController', () => {
     const form = createForm();
     const formConfig = createFormConfig();
     const pageList = createPageList();
+    const user = createUserLogIn();
     const router = { push: sinon.spy() };
     const setPreSubmit = sinon.spy();
     const setSubmission = sinon.spy();
@@ -133,6 +140,7 @@ describe('Schemaform review: SubmitController', () => {
           setSubmission={setSubmission}
           submitForm={submitForm}
           trackingPrefix={formConfig.trackingPrefix}
+          user={user}
         />
       </Provider>,
     );
@@ -149,6 +157,7 @@ describe('Schemaform review: SubmitController', () => {
           setSubmission={setSubmission}
           submitForm={submitForm}
           trackingPrefix={formConfig.trackingPrefix}
+          user={user}
         />
       </Provider>,
     );
@@ -161,6 +170,7 @@ describe('Schemaform review: SubmitController', () => {
   it('should not submit when privacy agreement not accepted', () => {
     const form = createForm();
     const formConfig = createFormConfig();
+    const user = createUserLogIn();
     const router = { push: sinon.spy() };
     const setPreSubmit = sinon.spy();
     const setSubmission = sinon.spy();
@@ -181,6 +191,7 @@ describe('Schemaform review: SubmitController', () => {
           setSubmission={setSubmission}
           submitForm={submitForm}
           trackingPrefix={formConfig.trackingPrefix}
+          user={user}
         />
       </Provider>,
     );
@@ -221,9 +232,11 @@ describe('Schemaform review: SubmitController', () => {
     const pageList = [
       { path: 'page-1', pageKey: 'page1', schema: page.schema },
     ];
+    const user = createUserLogIn();
     const setPreSubmit = sinon.spy();
     const setSubmission = sinon.spy();
     const submitForm = sinon.spy();
+    const autoSaveForm = sinon.spy();
 
     const store = createStore({
       form,
@@ -232,6 +245,7 @@ describe('Schemaform review: SubmitController', () => {
     const tree = render(
       <Provider store={store}>
         <SubmitController
+          autoSaveForm={autoSaveForm}
           form={form}
           formConfig={formConfig}
           pageList={pageList}
@@ -240,6 +254,7 @@ describe('Schemaform review: SubmitController', () => {
           setSubmission={setSubmission}
           submitForm={submitForm}
           trackingPrefix={formConfig.trackingPrefix}
+          user={user}
         />
       </Provider>,
     );
@@ -250,6 +265,72 @@ describe('Schemaform review: SubmitController', () => {
     expect(submitForm.called).to.be.false;
     expect(setSubmission.calledWith('hasAttemptedSubmit')).to.be.true;
     expect(setSubmission.calledWith('status', 'validationError')).to.be.true;
+    expect(autoSaveForm.called).to.be.true;
+    tree.unmount();
+  });
+
+  it('should not submit when invalid data is entered, and not call autoSaveForm when not logged in', () => {
+    // Form with missing required field
+    const page = {
+      title: 'Missing stuff',
+      schema: {
+        type: 'object',
+        required: ['stuff'],
+        properties: {
+          stuff: { type: 'string' },
+        },
+      },
+    };
+    const form = createForm({
+      data: { privacyAgreementAccepted: true },
+      pages: { page1: { schema: page.schema } },
+    });
+    const formConfig = createFormConfig({
+      chapters: {
+        chapter1: {
+          pages: {
+            page1: page,
+          },
+        },
+      },
+    });
+    const pageList = [
+      { path: 'page-1', pageKey: 'page1', schema: page.schema },
+    ];
+    const user = createUserLogIn(false);
+    const setPreSubmit = sinon.spy();
+    const setSubmission = sinon.spy();
+    const submitForm = sinon.spy();
+    const autoSaveForm = sinon.spy();
+
+    const store = createStore({
+      form,
+    });
+
+    const tree = render(
+      <Provider store={store}>
+        <SubmitController
+          autoSaveForm={autoSaveForm}
+          form={form}
+          formConfig={formConfig}
+          pageList={pageList}
+          route={{ formConfig, pageList }}
+          setPreSubmit={setPreSubmit}
+          setSubmission={setSubmission}
+          submitForm={submitForm}
+          trackingPrefix={formConfig.trackingPrefix}
+          user={user}
+        />
+      </Provider>,
+    );
+
+    const submitButton = tree.getByText('Submit application');
+    fireEvent.click(submitButton);
+
+    expect(submitForm.called).to.be.false;
+    expect(setSubmission.calledWith('hasAttemptedSubmit')).to.be.true;
+    expect(setSubmission.calledWith('status', 'validationError')).to.be.true;
+    expect(autoSaveForm.notCalled).to.be.true;
     tree.unmount();
   });
 
@@ -281,9 +362,11 @@ describe('Schemaform review: SubmitController', () => {
     const pageList = [
       { path: 'page-1', pageKey: 'page1', schema: page.schema },
     ];
+    const user = createUserLogIn();
     const setPreSubmit = sinon.spy();
     const setSubmission = sinon.spy();
     const submitForm = sinon.spy();
+    const autoSaveForm = sinon.spy();
 
     const store = createStore({
       form,
@@ -292,6 +375,7 @@ describe('Schemaform review: SubmitController', () => {
     const tree = render(
       <Provider store={store}>
         <SubmitController
+          autoSaveForm={autoSaveForm}
           form={form}
           formConfig={formConfig}
           pageList={pageList}
@@ -300,6 +384,7 @@ describe('Schemaform review: SubmitController', () => {
           setSubmission={setSubmission}
           submitForm={submitForm}
           trackingPrefix={formConfig.trackingPrefix}
+          user={user}
         />
       </Provider>,
     );
@@ -316,6 +401,7 @@ describe('Schemaform review: SubmitController', () => {
     expect(sentryReports[0].extra.errors)
       .to.be.an('array')
       .with.length('1');
+    expect(autoSaveForm.called).to.be.true;
 
     tree.unmount();
   });
@@ -326,6 +412,7 @@ describe('Schemaform review: SubmitController', () => {
     });
     const formConfig = createFormConfig();
     const pageList = createPageList();
+    const user = createUserLogIn();
     const setPreSubmit = sinon.spy();
     const setSubmission = sinon.spy();
     const submitForm = sinon.spy();
@@ -347,6 +434,7 @@ describe('Schemaform review: SubmitController', () => {
           submitForm={submitForm}
           autoSaveForm={autoSaveForm}
           trackingPrefix={formConfig.trackingPrefix}
+          user={user}
         />
       </Provider>,
     );
@@ -356,15 +444,17 @@ describe('Schemaform review: SubmitController', () => {
     fireEvent.click(submitButton);
 
     expect(submitForm.called).to.be.true;
+    expect(autoSaveForm.called).to.be.true;
     tree.unmount();
   });
 
-  it('should submit when valid and no preSubmit specified', () => {
-    const form = createForm();
-    const formConfig = createFormConfig({
-      preSubmitInfo: undefined,
+  it('should submit when valid, but not call autoSaveForm when not logged in', () => {
+    const form = createForm({
+      data: { privacyAgreementAccepted: true },
     });
+    const formConfig = createFormConfig();
     const pageList = createPageList();
+    const user = createUserLogIn(false);
     const setPreSubmit = sinon.spy();
     const setSubmission = sinon.spy();
     const submitForm = sinon.spy();
@@ -386,6 +476,49 @@ describe('Schemaform review: SubmitController', () => {
           submitForm={submitForm}
           autoSaveForm={autoSaveForm}
           trackingPrefix={formConfig.trackingPrefix}
+          user={user}
+        />
+      </Provider>,
+    );
+
+    // tree.find('.usa-button-primary').simulate('click');
+    const submitButton = tree.getByText('Submit application');
+    fireEvent.click(submitButton);
+
+    expect(submitForm.called).to.be.true;
+    expect(autoSaveForm.notCalled).to.be.true;
+    tree.unmount();
+  });
+
+  it('should submit when valid and no preSubmit specified', () => {
+    const form = createForm();
+    const formConfig = createFormConfig({
+      preSubmitInfo: undefined,
+    });
+    const pageList = createPageList();
+    const user = createUserLogIn();
+    const setPreSubmit = sinon.spy();
+    const setSubmission = sinon.spy();
+    const submitForm = sinon.spy();
+    const autoSaveForm = sinon.spy();
+
+    const store = createStore({
+      form,
+    });
+
+    const tree = render(
+      <Provider store={store}>
+        <SubmitController
+          form={form}
+          formConfig={formConfig}
+          pageList={pageList}
+          route={{ formConfig, pageList }}
+          setPreSubmit={setPreSubmit}
+          setSubmission={setSubmission}
+          submitForm={submitForm}
+          autoSaveForm={autoSaveForm}
+          trackingPrefix={formConfig.trackingPrefix}
+          user={user}
         />
       </Provider>,
     );
@@ -406,6 +539,7 @@ describe('Schemaform review: SubmitController', () => {
       },
     });
     const pageList = createPageList();
+    const user = createUserLogIn();
     const setPreSubmit = sinon.spy();
     const setSubmission = sinon.spy();
     const submitForm = sinon.spy();
@@ -427,6 +561,7 @@ describe('Schemaform review: SubmitController', () => {
           submitForm={submitForm}
           autoSaveForm={autoSaveForm}
           trackingPrefix={formConfig.trackingPrefix}
+          user={user}
         />
       </Provider>,
     );
@@ -436,6 +571,7 @@ describe('Schemaform review: SubmitController', () => {
 
     expect(tree.getByText('NOTICE')).to.not.be.null;
     expect(submitForm.called).to.be.true;
+    expect(autoSaveForm.called).to.be.true;
 
     tree.unmount();
   });
@@ -450,6 +586,7 @@ describe('Schemaform review: SubmitController', () => {
       },
     });
     const pageList = createPageList();
+    const user = createUserLogIn();
     const setPreSubmit = sinon.spy();
     const setSubmission = sinon.spy();
     const submitForm = sinon.spy();
@@ -472,6 +609,7 @@ describe('Schemaform review: SubmitController', () => {
           setSubmission={setSubmission}
           submitForm={submitForm}
           trackingPrefix={formConfig.trackingPrefix}
+          user={user}
         />
       </Provider>,
     );
@@ -489,6 +627,7 @@ describe('Schemaform review: SubmitController', () => {
           setSubmission={setSubmission}
           submitForm={submitForm}
           trackingPrefix={formConfig.trackingPrefix}
+          user={user}
         />
       </Provider>,
     );
@@ -512,6 +651,7 @@ describe('Schemaform review: SubmitController', () => {
       },
     });
     const pageList = createPageList();
+    const user = createUserLogIn();
     const setPreSubmit = sinon.spy();
     const setSubmission = sinon.spy();
     const submission = {
@@ -535,6 +675,7 @@ describe('Schemaform review: SubmitController', () => {
           submitForm={submitForm}
           submission={submission}
           trackingPrefix={formConfig.trackingPrefix}
+          user={user}
         />
       </Provider>,
     );
@@ -558,6 +699,7 @@ describe('Schemaform review: SubmitController', () => {
       },
     });
     const pageList = createPageList();
+    const user = createUserLogIn();
     const setPreSubmit = sinon.spy();
     const setSubmission = sinon.spy();
     const submission = {
@@ -581,6 +723,7 @@ describe('Schemaform review: SubmitController', () => {
           submitForm={submitForm}
           submission={submission}
           trackingPrefix={formConfig.trackingPrefix}
+          user={user}
         />
       </Provider>,
     );
@@ -602,6 +745,7 @@ describe('Schemaform review: SubmitController', () => {
     });
     const formConfig = createFormConfig();
     const pageList = createPageList();
+    const user = createUserLogIn();
     const router = { push: sinon.spy() };
     const setPreSubmit = sinon.spy();
     const setSubmission = sinon.spy();
@@ -627,6 +771,7 @@ describe('Schemaform review: SubmitController', () => {
           submitForm={submitForm}
           submission={submission}
           trackingPrefix={formConfig.trackingPrefix}
+          user={user}
         />
       </Provider>,
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2941,7 +2941,7 @@ axe-core@^3.5.4:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.4.tgz#5a7b49ba8c989cd59cde219810ccfb0b7cf72e97"
   integrity sha512-JRuxixN5bPHre+815qnyqBQzNpRTqGxLWflvjr4REpGZ5o0WXm+ik2IS4PZ01EnacWmVRB4jCPWFiYENMiiasA==
 
-axios@^0.18.0:
+axios@^0.18.0, axios@^0.18.1:
   version "0.18.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.1.tgz#ff3f0de2e7b5d180e757ad98000f1081b87bcea3"
   integrity sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==
@@ -3669,6 +3669,11 @@ bser@^2.0.0:
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
   dependencies:
     node-int64 "^0.4.0"
+
+btoa@^1.1.2:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/btoa/-/btoa-1.2.1.tgz#01a9909f8b2c93f6bf680ba26131eb30f7fa3d73"
+  integrity sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==
 
 buffer-alloc-unsafe@^1.1.0:
   version "1.1.0"
@@ -4640,9 +4645,19 @@ command-line-usage@^6.1.0:
     table-layout "^1.0.0"
     typical "^5.2.0"
 
+commander@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-0.6.1.tgz#fa68a14f6a945d54dbbe50d8cdb3320e9e3b1a06"
+  integrity sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=
+
 commander@2.15.1:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
+
+commander@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.3.0.tgz#fd430e889832ec353b9acd1de217c11cb3eef873"
+  integrity sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=
 
 commander@2.9.0:
   version "2.9.0"
@@ -5362,6 +5377,17 @@ cypress-plugin-tab@^1.0.5:
   integrity sha512-QtTJcifOVwwbeMP3hsOzQOKf3EqKsLyjtg9ZAGlYDntrCRXrsQhe4ZQGIthRMRLKpnP6/tTk6G0gJ2sZUfRliQ==
   dependencies:
     ally.js "^1.4.1"
+
+cypress-testrail-reporter@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/cypress-testrail-reporter/-/cypress-testrail-reporter-1.2.1.tgz#8c6537a7ae935374fc7f09d4523f996d450e37c7"
+  integrity sha512-SxOKdWfskNlGx2kPleIyAG62iUPUu+0Jd60pIelqG1O23QZV9WKt41iivUZwCDII/tvSLD/5aE54OjBuMd4VMQ==
+  dependencies:
+    axios "^0.18.1"
+    btoa "^1.1.2"
+    chalk "^2.4.1"
+    mocha "^2.2.5"
+    moment "^2.22.1"
 
 cypress@*, cypress@^4.8.0:
   version "4.8.0"
@@ -6587,6 +6613,11 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
+
+escape-string-regexp@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz#4dbc2fe674e71949caf3fb2695ce7f2dc1d9a8d1"
+  integrity sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=
 
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -8226,6 +8257,14 @@ glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
+
+glob@3.2.11:
+  version "3.2.11"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-3.2.11.tgz#4a973f635b9190f715d10987d5c00fd2815ebe3d"
+  integrity sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=
+  dependencies:
+    inherits "2"
+    minimatch "0.3"
 
 glob@7.0.5:
   version "7.0.5"
@@ -10161,6 +10200,14 @@ iterall@^1.2.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
   integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
+
+jade@0.26.3:
+  version "0.26.3"
+  resolved "https://registry.yarnpkg.com/jade/-/jade-0.26.3.tgz#8f10d7977d8d79f2f6ff862a81b0513ccb25686c"
+  integrity sha1-jxDXl32NefL2/4YqgbBRPMslaGw=
+  dependencies:
+    commander "0.6.1"
+    mkdirp "0.3.0"
 
 jake@^10.6.1:
   version "10.8.2"
@@ -12116,9 +12163,10 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@0.3.0:
+minimatch@0.3, minimatch@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-0.3.0.tgz#275d8edaac4f1bb3326472089e7949c8394699dd"
+  integrity sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=
   dependencies:
     lru-cache "2"
     sigmund "~1.0.0"
@@ -12249,6 +12297,11 @@ mkdirp-classic@^0.5.2:
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
+mkdirp@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.0.tgz#1bbf5ab1ba827af23575143490426455f481fe1e"
+  integrity sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=
+
 mkdirp@0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
@@ -12312,6 +12365,22 @@ mocha-snapshots@^4.2.0:
     colors "^1.3.3"
     diff "^3.5.0"
     enzyme-to-json "^3.3.5"
+
+mocha@^2.2.5:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-2.5.3.tgz#161be5bdeb496771eb9b35745050b622b5aefc58"
+  integrity sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=
+  dependencies:
+    commander "2.3.0"
+    debug "2.2.0"
+    diff "1.4.0"
+    escape-string-regexp "1.0.2"
+    glob "3.2.11"
+    growl "1.9.2"
+    jade "0.26.3"
+    mkdirp "0.5.1"
+    supports-color "1.2.0"
+    to-iso-string "0.0.2"
 
 mocha@^5.2.0:
   version "5.2.0"
@@ -12387,6 +12456,11 @@ moment@^2.10.6, moment@^2.15.1, moment@^2.24.0:
   version "2.27.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.27.0.tgz#8bff4e3e26a236220dfe3e36de756b6ebaa0105d"
   integrity sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==
+
+moment@^2.22.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
 moo@^0.4.3:
   version "0.4.3"
@@ -17067,6 +17141,11 @@ supercluster@^7.1.0:
   dependencies:
     kdbush "^3.0.0"
 
+supports-color@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-1.2.0.tgz#ff1ed1e61169d06b3cf2d588e188b18d8847e17e"
+  integrity sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=
+
 supports-color@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
@@ -17533,6 +17612,11 @@ to-fast-properties@^1.0.3:
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
+
+to-iso-string@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/to-iso-string/-/to-iso-string-0.0.2.tgz#4dc19e664dfccbe25bd8db508b00c6da158255d1"
+  integrity sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=
 
 to-object-path@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
## Description

I recently added form submission state to the save-in-progress (SiP) data, but this required the SiP data to be save upon submission. There are a few forms that don't require the user to be logged in to submit and thus throw a JS error since there is no user to associate the SiP data to.

This PR checks if the user is logged in, and if they are, it will then save the SiP data.

Related:
- Bug: https://dsva.slack.com/archives/CBU0KDSB1/p1605018423415400
- PR: https://github.com/department-of-veterans-affairs/vets-website/pull/14807
- Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/15642

## Testing done

Added unit tests for new log in checks

## Screenshots

![image](https://user-images.githubusercontent.com/136959/98695939-d2666a00-2338-11eb-8ec3-32c93f9ee7a0.png)
![image (1)](https://user-images.githubusercontent.com/136959/98695934-d1cdd380-2338-11eb-902b-9021a0ef1c20.png)

## Acceptance criteria
- [ ] SiP data is not auto-saved when the user is not logged in
- [ ] No JS error

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
