### PR TITLE
Add transformers for new fieldDatetimeRangeTimezone field

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -1,6 +1,6 @@
 const phoneNumberArrayToObject = require('./phoneNumberArrayToObject');
 
-const moment = require('moment');
+const moment = require('moment-timezone');
 const converter = require('number-to-words');
 const liquid = require('tinyliquid');
 const _ = require('lodash');
@@ -89,7 +89,12 @@ module.exports = function registerFilters() {
     return replaced;
   };
 
-  liquid.filters.dateFromUnix = (dt, format) => moment.unix(dt).format(format);
+  liquid.filters.dateFromUnix = (dt, format) => {
+    if (!dt) {
+      return null;
+    }
+    return moment.unix(dt).format(format);
+  };
 
   liquid.filters.unixFromDate = data => new Date(data).getTime();
 

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -39,6 +39,9 @@ module.exports = function registerFilters() {
   // Convert a timezone string (e.g. 'America/Los_Angeles') to an abbreviation
   // e.g. "PST"
   liquid.filters.timezoneAbbrev = (timezone, timestamp) => {
+    if (!timezone || !timestamp) {
+      return 'ET';
+    }
     if (moment.tz.zone(timezone)) {
       return moment.tz.zone(timezone).abbr(timestamp);
     } else {

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -14,3 +14,16 @@ describe('isLaterThan', () => {
     expect(liquid.filters.isLaterThan('2016-12-11', '2017-01-12')).to.be.false;
   });
 });
+
+// TODO: figure out how to get this working!
+describe.skip('timezoneAbbrev', () => {
+  it('returns PST for Los Angeles', () => {
+    expect(
+      liquid.filters.timezoneAbbrev('America/Los_Angeles', '2020-11-11'),
+    ).to.eq('PST');
+  });
+
+  it('returns ET for null', () => {
+    expect(liquid.filters.timezoneAbbrev()).to.eq('ET');
+  });
+});

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -15,15 +15,26 @@ describe('isLaterThan', () => {
   });
 });
 
-// TODO: figure out how to get this working!
-describe.skip('timezoneAbbrev', () => {
-  it('returns PST for Los Angeles', () => {
+describe('timezoneAbbrev', () => {
+  it('returns PDT for Los Angeles', () => {
     expect(
-      liquid.filters.timezoneAbbrev('America/Los_Angeles', '2020-11-11'),
-    ).to.eq('PST');
+      liquid.filters.timezoneAbbrev('America/Los_Angeles', 1604091600000),
+    ).to.eq('PDT');
   });
 
   it('returns ET for null', () => {
     expect(liquid.filters.timezoneAbbrev()).to.eq('ET');
+  });
+});
+
+describe('dateFromUnix', () => {
+  it('returns null for null', () => {
+    expect(liquid.filters.dateFromUnix()).to.be.null;
+  });
+
+  it('returns date with specified format', () => {
+    expect(liquid.filters.dateFromUnix(1604091600, 'dddd, MMM D YYYY')).to.eq(
+      'Friday, Oct. 30 2020',
+    );
   });
 });

--- a/src/site/stages/build/process-cms-exports/schemas/input/node-event.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/node-event.js
@@ -45,6 +45,17 @@ module.exports = {
         required: ['value', 'end_value'],
       },
     },
+    field_datetime_range_timezone: {
+      type: 'array',
+      items: {
+        properties: {
+          value: { type: 'string' },
+          end_value: { type: 'string' },
+          timezone: { type: 'string' },
+        },
+        required: ['value', 'end_value', 'timezone'],
+      },
+    },
     field_description: { $ref: 'GenericNestedString' },
     field_event_cost: { $ref: 'GenericNestedString' },
     field_event_cta: { $ref: 'GenericNestedString' },
@@ -78,6 +89,7 @@ module.exports = {
     'field_address',
     'field_body',
     'field_date',
+    'field_datetime_range_timezone',
     'field_description',
     'field_event_cost',
     'field_event_cta',

--- a/src/site/stages/build/process-cms-exports/schemas/input/paragraph-situation_update.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/paragraph-situation_update.js
@@ -4,11 +4,13 @@ module.exports = {
   type: 'object',
   properties: {
     field_date_and_time: { $ref: 'GenericNestedString' },
+    field_datetime_range_timezone: { $ref: 'GenericNestedString' },
     field_send_email_to_subscribers: { $ref: 'GenericNestedBoolean' },
     field_wysiwyg: { $ref: 'GenericNestedString' },
   },
   required: [
     'field_date_and_time',
+    'field_datetime_range_timezone',
     'field_send_email_to_subscribers',
     'field_wysiwyg',
   ],

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-event.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-event.js
@@ -22,6 +22,14 @@ module.exports = {
         endValue: { type: 'string' }, //  2019-06-12T23:00:00
       },
     },
+    fieldDatetimeRangeTimezone: {
+      type: 'object',
+      properties: {
+        value: { type: 'string' },
+        endValue: { type: 'string' },
+        timezone: { type: 'string' },
+      },
+    },
     fieldDescription: { type: ['string', 'null'] },
     fieldEventCost: { type: ['string', 'null'] },
     fieldEventCta: { type: ['string', 'null'] },
@@ -53,6 +61,7 @@ module.exports = {
     'fieldAddress',
     'fieldBody',
     'fieldDate',
+    'fieldDatetimeRangeTimezone',
     'fieldDescription',
     'fieldEventCost',
     'fieldEventCta',

--- a/src/site/stages/build/process-cms-exports/schemas/output/paragraph-situation_update.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/paragraph-situation_update.js
@@ -15,6 +15,14 @@ module.exports = {
             value: { type: 'string' },
           },
         },
+        fieldDatetimeRangeTimezone: {
+          type: 'object',
+          properties: {
+            value: { type: 'string' },
+            endValue: { type: 'string' },
+            timezone: { type: 'string' },
+          },
+        },
         fieldSendEmailToSubscribers: { type: ['boolean'] },
         fieldWysiwyg: {
           type: 'object',
@@ -27,6 +35,7 @@ module.exports = {
         'entityType',
         'entityBundle',
         'fieldDateAndTime',
+        'fieldDatetimeRangeTimezone',
         'fieldSendEmailToSubscribers',
         'fieldWysiwyg',
       ],

--- a/src/site/stages/build/process-cms-exports/transformers/node-event.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-event.js
@@ -53,6 +53,15 @@ const transform = entity => ({
     endDate: toUtc(entity.fieldDate[0].end_value),
     endValue: toUtc(entity.fieldDate[0].end_value, false),
   },
+  fieldDatetimeRangeTimezone:
+    entity.fieldDatetimeRangeTimezone &&
+    entity.fieldDatetimeRangeTimezone.length
+      ? {
+          startDate: entity.fieldDatetimeRangeTimezone[0].startDate,
+          endValue: entity.fieldDatetimeRangeTimezone[0].endValue,
+          timezone: entity.fieldDatetimeRangeTimezone[0].timezone,
+        }
+      : {},
   fieldDescription: getDrupalValue(entity.fieldDescription),
   fieldEventCost: getDrupalValue(entity.fieldEventCost),
   fieldEventCta: getDrupalValue(entity.fieldEventCta),
@@ -79,6 +88,7 @@ module.exports = {
     'field_address',
     'field_body',
     'field_date',
+    'field_datetime_range_timezone',
     'field_description',
     'field_event_cost',
     'field_event_cta',

--- a/src/site/stages/build/process-cms-exports/transformers/node-event.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-event.js
@@ -53,12 +53,18 @@ const transform = entity => ({
     endDate: toUtc(entity.fieldDate[0].end_value),
     endValue: toUtc(entity.fieldDate[0].end_value, false),
   },
+  // The templates expect timestamps, like we get from graphql,
+  // but the cms-export gives us UTC dates.
   fieldDatetimeRangeTimezone:
     entity.fieldDatetimeRangeTimezone &&
     entity.fieldDatetimeRangeTimezone.length
       ? {
-          startDate: entity.fieldDatetimeRangeTimezone[0].startDate,
-          endValue: entity.fieldDatetimeRangeTimezone[0].endValue,
+          value: entity.fieldDatetimeRangeTimezone[0].value
+            ? Date.parse(entity.fieldDatetimeRangeTimezone[0].value) / 1000
+            : null,
+          endValue: entity.fieldDatetimeRangeTimezone[0].endValue
+            ? Date.parse(entity.fieldDatetimeRangeTimezone[0].endValue) / 1000
+            : null,
           timezone: entity.fieldDatetimeRangeTimezone[0].timezone,
         }
       : {},

--- a/src/site/stages/build/process-cms-exports/transformers/paragraph-situation_update.js
+++ b/src/site/stages/build/process-cms-exports/transformers/paragraph-situation_update.js
@@ -23,8 +23,13 @@ const transform = entity => {
         entity.fieldDatetimeRangeTimezone &&
         entity.fieldDatetimeRangeTimezone.length
           ? {
-              startDate: entity.fieldDatetimeRangeTimezone[0].startDate,
-              endValue: entity.fieldDatetimeRangeTimezone[0].endValue,
+              value: entity.fieldDatetimeRangeTimezone[0].value
+                ? Date.parse(entity.fieldDatetimeRangeTimezone[0].value) / 1000
+                : null,
+              endValue: entity.fieldDatetimeRangeTimezone[0].endValue
+                ? Date.parse(entity.fieldDatetimeRangeTimezone[0].endValue) /
+                  1000
+                : null,
               timezone: entity.fieldDatetimeRangeTimezone[0].timezone,
             }
           : {},

--- a/src/site/stages/build/process-cms-exports/transformers/paragraph-situation_update.js
+++ b/src/site/stages/build/process-cms-exports/transformers/paragraph-situation_update.js
@@ -19,6 +19,15 @@ const transform = entity => {
           .format('YYYY-MM-DD HH:mm:ss UTC'),
         value: getDrupalValue(fieldDateAndTime),
       },
+      fieldDatetimeRangeTimezone:
+        entity.fieldDatetimeRangeTimezone &&
+        entity.fieldDatetimeRangeTimezone.length
+          ? {
+              startDate: entity.fieldDatetimeRangeTimezone[0].startDate,
+              endValue: entity.fieldDatetimeRangeTimezone[0].endValue,
+              timezone: entity.fieldDatetimeRangeTimezone[0].timezone,
+            }
+          : {},
       fieldSendEmailToSubscribers: getDrupalValue(fieldSendEmailToSubscribers),
       fieldWysiwyg: {
         processed: fieldWysiwyg[0].processed,
@@ -30,6 +39,7 @@ const transform = entity => {
 module.exports = {
   filter: [
     'field_date_and_time',
+    'field_datetime_range_timezone',
     'field_send_email_to_subscribers',
     'field_wysiwyg',
   ],


### PR DESCRIPTION
## Description
Add transformers for new fieldDatetimeRangeTimezone field

## Testing done
Manual

## Acceptance criteria
- [x]  No diffs in date/time format are found after running `yarn cms:compare` and `yarn cms:diff` on the following pages:
- pittsburgh-health-care/events/index.html
- pittsburgh-health-care/operating-status/index.html
- outreach-and-events/events/tele-townhall-live-in-california-with-under-secretary-for-benefits-0/index.html


## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
