### PR TITLE
Fix timezone issues with dates in staging and production

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -89,11 +89,28 @@ module.exports = function registerFilters() {
     return replaced;
   };
 
-  liquid.filters.dateFromUnix = (dt, format) => {
+  liquid.filters.dateFromUnix = (dt, format, tz = 'America/New_York') => {
     if (!dt) {
       return null;
     }
-    return moment.unix(dt).format(format);
+
+    let timezone = tz;
+
+    // TODO: figure out why this happens so frequently!
+    if (typeof tz !== 'string' || !tz.length) {
+      timezone = 'America/New_York';
+    } else if (!moment.tz.zone(tz)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Invalid timezone passed to dateFromUnix filter. Using default instead.',
+      );
+      timezone = 'America/New_York';
+    }
+
+    return moment
+      .unix(dt)
+      .tz(timezone)
+      .format(format);
   };
 
   liquid.filters.unixFromDate = data => new Date(data).getTime();

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -28,13 +28,41 @@ describe('timezoneAbbrev', () => {
 });
 
 describe('dateFromUnix', () => {
-  it('returns null for null', () => {
-    expect(liquid.filters.dateFromUnix()).to.be.null;
+  context('with default time zone', () => {
+    it('returns null for null', () => {
+      expect(liquid.filters.dateFromUnix()).to.be.null;
+    });
+
+    it('returns date with specified format', () => {
+      expect(liquid.filters.dateFromUnix(1604091600, 'dddd, MMM D YYYY')).to.eq(
+        'Friday, Oct. 30 2020',
+      );
+    });
+
+    it('returns time with specified format', () => {
+      expect(liquid.filters.dateFromUnix(1607958000, 'h:mm A')).to.eq(
+        '10:00 a.m.',
+      );
+    });
   });
 
-  it('returns date with specified format', () => {
-    expect(liquid.filters.dateFromUnix(1604091600, 'dddd, MMM D YYYY')).to.eq(
-      'Friday, Oct. 30 2020',
-    );
+  context('with specific time zone', () => {
+    it('returns time with specified format', () => {
+      expect(
+        liquid.filters.dateFromUnix(1607958000, 'h:mm A', 'America/Phoenix'),
+      ).to.eq('8:00 a.m.');
+    });
+
+    it('uses default if invalid timezone datatype passed', () => {
+      expect(liquid.filters.dateFromUnix(1607958000, 'h:mm A', {})).to.eq(
+        '10:00 a.m.',
+      );
+    });
+
+    it('uses default if invalid timezone passed', () => {
+      expect(
+        liquid.filters.dateFromUnix(1607958000, 'h:mm A', 'Not/A_Zone'),
+      ).to.eq('10:00 a.m.');
+    });
   });
 });

--- a/src/site/includes/date.drupal.liquid
+++ b/src/site/includes/date.drupal.liquid
@@ -1,14 +1,10 @@
 {% assign timezone = "ET" %}
 {% assign defaultTZ = "America/New_York" %}
 
-{% if fieldDatetimeRangeTimezone.timezone != empty %}
-    {% assign timezone = fieldDatetimeRangeTimezone.timezone |  timezoneAbbrev: fieldDatetimeRangeTimezone.value %}
-{% endif %}
-
 {% if fieldDatetimeRangeTimezone.value != empty %}
-    {% assign start_date_no_time = fieldDatetimeRangeTimezone.value | dateFromUnix: 'dddd, MMM D' %}
-    {% assign start_time = fieldDatetimeRangeTimezone.value | dateFromUnix: "h:mm A" %}
-    {% assign start_date_full = fieldDatetimeRangeTimezone.value | dateFromUnix: "dddd, MMM D, h:mm A" %}
+    {% assign start_date_no_time = fieldDatetimeRangeTimezone.value | dateFromUnix: 'dddd, MMM D', fieldDatetimeRangeTimezone.timezone %}
+    {% assign start_time = fieldDatetimeRangeTimezone.value | dateFromUnix: "h:mm A", fieldDatetimeRangeTimezone.timezone %}
+    {% assign start_date_full = fieldDatetimeRangeTimezone.value | dateFromUnix: "dddd, MMM D, h:mm A", fieldDatetimeRangeTimezone.timezone %}
     {% assign start_timestamp = fieldDatetimeRangeTimezone.value %}
 {% else %}
     {% assign start_date_no_time = fieldDate.startDate | timeZone: defaultTZ, "dddd, MMM D" %}
@@ -18,9 +14,9 @@
 {% endif %}
 
 {% if fieldDatetimeRangeTimezone.endValue != empty %}
-    {% assign end_date_no_time = fieldDatetimeRangeTimezone.endValue | dateFromUnix: 'dddd, MMM D' %}
-    {% assign end_time = fieldDatetimeRangeTimezone.endValue | dateFromUnix: "h:mm A" %}
-    {% assign end_date_full = fieldDatetimeRangeTimezone.endValue | dateFromUnix: "dddd, MMM D, h:mm A" %}
+    {% assign end_date_no_time = fieldDatetimeRangeTimezone.endValue | dateFromUnix: 'dddd, MMM D', fieldDatetimeRangeTimezone.timezone %}
+    {% assign end_time = fieldDatetimeRangeTimezone.endValue | dateFromUnix: "h:mm A", fieldDatetimeRangeTimezone.timezone %}
+    {% assign end_date_full = fieldDatetimeRangeTimezone.endValue | dateFromUnix: "dddd, MMM D, h:mm A", fieldDatetimeRangeTimezone.timezone %}
 {% else %}
     {% assign end_date_no_time = fieldDate.endValue | timeZone: defaultTZ, "dddd, MMM D" %}
     {% assign end_time = fieldDate.endDate | timeZone: defaultTZ, "h:mm A" %}


### PR DESCRIPTION
## Description
Bug: event times are being displayed in staging and production with the incorrect time (usually 5 hours too late).

Hypothesis: the moment "unix" function converts UNIX timestamp into a UTC date.

Our dateFromUnix filter passes that date to the format function, but without specifying
a timezone, so it uses the local timezone by default, which may be different in
staging and prod.

This PR add a specific timezone argument to `dateFromUnix`, which should resolve the bug.

## Testing done

This will need to be tested in the CI environment, if the review environments are working. If not, we'll have to push it to staging/production to test.

## Acceptance criteria
- [x] Dates are shown with the correct time zone on all event pages.

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
