### PR TITLE
Add uncheck logic in mailing address

### DIFF
--- a/src/applications/personalization/profile/components/personal-information/addresses/AddressEditView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/addresses/AddressEditView.jsx
@@ -14,6 +14,14 @@ class AddressEditView extends React.Component {
     focusElement(`#${this.props.fieldName}-edit-link`);
   }
 
+  // We need to clear the values in the addres form when the user un-checks
+  // my home address is the same as my mailing address. This logic ensures that the
+  // mailing address is not cleared upon render
+
+  state = {
+    hasChecked: false,
+  };
+
   onInput = (value, schema, uiSchema) => {
     const newFieldValue = {
       ...value,
@@ -69,7 +77,9 @@ class AddressEditView extends React.Component {
   };
 
   copyMailingAddress = mailingAddress => {
+    this.setState({ hasChecked: true });
     const newAddressValue = { ...this.props.field.value, ...mailingAddress };
+
     this.props.onChangeFormDataAndSchemas(
       this.transformInitialFormValues(newAddressValue),
       this.props.field.formSchema,
@@ -80,7 +90,10 @@ class AddressEditView extends React.Component {
   renderForm = (formButtons, onSubmit) => (
     <div>
       {this.props.fieldName === FIELD_NAMES.RESIDENTIAL_ADDRESS && (
-        <CopyMailingAddress copyMailingAddress={this.copyMailingAddress} />
+        <CopyMailingAddress
+          copyMailingAddress={this.copyMailingAddress}
+          hasChecked={this.state.hasChecked}
+        />
       )}
       <ContactInfoForm
         formData={this.props.field.value}

--- a/src/applications/personalization/profile/components/personal-information/addresses/AddressEditView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/addresses/AddressEditView.jsx
@@ -14,7 +14,7 @@ class AddressEditView extends React.Component {
     focusElement(`#${this.props.fieldName}-edit-link`);
   }
 
-  // We need to clear the values in the addres form when the user un-checks
+  // We need to clear the values in the address form when the user un-checks
   // my home address is the same as my mailing address. This logic ensures that the
   // mailing address is not cleared upon render
 

--- a/src/platform/user/profile/vap-svc/containers/CopyMailingAddress.jsx
+++ b/src/platform/user/profile/vap-svc/containers/CopyMailingAddress.jsx
@@ -24,17 +24,17 @@ const ADDRESS_PROPS = [
 class CopyMailingAddress extends React.Component {
   onChange = event => {
     event.stopPropagation();
-    const shouldClearValues = this.props.hasChecked && !event.target.checked;
-    let address;
+    const shouldClearHomeAddress =
+      this.props.hasChecked && !event.target.checked;
 
     // Upon explicit unchecking of 'my home address is the same as my mailing address'
-    if (shouldClearValues) {
-      address = mapValues(this.props.mailingAddress, () => null);
+    if (shouldClearHomeAddress) {
+      const address = mapValues(this.props.mailingAddress, () => null);
       this.props.copyMailingAddress(address, this.props.checked);
     }
 
     if (event.target.checked) {
-      address = pick(this.props.mailingAddress, ADDRESS_PROPS);
+      const address = pick(this.props.mailingAddress, ADDRESS_PROPS);
       this.props.copyMailingAddress(address, this.props.checked);
     }
   };

--- a/src/platform/user/profile/vap-svc/containers/CopyMailingAddress.jsx
+++ b/src/platform/user/profile/vap-svc/containers/CopyMailingAddress.jsx
@@ -30,13 +30,13 @@ class CopyMailingAddress extends React.Component {
     // Upon explicit unchecking of 'my home address is the same as my mailing address'
     if (shouldClearValues) {
       address = mapValues(this.props.mailingAddress, () => null);
+      this.props.copyMailingAddress(address, this.props.checked);
     }
 
     if (event.target.checked) {
       address = pick(this.props.mailingAddress, ADDRESS_PROPS);
+      this.props.copyMailingAddress(address, this.props.checked);
     }
-
-    this.props.copyMailingAddress(address, this.props.checked);
   };
 
   render() {


### PR DESCRIPTION
## Description


Behavior of the checkbox (**bold** is new)
- Is unchecked upon first render of the Home Address Edit View
- It is checked if the user has set their Home Address equal to their Mailing Address, either while editing the Mailing address, or in a previous session
- **The user can now explicitly uncheck the box**
- **Unchecking a previously checked box clears out the form** 
- **After clearing the form, the user can still re-check the box to set their Home Address equal to their Mailing Address**

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
