### PR TITLE
[R&S] Fix for search app showing up sitemap

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -901,6 +901,7 @@
       "title:": "Search results",
       "layout": "page-react.html",
       "includeBreadcrumbs": true,
+      "private": true,
       "breadcrumbs_override": [
         {
           "path": "resources/",

--- a/src/applications/resources-and-support/components/ResourcesAndSupportSearchApp.jsx
+++ b/src/applications/resources-and-support/components/ResourcesAndSupportSearchApp.jsx
@@ -35,6 +35,8 @@ const ResourcesAndSupportSearchApp = () => {
       if (queryFromUrl) {
         setUserInput(queryFromUrl);
         setQuery(queryFromUrl);
+      } else {
+        window.location.replace('/resources/');
       }
     },
     [articles, setUserInput, setQuery],


### PR DESCRIPTION
## Description
This PR prevents users from getting to `va.gov/resources/search` when there isn't a query in the URL.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/16286

## Testing done
I went to `http://localhost:3001/resources/search/` and confirmed that the redirect occurs when there isn't a query in the URL.

## Screenshots
No visual effect

## Acceptance criteria
- [ ] app is no longer in sitemap
- [ ] app is no longer accessible w/o a query

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
