### PR TITLE
Fix thumbnail for person profile

### DIFF
--- a/src/site/stages/build/process-cms-exports/transformers/node-person_profile.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-person_profile.js
@@ -23,7 +23,12 @@ const transform = (entity, { ancestors }) => ({
   fieldLastName: getDrupalValue(entity.fieldLastName),
   fieldMedia:
     entity.fieldMedia && entity.fieldMedia.length > 0
-      ? { entity: getImageCrop(entity.fieldMedia[0], '_23MEDIUMTHUMBNAIL') }
+      ? {
+          entity: getImageCrop(
+            entity.fieldMedia[0],
+            '_1_1_SQUARE_MEDIUM_THUMBNAIL',
+          ),
+        }
       : null,
   fieldNameFirst: getDrupalValue(entity.fieldNameFirst),
   fieldOffice: entity.fieldOffice[0]


### PR DESCRIPTION
## Description
The person_profile transformer was using the wrong thumbnail. This fixes that.


## Testing done
View pittsburgh-health-care/patient-advocates in a web browser.


## Screenshots


## Acceptance criteria
- [x] Thumbnail path is correct (/img/styles/1_1_square_medium_thumbnail/...)

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
