### PR TITLE
Fix event teaser transformer and template

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -110,7 +110,9 @@ module.exports = function registerFilters() {
     return moment
       .unix(dt)
       .tz(timezone)
-      .format(format);
+      .format(format)
+      .replace(/AM/g, 'a.m.')
+      .replace(/PM/g, 'p.m.');
   };
 
   liquid.filters.unixFromDate = data => new Date(data).getTime();

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-event_listing.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-event_listing.js
@@ -10,7 +10,7 @@ const reverseFieldSchema = {
         entity: partialSchema(eventSchema, [
           'title',
           'entityUrl',
-          'fieldDate',
+          'fieldDatetimeRangeTimezone',
           'fieldDescription',
           'fieldLocationHumanreadable',
         ]),

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-event_listing.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-event_listing.js
@@ -10,6 +10,7 @@ const reverseFieldSchema = {
         entity: partialSchema(eventSchema, [
           'title',
           'entityUrl',
+          'fieldDate',
           'fieldDatetimeRangeTimezone',
           'fieldDescription',
           'fieldLocationHumanreadable',

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
@@ -56,7 +56,7 @@ const eventTeasersSchema = max => ({
       items: {
         entity: partialSchema(eventSchema, [
           'title',
-          'fieldDate',
+          'fieldDatetimeRangeTimezone',
           'fieldDescription',
           'fieldLocationHumanreadable',
           'fieldFacilityLocation',

--- a/src/site/stages/build/process-cms-exports/transformers/node-event.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-event.js
@@ -65,8 +65,8 @@ const transform = entity => ({
           value: entity.fieldDatetimeRangeTimezone[0].value
             ? Date.parse(entity.fieldDatetimeRangeTimezone[0].value) / 1000
             : null,
-          endValue: entity.fieldDatetimeRangeTimezone[0].endValue
-            ? Date.parse(entity.fieldDatetimeRangeTimezone[0].endValue) / 1000
+          endValue: entity.fieldDatetimeRangeTimezone[0].end_value
+            ? Date.parse(entity.fieldDatetimeRangeTimezone[0].end_value) / 1000
             : null,
           timezone: entity.fieldDatetimeRangeTimezone[0].timezone,
         }

--- a/src/site/stages/build/process-cms-exports/transformers/node-event.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-event.js
@@ -47,6 +47,7 @@ const transform = entity => ({
   fieldBody: {
     processed: getWysiwygString(getDrupalValue(entity.fieldBody)),
   },
+  // This field is deprecated and can probably be removed
   fieldDate: {
     startDate: toUtc(entity.fieldDate[0]?.value),
     value: toUtc(entity.fieldDate[0]?.value, false),

--- a/src/site/stages/build/process-cms-exports/transformers/node-event_listing.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-event_listing.js
@@ -20,7 +20,7 @@ const reverseFields = reverseFieldListing => ({
           entityPublished: reverseField.entityPublished,
           uid: reverseField.uid,
           fieldFeatured: reverseField.fieldFeatured,
-          fieldDate: reverseField.fieldDate,
+          fieldDatetimeRangeTimezone: reverseField.fieldDatetimeRangeTimezone,
           fieldDescription: reverseField.fieldDescription,
           fieldFacilityLocation: reverseField.fieldFacilityLocation,
           fieldLocationHumanreadable: reverseField.fieldLocationHumanreadable,

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
@@ -119,6 +119,7 @@ const transform = ({
           .map(r => ({
             title: r.title,
             uid: r.uid,
+            fieldDate: r.fieldDate,
             fieldDatetimeRangeTimezone: r.fieldDatetimeRangeTimezone,
             fieldDescription: r.fieldDescription,
             fieldLocationHumanreadable: r.fieldLocationHumanreadable,
@@ -251,6 +252,7 @@ const transform = ({
                     .slice(0, 1000)
                     .map(e => ({
                       title: e.title,
+                      fieldDate: e.fieldDate,
                       fieldDatetimeRangeTimezone: e.fieldDatetimeRangeTimezone,
                       fieldDescription: e.fieldDescription,
                       fieldLocationHumanreadable: e.fieldLocationHumanreadable,
@@ -282,6 +284,7 @@ const transform = ({
                     )
                     .map(e => ({
                       title: e.title,
+                      fieldDate: e.fieldDate,
                       fieldDatetimeRangeTimezone: e.fieldDatetimeRangeTimezone,
                       fieldDescription: e.fieldDescription,
                       fieldLocationHumanreadable: e.fieldLocationHumanreadable,

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
@@ -1,4 +1,3 @@
-const moment = require('moment');
 const { getImageCrop } = require('./helpers');
 const {
   getDrupalValue,
@@ -14,6 +13,8 @@ const getSocialMediaObject = ({ uri, title }) =>
         title,
       }
     : null;
+
+const currentTimeInSeconds = new Date().getTime() / 1000;
 
 const transform = ({
   title,
@@ -106,14 +107,19 @@ const transform = ({
               reverseField.entityBundle === 'event' &&
               reverseField.entityPublished &&
               reverseField.fieldFeatured &&
-              moment(reverseField.fieldDate.value).isAfter(moment(), 'day'),
+              reverseField.fieldDatetimeRangeTimezone.value >
+                currentTimeInSeconds,
           )
-          .sort((a, b) => a.fieldDate.value - b.fieldDate.value)
+          .sort(
+            (a, b) =>
+              a.fieldDatetimeRangeTimezone.value -
+              b.fieldDatetimeRangeTimezone.value,
+          )
           .slice(0, 2)
           .map(r => ({
             title: r.title,
             uid: r.uid,
-            fieldDate: r.fieldDate,
+            fieldDatetimeRangeTimezone: r.fieldDatetimeRangeTimezone,
             fieldDescription: r.fieldDescription,
             fieldLocationHumanreadable: r.fieldLocationHumanreadable,
             fieldFacilityLocation: r.fieldFacilityLocation,
@@ -129,7 +135,11 @@ const transform = ({
               reverseField.entityBundle === 'event' &&
               reverseField.entityPublished,
           )
-          .sort((a, b) => a.fieldDate.value - b.fieldDate.value)
+          .sort(
+            (a, b) =>
+              a.fieldDatetimeRangeTimezone.value -
+              b.fieldDatetimeRangeTimezone.value,
+          )
           .slice(0, 500)
           .map(r => ({
             title: r.title,
@@ -235,15 +245,13 @@ const transform = ({
                       reverseField =>
                         reverseField.entityBundle === 'event' &&
                         reverseField.entityPublished &&
-                        moment(reverseField.fieldDate.value).isAfter(
-                          moment(),
-                          'day',
-                        ),
+                        reverseField.fieldDatetimeRangeTimezone.value >
+                          currentTimeInSeconds,
                     )
                     .slice(0, 1000)
                     .map(e => ({
                       title: e.title,
-                      fieldDate: e.fieldDate,
+                      fieldDatetimeRangeTimezone: e.fieldDatetimeRangeTimezone,
                       fieldDescription: e.fieldDescription,
                       fieldLocationHumanreadable: e.fieldLocationHumanreadable,
                       fieldFacilityLocation: e.fieldFacilityLocation,
@@ -269,14 +277,12 @@ const transform = ({
                         reverseField.entityBundle === 'event' &&
                         reverseField.entityPublished &&
                         reverseField.fieldFeatured &&
-                        moment(reverseField.fieldDate.value).isAfter(
-                          moment(),
-                          'day',
-                        ),
+                        reverseField.fieldDatetimeRangeTimezone.value >
+                          currentTimeInSeconds,
                     )
                     .map(e => ({
                       title: e.title,
-                      fieldDate: e.fieldDate,
+                      fieldDatetimeRangeTimezone: e.fieldDatetimeRangeTimezone,
                       fieldDescription: e.fieldDescription,
                       fieldLocationHumanreadable: e.fieldLocationHumanreadable,
                       fieldFacilityLocation: e.fieldFacilityLocation,

--- a/src/site/teasers/event.drupal.liquid
+++ b/src/site/teasers/event.drupal.liquid
@@ -1,33 +1,5 @@
-{% comment %}
-Required variable: node - the news story entity
-Optional variable: header - the header level ('h2','h3', etc.) defaults to h4
-Example data:
-     {
-        "title": "Another Test Event",
-        "fieldDate": {
-            "startDate": "2019-03-16 10:00:01 UTC",
-            "value": "2019-03-16T10:00:01",
-            "endDate": "2019-03-16 11:00:00 UTC",
-            "endValue": "2019-03-16T11:00:00"
-        },
-        "fieldDescription": "This gives the user an overview of the event in teaser views",
-        "fieldLocationHumanreadable": "Here",
-        "fieldFacilityLocation": {
-          "entity": {
-            "title": "Westmoreland County VA Clinic",
-            "entityUrl": {
-              "path": "/pittsburgh-health-care/locations/westmoreland-county"
-            }
-          }
-        },
-        "entityUrl": {
-          "path": "/node/98"
-        }
-      }
-{% endcomment %}
-
 {% if node != empty %}
-  {% include "src/site/includes/date.drupal.liquid" with fieldDate = node.fieldDate %}
+  {% include "src/site/includes/date.drupal.liquid" with fieldDate = node.fieldDate fieldDatetimeRangeTimezone = node.fieldDatetimeRangeTimezone %}
 
   {% if header == empty %}
       {% assign header = "h2" %}


### PR DESCRIPTION
## Description
The event teaser transformer was still using fieldDate rather than fieldDatetimeRangeTimezone.

## Testing done
Run `yarn build:content --use-cms-export`. View http://localhost:3001/outreach-and-events/events/ and http://localhost:3001/pittsburgh-health-care/events/

## Acceptance criteria
- [x] Event dates are shown correctly

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
