### PR TITLE
[16065] isVowel check for choose clinic intro copy

### DIFF
--- a/src/applications/vaos/new-appointment/components/ClinicChoicePage.jsx
+++ b/src/applications/vaos/new-appointment/components/ClinicChoicePage.jsx
@@ -20,6 +20,10 @@ export function formatTypeOfCare(careLabel) {
   return careLabel.slice(0, 1).toLowerCase() + careLabel.slice(1);
 }
 
+function vowelCheck(givenString) {
+  return /^[aeiou]$/i.test(givenString.charAt(0));
+}
+
 function getPageTitle(schema, typeOfCare) {
   const typeOfCareLabel = formatTypeOfCare(typeOfCare.name);
   let pageTitle = 'Clinic choice';
@@ -105,8 +109,9 @@ export function ClinicChoicePage({
           <h1 className="vads-u-font-size--h2">
             {getPageTitle(schema, typeOfCare)}
           </h1>
-          In the last 24 months you have had a {typeOfCareLabel} appointment in
-          the following clinics, located at:
+          In the last 24 months you have had{' '}
+          {vowelCheck(typeOfCareLabel) ? 'an' : 'a'} {typeOfCareLabel}{' '}
+          appointment in the following clinics, located at:
           {facilityDetails && (
             <div className="vads-u-margin-y--2p5">
               <FacilityAddress

--- a/src/applications/vaos/tests/new-appointment/components/ClinicChoicePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ClinicChoicePage.unit.spec.jsx
@@ -239,40 +239,4 @@ describe('VAOS <ClinicChoicePage>', () => {
 
     form.unmount();
   });
-
-  it('should render "a" if the first letter of the type of care sounds like a constant', () => {
-    const openClinicPage = sinon.spy();
-    const updateFormData = sinon.spy();
-
-    const newProps = { ...defaultProps };
-    newProps.typeOfCare = {
-      ...defaultProps.typeOfCare,
-      name: 'MOVE! weight management program',
-    };
-
-    const form = mount(
-      <ClinicChoicePage
-        openClinicPage={openClinicPage}
-        updateFormData={updateFormData}
-        {...newProps}
-        schema={{
-          type: 'object',
-          properties: {
-            clinicId: {
-              type: 'string',
-              enum: ['455', '456', 'NONE'],
-              enumNames: ['Testing', 'Testing2', 'No'],
-            },
-          },
-        }}
-      />,
-    );
-
-    expect(form.find('input').length).to.equal(3);
-    expect(form.text()).to.contain(
-      'In the last 24 months you have had a MOVE! weight management program appointment in the following clinics, located at',
-    );
-
-    form.unmount();
-  });
 });

--- a/src/applications/vaos/tests/new-appointment/components/ClinicChoicePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ClinicChoicePage.unit.spec.jsx
@@ -206,4 +206,73 @@ describe('VAOS <ClinicChoicePage>', () => {
       expect(result).to.equal('primary care');
     });
   });
+
+  it('should render "an" if the first letter of the type of care sounds like a vowel', () => {
+    const openClinicPage = sinon.spy();
+    const updateFormData = sinon.spy();
+
+    const newProps = { ...defaultProps };
+    newProps.typeOfCare = { ...defaultProps.typeOfCare, name: 'Optometry' };
+
+    const form = mount(
+      <ClinicChoicePage
+        openClinicPage={openClinicPage}
+        updateFormData={updateFormData}
+        {...newProps}
+        schema={{
+          type: 'object',
+          properties: {
+            clinicId: {
+              type: 'string',
+              enum: ['455', '456', 'NONE'],
+              enumNames: ['Testing', 'Testing2', 'No'],
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(form.find('input').length).to.equal(3);
+    expect(form.text()).to.contain(
+      'In the last 24 months you have had an optometry appointment in the following clinics, located at',
+    );
+
+    form.unmount();
+  });
+
+  it('should render "a" if the first letter of the type of care sounds like a constant', () => {
+    const openClinicPage = sinon.spy();
+    const updateFormData = sinon.spy();
+
+    const newProps = { ...defaultProps };
+    newProps.typeOfCare = {
+      ...defaultProps.typeOfCare,
+      name: 'MOVE! weight management program',
+    };
+
+    const form = mount(
+      <ClinicChoicePage
+        openClinicPage={openClinicPage}
+        updateFormData={updateFormData}
+        {...newProps}
+        schema={{
+          type: 'object',
+          properties: {
+            clinicId: {
+              type: 'string',
+              enum: ['455', '456', 'NONE'],
+              enumNames: ['Testing', 'Testing2', 'No'],
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(form.find('input').length).to.equal(3);
+    expect(form.text()).to.contain(
+      'In the last 24 months you have had a MOVE! weight management program appointment in the following clinics, located at',
+    );
+
+    form.unmount();
+  });
 });


### PR DESCRIPTION
## Description
When filling in the type of care/specialty value in the choose clinic intro copy, the article doesn't adjust for care types that start with a vowel.

**To Test a Vowel** 
Test User: Judy Morrison
Choose eye care
Choose optometry
Choose VA medical center or clinic
Choose Cheyenne or Dayton

**To Test a Constant**
Test User: Judy Morrison
Choose Move! weight management program
Choose VA medical center or clinic
Choose Cheyenne or Dayton

## Testing done
Local and Unit

## Screenshots
**Vowel**
![image](https://user-images.githubusercontent.com/8315447/99118374-68162980-25c5-11eb-9dab-a340713bbc34.png)

**Constant**
![image](https://user-images.githubusercontent.com/8315447/99118308-4b79f180-25c5-11eb-8ba7-4c058441f8db.png)

## Acceptance criteria
- [ ] If the first letter of the type of care sounds like a vowel, use "an"
- [ ] If the first letter of the type of care sounds like a consonant, use "a"

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
