### PR TITLE
Add some basic My VA Dashboard tests

### DIFF
--- a/src/applications/personalization/dashboard/tests/e2e/dashboard-e2e-helpers.js
+++ b/src/applications/personalization/dashboard/tests/e2e/dashboard-e2e-helpers.js
@@ -1,0 +1,103 @@
+export function mockLocalStorage() {
+  // make sure no first-time UX modals are in the way
+  window.localStorage.setItem(
+    'DISMISSED_ANNOUNCEMENTS',
+    JSON.stringify(['single-sign-on-intro', 'find-benefits-intro']),
+  );
+}
+
+export const enrollmentStatusEnrolled = {
+  applicationDate: '2006-01-30T00:00:00.000-06:00',
+  enrollmentDate: '2006-03-20T00:00:00.000-06:00',
+  preferredFacility: '626A4 - ALVIN C. YORK VAMC',
+  effectiveDate: '2018-04-28T18:21:56.000-05:00',
+  parsedStatus: 'enrolled',
+};
+
+export const enrollmentStatusNotEnrolled = {
+  parsedStatus: 'none_of_the_above',
+};
+
+export const userPreferences = {
+  data: {
+    id: '',
+    type: 'arrays',
+    attributes: {
+      userPreferences: [
+        {
+          code: 'benefits',
+          title:
+            'the benefits a veteran is interested in, so VA.gov can help you apply for them',
+          userPreferences: [
+            { code: 'health-care', description: 'Get health care coverage' },
+          ],
+        },
+      ],
+    },
+  },
+};
+
+export const userPreferencesEmpty = {
+  data: {
+    id: '',
+    type: 'arrays',
+    attributes: {
+      userPreferences: [],
+    },
+  },
+};
+
+export function makeUserObject(options = {}) {
+  const services = [];
+  if (options.rx) {
+    services.push('rx');
+  }
+  if (options.messaging) {
+    services.push('messaging');
+  }
+  return {
+    data: {
+      id: '',
+      type: 'users_scaffolds',
+      attributes: {
+        services,
+        account: { accountUuid: 'c049d895-ecdf-40a4-ac0f-7947a06ea0c2' },
+        profile: {
+          email: 'vets.gov.user+36@gmail.com',
+          firstName: 'WESLEY',
+          middleName: 'WATSON',
+          lastName: 'FORD',
+          birthDate: '1986-05-06',
+          gender: 'M',
+          zip: '21122-6706',
+          lastSignedIn: '2020-07-21T00:04:51.589Z',
+          loa: { current: 3, highest: 3 },
+          multifactor: true,
+          verified: true,
+          signIn: { serviceName: 'idme', accountType: 'N/A', ssoe: true },
+          authnContext: 'http://idmanagement.gov/ns/assurance/loa/3',
+        },
+        vaProfile: {
+          status: 'OK',
+          birthDate: '19860506',
+          familyName: 'Ford',
+          gender: 'M',
+          givenNames: ['Wesley', 'Watson'],
+          isCernerPatient: options.isCerner,
+          facilities: options.facilities || [],
+          vaPatient: options.isPatient,
+          mhvAccountState: 'NONE',
+        },
+        veteranStatus: {
+          status: 'OK',
+          isVeteran: true,
+          servedInMilitary: true,
+        },
+        inProgressForms: options.inProgressForms || [],
+        prefillsAvailable: [],
+        vet360ContactInformation: {},
+      },
+    },
+    meta: { errors: null },
+  };
+}

--- a/src/applications/personalization/dashboard/tests/e2e/dashboard.all-widgets.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/dashboard.all-widgets.cypress.spec.js
@@ -1,0 +1,94 @@
+import {
+  enrollmentStatusEnrolled,
+  makeUserObject,
+  mockLocalStorage,
+  userPreferences,
+} from './dashboard-e2e-helpers';
+
+describe('MyVA Dashboard', () => {
+  describe('when user should see all available widgets', () => {
+    beforeEach(() => {
+      mockLocalStorage();
+      const mockUser = makeUserObject({
+        isCerner: false,
+        messaging: true,
+        rx: true,
+        facilities: [{ facilityId: '618', isCerner: false }],
+        inProgressForms: [
+          {
+            form: '40-10007',
+            metadata: {
+              version: 0,
+              returnUrl: '/preparer',
+              savedAt: 1602619612576,
+              expiresAt: 1607803612,
+              lastUpdated: 1602619612,
+              inProgressFormId: 4950,
+            },
+            lastUpdated: 1602619612,
+          },
+        ],
+        isPatient: true,
+      });
+      cy.login(mockUser);
+      // login() calls cy.server() so we can now mock routes
+      cy.route('GET', '/v0/user/preferences', userPreferences);
+      cy.route(
+        'GET',
+        '/v0/health_care_applications/enrollment_status',
+        enrollmentStatusEnrolled,
+      );
+    });
+    it('should show all the available widgets', () => {
+      cy.visit('my-va/');
+
+      // The COVID-19 alert shows up
+      cy.findByText(
+        /You may be eligible to use health chat as part of our pilot/i,
+      ).should('exist');
+      // The preferences widget shows the homeless alert and the selected
+      // preference
+      cy.findByTestId('preferences-widget')
+        .should(
+          'contain.text',
+          'If you’re homeless or at risk of becoming homeless',
+        )
+        .should('contain.text', 'With VA health care');
+      cy.findByRole('heading', { name: 'Your applications' }).should('exist');
+      cy.findByRole('heading', {
+        name: /^Application for pre-need determination/,
+      }).should('exist');
+      cy.findByRole('heading', { name: 'Manage your VA health care' }).should(
+        'exist',
+      );
+      cy.findByRole('heading', {
+        name: 'You are enrolled in VA Health Care',
+      }).should('exist');
+      cy.findByRole('heading', {
+        name: 'Check secure messages',
+      }).should('exist');
+      cy.findByRole('heading', {
+        name: 'Refill prescriptions',
+      }).should('exist');
+      cy.findByRole('heading', {
+        name: 'Schedule an appointment',
+      }).should('exist');
+
+      cy.findByRole('heading', {
+        name: 'Explore our most used benefits',
+      }).should('not.exist');
+
+      cy.findByRole('heading', {
+        name: 'Manage benefits or request records',
+      }).should('exist');
+
+      cy.findByRole('heading', {
+        name: 'View your profile',
+      }).should('exist');
+
+      cy.findByRole('link', {
+        name: 'Go to your profile',
+      }).should('exist');
+    });
+  });
+});

--- a/src/applications/personalization/dashboard/tests/e2e/dashboard.health-care-widgets.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/dashboard.health-care-widgets.cypress.spec.js
@@ -1,18 +1,8 @@
-const enrollmentStatusEnrolled = {
-  applicationDate: '2006-01-30T00:00:00.000-06:00',
-  enrollmentDate: '2006-03-20T00:00:00.000-06:00',
-  preferredFacility: '626A4 - ALVIN C. YORK VAMC',
-  effectiveDate: '2018-04-28T18:21:56.000-05:00',
-  parsedStatus: 'enrolled',
-};
-
-function mockLocalStorage() {
-  // make sure no first-time UX modals are in the way
-  window.localStorage.setItem(
-    'DISMISSED_ANNOUNCEMENTS',
-    JSON.stringify(['single-sign-on-intro', 'find-benefits-intro']),
-  );
-}
+import {
+  enrollmentStatusEnrolled,
+  makeUserObject,
+  mockLocalStorage,
+} from './dashboard-e2e-helpers';
 
 function mockFeatureFlags() {
   cy.route('GET', '/v0/feature_toggles*', {
@@ -29,71 +19,6 @@ function mockFeatureFlags() {
   });
 }
 
-function makeUserObject(
-  options = {
-    isCerner: true,
-    rx: true,
-    messaging: true,
-    facilities: [
-      { facilityId: '668', isCerner: true },
-      { facilityId: '757', isCerner: true },
-    ],
-  },
-) {
-  const services = [];
-  if (options.rx) {
-    services.push('rx');
-  }
-  if (options.messaging) {
-    services.push('messaging');
-  }
-  return {
-    data: {
-      id: '',
-      type: 'users_scaffolds',
-      attributes: {
-        services,
-        account: { accountUuid: 'c049d895-ecdf-40a4-ac0f-7947a06ea0c2' },
-        profile: {
-          email: 'vets.gov.user+36@gmail.com',
-          firstName: 'WESLEY',
-          middleName: 'WATSON',
-          lastName: 'FORD',
-          birthDate: '1986-05-06',
-          gender: 'M',
-          zip: '21122-6706',
-          lastSignedIn: '2020-07-21T00:04:51.589Z',
-          loa: { current: 3, highest: 3 },
-          multifactor: true,
-          verified: true,
-          signIn: { serviceName: 'idme', accountType: 'N/A', ssoe: true },
-          authnContext: 'http://idmanagement.gov/ns/assurance/loa/3',
-        },
-        vaProfile: {
-          status: 'OK',
-          birthDate: '19860506',
-          familyName: 'Ford',
-          gender: 'M',
-          givenNames: ['Wesley', 'Watson'],
-          isCernerPatient: options.isCerner,
-          facilities: options.facilities,
-          vaPatient: true,
-          mhvAccountState: 'NONE',
-        },
-        veteranStatus: {
-          status: 'OK',
-          isVeteran: true,
-          servedInMilitary: true,
-        },
-        inProgressForms: [],
-        prefillsAvailable: [],
-        vet360ContactInformation: {},
-      },
-    },
-    meta: { errors: null },
-  };
-}
-
 describe('MyVA Dashboard - Health Care Widgets', () => {
   describe('when user is enrolled at Cerner facility with all features', () => {
     beforeEach(() => {
@@ -103,6 +28,7 @@ describe('MyVA Dashboard - Health Care Widgets', () => {
         messaging: true,
         rx: true,
         facilities: [{ facilityId: '668', isCerner: true }],
+        isPatient: true,
       });
       cy.login(mockUser);
       // login() calls cy.server() so we can now mock routes
@@ -131,6 +57,7 @@ describe('MyVA Dashboard - Health Care Widgets', () => {
         messaging: true,
         rx: true,
         facilities: [{ facilityId: '757', isCerner: true }],
+        isPatient: true,
       });
       cy.login(mockUser);
       // login() calls cy.server() so we can now mock routes
@@ -159,6 +86,7 @@ describe('MyVA Dashboard - Health Care Widgets', () => {
         messaging: false,
         rx: false,
         facilities: [{ facilityId: '757', isCerner: true }],
+        isPatient: true,
       });
       cy.login(mockUser);
       // login() calls cy.server() so we can now mock routes
@@ -187,6 +115,7 @@ describe('MyVA Dashboard - Health Care Widgets', () => {
         messaging: true,
         rx: true,
         facilities: [{ facilityId: '686', isCerner: false }],
+        isPatient: true,
       });
       cy.login(mockUser);
       // login() calls cy.server() so we can now mock routes
@@ -215,6 +144,7 @@ describe('MyVA Dashboard - Health Care Widgets', () => {
         messaging: false,
         rx: true,
         facilities: [{ facilityId: '686', isCerner: false }],
+        isPatient: true,
       });
       cy.login(mockUser);
       // login() calls cy.server() so we can now mock routes
@@ -243,6 +173,7 @@ describe('MyVA Dashboard - Health Care Widgets', () => {
         messaging: true,
         rx: false,
         facilities: [{ facilityId: '686', isCerner: false }],
+        isPatient: true,
       });
       cy.login(mockUser);
       // login() calls cy.server() so we can now mock routes

--- a/src/applications/personalization/dashboard/tests/e2e/dashboard.minimal-widgets.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/dashboard.minimal-widgets.cypress.spec.js
@@ -1,0 +1,91 @@
+import {
+  enrollmentStatusNotEnrolled,
+  makeUserObject,
+  mockLocalStorage,
+  userPreferencesEmpty,
+} from './dashboard-e2e-helpers';
+
+describe('MyVA Dashboard', () => {
+  describe('when user should see the minimal amount of widgets', () => {
+    beforeEach(() => {
+      mockLocalStorage();
+      const mockUser = makeUserObject({
+        isCerner: false,
+        messaging: false,
+        rx: false,
+        facilities: [],
+        inProgressForms: [],
+        isPatient: false,
+      });
+      cy.login(mockUser);
+      // login() calls cy.server() so we can now mock routes
+      cy.route('GET', '/v0/user/preferences', userPreferencesEmpty);
+      cy.route(
+        'GET',
+        '/v0/health_care_applications/enrollment_status',
+        enrollmentStatusNotEnrolled,
+      );
+    });
+    it('should show the correct widgets', () => {
+      cy.visit('my-va/');
+
+      cy.findByText(
+        /You may be eligible to use health chat as part of our pilot/i,
+      ).should('not.exist');
+      // Shows the preference widget empty state
+      cy.findByTestId('preferences-widget')
+        .should(
+          'contain.text',
+          'You haven’t selected any benefits to learn about',
+        )
+        .should(
+          'not.contain.text',
+          'If you’re homeless or at risk of becoming homeless',
+        );
+
+      cy.findByRole('heading', { name: 'Your applications' }).should(
+        'not.exist',
+      );
+
+      cy.findByRole('heading', {
+        name: /^Application for pre-need determination/,
+      }).should('not.exist');
+
+      cy.findByRole('heading', { name: 'Manage your VA health care' }).should(
+        'not.exist',
+      );
+
+      cy.findByRole('heading', {
+        name: 'You are enrolled in VA Health Care',
+      }).should('not.exist');
+
+      cy.findByRole('heading', {
+        name: 'Check secure messages',
+      }).should('not.exist');
+
+      cy.findByRole('heading', {
+        name: 'Refill prescriptions',
+      }).should('not.exist');
+
+      cy.findByRole('heading', {
+        name: 'Schedule an appointment',
+      }).should('not.exist');
+
+      cy.findByRole('heading', {
+        name: 'Explore our most used benefits',
+      }).should('exist');
+
+      cy.findByRole('heading', {
+        name: 'Manage benefits or request records',
+      }).should('exist');
+
+      cy.findByRole('heading', {
+        name: 'View your profile',
+      }).should('exist');
+
+      cy.findByRole('link', {
+        name: 'Go to your profile',
+      }).should('exist');
+    });
+  });
+});

--- a/src/applications/personalization/preferences/containers/PreferencesWidget.jsx
+++ b/src/applications/personalization/preferences/containers/PreferencesWidget.jsx
@@ -217,7 +217,7 @@ class PreferencesWidget extends React.Component {
     const { showSavedMessage } = this.state;
 
     return (
-      <div>
+      <div data-testid="preferences-widget">
         <div className="title-container">
           <h2>Find VA benefits</h2>
           {isLoaded &&


### PR DESCRIPTION
## Description
This PR adds a couple of Cypress tests for the My VA Dashboard:
- one test is for a user who is eligible to see a lot of the available widgets
- the other test is for a user who should see a minimal set of available widgets

This also moved some functionality out of the existing medical alerts tests into shared helpers.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs