### PR TITLE
Attempt to fix flaky confirmation page test

### DIFF
--- a/src/applications/vaos/new-appointment/components/ConfirmationPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/ConfirmationPage/index.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import recordEvent from 'platform/monitoring/record-event';
@@ -27,12 +27,12 @@ export function ConfirmationPage({
   facilityDetails,
   clinic,
   flowType,
-  history,
   slot,
   systemId,
   startNewAppointmentFlow,
   fetchFacilityDetails,
 }) {
+  const history = useHistory();
   const isDirectSchedule = flowType === FLOW_TYPES.DIRECT;
   const pageTitle = isDirectSchedule
     ? 'Your appointment has been scheduled'

--- a/src/applications/vaos/tests/new-appointment/components/ConfirmationPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ConfirmationPage/index.unit.spec.jsx
@@ -1,4 +1,5 @@
 import userEvent from '@testing-library/user-event';
+import { waitFor } from '@testing-library/dom';
 import { expect } from 'chai';
 import moment from 'moment';
 import React from 'react';
@@ -452,27 +453,17 @@ describe('VAOS <ConfirmationPage>', () => {
     expect(screen.history.push.getCall(0).args[0]).to.equal('/');
   });
 
-  it('should redirect to new appointment page if no form data', () => {
-    const flowType = FLOW_TYPES.REQUEST;
-    const data = {};
-    const history = {
-      replace: sinon.spy(),
-    };
-
-    renderWithStoreAndRouter(
-      <noConnect.ConfirmationPage
-        fetchFacilityDetails={fetchFacilityDetails}
-        flowType={flowType}
-        data={data}
-        history={history}
-      />,
-      {
-        initialState,
-      },
-    );
+  it('should redirect to new appointment page if no form data', async () => {
+    const store = createTestStore(initialState);
+    const screen = renderWithStoreAndRouter(<ConfirmationPage />, {
+      store,
+    });
 
     // Expect router to route to new appointment page
-    expect(history.replace.called).to.be.true;
-    expect(history.replace.getCall(0).args[0]).to.equal('/new-appointment');
+    await waitFor(() => {
+      expect(screen.history.replace.firstCall.args[0]).to.equal(
+        '/new-appointment',
+      );
+    });
   });
 });


### PR DESCRIPTION
## Description
Adds a wait to the confirmation page test that checks the redirect to the start of the form.

## Testing done
Unit testing

## Acceptance criteria
- [ ] Build passes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
