### PR TITLE
Fix error on facilities page after changing type of care

### DIFF
--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesNotShown.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesNotShown.jsx
@@ -26,14 +26,14 @@ export default function FacilitiesNotShown({ facilities, sortMethod }) {
     [isOpen],
   );
 
-  const nearbyUnsupportedFacilities = facilities.filter(
+  const nearbyUnsupportedFacilities = facilities?.filter(
     facility =>
       !facility.legacyVAR.directSchedulingSupported &&
       !facility.legacyVAR.requestSupported &&
       facility.legacyVAR[sortMethod] < UNSUPPORTED_FACILITY_RANGE,
   );
 
-  if (!nearbyUnsupportedFacilities.length) {
+  if (!nearbyUnsupportedFacilities?.length) {
     return null;
   }
 


### PR DESCRIPTION
## Description
When you change the type of care and come back to the facilities page, an error is thrown inside the new FacilitiesNotShown component because the facilities aren't defined yet.

## Testing done
Local and unit testing

## Acceptance criteria
- [ ] Facilities page works correctly after type of care change

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
