### PR TITLE
Fix for alertbox spacing on content pages

### DIFF
--- a/src/platform/site-wide/sass/shame.scss
+++ b/src/platform/site-wide/sass/shame.scss
@@ -542,14 +542,6 @@ img[data-srcset] {
   display: inline-table
 }
 
-.va-l-detail-page {
-  .usa-content {
-    p {
-      margin-top: 0
-    }
-  }
-}
-
 .usa-accordion > ul li ul,
 .usa-accordion-bordered > ul li ul {
     list-style: square;


### PR DESCRIPTION
## Description

This PR fixes this pesky issue with the headings in alert boxes being squished against the paragraph.

https://dsva.slack.com/archives/CDHBKAL9W/p1605036140013400

## Testing done
I confirmed `/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/` looks good after the changes. This is a sketchy global CSS rule though that could have side effects.

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/1915775/99683802-bbb5c680-2a4e-11eb-9ffd-742d46952e09.png)

### After
![image](https://user-images.githubusercontent.com/1915775/99683838-c4a69800-2a4e-11eb-8c5e-85c1b46d96fe.png)


## Acceptance criteria
- [ ] Spacing issue in AlertBoxes is resolved

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
