### PR TITLE
Update CTA cerner link text

### DIFF
--- a/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
@@ -180,7 +180,7 @@ export class CernerCallToAction extends Component {
             );
 
             // Derive the link text/label.
-            const linkText = isCerner ? 'Go to My VA Health' : myHealtheVetLink;
+            const linkText = isCerner ? 'Go to My VA Health' : myHealtheVetLinkText;
 
             return (
               <div key={`${id}-cta-link`}>

--- a/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
@@ -124,7 +124,10 @@ export class CernerCallToAction extends Component {
     }
 
     // Derive MyHealtheVet link text.
-    const myHealtheVetLinkText = myHealtheVetLink === appointmentsToolLink ? 'Go to the VA appointments tool' : 'Go to My HealtheVet';
+    const myHealtheVetLinkText =
+      myHealtheVetLink === appointmentsToolLink
+        ? 'Go to the VA appointments tool'
+        : 'Go to My HealtheVet';
 
     return (
       <div
@@ -180,7 +183,9 @@ export class CernerCallToAction extends Component {
             );
 
             // Derive the link text/label.
-            const linkText = isCerner ? 'Go to My VA Health' : myHealtheVetLinkText;
+            const linkText = isCerner
+              ? 'Go to My VA Health'
+              : myHealtheVetLinkText;
 
             return (
               <div key={`${id}-cta-link`}>

--- a/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
@@ -123,6 +123,9 @@ export class CernerCallToAction extends Component {
       );
     }
 
+    // Derive MyHealtheVet link text.
+    const myHealtheVetLinkText = myHealtheVetLink === appointmentsToolLink ? 'Go to the VA appointments tool' : 'Go to My HealtheVet';
+
     return (
       <div
         className="usa-alert usa-alert-warning"
@@ -176,6 +179,9 @@ export class CernerCallToAction extends Component {
               cernerFacility => cernerFacility?.facilityId === strippedID,
             );
 
+            // Derive the link text/label.
+            const linkText = isCerner ? 'Go to My VA Health' : myHealtheVetLink;
+
             return (
               <div key={`${id}-cta-link`}>
                 <p className="vads-u-margin-bottom--1">
@@ -187,11 +193,12 @@ export class CernerCallToAction extends Component {
                   rel="noreferrer noopener"
                   target="_blank"
                 >
-                  {isCerner ? 'Go to My VA Health' : 'Go to My HealtheVet'}
+                  {linkText}
                 </a>
               </div>
             );
           })}
+
           <div>
             <p className="vads-u-margin-bottom--1">
               <strong>Another VA health facility</strong>
@@ -202,9 +209,7 @@ export class CernerCallToAction extends Component {
               rel="noreferrer noopener"
               target="_blank"
             >
-              {myHealtheVetLink === appointmentsToolLink
-                ? 'Go to the VA appointments tool'
-                : 'Go to My HealtheVet'}
+              {myHealtheVetLinkText}
             </a>
           </div>
         </div>


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/16308

This PR updates the Cerner CTA widget text when authenticated, belonging to a Cerner facility, and only on the scheduling page.

## Testing done
N/A

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/100131173-ecc43b80-2e40-11eb-8c1c-e23629d0ba41.png)

## Acceptance criteria
- [x] Update Cerner CTA widget link text

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
