### PR TITLE
Fix liquid template current time filter function

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -115,9 +115,9 @@ module.exports = function registerFilters() {
 
   liquid.filters.unixFromDate = data => new Date(data).getTime();
 
-  liquid.filters.currentUnixFromDate = () => {
+  liquid.filters.currentTimeInSeconds = () => {
     const time = new Date();
-    return time.getTime();
+    return Math.floor(time.getTime() / 1000);
   };
 
   liquid.filters.numToWord = numConvert => converter.toWords(numConvert);

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -65,4 +65,11 @@ describe('dateFromUnix', () => {
       ).to.eq('10:00 a.m.');
     });
   });
+
+  describe('currentTimeInSeconds', () => {
+    it('returns time in seconds', () => {
+      expect(String(liquid.filters.currentTimeInSeconds()).length < 13).to.be
+        .true;
+    });
+  });
 });

--- a/src/site/includes/date.drupal.liquid
+++ b/src/site/includes/date.drupal.liquid
@@ -23,7 +23,7 @@
     {% assign end_date_full = fieldDate.endDate | timeZone: defaultTZ, "dddd, MMM D, h:mm A" %}
 {% endif %}
 
-{% assign current_timestamp = ''| currentUnixFromDate %}
+{% assign current_timestamp = ''| currentTimeInSeconds %}
 
 {% if start_date_no_time != empty and end_date_no_time == empty %}
     {% assign date_type = "start_date_only" %}


### PR DESCRIPTION
## Description
The liquid template current time function was returning the timestamp in ms, not seconds.
This caused the comparison logic to fail, and show all events as being in the past.


## Testing done
Manual, unit test added

## Acceptance criteria
- [x] Events with start times in the future do not show the "This event has already happened" message.

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
