### PR TITLE
Move pageList & path propTypes into route

### DIFF
--- a/src/platform/forms-system/src/js/review/ReviewPage.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewPage.jsx
@@ -66,10 +66,10 @@ class ReviewPage extends React.Component {
 }
 
 ReviewPage.propTypes = {
-  pageList: PropTypes.array.isRequired,
-  path: PropTypes.string.isRequired,
   route: PropTypes.shape({
     formConfig: PropTypes.object.isRequired,
+    pageList: PropTypes.array.isRequired,
+    path: PropTypes.string.isRequired,
   }).isRequired,
 };
 


### PR DESCRIPTION
## Description

In #15034 I made some changes to how the component receives some values, but I didn't update the `propTypes`. This has been causing warning messages to appear, so this should fix that.


## Testing done

Manual testing in localhost

## Screenshots

### Current behavior

In the console we see a warning/error about `propTypes` on the `ReviewPage` component

![image](https://user-images.githubusercontent.com/2008881/100280826-a7c20700-2f1d-11eb-86ee-1385f127a45a.png)


### With this change

No warnings/errors about `propTypes`

![image](https://user-images.githubusercontent.com/2008881/100280865-bad4d700-2f1d-11eb-9fb6-ac3dc1709517.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
