### PR TITLE
[covid vaccine] Fix for confirmation page navigating back to the intro

### DIFF
--- a/src/applications/coronavirus-vaccination/components/Confirmation.jsx
+++ b/src/applications/coronavirus-vaccination/components/Confirmation.jsx
@@ -45,7 +45,7 @@ function Confirmation({ router, formData }) {
 
 const mapStateToProps = state => {
   return {
-    formData: state.coronavirusVaccinationApp.formData,
+    formData: state.coronavirusVaccinationApp.formState?.formData,
   };
 };
 

--- a/src/applications/coronavirus-vaccination/components/Form.jsx
+++ b/src/applications/coronavirus-vaccination/components/Form.jsx
@@ -35,7 +35,7 @@ function Form({ formState, updateFormData, router, isLoggedIn, profile }) {
           event: 'covid-vaccination--submission-successful',
         });
         router.replace('/confirmation');
-      } else {
+      } else if (submitStatus === requestStates.failed) {
         recordEvent({
           event: 'covid-vaccination--submission-failed',
         });


### PR DESCRIPTION
## Description
The Confirmation page has a humble redirect to the intro page if there isn't any form data in state (to prevent direct navigation.) It was previously doing this lookup erroneously, causing this redirect to always happen. This fixes that.

## Testing done
I had to change some code locally to test bc the API doesn't run outside of the network but I confirmed the Confirmation page can be reached

## Screenshots
N/A

## Acceptance criteria
- [ ] Confirmation page can be accessed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
