### PR TITLE
[17364] Extra padding in breadcrumb wrap

### DIFF
--- a/src/applications/vaos/components/Breadcrumbs.jsx
+++ b/src/applications/vaos/components/Breadcrumbs.jsx
@@ -4,7 +4,7 @@ import Breadcrumbs from '@department-of-veterans-affairs/formation-react/Breadcr
 
 export default function VAOSBreadcrumbs({ children }) {
   return (
-    <Breadcrumbs customClasses="new-grid">
+    <Breadcrumbs className="medium-screen:vads-u-padding-x--0">
       <a href="/" key="home">
         Home
       </a>


### PR DESCRIPTION
## Description
Within the desktop responsive view, when the breadcrumbs wrap, there's extra padding around the items creating gaps. (Compare with wrap within tablet breakpoints.)

768px and above

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/8315447/102137779-5c6a8c80-3e29-11eb-8b5c-7a1bd8efdf8f.png)
![image](https://user-images.githubusercontent.com/8315447/102137807-668c8b00-3e29-11eb-9d20-c92eacf281b7.png)


## Acceptance criteria
- [ ] There should be less space between the 2 rows (similar to tablet)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
