### PR TITLE
Fix node-health_care_local_health_service transformer

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -511,7 +511,7 @@ module.exports = function registerFilters() {
   // react component `facility-appointment-wait-times-widget`
   // (line 22 in src/site/facilities/facility_health_service.drupal.liquid)
   liquid.filters.healthServiceApiId = serviceTaxonomy =>
-    serviceTaxonomy.fieldHealthServiceApiId;
+    serviceTaxonomy?.fieldHealthServiceApiId;
 
   // finds if a page is a child of a certain page using the entityUrl attribute
   // returns true or false

--- a/src/site/stages/build/process-cms-exports/schemas/input/node-health_care_local_health_service.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/node-health_care_local_health_service.js
@@ -7,7 +7,9 @@ module.exports = {
     field_body: { $ref: 'GenericNestedString' },
     field_regional_health_service: {
       type: 'array',
-      items: { $ref: 'EntityReference' },
+      items: {
+        oneOf: [{ $ref: 'EntityReference' }, { type: 'array', maxItems: 0 }],
+      },
       maxItems: 1,
     },
     field_service_location: { $ref: 'EntityReferenceArray' },

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_local_health_service.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_local_health_service.js
@@ -10,12 +10,12 @@ module.exports = {
         title: { type: 'string' },
         fieldBody: { $ref: 'ProcessedString' },
         fieldRegionalHealthService: {
-          oneOf: [
-            {
-              $ref: 'output/node-regional_health_care_service_des',
+          type: 'object',
+          items: {
+            entity: {
+              type: { $ref: 'output/node-regional_health_care_service_des' },
             },
-            { type: 'null' },
-          ],
+          },
         },
         fieldServiceLocation: {
           type: 'array',

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_health_service.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_health_service.js
@@ -8,7 +8,9 @@ const transform = entity => ({
     fieldBody: {
       processed: getWysiwygString(getDrupalValue(entity.fieldBody)),
     },
-    fieldRegionalHealthService: entity.fieldRegionalHealthService[0] || null,
+    fieldRegionalHealthService: {
+      entity: entity.fieldRegionalHealthService[0],
+    },
     fieldServiceLocation: entity.fieldServiceLocation.map(locationData => ({
       entity: locationData,
     })),


### PR DESCRIPTION
## Description

An error in this transformer was causing the entire health services section to be empty
in all VAMC location pages.

## Acceptance criteria
- [x] Fix the transformers so these sections are present again and do not differ from the GraphQL builds.

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
