### PR TITLE
Address flaky test by not rendering forms until Redux state is updated

### DIFF
--- a/src/applications/vaos/express-care/components/ExpressCareDetailsPage.jsx
+++ b/src/applications/vaos/express-care/components/ExpressCareDetailsPage.jsx
@@ -118,7 +118,7 @@ function ExpressCareDetailsPage({
   return (
     <div>
       <h1>{pageTitle}</h1>
-      {schema && (
+      {!!schema && (
         <SchemaForm
           name="Type of appointment"
           title="Type of appointment"

--- a/src/applications/vaos/express-care/components/ExpressCareDetailsPage.jsx
+++ b/src/applications/vaos/express-care/components/ExpressCareDetailsPage.jsx
@@ -118,55 +118,58 @@ function ExpressCareDetailsPage({
   return (
     <div>
       <h1>{pageTitle}</h1>
-      <SchemaForm
-        name="Type of appointment"
-        title="Type of appointment"
-        schema={schema || initialSchema}
-        uiSchema={uiSchema}
-        onSubmit={() => submitExpressCareRequest(history)}
-        onChange={newData => updateFormData(pageKey, uiSchema, newData)}
-        data={data}
-      >
-        <FormButtons
-          backButtonText="Back"
-          nextButtonText="Submit Express Care request"
-          pageChangeInProgress={submitStatus === FETCH_STATUS.loading}
-          disabled={submitStatus === FETCH_STATUS.failed}
-          loadingText="Submitting your Express Care request"
-          onBack={() => routeToPreviousAppointmentPage(history, pageKey)}
-        />
-        {submitStatus === FETCH_STATUS.failed && (
-          <>
-            {submitErrorReason === EXPRESS_CARE_ERROR_REASON.error && (
-              <AlertBox
-                status="error"
-                headline="Your request didn’t go through"
-                content={
-                  <p>
-                    Something went wrong when we tried to submit your request
-                    and you’ll need to start over. We suggest you wait a day to
-                    try again or you can call your medical center to help with
-                    your request.
-                  </p>
-                }
-              />
-            )}
-            {submitErrorReason ===
-              EXPRESS_CARE_ERROR_REASON.noActiveFacility && (
-              <AlertBox
-                status="error"
-                headline="Express Care isn’t available right now"
-                content={
-                  <p>
-                    Express Care is only available {localWindowString} today. To
-                    use Express Care, check back during the time shown above.
-                  </p>
-                }
-              />
-            )}
-          </>
-        )}
-      </SchemaForm>
+      {schema && (
+        <SchemaForm
+          name="Type of appointment"
+          title="Type of appointment"
+          schema={schema}
+          uiSchema={uiSchema}
+          onSubmit={() => submitExpressCareRequest(history)}
+          onChange={newData => updateFormData(pageKey, uiSchema, newData)}
+          data={data}
+        >
+          <FormButtons
+            backButtonText="Back"
+            nextButtonText="Submit Express Care request"
+            pageChangeInProgress={submitStatus === FETCH_STATUS.loading}
+            disabled={submitStatus === FETCH_STATUS.failed}
+            loadingText="Submitting your Express Care request"
+            onBack={() => routeToPreviousAppointmentPage(history, pageKey)}
+          />
+          {submitStatus === FETCH_STATUS.failed && (
+            <>
+              {submitErrorReason === EXPRESS_CARE_ERROR_REASON.error && (
+                <AlertBox
+                  status="error"
+                  headline="Your request didn’t go through"
+                  content={
+                    <p>
+                      Something went wrong when we tried to submit your request
+                      and you’ll need to start over. We suggest you wait a day
+                      to try again or you can call your medical center to help
+                      with your request.
+                    </p>
+                  }
+                />
+              )}
+              {submitErrorReason ===
+                EXPRESS_CARE_ERROR_REASON.noActiveFacility && (
+                <AlertBox
+                  status="error"
+                  headline="Express Care isn’t available right now"
+                  content={
+                    <p>
+                      Express Care is only available {localWindowString} today.
+                      To use Express Care, check back during the time shown
+                      above.
+                    </p>
+                  }
+                />
+              )}
+            </>
+          )}
+        </SchemaForm>
+      )}
     </div>
   );
 }

--- a/src/applications/vaos/express-care/components/ExpressCareReasonPage.jsx
+++ b/src/applications/vaos/express-care/components/ExpressCareReasonPage.jsx
@@ -125,45 +125,47 @@ function ExpressCareReasonPage({
   return (
     <div>
       <h1>{pageTitle}</h1>
-      <SchemaForm
-        name="Type of appointment"
-        title="Type of appointment"
-        schema={schema || initialSchema}
-        uiSchema={uiSchema}
-        onChange={newData => updateFormData(pageKey, uiSchema, newData)}
-        onSubmit={() => routeToNextAppointmentPage(history, pageKey)}
-        data={data}
-      >
-        <AlertBox status="info" className="vads-u-margin-y--2">
-          <h2 className="vads-u-margin-top--0 vads-u-font-size--h4 vads-u-margin-bottom--1">
-            If you need a mental health appointment today
-          </h2>
-          <p className="vads-u-margin-top--0">
-            Please call your nearest VA medical center or Vet center, and ask
-            for a “same-day mental health appointment.”
-            <br />
-            <a href="/find-locations?facilityType=health&serviceType=MentalHealthCare">
-              Find a VA location
-            </a>
-          </p>
-          <h2 className="vads-u-font-size--h4 vads-u-margin-bottom--1">
-            If your health concern isn’t listed here
-          </h2>
-          <p className="vads-u-margin-top--0">
-            Please use our{' '}
-            <Link id="new-appointment" to="/new-appointment">
-              appointments tool
-            </Link>{' '}
-            to schedule an appointment.
-          </p>
-        </AlertBox>
-        <FormButtons
-          backButtonText="Back"
-          nextButtonText="Continue"
-          pageChangeInProgress={pageChangeInProgress}
-          onBack={() => routeToPreviousAppointmentPage(history, pageKey)}
-        />
-      </SchemaForm>
+      {!!schema && (
+        <SchemaForm
+          name="Type of appointment"
+          title="Type of appointment"
+          schema={schema}
+          uiSchema={uiSchema}
+          onChange={newData => updateFormData(pageKey, uiSchema, newData)}
+          onSubmit={() => routeToNextAppointmentPage(history, pageKey)}
+          data={data}
+        >
+          <AlertBox status="info" className="vads-u-margin-y--2">
+            <h2 className="vads-u-margin-top--0 vads-u-font-size--h4 vads-u-margin-bottom--1">
+              If you need a mental health appointment today
+            </h2>
+            <p className="vads-u-margin-top--0">
+              Please call your nearest VA medical center or Vet center, and ask
+              for a “same-day mental health appointment.”
+              <br />
+              <a href="/find-locations?facilityType=health&serviceType=MentalHealthCare">
+                Find a VA location
+              </a>
+            </p>
+            <h2 className="vads-u-font-size--h4 vads-u-margin-bottom--1">
+              If your health concern isn’t listed here
+            </h2>
+            <p className="vads-u-margin-top--0">
+              Please use our{' '}
+              <Link id="new-appointment" to="/new-appointment">
+                appointments tool
+              </Link>{' '}
+              to schedule an appointment.
+            </p>
+          </AlertBox>
+          <FormButtons
+            backButtonText="Back"
+            nextButtonText="Continue"
+            pageChangeInProgress={pageChangeInProgress}
+            onBack={() => routeToPreviousAppointmentPage(history, pageKey)}
+          />
+        </SchemaForm>
+      )}
     </div>
   );
 }
@@ -177,7 +179,7 @@ const mapDispatchToProps = {
 };
 
 function mapStateToProps(state) {
-  return getExpressCareFormPageInfo(state);
+  return getExpressCareFormPageInfo(state, pageKey);
 }
 
 export default connect(

--- a/src/applications/vaos/new-appointment/components/ContactInfoPage.jsx
+++ b/src/applications/vaos/new-appointment/components/ContactInfoPage.jsx
@@ -112,22 +112,23 @@ export function ContactInfoPage({
   return (
     <div>
       <h1 className="vads-u-font-size--h2">{pageTitle}</h1>
-
-      <SchemaForm
-        name="Contact info"
-        title="Contact info"
-        schema={schema || initialSchema}
-        uiSchema={uiSchema}
-        onSubmit={() => routeToNextAppointmentPage(history, pageKey)}
-        onChange={newData => updateFormData(pageKey, uiSchema, newData)}
-        data={data}
-      >
-        <FormButtons
-          onBack={() => routeToPreviousAppointmentPage(history, pageKey)}
-          pageChangeInProgress={pageChangeInProgress}
-          loadingText="Page change in progress"
-        />
-      </SchemaForm>
+      {!!schema && (
+        <SchemaForm
+          name="Contact info"
+          title="Contact info"
+          schema={schema}
+          uiSchema={uiSchema}
+          onSubmit={() => routeToNextAppointmentPage(history, pageKey)}
+          onChange={newData => updateFormData(pageKey, uiSchema, newData)}
+          data={data}
+        >
+          <FormButtons
+            onBack={() => routeToPreviousAppointmentPage(history, pageKey)}
+            pageChangeInProgress={pageChangeInProgress}
+            loadingText="Page change in progress"
+          />
+        </SchemaForm>
+      )}
     </div>
   );
 }

--- a/src/applications/vaos/new-appointment/components/PreferredDatePage.jsx
+++ b/src/applications/vaos/new-appointment/components/PreferredDatePage.jsx
@@ -63,28 +63,30 @@ function PreferredDatePage({
   return (
     <div>
       <h1 className="vads-u-font-size--h2">{pageTitle}</h1>
-      <SchemaForm
-        name="Type of appointment"
-        title="Type of appointment"
-        schema={schema || initialSchema}
-        uiSchema={uiSchema}
-        onSubmit={() => routeToNextAppointmentPage(history, pageKey)}
-        onChange={newData => updateFormData(pageKey, uiSchema, newData)}
-        data={data}
-      >
-        <div className="vads-u-margin-bottom--2p5 vads-u-margin-top--neg2">
-          <AdditionalInfo triggerText="Why are you asking me this?">
-            Tell us the earliest day you’re available and we'll try find the
-            date closest to your request. Please note that we might not be able
-            to find an appointment for that particular day.
-          </AdditionalInfo>
-        </div>
-        <FormButtons
-          onBack={() => routeToPreviousAppointmentPage(history, pageKey)}
-          pageChangeInProgress={pageChangeInProgress}
-          loadingText="Page change in progress"
-        />
-      </SchemaForm>
+      {!!schema && (
+        <SchemaForm
+          name="Type of appointment"
+          title="Type of appointment"
+          schema={schema}
+          uiSchema={uiSchema}
+          onSubmit={() => routeToNextAppointmentPage(history, pageKey)}
+          onChange={newData => updateFormData(pageKey, uiSchema, newData)}
+          data={data}
+        >
+          <div className="vads-u-margin-bottom--2p5 vads-u-margin-top--neg2">
+            <AdditionalInfo triggerText="Why are you asking me this?">
+              Tell us the earliest day you’re available and we'll try find the
+              date closest to your request. Please note that we might not be
+              able to find an appointment for that particular day.
+            </AdditionalInfo>
+          </div>
+          <FormButtons
+            onBack={() => routeToPreviousAppointmentPage(history, pageKey)}
+            pageChangeInProgress={pageChangeInProgress}
+            loadingText="Page change in progress"
+          />
+        </SchemaForm>
+      )}
     </div>
   );
 }

--- a/src/applications/vaos/new-appointment/components/ReasonForAppointmentPage.jsx
+++ b/src/applications/vaos/new-appointment/components/ReasonForAppointmentPage.jsx
@@ -94,51 +94,53 @@ function ReasonForAppointmentPage({
   return (
     <div>
       <h1 className="vads-u-font-size--h2">{pageTitle}</h1>
-      <SchemaForm
-        name="Reason for appointment"
-        title="Reason for appointment"
-        schema={schema || pageInitialSchema}
-        uiSchema={pageUISchema}
-        onSubmit={() => routeToNextAppointmentPage(history, pageKey)}
-        onChange={newData =>
-          updateReasonForAppointmentData(pageKey, pageUISchema, newData)
-        }
-        data={data}
-      >
-        <AlertBox
-          status="warning"
-          headline="If you have an urgent medical need, please:"
-          className="vads-u-margin-y--3"
-          content={
-            <ul>
-              <li>
-                Call <a href="tel:911">911</a>,{' '}
-                <span className="vads-u-font-weight--bold">or</span>
-              </li>
-              <li>
-                Call the Veterans Crisis hotline at{' '}
-                <a href="tel:8002738255">800-273-8255</a> and press 1,{' '}
-                <span className="vads-u-font-weight--bold">or</span>
-              </li>
-              <li>
-                Go to your nearest emergency room or VA medical center.{' '}
-                <a
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  href="/find-locations"
-                >
-                  Find your nearest VA medical center
-                </a>
-              </li>
-            </ul>
+      {!!schema && (
+        <SchemaForm
+          name="Reason for appointment"
+          title="Reason for appointment"
+          schema={schema}
+          uiSchema={pageUISchema}
+          onSubmit={() => routeToNextAppointmentPage(history, pageKey)}
+          onChange={newData =>
+            updateReasonForAppointmentData(pageKey, pageUISchema, newData)
           }
-        />
-        <FormButtons
-          onBack={() => routeToPreviousAppointmentPage(history, pageKey)}
-          pageChangeInProgress={pageChangeInProgress}
-          loadingText="Page change in progress"
-        />
-      </SchemaForm>
+          data={data}
+        >
+          <AlertBox
+            status="warning"
+            headline="If you have an urgent medical need, please:"
+            className="vads-u-margin-y--3"
+            content={
+              <ul>
+                <li>
+                  Call <a href="tel:911">911</a>,{' '}
+                  <span className="vads-u-font-weight--bold">or</span>
+                </li>
+                <li>
+                  Call the Veterans Crisis hotline at{' '}
+                  <a href="tel:8002738255">800-273-8255</a> and press 1,{' '}
+                  <span className="vads-u-font-weight--bold">or</span>
+                </li>
+                <li>
+                  Go to your nearest emergency room or VA medical center.{' '}
+                  <a
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href="/find-locations"
+                  >
+                    Find your nearest VA medical center
+                  </a>
+                </li>
+              </ul>
+            }
+          />
+          <FormButtons
+            onBack={() => routeToPreviousAppointmentPage(history, pageKey)}
+            pageChangeInProgress={pageChangeInProgress}
+            loadingText="Page change in progress"
+          />
+        </SchemaForm>
+      )}
     </div>
   );
 }

--- a/src/applications/vaos/new-appointment/components/TypeOfAudiologyCarePage.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfAudiologyCarePage.jsx
@@ -78,21 +78,23 @@ function TypeOfAudiologyCarePage({
       <h1 className="vads-u-font-size--h2">
         Choose the type of audiology care you need
       </h1>
-      <SchemaForm
-        name="Type of appointment"
-        title="Type of appointment"
-        schema={schema || initialSchema}
-        uiSchema={uiSchema}
-        onSubmit={() => routeToNextAppointmentPage(history, pageKey)}
-        onChange={newData => updateFormData(pageKey, uiSchema, newData)}
-        data={data}
-      >
-        <FormButtons
-          onBack={() => routeToPreviousAppointmentPage(history, pageKey)}
-          pageChangeInProgress={pageChangeInProgress}
-          loadingText="Page change in progress"
-        />
-      </SchemaForm>
+      {!!schema && (
+        <SchemaForm
+          name="Type of appointment"
+          title="Type of appointment"
+          schema={schema}
+          uiSchema={uiSchema}
+          onSubmit={() => routeToNextAppointmentPage(history, pageKey)}
+          onChange={newData => updateFormData(pageKey, uiSchema, newData)}
+          data={data}
+        >
+          <FormButtons
+            onBack={() => routeToPreviousAppointmentPage(history, pageKey)}
+            pageChangeInProgress={pageChangeInProgress}
+            loadingText="Page change in progress"
+          />
+        </SchemaForm>
+      )}
     </div>
   );
 }

--- a/src/applications/vaos/new-appointment/components/TypeOfEyeCarePage.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfEyeCarePage.jsx
@@ -77,21 +77,23 @@ function TypeOfEyeCarePage({
   return (
     <div className="vaos-form__detailed-radio">
       <h1 className="vads-u-font-size--h2">{pageTitle}</h1>
-      <SchemaForm
-        name="Type of eye care"
-        title="Type of eye care"
-        schema={schema || initialSchema}
-        uiSchema={uiSchema}
-        onSubmit={() => routeToNextAppointmentPage(history, pageKey)}
-        onChange={newData => updateFormData(pageKey, uiSchema, newData)}
-        data={data}
-      >
-        <FormButtons
-          onBack={() => routeToPreviousAppointmentPage(history, pageKey)}
-          pageChangeInProgress={pageChangeInProgress}
-          loadingText="Page change in progress"
-        />
-      </SchemaForm>
+      {!!schema && (
+        <SchemaForm
+          name="Type of eye care"
+          title="Type of eye care"
+          schema={schema}
+          uiSchema={uiSchema}
+          onSubmit={() => routeToNextAppointmentPage(history, pageKey)}
+          onChange={newData => updateFormData(pageKey, uiSchema, newData)}
+          data={data}
+        >
+          <FormButtons
+            onBack={() => routeToPreviousAppointmentPage(history, pageKey)}
+            pageChangeInProgress={pageChangeInProgress}
+            loadingText="Page change in progress"
+          />
+        </SchemaForm>
+      )}
     </div>
   );
 }

--- a/src/applications/vaos/new-appointment/components/TypeOfFacilityPage.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfFacilityPage.jsx
@@ -73,21 +73,23 @@ function TypeOfFacilityPage({
   return (
     <div className="vaos-form__facility-type vaos-form__detailed-radio">
       <h1 className="vads-u-font-size--h2">{pageTitle}</h1>
-      <SchemaForm
-        name="Type of appointment"
-        title="Type of appointment"
-        schema={schema || initialSchema}
-        uiSchema={uiSchema}
-        onSubmit={() => routeToNextAppointmentPage(history, pageKey)}
-        onChange={newData => updateFormData(pageKey, uiSchema, newData)}
-        data={data}
-      >
-        <FormButtons
-          onBack={() => routeToPreviousAppointmentPage(history, pageKey)}
-          pageChangeInProgress={pageChangeInProgress}
-          loadingText="Page change in progress"
-        />
-      </SchemaForm>
+      {!!schema && (
+        <SchemaForm
+          name="Type of appointment"
+          title="Type of appointment"
+          schema={schema}
+          uiSchema={uiSchema}
+          onSubmit={() => routeToNextAppointmentPage(history, pageKey)}
+          onChange={newData => updateFormData(pageKey, uiSchema, newData)}
+          data={data}
+        >
+          <FormButtons
+            onBack={() => routeToPreviousAppointmentPage(history, pageKey)}
+            pageChangeInProgress={pageChangeInProgress}
+            loadingText="Page change in progress"
+          />
+        </SchemaForm>
+      )}
     </div>
   );
 }

--- a/src/applications/vaos/new-appointment/components/TypeOfSleepCarePage.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfSleepCarePage.jsx
@@ -77,21 +77,23 @@ function TypeOfSleepCarePage({
   return (
     <div className="vaos-form__detailed-radio">
       <h1 className="vads-u-font-size--h2">{pageTitle}</h1>
-      <SchemaForm
-        name="Type of sleep care"
-        title="Type of sleep care"
-        schema={schema || initialSchema}
-        uiSchema={uiSchema}
-        onSubmit={() => routeToNextAppointmentPage(history, pageKey)}
-        onChange={newData => updateFormData(pageKey, uiSchema, newData)}
-        data={data}
-      >
-        <FormButtons
-          onBack={() => routeToPreviousAppointmentPage(history, pageKey)}
-          pageChangeInProgress={pageChangeInProgress}
-          loadingText="Page change in progress"
-        />
-      </SchemaForm>
+      {!!schema && (
+        <SchemaForm
+          name="Type of sleep care"
+          title="Type of sleep care"
+          schema={schema}
+          uiSchema={uiSchema}
+          onSubmit={() => routeToNextAppointmentPage(history, pageKey)}
+          onChange={newData => updateFormData(pageKey, uiSchema, newData)}
+          data={data}
+        >
+          <FormButtons
+            onBack={() => routeToPreviousAppointmentPage(history, pageKey)}
+            pageChangeInProgress={pageChangeInProgress}
+            loadingText="Page change in progress"
+          />
+        </SchemaForm>
+      )}
     </div>
   );
 }

--- a/src/applications/vaos/new-appointment/components/TypeOfVisitPage.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfVisitPage.jsx
@@ -50,21 +50,23 @@ function TypeOfVisitPage({
   return (
     <div>
       <h1 className="vads-u-font-size--h2">{pageTitle}</h1>
-      <SchemaForm
-        name="Type of visit"
-        title="Type of visit"
-        schema={schema || initialSchema}
-        uiSchema={uiSchema}
-        onSubmit={() => routeToNextAppointmentPage(history, pageKey)}
-        onChange={newData => updateFormData(pageKey, uiSchema, newData)}
-        data={data}
-      >
-        <FormButtons
-          onBack={() => routeToPreviousAppointmentPage(history, pageKey)}
-          pageChangeInProgress={pageChangeInProgress}
-          loadingText="Page change in progress"
-        />
-      </SchemaForm>
+      {!!schema && (
+        <SchemaForm
+          name="Type of visit"
+          title="Type of visit"
+          schema={schema}
+          uiSchema={uiSchema}
+          onSubmit={() => routeToNextAppointmentPage(history, pageKey)}
+          onChange={newData => updateFormData(pageKey, uiSchema, newData)}
+          data={data}
+        >
+          <FormButtons
+            onBack={() => routeToPreviousAppointmentPage(history, pageKey)}
+            pageChangeInProgress={pageChangeInProgress}
+            loadingText="Page change in progress"
+          />
+        </SchemaForm>
+      )}
     </div>
   );
 }

--- a/src/applications/vaos/tests/new-appointment/components/ContactInfoPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ContactInfoPage.unit.spec.jsx
@@ -1,106 +1,93 @@
 import React from 'react';
+import { Route } from 'react-router-dom';
 import { expect } from 'chai';
-import sinon from 'sinon';
-import { mount } from 'enzyme';
+import userEvent from '@testing-library/user-event';
 
-import { fillData } from 'platform/testing/unit/schemaform-utils.jsx';
-import { ContactInfoPage } from '../../../new-appointment/components/ContactInfoPage';
+import ContactInfoPage from '../../../new-appointment/components/ContactInfoPage';
+import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
+import { FETCH_STATUS } from '../../../utils/constants';
+import { cleanup } from 'axe-core';
 
-xdescribe('VAOS <ContactInfoPage>', () => {
-  it('should render', () => {
-    const openFormPage = sinon.spy();
-    const updateFormData = sinon.spy();
+describe('VAOS <ContactInfoPage>', () => {
+  it('should submit with valid data', async () => {
+    const store = createTestStore({
+      newAppointment: {
+        pages: [],
+        previousPages: [],
+      },
+    });
 
-    const form = mount(
-      <ContactInfoPage
-        openFormPage={openFormPage}
-        updateFormData={updateFormData}
-        data={{}}
-      />,
+    let screen = renderWithStoreAndRouter(
+      <Route component={ContactInfoPage} />,
+      {
+        store,
+      },
     );
 
-    expect(form.find('input').length).to.equal(5);
-    form.unmount();
+    // it should display page heading
+    expect(await screen.findByText('Your contact information')).to.be.ok;
+
+    let input = screen.getByLabelText(/^Your phone number/);
+    userEvent.type(input, '5555555555');
+
+    let checkbox = screen.getByLabelText(/^Morning \(8 a.m. – noon\)/);
+    userEvent.click(checkbox);
+
+    input = screen.getByLabelText(/^Your email address/);
+    userEvent.type(input, 'joe.blow@gmail.com');
+
+    const button = await screen.findByText(/^Continue/);
+
+    userEvent.click(button);
+    expect(screen.history.push.called).to.be.true;
+
+    // Expect the previously entered form data is still there if you unmount and remount the page with the same store,
+    await cleanup();
+    screen = renderWithStoreAndRouter(<Route component={ContactInfoPage} />, {
+      store,
+    });
+
+    input = await screen.findByLabelText(/^Your phone number/);
+    expect(input.value).to.equal('5555555555');
+
+    checkbox = screen.getByLabelText(/^Morning \(8 a.m. – noon\)/);
+    expect(checkbox.checked).to.be.true;
+
+    input = screen.getByLabelText(/^Your email address/);
+    expect(input.value).to.equal('joe.blow@gmail.com');
   });
 
-  it('should not submit empty form', () => {
-    const openFormPage = sinon.spy();
-    const history = {
-      push: sinon.spy(),
-    };
+  it('should not submit empty form', async () => {
+    const store = createTestStore({
+      newAppointment: {
+        data: {
+          calendarData: {},
+        },
+        eligibility: [],
+        pages: [],
+        previousPages: [],
+        appointmentSlotsStatus: FETCH_STATUS.succeeded,
+      },
+    });
 
-    const form = mount(
-      <ContactInfoPage
-        openFormPage={openFormPage}
-        history={history}
-        data={{}}
-      />,
+    const screen = renderWithStoreAndRouter(
+      <Route component={ContactInfoPage} />,
+      {
+        store,
+      },
     );
 
-    form.find('form').simulate('submit');
+    // it should display page heading
+    expect(await screen.findByText('Your contact information')).to.be.ok;
 
-    expect(form.find('.usa-input-error').length).to.equal(3);
-    expect(history.push.called).to.be.false;
-    form.unmount();
-  });
+    const button = screen.getByText(/^Continue/);
+    userEvent.click(button);
 
-  it('should call updateFormData after change', () => {
-    const openFormPage = sinon.spy();
-    const updateFormData = sinon.spy();
-    const history = {
-      push: sinon.spy(),
-    };
+    expect(await screen.findByText(/^Please enter a phone number/)).to.be.ok;
+    expect(screen.getByText(/^Please choose at least one option/)).to.be.ok;
+    expect(screen.getByText(/^Please provide a response/)).to.be.ok;
 
-    const form = mount(
-      <ContactInfoPage
-        openFormPage={openFormPage}
-        updateFormData={updateFormData}
-        history={history}
-        data={{}}
-      />,
-    );
-
-    fillData(form, 'input#root_phoneNumber', '5555555555');
-
-    expect(updateFormData.firstCall.args[2].phoneNumber).to.equal('5555555555');
-    form.unmount();
-  });
-
-  it('should submit with valid data', () => {
-    const openFormPage = sinon.spy();
-    const routeToNextAppointmentPage = sinon.spy();
-
-    const form = mount(
-      <ContactInfoPage
-        openFormPage={openFormPage}
-        routeToNextAppointmentPage={routeToNextAppointmentPage}
-        data={{
-          phoneNumber: '5555555555',
-          email: 'fake@va.gov',
-          bestTimeToCall: {
-            morning: true,
-          },
-        }}
-      />,
-    );
-
-    form.find('form').simulate('submit');
-
-    expect(form.find('.usa-input-error').length).to.equal(0);
-    expect(routeToNextAppointmentPage.called).to.be.true;
-    form.unmount();
-  });
-
-  it('document title should match h1 text', () => {
-    const openFormPage = sinon.spy();
-    const pageTitle = 'Your contact information';
-
-    const form = mount(
-      <ContactInfoPage openFormPage={openFormPage} data={{}} />,
-    );
-
-    expect(form.find('h1').text()).to.equal(pageTitle);
-    expect(document.title).contain(pageTitle);
-    form.unmount();
+    userEvent.click(button);
+    expect(screen.history.push.called).to.be.false;
   });
 });

--- a/src/applications/vaos/tests/new-appointment/components/ContactInfoPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ContactInfoPage.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import { fillData } from 'platform/testing/unit/schemaform-utils.jsx';
 import { ContactInfoPage } from '../../../new-appointment/components/ContactInfoPage';
 
-describe('VAOS <ContactInfoPage>', () => {
+xdescribe('VAOS <ContactInfoPage>', () => {
   it('should render', () => {
     const openFormPage = sinon.spy();
     const updateFormData = sinon.spy();

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfAudiologyCare.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfAudiologyCare.unit.spec.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
 import { expect } from 'chai';
-import { fireEvent, waitFor } from '@testing-library/dom';
+import { waitFor } from '@testing-library/dom';
+import userEvent from '@testing-library/user-event';
 import { cleanup } from '@testing-library/react';
 
 import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
@@ -40,13 +41,13 @@ describe('VAOS <TypeOfAudiologyCarePage>', () => {
     );
 
     expect(screen.getAllByRole('radio').length).to.equal(2);
-    fireEvent.click(screen.getByText(/Continue/));
+    userEvent.click(screen.getByText(/Continue/));
 
     expect(await screen.findByText('Please provide a response')).to.exist;
     expect(screen.history.push.called).to.not.be.true;
 
-    fireEvent.click(await screen.findByLabelText(/hearing aid/i));
-    fireEvent.click(screen.getByText(/Continue/));
+    userEvent.click(await screen.findByLabelText(/hearing aid/i));
+    userEvent.click(screen.getByText(/Continue/));
     await waitFor(() =>
       expect(screen.history.push.lastCall?.args[0]).to.equal(
         '/new-appointment/request-date',
@@ -61,7 +62,10 @@ describe('VAOS <TypeOfAudiologyCarePage>', () => {
       { store },
     );
 
-    fireEvent.click(await screen.findByLabelText(/routine hearing/i));
+    userEvent.click(await screen.findByLabelText(/routine hearing/i));
+    await waitFor(() => {
+      expect(screen.getByLabelText(/routine hearing/i).checked).to.be.true;
+    });
     await cleanup();
 
     screen = renderWithStoreAndRouter(

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfCarePage.unit.spec.jsx
@@ -74,6 +74,9 @@ describe('VAOS <TypeOfCarePage>', () => {
     );
 
     fireEvent.click(await screen.findByLabelText(/primary care/i));
+    await waitFor(() => {
+      expect(screen.getByLabelText(/primary care/i).checked).to.be.true;
+    });
     fireEvent.click(screen.getByText(/Continue/));
     await waitFor(() =>
       expect(screen.history.push.lastCall.args[0]).to.equal(

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfEyeCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfEyeCarePage.unit.spec.jsx
@@ -52,6 +52,9 @@ describe('VAOS <TypeOfEyeCarePage>', () => {
     expect(screen.history.push.called).to.not.be.true;
 
     fireEvent.click(await screen.findByLabelText(/ophthalmology/i));
+    await waitFor(() => {
+      expect(screen.getByLabelText(/ophthalmology/i).checked).to.be.true;
+    });
     fireEvent.click(screen.getByText(/Continue/));
     await waitFor(() =>
       expect(screen.history.push.lastCall?.args[0]).to.equal(

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfFacilityPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfFacilityPage.unit.spec.jsx
@@ -62,6 +62,9 @@ describe('VAOS integration: VA facility page with a single-site user', () => {
     );
 
     fireEvent.click(await screen.findByLabelText(/Community care/i));
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Community care/i).checked).to.be.true;
+    });
     fireEvent.click(screen.getByText(/Continue/));
 
     await waitFor(() =>

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfSleepCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfSleepCarePage.unit.spec.jsx
@@ -63,6 +63,9 @@ describe('VAOS <TypeOfSleepCarePage>', () => {
     );
 
     fireEvent.click(await screen.findByLabelText(/sleep medicine/i));
+    await waitFor(() => {
+      expect(screen.getByLabelText(/sleep medicine/i).checked).to.be.true;
+    });
     await cleanup();
 
     screen = renderWithStoreAndRouter(

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfVisitPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfVisitPage.unit.spec.jsx
@@ -55,6 +55,9 @@ it('should save type of visit choice on page change', async () => {
   expect(await screen.getByLabelText(/Office visit/i)).to.exist;
 
   fireEvent.click(await screen.findByLabelText(/Office visit/i));
+  await waitFor(() => {
+    expect(screen.getByLabelText(/Office visit/i).checked).to.be.true;
+  });
   await cleanup();
 
   screen = renderWithStoreAndRouter(<Route component={TypeOfVisitPage} />, {


### PR DESCRIPTION
## Description
We have a pattern in some pages where we use the initial, unprocessed schema to render `SchemaForm` before we actually update the Redux store with it. This appears to lead in some cases to RTL rendering a form and inputing form data before the Redux store is updated. I suspect this because in the full error log where this test failure occurs in Jenkins, there's an error where the `schema` we pulled from Redux is null.

## Testing done
Unit testing

## Acceptance criteria
- [ ] Build passes, app works

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
