### PR TITLE
Add analytics updates

### DIFF
--- a/src/applications/personalization/profile/components/connected-apps/ConnectedApps.jsx
+++ b/src/applications/personalization/profile/components/connected-apps/ConnectedApps.jsx
@@ -116,6 +116,13 @@ export class ConnectedApps extends Component {
           <Link
             className="usa-button vads-u-margin-bottom--3"
             href="/resources/find-apps-you-can-use"
+            onClick={() =>
+              recordEvent({
+                event: 'go-to-app-directory',
+                'profile-action': 'view-link',
+                'profile-section': 'connected-apps',
+              })
+            }
           >
             Go to app directory
           </Link>
@@ -152,7 +159,16 @@ export class ConnectedApps extends Component {
             >
               To find out what other third-party apps are available to connect
               to your profile,{' '}
-              <a href="/resources/find-apps-you-can-use">
+              <a
+                href="/resources/find-apps-you-can-use"
+                onClick={() =>
+                  recordEvent({
+                    event: 'go-to-app-directory',
+                    'profile-action': 'view-link',
+                    'profile-section': 'connected-apps',
+                  })
+                }
+              >
                 go to the app directory
               </a>
             </AdditionalInfo>

--- a/src/platform/user/profile/vap-svc/actions/transactions.js
+++ b/src/platform/user/profile/vap-svc/actions/transactions.js
@@ -132,6 +132,9 @@ export function refreshTransaction(
             'profile-section': analyticsSectionName,
             'error-key': `${metaData?.code}-address-save-failure`,
           });
+          recordEvent({
+            'error-key': undefined,
+          });
         }
       }
     } catch (err) {
@@ -316,6 +319,10 @@ export const validateAddress = (
       'error-key': `${error.errors?.[0]?.code}_${
         error.errors?.[0]?.status
       }-address-suggestion-failure`,
+    });
+
+    recordEvent({
+      'error-key': undefined,
     });
 
     return dispatch({


### PR DESCRIPTION
## Description
There are 2 tasks pertaining to updating GA:

1) we need to add a second dataLayer.push that only includes the error-key and that the error-key be undefined
2) we need to record an event on the button and link in the profile, so we can see when users click that to navigate to the app directory from the profile

## Acceptance criteria
- [x] Add analytics in connected apps and address transaction files

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
