### PR TITLE
[Development] HLR no issue content changes

### DIFF
--- a/src/applications/disability-benefits/996/config/form.js
+++ b/src/applications/disability-benefits/996/config/form.js
@@ -96,11 +96,11 @@ const formConfig = {
       },
     },
     contestedIssues: {
-      title: 'Contested issues',
+      title: 'Issues eligible for review',
       pages: {
         contestedIssues: {
           title: ' ',
-          path: 'contested-issues',
+          path: 'eligible-issues',
           uiSchema: contestedIssuesPage.uiSchema,
           schema: contestedIssuesPage.schema,
           // initialData,

--- a/src/applications/disability-benefits/996/constants.js
+++ b/src/applications/disability-benefits/996/constants.js
@@ -6,9 +6,13 @@ export const HLR_INFO_URL = '/decision-reviews/higher-level-review/';
 export const BASE_URL = `${HLR_INFO_URL}request-higher-level-review-form-20-0996`;
 
 export const FORM_URL = 'https://www.vba.va.gov/pubs/forms/VBA-20-0996-ARE.pdf';
+
+export const BOARD_APPEALS_URL = '/decision-reviews/board-appeal/';
+export const DECISION_REVIEWS_URL = '/decision-reviews/';
+export const CLAIM_STATUS_TOOL_URL = '/claim-or-appeal-status/';
+export const SUPPLEMENTAL_CLAIM_URL = '/decision-reviews/supplemental-claim/';
 export const COVID_FAQ_URL =
   'https://www.va.gov/coronavirus-veteran-frequently-asked-questions/#more-benefit-and-claim-questio';
-export const SUPPLEMENTAL_CLAIM_URL = '/decision-reviews/supplemental-claim/';
 export const FACILITY_LOCATOR_URL = '/find-locations';
 export const GET_HELP_REVIEW_REQUEST_URL =
   '/decision-reviews/get-help-with-review-request';

--- a/src/applications/disability-benefits/996/content/GetFormHelp.jsx
+++ b/src/applications/disability-benefits/996/content/GetFormHelp.jsx
@@ -1,19 +1,24 @@
 import React from 'react';
 import Telephone, {
   CONTACTS,
-  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
 const GetFormHelp = () => (
   <>
     <p className="help-talk">
-      If you have questions or need help filling out this form, please call us
-      at <Telephone contact={CONTACTS.VA_BENEFITS} />. We’re here Monday through
-      Friday, 8:00 a.m. to 9:00 p.m. ET.
+      If you have questions or need help filling out this form, please call our{' '}
+      <span aria-label="My. VA. 4 1 1.">MYVA411</span> main information line at{' '}
+      <Telephone contact={CONTACTS.HELP_DESK} /> and select 0. We’re here{' '}
+      <abbr title="24 hours a day, 7 days a week">24/7</abbr>.
     </p>
     <p className="u-vads-margin-bottom--0">
       If you have hearing loss, call TTY:{' '}
-      <Telephone contact={CONTACTS['711']} pattern={PATTERNS['3_DIGIT']} />.
+      <Telephone
+        contact={CONTACTS['711']}
+        pattern={'###'}
+        ariaLabel={'7 1 1.'}
+      />
+      .
     </p>
   </>
 );

--- a/src/applications/disability-benefits/996/content/InformalConference.jsx
+++ b/src/applications/disability-benefits/996/content/InformalConference.jsx
@@ -4,15 +4,16 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 export const InformalConferenceDescription = (
   <>
     <p>
-      An informal conference is a phone call between you or your accredited
-      representative (claims agent, attorney, or Veterans Service Organization)
-      and the reviewer to discuss why you think the decision should be changed
-      and identify factual errors.
+      You or your accredited representative (claims agent, attorney, or Veterans
+      Service Organization) can request an informal conference with the reviewer
+      assigned to your Higher-Level Review. During this conference you or your
+      representative will have the chance to discuss why you think the decision
+      should be changed and identify factual errors.
     </p>
     <p className="vads-u-margin-bottom--3">
       If you request an informal conference, the reviewer will call you or your
-      representative. You can request only one informal conference for each
-      Higher-Level Review request.
+      representative. You can request only one informal conference for your
+      Higher-Level Review.
     </p>
   </>
 );
@@ -71,13 +72,10 @@ export const AttemptsInfoAlert = ({ isRep }) => {
   return (
     <AlertBox
       status="info"
-      headline={`We’ll make two attempts to call ${
-        isRep ? 'your representative' : 'you'
-      }`}
-      content={`If no one answers, we’ll leave a voice mail and a number for
-       ${contact} to return the call. If we aren’t able to leave a voice mail or
-       get in touch with ${contact} after two attempts, we’ll proceed with the
-       Higher-Level Review.`}
+      headline={`We’ll call ${isRep ? 'your representative' : 'you'} 2 times`}
+      content={`Each time we call, we’ll leave a voice mail and a number for
+      ${contact} to return the call. If we aren’t able to get in touch with
+      ${contact} after 2 attempts, we’ll proceed with the Higher-Level Review.`}
     />
   );
 };

--- a/src/applications/disability-benefits/996/content/OfficeForReview.jsx
+++ b/src/applications/disability-benefits/996/content/OfficeForReview.jsx
@@ -4,12 +4,12 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 export const OfficeForReviewAlert = (
   <AlertBox
     status="info"
-    headline="We will try to fulfill your request"
+    headline="We’ll try to grant your request"
     className="vads-u-margin-left--3 vads-u-margin-top--0 vads-u-font-weight--normal"
     content={
       <p>
-        If we cannot fulfill your request, we will notify you at the time the
-        Higher-Level Review decision is made.
+        If we can’t fulfill your request, we’ll let you know at the time we make
+        a decision on your Higher-Level Review.
       </p>
     }
   />
@@ -17,15 +17,15 @@ export const OfficeForReviewAlert = (
 
 export const OfficeForReviewTitle = (
   <strong className="normal-weight-in-review">
-    If available, I would like the same office to conduct this review.
+    I’d like the same office to do this review.
   </strong>
 );
 
 export const OfficeForReviewDescription = (
   <p className="vads-u-margin-left--3">
-    You have the right to request the same office conduct the review. VA may be
-    unable to grant this request. In either scenario, your case will be looked
-    at by a different individual and considered separately from your original
+    You can request to have the same office conduct your Higher-Level Review. We
+    might not be able to grant your request, however. Either way, a new reviewer
+    will look at your case and consider it separately from your original
     decision.
   </p>
 );

--- a/src/applications/disability-benefits/996/content/contestedIssues.jsx
+++ b/src/applications/disability-benefits/996/content/contestedIssues.jsx
@@ -1,7 +1,18 @@
 import React from 'react';
+import moment from 'moment';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
-import { COVID_FAQ_URL } from '../constants';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
+
+import {
+  BOARD_APPEALS_URL,
+  CLAIM_STATUS_TOOL_URL,
+  COVID_FAQ_URL,
+  DECISION_REVIEWS_URL,
+  NULL_CONDITION_STRING,
+} from '../constants';
 import DownloadLink from './DownloadLink';
 import { scrollTo } from '../helpers';
 
@@ -24,50 +35,125 @@ export const ContestedIssuesTitle = props =>
     </legend>
   );
 
+/**
+ * @typedef {Object} Disability
+ * @property {String} diagnosticCode
+ * @property {String} issue
+ * @property {String} percentNumber
+ * @param {Disability} disability
+ */
+export const disabilityOption = ({ attributes }) => {
+  const {
+    ratingIssueSubjectText,
+    description,
+    ratingIssuePercentNumber,
+    approxDecisionDate,
+  } = attributes;
+  // May need to throw an error to Sentry if any of these don't exist
+  // A valid rated disability *can* have a rating percentage of 0%
+  const showPercentNumber = (ratingIssuePercentNumber || '') !== '';
+
+  return (
+    <div className="widget-content">
+      <h3 className="vads-u-margin-y--0 vads-u-font-size--h4">
+        {typeof ratingIssueSubjectText === 'string'
+          ? ratingIssueSubjectText
+          : NULL_CONDITION_STRING}
+      </h3>
+      {description && (
+        <p className="vads-u-margin-bottom--0">{description || ''}</p>
+      )}
+      {showPercentNumber && (
+        <p className="vads-u-margin-bottom--0">
+          Current rating: <strong>{ratingIssuePercentNumber}%</strong>
+        </p>
+      )}
+      {approxDecisionDate && (
+        <p>
+          Decision date:{' '}
+          <strong>{moment(approxDecisionDate).format('MMM D, YYYY')}</strong>
+        </p>
+      )}
+    </div>
+  );
+};
+
+const leadInContent = (
+  <>
+    <p className="vads-u-margin-top--2p5">
+      Please refer to your decision notice for further information on decision
+      review options and HLR eligibility. For information on how COVID-19
+      affects claims and appeals, please visit our{' '}
+      <a href={COVID_FAQ_URL}>Coronavirus FAQ page</a>.
+    </p>
+    <h2 className="vads-u-font-size--h4">
+      Where can I find more information on review options?
+    </h2>
+    <p>
+      Information regarding review options can be found at our{' '}
+      <a href={DECISION_REVIEWS_URL}>decision review information page</a>, or
+      you can call us at <Telephone contact={CONTACTS.VA_BENEFITS} />.
+      Alternatively, you can work with an accredited representative to get help
+      filing a claim for disability compensation.
+    </p>
+  </>
+);
+
 // Wrapped in a <div> on purpose
 const disabilitiesList = (
   <div>
     <ul>
       <li>
-        We made the decision over a year ago. You have 1 year from the date on
-        your decision letter to request a Higher-Level Review.{' '}
-        <strong>Note:</strong> If you aren’t able to request a timely review due
-        to COVID-19, we may grant you a deadline extension. To request an
-        extension, fill out and submit VA Form 20-0996, with a note attached
-        that you’re requesting an extension due to COVID-19.
+        VA decided that issue more than one year ago (an HLR can only be
+        requested within one year of the last decision). The one year time
+        period from the date on your decision letter has expired for
+        Higher-Level Review. <strong>Note:</strong> If you weren’t able to
+        request a timely review due to the COVID-19 pandemic, we may grant you
+        an extension of the deadline. To request an extension, download and fill
+        out VA Form 20-0996 PDF (1.5MB), and attach a note that you’re
+        requesting a filing extension due to COVID-19.
       </li>
       <li>
-        Your issue is for a benefit type other than compensation or pension. To
-        request a Higher-Level Review for another benefit type, you’ll need to
-        fill out VA Form 20-0996 and submit it by mail or in person.
+        Your issue isn’t related to monthly compensation, pension or survivor
+        benefits. For all other benefits, like health care, insurance or
+        education, you’ll need to download and fill out VA Form 20-0996 PDF
+        (1.5MB) and submit it by mail or in person.
       </li>
       <li>
-        The issue or decision isn’t our system yet. You’ll need to fill VA Form
-        20-0996 and submit it by mail or in person.
+        The VA has not yet reached a decision on this claim. Please refer to the{' '}
+        <a href={CLAIM_STATUS_TOOL_URL}>Claims Status Tool</a> for more
+        information.
       </li>
       <li>
-        You and another surviving dependent of the Veteran are applying for the
-        same benefit. And by law, only 1 of you can receive that benefit. You’ll
-        need to{' '}
-        <a href="/decision-reviews/board-appeal/">
-          appeal to the Board of Veterans’ Appeals
-        </a>
+        The issue or decision isn’t in our system yet. You’ll need to download
+        and fill out VA Form 20-0996 PDF (1.5MB) and submit it by fax or mail.
+      </li>
+      <li>
+        You’re applying for a benefit that another surviving dependent of the
+        Veteran is also applying for. And by law, only 1 of you can receive that
+        benefit. You’ll need to{' '}
+        <a href={BOARD_APPEALS_URL}>appeal to the Board of Veterans’ Appeals</a>
         .
       </li>
       <li>
-        You’re requesting a review of a Board of Veterans’ Appeals decision.
-        Refer to the Board’s decision notice for your options.
+        You’re requesting a review of a Board of Veterans’ Appeals decision or
+        an existing decision already under Higher-Level Review. You’ll need to
+        refer to the Board’s decision notice for your review options.
       </li>
       <li>
-        You’re requesting a review of a Higher-Level Review decision. You’ll
-        need to either file a Supplemental Claim or appeal to the Board of
-        Veterans’ Appeals.
+        You’re requesting a review of a Higher-Level Review decision. You can
+        either submit a Supplemental Claim or appeal to the Board of Veterans’
+        Appeals.
+      </li>
+      <li>VA has not previously made a decision on that issue.</li>
+      <li>
+        The issue is ineligible under a Higher-Level Review (it cannot be
+        requested on contested claims, such as disagreements with attorney
+        fees).
       </li>
     </ul>
-    <DownloadLink content={'Download VA Form 20-0996'} />
-    <p>
-      To learn more about how COVID-19 affects claims or appeals, please visit
-      our <a href={COVID_FAQ_URL}>Coronavirus FAQ page</a>.
+    <p className="vads-u-padding-bottom--2p5">
+      <DownloadLink content={'Download VA Form 20-0996'} />
     </p>
   </div>
 );
@@ -76,6 +162,7 @@ export const disabilitiesExplanationAlert = (
   <>
     <p className="vads-u-margin-top--2p5" />
     <AdditionalInfo triggerText={'Why isn’t my issue eligible?'}>
+      {leadInContent}
       <p>Your issue may not be eligible if:</p>
       {disabilitiesList}
     </AdditionalInfo>
@@ -83,15 +170,11 @@ export const disabilitiesExplanationAlert = (
 );
 
 export const disabilitiesExplanation = (
-  <>
-    <p className="vads-u-margin-top--2p5" />
-    <AdditionalInfo triggerText={'Don’t see the issue you’re looking for?'}>
-      <p>
-        There are many reasons a decision might not appear in the list above.
-      </p>
-      {disabilitiesList}
-    </AdditionalInfo>
-  </>
+  <AdditionalInfo triggerText={'Don’t see the issue you’re looking for?'}>
+    {leadInContent}
+    <p>There are many reasons a decision might not appear in the list above.</p>
+    {disabilitiesList}
+  </AdditionalInfo>
 );
 
 /**

--- a/src/applications/disability-benefits/996/content/contestedIssues.jsx
+++ b/src/applications/disability-benefits/996/content/contestedIssues.jsx
@@ -79,6 +79,7 @@ export const disabilityOption = ({ attributes }) => {
 
 const disabilitiesList = (
   <div>
+    <p>Your issue may not be eligible for review if:</p>
     <ul>
       <li>
         We made the decision over a year ago. You have 1 year from the date on
@@ -136,7 +137,6 @@ export const disabilitiesExplanationAlert = (
   <>
     <p className="vads-u-margin-top--2p5" />
     <AdditionalInfo triggerText={'Why isn’t my issue eligible?'}>
-      <p>Your issue may not be eligible if:</p>
       {disabilitiesList}
     </AdditionalInfo>
   </>
@@ -144,7 +144,6 @@ export const disabilitiesExplanationAlert = (
 
 export const disabilitiesExplanation = (
   <AdditionalInfo triggerText={'Don’t see the issue you’re looking for?'}>
-    <p>There are many reasons a decision might not appear in the list above.</p>
     {disabilitiesList}
   </AdditionalInfo>
 );

--- a/src/applications/disability-benefits/996/content/contestedIssues.jsx
+++ b/src/applications/disability-benefits/996/content/contestedIssues.jsx
@@ -22,12 +22,12 @@ import { scrollTo } from '../helpers';
 export const ContestedIssuesTitle = props =>
   props?.formData?.contestedIssues?.length === 0 ? (
     <h2 className="vads-u-font-size--h4" name="eligibleScrollElement">
-      Sorry, we couldn’t find any contested issues
+      Sorry, we couldn’t find any eligible issues
     </h2>
   ) : (
     <legend name="eligibleScrollElement">
       <strong className="vads-u-font-size--lg">
-        Select the issue(s) you would like to contest
+        Select the issue(s) you would like reviewed
       </strong>
       <span className="schemaform-required-span vads-u-font-weight--normal vads-u-font-size--base">
         (*Required)

--- a/src/applications/disability-benefits/996/content/contestedIssues.jsx
+++ b/src/applications/disability-benefits/996/content/contestedIssues.jsx
@@ -8,7 +8,6 @@ import Telephone, {
 
 import {
   BOARD_APPEALS_URL,
-  CLAIM_STATUS_TOOL_URL,
   COVID_FAQ_URL,
   DECISION_REVIEWS_URL,
   NULL_CONDITION_STRING,
@@ -78,82 +77,57 @@ export const disabilityOption = ({ attributes }) => {
   );
 };
 
-const leadInContent = (
-  <>
-    <p className="vads-u-margin-top--2p5">
-      Please refer to your decision notice for further information on decision
-      review options and HLR eligibility. For information on how COVID-19
-      affects claims and appeals, please visit our{' '}
-      <a href={COVID_FAQ_URL}>Coronavirus FAQ page</a>.
-    </p>
-    <h2 className="vads-u-font-size--h4">
-      Where can I find more information on review options?
-    </h2>
-    <p>
-      Information regarding review options can be found at our{' '}
-      <a href={DECISION_REVIEWS_URL}>decision review information page</a>, or
-      you can call us at <Telephone contact={CONTACTS.VA_BENEFITS} />.
-      Alternatively, you can work with an accredited representative to get help
-      filing a claim for disability compensation.
-    </p>
-  </>
-);
-
-// Wrapped in a <div> on purpose
 const disabilitiesList = (
   <div>
     <ul>
       <li>
-        VA decided that issue more than one year ago (an HLR can only be
-        requested within one year of the last decision). The one year time
-        period from the date on your decision letter has expired for
-        Higher-Level Review. <strong>Note:</strong> If you weren’t able to
-        request a timely review due to the COVID-19 pandemic, we may grant you
-        an extension of the deadline. To request an extension, download and fill
-        out VA Form 20-0996 PDF (1.5MB), and attach a note that you’re
-        requesting a filing extension due to COVID-19.
+        We made the decision over a year ago. You have 1 year from the date on
+        your decision letter to request a Higher-Level Review.{' '}
+        <strong>Note:</strong> If you aren’t able to request a timely review due
+        to COVID-19, we may grant you a deadline extension. To request an
+        extension, fill out and submit VA Form 20-0996, with a note attached
+        that you’re requesting an extension due to COVID-19.
       </li>
       <li>
-        Your issue isn’t related to monthly compensation, pension or survivor
-        benefits. For all other benefits, like health care, insurance or
-        education, you’ll need to download and fill out VA Form 20-0996 PDF
-        (1.5MB) and submit it by mail or in person.
+        Your issue is for a benefit type other than compensation or pension. To
+        request a Higher-Level Review for another benefit type, you’ll need to
+        fill out VA Form 20-0996 and submit it by mail or in person.
       </li>
       <li>
-        The VA has not yet reached a decision on this claim. Please refer to the{' '}
-        <a href={CLAIM_STATUS_TOOL_URL}>Claims Status Tool</a> for more
-        information.
+        The issue or decision isn’t our system yet. You’ll need to fill VA Form
+        20-0996 and submit it by mail or in person.
       </li>
       <li>
-        The issue or decision isn’t in our system yet. You’ll need to download
-        and fill out VA Form 20-0996 PDF (1.5MB) and submit it by mail.
-      </li>
-      <li>
-        You’re applying for a benefit that another surviving dependent of the
-        Veteran is also applying for. And by law, only 1 of you can receive that
-        benefit. You’ll need to{' '}
+        You and another surviving dependent of the Veteran are applying for the
+        same benefit. And by law, only 1 of you can receive that benefit. You’ll
+        need to{' '}
         <a href={BOARD_APPEALS_URL}>appeal to the Board of Veterans’ Appeals</a>
         .
       </li>
       <li>
-        You’re requesting a review of a Board of Veterans’ Appeals decision or
-        an existing decision already under Higher-Level Review. You’ll need to
-        refer to the Board’s decision notice for your review options.
+        You’re requesting a review of a Board of Veterans’ Appeals decision.
+        Refer to your decision notice for your options.
       </li>
       <li>
-        You’re requesting a review of a Higher-Level Review decision. You can
-        either submit a Supplemental Claim or appeal to the Board of Veterans’
-        Appeals.
-      </li>
-      <li>VA has not previously made a decision on that issue.</li>
-      <li>
-        The issue is ineligible under a Higher-Level Review (it cannot be
-        requested on contested claims, such as disagreements with attorney
-        fees).
+        You’re requesting a review of a Higher-Level Review decision. You’ll
+        need to either file a Supplemental Claim or appeal to the Board of
+        Veterans’ Appeals.
       </li>
     </ul>
-    <p className="vads-u-padding-bottom--2p5">
+    <p>
       <DownloadLink content={'Download VA Form 20-0996'} />
+    </p>
+    <p className="vads-u-margin-top--2p5">
+      To learn more about how COVID-19 affect claims or appeals, please visit
+      our <a href={COVID_FAQ_URL}>Coronavirus FAQ page</a>.
+    </p>
+    <p className="vads-u-padding-bottom--2p5">
+      To learn more about decision review options, please visit our{' '}
+      <a href={DECISION_REVIEWS_URL}>decision reviews and appeals</a>{' '}
+      information page. You can call us at{' '}
+      <Telephone contact={CONTACTS.VA_BENEFITS} /> or work with an accredited
+      representative to{' '}
+      <a href="/disability/get-help-filing-claim/">get help with your claim</a>.
     </p>
   </div>
 );
@@ -162,7 +136,6 @@ export const disabilitiesExplanationAlert = (
   <>
     <p className="vads-u-margin-top--2p5" />
     <AdditionalInfo triggerText={'Why isn’t my issue eligible?'}>
-      {leadInContent}
       <p>Your issue may not be eligible if:</p>
       {disabilitiesList}
     </AdditionalInfo>
@@ -171,7 +144,6 @@ export const disabilitiesExplanationAlert = (
 
 export const disabilitiesExplanation = (
   <AdditionalInfo triggerText={'Don’t see the issue you’re looking for?'}>
-    {leadInContent}
     <p>There are many reasons a decision might not appear in the list above.</p>
     {disabilitiesList}
   </AdditionalInfo>

--- a/src/applications/disability-benefits/996/content/contestedIssues.jsx
+++ b/src/applications/disability-benefits/996/content/contestedIssues.jsx
@@ -126,7 +126,7 @@ const disabilitiesList = (
       </li>
       <li>
         The issue or decision isn’t in our system yet. You’ll need to download
-        and fill out VA Form 20-0996 PDF (1.5MB) and submit it by fax or mail.
+        and fill out VA Form 20-0996 PDF (1.5MB) and submit it by mail.
       </li>
       <li>
         You’re applying for a benefit that another surviving dependent of the

--- a/src/applications/disability-benefits/996/wizard/pages/other.jsx
+++ b/src/applications/disability-benefits/996/wizard/pages/other.jsx
@@ -12,7 +12,7 @@ const DecisionReviewPage = () => {
   });
   return (
     <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
-      You’ll need to fill out and submit VA form 20-0996 by mail or in person.{' '}
+      You’ll need to fill out and submit VA Form 20-0996 by mail or in person.{' '}
       <a
         href={BENEFIT_OFFICES_URL}
         onClick={() => {


### PR DESCRIPTION
## Description

Updated Higher-Level Review content shown to the Veteran when they don't have any contestable issues, or their desired contestable issue isn't shown in the list of available issues.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/16211
- Design/Content: https://github.com/department-of-veterans-affairs/va.gov-team/issues/16210
- Working doc: https://docs.google.com/document/d/1z_vqvE4tFvaab3LXYLmP-rXRuSbS0XChw_aKdX0tfLs/edit

## Testing done

N/A - content only changes

## Screenshots

--placeholder; awaiting final recommendations--

## Acceptance criteria
- [x] HLR content updated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
