### PR TITLE
remove dashboardShowCovid19Alert feature flag

### DIFF
--- a/src/applications/caregivers/tests/e2e/fixtures/mocks/feature-toggles.json
+++ b/src/applications/caregivers/tests/e2e/fixtures/mocks/feature-toggles.json
@@ -7,10 +7,6 @@
         "value": true
       },
       {
-        "name": "dashboardShowCovid19Alert",
-        "value": true
-      },
-      {
         "name": "facilityLocatorShowCommunityCares",
         "value": true
       },

--- a/src/applications/debt-letters/tests/e2e/fixtures/mocks/feature-toggles.json
+++ b/src/applications/debt-letters/tests/e2e/fixtures/mocks/feature-toggles.json
@@ -3,7 +3,6 @@
     "type": "feature_toggles",
     "features": [
       { "name": "preEntryCovid19Screener", "value": true },
-      { "name": "dashboardShowCovid19Alert", "value": true },
       { "name": "facilityLocatorShowCommunityCares", "value": true },
       { "name": "facilitiesPpmsSuppressPharmacies", "value": false },
       { "name": "facilitiesPpmsSuppressCommunityCare", "value": true },

--- a/src/applications/gi/tests/data/feature-toggles.json
+++ b/src/applications/gi/tests/data/feature-toggles.json
@@ -3,10 +3,6 @@
     "type": "feature_toggles",
     "features": [
       {
-        "name": "dashboardShowCovid19Alert",
-        "value": true
-      },
-      {
         "name": "facilityLocatorShowCommunityCares",
         "value": true
       },

--- a/src/applications/healthcare/questionnaire/tests/e2e/fixtures/mocks/feature-toggles.disabled.json
+++ b/src/applications/healthcare/questionnaire/tests/e2e/fixtures/mocks/feature-toggles.disabled.json
@@ -7,10 +7,6 @@
            "value":true
         },
         {
-           "name":"dashboardShowCovid19Alert",
-           "value":true
-        },
-        {
            "name":"facilityLocatorShowCommunityCares",
            "value":true
         },

--- a/src/applications/healthcare/questionnaire/tests/e2e/fixtures/mocks/feature-toggles.enabled.json
+++ b/src/applications/healthcare/questionnaire/tests/e2e/fixtures/mocks/feature-toggles.enabled.json
@@ -7,10 +7,6 @@
            "value":true
         },
         {
-           "name":"dashboardShowCovid19Alert",
-           "value":true
-        },
-        {
            "name":"facilityLocatorShowCommunityCares",
            "value":true
         },

--- a/src/applications/personalization/dashboard/containers/DashboardApp.jsx
+++ b/src/applications/personalization/dashboard/containers/DashboardApp.jsx
@@ -20,11 +20,7 @@ import { getEnrollmentStatus as getEnrollmentStatusAction } from 'applications/h
 import { hasServerError as hasESRServerError } from 'applications/hca/selectors';
 
 import { recordDashboardClick } from '../helpers';
-import {
-  COVID19Alert,
-  eligibleHealthSystems,
-  showCOVID19AlertSelector,
-} from '../covid-19';
+import { COVID19Alert, eligibleHealthSystems } from '../covid-19';
 
 import YourApplications from './YourApplications';
 import ManageYourVAHealthCare from '../components/ManageYourVAHealthCare';
@@ -368,8 +364,7 @@ export const mapStateToProps = state => {
     ? eligibleFacilities[0].facilityId
     : null;
 
-  const showCOVID19Alert =
-    !!showCOVID19AlertSelector(state) && !!vaHealthChatEligibleSystemId;
+  const showCOVID19Alert = !!vaHealthChatEligibleSystemId;
 
   return {
     canAccessRx,

--- a/src/applications/personalization/dashboard/covid-19.jsx
+++ b/src/applications/personalization/dashboard/covid-19.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import recordEvent from 'platform/monitoring/record-event';
 
 /*
@@ -195,6 +193,3 @@ export const COVID19Alert = ({ facilityId }) => (
     </p>
   </AlertBox>
 );
-
-export const showCOVID19AlertSelector = state =>
-  toggleValues(state)[FEATURE_FLAG_NAMES.dashboardShowCovid19Alert];

--- a/src/applications/personalization/dashboard/tests/containers/DashboardApp.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/containers/DashboardApp.unit.spec.jsx
@@ -115,9 +115,6 @@ describe('<DashboardApp>', () => {
 
 describe('mapStateToProps', () => {
   const defaultState = () => ({
-    featureToggles: {
-      dashboardShowCovid19Alert: true,
-    },
     hcaEnrollmentStatus: {},
     user: {
       profile: {

--- a/src/applications/personalization/dashboard/tests/covid-19.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/covid-19.unit.spec.jsx
@@ -2,21 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
 
-import { COVID19Alert, showCOVID19AlertSelector } from '../covid-19';
-
-describe('showCOVID19AlertSelector', () => {
-  it('returns true if the feature flag is on', () => {
-    const state = {
-      featureToggles: {
-        dashboardShowCovid19Alert: true,
-      },
-    };
-    expect(showCOVID19AlertSelector(state)).to.be.true;
-  });
-  it('does not return true if the feature flag is not set', () => {
-    expect(showCOVID19AlertSelector({})).to.not.be.true;
-  });
-});
+import { COVID19Alert } from '../covid-19';
 
 describe('COVID19Alert component', () => {
   it('renders', () => {

--- a/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/disabled.json
+++ b/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/disabled.json
@@ -7,10 +7,6 @@
         "value": false
       },
       {
-        "name": "dashboardShowCovid19Alert",
-        "value": false
-      },
-      {
         "name": "facilityLocatorShowCommunityCares",
         "value": false
       },

--- a/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/enabled.json
+++ b/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/enabled.json
@@ -7,10 +7,6 @@
         "value": true
       },
       {
-        "name": "dashboardShowCovid19Alert",
-        "value": true
-      },
-      {
         "name": "facilityLocatorShowCommunityCares",
         "value": true
       },

--- a/src/platform/testing/local-dev-mock-api/common.js
+++ b/src/platform/testing/local-dev-mock-api/common.js
@@ -54,7 +54,6 @@ const responses = {
     data: {
       type: 'feature_toggles',
       features: [
-        { name: 'dashboardShowCovid19Alert', value: true },
         { name: 'facilityLocatorShowCommunityCares', value: true },
         { name: 'profile_show_profile_2.0', value: false },
         { name: 'vaOnlineScheduling', value: true },

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -1,6 +1,5 @@
 export default Object.freeze({
   preEntryCovid19Screener: 'preEntryCovid19Screener',
-  dashboardShowCovid19Alert: 'dashboardShowCovid19Alert',
   dashboardShowDashboard2: 'dashboard_show_dashboard_2',
   facilityLocatorShowCommunityCares: 'facilityLocatorShowCommunityCares', // Facilities team has deprecated this flag for the frontEnd logic, there is still backend support though.
   facilitiesPpmsSuppressPharmacies: 'facilitiesPpmsSuppressPharmacies',


### PR DESCRIPTION
## Description
This PR removes all uses of the `showCOVID19AlertSelector` feature flag from the FE code.

## Testing done
Existing tests

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs