### PR TITLE
[covid vaccine] Wrap the app in a Flipper toggle

### DIFF
--- a/src/applications/coronavirus-vaccination/components/Layout.jsx
+++ b/src/applications/coronavirus-vaccination/components/Layout.jsx
@@ -1,28 +1,42 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 
 import * as userSelectors from 'platform/user/selectors';
 
-function Layout({ isProfileLoading, children }) {
-  return (
-    <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2p5">
-      <div className="vads-l-row">
-        <div className="vads-l-col--12 large-screen:vads-l-col--8">
+function Layout({ formIsEnabled, isProfileLoading, children }) {
+  if (formIsEnabled) {
+    return (
+      <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2p5">
+        <div className="vads-l-row">
           {isProfileLoading ? (
             <LoadingIndicator message="Loading your profile..." />
           ) : (
-            children
+            <div className="vads-l-col--12 large-screen:vads-l-col--8">
+              {children}
+            </div>
           )}
         </div>
       </div>
-    </div>
-  );
+    );
+  }
+
+  if (formIsEnabled === false) {
+    window.location.replace('/health-care/covid-19-vaccine/');
+  }
+
+  return <LoadingIndicator message="Loading the application..." />;
 }
 
 const mapStateToProps = state => {
   return {
     isProfileLoading: userSelectors.isProfileLoading(state),
+    formIsEnabled: toggleValues(state)[
+      FEATURE_FLAG_NAMES.covidVaccineUpdatesForm
+    ],
   };
 };
 

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -929,7 +929,6 @@
     "entryName": "coronavirus-vaccination",
     "rootUrl": "/health-care/covid-19-vaccine/stay-informed",
     "template": {
-      "vagovprod": false,
       "title": "COVID-19 vaccines — Stay informed and help us prepare",
       "layout": "page-react.html",
       "includeBreadcrumbs": true,

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -67,4 +67,5 @@ export default Object.freeze({
   form526ConfirmationEmailShowCopy: 'form526_confirmation_email_show_copy',
   searchTypeaheadEnabled: 'search_typeahead_enabled',
   covidVaccineUpdatesCTA: 'covid_vaccine_registration_frontend_cta',
+  covidVaccineUpdatesForm: 'covid_vaccine_registration_frontend',
 });


### PR DESCRIPTION
## Description
This PR gates access to the COVID vaccine form via a Flipper feature toggle. When on, a user is allowed access to the form. When off, they are redirected to the parent page.

## Testing done
Used the form locally while toggling the Flipper feature.

## Screenshots
No visual impact

## Acceptance criteria
- [ ] App access is controlled via Flipper admin

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
