### PR TITLE
[covid vaccine updates] Auto mount the widget w/o a widget ID

### DIFF
--- a/src/applications/static-pages/covid-vaccine-updates-cta/createCovidVaccineUpdatesWidget.js
+++ b/src/applications/static-pages/covid-vaccine-updates-cta/createCovidVaccineUpdatesWidget.js
@@ -9,7 +9,7 @@ export default function createCovidVaccineUpdatesWidget(store, _widgetType) {
     return;
   }
 
-  const introText = document.querySelector('.va-introtext');
+  const introText = document.querySelector('.va-introtext')?.nextElementSibling;
   const wrapper = introText.parentNode;
   const reactRoot = document.createElement('div');
 

--- a/src/applications/static-pages/covid-vaccine-updates-cta/createCovidVaccineUpdatesWidget.js
+++ b/src/applications/static-pages/covid-vaccine-updates-cta/createCovidVaccineUpdatesWidget.js
@@ -1,13 +1,25 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-export default function createCovidVaccineUpdatesWidget(store, widgetType) {
-  const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
-  if (root) {
+export default function createCovidVaccineUpdatesWidget(store, _widgetType) {
+  const isCovidVaccineUpdatesPage =
+    document.location.pathname === '/health-care/covid-19-vaccine/';
+
+  if (!isCovidVaccineUpdatesPage) {
+    return;
+  }
+
+  const introText = document.querySelector('.va-introtext');
+  const wrapper = introText.parentNode;
+  const reactRoot = document.createElement('div');
+
+  wrapper.insertBefore(reactRoot, introText);
+
+  if (reactRoot) {
     import(/* webpackChunkName: "CovidVaccineUpdatesCTA" */
     './widget').then(module => {
       const CovidVaccineUpdatesCTA = module.default;
-      ReactDOM.render(<CovidVaccineUpdatesCTA store={store} />, root);
+      ReactDOM.render(<CovidVaccineUpdatesCTA store={store} />, reactRoot);
     });
   }
 }


### PR DESCRIPTION
## Description
The COVID-19 Vaccine Updates widget previously followed the same pattern as the rest of our widgets. However, the content  model and the corresponding template don't support adding React Widgets above the Table of Contents - you can only put plain alert boxes. This means that the standard widget approach doesn't work. This PR does a programmatic render instead - it traverses the DOM and appends the React widget itself. 

## Testing done
Checked that the widget rendered okay

## Screenshots
This screenshot shows the React-backed alert box

![image](https://user-images.githubusercontent.com/1915775/101852227-26789000-3b2b-11eb-8a23-5c3234056763.png)


## Acceptance criteria
- [ ] Widget renders in the right spot

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
