### PR TITLE
15757 ga events ch31

### DIFF
--- a/src/applications/vre/28-1900/containers/OrientationWizardContainer.jsx
+++ b/src/applications/vre/28-1900/containers/OrientationWizardContainer.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import Wizard from 'applications/static-pages/wizard';
 import { WIZARD_STATUS_COMPLETE } from 'applications/vre/28-1900/constants';
 import pages from 'applications/vre/28-1900/wizard/pages';
+import recordEvent from 'platform/monitoring/record-event';
 import OrientationApp from 'applications/vre/28-1900/orientation/OrientationApp';
 
 const OrientationWizardContainer = props => {
@@ -43,6 +44,9 @@ const OrientationWizardContainer = props => {
           go directly to the online application without answering questions.{' '}
           <a
             onClick={() => {
+              recordEvent({
+                event: 'howToWizard-skip',
+              });
               handleWizardUpdate(WIZARD_STATUS_COMPLETE);
             }}
           >

--- a/src/applications/vre/28-1900/wizard/pages/helpers.js
+++ b/src/applications/vre/28-1900/wizard/pages/helpers.js
@@ -26,6 +26,6 @@ export const recordNotificationEvent = description => {
 export const fireLinkClickEvent = event => {
   recordEvent({
     event: 'howToWizard-alert-link-click',
-    'howToWizard-alert-link-click-label': event.target.innerHTML,
+    'howToWizard-alert-link-click-label': event.target.innerText,
   });
 };

--- a/src/applications/vre/28-1900/wizard/pages/helpers.js
+++ b/src/applications/vre/28-1900/wizard/pages/helpers.js
@@ -22,3 +22,10 @@ export const recordNotificationEvent = description => {
     'reason-for-alert': description,
   });
 };
+
+export const fireLinkClickEvent = event => {
+  recordEvent({
+    event: 'howToWizard-alert-link-click',
+    'howToWizard-alert-link-click-label': event.target.innerHTML,
+  });
+};

--- a/src/applications/vre/28-1900/wizard/pages/helpers.js
+++ b/src/applications/vre/28-1900/wizard/pages/helpers.js
@@ -1,0 +1,17 @@
+import recordEvent from 'platform/monitoring/record-event';
+
+const mapValueToOption = (value, options) => {
+  const optionText = options.filter(option => option.value === value);
+  return optionText[0].label;
+};
+
+export const handleChangeAndPageSet = (setPageState, value, options) => {
+  setPageState({ selected: value }, value);
+  const optionText = mapValueToOption(value, options);
+  recordEvent({
+    event: 'howToWizard-formChange',
+    'form-field-type': 'form-radio-buttons',
+    'form-field-label': 'Which of these describes you?',
+    'form-field-value': optionText,
+  });
+};

--- a/src/applications/vre/28-1900/wizard/pages/helpers.js
+++ b/src/applications/vre/28-1900/wizard/pages/helpers.js
@@ -15,3 +15,10 @@ export const handleChangeAndPageSet = (setPageState, value, options) => {
     'form-field-value': optionText,
   });
 };
+
+export const recordNotificationEvent = description => {
+  recordEvent({
+    event: 'howToWizard-alert-displayed',
+    'reason-for-alert': description,
+  });
+};

--- a/src/applications/vre/28-1900/wizard/pages/other/isOther.jsx
+++ b/src/applications/vre/28-1900/wizard/pages/other/isOther.jsx
@@ -4,6 +4,7 @@ import {
   WIZARD_STATUS_INELIGIBLE,
   CAREERS_EMPLOYMENT_ROOT_URL,
 } from 'applications/vre/28-1900/constants';
+import { recordNotificationEvent } from '../helpers';
 
 const AmOther = props => {
   const { setWizardStatus } = props;
@@ -13,6 +14,7 @@ const AmOther = props => {
     },
     [setWizardStatus],
   );
+  recordNotificationEvent('ineligibility - is not a Veteran or Service Member');
   return (
     <div className="feature vads-u-background-color--gray-lightest">
       <p>

--- a/src/applications/vre/28-1900/wizard/pages/other/isOther.jsx
+++ b/src/applications/vre/28-1900/wizard/pages/other/isOther.jsx
@@ -4,7 +4,7 @@ import {
   WIZARD_STATUS_INELIGIBLE,
   CAREERS_EMPLOYMENT_ROOT_URL,
 } from 'applications/vre/28-1900/constants';
-import { recordNotificationEvent } from '../helpers';
+import { recordNotificationEvent, fireLinkClickEvent } from '../helpers';
 
 const AmOther = props => {
   const { setWizardStatus } = props;
@@ -21,7 +21,10 @@ const AmOther = props => {
         To apply for VR&E benefits, you must be either a Veteran or active-duty
         service member.
       </p>
-      <a href={CAREERS_EMPLOYMENT_ROOT_URL}>
+      <a
+        onClick={e => fireLinkClickEvent(e)}
+        href={CAREERS_EMPLOYMENT_ROOT_URL}
+      >
         Find out about VA educational and career counseling
       </a>
     </div>

--- a/src/applications/vre/28-1900/wizard/pages/service-member/01-noHonorableDischarge.jsx
+++ b/src/applications/vre/28-1900/wizard/pages/service-member/01-noHonorableDischarge.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { serviceMemberPathPageNames } from '../pageList';
+import { recordNotificationEvent } from '../helpers';
 
 const NoHonorableDischargeSM = () => {
+  recordNotificationEvent('ineligibility - recieved an honorable discharge');
   return (
     <div className="feature vads-u-background-color--gray-lightest">
       <p>

--- a/src/applications/vre/28-1900/wizard/pages/service-member/01-noHonorableDischarge.jsx
+++ b/src/applications/vre/28-1900/wizard/pages/service-member/01-noHonorableDischarge.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { serviceMemberPathPageNames } from '../pageList';
-import { recordNotificationEvent } from '../helpers';
+import { recordNotificationEvent, fireLinkClickEvent } from '../helpers';
 
 const NoHonorableDischargeSM = () => {
   recordNotificationEvent('ineligibility - recieved an honorable discharge');
@@ -10,7 +10,10 @@ const NoHonorableDischargeSM = () => {
         To apply for VR&E benefits, you must have received an other than
         dishonorable discharge.
       </p>
-      <a href="/discharge-upgrade-instructions/">
+      <a
+        onClick={e => fireLinkClickEvent(e)}
+        href="/discharge-upgrade-instructions/"
+      >
         Learn more about how to apply for a discharge upgrade
       </a>
     </div>

--- a/src/applications/vre/28-1900/wizard/pages/service-member/01-noHonorableDischarge.jsx
+++ b/src/applications/vre/28-1900/wizard/pages/service-member/01-noHonorableDischarge.jsx
@@ -3,7 +3,7 @@ import { serviceMemberPathPageNames } from '../pageList';
 import { recordNotificationEvent, fireLinkClickEvent } from '../helpers';
 
 const NoHonorableDischargeSM = () => {
-  recordNotificationEvent('ineligibility - recieved an honorable discharge');
+  recordNotificationEvent('ineligibility - received a dishonorable discharge');
   return (
     <div className="feature vads-u-background-color--gray-lightest">
       <p>

--- a/src/applications/vre/28-1900/wizard/pages/service-member/01-yesHonorableDischarge.jsx
+++ b/src/applications/vre/28-1900/wizard/pages/service-member/01-yesHonorableDischarge.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
 import { serviceMemberPathPageNames } from '../pageList';
+import { handleChangeAndPageSet } from '../helpers';
 
 const options = [
   { value: serviceMemberPathPageNames.yesVaMemorandum, label: 'Yes' },
@@ -18,7 +19,9 @@ const yesHonorableDischargeSM = ({ setPageState, state = {} }) => (
     }
     id={`${serviceMemberPathPageNames.yesHonorableDischargeSM}-option`}
     options={options}
-    onValueChange={({ value }) => setPageState({ selected: value }, value)}
+    onValueChange={({ value }) =>
+      handleChangeAndPageSet(setPageState, value, options)
+    }
     value={{ value: state.selected }}
     additionalFieldsetClass="vads-u-margin-top--0"
   />

--- a/src/applications/vre/28-1900/wizard/pages/service-member/02-noVaMemorandum.jsx
+++ b/src/applications/vre/28-1900/wizard/pages/service-member/02-noVaMemorandum.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
 import { serviceMemberPathPageNames } from '../pageList';
+import { handleChangeAndPageSet } from '../helpers';
 
 const options = [
   { value: serviceMemberPathPageNames.yesIDES, label: 'Yes' },
@@ -18,7 +19,9 @@ const noVaMemorandum = ({ setPageState, state = {} }) => (
     }
     id={`${serviceMemberPathPageNames.noVaMemorandum}-option`}
     options={options}
-    onValueChange={({ value }) => setPageState({ selected: value }, value)}
+    onValueChange={({ value }) =>
+      handleChangeAndPageSet(setPageState, value, options)
+    }
     value={{ value: state.selected }}
     additionalFieldsetClass="vads-u-margin-top--0"
   />

--- a/src/applications/vre/28-1900/wizard/pages/service-member/03-noIDES.jsx
+++ b/src/applications/vre/28-1900/wizard/pages/service-member/03-noIDES.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { serviceMemberPathPageNames } from '../pageList';
 import { CAREERS_EMPLOYMENT_ROOT_URL } from 'applications/vre/28-1900/constants';
-import { recordNotificationEvent } from '../helpers';
+import { recordNotificationEvent, fireLinkClickEvent } from '../helpers';
 
 const NoIDES = () => {
   recordNotificationEvent('ineligibility - does not have a disability rating');
@@ -12,7 +12,10 @@ const NoIDES = () => {
         disability and an employment handicap in which your disability limits
         your ability to get a job.
       </p>
-      <a href={CAREERS_EMPLOYMENT_ROOT_URL}>
+      <a
+        onClick={e => fireLinkClickEvent(e)}
+        href={CAREERS_EMPLOYMENT_ROOT_URL}
+      >
         Find out about VA educational and career counseling
       </a>
     </div>

--- a/src/applications/vre/28-1900/wizard/pages/service-member/03-noIDES.jsx
+++ b/src/applications/vre/28-1900/wizard/pages/service-member/03-noIDES.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { serviceMemberPathPageNames } from '../pageList';
 import { CAREERS_EMPLOYMENT_ROOT_URL } from 'applications/vre/28-1900/constants';
+import { recordNotificationEvent } from '../helpers';
 
 const NoIDES = () => {
+  recordNotificationEvent('ineligibility - does not have a disability rating');
   return (
     <div className="feature vads-u-background-color--gray-lightest">
       <p>

--- a/src/applications/vre/28-1900/wizard/pages/service-member/isServiceMember.jsx
+++ b/src/applications/vre/28-1900/wizard/pages/service-member/isServiceMember.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
 import { serviceMemberPathPageNames } from '../pageList';
+import { handleChangeAndPageSet } from '../helpers';
 
 const options = [
   { value: serviceMemberPathPageNames.yesHonorableDischargeSM, label: 'Yes' },
@@ -13,7 +14,9 @@ const isServiceMember = ({ setPageState, state = {} }) => (
     label="Do you expect to receive an honorable discharge?"
     id={`${serviceMemberPathPageNames.isServiceMember}-option`}
     options={options}
-    onValueChange={({ value }) => setPageState({ selected: value }, value)}
+    onValueChange={({ value }) =>
+      handleChangeAndPageSet(setPageState, value, options)
+    }
     value={{ value: state.selected }}
     additionalFieldsetClass="vads-u-margin-top--0"
   />

--- a/src/applications/vre/28-1900/wizard/pages/start.jsx
+++ b/src/applications/vre/28-1900/wizard/pages/start.jsx
@@ -6,6 +6,7 @@ import {
   serviceMemberPathPageNames,
   otherPathPageNames,
 } from './pageList';
+import { handleChangeAndPageSet } from './helpers';
 
 const options = [
   { value: veteranPathPageNames.isVeteran, label: 'Veteran' },
@@ -22,7 +23,9 @@ const StartPage = ({ setPageState, state = {} }) => (
     label="Which of these describes you?"
     id={`${startingPageName.start}-option`}
     options={options}
-    onValueChange={({ value }) => setPageState({ selected: value }, value)}
+    onValueChange={({ value }) =>
+      handleChangeAndPageSet(setPageState, value, options)
+    }
     value={{ value: state.selected }}
     additionalFieldsetClass="vads-u-margin-top--0"
   />

--- a/src/applications/vre/28-1900/wizard/pages/veteran/01-noHonorableDischarge.jsx
+++ b/src/applications/vre/28-1900/wizard/pages/veteran/01-noHonorableDischarge.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { veteranPathPageNames } from '../pageList';
-import { recordNotificationEvent } from '../helpers';
+import { recordNotificationEvent, fireLinkClickEvent } from '../helpers';
 
 const NoHonorableDischarge = () => {
   recordNotificationEvent('ineligibility - recieved an honorable discharge');
@@ -10,7 +10,10 @@ const NoHonorableDischarge = () => {
         To apply for VR&E benefits, you must have received{' '}
         <strong>an other than</strong> dishonorable discharge.
       </p>
-      <a href="/discharge-upgrade-instructions/">
+      <a
+        onClick={e => fireLinkClickEvent(e)}
+        href="/discharge-upgrade-instructions/"
+      >
         Learn more about how to apply for a discharge upgrade
       </a>
     </div>

--- a/src/applications/vre/28-1900/wizard/pages/veteran/01-noHonorableDischarge.jsx
+++ b/src/applications/vre/28-1900/wizard/pages/veteran/01-noHonorableDischarge.jsx
@@ -3,7 +3,7 @@ import { veteranPathPageNames } from '../pageList';
 import { recordNotificationEvent, fireLinkClickEvent } from '../helpers';
 
 const NoHonorableDischarge = () => {
-  recordNotificationEvent('ineligibility - recieved an honorable discharge');
+  recordNotificationEvent('ineligibility - received a dishonorable discharge');
   return (
     <div className="feature vads-u-background-color--gray-lightest">
       <p>

--- a/src/applications/vre/28-1900/wizard/pages/veteran/01-noHonorableDischarge.jsx
+++ b/src/applications/vre/28-1900/wizard/pages/veteran/01-noHonorableDischarge.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { veteranPathPageNames } from '../pageList';
+import { recordNotificationEvent } from '../helpers';
 
 const NoHonorableDischarge = () => {
+  recordNotificationEvent('ineligibility - recieved an honorable discharge');
   return (
     <div className="feature vads-u-background-color--gray-lightest">
       <p>

--- a/src/applications/vre/28-1900/wizard/pages/veteran/01-yesHonorableDischarge.jsx
+++ b/src/applications/vre/28-1900/wizard/pages/veteran/01-yesHonorableDischarge.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
 import { veteranPathPageNames } from '../pageList';
 
+import { handleChangeAndPageSet } from '../helpers';
+
 const options = [
   { value: veteranPathPageNames.disabilityRating, label: 'Yes' },
   { value: veteranPathPageNames.noDisabilityRating, label: 'No' },
@@ -18,7 +20,9 @@ const yesHonorableDischarge = ({ setPageState, state = {} }) => (
     }
     id={`${veteranPathPageNames.yesHonorableDischarge}-option`}
     options={options}
-    onValueChange={({ value }) => setPageState({ selected: value }, value)}
+    onValueChange={({ value }) =>
+      handleChangeAndPageSet(setPageState, value, options)
+    }
     value={{ value: state.selected }}
     additionalFieldsetClass="vads-u-margin-top--0"
   />

--- a/src/applications/vre/28-1900/wizard/pages/veteran/01-yesHonorableDischarge.jsx
+++ b/src/applications/vre/28-1900/wizard/pages/veteran/01-yesHonorableDischarge.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
 import { veteranPathPageNames } from '../pageList';
-
 import { handleChangeAndPageSet } from '../helpers';
 
 const options = [

--- a/src/applications/vre/28-1900/wizard/pages/veteran/02-disabilityRating.jsx
+++ b/src/applications/vre/28-1900/wizard/pages/veteran/02-disabilityRating.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
 import { veteranPathPageNames } from '../pageList';
+import { handleChangeAndPageSet } from '../helpers';
 
 const options = [
   { value: veteranPathPageNames.yesActiveDutySeparation, label: 'Yes' },
@@ -18,7 +19,9 @@ const disabilityRating = ({ setPageState, state = {} }) => (
     }
     id={`${veteranPathPageNames.disabilityRating}-option`}
     options={options}
-    onValueChange={({ value }) => setPageState({ selected: value }, value)}
+    onValueChange={({ value }) =>
+      handleChangeAndPageSet(setPageState, value, options)
+    }
     value={{ value: state.selected }}
     additionalFieldsetClass="vads-u-margin-top--0"
   />

--- a/src/applications/vre/28-1900/wizard/pages/veteran/02-noDisabilityRating.jsx
+++ b/src/applications/vre/28-1900/wizard/pages/veteran/02-noDisabilityRating.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { veteranPathPageNames } from '../pageList';
 import { CAREERS_EMPLOYMENT_ROOT_URL } from 'applications/vre/28-1900/constants';
+import { recordNotificationEvent } from '../helpers';
 
 const NoDisabilityRating = () => {
+  recordNotificationEvent('ineligibility - does not have disability rating');
   return (
     <div className="feature vads-u-background-color--gray-lightest">
       <p>

--- a/src/applications/vre/28-1900/wizard/pages/veteran/02-noDisabilityRating.jsx
+++ b/src/applications/vre/28-1900/wizard/pages/veteran/02-noDisabilityRating.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { veteranPathPageNames } from '../pageList';
 import { CAREERS_EMPLOYMENT_ROOT_URL } from 'applications/vre/28-1900/constants';
-import { recordNotificationEvent } from '../helpers';
+import { recordNotificationEvent, fireLinkClickEvent } from '../helpers';
 
 const NoDisabilityRating = () => {
   recordNotificationEvent('ineligibility - does not have disability rating');
@@ -12,7 +12,10 @@ const NoDisabilityRating = () => {
         disability and an employment handicap in which your disability limits
         your ability to get a job.
       </p>
-      <a href={CAREERS_EMPLOYMENT_ROOT_URL}>
+      <a
+        onClick={e => fireLinkClickEvent(e)}
+        href={CAREERS_EMPLOYMENT_ROOT_URL}
+      >
         Find out about VA educational and career counseling
       </a>
     </div>

--- a/src/applications/vre/28-1900/wizard/pages/veteran/03-noActiveDutySeparation.jsx
+++ b/src/applications/vre/28-1900/wizard/pages/veteran/03-noActiveDutySeparation.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { veteranPathPageNames } from '../pageList';
+import { recordNotificationEvent } from '../helpers';
 
 const NoActiveDutySeparation = () => {
+  recordNotificationEvent(
+    'ineligibility - outside time period from active duty discharge',
+  );
   return (
     <div className="feature vads-u-background-color--gray-lightest">
       <p>

--- a/src/applications/vre/28-1900/wizard/pages/veteran/isVeteran.jsx
+++ b/src/applications/vre/28-1900/wizard/pages/veteran/isVeteran.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
 import { veteranPathPageNames } from '../pageList';
+import { handleChangeAndPageSet } from '../helpers';
 
 const options = [
   { value: veteranPathPageNames.yesHonorableDischarge, label: 'Yes' },
@@ -18,7 +19,9 @@ const isVeteran = ({ setPageState, state = {} }) => (
     }
     id={`${veteranPathPageNames.isVeteran}-option`}
     options={options}
-    onValueChange={({ value }) => setPageState({ selected: value }, value)}
+    onValueChange={({ value }) =>
+      handleChangeAndPageSet(setPageState, value, options)
+    }
     value={{ value: state.selected }}
     additionalFieldsetClass="vads-u-margin-top--0"
   />


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/11240)

This PR is to add Google Analytics events to the wizard for the chapter 31 form. A general spec for these events was provided in [this ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/15757). The spec is provided below as well as the corresponding screenshots of the events firing in dataSlayer for Firefox.

Some of the events in the spec have been moved into the orientation videos for which we do not have a full event spec yet. These events have been left out of this PR.

## Testing done
Tested events using dataSlayer for Firefox

## Screenshots

<details><summary>Form field changes (clicks on radio button answers)</summary>

Spec
```
'event': 'howToWizard-formChange',
'form-field-type': '<form_component_type>',
'form-field-label': <question_text>',
'form-field-value': '<question_answer_or_form_value>',
```

Actual event

![Screen Shot 2020-12-09 at 11 08 58 AM](https://user-images.githubusercontent.com/1899695/101675678-fcca4680-3a0e-11eb-8774-41d698153977.png)

</details>


<details><summary>Received alert notice following a question answer</summary>

Spec
```
'event': 'howToWizard-alert-displayed',
'reason-for-alert': '<description>',
```

Actual event

![Screen Shot 2020-12-09 at 11 09 57 AM](https://user-images.githubusercontent.com/1899695/101675807-208d8c80-3a0f-11eb-9289-74964e651fba.png)

</details>


<details><summary>Click on link within blue box notice</summary>

Spec
```
'event': 'howToWizard-alert-link-click',
'howToWizard-alert-link-click-label'
```

Actual event

![Screen Shot 2020-12-09 at 11 10 54 AM](https://user-images.githubusercontent.com/1899695/101675886-3d29c480-3a0f-11eb-9de4-450e73c0fff4.png)


</details>


<details><summary>User clicks link to skip how to wizard</summary>

Spec
```
'event': 'howToWizard-skip'
```

Actual event

![Screen Shot 2020-12-09 at 11 11 25 AM](https://user-images.githubusercontent.com/1899695/101675921-4c107700-3a0f-11eb-84bb-0a1738bc1462.png)


</details>

## Acceptance criteria
- [x] ode/event names provided by the GA/Insights Team has been inserted into our feature for tracking

