### PR TITLE
Open the browser when --env.scaffold

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -390,7 +390,10 @@ module.exports = env => {
     // apps we're scaffolding
     baseConfig.devServer.open = true;
     baseConfig.devServer.openPage =
-      buildOptions.openTo || getEntryManifests(buildOptions.entry)[0].rootUrl;
+      buildOptions.openTo || buildOptions.entry
+        ? // Assumes the first in the list has a rootUrl
+          getEntryManifests(buildOptions.entry)[0].rootUrl
+        : '';
   }
 
   if (isOptimizedBuild) {

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -53,6 +53,18 @@ const globalEntryFiles = {
   'shared-modules': sharedModules,
 };
 
+function getEntryManifests(entry) {
+  const allManifests = getAppManifests();
+  let entryManifests = allManifests;
+  if (entry) {
+    const entryNames = entry.split(',').map(name => name.trim());
+    entryManifests = allManifests.filter(manifest =>
+      entryNames.includes(manifest.entryName),
+    );
+  }
+  return entryManifests;
+}
+
 /**
  * Get a list of all the entry points.
  *
@@ -61,14 +73,7 @@ const globalEntryFiles = {
  * @return {Object} - The entry file paths mapped to the entry names
  */
 function getEntryPoints(entry) {
-  const manifests = getAppManifests();
-  let manifestsToBuild = manifests;
-  if (entry) {
-    const entryNames = entry.split(',').map(name => name.trim());
-    manifestsToBuild = manifests.filter(manifest =>
-      entryNames.includes(manifest.entryName),
-    );
-  }
+  const manifestsToBuild = getEntryManifests(entry);
 
   return getWebpackEntryPoints(manifestsToBuild);
 }
@@ -380,6 +385,12 @@ module.exports = env => {
         ],
       }),
     );
+
+    // Open the browser to either --env.openTo or one of the root URLs of the
+    // apps we're scaffolding
+    baseConfig.devServer.open = true;
+    baseConfig.devServer.openPage =
+      buildOptions.openTo || getEntryManifests(buildOptions.entry)[0].rootUrl;
   }
 
   if (isOptimizedBuild) {

--- a/script/build-help.js
+++ b/script/build-help.js
@@ -46,6 +46,12 @@ const helpSections = [
         description:
           'Automatically generate application landing pages. Can be used as an alternative to running a full content build.',
       },
+      {
+        name: 'env.openTo',
+        typeLabel: '{underline URL}',
+        description:
+          'The path to open the browser to when --env.scaffold is true. {dim --env.openTo path/to/my/app} will open the browser to {underline http://localhost:3001/path/to/my/app}. Defaults to the either the rootUrl of an app in --env.entry or the home page.',
+      },
     ],
   },
   {


### PR DESCRIPTION
## Description
If we're running `--env.scaffold`, we're probably going to open the dev server to the application we're building. This PR will open the browser if we pass the `--env.scaffold` flag to the build task. The logic to determine the URL to open to is as follows:
1. If the `--env.openTo` flag is passed, open to that URL
2. If the `--env.entry` flag is present, open to the first URL in the list of applications to build
3. Open to the home page

## Testing done
Manual :eyes: 

## Screenshots
Mostly N/A, but I added the help.
![image](https://user-images.githubusercontent.com/12970166/101705033-e76b1180-3a3a-11eb-8487-783b92879a15.png)


## Acceptance criteria
- [x] A new browser tab is opened when `--env.scaffold` is true
- [x] The URL to open to uses the logic defined above