### PR TITLE
15484 ui updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -277,7 +277,7 @@
   "private": true,
   "dependencies": {
     "@department-of-veterans-affairs/formation": "6.10.1",
-    "@department-of-veterans-affairs/formation-react": "5.8.0",
+    "@department-of-veterans-affairs/formation-react": "5.9.0",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "@fortawesome/fontawesome-free": "^5.6.3",
     "@mapbox/mapbox-sdk": "^0.10.0",

--- a/src/applications/disability-benefits/view-payments/components/ViewPaymentsSidebar/ViewPaymentsSidebar.jsx
+++ b/src/applications/disability-benefits/view-payments/components/ViewPaymentsSidebar/ViewPaymentsSidebar.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 
 const ViewPaymentsSidebar = props => (
-  <div className="medium-screen:vads-u-padding-left--4">{props.children}</div>
+  <div className="large-screen:vads-u-padding-left--4 vads-u-padding--1p5 small-screen:vads-u-padding--1">
+    {props.children}
+  </div>
 );
 
 export default ViewPaymentsSidebar;

--- a/src/applications/disability-benefits/view-payments/components/ViewPaymentsSidebar/ViewPaymentsSidebarBlockStates/ViewPaymentsSidebarBlockStates.jsx
+++ b/src/applications/disability-benefits/view-payments/components/ViewPaymentsSidebar/ViewPaymentsSidebarBlockStates/ViewPaymentsSidebarBlockStates.jsx
@@ -13,7 +13,7 @@ export const firstSidebarBlock = {
         your disability compensation, pension, claims and appeal, VR&E, and VA
         health care benefits.
       </p>
-      <a href="/profile">Link to profile page</a>
+      <a href="/profile">Go to your profile</a>
     </>
   ),
 };

--- a/src/applications/disability-benefits/view-payments/components/view-payments-header/ViewPaymentsHeader.jsx
+++ b/src/applications/disability-benefits/view-payments/components/view-payments-header/ViewPaymentsHeader.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 
 const ViewPaymentsHeader = () => (
   <div>
-    <h2 className="vads-u-font-size--lg vads-u-font-weight--normal">
-      You can check the status of your VA disability, pension, and education
-      payments. You can also find information about any payments you returned.
+    <h2 className="vads-u-font-size--lg vads-u-font-weight--normal vads-u-line-height--5">
+      Check your payment history for your VA disability compensation, pension,
+      and education benefits.
     </h2>
   </div>
 );

--- a/src/applications/disability-benefits/view-payments/components/view-payments-lists/ViewPaymentsLists.jsx
+++ b/src/applications/disability-benefits/view-payments/components/view-payments-lists/ViewPaymentsLists.jsx
@@ -158,7 +158,7 @@ class ViewPaymentsLists extends Component {
             <Telephone contact={CONTACTS.VA_BENEFITS} />
             {paymentsReturnedTable}
             <h3>What if I find a check that I reported missing?</h3>
-            <p>
+            <p className="vads-u-margin-bottom--3">
               If you reported a check missing and found it later, you must
               return the original check to the U.S. Department of the Treasury
               and wait to receive your replacement check. If you endorse both

--- a/src/applications/disability-benefits/view-payments/components/view-payments-lists/ViewPaymentsLists.jsx
+++ b/src/applications/disability-benefits/view-payments/components/view-payments-lists/ViewPaymentsLists.jsx
@@ -149,13 +149,17 @@ class ViewPaymentsLists extends Component {
           <>
             <ViewPaymentsHeader />
             {paymentsReceivedTable}
-            <strong>Note:</strong> Some payment details might not be available
-            online. For example, direct-deposit payments less than $1 or check
-            payments less than $5, won’t show in your online payment history.
-            Gross (before deductions) payments and changes will show only for
-            recurring and irregular compensation payments. If you have questions
-            about payments made by VA, please call the VA Help Desk at{' '}
-            <Telephone contact={CONTACTS.VA_BENEFITS} />
+            <p>
+              <strong>Note:</strong> Some payment details might not be available
+              online. For example, direct-deposit payments less than $1 or check
+              payments less than $5, won’t show in your online payment history.
+              Gross (before deductions) payments and changes will show only for
+              recurring and irregular compensation payments.
+            </p>
+            <p>
+              If you have questions about payments made by VA, please call the
+              VA Help Desk at <Telephone contact={CONTACTS.VA_BENEFITS} />
+            </p>
             {paymentsReturnedTable}
             <h3>What if I find a check that I reported missing?</h3>
             <p className="vads-u-margin-bottom--3">

--- a/src/applications/disability-benefits/view-payments/components/view-payments-lists/helpers.js
+++ b/src/applications/disability-benefits/view-payments/components/view-payments-lists/helpers.js
@@ -5,6 +5,7 @@ export const paymentsReceivedFields = [
   {
     label: 'Date',
     value: 'payCheckDt',
+    alignRight: true,
   },
   {
     label: 'Amount',
@@ -25,6 +26,7 @@ export const paymentsReceivedFields = [
   {
     label: 'Account',
     value: 'accountNumber',
+    alignRight: true,
   },
 ];
 
@@ -44,6 +46,7 @@ export const paymentsReturnedFields = [
   {
     label: 'Check #',
     value: 'returnedCheckNumber',
+    alignRight: true,
   },
   {
     label: 'Type',

--- a/src/applications/disability-benefits/view-payments/components/view-payments-lists/helpers.js
+++ b/src/applications/disability-benefits/view-payments/components/view-payments-lists/helpers.js
@@ -30,11 +30,11 @@ export const paymentsReceivedFields = [
 
 export const paymentsReturnedFields = [
   {
-    label: 'Issue Date',
+    label: 'Issue date',
     value: 'returnedCheckIssueDt',
   },
   {
-    label: 'Cancel Date',
+    label: 'Cancel date',
     value: 'returnedCheckCancelDt',
   },
   {

--- a/src/applications/disability-benefits/view-payments/components/view-payments-lists/helpers.js
+++ b/src/applications/disability-benefits/view-payments/components/view-payments-lists/helpers.js
@@ -5,11 +5,11 @@ export const paymentsReceivedFields = [
   {
     label: 'Date',
     value: 'payCheckDt',
-    alignRight: true,
   },
   {
     label: 'Amount',
     value: 'payCheckAmount',
+    alignRight: true,
   },
   {
     label: 'Type',

--- a/src/applications/disability-benefits/view-payments/components/view-payments-lists/helpers.js
+++ b/src/applications/disability-benefits/view-payments/components/view-payments-lists/helpers.js
@@ -42,6 +42,7 @@ export const paymentsReturnedFields = [
   {
     label: 'Amount',
     value: 'returnedCheckAmount',
+    alignRight: true,
   },
   {
     label: 'Check #',

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -830,7 +830,17 @@
       "includeBreadcrumbs": true,
       "vagovprod": false,
       "layout": "page-react.html",
-      "title": "View Payments"
+      "title": "View Payments",
+      "breadcrumbs_override": [
+        {
+          "path": "va-payment-history/",
+          "name": "View your VA payment history"
+        },
+        {
+          "path": "va-payment-history/payments",
+          "name": "Your VA payments"
+        }
+      ]
     }
   },
   {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1254,16 +1254,17 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@department-of-veterans-affairs/formation-react@5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation-react/-/formation-react-5.8.0.tgz#5b37873bf8b46a7d8bec7530b798ba17db1eb39a"
-  integrity sha512-0GAqGtNHFIXHu6CstADr0CmSjxqP8cP+b/dJLLk56+0/O8eL3YJ32dJiwLjz1gKV3BGv+irByuMfUu4ce3kT8Q==
+"@department-of-veterans-affairs/formation-react@5.9.0":
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation-react/-/formation-react-5.9.0.tgz#aa9e3e6b1e8947df168fc3a1b6eccd00fa9e80a2"
+  integrity sha512-qdanv/4WTJkDkA+FR/XOgHWeOxAqWqqVYQUvnLJI7/LSD559wpPM50gp2VBEoVmAA+odtXNGmyJ94Oedy3Ajmw==
   dependencies:
     classnames "^2.2.6"
     lodash "^4.17.15"
     moment "^2.23.0"
     prop-types "^15.6.2"
     react-focus-lock "^2.4.0"
+    react-scroll "^1.7.16"
     react-transition-group "1"
 
 "@department-of-veterans-affairs/formation@6.10.1":
@@ -14898,6 +14899,14 @@ react-scroll@1.7.10:
   dependencies:
     lodash.throttle "^4.1.1"
     prop-types "^15.5.8"
+
+react-scroll@^1.7.16:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/react-scroll/-/react-scroll-1.8.1.tgz#eb4052265f1606cf60855c981ebcfed1bc3beff3"
+  integrity sha512-UAKmawFHn+c7x/DoXuHqOsQ5xwNk2Dxv7vP8Ft41K2hglPWkshcSos0tMTr8704UkFqImoUGzMTdN4vuZXoqbw==
+  dependencies:
+    lodash.throttle "^4.1.1"
+    prop-types "^15.7.2"
 
 react-tabs@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/15484)

This PR is to address a few of the UI updates on View Patments that have from the collaboration cycle. This PR is also accompanied by an update I made to the `<Table />` Component in the `formation-react` repo [here](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/503)


## Screenshots

Here are each of the changes along with screenshots of those changes
<details>
  <summary>The breadcrumb should say, "Your VA payments"</summary>
  
<img width="561" alt="Screen Shot 2020-11-12 at 1 10 21 PM" src="https://user-images.githubusercontent.com/1899695/98996872-73dfee00-24e8-11eb-9e34-87de0d26c09f.png">

</details>

<details>
  <summary>The intro text below the H1 need to have line-height increased--it's too tight.</summary>
  
<img width="679" alt="Screen Shot 2020-11-12 at 1 14 17 PM" src="https://user-images.githubusercontent.com/1899695/98997237-0b454100-24e9-11eb-886f-c4609ab7e280.png">

</details>

<details>
  <summary>Change intro text to "Check your payment history for your VA disability compensation, pension, and education benefits."</summary>
  
see the previous screenshot

</details>

<details>
  <summary>Need standard space (padding/margin) below last paragraph</summary>
  
<img width="667" alt="Screen Shot 2020-11-12 at 1 16 10 PM" src="https://user-images.githubusercontent.com/1899695/98997438-59f2db00-24e9-11eb-82cb-7259502e88fd.png">

</details>


<details>
  <summary>The line, "If you have questions about payments made by VA, please call the VA Help Desk at 800-827-1000," is its own paragraph</summary>
  
<img width="689" alt="Screen Shot 2020-11-12 at 1 17 41 PM" src="https://user-images.githubusercontent.com/1899695/98997538-7c84f400-24e9-11eb-8f8e-e8aa19c85804.png">

</details>


<details>
  <summary>Right sidebar content needs left/right margin in mobile view</summary>
  
![Screen Shot 2020-11-12 at 1 19 46 PM](https://user-images.githubusercontent.com/1899695/98997697-c241bc80-24e9-11eb-902b-2d06b8b87050.png)

</details>

<details>
  <summary>Link to profile" in sidebar should read, "Go to your profile"</summary>
  
![Screen Shot 2020-11-12 at 1 22 17 PM](https://user-images.githubusercontent.com/1899695/98997889-1fd60900-24ea-11eb-802c-e48f72994627.png)

</details>

<details>
  <summary>Right align numerical columns, e.g. Amount, Account, Check # etc</summary>
  
![Screen Shot 2020-11-12 at 1 29 05 PM](https://user-images.githubusercontent.com/1899695/98998530-21540100-24eb-11eb-8bac-5716f216be97.png)

</details>


<details>
  <summary>Sentence case these labels: "Issue date" and "Cancel date"</summary>
  
![Screen Shot 2020-11-12 at 1 41 24 PM](https://user-images.githubusercontent.com/1899695/98999521-cc18ef00-24ec-11eb-96c9-d0109350dd2c.png)


</details>

<details>
  <summary>There is no padding between the Payments table and the following paragraph when the is no pagination stepper</summary>
  
![Screen Shot 2020-11-12 at 1 42 37 PM](https://user-images.githubusercontent.com/1899695/98999629-f5397f80-24ec-11eb-900f-896c0f1434c4.png)

</details>



<details>
  <summary>Change content of "Missing check" paragraph, and right side bar content to match mockup</summary>
  
![Screen Shot 2020-11-12 at 1 44 12 PM](https://user-images.githubusercontent.com/1899695/98999798-3467d080-24ed-11eb-8e39-cc6abc0f9c79.png)

![Screen Shot 2020-11-12 at 1 44 22 PM](https://user-images.githubusercontent.com/1899695/98999812-37fb5780-24ed-11eb-837f-e62fa1811c8f.png)


</details>

## Testing done
existing unit tests pass


## Acceptance criteria
- [x] All items in the list above are addressed OR
- [x] Items that cannot be addressed are documented with a brief explanation in the comments

