### PR TITLE
[Development] Increase BDD/CST file upload size

### DIFF
--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -255,11 +255,22 @@ export function getClaimDetail(id, router, poll = pollRequest) {
     });
     poll({
       onError: response => {
+        /* Claim status development
+           comment out the next block of code to access the claim status, file &
+           details tabs for development
+        /* * /
+        return dispatch({
+          type: SET_CLAIM_DETAIL,
+          claim: response.data,
+          meta: response.meta,
+        });
+        /* */
         if (response.status !== 404 || !router) {
           dispatch({ type: SET_CLAIMS_UNAVAILABLE });
         } else {
           router.replace('your-claims');
         }
+        /* */
       },
       onSuccess: response =>
         dispatch({

--- a/src/applications/claims-status/components/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/AddFilesForm.jsx
@@ -28,6 +28,7 @@ import {
   isEmptyFileSize,
   isValidFileType,
   FILE_TYPES,
+  MAX_FILE_SIZE_MB,
 } from '../utils/validations';
 import { setFocus } from '../utils/page';
 
@@ -103,8 +104,7 @@ class AddFilesForm extends React.Component {
       });
     } else if (!isValidFileSize(file)) {
       this.setState({
-        errorMessage:
-          'The file you selected is larger than the 50MB maximum file size and could not be added.',
+        errorMessage: `The file you selected is larger than the ${MAX_FILE_SIZE_MB}MB maximum file size and could not be added.`,
       });
     } else if (isEmptyFileSize(file)) {
       this.setState({
@@ -179,7 +179,7 @@ class AddFilesForm extends React.Component {
           <p className="file-requirement-header">Accepted file types:</p>
           <p className="file-requirement-text">{displayTypes}</p>
           <p className="file-requirement-header">Maximum file size:</p>
-          <p className="file-requirement-text">50MB</p>
+          <p className="file-requirement-text">{`${MAX_FILE_SIZE_MB}MB`}</p>
         </div>
         {this.props.files.map(
           ({ file, docType, isEncrypted, password }, index) => (

--- a/src/applications/claims-status/components/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/AddFilesForm.jsx
@@ -27,14 +27,15 @@ import {
   isValidFileSize,
   isEmptyFileSize,
   isValidFileType,
+  isPdf,
   FILE_TYPES,
   MAX_FILE_SIZE_MB,
+  MAX_PDF_SIZE_MB,
 } from '../utils/validations';
 import { setFocus } from '../utils/page';
+import { uploadPdfLimitFeature } from '../utils/appeals-v2-helpers';
 
-const displayTypes = FILE_TYPES.map(
-  type => (type === 'pdf' ? 'pdf (unlocked)' : type),
-).join(', ');
+const displayTypes = FILE_TYPES.join(', ');
 
 const scrollToFile = position => {
   const options = getScrollOptions({ offset: -25 });
@@ -76,14 +77,15 @@ class AddFilesForm extends React.Component {
 
   add = async files => {
     const file = files[0];
-    const { requestLockedPdfPassword, onAddFile } = this.props;
+    const { requestLockedPdfPassword, onAddFile, pdfSizeFeature } = this.props;
     const extraData = {};
+    const hasPdfSizeLimit = isPdf(file) && pdfSizeFeature;
 
-    if (isValidFile(file)) {
+    if (isValidFile(file, pdfSizeFeature)) {
       // Check if the file is an encrypted PDF
       if (
         requestLockedPdfPassword && // feature flag
-        file.name?.endsWith('pdf')
+        file.name?.toLowerCase().endsWith('pdf')
       ) {
         extraData.isEncrypted = await this.isFileEncrypted(file);
       }
@@ -102,9 +104,10 @@ class AddFilesForm extends React.Component {
       this.setState({
         errorMessage: 'Please choose a file from one of the accepted types.',
       });
-    } else if (!isValidFileSize(file)) {
+    } else if (!isValidFileSize(file, pdfSizeFeature)) {
+      const maxSize = hasPdfSizeLimit ? MAX_PDF_SIZE_MB : MAX_FILE_SIZE_MB;
       this.setState({
-        errorMessage: `The file you selected is larger than the ${MAX_FILE_SIZE_MB}MB maximum file size and could not be added.`,
+        errorMessage: `The file you selected is larger than the ${maxSize}MB maximum file size and could not be added.`,
       });
     } else if (isEmptyFileSize(file)) {
       this.setState({
@@ -179,7 +182,16 @@ class AddFilesForm extends React.Component {
           <p className="file-requirement-header">Accepted file types:</p>
           <p className="file-requirement-text">{displayTypes}</p>
           <p className="file-requirement-header">Maximum file size:</p>
-          <p className="file-requirement-text">{`${MAX_FILE_SIZE_MB}MB`}</p>
+          <p className="file-requirement-text">
+            {`${MAX_FILE_SIZE_MB}MB${
+              this.props.pdfSizeFeature ? ' (non-PDF)' : ''
+            }`}
+          </p>
+          {this.props.pdfSizeFeature && (
+            <p className="file-requirement-text">
+              {`${MAX_PDF_SIZE_MB}MB (PDF only)`}
+            </p>
+          )}
         </div>
         {this.props.files.map(
           ({ file, docType, isEncrypted, password }, index) => (
@@ -325,6 +337,7 @@ AddFilesForm.propTypes = {
 
 const mapStateToProps = state => ({
   requestLockedPdfPassword: toggleValues(state).request_locked_pdf_password,
+  pdfSizeFeature: uploadPdfLimitFeature(state),
 });
 
 export { AddFilesForm };

--- a/src/applications/claims-status/tests/components/AddFilesForm.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/AddFilesForm.unit.spec.jsx
@@ -4,6 +4,12 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import { AddFilesForm } from '../../components/AddFilesForm';
+import {
+  MAX_FILE_SIZE_BYTES,
+  MAX_FILE_SIZE_MB,
+  MAX_PDF_SIZE_BYTES,
+  MAX_PDF_SIZE_MB,
+} from '../../utils/validations';
 
 describe('<AddFilesForm>', () => {
   it('should render component', () => {
@@ -243,7 +249,42 @@ describe('<AddFilesForm>', () => {
     ]);
     expect(onAddFile.called).to.be.false;
     expect(tree.getMountedInstance().state.errorMessage).to.contain(
-      'maximum file size',
+      `${MAX_FILE_SIZE_MB}MB maximum file size`,
+    );
+  });
+
+  it('should not add an invalid PDF file size', () => {
+    const files = [];
+    const field = { value: '', dirty: false };
+    const onSubmit = sinon.spy();
+    const onAddFile = sinon.spy();
+    const onRemoveFile = sinon.spy();
+    const onFieldChange = sinon.spy();
+    const onCancel = sinon.spy();
+    const onDirtyFields = sinon.spy();
+
+    const tree = SkinDeep.shallowRender(
+      <AddFilesForm
+        files={files}
+        field={field}
+        onSubmit={onSubmit}
+        onAddFile={onAddFile}
+        onRemoveFile={onRemoveFile}
+        onFieldChange={onFieldChange}
+        onCancel={onCancel}
+        onDirtyFields={onDirtyFields}
+        pdfSizeFeature
+      />,
+    );
+    tree.getMountedInstance().add([
+      {
+        name: 'something.pdf',
+        size: MAX_PDF_SIZE_BYTES + 100,
+      },
+    ]);
+    expect(onAddFile.called).to.be.false;
+    expect(tree.getMountedInstance().state.errorMessage).to.contain(
+      `${MAX_PDF_SIZE_MB}MB maximum file size`,
     );
   });
 
@@ -273,6 +314,43 @@ describe('<AddFilesForm>', () => {
       {
         name: 'something.jpg',
         size: 9999,
+      },
+    ]);
+    expect(onAddFile.called).to.be.true;
+    expect(tree.getMountedInstance().state.errorMessage).to.be.null;
+  });
+
+  it('should add a large PDF file', () => {
+    const files = [];
+    const field = { value: '', dirty: false };
+    const onSubmit = sinon.spy();
+    const onAddFile = sinon.spy();
+    const onRemoveFile = sinon.spy();
+    const onFieldChange = sinon.spy();
+    const onCancel = sinon.spy();
+    const onDirtyFields = sinon.spy();
+
+    // valid size larger than max non-PDF size, but smaller than max PDF size
+    const validPdfFileSize =
+      MAX_FILE_SIZE_BYTES + (MAX_PDF_SIZE_BYTES - MAX_FILE_SIZE_BYTES) / 2;
+
+    const tree = SkinDeep.shallowRender(
+      <AddFilesForm
+        files={files}
+        field={field}
+        onSubmit={onSubmit}
+        onAddFile={onAddFile}
+        onRemoveFile={onRemoveFile}
+        onFieldChange={onFieldChange}
+        onCancel={onCancel}
+        onDirtyFields={onDirtyFields}
+        pdfSizeFeature
+      />,
+    );
+    tree.getMountedInstance().add([
+      {
+        name: 'something.pdf',
+        size: validPdfFileSize,
       },
     ]);
     expect(onAddFile.called).to.be.true;

--- a/src/applications/claims-status/tests/utils/validations.unit.spec.js
+++ b/src/applications/claims-status/tests/utils/validations.unit.spec.js
@@ -5,13 +5,41 @@ import {
   isValidFileType,
   isValidFile,
   isValidDocument,
+  MAX_FILE_SIZE_BYTES,
+  MAX_PDF_SIZE_BYTES,
 } from '../../utils/validations';
+
+const pdfSizeFeature = true;
+const validPdfSize =
+  MAX_FILE_SIZE_BYTES + (MAX_PDF_SIZE_BYTES - MAX_FILE_SIZE_BYTES) / 2;
 
 describe('Claims status validation:', () => {
   describe('isValidFileSize', () => {
     it('should validate size is less than max', () => {
       const result = isValidFileSize({ size: 10 });
       expect(result).to.be.true;
+    });
+
+    it('should invalidate size is greater than max', () => {
+      const result = isValidFileSize({ size: MAX_PDF_SIZE_BYTES + 100 });
+      expect(result).to.be.false;
+    });
+
+    it('should validate PDF size is less than max', () => {
+      const result = isValidFileSize(
+        { name: 'test.pdf', size: validPdfSize },
+        pdfSizeFeature,
+      );
+      expect(result).to.be.true;
+    });
+
+    it('should invalidate PDF size is greater than max', () => {
+      const invalidSize = MAX_PDF_SIZE_BYTES;
+      const result = isValidFileSize(
+        { name: 'test.pdf', size: invalidSize },
+        pdfSizeFeature,
+      );
+      expect(result).to.be.false;
     });
   });
   describe('isValidFileType', () => {
@@ -50,6 +78,14 @@ describe('Claims status validation:', () => {
       const result = isValidFile();
 
       expect(result).to.be.false;
+    });
+    it('should validate file for size and type', () => {
+      const result = isValidFile(
+        { name: 'testing.pdf', size: validPdfSize },
+        pdfSizeFeature,
+      );
+
+      expect(result).to.be.true;
     });
   });
   describe('isValidDocument', () => {

--- a/src/applications/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/applications/claims-status/utils/appeals-v2-helpers.jsx
@@ -2173,3 +2173,6 @@ export function getVisibleRows(list, currentPage) {
   }
   return list.slice(currentIndex, currentIndex + ROWS_PER_PAGE);
 }
+
+export const uploadPdfLimitFeature = state =>
+  state.featureToggles?.['evss_upload_limit_150mb'];

--- a/src/applications/claims-status/utils/validations.js
+++ b/src/applications/claims-status/utils/validations.js
@@ -1,4 +1,7 @@
-const MAX_FILE_SIZE = 50 * 1024 * 1024;
+export const MAX_FILE_SIZE_MB = 150;
+
+const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024; // binary
+
 export const FILE_TYPES = ['pdf', 'gif', 'jpeg', 'jpg', 'bmp', 'txt'];
 
 export function isNotBlank(value) {
@@ -14,7 +17,7 @@ export function validateIfDirty(field, validator) {
 }
 
 export function isValidFileSize(file) {
-  return file.size < MAX_FILE_SIZE;
+  return file.size < MAX_FILE_SIZE_BYTES;
 }
 
 export function isEmptyFileSize(file) {

--- a/src/applications/claims-status/utils/validations.js
+++ b/src/applications/claims-status/utils/validations.js
@@ -1,6 +1,8 @@
-export const MAX_FILE_SIZE_MB = 150;
+export const MAX_FILE_SIZE_MB = 50;
+export const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 ** 2; // binary based
 
-const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024; // binary
+export const MAX_PDF_SIZE_MB = 150;
+export const MAX_PDF_SIZE_BYTES = MAX_PDF_SIZE_MB * 1024 ** 2; // binary based
 
 export const FILE_TYPES = ['pdf', 'gif', 'jpeg', 'jpg', 'bmp', 'txt'];
 
@@ -16,8 +18,12 @@ export function validateIfDirty(field, validator) {
   return true;
 }
 
-export function isValidFileSize(file) {
-  return file.size < MAX_FILE_SIZE_BYTES;
+export const isPdf = file => file.name?.toLowerCase().endsWith('pdf') || false;
+
+export function isValidFileSize(file, pdfSizeFeature) {
+  const maxSize =
+    isPdf(file) && pdfSizeFeature ? MAX_PDF_SIZE_BYTES : MAX_FILE_SIZE_BYTES;
+  return file.size < maxSize;
 }
 
 export function isEmptyFileSize(file) {
@@ -28,10 +34,10 @@ export function isValidFileType(file) {
   return FILE_TYPES.some(type => file.name.toLowerCase().endsWith(type));
 }
 
-export function isValidFile(file) {
+export function isValidFile(file, pdfSizeFeature) {
   return (
     !!file &&
-    isValidFileSize(file) &&
+    isValidFileSize(file, pdfSizeFeature) &&
     !isEmptyFileSize(file) &&
     isValidFileType(file)
   );

--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -17,8 +17,9 @@ import { MissingServices, MissingId } from './containers/MissingServices';
 
 import { MVI_ADD_SUCCEEDED } from './actions';
 import WizardContainer from './containers/WizardContainer';
-import { WIZARD_STATUS } from './constants';
+import { WIZARD_STATUS, PDF_SIZE_FEATURE } from './constants';
 import { show526Wizard, isBDD, getPageTitle } from './utils';
+import { uploadPdfLimitFeature } from './config/selectors';
 
 const wrapInBreadcrumb = (title, component) => (
   <>
@@ -61,6 +62,7 @@ export const Form526Entry = ({
   mvi,
   showWizard,
   isBDDForm,
+  pdfLimit,
 }) => {
   const defaultWizardState = getWizardStatus();
   const [wizardState, setWizardState] = useState(defaultWizardState);
@@ -119,6 +121,11 @@ export const Form526Entry = ({
     }
   }
 
+  // No easy method to pass a feature flag setting to a uiSchema, so we'll use
+  // sessionStorage for now. Done here because continuing an application may
+  // bypass the intro page.
+  sessionStorage.setItem(PDF_SIZE_FEATURE, pdfLimit);
+
   return wrapInBreadcrumb(
     title,
     <article id="form-526" data-location={`${location?.pathname?.slice(1)}`}>
@@ -136,6 +143,7 @@ const mapStateToProps = state => ({
   mvi: state.mvi,
   showWizard: show526Wizard(state),
   isBDDForm: isBDD(state?.form?.data),
+  pdfLimit: uploadPdfLimitFeature(state),
 });
 
 export default connect(mapStateToProps)(Form526Entry);

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -12,13 +12,10 @@ import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressI
 import { selectAvailableServices } from 'platform/user/selectors';
 
 import { itfNotice } from '../content/introductionPage';
-import {
-  originalClaimsFeature,
-  uploadPdfLimitFeature,
-} from '../config/selectors';
+import { originalClaimsFeature } from '../config/selectors';
 import fileOriginalClaimPage from '../../wizard/pages/file-original-claim';
 import { isBDD, getPageTitle, getStartText } from '../utils';
-import { BDD_INFO_URL, PDF_SIZE_FEATURE } from '../constants';
+import { BDD_INFO_URL } from '../constants';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {
@@ -33,10 +30,6 @@ class IntroductionPage extends React.Component {
       ? allowOriginalClaim // original claim feature flag
       : true; // services.includes('form526'); // <- "form526" service should
     // be required to proceed; not changing this now in case it breaks something
-
-    // No easy method to pass feature flag setting to a uiSchema, so we'll use
-    // sessionStorage for now.
-    sessionStorage.setItem(PDF_SIZE_FEATURE, this.props.pdfLimit);
 
     const isBDDForm = this.props.isBDDForm;
     const pageTitle = getPageTitle(isBDDForm);
@@ -254,7 +247,6 @@ const mapStateToProps = state => ({
   user: state.user,
   allowOriginalClaim: originalClaimsFeature(state),
   isBDDForm: isBDD(state?.form?.data),
-  pdfLimit: uploadPdfLimitFeature(state),
 });
 
 IntroductionPage.propTypes = {
@@ -268,7 +260,6 @@ IntroductionPage.propTypes = {
   user: PropTypes.shape({}),
   allowOriginalClaim: PropTypes.bool,
   isBDDForm: PropTypes.bool,
-  pdfLimit: PropTypes.bool,
 };
 
 export default connect(mapStateToProps)(IntroductionPage);

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -12,10 +12,13 @@ import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressI
 import { selectAvailableServices } from 'platform/user/selectors';
 
 import { itfNotice } from '../content/introductionPage';
-import { originalClaimsFeature } from '../config/selectors';
+import {
+  originalClaimsFeature,
+  uploadPdfLimitFeature,
+} from '../config/selectors';
 import fileOriginalClaimPage from '../../wizard/pages/file-original-claim';
 import { isBDD, getPageTitle, getStartText } from '../utils';
-import { BDD_INFO_URL } from '../constants';
+import { BDD_INFO_URL, PDF_SIZE_FEATURE } from '../constants';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {
@@ -30,6 +33,10 @@ class IntroductionPage extends React.Component {
       ? allowOriginalClaim // original claim feature flag
       : true; // services.includes('form526'); // <- "form526" service should
     // be required to proceed; not changing this now in case it breaks something
+
+    // No easy method to pass feature flag setting to a uiSchema, so we'll use
+    // sessionStorage for now.
+    sessionStorage.setItem(PDF_SIZE_FEATURE, this.props.pdfLimit);
 
     const isBDDForm = this.props.isBDDForm;
     const pageTitle = getPageTitle(isBDDForm);
@@ -247,6 +254,7 @@ const mapStateToProps = state => ({
   user: state.user,
   allowOriginalClaim: originalClaimsFeature(state),
   isBDDForm: isBDD(state?.form?.data),
+  pdfLimit: uploadPdfLimitFeature(state),
 });
 
 IntroductionPage.propTypes = {
@@ -260,6 +268,7 @@ IntroductionPage.propTypes = {
   user: PropTypes.shape({}),
   allowOriginalClaim: PropTypes.bool,
   isBDDForm: PropTypes.bool,
+  pdfLimit: PropTypes.bool,
 };
 
 export default connect(mapStateToProps)(IntroductionPage);

--- a/src/applications/disability-benefits/all-claims/config/selectors.js
+++ b/src/applications/disability-benefits/all-claims/config/selectors.js
@@ -7,3 +7,6 @@ export const originalClaimsFeature = state =>
 
 export const form526BDDFeature = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.form526BDD];
+
+export const uploadPdfLimitFeature = state =>
+  toggleValues(state).evss_upload_limit_150mb;

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -89,9 +89,12 @@ export const VA_FORM4142_URL =
 export const VA_FORM4192_URL =
   'https://www.vba.va.gov/pubs/forms/VBA-21-4192-ARE.pdf';
 
-export const TWENTY_FIVE_MB = 26214400;
+export const MAX_FILE_SIZE_MB = 50;
+export const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 ** 2; // binary based
 
-export const FIFTY_MB = 52428800;
+export const MAX_PDF_FILE_SIZE_MB = 150;
+// binary based
+export const MAX_PDF_FILE_SIZE_BYTES = MAX_PDF_FILE_SIZE_MB * 1024 ** 2;
 
 export const PTSD_MATCHES = [
   'ptsd',

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -289,3 +289,6 @@ export const EBEN_526_PATH =
 
 export const BDD_INFO_URL =
   '/disability/how-to-file-claim/when-to-file/pre-discharge-claim/';
+
+// PDF upload limit feature
+export const PDF_SIZE_FEATURE = 'pdfSizeFeature';

--- a/src/applications/disability-benefits/all-claims/content/fileUploadDescriptions.jsx
+++ b/src/applications/disability-benefits/all-claims/content/fileUploadDescriptions.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { MAX_FILE_SIZE_MB } from '../constants';
 
 export const UploadDescription = ({ uploadTitle }) => (
   <div>
@@ -16,7 +17,7 @@ export const UploadDescription = ({ uploadTitle }) => (
         File types you can upload: .pdf (unlocked), .jpg, .jpeg, .png, .gif,
         .bmp, or .txt
       </li>
-      <li>Maximum file size: 50MB</li>
+      <li>{`Maximum file size: ${MAX_FILE_SIZE_MB}MB`}</li>
     </ul>
     <p>
       <em>

--- a/src/applications/disability-benefits/all-claims/content/fileUploadDescriptions.jsx
+++ b/src/applications/disability-benefits/all-claims/content/fileUploadDescriptions.jsx
@@ -1,23 +1,42 @@
 import React from 'react';
-import { MAX_FILE_SIZE_MB } from '../constants';
 
+import {
+  MAX_FILE_SIZE_MB,
+  MAX_PDF_FILE_SIZE_MB,
+  PDF_SIZE_FEATURE,
+} from '../constants';
+
+const pdfSizeFeature = sessionStorage.getItem(PDF_SIZE_FEATURE) === 'true';
+
+/**
+ * Generic description added to file upload pages
+ * @param {String|ReactComponent} uploadTitle - page title
+ * @param {Boolean} uploadPdfLimit - state of the evss_upload_limit_150mb
+ *   feature flag
+ */
 export const UploadDescription = ({ uploadTitle }) => (
   <div>
     {uploadTitle && <h3 className="vads-u-font-size--h5">{uploadTitle}</h3>}
     <p>
-      You can upload your document in a .pdf (unlocked), .jpg, .jpeg, .png,
-      .gif, .bmp, or .txt file format. You’ll first need to scan a copy of your
-      document onto your computer or mobile phone. You can then upload the
-      document from there.
+      You can upload your document in a .pdf, .jpg, .jpeg, .png, .gif, .bmp, or
+      .txt file format. You’ll first need to scan a copy of your document onto
+      your computer or mobile phone. You can then upload the document from
+      there.
       <br />
       Guidelines for uploading a file:
     </p>
     <ul>
       <li>
-        File types you can upload: .pdf (unlocked), .jpg, .jpeg, .png, .gif,
-        .bmp, or .txt
+        File types you can upload: .pdf, .jpg, .jpeg, .png, .gif,.bmp, or .txt
       </li>
-      <li>{`Maximum file size: ${MAX_FILE_SIZE_MB}MB`}</li>
+      <li>
+        {`Maximum ${
+          pdfSizeFeature ? 'non-PDF ' : ''
+        }file size: ${MAX_FILE_SIZE_MB}MB`}
+      </li>
+      {pdfSizeFeature && (
+        <li>{`Maximum PDF file size: ${MAX_PDF_FILE_SIZE_MB}MB`}</li>
+      )}
     </ul>
     <p>
       <em>

--- a/src/applications/disability-benefits/all-claims/content/fileUploadDescriptions.jsx
+++ b/src/applications/disability-benefits/all-claims/content/fileUploadDescriptions.jsx
@@ -1,12 +1,7 @@
 import React from 'react';
 
-import {
-  MAX_FILE_SIZE_MB,
-  MAX_PDF_FILE_SIZE_MB,
-  PDF_SIZE_FEATURE,
-} from '../constants';
-
-const pdfSizeFeature = sessionStorage.getItem(PDF_SIZE_FEATURE) === 'true';
+import { MAX_FILE_SIZE_MB, MAX_PDF_FILE_SIZE_MB } from '../constants';
+import { getPdfSizeFeature } from '../utils';
 
 /**
  * Generic description added to file upload pages
@@ -14,7 +9,10 @@ const pdfSizeFeature = sessionStorage.getItem(PDF_SIZE_FEATURE) === 'true';
  * @param {Boolean} uploadPdfLimit - state of the evss_upload_limit_150mb
  *   feature flag
  */
-export const UploadDescription = ({ uploadTitle }) => (
+export const UploadDescription = ({
+  uploadTitle,
+  showPdfSize = getPdfSizeFeature(),
+}) => (
   <div>
     {uploadTitle && <h3 className="vads-u-font-size--h5">{uploadTitle}</h3>}
     <p>
@@ -31,10 +29,10 @@ export const UploadDescription = ({ uploadTitle }) => (
       </li>
       <li>
         {`Maximum ${
-          pdfSizeFeature ? 'non-PDF ' : ''
+          showPdfSize ? 'non-PDF ' : ''
         }file size: ${MAX_FILE_SIZE_MB}MB`}
       </li>
-      {pdfSizeFeature && (
+      {showPdfSize && (
         <li>{`Maximum PDF file size: ${MAX_PDF_FILE_SIZE_MB}MB`}</li>
       )}
     </ul>

--- a/src/applications/disability-benefits/all-claims/tests/content/fileUploadDescription.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/content/fileUploadDescription.unit.spec.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+import { UploadDescription } from '../../content/fileUploadDescriptions';
+import { MAX_FILE_SIZE_MB, MAX_PDF_FILE_SIZE_MB } from '../../constants';
+
+describe('526 All Claims -- File upload descriptions', () => {
+  it('should render', () => {
+    const tree = shallow(
+      <UploadDescription uploadTitle={'test'} showPdfSize={false} />,
+    );
+    expect(tree.find('UploadDescription')).to.exist;
+    tree.unmount();
+  });
+  it('should render only the max global file size', () => {
+    const tree = shallow(
+      <UploadDescription uploadTitle={'test'} showPdfSize={false} />,
+    );
+    const text = tree.text();
+    expect(text).to.contain(`Maximum file size: ${MAX_FILE_SIZE_MB}`);
+    expect(text).to.not.contain(MAX_PDF_FILE_SIZE_MB);
+    tree.unmount();
+  });
+  it('should render only the appropriate panels', () => {
+    const tree = shallow(
+      <UploadDescription uploadTitle={'test'} showPdfSize />,
+    );
+    const text = tree.text();
+    expect(text).to.contain(MAX_PDF_FILE_SIZE_MB);
+    tree.unmount();
+  });
+});

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -34,7 +34,7 @@ import {
   RESERVE_GUARD_TYPES,
   STATE_LABELS,
   STATE_VALUES,
-  FIFTY_MB,
+  MAX_FILE_SIZE_BYTES,
   USA,
   TYPO_THRESHOLD,
   itfStatuses,
@@ -649,7 +649,7 @@ export const ancillaryFormUploadUi = (
     fileUploadUrl: `${environment.API_URL}/v0/upload_supporting_evidence`,
     addAnotherLabel,
     fileTypes: ['pdf', 'jpg', 'jpeg', 'png', 'gif', 'bmp', 'txt'],
-    maxSize: FIFTY_MB,
+    maxSize: MAX_FILE_SIZE_BYTES,
     minSize: 1,
     createPayload: (file, _formId, password) => {
       const payload = new FormData();

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -634,6 +634,9 @@ export const hasHospitalCare = formData =>
   needsToAnswerUnemployability(formData) &&
   _.get('unemployability.hospitalized', formData, false);
 
+export const getPdfSizeFeature = () =>
+  sessionStorage.getItem(PDF_SIZE_FEATURE) === 'true';
+
 export const ancillaryFormUploadUi = (
   label,
   itemDescription,
@@ -645,7 +648,7 @@ export const ancillaryFormUploadUi = (
     addAnotherLabel = 'Add Another',
   } = {},
 ) => {
-  const pdfSizeFeature = sessionStorage.getItem(PDF_SIZE_FEATURE) === 'true';
+  const pdfSizeFeature = getPdfSizeFeature();
   return fileUploadUI(label, {
     itemDescription,
     hideLabelText: !label,

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -35,6 +35,7 @@ import {
   STATE_LABELS,
   STATE_VALUES,
   MAX_FILE_SIZE_BYTES,
+  MAX_PDF_FILE_SIZE_BYTES,
   USA,
   TYPO_THRESHOLD,
   itfStatuses,
@@ -44,6 +45,7 @@ import {
   PAGE_TITLES,
   START_TEXT,
   FORM_STATUS_BDD,
+  PDF_SIZE_FEATURE,
 } from './constants';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 
@@ -642,14 +644,18 @@ export const ancillaryFormUploadUi = (
     isDisabled = false,
     addAnotherLabel = 'Add Another',
   } = {},
-) =>
-  fileUploadUI(label, {
+) => {
+  const pdfSizeFeature = sessionStorage.getItem(PDF_SIZE_FEATURE) === 'true';
+  return fileUploadUI(label, {
     itemDescription,
     hideLabelText: !label,
     fileUploadUrl: `${environment.API_URL}/v0/upload_supporting_evidence`,
     addAnotherLabel,
     fileTypes: ['pdf', 'jpg', 'jpeg', 'png', 'gif', 'bmp', 'txt'],
+    // not sure what to do here... we need to differentiate pdf vs everything
+    // else; the check is in the actions.js > uploadFile function
     maxSize: MAX_FILE_SIZE_BYTES,
+    maxPdfSize: pdfSizeFeature ? MAX_PDF_FILE_SIZE_BYTES : MAX_FILE_SIZE_BYTES,
     minSize: 1,
     createPayload: (file, _formId, password) => {
       const payload = new FormData();
@@ -672,6 +678,7 @@ export const ancillaryFormUploadUi = (
     classNames: customClasses,
     attachmentName: false,
   });
+};
 
 export const isUploadingSupporting8940Documents = formData =>
   needsToAnswerUnemployability(formData) &&


### PR DESCRIPTION
## Description

File upload size has been increased to 150MB for all files uploaded to EVSS. They will in turn split the file into smaller 50MB files. This PR updates the file size validation and content visible to the Veteran

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/16003 (FE)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/16004 (BE)
- https://github.com/department-of-veterans-affairs/devops/pull/7990
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/17643 (feature flag)
- https://github.com/department-of-veterans-affairs/vets-website/pull/15596 (platform upload PDF size)
## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] BDD/CST file upload size increased to 150MB

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
