### PR TITLE
[Development] Add SiP ID to save status box

### DIFF
--- a/src/platform/forms-system/src/js/constants.js
+++ b/src/platform/forms-system/src/js/constants.js
@@ -1,7 +1,7 @@
 export const START_NEW_APP_DEFAULT_MESSAGE = 'Start a new application';
 export const CONTINUE_APP_DEFAULT_MESSAGE = 'Continue your application';
 export const APP_SAVED_SUCCESSFULLY_DEFAULT_MESSAGE =
-  'Application has been saved.';
+  'Your application has been saved.';
 export const FINISH_APP_LATER_DEFAULT_MESSAGE =
   'Finish this application later.';
 export const UNAUTH_SIGN_IN_DEFAULT_MESSAGE =

--- a/src/platform/forms/save-in-progress/SaveStatus.jsx
+++ b/src/platform/forms/save-in-progress/SaveStatus.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import moment from 'moment';
-
 import SignInLink from '../components/SignInLink';
 import { SAVE_STATUSES, saveErrors } from './actions';
 import {

--- a/src/platform/forms/save-in-progress/SaveStatus.jsx
+++ b/src/platform/forms/save-in-progress/SaveStatus.jsx
@@ -28,9 +28,10 @@ function SaveStatus({
   const formId = loadedData?.metadata?.inProgressFormId;
   const formIdMessage =
     formId && savedAtMessage ? (
-      <div className="vads-u-margin-left--3">
+      <>
+        {' '}
         Your application ID number is <strong>{formId}</strong>
-      </div>
+      </>
     ) : null;
 
   const hasError =
@@ -46,11 +47,13 @@ function SaveStatus({
   return (
     <div>
       {autoSavedStatus === SAVE_STATUSES.success && (
-        <div className="panel saved-success-container">
-          <i className="fa fa-check-circle saved-success-icon" />
-          {appSavedSuccessfullyMessage}
-          {savedAtMessage}
-          {formIdMessage}
+        <div className="panel saved-success-container vads-u-display--flex">
+          <i className="fa fa-check-circle saved-success-icon vads-u-margin-top--0p5" />
+          <div>
+            {appSavedSuccessfullyMessage}
+            {savedAtMessage}
+            {formIdMessage}
+          </div>
         </div>
       )}
       {autoSavedStatus === SAVE_STATUSES.pending && (

--- a/src/platform/forms/save-in-progress/SaveStatus.jsx
+++ b/src/platform/forms/save-in-progress/SaveStatus.jsx
@@ -30,7 +30,7 @@ function SaveStatus({
     formId && savedAtMessage ? (
       <>
         {' '}
-        Your application ID number is <strong>{formId}</strong>
+        Your application ID number is <strong>{formId}</strong>.
       </>
     ) : null;
 

--- a/src/platform/forms/save-in-progress/SaveStatus.jsx
+++ b/src/platform/forms/save-in-progress/SaveStatus.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import moment from 'moment';
+
 import SignInLink from '../components/SignInLink';
 import { SAVE_STATUSES, saveErrors } from './actions';
 import {
@@ -9,7 +10,7 @@ import {
 } from '../../forms-system/src/js/constants';
 
 function SaveStatus({
-  form: { lastSavedDate, autoSavedStatus },
+  form: { lastSavedDate, autoSavedStatus, loadedData },
   formConfig,
   isLoggedIn,
   showLoginModal,
@@ -24,6 +25,14 @@ function SaveStatus({
   } else {
     savedAtMessage = '';
   }
+
+  const formId = loadedData?.metadata?.inProgressFormId;
+  const formIdMessage =
+    formId && savedAtMessage ? (
+      <div className="vads-u-margin-left--3">
+        Your application ID is: <strong>{formId}</strong>
+      </div>
+    ) : null;
 
   const hasError =
     saveErrors.has(autoSavedStatus) &&
@@ -42,6 +51,7 @@ function SaveStatus({
           <i className="fa fa-check-circle saved-success-icon" />
           {appSavedSuccessfullyMessage}
           {savedAtMessage}
+          {formIdMessage}
         </div>
       )}
       {autoSavedStatus === SAVE_STATUSES.pending && (

--- a/src/platform/forms/save-in-progress/SaveStatus.jsx
+++ b/src/platform/forms/save-in-progress/SaveStatus.jsx
@@ -18,7 +18,7 @@ function SaveStatus({
   let savedAtMessage;
   if (lastSavedDate) {
     const savedAt = moment(lastSavedDate);
-    savedAtMessage = ` Last saved at ${savedAt.format(
+    savedAtMessage = ` It was last saved on ${savedAt.format(
       'MMM D, YYYY [at] h:mm a',
     )}`;
   } else {
@@ -29,7 +29,7 @@ function SaveStatus({
   const formIdMessage =
     formId && savedAtMessage ? (
       <div className="vads-u-margin-left--3">
-        Your application ID is: <strong>{formId}</strong>
+        Your application ID number is <strong>{formId}</strong>
       </div>
     ) : null;
 

--- a/src/platform/forms/tests/save-in-progress/SaveStatus.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveStatus.unit.spec.jsx
@@ -56,13 +56,18 @@ describe('<SaveStatus>', () => {
     const tree = SkinDeep.shallowRender(<SaveStatus {...props} />);
     expect(tree.text()).to.have.string('having some issues');
   });
-  it('should display the appSavedSuccessfullyMessage', () => {
+  it('should display the appSavedSuccessfullyMessage & SiP ID', () => {
     const appSavedSuccessfullyMessageProps = {
       ...props,
       form: {
         formId: VA_FORM_IDS.FORM_10_10EZ,
         lastSavedDate: 1505770055,
         autoSavedStatus: 'success',
+        loadedData: {
+          metadata: {
+            inProgressFormId: 98765,
+          },
+        },
       },
       formConfig: {
         customText: {
@@ -77,5 +82,6 @@ describe('<SaveStatus>', () => {
     expect(tree.subTree('.panel').text()).to.include(
       'Custom message saying your app has been saved.',
     );
+    expect(tree.subTree('.panel').text()).to.include('ID is: 98765');
   });
 });

--- a/src/platform/forms/tests/save-in-progress/SaveStatus.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveStatus.unit.spec.jsx
@@ -27,7 +27,7 @@ describe('<SaveStatus>', () => {
   it('should show last saved date', () => {
     props.form.autoSavedStatus = SAVE_STATUSES.success;
     const tree = SkinDeep.shallowRender(<SaveStatus {...props} />);
-    expect(tree.text()).to.include('Application has been saved.');
+    expect(tree.text()).to.include('Your application has been saved.');
   });
   it('should show saving', () => {
     props.form.autoSavedStatus = SAVE_STATUSES.pending;
@@ -38,7 +38,7 @@ describe('<SaveStatus>', () => {
     props.form.autoSavedStatus = undefined;
     props.form.lastSavedDate = undefined;
     const tree = SkinDeep.shallowRender(<SaveStatus {...props} />);
-    expect(tree.text()).to.not.have.string('Application has been saved.');
+    expect(tree.text()).to.not.have.string('Your application has been saved.');
     expect(tree.text()).to.not.have.string('Saving...');
   });
   it('should show session expired error', () => {
@@ -82,6 +82,6 @@ describe('<SaveStatus>', () => {
     expect(tree.subTree('.panel').text()).to.include(
       'Custom message saying your app has been saved.',
     );
-    expect(tree.subTree('.panel').text()).to.include('ID is: 98765');
+    expect(tree.subTree('.panel').text()).to.include('ID number is 98765');
   });
 });


### PR DESCRIPTION
## Description

To provide better support to Veteran's that call the help desk, we've included the save-in-progress ID within the save status banner.

- This banner is only shown to the user when they are logged in, and they modify a value within the form
- Currently in production, this ID is around 7-digits long. Locally, it will only show a single digit.
- With this save-in-progress ID, which can be freely shared since it isn't PII, a developer then gain access to the Veteran's save-in-progress data and attempt to reproduce the issue the Veteran has encountered
- The addition of this ID will need to be conveyed to the help desk personnel so they can advise the Veteran to find and obtain this number.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/15679

## Testing done

Updated unit test

## Screenshots

![](https://user-images.githubusercontent.com/54544300/99400381-e5d38100-28b4-11eb-80f3-c5ac144776fb.png)

## Acceptance criteria
- [x] The save-in-progress status panel includes the user's unique ID
- [ ] Inform help desk personnel of this change

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
