### PR TITLE
Fix the fieldFacilityLocation field in the event transformer

### DIFF
--- a/src/site/stages/build/process-cms-exports/schemas/output/node-event.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-event.js
@@ -34,7 +34,18 @@ module.exports = {
     fieldEventCost: { type: ['string', 'null'] },
     fieldEventCta: { type: ['string', 'null'] },
     fieldEventRegistrationrequired: { type: 'boolean' },
-    fieldFacilityLocation: { type: ['object', 'null'] }, // When it's an object, it's an entity of some sort
+    fieldFacilityLocation: {
+      type: ['object', 'null'],
+      properties: {
+        entityUrl: {
+          type: 'object',
+          properties: {
+            path: { type: 'string' },
+          },
+        },
+        title: { type: 'string' },
+      },
+    },
     fieldLink: {
       type: ['object', 'null'],
       properties: {

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-event.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-event.js
@@ -25,8 +25,8 @@ module.exports = {
     fieldDatetimeRangeTimezone: {
       type: 'object',
       properties: {
-        value: { type: 'string' },
-        endValue: { type: 'string' },
+        value: { type: 'number' },
+        endValue: { type: ['number', 'null'] },
         timezone: { type: 'string' },
       },
     },

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-event.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-event.js
@@ -37,14 +37,16 @@ module.exports = {
     fieldFacilityLocation: {
       type: ['object', 'null'],
       properties: {
-        entityUrl: {
+        entity: {
           type: 'object',
           properties: {
-            path: { type: 'string' },
+            entityUrl: { $ref: 'EntityUrl' },
+            title: { type: 'string' },
           },
+          required: ['entityUrl', 'title'],
         },
-        title: { type: 'string' },
       },
+      required: ['entity'],
     },
     fieldLink: {
       type: ['object', 'null'],

--- a/src/site/stages/build/process-cms-exports/transformers/node-event.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-event.js
@@ -74,7 +74,15 @@ const transform = entity => ({
   fieldEventRegistrationrequired: getDrupalValue(
     entity.fieldEventRegistrationrequired,
   ),
-  fieldFacilityLocation: entity.fieldFacilityLocation[0] || null,
+  fieldFacilityLocation:
+    entity.fieldFacilityLocation && entity.fieldFacilityLocation.length
+      ? {
+          entity: {
+            entityUrl: entity.fieldFacilityLocation[0].entityUrl,
+            title: entity.fieldFacilityLocation[0].title,
+          },
+        }
+      : null,
   fieldLink: createLink(entity.fieldLink, ['url']),
   fieldLocationHumanreadable: getDrupalValue(entity.fieldLocationHumanreadable),
   fieldMedia:

--- a/src/site/stages/build/process-cms-exports/transformers/node-event_listing.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-event_listing.js
@@ -20,6 +20,7 @@ const reverseFields = reverseFieldListing => ({
           fieldFeatured: reverseField.fieldFeatured,
           fieldDate: reverseField.fieldDate,
           fieldDescription: reverseField.fieldDescription,
+          fieldFacilityLocation: reverseField.fieldFacilityLocation,
           fieldLocationHumanreadable: reverseField.fieldLocationHumanreadable,
         }))
     : [],


### PR DESCRIPTION
## Description
Fix the fieldFacilityLocation field in the event transformer so the location fields show up

## Testing done
`opendiff build/localhost/pittsburgh-health-care/events/past-events/index.html build/graphql-localhost/pittsburgh-health-care/events/past-events/index.html`

## Screenshots
See issue

## Acceptance criteria
- [x] No diffs in the HTML

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
