### PR TITLE
[Bug] HLR: Fix IE11 alert box width

### DIFF
--- a/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
+++ b/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
@@ -125,8 +125,8 @@ article[data-location="contested-issues"] {
     display: none;
   }
 
-  .usa-alert {
-    width: auto;
+  #root_sameOfficeAlert__title {
+    width: 100%;
   }
 
   .usa-input-error {


### PR DESCRIPTION
## Description

My first attempt to fix the alert box width in IE11 did not work out... I had to test IE11 in staging

This change should fix the overflow width problem in IE11

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/16045

## Testing done

Visual testing

## Screenshots

N/A

## Acceptance criteria
- [x] Alert box does not overflow in IE11 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
