### PR TITLE
Update DD copy

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoForm.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoForm.jsx
@@ -28,14 +28,14 @@ export const schema = {
 export const uiSchema = {
   routingNumber: {
     'ui:title':
-      'Routing number (Your 9-digit routing number will update your bank’s name)',
+      'Routing number (Your bank’s name will appear after you add the 9-digit routing number)',
     'ui:errorMessages': {
       pattern: 'Please enter the bank’s 9-digit routing number.',
       required: 'Please enter the bank’s 9-digit routing number.',
     },
   },
   accountNumber: {
-    'ui:title': 'Account number (No more than 17 digits)',
+    'ui:title': 'Account number (This should be no more than 17 digits)',
     'ui:errorMessages': {
       pattern: 'Please enter your account number.',
       required: 'Please enter your account number.',

--- a/src/applications/personalization/profile/components/direct-deposit/DirectDepositContent.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/DirectDepositContent.jsx
@@ -392,7 +392,7 @@ export const DirectDepositContent = ({
                 scrollOnShow
               >
                 We’ve updated your bank account information for your{' '}
-                <strong>compensation and pension benefits</strong>.
+                <strong>compensation and pension benefits</strong>
               </AlertBox>
             )}
           </ReactCSSTransitionGroup>

--- a/src/applications/personalization/profile/components/direct-deposit/DirectDepositContent.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/DirectDepositContent.jsx
@@ -391,7 +391,8 @@ export const DirectDepositContent = ({
                 className="vads-u-margin-top--0 vads-u-margin-bottom--2"
                 scrollOnShow
               >
-                We’ve saved your direct deposit information.
+                We’ve updated your bank account information for your{' '}
+                <strong>compensation and pension benefits</strong>.
               </AlertBox>
             )}
           </ReactCSSTransitionGroup>

--- a/src/applications/personalization/profile/tests/components/direct-deposit/DirectDepositContent.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/direct-deposit/DirectDepositContent.unit.spec.jsx
@@ -184,7 +184,7 @@ describe('DirectDepositContent', () => {
       // shows a save succeeded alert
       expect(
         view.findByRole('alert', {
-          name: /we’ve saved your direct deposit information/i,
+          name: /We’ve updated your bank account information/i,
         }),
       ).to.exist;
 
@@ -229,7 +229,7 @@ describe('DirectDepositContent', () => {
       // shows a save succeeded alert
       expect(
         view.findByRole('alert', {
-          name: /we’ve saved your direct deposit information/i,
+          name: /We’ve updated your bank account information/i,
         }),
       ).to.exist;
 
@@ -257,7 +257,7 @@ describe('DirectDepositContent', () => {
 
       // does not show save succeeded alert
       expect(view.container).to.not.contain.text(
-        /we’ve saved your direct deposit information/i,
+        /We’ve updated your bank account information/i,
       );
     });
   });


### PR DESCRIPTION
## Description

```
As Jim was developing the direct deposit for edu designs, Peggy suggested we update some of the direct deposit copy. We'll implement this copy for direct deposit for edu when we do the direct deposit for edu build, but in the meantime, we should update the direct deposit for comp & pen copy so it's consistent.

Copy

Please update the following labels in the direct deposit for comp & pen edit state:

Routing number (Your bank’s name will appear after you add the 9-digit routing number)
Account number (This should be no more than 17 digits)
Please update the saved state confirmation copy:

We’ve updated your bank account information for your compensation and pension benefits
```

## Acceptance criteria
- [x] Update copy and relevant tests

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
