### PR TITLE
[Development] Fix handling of HLR API data

### DIFF
--- a/src/applications/disability-benefits/996/actions/index.js
+++ b/src/applications/disability-benefits/996/actions/index.js
@@ -35,10 +35,15 @@ export const getContestableIssues = props => {
         dispatch({
           type: FETCH_CONTESTABLE_ISSUES_SUCCEEDED,
           response,
+          benefitType,
         }),
       )
       .catch(errors =>
-        dispatch({ type: FETCH_CONTESTABLE_ISSUES_FAILED, errors }),
+        dispatch({
+          type: FETCH_CONTESTABLE_ISSUES_FAILED,
+          errors,
+          benefitType,
+        }),
       );
   };
 };

--- a/src/applications/disability-benefits/996/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/components/IntroductionPage.jsx
@@ -12,7 +12,6 @@ import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressI
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 import { focusElement } from 'platform/utilities/ui';
 import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
-import { setData } from 'platform/forms-system/src/js/actions';
 import {
   getContestableIssues as getContestableIssuesAction,
   FETCH_CONTESTABLE_ISSUES_INIT,
@@ -52,8 +51,6 @@ export class IntroductionPage extends React.Component {
     const {
       contestableIssues = {},
       getContestableIssues,
-      form,
-      setFormData,
       allowHlr,
     } = this.props;
     const wizardComplete = this.state.status === WIZARD_STATUS_COMPLETE;
@@ -61,15 +58,6 @@ export class IntroductionPage extends React.Component {
       const benefitType = sessionStorage.getItem(SAVED_CLAIM_TYPE);
       if (!contestableIssues?.status) {
         getContestableIssues({ benefitType });
-      } else if (
-        contestableIssues.status !== prevProps.contestableIssues.status &&
-        contestableIssues.issues?.length > 0
-      ) {
-        setFormData({
-          ...form.data,
-          benefitType,
-          contestedIssues: contestableIssues.issues,
-        });
       }
 
       // set focus on h1 only after wizard completes
@@ -284,7 +272,6 @@ function mapStateToProps(state) {
 
 const mapDispatchToProps = {
   toggleLoginModal,
-  setFormData: setData,
   getContestableIssues: getContestableIssuesAction,
 };
 

--- a/src/applications/disability-benefits/996/config/submit-transformer.js
+++ b/src/applications/disability-benefits/996/config/submit-transformer.js
@@ -1,4 +1,4 @@
-import { DEFAULT_BENEFIT_TYPE } from '../constants';
+import { DEFAULT_BENEFIT_TYPE, SELECTED } from '../constants';
 
 export function transform(formConfig, form) {
   // We require the user to input a 10-digit number; assuming we get a 3-digit
@@ -69,7 +69,7 @@ export function transform(formConfig, form) {
   }]
   */
   const getContestedIssues = ({ contestedIssues = [] }) =>
-    contestedIssues.filter(issue => issue['view:selected']).map(issue => {
+    contestedIssues.filter(issue => issue[SELECTED]).map(issue => {
       const attr = issue.attributes;
       const attributes = [
         'decisionIssueId',

--- a/src/applications/disability-benefits/996/constants.js
+++ b/src/applications/disability-benefits/996/constants.js
@@ -15,6 +15,8 @@ export const SUPPLEMENTAL_CLAIM_URL = '/decision-reviews/supplemental-claim/';
 export const BENEFIT_OFFICES_URL =
   '/decision-reviews/higher-level-review/#8622';
 
+export const SELECTED = 'view:selected';
+
 // Including a default until we determine how to get around the user restarting
 // the application after using the "Finish this application later" link
 // See https://dsva.slack.com/archives/C0113MPTGH5/p1600725048027200

--- a/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
@@ -9,6 +9,8 @@ import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
+import { SELECTED } from '../constants';
+
 const scroller = Scroll.scroller;
 const scrollToTop = () => {
   scroller.scrollTo('topScrollElement', {
@@ -29,7 +31,7 @@ export class ConfirmationPage extends React.Component {
     const { submission, formId } = form;
     const { response } = submission;
     const issues = (form.data?.contestedIssues || [])
-      .filter(el => el['view:selected'])
+      .filter(el => el[SELECTED])
       .map((issue, index) => (
         <li key={index} className="vads-u-margin-bottom--0">
           {issue.attributes.ratingIssueSubjectText}

--- a/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
@@ -9,7 +9,8 @@ import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
-import { SELECTED } from '../constants';
+import { WIZARD_STATUS } from 'applications/static-pages/wizard';
+import { SELECTED, SAVED_CLAIM_TYPE } from '../constants';
 
 const scroller = Scroll.scroller;
 const scrollToTop = () => {
@@ -24,6 +25,10 @@ export class ConfirmationPage extends React.Component {
   componentDidMount() {
     focusElement('.confirmation-page-title');
     scrollToTop();
+
+    // reset the wizard
+    window.sessionStorage.removeItem(WIZARD_STATUS);
+    window.sessionStorage.removeItem(SAVED_CLAIM_TYPE);
   }
 
   render() {

--- a/src/applications/disability-benefits/996/containers/SelectArrayItemsWidget.jsx
+++ b/src/applications/disability-benefits/996/containers/SelectArrayItemsWidget.jsx
@@ -3,23 +3,18 @@ import React from 'react';
 import get from 'platform/utilities/data/get';
 import set from 'platform/utilities/data/set';
 
+import { SELECTED } from '../constants';
+
 export default class SelectArrayItemsWidget extends React.Component {
   onChange = (index, checked) => {
-    const items = set(
-      `[${index}].${this.props.options.selectedPropName ||
-        this.defaultSelectedPropName}`,
-      checked,
-      this.props.value,
-    );
+    const items = set(`[${index}].${SELECTED}`, checked, this.props.value);
     this.props.onChange(items);
   };
-
-  defaultSelectedPropName = 'view:selected';
 
   render() {
     const { value: items, id, options, required, formContext } = this.props;
     // Need customTitle to set error message above title.
-    const { label: Label, selectedPropName, disabled } = options;
+    const { label: Label, disabled } = options;
 
     // inReviewMode = true (review page view, not in edit mode)
     // inReviewMode = false (in edit mode)
@@ -28,8 +23,7 @@ export default class SelectArrayItemsWidget extends React.Component {
     const customTitle = (options.customTitle || '').trim();
 
     const hasSelections = items?.reduce(
-      (result, item) =>
-        result || !!get(selectedPropName || this.defaultSelectedPropName, item),
+      (result, item) => result || !!get(SELECTED, item),
       false,
     );
 
@@ -39,12 +33,9 @@ export default class SelectArrayItemsWidget extends React.Component {
       <>
         {customTitle &&
           items && <Tag className="vads-u-font-size--h5">{customTitle}</Tag>}
-        {items.length && (!inReviewMode || (inReviewMode && hasSelections)) ? (
+        {items?.length && (!inReviewMode || (inReviewMode && hasSelections)) ? (
           items.map((item, index) => {
-            const itemIsSelected = !!get(
-              selectedPropName || this.defaultSelectedPropName,
-              item,
-            );
+            const itemIsSelected = !!get(SELECTED, item);
 
             // Don't show un-selected ratings in review mode
             if (inReviewMode && !itemIsSelected) {

--- a/src/applications/disability-benefits/996/containers/SelectArrayItemsWidget.jsx
+++ b/src/applications/disability-benefits/996/containers/SelectArrayItemsWidget.jsx
@@ -19,12 +19,13 @@ export default class SelectArrayItemsWidget extends React.Component {
   render() {
     const { value: items, id, options, required, formContext } = this.props;
     // Need customTitle to set error message above title.
-    const { label: Label, selectedPropName, disabled, customTitle } = options;
+    const { label: Label, selectedPropName, disabled } = options;
 
     // inReviewMode = true (review page view, not in edit mode)
     // inReviewMode = false (in edit mode)
     const onReviewPage = formContext.onReviewPage;
     const inReviewMode = onReviewPage && formContext.reviewMode;
+    const customTitle = (options.customTitle || '').trim();
 
     const hasSelections = items?.reduce(
       (result, item) =>
@@ -36,9 +37,9 @@ export default class SelectArrayItemsWidget extends React.Component {
 
     return (
       <>
-        {customTitle?.trim() &&
+        {customTitle &&
           items && <Tag className="vads-u-font-size--h5">{customTitle}</Tag>}
-        {items && (!inReviewMode || (inReviewMode && hasSelections)) ? (
+        {items.length && (!inReviewMode || (inReviewMode && hasSelections)) ? (
           items.map((item, index) => {
             const itemIsSelected = !!get(
               selectedPropName || this.defaultSelectedPropName,

--- a/src/applications/disability-benefits/996/content/contestedIssues.jsx
+++ b/src/applications/disability-benefits/996/content/contestedIssues.jsx
@@ -5,14 +5,22 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import { COVID_FAQ_URL, NULL_CONDITION_STRING } from '../constants';
 import DownloadLink from './DownloadLink';
 
-export const contestedIssuesTitle = (
-  <>
-    <strong>Select the issue you would like to have reviewed</strong>
-    <span className="schemaform-required-span vads-u-font-weight--normal vads-u-font-size--base">
-      (*Required)
-    </span>
-  </>
-);
+// We shouldn't ever see the couldn't find contestable issues message since we
+// prevent the user from navigating past the intro page; but it's here just in
+// case we end up filtering out deferred and expired issues
+export const ContestedIssuesTitle = props =>
+  props?.formData?.contestedIssues?.length === 0 ? (
+    <h2 className="vads-u-font-size--h4">
+      Sorry, we couldn’t find any contested issues
+    </h2>
+  ) : (
+    <>
+      <strong>Select the issue you would like to have reviewed</strong>
+      <span className="schemaform-required-span vads-u-font-weight--normal vads-u-font-size--base">
+        (*Required)
+      </span>
+    </>
+  );
 
 /**
  * @typedef {Object} Disability

--- a/src/applications/disability-benefits/996/content/veteranInformation.jsx
+++ b/src/applications/disability-benefits/996/content/veteranInformation.jsx
@@ -10,11 +10,12 @@ import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 import { srSubstitute } from '../../all-claims/utils';
+import { SELECTED } from '../constants';
 
 const mask = srSubstitute('●●●–●●–', 'ending with');
 
 export const VeteranInfoView = ({
-  formData,
+  formData = {},
   profile = {},
   veteran = {},
   setFormData,
@@ -28,7 +29,23 @@ export const VeteranInfoView = ({
   const { issues, benefitType } = contestableIssues;
 
   useEffect(() => {
-    if (formData) {
+    if (issues?.length > 0 && benefitType) {
+      // Everytime the user starts the form, we need to get an updated list of
+      // contestable issues. This bit of code ensures that exactly matching
+      // previously selected entries are still selected
+      const contestedIssues = issues.map(issue => {
+        const newAttrs = issue.attributes;
+        const existingIssue = (formData.contestedIssues || []).find(
+          ({ attributes: oldAttrs }) =>
+            ['ratingIssueReferenceId', 'ratingIssuePercentNumber'].every(
+              key => oldAttrs[key] === newAttrs[key],
+            ),
+        );
+        return existingIssue?.[SELECTED]
+          ? { ...issue, [SELECTED]: true }
+          : issue;
+      });
+
       // add benefitType (from wizard) and contestedIssues (from API) values to
       // the form; it's added here instead of the intro page because at this
       // point the prefill or save-in-progress data would overwrite it
@@ -36,7 +53,7 @@ export const VeteranInfoView = ({
         ...formData,
         // add benefitType from wizard
         benefitType: benefitType || formData.benefitType,
-        contestedIssues: issues,
+        contestedIssues,
       });
     }
   });

--- a/src/applications/disability-benefits/996/content/veteranInformation.jsx
+++ b/src/applications/disability-benefits/996/content/veteranInformation.jsx
@@ -9,7 +9,6 @@ import { selectProfile } from 'platform/user/selectors';
 import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
-import { SAVED_CLAIM_TYPE } from '../constants';
 import { srSubstitute } from '../../all-claims/utils';
 
 const mask = srSubstitute('●●●–●●–', 'ending with');
@@ -19,19 +18,26 @@ export const VeteranInfoView = ({
   profile = {},
   veteran = {},
   setFormData,
+  contestableIssues = {},
 }) => {
   const { ssnLastFour, vaFileLastFour } = veteran;
   const { dob, gender, userFullName } = profile;
 
   const { first, middle, last, suffix } = userFullName;
+  // ContestableIssues API needs a benefit type, so they are grouped together
+  const { issues, benefitType } = contestableIssues;
 
-  // benefit type is added by the wizard, but the session value will be empty
-  // if the user decides to restart the form; set in the submitTransformer
-  const benefitType = window.sessionStorage.getItem(SAVED_CLAIM_TYPE);
   useEffect(() => {
-    if (formData && benefitType) {
-      window.sessionStorage.removeItem(SAVED_CLAIM_TYPE);
-      setFormData({ ...formData, benefitType });
+    if (formData) {
+      // add benefitType (from wizard) and contestedIssues (from API) values to
+      // the form; it's added here instead of the intro page because at this
+      // point the prefill or save-in-progress data would overwrite it
+      setFormData({
+        ...formData,
+        // add benefitType from wizard
+        benefitType: benefitType || formData.benefitType,
+        contestedIssues: issues,
+      });
     }
   });
 
@@ -83,9 +89,11 @@ VeteranInfoView.propTypes = {
 const mapStateToProps = state => {
   const profile = selectProfile(state);
   const veteran = state.form?.data.veteran;
+  const { contestableIssues } = state;
   return {
     profile,
     veteran,
+    contestableIssues,
   };
 };
 

--- a/src/applications/disability-benefits/996/pages/contestedIssues.js
+++ b/src/applications/disability-benefits/996/pages/contestedIssues.js
@@ -14,6 +14,7 @@ import {
 
 import { requireRatedDisability } from '../validations';
 import SameOfficeReviewField from '../containers/SameOfficeReviewField';
+import { SELECTED } from '../constants';
 
 const hasNoContestedIssues = formData => !formData.contestedIssues?.length;
 
@@ -38,7 +39,7 @@ const contestedIssuesPage = {
       'ui:description': contestedIssuesAlert,
       'ui:options': {
         hideIf: formData =>
-          formData.contestedIssues?.some(entry => entry['view:selected']) ||
+          formData.contestedIssues?.some(entry => entry[SELECTED]) ||
           hasNoContestedIssues(formData),
       },
     },
@@ -81,7 +82,7 @@ const contestedIssuesPage = {
         items: {
           type: 'object',
           properties: {},
-          'view:selected': 'boolean',
+          [SELECTED]: 'boolean',
         },
       },
       'view:contestedIssuesAlert': {

--- a/src/applications/disability-benefits/996/pages/contestedIssues.js
+++ b/src/applications/disability-benefits/996/pages/contestedIssues.js
@@ -1,7 +1,7 @@
 import SelectArrayItemsWidget from '../containers/SelectArrayItemsWidget';
 
 import {
-  contestedIssuesTitle,
+  ContestedIssuesTitle,
   disabilityOption,
   disabilitiesExplanation,
   contestedIssuesAlert,
@@ -15,9 +15,11 @@ import {
 import { requireRatedDisability } from '../validations';
 import SameOfficeReviewField from '../containers/SameOfficeReviewField';
 
+const hasNoContestedIssues = formData => !formData.contestedIssues?.length;
+
 const contestedIssuesPage = {
   uiSchema: {
-    'ui:title': contestedIssuesTitle,
+    'ui:title': ContestedIssuesTitle,
     contestedIssues: {
       'ui:title': ' ',
       'ui:field': 'StringField',
@@ -36,7 +38,8 @@ const contestedIssuesPage = {
       'ui:description': contestedIssuesAlert,
       'ui:options': {
         hideIf: formData =>
-          formData.contestedIssues?.some(entry => entry['view:selected']),
+          formData.contestedIssues?.some(entry => entry['view:selected']) ||
+          hasNoContestedIssues(formData),
       },
     },
     'view:disabilitiesExplanation': {
@@ -49,16 +52,21 @@ const contestedIssuesPage = {
       'ui:reviewField': SameOfficeReviewField,
       'ui:options': {
         hideLabelText: true,
+        hideIf: hasNoContestedIssues,
       },
     },
     'view:sameOfficeDescription': {
       'ui:title': '',
       'ui:description': OfficeForReviewDescription,
+      'ui:options': {
+        hideIf: hasNoContestedIssues,
+      },
     },
     sameOfficeAlert: {
       'ui:title': OfficeForReviewAlert,
       'ui:options': {
-        hideIf: formData => formData?.sameOffice !== true,
+        hideIf: formData =>
+          formData?.sameOffice !== true || hasNoContestedIssues(formData),
       },
     },
   },

--- a/src/applications/disability-benefits/996/reducers/contestableIssues.js
+++ b/src/applications/disability-benefits/996/reducers/contestableIssues.js
@@ -24,6 +24,7 @@ export default function contestableIssues(state = initialState, action) {
         issues: action.response?.data || [],
         status: FETCH_CONTESTABLE_ISSUES_SUCCEEDED,
         error: '',
+        benefitType: action.benefitType,
       };
     }
     case FETCH_CONTESTABLE_ISSUES_FAILED: {
@@ -32,6 +33,7 @@ export default function contestableIssues(state = initialState, action) {
         issues: [],
         status: FETCH_CONTESTABLE_ISSUES_FAILED,
         error: action.errors,
+        benefitType: action.benefitType,
       };
     }
     default:

--- a/src/applications/disability-benefits/996/tests/actions/actions.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/actions/actions.unit.spec.js
@@ -19,24 +19,29 @@ describe('fetch contestable issues action', () => {
 
   it('should dispatch an init action', () => {
     const mockData = { data: 'asdf' };
+    const benefitType = 'compensation';
     mockApiRequest(mockData);
     const dispatch = sinon.spy();
-    return getContestableIssues()(dispatch).then(() => {
+    return getContestableIssues({ benefitType })(dispatch).then(() => {
       expect(dispatch.firstCall.args[0].type).to.equal(
         FETCH_CONTESTABLE_ISSUES_INIT,
       );
       expect(dispatch.secondCall.args[0]).to.eql({
         type: FETCH_CONTESTABLE_ISSUES_SUCCEEDED,
-        response: mockData,
+        response: {
+          ...mockData,
+        },
+        benefitType,
       });
     });
   });
 
   it('should dispatch an add person failed action', () => {
     const mockData = { data: 'asdf' };
+    const props = { benefitType: 'compensation' };
     mockApiRequest(mockData, false);
     const dispatch = sinon.spy();
-    return getContestableIssues()(dispatch).then(() => {
+    return getContestableIssues(props)(dispatch).then(() => {
       expect(dispatch.firstCall.args[0].type).to.equal(
         FETCH_CONTESTABLE_ISSUES_INIT,
       );

--- a/src/applications/disability-benefits/996/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -7,7 +7,8 @@ import formConfig from '../../config/form';
 import initialData from '../schema/initialData';
 
 import ConfirmationPage from '../../containers/ConfirmationPage';
-import { SELECTED } from '../../constants';
+import { SELECTED, SAVED_CLAIM_TYPE } from '../../constants';
+import { WIZARD_STATUS } from 'applications/static-pages/wizard';
 
 const data = {
   user: {
@@ -72,6 +73,14 @@ describe('Confirmation page', () => {
     const list = tree.find('ul').text();
     expect(list).to.contain('test 543');
     expect(list).not.to.contain('test 987');
+    tree.unmount();
+  });
+  it('should reset the wizard sessionStorage', () => {
+    sessionStorage.setItem(WIZARD_STATUS, 'foo');
+    sessionStorage.setItem(SAVED_CLAIM_TYPE, 'bar');
+    const tree = mount(<ConfirmationPage store={fakeStore} />);
+    expect(sessionStorage.getItem(WIZARD_STATUS)).to.be.null;
+    expect(sessionStorage.getItem(SAVED_CLAIM_TYPE)).to.be.null;
     tree.unmount();
   });
 });

--- a/src/applications/disability-benefits/996/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -7,6 +7,7 @@ import formConfig from '../../config/form';
 import initialData from '../schema/initialData';
 
 import ConfirmationPage from '../../containers/ConfirmationPage';
+import { SELECTED } from '../../constants';
 
 const data = {
   user: {
@@ -27,13 +28,13 @@ const data = {
       ...initialData,
       contestedIssues: [
         {
-          'view:selected': true,
+          [SELECTED]: true,
           attributes: {
             ratingIssueSubjectText: 'test 543',
           },
         },
         {
-          'view:selected': false,
+          [SELECTED]: false,
           attributes: {
             ratingIssueSubjectText: 'test 987',
           },

--- a/src/applications/disability-benefits/996/tests/content/veteranInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/content/veteranInformation.unit.spec.jsx
@@ -1,21 +1,45 @@
 import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
+import sinon from 'sinon';
 
 import { VeteranInfoView } from '../../content/veteranInformation';
-import { SAVED_CLAIM_TYPE } from '../../constants';
+import { SELECTED } from '../../constants';
 
 describe('veteranInformation', () => {
-  const form = {
-    data: {},
-  };
-  const setFormData = data => {
-    form.data = data;
-  };
-
-  it('should add benefitType in sessionStorage to formData', () => {
+  it('should add benefitType & contestedIssues to formData', () => {
+    const setFormData = sinon.spy();
     const data = {
-      formData: {},
+      formData: {
+        // issues from previous save-in-progress
+        contestedIssues: [
+          {
+            type: 'contestableIssue',
+            attributes: {
+              ratingIssueSubjectText: 'selected issue',
+              ratingIssueReferenceId: '111',
+              ratingIssuePercentNumber: 10,
+            },
+            [SELECTED]: true,
+          },
+          {
+            type: 'contestableIssue',
+            attributes: {
+              ratingIssueSubjectText: 'issue to be removed',
+              ratingIssueReferenceId: '555',
+              ratingIssuePercentNumber: 15,
+            },
+          },
+          {
+            type: 'contestableIssue',
+            attributes: {
+              ratingIssueSubjectText: 'non-selected issue',
+              ratingIssueReferenceId: '999',
+              ratingIssuePercentNumber: 20,
+            },
+          },
+        ],
+      },
       profile: {
         dob: '2000-01-01',
         gender: 'M',
@@ -28,8 +52,67 @@ describe('veteranInformation', () => {
         ssnLastFour: '9876',
         vaFileLastFour: '5432',
       },
+
+      // Content added from the API
+      contestableIssues: {
+        benefitType: 'compensation',
+        issues: [
+          {
+            type: 'contestableIssue',
+            attributes: {
+              ratingIssueSubjectText: 'should be selected issue',
+              ratingIssueReferenceId: '111',
+              ratingIssuePercentNumber: 10,
+            },
+          },
+          {
+            type: 'contestableIssue',
+            attributes: {
+              ratingIssueSubjectText: 'should be non-selected issue',
+              ratingIssueReferenceId: '999',
+              ratingIssuePercentNumber: 20,
+            },
+          },
+          {
+            type: 'contestableIssue',
+            attributes: {
+              ratingIssueSubjectText: 'new issue',
+              ratingIssueReferenceId: '333',
+              ratingIssuePercentNumber: 25,
+            },
+          },
+        ],
+      },
     };
-    window.sessionStorage.setItem(SAVED_CLAIM_TYPE, 'compensation');
+
+    const resultingIssueList = [
+      {
+        type: 'contestableIssue',
+        attributes: {
+          ratingIssueSubjectText: 'should be selected issue',
+          ratingIssueReferenceId: '111',
+          ratingIssuePercentNumber: 10,
+        },
+        [SELECTED]: true,
+      },
+      {
+        type: 'contestableIssue',
+        attributes: {
+          ratingIssueSubjectText: 'should be non-selected issue',
+          ratingIssueReferenceId: '999',
+          ratingIssuePercentNumber: 20,
+        },
+      },
+      {
+        type: 'contestableIssue',
+        attributes: {
+          ratingIssueSubjectText: 'new issue',
+          ratingIssueReferenceId: '333',
+          ratingIssuePercentNumber: 25,
+        },
+      },
+    ];
+
     const tree = mount(<VeteranInfoView {...data} setFormData={setFormData} />);
     expect(tree.find('.name').text()).to.equal('Foo  Bar');
     expect(tree.find('.ssn').text()).to.contain('9876');
@@ -37,7 +120,11 @@ describe('veteranInformation', () => {
     expect(tree.find('.dob').text()).to.contain('January 1, 2000');
     expect(tree.find('.gender').text()).to.contain('Male');
 
-    expect(form.data.benefitType).to.equal('compensation');
+    expect(setFormData.calledOnce).to.be.true;
+    expect(setFormData.firstCall.args[0].benefitType).to.equal('compensation');
+    expect(setFormData.firstCall.args[0].contestedIssues).to.deep.equal(
+      resultingIssueList,
+    );
     tree.unmount();
   });
 });

--- a/src/applications/disability-benefits/996/tests/wizard/WizardContainer.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/wizard/WizardContainer.unit.spec.jsx
@@ -11,7 +11,7 @@ describe('<WizardContainer>', () => {
   };
 
   it('should render', () => {
-    window.sessionStorage.removeItem(WIZARD_STATUS);
+    sessionStorage.removeItem(WIZARD_STATUS);
     const tree = shallow(<WizardContainer setWizardStatus={setWizardStatus} />);
     expect(tree.find('.wizard-container')).to.have.lengthOf(1);
     expect(tree.find('Connect(Wizard)')).to.have.lengthOf(1);

--- a/src/applications/disability-benefits/996/validations/index.js
+++ b/src/applications/disability-benefits/996/validations/index.js
@@ -1,7 +1,7 @@
-import { errorMessages } from '../constants';
+import { errorMessages, SELECTED } from '../constants';
 
 export const requireRatedDisability = (err, fieldData /* , formData */) => {
-  if (!fieldData.some(entry => entry['view:selected'])) {
+  if (!fieldData.some(entry => entry[SELECTED])) {
     // The actual validation error is displayed as an alert field. The message
     // here will be shown on the review page
     err.addError(errorMessages.contestedIssue);


### PR DESCRIPTION
## Description

In a QA review, test user 238 was displaying "no items found" when they had one contestable issue. Anna discovered that that particular user is anomalous in that [it behaves like a LOA1 user.

Digging into the problem, I discovered that the prefill data was over-writing the form data which contained the contestable issues added by Introduction page code. The solution is to move the form data update of the API loaded contestable issues to the first page of the form. This solution still isn't ideal as it should update the contested issues upon return to the form at a later date, but this won't happen unless the user navigates through the first form page. Hopefully, future updates to the form system will find a better solution to this common problem.

The actual reported UA issue should never have been visible as users with no contestable issues would be shown an alert on the introduction page and never allowed to proceed to the contested issues page of the form - this can be tested with user 234. Just in case the user is able to get to the contested issues page, the reported content will now be hidden.

Related:
- QA review: https://github.com/department-of-veterans-affairs/va.gov-team/issues/15996
- User user: https://dsva.slack.com/archives/CBU0KDSB1/p1605108711467300

## Testing done

Updated unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Users with no issues won't get past the introduction page
- [x] Work around prefill over-write of data added by a separate API

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
