### PR TITLE
Add search ignore list for rs search

### DIFF
--- a/src/applications/resources-and-support/constants/index.js
+++ b/src/applications/resources-and-support/constants/index.js
@@ -1,1 +1,21 @@
 export const RESULTS_PER_PAGE = 10;
+export const SEARCH_IGNORE_LIST = [
+  'of',
+  'the',
+  'a',
+  'an',
+  'as',
+  'at',
+  'and',
+  'or',
+  'but',
+  'for',
+  'from',
+  'to',
+  'in',
+  'on',
+  'by',
+  'with',
+  'so',
+  'yet',
+];

--- a/src/applications/resources-and-support/hooks/useGetSearchResults.js
+++ b/src/applications/resources-and-support/hooks/useGetSearchResults.js
@@ -17,8 +17,8 @@ export default function useGetSearchResults(articles, query, page) {
 
       const keywords = query
         .split(' ')
-        .filter((word) => !!word)
-        .filter((word) => !SEARCH_IGNORE_LIST.includes(word))
+        .filter(word => !!word)
+        .filter(word => !SEARCH_IGNORE_LIST.includes(word))
         .map(keyword => keyword.toLowerCase())
         .map(keyword => {
           if (keyword.length > 6 && keyword.endsWith('ies')) {

--- a/src/applications/resources-and-support/hooks/useGetSearchResults.js
+++ b/src/applications/resources-and-support/hooks/useGetSearchResults.js
@@ -2,6 +2,7 @@
 import { useEffect, useState } from 'react';
 import sortBy from 'lodash/sortBy';
 // Relative imports.
+import { SEARCH_IGNORE_LIST } from '../constants';
 import recordEvent from 'platform/monitoring/record-event';
 
 export default function useGetSearchResults(articles, query, page) {
@@ -15,7 +16,9 @@ export default function useGetSearchResults(articles, query, page) {
       }
 
       const keywords = query
+        .replace(new RegExp(SEARCH_IGNORE_LIST.join('|'), 'gi'), '')
         .split(' ')
+        .filter((word) => !!word)
         .map(keyword => keyword.toLowerCase())
         .map(keyword => {
           if (keyword.length > 6 && keyword.endsWith('ies')) {
@@ -29,6 +32,8 @@ export default function useGetSearchResults(articles, query, page) {
           }
           return keyword;
         });
+
+      console.log('keywords', keywords);
 
       const filteredArticles = articles.filter(article => {
         const articleTitleKeywords = article.title.toLowerCase().split(' ');

--- a/src/applications/resources-and-support/hooks/useGetSearchResults.js
+++ b/src/applications/resources-and-support/hooks/useGetSearchResults.js
@@ -16,9 +16,9 @@ export default function useGetSearchResults(articles, query, page) {
       }
 
       const keywords = query
-        .replace(new RegExp(SEARCH_IGNORE_LIST.join('|'), 'gi'), '')
         .split(' ')
         .filter((word) => !!word)
+        .filter((word) => !SEARCH_IGNORE_LIST.includes(word))
         .map(keyword => keyword.toLowerCase())
         .map(keyword => {
           if (keyword.length > 6 && keyword.endsWith('ies')) {

--- a/src/applications/resources-and-support/hooks/useGetSearchResults.js
+++ b/src/applications/resources-and-support/hooks/useGetSearchResults.js
@@ -33,8 +33,6 @@ export default function useGetSearchResults(articles, query, page) {
           return keyword;
         });
 
-      console.log('keywords', keywords);
-
       const filteredArticles = articles.filter(article => {
         const articleTitleKeywords = article.title.toLowerCase().split(' ');
 


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/16626

This PR adds the following ignore list to R&S search:

```
"of"
"the"
"a"
"an"
"as"
"at"
"and"
"or"
"but"
"for"
"from"
"to"
"in"
"on"
"by"
"with"
"so"
"yet"
```

## Testing done
N/A

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/100929936-9b055c00-34a5-11eb-9e8f-07c616e32c34.png)

## Acceptance criteria
- [x] Add ignore list for search

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
