### PR TITLE
[Development] Add updateSuggestions callback

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -57,12 +57,11 @@ export const uiSchema = {
           'ui:options': {
             debounceRate: 200,
             freeInput: true,
-            updateSuggestions: (suggestions = [], value = '') => {
-              return value.length > 3 &&
-                suggestions[0]?.label.toLowerCase() !== value?.toLowerCase()
+            updateSuggestions: (suggestions, value) =>
+              value?.length > 2 && // set to 2 because we have 3-letter abbrev
+              suggestions[0]?.label.toLowerCase() !== value?.toLowerCase()
                 ? [{ id: '', label: value }, ...suggestions]
-                : suggestions;
-            },
+                : suggestions,
             inputTransformers: [
               // Replace a bunch of things that aren't valid with valid equivalents
               input => input.replace(/["”’]/g, `'`),

--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -57,6 +57,12 @@ export const uiSchema = {
           'ui:options': {
             debounceRate: 200,
             freeInput: true,
+            updateSuggestions: (suggestions = [], value = '') => {
+              return value.length > 3 &&
+                suggestions[0]?.label.toLowerCase() !== value?.toLowerCase()
+                ? [{ id: '', label: value }, ...suggestions]
+                : suggestions;
+            },
             inputTransformers: [
               // Replace a bunch of things that aren't valid with valid equivalents
               input => input.replace(/["”’]/g, `'`),

--- a/src/platform/forms-system/src/js/fields/AutosuggestField.jsx
+++ b/src/platform/forms-system/src/js/fields/AutosuggestField.jsx
@@ -107,10 +107,12 @@ export default class AutosuggestField extends React.Component {
   getSuggestions = (options, value) => {
     if (value) {
       const uiOptions = this.props.uiSchema['ui:options'];
-      return sortListByFuzzyMatch(value, options).slice(
-        0,
-        uiOptions.maxOptions,
-      );
+      const max = uiOptions.maxOptions;
+      const suggestions = sortListByFuzzyMatch(value, options).slice(0, max);
+
+      return typeof uiOptions.updateSuggestions === 'function'
+        ? uiOptions.updateSuggestions(suggestions, value).slice(0, max)
+        : suggestions;
     }
 
     return options;

--- a/src/platform/forms-system/test/js/fields/AutosuggestField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/fields/AutosuggestField.unit.spec.jsx
@@ -476,6 +476,53 @@ describe('<AutosuggestField>', () => {
     });
   });
 
+  it('should run updateSuggestions if freeInput is true and if updateSuggestions specified in ui:options', () => {
+    const onChange = sinon.spy();
+    const props = {
+      uiSchema: {
+        'ui:options': {
+          freeInput: true,
+          updateSuggestions: (suggestions, value) => [
+            { id: '', label: value },
+            ...suggestions,
+          ],
+          labels: {
+            AL: 'Label 1',
+            BC: 'Label 2',
+          },
+        },
+      },
+      schema: {
+        type: 'string',
+        enum: ['AL', 'BC'],
+      },
+      formContext: { reviewMode: false },
+      idSchema: { $id: 'id' },
+      onChange,
+      onBlur: () => {},
+    };
+    const processedSuggestions = [
+      {
+        id: 'AL',
+        label: 'Label 1',
+      },
+      {
+        id: 'BC',
+        label: 'Label 2',
+      },
+    ];
+    const tree = mount(<AutosuggestField {...props} />);
+
+    const suggestions = tree
+      .instance()
+      .getSuggestions(processedSuggestions, 'Label');
+    expect(suggestions).to.deep.equal([
+      { id: '', label: 'Label' },
+      ...processedSuggestions,
+    ]);
+    tree.unmount();
+  });
+
   it('should call onChange if input exists when setting options', () => {
     const uiSchema = {
       'ui:options': {


### PR DESCRIPTION
## Description

During UAT for our Benefits Delivery at Discharge (BDD) rollout, more than a few service members were confused when they entered a new disability that did not exactly match a provided suggestion. We would have to instruct them to click outside the autosuggest dropdown and then click save.

This PR adds a new `updateSuggestions` uiSchema option that allows prepending the typed-in value into the suggestion list. This change would apply to the form system globally, but would require the ui-option to implement for a specific form.

We plan to include this change in our upcoming usability study of the entire form 526 flow.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/13639

## Testing done

Added a unit test

## Screenshots

<details><summary>Entering an existing selection</summary>

<!-- leave a blank line above -->
![autosuggest](https://user-images.githubusercontent.com/136959/100005848-35bbb780-2d8f-11eb-8f88-48f3c849c93d.gif)</details>

<details><summary>Entering a new selection</summary>

<!-- leave a blank line above -->
![autosuggest2](https://user-images.githubusercontent.com/136959/100005928-56840d00-2d8f-11eb-89c7-313d4d074c65.gif)</details>

## Acceptance criteria
- [x] Entered values are included in the autosuggest list when option is set

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
