### PR TITLE
Sanlouise 16218 add 2fa prompt

### DIFF
--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -223,11 +223,11 @@ const mapStateToProps = state => {
     backendServices.EVSS_CLAIMS,
   );
   const isDirectDepositSetUp = directDepositIsSetUp(state);
+  const isEvssAvailable = isEvssAvailableSelector(state);
   const isDirectDepositBlocked = directDepositIsBlocked(state);
   const isEligibleToSignUp = directDepositAddressIsSetUp(state);
   const is2faEnabled = isMultifactorEnabled(state);
-  const shouldFetchDirectDepositInformation =
-    isEvssAvailableSelector(state) && is2faEnabled;
+  const shouldFetchDirectDepositInformation = isEvssAvailable && is2faEnabled;
   const currentlyLoggedIn = isLoggedIn(state);
   const isLOA1 = isLOA1Selector(state);
   const isLOA3 = isLOA3Selector(state);

--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -225,7 +225,6 @@ const mapStateToProps = state => {
   const isDirectDepositSetUp = directDepositIsSetUp(state);
   const isDirectDepositBlocked = directDepositIsBlocked(state);
   const isEligibleToSignUp = directDepositAddressIsSetUp(state);
-  // HERE
   const is2faEnabled = isMultifactorEnabled(state);
   const shouldFetchDirectDepositInformation =
     isEvssAvailableSelector(state) && is2faEnabled;

--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -222,12 +222,13 @@ const mapStateToProps = state => {
   const isEvssAvailableSelector = createIsServiceAvailableSelector(
     backendServices.EVSS_CLAIMS,
   );
-  const isEvssAvailable = isEvssAvailableSelector(state);
   const isDirectDepositSetUp = directDepositIsSetUp(state);
   const isDirectDepositBlocked = directDepositIsBlocked(state);
   const isEligibleToSignUp = directDepositAddressIsSetUp(state);
+  // HERE
   const is2faEnabled = isMultifactorEnabled(state);
-  const shouldFetchDirectDepositInformation = isEvssAvailable && is2faEnabled;
+  const shouldFetchDirectDepositInformation =
+    isEvssAvailableSelector(state) && is2faEnabled;
   const currentlyLoggedIn = isLoggedIn(state);
   const isLOA1 = isLOA1Selector(state);
   const isLOA3 = isLOA3Selector(state);
@@ -270,10 +271,12 @@ const mapStateToProps = state => {
     isInMVI: isInMVISelector(state),
     isLOA3,
     shouldFetchDirectDepositInformation,
+
     shouldShowDirectDeposit:
-      shouldFetchDirectDepositInformation &&
-      !isDirectDepositBlocked &&
-      (isDirectDepositSetUp || isEligibleToSignUp),
+      (isLOA3 && !is2faEnabled) ||
+      (shouldFetchDirectDepositInformation &&
+        !isDirectDepositBlocked &&
+        (isDirectDepositSetUp || isEligibleToSignUp)),
     isDowntimeWarningDismissed: state.scheduledDowntime?.dismissedDowntimeWarnings?.includes(
       'profile',
     ),

--- a/src/applications/personalization/profile/components/direct-deposit/DirectDepositContent.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/DirectDepositContent.jsx
@@ -9,16 +9,16 @@ import AdditionalInfo from '@department-of-veterans-affairs/formation-react/Addi
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
-import recordEvent from 'platform/monitoring/record-event';
-import EbenefitsLink from 'platform/site-wide/ebenefits/containers/EbenefitsLink';
-import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
-import { mfa } from 'platform/user/authentication/utilities';
+import recordEvent from '~/platform/monitoring/record-event';
+import EbenefitsLink from '~/platform/site-wide/ebenefits/containers/EbenefitsLink';
+import { isAuthenticatedWithSSOe } from '~/platform/user/authentication/selectors';
+import { mfa } from '~/platform/user/authentication/utilities';
 
 import {
   isLOA3 as isLOA3Selector,
   isMultifactorEnabled,
-} from 'platform/user/selectors';
-import { usePrevious } from 'platform/utilities/react-hooks';
+} from '~/platform/user/selectors';
+import { usePrevious } from '~/platform/utilities/react-hooks';
 import {
   editModalToggled,
   savePaymentInformation as savePaymentInformationAction,
@@ -35,7 +35,7 @@ import PaymentInformationEditError from './PaymentInformationEditModalError';
 import ProfileInfoTable from '../ProfileInfoTable';
 import FraudVictimAlert from './FraudVictimAlert';
 
-import prefixUtilityClasses from 'platform/utilities/prefix-utility-classes';
+import prefixUtilityClasses from '~/platform/utilities/prefix-utility-classes';
 
 export const DirectDepositContent = ({
   isLOA3,
@@ -313,7 +313,7 @@ export const DirectDepositContent = ({
     return (
       <AlertBox
         className="vads-u-margin-bottom--2"
-        headline="You'll need to set up 2-factor authentication before you can edit your direct deposit information."
+        headline="You’ll need to set up 2-factor authentication before you can edit your direct deposit information."
         content={
           <>
             <p>
@@ -353,7 +353,7 @@ export const DirectDepositContent = ({
         >
           <p>
             {' '}
-            {`You haven’t finished editing your direct deposit information. If you cancel, your in-progress work won't be saved.`}
+            {`You haven’t finished editing your direct deposit information. If you cancel, your in-progress work won’t be saved.`}
           </p>
           <button
             className="usa-button-secondary"

--- a/src/applications/personalization/profile/components/direct-deposit/DirectDepositContent.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/DirectDepositContent.jsx
@@ -11,7 +11,13 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 import recordEvent from 'platform/monitoring/record-event';
 import EbenefitsLink from 'platform/site-wide/ebenefits/containers/EbenefitsLink';
-import { isLOA3, isMultifactorEnabled } from 'platform/user/selectors';
+import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
+import { mfa } from 'platform/user/authentication/utilities';
+
+import {
+  isLOA3 as isLOA3Selector,
+  isMultifactorEnabled,
+} from 'platform/user/selectors';
 import { usePrevious } from 'platform/utilities/react-hooks';
 import {
   editModalToggled,
@@ -32,8 +38,9 @@ import FraudVictimAlert from './FraudVictimAlert';
 import prefixUtilityClasses from 'platform/utilities/prefix-utility-classes';
 
 export const DirectDepositContent = ({
-  isAuthorized,
+  isLOA3,
   isDirectDepositSetUp,
+  is2faEnabled,
   directDepositAccountInfo,
   directDepositUiState,
   saveBankInformation,
@@ -143,11 +150,11 @@ export const DirectDepositContent = ({
     <div className={classes.bankInfo}>
       <dl className="vads-u-margin-y--0 vads-u-line-height--6">
         <dt className="sr-only">Bank name:</dt>
-        <dd>{directDepositAccountInfo.financialInstitutionName}</dd>
+        <dd>{directDepositAccountInfo?.financialInstitutionName}</dd>
         <dt className="sr-only">Bank account number:</dt>
-        <dd>{directDepositAccountInfo.accountNumber}</dd>
+        <dd>{directDepositAccountInfo?.accountNumber}</dd>
         <dt className="sr-only">Bank account type:</dt>
-        <dd>{`${directDepositAccountInfo.accountType} account`}</dd>
+        <dd>{`${directDepositAccountInfo?.accountType} account`}</dd>
       </dl>
       <button
         className={classes.editButton}
@@ -288,83 +295,122 @@ export const DirectDepositContent = ({
     },
   ];
 
-  // Render nothing if the user should not see the Direct Deposit feature.
+  const mfaHandler = isAuthenticatedWithSSO => {
+    recordEvent({ event: 'multifactor-link-clicked' });
+    mfa(isAuthenticatedWithSSO ? 'v1' : 'v0');
+  };
+
+  // Render nothing if the user is not LOA3.
   // This entire component should never be rendered in that case; this just
   // serves as another layer of protection.
-  if (!isAuthorized) {
+  if (!isLOA3) {
     return null;
   }
 
-  return (
-    <>
-      <Modal
-        title={'Are you sure?'}
-        status="warning"
-        visible={showConfirmCancelModal}
-        onClose={() => {
-          setShowConfirmCancelModal(false);
-        }}
-      >
-        <p>
-          {' '}
-          {`You haven’t finished editing your direct deposit information. If you cancel, your in-progress work won't be saved.`}
-        </p>
-        <button
-          className="usa-button-secondary"
-          onClick={() => {
-            setShowConfirmCancelModal(false);
-          }}
-        >
-          Continue Editing
-        </button>
-        <button
-          onClick={() => {
-            setShowConfirmCancelModal(false);
-            toggleEditState();
-          }}
-        >
-          Cancel
-        </button>
-      </Modal>
-      <Prompt
-        message="Are you sure you want to leave? If you leave, your in-progress work won’t be saved."
-        when={!isEmptyForm}
-      />
-      <div id="success" role="alert" aria-atomic="true">
-        <ReactCSSTransitionGroup
-          transitionName="form-expanding-group-inner"
-          transitionAppear
-          transitionAppearTimeout={500}
-          transitionEnterTimeout={500}
-          transitionLeaveTimeout={500}
-        >
-          {showSaveSucceededAlert && (
-            <AlertBox
-              status="success"
-              backgroundOnly
-              className="vads-u-margin-top--0 vads-u-margin-bottom--2"
-              scrollOnShow
+  if (isLOA3 && !is2faEnabled) {
+    return (
+      <AlertBox
+        className="vads-u-margin-bottom--2"
+        headline="You'll need to set up 2-factor authentication before you can edit your direct deposit information."
+        content={
+          <>
+            <p>
+              We require this to help protect your bank account information and
+              prevent fraud.
+            </p>
+            <p>
+              Authentication gives you an extra layer of security by letting you
+              into your account only after you've signed in with a password and
+              a 6-digit code sent directly to your mobile or home phone. This
+              helps to make sure that no one but you can access your account -
+              even if they get your password.
+            </p>
+            <button
+              type="button"
+              className="usa-button-primary va-button-primary"
+              onClick={() => mfaHandler(isAuthenticatedWithSSOe)}
             >
-              We’ve saved your direct deposit information.
-            </AlertBox>
-          )}
-        </ReactCSSTransitionGroup>
-      </div>
-      <ProfileInfoTable
-        title="Disability compensation and pension benefits"
-        data={directDepositData()}
+              Set up 2-factor authentication
+            </button>
+          </>
+        }
+        status="continue"
+        isVisible
       />
-      <FraudVictimAlert />
-      <ProfileInfoTable
-        title="Education benefits"
-        data={educationBenefitsData()}
-      />
-    </>
-  );
+    );
+  } else {
+    return (
+      <>
+        <Modal
+          title={'Are you sure?'}
+          status="warning"
+          visible={showConfirmCancelModal}
+          onClose={() => {
+            setShowConfirmCancelModal(false);
+          }}
+        >
+          <p>
+            {' '}
+            {`You haven’t finished editing your direct deposit information. If you cancel, your in-progress work won't be saved.`}
+          </p>
+          <button
+            className="usa-button-secondary"
+            onClick={() => {
+              setShowConfirmCancelModal(false);
+            }}
+          >
+            Continue Editing
+          </button>
+          <button
+            onClick={() => {
+              setShowConfirmCancelModal(false);
+              toggleEditState();
+            }}
+          >
+            Cancel
+          </button>
+        </Modal>
+        <Prompt
+          message="Are you sure you want to leave? If you leave, your in-progress work won’t be saved."
+          when={!isEmptyForm}
+        />
+        <div id="success" role="alert" aria-atomic="true">
+          <ReactCSSTransitionGroup
+            transitionName="form-expanding-group-inner"
+            transitionAppear
+            transitionAppearTimeout={500}
+            transitionEnterTimeout={500}
+            transitionLeaveTimeout={500}
+          >
+            {showSaveSucceededAlert && (
+              <AlertBox
+                status="success"
+                backgroundOnly
+                className="vads-u-margin-top--0 vads-u-margin-bottom--2"
+                scrollOnShow
+              >
+                We’ve saved your direct deposit information.
+              </AlertBox>
+            )}
+          </ReactCSSTransitionGroup>
+        </div>
+        <ProfileInfoTable
+          title="Disability compensation and pension benefits"
+          data={directDepositData()}
+        />
+        <FraudVictimAlert />
+        <ProfileInfoTable
+          title="Education benefits"
+          data={educationBenefitsData()}
+        />
+      </>
+    );
+  }
 };
 
 DirectDepositContent.propTypes = {
-  isAuthorized: PropTypes.bool.isRequired,
+  isLOA3: PropTypes.bool.isRequired,
+  is2faEnabled: PropTypes.bool.isRequired,
   directDepositAccountInfo: PropTypes.shape({
     accountNumber: PropTypes.string.isRequired,
     accountType: PropTypes.string.isRequired,
@@ -382,11 +428,13 @@ DirectDepositContent.propTypes = {
 };
 
 export const mapStateToProps = state => ({
-  isAuthorized: isLOA3(state) && isMultifactorEnabled(state),
+  isLOA3: isLOA3Selector(state),
   directDepositAccountInfo: directDepositAccountInformation(state),
   directDepositInfo: directDepositInformation(state),
   isDirectDepositSetUp: directDepositIsSetUp(state),
   directDepositUiState: directDepositUiStateSelector(state),
+  is2faEnabled: false,
+  isAuthenticatedWithSSOe: isAuthenticatedWithSSOe(state),
 });
 
 const mapDispatchToProps = {

--- a/src/applications/personalization/profile/components/direct-deposit/DirectDepositContent.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/DirectDepositContent.jsx
@@ -60,6 +60,8 @@ export const DirectDepositContent = ({
   const { accountNumber, accountType, routingNumber } = formData;
   const isEmptyForm = !accountNumber && !accountType && !routingNumber;
 
+  const showSetup2FactorAuthentication = isLOA3 && !is2faEnabled;
+
   // when we enter and exit edit mode...
   useEffect(
     () => {
@@ -307,7 +309,7 @@ export const DirectDepositContent = ({
     return null;
   }
 
-  if (isLOA3 && !is2faEnabled) {
+  if (showSetup2FactorAuthentication) {
     return (
       <AlertBox
         className="vads-u-margin-bottom--2"
@@ -433,7 +435,7 @@ export const mapStateToProps = state => ({
   directDepositInfo: directDepositInformation(state),
   isDirectDepositSetUp: directDepositIsSetUp(state),
   directDepositUiState: directDepositUiStateSelector(state),
-  is2faEnabled: false,
+  is2faEnabled: isMultifactorEnabled(state),
   isAuthenticatedWithSSOe: isAuthenticatedWithSSOe(state),
 });
 

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
@@ -359,7 +359,7 @@ class ContactInformationField extends React.Component {
           }}
         >
           <p>
-            {`You haven’t finished editing your ${activeSection}. If you cancel, your in-progress work won't be saved.`}
+            {`You haven’t finished editing your ${activeSection}. If you cancel, your in-progress work won’t be saved.`}
           </p>
           <button
             className="usa-button-secondary"

--- a/src/applications/personalization/profile/tests/components/Profile.unit.spec.js
+++ b/src/applications/personalization/profile/tests/components/Profile.unit.spec.js
@@ -268,14 +268,6 @@ describe('mapStateToProps', () => {
         expect(props.shouldShowDirectDeposit).to.be.false;
       });
     });
-    describe('when direct deposit info should not be fetched because user has not set up 2FA', () => {
-      it('should be `false`', () => {
-        const state = makeDefaultState();
-        state.user.profile.multifactor = false;
-        const props = mapStateToProps(state);
-        expect(props.shouldShowDirectDeposit).to.be.false;
-      });
-    });
     describe('when user is flagged as incompetent', () => {
       it('should be `false`', () => {
         const state = makeDefaultState();

--- a/src/applications/personalization/profile/tests/components/Profile.unit.spec.js
+++ b/src/applications/personalization/profile/tests/components/Profile.unit.spec.js
@@ -268,6 +268,15 @@ describe('mapStateToProps', () => {
         expect(props.shouldShowDirectDeposit).to.be.false;
       });
     });
+    describe('when direct deposit info should not be fetched because user has not set up 2FA', () => {
+      it('should be `true`', () => {
+        const state = makeDefaultState();
+        state.user.profile.multifactor = false;
+        const props = mapStateToProps(state);
+        expect(props.shouldShowDirectDeposit).to.be.true;
+      });
+    });
+
     describe('when user is flagged as incompetent', () => {
       it('should be `false`', () => {
         const state = makeDefaultState();

--- a/src/applications/personalization/profile/tests/components/direct-deposit/DirectDepositContent.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/direct-deposit/DirectDepositContent.unit.spec.jsx
@@ -123,7 +123,7 @@ describe('DirectDepositContent', () => {
     initialState = createBasicInitialState();
     initialState.user.profile.multifactor = false;
 
-    const { view } = renderWithProfileReducers(ui, {
+    const view = renderWithProfileReducers(ui, {
       initialState,
     });
     expect(
@@ -131,11 +131,10 @@ describe('DirectDepositContent', () => {
         /You'll need to set up 2-factor authentication before you can edit your direct deposit information./i,
       ),
     ).to.exist;
-    expect(view.getByText(paymentAccount.financialInstitutionName)).not.to
+    expect(view.queryByText(paymentAccount.financialInstitutionName)).not.to
       .exist;
-    expect(view.getByText(paymentAccount.accountNumber)).not.to.exist;
-    expect(view.getByText(paymentAccount.accountType, { exact: false })).not.to
-      .exist;
+    expect(view.queryByText(paymentAccount.accountNumber)).not.to.exist;
+    expect(view.queryByText(paymentAccount.accountType)).not.to.exist;
   });
   describe('when bank info is not set up', () => {
     let view;

--- a/src/applications/personalization/profile/tests/components/direct-deposit/DirectDepositContent.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/direct-deposit/DirectDepositContent.unit.spec.jsx
@@ -128,7 +128,7 @@ describe('DirectDepositContent', () => {
     });
     expect(
       view.getByText(
-        /You'll need to set up 2-factor authentication before you can edit your direct deposit information./i,
+        /You’ll need to set up 2-factor authentication before you can edit your direct deposit information./i,
       ),
     ).to.exist;
     expect(view.queryByText(paymentAccount.financialInstitutionName)).not.to

--- a/src/applications/personalization/profile/tests/components/direct-deposit/DirectDepositContent.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/direct-deposit/DirectDepositContent.unit.spec.jsx
@@ -119,14 +119,23 @@ describe('DirectDepositContent', () => {
     });
     expect(container).to.be.empty;
   });
-  it('should render nothing if the user does not have 2FA set up', () => {
+  it('should only render an AlertBox prompting the user to set up 2FA if the user does not have 2FA set up and is LOA3', () => {
     initialState = createBasicInitialState();
     initialState.user.profile.multifactor = false;
 
-    const { container } = renderWithProfileReducers(ui, {
+    const { view } = renderWithProfileReducers(ui, {
       initialState,
     });
-    expect(container).to.be.empty;
+    expect(
+      view.getByText(
+        /You'll need to set up 2-factor authentication before you can edit your direct deposit information./i,
+      ),
+    ).to.exist;
+    expect(view.getByText(paymentAccount.financialInstitutionName)).not.to
+      .exist;
+    expect(view.getByText(paymentAccount.accountNumber)).not.to.exist;
+    expect(view.getByText(paymentAccount.accountType, { exact: false })).not.to
+      .exist;
   });
   describe('when bank info is not set up', () => {
     let view;

--- a/src/applications/personalization/profile/tests/routes.unit.spec.js
+++ b/src/applications/personalization/profile/tests/routes.unit.spec.js
@@ -5,7 +5,7 @@ import { PROFILE_PATH_NAMES } from 'applications/personalization/profile/constan
 
 describe('getRoutes', () => {
   describe('when options.removeDirectDeposit is false', () => {
-    it('should return all possible PROFILE_PATHS`', () => {
+    it('should return the direct deposit path`', () => {
       const allRoutes = getRoutes({ removeDirectDeposit: false });
       const hasDirectDepositRoute = allRoutes.some(
         route => route.name === PROFILE_PATH_NAMES.DIRECT_DEPOSIT,
@@ -16,7 +16,7 @@ describe('getRoutes', () => {
   });
 
   describe('when options.removeDirectDeposit is true', () => {
-    it('should return all possible PROFILE_PATHS except for the Direct Deposit route', () => {
+    it('should not return the direct deposit path', () => {
       const allRoutes = getRoutes({ removeDirectDeposit: true });
       const hasDirectDepositRoute = allRoutes.some(
         route => route.name === PROFILE_PATH_NAMES.DIRECT_DEPOSIT,

--- a/src/applications/personalization/profile/tests/routes.unit.spec.js
+++ b/src/applications/personalization/profile/tests/routes.unit.spec.js
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+
+import getRoutes from 'applications/personalization/profile/routes.js';
+import { PROFILE_PATH_NAMES } from 'applications/personalization/profile/constants.js';
+
+describe('getRoutes', () => {
+  describe('when options.removeDirectDeposit is false', () => {
+    it('should return all possible PROFILE_PATHS`', () => {
+      const allRoutes = getRoutes({ removeDirectDeposit: false });
+      const hasDirectDepositRoute = allRoutes.some(
+        route => route.name === PROFILE_PATH_NAMES.DIRECT_DEPOSIT,
+      );
+
+      expect(hasDirectDepositRoute).to.be.true;
+    });
+  });
+
+  describe('when options.removeDirectDeposit is true', () => {
+    it('should return all possible PROFILE_PATHS except for the Direct Deposit route', () => {
+      const allRoutes = getRoutes({ removeDirectDeposit: true });
+      const hasDirectDepositRoute = allRoutes.some(
+        route => route.name === PROFILE_PATH_NAMES.DIRECT_DEPOSIT,
+      );
+
+      expect(hasDirectDepositRoute).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
## Description
In profile 1.0, if a direct deposit-eligible user was LOA3 but did not have 2FA set up (a rare use case that can happen if people sign on through DS Logon or MHV), we showed the direct deposit section of the profile, but we showed a prompt that told them they had to add 2FA before they could update their information.

Unfortunately, this state somehow got missed in the profile 2.0 transition, so we need to add it back.

## Testing done
Works well locally, updated unit test.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/100465116-01e0da80-308c-11eb-976e-751c44091fd7.png)

## Acceptance criteria
- [x] When user is LOA3 and does not have multifactor authentication set up, show DD in the navigation and show an AlertBox in DirectDepositContent.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
