### PR TITLE
[COVID vaccine] Various UI tweaks

### DIFF
--- a/src/applications/coronavirus-vaccination/components/Confirmation.jsx
+++ b/src/applications/coronavirus-vaccination/components/Confirmation.jsx
@@ -2,21 +2,24 @@ import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 
-function Confirmation({ router: _router, formData }) {
+import { focusElement } from 'platform/utilities/ui';
+
+function Confirmation({ router, formData }) {
   useEffect(() => {
+    focusElement('#covid-vaccination-heading-confirmation');
+
     if (!formData) {
       // Redirect to the homepage if there isn't any form data in state.
       // This is the case for direct navigation to "/confirmation/".
-      // @todo this next line is commented out only for visibility purposes,
-      // so we can see the content w/o submitting a new form
-      // we should uncomment it before launch.
-      // router.replace('/');
+      router.replace('/');
     }
-  });
+  }, []);
 
   return (
     <>
-      <h1>We've received your information</h1>
+      <h1 className="no-outline" id="covid-vaccination-heading-confirmation">
+        We've received your information
+      </h1>
       <p>
         Thank you for signing up to stay informed about COVID-19 vaccines at VA.
         When we have new information to share about our COVID-19 plans and your

--- a/src/applications/coronavirus-vaccination/components/Form.jsx
+++ b/src/applications/coronavirus-vaccination/components/Form.jsx
@@ -12,6 +12,7 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation-react/Lo
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import * as userSelectors from 'platform/user/selectors';
 import { requestStates } from 'platform/utilities/constants';
+import { focusElement } from 'platform/utilities/ui';
 
 import * as actions from '../actions';
 
@@ -22,6 +23,10 @@ import useSubmitForm from '../hooks/useSubmitForm';
 
 function Form({ formState, updateFormData, router, isLoggedIn, profile }) {
   const [submitStatus, submitToApi] = useSubmitForm();
+
+  useEffect(() => {
+    focusElement('#covid-vaccination-heading-form');
+  }, []);
 
   useEffect(
     () => {
@@ -96,18 +101,15 @@ function Form({ formState, updateFormData, router, isLoggedIn, profile }) {
     [router, formState],
   );
 
-  if (!formState) {
-    // The form is being initialized into Redux. Wait til next render.
-    return null;
-  }
-
   if (submitStatus === requestStates.pending) {
     return <LoadingIndicator message="Submitting your form..." />;
   }
 
   return (
     <>
-      <h1>Fill out the form below to sign up</h1>
+      <h1 id="covid-vaccination-heading-form" className="no-outline">
+        Fill out the form below to sign up
+      </h1>
       <p>
         We’ll send you regular updates on how we’re providing COVID-19 vaccines
         across the country—and when you can get your vaccine if you want one.
@@ -120,33 +122,37 @@ function Form({ formState, updateFormData, router, isLoggedIn, profile }) {
           accounts.
         </p>
       ) : null}
-      <SchemaForm
-        addNameAttribute
-        // "name" and "title" are used only internally to SchemaForm
-        name="Coronavirus vaccination"
-        title="Coronavirus vaccination"
-        data={formState.formData}
-        schema={formState.formSchema}
-        uiSchema={formState.uiSchema}
-        onChange={onFormChange}
-        onSubmit={onFormSubmit}
-      >
-        {submitStatus === requestStates.failed ? (
-          <div className="vads-u-margin-bottom-2">
-            <AlertBox
-              status={ALERT_TYPE.ERROR}
-              content="An error occurred while trying to save your form. Please try again later."
-            />
-          </div>
-        ) : null}
-        <button
-          type="submit"
-          className="usa-button"
-          aria-label="Sign up to stay informed about COVID-19 vaccines"
+      {formState ? (
+        <SchemaForm
+          addNameAttribute
+          // "name" and "title" are used only internally to SchemaForm
+          name="Coronavirus vaccination"
+          title="Coronavirus vaccination"
+          data={formState.formData}
+          schema={formState.formSchema}
+          uiSchema={formState.uiSchema}
+          onChange={onFormChange}
+          onSubmit={onFormSubmit}
         >
-          Sign up to stay informed
-        </button>
-      </SchemaForm>
+          {submitStatus === requestStates.failed ? (
+            <div className="vads-u-margin-bottom-2">
+              <AlertBox
+                status={ALERT_TYPE.ERROR}
+                content="An error occurred while trying to save your form. Please try again later."
+              />
+            </div>
+          ) : null}
+          <button
+            type="submit"
+            className="usa-button"
+            aria-label="Sign up to stay informed about COVID-19 vaccines"
+          >
+            Sign up to stay informed
+          </button>
+        </SchemaForm>
+      ) : (
+        <LoadingIndicator message="Loading the form..." />
+      )}
     </>
   );
 }

--- a/src/applications/coronavirus-vaccination/components/Form.jsx
+++ b/src/applications/coronavirus-vaccination/components/Form.jsx
@@ -107,7 +107,12 @@ function Form({ formState, updateFormData, router, isLoggedIn, profile }) {
 
   return (
     <>
-      <h1>COVID-19 vaccines — Stay informed and help us prepare</h1>
+      <h1>Fill out the form below to sign up</h1>
+      <p>
+        We’ll send you regular updates on how we’re providing COVID-19 vaccines
+        across the country—and when you can get your vaccine if you want one.
+        You don't need to sign up to get a vaccine.
+      </p>
       {isLoggedIn ? (
         <p>
           <strong>Note:</strong> Any changes you make to your information here
@@ -134,8 +139,12 @@ function Form({ formState, updateFormData, router, isLoggedIn, profile }) {
             />
           </div>
         ) : null}
-        <button type="submit" className="usa-button">
-          Submit
+        <button
+          type="submit"
+          className="usa-button"
+          aria-label="Sign up to stay informed about COVID-19 vaccines"
+        >
+          Sign up to stay informed
         </button>
       </SchemaForm>
     </>

--- a/src/applications/coronavirus-vaccination/style.scss
+++ b/src/applications/coronavirus-vaccination/style.scss
@@ -1,3 +1,7 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "../../platform/forms/sass/m-schemaform";
+
+.no-outline:focus {
+  outline: none;
+}


### PR DESCRIPTION
## Description
- Content tweaks per a11y feedback in https://github.com/department-of-veterans-affairs/va.gov-team/issues/17102
- Adds focus onto the H1s on the form and confirmation pages
- Adds back redirect during direct navigation to the confirmation page

## Testing done
Ran it all locally

## Screenshots
No visual diff

## Acceptance criteria
- [ ] Focus is correct
- [ ] a11y content updated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
