### PR TITLE
[Development] Add note to HLR confirmation page

### DIFF
--- a/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
@@ -121,8 +121,13 @@ export class ConfirmationPage extends React.Component {
           href="/claim-or-appeal-status/"
           className="usa-button usa-button-primary"
         >
-          Track the status of your decision review
+          Check the status of your decision review
         </a>
+        <p>
+          <strong>Note</strong>: Please allow some time for your decision review
+          to process through our system. It could take 7 to 10 days for it to
+          show up in our claim status tool.
+        </p>
       </div>
     );
   }


### PR DESCRIPTION
## Description

Add a note on the HLR confirmation page to notify the Veteran that the status of their newly submitted Higher-Level Review form may not be visible in the claim status tool for 7 to 10 days

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/16006

## Testing done

N/A

## Screenshots

![Screen Shot 2020-11-19 at 8 49 11 AM](https://user-images.githubusercontent.com/136959/99683894-7392a600-2a46-11eb-8e45-e80e287b3a6b.png)

## Acceptance criteria
- [x] Note added below link to the claim status tool
- [x] Content recommendations applied

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
