### PR TITLE
Aligns Continue button with dropdowns

### DIFF
--- a/src/applications/ask-a-question/styles/ask-a-question.scss
+++ b/src/applications/ask-a-question/styles/ask-a-question.scss
@@ -38,6 +38,8 @@ ul.claim-list {
     margin-right: 0;
     margin-left: 0;
     padding-right: 0;
+  }
+}
 
 .help-footer-box {
   @include media($medium-large-screen) {

--- a/src/applications/ask-a-question/styles/ask-a-question.scss
+++ b/src/applications/ask-a-question/styles/ask-a-question.scss
@@ -30,9 +30,13 @@ ul.claim-list {
   .medium-5 {
     width: 50%;
   }
+  .medium-5.end.columns {
+    padding-right: 0;
+    padding-left: 0;
+  }
   .schemaform-buttons [type="submit"] {
     margin-right: 0;
-    margin-left: 0.5rem;
+    margin-left: 0;
     padding-right: 0;
   }
 }

--- a/src/applications/ask-a-question/styles/ask-a-question.scss
+++ b/src/applications/ask-a-question/styles/ask-a-question.scss
@@ -25,3 +25,14 @@ ul.claim-list {
     margin-bottom: 0;
   }
 }
+
+@media only screen and (min-width: 40.0625em) {
+  .medium-5 {
+    width: 50%;
+  }
+  .schemaform-buttons [type="submit"] {
+    margin-right: 0;
+    margin-left: 0.5rem;
+    padding-right: 0;
+  }
+}


### PR DESCRIPTION
## Description
[department-of-veterans-affairs/orchid#225] Aligns the continue button with the dropdowns

## Testing done


## Screenshots
<img width="655" alt="Screen Shot 2020-12-04 at 3 57 24 PM" src="https://user-images.githubusercontent.com/9095250/101218853-692cfa80-3649-11eb-9943-8a91341aaecc.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
