### PR TITLE
Fix fieldEmailContacts on service location transformer

### DIFF
--- a/src/site/stages/build/process-cms-exports/transformers/paragraph-service_location.js
+++ b/src/site/stages/build/process-cms-exports/transformers/paragraph-service_location.js
@@ -8,7 +8,10 @@ const transform = entity => ({
   },
   fieldEmailContacts: entity.fieldEmailContacts
     ? entity.fieldEmailContacts.map(emailContactData => ({
-        entity: { ...emailContactData },
+        entity: {
+          fieldEmailLabel: getDrupalValue(emailContactData.fieldEmailLabel),
+          fieldEmailAddress: getDrupalValue(emailContactData.fieldEmailAddress),
+        },
       }))
     : null,
   fieldFacilityServiceHours: entity.fieldFacilityServiceHours[0],


### PR DESCRIPTION
## Acceptance criteria
- [x] The email section in the service locations no longer shows `[object Object]`

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
