### PR TITLE
[COVID vaccine updates] Update button color in widget

### DIFF
--- a/src/applications/static-pages/covid-vaccine-updates-cta/On.jsx
+++ b/src/applications/static-pages/covid-vaccine-updates-cta/On.jsx
@@ -24,7 +24,7 @@ export default function OnState() {
           <p>
             <strong>Note:</strong> You don’t need to sign up to get a vaccine.
           </p>
-          <a href={covidVaccineFormUrl} className="usa-button">
+          <a href={covidVaccineFormUrl} className="usa-button-primary">
             Sign up to stay informed
           </a>
         </>


### PR DESCRIPTION
## Description
The button in this widget has text that is sometimes white, sometimes blue. It should _always_ be white. This PR fixes that by using the proper class name.

## Testing done
Visually confirmed it is correct now

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/102097582-1ba45080-3df4-11eb-888c-8ddd44f7019b.png)


## Acceptance criteria
- [ ] button text is the right color

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
