### PR TITLE
526: ValidatedServicePeriodView Bug Fix and ConfirmationPoll Test Fix

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ValidatedServicePeriodView.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ValidatedServicePeriodView.jsx
@@ -4,8 +4,8 @@ import { formatDateRange } from '../utils';
 export default function ValidatedServicePeriodView({ formData }) {
   return (
     <div className="vads-u-flex--fill">
-      <strong>{formData.serviceBranch}</strong>
-      <p>{formatDateRange(formData.dateRange)}</p>
+      <strong>{formData?.serviceBranch}</strong>
+      <p>{formatDateRange(formData?.dateRange)}</p>
     </div>
   );
 }

--- a/src/applications/disability-benefits/all-claims/tests/components/ConfirmationPoll.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/ConfirmationPoll.unit.spec.jsx
@@ -129,15 +129,15 @@ describe('ConfirmationPoll', () => {
     ]);
 
     const form = mount(
-      <ConfirmationPoll {...defaultProps} pollRate={10} longWaitTime={20} />,
+      <ConfirmationPoll {...defaultProps} pollRate={10} longWaitTime={10} />,
     );
     setTimeout(() => {
-      expect(global.fetch.callCount).to.equal(3);
+      expect(global.fetch.callCount).to.equal(4);
       const alert = form.find('LoadingIndicator');
       expect(alert.text()).to.contain('longer than expected');
       form.unmount();
       done();
-    }, 30);
+    }, 50);
   });
 
   it('should ignore immediate api failures', done => {


### PR DESCRIPTION
## Description
ValidatedServicePeriodView frequently throws an error when `serviceBranch` is attempted to be displayed on an `undefined` service period. This adds a simple fix to check that the serviced period is defined before attempting to show the service branch. Also in this is an adjustment to the ConfirmationPoll test to hopefully combat a random failure we see with this due to the timing of `setTimeout`.

## Acceptance criteria
- [ ] ValidatedServicePeriodView doesn't call `serviceBranch` on `undefined`