### PR TITLE
Improves Sentry logging on the keepalive endpoint

### DIFF
--- a/src/platform/utilities/sso/keepAliveSSO.js
+++ b/src/platform/utilities/sso/keepAliveSSO.js
@@ -34,9 +34,30 @@ export default async function keepAlive() {
       }[resp.headers.get('va_eauth_csid')],
     };
   } catch (err) {
+    const caughtExceptions = {
+      'Failed to fetch': {
+        logType: Sentry.Severity.Error,
+      },
+      'NetworkError when attempting to fetch resource.': {
+        logType: Sentry.Severity.Error,
+      },
+      'The Internet connection appears to be offline': {
+        logType: Sentry.Severity.Info,
+      },
+      'The network connection was lost.': {
+        logType: Sentry.Severity.Info,
+      },
+      cancelled: {
+        logType: Sentry.Severity.Info,
+      },
+    }[err.message];
+
     Sentry.withScope(scope => {
       scope.setExtra('error', err);
-      Sentry.captureMessage(`SSOe error: ${err.message}`);
+      Sentry.captureMessage(
+        `SSOe error: ${err.message}`,
+        caughtExceptions ? caughtExceptions.logType : err.message,
+      );
     });
     return {};
   }

--- a/src/platform/utilities/sso/keepAliveSSO.js
+++ b/src/platform/utilities/sso/keepAliveSSO.js
@@ -2,25 +2,25 @@ import * as Sentry from '@sentry/browser';
 
 import { ssoKeepAliveEndpoint } from 'platform/user/authentication/utilities';
 
-const caughtExceptions = {
-  'Failed to fetch': {
-    logType: Sentry.Severity.Error,
-  },
-  'NetworkError when attempting to fetch resource.': {
-    logType: Sentry.Severity.Error,
-  },
-  'The Internet connection appears to be offline': {
-    logType: Sentry.Severity.Info,
-  },
-  'The network connection was lost.': {
-    logType: Sentry.Severity.Info,
-  },
-  cancelled: {
-    logType: Sentry.Severity.Info,
-  },
-};
-
 export default async function keepAlive() {
+  // Having outside of keepAlive method could expose information
+  const caughtExceptions = {
+    'Failed to fetch': {
+      logType: Sentry.Severity.Error,
+    },
+    'NetworkError when attempting to fetch resource.': {
+      logType: Sentry.Severity.Error,
+    },
+    'The Internet connection appears to be offline': {
+      logType: Sentry.Severity.Info,
+    },
+    'The network connection was lost.': {
+      logType: Sentry.Severity.Info,
+    },
+    cancelled: {
+      logType: Sentry.Severity.Info,
+    },
+  };
   // Return a TTL and authn values from the IAM keepalive endpoint that
   // 1) indicates how long the user's current SSOe session will be alive for,
   // 2) and the AuthN context the user used when authenticating.


### PR DESCRIPTION
## Description
**Issue** [Sentry SSOe Error Cleanup](https://github.com/department-of-veterans-affairs/va.gov-team/issues/16388)
This PR adds logic to the catch statement for the `keepAlive` method in `keepAliveSSO.js` .  This will reduce the amount of non-SSOe Errors that are being captured in Sentry (ie. Things like Internet or network connection being lost) and instead use Sentry's built-in LogLevels.

## Testing done
- Manual

## Screenshots
n/a

## Acceptance criteria
- [x] Research Sentry `setlevel` & Sentry JavaScript documentation
- [x] Classify the correct error levels for `SSOe errors` to ensure appropriate logging in Sentry
- [x] Provide a default log level for `SSOe errors` for Sentry
- [x] Errors will have more context to ensure the Identity team is able to properly resolve issues discovered via Sentry

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
