### PR TITLE
[Development] CST: Add password field for encrypted PDF

### DIFF
--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -425,8 +425,9 @@ export function submitFiles(claimId, trackedItem, files) {
                 });
                 dispatch(
                   setAdditionalEvidenceNotification({
-                    title: 'Error uploading files',
+                    title: `Error uploading ${hasError?.fileName || 'files'}`,
                     body:
+                      hasError?.errors?.[0]?.title ||
                       'There was an error uploading your files. Please try again',
                     type: 'error',
                   }),
@@ -457,16 +458,15 @@ export function submitFiles(claimId, trackedItem, files) {
                 ),
               });
             },
-            onError: (id, name, reason) => {
-              const errorCode = reason.substr(-3);
-              // this is a little hackish, but uploader expects a json response
-              if (!errorCode.startsWith('2')) {
-                hasError = true;
-              }
-              if (errorCode === '401') {
+            onError: (_id, fileName, _reason, { response, status }) => {
+              if (status === 401) {
                 dispatch({
                   type: SET_UNAUTHORIZED,
                 });
+              }
+              if (status < 200 || status > 299) {
+                hasError = JSON.parse(response || '{}');
+                hasError.fileName = fileName;
               }
             },
           },

--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -307,10 +307,11 @@ export function resetUploads() {
   };
 }
 
-export function addFile(files) {
+export function addFile(files, { isEncrypted = false } = {}) {
   return {
     type: ADD_FILE,
     files,
+    isEncrypted,
   };
 }
 
@@ -480,10 +481,11 @@ export function submitFiles(claimId, trackedItem, files) {
         });
 
         /* eslint-disable camelcase */
-        files.forEach(({ file, docType }) => {
+        files.forEach(({ file, docType, password }) => {
           uploader.addFiles(file, {
             tracked_item_id: trackedItemId,
             document_type: docType.value,
+            password: password.value,
           });
         });
         /* eslint-enable camelcase */

--- a/src/applications/claims-status/components/UploadStatus.jsx
+++ b/src/applications/claims-status/components/UploadStatus.jsx
@@ -20,7 +20,7 @@ export default function UploadStatus({ progress, files, onCancel }) {
               evt.preventDefault();
               onCancel();
             }}
-            href
+            href="#"
           >
             Cancel
           </a>

--- a/src/applications/claims-status/reducers/uploads.js
+++ b/src/applications/claims-status/reducers/uploads.js
@@ -36,8 +36,9 @@ export default function claimDetailReducer(state = initialState, action) {
       const files = Array.prototype.map.call(action.files, file => ({
         file,
         docType: makeField(''),
+        password: makeField(''),
+        isEncrypted: action.isEncrypted,
       }));
-
       return _.set('files', state.files.concat(files), state);
     }
     case REMOVE_FILE: {

--- a/src/applications/claims-status/tests/actions.unit.spec.js
+++ b/src/applications/claims-status/tests/actions.unit.spec.js
@@ -116,6 +116,18 @@ describe('Actions', () => {
       expect(action).to.eql({
         type: ADD_FILE,
         files: 'Testing',
+        isEncrypted: false,
+      });
+    });
+  });
+  describe('addFile with encrypted flag', () => {
+    it('should return the correct action object', () => {
+      const action = addFile('Testing', { isEncrypted: true });
+
+      expect(action).to.eql({
+        type: ADD_FILE,
+        files: 'Testing',
+        isEncrypted: true,
       });
     });
   });

--- a/src/applications/claims-status/tests/components/AddFilesForm.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/AddFilesForm.unit.spec.jsx
@@ -3,7 +3,7 @@ import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import AddFilesForm from '../../components/AddFilesForm';
+import { AddFilesForm } from '../../components/AddFilesForm';
 
 describe('<AddFilesForm>', () => {
   it('should render component', () => {
@@ -306,5 +306,48 @@ describe('<AddFilesForm>', () => {
     tree.getMountedInstance().state.errorMessage = 'message';
     message = tree.getMountedInstance().getErrorMessage();
     expect(message).to.equal('message');
+  });
+
+  it('should show password input', () => {
+    const files = [
+      {
+        file: {
+          size: 20,
+          name: 'something.pdf',
+        },
+        docType: {
+          value: 'L501',
+          dirty: false,
+        },
+        password: {
+          value: 'password123',
+          dirty: false,
+        },
+        isEncrypted: true,
+      },
+    ];
+    const field = { value: '', dirty: false };
+    const onSubmit = sinon.spy();
+    const onAddFile = sinon.spy();
+    const onRemoveFile = sinon.spy();
+    const onFieldChange = sinon.spy();
+    const onCancel = sinon.spy();
+    const onDirtyFields = sinon.spy();
+
+    const tree = SkinDeep.shallowRender(
+      <AddFilesForm
+        files={files}
+        field={field}
+        onSubmit={onSubmit}
+        onAddFile={onAddFile}
+        onRemoveFile={onRemoveFile}
+        onFieldChange={onFieldChange}
+        onCancel={onCancel}
+        onDirtyFields={onDirtyFields}
+        requestLockedPdfPassword
+      />,
+    );
+    expect(tree.getMountedInstance().state.errorMessage).to.be.null;
+    expect(tree.subTree('ErrorableTextInput')).to.exist;
   });
 });

--- a/src/applications/claims-status/tests/components/AdditionalEvidencePage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/AdditionalEvidencePage.unit.spec.jsx
@@ -3,7 +3,9 @@ import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import ReactTestUtils from 'react-dom/test-utils';
+import { Provider } from 'react-redux';
 
+import { uploadStore } from 'platform/forms-system/test/config/helpers';
 import { AdditionalEvidencePage } from '../../containers/AdditionalEvidencePage';
 
 const params = { id: 1 };
@@ -103,7 +105,7 @@ describe('<AdditionalEvidencePage>', () => {
         submitFiles={onSubmit}
       />,
     );
-    tree.subTree('AddFilesForm').props.onSubmit();
+    tree.subTree('Connect(AddFilesForm)').props.onSubmit();
     expect(onSubmit.calledWith(1, null, files)).to.be.true;
   });
   it('should reset uploads and set title on mount', () => {
@@ -116,13 +118,15 @@ describe('<AdditionalEvidencePage>', () => {
     mainDiv.classList.add('va-nav-breadcrumbs');
     document.body.appendChild(mainDiv);
     ReactTestUtils.renderIntoDocument(
-      <AdditionalEvidencePage
-        params={params}
-        claim={claim}
-        files={[]}
-        uploadField={{ value: null, dirty: false }}
-        resetUploads={resetUploads}
-      />,
+      <Provider store={uploadStore}>
+        <AdditionalEvidencePage
+          params={params}
+          claim={claim}
+          files={[]}
+          uploadField={{ value: null, dirty: false }}
+          resetUploads={resetUploads}
+        />
+      </Provider>,
     );
 
     expect(document.title).to.equal('Additional Evidence');

--- a/src/applications/claims-status/tests/components/DocumentRequestPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/DocumentRequestPage.unit.spec.jsx
@@ -3,7 +3,9 @@ import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import ReactTestUtils from 'react-dom/test-utils';
+import { Provider } from 'react-redux';
 
+import { uploadStore } from 'platform/forms-system/test/config/helpers';
 import { DocumentRequestPage } from '../../containers/DocumentRequestPage';
 
 const params = { id: 1 };
@@ -150,7 +152,7 @@ describe('<DocumentRequestPage>', () => {
         submitFiles={onSubmit}
       />,
     );
-    tree.subTree('AddFilesForm').props.onSubmit();
+    tree.subTree('Connect(AddFilesForm)').props.onSubmit();
     expect(onSubmit.called).to.be.true;
   });
   it('should reset uploads and set title on mount', () => {
@@ -167,14 +169,16 @@ describe('<DocumentRequestPage>', () => {
     mainDiv.classList.add('va-nav-breadcrumbs');
     document.body.appendChild(mainDiv);
     ReactTestUtils.renderIntoDocument(
-      <DocumentRequestPage
-        params={params}
-        claim={claim}
-        files={[]}
-        uploadField={{ value: null, dirty: false }}
-        trackedItem={trackedItem}
-        resetUploads={resetUploads}
-      />,
+      <Provider store={uploadStore}>
+        <DocumentRequestPage
+          params={params}
+          claim={claim}
+          files={[]}
+          uploadField={{ value: null, dirty: false }}
+          trackedItem={trackedItem}
+          resetUploads={resetUploads}
+        />
+      </Provider>,
     );
 
     expect(document.title).to.equal('Request for Testing');

--- a/src/applications/claims-status/tests/reducers/uploads.unit.spec.jsx
+++ b/src/applications/claims-status/tests/reducers/uploads.unit.spec.jsx
@@ -43,7 +43,29 @@ describe('Uploads reducer', () => {
     );
 
     expect(state.files.length).to.equal(1);
-    expect(state.files[0].file.name).to.equal('test');
+    const file = state.files[0];
+    expect(file.file.name).to.equal('test');
+    expect(file.password.value).to.equal('');
+    expect(file.isEncrypted).to.be.undefined;
+  });
+
+  it('should add a file that needs a password', () => {
+    const state = uploads(
+      {
+        files: [],
+      },
+      {
+        type: ADD_FILE,
+        files: [{ name: 'test' }],
+        isEncrypted: true,
+      },
+    );
+
+    expect(state.files.length).to.equal(1);
+    const file = state.files[0];
+    expect(file.file.name).to.equal('test');
+    expect(file.password.value).to.equal('');
+    expect(file.isEncrypted).to.be.true;
   });
 
   it('remove a file', () => {


### PR DESCRIPTION
## Description

Veterans & active service members, specifically those applying for the Benefits Delivery at Discharge, make have encrypted PDF provided to them. The claim status tool (CST) code is separate from the form-related file uploads and therefore has been updated separately.

When an encrypted PDF is detected and the **feature flag** is set, a password field is added to the file card enabling the user to enter a password which is then passed to the server when files are submitted for review. It does not submit each file independently as the form file upload behaves.

Encrypted PDFs with in invalid password are not distinguished from non-encrypted PDFs in the server response

**NOTE**: I am unable to find a test user which shows this view, so that I can test uploading encrypted PDFs.

Related:
- Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/14723
- Backend password update: https://github.com/department-of-veterans-affairs/va.gov-team/issues/14002
- CST Swagger - https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/api-reference/#/claim_status_tool/postDocument
- Form system PDF passwords: https://github.com/department-of-veterans-affairs/va.gov-team/issues/14011

## Testing done

Updated unit tests

## Screenshots

<details><summary>File card with password input</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-11-30 at 1 56 32 PM](https://user-images.githubusercontent.com/136959/100675507-b436cd00-332c-11eb-81f6-e87c6eb66ef9.png)
</details>

<details><summary>Invalid password (before & after)</summary>

<!-- leave a blank line above -->
**Before**
![Screen Shot 2020-12-01 at 9 13 21 AM](https://user-images.githubusercontent.com/136959/100762358-7df35f00-33b9-11eb-8680-ad00648fd57f.png)

**After**
![Screen Shot 2020-12-01 at 9 10 41 AM](https://user-images.githubusercontent.com/136959/100762363-7e8bf580-33b9-11eb-9622-74bac3a420c7.png)</details>

## Acceptance criteria
- [x] Encrypted PDFs are detected and a password input is provided
- [x] PDF password fields are behind a feature flag
- [x] Provide better error messages

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
