### PR TITLE
[Development] Add 526 confirmation print button

### DIFF
--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -121,11 +121,13 @@ export const Form526Entry = ({
 
   return wrapInBreadcrumb(
     title,
-    <RequiredLoginView serviceRequired={serviceRequired} user={user} verify>
-      <ITFWrapper location={location} title={title}>
-        {content}
-      </ITFWrapper>
-    </RequiredLoginView>,
+    <article id="form-526" data-location={`${location?.pathname?.slice(1)}`}>
+      <RequiredLoginView serviceRequired={serviceRequired} user={user} verify>
+        <ITFWrapper location={location} title={title}>
+          {content}
+        </ITFWrapper>
+      </RequiredLoginView>
+    </article>,
   );
 };
 

--- a/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
+++ b/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
@@ -17,6 +17,11 @@ const template = (props, title, content, submissionMessage, messageType) => {
   const { fullName, disabilities, submittedAt } = props;
   const { first, last, middle, suffix } = fullName;
 
+  // This is easier than passing down props and checking if the form type
+  const pageTitle = document.title.includes('Benefits')
+    ? 'Benefits Delivery at Discharge Claim'
+    : 'Disability Compensation Claim';
+
   const renderableContent =
     typeof content === 'string' && content !== '' ? <p>{content}</p> : content;
 
@@ -49,17 +54,15 @@ const template = (props, title, content, submissionMessage, messageType) => {
   }
 
   return (
-    <div>
-      {props.areConfirmationEmailTogglesOn ? (
-        <h2 className="vads-u-font-size--h5" id="note-email">
-          We'll send you an email to confirm that we received your claim. You
-          can also print this page for your records.
-        </h2>
-      ) : (
-        <h2 className="vads-u-font-size--h5" id="note-print">
-          Please print this page for your records.
-        </h2>
-      )}
+    <div className="confirmation-page">
+      <div className="print-only">
+        <img
+          src="https://www.va.gov/img/design/logo/logo-black-and-white.png"
+          alt="VA logo"
+          width="300"
+        />
+        <h2>{pageTitle}</h2>
+      </div>
 
       <AlertBox
         isVisible
@@ -68,10 +71,22 @@ const template = (props, title, content, submissionMessage, messageType) => {
         status={messageType}
       />
 
+      {props.areConfirmationEmailTogglesOn ? (
+        <h2 className="vads-u-font-size--h5" id="note-email">
+          We'll send you an email to confirm that we received your claim.{' '}
+          <span className="screen-only">
+            You can also print this page for your records.
+          </span>
+        </h2>
+      ) : (
+        <h2 className="vads-u-font-size--h5 screen-only" id="note-print">
+          Please print this page for your records.
+        </h2>
+      )}
+
       <div className="inset">
         <h3 className="vads-u-font-size--h4">
-          Disability Compensation Claim{' '}
-          <span className="additional">(Form 21-526EZ)</span>
+          {pageTitle} <span className="additional">(Form 21-526EZ)</span>
         </h3>
         <span>
           For {first} {middle} {last} {suffix}
@@ -85,9 +100,9 @@ const template = (props, title, content, submissionMessage, messageType) => {
           <li>
             <strong>Conditions claimed</strong>
             <br />
-            <ul className="disability-list">
+            <ul className="disability-list vads-u-margin-top--0">
               {disabilities.map((disability, i) => (
-                <li key={i}>
+                <li key={i} className="vads-u-margin-bottom--0">
                   {typeof disability === 'string'
                     ? capitalizeEachWord(disability)
                     : NULL_CONDITION_STRING}
@@ -97,6 +112,12 @@ const template = (props, title, content, submissionMessage, messageType) => {
             {submissionMessage}
           </li>
         </ul>
+        <button
+          className="usa-button screen-only"
+          onClick={() => window.print()}
+        >
+          Print for your records
+        </button>
       </div>
 
       <div className="confirmation-guidance-container">

--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -191,3 +191,26 @@ div.review {
     }
   }
 }
+
+/* Confirmation page */
+article[data-location="confirmation"] {
+  h1[tabindex="-1"] {
+    outline: none;
+  }
+  @media print {
+    .confirmation-page-title, a {
+      text-align: left;
+      padding-left: 0;
+    }
+  }
+}
+
+@media print {
+  .usa-width-two-thirds {
+    width: 100%;
+  }
+  .schemaform-title,
+  .schemaform-subtitle {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Description

To enable Veterans to print form 526's confirmation page, a print button is added. The printed page includes styling to hide unnecessary content and include a logo and URLs to all links.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/17196
- https://vsateams.invisionapp.com/share/8GXOG91ZWNJ#/screens/421411451
- Similar print result design: https://vsateams.invisionapp.com/share/UDW9MPS5ETW#/screens/410061504

## Testing done

Visual confirmation of printed page layout (see screenshots)

## Screenshots

<details><summary>Button implemented</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-12-09 at 2 12 29 PM](https://user-images.githubusercontent.com/136959/101687057-9144a100-3a2f-11eb-85ee-3eaa07217158.png)</details>

<details><summary>BDD printed confirmation (successful)</summary>

<!-- leave a blank line above -->
<img width="410" alt="Screen Shot 2020-12-09 at 2 02 59 PM" src="https://user-images.githubusercontent.com/136959/101687017-7e31d100-3a2f-11eb-95fe-30b8704df778.png"></details>

<details><summary>Disability compensation claim printed confirmation (with delay)</summary>

<!-- leave a blank line above -->
<img width="409" alt="Screen Shot 2020-12-09 at 2 05 07 PM" src="https://user-images.githubusercontent.com/136959/101686951-64908980-3a2f-11eb-8705-28d10ad49e06.png"></details>

## Acceptance criteria
- [x] Print button included on confirmation page
- [x] Printed layout matches other designs

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
