### PR TITLE
Fix - When "Search this area" button is introduced, it must be announced and available to assistive technology

### DIFF
--- a/src/applications/facility-locator/containers/FacilitesMap.jsx
+++ b/src/applications/facility-locator/containers/FacilitesMap.jsx
@@ -239,6 +239,7 @@ const FacilitiesMap = props => {
 
     if (searchAreaControlId.style.display === 'none') {
       searchAreaControlId.style.display = 'block';
+      setFocus('#search-area-control');
     }
 
     if (searchAreaControlId && !searchAreaSet) {


### PR DESCRIPTION
Issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/17405

## Description


## Testing done


## Screenshots


## Acceptance criteria
- [x] When the "Search this area" button is introduced, it is announced for screen readers

- [x] When the "Search this area" button is introduced, focus is moved to the relevant `<button>`

- [x] When the "Search this area" button is introduced, focus is visible on the relevant `<button>`


## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
