### PR TITLE
Remove extra whitespace in Markdown tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ There are several repositories that contain the code and content used to build V
 
 Once you have the site set up locally, these are some common commands you might find useful:
 
-| I want to...                                  | Then you should...                                       |
-| --------------------------------------------- | -------------------------------------------------------- |
-| fetch all dependencies                        | `yarn install`; run this any time `package.json` changes |
-| build both static HTML pages and applications | `yarn build`                                             |
-| run the webpack dev server                    | `yarn watch`                                             |
+| I want to... | Then you should... |
+| :--- | :--- |
+| fetch all dependencies | `yarn install`; run this any time `package.json` changes |
+| build both static HTML pages and applications | `yarn build` |
+| run the webpack dev server | `yarn watch` |
 
 ## Building `vets-website`
 
@@ -380,43 +380,43 @@ module.exports = {
 After a while, you may run into a less common task. We have a lot of commands
 for doing very specific things.
 
-| I want to...                                                                                                | Then you should...                                                                                                                                                                                                           |
-| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| build the production site (dev features disabled).                                                          | `NODE_ENV=production yarn build --buildtype vagovprod`                                                                                                                                                                       |
-| fetch the latest content cache from S3                                                                      | `yarn fetch-drupal-cache` (does not require SOCKS proxy access)                                                                                                                                                              |
-| reset local environment (clean out node modules and runs npm install)                                       | `yarn reset:env`                                                                                                                                                                                                             |
-| run only the app pages on the site for local development without building content.                          | `yarn watch --env.scaffold`                                                                                                                                                                                                  |
-| run the site for local development with automatic rebuilding of Javascript and sass **with** css sourcemaps | `yarn watch:css-sourcemaps` then visit `http://localhost:3001/`. You may also set `--env.buildtype` and `NODE_ENV` though setting `NODE_ENV` to production will make incremental builds slow.                                |
-| run the site for local development with automatic rebuilding of code and styles for specific **apps**       | `yarn watch --env.entry disability-benefits,static-pages`. Valid application names are in each app's `manifest.json` under `entryName`                                                                                       |
-| run the site for local development with automatic rebuilding of code and styles for static **content**      | `yarn watch:static`                                                                                                                                                                                                          |
-| run the site so that devices on your local network can access it                                            | `yarn watch --host 0.0.0.0 --public 198.162.x.x:3001` Note that we use CORS to limit what hosts can access different APIs, so accessing with a `192.168.x.x` address may run into problems                                   |
-| run all unit tests and watch                                                                                | `yarn test:watch`                                                                                                                                                                                                            |
-| run only e2e tests                                                                                          | Make sure the site is running locally (`yarn watch`) and run the tests with `yarn test:e2e`                                                                                                                                  |
-| run e2e tests in headless mode                                                                              | `yarn test:e2e:headless`                                                                                                                                                                                                     |
-| run all linters                                                                                             | `yarn lint`                                                                                                                                                                                                                  |
-| run only javascript linter                                                                                  | `yarn lint:js`                                                                                                                                                                                                               |
-| run only sass linter                                                                                        | `yarn lint:sass`                                                                                                                                                                                                             |
-| run lint on JS and fix anything that changed                                                                | `yarn lint:js:changed:fix`                                                                                                                                                                                                   |
-| run automated accessibility tests                                                                           | `yarn build && yarn test:accessibility`                                                                                                                                                                                      |
-| run visual regression testing                                                                               | Start the site. Generate your baseline image set using `yarn test:visual:baseline`. Make your changes. Then run `yarn test:visual`.                                                                                          |
-| test for broken links                                                                                       | Build the site. Broken Link Checking is done via a Metalsmith plugin during build. Note that it only runs on _build_ not watch.                                                                                              |
-| add new npm modules                                                                                         | `yarn add my-module`. Use the `--dev` flag for modules that are build or test related.                                                                                                                                       |
-| get the latest json schema                                                                                  | `yarn update:schema`. This updates our [vets-json-schema](https://github.com/department-of-veterans-affairs/vets-json-schema) vets-json-schema https://github.com/department-of-veterans-affairs/ to the most recent commit. |
-| check test coverage                                                                                         | `yarn test:coverage`                                                                                                                                                                                                         |
-| run bundle analyzer on our production JS bundles                                                            | `yarn build-analyze`                                                                                                                                                                                                         |
-| generate a stats file for analysis by bundle analyzer                                                       | `NODE_ENV=production yarn build:webpack --env.buildtype=vagovprod --env.analyzer`. Note that if you get an error like `FetchError: request to http://prod.cms.va.gov/graphql failed` you need to be on the SOCKS proxy       |
-| load the analyzer tool on a stats file                                                                      | `yarn analyze`                                                                                                                                                                                                               |
-| add a new React app                                                                                         | `yarn new:app` (make sure you have [`vagov-content`](https://github.com/department-of-veterans-affairs/vagov-content/) sibling to `vets-website`)                                                                            |
+| I want to... | Then you should... |
+| :--- | :--- |
+| build the production site (dev features disabled). | `NODE_ENV=production yarn build --buildtype vagovprod` |
+| fetch the latest content cache from S3 | `yarn fetch-drupal-cache` (does not require SOCKS proxy access) |
+| reset local environment (clean out node modules and runs npm install) | `yarn reset:env` |
+| run only the app pages on the site for local development without building content. | `yarn watch --env.scaffold` |
+| run the site for local development with automatic rebuilding of Javascript and sass **with** css sourcemaps | `yarn watch:css-sourcemaps` then visit `http://localhost:3001/`. You may also set `--env.buildtype` and `NODE_ENV` though setting `NODE_ENV` to production will make incremental builds slow. |
+| run the site for local development with automatic rebuilding of code and styles for specific **apps** | `yarn watch --env.entry disability-benefits,static-pages`. Valid application names are in each app's `manifest.json` under `entryName` |
+| run the site for local development with automatic rebuilding of code and styles for static **content** | `yarn watch:static` |
+| run the site so that devices on your local network can access it | `yarn watch --host 0.0.0.0 --public 198.162.x.x:3001` Note that we use CORS to limit what hosts can access different APIs, so accessing with a `192.168.x.x` address may run into problems |
+| run all unit tests and watch | `yarn test:watch` |
+| run only e2e tests | Make sure the site is running locally (`yarn watch`) and run the tests with `yarn test:e2e` |
+| run e2e tests in headless mode | `yarn test:e2e:headless` |
+| run all linters | `yarn lint` |
+| run only javascript linter | `yarn lint:js` |
+| run only sass linter | `yarn lint:sass` |
+| run lint on JS and fix anything that changed | `yarn lint:js:changed:fix` |
+| run automated accessibility tests | `yarn build && yarn test:accessibility` |
+| run visual regression testing | Start the site. Generate your baseline image set using `yarn test:visual:baseline`. Make your changes. Then run `yarn test:visual`. |
+| test for broken links | Build the site. Broken Link Checking is done via a Metalsmith plugin during build. Note that it only runs on _build_ not watch. |
+| add new npm modules | `yarn add my-module`. Use the `--dev` flag for modules that are build or test related. |
+| get the latest json schema | `yarn update:schema`. This updates our [vets-json-schema](https://github.com/department-of-veterans-affairs/vets-json-schema) vets-json-schema https://github.com/department-of-veterans-affairs/ to the most recent commit. |
+| check test coverage | `yarn test:coverage` |
+| run bundle analyzer on our production JS bundles | `yarn build-analyze` |
+| generate a stats file for analysis by bundle analyzer | `NODE_ENV=production yarn build:webpack --env.buildtype=vagovprod --env.analyzer`. Note that if you get an error like `FetchError: request to http://prod.cms.va.gov/graphql failed` you need to be on the SOCKS proxy |
+| load the analyzer tool on a stats file | `yarn analyze` |
+| add a new React app | `yarn new:app` (make sure you have [`vagov-content`](https://github.com/department-of-veterans-affairs/vagov-content/) sibling to `vets-website`) |
 
 ## Supported Browsers
 
-| Browser                   | Minimum version | Note                                   |
-| ------------------------- | --------------- | -------------------------------------- |
-| Internet Explorer         | 11              |                                        |
-| Microsoft Edge            | 13              |                                        |
-| Safari / iOS Safari       | 9               |                                        |
-| Chrome / Android Web view | 44              | _Latest version with >0.5% of traffic_ |
-| Firefox                   | 52              | _Latest version with >0.5% of traffic_ |
+| Browser | Minimum version | Note |
+| :--- | :---: | :--- |
+| Internet Explorer | 11 | |
+| Microsoft Edge | 13 | |
+| Safari / iOS Safari | 9 | |
+| Chrome / Android Web view | 44 | _Latest version with >0.5% of traffic_ |
+| Firefox | 52 | _Latest version with >0.5% of traffic_ |
 
 ## Additional Resources
 


### PR DESCRIPTION
## Description
Trying to read the main README's tables in a code editor was _very_ difficult because the line for each row was full of a ton of trailing whitespace, causing lines to wrap multiple times. This PR simply gets rid of all the trailing whitespace in every row's "cell."

It also:
- left-aligns each table's header
- center-aligns the "minimum version" column of the browser support table

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs