### PR TITLE
[Development] Remove all reference to faxing in form 526 & CST

### DIFF
--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -54,7 +54,7 @@ export const DONE_UPLOADING = 'DONE_UPLOADING';
 export const SET_PROGRESS = 'SET_PROGRESS';
 export const SET_UPLOAD_ERROR = 'SET_UPLOAD_ERROR';
 export const UPDATE_FIELD = 'UPDATE_FIELD';
-export const SHOW_MAIL_OR_FAX = 'SHOW_MAIL_OR_FAX';
+export const SHOW_MAIL_MESSAGE = 'SHOW_MAIL_MESSAGE';
 export const CANCEL_UPLOAD = 'CANCEL_UPLOAD';
 export const SET_FIELDS_DIRTY = 'SET_FIELD_DIRTY';
 export const SHOW_CONSOLIDATED_MODAL = 'SHOW_CONSOLIDATED_MODAL';
@@ -572,9 +572,9 @@ export function updateField(path, field) {
   };
 }
 
-export function showMailOrFaxModal(visible) {
+export function showMailMessageModal(visible) {
   return {
-    type: SHOW_MAIL_OR_FAX,
+    type: SHOW_MAIL_MESSAGE,
     visible,
   };
 }

--- a/src/applications/claims-status/components/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/AddFilesForm.jsx
@@ -21,7 +21,7 @@ import {
 } from 'platform/forms-system/src/js/utilities/file';
 
 import UploadStatus from './UploadStatus';
-import MailOrFax from './MailOrFax';
+import MailMessage from './MailMessage';
 import { displayFileSize, DOC_TYPES, getTopPosition } from '../utils/helpers';
 import { getScrollOptions } from 'platform/utilities/ui';
 import {
@@ -170,10 +170,10 @@ class AddFilesForm extends React.Component {
                 recordEvent({
                   event: 'claims-mailfax-modal',
                 });
-                this.props.onShowMailOrFax(true);
+                this.props.onShowMailMessage(true);
               }}
             >
-              Need to mail or fax your files
+              Need to mail your files
             </a>
             ?
           </p>
@@ -324,12 +324,12 @@ class AddFilesForm extends React.Component {
         />
         <Modal
           onClose={() => true}
-          visible={this.props.showMailOrFax}
+          visible={this.props.showMailMessage}
           hideCloseButton
           focusSelector="button"
           cssClass=""
           contents={
-            <MailOrFax onClose={() => this.props.onShowMailOrFax(false)} />
+            <MailMessage onClose={() => this.props.onShowMailMessage(false)} />
           }
         />
       </div>
@@ -341,7 +341,7 @@ AddFilesForm.propTypes = {
   files: PropTypes.array.isRequired,
   field: PropTypes.object.isRequired,
   uploading: PropTypes.bool,
-  showMailOrFax: PropTypes.bool,
+  showMailMessage: PropTypes.bool,
   backUrl: PropTypes.string,
   onSubmit: PropTypes.func.isRequired,
   onAddFile: PropTypes.func.isRequired,

--- a/src/applications/claims-status/components/MailMessage.jsx
+++ b/src/applications/claims-status/components/MailMessage.jsx
@@ -1,10 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-export default function MailOrFax({ onClose }) {
+export default function MailMessage({ onClose }) {
   return (
     <div>
-      <h3 className="claims-status-upload-header">Mail and Fax Instructions</h3>
+      <h3 className="claims-status-upload-header">Mail Instructions</h3>
       <button
         className="va-modal-close"
         type="button"
@@ -22,7 +22,7 @@ export default function MailOrFax({ onClose }) {
         <li>Make copies of the documents.</li>
         <li>Make sure you write your name and claim number on every page.</li>
         <li>
-          Mail or fax them to the{' '}
+          Mail them to the{' '}
           <a
             target="_blank"
             rel="noopener noreferrer"
@@ -36,6 +36,6 @@ export default function MailOrFax({ onClose }) {
   );
 }
 
-MailOrFax.propTypes = {
+MailMessage.propTypes = {
   onClose: PropTypes.func.isRequired,
 };

--- a/src/applications/claims-status/containers/AdditionalEvidencePage.jsx
+++ b/src/applications/claims-status/containers/AdditionalEvidencePage.jsx
@@ -16,7 +16,7 @@ import {
   removeFile,
   submitFiles,
   updateField,
-  showMailOrFaxModal,
+  showMailMessageModal,
   cancelUpload,
   getClaimDetail,
   setFieldsDirty,
@@ -95,7 +95,7 @@ class AdditionalEvidencePage extends React.Component {
             progress={this.props.progress}
             uploading={this.props.uploading}
             files={this.props.files}
-            showMailOrFax={this.props.showMailOrFax}
+            showMailMessage={this.props.showMailMessage}
             backUrl={this.props.lastPage || filesPath}
             onSubmit={() =>
               this.props.submitFiles(
@@ -107,7 +107,7 @@ class AdditionalEvidencePage extends React.Component {
             onAddFile={this.props.addFile}
             onRemoveFile={this.props.removeFile}
             onFieldChange={this.props.updateField}
-            onShowMailOrFax={this.props.showMailOrFaxModal}
+            onShowMailMessage={this.props.showMailMessageModal}
             onCancel={this.props.cancelUpload}
             onDirtyFields={this.props.setFieldsDirty}
           />
@@ -135,7 +135,7 @@ function mapStateToProps(state) {
     uploadError: claimsState.uploads.uploadError,
     uploadComplete: claimsState.uploads.uploadComplete,
     uploadField: claimsState.uploads.uploadField,
-    showMailOrFax: claimsState.uploads.showMailOrFax,
+    showMailMessage: claimsState.uploads.showMailMessage,
     lastPage: claimsState.routing.lastPage,
     message: claimsState.notifications.additionalEvidenceMessage,
   };
@@ -146,7 +146,7 @@ const mapDispatchToProps = {
   removeFile,
   submitFiles,
   updateField,
-  showMailOrFaxModal,
+  showMailMessageModal,
   cancelUpload,
   getClaimDetail,
   setFieldsDirty,

--- a/src/applications/claims-status/containers/DocumentRequestPage.jsx
+++ b/src/applications/claims-status/containers/DocumentRequestPage.jsx
@@ -18,7 +18,7 @@ import {
   submitFiles,
   resetUploads,
   updateField,
-  showMailOrFaxModal,
+  showMailMessageModal,
   cancelUpload,
   getClaimDetail,
   setFieldsDirty,
@@ -117,7 +117,7 @@ class DocumentRequestPage extends React.Component {
             progress={this.props.progress}
             uploading={this.props.uploading}
             files={this.props.files}
-            showMailOrFax={this.props.showMailOrFax}
+            showMailMessage={this.props.showMailMessage}
             backUrl={this.props.lastPage || filesPath}
             onSubmit={() =>
               this.props.submitFiles(
@@ -129,7 +129,7 @@ class DocumentRequestPage extends React.Component {
             onAddFile={this.props.addFile}
             onRemoveFile={this.props.removeFile}
             onFieldChange={this.props.updateField}
-            onShowMailOrFax={this.props.showMailOrFaxModal}
+            onShowMailMessage={this.props.showMailMessageModal}
             onCancel={this.props.cancelUpload}
             onDirtyFields={this.props.setFieldsDirty}
           />
@@ -192,7 +192,7 @@ function mapStateToProps(state, ownProps) {
     uploadError: claimsState.uploads.uploadError,
     uploadComplete: claimsState.uploads.uploadComplete,
     uploadField: claimsState.uploads.uploadField,
-    showMailOrFax: claimsState.uploads.showMailOrFax,
+    showMailMessage: claimsState.uploads.showMailMessage,
     lastPage: claimsState.routing.lastPage,
     message: claimsState.notifications.message,
   };
@@ -203,7 +203,7 @@ const mapDispatchToProps = {
   removeFile,
   submitFiles,
   updateField,
-  showMailOrFaxModal,
+  showMailMessageModal,
   cancelUpload,
   getClaimDetail,
   setFieldsDirty,

--- a/src/applications/claims-status/reducers/uploads.js
+++ b/src/applications/claims-status/reducers/uploads.js
@@ -8,7 +8,7 @@ import {
   DONE_UPLOADING,
   SET_UPLOAD_ERROR,
   UPDATE_FIELD,
-  SHOW_MAIL_OR_FAX,
+  SHOW_MAIL_MESSAGE,
   CANCEL_UPLOAD,
   SET_FIELDS_DIRTY,
   SET_UPLOADER,
@@ -23,7 +23,7 @@ const initialState = {
   uploadComplete: false,
   uploadError: false,
   uploadField: makeField(''),
-  showMailOrFax: false,
+  showMailMessage: false,
   uploader: null,
 };
 
@@ -86,8 +86,8 @@ export default function claimDetailReducer(state = initialState, action) {
     case UPDATE_FIELD: {
       return set(action.path, action.field, state);
     }
-    case SHOW_MAIL_OR_FAX: {
-      return set('showMailOrFax', action.visible, state);
+    case SHOW_MAIL_MESSAGE: {
+      return set('showMailMessage', action.visible, state);
     }
     case CANCEL_UPLOAD: {
       return {

--- a/src/applications/claims-status/tests/actions.unit.spec.js
+++ b/src/applications/claims-status/tests/actions.unit.spec.js
@@ -44,9 +44,9 @@ import {
   setAdditionalEvidenceNotification,
   setUnavailable,
   SHOW_CONSOLIDATED_MODAL,
-  SHOW_MAIL_OR_FAX,
+  SHOW_MAIL_MESSAGE,
   showConsolidatedMessage,
-  showMailOrFaxModal,
+  showMailMessageModal,
   SUBMIT_DECISION_REQUEST,
   submitRequest,
   UPDATE_FIELD,
@@ -166,12 +166,12 @@ describe('Actions', () => {
       });
     });
   });
-  describe('showMailOrFaxModal', () => {
+  describe('showMailMessageModal', () => {
     it('should return the correct action object', () => {
-      const action = showMailOrFaxModal(true);
+      const action = showMailMessageModal(true);
 
       expect(action).to.eql({
-        type: SHOW_MAIL_OR_FAX,
+        type: SHOW_MAIL_MESSAGE,
         visible: true,
       });
     });

--- a/src/applications/claims-status/tests/components/AddFilesForm.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/AddFilesForm.unit.spec.jsx
@@ -70,7 +70,7 @@ describe('<AddFilesForm>', () => {
     expect(tree.everySubTree('Modal')[0].props.visible).to.be.true;
   });
 
-  it('should show mail or fax modal', () => {
+  it('should show mail modal', () => {
     const files = [];
     const field = { value: '', dirty: false };
     const onSubmit = sinon.spy();
@@ -82,7 +82,7 @@ describe('<AddFilesForm>', () => {
 
     const tree = SkinDeep.shallowRender(
       <AddFilesForm
-        showMailOrFax
+        showMailMessage
         files={files}
         field={field}
         onSubmit={onSubmit}

--- a/src/applications/claims-status/tests/reducers/uploads.unit.spec.jsx
+++ b/src/applications/claims-status/tests/reducers/uploads.unit.spec.jsx
@@ -11,7 +11,7 @@ import {
   DONE_UPLOADING,
   SET_UPLOAD_ERROR,
   UPDATE_FIELD,
-  SHOW_MAIL_OR_FAX,
+  SHOW_MAIL_MESSAGE,
   CANCEL_UPLOAD,
   SET_FIELDS_DIRTY,
 } from '../../actions';
@@ -167,16 +167,16 @@ describe('Uploads reducer', () => {
     expect(state.uploadField.value).to.equal('test');
   });
 
-  it('toggle mail or fax modal', () => {
+  it('toggle mail modal', () => {
     const state = uploads(
       {},
       {
-        type: SHOW_MAIL_OR_FAX,
+        type: SHOW_MAIL_MESSAGE,
         visible: true,
       },
     );
 
-    expect(state.showMailOrFax).to.be.true;
+    expect(state.showMailMessage).to.be.true;
   });
 
   it('cancel upload', () => {

--- a/src/applications/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/applications/claims-status/utils/appeals-v2-helpers.jsx
@@ -653,8 +653,6 @@ export function getStatusContents(appeal, name = {}) {
             PO Box 27063
             <br />
             Washington, DC 20038
-            <br />
-            Fax 844-678-8979
           </p>
         </div>
       );
@@ -747,8 +745,6 @@ export function getStatusContents(appeal, name = {}) {
                 PO Box 4444
                 <br />
                 Janesville, WI 53547-4444
-                <br />
-                Fax 844-531-7818
               </p>
             </div>
           )}
@@ -1811,8 +1807,6 @@ export function getAlertContent(alert, appealIsActive) {
               PO Box 27063
               <br />
               Washington, DC 20038
-              <br />
-              Fax 844-678-8979
             </p>
             <p>
               Please contact your Veterans Service Organization or
@@ -1842,8 +1836,6 @@ export function getAlertContent(alert, appealIsActive) {
               PO Box 27063
               <br />
               Washington, DC 20038
-              <br />
-              Fax 844-678-8979
             </p>
           </div>
         ),

--- a/src/applications/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/applications/claims-status/utils/appeals-v2-helpers.jsx
@@ -653,6 +653,8 @@ export function getStatusContents(appeal, name = {}) {
             PO Box 27063
             <br />
             Washington, DC 20038
+            <br />
+            Fax 844-678-8979
           </p>
         </div>
       );
@@ -1807,6 +1809,8 @@ export function getAlertContent(alert, appealIsActive) {
               PO Box 27063
               <br />
               Washington, DC 20038
+              <br />
+              Fax 844-678-8979
             </p>
             <p>
               Please contact your Veterans Service Organization or
@@ -1836,6 +1840,8 @@ export function getAlertContent(alert, appealIsActive) {
               PO Box 27063
               <br />
               Washington, DC 20038
+              <br />
+              Fax 844-678-8979
             </p>
           </div>
         ),

--- a/src/applications/disability-benefits/all-claims/content/instructionalPart3.jsx
+++ b/src/applications/disability-benefits/all-claims/content/instructionalPart3.jsx
@@ -10,7 +10,6 @@ export const instructionalPart3Description = (
       after they’ve completed their sections.
     </p>
     {claimsIntakeAddress}
-    <p>Or fax them toll-free: 844-531-7818</p>
     <img src="/img/part3-image.png" alt="Box 2" />
   </div>
 );

--- a/src/applications/disability-benefits/all-claims/content/pastEmploymentFormDownload.jsx
+++ b/src/applications/disability-benefits/all-claims/content/pastEmploymentFormDownload.jsx
@@ -23,7 +23,6 @@ export const download4192Notice = (
       return to this application and upload it. Or, mail the form to:
     </p>
     {claimsIntakeAddress}
-    <p>Or fax them toll-free: 844-531-7818</p>
     <p>
       If they need help completing this form, they can call Veterans Benefits
       Assistance at <Telephone contact={CONTACTS.VA_BENEFITS} />, Monday through


### PR DESCRIPTION
## Description

> All fax lines will be turned off on January 1, 2021. Each business line is part of a work group ensuring all updates and changes are made accordingly.

To support this change, we are removing all references to faxing forms and supporting evidence in form 526 and within the claims status tool (CST).

Specifically, this fax number is being removed: `844-531-7818`

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/16733

## Testing done

Unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Fax service references are removed from 526 & CST

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
