### PR TITLE
rename Vet360 constants

### DIFF
--- a/src/applications/disability-benefits/996/config/form.js
+++ b/src/applications/disability-benefits/996/config/form.js
@@ -35,7 +35,7 @@ const formConfig = {
   downtime: {
     requiredForPrefill: true,
     dependencies: [
-      services.vet360,
+      services.vaProfile,
       services.bgs,
       services.mvi,
       services.appeals,

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -136,7 +136,12 @@ const formConfig = {
   trackingPrefix: 'disability-526EZ-',
   downtime: {
     requiredForPrefill: true,
-    dependencies: [services.evss, services.emis, services.mvi, services.vet360],
+    dependencies: [
+      services.evss,
+      services.emis,
+      services.mvi,
+      services.vaProfile,
+    ],
   },
   formId: VA_FORM_IDS.FORM_21_526EZ,
   saveInProgress: {

--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -194,7 +194,7 @@ class Profile extends Component {
             externalServices.emis,
             externalServices.evss,
             externalServices.mvi,
-            externalServices.vet360,
+            externalServices.vaProfile,
           ]}
         >
           {this.renderContent()}

--- a/src/applications/personalization/profile/components/personal-information/PersonalInformation.jsx
+++ b/src/applications/personalization/profile/components/personal-information/PersonalInformation.jsx
@@ -69,7 +69,7 @@ const PersonalInformation = ({
       </h2>
       <DowntimeNotification
         render={handleDowntimeForSection('personal and contact')}
-        dependencies={[externalServices.mvi, externalServices.vet360]}
+        dependencies={[externalServices.mvi, externalServices.vaProfile]}
       >
         {showDirectDepositBlockedError && <PaymentInformationBlocked />}
         <PersonalInformationContent />

--- a/src/platform/monitoring/DowntimeNotification/config/externalServices.js
+++ b/src/platform/monitoring/DowntimeNotification/config/externalServices.js
@@ -26,8 +26,8 @@ export default {
   vic: 'vic',
   // Intake, conversion, and mail handling services (central mail)
   icmhs: 'icmhs',
-  // Vet360 - data source for centralized veteran contact information
-  vet360: 'vet360',
+  // VA Profile (formerly Vet360) - data source for centralized veteran contact information
+  vaProfile: 'vet360',
   // Search.gov API
   search: 'search',
   // Online appointment scheduling

--- a/src/platform/monitoring/external-services/config.js
+++ b/src/platform/monitoring/external-services/config.js
@@ -25,8 +25,8 @@ export const EXTERNAL_SERVICES = {
   ssoe: 'ssoe',
   // The Image Management System (education forms)
   tims: 'tims',
-  // Vet360 - data source for centralized veteran contact information
-  vet360: 'vet360',
+  // VA Profile (formerly Vet360) - data source for centralized veteran contact information
+  vaProfile: 'vet360',
   // Veteran ID Card v1
   vic: 'vic',
 };

--- a/src/platform/user/profile/constants/backendServices.js
+++ b/src/platform/user/profile/constants/backendServices.js
@@ -12,7 +12,7 @@ export default {
   USER_PROFILE: 'user-profile',
   ID_CARD: 'id-card',
   IDENTITY_PROOFED: 'identity-proofed',
-  VET360: 'vet360',
+  VA_PROFILE: 'vet360',
 
   // MHV services
   RX: 'rx',

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -23,7 +23,7 @@ import {
 const commonServices = {
   EMIS: 'EMIS',
   MVI: 'MVI',
-  Vet360: 'Vet360',
+  VA_PROFILE: 'Vet360',
 };
 
 function getErrorStatusDesc(code) {
@@ -118,7 +118,7 @@ export function mapRawUserDataToState(json) {
   // easier to leave the mocking code the way it is
   if (meta && userState.vapContactInfo === null) {
     const errorStatus = meta.errors.find(
-      error => error.externalService === commonServices.Vet360,
+      error => error.externalService === commonServices.VA_PROFILE,
     ).status;
     userState.vapContactInfo = { status: getErrorStatusDesc(errorStatus) };
   }

--- a/src/platform/user/profile/vap-svc/selectors.js
+++ b/src/platform/user/profile/vap-svc/selectors.js
@@ -15,7 +15,7 @@ import { isFailedTransaction, isPendingTransaction } from './util/transactions';
 
 export function selectIsVAProfileServiceAvailableForUser(state) {
   if (!isVAProfileServiceConfigured()) return true; // returns true if on localhost
-  return selectAvailableServices(state).includes(backendServices.VET360);
+  return selectAvailableServices(state).includes(backendServices.VA_PROFILE);
 }
 
 export function selectVAPContactInfoField(state, fieldName) {

--- a/src/platform/user/profile/vap-svc/tests/selectors.unit.spec.js
+++ b/src/platform/user/profile/vap-svc/tests/selectors.unit.spec.js
@@ -16,7 +16,7 @@ const hooks = {
   beforeEach() {
     const user = {
       profile: {
-        services: [backendServices.VET360],
+        services: [backendServices.VA_PROFILE],
         vapContactInfo: {},
       },
     };


### PR DESCRIPTION
## Description
This PR is the tenth (and almost certainly final!) PR to remove mentions of vet360 from our frontend code.

This PR is focused on:
- Renaming remaining Vet360 constants

[PR 1 renamed the `vet360` folder to `vap-svc`](https://github.com/department-of-veterans-affairs/vets-website/pull/14798)
[PR 2 renamed the `vet360` Babel alias to `@@vap-svc`](https://github.com/department-of-veterans-affairs/vets-website/pull/14811)
[PR 3 renamed the `isVet360Configured` helper to `isVAProfileServiceConfigured`](https://github.com/department-of-veterans-affairs/vets-website/pull/14834)
[PR 4 renamed Redux's `profile.vet360` data to `profile.vapContactInfo`](https://github.com/department-of-veterans-affairs/vets-website/issues/14866)
[PR 5 renamed some `VET360` constants, actions and selectors](https://github.com/department-of-veterans-affairs/vets-website/pull/14888)
[PR 6 renamed more `VET360` constants to `VAP_SERVICE`](https://github.com/department-of-veterans-affairs/vets-website/pull/14899)
[PR 7 renamed some contact information selectors](https://github.com/department-of-veterans-affairs/vets-website/pull/14912)
[PR 8 renamed the top-level `vet360` slice in Redux to `vapService`](https://github.com/department-of-veterans-affairs/vets-website/pull/14917)
[PR 9 renamed remaining Vet360 components](https://github.com/department-of-veterans-affairs/vets-website/pull/14929)

## Testing done
Local + existing tests

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs