### PR TITLE
Removed some unused CMS fields from some templates

### DIFF
--- a/src/site/includes/metatags.drupal.liquid
+++ b/src/site/includes/metatags.drupal.liquid
@@ -48,16 +48,8 @@
 <meta name="twitter:image" content="{{ hostUrl }}/img/design/logo/va-og-twitter-image.png">
 <meta content="{{ metaTitle }}" property="og:title">
 <meta content="{{ metaTitle }}" name="twitter:title" >
-  {% if fieldIntroTextNewsStories %}
-    {% assign description = fieldIntroTextNewsStories.processed  | strip_html %}
-  {% elsif fieldIntroTextEventsPage %}
-    {% assign description = fieldIntroTextEventsPage.processed | strip_html %}
-  {% elsif fieldClinicalHealthServi %}
+  {% if fieldClinicalHealthServi %}
     {% assign description = fieldClinicalHealthServi.processed | strip_html %}
-  {% elsif fieldLocationsIntroBlurb %}
-    {% assign description = fieldLocationsIntroBlurb.processed | strip_html %}
-  {% elsif fieldPatientFamilyServicesIn %}
-    {% assign description = fieldPatientFamilyServicesIn.processed | strip_html %}
   {% elsif fieldPressReleaseBlurb %}
     {% assign description = fieldPressReleaseBlurb.processed | strip_html %}
   {% elsif fieldDescription %}

--- a/src/site/layouts/events_page.drupal.liquid
+++ b/src/site/layouts/events_page.drupal.liquid
@@ -54,9 +54,6 @@ Example data:
       <div class="usa-width-three-fourths">
         <article class="usa-content">
           <h1>Events</h1>
-          <div class="va-introtext vads-u-margin-bottom--6">
-            {{ fieldIntroTextEventsPage.processed }}
-          </div>
 
           {% include "src/site/facilities/facilities_events_toggle.drupal.liquid" with url = entityUrl.path %}
 


### PR DESCRIPTION
## Description
Removed some fields that were removed from graphql in #14829 (or earlier) but remain in the liquid templates.
