### PR TITLE
add reusable yarn-install-cache command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,30 @@
 version: 2.1
 
+commands:
+  yarn-install-cache:
+    description: "Install packages with yarn using saved cache"
+    parameters:
+      key-prefix:
+        type: string
+        default: yarn-packages
+    steps:
+      - restore_cache:
+          keys:
+            - << parameters.key-prefix >>-{{ checksum "yarn.lock" }}
+      - run:
+          command: yarn install --frozen-lockfile
+      - save_cache:
+          key: << parameters.key-prefix >>-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache/yarn
+
 jobs:
   lint:
     docker:
       - image: circleci/node:14.15.0
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - yarn-packages-{{ checksum "yarn.lock" }}
-      - run:
-          command: yarn install --frozen-lockfile
-      - save_cache:
-          key: yarn-packages-{{ checksum "yarn.lock" }}
-          paths:
-            - ~/.cache/yarn
+      - yarn-install-cache
       - run: mkdir -p ./test-results
       - run: npx eslint --ext .js --ext .jsx --format junit --output-file ./test-results/eslint.xml .
       - run: yarn lint:sass
@@ -28,15 +38,7 @@ jobs:
       - image: circleci/node:14.15.0
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - yarn-packages-{{ checksum "yarn.lock" }}
-      - run:
-          command: yarn install --frozen-lockfile
-      - save_cache:
-          key: yarn-packages-{{ checksum "yarn.lock" }}
-          paths:
-            - ~/.cache/yarn
+      - yarn-install-cache
       - run: mkdir -p ./test-results
       - run:
           command: yarn test:unit --coverage
@@ -53,14 +55,7 @@ jobs:
       - image: circleci/node:14.15.0
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - yarn-packages-{{ checksum "yarn.lock" }}
-      - run: yarn install --frozen-lockfile
-      - save_cache:
-          key: yarn-packages-{{ checksum "yarn.lock" }}
-          paths:
-            - ~/.cache/yarn
+      - yarn-install-cache
       - run: mkdir -p ./test-results
       - run: mkdir -p ./pacts
       - run:
@@ -84,14 +79,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - restore_cache:
-          keys:
-            - yarn-packages-{{ checksum "yarn.lock" }}
-      - run: yarn install --frozen-lockfile
-      - save_cache:
-          key: yarn-packages-{{ checksum "yarn.lock" }}
-          paths:
-            - ~/.cache/yarn
+      - yarn-install-cache
       - run: yarn pact:verify
       - run: yarn pact:can-i-deploy
 
@@ -107,15 +95,7 @@ jobs:
       - image: circleci/node:14.15.0
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - yarn-packages-{{ checksum "yarn.lock" }}
-      - run:
-          command: yarn install --frozen-lockfile
-      - save_cache:
-          key: yarn-packages-{{ checksum "yarn.lock" }}
-          paths:
-            - ~/.cache/yarn
+      - yarn-install-cache
       - run: npm run lint:circle
 
   build:
@@ -123,15 +103,7 @@ jobs:
       - image: circleci/node:14.15.0
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - yarn-packages-{{ checksum "yarn.lock" }}
-      - run:
-          command: yarn install --frozen-lockfile
-      - save_cache:
-          key: yarn-packages-{{ checksum "yarn.lock" }}
-          paths:
-            - ~/.cache/yarn
+      - yarn-install-cache
       - run: yarn build:webpack
 
   eslint-check:


### PR DESCRIPTION
## Description
reference: https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-commands

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
