### PR TITLE
DT a11y 508 header being read twice

### DIFF
--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -121,23 +121,25 @@
             <ul class="usa-unstyled-list">
             {% for vaForm in fieldVaFormRelatedForms %}
               <li>
+                <hgroup>
                   <h3>VA Form {{ vaForm.entity.fieldVaFormNumber }}</h3>
-                  <p class="vads-u-margin-top--0 vads-u-font-size--h4 vads-u-font-weight--bold">
-                    <dfn class="vads-u-visibility--screen-reader">Form name:</dfn> {{ vaForm.entity.fieldVaFormName }}
-                  </p>
+                  <h4 class="vads-u-margin-top--0">
+                    Form name: {{ vaForm.entity.fieldVaFormName }}
+                  </h4>
+                </hgroup>
 
-                  {{ vaForm.entity.fieldVaFormUsage.processed }}
+                {{ vaForm.entity.fieldVaFormUsage.processed }}
 
-                  <a
-                    href="{{ vaForm.entity.fieldVaFormUrl.uri }}"
-                    target="_blank"
-                    download
-                    data-widget-type="find-va-forms-invalid-pdf-alert"
-                    data-form-number="{{ vaForm.entity.fieldVaFormNumber }}">
-                    Download VA Form {{ vaForm.entity.fieldVaFormNumber }} (PDF)
-                  </a>
-                </li>
-              {% endfor %}
+                <a
+                  href="{{ vaForm.entity.fieldVaFormUrl.uri }}"
+                  target="_blank"
+                  download
+                  data-widget-type="find-va-forms-invalid-pdf-alert"
+                  data-form-number="{{ vaForm.entity.fieldVaFormNumber }}">
+                  Download VA Form {{ vaForm.entity.fieldVaFormNumber }} (PDF)
+                </a>
+              </li>
+            {% endfor %}
             </ul>
           </section>
         {% endif %}


### PR DESCRIPTION
## Description
A continuation of [15042](https://github.com/department-of-veterans-affairs/vets-website/pull/15042).
I misinterpreted the answer to the question of using paragraph tags with nested definition tag or h4 tags and making the `From Name:` syntax visible between Design and a11y teams. Here is the remedy. 

## Testing done
1. yarn build:content --pull-drupal   
2. yarn watch --env.entry=static-pages  
3. Navigate to => http://localhost:3001/find-forms/about-form-21p-0969/
4. Run a screen reader on the page to read the whole page. (`control + option + a`)
5. Notice the reader does not repeat the header.

## Acceptance criteria
- [x] The screen reader does not repeat the headers of the forms.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
