### PR TITLE
[Development] Add STR not required for BDD message

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/serviceTreatmentRecords.jsx
+++ b/src/applications/disability-benefits/all-claims/content/serviceTreatmentRecords.jsx
@@ -8,9 +8,8 @@ const alertContent = (
       getting your service treatment records.
     </p>
     <p>
-      You don't have to turn in your records now, but we recommend that you
-      submit them with this application. If you decide to submit them later,
-      please do so as soon as possible.
+      While you don’t have to turn them in now, please submit them as soon as
+      you can.
     </p>
   </>
 );
@@ -18,7 +17,7 @@ const alertContent = (
 export const serviceTreatmentRecordsSubmitLater = (
   <div className="service-treatment-records-submit-later">
     <AlertBox
-      headline="We recommend you submit your service treatment records"
+      headline="Please submit your service treatment records as soon as possible"
       content={alertContent}
       status="warning"
     />

--- a/src/applications/disability-benefits/all-claims/content/serviceTreatmentRecords.jsx
+++ b/src/applications/disability-benefits/all-claims/content/serviceTreatmentRecords.jsx
@@ -2,16 +2,11 @@ import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 const alertContent = (
-  <>
-    <p>
-      Your eligibility for the BDD program could expire if there is a delay in
-      getting your service treatment records.
-    </p>
-    <p>
-      While you don’t have to turn them in now, please submit them as soon as
-      you can.
-    </p>
-  </>
+  <p>
+    You don’t have to turn in your service treatment records with your
+    application, but your eligibility for the BDD program could expire if there
+    is a delay in us receiving them.
+  </p>
 );
 
 export const serviceTreatmentRecordsSubmitLater = (

--- a/src/applications/disability-benefits/all-claims/pages/serviceTreatmentRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/serviceTreatmentRecords.js
@@ -22,6 +22,8 @@ export const uiSchema = {
   'view:uploadServiceTreatmentRecordsQualifier': {
     'view:hasServiceTreatmentRecordsToUpload': {
       'ui:title': 'Do you want to upload your service treatment records?',
+      'ui:description':
+        'You can still  submit a Benefits Delivery at Discharge claim without your service treatment record.',
       'ui:widget': 'yesNo',
       'ui:options': {
         labels: {

--- a/src/applications/disability-benefits/all-claims/pages/serviceTreatmentRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/serviceTreatmentRecords.js
@@ -22,8 +22,8 @@ export const uiSchema = {
   'view:uploadServiceTreatmentRecordsQualifier': {
     'view:hasServiceTreatmentRecordsToUpload': {
       'ui:title': 'Do you want to upload your service treatment records?',
-      'ui:description':
-        'You can still  submit a Benefits Delivery at Discharge claim without your service treatment record.',
+      'ui:description': `(You can still submit a Benefits Delivery at Discharge
+        (BDD) claim online without your service treatment records.)`,
       'ui:widget': 'yesNo',
       'ui:options': {
         labels: {

--- a/src/applications/disability-benefits/all-claims/pages/serviceTreatmentRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/serviceTreatmentRecords.js
@@ -21,9 +21,8 @@ const { serviceTreatmentRecordsAttachments } = fullSchema.properties;
 export const uiSchema = {
   'view:uploadServiceTreatmentRecordsQualifier': {
     'view:hasServiceTreatmentRecordsToUpload': {
-      'ui:title': 'Do you want to upload your service treatment records?',
-      'ui:description': `(You can still submit a Benefits Delivery at Discharge
-        (BDD) claim online without your service treatment records.)`,
+      'ui:title': `Do you want to upload your service treatment records? (You’ll
+        have a chance to upload your medical records later in the application.)`,
       'ui:widget': 'yesNo',
       'ui:options': {
         labels: {


### PR DESCRIPTION
## Description

Active duty members may not have their service treatment records (STR) ready to upload while filling out a Benefits Delivery at Discharge (BDD) form.
- They forgot to request it
- The file is too big; we're limited to 50MB currently, one UAT participant had a 95MB file.
- The file may be encrypted. We have a method to remove the encryption, but the participant may not know the password, or lost it.

So as not to delay the application, the stakeholders wanted to emphasize to the member that uploading an STR was not required.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/16531

## Testing done

N/A - content update only

## Screenshots

<details><summary>Addition shown with no selection</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-11-23 at 3 22 42 PM](https://user-images.githubusercontent.com/136959/100017007-e0d46d00-2d9f-11eb-81d2-0921d723de6d.png)</details>

<details><summary>Addition shown with warning alert</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-11-23 at 3 26 43 PM](https://user-images.githubusercontent.com/136959/100017456-8982cc80-2da0-11eb-9899-a0f5c8412808.png)</details>

## Acceptance criteria
- [x] Message added emphasizing that STR is not required for BDD submission

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
