### PR TITLE
Comparison Tool - search result reset fix

### DIFF
--- a/src/applications/gi/constants.js
+++ b/src/applications/gi/constants.js
@@ -4,6 +4,9 @@ export const WAIT_INTERVAL = 333;
 // ELIGIBILITY_LIFESPAN is in milliseconds
 export const ELIGIBILITY_LIFESPAN = 3600000;
 
+// QUERY_LIFESPAN is in milliseconds
+export const QUERY_LIFESPAN = 3600000;
+
 // SMALL_SCREEN_WIDTH is in pixels
 export const SMALL_SCREEN_WIDTH = 481;
 

--- a/src/applications/gi/containers/ProfilePage.jsx
+++ b/src/applications/gi/containers/ProfilePage.jsx
@@ -41,7 +41,9 @@ export function ProfilePage({
 
   useEffect(
     () => {
-      dispatchSetPageTitle(`${institutionName} - GI Bill® Comparison Tool`);
+      if (institutionName) {
+        dispatchSetPageTitle(`${institutionName} - GI Bill® Comparison Tool`);
+      }
     },
     [institutionName],
   );

--- a/src/applications/gi/reducers/eligibility.js
+++ b/src/applications/gi/reducers/eligibility.js
@@ -63,8 +63,7 @@ export default function(state = INITIAL_STATE, action) {
     const storedEligibility = JSON.parse(localStorage.getItem('giEligibility'));
 
     if (
-      storedEligibility &&
-      storedEligibility.timestamp &&
+      storedEligibility?.timestamp &&
       new Date().getTime() - storedEligibility.timestamp < ELIGIBILITY_LIFESPAN
     ) {
       newState = {

--- a/src/applications/gi/reducers/eligibility.js
+++ b/src/applications/gi/reducers/eligibility.js
@@ -1,7 +1,8 @@
-import { ELIGIBILITY_CHANGED } from '../actions';
-import { ELIGIBILITY_LIFESPAN } from '../constants';
 import localStorage from 'platform/utilities/storage/localStorage';
 import environment from 'platform/utilities/environment';
+
+import { ELIGIBILITY_CHANGED } from '../actions';
+import { ELIGIBILITY_LIFESPAN } from '../constants';
 
 const INITIAL_STATE = Object.freeze({
   militaryStatus: 'veteran',
@@ -48,7 +49,7 @@ export default function(state = INITIAL_STATE, action) {
       };
     }
 
-    // Fix for 7528 and 8228
+    // Fix for 8228
     if (!environment.isProduction()) {
       newState.timestamp = new Date().getTime();
       localStorage.setItem('giEligibility', JSON.stringify(newState));
@@ -57,7 +58,7 @@ export default function(state = INITIAL_STATE, action) {
     return newState;
   }
 
-  // Fix for 7528 and 8228
+  // Fix for 8228
   if (!environment.isProduction()) {
     const storedEligibility = JSON.parse(localStorage.getItem('giEligibility'));
 

--- a/src/applications/gi/reducers/search.js
+++ b/src/applications/gi/reducers/search.js
@@ -138,8 +138,7 @@ export default function(state = INITIAL_STATE, action) {
         const storedQuery = JSON.parse(localStorage.getItem('giQuery'));
 
         if (
-          storedQuery &&
-          storedQuery.timestamp &&
+          storedQuery?.timestamp &&
           new Date().getTime() - storedQuery.timestamp < QUERY_LIFESPAN
         ) {
           newState = {


### PR DESCRIPTION
## Description
Store search query in localstorage to prevent it from being lost when the app reloads.

[Zenhub Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/7528)

## Testing done
Tested locally and QA reviewed

## Screenshots
N/A

## Acceptance criteria
- [x] Comparison tool does not lose search query

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
