### PR TITLE
Fix the fieldAuthor field in the news-story transformer.

### DIFF
--- a/src/site/stages/build/process-cms-exports/transformers/node-news_story.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-news_story.js
@@ -15,7 +15,14 @@ const transform = (entity, { ancestors }) => ({
   promote: getDrupalValue(entity.promote),
   entityMetatags: createMetaTagArray(entity.metatag.value),
   entityPublished: isPublished(getDrupalValue(entity.status)),
-  fieldAuthor: entity.fieldAuthor[0] || null,
+  fieldAuthor: entity.fieldAuthor[0]
+    ? {
+        entity: {
+          title: entity.fieldAuthor[0].title,
+          fieldDescription: entity.fieldAuthor[0].fieldDescription,
+        },
+      }
+    : null,
   fieldFullStory: {
     processed: getWysiwygString(getDrupalValue(entity.fieldFullStory)),
   },


### PR DESCRIPTION
## Description
The fieldAuthor field in the news-story transformer had a boo boo.

## Testing done
Mañuel Diff

## Screenshots
See linked issue

## Acceptance criteria
- [x] No diffs in pittsburgh-health-care/stories/healing-the-wounds-of-suicide/index.html

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
