### PR TITLE
Add back the breadcrumb

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -937,7 +937,10 @@
           "path": "health-care/",
           "name": "Health care"
         },
-
+        {
+          "path": "health-care/covid-19-vaccine/",
+          "name": "COVID-19 vaccines"
+        },
         {
           "path": "health-care/covid-19-vaccine/stay-informed",
           "name": "Stay informed and help us prepare"


### PR DESCRIPTION
## Description
This PR adds back a breadcrumb for a page that was was unpublished before but is now published.

Related to https://github.com/department-of-veterans-affairs/vets-website/pull/15298

## Testing done
Confirmed the page is published at https://staging.va.gov/health-care/covid-19-vaccine/

## Screenshots
n/a

## Acceptance criteria
- [ ] Breadcrumbs are correct

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
