### PR TITLE
removed unneded logic by reset to master and used scss.

### DIFF
--- a/src/applications/find-forms/containers/SearchResults.jsx
+++ b/src/applications/find-forms/containers/SearchResults.jsx
@@ -122,8 +122,9 @@ export class SearchResults extends Component {
           className="vads-u-font-size--base vads-u-line-height--3 vads-u-font-family--sans vads-u-font-weight--normal vads-u-margin-y--1p5"
           data-forms-focus
         >
-          Showing {startLabel} &ndash; {lastLabel} of {results.length} results
-          for "<strong>{query}</strong>"
+          Showing <strong>{startLabel}</strong> &ndash;{' '}
+          <strong>{lastLabel}</strong> of <strong>{results.length}</strong>{' '}
+          results for "<strong>{query}</strong>"
         </h2>
 
         <dl className="vads-l-grid-container--full">{searchResults}</dl>
@@ -131,6 +132,7 @@ export class SearchResults extends Component {
         {/* Pagination Row */}
         {results.length > MAX_PAGE_LIST_LENGTH && (
           <Pagination
+            className="find-va-froms-pagination-override"
             maxPageListLength={MAX_PAGE_LIST_LENGTH}
             onPageSelect={onPageSelect}
             page={page}

--- a/src/applications/find-forms/sass/find-va-forms.scss
+++ b/src/applications/find-forms/sass/find-va-forms.scss
@@ -1,5 +1,12 @@
-.find-va-forms-table {
-  th {
-    min-width: 120px;
+@import "~@department-of-veterans-affairs/formation/sass/shared-variables";
+
+[data-widget-type="find-va-forms"] {
+  .vads-l-grid-container--full {
+    border-bottom: 1px solid $color-gray-lighter;
+    margin-bottom: 0;
+  }
+
+  .find-va-froms-pagination-override {
+    border: none;
   }
 }


### PR DESCRIPTION
## Description
Reopen of this [PR](https://github.com/department-of-veterans-affairs/vets-website/pull/15099) after it was closed with a reverting the branch back to master.

## Testing done
1. Spin up FE local.
2. Navigate to http://localhost:3001/find-forms/
3. Compare what you see to what is pointed out on 8200
3.5 NOTE: Number 5 on that the list from the user story was ruled as not within the VA design system par the conversation on the ticket.

## Screenshots
![Screen Shot 2020-11-27 at 9 26 15 AM](https://user-images.githubusercontent.com/26075258/100470411-33669f80-30a6-11eb-8288-5a08214b2bb3.png)
![Screen Shot 2020-11-27 at 9 25 57 AM](https://user-images.githubusercontent.com/26075258/100470415-35306300-30a6-11eb-86f0-c82ed5f24208.png)


## Acceptance criteria
- [x] Fix the missed styling from 1.0.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
