### PR TITLE
13827: Removal of stem_text_message_question feature flag.

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -44,7 +44,6 @@ export default Object.freeze({
   showEduBenefits1990EWizard: 'show_edu_benefits_1990e_wizard',
   showEduBenefits1990Wizard: 'show_edu_benefits_1990_wizard',
   stemSCOEmail: 'stem_sco_email',
-  stemTextMessageQuestion: 'stem_text_message_question',
   showHealthcareExperienceQuestionnaire:
     'showHealthcareExperienceQuestionnaire',
   showNewGetMedicalRecordsPage: 'show_new_get_medical_records_page',


### PR DESCRIPTION
## Description
As a developer, I need to remove the feature flag for 10203 text message question because it will not be disabled going forward.

[Originating Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/13827)

## Testing done
Testing passes locally

## Screenshots
N/A

## Acceptance criteria
- [x] The feature flag 'stem_text_message_question' is removed.
- [x] The feature flag 'stem_text_message_question' is not displayed here: https://[environment]-api.va.gov/flipper/features.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
