### PR TITLE
Fix validation error in health_care_local_facility nodes

### DIFF
--- a/src/site/stages/build/process-cms-exports/schemas/input/node-health_care_local_facility.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/node-health_care_local_facility.js
@@ -39,7 +39,7 @@ module.exports = {
             },
             required: ['0', '1', '2', '3', '4', '5', '6', 'caption'],
           },
-          format: { type: 'null' }, // Only ever seen it as null
+          format: { type: ['string', 'null'] },
           caption: { type: ['string', 'null'] },
         },
         required: ['value', 'format', 'caption'],


### PR DESCRIPTION
## Description

Fixes this error:
```
Transforming CMS export
node.e15ebe41-f7cf-4f2c-a407-3728c341220b (node-health_care_local_facility) is invalid before transformation:
{
  "keyword": "type",
  "dataPath": ".field_facility_hours[0].format",
  "schemaPath": "#/properties/field_facility_hours/items/properties/format/type",
  "params": {
    "type": "null"
  },
  "message": "should be null"
}
Data found at .field_facility_hours[0].format: "plain_text"
```

## Testing done
Run cms-export build

## Acceptance criteria
- [x] cms-export build works again

