### PR TITLE
Use the standard SSN form definition

### DIFF
--- a/src/applications/coronavirus-vaccination/config/uiSchema.js
+++ b/src/applications/coronavirus-vaccination/config/uiSchema.js
@@ -1,6 +1,8 @@
 import PhoneNumberWidget from 'platform/forms-system/src/js/widgets/PhoneNumberWidget';
 // import SelectFacilityWidget from '../components/SelectFacilityWidget';
 
+import ssnUiSchema from 'platform/forms-system/src/js/definitions/ssn';
+
 export default {
   isIdentityVerified: {
     'ui:options': {
@@ -27,13 +29,10 @@ export default {
     },
   },
   ssn: {
-    'ui:title': 'Social Security Number (SSN)',
-    'ui:errorMessages': {
-      required: 'Please enter your social security number.',
-      pattern: 'Please enter a valid social security number.',
-    },
+    ...ssnUiSchema,
     'ui:required': formData => !formData.isIdentityVerified,
     'ui:options': {
+      ...ssnUiSchema['ui:options'],
       hideIf: formData => formData.isIdentityVerified,
     },
   },


### PR DESCRIPTION
## Description
This PR switches the COVID vaccination form's SSN input to use the form system's SSN UI definition.

## Testing done
Played with the input locally

## Screenshots
The input is a little smaller and it allows slashes. No masking though.

![image](https://user-images.githubusercontent.com/1915775/101499710-932d3800-393b-11eb-9513-a5fac5481480.png)



## Acceptance criteria
- [ ]  SSN input is the forms system standard

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
