### PR TITLE
Remove debugging output from event template

### DIFF
--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -103,8 +103,6 @@
                 {% if fieldLink or fieldEventCta or fieldAdditionalInformationAbo %}
                   <div class="registration vads-u-margin-top--4 vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--1">
                       <p class="vads-u-font-weight--bold vads-u-margin-top--0 vads-u-margin-bottom--1">Registration</p>
-                    {{  start_timestamp |  json }}
-                    {{  current_timestamp |  json }}
                       {% if start_timestamp < current_timestamp %}
                           <p class="vads-u-margin--0 vads-u-color--secondary vads-u-font-weight--bold">This event already happened.</p>
                       {% else %}


### PR DESCRIPTION
Some debug statements were accidentally left in the event template and pushed to production.

This PR removes them.