### PR TITLE
Remove breadcrumb to unpublished page

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -938,10 +938,7 @@
           "path": "health-care/",
           "name": "Health care"
         },
-        {
-          "path": "health-care/covid-19-vaccine/",
-          "name": "COVID-19 vaccines"
-        },
+
         {
           "path": "health-care/covid-19-vaccine/stay-informed",
           "name": "Stay informed and help us prepare"

--- a/src/site/stages/build/plugins/check-broken-links/helpers/applyIgnoredRoutes.js
+++ b/src/site/stages/build/plugins/check-broken-links/helpers/applyIgnoredRoutes.js
@@ -1,7 +1,7 @@
 function _getReactLandingPages(files) {
   return Object.keys(files)
     .map(fileName => files[fileName])
-    .filter(file => !!file.entryname)
+    .filter(file => !!file.entryName)
     .map(file => `/${file.path}`);
 }
 

--- a/src/site/stages/build/plugins/check-broken-links/helpers/applyIgnoredRoutes.js
+++ b/src/site/stages/build/plugins/check-broken-links/helpers/applyIgnoredRoutes.js
@@ -1,7 +1,7 @@
 function _getReactLandingPages(files) {
   return Object.keys(files)
     .map(fileName => files[fileName])
-    .filter(file => !!file.entryName)
+    .filter(file => !!file.entryname)
     .map(file => `/${file.path}`);
 }
 


### PR DESCRIPTION
## Description
Related to the COVID vaccine updates tool, we merged our app gated behind a Flipper toggle, https://github.com/department-of-veterans-affairs/vets-website/pull/15286. However, the breadcrumbs link to a Drupal that is not published. This PR removes that breadcrumb so the link checker allows a build to pass.

## Testing done
Ran the link checker locally

## Screenshots
N/A

## Acceptance criteria
- [ ] Build passes w/o broken links

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
