### PR TITLE
Make the broken link CSV public

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -156,6 +156,8 @@ def checkForBrokenLinks(String buildLogPath, String envName, Boolean contentOnly
   // Output a csv file with the broken links
   sh "cd /application && jenkins/glean-broken-links.sh ${buildLogPath} ${csvFileName}"
   if (fileExists(csvFile)) {
+    sh "cd /application && echo \"${csvFile}\" > build/${envName}/vagov-broken-links.csv"
+
     echo "Found broken links; notifying the Slack channel."
     // TODO: Move this slackUploadFile to cacheDrupalContent and update the echo statement above
     // slackUploadFile(filePath: csvFile, channel: 'dev_null', failOnError: true, initialComment: "Found broken links in the ${envName} build on `${env.BRANCH_NAME}`.")


### PR DESCRIPTION
## Description

Make the CSV of broken links created by the [`glean-broken-links.sh` script](https://github.com/department-of-veterans-affairs/vets-website/blob/master/jenkins/glean-broken-links.sh) publicly available so the CMS can read it. 

The change in this PR was inspired by how the [BUILD.txt](https://staging.va.gov/BUILD.txt) gets created by the [`build` function in `common.groovy`](https://github.com/department-of-veterans-affairs/vets-website/blob/d412bc0a1834ff507761f4be7f4d94eebb876349/jenkins/common.groovy#L201).

## Related Links

- Issue: [Create a design doc for how to handle broken link incidents](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/2417)
- PR: [VACMS-2417 Add broken link design doc](https://github.com/department-of-veterans-affairs/va.gov-team/pull/14092/)
- Content Validation Design Doc PR: https://github.com/department-of-veterans-affairs/va.gov-team/pull/9658

## Requested Feedback

- Does my shell script code look correct? 
- Does each environment have separate broken link CSVs, or is there only a single broken link CSV?
- Is there any reason the broken links shouldn't be public?
- The [Add broken link design doc](https://github.com/department-of-veterans-affairs/va.gov-team/pull/14092/) proposed `/data/vagov-broken-links.csv` as the route to the publicly available broken link CSV. But the [`/data` route redirects to data.va.gov](https://github.com/department-of-veterans-affairs/va.gov-team/pull/14092/files#r527255744). Is it acceptable to write the broken link file to the root, for example `staging.va.gov/vagov-broken-links.csv`? 

## Acceptance criteria

- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
