### PR TITLE
Fix missing regional benefit office phone numbers (1-800)

### DIFF
--- a/src/applications/facility-locator/components/search-results-items/common/LocationPhoneLink.jsx
+++ b/src/applications/facility-locator/components/search-results-items/common/LocationPhoneLink.jsx
@@ -15,12 +15,6 @@ const renderPhoneNumber = (title, subTitle = null, phone, from) => {
 
   const { formattedPhoneNumber, extension, contact } = parsePhoneNumber(phone);
 
-  // The Telephone component will throw an error if passed an invalid phone number.
-  // Since we can't use try/catch or componentDidCatch here, we'll just do this:
-  if (contact.length !== 10) {
-    return null;
-  }
-
   return (
     <div>
       {from === 'FacilityDetail' && (

--- a/src/applications/facility-locator/components/search-results-items/common/LocationPhoneLink.jsx
+++ b/src/applications/facility-locator/components/search-results-items/common/LocationPhoneLink.jsx
@@ -15,6 +15,12 @@ const renderPhoneNumber = (title, subTitle = null, phone, from) => {
 
   const { formattedPhoneNumber, extension, contact } = parsePhoneNumber(phone);
 
+  // The Telephone component will throw an error if passed an invalid phone number.
+  // Since we can't use try/catch or componentDidCatch here, we'll just do this:
+  if (contact.length !== 10) {
+    return null;
+  }
+
   return (
     <div>
       {from === 'FacilityDetail' && (

--- a/src/applications/facility-locator/tests/helpers/phoneNumbers.unit.spec.js
+++ b/src/applications/facility-locator/tests/helpers/phoneNumbers.unit.spec.js
@@ -41,4 +41,14 @@ describe('parsePhoneNumber', () => {
     expect(extension).to.equal('123');
     expect(contact).to.equal('1234567890');
   });
+
+  it('with 800 numbers', () => {
+    const phone = '1-800-392-0000';
+    const { formattedPhoneNumber, extension, contact } = parsePhoneNumber(
+      phone,
+    );
+    expect(formattedPhoneNumber).to.equal('1-800-392-0000');
+    expect(extension).to.equal('');
+    expect(contact).to.equal('8003920000');
+  });
 });

--- a/src/applications/facility-locator/tests/helpers/phoneNumbers.unit.spec.js
+++ b/src/applications/facility-locator/tests/helpers/phoneNumbers.unit.spec.js
@@ -43,12 +43,12 @@ describe('parsePhoneNumber', () => {
   });
 
   it('with 800 numbers', () => {
-    const phone = '1-800-392-0000';
+    const phone = '1-800-827-1000';
     const { formattedPhoneNumber, extension, contact } = parsePhoneNumber(
       phone,
     );
-    expect(formattedPhoneNumber).to.equal('1-800-392-0000');
+    expect(formattedPhoneNumber).to.equal('800-827-1000');
     expect(extension).to.equal('');
-    expect(contact).to.equal('8003920000');
+    expect(contact).to.equal('8008271000');
   });
 });

--- a/src/applications/facility-locator/utils/phoneNumbers.js
+++ b/src/applications/facility-locator/utils/phoneNumbers.js
@@ -19,6 +19,6 @@ export const parsePhoneNumber = phone => {
   const formattedPhoneNumber = extension
     ? phone.replace(re, '$1-$2-$3 x$5').replace(/x$/, '')
     : phone.replace(re, '$1-$2-$3');
-  const contact = phone.replace(re, '$1$2$3');
+  const contact = phone.replace(re, '$1$2$3').replace(/^1-/, '');
   return { formattedPhoneNumber, extension, contact };
 };

--- a/src/applications/facility-locator/utils/phoneNumbers.js
+++ b/src/applications/facility-locator/utils/phoneNumbers.js
@@ -14,11 +14,13 @@
  */
 
 export const parsePhoneNumber = phone => {
+  const phoneUS = phone.replace(/^1-/, '');
   const re = /^(\d{3})[ -]*?(\d{3})[ -]*?(\d{4})\s?(\D*)?[ ]?(\d*)?/;
-  const extension = phone.replace(re, '$5').replace(/\D/g, '');
+  const extension = phoneUS.replace(re, '$5').replace(/\D/g, '');
   const formattedPhoneNumber = extension
-    ? phone.replace(re, '$1-$2-$3 x$5').replace(/x$/, '')
-    : phone.replace(re, '$1-$2-$3');
-  const contact = phone.replace(re, '$1$2$3').replace(/^1-/, '');
+    ? phoneUS.replace(re, '$1-$2-$3 x$5').replace(/x$/, '')
+    : phoneUS.replace(re, '$1-$2-$3');
+  const contact = phoneUS.replace(re, '$1$2$3');
+
   return { formattedPhoneNumber, extension, contact };
 };


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/15818

## Testing done
Unit test


## Screenshots
<img width="971" alt="Screen Shot 2020-11-18 at 10 51 50 PM" src="https://user-images.githubusercontent.com/100468/99622932-b590fd00-29f0-11eb-94fc-4621dffa0638.png">
<img width="1051" alt="Screen Shot 2020-11-18 at 10 52 00 PM" src="https://user-images.githubusercontent.com/100468/99622936-b75ac080-29f0-11eb-9930-676fffd6ce5b.png">


## Acceptance criteria
- [x]  If phone number is available in source data, it should be displayed in search results and on detail pages.

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
