### PR TITLE
DT 508-defect-2's for find a form.

### DIFF
--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -120,13 +120,11 @@
             <h2>Related forms and instructions</h2>
             <ul class="usa-unstyled-list">
             {% for vaForm in fieldVaFormRelatedForms %}
-                <li>
-                  <hgroup>
-                    <h3>VA Form {{ vaForm.entity.fieldVaFormNumber }}</h3>
-                    <h4 class="vads-u-margin-top--0">
-                      <span class="vads-u-visibility--screen-reader">Form name:</span> {{ vaForm.entity.fieldVaFormName }}
-                    </h4>
-                  </hgroup>
+              <li>
+                  <h3>VA Form {{ vaForm.entity.fieldVaFormNumber }}</h3>
+                  <p class="vads-u-margin-top--0 vads-u-font-size--h4 vads-u-font-weight--bold">
+                    <dfn class="vads-u-visibility--screen-reader">Form name:</dfn> {{ vaForm.entity.fieldVaFormName }}
+                  </p>
 
                   {{ vaForm.entity.fieldVaFormUsage.processed }}
 

--- a/src/site/paragraphs/linkTeaser.drupal.liquid
+++ b/src/site/paragraphs/linkTeaser.drupal.liquid
@@ -20,8 +20,8 @@
         {% assign header = "b" %}
         {% assign headerClass = "" %}
     {% else %}
-        {% assign header = "h4" %}
-        {% assign headerClass = "va-nav-linkslist-title" %}
+        {% assign header = "h3" %}
+        {% assign headerClass = "va-nav-linkslist-title vads-u-font-size--h4" %}
     {% endif %}
 {% endif %}
 


### PR DESCRIPTION
# Issue(s)
[14482](https://github.com/department-of-veterans-affairs/va.gov-team/issues/14482) 
[15772](https://github.com/department-of-veterans-affairs/va.gov-team/issues/15772) 
[15785](https://github.com/department-of-veterans-affairs/va.gov-team/issues/15785) 

## Description
Worked with Accessibility team to determine best way to solve screen reader issues on /find-a-form/ and solved a small heading's should only be in sequential order of h1 => h6.

## Testing done
I ran voice over locally http://localhost:3001/find-forms/about-form-21p-0969/ to make sure the Form title's where not repeated when the entire page was read. That is focus the page and use `control + opt + a` to read the whole page.

For the headings. I reran the axe chrome extension on http://localhost:3001/find-forms/ and the axe warning for "Heading levels should only increase by one" disappeared. 

## Screenshots
![Screen Shot 2020-11-20 at 2 17 03 PM](https://user-images.githubusercontent.com/26075258/99840718-1298ca00-2b3b-11eb-8ef2-56155195d58d.png)


## Acceptance criteria
- [x] For A11y, the headers should be in descending according to the w3 standard. 
- [x] The Screen reader should only ready a text once as it reads the page.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
