### PR TITLE
VACMS-000: Add get updates block back to system page.

### DIFF
--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -312,6 +312,7 @@ Example data:
             </a>
           </section>
           {% endif %}
+          {% include "src/site/facilities/facility_social_links.drupal.liquid" with regionNickname = title %}
 
         </article>
       </div>


### PR DESCRIPTION
## Description
Get updates block was unintentionally removed from system landing pages. This pr adds block back.

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/99285608-c2053200-2805-11eb-82f2-73638eb519c1.png)

## Acceptance criteria
- [ ] Go to `/pittsburgh-health-care/` and visually verify that the Get updates block appears
