### PR TITLE
Sanlouise 16213 undo prop spreading

### DIFF
--- a/src/applications/personalization/profile/components/personal-information/ContactInformationEditView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationEditView.jsx
@@ -13,6 +13,7 @@ class ContactInformationEditView extends Component {
   static propTypes = {
     analyticsSectionName: PropTypes.string.isRequired,
     clearErrors: PropTypes.func.isRequired,
+    deleteDisabled: PropTypes.bool,
     getInitialFormValues: PropTypes.func.isRequired,
     field: PropTypes.shape({
       value: PropTypes.object,
@@ -29,6 +30,7 @@ class ContactInformationEditView extends Component {
     title: PropTypes.string.isRequired,
     transaction: PropTypes.object,
     transactionRequest: PropTypes.object,
+    uiSchema: PropTypes.object,
     useSchemaForm: PropTypes.bool,
   };
 

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
@@ -268,18 +268,6 @@ class ContactInformationField extends React.Component {
       activeEditView
     ]?.toLowerCase();
 
-    const childProps = {
-      ...this.props,
-      clearErrors: this.clearErrors,
-      onAdd: this.onAdd,
-      onCancel: this.onCancel,
-      onChangeFormDataAndSchemas: this.onChangeFormDataAndSchemas,
-      onDelete: this.onDelete,
-      onEdit: this.onEdit,
-      onSubmit: this.onSubmit,
-      refreshTransaction: this.refreshTransaction,
-    };
-
     const wrapInTransaction = children => {
       return (
         <VAPServiceTransaction

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
@@ -322,6 +322,7 @@ class ContactInformationField extends React.Component {
           clearTransactionRequest={this.props.clearTransactionRequest}
           convertCleanDataToPayLoad={this.props.convertCleanDataToPayLoad}
           createTransaction={this.props.createTransaction}
+          deleteDisabled={this.props.deleteDisabled}
           data={this.props.data}
           field={this.props.field}
           fieldName={this.props.fieldName}
@@ -339,6 +340,8 @@ class ContactInformationField extends React.Component {
           transactionRequest={this.props.transactionRequest}
           uiSchema={this.props.uiSchema}
           validateAddress={this.props.validateAddress}
+          EditView={this.props.EditView}
+          ContentView={this.props.ContentView}
         />
       );
     }

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
@@ -331,6 +331,7 @@ class ContactInformationField extends React.Component {
           onCancel={this.onCancel}
           onChangeFormDataAndSchemas={this.onChangeFormDataAndSchemas}
           onDelete={this.onDelete}
+          title={this.props.title}
           onEdit={this.onEdit}
           onSubmit={this.onSubmit}
           showEditView={this.props.showEditView}

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
@@ -327,7 +327,29 @@ class ContactInformationField extends React.Component {
       content = (
         <EditView
           refreshTransaction={this.refreshTransaction}
-          {...childProps}
+          analyticsSectionName={this.props.analyticsSectionName}
+          apiRoute={this.props.apiRoute}
+          blockEditMode={this.props.blockEditMode}
+          clearErrors={this.clearErrors}
+          clearTransactionRequest={this.props.clearTransactionRequest}
+          convertCleanDataToPayLoad={this.props.convertCleanDataToPayLoad}
+          createTransaction={this.props.createTransaction}
+          data={this.props.data}
+          field={this.props.field}
+          fieldName={this.props.fieldName}
+          formSchema={this.props.formSchema}
+          hasUnsavedEdits={this.props.hasUnsavedEdits}
+          isEmpty={this.props.isEmpty}
+          onCancel={this.onCancel}
+          onChangeFormDataAndSchemas={this.onChangeFormDataAndSchemas}
+          onDelete={this.onDelete}
+          onEdit={this.onEdit}
+          onSubmit={this.onSubmit}
+          showEditView={this.props.showEditView}
+          transaction={this.props.transaction}
+          transactionRequest={this.props.transactionRequest}
+          uiSchema={this.props.uiSchema}
+          validateAddress={this.props.validateAddress}
         />
       );
     }

--- a/src/applications/personalization/profile/components/personal-information/addresses/AddressEditView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/addresses/AddressEditView.jsx
@@ -116,6 +116,8 @@ class AddressEditView extends React.Component {
         transaction={this.props.transaction}
         transactionRequest={this.props.transactionRequest}
         uiSchema={this.props.uiSchema}
+        EditView={this.props.EditView}
+        ContentView={this.props.ContentView}
       />
     );
   }

--- a/src/applications/personalization/profile/components/personal-information/addresses/AddressEditView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/addresses/AddressEditView.jsx
@@ -99,6 +99,7 @@ class AddressEditView extends React.Component {
       <ContactInformationEditView
         analyticsSectionName={this.props.analyticsSectionName}
         clearErrors={this.props.clearErrors}
+        hasUnsavedEdits={this.props.hasUnsavedEdits}
         deleteDisabled={this.props.deleteDisabled}
         field={this.props.field}
         formSchema={this.props.formSchema}

--- a/src/applications/personalization/profile/components/personal-information/addresses/AddressEditView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/addresses/AddressEditView.jsx
@@ -99,11 +99,11 @@ class AddressEditView extends React.Component {
       <ContactInformationEditView
         analyticsSectionName={this.props.analyticsSectionName}
         clearErrors={this.props.clearErrors}
-        hasUnsavedEdits={this.props.hasUnsavedEdits}
         deleteDisabled={this.props.deleteDisabled}
         field={this.props.field}
         formSchema={this.props.formSchema}
         getInitialFormValues={this.getInitialFormValues}
+        hasUnsavedEdits={this.props.hasUnsavedEdits}
         hasValidationError={this.props.hasValidationError}
         isEmpty={this.props.isEmpty}
         onCancel={this.props.onCancel}

--- a/src/applications/personalization/profile/components/personal-information/addresses/AddressEditView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/addresses/AddressEditView.jsx
@@ -97,9 +97,24 @@ class AddressEditView extends React.Component {
   render() {
     return (
       <ContactInformationEditView
+        analyticsSectionName={this.props.analyticsSectionName}
+        clearErrors={this.props.clearErrors}
+        deleteDisabled={this.props.deleteDisabled}
+        field={this.props.field}
+        formSchema={this.props.formSchema}
         getInitialFormValues={this.getInitialFormValues}
+        hasValidationError={this.props.hasValidationError}
+        isEmpty={this.props.isEmpty}
+        onCancel={this.props.onCancel}
+        onChangeFormDataAndSchemas={this.props.onChangeFormDataAndSchemas}
+        onDelete={this.props.onDelete}
+        onSubmit={this.props.onSubmit}
+        refreshTransaction={this.props.refreshTransaction}
         render={this.renderForm}
-        {...this.props}
+        title={this.props.title}
+        transaction={this.props.transaction}
+        transactionRequest={this.props.transactionRequest}
+        uiSchema={this.props.uiSchema}
       />
     );
   }

--- a/src/applications/personalization/profile/components/personal-information/email-addresses/EmailEditView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/email-addresses/EmailEditView.jsx
@@ -25,9 +25,24 @@ class EmailEditView extends React.Component {
   render() {
     return (
       <ContactInformationEditView
-        {...this.props}
+        analyticsSectionName={this.props.analyticsSectionName}
+        clearErrors={this.props.clearErrors}
+        deleteDisabled={this.props.deleteDisabled}
+        field={this.props.field}
+        formSchema={this.props.formSchema}
         getInitialFormValues={this.getInitialFormValues}
+        hasValidationError={this.props.hasValidationError}
+        isEmpty={this.props.isEmpty}
+        onCancel={this.props.onCancel}
+        onChangeFormDataAndSchemas={this.props.onChangeFormDataAndSchemas}
+        onDelete={this.props.onDelete}
+        onSubmit={this.props.onSubmit}
+        refreshTransaction={this.props.refreshTransaction}
         render={this.renderForm}
+        title={this.props.title}
+        transaction={this.props.transaction}
+        transactionRequest={this.props.transactionRequest}
+        uiSchema={this.props.uiSchema}
       />
     );
   }

--- a/src/applications/personalization/profile/components/personal-information/email-addresses/EmailEditView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/email-addresses/EmailEditView.jsx
@@ -31,6 +31,7 @@ class EmailEditView extends React.Component {
         field={this.props.field}
         formSchema={this.props.formSchema}
         getInitialFormValues={this.getInitialFormValues}
+        hasUnsavedEdits={this.props.hasUnsavedEdits}
         hasValidationError={this.props.hasValidationError}
         isEmpty={this.props.isEmpty}
         onCancel={this.props.onCancel}

--- a/src/applications/personalization/profile/components/personal-information/phone-numbers/PhoneEditView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/phone-numbers/PhoneEditView.jsx
@@ -55,9 +55,12 @@ class PhoneEditView extends React.Component {
       <ContactInformationEditView
         analyticsSectionName={this.props.analyticsSectionName}
         clearErrors={this.props.clearErrors}
+        deleteDisabled={this.props.deleteDisabled}
         field={this.props.field}
         formSchema={this.props.formSchema}
         getInitialFormValues={this.getInitialFormValues}
+        hasUnsavedEdits={this.props.hasUnsavedEdits}
+        hasValidationError={this.props.hasValidationError}
         isEmpty={this.props.isEmpty}
         onCancel={this.props.onCancel}
         onChangeFormDataAndSchemas={this.props.onChangeFormDataAndSchemas}
@@ -68,7 +71,6 @@ class PhoneEditView extends React.Component {
         title={this.props.title}
         transaction={this.props.transaction}
         transactionRequest={this.props.transactionRequest}
-        type="phone"
         uiSchema={this.props.uiSchema}
       />
     );

--- a/src/applications/personalization/profile/components/personal-information/phone-numbers/PhoneEditView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/phone-numbers/PhoneEditView.jsx
@@ -53,9 +53,23 @@ class PhoneEditView extends React.Component {
   render() {
     return (
       <ContactInformationEditView
-        {...this.props}
+        analyticsSectionName={this.props.analyticsSectionName}
+        clearErrors={this.props.clearErrors}
+        field={this.props.field}
+        formSchema={this.props.formSchema}
         getInitialFormValues={this.getInitialFormValues}
+        isEmpty={this.props.isEmpty}
+        onCancel={this.props.onCancel}
+        onChangeFormDataAndSchemas={this.props.onChangeFormDataAndSchemas}
+        onDelete={this.props.onDelete}
+        onSubmit={this.props.onSubmit}
+        refreshTransaction={this.props.refreshTransaction}
         render={this.renderForm}
+        title={this.props.title}
+        transaction={this.props.transaction}
+        transactionRequest={this.props.transactionRequest}
+        type="phone"
+        uiSchema={this.props.uiSchema}
       />
     );
   }

--- a/src/applications/personalization/profile/tests/components/ContactInformationField.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/ContactInformationField.unit.spec.jsx
@@ -94,12 +94,6 @@ describe('<ContactInformationField/>', () => {
 
     component.find('EditView').dive();
     expect(props.EditView.called).to.be.true;
-
-    const args = props.EditView.getCall(0).args[0];
-    expect(
-      args,
-      'All props were passed to the EditView constructor',
-    ).to.have.all.keys(Object.keys(props));
     component.unmount();
   });
 


### PR DESCRIPTION
This is **PR 2** of a list of a yet undetermined length of PRs to clean up contact information components.

[First PR](https://github.com/department-of-veterans-affairs/vets-website/pull/15224) 

## Background
There are quite a few opportunities to make our Profile code more readable and maintainable. We should take some time to invest in cleaning up code where we can, since this will make it easier to debug and update our existing code - saving us time in the long run and make us more efficient on the frontend.

We are passing in a large number of props to child components that are not used down the component chain. Using prop spreading, it is also very unclear what props the component actually _needs_.

- We need to remove `{...this.props}` and explicitly pass needed props to `ContactInformationEditView`
- We need to remove `{...this.props}` in `childProps` and explicitly pass props in `ContactInformationField`

This PR is not yet responsible for weeding out unused props in the address components, and a follow-up PR will also be created to minimize the number of props passed down the component chain even further.

## Testing done
All seems to work well locally.

## Screenshots


## Acceptance criteria
- [x] Remove `{...this.props}`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
