### PR TITLE
Make Search this area button responsive

### DIFF
--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -531,8 +531,6 @@ $facility-locator-shadow: rgba(0, 0, 0, 0.5);
 #search-area-control {
   background: $color-blue;
   border-radius: 5px;
-  width: 215px;
-  height: 37px;
   cursor: pointer;
   padding: 8px;
   margin-top: 15px;


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/17469

Ensure that the "Search This Area of the Map" button stays within the screen when the map is zoomed in.

## Testing done
Manual

## Screenshots
![Find_VA_Locations___Veterans_Affairs](https://user-images.githubusercontent.com/80267/102266928-1f64cf80-3ee7-11eb-8e15-8b0b5e0d6534.png)

## Acceptance criteria
- [x] "Search This Area of the Map" button stays within the screen when the map is zoomed in.

## Definition of done
- [x ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
