### PR TITLE
CST: Text Change for No Claims (don't direct to eBenefits)

### DIFF
--- a/src/applications/claims-status/components/NoClaims.jsx
+++ b/src/applications/claims-status/components/NoClaims.jsx
@@ -1,21 +1,12 @@
 import React from 'react';
 
-import EbenefitsLink from 'platform/site-wide/ebenefits/containers/EbenefitsLink';
-
 export default function NoClaims() {
   return (
     <div className="usa-alert usa-alert-info claims-alert background-color-only claims-alert-status">
       <h4 className="claims-alert-header usa-alert-heading">
         You do not have any submitted claims
       </h4>
-      <p>
-        This page shows only completed claim applications. If you started a
-        claim but haven’t finished it yet, go to{' '}
-        <EbenefitsLink path="ebenefits-portal/ebenefits.portal">
-          eBenefits
-        </EbenefitsLink>{' '}
-        to work on it.
-      </p>
+      <p>This page shows only completed claim applications.</p>
     </div>
   );
 }


### PR DESCRIPTION
## Description
This PR makes a simple text change to the claim status tool's messaging when the user has no claims. Previously, we directed users to eBenefits to complete their claims. Now, we have removed this specific text and will look into options for directing users to specific forms that need to be completed in a future PR.

## Acceptance criteria
- [ ] CST no longer directs to eBenefits when there are no claims