### PR TITLE
10-10CG Signaturebox Error Rework

### DIFF
--- a/src/applications/caregivers/components/AdditionalInfo/index.jsx
+++ b/src/applications/caregivers/components/AdditionalInfo/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 import AlertBox, {
   ALERT_TYPE,

--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
@@ -20,6 +20,8 @@ const SignatureCheckbox = ({
   const isSignatureComplete = isSigned && isChecked;
   const hasSubmit = globalFormState.submission.status;
   const createInputContent = inputLabel => `Enter ${inputLabel} full name`;
+  console.log('globalFormState: ', globalFormState);
+  console.log('showError: ', showError);
 
   useEffect(
     () => {
@@ -53,6 +55,7 @@ const SignatureCheckbox = ({
         fullName={fullName}
         required={isRequired}
         showError={showError}
+        hasSubmit={hasSubmit}
       />
 
       <ErrorableCheckbox

--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
@@ -20,8 +20,6 @@ const SignatureCheckbox = ({
   const isSignatureComplete = isSigned && isChecked;
   const hasSubmit = globalFormState.submission.status;
   const createInputContent = inputLabel => `Enter ${inputLabel} full name`;
-  console.log('globalFormState: ', globalFormState);
-  console.log('showError: ', showError);
 
   useEffect(
     () => {

--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import ErrorableCheckbox from '@department-of-veterans-affairs/formation-react/ErrorableCheckbox';
 
 import SignatureInput from './SignatureInput';
@@ -11,11 +12,13 @@ const SignatureCheckbox = ({
   label,
   setSignature,
   showError,
+  globalFormState,
 }) => {
+  const [hasError, setError] = useState(null);
   const [isSigned, setIsSigned] = useState(false);
   const [isChecked, setIsChecked] = useState(false);
-  const [hasError, setError] = useState(null);
   const isSignatureComplete = isSigned && isChecked;
+  const hasSubmit = globalFormState.submission.status;
   const createInputContent = inputLabel => `Enter ${inputLabel} full name`;
 
   useEffect(
@@ -32,9 +35,9 @@ const SignatureCheckbox = ({
     () => {
       setError(showError);
 
-      if (isChecked === true) setError(false);
+      if (isChecked === true || hasSubmit) setError(false);
     },
-    [showError, setIsChecked, isChecked],
+    [showError, setIsChecked, isChecked, hasSubmit],
   );
 
   return (
@@ -70,6 +73,16 @@ SignatureCheckbox.propTypes = {
   setSignature: PropTypes.func.isRequired,
   showError: PropTypes.bool.isRequired,
   signatures: PropTypes.object.isRequired,
+  globalFormState: PropTypes.object.isRequired,
 };
 
-export default SignatureCheckbox;
+const mapStateToProps = state => {
+  return {
+    globalFormState: state.form,
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  null,
+)(SignatureCheckbox);

--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
@@ -1,7 +1,15 @@
 import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
 import ErrorableTextInput from '@department-of-veterans-affairs/formation-react/ErrorableTextInput';
 
-const SignatureInput = ({ fullName, required, label, setIsSigned }) => {
+const SignatureInput = ({
+  fullName,
+  required,
+  label,
+  setIsSigned,
+  showError,
+  hasSubmit,
+}) => {
   const [hasError, setError] = useState(false);
   const firstName = fullName.first?.toLowerCase() || '';
   const lastName = fullName.last?.toLowerCase() || '';
@@ -43,7 +51,9 @@ const SignatureInput = ({ fullName, required, label, setIsSigned }) => {
     () => {
       const isDirty = signature.dirty;
 
-      if (isDirty && !signatureMatches) {
+      // show error if user has touched input and signature does not match
+      // show error if there is a form error and has not been submitted
+      if ((isDirty && !signatureMatches) || (showError && !hasSubmit)) {
         setIsSigned(false);
         setError(true);
       }
@@ -53,7 +63,7 @@ const SignatureInput = ({ fullName, required, label, setIsSigned }) => {
         setError(false);
       }
     },
-    [setIsSigned, signature.dirty, signatureMatches],
+    [setIsSigned, signature.dirty, signatureMatches, showError, hasSubmit],
   );
 
   return (
@@ -69,6 +79,15 @@ const SignatureInput = ({ fullName, required, label, setIsSigned }) => {
       }
     />
   );
+};
+
+SignatureInput.propTypes = {
+  fullName: PropTypes.object.isRequired,
+  label: PropTypes.string.isRequired,
+  setIsSigned: PropTypes.func.isRequired,
+  showError: PropTypes.bool.isRequired,
+  hasSubmit: PropTypes.bool.isRequired,
+  required: PropTypes.bool,
 };
 
 export default SignatureInput;

--- a/src/applications/caregivers/components/PreSubmitInfo/index.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/index.jsx
@@ -3,7 +3,9 @@ import { cloneDeep } from 'lodash';
 
 import SignatureCheckbox from './SignatureCheckbox';
 
-const PreSubmitCheckboxGroup = ({ onSectionComplete, formData, showError }) => {
+const PreSubmitCheckboxGroup = props => {
+  console.log('props: ', props);
+  const { onSectionComplete, formData, showError } = props;
   const veteranLabel = `Veteran\u2019s`;
   const primaryLabel = `Primary Family Caregiver applicant\u2019s`;
   const secondaryOneLabel = `Secondary Family Caregiver applicant\u2019s`;

--- a/src/applications/caregivers/components/PreSubmitInfo/index.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/index.jsx
@@ -3,9 +3,7 @@ import { cloneDeep } from 'lodash';
 
 import SignatureCheckbox from './SignatureCheckbox';
 
-const PreSubmitCheckboxGroup = props => {
-  console.log('props: ', props);
-  const { onSectionComplete, formData, showError } = props;
+const PreSubmitCheckboxGroup = ({ onSectionComplete, formData, showError }) => {
   const veteranLabel = `Veteran\u2019s`;
   const primaryLabel = `Primary Family Caregiver applicant\u2019s`;
   const secondaryOneLabel = `Secondary Family Caregiver applicant\u2019s`;


### PR DESCRIPTION
## Description
When submitting the form the signature input would not error out. It would only error if signature didn't match and input was dirty. As for the Checkbox it would error too much and would error after form was submitted making the user think it didn't go through with a delayed confirmation page.

![](https://media0.giphy.com/media/EFXGvbDPhLoWs/giphy.gif)

## Testing done
- Manual testing

## Screenshots
![signature-error-3](https://user-images.githubusercontent.com/23741323/99886136-39710200-2c08-11eb-92b8-798b6836bfeb.gif)

## Acceptance criteria
- [x] After submission no inputs should error in signature box
- [x] Inputs should error if dirty and if signature does not match
- [x] Inputs should also error if submission has been attempted and required data is not present 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
