### PR TITLE
Map selected provider to CC form submit

### DIFF
--- a/src/applications/vaos/new-appointment/components/ConfirmationPage/ConfirmationRequestInfo.jsx
+++ b/src/applications/vaos/new-appointment/components/ConfirmationPage/ConfirmationRequestInfo.jsx
@@ -38,6 +38,9 @@ export default function ConfirmationRequestInfo({
   const isCommunityCare = data.facilityType === FACILITY_TYPES.COMMUNITY_CARE;
   const isVideoVisit = data.visitType === 'telehealth';
   const [isAdditionalInfoOpen, toggleAdditionalInfo] = useState(false);
+  const hasSelectedProvider =
+    !!data.communityCareProvider &&
+    !!Object.keys(data.communityCareProvider).length;
 
   return (
     <div>
@@ -76,7 +79,7 @@ export default function ConfirmationRequestInfo({
             <div className="vads-u-margin--0">
               {isCommunityCare &&
                 ((!useProviderSelection && !data.hasCommunityCareProvider) ||
-                  (useProviderSelection && !data.communityCareProvider)) && (
+                  (useProviderSelection && !hasSelectedProvider)) && (
                   <>
                     <h3 className="vaos-appts__block-label">
                       <strong>Preferred provider</strong>
@@ -126,7 +129,7 @@ export default function ConfirmationRequestInfo({
                 )}
               {isCommunityCare &&
                 useProviderSelection &&
-                data.communityCareProvider && (
+                hasSelectedProvider && (
                   <>
                     <h3 className="vaos-appts__block-label">
                       <strong>Preferred provider</strong>

--- a/src/applications/vaos/new-appointment/components/ConfirmationPage/ConfirmationRequestInfo.jsx
+++ b/src/applications/vaos/new-appointment/components/ConfirmationPage/ConfirmationRequestInfo.jsx
@@ -33,6 +33,7 @@ export default function ConfirmationRequestInfo({
   data,
   facilityDetails,
   pageTitle,
+  useProviderSelection,
 }) {
   const isCommunityCare = data.facilityType === FACILITY_TYPES.COMMUNITY_CARE;
   const isVideoVisit = data.visitType === 'telehealth';
@@ -74,7 +75,8 @@ export default function ConfirmationRequestInfo({
           <div className="vads-u-flex--1 vads-u-margin-right--1 vads-u-margin-top--2 vaos-u-word-break--break-word">
             <div className="vads-u-margin--0">
               {isCommunityCare &&
-                !data.hasCommunityCareProvider && (
+                ((!useProviderSelection && !data.hasCommunityCareProvider) ||
+                  (useProviderSelection && !data.communityCareProvider)) && (
                   <>
                     <h3 className="vaos-appts__block-label">
                       <strong>Preferred provider</strong>
@@ -88,6 +90,7 @@ export default function ConfirmationRequestInfo({
                   </>
                 )}
               {isCommunityCare &&
+                !useProviderSelection &&
                 data.hasCommunityCareProvider && (
                   <>
                     <h3 className="vaos-appts__block-label">
@@ -118,6 +121,29 @@ export default function ConfirmationRequestInfo({
                         {data.communityCareProvider.address.postalCode}
                         <br />
                       </p>
+                    </div>
+                  </>
+                )}
+              {isCommunityCare &&
+                useProviderSelection &&
+                data.communityCareProvider && (
+                  <>
+                    <h3 className="vaos-appts__block-label">
+                      <strong>Preferred provider</strong>
+                    </h3>
+                    <div>
+                      {data.communityCareProvider.name}
+                      <br />
+                      {data.communityCareProvider.address.line.map(line => (
+                        <>
+                          {line}
+                          <br />
+                        </>
+                      ))}
+                      {data.communityCareProvider.address.city},{' '}
+                      {data.communityCareProvider.address.state}{' '}
+                      {data.communityCareProvider.address.postalCode}
+                      <br />
                     </div>
                   </>
                 )}

--- a/src/applications/vaos/new-appointment/components/ConfirmationPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/ConfirmationPage/index.jsx
@@ -11,6 +11,7 @@ import {
   getChosenFacilityDetails,
   getSiteIdForChosenFacility,
   getChosenSlot,
+  selectUseProviderSelection,
 } from '../../../utils/selectors';
 import { scrollAndFocus } from '../../../utils/scrollAndFocus';
 import * as actions from '../../redux/actions';
@@ -31,6 +32,7 @@ export function ConfirmationPage({
   systemId,
   startNewAppointmentFlow,
   fetchFacilityDetails,
+  useProviderSelection,
 }) {
   const history = useHistory();
   const isDirectSchedule = flowType === FLOW_TYPES.DIRECT;
@@ -72,6 +74,7 @@ export function ConfirmationPage({
           data={data}
           facilityDetails={facilityDetails}
           pageTitle={pageTitle}
+          useProviderSelection={useProviderSelection}
         />
       )}
       <div className="vads-u-margin-y--2">
@@ -120,6 +123,7 @@ function mapStateToProps(state) {
     appointmentLength: getAppointmentLength(state),
     systemId: getSiteIdForChosenFacility(state),
     slot: getChosenSlot(state),
+    useProviderSelection: selectUseProviderSelection(state),
   };
 }
 

--- a/src/applications/vaos/new-appointment/components/ReviewPage/CommunityCareSection.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/CommunityCareSection.jsx
@@ -3,19 +3,26 @@ import ContactDetailSection from './ContactDetailSection';
 import ReasonForAppointmentSection from './ReasonForAppointmentSection';
 import PreferredDatesSection from './PreferredDatesSection';
 import PreferredProviderSection from './PreferredProviderSection';
+import SelectedProviderSection from './SelectedProviderSection';
 
-export default function CommunityCareSection(props) {
+export default function CommunityCareSection({
+  data,
+  vaCityState,
+  useProviderSelection,
+}) {
   return (
     <>
-      <PreferredDatesSection data={props.data} />
+      <PreferredDatesSection data={data} />
       <hr aria-hidden="true" className="vads-u-margin-y--2" />
-      <PreferredProviderSection
-        data={props.data}
-        vaCityState={props.vaCityState}
-      />
-      <ReasonForAppointmentSection data={props.data} />
+      {!useProviderSelection && (
+        <PreferredProviderSection data={data} vaCityState={vaCityState} />
+      )}
+      {useProviderSelection && (
+        <SelectedProviderSection data={data} vaCityState={vaCityState} />
+      )}
+      <ReasonForAppointmentSection data={data} />
       <hr aria-hidden="true" className="vads-u-margin-y--2" />
-      <ContactDetailSection data={props.data} />
+      <ContactDetailSection data={data} />
     </>
   );
 }

--- a/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo.jsx
@@ -10,6 +10,7 @@ export default function ReviewRequestInfo({
   facility,
   vaCityState,
   pageTitle,
+  useProviderSelection,
 }) {
   const isCommunityCare = data.facilityType === FACILITY_TYPES.COMMUNITY_CARE;
   const isVAAppointment = data.facilityType === FACILITY_TYPES.VAMC;
@@ -25,6 +26,7 @@ export default function ReviewRequestInfo({
           data={data}
           facility={facility}
           vaCityState={vaCityState}
+          useProviderSelection={useProviderSelection}
         />
       )}
       {isVAAppointment && (

--- a/src/applications/vaos/new-appointment/components/ReviewPage/SelectedProviderSection.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/SelectedProviderSection.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import newAppointmentFlow from '../../newAppointmentFlow';
+
+import { LANGUAGES } from '../../../utils/constants';
+
+export default function SelectedProviderSection({ data, vaCityState }) {
+  const provider = data.communityCareProvider;
+  const hasProvider =
+    !!provider && !!Object.keys(data.communityCareProvider).length;
+
+  return (
+    <div className="vads-l-grid-container vads-u-padding--0">
+      <div className="vads-l-row vads-u-justify-content--space-between">
+        <div className="vads-u-flex--1 vads-u-padding-right--1">
+          <h3 className="vaos-appts__block-label">Preferred provider</h3>
+          {!hasProvider && <>No provider specified</>}
+          <span className="vaos-u-word-break--break-word">
+            {!!hasProvider && (
+              <>
+                {provider.name}
+                <br />
+                {provider.address.line.map(line => (
+                  <>
+                    {line}
+                    <br />
+                  </>
+                ))}
+                {provider.address.city}, {provider.address.state}{' '}
+                {provider.address.postalCode}
+              </>
+            )}
+            <br />
+            <br />
+            Prefers provider to speak{' '}
+            {
+              LANGUAGES.find(language => language.id === data.preferredLanguage)
+                ?.value
+            }
+            <br />
+            {vaCityState && <>Closest VA health system: {vaCityState}</>}
+          </span>
+        </div>
+        <div>
+          <Link
+            to={newAppointmentFlow.ccPreferences.url}
+            aria-label="Edit provider preference"
+          >
+            Edit
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/applications/vaos/new-appointment/components/ReviewPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/index.jsx
@@ -10,6 +10,7 @@ import {
   getChosenVACityState,
   getChosenFacilityDetails,
   getSiteIdForChosenFacility,
+  selectUseProviderSelection,
 } from '../../../utils/selectors';
 import { FLOW_TYPES, FETCH_STATUS } from '../../../utils/constants';
 import { getRealFacilityId } from '../../../utils/appointment';
@@ -34,6 +35,7 @@ export function ReviewPage({
   submitStatusVaos400,
   systemId,
   submitAppointmentOrRequest,
+  useProviderSelection,
 }) {
   useEffect(() => {
     if (history && !data?.typeOfCareId) {
@@ -62,6 +64,7 @@ export function ReviewPage({
           facility={facility}
           vaCityState={vaCityState}
           pageTitle={pageTitle}
+          useProviderSelection={useProviderSelection}
         />
       )}
       <div className="vads-u-margin-y--2">
@@ -147,6 +150,7 @@ function mapStateToProps(state) {
     submitStatus: state.newAppointment.submitStatus,
     submitStatusVaos400: state.newAppointment.submitStatusVaos400,
     systemId: getSiteIdForChosenFacility(state),
+    useProviderSelection: selectUseProviderSelection(state),
   };
 }
 

--- a/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.js
@@ -132,7 +132,11 @@ export function transformFormToCCRequest(state) {
   const provider = data.communityCareProvider;
   let preferredProviders = [];
 
-  if (useProviderSelection && provider) {
+  if (
+    useProviderSelection &&
+    !!data.communityCareProvider &&
+    Object.keys(data.communityCareProvider).length
+  ) {
     preferredProviders = [
       {
         address: {
@@ -142,10 +146,6 @@ export function transformFormToCCRequest(state) {
           zipCode: provider.address.postalCode,
         },
         practiceName: provider.name,
-        providerStreet: provider.address.line.join(', '),
-        providerCity: provider.address.city,
-        providerState: provider.address.state,
-        providerZipCode1: provider.address.postalCode,
       },
     ];
   } else if (data.hasCommunityCareProvider) {

--- a/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.js
@@ -19,6 +19,7 @@ import {
   getChosenCCSystemId,
   getChosenSlot,
   selectUseFlatFacilityPage,
+  selectUseProviderSelection,
 } from '../../../utils/selectors';
 import {
   findCharacteristic,
@@ -127,27 +128,43 @@ export function transformFormToVARequest(state) {
 
 export function transformFormToCCRequest(state) {
   const data = getFormData(state);
+  const useProviderSelection = selectUseProviderSelection(state);
+  const provider = data.communityCareProvider;
   let preferredProviders = [];
 
-  if (data.hasCommunityCareProvider) {
-    const street = `${data.communityCareProvider.address.street}, ${
-      data.communityCareProvider.address.street2
-    }`;
+  if (useProviderSelection && provider) {
+    preferredProviders = [
+      {
+        address: {
+          street: provider.address.line.join(', '),
+          city: provider.address.city,
+          state: provider.address.state,
+          zipCode: provider.address.postalCode,
+        },
+        practiceName: provider.name,
+        providerStreet: provider.address.line.join(', '),
+        providerCity: provider.address.city,
+        providerState: provider.address.state,
+        providerZipCode1: provider.address.postalCode,
+      },
+    ];
+  } else if (data.hasCommunityCareProvider) {
+    const street = `${provider.address.street}, ${provider.address.street2}`;
     preferredProviders = [
       {
         address: {
           street,
-          city: data.communityCareProvider.address.city,
-          state: data.communityCareProvider.address.state,
-          zipCode: data.communityCareProvider.address.postalCode,
+          city: provider.address.city,
+          state: provider.address.state,
+          zipCode: provider.address.postalCode,
         },
-        firstName: data.communityCareProvider.firstName,
-        lastName: data.communityCareProvider.lastName,
-        practiceName: data.communityCareProvider.practiceName,
+        firstName: provider.firstName,
+        lastName: provider.lastName,
+        practiceName: provider.practiceName,
         providerStreet: street,
-        providerCity: data.communityCareProvider.address.city,
-        providerState: data.communityCareProvider.address.state,
-        providerZipCode1: data.communityCareProvider.address.postalCode,
+        providerCity: provider.address.city,
+        providerState: provider.address.state,
+        providerZipCode1: provider.address.postalCode,
       },
     ];
   }

--- a/src/applications/vaos/services/location/transformers.js
+++ b/src/applications/vaos/services/location/transformers.js
@@ -319,9 +319,9 @@ export function transformCommunityProviders(providers) {
       resourceType: 'Location',
       address: {
         line: [provider.address.street],
-        city: [provider.address.city],
-        state: [provider.address.state],
-        postalCode: [provider.address.zip],
+        city: provider.address.city,
+        state: provider.address.state,
+        postalCode: provider.address.zip,
       },
       name: provider.name,
       position: {

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.cc-request.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.cc-request.unit.spec.jsx
@@ -277,3 +277,265 @@ describe('VAOS <ReviewPage> CC request', () => {
     expect(screen.history.push.called).to.be.false;
   });
 });
+
+describe('VAOS <ReviewPage> CC request with provider selection', () => {
+  let store;
+  let start;
+
+  beforeEach(() => {
+    mockFetch();
+    start = moment();
+    store = createTestStore({
+      featureToggles: {
+        vaOnlineSchedulingProviderSelection: true,
+      },
+      user: {
+        profile: {
+          facilities: [{ facilityId: '983', isCerner: false }],
+          vapContactInfo: {
+            residentialAddress: {
+              addressLine1: '123 big sky st',
+              city: 'Cincinnati',
+              stateCode: 'OH',
+              zipCode: '45220',
+              latitude: 39.1,
+              longitude: -84.6,
+            },
+          },
+        },
+      },
+      newAppointment: {
+        pages: {},
+        data: {
+          facilityType: FACILITY_TYPES.COMMUNITY_CARE,
+          typeOfCareId: '323',
+          phoneNumber: '1234567890',
+          email: 'joeblow@gmail.com',
+          reasonAdditionalInfo: 'I need an appt',
+          communityCareSystemId: 'var983',
+          hasCommunityCareProvider: true,
+          communityCareProvider: {
+            resourceType: 'Location',
+            address: {
+              line: ['1012 14TH ST NW STE 700'],
+              city: 'WASHINGTON',
+              state: 'DC',
+              postalCode: '20005-3477',
+            },
+            name: 'CAMPBELL, WILLIAM',
+          },
+          bestTimeToCall: {
+            morning: true,
+            afternoon: true,
+            evening: true,
+          },
+        },
+        clinics: {},
+        ccEnabledSystems: [
+          {
+            id: 'var983',
+            identifier: [
+              { system: 'urn:oid:2.16.840.1.113883.6.233', value: '983' },
+              {
+                system: 'http://med.va.gov/fhir/urn',
+                value: 'urn:va:facility:983',
+              },
+            ],
+          },
+        ],
+        parentFacilities: [
+          {
+            id: 'var983',
+            identifier: [
+              { system: 'urn:oid:2.16.840.1.113883.6.233', value: '983' },
+              {
+                system: 'http://med.va.gov/fhir/urn',
+                value: 'urn:va:facility:983',
+              },
+            ],
+          },
+        ],
+        facilityDetails: {
+          var983: {
+            id: 'var983',
+            name: 'Cheyenne VA Medical Center',
+            address: {
+              postalCode: '82001-5356',
+              city: 'Cheyenne',
+              state: 'WY',
+              line: ['2360 East Pershing Boulevard'],
+            },
+          },
+        },
+        facilities: {
+          '323_var983': [
+            {
+              id: 'var983',
+              name: 'Cheyenne VA Medical Center',
+              identifier: [
+                { system: 'urn:oid:2.16.840.1.113883.6.233', value: '983' },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    store.dispatch(startRequestAppointmentFlow());
+    store.dispatch(
+      onCalendarChange({
+        currentlySelectedDate: start.format('YYYY-MM-DD'),
+        selectedDates: [
+          {
+            date: start.format('YYYY-MM-DD'),
+            optionTime: 'AM',
+          },
+        ],
+      }),
+    );
+  });
+  afterEach(() => resetFetch());
+
+  it('should show form information for review', async () => {
+    const screen = renderWithStoreAndRouter(<ReviewPage />, {
+      store,
+    });
+
+    await screen.findByText(/requesting a community care appointment/i);
+    expect(screen.getByText('Primary care')).to.have.tagName('h2');
+    const [
+      pageHeading,
+      descHeading,
+      typeOfCareHeading,
+      dateHeading,
+      providerHeading,
+      additionalHeading,
+      contactHeading,
+    ] = screen.getAllByRole('heading');
+    expect(pageHeading).to.contain.text('Review your appointment details');
+    expect(descHeading).to.contain.text(
+      'requesting a community care appointment',
+    );
+    expect(typeOfCareHeading).to.contain.text('Primary care');
+    expect(screen.baseElement).to.contain.text('Community Care');
+
+    expect(dateHeading).to.contain.text('Preferred date and time');
+    expect(screen.baseElement).to.contain.text(
+      `${start.format('MMMM DD, YYYY')} in the morning`,
+    );
+
+    expect(providerHeading).to.contain.text('Preferred provider');
+    expect(screen.baseElement).to.contain.text('CAMPBELL, WILLIAM');
+    expect(screen.baseElement).to.contain.text('1012 14TH ST NW STE 700');
+    expect(screen.baseElement).to.contain.text('WASHINGTON, DC 20005-3477');
+
+    expect(additionalHeading).to.contain.text('Additional details');
+    expect(screen.baseElement).to.contain.text('I need an appt');
+
+    expect(contactHeading).to.contain.text('Your contact details');
+    expect(screen.baseElement).to.contain.text('joeblow@gmail.com');
+    expect(screen.baseElement).to.contain.text('1234567890');
+    expect(screen.baseElement).to.contain.text('Call anytime during the day');
+
+    const editLinks = screen.getAllByText(/^Edit/, { selector: 'a' });
+    const uniqueLinks = new Set();
+    editLinks.forEach(link => {
+      expect(link).to.have.attribute('aria-label');
+      uniqueLinks.add(link.getAttribute('aria-label'));
+    });
+    expect(uniqueLinks.size).to.equal(editLinks.length);
+  });
+
+  it('should submit successfully', async () => {
+    mockRequestSubmit('cc', {
+      id: 'fake_id',
+    });
+    mockPreferences(null);
+    mockMessagesFetch('fake_id', {});
+
+    const screen = renderWithStoreAndRouter(<Route component={ReviewPage} />, {
+      store,
+    });
+
+    await screen.findByText(/requesting a community care appointment/i);
+
+    userEvent.click(screen.getByText(/Request appointment/i));
+    await waitFor(() => {
+      expect(screen.history.push.lastCall.args[0]).to.equal(
+        '/new-appointment/confirmation',
+      );
+    });
+    const submitData = JSON.parse(global.fetch.getCall(0).args[1].body);
+
+    expect(submitData.facility.facilityCode).to.equal('983');
+    expect(submitData.facility.parentSiteCode).to.equal('983');
+    expect(submitData.typeOfCareId).to.equal('CCPRMYRTNE');
+    expect(submitData.preferredProviders[0].practiceName).to.equal(
+      'CAMPBELL, WILLIAM',
+    );
+    expect(submitData.preferredProviders[0].address).to.deep.equal({
+      street: '1012 14TH ST NW STE 700',
+      city: 'WASHINGTON',
+      state: 'DC',
+      zipCode: '20005-3477',
+    });
+
+    const messageData = JSON.parse(global.fetch.getCall(1).args[1].body);
+    expect(messageData.messageText).to.equal('I need an appt');
+
+    const preferences = JSON.parse(global.fetch.getCall(3).args[1].body);
+    expect(preferences.emailAddress).to.equal('joeblow@gmail.com');
+  });
+
+  it('should show error message on failure', async () => {
+    mockFacilityFetch('vha_442', {
+      id: 'vha_442',
+      attributes: {
+        ...getVAFacilityMock().attributes,
+        uniqueId: '442',
+        name: 'Cheyenne VA Medical Center',
+        address: {
+          physical: {
+            zip: '82001-5356',
+            city: 'Cheyenne',
+            state: 'WY',
+            address1: '2360 East Pershing Boulevard',
+          },
+        },
+        phone: {
+          main: '307-778-7550',
+        },
+      },
+    });
+    setFetchJSONFailure(
+      global.fetch.withArgs(
+        `${environment.API_URL}/vaos/v0/appointment_requests?type=cc`,
+      ),
+      {
+        errors: [{}],
+      },
+    );
+
+    const screen = renderWithStoreAndRouter(<Route component={ReviewPage} />, {
+      store,
+    });
+
+    await screen.findByText(/requesting a community care appointment/i);
+
+    userEvent.click(screen.getByText(/Request appointment/i));
+
+    await screen.findByText('We couldn’t schedule this appointment');
+
+    expect(screen.baseElement).contain.text(
+      'Something went wrong when we tried to submit your request and you’ll need to start over. We suggest you wait a day',
+    );
+
+    await screen.findByText('307-778-7550');
+
+    // Not sure of a better way to search for test just within the alert
+    const alert = screen.baseElement.querySelector('.usa-alert');
+    expect(alert).contain.text('Cheyenne VA Medical Center');
+    expect(alert).contain.text('2360 East Pershing Boulevard');
+    expect(alert).contain.text('Cheyenne, WY 82001-5356');
+    expect(screen.history.push.called).to.be.false;
+  });
+});

--- a/src/applications/vaos/tests/new-appointment/redux/helpers/formSubmitTransformers.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/redux/helpers/formSubmitTransformers.unit.spec.js
@@ -738,4 +738,147 @@ describe('VAOS data transformation', () => {
       providerOption: '',
     });
   });
+
+  it('should transform form using provider selection into CC request', () => {
+    const state = {
+      featureToggles: {
+        vaOnlineSchedulingProviderSelection: true,
+      },
+      user: {
+        profile: {
+          facilities: [{ facilityId: '983', isCerner: false }],
+          vapContactInfo: {
+            residentialAddress: {
+              addressLine1: '123 big sky st',
+              city: 'Cincinnati',
+              stateCode: 'OH',
+              zipCode: '45220',
+              latitude: 39.1,
+              longitude: -84.6,
+            },
+          },
+        },
+      },
+      newAppointment: {
+        data: {
+          phoneNumber: '5035551234',
+          bestTimeToCall: {
+            afternoon: true,
+          },
+          email: 'test@va.gov',
+          reasonForAppointment: 'routine-follow-up',
+          reasonAdditionalInfo: 'asdf',
+          communityCareSystemId: 'var983',
+          preferredLanguage: 'english',
+          communityCareProvider: {
+            name: 'Practice',
+            address: {
+              line: ['456 elm st', 'sfasdf'],
+              state: 'MA',
+              city: 'northampton',
+              postalCode: '01050',
+            },
+          },
+          calendarData: {
+            currentlySelectedDate: '2019-11-20',
+            selectedDates: [
+              {
+                date: '2019-11-20',
+                optionTime: 'PM',
+              },
+            ],
+          },
+          facilityType: 'communityCare',
+          typeOfCareId: '323',
+        },
+        facilities: {},
+        facilityDetails: {},
+        clinics: {},
+        eligibility: {},
+        ccEnabledSystems: [
+          {
+            id: 'var983',
+            identifier: [
+              {
+                system: VHA_FHIR_ID,
+                value: '983',
+              },
+            ],
+            name: 'CHYSHR-Cheyenne VA Medical Center',
+            address: {
+              city: 'Cheyenne',
+              state: 'WY',
+            },
+          },
+          {
+            id: 'var984',
+            identifier: [
+              {
+                system: VHA_FHIR_ID,
+                value: '984',
+              },
+            ],
+            address: {
+              city: 'Dayton',
+              state: 'OH',
+            },
+          },
+        ],
+        pageChangeInProgress: false,
+        parentFacilitiesStatus: FETCH_STATUS.succeeded,
+        eligibilityStatus: FETCH_STATUS.succeeded,
+        facilityDetailsStatus: FETCH_STATUS.succeeded,
+        pastAppointments: null,
+        submitStatus: 'succeeded',
+      },
+    };
+    const data = transformFormToCCRequest(state);
+    expect(data).to.deep.equal({
+      typeOfCare: 'CCPRMYRTNE',
+      typeOfCareId: 'CCPRMYRTNE',
+      appointmentType: 'Primary care',
+      facility: {
+        name: 'CHYSHR-Cheyenne VA Medical Center',
+        facilityCode: '983',
+        parentSiteCode: '983',
+      },
+      purposeOfVisit: 'other',
+      phoneNumber: '5035551234',
+      verifyPhoneNumber: '5035551234',
+      bestTimetoCall: ['Afternoon'],
+      preferredProviders: [
+        {
+          address: {
+            street: '456 elm st, sfasdf',
+            city: 'northampton',
+            state: 'MA',
+            zipCode: '01050',
+          },
+          practiceName: 'Practice',
+        },
+      ],
+      newMessage: 'asdf',
+      preferredLanguage: 'English',
+      optionDate1: '11/20/2019',
+      optionDate2: 'No Date Selected',
+      optionDate3: 'No Date Selected',
+      optionTime1: 'PM',
+      optionTime2: 'No Time Selected',
+      optionTime3: 'No Time Selected',
+      preferredCity: 'Cincinnati',
+      preferredState: 'OH',
+      requestedPhoneCall: false,
+      email: 'test@va.gov',
+      officeHours: [],
+      reasonForVisit: '',
+      visitType: 'Office Visit',
+      distanceWillingToTravel: 40,
+      secondRequest: false,
+      secondRequestSubmitted: false,
+      inpatient: false,
+      status: 'Submitted',
+      providerId: '0',
+      providerOption: '',
+    });
+  });
 });


### PR DESCRIPTION
## Description
This maps the provider data from PPMS correctly into the VAOS form submission. It also updates the review and confirmation pages to display the data correctly.

## Testing done
Unit and local testing

## Screenshots
![Screen Shot 2020-12-03 at 2 01 32 PM](https://user-images.githubusercontent.com/634932/101086466-e3dd1380-357e-11eb-9099-f1a2314fb957.png)
![Screen Shot 2020-12-03 at 11 35 28 AM](https://user-images.githubusercontent.com/634932/101086467-e3dd1380-357e-11eb-9a1a-ae8562611331.png)


## Acceptance criteria
- [ ] Submitted data is correct, form info displays correctly

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
