### PR TITLE
Make sure we're properly awaiting page renders on form pages

### DIFF
--- a/src/applications/vaos/tests/express-care/components/ExpressCareConfirmationPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/express-care/components/ExpressCareConfirmationPage.unit.spec.jsx
@@ -369,10 +369,10 @@ describe('VAOS integration: Express Care form submission', () => {
       store,
     });
 
-    fireEvent.change(await screen.getByLabelText(/phone number/i), {
+    fireEvent.change(await screen.findByLabelText(/phone number/i), {
       target: { value: '9737790338' },
     });
-    fireEvent.change(await screen.getByLabelText(/email address/i), {
+    fireEvent.change(await screen.findByLabelText(/email address/i), {
       target: { value: 'judy.morrison@va.gov' },
     });
     fireEvent.click(await screen.findByText(/submit express care/i));

--- a/src/applications/vaos/tests/express-care/components/ExpressCareDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/express-care/components/ExpressCareDetailsPage.unit.spec.jsx
@@ -64,9 +64,8 @@ describe('VAOS integration: Express Care form - Additional Details Page', () => 
       store,
     });
 
-    await waitFor(() =>
-      expect(screen.baseElement).to.contain.text('Tell us about your cough'),
-    );
+    await screen.findByText(/tell us about your cough/i);
+
     expect(screen.baseElement).to.contain.text(
       'Please provide additional details about your symptoms',
     );

--- a/src/applications/vaos/tests/new-appointment/components/PreferredDatePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/PreferredDatePage.unit.spec.jsx
@@ -28,19 +28,22 @@ describe('VAOS integration: preferred date page with a single-site user', () => 
   beforeEach(() => mockFetch());
   afterEach(() => resetFetch());
 
-  it('should render', () => {
+  it('should render', async () => {
     const store = createTestStore(initialState);
     const screen = renderWithStoreAndRouter(<PreferredDatePage />, {
       store,
     });
 
+    expect(
+      await screen.findByText(
+        /What is the earliest date you’d like to be seen/,
+      ),
+    ).to.exist;
+
     expect(screen.baseElement).to.contain.text(
       'Tell us when you want to schedule your appointment',
     );
 
-    expect(screen.baseElement).to.contain.text(
-      'What is the earliest date you’d like to be seen?',
-    );
     expect(screen.baseElement).to.contain.text(
       'Please pick a date within the next 13 months.',
     );
@@ -56,7 +59,7 @@ describe('VAOS integration: preferred date page with a single-site user', () => 
       store,
     });
 
-    fireEvent.click(screen.getByText(/Continue/));
+    fireEvent.click(await screen.findByText(/Continue/));
     expect(await screen.findByRole('alert')).to.contain.text(
       'Please provide a response',
     );
@@ -68,6 +71,8 @@ describe('VAOS integration: preferred date page with a single-site user', () => 
     const screen = renderWithStoreAndRouter(<PreferredDatePage />, {
       store,
     });
+
+    await screen.findByText(/Continue/);
 
     userEvent.selectOptions(screen.getByRole('combobox', { name: /month/i }), [
       '2',
@@ -91,6 +96,8 @@ describe('VAOS integration: preferred date page with a single-site user', () => 
     const screen = renderWithStoreAndRouter(<PreferredDatePage />, {
       store,
     });
+
+    await screen.findByText(/Continue/);
 
     userEvent.selectOptions(screen.getByRole('combobox', { name: /month/i }), [
       '2',
@@ -125,6 +132,8 @@ describe('VAOS integration: preferred date page with a single-site user', () => 
     const screen = renderWithStoreAndRouter(<PreferredDatePage />, {
       store,
     });
+
+    await screen.findByText(/Continue/);
 
     userEvent.selectOptions(screen.getByRole('combobox', { name: /month/i }), [
       maxMonth,

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfAudiologyCare.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfAudiologyCare.unit.spec.jsx
@@ -40,7 +40,7 @@ describe('VAOS <TypeOfAudiologyCarePage>', () => {
       },
     );
 
-    await expect(screen.getAllByRole('radio').length).to.equal(2);
+    expect((await screen.findAllByRole('radio')).length).to.equal(2);
     userEvent.click(screen.getByText(/Continue/));
 
     expect(await screen.findByText('Please provide a response')).to.exist;

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfCarePage.unit.spec.jsx
@@ -49,7 +49,7 @@ describe('VAOS <TypeOfCarePage>', () => {
       { store },
     );
 
-    expect(screen.getAllByRole('radio').length).to.equal(11);
+    expect((await screen.findAllByRole('radio')).length).to.equal(11);
 
     // Verify alert is shown
     expect(
@@ -117,7 +117,7 @@ describe('VAOS <TypeOfCarePage>', () => {
     );
   });
 
-  it('should show type of care page without podiatry when CC flag is off', () => {
+  it('should show type of care page without podiatry when CC flag is off', async () => {
     const store = createTestStore({
       ...initialState,
       featureToggles: {
@@ -130,7 +130,7 @@ describe('VAOS <TypeOfCarePage>', () => {
       { store },
     );
 
-    expect(screen.getAllByRole('radio').length).to.equal(10);
+    expect((await screen.findAllByRole('radio')).length).to.equal(10);
   });
   it('should not allow users who are not CC eligible to use Podiatry', async () => {
     const store = createTestStore(initialState);

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfEyeCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfEyeCarePage.unit.spec.jsx
@@ -45,7 +45,7 @@ describe('VAOS <TypeOfEyeCarePage>', () => {
       },
     );
 
-    expect(screen.getAllByRole('radio').length).to.equal(2);
+    expect((await screen.getAllByRole('radio')).length).to.equal(2);
     fireEvent.click(screen.getByText(/Continue/));
 
     expect(await screen.findByText('Please provide a response')).to.exist;

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfFacilityPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfFacilityPage.unit.spec.jsx
@@ -37,7 +37,7 @@ describe('VAOS integration: VA facility page with a single-site user', () => {
       'Choose where you want to receive your care',
     );
 
-    expect(screen.getAllByRole('radio').length).to.equal(2);
+    expect((await screen.findAllByRole('radio')).length).to.equal(2);
   });
 
   it('should show validation', async () => {
@@ -46,7 +46,7 @@ describe('VAOS integration: VA facility page with a single-site user', () => {
       store,
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /continue »/i }));
+    fireEvent.click(await screen.findByText(/continue »/i));
     expect(await screen.findByRole('alert')).to.contain.text(
       'Please provide a response',
     );


### PR DESCRIPTION
## Description
Not properly waiting for form fields to appear on form pages is causing some flaky tests, made more obvious now by a recent change to not render the form before Redux is updated with form info. This goes through and cleans up some of those tests, as well as fixes some bad async code that was added in some VSP updates.

Flaky test that prompted this: http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fvets-website/detail/master/9093/tests

## Testing done
Unit tests

## Acceptance criteria
- [ ] Build passes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
