### PR TITLE
App directory accessibility updates

### DIFF
--- a/src/applications/third-party-app-directory/components/SearchResult/index.jsx
+++ b/src/applications/third-party-app-directory/components/SearchResult/index.jsx
@@ -49,10 +49,7 @@ export class SearchResult extends Component {
     };
 
     return (
-      <li
-        aria-live="polite"
-        className="third-party-app vads-u-display--flex vads-u-flex-direction--column vads-u-margin-bottom--2 vads-u-padding--3 vads-u-border-color--gray-lightest vads-u-border--2px"
-      >
+      <li className="third-party-app vads-u-display--flex vads-u-flex-direction--column vads-u-margin-bottom--2 vads-u-padding--3 vads-u-border-color--gray-lightest vads-u-border--2px">
         <div className="vads-u-display--flex vads-u-align-items--center vads-u-justify-content--space-between">
           {/* App Icon */}
           <img alt={`${item?.name} icon`} src={item?.logo_url} />

--- a/src/applications/third-party-app-directory/components/SearchResult/index.jsx
+++ b/src/applications/third-party-app-directory/components/SearchResult/index.jsx
@@ -49,7 +49,10 @@ export class SearchResult extends Component {
     };
 
     return (
-      <li className="third-party-app vads-u-display--flex vads-u-flex-direction--column vads-u-margin-bottom--2 vads-u-padding--3 vads-u-border-color--gray-lightest vads-u-border--2px">
+      <li
+        aria-live="polite"
+        className="third-party-app vads-u-display--flex vads-u-flex-direction--column vads-u-margin-bottom--2 vads-u-padding--3 vads-u-border-color--gray-lightest vads-u-border--2px"
+      >
         <div className="vads-u-display--flex vads-u-align-items--center vads-u-justify-content--space-between">
           {/* App Icon */}
           <img alt={`${item?.name} icon`} src={item?.logo_url} />
@@ -104,7 +107,7 @@ export class SearchResult extends Component {
           </button>
         </div>
         {show && (
-          <>
+          <div>
             <hr aria-hidden="true" />
 
             {/* Description */}
@@ -117,28 +120,28 @@ export class SearchResult extends Component {
 
             {/* Legal Links */}
             <a
-              className="vads-u-margin-top--2"
+              className="vads-u-margin-top--3 vads-u-display--block"
               href={item?.privacy_url}
               rel="noopener noreferrer"
               target="_blank"
             >
-              View the privacy policy
+              {`View the ${item.name} privacy policy`}
             </a>
             <a
-              className="vads-u-margin-top--1"
+              className="vads-u-margin-top--1 vads-u-display--block"
               href={item?.tos_url}
               rel="noopener noreferrer"
               target="_blank"
             >
-              View terms of service
+              {`View the ${item.name} terms of service`}
             </a>
             <a
-              className="vads-u-margin-top--1"
+              className="vads-u-margin-top--1  vads-u-margin-bottom--1 vads-u-display--block"
               href={`mailto:api@va.gov?subject=Report ${item?.name} to VA`}
               rel="noopener noreferrer"
               target="_blank"
             >
-              Report this app to VA
+              {`Report ${item.name} to VA`}
             </a>
 
             {/* Permissions */}
@@ -148,7 +151,10 @@ export class SearchResult extends Component {
                   {item?.name} may request access to your VA information,
                   including:
                 </h3>
-                <ul className="vads-u-margin--0 vads-u-margin-top--1 vads-u-padding-left--2p5">
+                <ul
+                  aria-label={`${item.name} - potential data requests`}
+                  className="vads-u-margin--0 vads-u-margin-top--2 vads-u-padding-left--2p5"
+                >
                   {reduce(
                     item?.service_categories,
                     (allPermissions, scope) => {
@@ -167,7 +173,7 @@ export class SearchResult extends Component {
                 </ul>
               </>
             )}
-          </>
+          </div>
         )}
       </li>
     );


### PR DESCRIPTION
## Description

This PR resolves the remaining accessibility issues found in the VSP staging review.

[JIRA ticket](https://vajira.max.gov/browse/API-3735)

The following tickets are addressed:

- Add context (app name) to similar links: [16450](https://github.com/department-of-veterans-affairs/va.gov-team/issues/16450)
- Expanded content screen reader issues: [16464](https://github.com/department-of-veterans-affairs/va.gov-team/issues/16464)
- aria labels for nested lists: [16702](https://github.com/department-of-veterans-affairs/va.gov-team/issues/16702)


## Testing done

- local testing on chrome, firefox, and ie11
- axe/coconut extension scans


## Screenshots

Small content update to legal links to add context for similar links. Links have been updated from a generic `View the privacy policy` to `View the App Name privacy policy`.

<img width="648" alt="Screen Shot 2020-12-08 at 8 10 39 AM" src="https://user-images.githubusercontent.com/9746156/101508993-257a0f80-392d-11eb-8b34-04fc916b946a.png">




## Acceptance criteria
- [x] 0 axe scan violations

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
