### PR TITLE
Fix - When focus moves to the map, the focus halo should be visible

### DIFF
--- a/src/applications/facility-locator/containers/FacilitesMap.jsx
+++ b/src/applications/facility-locator/containers/FacilitesMap.jsx
@@ -257,6 +257,9 @@ const FacilitiesMap = props => {
       zoom: MapboxInit.zoomInit,
     });
 
+    const mapContainerElement = document.getElementById('mapbox-gl-container');
+    if (mapContainerElement) mapContainerElement.setAttribute('tabindex', 0);
+
     const searchAreaControl = new SearchAreaControl(isMobile);
     mapInit.addControl(searchAreaControl);
     mapInit.addControl(

--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -573,3 +573,8 @@ button.mapboxgl-ctrl-zoom-out  {
   margin-bottom: 0;
   margin-right: 0;
 }
+
+canvas.mapboxgl-canvas:focus {
+  outline: 2px solid $color-gold-light !important;
+  outline-offset: 2px;
+}

--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -575,6 +575,6 @@ button.mapboxgl-ctrl-zoom-out  {
 }
 
 canvas.mapboxgl-canvas:focus {
-  outline: 2px solid $color-gold-light !important;
+  outline: 2px solid $color-gold-light;
   outline-offset: 2px;
 }


### PR DESCRIPTION
## Description
Issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/17404

## Screenshots
<img width="1241" alt="Screen Shot 2020-12-15 at 4 19 02 PM" src="https://user-images.githubusercontent.com/100468/102280056-10cfe580-3ef2-11eb-9be6-be4b195ac3ca.png">


## Acceptance criteria
- [x] When focus is moved to keyboard operable user interface element, the focus indicator is visible for sighted users.

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
