### PR TITLE
Copy-paste the DowntimeNotification from savable

### DIFF
--- a/src/platform/forms-system/src/js/review/ReviewPage.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewPage.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Scroll from 'react-scroll';
-import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 
 import DowntimeNotification, {
@@ -43,7 +42,7 @@ class ReviewPage extends React.Component {
   };
 
   render() {
-    const { formConfig, pageList, path } = this.props;
+    const { formConfig, pageList, path } = this.props.route;
 
     const downtimeDependencies = formConfig?.downtime?.dependencies || [];
     return (
@@ -66,20 +65,6 @@ class ReviewPage extends React.Component {
   }
 }
 
-function mapStateToProps(state, ownProps) {
-  const route = ownProps.route;
-  const { formConfig, pageList, path } = route;
-
-  return {
-    formConfig,
-    pageList,
-    path,
-    route,
-  };
-}
-
-const mapDispatchToProps = {};
-
 ReviewPage.propTypes = {
   pageList: PropTypes.array.isRequired,
   path: PropTypes.string.isRequired,
@@ -88,11 +73,6 @@ ReviewPage.propTypes = {
   }).isRequired,
 };
 
-export default withRouter(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-  )(ReviewPage),
-);
+export default withRouter(ReviewPage);
 
 export { ReviewPage };

--- a/src/platform/forms-system/src/js/review/ReviewPage.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewPage.jsx
@@ -4,6 +4,11 @@ import Scroll from 'react-scroll';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 
+import DowntimeNotification, {
+  externalServiceStatus,
+} from 'platform/monitoring/DowntimeNotification';
+import DowntimeMessage from 'platform/monitoring/DowntimeNotification/components/Down';
+
 import { focusElement } from '../utilities/ui';
 import ReviewChapters from '../review/ReviewChapters';
 import SubmitController from '../review/SubmitController';
@@ -27,17 +32,35 @@ class ReviewPage extends React.Component {
     focusElement('h2');
   }
 
+  renderDowntime = (downtime, children) => {
+    if (downtime.status === externalServiceStatus.down) {
+      const Message = this.props.formConfig.downtime.message || DowntimeMessage;
+
+      return <Message downtime={downtime} />;
+    }
+
+    return children;
+  };
+
   render() {
     const { formConfig, pageList, path } = this.props;
 
+    const downtimeDependencies = formConfig?.downtime?.dependencies || [];
     return (
       <div>
         <ReviewChapters formConfig={formConfig} pageList={pageList} />
-        <SubmitController
-          formConfig={formConfig}
-          pageList={pageList}
-          path={path}
-        />
+        <DowntimeNotification
+          appTitle="application"
+          render={this.renderDowntime}
+          dependencies={downtimeDependencies}
+          customText={formConfig.customText}
+        >
+          <SubmitController
+            formConfig={formConfig}
+            pageList={pageList}
+            path={path}
+          />
+        </DowntimeNotification>
       </div>
     );
   }

--- a/src/platform/forms-system/test/js/review/ReviewPage.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewPage.unit.spec.jsx
@@ -9,42 +9,60 @@ describe('Schemaform review: ReviewPage', () => {
     pathname: '/testing/0',
   };
 
+  const formConfig = {
+    chapters: {
+      chapter1: {
+        pages: {
+          page1: {},
+        },
+      },
+      chapter2: {
+        pages: {
+          page2: {},
+        },
+      },
+    },
+  };
+
+  const pageList = [
+    {
+      path: 'previous-page',
+    },
+    {
+      path: 'testing',
+      pageKey: 'testPage',
+    },
+    {
+      path: 'next-page',
+    },
+  ];
+
+  const form = {
+    submission: {
+      hasAttemptedSubmit: false,
+    },
+    data: {},
+  };
+
   it('should render chapters', () => {
-    const formConfig = {
-      chapters: {
-        chapter1: {
-          pages: {
-            page1: {},
-          },
-        },
-        chapter2: {
-          pages: {
-            page2: {},
-          },
-        },
-      },
-    };
+    const tree = shallow(
+      <ReviewPage
+        form={form}
+        openChapters={[]}
+        route={{ formConfig, pageList }}
+        setEditMode={f => f}
+        setPreSubmit={f => f}
+        location={location}
+      />,
+    );
+    expect(tree.find('withRouter(Connect(ReviewChapters))')).to.have.length(1);
+    expect(tree.find('withRouter(Connect(SubmitController))')).to.have.length(
+      1,
+    );
+    tree.unmount();
+  });
 
-    const pageList = [
-      {
-        path: 'previous-page',
-      },
-      {
-        path: 'testing',
-        pageKey: 'testPage',
-      },
-      {
-        path: 'next-page',
-      },
-    ];
-
-    const form = {
-      submission: {
-        hasAttemptedSubmit: false,
-      },
-      data: {},
-    };
-
+  it('should appropriately render a downtime notification', () => {
     const tree = shallow(
       <ReviewPage
         form={form}
@@ -56,10 +74,7 @@ describe('Schemaform review: ReviewPage', () => {
       />,
     );
 
-    expect(tree.find('withRouter(Connect(ReviewChapters))')).to.have.length(1);
-    expect(tree.find('withRouter(Connect(SubmitController))')).to.have.length(
-      1,
-    );
+    expect(tree.find('Connect(DowntimeNotification)')).to.have.length(1);
     tree.unmount();
   });
 });


### PR DESCRIPTION
## Description

An action item resulting from this support ticket: https://github.com/department-of-veterans-affairs/vsp-support/issues/24

The caregivers team noticed that in their non-SiP-enabled form, downtime notifications were not displaying at all on the review page. This should resolve that by making `ReviewPage` more closely resemble `RoutedSavableReviewPage`.

## Testing done

Unit testing


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
