### PR TITLE
Split up HCA reducers

### DIFF
--- a/src/applications/hca/hca-entry.jsx
+++ b/src/applications/hca/hca-entry.jsx
@@ -1,10 +1,10 @@
 import 'platform/polyfills';
 import './sass/hca.scss';
 
-import startApp from 'platform/startup';
+import startApp from '~/platform/startup';
 
 import routes from './routes';
-import reducer from './reducer';
+import reducer from './reducers';
 import manifest from './manifest.json';
 
 let rootUrl = manifest.rootUrl;

--- a/src/applications/hca/reducers/hca-enrollment-status-reducer.js
+++ b/src/applications/hca/reducers/hca-enrollment-status-reducer.js
@@ -1,5 +1,3 @@
-import formConfig from './config/form';
-import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
 import {
   FETCH_ENROLLMENT_STATUS_STARTED,
   FETCH_ENROLLMENT_STATUS_SUCCEEDED,
@@ -9,8 +7,8 @@ import {
   FETCH_DISMISSED_HCA_NOTIFICATION_FAILED,
   SET_DISMISSED_HCA_NOTIFICATION,
   SHOW_HCA_REAPPLY_CONTENT,
-} from './actions';
-import { HCA_ENROLLMENT_STATUSES } from './constants';
+} from '../actions';
+import { HCA_ENROLLMENT_STATUSES } from '../constants';
 
 const initialState = {
   applicationDate: null,
@@ -28,7 +26,7 @@ const initialState = {
   showHCAReapplyContent: false,
 };
 
-export function hcaEnrollmentStatus(state = initialState, action) {
+function hcaEnrollmentStatus(state = initialState, action) {
   switch (action.type) {
     case FETCH_ENROLLMENT_STATUS_STARTED:
       return { ...state, isLoadingApplicationStatus: true };
@@ -112,7 +110,4 @@ export function hcaEnrollmentStatus(state = initialState, action) {
   }
 }
 
-export default {
-  form: createSaveInProgressFormReducer(formConfig),
-  hcaEnrollmentStatus,
-};
+export default hcaEnrollmentStatus;

--- a/src/applications/hca/reducers/index.js
+++ b/src/applications/hca/reducers/index.js
@@ -1,0 +1,8 @@
+import { createSaveInProgressFormReducer } from '~/platform/forms/save-in-progress/reducers';
+import formConfig from '../config/form';
+import hcaEnrollmentStatus from './hca-enrollment-status-reducer';
+
+export default {
+  form: createSaveInProgressFormReducer(formConfig),
+  hcaEnrollmentStatus,
+};

--- a/src/applications/hca/tests/reducers.unit.spec.js
+++ b/src/applications/hca/tests/reducers.unit.spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 
 import * as actions from '../actions';
-import { hcaEnrollmentStatus as reducer } from '../reducer';
+import reducer from '../reducers/hca-enrollment-status-reducer';
 
 describe('HCA Enrollment Status Reducer', () => {
   let state;

--- a/src/applications/personalization/dashboard/reducers/index.js
+++ b/src/applications/personalization/dashboard/reducers/index.js
@@ -1,10 +1,10 @@
 import claimsAppeals from '~/applications/claims-status/reducers';
+import hcaEnrollmentStatus from '~/applications/hca/reducers/hca-enrollment-status-reducer';
 import prescriptions from './prescriptions';
 import recipients from './recipients';
 import folders from './folders';
 import preferences from '../../preferences/reducers';
 import appointments from '../../appointments/reducers';
-import { hcaEnrollmentStatus } from 'applications/hca/reducer';
 
 import { combineReducers } from 'redux';
 

--- a/src/applications/personalization/profile/reducers/index.js
+++ b/src/applications/personalization/profile/reducers/index.js
@@ -1,5 +1,5 @@
 import vapService from '@@vap-svc/reducers';
-import { hcaEnrollmentStatus } from 'applications/hca/reducer';
+import hcaEnrollmentStatus from '~/applications/hca/reducers/hca-enrollment-status-reducer';
 import vaProfile from './vaProfile';
 
 export default {


### PR DESCRIPTION
## Description
This PR breaks up the HCA reducer into two modules, splitting the "enrollment status" piece into its own module. This way the Dashboard can pull in only that module which stops Webpack from bundling in a whole bunch of code that is not needed by the Dashboard. The total size of the Dashboard bundles went down from ~1.2MB to ~815KB with this change. As an added bonus, the Dashboard entry bundle shrunk by nearly 50% and some of the total weight moved to the Dashboard v1 bundle. This is nice because it means even less code needs to be downloaded before the app can determine which version, either v1 or v2, of the Dashboard needs to be loaded to show the user. 

## Testing done
Existing tests.

## Screenshots
**Before**
<img width="749" alt="dash-step-1" src="https://user-images.githubusercontent.com/20728956/99341521-e3cedb00-283e-11eb-9c3b-ba8da4d5fac6.png">

**After**
<img width="755" alt="dash-step-2" src="https://user-images.githubusercontent.com/20728956/99341545-f34e2400-283e-11eb-89e8-25960c4b019b.png">

## Acceptance criteria
- [x] smaller bundles, and nothing breaks

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs