### PR TITLE
Omit draft content blocks

### DIFF
--- a/src/site/stages/build/process-cms-exports/schemas/input/paragraph-staff_profile.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/paragraph-staff_profile.js
@@ -10,7 +10,6 @@ module.exports = {
         $ref: 'EntityReference',
       },
     },
-    status: { $ref: 'GenericNestedBoolean' },
   },
-  required: ['field_staff_profile', 'status'],
+  required: ['field_staff_profile'],
 };

--- a/src/site/stages/build/process-cms-exports/schemas/input/paragraph-staff_profile.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/paragraph-staff_profile.js
@@ -10,6 +10,7 @@ module.exports = {
         $ref: 'EntityReference',
       },
     },
+    status: { $ref: 'GenericNestedBoolean' },
   },
-  required: ['field_staff_profile'],
+  required: ['field_staff_profile', 'status'],
 };

--- a/src/site/stages/build/process-cms-exports/schemas/output/paragraph-staff_profile.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/paragraph-staff_profile.js
@@ -7,6 +7,7 @@ module.exports = {
       properties: {
         entityType: { enum: ['paragraph'] },
         entityBundle: { enum: ['staff_profile'] },
+        entityPublished: { type: 'boolean' },
         queryFieldStaffProfile: {
           type: 'object',
           properties: {

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_detail_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_detail_page.js
@@ -13,7 +13,9 @@ const transform = (entity, { ancestors }) => ({
   entityPublished: isPublished(getDrupalValue(entity.status)),
   entityMetatags: createMetaTagArray(entity.metatag.value),
   fieldAlert: getDrupalValue(entity.fieldAlert),
-  fieldContentBlock: entity.fieldContentBlock,
+  fieldContentBlock: entity.fieldContentBlock.filter(
+    content => content.entityPublished,
+  ),
   fieldFeaturedContent: entity.fieldFeaturedContent,
   fieldIntroText: getDrupalValue(entity.fieldIntroText),
   fieldOffice: entity.fieldOffice[0]

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_detail_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_detail_page.js
@@ -14,7 +14,12 @@ const transform = (entity, { ancestors }) => ({
   entityMetatags: createMetaTagArray(entity.metatag.value),
   fieldAlert: getDrupalValue(entity.fieldAlert),
   fieldContentBlock: entity.fieldContentBlock.filter(
-    content => content.entityPublished,
+    content =>
+      // Include only published content blocks.
+      // Limiting scope of this check to staff_profile for now.
+      content.entity?.entityBundle === 'staff_profile'
+        ? content.entity?.entityPublished
+        : true,
   ),
   fieldFeaturedContent: entity.fieldFeaturedContent,
   fieldIntroText: getDrupalValue(entity.fieldIntroText),

--- a/src/site/stages/build/process-cms-exports/transformers/paragraph-staff_profile.js
+++ b/src/site/stages/build/process-cms-exports/transformers/paragraph-staff_profile.js
@@ -1,3 +1,5 @@
+const { isPublished, getDrupalValue } = require('./helpers');
+
 const transform = entity => ({
   entity: {
     entityType: 'paragraph',
@@ -5,9 +7,10 @@ const transform = entity => ({
     queryFieldStaffProfile: {
       entities: [entity.fieldStaffProfile[0] || null],
     },
+    entityPublished: isPublished(getDrupalValue(entity.status)),
   },
 });
 module.exports = {
-  filter: ['field_staff_profile'],
+  filter: ['field_staff_profile', 'status'],
   transform,
 };

--- a/src/site/stages/build/process-cms-exports/transformers/paragraph-staff_profile.js
+++ b/src/site/stages/build/process-cms-exports/transformers/paragraph-staff_profile.js
@@ -1,5 +1,3 @@
-const { isPublished, getDrupalValue } = require('./helpers');
-
 const transform = entity => ({
   entity: {
     entityType: 'paragraph',
@@ -7,10 +5,12 @@ const transform = entity => ({
     queryFieldStaffProfile: {
       entities: [entity.fieldStaffProfile[0] || null],
     },
-    entityPublished: isPublished(getDrupalValue(entity.status)),
+    // Unpublished person nodes will still have status == true here
+    // So we need to make sure we have fieldStaffProfile data instead.
+    entityPublished: !!entity.fieldStaffProfile[0],
   },
 });
 module.exports = {
-  filter: ['field_staff_profile', 'status'],
+  filter: ['field_staff_profile'],
   transform,
 };


### PR DESCRIPTION
## Description
Sometimes a published node can contain draft staff_profile nodes.

We should omit the draft staff_profile nodes from the JSON page data. 

## Testing done
View http://localhost:3001/pittsburgh-health-care/returning-service-member-care/

## Acceptance criteria
- [x] Only published staff_profile content blocks are rendered on /pittsburgh-health-care/returning-service-member-care/

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
