### PR TITLE
Fix styled image paths in export build

### DIFF
--- a/src/site/stages/build/process-cms-exports/transformers/helpers.js
+++ b/src/site/stages/build/process-cms-exports/transformers/helpers.js
@@ -107,7 +107,14 @@ function getImageCrop(obj, imageStyle = null) {
       imageObj.image.derivative.url
     }`.replace('public:/', 'public');
     imageObj.image.url = url;
-    imageObj.image.derivative.url = url;
+    // Derivative urls have a full path starting with
+    // 'https://{buildtype}.cms.va.gov/sites/default/files/', so add that here.
+    // It doesn't matter what the build type is since it gets stripped out in convertDrupalFilesToLocal
+    // so just use prod here
+    imageObj.image.derivative.url = `https://prod.cms.va.gov/sites/default/files/${url.replace(
+      '/img/',
+      '',
+    )}`;
     imageObj.image.derivative.width = image.width;
     imageObj.image.derivative.height = image.height;
     return imageObj;


### PR DESCRIPTION
## Description
Currently, many of the images with styles applied to them aren't being put in `/img/styles`. This is due to the `derivative.url` field in an image object not having an absolute path. Because it doesn't have an absolute path, the image paths aren't getting converted [here](https://github.com/department-of-veterans-affairs/vets-website/blob/38c7870a917dc984fdb65d55acc87ef5b91ece3e/src/site/stages/build/drupal/assets.js#L118).

This PR fixes the path for images that are part of the `/img/styles` folder in the CMS export build.

## Testing done
Compared the CMS export build & GraphQL build `img` folders to verify styled images were being applied to the correct folder.

## Screenshots


## Acceptance criteria
- [ ] Styled Images should be in the proper folder within `/img/styles` in the CMS export build.
- [ ] Images should now be visible in the CMS export buid.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
