### PR TITLE
Remove axe-check exception for 526

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
@@ -16,7 +16,6 @@ const todayPlus120 = moment()
 
 const testConfig = createTestConfig(
   {
-    _13647Exception: true,
     dataPrefix: 'data',
 
     dataSets: [


### PR DESCRIPTION
## Description

Form 526 previously had a critical level axe violation for which an exception was added. The issue was fixed and now we need to remove the exception flag

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/13647
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/14013
- https://github.com/department-of-veterans-affairs/vets-website/pull/14886

## Testing done

Cypress e2e tests

## Screenshots

N/A

## Acceptance criteria
- [x] Form 526 has no axe violations

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
