### PR TITLE
Fix build issues due to empty fieldDate data

### DIFF
--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -37,21 +37,13 @@ function createPastEventListPages(page, drupalPagePath, files) {
 
   // separate current events from past events;
   allEvents.entities.forEach(eventTeaser => {
-    // Get startdate from fieldDate Object
-    const startDate = eventTeaser.fieldDate.startDate;
-
-    // Convert the string to a date object to suppress a deprecation warning
-    const startDateObj = new Date(startDate);
-
-    // Pass the date object into Moment for formatting
-    const startDateUtc = moment(startDateObj)
-      .utc()
-      .format();
+    const startDate = eventTeaser.fieldDatetimeRangeTimezone.value;
 
     // Check if the date is in the past
-    const isPast = moment().diff(startDateUtc, 'days');
+    const startDateUTC = moment.unix(startDate);
+    const currentDateUTC = new Date().getTime() / 1000;
 
-    if (isPast >= 1) {
+    if (startDateUTC < currentDateUTC) {
       pastEventTeasers.entities.push(eventTeaser);
     }
   });
@@ -59,7 +51,7 @@ function createPastEventListPages(page, drupalPagePath, files) {
   // sort past events into reverse chronological order by start date
   pastEventTeasers.entities = _.orderBy(
     pastEventTeasers.entities,
-    ['fieldDate.startDate'],
+    ['fieldDatetimeRangeTimezone.value'],
     ['desc'],
   );
 
@@ -286,7 +278,7 @@ function addPager(page, files, field, template, aria) {
   if (page.allEventTeasers) {
     page.allEventTeasers.entities = itemSorter(
       page.allEventTeasers,
-      'fieldDate',
+      'fieldDatetimeRangeTimezone',
     );
   }
   // Sort news teasers.

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -242,23 +242,23 @@ function addGetUpdatesFields(page, pages) {
 }
 
 /**
- * Sorts legacy dates (fieldDate) from oldest to newest, removing expired items.
+ * Sorts release dates (fieldReleaseDate) from oldest to newest, removing expired items.
  *
- * @param {legacyDates} array The dates array.
+ * @param {releaseDates} array The dates array.
  * @param {reverse} bool Sorting order set to default false.
  * @param {stale} bool Remove expired date items set to default false.
  * @return Filtered array of sorted items.
  */
-function legacyDateSorter(legacyDates = [], reverse = false, stale = true) {
+function releaseDateSorter(legacyDates = [], reverse = false, stale = true) {
   let sorted = legacyDates.entities.sort((a, b) => {
-    const start1 = moment(a.fieldDate.value);
-    const start2 = moment(b.fieldDate.value);
+    const start1 = moment(a.fieldReleaseDate.value);
+    const start2 = moment(b.fieldReleaseDate.value);
     return reverse ? start2 - start1 : start1 - start2;
   });
 
   if (stale) {
     sorted = sorted.filter(item =>
-      moment(item.fieldDate.value).isAfter(moment()),
+      moment(item.fieldReleaseDate.value).isAfter(moment()),
     );
   }
 
@@ -266,14 +266,14 @@ function legacyDateSorter(legacyDates = [], reverse = false, stale = true) {
 }
 
 /**
- * Sorts dates (fieldDatetimeRangeTimezone) from oldest to newest, removing expired items.
+ * Sorts event dates (fieldDatetimeRangeTimezone) from oldest to newest, removing expired items.
  *
  * @param {dates} array The dates array.
  * @param {reverse} bool Sorting order set to default false.
  * @param {stale} bool Remove expired date items set to default false.
  * @return Filtered array of sorted items.
  */
-function dateSorter(dates = [], reverse = false, stale = true) {
+function eventDateSorter(dates = [], reverse = false, stale = true) {
   let sorted = dates.entities.sort((a, b) => {
     const start1 = a.fieldDatetimeRangeTimezone.value;
     const start2 = b.fieldDatetimeRangeTimezone.value;
@@ -304,12 +304,12 @@ function dateSorter(dates = [], reverse = false, stale = true) {
 function addPager(page, files, field, template, aria) {
   // Sort events and remove stale items.
   if (page.allEventTeasers) {
-    page.allEventTeasers.entities = dateSorter(page.allEventTeasers);
+    page.allEventTeasers.entities = eventDateSorter(page.allEventTeasers);
   }
 
   // Sort news teasers.
   if (page.allPressReleaseTeasers) {
-    page.allPressReleaseTeasers.entities = legacyDateSorter(
+    page.allPressReleaseTeasers.entities = releaseDateSorter(
       page.allPressReleaseTeasers,
       true,
       false,

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -40,7 +40,7 @@ function createPastEventListPages(page, drupalPagePath, files) {
     const startDate = eventTeaser.fieldDatetimeRangeTimezone.value;
 
     // Check if the date is in the past
-    const startDateUTC = moment.unix(startDate);
+    const startDateUTC = startDate;
     const currentDateUTC = new Date().getTime() / 1000;
 
     if (startDateUTC < currentDateUTC) {
@@ -242,27 +242,55 @@ function addGetUpdatesFields(page, pages) {
 }
 
 /**
- * Sorts items from oldest to newest, removing expired items.
+ * Sorts legacy dates (fieldDate) from oldest to newest, removing expired items.
  *
- * @param {items} array The items array.
- * @param {field} string The target date field.
+ * @param {legacyDates} array The dates array.
  * @param {reverse} bool Sorting order set to default false.
  * @param {stale} bool Remove expired date items set to default false.
  * @return Filtered array of sorted items.
  */
-function itemSorter(items = [], field, reverse = false, stale = true) {
-  let sorted = items.entities.sort((a, b) => {
-    const start1 = moment(a[field].value);
-    const start2 = moment(b[field].value);
+function legacyDateSorter(legacyDates = [], reverse = false, stale = true) {
+  let sorted = legacyDates.entities.sort((a, b) => {
+    const start1 = moment(a.fieldDate.value);
+    const start2 = moment(b.fieldDate.value);
     return reverse ? start2 - start1 : start1 - start2;
   });
 
   if (stale) {
-    sorted = sorted.filter(item => moment(item[field].value).isAfter(moment()));
+    sorted = sorted.filter(item =>
+      moment(item.fieldDate.value).isAfter(moment()),
+    );
   }
 
   return sorted;
 }
+
+/**
+ * Sorts dates (fieldDatetimeRangeTimezone) from oldest to newest, removing expired items.
+ *
+ * @param {dates} array The dates array.
+ * @param {reverse} bool Sorting order set to default false.
+ * @param {stale} bool Remove expired date items set to default false.
+ * @return Filtered array of sorted items.
+ */
+function dateSorter(dates = [], reverse = false, stale = true) {
+  let sorted = dates.entities.sort((a, b) => {
+    const start1 = a.fieldDatetimeRangeTimezone.value;
+    const start2 = b.fieldDatetimeRangeTimezone.value;
+    return reverse ? start2 - start1 : start1 - start2;
+  });
+
+  const currentDateUTC = new Date().getTime() / 1000;
+
+  if (stale) {
+    sorted = sorted.filter(
+      item => item.fieldDatetimeRangeTimezone.value > currentDateUTC,
+    );
+  }
+
+  return sorted;
+}
+
 /**
  * Add pagers to cms content listing pages.
  *
@@ -276,16 +304,13 @@ function itemSorter(items = [], field, reverse = false, stale = true) {
 function addPager(page, files, field, template, aria) {
   // Sort events and remove stale items.
   if (page.allEventTeasers) {
-    page.allEventTeasers.entities = itemSorter(
-      page.allEventTeasers,
-      'fieldDatetimeRangeTimezone',
-    );
+    page.allEventTeasers.entities = dateSorter(page.allEventTeasers);
   }
+
   // Sort news teasers.
   if (page.allPressReleaseTeasers) {
-    page.allPressReleaseTeasers.entities = itemSorter(
+    page.allPressReleaseTeasers.entities = legacyDateSorter(
       page.allPressReleaseTeasers,
-      'fieldReleaseDate',
       true,
       false,
     );

--- a/src/site/stages/build/drupal/menus.js
+++ b/src/site/stages/build/drupal/menus.js
@@ -264,6 +264,12 @@ function makeSection(hostUrl, hub, arrayDepth, promo, pages) {
  * @return {Array} headerData - Menu information formatted for the megaMenu React widget.
  */
 function formatHeaderData(buildOptions, contentData) {
+  if (!contentData?.data) {
+    // eslint-disable-next-line no-console
+    console.warn('formatHeaderData has no data');
+    return null;
+  }
+
   let menuLinks = contentData.data.menuLinkContentQuery.entities;
   const pages = contentData.data.nodeQuery.entities;
   const headerData = [];

--- a/src/site/stages/build/process-cms-exports/transformers/node-event.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-event.js
@@ -48,10 +48,12 @@ const transform = entity => ({
     processed: getWysiwygString(getDrupalValue(entity.fieldBody)),
   },
   fieldDate: {
-    startDate: toUtc(entity.fieldDate[0].value),
-    value: toUtc(entity.fieldDate[0].value, false),
-    endDate: toUtc(entity.fieldDate[0].end_value),
-    endValue: toUtc(entity.fieldDate[0].end_value, false),
+    startDate: toUtc(entity.fieldDate[0]?.value),
+    value: toUtc(entity.fieldDate[0]?.value, false),
+    // eslint-disable-next-line camelcase
+    endDate: toUtc(entity.fieldDate[0]?.end_value),
+    // eslint-disable-next-line camelcase
+    endValue: toUtc(entity.fieldDate[0]?.end_value, false),
   },
   // The templates expect timestamps, like we get from graphql,
   // but the cms-export gives us UTC dates.


### PR DESCRIPTION
## Description

Our production build is currently broken due to a change to the CMS data. New events are being added which do not include the legacy fieldDate. Our templates can handle the missing data just fine, but there is some code in our build pipeline that still expects the data to be present.

Pages impacted include events and news-releases, possibly others.

## Testing done
Build locally, spot-check pages manually

## Acceptance criteria
- [x] Build works and pages impacted match production

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
