### PR TITLE
Covid Vaccine - add validation to optional date field

### DIFF
--- a/src/applications/coronavirus-vaccination/config/schema.js
+++ b/src/applications/coronavirus-vaccination/config/schema.js
@@ -21,6 +21,7 @@ export default {
     },
     birthDate: {
       type: 'string',
+      pattern: '^\\d{4}-\\d{2}-\\d{2}$',
     },
     ssn: {
       type: 'string',

--- a/src/applications/coronavirus-vaccination/config/uiSchema.js
+++ b/src/applications/coronavirus-vaccination/config/uiSchema.js
@@ -5,7 +5,10 @@ import PhoneNumberWidget from 'platform/forms-system/src/js/widgets/PhoneNumberW
 // import SelectFacilityWidget from '../components/SelectFacilityWidget';
 
 import MaskedSSNWidget from '../components/MaskedSSNWidget';
-import { validateSSN } from 'platform/forms-system/src/js/validation';
+import {
+  validateSSN,
+  validateCurrentOrPastDate,
+} from 'platform/forms-system/src/js/validation';
 
 export default {
   isIdentityVerified: {
@@ -35,6 +38,10 @@ export default {
       </span>
     ),
     'ui:widget': 'date',
+    'ui:errorMessages': {
+      pattern: 'Please enter a complete date',
+    },
+    'ui:validations': [validateCurrentOrPastDate],
   },
   ssn: {
     'ui:widget': MaskedSSNWidget,


### PR DESCRIPTION
## Description
Add Regex to ensure only complete dates are sent to API

## Testing done
Manual testing.  Existing tests pass. 

## Screenshots
![image](https://user-images.githubusercontent.com/2481110/102291097-54d1e300-3f10-11eb-8f79-16c5a6751ade.png)


## Acceptance criteria
- [ ] Form is not able to be submitted and error message is shown to user if all three parts of the date is not completed 
- [ ] Form is still able to be submitted without entering a date at all

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
