### PR TITLE
Allow disabling datewidget

### DIFF
--- a/src/platform/forms-system/src/js/widgets/DateWidget.jsx
+++ b/src/platform/forms-system/src/js/widgets/DateWidget.jsx
@@ -72,7 +72,7 @@ export default class DateWidget extends React.Component {
   }
 
   render() {
-    const { id, options = {} } = this.props;
+    const { id, disabled, options = {} } = this.props;
     const { month, day, year } = this.state.value;
     let daysForSelectedMonth;
 
@@ -90,6 +90,7 @@ export default class DateWidget extends React.Component {
             name={`${id}Month`}
             id={`${id}Month`}
             value={month}
+            disabled={disabled}
             onChange={event => this.handleChange('month', event.target.value)}
           >
             <option value="" />
@@ -109,6 +110,7 @@ export default class DateWidget extends React.Component {
               name={`${id}Day`}
               id={`${id}Day`}
               value={day}
+              disabled={disabled}
               onChange={event => this.handleChange('day', event.target.value)}
             >
               <option value="" />
@@ -130,6 +132,7 @@ export default class DateWidget extends React.Component {
             autoComplete={options.autocomplete}
             name={`${id}Year`}
             id={`${id}Year`}
+            disabled={disabled}
             max="3000"
             min="1900"
             pattern="[0-9]{4}"

--- a/src/platform/forms-system/test/js/widgets/DateWidget.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/widgets/DateWidget.unit.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import SkinDeep from 'skin-deep';
+import { render } from '@testing-library/react';
 import sinon from 'sinon';
 
 import DateWidget from '../../../src/js/widgets/DateWidget';
@@ -73,6 +74,21 @@ describe('Schemaform: DateWidget', () => {
     instance.handleBlur('day');
 
     expect(onBlur.calledOnce).to.be.true;
+  });
+  it('should be able to be disabled', () => {
+    const onChange = sinon.spy();
+    const onBlur = sinon.spy();
+    const tree = render(
+      <DateWidget disabled id="test" onChange={onChange} onBlur={onBlur} />,
+    );
+
+    const month = tree.getByLabelText('Month');
+    const day = tree.getByLabelText('Day');
+    const year = tree.getByLabelText('Year');
+
+    expect(month).to.have.attribute('disabled');
+    expect(day).to.have.attribute('disabled');
+    expect(year).to.have.attribute('disabled');
   });
   describe('Month/Year', () => {
     it('should render', () => {

--- a/src/platform/forms/sass/_m-schemaform.scss
+++ b/src/platform/forms/sass/_m-schemaform.scss
@@ -696,3 +696,7 @@ textarea.resize-y {
 textarea.resize-x {
   resize: horizontal;
 }
+
+select:disabled {
+  background-color: $color-gray-lighter;
+}


### PR DESCRIPTION
## Description

The `<DateWidget>` wasn't able to be disabled. With this PR, the widget can now be disabled by setting `ui:disabled` in the `uiSchema`.

Context: https://dsva.slack.com/archives/CBU0KDSB1/p1608134523456600


## Testing done

Unit testing & browser testing


## Screenshots

The `<select>`s are actually disabled even though they don't look like it. This may be an opportunity to improve the CSS at some point.

![image](https://user-images.githubusercontent.com/2008881/102389808-7e2e5580-3f88-11eb-8a40-79c4070b09f0.png)



## Acceptance criteria
- [ ] `<DateWidget>` can be disabled

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
