### PR TITLE
Removed ready to apply text

### DIFF
--- a/src/applications/static-pages/vre-chapter31/buildChapter31Content.js
+++ b/src/applications/static-pages/vre-chapter31/buildChapter31Content.js
@@ -64,9 +64,6 @@ const Chapter31Content = props => {
             {optionalSubwayMapItem}
           </ol>
         </div>
-        <p className="vads-u-font-size--h2 vads-u-font-family--serif vads-u-margin-bottom--0 vads-u-font-weight--bold">
-          Ready to apply?
-        </p>
         <EbenefitsLink
           path="ebenefits/about/feature?feature=vocational-rehabilitation-and-employment"
           className="usa-button-primary va-button-primary"


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/16573)

This PR is to update the text inside the flipper component for chapter 31 by removing the text "Ready To Apply?" above the CTA.

## Acceptance criteria
- [x] The feature toggle has been adjusted accordingly
- [x] A PR has been requested for merging

