### PR TITLE
[15990] Community Care preference list analytics

### DIFF
--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
@@ -267,13 +267,16 @@ function ProviderSelectionField({
                         <button
                           type="button"
                           onClick={() => {
-                            onChange(
-                              communityCareProviderList.find(
-                                p => p.id === checkedProvider,
-                              ),
+                            const providerIndex = communityCareProviderList.findIndex(
+                              p => p.id === checkedProvider,
                             );
+                            onChange(communityCareProviderList[providerIndex]);
                             setCheckedProvider();
                             setShowProvidersList(false);
+                            recordEvent({
+                              event: 'vaos-order-position-provider-selection',
+                              providerPosition: providerIndex,
+                            });
                           }}
                         >
                           Choose provider

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
@@ -271,7 +271,6 @@ function ProviderSelectionField({
                         <button
                           type="button"
                           onClick={() => {
-                            onChange(communityCareProviderList[providerIndex]);
                             onChange(provider);
                             setCheckedProvider();
                             setShowProvidersList(false);

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
@@ -273,7 +273,7 @@ function ProviderSelectionField({
                             setShowProvidersList(false);
                             recordEvent({
                               event: `${GA_PREFIX}-order-position-provider-selection`,
-                              providerPosition: providerIndex,
+                              providerPosition: providerIndex + 1,
                             });
                           }}
                         >

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
@@ -9,6 +9,7 @@ import { distanceBetween } from '../../../utils/address';
 import { scrollAndFocus } from '../../../utils/scrollAndFocus';
 import ErrorMessage from '../../../components/ErrorMessage';
 import RemoveProviderModal from './RemoveProviderModal';
+import recordEvent from 'platform/monitoring/record-event';
 
 const INITIAL_PROVIDER_DISPLAY_COUNT = 5;
 
@@ -91,7 +92,10 @@ function ProviderSelectionField({
           <button
             className="va-button-link"
             type="button"
-            onClick={() => setShowProvidersList(true)}
+            onClick={() => {
+              setShowProvidersList(true);
+              recordEvent({ event: 'vaos-choose-provider-click' });
+            }}
           >
             <i className="fas fa-plus vads-u-padding-right--0p5" />
             Choose a provider
@@ -294,9 +298,10 @@ function ProviderSelectionField({
                 <button
                   type="button"
                   className="additional-info-button va-button-link vads-u-display--block vads-u-margin-right--2"
-                  onClick={() =>
-                    setProvidersListLength(providersListLength + 5)
-                  }
+                  onClick={() => {
+                    setProvidersListLength(providersListLength + 5);
+                    recordEvent({ event: 'vaos-provider-list-paginate' });
+                  }}
                 >
                   <span className="va-button-link">
                     +{' '}

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
@@ -3,8 +3,11 @@ import { selectProviderSelectionInfo } from '../../../utils/selectors';
 import ResidentialAddress from '../../../components/ResidentialAddress';
 import { connect } from 'react-redux';
 import * as actions from '../../redux/actions';
-import { FETCH_STATUS, FACILITY_SORT_METHODS } from '../../../utils/constants';
-import { FETCH_STATUS, GA_PREFIX } from '../../../utils/constants';
+import {
+  FETCH_STATUS,
+  FACILITY_SORT_METHODS,
+  GA_PREFIX,
+} from '../../../utils/constants';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import { distanceBetween } from '../../../utils/address';
 import { scrollAndFocus } from '../../../utils/scrollAndFocus';
@@ -235,7 +238,7 @@ function ProviderSelectionField({
                   Displaying 1 to {currentlyShownProvidersList.length} of{' '}
                   {communityCareProviderList.length} providers
                 </p>
-                {currentlyShownProvidersList.map(provider => {
+                {currentlyShownProvidersList.map((provider, providerIndex) => {
                   const { name } = provider;
                   const checked = provider.id === checkedProvider;
                   return (
@@ -268,6 +271,7 @@ function ProviderSelectionField({
                         <button
                           type="button"
                           onClick={() => {
+                            onChange(communityCareProviderList[providerIndex]);
                             onChange(provider);
                             setCheckedProvider();
                             setShowProvidersList(false);

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
@@ -4,6 +4,7 @@ import ResidentialAddress from '../../../components/ResidentialAddress';
 import { connect } from 'react-redux';
 import * as actions from '../../redux/actions';
 import { FETCH_STATUS, FACILITY_SORT_METHODS } from '../../../utils/constants';
+import { FETCH_STATUS, GA_PREFIX } from '../../../utils/constants';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import { distanceBetween } from '../../../utils/address';
 import { scrollAndFocus } from '../../../utils/scrollAndFocus';
@@ -94,7 +95,7 @@ function ProviderSelectionField({
             type="button"
             onClick={() => {
               setShowProvidersList(true);
-              recordEvent({ event: 'vaos-choose-provider-click' });
+              recordEvent({ event: `${GA_PREFIX}-choose-provider-click` });
             }}
           >
             <i className="fas fa-plus vads-u-padding-right--0p5" />
@@ -267,14 +268,11 @@ function ProviderSelectionField({
                         <button
                           type="button"
                           onClick={() => {
-                            const providerIndex = communityCareProviderList.findIndex(
-                              p => p.id === checkedProvider,
-                            );
-                            onChange(communityCareProviderList[providerIndex]);
+                            onChange(provider);
                             setCheckedProvider();
                             setShowProvidersList(false);
                             recordEvent({
-                              event: 'vaos-order-position-provider-selection',
+                              event: `${GA_PREFIX}-order-position-provider-selection`,
                               providerPosition: providerIndex,
                             });
                           }}
@@ -303,7 +301,9 @@ function ProviderSelectionField({
                   className="additional-info-button va-button-link vads-u-display--block vads-u-margin-right--2"
                   onClick={() => {
                     setProvidersListLength(providersListLength + 5);
-                    recordEvent({ event: 'vaos-provider-list-paginate' });
+                    recordEvent({
+                      event: `${GA_PREFIX}-provider-list-paginate`,
+                    });
                   }}
                 >
                   <span className="va-button-link">

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/index.jsx
@@ -3,7 +3,7 @@ import { useHistory } from 'react-router-dom';
 import { connect } from 'react-redux';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import FormButtons from '../../../components/FormButtons';
-import { LANGUAGES } from '../../../utils/constants';
+import { GA_PREFIX, LANGUAGES } from '../../../utils/constants';
 import * as actions from '../../redux/actions';
 import { getFormPageInfo } from '../../../utils/selectors';
 import { scrollAndFocus } from '../../../utils/scrollAndFocus';
@@ -85,8 +85,8 @@ function CommunityCareProviderSelectionPage({
             recordEvent({
               event:
                 Object.keys(data.communityCareProvider).length === 0
-                  ? 'vaos-continue-without-provider '
-                  : 'vaos-continue-with-provider',
+                  ? `${GA_PREFIX}-continue-without-provider`
+                  : `${GA_PREFIX}-continue-with-provider`,
             });
             routeToNextAppointmentPage(history, pageKey);
           }}

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/index.jsx
@@ -8,6 +8,7 @@ import * as actions from '../../redux/actions';
 import { getFormPageInfo } from '../../../utils/selectors';
 import { scrollAndFocus } from '../../../utils/scrollAndFocus';
 import ProviderSelectionField from './ProviderSelectionField';
+import recordEvent from 'platform/monitoring/record-event';
 
 const initialSchema = {
   type: 'object',
@@ -80,8 +81,18 @@ function CommunityCareProviderSelectionPage({
           title="Community Care preferences"
           schema={schema}
           uiSchema={uiSchema}
-          onSubmit={() => routeToNextAppointmentPage(history, pageKey)}
-          onChange={newData => updateFormData(pageKey, uiSchema, newData)}
+          onSubmit={() => {
+            recordEvent({
+              event:
+                Object.keys(data.communityCareProvider).length === 0
+                  ? 'vaos-continue-without-provider '
+                  : 'vaos-continue-with-provider',
+            });
+            routeToNextAppointmentPage(history, pageKey);
+          }}
+          onChange={newData => {
+            updateFormData(pageKey, uiSchema, newData);
+          }}
           data={data}
         >
           <FormButtons

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
@@ -21,7 +21,6 @@ import {
 import CommunityCareProviderSelectionPage from '../../../../new-appointment/components/CommunityCareProviderSelectionPage';
 import { calculateBoundingBox } from '../../../../utils/address';
 import { CC_PROVIDERS_DATA } from './cc_providers_data';
-import { fireEvent } from '@testing-library/dom';
 import { GA_PREFIX } from '../../../../utils/constants';
 
 const initialState = {
@@ -131,10 +130,12 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
       /do you prefer that your community care provider speak a certain language?/i,
     );
 
-    fireEvent.change(languageSelect, { target: { value: 'english' } });
+    userEvent.selectOptions(languageSelect, ['english']);
     userEvent.click(screen.getByText(/Continue/i));
-    expect(global.window.dataLayer[2].event).to.equal(
-      `${GA_PREFIX}-continue-without-provider`,
+    expect(
+      global.window.dataLayer.some(
+        e => e === `${GA_PREFIX}-continue-without-provider`,
+      ),
     );
     expect(screen.history.push.called).to.be.true;
 
@@ -144,13 +145,20 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
     userEvent.click(
       await screen.getByRole('button', { name: /choose provider/i }),
     );
+    expect(
+      global.window.dataLayer.some(
+        e => e === `${GA_PREFIX}-order-position-provider-selection`,
+      ),
+    );
     expect(await screen.baseElement).to.contain.text(
       'AJADI, ADEDIWURA700 CONSTITUTION AVE NEWASHINGTON, DC 20002-65999349.3 miles',
     );
 
     userEvent.click(screen.getByText(/Continue/i));
-    expect(global.window.dataLayer[5].event).to.equal(
-      `${GA_PREFIX}-continue-with-provider`,
+    expect(
+      global.window.dataLayer.some(
+        e => e === `${GA_PREFIX}-continue-with-provider`,
+      ),
     );
     expect(screen.history.push.called).to.be.true;
   });

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
@@ -141,7 +141,7 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
 
     // Continue with filling in required fields with provider
     userEvent.click(await screen.findByText(/Choose a provider/i));
-    userEvent.click(await screen.findByText(/AJADI, ADEDIWURA/i));
+    userEvent.click(await screen.findByText(/OH, JANICE/i));
     userEvent.click(
       await screen.getByRole('button', { name: /choose provider/i }),
     );
@@ -151,7 +151,7 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
       ),
     );
     expect(await screen.baseElement).to.contain.text(
-      'AJADI, ADEDIWURA700 CONSTITUTION AVE NEWASHINGTON, DC 20002-65999349.3 miles',
+      'OH, JANICE7700 LITTLE RIVER TPKE STE 102ANNANDALE, VA 22003-24009342.6 miles',
     );
 
     userEvent.click(screen.getByText(/Continue/i));


### PR DESCRIPTION
## Description
Add tracking events to new preferred community care provider list page

- [x]  Track order position of provider selection `vaos-order-position-provider-selection`
- [x]  Track provider list pagination clicks `vaos-provider-list-paginate`
- [x]  Track # of "Choose a provider" clicks per user session `vaos-choose-provider-click`
- [x]  Track continue with no provider selected (similar to current page) `vaos-continue-without-provider `
- [x]  Track continue with provider selected (similar to current page) `vaos-continue-with-provider`

## Testing done
Local, Unit, and Network call observations

## Screenshots
n/a

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
