### PR TITLE
Covid 19 vaccine fix pattern matching issue during validation of zipCodeDetails

### DIFF
--- a/src/applications/coronavirus-vaccination/config/schema.js
+++ b/src/applications/coronavirus-vaccination/config/schema.js
@@ -7,7 +7,7 @@ export default {
     'phone',
     'zipCode',
     'vaccineInterest',
-    'zipCodeDetails',
+    'locationDetails',
   ],
   properties: {
     isIdentityVerified: {
@@ -37,7 +37,7 @@ export default {
       type: 'string',
       pattern: '^\\d{5}(-\\d{4})?$',
     },
-    zipCodeDetails: {
+    locationDetails: {
       type: 'string',
       enum: ['Yes', 'No', 'Unsure'],
     },

--- a/src/applications/coronavirus-vaccination/config/uiSchema.js
+++ b/src/applications/coronavirus-vaccination/config/uiSchema.js
@@ -80,7 +80,7 @@ export default {
       pattern: 'Please enter a valid zip code',
     },
   },
-  zipCodeDetails: {
+  locationDetails: {
     'ui:title': 'Will you be in this zip code for the next 6 to 12 months?',
     'ui:widget': 'radio',
     'ui:errorMessages': {


### PR DESCRIPTION
## Description
Change name of zipCodeDetails so validation does not pick it up when validating zipCode
https://github.com/department-of-veterans-affairs/va.gov-team/issues/17241

## Testing done
manual testing

## Screenshots
![image](https://user-images.githubusercontent.com/2481110/101917139-e6022c00-3b95-11eb-9058-1d569765b367.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
