### PR TITLE
15483 accessibility fix

### DIFF
--- a/src/applications/vre/28-1900/config/chapters/communication-preferences/communicationPreferences.js
+++ b/src/applications/vre/28-1900/config/chapters/communication-preferences/communicationPreferences.js
@@ -74,6 +74,7 @@ export const uiSchema = {
       // this needed because ObjectField adds the schemaform-block class to this, which creates a huge top margin.
       classNames: 'vads-u-margin-top--neg2',
       showFieldLabel: true,
+      forceDivWrapper: true,
     },
     morning: {
       'ui:title': 'Mornings 6:00 to 10:00 a.m.',


### PR DESCRIPTION
## Description
This pull request adds the property `forceDivWrapper: true` to the `ui:options` for a selection of checkboxes in the chapter 31 form. This fixes an accessibility issue where uiSchema injects an extra fieldset into the DOM without a corresponding legend. 

## Testing done
- local

## Acceptance criteria
- [x] WAVE warning is resolved

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
