### PR TITLE
Add other VA locations to health_care_region_page transformer

### DIFF
--- a/src/site/layouts/health_care_region_locations_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_locations_page.drupal.liquid
@@ -28,8 +28,7 @@
               {% include 'src/site/includes/facilityListing.drupal.liquid' with entity = other %}
             {% endfor %}
             {% if fieldOtherVaLocations != empty and fieldOtherVaLocations.length %}
-              <h2 class="medium-screen:vads-u-margin-bottom--4" id="other-nearby-va-locations">Other
-                              nearby VA locations</h2>
+              <h2 class="medium-screen:vads-u-margin-bottom--4" id="other-nearby-va-locations">Other nearby VA locations</h2>
               <div data-widget-type="other-facility-locations-list" data-facilities="{{ fieldOtherVaLocations }}"></div>
             {% endif %}
           </section>

--- a/src/site/stages/build/process-cms-exports/schemas/input/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/node-health_care_region_page.js
@@ -36,6 +36,10 @@ module.exports = {
     field_govdelivery_id_emerg: { $ref: 'GenericNestedString' },
     field_govdelivery_id_news: { $ref: 'GenericNestedString' },
     field_operating_status: socialMediaLinkSchema,
+    field_other_va_locations: {
+      type: 'array',
+      items: { value: 'string' },
+    },
     reverse_field_region_page: { $ref: 'EntityReferenceArray' },
     reverse_field_office: { $ref: 'EntityReferenceArray' },
     field_media: { $ref: 'EntityReferenceArray' },
@@ -51,6 +55,7 @@ module.exports = {
     'field_govdelivery_id_emerg',
     'field_govdelivery_id_news',
     'field_operating_status',
+    'field_other_va_locations',
     'reverse_field_region_page',
     'reverse_field_office',
     'field_media',

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
@@ -98,6 +98,7 @@ module.exports = {
     fieldGovdeliveryIdEmerg: { type: 'string' },
     fieldGovdeliveryIdNews: { type: 'string' },
     fieldOperatingStatus: socialMediaSchema,
+    fieldOtherVaLocations: { type: 'array' },
     fieldNicknameForThisFacility: { type: ['string', 'null'] },
     fieldLinkFacilityEmergList: {
       type: ['object', 'null'],
@@ -161,6 +162,7 @@ module.exports = {
     'fieldGovdeliveryIdEmerg',
     'fieldGovdeliveryIdNews',
     'fieldOperatingStatus',
+    'fieldOtherVaLocations',
     'fieldNicknameForThisFacility',
     'fieldLinkFacilityEmergList',
     'fieldPressReleaseBlurb',

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
@@ -23,6 +23,7 @@ const transform = ({
   fieldGovdeliveryIdEmerg,
   fieldGovdeliveryIdNews,
   fieldOperatingStatus,
+  fieldOtherVaLocations,
   fieldNicknameForThisFacility,
   fieldRelatedLinks,
   fieldPressReleaseBlurb,
@@ -193,6 +194,7 @@ const transform = ({
           }))
       : [],
   },
+  fieldOtherVaLocations: fieldOtherVaLocations.map(i => i.value),
   otherFacilities: {
     entities: reverseFieldRegionPage
       ? reverseFieldRegionPage
@@ -330,6 +332,7 @@ module.exports = {
     'field_media',
     'field_nickname_for_this_facility',
     'field_operating_status',
+    'field_other_va_locations',
     'field_press_release_blurb',
     'field_related_links',
     'metatag',


### PR DESCRIPTION
## Description
Add other VA locations to health_care_region_page transformer

## Acceptance criteria
- [x] View /pittsburgh-health-care/locations in a browser, note that the "Other nearby VA locations" section is visible.

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
