### PR TITLE
Remove form1995EduUpdates feature flag

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -61,7 +61,6 @@ export default Object.freeze({
   showChapter36: 'show_chapter_36',
   showChapter31: 'show_chapter_31',
   viewPaymentHistory: 'view_payment_history',
-  form1995EduUpdates: 'form_1995_edu_updates',
   requestLockedPdfPassword: 'request_locked_pdf_password',
   form526ConfirmationEmail: 'form526_confirmation_email',
   form526ConfirmationEmailShowCopy: 'form526_confirmation_email_show_copy',


### PR DESCRIPTION
## Description
Removed last reference to `form1995EduUpdates` feature flag

## Testing done
Tested locally and QA reviewed.

## Screenshots
N/A

## Acceptance criteria
- [x] `form1995EduUpdates` feature flag removed

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
