### PR TITLE
10279 redundant title text

### DIFF
--- a/src/applications/personalization/rated-disabilities/components/RatedDisabilitiesSidebar.jsx
+++ b/src/applications/personalization/rated-disabilities/components/RatedDisabilitiesSidebar.jsx
@@ -29,7 +29,6 @@ const RatedDisabilitiesSidebar = () => (
     <a
       href="/disability/about-disability-ratings/"
       aria-label="About VA disability ratings"
-      title="About VA disability ratings"
     >
       About VA disability ratings
     </a>

--- a/src/applications/personalization/view-dependents/components/ViewDependentsSidebar/ViewDependentsSidebarBlockStates/ViewDependentSidebarBlockStates.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsSidebar/ViewDependentsSidebarBlockStates/ViewDependentSidebarBlockStates.jsx
@@ -30,9 +30,8 @@ export const secondSidebarBlock = {
         a claim for you.
       </p>
       <a
-        href="#"
+        href="/disability/get-help-filing-claim/"
         aria-label="Get help filing a claim"
-        title="Get help filiing a claim"
       >
         Get help filing a claim
       </a>


### PR DESCRIPTION
## Description
This pull request removes redundant title text to resolve a WAVE warning. 

## Testing done
- local

## Acceptance criteria
- [x] redundant title text removed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
