### PR TITLE
Fixed precedence of routes in test server

### DIFF
--- a/src/platform/testing/e2e/test-server.js
+++ b/src/platform/testing/e2e/test-server.js
@@ -37,8 +37,10 @@ app.use(
     skip: (req, _res) => req.path.match(/(css|js|gif|jpg|png|svg)$/),
   }),
 );
+
 app.use(express.static(root));
-routes.forEach(url => {
+
+routes.sort((a, b) => b.length - a.length).forEach(url => {
   app.use(url, fallback(`${url}/index.html`, { root }));
 });
 

--- a/src/platform/testing/e2e/test-server.js
+++ b/src/platform/testing/e2e/test-server.js
@@ -2,8 +2,8 @@
 
 // Simple test server to serve up the build files.
 
-// This is used over a bear http-server invocation because it handles paths inside React apps
-// using the expression-history-api-fallback option.
+// This is used over a vanilla http-server because it handles paths
+// inside React apps using the express-history-api-fallback option.
 
 const fs = require('fs');
 const commandLineArgs = require('command-line-args');

--- a/src/platform/testing/e2e/test-server.js
+++ b/src/platform/testing/e2e/test-server.js
@@ -34,7 +34,11 @@ app.use(
 
 app.use(express.static(root));
 
-routes.sort((a, b) => b.length - a.length).forEach(url => {
+// Sort by descending path length to give precedence to deeper root URLs.
+// For example, '/foo/bar/baz' should match '/foo/bar' instead of '/foo'
+// because '/foo/bar' is a deeper and more specific path than '/foo'.
+routes.sort((a, b) => b.length - a.length);
+routes.forEach(url => {
   app.use(url, fallback(`${url}/index.html`, { root }));
 });
 

--- a/src/platform/testing/e2e/test-server.js
+++ b/src/platform/testing/e2e/test-server.js
@@ -5,12 +5,12 @@
 // This is used over a vanilla http-server because it handles paths
 // inside React apps using the express-history-api-fallback option.
 
-const fs = require('fs');
 const commandLineArgs = require('command-line-args');
 const express = require('express');
 const fallback = require('express-history-api-fallback');
-const path = require('path');
 const morgan = require('morgan');
+const path = require('path');
+
 const manifestHelpers = require('../../../../config/manifest-helpers');
 const ENVIRONMENTS = require('../../../site/constants/environments');
 
@@ -19,18 +19,12 @@ const optionDefinitions = [
   { name: 'port', type: Number, defaultValue: +(process.env.WEB_PORT || 3333) },
   { name: 'host', type: String, defaultValue: 'localhost' },
 ];
+
 const options = commandLineArgs(optionDefinitions);
+const root = path.resolve(__dirname, `../../../../build/${options.buildtype}`);
+const routes = manifestHelpers.getAppRoutes();
 
 const app = express();
-
-let root = path.resolve(__dirname, `../../../../build/${options.buildtype}`);
-if (!fs.existsSync(root)) {
-  // if there isn't a build directory here, then check the parent directory.
-  // This is a temporary adapation as we transition to vagov-content.
-  root = path.resolve(__dirname, `../../../../../build/${options.buildtype}`);
-}
-
-const routes = manifestHelpers.getAppRoutes();
 
 app.use(
   morgan('combined', {


### PR DESCRIPTION
## Description
This fixes E2E test failures where the test would visit the wrong app due to URLs incorrectly resolving to less specific routes.

To give a real life example, there are going to be two apps hosted at the following paths:

Questionnaire List: `/health-care/health-questionnaires/questionnaires`
Health Care Questionnaire: `/health-care/health-questionnaires/questionnaires/answer-questions`

Visiting `/health-care/health-questionnaires/questionnaires/answer-questions/introduction` would end up resolving to `/health-care/health-questionnaires/questionnaires` because of the order in which the routes were set up.

The fix is to create the routes in order of descending path length, which mimics [how the rewrites are set up in `webpack.dev.config.js`](https://github.com/department-of-veterans-affairs/vets-website/blob/master/config/webpack.dev.config.js#L11).

## Testing done
Locally reproduced the test failure from the feature branch and verified that the tests passed after this fix.

## Acceptance criteria
- [ ] Routes visited in E2E tests should fall back to the expected paths.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
