### PR TITLE
Update checkbox logic copy mailing address

### DIFF
--- a/src/platform/user/profile/vap-svc/containers/CopyMailingAddress.jsx
+++ b/src/platform/user/profile/vap-svc/containers/CopyMailingAddress.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import isEqual from 'lodash/isEqual';
+import PropTypes from 'prop-types';
 import pick from 'lodash/pick';
 import pickBy from 'lodash/pickBy';
-
+import mapValues from 'lodash/mapValues';
 import { isEmptyAddress } from 'platform/forms/address/helpers';
 
 import { FIELD_NAMES } from '../constants';
@@ -23,26 +24,59 @@ const ADDRESS_PROPS = [
 ];
 
 class CopyMailingAddress extends React.Component {
-  onChange = event => {
-    event.stopPropagation();
-    if (event.target.checked) {
-      const address = pick(this.props.mailingAddress, ADDRESS_PROPS);
-      this.props.copyMailingAddress(address);
+  static propTypes = {
+    emptyMailingAddress: PropTypes.bool.isRequired,
+    mailingAddress: PropTypes.object.isRequired,
+    residentialAddress: PropTypes.object.isRequired,
+  };
+
+  areHomeMailingAddressesEqual = () => {
+    const { mailingAddress, residentialAddress } = this.props;
+
+    const mailingAddressFields = pickBy(
+      pick(mailingAddress, ADDRESS_PROPS),
+      value => !!value,
+    );
+    const residentialAddressFields = pickBy(
+      pick(residentialAddress, ADDRESS_PROPS),
+      value => !!value,
+    );
+
+    return isEqual(mailingAddressFields, residentialAddressFields);
+  };
+
+  onChange = () => {
+    const { copyMailingAddress, mailingAddress } = this.props;
+
+    // If mailing + home addresses are the same, clear the home address
+    if (this.areHomeMailingAddressesEqual()) {
+      const clearedHomeAddress = mapValues(mailingAddress, () => null);
+      copyMailingAddress(clearedHomeAddress);
+      return;
     }
+
+    // Otherwise, make the home address the same as the mailing address
+    const copiedHomeAddress = pick(mailingAddress, ADDRESS_PROPS);
+    copyMailingAddress(copiedHomeAddress);
   };
 
   render() {
-    if (this.props.hasEmptyMailingAddress) return <div />;
+    const { areHomeMailingAddressesEqual, onChange } = this;
+
+    if (this.props.emptyMailingAddress) {
+      return <div />;
+    }
+
     return (
       <div className="copy-mailing-address-to-residential-address">
         <div className="form-checkbox-buttons form-checkbox">
           <input
-            type="checkbox"
-            name="copy-mailing-address-to-residential-address"
-            id="copy-mailing-address-to-residential-address"
             autoComplete="false"
-            checked={this.props.checked}
-            onChange={this.onChange}
+            checked={areHomeMailingAddressesEqual()}
+            id="copy-mailing-address-to-residential-address"
+            name="copy-mailing-address-to-residential-address"
+            onChange={onChange}
+            type="checkbox"
           />
           <label htmlFor="copy-mailing-address-to-residential-address">
             My home address is the same as my mailing address.
@@ -58,27 +92,13 @@ export function mapStateToProps(state) {
     state,
     FIELD_NAMES.MAILING_ADDRESS,
   );
-  const hasEmptyMailingAddress = isEmptyAddress(mailingAddress);
-
-  const residentialAddress = selectEditedFormField(
-    state,
-    FIELD_NAMES.RESIDENTIAL_ADDRESS,
-  ).value;
-
-  const isChecked = () => {
-    if (hasEmptyMailingAddress) {
-      return false;
-    }
-    return isEqual(
-      pickBy(pick(mailingAddress, ADDRESS_PROPS), e => !!e),
-      pick(residentialAddress, ADDRESS_PROPS),
-    );
-  };
-
   return {
+    emptyMailingAddress: isEmptyAddress(mailingAddress),
+    residentialAddress: selectEditedFormField(
+      state,
+      FIELD_NAMES.RESIDENTIAL_ADDRESS,
+    ).value,
     mailingAddress,
-    hasEmptyMailingAddress,
-    checked: isChecked(),
   };
 }
 

--- a/src/platform/user/profile/vap-svc/tests/containers/CopyMailingAddress.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/containers/CopyMailingAddress.unit.spec.jsx
@@ -43,7 +43,7 @@ describe('<CopyMailingAddress/>', () => {
       const result = mapStateToProps(state, ownProps);
 
       expect(result.mailingAddress).to.be.equal(mailingAddress);
-      expect(result.hasEmptyMailingAddress).to.be.false;
+      expect(result.emptyMailingAddress).to.be.false;
       expect(result.checked).to.be.false;
     });
 

--- a/src/platform/user/profile/vap-svc/tests/containers/CopyMailingAddress.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/containers/CopyMailingAddress.unit.spec.jsx
@@ -1,122 +1,116 @@
+import React from 'react';
+import enzyme from 'enzyme';
 import { expect } from 'chai';
 
-import { FIELD_NAMES } from '@@vap-svc/constants';
-
-import { mapStateToProps } from '@@vap-svc/containers/CopyMailingAddress';
-
-import { convertNextValueToCleanData } from '@@vap-svc/components/AddressField/AddressField';
+import CopyMailingAddress from '@@vap-svc/containers/CopyMailingAddress';
 
 describe('<CopyMailingAddress/>', () => {
-  describe('mapStateToProps', () => {
-    let state = null;
-    const ownProps = {
-      convertNextValueToCleanData,
-    };
-
-    beforeEach(() => {
-      state = {
-        user: {
-          profile: {
-            vapContactInfo: {
-              [FIELD_NAMES.MAILING_ADDRESS]: null,
+  describe('the checkbox', () => {
+    it('is checked when the Mailing Address and Home Address are equal', () => {
+      const fakeStore = {
+        getState: () => ({
+          vapService: {
+            formFields: {
+              residentialAddress: {
+                value: {
+                  addressLine1: '36320 Coronado Dr',
+                  addressLine2: null,
+                  addressLine3: null,
+                  addressPou: 'CORRESPONDENCE',
+                  city: 'Fremont',
+                  countryName: 'United States',
+                  countryCodeIso3: 'USA',
+                  internationalPostalCode: null,
+                  province: null,
+                  stateCode: 'CA',
+                  zipCode: '94536',
+                },
+              },
             },
           },
-        },
-        vapService: {
-          formFields: {
-            [FIELD_NAMES.MAILING_ADDRESS]: null,
+          user: {
+            profile: {
+              vapContactInfo: {
+                mailingAddress: {
+                  addressLine1: '36320 Coronado Dr',
+                  addressLine2: null,
+                  addressLine3: null,
+                  addressPou: 'CORRESPONDENCE',
+                  city: 'Fremont',
+                  countryName: 'United States',
+                  countryCodeIso3: 'USA',
+                  internationalPostalCode: null,
+                  province: null,
+                  stateCode: 'CA',
+                  zipCode: '94536',
+                },
+              },
+            },
           },
-        },
+        }),
+        subscribe: () => {},
+        dispatch: () => {},
       };
+      const component = enzyme.mount(<CopyMailingAddress store={fakeStore} />);
+      const checkbox = component.find(
+        '#copy-mailing-address-to-residential-address',
+      );
+      expect(checkbox.props().checked).to.equal(true);
+      component.unmount();
     });
 
-    it('returns the required props', () => {
-      const mailingAddress = { city: 'some city' };
-
-      state.user.profile.vapContactInfo[
-        FIELD_NAMES.MAILING_ADDRESS
-      ] = mailingAddress;
-      state.vapService.formFields[FIELD_NAMES.RESIDENTIAL_ADDRESS] = {
-        city: 'some other city',
+    it('is not checked when the Mailing Address and Home Address are not equal', () => {
+      const fakeStore = {
+        getState: () => ({
+          vapService: {
+            formFields: {
+              residentialAddress: {
+                value: {
+                  addressLine1: '36320 Coronado Dr',
+                  addressLine2: null,
+                  addressLine3: null,
+                  addressPou: 'CORRESPONDENCE',
+                  city: 'Fremont',
+                  countryName: 'United States',
+                  countryCodeIso3: 'USA',
+                  internationalPostalCode: null,
+                  province: null,
+                  stateCode: 'CA',
+                  zipCode: '94536',
+                },
+              },
+            },
+          },
+          user: {
+            profile: {
+              vapContactInfo: {
+                mailingAddress: {
+                  addressLine1: '36310 Coronado Dr',
+                  addressLine2: null,
+                  addressLine3: null,
+                  addressPou: 'CORRESPONDENCE',
+                  city: 'Fremont',
+                  countryName: 'United States',
+                  countryCodeIso3: 'USA',
+                  internationalPostalCode: null,
+                  province: null,
+                  stateCode: 'CA',
+                  zipCode: '94536',
+                },
+              },
+            },
+          },
+        }),
+        subscribe: () => {},
+        dispatch: () => {},
       };
 
-      const result = mapStateToProps(state, ownProps);
-
-      expect(result.mailingAddress).to.be.equal(mailingAddress);
-      expect(result.emptyMailingAddress).to.be.false;
-      expect(result.checked).to.be.false;
-    });
-
-    describe('checked prop', () => {
-      beforeEach(() => {
-        // this is real data from staging
-        state.user.profile.vapContactInfo[FIELD_NAMES.MAILING_ADDRESS] = {
-          addressLine1: '36320 Coronado Dr',
-          addressLine2: null,
-          addressLine3: null,
-          addressPou: 'CORRESPONDENCE',
-          addressType: 'DOMESTIC',
-          city: 'Fremont',
-          countryName: 'United States',
-          countryCodeIso2: 'US',
-          countryCodeIso3: 'USA',
-          countryCodeFips: null,
-          countyCode: '06001',
-          countyName: 'Alameda County',
-          createdAt: '2019-10-04T17:52:48.000Z',
-          effectiveEndDate: null,
-          effectiveStartDate: '2020-03-04T18:33:56.000Z',
-          id: 104273,
-          internationalPostalCode: null,
-          province: null,
-          sourceDate: '2020-03-04T18:33:56.000Z',
-          sourceSystemUser: null,
-          stateCode: 'CA',
-          transactionId: '17a5fa0c-36be-4ce0-960d-b06d3b297ebe',
-          updatedAt: '2020-03-04T18:33:57.000Z',
-          validationKey: null,
-          vet360Id: '139281',
-          zipCode: '94536',
-          zipCodeSuffix: '5537',
-        };
-      });
-
-      it('is `true` when addresses are equal', () => {
-        // This is real data from staging
-        state.vapService.formFields[FIELD_NAMES.RESIDENTIAL_ADDRESS] = {
-          value: {
-            id: 145184,
-            addressLine1: '36320 Coronado Dr',
-            addressType: 'DOMESTIC',
-            city: 'Fremont',
-            countryCodeIso3: 'USA',
-            stateCode: 'CA',
-            zipCode: '94536',
-            addressPou: 'RESIDENCE/CHOICE',
-          },
-        };
-
-        const result = mapStateToProps(state, { useNewAddressForm: true });
-        expect(result.checked).to.be.true;
-      });
-
-      it('is `false` when addresses are not equal', () => {
-        state.vapService.formFields[FIELD_NAMES.RESIDENTIAL_ADDRESS] = {
-          value: {
-            id: 145184,
-            addressLine1: '123 Main St.',
-            addressType: 'DOMESTIC',
-            city: 'Fremont',
-            countryCodeIso3: 'USA',
-            stateCode: 'CA',
-            zipCode: '94536',
-            addressPou: 'RESIDENCE/CHOICE',
-          },
-        };
-
-        const result = mapStateToProps(state, { useNewAddressForm: true });
-        expect(result.checked).to.be.false;
-      });
+      const component = enzyme.mount(<CopyMailingAddress store={fakeStore} />);
+      const checkbox = component.find(
+        '#copy-mailing-address-to-residential-address',
+      );
+      expect(checkbox.props().checked).to.equal(false);
+      component.unmount();
     });
   });
 });


### PR DESCRIPTION
## Description
Behavior of the checkbox (**bold** is new)
- Is unchecked upon first render of the Home Address Edit View
- It is checked if the user has set their Home Address equal to their Mailing Address, either while editing the Mailing address, or in a previous session
- **The user can now explicitly uncheck the box**
- **Unchecking a previously checked box clears out the form** 
- **After clearing the form, the user can still re-check the box to set their Home Address equal to their Mailing Address**

## Testing done
Works well locally.

## Acceptance criteria
- [x] Updated checkbox behavior per ticket's criteria

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
