### PR TITLE
Record more GA data when we get a user's direct deposit info

### DIFF
--- a/src/applications/personalization/profile/selectors.js
+++ b/src/applications/personalization/profile/selectors.js
@@ -1,3 +1,9 @@
+import {
+  directDepositBankInfo,
+  isEligibleForDirectDeposit,
+  isSignedUpForDirectDeposit,
+} from './util';
+
 export const directDepositInformation = state =>
   state.vaProfile?.paymentInformation;
 
@@ -5,10 +11,10 @@ export const directDepositUiState = state =>
   state.vaProfile?.paymentInformationUiState;
 
 export const directDepositAccountInformation = state =>
-  directDepositInformation(state)?.responses?.[0]?.paymentAccount;
+  directDepositBankInfo(directDepositInformation(state));
 
 export const directDepositIsSetUp = state =>
-  !!directDepositAccountInformation(state)?.accountNumber;
+  isSignedUpForDirectDeposit(directDepositInformation(state));
 
 export const directDepositLoadError = state =>
   directDepositInformation(state)?.error;
@@ -17,12 +23,7 @@ export const directDepositAddressInformation = state =>
   directDepositInformation(state)?.responses?.[0]?.paymentAddress;
 
 export const directDepositAddressIsSetUp = state => {
-  const addressInfo = directDepositAddressInformation(state);
-  return !!(
-    addressInfo?.addressOne &&
-    addressInfo?.city &&
-    addressInfo?.stateCode
-  );
+  return isEligibleForDirectDeposit(directDepositInformation(state));
 };
 
 export const directDepositIsBlocked = state => {

--- a/src/applications/personalization/profile/tests/actions/paymentInformation.unit.spec.js
+++ b/src/applications/personalization/profile/tests/actions/paymentInformation.unit.spec.js
@@ -71,7 +71,151 @@ describe('actions/paymentInformation', () => {
         );
       });
 
-      describe('if the call succeeds', () => {
+      describe('if the call succeeds and the user is not eligible direct deposit', () => {
+        const paymentInfo = {
+          controlInformation: {
+            canUpdateAddress: true,
+            corpAvailIndicator: true,
+            corpRecFoundIndicator: true,
+            hasNoBdnPaymentsIndicator: true,
+            identityIndicator: true,
+            isCompetentIndicator: true,
+            indexIndicator: true,
+            noFiduciaryAssignedIndicator: true,
+            notDeceasedIndicator: true,
+          },
+          paymentAccount: {
+            accountType: null,
+            financialInstitutionName: null,
+            accountNumber: null,
+            financialInstitutionRoutingNumber: null,
+          },
+          paymentAddress: {
+            type: null,
+            addressEffectiveDate: null,
+            addressOne: null,
+            addressTwo: null,
+            addressThree: null,
+            city: null,
+            stateCode: null,
+            zipCode: null,
+            zipSuffix: null,
+            countryName: null,
+            militaryPostOfficeTypeCode: null,
+            militaryStateCode: null,
+          },
+          paymentType: 'CNP',
+        };
+
+        beforeEach(async () => {
+          setFetchJSONResponse(global.fetch.onFirstCall(), {
+            data: {
+              attributes: {
+                responses: [paymentInfo],
+              },
+            },
+          });
+          await actionCreator(dispatch);
+        });
+
+        it('dispatches PAYMENT_INFORMATION_FETCH_SUCCEEDED and passes along the data it got from the endpoint', () => {
+          expect(dispatch.secondCall.args[0].type).to.be.equal(
+            paymentInformationActions.PAYMENT_INFORMATION_FETCH_SUCCEEDED,
+          );
+          expect(dispatch.secondCall.args[0].response).to.deep.equal({
+            responses: [paymentInfo],
+          });
+        });
+
+        it('reports the correct data to Google Analytics', () => {
+          expect(recordEventSpy.firstCall.args[0].event).to.equal(
+            'profile-get-direct-deposit-started',
+          );
+          expect(recordEventSpy.secondCall.args[0].event).to.equal(
+            'profile-get-direct-deposit-retrieved',
+          );
+          expect(
+            recordEventSpy.secondCall.args[0]['direct-deposit-setup-eligible'],
+          ).to.be.false;
+          expect(
+            recordEventSpy.secondCall.args[0]['direct-deposit-setup-complete'],
+          ).to.be.false;
+        });
+      });
+
+      describe('if the call succeeds and the user is eligible to sign up for direct deposit', () => {
+        const paymentInfo = {
+          controlInformation: {
+            canUpdateAddress: true,
+            corpAvailIndicator: true,
+            corpRecFoundIndicator: true,
+            hasNoBdnPaymentsIndicator: true,
+            identityIndicator: true,
+            isCompetentIndicator: true,
+            indexIndicator: true,
+            noFiduciaryAssignedIndicator: true,
+            notDeceasedIndicator: true,
+          },
+          paymentAccount: {
+            accountType: null,
+            financialInstitutionName: null,
+            accountNumber: null,
+            financialInstitutionRoutingNumber: null,
+          },
+          paymentAddress: {
+            type: null,
+            addressEffectiveDate: null,
+            addressOne: '123 main st',
+            addressTwo: null,
+            addressThree: null,
+            city: 'San Francisco',
+            stateCode: 'CA',
+            zipCode: '94536',
+            zipSuffix: null,
+            countryName: null,
+            militaryPostOfficeTypeCode: null,
+            militaryStateCode: null,
+          },
+          paymentType: 'CNP',
+        };
+
+        beforeEach(async () => {
+          setFetchJSONResponse(global.fetch.onFirstCall(), {
+            data: {
+              attributes: {
+                responses: [paymentInfo],
+              },
+            },
+          });
+          await actionCreator(dispatch);
+        });
+
+        it('dispatches PAYMENT_INFORMATION_FETCH_SUCCEEDED and passes along the data it got from the endpoint', () => {
+          expect(dispatch.secondCall.args[0].type).to.be.equal(
+            paymentInformationActions.PAYMENT_INFORMATION_FETCH_SUCCEEDED,
+          );
+          expect(dispatch.secondCall.args[0].response).to.deep.equal({
+            responses: [paymentInfo],
+          });
+        });
+
+        it('reports the correct data to Google Analytics', () => {
+          expect(recordEventSpy.firstCall.args[0].event).to.equal(
+            'profile-get-direct-deposit-started',
+          );
+          expect(recordEventSpy.secondCall.args[0].event).to.equal(
+            'profile-get-direct-deposit-retrieved',
+          );
+          expect(
+            recordEventSpy.secondCall.args[0]['direct-deposit-setup-eligible'],
+          ).to.be.true;
+          expect(
+            recordEventSpy.secondCall.args[0]['direct-deposit-setup-complete'],
+          ).to.be.false;
+        });
+      });
+
+      describe('if the call succeeds and the user is signed up for direct deposit', () => {
         const paymentInfo = {
           controlInformation: {
             canUpdateAddress: true,

--- a/src/applications/personalization/profile/tests/actions/paymentInformation.unit.spec.js
+++ b/src/applications/personalization/profile/tests/actions/paymentInformation.unit.spec.js
@@ -134,6 +134,12 @@ describe('actions/paymentInformation', () => {
           expect(recordEventSpy.secondCall.args[0].event).to.equal(
             'profile-get-direct-deposit-retrieved',
           );
+          expect(
+            recordEventSpy.secondCall.args[0]['direct-deposit-setup-eligible'],
+          ).to.be.true;
+          expect(
+            recordEventSpy.secondCall.args[0]['direct-deposit-setup-complete'],
+          ).to.be.true;
         });
       });
 

--- a/src/applications/personalization/profile/tests/e2e/address-validation/setup.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/setup.js
@@ -16,7 +16,9 @@ export const setUp = type => {
   cy.visit(PROFILE_PATHS.PERSONAL_INFORMATION);
   cy.injectAxe();
 
-  cy.findByRole('button', { name: /edit mailing address/i }).click();
+  cy.findByRole('button', { name: /edit mailing address/i }).click({
+    force: true,
+  });
 
   cy.route({
     method: 'POST',

--- a/src/applications/personalization/profile/util/index.js
+++ b/src/applications/personalization/profile/util/index.js
@@ -70,6 +70,26 @@ export const hasInvalidWorkPhoneNumberError = errors =>
 export const hasPaymentRestrictionIndicatorsError = errors =>
   hasErrorMessage(errors, PAYMENT_RESTRICTIONS_PRESENT_KEY);
 
+export const directDepositBankInfo = apiData => {
+  return apiData?.responses?.[0]?.paymentAccount;
+};
+
+const directDepositAddressInfo = apiData => {
+  return apiData?.responses?.[0]?.paymentAddress;
+};
+
+export const isEligibleForDirectDeposit = apiData => {
+  const addressData = directDepositAddressInfo(apiData) ?? {};
+  return !!(
+    addressData.addressOne &&
+    addressData.city &&
+    addressData.stateCode
+  );
+};
+
+export const isSignedUpForDirectDeposit = apiData =>
+  !!directDepositBankInfo(apiData)?.accountNumber;
+
 // Helper that creates and returns an object to pass to the recordEvent()
 // function when an error occurs while trying to save/update a user's direct
 // deposit payment information. The value of the `error-key` prop will change


### PR DESCRIPTION
## Description
This PR adds more data to the call to GA when we get a user's direct deposit info. But to accomplish that it required moving some data-digging logic from the selectors file into shared helpers.

## Testing done
- [x] Existing unit test for the selectors still pass
- [x] Expand the existing test that makes sure we send the correct data to GA

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs