### PR TITLE
Add widget for COVID vaccine updates

### DIFF
--- a/src/applications/static-pages/covid-vaccine-updates-cta/Off.jsx
+++ b/src/applications/static-pages/covid-vaccine-updates-cta/Off.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import AlertBox, {
+  ALERT_TYPE,
+} from '@department-of-veterans-affairs/formation-react/AlertBox';
+
+export default function OffState() {
+  return (
+    <AlertBox
+      status={ALERT_TYPE.INFO}
+      headline="Check back soon for an easy way to stay informed and help us prepare"
+      content={
+        <>
+          <p>
+            We're creating an easy way for you to sign up to stay informed about
+            our COVID-19 vaccine plans.
+          </p>
+          <p>
+            When you sign up, we’ll also ask about your interest in getting a
+            vaccine when one is available to you. By sharing your interest, you
+            can help us better prepare as we work to offer vaccines to more
+            Veterans.
+          </p>
+          <p>
+            <strong>Note:</strong> You don't need to sign up to get a vaccine.
+          </p>
+        </>
+      }
+    />
+  );
+}

--- a/src/applications/static-pages/covid-vaccine-updates-cta/On.jsx
+++ b/src/applications/static-pages/covid-vaccine-updates-cta/On.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import AlertBox, {
+  ALERT_TYPE,
+} from '@department-of-veterans-affairs/formation-react/AlertBox';
+
+import { rootUrl as covidVaccineFormUrl } from 'applications/coronavirus-vaccination/manifest.json';
+
+export default function OnState() {
+  return (
+    <AlertBox
+      status={ALERT_TYPE.INFO}
+      headline="Stay informed and help us prepare"
+      content={
+        <>
+          <p>
+            Sign up for an easy way to stay informed about our COVID-19 plans.
+          </p>
+          <p>
+            When you sign up, we'll also ask about your interest in getting a
+            vaccine when one is available to you. By sharing your interest, you
+            can help us better prepare as we work to offer vaccines to more
+            Veterans.
+          </p>
+          <p>
+            <strong>Note:</strong> You don’t need to sign up to get a vaccine.
+          </p>
+          <a href={covidVaccineFormUrl} className="usa-button">
+            Sign up to stay informed
+          </a>
+        </>
+      }
+    />
+  );
+}

--- a/src/applications/static-pages/covid-vaccine-updates-cta/createCovidVaccineUpdatesWidget.js
+++ b/src/applications/static-pages/covid-vaccine-updates-cta/createCovidVaccineUpdatesWidget.js
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom';
 export default function createCovidVaccineUpdatesWidget(store, widgetType) {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
   if (root) {
-    import(/* webpackChunkName: "CaregiverContentToggle" */
+    import(/* webpackChunkName: "CovidVaccineUpdatesCTA" */
     './widget').then(module => {
       const CovidVaccineUpdatesCTA = module.default;
       ReactDOM.render(<CovidVaccineUpdatesCTA store={store} />, root);

--- a/src/applications/static-pages/covid-vaccine-updates-cta/createCovidVaccineUpdatesWidget.js
+++ b/src/applications/static-pages/covid-vaccine-updates-cta/createCovidVaccineUpdatesWidget.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+export default function createCovidVaccineUpdatesWidget(store, widgetType) {
+  const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
+  if (root) {
+    import(/* webpackChunkName: "CaregiverContentToggle" */
+    './widget').then(module => {
+      const CovidVaccineUpdatesCTA = module.default;
+      ReactDOM.render(<CovidVaccineUpdatesCTA store={store} />, root);
+    });
+  }
+}

--- a/src/applications/static-pages/covid-vaccine-updates-cta/widget.jsx
+++ b/src/applications/static-pages/covid-vaccine-updates-cta/widget.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import { connect } from 'react-redux';
 
 import OnState from './On';
@@ -11,11 +12,14 @@ function CovidVaccineUpdatesCTA({ showLinkToOnlineForm }) {
     return <OnState />;
   }
 
-  return <OffState />;
+  if (showLinkToOnlineForm === false) {
+    return <OffState />;
+  }
+
+  return <LoadingIndicator message="Loading..." />;
 }
 
 const mapStateToProps = store => ({
-  user: store.user,
   showLinkToOnlineForm: toggleValues(store)[
     FEATURE_FLAG_NAMES.covidVaccineUpdatesCTA
   ],

--- a/src/applications/static-pages/covid-vaccine-updates-cta/widget.jsx
+++ b/src/applications/static-pages/covid-vaccine-updates-cta/widget.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+import { connect } from 'react-redux';
+
+import OnState from './On';
+import OffState from './Off';
+
+function CovidVaccineUpdatesCTA({ showLinkToOnlineForm }) {
+  if (showLinkToOnlineForm) {
+    return <OnState />;
+  }
+
+  return <OffState />;
+}
+
+const mapStateToProps = store => ({
+  user: store.user,
+  showLinkToOnlineForm: toggleValues(store)[
+    FEATURE_FLAG_NAMES.covidVaccineUpdatesCTA
+  ],
+});
+
+export default connect(mapStateToProps)(CovidVaccineUpdatesCTA);

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -66,6 +66,7 @@ import {
   createScoAnnouncementsWidget,
 } from './school-resources/SchoolResources';
 import createCoronavirusChatbot from '../coronavirus-chatbot/createCoronavirusChatbot';
+import createCovidVaccineUpdatesWidget from './covid-vaccine-updates-cta/createCovidVaccineUpdatesWidget';
 
 import createThirdPartyApps, {
   thirdPartyAppsReducer,
@@ -163,6 +164,7 @@ createPost911GiBillStatusWidget(
 );
 
 createCoronavirusChatbot(store, widgetTypes.CORONAVIRUS_CHATBOT);
+createCovidVaccineUpdatesWidget(store, widgetTypes.COVID_VACCINE_UPDATES_CTA);
 
 createViewDependentsCTA(store, widgetTypes.VIEW_DEPENDENTS_CTA);
 form686CTA(store, widgetTypes.FORM_686_CTA);

--- a/src/applications/static-pages/widgetTypes.js
+++ b/src/applications/static-pages/widgetTypes.js
@@ -5,6 +5,7 @@ export default {
   CHAPTER_36_CTA: 'chapter-36-cta',
   CHAPTER_31_CTA: 'chapter-31-cta',
   CORONAVIRUS_CHATBOT: 'va-coronavirus-chatbot',
+  COVID_VACCINE_UPDATES_CTA: 'va-covid-vaccine-updates-cta',
   CTA: 'cta',
   DISABILITY_APP_STATUS: 'disability-app-status',
   DISABILITY_RATING_CALCULATOR: 'disability-rating-calculator',

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -66,4 +66,6 @@ export default Object.freeze({
   form526ConfirmationEmail: 'form526_confirmation_email',
   form526ConfirmationEmailShowCopy: 'form526_confirmation_email_show_copy',
   searchTypeaheadEnabled: 'search_typeahead_enabled',
+  covidVaccineUpdatesCTA: '',
+  covidVaccineUpdatesForm: '',
 });

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -66,6 +66,5 @@ export default Object.freeze({
   form526ConfirmationEmail: 'form526_confirmation_email',
   form526ConfirmationEmailShowCopy: 'form526_confirmation_email_show_copy',
   searchTypeaheadEnabled: 'search_typeahead_enabled',
-  covidVaccineUpdatesCTA: '',
-  covidVaccineUpdatesForm: '',
+  covidVaccineUpdatesCTA: 'covid_vaccine_registration_frontend_cta',
 });


### PR DESCRIPTION
## Description
This PR adds a new Flipper widget that prompts the user to sign up for COVID vaccine updates.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/17102#issuecomment-741114051

## Testing done
I added `<div data-widget-type="va-covid-vaccine-updates-cta"></div>` into a local page in my vagov-content repo. Then I navigated to that page and toggled the feature in my local API `http://localhost:3000/flipper/features/covid_vaccine_registration_frontend_cta`.

## Screenshots

### Off state
![image](https://user-images.githubusercontent.com/1915775/101661464-4c604080-3a16-11eb-8080-5d741c01ba86.png)

### On state
![image](https://user-images.githubusercontent.com/1915775/101661801-b7117c00-3a16-11eb-84d7-ca842a3944f1.png)


## Acceptance criteria
- [ ] Widget is ready

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
