### PR TITLE
[Development] HLR - fix analytic event issues

### DIFF
--- a/src/applications/disability-benefits/996/config/submitForm.js
+++ b/src/applications/disability-benefits/996/config/submitForm.js
@@ -1,6 +1,18 @@
 import { submitToUrl } from 'platform/forms-system/src/js/actions';
 import { transformForSubmit } from 'platform/forms-system/src/js/helpers';
-import recordEvent from 'platform/monitoring/record-event';
+
+export const buildEventData = ({ sameOffice, informalConference }) => {
+  let informalConf = 'no';
+  if (informalConference !== 'no') {
+    informalConf = informalConference === 'rep' ? 'yes-with-rep' : 'yes';
+  }
+  return {
+    // or 'no'; this event should be renamed to decision-reviews-sameOffice
+    'decision-reviews-differentOffice': sameOffice ? 'yes' : 'no',
+    // or 'no', or 'yes-with-rep'
+    'decision-reviews-informalConf': informalConf,
+  };
+};
 
 const submitForm = (form, formConfig) => {
   const { submitUrl, trackingPrefix } = formConfig;
@@ -8,24 +20,9 @@ const submitForm = (form, formConfig) => {
     ? formConfig.transformForSubmit(formConfig, form)
     : transformForSubmit(formConfig, form);
 
-  // event data needed on successful submission
-  const { sameOffice, informalConference } = form.data;
-  let informalConf = 'no';
-  if (informalConference !== 'no') {
-    informalConf = informalConference === 'rep' ? 'yes-with-rep' : 'yes';
-  }
-  const eventData = {
-    // or 'no'
-    'decision-reviews-differentOffice': sameOffice ? 'yes' : 'no',
-    // or 'no', or 'yes-with-rep'
-    'decision-reviews-informalConf': informalConf,
-  };
-  return submitToUrl(body, submitUrl, trackingPrefix, eventData).catch(() => {
-    recordEvent({
-      event: `${trackingPrefix}-submission-failed`,
-      ...eventData,
-    });
-  });
+  // eventData for analytics
+  const eventData = buildEventData(form.data);
+  return submitToUrl(body, submitUrl, trackingPrefix, eventData);
 };
 
 export default submitForm;

--- a/src/applications/disability-benefits/996/config/submitForm.js
+++ b/src/applications/disability-benefits/996/config/submitForm.js
@@ -22,7 +22,7 @@ const submitForm = (form, formConfig) => {
   };
   return submitToUrl(body, submitUrl, trackingPrefix, eventData).catch(() => {
     recordEvent({
-      event: `${trackingPrefix}-submission-failure`,
+      event: `${trackingPrefix}-submission-failed`,
       ...eventData,
     });
   });

--- a/src/applications/disability-benefits/996/config/submitForm.js
+++ b/src/applications/disability-benefits/996/config/submitForm.js
@@ -20,11 +20,6 @@ const submitForm = (form, formConfig) => {
     // or 'no', or 'yes-with-rep'
     'decision-reviews-informalConf': informalConf,
   };
-  // Submission attempt event
-  recordEvent({
-    event: `${trackingPrefix}-submission`,
-    ...eventData,
-  });
   return submitToUrl(body, submitUrl, trackingPrefix, eventData).catch(() => {
     recordEvent({
       event: `${trackingPrefix}-submission-failure`,

--- a/src/applications/disability-benefits/996/config/submitForm.js
+++ b/src/applications/disability-benefits/996/config/submitForm.js
@@ -7,8 +7,8 @@ export const buildEventData = ({ sameOffice, informalConference }) => {
     informalConf = informalConference === 'rep' ? 'yes-with-rep' : 'yes';
   }
   return {
-    // or 'no'; this event should be renamed to decision-reviews-sameOffice
-    'decision-reviews-differentOffice': sameOffice ? 'yes' : 'no',
+    // or 'no'
+    'decision-reviews-same-office-to-review': sameOffice ? 'yes' : 'no',
     // or 'no', or 'yes-with-rep'
     'decision-reviews-informalConf': informalConf,
   };

--- a/src/applications/disability-benefits/996/form-entry.jsx
+++ b/src/applications/disability-benefits/996/form-entry.jsx
@@ -11,4 +11,5 @@ startApp({
   url: manifest.rootUrl,
   reducer,
   routes,
+  analyticsEvents: [],
 });

--- a/src/applications/disability-benefits/996/tests/schema/submitForm.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/schema/submitForm.unit.spec.js
@@ -24,10 +24,7 @@ describe('HLR submit form', () => {
     };
     formConfig.submit(getFormData(false, 'no'), config).finally(() => {
       expect(global.window.dataLayer[0]).to.deep.equal(
-        getEvent('', 'no', 'no'),
-      );
-      expect(global.window.dataLayer[1]).to.deep.equal(
-        getEvent('-failure', 'no', 'no'),
+        getEvent('-failed', 'no', 'no'),
       );
       done();
     });
@@ -39,10 +36,7 @@ describe('HLR submit form', () => {
     };
     formConfig.submit(getFormData(true, 'yes'), config).finally(() => {
       expect(global.window.dataLayer[0]).to.deep.equal(
-        getEvent('', 'yes', 'yes'),
-      );
-      expect(global.window.dataLayer[1]).to.deep.equal(
-        getEvent('-failure', 'yes', 'yes'),
+        getEvent('-failed', 'yes', 'yes'),
       );
       done();
     });
@@ -54,10 +48,7 @@ describe('HLR submit form', () => {
     };
     formConfig.submit(getFormData(true, 'rep'), config).finally(() => {
       expect(global.window.dataLayer[0]).to.deep.equal(
-        getEvent('', 'yes', 'yes-with-rep'),
-      );
-      expect(global.window.dataLayer[1]).to.deep.equal(
-        getEvent('-failure', 'yes', 'yes-with-rep'),
+        getEvent('-failed', 'yes', 'yes-with-rep'),
       );
       done();
     });

--- a/src/applications/disability-benefits/996/tests/schema/submitForm.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/schema/submitForm.unit.spec.js
@@ -1,57 +1,26 @@
 import { expect } from 'chai';
 
-import formConfig from '../../config/form';
+import { buildEventData } from '../../config/submitForm';
 
-const getFormData = (sameOffice, informalConference) => ({
-  data: {
-    sameOffice,
-    informalConference,
-    informalConferenceTimes: [],
-  },
-});
-
-const getEvent = (result, office, conf) => ({
-  event: `${formConfig.trackingPrefix}-submission${result}`,
-  'decision-reviews-differentOffice': office,
-  'decision-reviews-informalConf': conf,
-});
-
-describe('HLR submit form', () => {
-  it('should record a submission attempt & failed attempt', done => {
-    const config = {
-      ...formConfig,
-      submitUrl: '', // something that will always fail
-    };
-    formConfig.submit(getFormData(false, 'no'), config).finally(() => {
-      expect(global.window.dataLayer[0]).to.deep.equal(
-        getEvent('-failed', 'no', 'no'),
-      );
-      done();
+describe('HLR submit event data', () => {
+  it('should build submit event data', () => {
+    expect(
+      buildEventData({ sameOffice: true, informalConference: 'no' }),
+    ).to.deep.equal({
+      'decision-reviews-differentOffice': 'yes',
+      'decision-reviews-informalConf': 'no',
+    });
+    expect(
+      buildEventData({ sameOffice: false, informalConference: 'rep' }),
+    ).to.deep.equal({
+      'decision-reviews-differentOffice': 'no',
+      'decision-reviews-informalConf': 'yes-with-rep',
+    });
+    expect(
+      buildEventData({ sameOffice: false, informalConference: 'yes' }),
+    ).to.deep.equal({
+      'decision-reviews-differentOffice': 'no',
+      'decision-reviews-informalConf': 'yes',
     });
   });
-  it('should record a submission attempt & failed attempt with different data', done => {
-    const config = {
-      ...formConfig,
-      submitUrl: '', // something that will always fail
-    };
-    formConfig.submit(getFormData(true, 'yes'), config).finally(() => {
-      expect(global.window.dataLayer[0]).to.deep.equal(
-        getEvent('-failed', 'yes', 'yes'),
-      );
-      done();
-    });
-  });
-  it('should record a submission attempt & failed attempt with different data', done => {
-    const config = {
-      ...formConfig,
-      submitUrl: '', // something that will always fail
-    };
-    formConfig.submit(getFormData(true, 'rep'), config).finally(() => {
-      expect(global.window.dataLayer[0]).to.deep.equal(
-        getEvent('-failed', 'yes', 'yes-with-rep'),
-      );
-      done();
-    });
-  });
-  // TODO: Test successful XMLHttpRequest
 });

--- a/src/applications/disability-benefits/996/tests/schema/submitForm.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/schema/submitForm.unit.spec.js
@@ -7,19 +7,19 @@ describe('HLR submit event data', () => {
     expect(
       buildEventData({ sameOffice: true, informalConference: 'no' }),
     ).to.deep.equal({
-      'decision-reviews-differentOffice': 'yes',
+      'decision-reviews-same-office-to-review': 'yes',
       'decision-reviews-informalConf': 'no',
     });
     expect(
       buildEventData({ sameOffice: false, informalConference: 'rep' }),
     ).to.deep.equal({
-      'decision-reviews-differentOffice': 'no',
+      'decision-reviews-same-office-to-review': 'no',
       'decision-reviews-informalConf': 'yes-with-rep',
     });
     expect(
       buildEventData({ sameOffice: false, informalConference: 'yes' }),
     ).to.deep.equal({
-      'decision-reviews-differentOffice': 'no',
+      'decision-reviews-same-office-to-review': 'no',
       'decision-reviews-informalConf': 'yes',
     });
   });


### PR DESCRIPTION
## Description

This PR fixes two QA analytics event problems:

- Duplicate submission event
- Mis-named `-submission-failed` event

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/16300
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/3825#issuecomment-728259048

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] Remove duplicate event
- [x] Rename failed event

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
