### PR TITLE
bradl3yC - Correct key being accessed for DL analytics call

### DIFF
--- a/src/applications/debt-letters/actions/index.js
+++ b/src/applications/debt-letters/actions/index.js
@@ -107,7 +107,7 @@ export const fetchDebtLetters = () => async dispatch => {
 
     recordEvent({
       event: 'bam-get-veteran-dmc-info-successful',
-      'veteran-has-dependent-debt': response.hasDependentDebt,
+      'veteran-has-dependent-debt': response.hasDependentDebts,
     });
 
     if (filteredResponse.length > 0) {


### PR DESCRIPTION
## Description
Analytics record event was accessing wrong key on the response

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
