### PR TITLE
[Development] Fix empty array preventing submission

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
@@ -10,9 +10,9 @@ import {
   validateMilitaryTreatmentState,
   startedAfterServicePeriod,
   hasMonthYear,
+  validateBooleanGroup,
 } from '../validations';
 import { USA } from '../constants';
-import { validateBooleanGroup } from 'platform/forms-system/src/js/validation';
 
 const { vaTreatmentFacilities } = fullSchema.properties;
 

--- a/src/applications/disability-benefits/all-claims/submit-transformer.js
+++ b/src/applications/disability-benefits/all-claims/submit-transformer.js
@@ -241,6 +241,44 @@ export function filterServicePeriods(formData) {
   return clonedData;
 }
 
+// Transform the related disabilities lists into an array of strings
+export const stringifyRelatedDisabilities = formData => {
+  if (!formData.vaTreatmentFacilities) {
+    return formData;
+  }
+  const clonedData = _.cloneDeep(formData);
+  const newVAFacilities = clonedData.vaTreatmentFacilities.map(facility => {
+    const allTreatedNames = Object.entries(
+      facility.treatedDisabilityNames,
+    ).reduce((list, [name, state]) => {
+      if (state) {
+        list.push(name);
+      }
+      return list;
+    }, []);
+
+    // Transform the related disabilities lists into an array of strings
+    return _.set(
+      'treatedDisabilityNames',
+      // transformRelatedDisabilities(
+      //   facility.treatedDisabilityNames,
+      //   getClaimedConditionNames(formData, false),
+      // ),
+
+      // Return all facility.treatedDisabilityNames set to true; this fixes an
+      // issue with SiPs data returning these names an inflection applied; not
+      // an ideal solution, but it will stop submitting empty arrays and
+      // causing the submission to be rejected. See
+      // github.com/department-of-veterans-affairs/va.gov-team/issues/15368
+      allTreatedNames,
+      facility,
+    );
+  });
+
+  clonedData.vaTreatmentFacilities = newVAFacilities;
+  return clonedData;
+};
+
 export function transform(formConfig, form) {
   // Grab isBDD before things are changed/deleted
   const isBDDForm = isBDD(form.data);
@@ -462,27 +500,6 @@ export function transform(formConfig, form) {
     ).concat(transformedSecondaries);
 
     delete clonedData.newSecondaryDisabilities;
-    return clonedData;
-  };
-
-  // Transform the related disabilities lists into an array of strings
-  const stringifyRelatedDisabilities = formData => {
-    if (!formData.vaTreatmentFacilities) {
-      return formData;
-    }
-    const clonedData = _.cloneDeep(formData);
-    const newVAFacilities = clonedData.vaTreatmentFacilities.map(facility =>
-      // Transform the related disabilities lists into an array of strings
-      _.set(
-        'treatedDisabilityNames',
-        transformRelatedDisabilities(
-          facility.treatedDisabilityNames,
-          getClaimedConditionNames(formData, false),
-        ),
-        facility,
-      ),
-    );
-    clonedData.vaTreatmentFacilities = newVAFacilities;
     return clonedData;
   };
 

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/secondary-new-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/secondary-new-test.json
@@ -95,7 +95,7 @@
         },
         "treatedDisabilityNames": {
           "Diabetes mellitus0": true,
-          "De-selected": true,
+          "De-selected": false,
           "knee replacement": true
         }
       }

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/maximal-test.json
@@ -43,9 +43,9 @@
           "state": "AK"
         },
         "treatedDisabilityNames": [
-          "Diabetes mellitus0",
-          "Diabetes mellitus1",
-          "myocardial infarction (MI)"
+          "diabetes mellitus0",
+          "diabetes mellitus1",
+          "myocardial infarction (mi)"
         ]
       },
       {

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/secondary-new-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/secondary-new-test.json
@@ -39,7 +39,7 @@
           "city": "Bigcity",
           "state": "AK"
         },
-        "treatedDisabilityNames": ["knee replacement"]
+        "treatedDisabilityNames": ["Diabetes mellitus0", "knee replacement"]
       }
     ],
     "ratedDisabilities": [

--- a/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
@@ -11,6 +11,21 @@ describe('VA Medical Records', () => {
     uiSchema,
   } = formConfig.chapters.supportingEvidence.pages.vaMedicalRecords;
 
+  const ratedDisabilities = [
+    {
+      name: 'Post traumatic stress disorder',
+      'view:selected': true,
+    },
+    {
+      name: 'Intervertebral disc syndrome',
+      'view:selected': true,
+    },
+    {
+      name: 'Diabetes Melitus',
+      'view:selected': true,
+    },
+  ];
+
   it('should render ', () => {
     const form = mount(
       <DefinitionTester
@@ -18,21 +33,12 @@ describe('VA Medical Records', () => {
         schema={schema}
         uiSchema={uiSchema}
         data={{
-          ratedDisabilities: [
-            {
-              name: 'Post traumatic stress disorder',
-              'view:selected': true,
-            },
-            {
-              name: 'Intervertebral disc syndrome',
-              'view:selected': true,
-            },
-          ],
+          ratedDisabilities,
         }}
       />,
     );
 
-    expect(form.find('input').length).to.equal(6);
+    expect(form.find('input').length).to.equal(7);
     expect(form.find('select').length).to.equal(4);
     form.unmount();
   });
@@ -45,16 +51,7 @@ describe('VA Medical Records', () => {
         schema={schema}
         uiSchema={uiSchema}
         data={{
-          ratedDisabilities: [
-            {
-              name: 'Post traumatic stress disorder',
-              'view:selected': true,
-            },
-            {
-              name: 'Intervertebral disc syndrome',
-              'view:selected': true,
-            },
-          ],
+          ratedDisabilities,
           vaTreatmentFacilities: [],
         }}
         onSubmit={onSubmit}
@@ -76,16 +73,7 @@ describe('VA Medical Records', () => {
         schema={schema}
         uiSchema={uiSchema}
         data={{
-          ratedDisabilities: [
-            {
-              name: 'Post traumatic stress disorder',
-              'view:selected': true,
-            },
-            {
-              name: 'Intervertebral disc syndrome',
-              'view:selected': true,
-            },
-          ],
+          ratedDisabilities,
           vaTreatmentFacilities: [
             {
               treatmentCenterName: 'Sommerset VA Clinic',
@@ -128,16 +116,7 @@ describe('VA Medical Records', () => {
         schema={schema}
         uiSchema={uiSchema}
         data={{
-          ratedDisabilities: [
-            {
-              name: 'Post traumatic stress disorder',
-              'view:selected': true,
-            },
-            {
-              name: 'Intervertebral disc syndrome',
-              'view:selected': true,
-            },
-          ],
+          ratedDisabilities,
           vaTreatmentFacilities: [
             {
               treatmentCenterName: 'Sommerset VA Clinic',
@@ -180,16 +159,7 @@ describe('VA Medical Records', () => {
         schema={schema}
         uiSchema={uiSchema}
         data={{
-          ratedDisabilities: [
-            {
-              name: 'Post traumatic stress disorder',
-              'view:selected': true,
-            },
-            {
-              name: 'Intervertebral disc syndrome',
-              'view:selected': true,
-            },
-          ],
+          ratedDisabilities,
           vaTreatmentFacilities: [
             {
               treatmentCenterName: 'Sommerset VA Clinic',
@@ -226,16 +196,7 @@ describe('VA Medical Records', () => {
         schema={schema}
         uiSchema={uiSchema}
         data={{
-          ratedDisabilities: [
-            {
-              name: 'Post traumatic stress disorder',
-              'view:selected': true,
-            },
-            {
-              name: 'Intervertebral disc syndrome',
-              'view:selected': true,
-            },
-          ],
+          ratedDisabilities,
           vaTreatmentFacilities: [
             {
               treatmentCenterName: 'Sommerset VA Clinic',
@@ -272,16 +233,7 @@ describe('VA Medical Records', () => {
         schema={schema}
         uiSchema={uiSchema}
         data={{
-          ratedDisabilities: [
-            {
-              name: 'Post traumatic stress disorder',
-              'view:selected': true,
-            },
-            {
-              name: 'Intervertebral disc syndrome',
-              'view:selected': true,
-            },
-          ],
+          ratedDisabilities,
           vaTreatmentFacilities: [
             {
               treatmentCenterName: 'Sommerset VA Clinic',

--- a/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
@@ -11,6 +11,7 @@ import formConfig from '../config/form';
 import {
   transform,
   transformRelatedDisabilities,
+  stringifyRelatedDisabilities,
   getFlatIncidentKeys,
   getPtsdChangeText,
   setActionTypes,
@@ -99,6 +100,55 @@ describe('transformRelatedDisabilities', () => {
     expect(
       transformRelatedDisabilities(treatedDisabilityNames, claimedConditions),
     ).to.eql(['Some Condition Name']);
+  });
+});
+
+describe('stringifyRelatedDisabilities', () => {
+  it('should return an array of strings', () => {
+    const formData = {
+      vaTreatmentFacilities: [
+        {
+          treatedDisabilityNames: {
+            'some condition name': true,
+            'another condition name': true,
+            'this condition is falsey!': false,
+          },
+        },
+      ],
+    };
+    expect(stringifyRelatedDisabilities(formData)).to.deep.equal({
+      vaTreatmentFacilities: [
+        {
+          treatedDisabilityNames: [
+            'some condition name',
+            'another condition name',
+          ],
+        },
+      ],
+    });
+  });
+  it('will still add conditions to treatment names if they are not claimed', () => {
+    const formData = {
+      vaTreatmentFacilities: [
+        {
+          treatedDisabilityNames: {
+            'some condition name': true,
+            'another condition name': true,
+            'this condition is falsey!': false,
+          },
+        },
+      ],
+    };
+    expect(stringifyRelatedDisabilities(formData)).to.deep.equal({
+      vaTreatmentFacilities: [
+        {
+          treatedDisabilityNames: [
+            'some condition name',
+            'another condition name',
+          ],
+        },
+      ],
+    });
   });
 });
 

--- a/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
@@ -244,8 +244,8 @@ describe('526 All Claims validations', () => {
   describe('validateBooleanGroup', () => {
     it('should add error if no props are true', () => {
       const errors = { addError: sinon.spy() };
-      validateBooleanGroup(errors, {
-        tests: false,
+      validateBooleanGroup(errors, { tests: false }, null, {
+        properties: { tests: 'string' },
       });
 
       expect(errors.addError.called).to.be.true;
@@ -253,7 +253,9 @@ describe('526 All Claims validations', () => {
 
     it('should add error if empty object', () => {
       const errors = { addError: sinon.spy() };
-      validateBooleanGroup(errors, {});
+      validateBooleanGroup(errors, {}, null, {
+        properties: { tests: 'string' },
+      });
 
       expect(errors.addError.called).to.be.true;
     });
@@ -278,9 +280,17 @@ describe('526 All Claims validations', () => {
 
     it('should use custom message', () => {
       const errors = { addError: sinon.spy() };
-      validateBooleanGroup(errors, { tests: false }, null, null, {
-        atLeastOne: 'testing',
-      });
+      validateBooleanGroup(
+        errors,
+        { tests: false },
+        null,
+        {
+          properties: { tests: 'string' },
+        },
+        {
+          atLeastOne: 'testing',
+        },
+      );
 
       expect(errors.addError.firstCall.args[0]).to.equal('testing');
     });

--- a/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
@@ -7,6 +7,7 @@ import {
   oneDisabilityRequired,
   hasMonthYear,
   validateDisabilityName,
+  validateBooleanGroup,
 } from '../validations';
 
 import disabilityLabels from '../content/disabilityLabels';
@@ -237,6 +238,51 @@ describe('526 All Claims validations', () => {
       const err = { addError: sinon.spy() };
       validateDisabilityName(err, tooLong);
       expect(err.addError.calledOnce).to.be.true;
+    });
+  });
+
+  describe('validateBooleanGroup', () => {
+    it('should add error if no props are true', () => {
+      const errors = { addError: sinon.spy() };
+      validateBooleanGroup(errors, {
+        tests: false,
+      });
+
+      expect(errors.addError.called).to.be.true;
+    });
+
+    it('should add error if empty object', () => {
+      const errors = { addError: sinon.spy() };
+      validateBooleanGroup(errors, {});
+
+      expect(errors.addError.called).to.be.true;
+    });
+
+    it('should add error if true prop isnt in the schema', () => {
+      const errors = { addError: sinon.spy() };
+      validateBooleanGroup(errors, { testz: true, tests: false }, null, {
+        properties: { tests: 'string' },
+      });
+
+      expect(errors.addError.called).to.be.true;
+    });
+
+    it('should not add error if at least one prop is true', () => {
+      const errors = { addError: sinon.spy() };
+      validateBooleanGroup(errors, { tests: true }, null, {
+        properties: { tests: 'string' },
+      });
+
+      expect(errors.addError.called).to.be.false;
+    });
+
+    it('should use custom message', () => {
+      const errors = { addError: sinon.spy() };
+      validateBooleanGroup(errors, { tests: false }, null, null, {
+        atLeastOne: 'testing',
+      });
+
+      expect(errors.addError.firstCall.args[0]).to.equal('testing');
     });
   });
 });

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -326,7 +326,7 @@ export function validateBooleanGroup(
 ) {
   const { atLeastOne = 'Please choose at least one option' } = errorMessages;
   const group = userGroup || {};
-  const props = schema.properties;
+  const props = schema?.properties || {};
   if (
     !Object.keys(group).filter(
       item =>

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -310,3 +310,29 @@ export const requireSeparationLocation = (err, fieldData, formData) => {
     err.addError('Please select a separation location from the suggestions');
   }
 };
+
+// Originally used the function from platform/forms-system/src/js/validation.js,
+// but we need to ignore conditions that have been removed from the new
+// disabilities array; the form data for treatedDisabilityNames doesn't remove
+// previous entries and they may still be true - see
+// https://github.com/department-of-veterans-affairs/va.gov-team/issues/15368
+// the schema name is not altered, only the form data from SiPs
+export function validateBooleanGroup(
+  errors,
+  userGroup,
+  form,
+  schema,
+  errorMessages = {},
+) {
+  const { atLeastOne = 'Please choose at least one option' } = errorMessages;
+  const group = userGroup || {};
+  const props = schema.properties;
+  if (
+    !Object.keys(group).filter(
+      item =>
+        group[item] === true && (props[item] || props[item.toLowerCase()]),
+    ).length
+  ) {
+    errors.addError(atLeastOne);
+  }
+}


### PR DESCRIPTION
## Description

### Problem

When a Veteran enters a new disability that includes dashes, e.g. `condition type-a-b`, a set of checkboxes are created for treatment centers that allow the Veteran to choose which disabilities were treated at which center. It is added to the form data in this format (`true` means the Veteran checked it)

```js
{
  'treated_disability_names': {
    'condition type-a-b': true
  }
}
```

If the form is saved and later reopened, the save-in-progress endpoint ends up altering the 'keys' of the object data (using key inflection) to return this result:

```js
{
  'treated_disability_names': {
    'condition typeAB': true
  }
}
```

The result is the disability name doesn't match, so the checkbox is unchecked. The previous validation method did not result in any errors because it was only look for any entry with a `true` value. The submission transformer then went though the list matching it against the list of rated and new disabilities and not finding any would return an empty array.

If the unchecked `treated_disability_names` entry is then checked, a new `'condition type-a-b': true` is added, but again upon saving the form, it is a duplicate and thus returns an altered save state (see the screenshot)

### Solutions

- Remove save-in-progress data key inflection - may be problematic with metadata and doesn't solve the current problem of altered data
- Add BE or FE code to revert these changes - may not be accurate and could still introduce mismatched entries
- Use levenshtein distance comparison of names to migrate the data - maybe the best solution?
- Provide all `treated_disability_names` values with a `true` setting on submission (**chosen "simplest solution**)

### Related
- Bug ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/15368
- Slack discussion: https://dsva.slack.com/archives/CBU0KDSB1/p1606932092415400
- Problem page: https://staging.va.gov/disability/file-disability-claim-form-21-526ez/supporting-evidence/va-medical-records

## Testing done

- Updated unit tests
- Verified e2e tests still pass after updating mock data

## Screenshots

<details><summary>Page view</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-12-03 at 2 47 04 PM](https://user-images.githubusercontent.com/136959/101086509-8fce3100-3576-11eb-8ba3-186af9a0963e.png)</details>

<details>
<summary>Result after several save/resumes</summary>

<!-- leave a blank line above -->

<br>

On page load
![Screen Shot 2020-12-03 at 2 49 39 PM](https://user-images.githubusercontent.com/136959/101086740-e9366000-3576-11eb-8e03-6618838ff7ce.png)

After checking the condition (again)
![Screen Shot 2020-12-03 at 2 51 20 PM](https://user-images.githubusercontent.com/136959/101086972-374b6380-3577-11eb-8796-2ebbdc36200c.png)</details>

## Acceptance criteria
- [x] Attempting to continue or update the page when a disability name isn't checked will now show an error
- [x] Submitting the form with this existing problem will now allow submission and provide all set (to `true`) disabilities names

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
