### PR TITLE
Revert "Dynamic sidenav menus - take 4 (#14854)"

### DIFF
--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -17,8 +17,6 @@ const {
 } = require('../process-cms-exports/helpers');
 const entityTreeFactory = require('../process-cms-exports');
 
-/* eslint-disable no-console */
-
 function encodeCredentials({ user, password }) {
   const credentials = `${user}:${password}`;
   return Buffer.from(credentials).toString('base64');
@@ -95,6 +93,7 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
           try {
             return JSON.parse(data);
           } catch (error) {
+            /* eslint-disable no-console */
             console.error(
               chalk.red(
                 "There was an error parsing the response body, it isn't valid JSON. Here is the error:",
@@ -168,11 +167,9 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
       }
     },
 
-    async getAllPages(onlyPublishedContent = true) {
-      const allPagesQuery = await getQuery(queries.GET_ALL_PAGES);
-      // console.log("allPagesQuery:", allPagesQuery);
+    getAllPages(onlyPublishedContent = true) {
       return this.query({
-        query: allPagesQuery,
+        query: getQuery(queries.GET_ALL_PAGES),
         variables: {
           today: moment().format('YYYY-MM-DD'),
           onlyPublishedContent,
@@ -180,14 +177,10 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
       });
     },
 
-    async getNonNodeContent(onlyPublishedContent = true) {
-      const nonNodeQuery = await getQuery(queries.GET_ALL_PAGES, {
-        useTomeSync: true,
-      });
-      // console.log("nonNodeQuery:", nonNodeQuery);
+    getNonNodeContent(onlyPublishedContent = true) {
       say('Querying for non-node content');
       return this.query({
-        query: nonNodeQuery,
+        query: getQuery(queries.GET_ALL_PAGES, { useTomeSync: true }),
         variables: {
           onlyPublishedContent,
         },
@@ -226,22 +219,12 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
       return transformedEntities;
     },
 
-    async getLatestPageById(nodeId) {
+    getLatestPageById(nodeId) {
       return this.query({
-        query: await getQuery(queries.GET_LATEST_PAGE_BY_ID),
+        query: getQuery(queries.GET_LATEST_PAGE_BY_ID),
         variables: {
           id: nodeId,
           today: moment().format('YYYY-MM-DD'),
-          onlyPublishedContent: false,
-        },
-      });
-    },
-
-    // Sets up the CMS SideNav Menus list.
-    async getSideNavigations() {
-      return this.query({
-        query: await getQuery(queries.GET_HEALTH_SYSTEM_NAVS),
-        variables: {
           onlyPublishedContent: false,
         },
       });

--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -55,7 +55,7 @@ queryParamToBeChanged.forEach(param => {
 
 const regex = new RegExp(`${regString}`, 'g');
 
-const buildQuery = async ({ useTomeSync }) => {
+const buildQuery = ({ useTomeSync }) => {
   const nodeContentFragments = useTomeSync
     ? ''
     : `
@@ -134,8 +134,6 @@ const buildQuery = async ({ useTomeSync }) => {
    * Queries for all of the pages out of Drupal
    * To execute, run this query at http://staging.va.agile6.com/graphql/explorer.
    */
-  const sideNavQuery = await facilitySidebarQuery.compiledQuery();
-
   const query = `
 
   ${nodeContentFragments}
@@ -144,7 +142,7 @@ const buildQuery = async ({ useTomeSync }) => {
     ${nodeQuery}
     ${icsFileQuery}
     ${sidebarQuery}
-    ${sideNavQuery}
+    ${facilitySidebarQuery}
     ${outreachSidebarQuery}
     ${alertsQuery}
     ${bannerAlertsQuery}

--- a/src/site/stages/build/drupal/graphql/GetLatestPageById.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetLatestPageById.graphql.js
@@ -40,9 +40,8 @@ const {
  * Queries for a page by the node id, getting the latest revision
  * To execute, run this query at http://staging.va.agile6.com/graphql/explorer.
  */
-const buildQuery = async () => {
-  const sideNavQuery = await facilitySidebarQuery.compiledQuery();
-  return `
+module.exports = `
+
   ${fragments}
   ${landingPage}
   ${page}
@@ -94,7 +93,7 @@ const buildQuery = async () => {
     }
     ${icsFileQuery}
     ${sidebarQuery}
-    ${sideNavQuery}
+    ${facilitySidebarQuery}
     ${alertsQuery}
     ${bannerAlertsQuery}
     ${
@@ -105,9 +104,8 @@ const buildQuery = async () => {
     ${menuLinksQuery}
   }
 `;
-};
 
-const query = buildQuery();
+const query = module.exports;
 
 let regString = '';
 queryParamToBeChanged.forEach(param => {
@@ -115,4 +113,4 @@ queryParamToBeChanged.forEach(param => {
 });
 
 const regex = new RegExp(`${regString}`, 'g');
-module.exports = query.then(q => q.replace(regex, updateQueryString));
+module.exports = query.replace(regex, updateQueryString);

--- a/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
+++ b/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
@@ -6,7 +6,25 @@
 // String Helpers
 const { camelize } = require('./../../../../../utilities/stringHelpers');
 
-const { getSideNavsViaGraphQL } = require('../../metalsmith-drupal');
+const FACILITY_MENU_NAMES = [
+  'pittsburgh-health-care',
+  'va-altoona-health-care',
+  'va-butler-health-care',
+  'va-cheyenne-health-care',
+  'va-coatesville-health-care',
+  'va-eastern-colorado-health-care',
+  'va-eastern-oklahoma-health-care',
+  'va-erie-health-care',
+  'va-lebanon',
+  'va-montana-health-care',
+  'va-oklahoma-health-care',
+  'va-philadelphia-health-care',
+  'va-salt-lake-city-health-care',
+  'va-sheridan-health-care',
+  'va-western-colorado-health-care',
+  'va-wilkes-barre-health-care',
+  'va-wilmington-health-care',
+];
 
 const FACILITY_SIDEBAR_QUERY = `
     name
@@ -61,19 +79,16 @@ const FACILITY_SIDEBAR_QUERY = `
     }
 `;
 
-async function compiledQuery() {
-  const sideNavs = await getSideNavsViaGraphQL();
-  const queries = [];
-  sideNavs.forEach(facilityMenuName => {
-    queries.push(`
-      ${camelize(
-        facilityMenuName,
-      )}FacilitySidebarQuery: menuByName(name: "${facilityMenuName}") {
+let compiledQuery = '';
+
+FACILITY_MENU_NAMES.forEach(facilityMenuName => {
+  compiledQuery += `
+         ${camelize(
+           facilityMenuName,
+         )}FacilitySidebarQuery: menuByName(name: "${facilityMenuName}") {
             ${FACILITY_SIDEBAR_QUERY}
          }
-        `);
-  });
-  return queries.join('');
-}
+        `;
+});
 
-module.exports = { compiledQuery };
+module.exports = compiledQuery;

--- a/src/site/stages/build/drupal/graphql/sideNavMenus.graphql.js
+++ b/src/site/stages/build/drupal/graphql/sideNavMenus.graphql.js
@@ -1,3 +1,0 @@
-module.exports = `{
-  sideNavMenus
-}`;

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -140,52 +140,6 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
  * @param {Object} buildOptions
  * @return {Object} - The result of the GraphQL query
  */
-async function getSideNavsViaGraphQL(buildOptions = global.buildOptions) {
-  // When this function is called in the preview server,
-  // buildOptions will be null, so we need to get them.
-
-  if (!buildOptions) {
-    const getOptions = require('../options');
-    buildOptions = await getOptions();
-  }
-
-  global.buildtype = buildOptions.buildtype;
-  let sideNavs;
-
-  const sideNavFile = path.join(
-    buildOptions.cacheDirectory,
-    'drupal',
-    'side-nav-menus.json',
-  );
-
-  if (shouldPullDrupal(buildOptions) || !fs.existsSync(sideNavFile)) {
-    const contentApi = getApiClient(buildOptions);
-    log('Pulling side nav menus from Drupal...');
-    const response = await contentApi.getSideNavigations();
-    sideNavs = response.data.sideNavMenus;
-    // Write them to .cache/{buildtype}/drupal/side-nav-menus.json
-    fs.ensureDirSync(buildOptions.cacheDirectory);
-    fs.emptyDirSync(path.dirname(sideNavFile));
-    fs.writeJsonSync(sideNavFile, sideNavs, { spaces: 2 });
-  } else {
-    log(`Using cached side navs in ${sideNavFile}`);
-    sideNavs = fs.existsSync(sideNavFile) ? fs.readJsonSync(sideNavFile) : {};
-  }
-
-  if (global.verbose) {
-    log(`Drupal side navs:\n${JSON.stringify(sideNavs, null, 2)}`);
-  }
-
-  return sideNavs || [];
-}
-
-/**
- * Uses Drupal content via a new GraphQL query or the cached result of a
- * previous query. This is where the cache is saved.
- *
- * @param {Object} buildOptions
- * @return {Object} - The result of the GraphQL query
- */
 async function getContentViaGraphQL(buildOptions) {
   const contentApi = getApiClient(buildOptions);
   const drupalCache = getDrupalCachePath(buildOptions);
@@ -250,12 +204,6 @@ async function getContentFromExport(buildOptions) {
   }
 
   const drupalPages = await contentApi.getNonNodeContent();
-
-  if (drupalPages.errors && drupalPages.errors.length) {
-    log(JSON.stringify(drupalPages.errors, null, 2));
-    throw new Error('Drupal query returned with errors');
-  }
-
   drupalPages.data.nodeQuery = {
     entities: contentApi.getExportedPages(),
   };
@@ -344,4 +292,4 @@ function getDrupalContent(buildOptions) {
   };
 }
 
-module.exports = { getSideNavsViaGraphQL, getDrupalContent, shouldPullDrupal };
+module.exports = { getDrupalContent, shouldPullDrupal };

--- a/src/site/stages/build/drupal/queries.js
+++ b/src/site/stages/build/drupal/queries.js
@@ -1,7 +1,6 @@
 const queries = {
   GET_ALL_PAGES: './graphql/GetAllPages.graphql',
   GET_LATEST_PAGE_BY_ID: './graphql/GetLatestPageById.graphql',
-  GET_HEALTH_SYSTEM_NAVS: './graphql/sideNavMenus.graphql',
 };
 
 function getQuery(query, { useTomeSync } = {}) {

--- a/src/site/stages/build/index.js
+++ b/src/site/stages/build/index.js
@@ -94,7 +94,6 @@ function preserveWebpackOutput(metalsmithDestination, buildType) {
 }
 
 function build(BUILD_OPTIONS) {
-  global.buildOptions = BUILD_OPTIONS;
   const smith = silverSmith();
 
   registerLiquidFilters();


### PR DESCRIPTION
This reverts commit 0a327549fecb9e79788cef431961784bda84841f.

## Description
This allows for the `GetAllPages` query to be static again, enabling fetching cached content. This should fix the review instances issue. More context [at](https://dsva.slack.com/archives/CBU0KDSB1/p1605557619162400).


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
