### PR TITLE
CT - Remove prod flags for app reload fix

### DIFF
--- a/src/applications/gi/reducers/eligibility.js
+++ b/src/applications/gi/reducers/eligibility.js
@@ -1,5 +1,4 @@
 import localStorage from 'platform/utilities/storage/localStorage';
-import environment from 'platform/utilities/environment';
 
 import { ELIGIBILITY_CHANGED } from '../actions';
 import { ELIGIBILITY_LIFESPAN } from '../constants';
@@ -49,28 +48,22 @@ export default function(state = INITIAL_STATE, action) {
       };
     }
 
-    // Fix for 8228
-    if (!environment.isProduction()) {
-      newState.timestamp = new Date().getTime();
-      localStorage.setItem('giEligibility', JSON.stringify(newState));
-    }
+    newState.timestamp = new Date().getTime();
+    localStorage.setItem('giEligibility', JSON.stringify(newState));
 
     return newState;
   }
 
-  // Fix for 8228
-  if (!environment.isProduction()) {
-    const storedEligibility = JSON.parse(localStorage.getItem('giEligibility'));
+  const storedEligibility = JSON.parse(localStorage.getItem('giEligibility'));
 
-    if (
-      storedEligibility?.timestamp &&
-      new Date().getTime() - storedEligibility.timestamp < ELIGIBILITY_LIFESPAN
-    ) {
-      newState = {
-        ...newState,
-        ...storedEligibility,
-      };
-    }
+  if (
+    storedEligibility?.timestamp &&
+    new Date().getTime() - storedEligibility.timestamp < ELIGIBILITY_LIFESPAN
+  ) {
+    newState = {
+      ...newState,
+      ...storedEligibility,
+    };
   }
 
   return newState;

--- a/src/applications/gi/reducers/eligibility.js
+++ b/src/applications/gi/reducers/eligibility.js
@@ -60,6 +60,7 @@ export default function(state = INITIAL_STATE, action) {
     storedEligibility?.timestamp &&
     new Date().getTime() - storedEligibility.timestamp < ELIGIBILITY_LIFESPAN
   ) {
+    delete storedEligibility.timestamp;
     newState = {
       ...newState,
       ...storedEligibility,

--- a/src/applications/gi/reducers/search.js
+++ b/src/applications/gi/reducers/search.js
@@ -135,6 +135,7 @@ export default function(state = INITIAL_STATE, action) {
         storedQuery?.timestamp &&
         new Date().getTime() - storedQuery.timestamp < QUERY_LIFESPAN
       ) {
+        delete storedQuery.timestamp;
         newState = {
           ...newState,
           query: { ...storedQuery },

--- a/src/applications/gi/reducers/search.js
+++ b/src/applications/gi/reducers/search.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-case-declarations */
 import camelCaseKeysRecursive from 'camelcase-keys-recursive';
 import localStorage from 'platform/utilities/storage/localStorage';
-import environment from 'platform/utilities/environment';
 
 import { QUERY_LIFESPAN } from '../constants';
 
@@ -82,14 +81,11 @@ export default function(state = INITIAL_STATE, action) {
     case FILTER_TOGGLED:
       return { ...state, filterOpened: !state.filterOpened };
     case SEARCH_STARTED:
-      // Fix for 7528
-      if (!environment.isProduction()) {
-        const query = {
-          ...action.query,
-          timestamp: new Date().getTime(),
-        };
-        localStorage.setItem('giQuery', JSON.stringify(query));
-      }
+      const query = {
+        ...action.query,
+        timestamp: new Date().getTime(),
+      };
+      localStorage.setItem('giQuery', JSON.stringify(query));
 
       return { ...state, query: action.query, inProgress: true };
     case SEARCH_FAILED:
@@ -133,20 +129,18 @@ export default function(state = INITIAL_STATE, action) {
     default:
       let newState = { ...state };
 
-      // Fix for 7528
-      if (!environment.isProduction()) {
-        const storedQuery = JSON.parse(localStorage.getItem('giQuery'));
+      const storedQuery = JSON.parse(localStorage.getItem('giQuery'));
 
-        if (
-          storedQuery?.timestamp &&
-          new Date().getTime() - storedQuery.timestamp < QUERY_LIFESPAN
-        ) {
-          newState = {
-            ...newState,
-            query: { ...storedQuery },
-          };
-        }
+      if (
+        storedQuery?.timestamp &&
+        new Date().getTime() - storedQuery.timestamp < QUERY_LIFESPAN
+      ) {
+        newState = {
+          ...newState,
+          query: { ...storedQuery },
+        };
       }
+
       return newState;
   }
 }


### PR DESCRIPTION
## Description
Remove prod flags around fixes for the app reloading and losing CT state.

ZenHub Issues:
- [7528](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/7528)
- [8228](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/8228)

## Testing done
Tested locally and QA reviewed

## Screenshots
N/A

## Acceptance criteria
- [X] CT works correctly

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
