### PR TITLE
CT - VET TEC search fix

### DIFF
--- a/src/applications/gi/containers/VetTecSearchPage.jsx
+++ b/src/applications/gi/containers/VetTecSearchPage.jsx
@@ -145,15 +145,12 @@ function VetTecSearchPage({
   const queryFilterFields = getQueryFilterFields();
   useEffect(
     () => {
-      if (
-        !search.inProgress &&
-        !_.isEqual(search.query, queryFilterFields.query)
-      ) {
+      if (!search.inProgress) {
         dispatchInstitutionFilterChange(queryFilterFields.institutionFilter);
         dispatchFetchProgramSearchResults(queryFilterFields.query);
       }
     },
-    [location.search, queryFilterFields.query],
+    [!_.isEqual(search.query, queryFilterFields.query)],
   );
 
   useEffect(


### PR DESCRIPTION
## Description
Update the logic that triggers the VET TEC search effect in order to

## Testing done
Tested locally and QA reviewed

## Screenshots
N/A

## Acceptance criteria
- [x] Clicking the "Search results" breadcrumb for a VET TEC search correctly loads the search results page

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
