### PR TITLE
Modifies Sentry logging for SSO

### DIFF
--- a/src/platform/monitoring/sentry.js
+++ b/src/platform/monitoring/sentry.js
@@ -19,6 +19,7 @@ if (trackErrors) {
       // https://github.com/getsentry/sentry/issues/5267
       /Blocked a frame with origin/,
     ],
+    attachStacktrace: true,
   });
   Sentry.setTag('source', 'unknown');
   Sentry.configureScope(scope => {

--- a/src/platform/utilities/sso/keepAliveSSO.js
+++ b/src/platform/utilities/sso/keepAliveSSO.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import * as Sentry from '@sentry/browser';
 
 import { ssoKeepAliveEndpoint } from 'platform/user/authentication/utilities';

--- a/src/platform/utilities/sso/keepAliveSSO.js
+++ b/src/platform/utilities/sso/keepAliveSSO.js
@@ -2,6 +2,8 @@ import * as Sentry from '@sentry/browser';
 
 import { ssoKeepAliveEndpoint } from 'platform/user/authentication/utilities';
 
+const SENTRY_LOG_THRESHOLD = [Sentry.Severity.Info];
+
 const logToSentry = data => {
   let isCaptured = null;
   const { message } = data;
@@ -30,8 +32,7 @@ const logToSentry = data => {
     ? caughtExceptions[message].TYPE
     : caughtExceptions.default.TYPE;
 
-  // Doesn't log "info" to Sentry
-  if (LEVEL !== Sentry.Severity.Info) {
+  if (!SENTRY_LOG_THRESHOLD.includes(LEVEL)) {
     Sentry.withScope(scope => {
       scope.setLevel(LEVEL);
       scope.setExtra(`${LEVEL}`, data);


### PR DESCRIPTION
## Description
Discovery during a Sentry Hackathon for the Identity team.  There is an issue with Sentry appropriately tagging/ignoring exceptions as it relates to the Identity team.  This PR updates Sentry logging in the `keepAliveSSO.js` file and ensures `monitoring/sentry.js` attaches stack traces appropriately.

## Testing done
manual

## Screenshots


## Acceptance criteria
- [x] Sentry filters out unneeded log events that are of type `info` as determined by the team. (ie TypeError: The network connection was lost., etc)
- [x] Sentry continues to log `error` and `warning` levels.
- [x] Sentry attaches the stack traces if they are available

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
