### PR TITLE
Use fieldDatetimeRangeTimezone in production when present

### DIFF
--- a/src/site/components/situation_updates.drupal.liquid
+++ b/src/site/components/situation_updates.drupal.liquid
@@ -10,12 +10,12 @@
           </h3>
           <div class="vads-u-margin-bottom--0 no-p-bottom-margin">
             <h4 class="vads-u-margin-top--1 vads-u-margin-bottom--2">
-                {% if update.entity.fieldDatetimeRangeTimezone.value != empty and buildtype != 'vagovprod' %}
+                {% if update.entity.fieldDatetimeRangeTimezone.value != empty %}
                  {{update.entity.fieldDatetimeRangeTimezone.value | dateFromUnix: "dddd, MMM D, h:mm A"}}
                 {% else %}
                  {{update.entity.fieldDateAndTime.date | timeZone: "America/New_York", "dddd, MMM D, h:mm A"}}
                 {% endif %}
-                {% if update.entity.fieldDatetimeRangeTimezone.timezone != empty and buildtype != 'vagovprod' %}
+                {% if update.entity.fieldDatetimeRangeTimezone.timezone != empty %}
                   {{update.entity.fieldDatetimeRangeTimezone.timezone | timezoneAbbrev: fieldDatetimeRangeTimezone.value }}
                 {% else %}
                   {{ timezone }}

--- a/src/site/includes/date.drupal.liquid
+++ b/src/site/includes/date.drupal.liquid
@@ -1,11 +1,11 @@
 {% assign timezone = "ET" %}
 {% assign defaultTZ = "America/New_York" %}
 
-{% if fieldDatetimeRangeTimezone.timezone != empty and buildtype != 'vagovprod' %}
+{% if fieldDatetimeRangeTimezone.timezone != empty %}
     {% assign timezone = fieldDatetimeRangeTimezone.timezone |  timezoneAbbrev: fieldDatetimeRangeTimezone.value %}
 {% endif %}
 
-{% if fieldDatetimeRangeTimezone.value != empty and buildtype != 'vagovprod' %}
+{% if fieldDatetimeRangeTimezone.value != empty %}
     {% assign start_date_no_time = fieldDatetimeRangeTimezone.value | dateFromUnix: 'dddd, MMM D' %}
     {% assign start_time = fieldDatetimeRangeTimezone.value | dateFromUnix: "h:mm A" %}
     {% assign start_date_full = fieldDatetimeRangeTimezone.value | dateFromUnix: "dddd, MMM D, h:mm A" %}
@@ -17,7 +17,7 @@
     {% assign start_timestamp = fieldDate.value | unixFromDate %}
 {% endif %}
 
-{% if fieldDatetimeRangeTimezone.endValue != empty and buildtype != 'vagovprod' %}
+{% if fieldDatetimeRangeTimezone.endValue != empty %}
     {% assign end_date_no_time = fieldDatetimeRangeTimezone.endValue | dateFromUnix: 'dddd, MMM D' %}
     {% assign end_time = fieldDatetimeRangeTimezone.endValue | dateFromUnix: "h:mm A" %}
     {% assign end_date_full = fieldDatetimeRangeTimezone.endValue | dateFromUnix: "dddd, MMM D, h:mm A" %}


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/va.gov-team/issues/15691

## Description

Remove the code that was preventing the use of `fieldDatetimeRangeTimezone` in production when present.
Retain the fallback code that uses `fieldDateAndTime` when `fieldDatetimeRangeTimezone` is null.


## Acceptance criteria
- [ ] Pages that use `fieldDatetimeRangeTimezone` display the date with the correct time zone. This will need to be confirmed in production.

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
