### PR TITLE
Downtime content update

### DIFF
--- a/src/applications/caregivers/containers/IntroductionPage.jsx
+++ b/src/applications/caregivers/containers/IntroductionPage.jsx
@@ -20,9 +20,6 @@ const IntroductionPage = ({ route, router }) => {
     focusElement('.va-nav-breadcrumbs-list');
   }, []);
 
-  const applicationTitle =
-    'Apply for the Program of Comprehensive Assistance for Family Caregivers';
-
   const startForm = () => {
     recordEvent({ event: 'caregivers-10-10cg-start-form' });
     const pageList = route.pageList;
@@ -208,10 +205,13 @@ const IntroductionPage = ({ route, router }) => {
   return (
     <div className="caregivers-intro schemaform-intro">
       <DowntimeNotification
-        appTitle={applicationTitle}
+        appTitle="Application for the Program of Comprehensive Assistance for Family Caregivers"
         dependencies={[externalServices.mvi, externalServices.carma]}
       >
-        <FormTitle className="form-title" title={applicationTitle} />
+        <FormTitle
+          className="form-title"
+          title="Apply for the Program of Comprehensive Assistance for Family Caregivers"
+        />
 
         <p>
           Equal to VA Form 10-10CG (Application for Family Caregiver Benefits)


### PR DESCRIPTION
## Description
As a developer I did not expect the DowntimeNotification to add content to my application title. Updating content so the content semantically makes sense.



## Screenshots
`old content:`
![upcoming-maitnance](https://user-images.githubusercontent.com/23741323/100773337-b81b2b80-33ce-11eb-85fe-83fcf6c41a53.png)

## Acceptance criteria
- [x] Update downtime content

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
