### PR TITLE
Add GA event to measure eligibility loading time

### DIFF
--- a/src/applications/vaos/components/LoadingOverlay.jsx
+++ b/src/applications/vaos/components/LoadingOverlay.jsx
@@ -1,13 +1,21 @@
 import React, { useEffect } from 'react';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
+import recordEvent from 'platform/monitoring/record-event';
+
+let openTime;
 
 export default function LoadingOverlay({ show, message }) {
   useEffect(
     () => {
       if (show) {
         document.body.classList.add('modal-open');
+        openTime = Date.now();
       } else {
         document.body.classList.remove('modal-open');
+        recordEvent({
+          event: 'loading-indicator-displayed',
+          'loading-indicator-display-time': Date.now() - openTime,
+        });
       }
     },
     [show],

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.multi.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.multi.unit.spec.jsx
@@ -483,6 +483,13 @@ describe('VAOS integration: VA flat facility page - multiple facilities', () => 
     await screen.findByText(
       /This facility does not allow scheduling requests/i,
     );
+    const loadingEvent = global.window.dataLayer.find(
+      ev => ev.event === 'loading-indicator-displayed',
+    );
+
+    // It should record GA event for loading modal
+    expect(loadingEvent).to.exist;
+    expect('loading-indicator-display-time' in loadingEvent).to.be.true;
   });
 
   it('should show eligibility modal again if user closes it out and hits continue again with the same facility selected', async () => {


### PR DESCRIPTION
## Description
Records eligibility loading time to GA event, using the time the modal is displayed for

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
