### PR TITLE
Explicitly mock the VAOS test user's contact info

### DIFF
--- a/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
@@ -1,4 +1,6 @@
 /* eslint-disable no-param-reassign */
+import { mockContactInformation } from '~/platform/user/profile/vap-svc/util/local-vapsvc.js';
+
 import moment from '../../lib/moment-tz';
 
 import confirmedVA from '../../services/mocks/var/confirmed_va.json';
@@ -16,6 +18,108 @@ import {
   getExpressCareRequestCriteriaMock,
   getParentSiteMock,
 } from '../mocks/v0';
+
+const mockUser = {
+  data: {
+    id: '',
+    type: 'users_scaffolds',
+    attributes: {
+      services: [
+        'facilities',
+        'hca',
+        'edu-benefits',
+        'form-save-in-progress',
+        'form-prefill',
+        'evss-claims',
+        'form526',
+        'user-profile',
+        'appeals-status',
+        'identity-proofed',
+      ],
+      account: {
+        accountUuid: '6af59b36-f14d-482e-88b4-3d7820422343',
+      },
+      profile: {
+        email: 'vets.gov.user+228@gmail.com',
+        firstName: 'MARK',
+        middleName: null,
+        lastName: 'WEBB',
+        birthDate: '1950-10-04',
+        gender: 'M',
+        zip: null,
+        lastSignedIn: '2020-06-18T21:15:19.664Z',
+        loa: {
+          current: 3,
+          highest: 3,
+        },
+        multifactor: true,
+        verified: true,
+        signIn: {
+          serviceName: 'idme',
+          accountType: 'N/A',
+        },
+        authnContext: 'http://idmanagement.gov/ns/assurance/loa/3/vets',
+      },
+      vaProfile: {
+        status: 'OK',
+        birthDate: '19501004',
+        familyName: 'Webb-ster',
+        gender: 'M',
+        givenNames: ['Mark'],
+        isCernerPatient: false,
+        facilities: [
+          {
+            facilityId: '556',
+            isCerner: false,
+          },
+          {
+            facilityId: '668',
+            isCerner: false,
+          },
+        ],
+        vaPatient: true,
+        mhvAccountState: 'NONE',
+      },
+      veteranStatus: null,
+      inProgressForms: [],
+      prefillsAvailable: [
+        '21-686C',
+        '40-10007',
+        '22-1990',
+        '22-1990N',
+        '22-1990E',
+        '22-1995',
+        '22-1995S',
+        '22-5490',
+        '22-5495',
+        '22-0993',
+        '22-0994',
+        'FEEDBACK-TOOL',
+        '22-10203',
+        '21-526EZ',
+        '1010ez',
+        '21P-530',
+        '21P-527EZ',
+        '686C-674',
+        '20-0996',
+        'MDOT',
+      ],
+      vet360ContactInformation: mockContactInformation,
+    },
+  },
+  meta: {
+    errors: [
+      {
+        externalService: 'EMIS',
+        startTime: '2020-06-18T21:15:34Z',
+        endTime: null,
+        description:
+          'IOError, Betamocks default response requested but none exist. Please create one at: [/cache/emis/veteran_status/default.yml]., Betamocks default response requested but none exist. Please create one at: [/cache/emis/veteran_status/default.yml].',
+        status: 503,
+      },
+    ],
+  },
+};
 
 function updateConfirmedVADates(data) {
   data.data.forEach(item => {
@@ -216,7 +320,8 @@ function mockSubmitVAAppointment() {
 
 function setupSchedulingMocks() {
   cy.server();
-  cy.login();
+  cy.login(mockUser);
+
   mockFeatureToggles();
   mockSupportedSites();
   mockCCPrimaryCareEligibility();


### PR DESCRIPTION
Since we can no longer rely on the default contact info that `mapRawUserDataToState()` was injecting into Redux

## Description


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs