### PR TITLE
[Development] Add analytics to HLR wizard

### DIFF
--- a/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
@@ -7,6 +7,7 @@ import Telephone, {
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 
+import recordEvent from 'platform/monitoring/record-event';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 import CallToActionWidget from 'platform/site-wide/cta-widget';
@@ -200,6 +201,7 @@ export class IntroductionPage extends React.Component {
                   onClick={() => {
                     this.setWizardStatus(WIZARD_STATUS_NOT_STARTED);
                     this.setPageFocus();
+                    recordEvent({ event: `howToWizard-start-over` });
                   }}
                 >
                   go back and answer questions again

--- a/src/applications/disability-benefits/996/content/DownloadLink.jsx
+++ b/src/applications/disability-benefits/996/content/DownloadLink.jsx
@@ -1,10 +1,24 @@
 import React from 'react';
+import recordEvent from 'platform/monitoring/record-event';
 import { FORM_URL } from '../constants';
 
 const DownloadLink = ({
   content = 'download and fill out VA Form 20-0996',
+  wizardEvent = false,
 }) => (
-  <a href={FORM_URL} download="VBA-20-0996-ARE.pdf" type="application/pdf">
+  <a
+    href={FORM_URL}
+    download="VBA-20-0996-ARE.pdf"
+    type="application/pdf"
+    onClick={() => {
+      if (wizardEvent) {
+        recordEvent({
+          event: 'howToWizard-alert-link-click',
+          'howToWizard-alert-link-click-label': content,
+        });
+      }
+    }}
+  >
     <i
       aria-hidden="true"
       className="fas fa-download vads-u-padding-right--1"

--- a/src/applications/disability-benefits/996/wizard/pages/claimType.jsx
+++ b/src/applications/disability-benefits/996/wizard/pages/claimType.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
+import recordEvent from 'platform/monitoring/record-event';
+
 import { SAVED_CLAIM_TYPE } from '../../constants';
 import pageNames from './pageNames';
 
@@ -21,6 +23,14 @@ const name = 'higher-level-review-option';
 
 const ClaimType = ({ setPageState, state = {} }) => {
   const setState = ({ value }) => {
+    recordEvent({
+      event: 'howToWizard-formChange',
+      'form-field-type': 'form-radio-buttons',
+      'form-field-label':
+        'For what type of claim are you requesting a Higher-Level Review?',
+      'form-field-value': value,
+    });
+
     // Show 'other' or 'legacyChoice' page
     const page =
       pageNames[value !== pageNames.other ? 'legacyChoice' : 'other'];

--- a/src/applications/disability-benefits/996/wizard/pages/legacyChoice.jsx
+++ b/src/applications/disability-benefits/996/wizard/pages/legacyChoice.jsx
@@ -1,11 +1,24 @@
 import React from 'react';
 import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
+import recordEvent from 'platform/monitoring/record-event';
+
 import pageNames from './pageNames';
 
 const label = (
   <p>
     Is this claim going through the{' '}
-    <a href="/disability/file-an-appeal/">legacy appeals</a> process?
+    <a
+      href="/disability/file-an-appeal/"
+      onClick={() => {
+        recordEvent({
+          event: 'howToWizard-alert-link-click',
+          'howToWizard-alert-link-click-label': 'legacy appeals',
+        });
+      }}
+    >
+      legacy appeals
+    </a>{' '}
+    process?
   </p>
 );
 
@@ -16,18 +29,27 @@ const options = [
 
 const name = 'higher-level-review-legacy';
 
-const LegacyChoice = ({ setPageState, state = {} }) => (
-  <ErrorableRadioButtons
-    id={name}
-    label={label}
-    options={options}
-    onValueChange={({ value }) => {
-      setPageState({ selected: value }, value);
-    }}
-    value={{ value: state.selected }}
-    additionalFieldsetClass={`${name}-legacy vads-u-margin-top--0`}
-  />
-);
+const LegacyChoice = ({ setPageState, state = {} }) => {
+  return (
+    <ErrorableRadioButtons
+      id={name}
+      label={label}
+      options={options}
+      onValueChange={({ value }) => {
+        recordEvent({
+          event: 'howToWizard-formChange',
+          'form-field-type': 'form-radio-buttons',
+          'form-field-label':
+            'Is this claim going through the legacy appeals process?',
+          'form-field-value': value,
+        });
+        setPageState({ selected: value }, value);
+      }}
+      value={{ value: state.selected }}
+      additionalFieldsetClass={`${name}-legacy vads-u-margin-top--0`}
+    />
+  );
+};
 
 export default {
   name: pageNames.legacyChoice,

--- a/src/applications/disability-benefits/996/wizard/pages/legacyNo.jsx
+++ b/src/applications/disability-benefits/996/wizard/pages/legacyNo.jsx
@@ -1,26 +1,56 @@
 import React from 'react';
+import recordEvent from 'platform/monitoring/record-event';
 import { WIZARD_STATUS_COMPLETE } from 'applications/static-pages/wizard';
 
 import pageNames from './pageNames';
 
 // Does not have a legacy appeal
-const LegacyNo = ({ setWizardStatus }) => (
-  <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
-    You can request a Higher-Level Review online using{' '}
-    <strong>VA Form 20-0996</strong>.
-    <p>
-      <button
-        onClick={() => setWizardStatus(WIZARD_STATUS_COMPLETE)}
-        className="usa-button-primary va-button-primary"
+const LegacyNo = ({ setWizardStatus }) => {
+  recordEvent({
+    event: 'howToWizard-alert-displayed',
+    'reason-for-alert': 'no legacy issues; form can be started',
+  });
+  recordEvent({
+    event: 'howToWizard-cta-displayed',
+  });
+  return (
+    <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
+      You can request a Higher-Level Review online using{' '}
+      <strong>VA Form 20-0996</strong>.
+      <p>
+        <button
+          onClick={() => {
+            recordEvent({
+              event: 'howToWizard-hidden',
+              'reason-for-hidden-wizard': 'wizard completed, starting form',
+            });
+            recordEvent({
+              event: 'cta-button-click',
+              'button-type': 'primary',
+              'button-click-label': 'Request a Higher-Level Review online',
+            });
+            setWizardStatus(WIZARD_STATUS_COMPLETE);
+          }}
+          className="usa-button-primary va-button-primary"
+        >
+          Request a Higher-Level Review online
+        </button>
+      </p>
+      <a
+        href="/decision-reviews/higher-level-review"
+        onClick={() => {
+          recordEvent({
+            event: 'howToWizard-alert-link-click',
+            'howToWizard-alert-link-click-label':
+              'Learn about other ways you can request a Higher-Level Review',
+          });
+        }}
       >
-        Request a Higher-Level Review online
-      </button>
-    </p>
-    <a href="/decision-reviews/higher-level-review">
-      Learn about other ways you can request a Higher-Level Review
-    </a>
-  </div>
-);
+        Learn about other ways you can request a Higher-Level Review
+      </a>
+    </div>
+  );
+};
 
 export default {
   name: pageNames.legacyNo,

--- a/src/applications/disability-benefits/996/wizard/pages/legacyYes.jsx
+++ b/src/applications/disability-benefits/996/wizard/pages/legacyYes.jsx
@@ -1,29 +1,49 @@
 import React from 'react';
+import recordEvent from 'platform/monitoring/record-event';
 import pageNames from './pageNames';
 import { SUPPLEMENTAL_CLAIM_URL } from '../../constants';
 import DownloadLink from '../../content/DownloadLink';
 
 // Yes, has a legacy appeal
-const LegacyYes = () => (
-  <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
-    <p className="vads-u-margin-top--0">
-      Since your claim is in the legacy appeals process, you’ll need to opt in
-      to the new decision review process within 60 days of receiving your
-      Statement of the Case (SOC) or Supplemental Statement of the Case (SSOC).
-    </p>
-    <p>
-      To opt in, fill out and submit VA Form 20-0996 by mail or in person. On
-      the form, you’ll need to check Box 15 to "opt-in from SOC/SSOC".
-    </p>
-    <p>
-      <DownloadLink content={'Download VA Form 20-0996'} />
-    </p>
-    <p className="vads-u-margin-bottom--0">
-      If you haven’t filed a legacy appeal for this claim, you’ll need to{' '}
-      <a href={SUPPLEMENTAL_CLAIM_URL}>file a Supplemental Claim</a>.
-    </p>
-  </div>
-);
+const LegacyYes = () => {
+  recordEvent({
+    event: 'howToWizard-alert-displayed',
+    'reason-for-alert':
+      'Veteran has, or may have, a claim in the legacy appeals process',
+  });
+  return (
+    <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
+      <p className="vads-u-margin-top--0">
+        Since your claim is in the legacy appeals process, you’ll need to opt in
+        to the new decision review process within 60 days of receiving your
+        Statement of the Case (SOC) or Supplemental Statement of the Case
+        (SSOC).
+      </p>
+      <p>
+        To opt in, fill out and submit VA Form 20-0996 by mail or in person. On
+        the form, you’ll need to check Box 15 to "opt-in from SOC/SSOC".
+      </p>
+      <p>
+        <DownloadLink content={'Download VA Form 20-0996'} wizardEvent />
+      </p>
+      <p className="vads-u-margin-bottom--0">
+        If you haven’t filed a legacy appeal for this claim, you’ll need to{' '}
+        <a
+          href={SUPPLEMENTAL_CLAIM_URL}
+          onClick={() => {
+            recordEvent({
+              event: 'howToWizard-alert-link-click',
+              'howToWizard-alert-link-click-label': 'file a Supplemental Claim',
+            });
+          }}
+        >
+          file a Supplemental Claim
+        </a>
+        .
+      </p>
+    </div>
+  );
+};
 
 export default {
   name: pageNames.legacyYes,

--- a/src/applications/disability-benefits/996/wizard/pages/other.jsx
+++ b/src/applications/disability-benefits/996/wizard/pages/other.jsx
@@ -1,20 +1,37 @@
 import React from 'react';
+import recordEvent from 'platform/monitoring/record-event';
 
 import pageNames from './pageNames';
 import DownloadLink from '../../content/DownloadLink';
 import { BENEFIT_OFFICES_URL } from '../../constants';
 
-const DecisionReviewPage = () => (
-  <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
-    You’ll need to fill out and submit VA form 20-0996 by mail or in person.
-    Send the completed form to the{' '}
-    <a href={BENEFIT_OFFICES_URL}>benefit office</a> that matches the benefit
-    type you select on the form.
-    <p className="vads-u-margin-bottom--0">
-      <DownloadLink content={'Download VA Form 20-0996'} wizardEvent />
-    </p>
-  </div>
-);
+const DecisionReviewPage = () => {
+  recordEvent({
+    event: 'howToWizard-alert-displayed',
+    'reason-for-alert': 'veteran wants to submit an unsupported claim type',
+  });
+  return (
+    <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
+      You’ll need to fill out and submit VA form 20-0996 by mail or in person.
+      Send the completed form to the{' '}
+      <a
+        href={BENEFIT_OFFICES_URL}
+        onClick={() => {
+          recordEvent({
+            event: 'howToWizard-alert-link-click',
+            'howToWizard-alert-link-click-label': 'benefit office',
+          });
+        }}
+      >
+        benefit office
+      </a>{' '}
+      that matches the benefit type you select on the form.
+      <p className="vads-u-margin-bottom--0">
+        <DownloadLink content={'Download VA Form 20-0996'} wizardEvent />
+      </p>
+    </div>
+  );
+};
 
 export default {
   name: pageNames.other,

--- a/src/applications/disability-benefits/996/wizard/pages/other.jsx
+++ b/src/applications/disability-benefits/996/wizard/pages/other.jsx
@@ -5,15 +5,15 @@ import DownloadLink from '../../content/DownloadLink';
 import { BENEFIT_OFFICES_URL } from '../../constants';
 
 const DecisionReviewPage = () => (
-  <p className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
+  <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
     You’ll need to fill out and submit VA form 20-0996 by mail or in person.
     Send the completed form to the{' '}
     <a href={BENEFIT_OFFICES_URL}>benefit office</a> that matches the benefit
     type you select on the form.
     <p className="vads-u-margin-bottom--0">
-      <DownloadLink content={'Download VA Form 20-0996'} />
+      <DownloadLink content={'Download VA Form 20-0996'} wizardEvent />
     </p>
-  </p>
+  </div>
 );
 
 export default {


### PR DESCRIPTION
## Description

Adding analytics tracking to the Higher-Level Review wizard per the [wizard tracking documentation](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/analytics/google-analytics/tracking-how-to-wizards.md).

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/17076
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/3825

## Testing done

Unit tests 

## Screenshots

N/A

## Acceptance criteria
- [x] HLR wizard tracking events recorded to analytics

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
