### PR TITLE
Fix media-image path

### DIFF
--- a/src/site/stages/build/process-cms-exports/transformers/helpers.js
+++ b/src/site/stages/build/process-cms-exports/transformers/helpers.js
@@ -103,9 +103,9 @@ function getImageCrop(obj, imageStyle = null) {
           .join(', ')}.`,
       );
     }
-    const url = `/img/styles/${image.machine}/${
-      imageObj.image.derivative.url
-    }`.replace('public:/', 'public');
+    const url = `/img/styles/${
+      image.machine
+    }/public${imageObj.image.derivative.url.replace('/img', '')}`;
     imageObj.image.url = url;
     imageObj.image.derivative.url = url;
     imageObj.image.derivative.width = image.width;

--- a/src/site/stages/build/process-cms-exports/transformers/media-image.js
+++ b/src/site/stages/build/process-cms-exports/transformers/media-image.js
@@ -11,9 +11,9 @@ const transform = entity => ({
   image: {
     alt: entity.image[0].alt || '',
     title: entity.image[0].title || '',
-    url: encodeURI(entity.thumbnail[0].url),
+    url: encodeURI(entity.thumbnail[0].url.replace('public:/', '/img')),
     derivative: {
-      url: encodeURI(entity.thumbnail[0].url),
+      url: encodeURI(entity.thumbnail[0].url.replace('public:/', '/img')),
       width: entity.image[0].width,
       height: entity.image[0].height,
     },

--- a/src/site/stages/build/process-cms-exports/transformers/paragraph-media.js
+++ b/src/site/stages/build/process-cms-exports/transformers/paragraph-media.js
@@ -1,4 +1,4 @@
-const { getDrupalValue, getImageCrop } = require('./helpers');
+const { getDrupalValue } = require('./helpers');
 
 const transform = entity => ({
   entity: {
@@ -9,7 +9,7 @@ const transform = entity => ({
       getDrupalValue(entity.fieldAllowClicksOnThisImage) || false,
     fieldMedia:
       entity.fieldMedia && entity.fieldMedia.length
-        ? { entity: getImageCrop(entity.fieldMedia[0], '_21MEDIUMTHUMBNAIL') }
+        ? { entity: entity.fieldMedia[0] }
         : null,
   },
 });


### PR DESCRIPTION
## Description
This PR will fix the `public://` prefix in all `media-image` nodes where there are no image styles applied

## Testing done
Locally

## Screenshots
![Screen Shot 2020-11-17 at 2 53 02 PM](https://user-images.githubusercontent.com/55560129/99718903-9a1e0480-2a79-11eb-8a95-6cb183e1b467.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
