### PR TITLE
Fix - Instruction in empty result-list missing required Facility-type…

### DIFF
--- a/src/applications/facility-locator/components/SearchResultMessage.jsx
+++ b/src/applications/facility-locator/components/SearchResultMessage.jsx
@@ -45,8 +45,8 @@ const SearchResultMessage = ({
 
   return (
     <div className="search-result-title">
-      Please enter a location (street, city, state or postal code) and click
-      search above to find facilities.
+      Please enter a location (street, city, state, or postal code) and facility
+      type, then click search above to find facilities.
     </div>
   );
 };

--- a/src/applications/facility-locator/tests/components/__snapshots__/SearchResultMessage.unit.spec.jsx.mocha-snapshot
+++ b/src/applications/facility-locator/tests/components/__snapshots__/SearchResultMessage.unit.spec.jsx.mocha-snapshot
@@ -1,225 +1,3 @@
-exports["SearchResultMessage/Should render SearchResultMessage with location error(0)"] = {
-  "node": {
-    "nodeType": "host",
-    "type": "div",
-    "props": {
-      "className": "search",
-      "children": [
-        {
-          "type": "p",
-          "props": {
-            "children": "Something’s not quite right. Please enter a valid or different location and try your search again."
-          },
-          "_store": {}
-        },
-        {
-          "type": "p",
-          "props": {
-            "children": "If you need care right away for a minor illness or injury, select Urgent care under facility type, then select either VA or community providers as the service type."
-          },
-          "_store": {}
-        },
-        {
-          "type": "p",
-          "props": {
-            "children": "If you have a medical emergency, please go to your nearest emergency room or call 911."
-          },
-          "_store": {}
-        }
-      ]
-    },
-    "ref": {},
-    "rendered": [
-      {
-        "nodeType": "host",
-        "type": "p",
-        "props": {
-          "children": "Something’s not quite right. Please enter a valid or different location and try your search again."
-        },
-        "rendered": "Something’s not quite right. Please enter a valid or different location and try your search again."
-      },
-      {
-        "nodeType": "host",
-        "type": "p",
-        "props": {
-          "children": "If you need care right away for a minor illness or injury, select Urgent care under facility type, then select either VA or community providers as the service type."
-        },
-        "rendered": "If you need care right away for a minor illness or injury, select Urgent care under facility type, then select either VA or community providers as the service type."
-      },
-      {
-        "nodeType": "host",
-        "type": "p",
-        "props": {
-          "children": "If you have a medical emergency, please go to your nearest emergency room or call 911."
-        },
-        "rendered": "If you have a medical emergency, please go to your nearest emergency room or call 911."
-      }
-    ]
-  },
-  "type": "div",
-  "props": {
-    "className": "search"
-  },
-  "children": [
-    {
-      "node": {
-        "nodeType": "host",
-        "type": "p",
-        "props": {
-          "children": "Something’s not quite right. Please enter a valid or different location and try your search again."
-        },
-        "rendered": "Something’s not quite right. Please enter a valid or different location and try your search again."
-      },
-      "type": "p",
-      "props": {},
-      "children": [
-        "Something’s not quite right. Please enter a valid or different location and try your search again."
-      ]
-    },
-    {
-      "node": {
-        "nodeType": "host",
-        "type": "p",
-        "props": {
-          "children": "If you need care right away for a minor illness or injury, select Urgent care under facility type, then select either VA or community providers as the service type."
-        },
-        "rendered": "If you need care right away for a minor illness or injury, select Urgent care under facility type, then select either VA or community providers as the service type."
-      },
-      "type": "p",
-      "props": {},
-      "children": [
-        "If you need care right away for a minor illness or injury, select Urgent care under facility type, then select either VA or community providers as the service type."
-      ]
-    },
-    {
-      "node": {
-        "nodeType": "host",
-        "type": "p",
-        "props": {
-          "children": "If you have a medical emergency, please go to your nearest emergency room or call 911."
-        },
-        "rendered": "If you have a medical emergency, please go to your nearest emergency room or call 911."
-      },
-      "type": "p",
-      "props": {},
-      "children": [
-        "If you have a medical emergency, please go to your nearest emergency room or call 911."
-      ]
-    }
-  ]
-};
-
-exports["SearchResultMessage/Should render SearchResultMessage with Default error(0)"] = {
-  "node": {
-    "nodeType": "host",
-    "type": "div",
-    "props": {
-      "className": "search",
-      "children": [
-        {
-          "type": "p",
-          "props": {
-            "children": "We’re sorry. Something went wrong on our end. Please try again."
-          },
-          "_store": {}
-        },
-        {
-          "type": "p",
-          "props": {
-            "children": "If you need care right away for a minor illness or injury, select Urgent care under facility type, then select either VA or community providers as the service type."
-          },
-          "_store": {}
-        },
-        {
-          "type": "p",
-          "props": {
-            "children": "If you have a medical emergency, please go to your nearest emergency room or call 911."
-          },
-          "_store": {}
-        }
-      ]
-    },
-    "ref": {},
-    "rendered": [
-      {
-        "nodeType": "host",
-        "type": "p",
-        "props": {
-          "children": "We’re sorry. Something went wrong on our end. Please try again."
-        },
-        "rendered": "We’re sorry. Something went wrong on our end. Please try again."
-      },
-      {
-        "nodeType": "host",
-        "type": "p",
-        "props": {
-          "children": "If you need care right away for a minor illness or injury, select Urgent care under facility type, then select either VA or community providers as the service type."
-        },
-        "rendered": "If you need care right away for a minor illness or injury, select Urgent care under facility type, then select either VA or community providers as the service type."
-      },
-      {
-        "nodeType": "host",
-        "type": "p",
-        "props": {
-          "children": "If you have a medical emergency, please go to your nearest emergency room or call 911."
-        },
-        "rendered": "If you have a medical emergency, please go to your nearest emergency room or call 911."
-      }
-    ]
-  },
-  "type": "div",
-  "props": {
-    "className": "search"
-  },
-  "children": [
-    {
-      "node": {
-        "nodeType": "host",
-        "type": "p",
-        "props": {
-          "children": "We’re sorry. Something went wrong on our end. Please try again."
-        },
-        "rendered": "We’re sorry. Something went wrong on our end. Please try again."
-      },
-      "type": "p",
-      "props": {},
-      "children": [
-        "We’re sorry. Something went wrong on our end. Please try again."
-      ]
-    },
-    {
-      "node": {
-        "nodeType": "host",
-        "type": "p",
-        "props": {
-          "children": "If you need care right away for a minor illness or injury, select Urgent care under facility type, then select either VA or community providers as the service type."
-        },
-        "rendered": "If you need care right away for a minor illness or injury, select Urgent care under facility type, then select either VA or community providers as the service type."
-      },
-      "type": "p",
-      "props": {},
-      "children": [
-        "If you need care right away for a minor illness or injury, select Urgent care under facility type, then select either VA or community providers as the service type."
-      ]
-    },
-    {
-      "node": {
-        "nodeType": "host",
-        "type": "p",
-        "props": {
-          "children": "If you have a medical emergency, please go to your nearest emergency room or call 911."
-        },
-        "rendered": "If you have a medical emergency, please go to your nearest emergency room or call 911."
-      },
-      "type": "p",
-      "props": {},
-      "children": [
-        "If you have a medical emergency, please go to your nearest emergency room or call 911."
-      ]
-    }
-  ]
-};
-
 exports["SearchResultMessage/Should render SearchResultMessage with Default error message(0)"] = {
   "node": {
     "nodeType": "host",
@@ -328,6 +106,25 @@ exports["SearchResultMessage/Should render SearchResultMessage with Default erro
         "If you have a medical emergency, please go to your nearest emergency room or call 911."
       ]
     }
+  ]
+};
+
+exports["SearchResultMessage/Should render SearchResultMessage init(0)"] = {
+  "node": {
+    "nodeType": "host",
+    "type": "div",
+    "props": {
+      "className": "search",
+      "children": "Please enter a location (street, city, state, or postal code) and facility type, then click search above to find facilities."
+    },
+    "rendered": "Please enter a location (street, city, state, or postal code) and facility type, then click search above to find facilities."
+  },
+  "type": "div",
+  "props": {
+    "className": "search"
+  },
+  "children": [
+    "Please enter a location (street, city, state, or postal code) and facility type, then click search above to find facilities."
   ]
 };
 
@@ -539,25 +336,6 @@ exports["SearchResultMessage/Should render SearchResultMessage with location err
         "If you have a medical emergency, please go to your nearest emergency room or call 911."
       ]
     }
-  ]
-};
-
-exports["SearchResultMessage/Should render SearchResultMessage init(0)"] = {
-  "node": {
-    "nodeType": "host",
-    "type": "div",
-    "props": {
-      "className": "search",
-      "children": "Please enter a location (street, city, state or postal code) and click search above to find facilities."
-    },
-    "rendered": "Please enter a location (street, city, state or postal code) and click search above to find facilities."
-  },
-  "type": "div",
-  "props": {
-    "className": "search"
-  },
-  "children": [
-    "Please enter a location (street, city, state or postal code) and click search above to find facilities."
   ]
 };
 


### PR DESCRIPTION
## Description
issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/17261

## Testing done


## Screenshots
<img width="675" alt="Screen Shot 2020-12-11 at 4 51 01 PM" src="https://user-images.githubusercontent.com/100468/101962175-10250f80-3bd1-11eb-8bc6-ce4be69f43dc.png">


## Acceptance criteria
- [x] Instruction should include mention of required Facility-type selection before "and click search".

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
