### PR TITLE
Record mysterious address validation errors with Sentry

### DIFF
--- a/src/platform/user/profile/vap-svc/actions/transactions.js
+++ b/src/platform/user/profile/vap-svc/actions/transactions.js
@@ -321,7 +321,11 @@ export const validateAddress = (
     const errorCode = error.errors?.[0]?.code;
     const errorStatus = error.errors?.[0]?.status;
     if (!errorCode || !errorStatus) {
-      Sentry.captureException(error);
+      if (error instanceof Error) {
+        Sentry.captureException(error);
+      } else {
+        Sentry.captureException(new Error('Unknown address validation error'));
+      }
     }
     recordEvent({
       event: 'profile-edit-failure',

--- a/src/platform/user/profile/vap-svc/actions/transactions.js
+++ b/src/platform/user/profile/vap-svc/actions/transactions.js
@@ -1,3 +1,5 @@
+import * as Sentry from '@sentry/browser';
+
 import { apiRequest } from '~/platform/utilities/api';
 import { refreshProfile } from '~/platform/user/profile/actions';
 import recordEvent from '~/platform/monitoring/record-event';
@@ -316,13 +318,16 @@ export const validateAddress = (
       ),
     );
   } catch (error) {
+    const errorCode = error.errors?.[0]?.code;
+    const errorStatus = error.errors?.[0]?.status;
+    if (!errorCode || !errorStatus) {
+      Sentry.captureException(error);
+    }
     recordEvent({
       event: 'profile-edit-failure',
       'profile-action': 'address-suggestion-failure',
       'profile-section': analyticsSectionName,
-      'error-key': `${error.errors?.[0]?.code}_${
-        error.errors?.[0]?.status
-      }-address-suggestion-failure`,
+      'error-key': `${errorCode}_${errorStatus}-address-suggestion-failure`,
     });
 
     recordEvent({


### PR DESCRIPTION
## Description
We're seeing a fair amount of entries in Google Analytics where the `code` and `key` values we drill down to are `undefined`, which is rather unexpected. This PR will log the entire error object to Sentry if either of those values if `undefined`.

## Testing done


## Screenshots
We'd like to get more info about the error object that generates these events in GA:
![image](https://user-images.githubusercontent.com/20728956/101554506-9dffc100-396b-11eb-83e8-ceaa9c3495c5.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs