### PR TITLE
Add reverse fields needed to display events on VAMC pages

### DIFF
--- a/src/site/stages/build/process-cms-exports/transformers/node-event_listing.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-event_listing.js
@@ -16,6 +16,8 @@ const reverseFields = reverseFieldListing => ({
         .map(reverseField => ({
           title: reverseField.title,
           entityUrl: reverseField.entityUrl,
+          entityBundle: reverseField.entityBundle,
+          entityPublished: reverseField.entityPublished,
           uid: reverseField.uid,
           fieldFeatured: reverseField.fieldFeatured,
           fieldDate: reverseField.fieldDate,


### PR DESCRIPTION
## Description
Events section was missing from VAMC pages, eg. /pittsburgh-health-care/

## Testing done
Run cms export build, examine page

## Acceptance criteria
- [x] Correct events are displayed on pittsburgh-health-care

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
