### PR TITLE
Rename remaining Vet360 components

### DIFF
--- a/src/applications/letters/containers/AddressSection.jsx
+++ b/src/applications/letters/containers/AddressSection.jsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { focusElement } from 'platform/utilities/ui';
-import { selectVAPContactInfo } from 'platform/user/selectors';
+import { focusElement } from '~/platform/utilities/ui';
+import { selectVAPContactInfo } from '~/platform/user/selectors';
 
 import { isAddressEmpty } from '../utils/helpers';
 import noAddressBanner from '../components/NoAddressBanner';
 
 import { TRANSACTION_CATEGORY_TYPES } from '@@vap-svc/constants';
 
-import Vet360InitializeID from '@@vap-svc/containers/InitializeVet360ID';
-import Vet360PendingTransactionCategory from '@@vap-svc/containers/Vet360PendingTransactionCategory';
+import InitializeVAPServiceID from '@@vap-svc/containers/InitializeVAPServiceID';
+import VAPServicePendingTransactionCategory from '@@vap-svc/containers/VAPServicePendingTransactionCategory';
 import MailingAddress from '@@vap-svc/components/MailingAddress';
 
 export class AddressSection extends React.Component {
@@ -31,13 +31,13 @@ export class AddressSection extends React.Component {
       <div className="step-content">
         <p>Downloaded documents will list your address as:</p>
         <div className="va-profile-wrapper">
-          <Vet360InitializeID>
-            <Vet360PendingTransactionCategory
+          <InitializeVAPServiceID>
+            <VAPServicePendingTransactionCategory
               categoryType={TRANSACTION_CATEGORY_TYPES.ADDRESS}
             >
               <MailingAddress />
-            </Vet360PendingTransactionCategory>
-          </Vet360InitializeID>
+            </VAPServicePendingTransactionCategory>
+          </InitializeVAPServiceID>
         </div>
         <p>
           When you download a letter, it will show this address. If this address

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationEditView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationEditView.jsx
@@ -6,8 +6,8 @@ import {
   isFailedTransaction,
   isPendingTransaction,
 } from '@@vap-svc/util/transactions';
+import VAPServiceEditModalErrorMessage from '@@vap-svc/components/base/VAPServiceEditModalErrorMessage';
 import ContactInformationActionButtons from './ContactInformationActionButtons';
-import Vet360EditModalErrorMessage from '@@vap-svc/components/base/Vet360EditModalErrorMessage';
 
 class ContactInformationEditView extends Component {
   static propTypes = {
@@ -141,7 +141,7 @@ class ContactInformationEditView extends Component {
             className="vads-u-margin-bottom--1"
             data-testid="edit-error-alert"
           >
-            <Vet360EditModalErrorMessage
+            <VAPServiceEditModalErrorMessage
               title={title}
               error={error}
               clearErrors={clearErrors}

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
@@ -32,8 +32,8 @@ import {
   selectVAPServiceTransaction,
 } from '@@vap-svc/selectors';
 
+import VAPServiceTransaction from '@@vap-svc/components/base/VAPServiceTransaction';
 import ContactInformationEditButton from './ContactInformationEditButton';
-import Vet360Transaction from '@@vap-svc/components/base/Vet360Transaction';
 
 const wrapperClasses = prefixUtilityClasses([
   'display--flex',
@@ -282,7 +282,7 @@ class ContactInformationField extends React.Component {
 
     const wrapInTransaction = children => {
       return (
-        <Vet360Transaction
+        <VAPServiceTransaction
           isModalOpen={showEditView || showValidationView}
           id={`${fieldName}-transaction-status`}
           title={title}
@@ -291,7 +291,7 @@ class ContactInformationField extends React.Component {
           refreshTransaction={this.refreshTransaction}
         >
           {children}
-        </Vet360Transaction>
+        </VAPServiceTransaction>
       );
     };
 

--- a/src/applications/personalization/profile/components/personal-information/PersonalInformationContent.jsx
+++ b/src/applications/personalization/profile/components/personal-information/PersonalInformationContent.jsx
@@ -1,6 +1,6 @@
 import React, { memo } from 'react';
 
-import Vet360InitializeID from '@@vap-svc/containers/InitializeVet360ID';
+import InitializeVAPServiceID from '@@vap-svc/containers/InitializeVAPServiceID';
 
 import GenderAndDOBSection from './GenderAndDOBSection';
 import ContactInformationSection from './ContactInformationSection';
@@ -10,10 +10,10 @@ const PersonalInformationContent = () => (
   <>
     <GenderAndDOBSection className="vads-u-margin-bottom--6" />
 
-    <Vet360InitializeID>
+    <InitializeVAPServiceID>
       <ContactInformationSection className="vads-u-margin-bottom--6" />
       <EmailInformationSection />
-    </Vet360InitializeID>
+    </InitializeVAPServiceID>
   </>
 );
 

--- a/src/applications/personalization/profile/tests/components/ContactInformationEditView.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/ContactInformationEditView.unit.spec.jsx
@@ -125,11 +125,11 @@ describe('<ContactInformationEditView/>', () => {
     });
   });
 
-  describe('Vet360EditModalErrorMessage', () => {
+  describe('VAPServiceEditModalErrorMessage', () => {
     it("is not shown if there isn't an error", () => {
       component = enzyme.shallow(<ContactInformationEditView {...props} />);
 
-      const errorMessage = component.find('Vet360EditModalErrorMessage');
+      const errorMessage = component.find('VAPServiceEditModalErrorMessage');
       expect(errorMessage).to.have.lengthOf(0);
 
       component.unmount();
@@ -138,7 +138,7 @@ describe('<ContactInformationEditView/>', () => {
       props.transactionRequest = { error: true };
       component = enzyme.shallow(<ContactInformationEditView {...props} />);
 
-      const errorMessage = component.find('Vet360EditModalErrorMessage');
+      const errorMessage = component.find('VAPServiceEditModalErrorMessage');
       expect(errorMessage).to.have.lengthOf(1);
 
       component.unmount();
@@ -147,7 +147,7 @@ describe('<ContactInformationEditView/>', () => {
       props.transactionRequest = { error: {} };
       component = enzyme.shallow(<ContactInformationEditView {...props} />);
 
-      const errorMessage = component.find('Vet360EditModalErrorMessage');
+      const errorMessage = component.find('VAPServiceEditModalErrorMessage');
       expect(errorMessage).to.have.lengthOf(1);
 
       component.unmount();
@@ -162,7 +162,7 @@ describe('<ContactInformationEditView/>', () => {
       };
       component = enzyme.shallow(<ContactInformationEditView {...props} />);
 
-      const errorMessage = component.find('Vet360EditModalErrorMessage');
+      const errorMessage = component.find('VAPServiceEditModalErrorMessage');
       expect(errorMessage).to.have.lengthOf(1);
 
       component.unmount();

--- a/src/applications/personalization/profile/tests/components/direct-deposit/PaymentInformationEditModalError.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/direct-deposit/PaymentInformationEditModalError.unit.spec.jsx
@@ -190,7 +190,7 @@ describe('<PaymentInformationEditModalError />', () => {
     ],
   };
 
-  // When vet360 was not working in the staging env, we saw this error when
+  // When VA Profile was not working in the staging env, we saw this error when
   // saving direct deposit info (hitting PUT ppiu/payment_information)
   const upstreamError = {
     errors: [

--- a/src/platform/user/profile/vap-svc/actions/transactions.js
+++ b/src/platform/user/profile/vap-svc/actions/transactions.js
@@ -57,7 +57,7 @@ export function fetchTransactions() {
       } else {
         response = { data: [] };
         // Uncomment the line below to simulate transactions being processed during initialization
-        // response = localVet360.getUserTransactions();
+        // response = localVAProfileService.getUserTransactions();
       }
       dispatch({
         type: VAP_SERVICE_TRANSACTIONS_FETCH_SUCCESS,

--- a/src/platform/user/profile/vap-svc/components/AddressField/AddressEditModal.jsx
+++ b/src/platform/user/profile/vap-svc/components/AddressField/AddressEditModal.jsx
@@ -5,7 +5,7 @@ import ADDRESS_DATA from 'platform/forms/address/data';
 import { focusElement } from 'platform/utilities/ui';
 
 import { ADDRESS_POU, FIELD_NAMES, USA } from '@@vap-svc/constants';
-import Vet360EditModal from '../base/Vet360EditModal';
+import VAPServiceEditModal from '../base/VAPServiceEditModal';
 import CopyMailingAddress from '@@vap-svc/containers/CopyMailingAddress';
 import ContactInfoForm from '../ContactInfoForm';
 
@@ -116,7 +116,7 @@ class AddressEditModal extends React.Component {
 
   render() {
     return (
-      <Vet360EditModal
+      <VAPServiceEditModal
         getInitialFormValues={this.getInitialFormValues}
         render={this.renderForm}
         {...this.props}

--- a/src/platform/user/profile/vap-svc/components/AddressField/AddressField.jsx
+++ b/src/platform/user/profile/vap-svc/components/AddressField/AddressField.jsx
@@ -11,7 +11,7 @@ import {
   USA,
 } from '@@vap-svc/constants';
 
-import Vet360ProfileField from '@@vap-svc/containers/Vet360ProfileField';
+import VAPServiceProfileField from '@@vap-svc/containers/VAPServiceProfileField';
 
 import AddressEditModal from './AddressEditModal';
 import AddressValidationModal from '../../containers/AddressValidationModal';
@@ -96,7 +96,7 @@ export const convertCleanDataToPayload = (data, fieldName) => {
 
 function AddressField({ title, fieldName, deleteDisabled }) {
   return (
-    <Vet360ProfileField
+    <VAPServiceProfileField
       title={title}
       fieldName={fieldName}
       apiRoute={API_ROUTES.ADDRESSES}

--- a/src/platform/user/profile/vap-svc/components/EmailField/EmailEditModal.jsx
+++ b/src/platform/user/profile/vap-svc/components/EmailField/EmailEditModal.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import Vet360EditModal from '../base/Vet360EditModal';
+import VAPServiceEditModal from '../base/VAPServiceEditModal';
 
 import ContactInfoForm from '../ContactInfoForm';
 
@@ -30,7 +30,7 @@ class EmailEditModal extends React.Component {
 
   render() {
     return (
-      <Vet360EditModal
+      <VAPServiceEditModal
         {...this.props}
         getInitialFormValues={this.getInitialFormValues}
         render={this.renderForm}

--- a/src/platform/user/profile/vap-svc/components/EmailField/EmailField.jsx
+++ b/src/platform/user/profile/vap-svc/components/EmailField/EmailField.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import { API_ROUTES, FIELD_NAMES } from '@@vap-svc/constants';
 
-import Vet360ProfileField from '@@vap-svc/containers/Vet360ProfileField';
+import VAPServiceProfileField from '@@vap-svc/containers/VAPServiceProfileField';
 
 import EmailEditModal from './EmailEditModal';
 import EmailView from './EmailView';
@@ -45,7 +45,7 @@ export default class EmailField extends React.Component {
 
   render() {
     return (
-      <Vet360ProfileField
+      <VAPServiceProfileField
         title={this.props.title}
         fieldName={this.props.fieldName}
         apiRoute={API_ROUTES.EMAILS}

--- a/src/platform/user/profile/vap-svc/components/PhoneField/PhoneEditModal.jsx
+++ b/src/platform/user/profile/vap-svc/components/PhoneField/PhoneEditModal.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import Vet360EditModal from '../base/Vet360EditModal';
+import VAPServiceEditModal from '../base/VAPServiceEditModal';
 
 import { isVAPatient } from 'platform/user/selectors';
 
@@ -53,7 +53,7 @@ class PhoneEditModal extends React.Component {
 
   render() {
     return (
-      <Vet360EditModal
+      <VAPServiceEditModal
         {...this.props}
         getInitialFormValues={this.getInitialFormValues}
         render={this.renderForm}

--- a/src/platform/user/profile/vap-svc/components/PhoneField/PhoneField.jsx
+++ b/src/platform/user/profile/vap-svc/components/PhoneField/PhoneField.jsx
@@ -5,9 +5,9 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 import { API_ROUTES, FIELD_NAMES, PHONE_TYPE, USA } from '@@vap-svc/constants';
 
-import PhoneNumberWidget from 'platform/forms-system/src/js/widgets/PhoneNumberWidget';
+import PhoneNumberWidget from '~/platform/forms-system/src/js/widgets/PhoneNumberWidget';
 
-import Vet360ProfileField from '@@vap-svc/containers/Vet360ProfileField';
+import VAPServiceProfileField from '@@vap-svc/containers/VAPServiceProfileField';
 
 import PhoneEditModal from './PhoneEditModal';
 import PhoneView from './PhoneView';
@@ -130,7 +130,7 @@ export default class PhoneField extends React.Component {
 
   render() {
     return (
-      <Vet360ProfileField
+      <VAPServiceProfileField
         title={this.props.title}
         fieldName={this.props.fieldName}
         apiRoute={API_ROUTES.TELEPHONES}

--- a/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModal.jsx
+++ b/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModal.jsx
@@ -3,15 +3,15 @@ import PropTypes from 'prop-types';
 
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
 
-import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
+import LoadingButton from '~/platform/site-wide/loading-button/LoadingButton';
 import {
   isFailedTransaction,
   isPendingTransaction,
 } from '@@vap-svc/util/transactions';
-import Vet360EditModalActionButtons from './Vet360EditModalActionButtons';
-import Vet360EditModalErrorMessage from './Vet360EditModalErrorMessage';
+import VAPServiceEditModalActionButtons from './VAPServiceEditModalActionButtons';
+import VAPServiceEditModalErrorMessage from './VAPServiceEditModalErrorMessage';
 
-export default class Vet360EditModal extends React.Component {
+export default class VAPServiceEditModal extends React.Component {
   static propTypes = {
     analyticsSectionName: PropTypes.string.isRequired,
     clearErrors: PropTypes.func.isRequired,
@@ -82,7 +82,7 @@ export default class Vet360EditModal extends React.Component {
       (isFailedTransaction(transaction) ? {} : null);
 
     const actionButtons = (
-      <Vet360EditModalActionButtons
+      <VAPServiceEditModalActionButtons
         onCancel={onCancel}
         onDelete={onDelete}
         title={title}
@@ -100,7 +100,7 @@ export default class Vet360EditModal extends React.Component {
         >
           Cancel
         </button>
-      </Vet360EditModalActionButtons>
+      </VAPServiceEditModalActionButtons>
     );
 
     return (
@@ -108,7 +108,7 @@ export default class Vet360EditModal extends React.Component {
         <h3>Edit {title.toLowerCase()}</h3>
         {error && (
           <div className="vads-u-margin-bottom--1">
-            <Vet360EditModalErrorMessage
+            <VAPServiceEditModalErrorMessage
               title={title}
               error={error}
               clearErrors={clearErrors}

--- a/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalActionButtons.jsx
+++ b/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalActionButtons.jsx
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import { toLower } from 'lodash';
 
-import recordEvent from 'platform/monitoring/record-event';
-import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
+import recordEvent from '~/platform/monitoring/record-event';
+import LoadingButton from '~/platform/site-wide/loading-button/LoadingButton';
 
-class Vet360EditModalActionButtons extends React.Component {
+class VAPServiceEditModalActionButtons extends React.Component {
   constructor(props) {
     super(props);
 
@@ -129,7 +129,7 @@ class Vet360EditModalActionButtons extends React.Component {
   }
 }
 
-Vet360EditModalActionButtons.propTypes = {
+VAPServiceEditModalActionButtons.propTypes = {
   deleteEnabled: PropTypes.bool,
   title: PropTypes.string.isRequired,
   onDelete: PropTypes.func.isRequired,
@@ -137,8 +137,8 @@ Vet360EditModalActionButtons.propTypes = {
   isLoading: PropTypes.bool,
 };
 
-Vet360EditModalActionButtons.defaultProps = {
+VAPServiceEditModalActionButtons.defaultProps = {
   deleteEnabled: true,
 };
 
-export default Vet360EditModalActionButtons;
+export default VAPServiceEditModalActionButtons;

--- a/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage.jsx
+++ b/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import AlertBox, {
   ALERT_TYPE,
 } from '@department-of-veterans-affairs/formation-react/AlertBox';
-import facilityLocator from 'applications/facility-locator/manifest.json';
+import facilityLocator from '~/applications/facility-locator/manifest.json';
 
 import {
   DECEASED_ERROR_CODES,
@@ -14,7 +14,7 @@ function hasError(codes, errors) {
   return errors.some(error => codes.has(error.code));
 }
 
-export default function Vet360EditModalErrorMessage({
+export default function VAPServiceEditModalErrorMessage({
   error: { errors = [] },
   clearErrors,
   title,

--- a/src/platform/user/profile/vap-svc/components/base/VAPServiceProfileFieldHeading.jsx
+++ b/src/platform/user/profile/vap-svc/components/base/VAPServiceProfileFieldHeading.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-function Vet360ProfileFieldHeading({ children, onEditClick, fieldName }) {
+function VAPServiceProfileFieldHeading({ children, onEditClick, fieldName }) {
   return (
     <div>
       <h3 style={{ display: 'inline-block' }}>{children}</h3>{' '}
@@ -21,9 +21,9 @@ function Vet360ProfileFieldHeading({ children, onEditClick, fieldName }) {
   );
 }
 
-Vet360ProfileFieldHeading.propTypes = {
+VAPServiceProfileFieldHeading.propTypes = {
   children: PropTypes.string.isRequired,
   onEditClick: PropTypes.func,
 };
 
-export default Vet360ProfileFieldHeading;
+export default VAPServiceProfileFieldHeading;

--- a/src/platform/user/profile/vap-svc/components/base/VAPServiceTransaction.jsx
+++ b/src/platform/user/profile/vap-svc/components/base/VAPServiceTransaction.jsx
@@ -7,10 +7,10 @@ import {
   isFailedTransaction,
 } from '@@vap-svc/util/transactions';
 
-import Vet360TransactionInlineErrorMessage from './Vet360TransactionInlineErrorMessage';
-import Vet360TransactionPending from './Vet360TransactionPending';
+import VAPServiceTransactionInlineErrorMessage from './VAPServiceTransactionInlineErrorMessage';
+import VAPServiceTransactionPending from './VAPServiceTransactionPending';
 
-function Vet360Transaction(props) {
+function VAPServiceTransaction(props) {
   const {
     id,
     isModalOpen,
@@ -33,10 +33,10 @@ function Vet360Transaction(props) {
 
   return (
     <div className={classes}>
-      {hasError && <Vet360TransactionInlineErrorMessage {...props} />}
+      {hasError && <VAPServiceTransactionInlineErrorMessage {...props} />}
       {transactionRequestPending && (
         <div id={id}>
-          <Vet360TransactionPending
+          <VAPServiceTransactionPending
             title={title}
             refreshTransaction={() => {}}
             method={method}
@@ -45,12 +45,12 @@ function Vet360Transaction(props) {
                the `Vet360TransactionPending` component from rendering the
                "we're saving your info..." message */}
             {isModalOpen && children}
-          </Vet360TransactionPending>
+          </VAPServiceTransactionPending>
         </div>
       )}
       {transactionPending && (
         <div id={id}>
-          <Vet360TransactionPending
+          <VAPServiceTransactionPending
             title={title}
             refreshTransaction={refreshTransaction}
             method={method}
@@ -59,7 +59,7 @@ function Vet360Transaction(props) {
                the `Vet360TransactionPending` component from rendering the
                "we're saving your info..." message */}
             {isModalOpen && children}
-          </Vet360TransactionPending>
+          </VAPServiceTransactionPending>
         </div>
       )}
       {transactionResolved && children}
@@ -67,11 +67,11 @@ function Vet360Transaction(props) {
   );
 }
 
-Vet360Transaction.propTypes = {
+VAPServiceTransaction.propTypes = {
   children: PropTypes.node.isRequired,
   refreshTransaction: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
   transaction: PropTypes.object,
 };
 
-export default Vet360Transaction;
+export default VAPServiceTransaction;

--- a/src/platform/user/profile/vap-svc/components/base/VAPServiceTransactionErrorBanner.jsx
+++ b/src/platform/user/profile/vap-svc/components/base/VAPServiceTransactionErrorBanner.jsx
@@ -3,7 +3,7 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
-import facilityLocator from 'applications/facility-locator/manifest.json';
+import facilityLocator from '~/applications/facility-locator/manifest.json';
 
 import {
   hasGenericUpdateError,
@@ -119,7 +119,7 @@ export function MVIError(props) {
   );
 }
 
-export default function Vet360TransactionErrorBanner({
+export default function VAPServiceTransactionErrorBanner({
   transaction,
   clearTransaction,
 }) {

--- a/src/platform/user/profile/vap-svc/components/base/VAPServiceTransactionInlineErrorMessage.jsx
+++ b/src/platform/user/profile/vap-svc/components/base/VAPServiceTransactionInlineErrorMessage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default function Vet360TransactionInlineErrorMessage({
+export default function VAPServiceTransactionInlineErrorMessage({
   title: fieldTitle,
 }) {
   return (

--- a/src/platform/user/profile/vap-svc/components/base/VAPServiceTransactionPending.jsx
+++ b/src/platform/user/profile/vap-svc/components/base/VAPServiceTransactionPending.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-class Vet360TransactionPending extends React.Component {
+class VAPServiceTransactionPending extends React.Component {
   static propTypes = {
     title: PropTypes.string,
     refreshTransaction: PropTypes.func.isRequired,
@@ -60,4 +60,4 @@ class Vet360TransactionPending extends React.Component {
   }
 }
 
-export default Vet360TransactionPending;
+export default VAPServiceTransactionPending;

--- a/src/platform/user/profile/vap-svc/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vap-svc/containers/AddressValidationModal.jsx
@@ -4,8 +4,8 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
-import { formatAddress } from 'platform/forms/address/helpers';
-import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
+import { formatAddress } from '~/platform/forms/address/helpers';
+import LoadingButton from '~/platform/site-wide/loading-button/LoadingButton';
 import {
   openModal,
   createTransaction,
@@ -14,10 +14,10 @@ import {
   closeModal,
   resetAddressValidation as resetAddressValidationAction,
 } from '../actions';
-import { focusElement } from 'platform/utilities/ui';
+import { focusElement } from '~/platform/utilities/ui';
 import { getValidationMessageKey } from '../../utilities';
 import { ADDRESS_VALIDATION_MESSAGES } from '../../constants/addressValidationMessages';
-import recordEvent from 'platform/monitoring/record-event';
+import recordEvent from '~/platform/monitoring/record-event';
 
 import * as VAP_SERVICE from '../constants';
 
@@ -26,7 +26,7 @@ import {
   isPendingTransaction,
 } from '@@vap-svc/util/transactions';
 
-import Vet360EditModalErrorMessage from '@@vap-svc/components/base/Vet360EditModalErrorMessage';
+import VAPServiceEditModalErrorMessage from '@@vap-svc/components/base/VAPServiceEditModalErrorMessage';
 
 class AddressValidationModal extends React.Component {
   componentWillUnmount() {
@@ -237,7 +237,7 @@ class AddressValidationModal extends React.Component {
       >
         {error && (
           <div className="vads-u-margin-bottom--1">
-            <Vet360EditModalErrorMessage
+            <VAPServiceEditModalErrorMessage
               title={title}
               error={error}
               clearErrors={clearErrors}

--- a/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
+++ b/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
-import { formatAddress } from 'platform/forms/address/helpers';
-import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
-import recordEvent from 'platform/monitoring/record-event';
-import { focusElement } from 'platform/utilities/ui';
+import { formatAddress } from '~/platform/forms/address/helpers';
+import LoadingButton from '~/platform/site-wide/loading-button/LoadingButton';
+import recordEvent from '~/platform/monitoring/record-event';
+import { focusElement } from '~/platform/utilities/ui';
 
 import {
   isFailedTransaction,
@@ -13,7 +13,7 @@ import {
 } from '@@vap-svc/util/transactions';
 import { selectAddressValidation } from '@@vap-svc/selectors';
 
-import Vet360EditModalErrorMessage from '@@vap-svc/components/base/Vet360EditModalErrorMessage';
+import VAPServiceEditModalErrorMessage from '@@vap-svc/components/base/VAPServiceEditModalErrorMessage';
 
 import * as VAP_SERVICE from '../constants';
 import {
@@ -244,7 +244,7 @@ class AddressValidationView extends React.Component {
       <>
         {error && (
           <div className="vads-u-margin-bottom--1">
-            <Vet360EditModalErrorMessage
+            <VAPServiceEditModalErrorMessage
               title={title}
               error={error}
               clearErrors={clearErrors}

--- a/src/platform/user/profile/vap-svc/containers/InitializeVAPServiceID.jsx
+++ b/src/platform/user/profile/vap-svc/containers/InitializeVAPServiceID.jsx
@@ -18,18 +18,18 @@ import {
 
 import { selectVAPServiceInitializationStatus } from '../selectors';
 
-import TransactionPending from '../components/base/Vet360TransactionPending';
+import TransactionPending from '../components/base/VAPServiceTransactionPending';
 
-class InitializeVet360ID extends React.Component {
+class InitializeVAPServiceID extends React.Component {
   componentDidMount() {
     if (this.props.status === VAP_SERVICE_INITIALIZATION_STATUS.INITIALIZED) {
       this.props.fetchTransactions();
     } else {
-      this.initializeVet360ID();
+      this.initializeVAPServiceID();
     }
   }
 
-  initializeVet360ID() {
+  initializeVAPServiceID() {
     const route = API_ROUTES.INIT_VAP_SERVICE_ID;
     const fieldName = INIT_VAP_SERVICE_ID;
     const method = 'POST';
@@ -112,12 +112,14 @@ const mapDispatchToProps = {
 };
 
 /**
- * A Container for initializing the user into Vet360 if they are not already. Otherwise, this container will initialize the Vet360 app state by fetching all transactions.
+ * A Container for initializing the user into VA Profile if they are not
+ * already. Otherwise, this container will initialize the Profile app state by
+ * fetching all transactions.
  */
-const InitializeVet360IDContainer = connect(
+const InitializeVAPServiceIDContainer = connect(
   mapStateToProps,
   mapDispatchToProps,
-)(InitializeVet360ID);
+)(InitializeVAPServiceID);
 
-export default InitializeVet360IDContainer;
-export { InitializeVet360ID };
+export default InitializeVAPServiceIDContainer;
+export { InitializeVAPServiceID };

--- a/src/platform/user/profile/vap-svc/containers/VAPServicePendingTransactionCategory.jsx
+++ b/src/platform/user/profile/vap-svc/containers/VAPServicePendingTransactionCategory.jsx
@@ -4,12 +4,12 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 import { refreshTransaction } from '../actions';
 
-import Vet360TransactionPending from '../components/base/Vet360TransactionPending';
+import VAPServiceTransactionPending from '../components/base/VAPServiceTransactionPending';
 
 import { TRANSACTION_CATEGORY_TYPES } from '../constants';
 import { selectVAPServicePendingCategoryTransactions } from '../selectors';
 
-function Vet360PendingTransactionCategory({
+function VAPServicePendingTransactionCategory({
   refreshTransaction: dispatchRefreshTransaction,
   transactions,
   hasPendingCategoryTransaction,
@@ -32,7 +32,7 @@ function Vet360PendingTransactionCategory({
   };
 
   return (
-    <Vet360TransactionPending refreshTransaction={refreshAllTransactions}>
+    <VAPServiceTransactionPending refreshTransaction={refreshAllTransactions}>
       <AlertBox isVisible status="warning">
         <h4>We’re updating your {plural}</h4>
         <p>
@@ -40,7 +40,7 @@ function Vet360PendingTransactionCategory({
           information below as soon as it’s finished saving.
         </p>
       </AlertBox>
-    </Vet360TransactionPending>
+    </VAPServiceTransactionPending>
   );
 }
 
@@ -64,5 +64,7 @@ const mapDispatchToProps = {
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-)(Vet360PendingTransactionCategory);
-export { Vet360PendingTransactionCategory };
+)(VAPServicePendingTransactionCategory);
+export {
+  VAPServicePendingTransactionCategory as Vet360PendingTransactionCategory,
+};

--- a/src/platform/user/profile/vap-svc/containers/VAPServiceProfileField.jsx
+++ b/src/platform/user/profile/vap-svc/containers/VAPServiceProfileField.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { focusElement } from 'platform/utilities/ui';
 
-import recordEvent from 'platform/monitoring/record-event';
+import recordEvent from '~/platform/monitoring/record-event';
 
 import * as VAP_SERVICE from '../constants';
 
@@ -25,10 +25,10 @@ import {
   selectEditedFormField,
 } from '../selectors';
 
-import Vet360ProfileFieldHeading from '../components/base/Vet360ProfileFieldHeading';
-import Vet360Transaction from '../components/base/Vet360Transaction';
+import VAPServiceProfileFieldHeading from '../components/base/VAPServiceProfileFieldHeading';
+import VAPServiceTransaction from '../components/base/VAPServiceTransaction';
 
-class Vet360ProfileField extends React.Component {
+class VAPServiceProfileField extends React.Component {
   static propTypes = {
     Content: PropTypes.func.isRequired,
     data: PropTypes.object,
@@ -222,12 +222,12 @@ class Vet360ProfileField extends React.Component {
 
     return (
       <div className="vet360-profile-field" data-field-name={fieldName}>
-        <Vet360ProfileFieldHeading
+        <VAPServiceProfileFieldHeading
           onEditClick={this.isEditLinkVisible() ? this.onEdit : null}
           fieldName={fieldName}
         >
           {title}
-        </Vet360ProfileFieldHeading>
+        </VAPServiceProfileFieldHeading>
         {isEditing && <EditModal {...childProps} />}
         {showValidationModal && (
           <ValidationModal
@@ -237,7 +237,7 @@ class Vet360ProfileField extends React.Component {
             clearErrors={this.clearErrors}
           />
         )}
-        <Vet360Transaction
+        <VAPServiceTransaction
           isModalOpen={isEditing || showValidationModal}
           id={`${fieldName}-transaction-status`}
           title={title}
@@ -258,7 +258,7 @@ class Vet360ProfileField extends React.Component {
           ) : (
             <Content {...childProps} />
           )}
-        </Vet360Transaction>
+        </VAPServiceTransaction>
       </div>
     );
   }
@@ -302,7 +302,7 @@ const mapDispatchToProps = {
 };
 
 /**
- * Container used to easily create components for Vet360 contact information.
+ * Container used to easily create components for VA Profile Service-backed contact information.
  * @property {string} fieldName The name of the property as it appears in the user.profile.vapContactInfo object.
  * @property {func} Content The component used to render the read-display of the field.
  * @property {func} EditModal The component used to render the contents of the field's edit-modal.
@@ -311,12 +311,12 @@ const mapDispatchToProps = {
  * @property {func} convertNextValueToCleanData A function called to derive or make changes to form values after form values are changed in the edit-modal. Called prior to validation.
  * @property {func} [convertCleanDataToPayload] An optional function used to convert the clean edited data to a payload for sending to the API. Used to remove any values (especially falsy) that may cause errors in Vet360.
  */
-const Vet360ProfileFieldContainer = connect(
+const VAPServiceProfileFieldContainer = connect(
   mapStateToProps,
   mapDispatchToProps,
-)(Vet360ProfileField);
+)(VAPServiceProfileField);
 
-Vet360ProfileFieldContainer.propTypes = {
+VAPServiceProfileFieldContainer.propTypes = {
   fieldName: PropTypes.oneOf(Object.values(VAP_SERVICE.FIELD_NAMES)).isRequired,
   Content: PropTypes.func.isRequired,
   EditModal: PropTypes.func.isRequired,
@@ -326,5 +326,5 @@ Vet360ProfileFieldContainer.propTypes = {
   convertCleanDataToPayload: PropTypes.func,
 };
 
-export default Vet360ProfileFieldContainer;
-export { Vet360ProfileField };
+export default VAPServiceProfileFieldContainer;
+export { VAPServiceProfileField };

--- a/src/platform/user/profile/vap-svc/containers/VAPServiceTransactionReporter.jsx
+++ b/src/platform/user/profile/vap-svc/containers/VAPServiceTransactionReporter.jsx
@@ -11,9 +11,9 @@ import {
 
 import { clearTransaction } from '../actions';
 
-import Vet360TransactionErrorBanner from '../components/base/Vet360TransactionErrorBanner';
+import VAPServiceTransactionErrorBanner from '../components/base/VAPServiceTransactionErrorBanner';
 
-class Vet360TransactionReporter extends React.Component {
+class VAPServiceTransactionReporter extends React.Component {
   static propTypes = {
     clearTransaction: PropTypes.func.isRequired,
     mostRecentErroredTransaction: PropTypes.object,
@@ -40,7 +40,7 @@ class Vet360TransactionReporter extends React.Component {
     return (
       <div className="vet360-transaction-reporter">
         {mostRecentErroredTransaction && (
-          <Vet360TransactionErrorBanner
+          <VAPServiceTransactionErrorBanner
             transaction={mostRecentErroredTransaction}
             clearTransaction={this.clearAllErroredTransactions}
           />
@@ -62,5 +62,5 @@ const mapDispatchToProps = {
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-)(Vet360TransactionReporter);
-export { Vet360TransactionReporter };
+)(VAPServiceTransactionReporter);
+export { VAPServiceTransactionReporter };

--- a/src/platform/user/profile/vap-svc/reducers/index.js
+++ b/src/platform/user/profile/vap-svc/reducers/index.js
@@ -60,7 +60,7 @@ const initialState = {
   transactionStatus: '',
 };
 
-export default function vet360(state = initialState, action) {
+export default function vapService(state = initialState, action) {
   switch (action.type) {
     case VAP_SERVICE_CLEAR_TRANSACTION_STATUS: {
       return {

--- a/src/platform/user/profile/vap-svc/tests/components/VAPServiceEditModal.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/components/VAPServiceEditModal.unit.spec.jsx
@@ -3,11 +3,11 @@ import enzyme from 'enzyme';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
+import LoadingButton from '~/platform/site-wide/loading-button/LoadingButton';
 
-import Vet360EditModal from '../../components/base/Vet360EditModal';
+import VAPServiceEditModal from '../../components/base/VAPServiceEditModal';
 
-describe('<Vet360EditModal/>', () => {
+describe('<VAPServiceEditModal/>', () => {
   let props = null;
   let component = null;
 
@@ -38,7 +38,7 @@ describe('<Vet360EditModal/>', () => {
 
     props.render = () => <div>Rendered output</div>;
 
-    component = enzyme.shallow(<Vet360EditModal {...props} />);
+    component = enzyme.shallow(<VAPServiceEditModal {...props} />);
 
     expect(
       props.onChangeFormDataAndSchemas.calledWith(initialFormValues),
@@ -61,7 +61,7 @@ describe('<Vet360EditModal/>', () => {
     it('is `true` if the transactionRequest is pending', () => {
       props.transactionRequest = { isPending: true };
       props.render = actionButtons => actionButtons;
-      component = enzyme.shallow(<Vet360EditModal {...props} />);
+      component = enzyme.shallow(<VAPServiceEditModal {...props} />);
 
       const loadingButton = component.find(LoadingButton);
       expect(loadingButton.prop('isLoading')).to.be.true;
@@ -78,7 +78,7 @@ describe('<Vet360EditModal/>', () => {
         },
       };
       props.render = actionButtons => actionButtons;
-      component = enzyme.shallow(<Vet360EditModal {...props} />);
+      component = enzyme.shallow(<VAPServiceEditModal {...props} />);
 
       const loadingButton = component.find(LoadingButton);
       expect(loadingButton.prop('isLoading')).to.be.true;
@@ -96,7 +96,7 @@ describe('<Vet360EditModal/>', () => {
         },
       };
       props.render = actionButtons => actionButtons;
-      component = enzyme.shallow(<Vet360EditModal {...props} />);
+      component = enzyme.shallow(<VAPServiceEditModal {...props} />);
 
       const loadingButton = component.find(LoadingButton);
       expect(loadingButton.prop('isLoading')).to.be.false;
@@ -107,29 +107,29 @@ describe('<Vet360EditModal/>', () => {
     it('sets the LoadingButton to isLoading if the transaction is pending', () => {});
   });
 
-  describe('Vet360EditModalErrorMessage', () => {
+  describe('VAPServiceEditModalErrorMessage', () => {
     it("is not shown if there isn't an error", () => {
-      component = enzyme.shallow(<Vet360EditModal {...props} />);
+      component = enzyme.shallow(<VAPServiceEditModal {...props} />);
 
-      const errorMessage = component.find('Vet360EditModalErrorMessage');
+      const errorMessage = component.find('VAPServiceEditModalErrorMessage');
       expect(errorMessage).to.have.lengthOf(0);
 
       component.unmount();
     });
     it('is shown if there is a transactionRequest error', () => {
       props.transactionRequest = { error: true };
-      component = enzyme.shallow(<Vet360EditModal {...props} />);
+      component = enzyme.shallow(<VAPServiceEditModal {...props} />);
 
-      const errorMessage = component.find('Vet360EditModalErrorMessage');
+      const errorMessage = component.find('VAPServiceEditModalErrorMessage');
       expect(errorMessage).to.have.lengthOf(1);
 
       component.unmount();
     });
     it('is shown if there is a transactionRequest error', () => {
       props.transactionRequest = { error: {} };
-      component = enzyme.shallow(<Vet360EditModal {...props} />);
+      component = enzyme.shallow(<VAPServiceEditModal {...props} />);
 
-      const errorMessage = component.find('Vet360EditModalErrorMessage');
+      const errorMessage = component.find('VAPServiceEditModalErrorMessage');
       expect(errorMessage).to.have.lengthOf(1);
 
       component.unmount();
@@ -142,9 +142,9 @@ describe('<Vet360EditModal/>', () => {
           },
         },
       };
-      component = enzyme.shallow(<Vet360EditModal {...props} />);
+      component = enzyme.shallow(<VAPServiceEditModal {...props} />);
 
-      const errorMessage = component.find('Vet360EditModalErrorMessage');
+      const errorMessage = component.find('VAPServiceEditModalErrorMessage');
       expect(errorMessage).to.have.lengthOf(1);
 
       component.unmount();

--- a/src/platform/user/profile/vap-svc/tests/components/VAPServiceEditModalActionButtons.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/components/VAPServiceEditModalActionButtons.unit.spec.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import enzyme from 'enzyme';
 import { expect } from 'chai';
 
-import Vet360EditModalActionButtons from '../../components/base/Vet360EditModalActionButtons';
+import VAPServiceEditModalActionButtons from '../../components/base/VAPServiceEditModalActionButtons';
 
-describe('<Vet360EditModalActionButtons/>', () => {
+describe('<VAPServiceEditModalActionButtons/>', () => {
   let props = null;
 
   beforeEach(() => {
@@ -19,9 +19,9 @@ describe('<Vet360EditModalActionButtons/>', () => {
 
   it('renders correctly when delete enabled', () => {
     const component = enzyme.shallow(
-      <Vet360EditModalActionButtons {...props}>
+      <VAPServiceEditModalActionButtons {...props}>
         <p>Children</p>
-      </Vet360EditModalActionButtons>,
+      </VAPServiceEditModalActionButtons>,
     );
 
     expect(component.html(), 'renders children components').to.contain(
@@ -41,9 +41,9 @@ describe('<Vet360EditModalActionButtons/>', () => {
 
   it('renders correctly when delete triggered', () => {
     const component = enzyme.shallow(
-      <Vet360EditModalActionButtons {...props}>
+      <VAPServiceEditModalActionButtons {...props}>
         <p>Children</p>
-      </Vet360EditModalActionButtons>,
+      </VAPServiceEditModalActionButtons>,
     );
 
     component.setState({
@@ -73,9 +73,9 @@ describe('<Vet360EditModalActionButtons/>', () => {
 
   it('renders correctly when delete disabled', () => {
     const component = enzyme.shallow(
-      <Vet360EditModalActionButtons {...props}>
+      <VAPServiceEditModalActionButtons {...props}>
         <p>Children</p>
-      </Vet360EditModalActionButtons>,
+      </VAPServiceEditModalActionButtons>,
     );
 
     expect(component.html(), 'renders children components').to.contain(

--- a/src/platform/user/profile/vap-svc/tests/components/VAPServiceEditModalErrorMessage.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/components/VAPServiceEditModalErrorMessage.unit.spec.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
-import Vet360EditModalErrorMessage from '../../components/base/Vet360EditModalErrorMessage';
+import VAPServiceEditModalErrorMessage from '../../components/base/VAPServiceEditModalErrorMessage';
 
-describe('<Vet360EditModalErrorMessage />', () => {
+describe('<VAPServiceEditModalErrorMessage />', () => {
   it('shows the correct error message when there is an invalid email', () => {
     const invalidEmailError = {
       errors: [
@@ -18,7 +18,7 @@ describe('<Vet360EditModalErrorMessage />', () => {
       ],
     };
     const wrapper = shallow(
-      <Vet360EditModalErrorMessage
+      <VAPServiceEditModalErrorMessage
         clearErrors={() => {}}
         error={invalidEmailError}
         title=""

--- a/src/platform/user/profile/vap-svc/tests/components/VAPServiceTransaction.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/components/VAPServiceTransaction.unit.spec.jsx
@@ -3,11 +3,11 @@ import enzyme from 'enzyme';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import Vet360Transaction from '../../components/base/Vet360Transaction';
-import Vet360TransactionPending from '../../components/base/Vet360TransactionPending';
+import VAPServiceTransaction from '../../components/base/VAPServiceTransaction';
+import VAPServiceTransactionPending from '../../components/base/VAPServiceTransactionPending';
 import { TRANSACTION_STATUS } from '../../constants';
 
-describe('<Vet360Transaction/>', () => {
+describe('<VAPServiceTransaction/>', () => {
   let props = null;
   beforeEach(() => {
     props = {
@@ -19,9 +19,9 @@ describe('<Vet360Transaction/>', () => {
 
   it('renders', () => {
     const component = enzyme.shallow(
-      <Vet360Transaction {...props}>
+      <VAPServiceTransaction {...props}>
         <div className="content">Children</div>
-      </Vet360Transaction>,
+      </VAPServiceTransaction>,
     );
 
     expect(component.html(), 'renders children components').to.contain(
@@ -32,7 +32,7 @@ describe('<Vet360Transaction/>', () => {
       'renders children components',
     ).to.have.lengthOf(1);
     expect(
-      component.find(Vet360TransactionPending),
+      component.find(VAPServiceTransactionPending),
       'does not render a transaction-pending message',
     ).to.have.lengthOf(0);
 
@@ -45,7 +45,7 @@ describe('<Vet360Transaction/>', () => {
     });
 
     expect(
-      component.find('Vet360TransactionInlineErrorMessage'),
+      component.find('VAPServiceTransactionInlineErrorMessage'),
       'renders error messages',
     ).to.have.lengthOf(1);
 
@@ -57,7 +57,7 @@ describe('<Vet360Transaction/>', () => {
       },
     });
     expect(
-      component.find(Vet360TransactionPending),
+      component.find(VAPServiceTransactionPending),
       'renders a transaction-pending message',
     ).to.have.lengthOf(1);
     expect(

--- a/src/platform/user/profile/vap-svc/tests/components/VAPServiceTransactionPending.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/components/VAPServiceTransactionPending.unit.spec.jsx
@@ -3,9 +3,9 @@ import enzyme from 'enzyme';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import Vet360TransactionPending from '../../components/base/Vet360TransactionPending';
+import VAPServiceTransactionPending from '../../components/base/VAPServiceTransactionPending';
 
-describe('<Vet360TransactionPending/>', () => {
+describe('<VAPServiceTransactionPending/>', () => {
   let props = null;
   beforeEach(() => {
     props = {
@@ -15,7 +15,9 @@ describe('<Vet360TransactionPending/>', () => {
   });
 
   it('renders', done => {
-    const component = enzyme.shallow(<Vet360TransactionPending {...props} />);
+    const component = enzyme.shallow(
+      <VAPServiceTransactionPending {...props} />,
+    );
 
     setTimeout(() => {
       // This should be a 3 or 4, but I'm undershooting this by setting it at 2. I don't know what to expect with a shallow-render on the Jenkins server.

--- a/src/platform/user/profile/vap-svc/tests/containers/VAPServiceProfileField.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/containers/VAPServiceProfileField.unit.spec.jsx
@@ -4,9 +4,9 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import {
-  Vet360ProfileField,
+  VAPServiceProfileField,
   mapStateToProps,
-} from '../../containers/Vet360ProfileField';
+} from '../../containers/VAPServiceProfileField';
 import { TRANSACTION_STATUS } from '../../constants';
 
 function Content() {
@@ -21,7 +21,7 @@ function ValidationModal() {
   return <span>ValidationModal</span>;
 }
 
-describe('<Vet360ProfileField/>', () => {
+describe('<VAPServiceProfileField/>', () => {
   let props = null;
   let component = null;
 
@@ -52,7 +52,7 @@ describe('<Vet360ProfileField/>', () => {
   });
 
   it('renders the Content prop', () => {
-    component = enzyme.shallow(<Vet360ProfileField {...props} />);
+    component = enzyme.shallow(<VAPServiceProfileField {...props} />);
     expect(
       component.find('Content'),
       'the Content was rendered',
@@ -66,7 +66,7 @@ describe('<Vet360ProfileField/>', () => {
       isEmpty: true,
     };
 
-    component = enzyme.shallow(<Vet360ProfileField {...isEmptyProps} />);
+    component = enzyme.shallow(<VAPServiceProfileField {...isEmptyProps} />);
     expect(
       component.find('Content'),
       'the Content was NOT rendered',
@@ -82,7 +82,7 @@ describe('<Vet360ProfileField/>', () => {
     props.isEditing = true;
     sinon.spy(props, 'EditModal');
 
-    component = enzyme.shallow(<Vet360ProfileField {...props} />);
+    component = enzyme.shallow(<VAPServiceProfileField {...props} />);
 
     expect(
       component.find('EditModal'),
@@ -111,7 +111,7 @@ describe('<Vet360ProfileField/>', () => {
     };
     sinon.spy(props, 'ValidationModal');
 
-    component = enzyme.shallow(<Vet360ProfileField {...props} />);
+    component = enzyme.shallow(<VAPServiceProfileField {...props} />);
 
     expect(
       component.find('ValidationModal'),
@@ -130,9 +130,9 @@ describe('<Vet360ProfileField/>', () => {
   });
 
   it('renders the edit link', () => {
-    component = enzyme.shallow(<Vet360ProfileField {...props} />);
+    component = enzyme.shallow(<VAPServiceProfileField {...props} />);
 
-    let onEditClick = component.find('Vet360ProfileFieldHeading').props()
+    let onEditClick = component.find('VAPServiceProfileFieldHeading').props()
       .onEditClick;
     onEditClick();
     props.openModal();
@@ -146,7 +146,7 @@ describe('<Vet360ProfileField/>', () => {
       },
     });
 
-    onEditClick = component.find('Vet360ProfileFieldHeading').props()
+    onEditClick = component.find('VAPServiceProfileFieldHeading').props()
       .onEditClick;
     expect(
       onEditClick,
@@ -200,7 +200,7 @@ describe('mapStateToProps', () => {
         expect(mappedProps.showValidationModal).to.be.false;
       });
     });
-    describe('when no ValidationModal was passed to the Vet360ProfileField component', () => {
+    describe('when no ValidationModal was passed to the VAPServiceProfileField component', () => {
       it('sets `showValidationModal` to `false`', () => {
         const state = showValidationModalState();
         const mappedProps = mapStateToProps(state, {
@@ -209,7 +209,7 @@ describe('mapStateToProps', () => {
         expect(mappedProps.showValidationModal).to.be.false;
       });
     });
-    describe("when this Vet360ProfileField's `fieldName` does not match address validation type", () => {
+    describe("when this VAPServiceProfileField's `fieldName` does not match address validation type", () => {
       it('sets `showValidationModal` to `false`', () => {
         const state = showValidationModalState();
         const mappedProps = mapStateToProps(state, {

--- a/src/platform/user/profile/vap-svc/tests/containers/VAPServiceTransactionReporter.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/containers/VAPServiceTransactionReporter.unit.spec.jsx
@@ -3,9 +3,9 @@ import enzyme from 'enzyme';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { Vet360TransactionReporter } from '../../containers/Vet360TransactionReporter';
+import { VAPServiceTransactionReporter } from '../../containers/VAPServiceTransactionReporter';
 
-describe('<Vet360ProfileField/>', () => {
+describe('<VAPServiceTransactionReporter/>', () => {
   let props = null;
 
   beforeEach(() => {
@@ -17,7 +17,9 @@ describe('<Vet360ProfileField/>', () => {
   });
 
   it('renders nothing when there are no successful or errored transactions', () => {
-    const component = enzyme.shallow(<Vet360TransactionReporter {...props} />);
+    const component = enzyme.shallow(
+      <VAPServiceTransactionReporter {...props} />,
+    );
     expect(component.text()).to.be.equal('');
     component.unmount();
   });
@@ -29,13 +31,15 @@ describe('<Vet360ProfileField/>', () => {
 
     props.mostRecentErroredTransaction = props.erroredTransactions[0];
 
-    const component = enzyme.shallow(<Vet360TransactionReporter {...props} />);
+    const component = enzyme.shallow(
+      <VAPServiceTransactionReporter {...props} />,
+    );
 
-    const vet360TransactionErrorBanner = component.find(
-      'Vet360TransactionErrorBanner',
+    const vapServiceTransactionErrorBanner = component.find(
+      'VAPServiceTransactionErrorBanner',
     );
     expect(
-      vet360TransactionErrorBanner,
+      vapServiceTransactionErrorBanner,
       'the errored transaction rendered',
     ).to.have.lengthOf(1);
     component.unmount();
@@ -50,9 +54,11 @@ describe('<Vet360ProfileField/>', () => {
     ];
     props.mostRecentErroredTransaction = props.erroredTransactions[0];
 
-    const component = enzyme.shallow(<Vet360TransactionReporter {...props} />);
+    const component = enzyme.shallow(
+      <VAPServiceTransactionReporter {...props} />,
+    );
 
-    const errorBanner = component.find('Vet360TransactionErrorBanner');
+    const errorBanner = component.find('VAPServiceTransactionErrorBanner');
     errorBanner.props().clearTransaction();
 
     expect(

--- a/src/platform/user/profile/vap-svc/tests/reducers/index.unit.spec.js
+++ b/src/platform/user/profile/vap-svc/tests/reducers/index.unit.spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import vet360 from '../../reducers';
+import vapService from '../../reducers';
 import * as VAP_SERVICE from '../../constants';
 import {
   ADDRESS_VALIDATION_RESET,
@@ -9,9 +9,9 @@ import {
   ADDRESS_VALIDATION_UPDATE,
 } from '../../actions';
 
-describe('vet360 reducer', () => {
+describe('vapService reducer', () => {
   it('should return array of transaction data', () => {
-    const state = vet360(
+    const state = vapService(
       {},
       {
         type: 'VAP_SERVICE_TRANSACTIONS_FETCH_SUCCESS',
@@ -24,7 +24,7 @@ describe('vet360 reducer', () => {
   });
 
   it('should set pending transaction', () => {
-    const state = vet360(
+    const state = vapService(
       {},
       {
         type: 'VAP_SERVICE_TRANSACTION_REQUESTED',
@@ -42,7 +42,7 @@ describe('vet360 reducer', () => {
   });
 
   it('should set pending transaction failure', () => {
-    const state = vet360(
+    const state = vapService(
       {
         fieldTransactionMap: {
           fieldName: {
@@ -68,7 +68,7 @@ describe('vet360 reducer', () => {
   });
 
   it('should set pending transaction success', () => {
-    const state = vet360(
+    const state = vapService(
       {
         fieldTransactionMap: {
           fieldName: {
@@ -103,7 +103,7 @@ describe('vet360 reducer', () => {
   });
 
   it('should set transaction update request', () => {
-    const state = vet360(
+    const state = vapService(
       { transactionsAwaitingUpdate: [] },
       {
         type: 'VAP_SERVICE_TRANSACTION_UPDATE_REQUESTED',
@@ -122,7 +122,7 @@ describe('vet360 reducer', () => {
   });
 
   it('should set updated transaction request success', () => {
-    const state = vet360(
+    const state = vapService(
       {
         transactions: [
           {
@@ -156,7 +156,7 @@ describe('vet360 reducer', () => {
   });
 
   it('should set updated transaction request failure', () => {
-    const state = vet360(
+    const state = vapService(
       {
         transactions: [
           {
@@ -191,7 +191,7 @@ describe('vet360 reducer', () => {
   });
 
   it('should set transaction update failed', () => {
-    const state = vet360(
+    const state = vapService(
       { transactionsAwaitingUpdate: [111] },
       {
         type: 'VAP_SERVICE_TRANSACTION_UPDATE_FAILED',
@@ -209,12 +209,15 @@ describe('vet360 reducer', () => {
   });
 
   it('should set transaction status cleared', () => {
-    const state = vet360({}, { type: 'VAP_SERVICE_CLEAR_TRANSACTION_STATUS' });
+    const state = vapService(
+      {},
+      { type: 'VAP_SERVICE_CLEAR_TRANSACTION_STATUS' },
+    );
     expect(state.transactionStatus.length).to.eql(0);
   });
 
   it('should set transaction cleared', () => {
-    const state = vet360(
+    const state = vapService(
       {
         transactions: [
           {
@@ -247,7 +250,7 @@ describe('vet360 reducer', () => {
   });
 
   it('should set transaction request cleared', () => {
-    const state = vet360(
+    const state = vapService(
       {
         fieldTransactionMap: {
           fieldName: 'name',
@@ -263,7 +266,7 @@ describe('vet360 reducer', () => {
   });
 
   it('should update profile form fields', () => {
-    const state = vet360(
+    const state = vapService(
       {
         initialFormFields: {
           mailingAddress: {
@@ -292,7 +295,7 @@ describe('vet360 reducer', () => {
   });
 
   it('should open modal', () => {
-    const state = vet360(
+    const state = vapService(
       {},
       {
         type: 'OPEN_MODAL',
@@ -304,7 +307,7 @@ describe('vet360 reducer', () => {
   });
 
   it('should update addressValidation on confirm', () => {
-    const state = vet360(
+    const state = vapService(
       {},
       {
         type: 'ADDRESS_VALIDATION_CONFIRM',
@@ -365,7 +368,7 @@ describe('vet360 reducer', () => {
         },
         modal: 'mailingAddress',
       };
-      expect(vet360(state, action)).to.eql(expectedState);
+      expect(vapService(state, action)).to.eql(expectedState);
     });
   });
 
@@ -416,7 +419,7 @@ describe('vet360 reducer', () => {
           selectedAddressId: null,
         },
       };
-      expect(vet360(state, action)).to.eql(expectedState);
+      expect(vapService(state, action)).to.eql(expectedState);
     });
   });
 
@@ -444,7 +447,7 @@ describe('vet360 reducer', () => {
           selectedAddressId: '0',
         },
       };
-      expect(vet360(state, action)).to.eql(expectedState);
+      expect(vapService(state, action)).to.eql(expectedState);
     });
   });
 
@@ -482,7 +485,7 @@ describe('vet360 reducer', () => {
           mailingAddress: { isPending: true },
         },
       };
-      expect(vet360(state, action)).to.eql(expectedState);
+      expect(vapService(state, action)).to.eql(expectedState);
     });
   });
 
@@ -502,7 +505,7 @@ describe('vet360 reducer', () => {
         type: ADDRESS_VALIDATION_UPDATE,
         fieldName: 'mailingAddress',
       };
-      expect(vet360(state, action)).to.eql(expectedState);
+      expect(vapService(state, action)).to.eql(expectedState);
     });
   });
 });

--- a/src/platform/user/profile/vap-svc/tests/selectors.unit.spec.js
+++ b/src/platform/user/profile/vap-svc/tests/selectors.unit.spec.js
@@ -117,7 +117,7 @@ describe('selectors', () => {
     });
   });
 
-  describe('selectVet360FailedTransactions', () => {
+  describe('selectVAPServiceFailedTransactions', () => {
     beforeEach(hooks.beforeEach);
     it('returns only failed transactions from a list of transactions', () => {
       const failed = [
@@ -179,7 +179,7 @@ describe('selectors', () => {
     });
   });
 
-  describe('selectVet360PendingCategoryTransactions', () => {
+  describe('selectVAPServicePendingCategoryTransactions', () => {
     beforeEach(hooks.beforeEach);
     it('selects transactions of the passed transaction category type that is still pending and without field-level data', () => {
       const type = TRANSACTION_CATEGORY_TYPES.ADDRESS;

--- a/src/platform/user/tests/profile/utilities/index.unit.spec.js
+++ b/src/platform/user/tests/profile/utilities/index.unit.spec.js
@@ -67,7 +67,7 @@ let oldLocation;
 
 describe('Profile utilities', () => {
   describe('mapRawUserDataToState', () => {
-    // This url change is to work around the Vet 360 data mocking
+    // This url change is to work around the VA Profile Service data mocking
     beforeEach(() => {
       oldLocation = document.location.href;
       global.dom.reconfigure({ url: 'https://www.va.gov' });


### PR DESCRIPTION
## Description
This PR is the ninth in a handful to remove mentions of vet360 from our frontend code.

This PR is focused on:
- Renaming remaining Vet360 components

[PR 1 renamed the `vet360` folder to `vap-svc`](https://github.com/department-of-veterans-affairs/vets-website/pull/14798)
[PR 2 renamed the `vet360` Babel alias to `@@vap-svc`](https://github.com/department-of-veterans-affairs/vets-website/pull/14811)
[PR 3 renamed the `isVet360Configured` helper to `isVAProfileServiceConfigured`](https://github.com/department-of-veterans-affairs/vets-website/pull/14834)
[PR 4 renamed Redux's `profile.vet360` data to `profile.vapContactInfo`](https://github.com/department-of-veterans-affairs/vets-website/issues/14866)
[PR 5 renamed some `VET360` constants, actions and selectors](https://github.com/department-of-veterans-affairs/vets-website/pull/14888)
[PR 6 renamed more `VET360` constants to `VAP_SERVICE`](https://github.com/department-of-veterans-affairs/vets-website/pull/14899)
[PR 7 renamed some contact information selectors](https://github.com/department-of-veterans-affairs/vets-website/pull/14912)
[PR 8 renamed the top-level `vet360` slice in Redux to `vapService`](https://github.com/department-of-veterans-affairs/vets-website/pull/14917)

## Testing done
Local + existing tests

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs