### PR TITLE
fix logic for facility codes with suffix like 459GE

### DIFF
--- a/src/applications/coronavirus-screener/containers/App.jsx
+++ b/src/applications/coronavirus-screener/containers/App.jsx
@@ -8,12 +8,14 @@ export default function App({ params }) {
   let selectedLanguage = 'en';
   let alternateLangauge = 'es';
   let alternateRefBase = '/covid19screen/';
+
   // Control for facility ids that have letters in them e.g. 459GE.
-  let customId = params.id?.slice(0, 3);
+  const customId = params.id;
+  let customIdBase = params.id?.slice(0, 3);
 
   // If the first value is not a number, then there is no custom site id.
-  if (isNaN(customId)) {
-    customId = undefined;
+  if (isNaN(customIdBase)) {
+    customIdBase = undefined;
   } else {
     // If the first three chars of the first value is a number,
     // then there is a custom site id.


### PR DESCRIPTION
## Description
Bug fix. Screener was dropping CBOC suffixes (e.g. the "GF" part of 459GF). 

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
