### PR TITLE
Remove legacy logic and repair health services page.

### DIFF
--- a/src/site/layouts/health_services_listing.drupal.liquid
+++ b/src/site/layouts/health_services_listing.drupal.liquid
@@ -30,12 +30,12 @@
             <ul class="usa-unstyled-list"></ul>
           </section>
 
-          {% if featuredContentHealthServices.length %}
+          {% if fieldFeaturedContentHealthser %}
           <section class="featured-services" id="featured-services">
-            <h3>In the spotlight at {{ regionNickname }}</h3>
+            <h3>In the spotlight at {{ facilitySidebar.name }}</h3>
             <ul
               class="usa-grid usa-grid-full vads-u-margin-top--3 vads-u-margin-bottom--4 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">
-              {% for featuredService in featuredContentHealthServices %}
+              {% for featuredService in fieldFeaturedContentHealthser %}
               {% include "src/site/paragraphs/link_teaser_featured_content.drupal.liquid" with linkTeaser = featuredService.entity %}
               {% endfor %}
             </ul>

--- a/src/site/paragraphs/link_teaser_featured_content.drupal.liquid
+++ b/src/site/paragraphs/link_teaser_featured_content.drupal.liquid
@@ -1,6 +1,6 @@
 <li data-template="paragraphs/link_teaser_featured_content" data-entity-id="{{ linkTeaser.entityId }}"
   class="featured-content-list-item vads-u-background-color--primary-alt-lightest  vads-u-padding-y--1p5 vads-u-padding-x--1p5 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0 vads-u-display--flex vads-u-flex-direction--column">
-    {% assign link = linkTeaser.fieldLink | featureSingleValueFieldLink %}
+  {% assign link = linkTeaser.fieldLink | featureSingleValueFieldLink %}
     {% if link.title != empty %}
         <b>{{ link.title }}</b>
         <hr class="featured-content-hr vads-u-margin-y--1p5 vads-u-border-color--primary">

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -134,42 +134,6 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     'health_care_region_locations_page.drupal.liquid',
   );
 
-  // Create "A-Z Services" || "Our health services" Page
-  // sort and group health services by their weight in drupal
-  if (page.fieldClinicalHealthServices) {
-    const clinicalHealthServices = sortServices(
-      page.fieldClinicalHealthServices.entities,
-    );
-
-    const hsEntityUrl = createEntityUrlObj(drupalPagePath);
-    const hsObj = {
-      featuredContentHealthServices: page.fieldFeaturedContentHealthser,
-      fieldIntroText: page.fieldIntroText,
-      facilitySidebar: sidebar,
-      entityUrl: hsEntityUrl,
-      alert: page.alert,
-      bannerAlert: page.bannerAlert,
-      title: page.title,
-      regionNickname: page.fieldNicknameForThisFacility,
-      clinicalHealthServices,
-    };
-
-    const hsPage = updateEntityUrlObj(
-      hsObj,
-      drupalPagePath,
-      'Health services',
-      'health-services',
-    );
-    const hsPath = hsPage.entityUrl.path;
-    hsPage.regionOrOffice = page.title;
-    hsPage.entityUrl = generateBreadCrumbs(hsPath);
-
-    files[`${drupalPagePath}/health-services/index.html`] = createFileObj(
-      hsPage,
-      'health_services_listing.drupal.liquid',
-    );
-  }
-
   // Press Release listing page
   const prEntityUrl = createEntityUrlObj(drupalPagePath);
   const prObj = {


### PR DESCRIPTION
## Description
Repairs system health services listing pages
attn: @mpelzsherman @kevwalsh @mmiddaugh 

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/101221951-c4b1b500-3656-11eb-88d2-b81dbb211030.png)
![image](https://user-images.githubusercontent.com/2404547/101221959-c8ddd280-3656-11eb-9062-8e9b9e74c3d9.png)
![image](https://user-images.githubusercontent.com/2404547/101221968-cc715980-3656-11eb-8e82-ce48fe712a85.png)


## Acceptance criteria
- [ ] `pittsburgh-health-care/health-services/` looks like the above screenshots, with spotlight items visible

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
