### PR TITLE
Fix title and restore spotlight section on health-services page.

### DIFF
--- a/src/site/layouts/health_services_listing.drupal.liquid
+++ b/src/site/layouts/health_services_listing.drupal.liquid
@@ -30,12 +30,12 @@
             <ul class="usa-unstyled-list"></ul>
           </section>
 
-          {% if fieldFeaturedContentHealthser.length %}
+          {% if featuredContentHealthServices.length %}
           <section class="featured-services" id="featured-services">
             <h3>In the spotlight at {{ regionNickname }}</h3>
             <ul
               class="usa-grid usa-grid-full vads-u-margin-top--3 vads-u-margin-bottom--4 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">
-              {% for featuredService in fieldFeaturedContentHealthser %}
+              {% for featuredService in featuredContentHealthServices %}
               {% include "src/site/paragraphs/link_teaser_featured_content.drupal.liquid" with linkTeaser = featuredService.entity %}
               {% endfor %}
             </ul>

--- a/src/site/layouts/health_services_listing.drupal.liquid
+++ b/src/site/layouts/health_services_listing.drupal.liquid
@@ -30,12 +30,12 @@
             <ul class="usa-unstyled-list"></ul>
           </section>
 
-          {% if featuredContentHealthServices.length %}
+          {% if fieldFeaturedContentHealthser.length %}
           <section class="featured-services" id="featured-services">
             <h3>In the spotlight at {{ regionNickname }}</h3>
             <ul
               class="usa-grid usa-grid-full vads-u-margin-top--3 vads-u-margin-bottom--4 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">
-              {% for featuredService in featuredContentHealthServices %}
+              {% for featuredService in fieldFeaturedContentHealthser %}
               {% include "src/site/paragraphs/link_teaser_featured_content.drupal.liquid" with linkTeaser = featuredService.entity %}
               {% endfor %}
             </ul>

--- a/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
@@ -5,6 +5,7 @@
 const entityElementsFromPages = require('./entityElementsForPages.graphql');
 const healthCareLocalFacilities = require('./facilities-fragments/healthCareLocalFacility.node.graphql');
 const healthCareRegionHealthServices = require('./facilities-fragments/healthCareRegionHealthServices.node.graphql');
+const healthCareRegionFeaturedHealthServices = require('./facilities-fragments/healthCareRegionFeaturedHealthServces.node.graphql');
 const healthCareRegionNewsStories = require('./facilities-fragments/healthCareRegionNewsStories.node.graphql');
 const healthCareRegionEvents = require('./facilities-fragments/healthCareRegionEvents.node.graphql');
 
@@ -73,6 +74,7 @@ module.exports = `
     }
     ${healthCareLocalFacilities}
     fieldOtherVaLocations
+    ${healthCareRegionFeaturedHealthServices}    
     ${healthCareRegionHealthServices}
     eventTeasersAll: reverseFieldOfficeNode(limit: 1000, filter: {conditions: [{field: "type", value: "event_listing"}]}) {
       entities {

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -134,6 +134,41 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     'health_care_region_locations_page.drupal.liquid',
   );
 
+  // Create "A-Z Services" || "Our health services" Page
+  // sort and group health services by their weight in drupal
+  if (page.fieldClinicalHealthServices) {
+    const clinicalHealthServices = sortServices(
+      page.fieldClinicalHealthServices.entities,
+    );
+
+    const hsEntityUrl = createEntityUrlObj(drupalPagePath);
+    const hsObj = {
+      featuredContentHealthServices: page.fieldFeaturedContentHealthser,
+      facilitySidebar: sidebar,
+      entityUrl: hsEntityUrl,
+      alert: page.alert,
+      bannerAlert: page.bannerAlert,
+      title: page.title,
+      regionNickname: page.fieldNicknameForThisFacility,
+      clinicalHealthServices,
+    };
+
+    const hsPage = updateEntityUrlObj(
+      hsObj,
+      drupalPagePath,
+      'Health services',
+      'health-services',
+    );
+    const hsPath = hsPage.entityUrl.path;
+    hsPage.regionOrOffice = page.title;
+    hsPage.entityUrl = generateBreadCrumbs(hsPath);
+
+    files[`${drupalPagePath}/health-services/index.html`] = createFileObj(
+      hsPage,
+      'health_services_listing.drupal.liquid',
+    );
+  }
+
   // Press Release listing page
   const prEntityUrl = createEntityUrlObj(drupalPagePath);
   const prObj = {

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -144,6 +144,7 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     const hsEntityUrl = createEntityUrlObj(drupalPagePath);
     const hsObj = {
       featuredContentHealthServices: page.fieldFeaturedContentHealthser,
+      fieldIntroText: page.fieldIntroText,
       facilitySidebar: sidebar,
       entityUrl: hsEntityUrl,
       alert: page.alert,

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -134,41 +134,6 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     'health_care_region_locations_page.drupal.liquid',
   );
 
-  // Create "A-Z Services" || "Our health services" Page
-  // sort and group health services by their weight in drupal
-  if (page.fieldClinicalHealthServices) {
-    const clinicalHealthServices = sortServices(
-      page.fieldClinicalHealthServices.entities,
-    );
-
-    const hsEntityUrl = createEntityUrlObj(drupalPagePath);
-    const hsObj = {
-      featuredContentHealthServices: page.fieldFeaturedContentHealthser,
-      facilitySidebar: sidebar,
-      entityUrl: hsEntityUrl,
-      alert: page.alert,
-      bannerAlert: page.bannerAlert,
-      title: page.title,
-      regionNickname: page.fieldNicknameForThisFacility,
-      clinicalHealthServices,
-    };
-
-    const hsPage = updateEntityUrlObj(
-      hsObj,
-      drupalPagePath,
-      'Patient and health services',
-      'health-services',
-    );
-    const hsPath = hsPage.entityUrl.path;
-    hsPage.regionOrOffice = page.title;
-    hsPage.entityUrl = generateBreadCrumbs(hsPath);
-
-    files[`${drupalPagePath}/health-services/index.html`] = createFileObj(
-      hsPage,
-      'health_services_listing.drupal.liquid',
-    );
-  }
-
   // Press Release listing page
   const prEntityUrl = createEntityUrlObj(drupalPagePath);
   const prObj = {


### PR DESCRIPTION
## Description
The title on /pittsburgh-health-care/health-services is wrong in staging/prod - says "Patient and health services", s/b "Health services". And the "in the spotlight" section is missing.

## Testing done
Run build, check page visually

## Screenshots


## Acceptance criteria
- [x] Page matches http://eriehealthcare.web.demo.ci.cms.va.gov/pittsburgh-health-care/health-services/, which is based on an older version of the code.

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
