### PR TITLE
Updates Session Timeout Modal content

### DIFF
--- a/src/platform/user/authentication/components/SessionTimeoutModal.jsx
+++ b/src/platform/user/authentication/components/SessionTimeoutModal.jsx
@@ -90,7 +90,7 @@ class SessionTimeoutModal extends React.Component {
         </div>
         <p>
           If you need more time, please click I need more time below. Otherwise,
-          we’ll sign you out to protect your privacy.
+          we’ll sign you out of your account to protect your privacy.
         </p>
         <div className="alert-actions">
           <button className="usa-button" onClick={this.extendSession}>

--- a/src/platform/user/authentication/components/SessionTimeoutModal.jsx
+++ b/src/platform/user/authentication/components/SessionTimeoutModal.jsx
@@ -89,8 +89,8 @@ class SessionTimeoutModal extends React.Component {
           <div>SECONDS</div>
         </div>
         <p>
-          If you need more time, please click on the blue button below.
-          Otherwise, we’ll sign you out to protect your privacy.
+          If you need more time, please click I need more time below. Otherwise,
+          we’ll sign you out to protect your privacy.
         </p>
         <div className="alert-actions">
           <button className="usa-button" onClick={this.extendSession}>


### PR DESCRIPTION
## Description
**Issue**: [SessionTimeoutModal language is not WCAG compliant](https://github.com/department-of-veterans-affairs/va.gov-team/issues/16301)
The Session Timeout Modal (SessionTimeoutModal.jsx) is displayed when a user's session will expire (in 30 seconds) and the content is not WCAG compliant (it refers to a button's color for a user action, rather than allowing the content to instruct the user) which is an accessibility issue.

## Testing done
- Manually

## Steps to Test
With a logged in user
1.) In Chrome DevTools > Application tab > Storage (in sidebar) > Local Storage >
2.) Right-click on `sessionExpiration` or `sessionExpirationSSO` and select 'Edit "Key"'
3.) Modify the time (within in a few minutes) to display the Session Timeout Modal
4.) Verify Session Timeout Modal content is changed.

## Screenshots
[
![Screen Shot 2020-12-01 at 2 50 45 PM](https://user-images.githubusercontent.com/67602137/100794258-4a312d00-33eb-11eb-9c70-66d21bf9fc24.jpeg)
](url)

## Acceptance criteria
- [x] Content specialist approves the text change
- [x] Change is communicated broadly in Slack
- [x] Change is verified in Staging environment

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
