### PR TITLE
[526] Change Confirmation Page submittedAt to timestamp

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ConfirmationPoll.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationPoll.jsx
@@ -138,7 +138,7 @@ function mapStateToProps(state) {
   return {
     fullName: state.user.profile.userFullName,
     disabilities: selectAllDisabilityNames(state),
-    submittedAt: state.form.submission.submittedAt,
+    submittedAt: state.form.submission.timestamp,
     jobId: state.form.submission.response?.attributes?.jobId,
     areConfirmationEmailTogglesOn: confirmationEmailFeature(state),
   };


### PR DESCRIPTION
## Description
This is a small fix to properly show the time the 526 form was submitted at on the confirmation page. 

## Acceptance criteria
- [ ] Confirmation page properly shows the time the form was submitted at