### PR TITLE
VACMS-3487: Remove legacy fields from system type.

### DIFF
--- a/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
@@ -5,7 +5,6 @@
 const entityElementsFromPages = require('./entityElementsForPages.graphql');
 const healthCareLocalFacilities = require('./facilities-fragments/healthCareLocalFacility.node.graphql');
 const healthCareRegionHealthServices = require('./facilities-fragments/healthCareRegionHealthServices.node.graphql');
-const healthCareRegionFeaturedHealthServices = require('./facilities-fragments/healthCareRegionFeaturedHealthServces.node.graphql');
 const healthCareRegionNewsStories = require('./facilities-fragments/healthCareRegionNewsStories.node.graphql');
 const healthCareRegionEvents = require('./facilities-fragments/healthCareRegionEvents.node.graphql');
 
@@ -74,11 +73,7 @@ module.exports = `
     }
     ${healthCareLocalFacilities}
     fieldOtherVaLocations
-    ${healthCareRegionFeaturedHealthServices}
     ${healthCareRegionHealthServices}
-    fieldPressReleaseBlurb {
-      processed
-    }
     eventTeasersAll: reverseFieldOfficeNode(limit: 1000, filter: {conditions: [{field: "type", value: "event_listing"}]}) {
       entities {
         ... on NodeEventListing {

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
@@ -115,7 +115,6 @@ module.exports = {
     fieldRelatedLinks: {
       $ref: 'output/paragraph-list_of_link_teasers',
     },
-    fieldPressReleaseBlurb: { $ref: 'ProcessedString' },
     fieldMedia: { $ref: 'Media' },
     reverseFieldRegionPageNode: {
       type: 'object',
@@ -165,7 +164,6 @@ module.exports = {
     'fieldOtherVaLocations',
     'fieldNicknameForThisFacility',
     'fieldLinkFacilityEmergList',
-    'fieldPressReleaseBlurb',
     'reverseFieldRegionPageNode',
     'newsStoryTeasers',
     'allNewsStoryTeasers',

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
@@ -2,7 +2,6 @@ const moment = require('moment');
 const { getImageCrop } = require('./helpers');
 const {
   getDrupalValue,
-  getWysiwygString,
   createMetaTagArray,
   uriToUrl,
   isPublished,
@@ -26,7 +25,6 @@ const transform = ({
   fieldOtherVaLocations,
   fieldNicknameForThisFacility,
   fieldRelatedLinks,
-  fieldPressReleaseBlurb,
   fieldLinkFacilityEmergList,
   reverseFieldRegionPage,
   reverseFieldOffice,
@@ -57,9 +55,6 @@ const transform = ({
         }
       : null,
   fieldRelatedLinks: fieldRelatedLinks[0],
-  fieldPressReleaseBlurb: {
-    processed: getWysiwygString(getDrupalValue(fieldPressReleaseBlurb)),
-  },
   entityMetatags: createMetaTagArray(metaTags),
   reverseFieldRegionPageNode: {
     entities: reverseFieldRegionPage || [],


### PR DESCRIPTION
## Notice
Attention: @davidconlon @mmiddaugh @mpelzsherman @kevwalsh this pr removes fields (see screenshot) from system pages (e.g. `/pittsburgh-health-care`)
https://user-images.githubusercontent.com/643678/99266341-a80d2480-27f0-11eb-896d-b56a7d86ca15.jpg

## Description
Removes legacy fields (no longer in use) from VAMC system pages, e.g.: `/pittsburgh-health-care`

## Testing done
Visual, build

## Acceptance criteria
- [ ] Successful build

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
