### PR TITLE
remove space holder if street2 is missing

### DIFF
--- a/src/applications/vaos/new-appointment/components/ReviewPage/PreferredProviderSection.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/PreferredProviderSection.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import newAppointmentFlow from '../../newAppointmentFlow';
+
 import { LANGUAGES } from '../../../utils/constants';
 
 export default function PreferredProviderSection(props) {

--- a/src/applications/vaos/new-appointment/components/ReviewPage/PreferredProviderSection.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/PreferredProviderSection.jsx
@@ -22,8 +22,12 @@ export default function PreferredProviderSection(props) {
                 {props.data.communityCareProvider.lastName}
                 <br />
                 {props.data.communityCareProvider.address.street}
-                <br />
-                {props.data.communityCareProvider.address.street2}
+                {!!props.data.communityCareProvider.address.street2 && (
+                  <>
+                    <br />
+                    {props.data.communityCareProvider.address.street2}
+                  </>
+                )}
                 <br />
                 {props.data.communityCareProvider.address.city},{' '}
                 {props.data.communityCareProvider.address.state}{' '}


### PR DESCRIPTION
## Description
In the review page for preferred provider, when the mailing address does not have a second line value, it currently displays a blank space holder for line 2. Need to remove the spacing when street2 doesn't exist.

## Testing done
local test

## Screenshots
![image](https://user-images.githubusercontent.com/54327023/100671803-12fd4600-332f-11eb-8e45-a736e4ba1b13.png)


## Acceptance criteria
- [ ] If preferred provider doesn't have a mailing address line 2 value, city/state/zip line displays immediately below mailing address line 1
- [ ]  If preferred provider has a mailing address line 2 value, display it between mailing address line 1 and city/state/zip

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
