### PR TITLE
Fix fieldWysiwyg by using the right value

### DIFF
--- a/src/site/stages/build/process-cms-exports/transformers/helpers.js
+++ b/src/site/stages/build/process-cms-exports/transformers/helpers.js
@@ -70,6 +70,7 @@ function unescapeUnicode(string) {
  */
 function getDrupalValue(arr) {
   if (!arr || arr.length === 0) return null;
+  if (arr.length === 1 && arr[0].processed === '') return null;
   if (arr.length === 1)
     if (arr[0].processed)
       return typeof arr[0].processed === 'string'

--- a/src/site/stages/build/process-cms-exports/transformers/paragraph-collapsible_panel_item.js
+++ b/src/site/stages/build/process-cms-exports/transformers/paragraph-collapsible_panel_item.js
@@ -7,7 +7,6 @@ const transform = entity => ({
     fieldTitle: getDrupalValue(entity.fieldTitle),
     fieldVaParagraphs: entity.fieldVaParagraphs,
     fieldWysiwyg: {
-      // processed: getWysiwygString(entity.fieldWysiwyg.processed),
       processed: getWysiwygString(getDrupalValue(entity.fieldWysiwyg)),
     },
   },

--- a/src/site/stages/build/process-cms-exports/transformers/paragraph-collapsible_panel_item.js
+++ b/src/site/stages/build/process-cms-exports/transformers/paragraph-collapsible_panel_item.js
@@ -7,7 +7,8 @@ const transform = entity => ({
     fieldTitle: getDrupalValue(entity.fieldTitle),
     fieldVaParagraphs: entity.fieldVaParagraphs,
     fieldWysiwyg: {
-      processed: getWysiwygString(entity.fieldWysiwyg.processed),
+      // processed: getWysiwygString(entity.fieldWysiwyg.processed),
+      processed: getWysiwygString(getDrupalValue(entity.fieldWysiwyg)),
     },
   },
 });

--- a/src/site/stages/build/process-cms-exports/transformers/paragraph-collapsible_panel_item.js
+++ b/src/site/stages/build/process-cms-exports/transformers/paragraph-collapsible_panel_item.js
@@ -7,7 +7,7 @@ const transform = entity => ({
     fieldTitle: getDrupalValue(entity.fieldTitle),
     fieldVaParagraphs: entity.fieldVaParagraphs,
     fieldWysiwyg: {
-      processed: getWysiwygString(getDrupalValue(entity.fieldWysiwyg)),
+      processed: getWysiwygString(entity.fieldWysiwyg.processed),
     },
   },
 });


### PR DESCRIPTION
## Description
The `field_wysiwyg` was using the wrong value in the transformer. Based on the cms team, `processed` should always be used instead of `value`

```
"field_wysiwyg": [
        {
            "value": "<div id=\"age-29-below\" class=\"usa-accordion-content\"> <\/div>",
            "format": "rich_text",
            "processed": ""
        }
    ]
```

In this case, `processed` is empty forcing to use the `value` field in the `getDrupalValue` function.

## Testing done
Locally

## Screenshots
![Screen Shot 2020-11-24 at 8 42 55 AM](https://user-images.githubusercontent.com/55560129/100247818-bfdb5b80-2f08-11eb-9d39-41c1b0a28309.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
