### PR TITLE
Fix link to sign-in FAQs

### DIFF
--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -304,7 +304,7 @@ export class SignInModal extends React.Component {
                 </a>{' '}
                 and{' '}
                 <a
-                  href="/resources/verifying-your-identity-on-va-gov/"
+                  href="/resources/verifying-your-identity-on-vagov/"
                   target="_blank"
                 >
                   verifying your identity


### PR DESCRIPTION
## Description
This PR fixes a link to the sign-in FAQ page.

## Testing done
N/A

## Screenshots
No visual change

## Acceptance criteria
- [ ] Link is correct

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
