### PR TITLE
Fix staff thumbnail images in cms-export build

### DIFF
--- a/src/site/stages/build/process-cms-exports/transformers/node-person_profile.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-person_profile.js
@@ -6,6 +6,22 @@ const {
   getImageCrop,
 } = require('./helpers');
 
+// Add any other pages here that require square thumbnails
+const squareThumnbnailPages = ['/pittsburgh-health-care/programs/cardiology'];
+
+const getThumbnail = ancestors => {
+  if (
+    ancestors.find(
+      a =>
+        a.entity.entityUrl &&
+        squareThumnbnailPages.includes(a.entity.entityUrl.path),
+    )
+  ) {
+    return '_1_1_SQUARE_MEDIUM_THUMBNAIL';
+  }
+  return '_23MEDIUMTHUMBNAIL';
+};
+
 const transform = (entity, { ancestors }) => ({
   entityType: 'node',
   entityBundle: 'person_profile',
@@ -24,10 +40,7 @@ const transform = (entity, { ancestors }) => ({
   fieldMedia:
     entity.fieldMedia && entity.fieldMedia.length > 0
       ? {
-          entity: getImageCrop(
-            entity.fieldMedia[0],
-            '_1_1_SQUARE_MEDIUM_THUMBNAIL',
-          ),
+          entity: getImageCrop(entity.fieldMedia[0], getThumbnail(ancestors)),
         }
       : null,
   fieldNameFirst: getDrupalValue(entity.fieldNameFirst),


### PR DESCRIPTION
## Description
Use the correct staff thumbnail image on staff profile pages and other pages that include staff profiles, e.g. `/pittsburgh-health-care/programs/cardiology`.

## Testing done
View pages locally

## Screenshots

Should match these (from staging):

## Square

![VA_Pittsburgh_Health_Care___Cardiology___Veterans_Affairs](https://user-images.githubusercontent.com/80267/101802444-6d3f9900-3add-11eb-9855-8b242a7984fe.png)

## 2 x 3
![Ali_Sonel___VA_Pittsburgh_health_care___Veterans_Affairs](https://user-images.githubusercontent.com/80267/101802508-821c2c80-3add-11eb-93cb-78160c074a93.png)

## Acceptance criteria
- [ ] The correct thumbnail path is used in all pages that display a staff profile image

## Definition of done
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
