### PR TITLE
[Development] Make benefit office link more accessible

### DIFF
--- a/src/applications/disability-benefits/996/wizard/pages/other.jsx
+++ b/src/applications/disability-benefits/996/wizard/pages/other.jsx
@@ -12,8 +12,7 @@ const DecisionReviewPage = () => {
   });
   return (
     <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
-      You’ll need to fill out and submit VA form 20-0996 by mail or in person.
-      Send the completed form to the{' '}
+      You’ll need to fill out and submit VA form 20-0996 by mail or in person.{' '}
       <a
         href={BENEFIT_OFFICES_URL}
         onClick={() => {
@@ -23,7 +22,7 @@ const DecisionReviewPage = () => {
           });
         }}
       >
-        benefit office
+        Send the completed form to the benefit office
       </a>{' '}
       that matches the benefit type you select on the form.
       <p className="vads-u-margin-bottom--0">


### PR DESCRIPTION
## Description

Update the  wizard link to the (non-compensation type HLR) benefit office list.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/16049

## Testing done

N/A

## Screenshots

![](https://user-images.githubusercontent.com/14154792/98837282-c6e67200-2410-11eb-9215-20841471e744.png)

## Acceptance criteria
- [x] Link text makes sense when taken out of context

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
