### PR TITLE
[COVID vaccine] Adjust app width on mobile

### DIFF
--- a/src/applications/coronavirus-vaccination/components/Layout.jsx
+++ b/src/applications/coronavirus-vaccination/components/Layout.jsx
@@ -8,7 +8,7 @@ function Layout({ isProfileLoading, children }) {
   return (
     <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2p5">
       <div className="vads-l-row">
-        <div className="vads-l-col--8">
+        <div className="vads-l-col--12 large-screen:vads-l-col--8">
           {isProfileLoading ? (
             <LoadingIndicator message="Loading your profile..." />
           ) : (

--- a/src/applications/coronavirus-vaccination/config/uiSchema.js
+++ b/src/applications/coronavirus-vaccination/config/uiSchema.js
@@ -67,10 +67,6 @@ export default {
     'ui:errorMessages': {
       required: 'Please select an answer.',
     },
-    'ui:options': {
-      // hideIf: formData => !formData.zipCode,
-      expandUnder: 'zipCode',
-    },
   },
   vaccineInterest: {
     'ui:title': 'Are you interested in getting a COVID-19 vaccine at VA?',


### PR DESCRIPTION
## Description
The layout was too skinny on mobile because the grid wasn't using a responsive prefix. This fixes that issue to use 100% width on mobile.

## Testing done
Confirmed visually

## Screenshots
Fixed
![image](https://user-images.githubusercontent.com/1915775/101556622-46704e00-3989-11eb-8517-ee18c28cb80f.png)


## Acceptance criteria
- [ ] App width is 100 on small screens

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
