### PR TITLE
Kelsonic 15196 analytics for R&S

### DIFF
--- a/src/applications/resources-and-support/components/ResourcesAndSupportSearchApp.jsx
+++ b/src/applications/resources-and-support/components/ResourcesAndSupportSearchApp.jsx
@@ -6,7 +6,6 @@ import Pagination from '@department-of-veterans-affairs/formation-react/Paginati
 import URLSearchParams from 'url-search-params';
 import { focusElement } from 'platform/utilities/ui';
 import searchSettings from 'applications/search/manifest.json';
-
 // Relative imports.
 import SearchBar from './SearchBar';
 import SearchResultList from './SearchResultList';
@@ -117,7 +116,11 @@ const ResourcesAndSupportSearchApp = () => {
             <p className="vads-u-padding-x--1p5" id="pagination-summary">
               {paginationSummary}
             </p>
-            <SearchResultList results={currentPageOfResults} />
+            <SearchResultList
+              query={query}
+              results={currentPageOfResults}
+              totalResults={results.length}
+            />
             <Pagination
               maxPageListLength={RESULTS_PER_PAGE}
               onPageSelect={onPageSelect}

--- a/src/applications/resources-and-support/components/SearchResult.jsx
+++ b/src/applications/resources-and-support/components/SearchResult.jsx
@@ -1,7 +1,8 @@
+// Node modules.
 import React from 'react';
-
+import PropTypes from 'prop-types';
+// Relative imports.
 import { ENTITY_BUNDLES } from 'site/constants/content-modeling';
-
 import { Article } from '../prop-types';
 
 const articleTypes = {
@@ -14,7 +15,23 @@ const articleTypes = {
   [ENTITY_BUNDLES.STEP_BY_STEP]: 'Step-by-step',
 };
 
-export default function SearchResult({ article }) {
+export default function SearchResult({
+  article,
+  position,
+  query,
+  totalResults,
+}) {
+  const onSearchResultClick = () => {
+    recordEvent({
+      event: 'onsite-search-results-click',
+      'search-text-input': query,
+      'search-selection': 'Resources and support',
+      'search-results-total-count': totalResults,
+      'search-results-total-pages': Math.ceil(totalResults / 10),
+      'search-results-position-number': position,
+    });
+  };
+
   return (
     <div className="vads-u-padding-y--3 vads-u-border-top--1px vads-u-border-color--gray-lighter">
       <div>
@@ -22,7 +39,9 @@ export default function SearchResult({ article }) {
         {articleTypes[article.entityBundle]}
       </div>
       <h2 className="vads-u-font-size--h3 vads-u-margin-top--0">
-        <a href={article.entityUrl.path}>{article.title}</a>
+        <a onClick={onSearchResultClick} href={article.entityUrl.path}>
+          {article.title}
+        </a>
       </h2>
       <p
         className="vads-u-margin-bottom--0"
@@ -36,4 +55,7 @@ export default function SearchResult({ article }) {
 
 SearchResult.propTypes = {
   article: Article,
+  position: PropTypes.number.isRequired,
+  query: PropTypes.string,
+  totalResults: PropTypes.number,
 };

--- a/src/applications/resources-and-support/components/SearchResult.jsx
+++ b/src/applications/resources-and-support/components/SearchResult.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 // Relative imports.
+import recordEvent from 'platform/monitoring/record-event';
 import { ENTITY_BUNDLES } from 'site/constants/content-modeling';
 import { Article } from '../prop-types';
 

--- a/src/applications/resources-and-support/components/SearchResultList.jsx
+++ b/src/applications/resources-and-support/components/SearchResultList.jsx
@@ -5,13 +5,18 @@ import { Article } from '../prop-types';
 
 import SearchResult from './SearchResult';
 
-export default function SearchResultList({ results }) {
+export default function SearchResultList({ results, totalResults, query }) {
   return (
     <ul className="usa-unstyled-list">
       {results.map((article, articleIndex) => {
         return (
           <li key={`article-${articleIndex}`}>
-            <SearchResult article={article} />
+            <SearchResult
+              article={article}
+              position={articleIndex + 1}
+              query={query}
+              totalResults={totalResults}
+            />
           </li>
         );
       })}
@@ -20,5 +25,7 @@ export default function SearchResultList({ results }) {
 }
 
 SearchResultList.propTypes = {
+  query: PropTypes.string,
   results: PropTypes.arrayOf(Article).isRequired,
+  totalResults: PropTypes.number,
 };

--- a/src/applications/resources-and-support/hooks/useGetSearchResults.js
+++ b/src/applications/resources-and-support/hooks/useGetSearchResults.js
@@ -40,13 +40,13 @@ export default function useGetSearchResults(articles, query, page) {
       const orderedResults = sortBy(filteredArticles, 'title');
 
       // Track the ordered results.
-      recordEvent(
+      recordEvent({
         'event': 'view_search_results',
         'search-text-input': query,
         'search-selection': "Resources and support",
         'search-results-total-count': orderedResults.length,
         'search-results-total-pages': Math.ceil(orderedResults.length / 10),
-      );
+      });
 
       setResults(orderedResults);
     },

--- a/src/applications/resources-and-support/hooks/useGetSearchResults.js
+++ b/src/applications/resources-and-support/hooks/useGetSearchResults.js
@@ -1,5 +1,8 @@
+// Node modules.
 import { useEffect, useState } from 'react';
 import sortBy from 'lodash/sortBy';
+// Relative imports.
+import recordEvent from 'platform/monitoring/record-event';
 
 export default function useGetSearchResults(articles, query, page) {
   const [results, setResults] = useState([]);
@@ -41,9 +44,9 @@ export default function useGetSearchResults(articles, query, page) {
 
       // Track the ordered results.
       recordEvent({
-        'event': 'view_search_results',
+        event: 'view_search_results',
         'search-text-input': query,
-        'search-selection': "Resources and support",
+        'search-selection': 'Resources and support',
         'search-results-total-count': orderedResults.length,
         'search-results-total-pages': Math.ceil(orderedResults.length / 10),
       });

--- a/src/applications/resources-and-support/hooks/useGetSearchResults.js
+++ b/src/applications/resources-and-support/hooks/useGetSearchResults.js
@@ -39,6 +39,15 @@ export default function useGetSearchResults(articles, query, page) {
 
       const orderedResults = sortBy(filteredArticles, 'title');
 
+      // Track the ordered results.
+      recordEvent(
+        'event': 'view_search_results',
+        'search-text-input': query,
+        'search-selection': "Resources and support",
+        'search-results-total-count': orderedResults.length,
+        'search-results-total-pages': Math.ceil(orderedResults.length / 10),
+      );
+
       setResults(orderedResults);
     },
     [articles, setResults, query, page],

--- a/src/site/includes/benefit-hubs-links.drupal.liquid
+++ b/src/site/includes/benefit-hubs-links.drupal.liquid
@@ -7,7 +7,7 @@
         <li>
           <p class="vads-u-margin--0">
             <strong>
-              <a href="{{ relatedBenefitHub.entity.path.alias }}">
+              <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ relatedBenefitHub.entity.fieldHomePageHubLabel }}', 'links-list-section-header': 'VA benefits' })" href="{{ relatedBenefitHub.entity.path.alias }}">
                 {{ relatedBenefitHub.entity.fieldHomePageHubLabel }}
               </a>
             </strong>

--- a/src/site/includes/benefit-hubs-links.drupal.liquid
+++ b/src/site/includes/benefit-hubs-links.drupal.liquid
@@ -7,7 +7,7 @@
         <li>
           <p class="vads-u-margin--0">
             <strong>
-              <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ relatedBenefitHub.entity.fieldHomePageHubLabel }}', 'links-list-section-header': 'VA benefits' })" href="{{ relatedBenefitHub.entity.path.alias }}">
+              <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ relatedBenefitHub.entity.fieldHomePageHubLabel | escape }}', 'links-list-section-header': 'VA benefits' })" href="{{ relatedBenefitHub.entity.path.alias }}">
                 {{ relatedBenefitHub.entity.fieldHomePageHubLabel }}
               </a>
             </strong>

--- a/src/site/includes/breadcrumbs.drupal.liquid
+++ b/src/site/includes/breadcrumbs.drupal.liquid
@@ -1,26 +1,30 @@
-<nav data-template="includes/breadcrumbs" aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs" id="va-breadcrumbs">
+<nav data-template="includes/breadcrumbs" aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
+  id="va-breadcrumbs">
   <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
     {% assign crumbs = entityUrl.breadcrumb %}
     {% if deriveBreadcrumbsFromUrl == true %}
-    {% assign crumbs = entityUrl.breadcrumb | deriveLastBreadcrumbFromPath: title, entityUrl.path %}
+      {% assign crumbs = entityUrl.breadcrumb | deriveLastBreadcrumbFromPath: title, entityUrl.path %}
     {% endif %}
 
     {% if constructLcBreadcrumbs == true %}
-    {% assign crumbs = entityUrl.breadcrumb | deriveLcBreadcrumbs: title, entityUrl.path, titleInclude %}
+      {% assign crumbs = entityUrl.breadcrumb | deriveLcBreadcrumbs: title, entityUrl.path, titleInclude %}
     {% endif %}
 
     {% for crumb in crumbs %}
       {% if forloop.last == true %}
-        <li><a aria-current="page" href="/{{ path }}">{{ crumb.text }}</a></li>
+        <li><a onclick="recordEvent({ 'event': 'nav-breadcrumb', 'breadcrumb-click-label': '{{ crumb.text }}', 'breadcrumb-click-level': '{{ forloop.index }}', 'breadcrumb-total-levels': '{{ crumbs.length }}' });" aria-current="page" href="/{{ path }}">{{ crumb.text }}</a></li>
       {% elsif crumb.url.path %}
         {% if crumb.url.path == '/' %}
           {% if hideHomeBreadcrumb != true %}
             <li>
-              <a href="{{ crumb.url.path }}" onClick="recordEvent({ event: 'nav-breadcrumb', 'nav-breadcrumb-section': 'home' });">{{ crumb.text }}</a>
+              <a href="{{ crumb.url.path }}"
+                onclick="recordEvent({ event: 'nav-breadcrumb', 'nav-breadcrumb-section': 'home' });">{{ crumb.text }}</a>
             </li>
           {% endif %}
         {% else %}
-          <li><a href="{{ crumb.url.path }}">{{ crumb.text }}</a></li>
+          <li><a
+            onclick="recordEvent({ 'event': 'nav-breadcrumb', 'breadcrumb-click-label': '{{ crumb.text }}', 'breadcrumb-click-level': '{{ forloop.index }}', 'breadcrumb-total-levels': '{{ crumbs.length }}' });"
+            href="{{ crumb.url.path }}">{{ crumb.text }}</a></li>
         {% endif %}
       {% endif %}
     {% endfor %}

--- a/src/site/includes/related-information.drupal.liquid
+++ b/src/site/includes/related-information.drupal.liquid
@@ -10,7 +10,7 @@
       <li>
         <p class="vads-u-margin--0">
           <strong>
-            <a href="{{ fieldRelatedInformationLink.entity.fieldLink.url.path }}">
+            <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ fieldRelatedInformationLink.entity.fieldLink.title }}', 'links-list-section-header': 'Related information' })" href="{{ fieldRelatedInformationLink.entity.fieldLink.url.path }}">
               {{ fieldRelatedInformationLink.entity.fieldLink.title }}
             </a>
           </strong>

--- a/src/site/includes/related-information.drupal.liquid
+++ b/src/site/includes/related-information.drupal.liquid
@@ -10,7 +10,7 @@
       <li>
         <p class="vads-u-margin--0">
           <strong>
-            <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ fieldRelatedInformationLink.entity.fieldLink.title }}', 'links-list-section-header': 'Related information' })" href="{{ fieldRelatedInformationLink.entity.fieldLink.url.path }}">
+            <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ fieldRelatedInformationLink.entity.fieldLink.title | escape }}', 'links-list-section-header': 'Related information' })" href="{{ fieldRelatedInformationLink.entity.fieldLink.url.path }}">
               {{ fieldRelatedInformationLink.entity.fieldLink.title }}
             </a>
           </strong>

--- a/src/site/includes/tags.drupal.liquid
+++ b/src/site/includes/tags.drupal.liquid
@@ -1,18 +1,25 @@
 {% if fieldTags.entity != empty %}
-  <div class="vads-u-border-top--1px vads-u-border-bottom--1px vads-u-border-color--gray-light vads-u-padding-top--3 vads-u-padding-bottom--1 medium-screen:vads-u-padding-bottom--3" data-template="includes/tags">
-    <div class="vads-u-display--flex vads-u-align-items--flex-start medium-screen:vads-u-align-items--center vads-u-flex-direction--row vads-u-padding-x--1 medium-screen:vads-u-padding-x--0">
-      <!-- Title -->
-      <strong class="vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0">Tags</strong>
+<div
+  class="vads-u-border-top--1px vads-u-border-bottom--1px vads-u-border-color--gray-light vads-u-padding-top--3 vads-u-padding-bottom--1 medium-screen:vads-u-padding-bottom--3"
+  data-template="includes/tags">
+  <div
+    class="vads-u-display--flex vads-u-align-items--flex-start medium-screen:vads-u-align-items--center vads-u-flex-direction--row vads-u-padding-x--1 medium-screen:vads-u-padding-x--0">
+    <!-- Title -->
+    <strong class="vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0">Tags</strong>
 
-      <!-- Topic tags -->
-      <div class="vads-u-display--flex vads-u-flex-wrap--wrap">
-        {% for topic in fieldTags.entity.fieldTopics %}
-          <a href="{{ topic.entity.entityUrl.path }}" style="border-radius: 3px;" class="vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0 usa-button-secondary vads-u-font-size--sm vads-u-border--1px vads-u-border-color--primary vads-u-padding--0p25 vads-u-padding-x--0p5 vads-u-margin-left--1 vads-u-text-decoration--none vads-u-color--base">{{ topic.entity.name }}</a>
-        {% endfor %}
+    <!-- Topic tags -->
+    <div class="vads-u-display--flex vads-u-flex-wrap--wrap">
+      {% for topic in fieldTags.entity.fieldTopics %}
+      <a onclick="recordEvent({ 'event': 'nav-page-tag-click', 'page-tag-click-label': '{{ topic.entity.name }}', 'page-tag-category-label': 'Topics' });"
+        href="{{ topic.entity.entityUrl.path }}" style="border-radius: 3px;"
+        class="vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0 usa-button-secondary vads-u-font-size--sm vads-u-border--1px vads-u-border-color--primary vads-u-padding--0p25 vads-u-padding-x--0p5 vads-u-margin-left--1 vads-u-text-decoration--none vads-u-color--base">{{ topic.entity.name }}</a>
+      {% endfor %}
 
-        <!-- Audience beneficiary tag -->
-        <a href="{{ fieldTags.entity.fieldAudienceBeneficiares.entity.entityUrl.path }}" style="border-radius: 3px;" class="usa-button-secondary vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0 vads-u-font-size--sm vads-u-border--1px vads-u-border-color--primary vads-u-padding--0p25 vads-u-padding-x--0p5 vads-u-margin-left--1 vads-u-text-decoration--none vads-u-color--base">{{ fieldTags.entity.fieldAudienceBeneficiares.entity.name }}</a>
-      </div>
+      <!-- Audience beneficiary tag -->
+      <a onclick="recordEvent({ 'event': 'nav-page-tag-click', 'page-tag-click-label': '{{ fieldTags.entity.fieldAudienceBeneficiares.entity.name }}', 'page-tag-category-label': 'Audience' });"
+        href="{{ fieldTags.entity.fieldAudienceBeneficiares.entity.entityUrl.path }}" style="border-radius: 3px;"
+        class="usa-button-secondary vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0 vads-u-font-size--sm vads-u-border--1px vads-u-border-color--primary vads-u-padding--0p25 vads-u-padding-x--0p5 vads-u-margin-left--1 vads-u-text-decoration--none vads-u-color--base">{{ fieldTags.entity.fieldAudienceBeneficiares.entity.name }}</a>
     </div>
   </div>
+</div>
 {% endif %}

--- a/src/site/paragraphs/button.drupal.liquid
+++ b/src/site/paragraphs/button.drupal.liquid
@@ -1,17 +1,8 @@
-{% comment %}
-  Example data:
-  "entity": {
-      "entityId": "12662",
-      "entityBundle": "button",
-      "fieldButtonLabel": "Sample button",
-      "fieldButtonLink": {
-          "url": {
-              "path": "/"
-          }
-      }
-  }
-{% endcomment %}
 <a
-  data-template="paragraphs/button"
   class="usa-button-primary"
-  href="{{ entity.fieldButtonLink.url.path }}">{{ entity.fieldButtonLabel }}</a>
+  data-template="paragraphs/button"
+  href="{{ entity.fieldButtonLink.url.path }}"
+  onclick="recordEvent({ 'event': 'cta-button-click', 'button-type': 'default', 'button-click-label': '{{ entity.fieldButtonLabel }}', 'button-background-color': '#0071bb' });"
+>
+  {{ entity.fieldButtonLabel }}
+</a>

--- a/src/site/paragraphs/contact_information.drupal.liquid
+++ b/src/site/paragraphs/contact_information.drupal.liquid
@@ -8,7 +8,9 @@
         <li class="vads-u-margin-top--1">
           <strong>{{ entity.fieldContactDefault.entity.title }} </strong>
           {% if entity.fieldContactDefault.entity.fieldLink %}
-            <a href="{{ entity.fieldContactDefault.entity.fieldLink.url.path }}" rel="noreferrer noopener">
+            <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ entity.fieldContactDefault.entity.fieldPhoneNumber }}', 'links-list-section-header': 'Need more help?' })"
+                href="{{ entity.fieldContactDefault.entity.fieldLink.url.path }}"
+                rel="noreferrer noopener">
               {{ entity.fieldContactDefault.entity.fieldPhoneNumber }}
             </a>
           {% endif %}
@@ -22,7 +24,9 @@
           {% if entity.fieldAdditionalContact.entity.fieldEmailLabel and entity.fieldAdditionalContact.entity.fieldEmailAddress %}
             <strong>{{ entity.fieldAdditionalContact.entity.fieldEmailLabel }}: </strong>
             {% if entity.fieldAdditionalContact.entity.fieldEmailAddress %}
-              <a href="mailto:{{ entity.fieldAdditionalContact.entity.fieldEmailAddress }}" rel="noreferrer noopener">
+              <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ entity.fieldAdditionalContact.entity.fieldEmailAddress }}', 'links-list-section-header': 'Need more help?' })"
+                  href="mailto:{{ entity.fieldAdditionalContact.entity.fieldEmailAddress }}"
+                  rel="noreferrer noopener">
                 {{ entity.fieldAdditionalContact.entity.fieldEmailAddress }}
               </a>
             {% endif %}
@@ -32,7 +36,9 @@
           {% if entity.fieldAdditionalContact.entity.fieldPhoneLabel and entity.fieldAdditionalContact.entity.fieldPhoneNumber %}
             <strong>{{ entity.fieldAdditionalContact.entity.fieldPhoneLabel }}: </strong>
             {% if entity.fieldAdditionalContact.entity.fieldPhoneNumber %}
-              <a href="tel:{{ entity.fieldAdditionalContact.entity.fieldPhoneNumber }}{% if fieldPhoneExtension %}p{{ fieldPhoneExtension }}{% endif %}" rel="noreferrer noopener">
+              <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ entity.fieldAdditionalContact.entity.fieldPhoneNumber }}{% if fieldPhoneExtension %}p{{ fieldPhoneExtension }}{% endif %}', 'links-list-section-header': 'Need more help?' })"
+                  href="tel:{{ entity.fieldAdditionalContact.entity.fieldPhoneNumber }}{% if fieldPhoneExtension %}p{{ fieldPhoneExtension }}{% endif %}"
+                  rel="noreferrer noopener">
                 {{ entity.fieldAdditionalContact.entity.fieldPhoneNumber }}{% if fieldPhoneExtension %}p{{ fieldPhoneExtension }}{% endif %}
               </a>
             {% endif %}
@@ -46,7 +52,9 @@
           <li class="vads-u-margin-top--1">
             <strong>{{ supportService.entity.title }} </strong>
             {% if supportService.entity.fieldLink %}
-              <a href="{{ supportService.entity.fieldLink.url.path }}" rel="noreferrer noopener">
+              <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ supportService.entity.fieldPhoneNumber }}', 'links-list-section-header': 'Need more help?' })"
+                  href="{{ supportService.entity.fieldLink.url.path }}"
+                  rel="noreferrer noopener">
                 {{ supportService.entity.fieldPhoneNumber }}
               </a>
             {% endif %}

--- a/src/site/paragraphs/contact_information.drupal.liquid
+++ b/src/site/paragraphs/contact_information.drupal.liquid
@@ -24,7 +24,7 @@
           {% if entity.fieldAdditionalContact.entity.fieldEmailLabel and entity.fieldAdditionalContact.entity.fieldEmailAddress %}
             <strong>{{ entity.fieldAdditionalContact.entity.fieldEmailLabel }}: </strong>
             {% if entity.fieldAdditionalContact.entity.fieldEmailAddress %}
-              <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ entity.fieldAdditionalContact.entity.fieldEmailAddress }}', 'links-list-section-header': 'Need more help?' })"
+              <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ entity.fieldAdditionalContact.entity.fieldEmailAddress | escape }}', 'links-list-section-header': 'Need more help?' })"
                   href="mailto:{{ entity.fieldAdditionalContact.entity.fieldEmailAddress }}"
                   rel="noreferrer noopener">
                 {{ entity.fieldAdditionalContact.entity.fieldEmailAddress }}
@@ -36,7 +36,7 @@
           {% if entity.fieldAdditionalContact.entity.fieldPhoneLabel and entity.fieldAdditionalContact.entity.fieldPhoneNumber %}
             <strong>{{ entity.fieldAdditionalContact.entity.fieldPhoneLabel }}: </strong>
             {% if entity.fieldAdditionalContact.entity.fieldPhoneNumber %}
-              <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ entity.fieldAdditionalContact.entity.fieldPhoneNumber }}{% if fieldPhoneExtension %}p{{ fieldPhoneExtension }}{% endif %}', 'links-list-section-header': 'Need more help?' })"
+              <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ entity.fieldAdditionalContact.entity.fieldPhoneNumber | escape }}{% if fieldPhoneExtension %}p{{ fieldPhoneExtension }}{% endif %}', 'links-list-section-header': 'Need more help?' })"
                   href="tel:{{ entity.fieldAdditionalContact.entity.fieldPhoneNumber }}{% if fieldPhoneExtension %}p{{ fieldPhoneExtension }}{% endif %}"
                   rel="noreferrer noopener">
                 {{ entity.fieldAdditionalContact.entity.fieldPhoneNumber }}{% if fieldPhoneExtension %}p{{ fieldPhoneExtension }}{% endif %}
@@ -52,7 +52,7 @@
           <li class="vads-u-margin-top--1">
             <strong>{{ supportService.entity.title }} </strong>
             {% if supportService.entity.fieldLink %}
-              <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ supportService.entity.fieldPhoneNumber }}', 'links-list-section-header': 'Need more help?' })"
+              <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ supportService.entity.fieldPhoneNumber | escape }}', 'links-list-section-header': 'Need more help?' })"
                   href="{{ supportService.entity.fieldLink.url.path }}"
                   rel="noreferrer noopener">
                 {{ supportService.entity.fieldPhoneNumber }}


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/15196

**WARNING:** This PR does NOT add the following because I don't think we have any additional info components being used yet, please lmk otherwise if we are though!!

![image](https://user-images.githubusercontent.com/12773166/99595989-cae73680-29b2-11eb-8cce-a9bae75c9052.png)

**This PR DOES add the following analytics:**

Description of Interaction | Screenshot of Interaction | Data Layer Specification
------------ | ------------- | -------------
Clicks on primary button CTAs on `/resources` subpages |  ![image](https://user-images.githubusercontent.com/48527022/97979561-64043380-1d9d-11eb-80ae-626e5002d954.png) | `'event': 'cta-button-click',`<br>`'button-type': 'default',`<br>`'button-click-label': 'Go to eBenefits to change your info' //dynamically populate with button text,`<br>`'button-background-color': //rgb code from css of button` (correlation with design system of [standardization ](https://github.com/department-of-veterans-affairs/va.gov-team/issues/14491) effort)
Clicks on page tags | ![image](https://user-images.githubusercontent.com/48527022/97980103-41bee580-1d9e-11eb-9f8f-f066b50cfb92.png) ![image](https://user-images.githubusercontent.com/48527022/97980922-85661f00-1d9f-11eb-8ce3-c81f80f236a1.png) | `'event': 'nav-page-tag-click',`<br>`'page-tag-click-label': 'Lorem impsum' //dynamically populate with tag text`<br>`'page-tag-category-label': 'Topics' //dynamically populate with category of tag`
Clicks on breadcrumb links | ![image](https://user-images.githubusercontent.com/48527022/97981319-16d59100-1da0-11eb-82ce-a0793a15f5ce.png) | `'event': 'nav-breadcrumb',`<br>`'breadcrumb-click-label': 'Resources and support' //dynamically populate with click label,`<br>`'breadcrumb-click-level': 2 //from LEFT TO RIGHT, level of the breadcrumb that is clicked`<br>`'breadcrumb-total-levels': 3 //total number of breadcrumbs in series (including one currently on)`<br>`'breadcrumb-mobile-first-enabled': true\|false //Boolean if the mobileFirst flag is used at time of click`
Clicks on additional info component [1.1] | ![image](https://user-images.githubusercontent.com/48527022/97981752-c27ee100-1da0-11eb-8e7e-bd5fedfc860b.png) | `'event': 'int-additionalInfo-expand' //or 'int-additionalInfo-collapse'`,<br>`'additionalInfo-click-label' //dynamically populate with click label`
Clicks on links within "Related information", "VA benefits", "Need more help?" section | ![image](https://user-images.githubusercontent.com/48527022/97985547-6ae37400-1da6-11eb-9334-86122e221d64.png) | `'event': 'nav-linkslist',`<br>`'links-list-header': //populate with blue header text (link),`<br>`'links-list-section-header': //dynamically populate with high level section, i.e "Related information"` 

### Search

#### On Search
- The following data layer code should execute following the user **completing a search** from any R+S page 
```javascript
recordEvent(
  'event': 'view_search_results', //fyi this taxonomy difference is to align with upcoming 2021 GA4 taxonomy
  'search-text-input': //populate precisely with query user initiated search
  'search-selection': //populate with "Resources and support", "All VA.gov" 
  'search-results-total-count': //populate with total count of search results returned
  'search-results-total-pages': //populate with total page count returned on search
)
```
#### On Search Result Click
- The following data layer code should execute when a user has **clicked on a search result**
```javascript
recordEvent(
  'event': 'onsite-search-results-click', //fyi this taxonomy difference is to align with upcoming 2021 GA4 taxonomy
  'search-text-input': //populate precisely with query user initiated search
  'search-selection': //populate with "Resources and support", "All VA.gov" 
  'search-results-total-count': //populate with total count of search results returned
  'search-results-total-pages': //populate with total page count returned on search
  'search-results-position-number':  //populate with the numerical position of the search result, relative to the current result page
)
```

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Add analytics for R&S

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
