### PR TITLE
[Site-wide] Update URL for Sign-In FAQs

### DIFF
--- a/src/applications/login/containers/SignInApp.jsx
+++ b/src/applications/login/containers/SignInApp.jsx
@@ -130,7 +130,7 @@ class SignInPage extends React.Component {
                 Having trouble signing in?
               </h2>
               <p>
-                <a href="/sign-in-faq/" target="_blank">
+                <a href="/resources/signing-in-to-vagov/" target="_blank">
                   Get answers to Frequently Asked Questions
                 </a>
               </p>

--- a/src/applications/verify/containers/VerifyApp.jsx
+++ b/src/applications/verify/containers/VerifyApp.jsx
@@ -98,7 +98,7 @@ export class VerifyApp extends React.Component {
               <div className="help-info">
                 <h4>Having trouble verifying your identity?</h4>
                 <p>
-                  <a href="/sign-in-faq/" target="_blank">
+                  <a href="/resources/signing-in-to-vagov/" target="_blank">
                     Get answers to Frequently Asked Questions
                   </a>
                 </p>

--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -295,7 +295,7 @@ export class SignInModal extends React.Component {
                 Having trouble signing in?
               </h2>
               <p>
-                <a href="/sign-in-faq/" target="_blank">
+                <a href="/resources/signing-in-to-vagov/" target="_blank">
                   Get answers to Frequently Asked Questions
                 </a>
               </p>


### PR DESCRIPTION
## Description
The sign-in FAQ page has a new location, so `/sign-in-faq` is now being redirected. This PR updates links in FE code to go directly to the new location.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/15782

## Testing done
Confirmed the URL paths are correct across code

## Screenshots
N/A

## Acceptance criteria
- [x] URLs to sign-in faq are updated.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
