### PR TITLE
[16038] Remove provider dialog

### DIFF
--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
@@ -108,6 +108,7 @@ function ProviderSelectionField({
                 Change provider
               </button>
               <button
+                aria-label={`Remove ${formData.name}`}
                 type="button"
                 className="vaos-appts__cancel-btn va-button-link vads-u-margin--0 vads-u-flex--0 vads-u-margin-right--2"
                 onClick={() => {

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
@@ -8,6 +8,7 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation-react/Lo
 import { distanceBetween } from '../../../utils/address';
 import { scrollAndFocus } from '../../../utils/scrollAndFocus';
 import ErrorMessage from '../../../components/ErrorMessage';
+import RemoveProviderModal from './RemoveProviderModal';
 
 const INITIAL_PROVIDER_DISPLAY_COUNT = 5;
 
@@ -20,7 +21,9 @@ function ProviderSelectionField({
   requestProvidersList,
   communityCareProviderList,
 }) {
-  const [checkedProvider, setCheckedProvider] = useState();
+  const [checkedProvider, setCheckedProvider] = useState(false);
+  const [removedProvider, setRemovedProvider] = useState(false);
+  const [showRemoveProviderModal, setShowRemoveProviderModal] = useState(false);
   const [mounted, setMounted] = useState(false);
   const [showProvidersList, setShowProvidersList] = useState(false);
   const [providersListLength, setProvidersListLength] = useState(
@@ -43,11 +46,13 @@ function ProviderSelectionField({
     () => {
       if (showProvidersList) {
         scrollAndFocus('h2');
+      } else if (mounted && removedProvider) {
+        scrollAndFocus('h2');
       } else if (mounted) {
         scrollAndFocus('.va-button-link');
       }
     },
-    [showProvidersList],
+    [showProvidersList, removedProvider],
   );
 
   return (
@@ -95,6 +100,15 @@ function ProviderSelectionField({
                 }}
               >
                 Change provider
+              </button>
+              <button
+                type="button"
+                className="vaos-appts__cancel-btn va-button-link vads-u-margin--0 vads-u-flex--0 vads-u-margin-right--2"
+                onClick={() => {
+                  setShowRemoveProviderModal(true);
+                }}
+              >
+                Remove
               </button>
             </div>
           </>
@@ -217,6 +231,20 @@ function ProviderSelectionField({
             </button>
           </div>
         )}
+      {showRemoveProviderModal && (
+        <RemoveProviderModal
+          provider={formData}
+          address={address}
+          onClose={response => {
+            setShowRemoveProviderModal(false);
+            if (response === true) {
+              setRemovedProvider(true);
+              setCheckedProvider(false);
+              onChange({});
+            }
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
@@ -22,7 +22,6 @@ function ProviderSelectionField({
   communityCareProviderList,
 }) {
   const [checkedProvider, setCheckedProvider] = useState(false);
-  const [removedProvider, setRemovedProvider] = useState(false);
   const [showRemoveProviderModal, setShowRemoveProviderModal] = useState(false);
   const [mounted, setMounted] = useState(false);
   const [showProvidersList, setShowProvidersList] = useState(false);
@@ -46,13 +45,20 @@ function ProviderSelectionField({
     () => {
       if (showProvidersList) {
         scrollAndFocus('h2');
-      } else if (mounted && removedProvider) {
-        scrollAndFocus('h2');
       } else if (mounted) {
         scrollAndFocus('.va-button-link');
       }
     },
-    [showProvidersList, removedProvider],
+    [showProvidersList],
+  );
+
+  useEffect(
+    () => {
+      if (mounted && Object.keys(formData).length === 0) {
+        scrollAndFocus('.va-button-link');
+      }
+    },
+    [formData],
   );
 
   return (
@@ -238,7 +244,6 @@ function ProviderSelectionField({
           onClose={response => {
             setShowRemoveProviderModal(false);
             if (response === true) {
-              setRemovedProvider(true);
               setCheckedProvider(false);
               onChange({});
             }

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/RemoveProviderModal.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/RemoveProviderModal.jsx
@@ -14,7 +14,7 @@ export default function RemoveProviderModal({ onClose, provider, address }) {
         {provider.address?.city}, {provider.address?.state}{' '}
         {provider.address?.postalCode}
       </span>
-      <span className="vads-u-display--block vads-u-font-size--sm vads-u-font-weight--bold">
+      <span className="vads-u-display--block vads-u-font-size--sm vads-u-font-weight--bold vads-u-margin-bottom--2">
         {distanceBetween(
           provider.position?.latitude,
           provider.position?.longitude,
@@ -44,9 +44,7 @@ export default function RemoveProviderModal({ onClose, provider, address }) {
       title={title}
       hideCloseButton
     >
-      <div aria-atomic="true" aria-live="assertive">
-        {content}
-      </div>
+      {content}
     </Modal>
   );
 }

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/RemoveProviderModal.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/RemoveProviderModal.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import Modal from '@department-of-veterans-affairs/formation-react/Modal';
+import { distanceBetween } from '../../../utils/address';
+
+export default function RemoveProviderModal({ onClose, provider, address }) {
+  const title = 'Are you sure you want to remove this provider?';
+  const content = (
+    <>
+      <span className="vads-u-display--block vads-u-font-weight--bold">
+        {provider.name}
+      </span>
+      <span className="vads-u-display--block">{provider.address?.line}</span>
+      <span className="vads-u-display--block">
+        {provider.address?.city}, {provider.address?.state}{' '}
+        {provider.address?.postalCode}
+      </span>
+      <span className="vads-u-display--block vads-u-font-size--sm vads-u-font-weight--bold">
+        {distanceBetween(
+          provider.position?.latitude,
+          provider.position?.longitude,
+          address.latitude,
+          address.longitude,
+        )}{' '}
+        miles
+      </span>
+      <button type="button" onClick={() => onClose(true)}>
+        Yes, remove provider
+      </button>
+      <button
+        className="usa-button-secondary"
+        type="button"
+        onClick={() => onClose(false)}
+      >
+        Cancel
+      </button>
+    </>
+  );
+
+  return (
+    <Modal
+      id="removeProviderModal"
+      visible
+      onClose={onClose}
+      title={title}
+      hideCloseButton
+    >
+      <div aria-atomic="true" aria-live="assertive">
+        {content}
+      </div>
+    </Modal>
+  );
+}

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
@@ -195,8 +195,53 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
       'LYONS, KRISTYN1785 S HAYES STARLINGTON, VA 22202-27149347.1 miles',
     );
   });
-  // TODO: show more
-  // TODO: provider fetch failure
+
+  it('should display choose provider when remove provider clicked', async () => {
+    const store = createTestStore(initialState);
+    await setTypeOfCare(store, /primary care/i);
+    await setTypeOfFacility(store, /Community Care/i);
+    const screen = renderWithStoreAndRouter(
+      <CommunityCareProviderSelectionPage />,
+      {
+        store,
+      },
+    );
+
+    // Choose Provider
+    userEvent.click(await screen.findByText(/Choose a provider/i));
+    userEvent.click(await screen.findByText(/AJADI, ADEDIWURA/i));
+    userEvent.click(
+      await screen.getByRole('button', { name: /choose provider/i }),
+    );
+    expect(screen.baseElement).to.contain.text(
+      'AJADI, ADEDIWURA700 CONSTITUTION AVE NEWASHINGTON, DC 20002-65999349.3 miles',
+    );
+
+    // Remove Provider Cancel
+    userEvent.click(await screen.findByRole('button', { name: /remove/i }));
+    userEvent.click(
+      await screen.findByText(
+        /Are you sure you want to remove this provider\?/i,
+      ),
+    );
+    userEvent.click(await screen.findByRole('button', { name: /Cancel/i }));
+    expect(screen.baseElement).to.contain.text(
+      'AJADI, ADEDIWURA700 CONSTITUTION AVE NEWASHINGTON, DC 20002-65999349.3 miles',
+    );
+
+    // Remove Provider
+    userEvent.click(await screen.findByRole('button', { name: /remove/i }));
+    userEvent.click(
+      await screen.findByText(
+        /Are you sure you want to remove this provider\?/i,
+      ),
+    );
+    userEvent.click(
+      await screen.findByRole('button', { name: /Yes, remove provider/i }),
+    );
+    expect(await screen.getByRole('button', { name: /Choose a provider/i }));
+  });
+
   it('should display an error when choose a provider clicked and provider fetch error', async () => {
     const store = createTestStore(initialState);
     await setTypeOfCare(store, /primary care/i);


### PR DESCRIPTION
## Description
As a user, I would like the ability to remove my preferred provider selection so that I can make changes to my provider preferences

## Testing done
Local and unit

## Screenshots
![image](https://user-images.githubusercontent.com/8315447/101405124-a1c91000-38a5-11eb-8587-f81b66e4343b.png)

## Acceptance criteria
- [ ] Given a provider is selected, When user clicks/taps Remove provider, Then the preferred provider is removed AND returns to default options (add or no preference)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
