### PR TITLE
Add downtime notifications to intro page

### DIFF
--- a/src/applications/caregivers/containers/IntroductionPage.jsx
+++ b/src/applications/caregivers/containers/IntroductionPage.jsx
@@ -10,11 +10,18 @@ import { focusElement } from 'platform/utilities/ui';
 import { links } from 'applications/caregivers/definitions/content';
 import { withRouter } from 'react-router';
 import { CaregiverSupportInfo } from 'applications/caregivers/components/AdditionalInfo';
+import {
+  DowntimeNotification,
+  externalServices,
+} from 'platform/monitoring/DowntimeNotification';
 
 const IntroductionPage = ({ route, router }) => {
   useEffect(() => {
     focusElement('.va-nav-breadcrumbs-list');
   }, []);
+
+  const applicationTitle =
+    'Apply for the Program of Comprehensive Assistance for Family Caregivers';
 
   const startForm = () => {
     recordEvent({ event: 'caregivers-10-10cg-start-form' });
@@ -200,35 +207,38 @@ const IntroductionPage = ({ route, router }) => {
 
   return (
     <div className="caregivers-intro schemaform-intro">
-      <FormTitle
-        className="form-title"
-        title="Apply for the Program of Comprehensive Assistance for Family Caregivers"
-      />
-      <p>
-        Equal to VA Form 10-10CG (Application for Family Caregiver Benefits)
-      </p>
-      <p className="va-introtext">
-        We recognize the important role of family caregivers in supporting the
-        health and wellness of Veterans.
-      </p>
+      <DowntimeNotification
+        appTitle={applicationTitle}
+        dependencies={[externalServices.mvi, externalServices.carma]}
+      >
+        <FormTitle className="form-title" title={applicationTitle} />
 
-      <button
-        style={{ display: 'inherit ' }}
-        className="usa-button vads-u-margin-y--3"
-        onClick={startForm}
-      >
-        Start your application
-      </button>
-      <ProcessTimeline />
-      <button
-        className="usa-button vads-u-margin-bottom--3"
-        onClick={startForm}
-      >
-        Start your application
-      </button>
-      <div className="omb-info--container vads-u-padding-left--0">
-        <OMBInfo resBurden={15} ombNumber="2900-0768" expDate="09/30/2021" />
-      </div>
+        <p>
+          Equal to VA Form 10-10CG (Application for Family Caregiver Benefits)
+        </p>
+        <p className="va-introtext">
+          We recognize the important role of family caregivers in supporting the
+          health and wellness of Veterans.
+        </p>
+
+        <button
+          style={{ display: 'inherit ' }}
+          className="usa-button vads-u-margin-y--3"
+          onClick={startForm}
+        >
+          Start your application
+        </button>
+        <ProcessTimeline />
+        <button
+          className="usa-button vads-u-margin-bottom--3"
+          onClick={startForm}
+        >
+          Start your application
+        </button>
+        <div className="omb-info--container vads-u-padding-left--0">
+          <OMBInfo resBurden={15} ombNumber="2900-0768" expDate="09/30/2021" />
+        </div>
+      </DowntimeNotification>
     </div>
   );
 };


### PR DESCRIPTION
## Description
As a user I would like to know if a form application is down before I spend my time filling out the entire form. Please add downtime notifications to intro page so users know when downtime is coming up, AND when it is down before users start the form.

## Testing done
- Manual testing

## Screenshots
![image](https://user-images.githubusercontent.com/23741323/100471723-e0421c00-30a8-11eb-9d79-1d0de45ff356.png)


## Acceptance criteria
- [x] Users know about downtime before they start the form

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
