### PR TITLE
[Resources and support] Fix for search param not carrying to search app

### DIFF
--- a/src/applications/resources-and-support/components/ResourcesAndSupportSearchApp.jsx
+++ b/src/applications/resources-and-support/components/ResourcesAndSupportSearchApp.jsx
@@ -5,6 +5,8 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation-react/Lo
 import Pagination from '@department-of-veterans-affairs/formation-react/Pagination';
 import URLSearchParams from 'url-search-params';
 import { focusElement } from 'platform/utilities/ui';
+import searchSettings from 'applications/search/manifest.json';
+
 // Relative imports.
 import SearchBar from './SearchBar';
 import SearchResultList from './SearchResultList';
@@ -83,7 +85,9 @@ const ResourcesAndSupportSearchApp = () => {
         We didn’t find any resources and support articles for "
         <strong>{query}</strong>
         ." Try using different words or{' '}
-        <a href={`/search?query=${encodeURIComponent(query)}`}>
+        <a
+          href={`${searchSettings.rootUrl}/?query=${encodeURIComponent(query)}`}
+        >
           search all of VA.gov
         </a>
         .


### PR DESCRIPTION
## Description
This URL was missing a trailing slash. It missing was causing a redirect to occur (to go to the URL w/the slash) which caused the URL params to be lost. 

## Testing done
Confirmed locally the URL param carries over

## Screenshots

### Issue
![search-all-vagov-redirecting-to-homepage](https://user-images.githubusercontent.com/43381063/98706432-d4d2bf00-234c-11eb-8804-86aab7c4f99d.gif)

## Acceptance criteria
- [ ] URL param is carried over

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
