### PR TITLE
Convert NeedHelp, Textarea tests, use Telephone component

### DIFF
--- a/src/applications/vaos/appointment-list/components/cancel/CancelCommunityCareAppointmentModal.jsx
+++ b/src/applications/vaos/appointment-list/components/cancel/CancelCommunityCareAppointmentModal.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
+import Telephone from '@department-of-veterans-affairs/formation-react/Telephone';
 
 export default function CancelCommunityCareAppointmentModal({
   onClose,
@@ -56,7 +57,7 @@ export default function CancelCommunityCareAppointmentModal({
               <strong>Main phone:</strong>
             </dt>{' '}
             <dd className="vads-u-display--inline">
-              <a href={`tel:${phone.replace(/[^0-9]/g, '')}`}>{phone}</a>
+              <Telephone contact={phone} />
             </dd>
           </dl>
         )}

--- a/src/applications/vaos/appointment-list/components/cancel/CancelVideoAppointmentModal.jsx
+++ b/src/applications/vaos/appointment-list/components/cancel/CancelVideoAppointmentModal.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
+import Telephone from '@department-of-veterans-affairs/formation-react/Telephone';
 
 export default function CancelVideoAppointmentModal({ onClose, facility }) {
   const phone = facility?.telecom?.find(tele => tele.system === 'phone').value;
@@ -26,7 +27,7 @@ export default function CancelVideoAppointmentModal({ onClose, facility }) {
               <strong>Main phone:</strong>
             </dt>{' '}
             <dd className="vads-u-display--inline">
-              <a href={`tel:${phone.replace(/[^0-9]/g, '')}`}>{phone}</a>
+              <Telephone contact={phone} />
             </dd>
           </dl>
         )}

--- a/src/applications/vaos/components/NeedHelp.jsx
+++ b/src/applications/vaos/components/NeedHelp.jsx
@@ -16,25 +16,20 @@ export default function NeedHelp() {
       />
       <p className="vads-u-margin-top--0">
         If you have questions about using the VA appointments tool, or if the
-        tool isn’t working right, please call{' '}
-        <a href="tel:8774705947">877-470-5947</a> (TTY:{' '}
-        <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
+        tool isn’t working right, please call <Telephone contact="8774705947" />{' '}
+        (TTY: <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
         ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
       </p>
       <p className="vads-u-margin-top--0">
         If you need help scheduling a VA or community care appointment, please
         call your VA or community care facility.{' '}
-        <a
-          href="https://www.va.gov/find-locations/"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <a href="/find-locations" target="_blank" rel="noopener noreferrer">
           Find your health facility’s phone number.
         </a>
       </p>
       <p className="vads-u-margin-top--0">
         For questions about joining a VA Video Connect appointment, please call{' '}
-        <a href="tel:8666513180">866-651-3180</a> (TTY:{' '}
+        <Telephone contact="8666513180" /> (TTY:{' '}
         <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
         ). We’re here Monday through Saturday, 7:00 a.m. to 11:00 p.m. ET.
       </p>

--- a/src/applications/vaos/new-appointment/components/DateTimeSelectPage/WaitTimeAlert.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeSelectPage/WaitTimeAlert.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 import { Link } from 'react-router-dom';
 import { MENTAL_HEALTH } from '../../../utils/constants';
 import { getRealFacilityId } from '../../../utils/appointment';
@@ -68,7 +71,7 @@ export const WaitTimeAlert = ({
                   <ul>
                     <li>
                       Call the Veterans Crisis hotline at{' '}
-                      <a href="tel:8002738255">800-273-8255</a> and press 1,{' '}
+                      <Telephone contact={CONTACTS.CRISIS_LINE} /> and press 1,{' '}
                       <span className="vads-u-font-weight--bold">or</span>
                     </li>
                     <li>

--- a/src/applications/vaos/new-appointment/components/ReasonForAppointmentPage.jsx
+++ b/src/applications/vaos/new-appointment/components/ReasonForAppointmentPage.jsx
@@ -1,6 +1,9 @@
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import { validateWhiteSpace } from 'platform/forms/validations';
 import * as actions from '../redux/actions';
@@ -113,12 +116,12 @@ function ReasonForAppointmentPage({
             content={
               <ul>
                 <li>
-                  Call <a href="tel:911">911</a>,{' '}
+                  Call <Telephone contact={CONTACTS['911']} />,{' '}
                   <span className="vads-u-font-weight--bold">or</span>
                 </li>
                 <li>
                   Call the Veterans Crisis hotline at{' '}
-                  <a href="tel:8002738255">800-273-8255</a> and press 1,{' '}
+                  <Telephone contact={CONTACTS.CRISIS_LINE} /> and press 1,{' '}
                   <span className="vads-u-font-weight--bold">or</span>
                 </li>
                 <li>

--- a/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/index.cancel.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/index.cancel.unit.spec.jsx
@@ -194,7 +194,7 @@ describe('VAOS integration appointment cancellation:', () => {
 
     expect(modal).to.contain.text('Big sky medical');
     expect(modal).to.contain.text('Jane Doctor');
-    expect(modal).to.contain.text('4065555555');
+    expect(modal).to.contain.text('406-555-5555');
 
     fireEvent.click(getByText(/OK/i));
 

--- a/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/index.cancel.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/index.cancel.unit.spec.jsx
@@ -515,7 +515,9 @@ describe('VAOS integration appointment cancellation:', () => {
 
     expect(queryByRole('alertdialog')).to.not.be.ok;
     expect(baseElement).to.contain.text('Canceled');
-    expect(document.activeElement).to.have.tagName('h1');
+    await waitFor(() => {
+      expect(document.activeElement).to.have.tagName('h1');
+    });
   });
 
   it('va appointments at Cerner site should direct users to portal', async () => {

--- a/src/applications/vaos/tests/components/NeedHelp.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/NeedHelp.unit.spec.jsx
@@ -1,44 +1,26 @@
 import React from 'react';
 import { expect } from 'chai';
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 
 import NeedHelp from '../../components/NeedHelp';
 
 describe('VAOS <NeedHelp>', () => {
-  it('should render', () => {
-    const tree = shallow(<NeedHelp />);
+  it('should show contact information and feedback link', () => {
+    const screen = render(<NeedHelp />);
 
-    expect(tree.find('h2').text()).to.contain('Need help?');
-    expect(tree.hasClass('vads-u-margin-top--9')).be.true;
+    expect(screen.getByRole('heading', { level: 2, name: /need help/i })).to
+      .exist;
 
-    const links = tree.find('a');
-    expect(links.length).to.equal(4);
-    expect(links.at(0).props().href).to.equal('tel:8774705947');
-    expect(links.at(0).text()).to.equal('877-470-5947');
-    expect(links.at(1).props().href).to.equal(
-      'https://www.va.gov/find-locations/',
-    );
-    expect(links.at(1).text()).to.equal(
-      'Find your health facility’s phone number.',
-    );
-    expect(links.at(2).props().href).to.equal('tel:8666513180');
-    expect(links.at(2).text()).to.equal('866-651-3180');
-    expect(links.at(3).props().href).to.equal(
+    expect(screen.getByText(/877-470-5947/i)).to.have.attribute('href');
+    expect(screen.getByText(/866-651-3180/i)).to.have.attribute('href');
+    expect(
+      screen.getByRole('link', { name: /find your health facility/i }),
+    ).to.have.attribute('href', '/find-locations');
+    expect(
+      screen.getByRole('link', { name: /leave feedback/i }),
+    ).to.have.attribute(
+      'href',
       'https://veteran.apps.va.gov/feedback-web/v1/?appId=85870ADC-CC55-405E-9AC3-976A92BBBBEE',
     );
-    expect(links.at(3).text()).to.equal(
-      'Leave feedback about this application',
-    );
-
-    const telephoneLinks = tree.find('Telephone');
-    expect(telephoneLinks.length).to.equal(2);
-
-    tree.unmount();
-  });
-  it('should have aria labels to hide from screen reader', () => {
-    const tree = shallow(<NeedHelp />);
-
-    expect(tree.find('hr[aria-hidden="true"]').exists()).to.be.true;
-    tree.unmount();
   });
 });

--- a/src/applications/vaos/tests/components/TextareaWidget.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/TextareaWidget.unit.spec.jsx
@@ -1,32 +1,37 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 
 import TextareaWidget from '../../components/TextareaWidget';
+import userEvent from '@testing-library/user-event';
 
 describe('VAOS <TextareaWidget>', () => {
   it('should render character limit', () => {
-    const tree = shallow(
+    const screen = render(
       <TextareaWidget value="Test" schema={{ maxLength: 20 }} />,
     );
 
-    expect(tree.find('textarea').props().maxLength).to.equal(20);
-    expect(tree.text()).to.contain('16 characters remaining');
-    tree.unmount();
+    expect(screen.getByText(/16 characters remaining/i)).to.exist;
+    expect(screen.getByRole('textbox')).to.have.attribute('maxlength', '20');
+    expect(screen.getByRole('textbox')).to.have.value('Test');
+  });
+
+  it('should render over the limit message', () => {
+    const screen = render(
+      <TextareaWidget value="Test" schema={{ maxLength: 2 }} />,
+    );
+
+    expect(screen.getByText(/2 characters over the limit/i)).to.exist;
+    expect(screen.getByRole('textbox')).to.have.attribute('maxlength', '2');
+    expect(screen.getByRole('textbox')).to.have.value('Test');
   });
 
   it('should call onChange', () => {
     const onChange = sinon.spy();
-    const tree = shallow(
-      <TextareaWidget onChange={onChange} value="Test" schema={{}} />,
-    );
+    const screen = render(<TextareaWidget onChange={onChange} schema={{}} />);
 
-    tree
-      .find('textarea')
-      .props()
-      .onChange({ target: { value: 'what' } });
-    expect(onChange.calledWith('what')).to.be.true;
-    tree.unmount();
+    userEvent.type(screen.getByRole('textbox'), 'w');
+    expect(onChange.calledWith('w')).to.be.true;
   });
 });

--- a/src/applications/vaos/tests/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
@@ -189,11 +189,7 @@ describe('VAOS <DateTimeSelectPage>', () => {
     ).to.be.ok;
 
     // it should display link to phone number
-    expect(
-      screen.getByRole('link', {
-        name: '800-273-8255',
-      }),
-    ).to.be.ok;
+    expect(screen.getByText(/800-273-8255/)).to.have.tagName('a');
   });
 
   it('should allow a user to choose available slot and fetch new slots after changing clinics', async () => {


### PR DESCRIPTION
## Description
This converts our NeedHelp and Textarea component tests to use RTL.

In the course of updating the NeedHelp tests, I noticed that some phone number links in there weren't using the Telephone component, so I updated those and checked the rest of the app for other missed usages. I've updated those in here as well.

## Testing done
Unit testing

## Acceptance criteria
- [ ] Build passes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
