### PR TITLE
Fix link to R&S page

### DIFF
--- a/src/applications/login/containers/SignInApp.jsx
+++ b/src/applications/login/containers/SignInApp.jsx
@@ -136,7 +136,7 @@ class SignInPage extends React.Component {
                 </a>{' '}
                 and{' '}
                 <a
-                  href="/resources/verifying-your-identity-on-va-gov/"
+                  href="/resources/verifying-your-identity-on-vagov/"
                   target="_blank"
                 >
                   verifying your identity


### PR DESCRIPTION
## Description
This PR fixes the broken link over at https://github.com/department-of-veterans-affairs/vets-website/pull/15029/files#diff-235e049038f0f89396ca4a499cbdfad0f47076a5ef5ca1519a45661dddf1eaf2R139

## Testing done
Confirmed that the link is corrected

## Screenshots
N/A

## Acceptance criteria 
- [ ] Link is corrected

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
