### PR TITLE
Set focus on search result header and make search area button assistive

### DIFF
--- a/src/applications/facility-locator/containers/FacilitesMap.jsx
+++ b/src/applications/facility-locator/containers/FacilitesMap.jsx
@@ -158,6 +158,9 @@ const FacilitiesMap = props => {
         new mapboxgl.LngLat(locationCoords.lng, locationCoords.lat),
       );
     }
+    if (searchResultTitleRef.current) {
+      setFocus(searchResultTitleRef.current);
+    }
   };
 
   const handleSearch = async () => {
@@ -557,9 +560,6 @@ const FacilitiesMap = props => {
             radius,
           });
           setIsSearching(false);
-        }
-        if (searchResultTitleRef.current) {
-          setFocus(searchResultTitleRef.current);
         }
       }
     },

--- a/src/applications/facility-locator/utils/SearchAreaControl.js
+++ b/src/applications/facility-locator/utils/SearchAreaControl.js
@@ -7,6 +7,7 @@ export default class SearchAreaControl {
     this.map = map;
     this.container = document.createElement('div');
     this.container.id = 'search-area-control-container';
+    this.container.setAttribute('aria-live', 'polite');
     this.container.className = this.isMobile
       ? 'mapboxgl-ctrl-bottom-center'
       : 'mapboxgl-ctrl-top-center';


### PR DESCRIPTION
## Description
issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/17252

## Testing done


## Acceptance criteria
- [x] Make "Search this area" button available to screenreaders
- [x] Move focus to search results header after the "Search this area" button has been used to trigger a new search. 

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
