### PR TITLE
[COVID vaccine] Fix a runtime error during the pre-fill

### DIFF
--- a/src/applications/coronavirus-vaccination/components/Form.jsx
+++ b/src/applications/coronavirus-vaccination/components/Form.jsx
@@ -64,7 +64,7 @@ function Form({ formState, updateFormData, router, isLoggedIn, profile }) {
           birthDate: profile?.dob,
           ssn: undefined,
           email: profile?.vapContactInfo?.email?.emailAddress,
-          zipCode: profile?.vapContactInfo?.residentialAddress.zipCode,
+          zipCode: profile?.vapContactInfo?.residentialAddress?.zipCode,
           phone: profile?.vapContactInfo?.homePhone
             ? `${profile.vapContactInfo.homePhone.areaCode}${
                 profile.vapContactInfo.homePhone.phoneNumber


### PR DESCRIPTION
## Description
This PR fixes a runtime error where residential address does't exist but we try to access the zipcode property.

## Testing done


## Screenshots
N/A

## Acceptance criteria
- [ ] Prefilling zipcode on a user w/o a residential address doesn't cause a runtime error

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
