### PR TITLE
Remove unnecessary environment checks from event and news story templates

### DIFF
--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -1,76 +1,3 @@
-{% comment %}
-Example data:
-{
-"entityId": "152",
-"entityBundle": "event",
-"entityPublished": true,
-"title": "Test Event",
-"entityUrl": {
-"breadcrumb": [
-{
-"url": {
-"path": "/",
-"routed": true
-},
-"text": "Home"
-},
-{
-"url": {
-"path": "/pittsburgh-health-care",
-"routed": true
-},
-"text": "Pittsburgh Health Care System"
-}
-],
-"path": "/pittsburgh-health-care/events/test-event"
-},
-"fieldEventDate": {
-"date": "2019-03-15 08:00:00 UTC",
-"value": "2019-03-15T08:00:00"
-},
-"fieldEventDateEnd": {
-"date": "2019-03-15 11:00:00 UTC",
-"value": "2019-03-15T11:00:00"
-},
-"fieldAddress": {
-"addressLine1": "123 Anywhere St.",
-"addressLine2": "",
-"locality": "Pittsburgh",
-"administrativeArea": "PA"
-},
-"fieldFacilityLocation": {
-"entity": {
-"title": "H. John Heinz III Department of Veterans Affairs Medical Center",
-"fieldFacilityLocatorApiId": "VHA_646A4",
-"entityUrl": {
-"path": "/pittsburgh-health-care/locations/heinz-medical-center"
-}
-}
-},
-"fieldLocationHumanreadable": "Kittery Public Library, 3rd Floor Meeting Room",
-"fieldDescription": "This is an event to test. ",
-"fieldBody": {
-"processed": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-  Maecenas dignissim vel tellus a posuere. Quisque cursus a turpis nec lobortis.
-  Nunc sit amet massa pellentesque, dictum leo a, aliquet neque. Duis ac
-  vulputate quam, at varius sem. Maecenas lacinia, elit quis imperdiet
-  convallis, ligula tortor ullamcorper ante, nec venenatis tortor sapien eu est.
-  Integer rhoncus leo quis augue hendrerit interdum. Duis ornare venenatis
-  ornare. Aliquam quis nisl ipsum.</p>\n\n<p>Nam lobortis arcu ac maximus
-  gravida. Nunc id odio sed nisi gravida pulvinar. Duis eleifend erat nec enim
-  convallis, id cursus risus convallis. Phasellus et commodo turpis. Etiam augue
-  est, sollicitudin id facilisis id, interdum quis est. Cras at ex sed est
-  finibus fermentum. Nullam rhoncus libero vel tellus suscipit, quis eleifend
-  elit dictum. Donec feugiat velit consequat ex mattis ornare. Praesent vel odio
-  accumsan, blandit sapien et, euismod mauris.</p>"
-},
-"fieldEventCost": "8",
-"fieldEventRegistrationrequired": false,
-"fieldAdditionalInformationAbo": "Registration isn't required."
-}
-]
-}
-{% endcomment %}
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
@@ -80,159 +7,14 @@ Example data:
 
 <div class="interior" id="content">
   <main class="va-l-detail-page va-facility-page">
+    <div class="usa-grid usa-grid-full">
+      {% if entityUrl.path contains "/outreach-and-events" %}
+        {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = outreachSidebar %}
+      {% else %}
+        {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
+      {% endif %}
 
-    {% comment %} On prod, show the SideNav. {% endcomment %}
-    {% if buildtype == 'vagovprod' %}
-      <div class="usa-grid usa-grid-full">
-        {% comment %} SideNav {% endcomment %}
-        {% if entityUrl.path contains "/outreach-and-events" %}
-          {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = outreachSidebar %}
-        {% else %}
-          {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
-        {% endif %}
-
-        {% comment %} Content {% endcomment %}
-        <div class="usa-width-three-fourths">
-          {% if !entityPublished %}
-            <div class="usa-alert usa-alert-info">
-              <div class="usa-alert-body">
-                <p class="usa-alert-text">You are viewing a draft.</p>
-              </div>
-            </div>
-          {% endif %}
-
-          <article aria-labelledby="article-heading" class="usa-content" role="region">
-            <div class="usa-grid usa-grid-full">
-              <h1 id="article-heading" class="{% if fieldMedia %}vads-u-margin-bottom--4{% else %}vads-u-margin-bottom--2{% endif %}">
-                {{ title }}</h1>
-              {% if fieldMedia %}
-                <img class="event-detail-img vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4" alt="{{fieldMedia.entity.image.alt}}" src="{{fieldMedia.entity.image.derivative.url}}"/>
-              {% endif %}
-              <div class="va-introtext">
-                <p class="vads-u-margin-top--0 vads-u-margin-bottom--1 medium-screen:vads-u-margin-bottom--4">
-                  {{ fieldDescription }}</p>
-              </div>
-
-              <div class="usa-width-one-half vads-u-margin-bottom--2p5 medium-screen:vads-u-margin-bottom--0">
-                {% assign facility = fieldFacilityLocation.entity %}
-                <dl class="va-c-event-info">
-                  <dt class="vads-u-font-weight--bold when-where-width vads-u-margin-right--2">
-                    When
-                  </dt>
-                  <dd>
-                    {% if date_type == "start_date_only" %}
-                      <span>{{ start_date_no_time }}</span><br>
-                      <span>{{ start_time }}</span>
-                    {% else %}
-                      {% if date_type == "same_day" %}
-                        <span>{{ start_date_no_time }}</span><br>
-                        <span>{{ start_time }}
-                          –
-                          {{ end_time }}</span>
-                      {% else %}
-                        <span>{{ start_date_full }}
-                          –</span><br>
-                        <span>{{ end_date_full }}</span>
-                      {% endif %}
-                    {% endif %}
-                    <span>{{ timezone }}</span>
-                  </dd>
-                </dl>
-
-                {% if fieldFacilityLocation or fieldAddress.addressLine1 %}
-                  <dl class="va-c-event-info">
-                    <dt class="vads-u-font-weight--bold when-where-width vads-u-margin-right--2">
-                      Where</dt>
-                    <dd>
-                      {% if facility %}
-                        <p class="vads-u-margin--0">
-                          <a href="{{ facility.entityUrl.path }}">{{ facility.title }}</a>
-                        </p>
-                        <p class="vads-u-margin--0">{{ fieldLocationHumanreadable }}
-                        </p>
-                      {% else %}
-                        {% if fieldAddress.addressLine1 %}
-                          <p class="vads-u-margin--0">{{ fieldAddress.addressLine1 }}
-                          </p>
-                        {% endif %}
-                        {% if fieldAddress.addressLine2 %}
-                          <p class="vads-u-margin--0">{{ fieldAddress.addressLine2 }}
-                          </p>
-                        {% endif %}
-                        <p class="vads-u-margin--0">
-                          {% if fieldAddress.locality %}
-                            {{ fieldAddress.locality }}
-                          {% endif %}
-                          {% if fieldAddress.administrativeArea %}
-                            ,
-                            {{ fieldAddress.administrativeArea }}
-                          {% endif %}
-                        </p>
-                      {% endif %}
-                    </dd>
-
-                  </dl>
-                {% endif %}
-
-                  {% if fieldEventCost %}
-                      <dl class="va-c-event-info">
-                        <dt class="vads-u-font-weight--bold vads-u-margin-right--2">Cost</dt>
-                        <dd>
-                          <span>{{ fieldEventCost }}</span>
-                        </dd>
-                      </dl>
-                  {% endif %}
-                  {% if fieldLink or fieldEventCta or fieldAdditionalInformationAbo %}
-                    <div class="registration vads-u-margin-top--4 vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--1">
-                        <p class="vads-u-font-weight--bold vads-u-margin-top--0 vads-u-margin-bottom--1">Registration</p>
-                        {% if start_timestamp < current_timestamp %}
-                            <p class="vads-u-margin--0 vads-u-color--secondary vads-u-font-weight--bold">This event already happened.</p>
-                        {% else %}
-                            {% if fieldLink %}
-                                <p class="vads-u-margin--0"><a
-                                            href="{{ fieldLink.url.path }}"><button class="vads-u-margin--0">
-                                              {% if fieldEventCta %}
-                                                {{ fieldEventCta | removeUnderscores | capitalize }}
-                                              {% else %}
-                                                More details
-                                              {% endif %}
-                                            </button></a>
-                                </p>
-                            {% endif %}
-                            {% if fieldAdditionalInformationAbo %}
-                                <p class="vads-u-margin--0">{{ fieldAdditionalInformationAbo.processed | outputLinks }}</p>
-                            {% endif %}
-                        {% endif %}
-                    </div>
-                  {% endif %}
-              </div>
-
-              <div class="usa-width-one-half va-c-event-share vads-u-margin-bottom--1">
-                {% include "src/site/includes/social-share.drupal.liquid" %}
-              </div>
-            </div>
-
-            <div class="usa-grid usa-grid-full vads-u-margin-top--2">
-              <div class="event-description">
-                {{ fieldBody.processed }}
-              </div>
-            </div>
-            {% assign index = entityUrl.breadcrumb.length | minus: 2 %}
-            <a onclick="recordEvent({ event: 'nav-secondary-button-click' });" href="{{ entityUrl.breadcrumb | getValueFromArrayObjPath: index, 'url.path' }}">See
-                          all events</a>
-          </article>
-
-          <div class="last-updated usa-content">
-            Last updated:
-            <time datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
-          </div>
-        </div>
-      </div>
-
-      {% comment %} On non-prod environments, do not show the SideNav.
-    {% endcomment %}
-    {% else %}
-      <div class="usa-grid usa-grid-full">
+      <div class="usa-width-three-fourths">
         {% if !entityPublished %}
           <div class="usa-alert usa-alert-info">
             <div class="usa-alert-body">
@@ -292,10 +74,12 @@ Example data:
                       </p>
                     {% else %}
                       {% if fieldAddress.addressLine1 %}
-                        <p class="vads-u-margin--0">{{ fieldAddress.addressLine1 }}</p>
+                        <p class="vads-u-margin--0">{{ fieldAddress.addressLine1 }}
+                        </p>
                       {% endif %}
                       {% if fieldAddress.addressLine2 %}
-                        <p class="vads-u-margin--0">{{ fieldAddress.addressLine2 }}</p>
+                        <p class="vads-u-margin--0">{{ fieldAddress.addressLine2 }}
+                        </p>
                       {% endif %}
                       <p class="vads-u-margin--0">
                         {% if fieldAddress.locality %}
@@ -357,7 +141,7 @@ Example data:
           </div>
           {% assign index = entityUrl.breadcrumb.length | minus: 2 %}
           <a onclick="recordEvent({ event: 'nav-secondary-button-click' });" href="{{ entityUrl.breadcrumb | getValueFromArrayObjPath: index, 'url.path' }}">See
-                      all events</a>
+                        all events</a>
         </article>
 
         <div class="last-updated usa-content">
@@ -365,7 +149,7 @@ Example data:
           <time datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
         </div>
       </div>
-    {% endif %}
+    </div>
   </main>
 </div>
 {% include "src/site/includes/footer.html" %}

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -70,16 +70,13 @@
                       <p class="vads-u-margin--0">
                         <a href="{{ facility.entityUrl.path }}">{{ facility.title }}</a>
                       </p>
-                      <p class="vads-u-margin--0">{{ fieldLocationHumanreadable }}
-                      </p>
+                      <p class="vads-u-margin--0">{{ fieldLocationHumanreadable }}</p>
                     {% else %}
                       {% if fieldAddress.addressLine1 %}
-                        <p class="vads-u-margin--0">{{ fieldAddress.addressLine1 }}
-                        </p>
+                        <p class="vads-u-margin--0">{{ fieldAddress.addressLine1 }}</p>
                       {% endif %}
                       {% if fieldAddress.addressLine2 %}
-                        <p class="vads-u-margin--0">{{ fieldAddress.addressLine2 }}
-                        </p>
+                        <p class="vads-u-margin--0">{{ fieldAddress.addressLine2 }}</p>
                       {% endif %}
                       <p class="vads-u-margin--0">
                         {% if fieldAddress.locality %}
@@ -92,7 +89,6 @@
                       </p>
                     {% endif %}
                   </dd>
-
                 </dl>
               {% endif %}
 
@@ -107,18 +103,22 @@
                 {% if fieldLink or fieldEventCta or fieldAdditionalInformationAbo %}
                   <div class="registration vads-u-margin-top--4 vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--1">
                       <p class="vads-u-font-weight--bold vads-u-margin-top--0 vads-u-margin-bottom--1">Registration</p>
+                    {{  start_timestamp |  json }}
+                    {{  current_timestamp |  json }}
                       {% if start_timestamp < current_timestamp %}
                           <p class="vads-u-margin--0 vads-u-color--secondary vads-u-font-weight--bold">This event already happened.</p>
                       {% else %}
                           {% if fieldLink %}
-                              <p class="vads-u-margin--0"><a
-                                          href="{{ fieldLink.url.path }}"><button class="vads-u-margin--0">
-                                            {% if fieldEventCta %}
-                                              {{ fieldEventCta | removeUnderscores | capitalize }}
-                                            {% else %}
-                                              More details
-                                            {% endif %}
-                                          </button></a>
+                              <p class="vads-u-margin--0">
+                                <a href="{{ fieldLink.url.path }}">
+                                  <button class="vads-u-margin--0">
+                                    {% if fieldEventCta %}
+                                      {{ fieldEventCta | removeUnderscores | capitalize }}
+                                    {% else %}
+                                      More details
+                                    {% endif %}
+                                  </button>
+                                </a>
                               </p>
                           {% endif %}
                           {% if fieldAdditionalInformationAbo %}
@@ -140,8 +140,10 @@
             </div>
           </div>
           {% assign index = entityUrl.breadcrumb.length | minus: 2 %}
-          <a onclick="recordEvent({ event: 'nav-secondary-button-click' });" href="{{ entityUrl.breadcrumb | getValueFromArrayObjPath: index, 'url.path' }}">See
-                        all events</a>
+          <a onclick="recordEvent({ event: 'nav-secondary-button-click' });"
+             href="{{ entityUrl.breadcrumb | getValueFromArrayObjPath: index, 'url.path' }}">
+            See all events
+          </a>
         </article>
 
         <div class="last-updated usa-content">

--- a/src/site/layouts/news_story.drupal.liquid
+++ b/src/site/layouts/news_story.drupal.liquid
@@ -1,57 +1,3 @@
-{% comment %}
-Example data:
-{
-    "entityId": "93",
-    "entityBundle": "news_story",
-    "entityPublished": false,
-    "promote": false,
-    "created": 1551049412,
-    "entityUrl": {
-        "breadcrumb": [
-            {
-                "url": {
-                "path": "/",
-                "routed": true
-            },
-                "text": "Home"
-            },
-            {
-                "url": {
-                "path": "/pittsburgh-health-care",
-                "routed": true
-            },
-                "text": "Pittsburgh Health Care System"
-            }
-            ],
-        "path": "/pittsburgh-health-care/news/opioid-use-review-clinic"
-    },
-    "title": "Opioid Use Review clinic",
-    "fieldAuthor": {
-        "entity": {
-            "title": "Sheila Tunney",
-            "fieldDescription": "Public Affairs Office"
-        }
-    },
-    "fieldImageCaption": "During a one-time, hourlong session, Opioid Use Review clinic staff talk with Veterans about their pain, discuss\r\nways to improve quality of life and provide opioid safety education, either in person in Pittsburgh or via\r\ntelehealth at regional VA outpatient clinics.",
-    "fieldIntroText": "Since 2014, more than 55 people* who may have otherwise overdosed and died have been saved with naloxone rescue kits issued to Veterans by VA Pittsburgh Healthcare System.",
-    "fieldMedia": {
-        "entity": {
-            "image": {
-                "alt": "Opioid Use Review clinic staff talk with Veterans about their pain",
-                "title": "",
-                "derivative": {
-                    "url": "http://stg.va.agile6.com/sites/default/files/styles/crop_2_1/public/2019-02/VAMC-Region-2019-02-21_0.jpg?itok=OwvOlLIz",
-                    "width": 468,
-                    "height": 326
-                }
-            }
-        }
-    },
-    "fieldFullStory": {
-        "processed": "<p>While that is an amazing fact, it is a small number compared to the more than 70,000* people in</p> ..."
-    }
-}
-{% endcomment %}
 {% if header == empty %}
     {% assign header = "h4" %}
 {% endif %}
@@ -62,53 +8,10 @@ Example data:
 
 <div id="content" class="interior">
     <main class="va-l-detail-page va-facility-page">
-        {% comment %} On prod environments, show the SideNav. {% endcomment %}
-        {% if buildtype == 'vagovprod' %}
-            <div class="usa-grid usa-grid-full">
-                {% comment %} SideNav {% endcomment %}
-                {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
+        <div class="usa-grid usa-grid-full">
+            {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
 
-                {% comment %} Content {% endcomment %}
-                <div class="usa-width-three-fourths">
-                    {% if !entityPublished %}
-                        <div class="usa-alert usa-alert-info" >
-                            <div class="usa-alert-body">
-                                <p class="usa-alert-text">You are viewing a draft.</p>
-                            </div>
-                        </div>
-                    {% endif %}
-
-                    <article class="usa-content">
-                        <h1>{{ title }}</h1>
-                        {% assign image = fieldMedia.entity.image %}
-                        <img class="story-detail-img {% if fieldImageCaption == empty %}vads-u-margin-bottom--2p5{% else %}vads-u-margin-bottom--1{% endif %}" src="{{ image.derivative.url }}" alt="{{ image.alt }}" title="{{ image.title }}" width="100%">
-                        <div class="vads-u-font-size--sm vads-u-margin-bottom--2p5">{{ fieldImageCaption }}</div>
-                        {% if fieldAuthor != empty and fieldAuthor.entity != empty %}
-                            {% assign author = fieldAuthor.entity %}
-                            <div class="authored-by-line vads-u-margin-bottom--0p5 vads-u-font-weight--bold">By {{ author.title }}{% if author.fieldDescription != empty %}, {{ author.fieldDescription }} {% endif %}</div>
-                        {% endif %}
-                        <div class="created-line vads-u-margin-bottom--2p5">
-                            <time datetime="{{ created | dateFromUnix: 'YYYY-MM-DD'}}">{{ created | humanizeTimestamp }}</time>
-                        </div>
-
-                        {% include "src/site/facilities/story_social_share.drupal.liquid" %}
-
-                        <div class="usa-grid usa-grid-full vads-u-margin-bottom--2">
-                            <div class="va-introtext">
-                                <p>{{ fieldIntroText }}</p>
-                            </div>
-                            <div class="full-story">
-                                {{ fieldFullStory.processed }}
-                            </div>
-                        </div>
-                        <a onClick="recordEvent({ event: 'nav-secondary-button-click' });" class="vads-u-display--block vads-u-margin-bottom--7" href="{{ fieldListing.entity.entityUrl.path }}">See all stories</a>
-                    </article>
-                </div>
-            </div>
-
-        {% comment %} On non-prod environments, do not show the SideNav. {% endcomment %}
-        {% else %}
-            <div class="usa-grid usa-grid-full">
+            <div class="usa-width-three-fourths">
                 {% if !entityPublished %}
                     <div class="usa-alert usa-alert-info" >
                         <div class="usa-alert-body">
@@ -143,7 +46,7 @@ Example data:
                     <a onClick="recordEvent({ event: 'nav-secondary-button-click' });" class="vads-u-display--block vads-u-margin-bottom--7" href="{{ fieldListing.entity.entityUrl.path }}">See all stories</a>
                 </article>
             </div>
-        {% endif %}
+        </div>
     </main>
 </div>
 {% include "src/site/includes/footer.html" %}


### PR DESCRIPTION
## Description
These environment checks are no longer needed.

## Testing done
Build and spot check some events and news stories pages.

## Acceptance criteria
- [x] Environment checks are gone and nothing is broken

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
