### PR TITLE
add Vet360InitializeID wrapper

### DIFF
--- a/src/applications/personalization/profile/components/personal-information/PersonalInformationContent.jsx
+++ b/src/applications/personalization/profile/components/personal-information/PersonalInformationContent.jsx
@@ -1,5 +1,7 @@
 import React, { memo } from 'react';
 
+import Vet360InitializeID from '@@vap-svc/containers/InitializeVet360ID';
+
 import GenderAndDOBSection from './GenderAndDOBSection';
 import ContactInformationSection from './ContactInformationSection';
 import EmailInformationSection from './email-addresses/EmailInformationSection';
@@ -8,9 +10,10 @@ const PersonalInformationContent = () => (
   <>
     <GenderAndDOBSection className="vads-u-margin-bottom--6" />
 
-    <ContactInformationSection className="vads-u-margin-bottom--6" />
-
-    <EmailInformationSection />
+    <Vet360InitializeID>
+      <ContactInformationSection className="vads-u-margin-bottom--6" />
+      <EmailInformationSection />
+    </Vet360InitializeID>
   </>
 );
 

--- a/src/applications/personalization/profile/tests/unit-test-helpers.js
+++ b/src/applications/personalization/profile/tests/unit-test-helpers.js
@@ -188,6 +188,7 @@ export function createBasicInitialState() {
     user: {
       profile: {
         vapContactInfo: getBasicContactInfoState(),
+        services: ['vet360'],
       },
     },
   };


### PR DESCRIPTION
## Description
Wrap the Profile's contact info sections in a `Vet360InitializeID` component to properly handle users who are not yet initialized in VA Profile/Vet360

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs