### PR TITLE
Only enable provider selection for those with an address

### DIFF
--- a/src/applications/vaos/new-appointment/index.jsx
+++ b/src/applications/vaos/new-appointment/index.jsx
@@ -10,7 +10,7 @@ import {
 import {
   selectUseFlatFacilityPage,
   selectIsCernerOnlyPatient,
-  vaosProviderSelection,
+  selectUseProviderSelection,
 } from '../utils/selectors';
 import newAppointmentReducer from './redux/reducer';
 import FormLayout from './components/FormLayout';
@@ -175,7 +175,7 @@ function mapStateToProps(state) {
   return {
     isCernerOnlyPatient: selectIsCernerOnlyPatient(state),
     flatFacilityPageEnabled: selectUseFlatFacilityPage(state),
-    providerSelectionEnabled: vaosProviderSelection(state),
+    providerSelectionEnabled: selectUseProviderSelection(state),
   };
 }
 

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -77,8 +77,12 @@ export const selectUseFlatFacilityPage = state =>
   !selectIsCernerPatient(state) &&
   (!selectIsRegisteredToSacramentoVA(state) ||
     vaosFlatFacilityPageSacramento(state));
-export const vaosProviderSelection = state =>
+
+const vaosProviderSelection = state =>
   toggleValues(state).vaOnlineSchedulingProviderSelection;
+export const selectUseProviderSelection = state =>
+  vaosProviderSelection(state) &&
+  !!selectVAPResidentialAddress(state)?.addressLine1;
 
 export function getNewAppointment(state) {
   return state.newAppointment;


### PR DESCRIPTION
## Description
Update our feature toggle logic to only enable provider selection for those with an address.

## Acceptance criteria
- [ ] Toggle works correctly

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
