### PR TITLE
Add caregivers to HCA CodeOwners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,6 +66,9 @@ src/site/filters @department-of-veterans-affairs/vsa-facilities-frontend @depart
 # Caregiver
 src/applications/caregivers @department-of-veterans-affairs/vsa-caregiver-frontend @department-of-veterans-affairs/vsa-bam-1-frontend
 
+# Health Care Application 
+src/applications/hca @department-of-veterans-affairs/vsa-caregiver-frontend @department-of-veterans-affairs/vsa-bam-1-frontend
+
 # Healthcare Experience
 src/applications/healthcare @department-of-veterans-affairs/vsa-healthcare-experience
 


### PR DESCRIPTION
## Description
As a Developer I need to get peer reviews for applications my team owns. Add the CodeOwners from Caregivers team to the Health Care Application to reflect ownership.

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Add caregiver team to HCA CodeOwners

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
