### PR TITLE
stop using Object.values in flipper-client

### DIFF
--- a/src/platform/utilities/feature-toggles/flipper-client.js
+++ b/src/platform/utilities/feature-toggles/flipper-client.js
@@ -4,7 +4,10 @@ import FEATURE_FLAG_NAMES from './featureFlagNames';
 import { getFlipperId } from './helpers';
 
 const FLIPPER_ID = getFlipperId();
-const featureToggleQueryList = Object.values(FEATURE_FLAG_NAMES);
+
+const featureToggleQueryList = Object.keys(FEATURE_FLAG_NAMES).map(key => {
+  return FEATURE_FLAG_NAMES[key];
+});
 const TOGGLE_VALUES_PATH = `/v0/feature_toggles?features=${featureToggleQueryList.join(
   ',',
 )}&cookie_id=${FLIPPER_ID}`;


### PR DESCRIPTION
I'm not sure this is really required. Seems much more likely the polyfill PR that's already merged should fix the issue. I jumped into fixing this without really doing my research.

## Description
Apparently this particular file is not run through Babel (or much less likely our Babel config does not transpile `Object.values()`). This uses the old-school way to get out all of an Object's values.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs