### PR TITLE
Fix the ordering of metatags in createMetaTagArray

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -527,4 +527,7 @@ module.exports = function registerFilters() {
     moment(timestamp1, 'YYYY-MM-DD').isAfter(moment(timestamp2, 'YYYY-MM-DD'));
 
   liquid.filters.phoneNumberArrayToObject = phoneNumberArrayToObject;
+
+  liquid.filters.sortEntityMetatags = item =>
+    item ? item.sort((a, b) => a.key.localeCompare(b.key)) : undefined;
 };

--- a/src/site/includes/metatags.drupal.liquid
+++ b/src/site/includes/metatags.drupal.liquid
@@ -14,8 +14,9 @@
 
 {% assign tagsSize = entityMetatags | size %}
 {% if tagsSize > 0 %}
+{% assign sortedEntityMetatags = entityMetatags | sortEntityMetatags %}
 <!-- Metatags -->
-{% for tag in entityMetatags %}
+{% for tag in sortedEntityMetatags %}
     {% case tag.__typename %}
       {% when "MetaValue" %}
         {% if tag.key == "title" %}
@@ -43,10 +44,10 @@
   {% endif %}
   {% assign metaTitle = metaTitle | append: " | Veterans Affairs" %}
 <meta property="og:site_name" content="Veterans Affairs">
+<meta content="{{ metaTitle }}" property="og:title">
 <meta name="twitter:card" content="Summary">
 <meta name="twitter:site" content="@DeptVetAffairs">
 <meta name="twitter:image" content="{{ hostUrl }}/img/design/logo/va-og-twitter-image.png">
-<meta content="{{ metaTitle }}" property="og:title">
 <meta content="{{ metaTitle }}" name="twitter:title" >
   {% if fieldIntroTextNewsStories %}
     {% assign description = fieldIntroTextNewsStories.processed  | strip_html %}

--- a/src/site/stages/build/process-cms-exports/transformers/helpers.js
+++ b/src/site/stages/build/process-cms-exports/transformers/helpers.js
@@ -227,13 +227,13 @@ module.exports = {
       createMetaTag('MetaProperty', 'og:title', metaTags.og_title),
       createMetaTag('MetaValue', 'keywords', metaTags.keywords),
       createMetaTag('MetaProperty', 'og:description', metaTags.og_description),
+      createMetaTag('MetaValue', 'twitter:image', metaTags.twitter_cards_image),
+      createMetaTag('MetaProperty', 'og:image', metaTags.og_image_0),
       createMetaTag(
         'MetaProperty',
         'og:image:height',
         metaTags.og_image_height,
       ),
-      createMetaTag('MetaValue', 'twitter:image', metaTags.twitter_cards_image),
-      createMetaTag('MetaProperty', 'og:image', metaTags.og_image_0),
     ].filter(t => t.value);
   },
 


### PR DESCRIPTION
## Description
A small fix, but this PR updates the ordering of the metatags created in the `createMetaTagArray` function. This resolves a discrepancy with the ordering of metatags for the entity `node.d3542034-12c4-4337-89e4-5a29ef3cc1dd.json`.
## Testing done
Performed a `diff` on `/outreach-and-events/events/va-caregiver-support-program-expansion/index.html` and `/outreach-and-events/events/pave-connect-employer-session-amazon-entry-level-and-hourly-jobs/index.html`.

## Screenshots


## Acceptance criteria
- [ ] `/outreach-and-events/events/pave-connect-employer-session-amazon-entry-level-and-hourly-jobs/index.html` and `/outreach-and-events/events/va-caregiver-support-program-expansion/index.html` have the correct ordering of metatags.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
