### PR TITLE
[Templates] Add dynamic heading tag to multiple faq template

### DIFF
--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -81,12 +81,13 @@
                   </ul>
                 </div>
               {% else %}
+                  {% assign fieldSectionHeaderTag = 'h2' %}
+                  {% if fieldQAGroup.entity.fieldSectionHeader %}
+                    {% assign fieldSectionHeaderTag = 'h3' %}
+                  {% endif %}
+
                   {% for fieldQA in fieldQAGroup.entity.fieldQAs %}
-                    {% if fieldQAGroup.entity.fieldSectionHeader %}
-                      <h3>{{ fieldQA.entity.title }}</h3>
-                    {% else %}
-                      <h2>{{ fieldQA.entity.title }}</h2>
-                    {% endif %}
+                    <{{ fieldSectionHeaderTag }}>{{ fieldQA.entity.title }}</{{ fieldSectionHeaderTag }}>
                     {% if fieldQA.entity %}
                       {% assign fieldAnswer = fieldQA.entity.fieldAnswer %}
                       {% assign bundleComponent = "src/site/paragraphs/" | append: fieldAnswer.entity.entityBundle %}


### PR DESCRIPTION
## Description
This PR is a follow up PR to fix an issue where heading tags should be adjusted based on the presence of a section header.

https://github.com/department-of-veterans-affairs/vets-website/pull/14903
https://github.com/department-of-veterans-affairs/va.gov-team/issues/15797

## Testing done
Tested against http://localhost:3001/preview?nodeId=8222 (has section header) and http://localhost:3001/preview?nodeId=9275 (does not have section header)

## Screenshots
Notice the heading tags have a proper hierarchy

![image](https://user-images.githubusercontent.com/1915775/98698633-435f4f00-2344-11eb-838d-9095abad4983.png)


## Acceptance criteria
- [ ] Heading tags are semantic

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
