### PR TITLE
DT-8253 508 

### DIFF
--- a/src/site/paragraphs/linkTeaser.drupal.liquid
+++ b/src/site/paragraphs/linkTeaser.drupal.liquid
@@ -42,9 +42,8 @@
                 <img class="all-link-arrow" src="/img/arrow-right-blue.svg" alt="right-arrow">
             {% endif %}
         {% endif %}
-
-        {% if linkTeaser.fieldLinkSummary != empty %}
-            <p class="va-nav-linkslist-description">{{ linkTeaser.fieldLinkSummary }}</p>
-        {% endif %}
     </a>
+    {% if linkTeaser.fieldLinkSummary != empty %}
+        <p class="va-nav-linkslist-description">{{ linkTeaser.fieldLinkSummary }}</p>
+    {% endif %}
 </li>


### PR DESCRIPTION
## Issue
https://github.com/department-of-veterans-affairs/va.gov-team/issues/8253

## Description
The screen reader as reading the header and paragraph all in 1 sentence which is undesired behavior. 
Moving the paragraph tag outside of the in an anchor tag encapsulation fixes the behavior.

## Testing done
Ran Voice Over Utility locally.

## Screenshots
![Screen Shot 2020-12-04 at 12 28 49 PM](https://user-images.githubusercontent.com/26075258/101197482-27dc2100-3630-11eb-8e08-458039bf8d27.png)


## Acceptance criteria
- [x] The sentence text MUST not be included in the focusable link.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
