### PR TITLE
Skip Find Forms Cypress test in CircleCI

### DIFF
--- a/src/applications/find-forms/tests/e2e/00-required.cypress.spec.js
+++ b/src/applications/find-forms/tests/e2e/00-required.cypress.spec.js
@@ -16,6 +16,10 @@ function axeTestPage() {
 }
 
 describe('functionality of Find Forms', () => {
+  before(function() {
+    if (Cypress.env('CIRCLECI')) this.skip();
+  });
+
   it('search the form and expect dom to have elements', () => {
     cy.server();
     cy.route({


### PR DESCRIPTION
## Description
This skips the Cypress test for Find Forms in CircleCI.

It has been breaking because the CircleIC build does not build the full site with content and instead relies on the `manifest.json` and `registry.json` to imitate the actual content pages.

I took a look at the project structure and it doesn't look like the page for the app actually depends on those files to build. AFAIK, we don't really have a way to support tests on content pages in CircleCI at the moment (but looking into a possible solution for that in the hopefully near future). But I will let y'all take it from here to see if doing so makes sense.

**If it makes sense, in order to re-enable this test in CircleCI**, please create:
- a `manifest.json` for the app in its directory with the appropriate `rootUrl`
- an entry in `registry.json`

## Testing done
Tests pass in CircleCI.

## Acceptance criteria
- [ ] Tests should pass in CircleCI.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
