### PR TITLE
[Development] HLR: Filter out ineligible contestable issues

### DIFF
--- a/src/applications/disability-benefits/996/components/VeteranInformation.jsx
+++ b/src/applications/disability-benefits/996/components/VeteranInformation.jsx
@@ -53,8 +53,8 @@ export const VeteranInformation = ({
           formData.contestedIssues || []
         ).every(
           (issue, index) =>
-            contestedIssues[index].ratingIssueReferenceId ===
-            issue.ratingIssueReferenceId,
+            contestedIssues[index]?.ratingIssueReferenceId ===
+            issue?.ratingIssueReferenceId,
         );
 
         if (

--- a/src/applications/disability-benefits/996/helpers.js
+++ b/src/applications/disability-benefits/996/helpers.js
@@ -1,4 +1,5 @@
 import Scroll from 'react-scroll';
+import moment from 'moment';
 
 // import the toggleValues helper
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
@@ -16,5 +17,55 @@ export const scrollToTop = () => {
     duration: 500,
     delay: 0,
     smooth: true,
+  });
+};
+
+/**
+ * @typedef ContestableIssues
+ * @type {Array<Object>}
+ * @property {ContestableIssueItem}
+ */
+/**
+ * @typedef ContestableIssueItem
+ * @type {Object}
+ * @property {String} type - always set to "contestableIssue"
+ * @property {ContestableIssueAttributes} attributes - essential properties
+ * @property {Boolean} 'view:selected' - internal boolean indicating that the
+ *   issue has been selected by the user
+ */
+/**
+ * @typedef ContestableIssueAttributes
+ * @type {Object}
+ * @property {String} ratingIssueSubjectText - title of issue
+ * @property {String} description - issue description
+ * @property {Number} ratingIssuePercentNumber - disability rating percentage
+ * @property {String} approxDecisionDate - decision date (YYYY-MM-DD)
+ * @property {Number} decisionIssueId - decision id
+ * @property {String} ratingIssueReferenceId - issue reference number
+ * @property {String} ratingDecisionReferenceId - decision reference id
+ */
+/** Filter out ineligible contestable issues:
+ * - remove issues more than one year past their decision date
+ * - remove issues that are deferred
+ * @prop {ContestableIssues} - Array of both eligible & ineligible contestable
+ *  issues
+ */
+export const getEligibleContestableIssues = issues => {
+  const today = moment().startOf('day');
+  return (issues || []).filter(issue => {
+    const {
+      approxDecisionDate = '',
+      ratingIssueSubjectText = '',
+      description = '',
+    } = issue?.attributes || {};
+
+    const isDeferred = [ratingIssueSubjectText, description]
+      .join(' ')
+      .includes('deferred');
+    const date = moment(approxDecisionDate);
+    if (isDeferred || !date.isValid()) {
+      return false;
+    }
+    return date.add(1, 'years').isAfter(today);
   });
 };

--- a/src/applications/disability-benefits/996/reducers/contestableIssues.js
+++ b/src/applications/disability-benefits/996/reducers/contestableIssues.js
@@ -3,6 +3,7 @@ import {
   FETCH_CONTESTABLE_ISSUES_SUCCEEDED,
   FETCH_CONTESTABLE_ISSUES_FAILED,
 } from '../actions';
+import { getEligibleContestableIssues } from '../helpers';
 
 const initialState = {
   issues: [],
@@ -21,7 +22,7 @@ export default function contestableIssues(state = initialState, action) {
     case FETCH_CONTESTABLE_ISSUES_SUCCEEDED: {
       return {
         ...state,
-        issues: action.response?.data || [],
+        issues: getEligibleContestableIssues(action.response?.data),
         status: FETCH_CONTESTABLE_ISSUES_SUCCEEDED,
         error: '',
         benefitType: action.benefitType,

--- a/src/applications/disability-benefits/996/tests/fixtures/data/maximal-test.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/data/maximal-test.json
@@ -23,7 +23,7 @@
           "ratingIssueSubjectText": "Headaches",
           "description": "Acute chronic head pain",
           "ratingIssuePercentNumber": 20,
-          "approxDecisionDate": "2011-01-02",
+          "approxDecisionDate": "2020-11-10",
           "decisionIssueId": 44,
           "ratingIssueReferenceId": "66",
           "ratingDecisionReferenceId": null
@@ -36,7 +36,7 @@
           "ratingIssueSubjectText": "Being green",
           "description": "Chronic greenness",
           "ratingIssuePercentNumber": 50,
-          "approxDecisionDate": "2011-01-01",
+          "approxDecisionDate": "2020-11-01",
           "decisionIssueId": 42,
           "ratingIssueReferenceId": "52",
           "ratingDecisionReferenceId": "999"
@@ -48,7 +48,7 @@
         "attributes": {
           "ratingIssueSubjectText": "Monocular vision",
           "ratingIssuePercentNumber": 5,
-          "approxDecisionDate": "2010-01-01",
+          "approxDecisionDate": "2020-11-04",
           "decisionIssueId": 1,
           "ratingIssueReferenceId": "2",
           "ratingDecisionReferenceId": ""

--- a/src/applications/disability-benefits/996/tests/fixtures/data/minimal-test.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/data/minimal-test.json
@@ -15,7 +15,7 @@
           "ratingIssueSubjectText": "Headaches",
           "description": "Acute chronic head pain",
           "ratingIssuePercentNumber": 20,
-          "approxDecisionDate": "2011-01-02",
+          "approxDecisionDate": "2020-11-10",
           "decisionIssueId": 44,
           "ratingIssueReferenceId": "66",
           "ratingDecisionReferenceId": ""

--- a/src/applications/disability-benefits/996/tests/fixtures/data/transformed-maximal-test.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/data/transformed-maximal-test.json
@@ -27,7 +27,7 @@
       "type": "contestableIssue",
       "attributes": {
         "issue": "Headaches - 20% - Acute chronic head pain",
-        "decisionDate": "2011-01-02",
+        "decisionDate": "2020-11-10",
         "decisionIssueId": 44,
         "ratingIssueReferenceId": "66"
       }
@@ -36,7 +36,7 @@
       "type": "contestableIssue",
       "attributes": {
         "issue": "Being green - 50% - Chronic greenness",
-        "decisionDate": "2011-01-01",
+        "decisionDate": "2020-11-01",
         "decisionIssueId": 42,
         "ratingIssueReferenceId": "52",
         "ratingDecisionReferenceId": "999"

--- a/src/applications/disability-benefits/996/tests/helpers.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/helpers.unit.spec.js
@@ -1,0 +1,62 @@
+import { expect } from 'chai';
+import moment from 'moment';
+
+import { getEligibleContestableIssues } from '../helpers';
+
+describe('getEligibleContestableIssues', () => {
+  const today = () => moment().startOf('day');
+  const template = 'YYYY-MM-DD';
+  const format = (date, templ = template) => date.format(templ);
+
+  const eligibleIssue = {
+    type: 'contestableIssue',
+    attributes: {
+      ratingIssueSubjectText: 'Issue 2',
+      description: '',
+      approxDecisionDate: format(today().subtract(10, 'months')),
+    },
+  };
+  const ineligibleIssue = [
+    {
+      type: 'contestableIssue',
+      attributes: {
+        ratingIssueSubjectText: 'Issue 1',
+        description: '',
+        approxDecisionDate: format(today().subtract(2, 'years')),
+      },
+    },
+  ];
+  const deferredIssue = {
+    type: 'contestableIssue',
+    attributes: {
+      ratingIssueSubjectText: 'Issue 2',
+      description: 'this is a deferred issue',
+      approxDecisionDate: format(today().subtract(1, 'months')),
+    },
+  };
+
+  it('should return empty array', () => {
+    expect(getEligibleContestableIssues()).to.have.lengthOf(0);
+    expect(getEligibleContestableIssues([])).to.have.lengthOf(0);
+    expect(getEligibleContestableIssues([{}])).to.have.lengthOf(0);
+  });
+  it('should filter out dates more than one year in the past', () => {
+    expect(
+      getEligibleContestableIssues([ineligibleIssue, eligibleIssue]),
+    ).to.deep.equal([eligibleIssue]);
+  });
+  it('should filter out dates more than one year in the past', () => {
+    expect(
+      getEligibleContestableIssues([eligibleIssue, ineligibleIssue]),
+    ).to.deep.equal([eligibleIssue]);
+  });
+  it('should filter out deferred issues', () => {
+    expect(
+      getEligibleContestableIssues([
+        eligibleIssue,
+        deferredIssue,
+        ineligibleIssue,
+      ]),
+    ).to.deep.equal([eligibleIssue]);
+  });
+});

--- a/src/applications/disability-benefits/996/tests/schema/initialData.js
+++ b/src/applications/disability-benefits/996/tests/schema/initialData.js
@@ -1,5 +1,4 @@
 // Test data for HLR
-// import { addXMonths } from '../../helpers';
 
 export default {
   veteran: {
@@ -16,7 +15,7 @@ export default {
         description: `Rinnging in the ears. More intese in right ear. This is
           more text so the description goes into the second line.`,
         ratingIssuePercentNumber: 10,
-        approxDecisionDate: '2011-01-01',
+        approxDecisionDate: '2020-11-01',
         decisionIssueId: 42,
         ratingIssueReferenceId: '52',
         ratingDecisionReferenceId: '',
@@ -29,7 +28,7 @@ export default {
         ratingIssueSubjectText: 'Headaches',
         description: 'Acute chronic head pain',
         ratingIssuePercentNumber: 50,
-        approxDecisionDate: '2011-01-02',
+        approxDecisionDate: '2020-11-10',
         decisionIssueId: 44,
         ratingIssueReferenceId: '66',
         ratingDecisionReferenceId: '',
@@ -41,7 +40,7 @@ export default {
       attributes: {
         ratingIssueSubjectText: 'Back sprain',
         ratingIssuePercentNumber: 5,
-        approxDecisionDate: '2010-01-01',
+        approxDecisionDate: '2020-11-15',
         decisionIssueId: 1,
         ratingIssueReferenceId: '2',
         ratingDecisionReferenceId: '',
@@ -50,10 +49,14 @@ export default {
   ],
 
   sameOffice: false,
-  informalConference: null,
+  informalConference: 'rep',
   informalConferenceRep: {
     name: 'Fred Flintstone',
     phone: '8005551212',
   },
-  informalConferenceTimes: [],
+  informalConferenceTimes: {
+    time0800to1000: true,
+  },
+  benefitType: 'compensation',
+  zipCode5: '98765',
 };


### PR DESCRIPTION
## Description

Lighthouse's endpoint provides a complete list of contestable issues. Some of which may be ineligible due to decision dates more than one year in the past or have been deferred.

This PR filters out ineligible issues immediately after getting the list from the API

Note: This PR also updates the dates of all hard-coded contestable issues in the mock data. Because the dates are hard-coded, tests will start failing around this time next year unless the dates are updated. I've created an [enhancement feature request](https://github.com/department-of-veterans-affairs/va.gov-team/issues/16262) to allow adding placeholders to the mock data which would then be set to calculated dates dynamically.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/16207
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/16262
- https://dsva.slack.com/archives/CBU0KDSB1/p1605298769114500

## Testing done

Added unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Only eligible contestable issues are shown to the user

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
