### PR TITLE
Add hyphen to regex for web build

### DIFF
--- a/src/site/stages/build/drupal/assets.js
+++ b/src/site/stages/build/drupal/assets.js
@@ -91,7 +91,7 @@ function updateAttr(attr, doc, client) {
     const srcAttr = item.attr(attr);
 
     const siteURI = srcAttr.match(
-      /https?:\/\/([a-zA-Z0-9]+[.])*cms[.]va[.]gov/,
+      /https?:\/\/([a-zA-Z0-9-]+[.])*cms[.]va[.]gov/,
     )[0];
     // *.ci.cms.va.gov ENVs don't have AWS URLs.
     const newAssetPath = convertAssetPath(srcAttr);


### PR DESCRIPTION
This is really urgent and we need to get merged as soon as possible to get CMS working on our CI builds because we just switched to a new CI system that has hyphens in the URLs and our tests are breaking. This fixes that. 

New CI URLs have hyphens in them.

Old URL = `pr123.ci.cms.va.gov`
New URL = `pr123-zxhglnujna09taaq3xoz3kptv6l6qfwq.ci.cms.va.gov` (has hyphen)
