### PR TITLE
Sanlouise 16088 add analytics address failure

### DIFF
--- a/src/platform/user/profile/vap-svc/actions/transactions.js
+++ b/src/platform/user/profile/vap-svc/actions/transactions.js
@@ -14,6 +14,7 @@ import { CONFIRMED } from '../../constants/addressValidationMessages';
 import {
   isSuccessfulTransaction,
   isFailedTransaction,
+  failedTransactionStatus,
 } from '../util/transactions';
 
 export const VAP_SERVICE_TRANSACTIONS_FETCH_SUCCESS =
@@ -130,7 +131,7 @@ export function refreshTransaction(
             event: 'profile-edit-failure',
             'profile-action': 'save-failure',
             'profile-section': analyticsSectionName,
-            'error-key': transaction?.errors,
+            'error-key': failedTransactionStatus(transactionRefreshed),
           });
         }
       }
@@ -313,7 +314,7 @@ export const validateAddress = (
       event: 'profile-edit-failure',
       'profile-action': 'address-suggestion-failure',
       'profile-section': analyticsSectionName,
-      'error-key': error?.status,
+      'error-key': `${error[0]?.code}_${error[0]?.status}`,
     });
 
     return dispatch({

--- a/src/platform/user/profile/vap-svc/actions/transactions.js
+++ b/src/platform/user/profile/vap-svc/actions/transactions.js
@@ -130,6 +130,7 @@ export function refreshTransaction(
             event: 'profile-edit-failure',
             'profile-action': 'save-failure',
             'profile-section': analyticsSectionName,
+            'error-key': transaction?.errors,
           });
         }
       }
@@ -312,6 +313,7 @@ export const validateAddress = (
       event: 'profile-edit-failure',
       'profile-action': 'address-suggestion-failure',
       'profile-section': analyticsSectionName,
+      'error-key': error?.status,
     });
 
     return dispatch({

--- a/src/platform/user/profile/vap-svc/actions/transactions.js
+++ b/src/platform/user/profile/vap-svc/actions/transactions.js
@@ -91,7 +91,7 @@ export function refreshTransaction(
 ) {
   return async (dispatch, getState) => {
     try {
-      const { transactionId } = transaction.data.attributes;
+      const { transactionId, metaData } = transaction.data.attributes;
       const state = getState();
       const isAlreadyAwaitingUpdate = state.vapService.transactionsAwaitingUpdate.includes(
         transactionId,
@@ -131,7 +131,7 @@ export function refreshTransaction(
             event: 'profile-edit-failure',
             'profile-action': 'save-failure',
             'profile-section': analyticsSectionName,
-            'error-key': failedTransactionStatus(transactionRefreshed),
+            'error-key': `${metaData?.code}-address-save-failure`,
           });
         }
       }
@@ -314,7 +314,9 @@ export const validateAddress = (
       event: 'profile-edit-failure',
       'profile-action': 'address-suggestion-failure',
       'profile-section': analyticsSectionName,
-      'error-key': `${error[0]?.code}_${error[0]?.status}`,
+      'error-key': `${error.errors?.[0]?.code}_${
+        error.errors?.[0]?.status
+      }-address-suggestion-failure`,
     });
 
     return dispatch({

--- a/src/platform/user/profile/vap-svc/actions/transactions.js
+++ b/src/platform/user/profile/vap-svc/actions/transactions.js
@@ -14,7 +14,6 @@ import { CONFIRMED } from '../../constants/addressValidationMessages';
 import {
   isSuccessfulTransaction,
   isFailedTransaction,
-  failedTransactionStatus,
 } from '../util/transactions';
 
 export const VAP_SERVICE_TRANSACTIONS_FETCH_SUCCESS =

--- a/src/platform/user/profile/vap-svc/util/transactions.js
+++ b/src/platform/user/profile/vap-svc/util/transactions.js
@@ -76,10 +76,6 @@ export function isFailedTransaction(transaction) {
   return FAILURE_STATUSES.has(transaction?.data.attributes.transactionStatus);
 }
 
-export function failedTransactionStatus(transaction) {
-  return FAILURE_STATUSES[(transaction?.data.attributes.transactionStatus)];
-}
-
 function matchErrorCode(codeSet, transaction) {
   // Create a codeSet that contains all the values of the passed-in codeSet,
   // with and without a `VET360_` prefix. The `VET360_` prefix is added by our

--- a/src/platform/user/profile/vap-svc/util/transactions.js
+++ b/src/platform/user/profile/vap-svc/util/transactions.js
@@ -76,6 +76,10 @@ export function isFailedTransaction(transaction) {
   return FAILURE_STATUSES.has(transaction?.data.attributes.transactionStatus);
 }
 
+export function failedTransactionStatus(transaction) {
+  return FAILURE_STATUSES[(transaction?.data.attributes.transactionStatus)];
+}
+
 function matchErrorCode(codeSet, transaction) {
   // Create a codeSet that contains all the values of the passed-in codeSet,
   // with and without a `VET360_` prefix. The `VET360_` prefix is added by our


### PR DESCRIPTION
## Description
We need to add `error-key` to the `profile-edit-failure` event.

## Acceptance criteria
- [x] Add `error-key` to the `profile-edit-failure` event.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
