### PR TITLE
Encode URLs used in Pact Broker operations

### DIFF
--- a/src/platform/testing/contract/client.js
+++ b/src/platform/testing/contract/client.js
@@ -149,7 +149,7 @@ module.exports = class PactBrokerClient {
         this.url,
         `pacticipants/${consumer}`,
         `versions/${version}`,
-        `tags/${tag}`,
+        `tags/${encodeURIComponent(tag)}`,
       ),
     );
 

--- a/src/platform/testing/contract/client.js
+++ b/src/platform/testing/contract/client.js
@@ -54,7 +54,7 @@ const generateBasicAuthHeader = (username, password) => ({
  * @param {string} url - String to be validated as URL.
  * @return {string} URL that's been validated and cast to string.
  */
-const urlString = url => new URL(url).toString();
+const urlString = url => new URL(encodeURI(url)).toString();
 
 /**
  * Client that interacts with a Pact Broker.
@@ -99,15 +99,15 @@ module.exports = class PactBrokerClient {
    */
   publishPact = async pactObject => {
     const { data, version } = pactObject;
-    const consumer = encodeURIComponent(data.consumer.name);
-    const provider = encodeURIComponent(data.provider.name);
+    const consumer = data.consumer.name;
+    const provider = data.provider.name;
 
     const url = urlString(
       path.join(
         this.url,
         'pacts',
-        `provider/${provider}`,
-        `consumer/${consumer}`,
+        `provider/${encodeURIComponent(provider)}`,
+        `consumer/${encodeURIComponent(consumer)}`,
         `version/${version}`,
       ),
     );
@@ -142,16 +142,18 @@ module.exports = class PactBrokerClient {
    */
   tagPact = async pactObject => {
     const { data, version, tag } = pactObject;
-    const consumer = encodeURIComponent(data.consumer.name);
+    const consumer = data.consumer.name;
 
     const url = urlString(
       path.join(
         this.url,
-        `pacticipants/${consumer}`,
+        `pacticipants/${encodeURIComponent(consumer)}`,
         `versions/${version}`,
         `tags/${encodeURIComponent(tag)}`,
       ),
     );
+
+    console.log(url);
 
     const response = await fetch(url, {
       method: 'PUT',

--- a/src/platform/testing/contract/client.js
+++ b/src/platform/testing/contract/client.js
@@ -99,8 +99,8 @@ module.exports = class PactBrokerClient {
    */
   publishPact = async pactObject => {
     const { data, version } = pactObject;
-    const consumer = data.consumer.name;
-    const provider = data.provider.name;
+    const consumer = encodeURIComponent(data.consumer.name);
+    const provider = encodeURIComponent(data.provider.name);
 
     const url = urlString(
       path.join(
@@ -142,7 +142,7 @@ module.exports = class PactBrokerClient {
    */
   tagPact = async pactObject => {
     const { data, version, tag } = pactObject;
-    const consumer = data.consumer.name;
+    const consumer = encodeURIComponent(data.consumer.name);
 
     const url = urlString(
       path.join(


### PR DESCRIPTION
## Description
Encode all the things so URI reserved characters don't break Pact Broker operations.

## Testing done
Verified that pacts are able to be published and tagged under this branch, which includes a slash (a reserved character in URIs).

## Acceptance criteria
- [ ] Pacts should be able to be tagged using URI reserved characters.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
