### PR TITLE
bradl3yC - Remove prop to hide start button

### DIFF
--- a/src/applications/financial-status-report/containers/IntroductionPage.jsx
+++ b/src/applications/financial-status-report/containers/IntroductionPage.jsx
@@ -12,7 +12,6 @@ const IntroductionPage = props => {
       <SaveInProgressIntro
         startText="Apply for financial hardship assistance"
         unauthStartText="Sign in or create an account"
-        hideUnauthedStartLink
         prefillEnabled={props.route.formConfig.prefillEnabled}
         messages={props.route.formConfig.savedFormMessages}
         pageList={props.route.pageList}
@@ -70,7 +69,6 @@ const IntroductionPage = props => {
         pageList={props.route.pageList}
         startText="Apply for financial hardship assistance"
         unauthStartText="Sign in or create an account"
-        hideUnauthedStartLink
         prefillEnabled={props.route.formConfig.prefillEnabled}
         formConfig={formConfig}
       />


### PR DESCRIPTION
## Description
Link is now available to start form without being logged in

## Testing done


## Screenshots
![Screen Shot 2020-12-09 at 10 27 36 AM](https://user-images.githubusercontent.com/6165421/101649707-3304c780-3a09-11eb-91cf-913b8048fb1a.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
