### PR TITLE
bah-code-reviewers as codeowners for 0993

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -74,8 +74,8 @@ src/applications/healthcare @department-of-veterans-affairs/vsa-healthcare-exper
 # Booz Allen Team
 src/applications/static-pages/school-resources @department-of-veterans-affairs/bah-code-reviewers
 src/applications/gi @department-of-veterans-affairs/bah-code-reviewers
+src/applications/edu-benefits/0993 @department-of-veterans-affairs/bah-code-reviewers
 src/applications/edu-benefits/1995 @department-of-veterans-affairs/bah-code-reviewers
-src/applications/edu-benefits/tests/1995 @department-of-veterans-affairs/bah-code-reviewers
 src/applications/edu-benefits/10203 @department-of-veterans-affairs/bah-code-reviewers
 src/applications/edu-benefits/feedback-tool @department-of-veterans-affairs/bah-code-reviewers
 


### PR DESCRIPTION
## Description

Ahead of https://github.com/department-of-veterans-affairs/va.gov-team/issues/16853 and https://github.com/department-of-veterans-affairs/va.gov-team/issues/16852 change codeowners of 0993

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
