### PR TITLE
Mark DOB and SSN as optional

### DIFF
--- a/src/applications/coronavirus-vaccination/config/schema.js
+++ b/src/applications/coronavirus-vaccination/config/schema.js
@@ -6,7 +6,6 @@ export default {
     'email',
     'phone',
     'zipCode',
-    'birthDate',
     'vaccineInterest',
     'zipCodeDetails',
   ],

--- a/src/applications/coronavirus-vaccination/config/uiSchema.js
+++ b/src/applications/coronavirus-vaccination/config/uiSchema.js
@@ -24,14 +24,10 @@ export default {
   birthDate: {
     'ui:title': 'Date of birth',
     'ui:widget': 'date',
-    'ui:errorMessages': {
-      required: 'Please enter your date of birth.',
-    },
   },
   ssn: {
     ...ssnUiSchema,
     'ui:title': 'Social Security number (SSN)',
-    'ui:required': formData => !formData.isIdentityVerified,
     'ui:options': {
       ...ssnUiSchema['ui:options'],
       hideIf: formData => formData.isIdentityVerified,

--- a/src/applications/coronavirus-vaccination/hooks/useSubmitForm.jsx
+++ b/src/applications/coronavirus-vaccination/hooks/useSubmitForm.jsx
@@ -5,19 +5,14 @@ import { apiRequest } from 'platform/utilities/api';
 import { requestStates } from 'platform/utilities/constants';
 
 const apiUrl = `${environment.API_URL}/covid_vaccine/v0/registration`;
-const unauthenticatedApiUrl = `${apiUrl}/unauthenticated`;
 
 export default function useSubmitForm() {
   const [status, setSubmitStatus] = useState(requestStates.notCalled);
 
   const submit = useCallback(formData => {
     async function sendToApi() {
-      const submissionUrl = formData.isIdentityVerified
-        ? apiUrl
-        : unauthenticatedApiUrl;
-
       try {
-        await apiRequest(submissionUrl, {
+        await apiRequest(apiUrl, {
           method: 'POST',
           body: JSON.stringify(formData),
           headers: {


### PR DESCRIPTION
## Description
SSN and DOB should always be optional fields so this PR updates the schema to reflect that.

This PR also update the API route to always use `/covid_vaccine/v0/registration`.

https://dsva.slack.com/archives/C01FNSTQD7H/p1607538977339800

## Testing done
Confirmed locally they are not required

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/101680189-555d0c00-3a2e-11eb-9f83-23efc99b35bf.png)


## Acceptance criteria
- [ ] DOB and SSN are optional

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
