### PR TITLE
Update `reset:env` description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ for doing very specific things.
 | :--- | :--- |
 | build the production site (dev features disabled). | `NODE_ENV=production yarn build --buildtype vagovprod` |
 | fetch the latest content cache from S3 | `yarn fetch-drupal-cache` (does not require SOCKS proxy access) |
-| reset local environment (clean out node modules and runs npm install) | `yarn reset:env` |
+| reset local environment (clean out node modules, Babel cache, and runs `npm install`) | `yarn reset:env` |
 | run only the app pages on the site for local development without building content. | `yarn watch --env.scaffold` |
 | run the site for local development with automatic rebuilding of Javascript and sass **with** css sourcemaps | `yarn watch:css-sourcemaps` then visit `http://localhost:3001/`. You may also set `--env.buildtype` and `NODE_ENV` though setting `NODE_ENV` to production will make incremental builds slow. |
 | run the site for local development with automatic rebuilding of code and styles for specific **apps** | `yarn watch --env.entry disability-benefits,static-pages`. Valid application names are in each app's `manifest.json` under `entryName` |


### PR DESCRIPTION
## Description
Just a small change to point out that `reset:env` also clears the Babel cache.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs