### PR TITLE
Update tests to add awaits after each render

### DIFF
--- a/src/applications/vaos/tests/appointment-list/components/FutureAppointmentsList.cc.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/FutureAppointmentsList.cc.unit.spec.jsx
@@ -108,7 +108,7 @@ describe('VAOS integration: upcoming CC appointments', () => {
     expect(getByText(/cancel appointment/i)).to.have.tagName('button');
   });
 
-  it('should not display when over 13 months away', () => {
+  it('should not display when over 13 months away', async () => {
     const appointment = getCCAppointmentMock();
     appointment.attributes = {
       ...appointment.attributes,
@@ -126,8 +126,7 @@ describe('VAOS integration: upcoming CC appointments', () => {
       },
     );
 
-    return expect(findByText(/You don’t have any appointments/i)).to.eventually
-      .be.ok;
+    expect(await findByText(/You don’t have any appointments/i)).to.exist;
   });
 
   it('should handle UTC zone', async () => {

--- a/src/applications/vaos/tests/appointment-list/components/PastAppointmentsList/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/PastAppointmentsList/index.unit.spec.jsx
@@ -32,11 +32,11 @@ describe('VAOS integration: past appointments', () => {
   it('should show select date range dropdown', async () => {
     mockPastAppointmentInfo({ va: [] });
 
-    const { queryByText } = renderWithStoreAndRouter(<PastAppointmentsList />, {
+    const { findByText } = renderWithStoreAndRouter(<PastAppointmentsList />, {
       initialState,
     });
 
-    expect(queryByText(/Past 3 months/i)).to.exist;
+    expect(await findByText(/Past 3 months/i)).to.exist;
   });
 
   it('should update range on dropdown change', async () => {

--- a/src/applications/vaos/tests/express-care/components/ExpressCareConfirmationPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/express-care/components/ExpressCareConfirmationPage.unit.spec.jsx
@@ -156,7 +156,7 @@ describe('VAOS integration: Express Care form submission', () => {
     screen = renderWithStoreAndRouter(<ExpressCareConfirmationPage />, {
       store,
     });
-    expect(screen.baseElement).to.contain.text('Next step');
+    expect(await screen.findByText(/Next step/)).to.exist;
     expect(screen.baseElement).to.contain('.fa-exclamation-triangle');
     expect(screen.baseElement).to.contain(
       '.vads-u-border-color--warning-message',

--- a/src/applications/vaos/tests/new-appointment/components/ConfirmationPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ConfirmationPage/index.unit.spec.jsx
@@ -100,7 +100,8 @@ describe('VAOS <ConfirmationPage>', () => {
       store,
     });
 
-    expect(screen.getByText(/Your appointment has been scheduled./i)).to.be.ok;
+    expect(await screen.findByText(/Your appointment has been scheduled./i)).to
+      .be.ok;
     expect(
       screen.getByText(
         new RegExp(start.format('MMMM D, YYYY [at] h:mm a'), 'i'),

--- a/src/applications/vaos/tests/new-appointment/components/DateTimeRequestPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/DateTimeRequestPage.unit.spec.jsx
@@ -118,7 +118,7 @@ describe('VAOS <DateTimeRequestPage>', () => {
       );
 
       // it should not allow the user to view the previous month if viewing the current month
-      let button = screen.getByText('Previous');
+      let button = await screen.findByText('Previous');
       userEvent.click(button);
       await waitFor(() => {
         expect(screen.history.push.called).to.be.false;
@@ -324,7 +324,7 @@ describe('VAOS <DateTimeRequestPage>', () => {
       );
 
       // it should display an alert when users tries to submit the form
-      let button = screen.getByText(/^Continue/);
+      let button = await screen.findByText(/^Continue/);
       userEvent.click(button);
 
       // NOTE: alert doesn't have a name so search for text too

--- a/src/applications/vaos/tests/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
@@ -38,11 +38,11 @@ describe('VAOS integration: reason for appointment page with a single-site user'
       store,
     });
 
+    expect((await screen.findAllByRole('radio')).length).to.equal(4);
+
     expect(screen.baseElement).to.contain.text(
       'Please let us know why you’re making this appointment',
     );
-
-    expect((await screen.findAllByRole('radio')).length).to.equal(4);
 
     expect(
       screen.getByRole('heading', {
@@ -59,15 +59,15 @@ describe('VAOS integration: reason for appointment page with a single-site user'
       store,
     });
 
-    expect(screen.baseElement).to.contain.text(
-      'Tell us the reason for this appointment',
-    );
-
     const textBox = await screen.findByRole('textbox');
     expect(textBox).to.exist;
     expect(textBox)
       .to.have.attribute('maxlength')
       .to.equal('100');
+
+    expect(screen.baseElement).to.contain.text(
+      'Tell us the reason for this appointment',
+    );
 
     expect(
       screen.getByRole('heading', {
@@ -141,13 +141,14 @@ describe('VAOS integration: reason for appointment page with a single-site user'
       store,
     });
 
+    const textBox = await screen.findByRole('textbox');
+    fireEvent.change(textBox, { target: { value: '   ' } });
+    expect(textBox.value).to.equal('   ');
+
     expect(screen.baseElement).to.contain.text(
       'Tell us the reason for this appointment',
     );
 
-    const textBox = await screen.findByRole('textbox');
-    fireEvent.change(textBox, { target: { value: '   ' } });
-    expect(textBox.value).to.equal('   ');
     fireEvent.click(screen.getByText(/Continue/));
 
     expect(await screen.findByRole('alert')).to.contain.text(
@@ -190,13 +191,13 @@ describe('VAOS integration: reason for appointment page with a single-site user'
       },
     );
 
-    expect(screen.baseElement).to.contain.text(
-      'Tell us the reason for this appointment',
-    );
-
     const textBox = await screen.findByRole('textbox');
     fireEvent.change(textBox, { target: { value: 'test' } });
     expect(textBox.value).to.equal('test');
+
+    expect(screen.baseElement).to.contain.text(
+      'Tell us the reason for this appointment',
+    );
 
     fireEvent.click(screen.getByText(/Continue/));
 

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.cc-request.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.cc-request.unit.spec.jsx
@@ -193,15 +193,16 @@ describe('VAOS <ReviewPage> CC request', () => {
   });
 
   it('should submit successfully', async () => {
-    const screen = renderWithStoreAndRouter(<Route component={ReviewPage} />, {
-      store,
-    });
-
     mockRequestSubmit('cc', {
       id: 'fake_id',
     });
     mockPreferences(null);
     mockMessagesFetch('fake_id', {});
+
+    const screen = renderWithStoreAndRouter(<Route component={ReviewPage} />, {
+      store,
+    });
+
     await screen.findByText(/requesting a community care appointment/i);
 
     userEvent.click(screen.getByText(/Request appointment/i));
@@ -224,10 +225,6 @@ describe('VAOS <ReviewPage> CC request', () => {
   });
 
   it('should show error message on failure', async () => {
-    const screen = renderWithStoreAndRouter(<Route component={ReviewPage} />, {
-      store,
-    });
-
     mockFacilityFetch('vha_442', {
       id: 'vha_442',
       attributes: {
@@ -255,6 +252,11 @@ describe('VAOS <ReviewPage> CC request', () => {
         errors: [{}],
       },
     );
+
+    const screen = renderWithStoreAndRouter(<Route component={ReviewPage} />, {
+      store,
+    });
+
     await screen.findByText(/requesting a community care appointment/i);
 
     userEvent.click(screen.getByText(/Request appointment/i));

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.direct.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.direct.unit.spec.jsx
@@ -191,11 +191,12 @@ describe('VAOS <ReviewPage> direct scheduling', () => {
   });
 
   it('should submit successfully', async () => {
+    mockAppointmentSubmit({});
+
     const screen = renderWithStoreAndRouter(<Route component={ReviewPage} />, {
       store,
     });
 
-    mockAppointmentSubmit({});
     await screen.findByText(/scheduling a primary care appointment/i);
 
     userEvent.click(screen.getByText(/Confirm appointment/i));
@@ -212,10 +213,6 @@ describe('VAOS <ReviewPage> direct scheduling', () => {
   });
 
   it('should show appropriate message on bad request submit error', async () => {
-    const screen = renderWithStoreAndRouter(<Route component={ReviewPage} />, {
-      store,
-    });
-
     mockFacilityFetch('vha_442', {
       id: 'vha_442',
       attributes: {
@@ -245,6 +242,11 @@ describe('VAOS <ReviewPage> direct scheduling', () => {
         ],
       },
     );
+
+    const screen = renderWithStoreAndRouter(<Route component={ReviewPage} />, {
+      store,
+    });
+
     await screen.findByText(/scheduling a primary care appointment/i);
 
     userEvent.click(screen.getByText(/Confirm appointment/i));

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.va-request.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.va-request.unit.spec.jsx
@@ -174,15 +174,16 @@ describe('VAOS <ReviewPage> VA request', () => {
   });
 
   it('should submit successfully', async () => {
-    const screen = renderWithStoreAndRouter(<Route component={ReviewPage} />, {
-      store,
-    });
-
     mockRequestSubmit('va', {
       id: 'fake_id',
     });
     mockPreferences(null);
     mockMessagesFetch('fake_id', {});
+
+    const screen = renderWithStoreAndRouter(<Route component={ReviewPage} />, {
+      store,
+    });
+
     await screen.findByText(/requesting a primary care appointment/i);
 
     userEvent.click(screen.getByText(/Request appointment/i));
@@ -235,10 +236,6 @@ describe('VAOS <ReviewPage> VA request', () => {
   });
 
   it('should show error message on failure', async () => {
-    const screen = renderWithStoreAndRouter(<Route component={ReviewPage} />, {
-      store,
-    });
-
     mockFacilityFetch('vha_442', {
       id: 'vha_442',
       attributes: {
@@ -266,6 +263,11 @@ describe('VAOS <ReviewPage> VA request', () => {
         errors: [{}],
       },
     );
+
+    const screen = renderWithStoreAndRouter(<Route component={ReviewPage} />, {
+      store,
+    });
+
     await screen.findByText(/requesting a primary care appointment/i);
 
     userEvent.click(screen.getByText(/Request appointment/i));

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfCarePage.unit.spec.jsx
@@ -300,6 +300,7 @@ describe('VAOS <TypeOfCarePage>', () => {
       store,
     });
 
+    await screen.findAllByRole('radio');
     expect(screen.queryByText(/You need to have a home address/i)).to.not.exist;
   });
 

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfFacilityPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfFacilityPage.unit.spec.jsx
@@ -33,11 +33,11 @@ describe('VAOS integration: VA facility page with a single-site user', () => {
       store,
     });
 
+    expect((await screen.findAllByRole('radio')).length).to.equal(2);
+
     expect(screen.baseElement).to.contain.text(
       'Choose where you want to receive your care',
     );
-
-    expect((await screen.findAllByRole('radio')).length).to.equal(2);
   });
 
   it('should show validation', async () => {

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.multi-site.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.multi-site.unit.spec.jsx
@@ -220,7 +220,7 @@ describe('VAOS integration: VA facility page with a multi-site user', () => {
     });
 
     expect(
-      screen.getByLabelText(/Bozeman VA medical center/i),
+      await screen.findByLabelText(/Bozeman VA medical center/i),
     ).to.have.attribute('checked');
   });
 

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.single-site.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.single-site.unit.spec.jsx
@@ -101,16 +101,15 @@ describe('VAOS integration: VA facility page with a single-site user', () => {
       store,
     });
 
+    await screen.findByText(
+      /appointments are available at the following locations/i,
+    );
+
     expect(global.document.title).to.equal(
       'Choose a VA location for your appointment | Veterans Affairs',
     );
     expect(screen.baseElement).to.contain.text(
       'Choose a VA location for your appointment',
-    );
-    expect(screen.baseElement).to.contain.text('Finding your VA facility');
-
-    await screen.findByText(
-      /appointments are available at the following locations/i,
     );
     expect(screen.baseElement).to.contain.text(
       'Bozeman VA medical center (Bozeman, MT)',
@@ -175,7 +174,6 @@ describe('VAOS integration: VA facility page with a single-site user', () => {
       store,
     });
 
-    expect(baseElement).to.contain.text('Finding your VA facility');
     await findByText(/we found one VA location for you/i);
 
     expect(baseElement).to.contain.text('Belgrade VA clinic');
@@ -248,7 +246,6 @@ describe('VAOS integration: VA facility page with a single-site user', () => {
       store,
     });
 
-    expect(screen.baseElement).to.contain.text('Finding your VA facility');
     await screen.findByText(/we found one VA location for you/i);
 
     expect(screen.baseElement).to.contain.text(
@@ -366,7 +363,6 @@ describe('VAOS integration: VA facility page with a single-site user', () => {
       store,
     });
 
-    expect(screen.baseElement).to.contain.text('Finding your VA facility');
     await screen.findByText(
       /There are no primary care appointments at this location/,
     );
@@ -725,7 +721,6 @@ describe('VAOS integration: VA facility page with a single-site user', () => {
       },
     );
 
-    expect(screen.baseElement).to.contain.text('Finding your VA facility');
     await waitFor(() =>
       expect(screen.getByText(/Continue/)).not.to.have.attribute('disabled'),
     );
@@ -784,7 +779,6 @@ describe('VAOS integration: VA facility page with a single-site user', () => {
       },
     );
 
-    expect(screen.baseElement).to.contain.text('Finding your VA facility');
     await waitFor(() =>
       expect(screen.getByText(/Continue/)).not.to.have.attribute('disabled'),
     );


### PR DESCRIPTION
## Description
We almost always want an await after each render call in our tests, so I went through and updated as many as I could.

I also removed some loading state checks, which have been flaky in the past.

## Testing done
Unit testing

## Acceptance criteria
- [ ] Build passes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
