### PR TITLE
[Bug] HLR: Reset alert box width

### DIFF
--- a/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
+++ b/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
@@ -125,6 +125,10 @@ article[data-location="contested-issues"] {
     display: none;
   }
 
+  .usa-alert {
+    width: auto;
+  }
+
   .usa-input-error {
     padding-top: 0;
     margin-top: 0;


### PR DESCRIPTION
## Description

On the Higher-Level Review contested issues page, when a user selects the same office checkbox, an alert appears. This alert is indented to keep in alignment with the checkbox, but it is set to have 100% width, which causes overflow issues in IE11 and mobile devices.

This PR sets the alert box width to `auto` which appears to fix the overflow problem on mobile devices - I have not be able to verify this fix works for IE11

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/16045
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/337

## Testing done

Visual testing via Chrome dev tools

## Screenshots

<details><summary>iPhone 5/SE device view</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-11-12 at 4 10 53 PM](https://user-images.githubusercontent.com/136959/99003317-89164600-2503-11eb-8ddd-3812df2b59d2.png)</details>

## Acceptance criteria
- [x] Alert content does not overflow the viewport on mobile
- [ ] Alert content does not overflow the viewport in IE11

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
