### PR TITLE
Removed hash from production file names in webpack

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -26,8 +26,6 @@ const vaMedalliaStylesFilename = 'va-medallia-styles';
 
 const generateWebpackDevConfig = require('./webpack.dev.config.js');
 
-const timestamp = new Date().getTime();
-
 const getAbsolutePath = relativePath =>
   path.join(__dirname, '../', relativePath);
 
@@ -97,10 +95,6 @@ module.exports = env => {
     ENVIRONMENTS.VAGOVPROD,
   ].includes(buildOptions.buildtype);
 
-  const useHashFilenames = [ENVIRONMENTS.VAGOVPROD].includes(
-    buildOptions.buildtype,
-  );
-
   // enable css sourcemaps for all non-localhost builds
   // or if build options include local-css-sourcemaps or entry
   const enableCSSSourcemaps =
@@ -116,12 +110,8 @@ module.exports = env => {
     output: {
       path: outputPath,
       publicPath: '/generated/',
-      filename: !useHashFilenames
-        ? '[name].entry.js'
-        : `[name].entry.[chunkhash]-${timestamp}.js`,
-      chunkFilename: !useHashFilenames
-        ? '[name].entry.js'
-        : `[name].entry.[chunkhash]-${timestamp}.js`,
+      filename: '[name].entry.js',
+      chunkFilename: '[name].entry.js',
     },
     module: {
       rules: [
@@ -257,9 +247,7 @@ module.exports = env => {
 
           if (isMedalliaStyleFile && isStaging) return `[name].css`;
 
-          return useHashFilenames
-            ? `[name].[contenthash]-${timestamp}.css`
-            : `[name].css`;
+          return `[name].css`;
         },
       }),
 


### PR DESCRIPTION
After testing in staging, this update appears to be good to go for production. Update is being made to promoted better caching through cache-control.

**Zenhub**: https://app.zenhub.com/workspaces/vsp-5cedc9cce6e3335dc5a49fc4/issues/department-of-veterans-affairs/va.gov-team/12700 

**Tested**:
Localhost build: pass
Local vagovprod build: pass
Staging build: pass ([https://staging.va.gov/education/how-to-apply/](https://staging.va.gov/education/how-to-apply/))