### PR TITLE
Tweak feature flag usage

### DIFF
--- a/src/platform/site-wide/user-nav/components/SearchMenu.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchMenu.jsx
@@ -1,5 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { connect } from 'react-redux';
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import classNames from 'classnames';
 import recordEvent from 'platform/monitoring/record-event';
 
@@ -9,7 +12,7 @@ import DropDownPanel from '@department-of-veterans-affairs/formation-react/DropD
 
 import Typeahead, { typeaheadListId } from './Typeahead';
 
-class SearchMenu extends React.Component {
+export class SearchMenu extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -53,7 +56,10 @@ class SearchMenu extends React.Component {
             list={typeaheadListId}
             onChange={this.handleInputChange}
           />
-          <Typeahead userInput={this.state.userInput} />
+          <Typeahead
+            userInput={this.state.userInput}
+            searchTypeaheadEnabled={this.props.searchTypeaheadEnabled}
+          />
           <button type="submit" disabled={!validUserInput}>
             <IconSearch color="#fff" />
             <span className="usa-sr-only">Search</span>
@@ -92,6 +98,13 @@ SearchMenu.propTypes = {
   cssClass: PropTypes.string,
   isOpen: PropTypes.bool.isRequired,
   clickHandler: PropTypes.func,
+  searchTypeaheadEnabled: PropTypes.bool,
 };
 
-export default SearchMenu;
+const mapStateToProps = store => ({
+  searchTypeaheadEnabled: toggleValues(store)[
+    FEATURE_FLAG_NAMES.searchTypeaheadEnabled
+  ],
+});
+
+export default connect(mapStateToProps)(SearchMenu);

--- a/src/platform/site-wide/user-nav/components/SearchMenu.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchMenu.jsx
@@ -7,7 +7,7 @@ import { replaceWithStagingDomain } from '../../../utilities/environment/staging
 import IconSearch from '@department-of-veterans-affairs/formation-react/IconSearch';
 import DropDownPanel from '@department-of-veterans-affairs/formation-react/DropDownPanel';
 
-import Typeahead, { isTypeaheadEnabled, typeaheadListId } from './Typeahead';
+import Typeahead, { typeaheadListId } from './Typeahead';
 
 class SearchMenu extends React.Component {
   constructor(props) {
@@ -53,7 +53,7 @@ class SearchMenu extends React.Component {
             list={typeaheadListId}
             onChange={this.handleInputChange}
           />
-          {isTypeaheadEnabled && <Typeahead userInput={this.state.userInput} />}
+          <Typeahead userInput={this.state.userInput} />
           <button type="submit" disabled={!validUserInput}>
             <IconSearch color="#fff" />
             <span className="usa-sr-only">Search</span>

--- a/src/platform/site-wide/user-nav/components/Typeahead.jsx
+++ b/src/platform/site-wide/user-nav/components/Typeahead.jsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import environment from 'platform/utilities/environment';
+import { connect } from 'react-redux';
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import debounce from 'platform/utilities/data/debounce';
-
-export const isTypeaheadEnabled =
-  !environment.isProduction() && document.location.pathname === '/';
 
 export const typeaheadListId = 'onsite-search-typeahead';
 
-export default class Typeahead extends React.Component {
+class Typeahead extends React.Component {
   constructor(props) {
     super(props);
     this.getSuggestions = debounce(
@@ -49,6 +48,11 @@ export default class Typeahead extends React.Component {
   }
 
   render() {
+    // if the feature toggle is off, don't render any suggestions
+    if (!this.props.searchTypeaheadEnabled) {
+      return null;
+    }
+
     return (
       <datalist id={typeaheadListId}>
         {this.state.suggestions.map(suggestion => (
@@ -62,8 +66,20 @@ export default class Typeahead extends React.Component {
 Typeahead.propTypes = {
   userInput: PropTypes.string,
   debounceRate: PropTypes.number,
+  searchTypeaheadEnabled: PropTypes.bool,
 };
 
 Typeahead.defaultProps = {
   debounceRate: 200,
 };
+
+const mapStateToProps = store => ({
+  searchTypeaheadEnabled: toggleValues(store)[
+    FEATURE_FLAG_NAMES.searchTypeaheadEnabled
+  ],
+});
+
+export default connect(
+  mapStateToProps,
+  null,
+)(Typeahead);

--- a/src/platform/site-wide/user-nav/components/Typeahead.jsx
+++ b/src/platform/site-wide/user-nav/components/Typeahead.jsx
@@ -1,13 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import debounce from 'platform/utilities/data/debounce';
 
 export const typeaheadListId = 'onsite-search-typeahead';
 
-class Typeahead extends React.Component {
+export class Typeahead extends React.Component {
   constructor(props) {
     super(props);
     this.getSuggestions = debounce(
@@ -73,13 +70,4 @@ Typeahead.defaultProps = {
   debounceRate: 200,
 };
 
-const mapStateToProps = store => ({
-  searchTypeaheadEnabled: toggleValues(store)[
-    FEATURE_FLAG_NAMES.searchTypeaheadEnabled
-  ],
-});
-
-export default connect(
-  mapStateToProps,
-  null,
-)(Typeahead);
+export default Typeahead;

--- a/src/platform/site-wide/user-nav/tests/components/SearchHelpSignIn.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/components/SearchHelpSignIn.unit.spec.jsx
@@ -78,7 +78,7 @@ describe('<SearchHelpSignIn>', () => {
 
   it('should open the search bar when the search dropdown is clicked', () => {
     const wrapper = shallow(<SearchHelpSignIn {...defaultProps} />);
-    wrapper.find('SearchMenu').prop('clickHandler')();
+    wrapper.find('Connect(SearchMenu)').prop('clickHandler')();
     expect(defaultProps.toggleMenu.calledWith('search', true)).to.be.true;
     wrapper.unmount();
   });

--- a/src/platform/site-wide/user-nav/tests/components/SearchMenu.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/components/SearchMenu.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { mount, shallow } from 'enzyme';
 import sinon from 'sinon';
 
-import SearchMenu from '../../components/SearchMenu.jsx';
+import { SearchMenu } from '../../components/SearchMenu.jsx';
 
 describe('<SearchMenu>', () => {
   const props = {
@@ -12,13 +12,13 @@ describe('<SearchMenu>', () => {
   };
 
   it('should hide the search bar', () => {
-    const wrapper = shallow(<SearchMenu {...props} />);
+    const wrapper = shallow(<SearchMenu {...props} searchTypeaheadEnabled />);
     expect(wrapper.find('#search-menu').prop('isOpen')).to.be.false;
     wrapper.unmount();
   });
 
   it('should show and focus the search bar when opened', () => {
-    const wrapper = mount(<SearchMenu {...props} />);
+    const wrapper = mount(<SearchMenu {...props} searchTypeaheadEnabled />);
     const searchField = wrapper.ref('searchField');
     sinon.spy(searchField, 'focus');
     wrapper.setProps({ isOpen: true });
@@ -28,7 +28,9 @@ describe('<SearchMenu>', () => {
   });
 
   it('should update the user input state', () => {
-    const wrapper = mount(<SearchMenu {...props} isOpen />);
+    const wrapper = mount(
+      <SearchMenu {...props} isOpen searchTypeaheadEnabled />,
+    );
     const changeEvent = { target: { value: 'testing' } };
     wrapper.find('#query').simulate('change', changeEvent);
     expect(wrapper.state('userInput')).to.equal('testing');

--- a/src/platform/site-wide/user-nav/tests/components/Typeahead.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/components/Typeahead.unit.spec.jsx
@@ -8,7 +8,7 @@ import {
   setFetchJSONResponse as setFetchResponse,
 } from 'platform/testing/unit/helpers';
 
-import Typeahead from '../../components/Typeahead';
+import { Typeahead } from '../../components/Typeahead';
 
 describe('<Typeahead>', () => {
   beforeEach(() => {
@@ -26,13 +26,13 @@ describe('<Typeahead>', () => {
   });
 
   it('renders', () => {
-    const wrapper = shallow(<Typeahead />);
+    const wrapper = shallow(<Typeahead searchTypeaheadEnabled />);
     expect(wrapper.find('#onsite-search-typeahead')).to.exist;
     wrapper.unmount();
   });
 
   it('does not show suggestions when user input is limited', () => {
-    const wrapper = shallow(<Typeahead />);
+    const wrapper = shallow(<Typeahead searchTypeaheadEnabled />);
     wrapper.setProps({ userInput: 'hm' });
 
     expect(global.fetch.called).to.be.false;
@@ -40,7 +40,9 @@ describe('<Typeahead>', () => {
   });
 
   it('shows suggestions', async () => {
-    const wrapper = shallow(<Typeahead debounceRate={1} />);
+    const wrapper = shallow(
+      <Typeahead debounceRate={1} searchTypeaheadEnabled />,
+    );
     wrapper.setProps({ userInput: 'test' });
 
     await new Promise(resolve => setTimeout(resolve, 2));

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -60,4 +60,5 @@ export default Object.freeze({
   showChapter31: 'show_chapter_31',
   form1995EduUpdates: 'form_1995_edu_updates',
   requestLockedPdfPassword: 'request_locked_pdf_password',
+  searchTypeaheadEnabled: 'search_typeahead_enabled',
 });


### PR DESCRIPTION
## Description
Add code to use Feature Toggle to enable / disable Search Typeahead functionality.
Removed old "typeahead enabled" flag in favor of new feature toggle

This completes:
department-of-veterans-affairs/va.gov-team#14452

## Testing done
Need to update unit tests

## Screenshots
N/A no layout change

## Acceptance criteria
- [X] Typeahead can be enabled or disabled using Feature Toggle

## Definition of done
- [X] Events are logged appropriately
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
