### PR TITLE
Added BAH as owner of edu-benefits

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -74,10 +74,7 @@ src/applications/healthcare @department-of-veterans-affairs/vsa-healthcare-exper
 # Booz Allen Team
 src/applications/static-pages/school-resources @department-of-veterans-affairs/bah-code-reviewers
 src/applications/gi @department-of-veterans-affairs/bah-code-reviewers
-src/applications/edu-benefits/0993 @department-of-veterans-affairs/bah-code-reviewers
-src/applications/edu-benefits/1995 @department-of-veterans-affairs/bah-code-reviewers
-src/applications/edu-benefits/10203 @department-of-veterans-affairs/bah-code-reviewers
-src/applications/edu-benefits/feedback-tool @department-of-veterans-affairs/bah-code-reviewers
+src/applications/edu-benefits @department-of-veterans-affairs/bah-code-reviewers
 
 # CTO Health Products
 src/applications/coronavirus-research @department-of-veterans-affairs/va-cto-health-products


### PR DESCRIPTION
## Description
We keep updating CODEOWNERS as we need to make changes to additional apps under `edu-benefits` but we "own" them all anyway so we might as well make it one more update.

I'm making content updates to the [5490](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/16894) and [0993](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/16852) but this keeps coming up

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [X] BAH team listed as owner of `edu-benefits`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
