### PR TITLE
added configuration for hiding the `start a new app` on the form saved page

### DIFF
--- a/src/applications/healthcare/questionnaire/config/form.js
+++ b/src/applications/healthcare/questionnaire/config/form.js
@@ -29,6 +29,7 @@ const formConfig = {
   },
   formId: VA_FORM_IDS.FORM_HC_QSTNR,
   saveInProgress: {
+    resumeOnly: true,
     messages: {
       inProgress: '',
       expired:

--- a/src/applications/healthcare/questionnaire/containers/IntroductionPage.jsx
+++ b/src/applications/healthcare/questionnaire/containers/IntroductionPage.jsx
@@ -52,7 +52,7 @@ const IntroductionPage = props => {
           pageList={props.route?.pageList}
           startText="Start the questionnaire"
           formConfig={props.route?.formConfig}
-          resumeOnly
+          resumeOnly={props.route?.formConfig.saveInProgress.resumeOnly}
           renderSignInMessage={UnAuthedWelcomeMessage}
         />
       );

--- a/src/platform/forms/save-in-progress/FormSaved.jsx
+++ b/src/platform/forms/save-in-progress/FormSaved.jsx
@@ -39,6 +39,9 @@ class FormSaved extends React.Component {
     }
   }
 
+  getResumeOnly = () => {
+    return this.props.route?.formConfig?.saveInProgress?.resumeOnly;
+  };
   render() {
     const { formId, lastSavedDate, expirationMessage } = this.props;
     const { profile } = this.props.user;
@@ -108,6 +111,7 @@ class FormSaved extends React.Component {
           removeInProgressForm={this.props.removeInProgressForm}
           prefillAvailable={prefillAvailable}
           formSaved
+          resumeOnly={this.getResumeOnly()}
         />
       </div>
     );

--- a/src/platform/forms/tests/save-in-progress/FormSaved.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/FormSaved.unit.spec.jsx
@@ -90,4 +90,86 @@ describe('Schemaform <FormSaved>', () => {
 
     expect(tree.everySubTree('.usa-alert').length).to.equal(1);
   });
+  it('should still show start a new button', () => {
+    const tree = SkinDeep.shallowRender(
+      <FormSaved
+        scrollParams={{}}
+        location={{}}
+        formId={formId}
+        lastSavedDate={lastSavedDate}
+        expirationDate={expirationDate}
+        route={route}
+        user={user()}
+      />,
+    );
+    expect(tree.subTree('withRouter(FormStartControls)').props.resumeOnly).to.be
+      .false;
+  });
+  it('should config form controls to be resume only', () => {
+    const thisRoute = {
+      pageList: [
+        {
+          path: 'wrong-path',
+        },
+        {
+          path: 'testing',
+        },
+      ],
+      formConfig: {
+        formId: '123',
+        saveInProgress: {
+          resumeOnly: true,
+          messages: {
+            saved: 'Your education benefits (123) application has been saved.',
+          },
+        },
+      },
+    };
+    const tree = SkinDeep.shallowRender(
+      <FormSaved
+        scrollParams={{}}
+        location={{}}
+        formId={formId}
+        lastSavedDate={lastSavedDate}
+        expirationDate={expirationDate}
+        route={thisRoute}
+        user={user()}
+      />,
+    );
+    expect(tree.subTree('withRouter(FormStartControls)').props.resumeOnly).to.be
+      .true;
+  });
+
+  it('should handle form config being empty', () => {
+    const thisRoute = {
+      pageList: [
+        {
+          path: 'wrong-path',
+        },
+        {
+          path: 'testing',
+        },
+      ],
+      formConfig: {},
+    };
+    const tree = SkinDeep.shallowRender(<FormSaved route={thisRoute} />);
+    expect(tree.subTree('withRouter(FormStartControls)')).exist();
+  });
+  it('should handle save in progress being empty', () => {
+    const thisRoute = {
+      pageList: [
+        {
+          path: 'wrong-path',
+        },
+        {
+          path: 'testing',
+        },
+      ],
+      formConfig: {
+        saveInProgress: {},
+      },
+    };
+    const tree = SkinDeep.shallowRender(<FormSaved route={thisRoute} />);
+    expect(tree.subTree('withRouter(FormStartControls)')).exist();
+  });
 });

--- a/src/platform/forms/tests/save-in-progress/FormSaved.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/FormSaved.unit.spec.jsx
@@ -152,7 +152,17 @@ describe('Schemaform <FormSaved>', () => {
       ],
       formConfig: {},
     };
-    const tree = SkinDeep.shallowRender(<FormSaved route={thisRoute} />);
+    const tree = SkinDeep.shallowRender(
+      <FormSaved
+        scrollParams={{}}
+        location={{}}
+        formId={formId}
+        lastSavedDate={lastSavedDate}
+        expirationDate={expirationDate}
+        route={thisRoute}
+        user={user()}
+      />,
+    );
     expect(tree.subTree('withRouter(FormStartControls)')).exist();
   });
   it('should handle save in progress being empty', () => {
@@ -169,7 +179,17 @@ describe('Schemaform <FormSaved>', () => {
         saveInProgress: {},
       },
     };
-    const tree = SkinDeep.shallowRender(<FormSaved route={thisRoute} />);
+    const tree = SkinDeep.shallowRender(
+      <FormSaved
+        scrollParams={{}}
+        location={{}}
+        formId={formId}
+        lastSavedDate={lastSavedDate}
+        expirationDate={expirationDate}
+        route={thisRoute}
+        user={user()}
+      />,
+    );
     expect(tree.subTree('withRouter(FormStartControls)')).exist();
   });
 });

--- a/src/platform/forms/tests/save-in-progress/FormSaved.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/FormSaved.unit.spec.jsx
@@ -163,7 +163,7 @@ describe('Schemaform <FormSaved>', () => {
         user={user()}
       />,
     );
-    expect(tree.subTree('withRouter(FormStartControls)')).exist();
+    expect(tree.subTree('withRouter(FormStartControls)')).exist;
   });
   it('should handle save in progress being empty', () => {
     const thisRoute = {
@@ -190,6 +190,6 @@ describe('Schemaform <FormSaved>', () => {
         user={user()}
       />,
     );
-    expect(tree.subTree('withRouter(FormStartControls)')).exist();
+    expect(tree.subTree('withRouter(FormStartControls)')).to.exist;
   });
 });

--- a/src/platform/forms/tests/save-in-progress/FormSaved.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/FormSaved.unit.spec.jsx
@@ -102,8 +102,8 @@ describe('Schemaform <FormSaved>', () => {
         user={user()}
       />,
     );
-    expect(tree.subTree('withRouter(FormStartControls)').props.resumeOnly).to.be
-      .false;
+    expect(tree.subTree('withRouter(FormStartControls)').props.resumeOnly).to
+      .not.be.true;
   });
   it('should config form controls to be resume only', () => {
     const thisRoute = {


### PR DESCRIPTION
## Description
For our use case, a veteran can not restart a form once started. This PR adds a configuration to the save in-progress object that allows that option to be set in the form config. I will update docs when/if this gets approved. 

## Testing done
- [x] added units tests

## Screenshots
![screencapture-localhost-3001-health-care-health-questionnaires-questionnaires-answer-questions-form-saved-2020-12-14-10_45_50](https://user-images.githubusercontent.com/1793923/102102210-8c01a080-3df9-11eb-9317-5ba5b1f5fa77.png)


## Definition of done
- [Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/15895)