### PR TITLE
Disable FTUX Modals

### DIFF
--- a/src/applications/disability-benefits/view-payments/tests/e2e/view-payments.cypress.spec.js
+++ b/src/applications/disability-benefits/view-payments/tests/e2e/view-payments.cypress.spec.js
@@ -1,3 +1,4 @@
+import disableFTUXModals from '~/platform/user/tests/disableFTUXModals';
 import mockUser from '../fixtures/test-user.json';
 import mockPayments from '../fixtures/test-payments-response.json';
 import mockEmptyPayments from '../fixtures/test-empty-payments-response.json';
@@ -101,10 +102,7 @@ const testApiError = (errCode = '500') => {
 // Disabling until view-payments is ready for production
 describe.skip('View payment history', () => {
   beforeEach(() => {
-    window.localStorage.setItem(
-      'DISMISSED_ANNOUNCEMENTS',
-      JSON.stringify(['single-sign-on-intro']),
-    );
+    disableFTUXModals();
     cy.login(mockUser);
   });
   it('should pass an aXe scan and paginate through payment data', () => {

--- a/src/applications/healthcare/questionnaire/tests/e2e/01.questionnaire.demographics.address.cypress.spec.js
+++ b/src/applications/healthcare/questionnaire/tests/e2e/01.questionnaire.demographics.address.cypress.spec.js
@@ -1,3 +1,4 @@
+import disableFTUXModals from '~/platform/user/tests/disableFTUXModals';
 import basicUser from './fixtures/users/user-basic.js';
 
 describe('healthcare questionnaire -- demographics -- addresses', () => {
@@ -7,10 +8,7 @@ describe('healthcare questionnaire -- demographics -- addresses', () => {
     ).then(async features => {
       cy.route('GET', '/v0/feature_toggles*', features);
       cy.login(basicUser);
-      window.localStorage.setItem(
-        'DISMISSED_ANNOUNCEMENTS',
-        JSON.stringify(['single-sign-on-intro']),
-      );
+      disableFTUXModals();
       cy.visit(
         '/health-care/health-questionnaires/questionnaires/answer-questions/demographics?skip',
       );

--- a/src/applications/healthcare/questionnaire/tests/e2e/01.questionnaire.demographics.basicInformation.cypress.spec.js
+++ b/src/applications/healthcare/questionnaire/tests/e2e/01.questionnaire.demographics.basicInformation.cypress.spec.js
@@ -7,10 +7,6 @@ describe('healthcare questionnaire -- demographics -- basic information', () => 
     ).then(async features => {
       cy.route('GET', '/v0/feature_toggles*', features);
       cy.login(basicUser);
-      window.localStorage.setItem(
-        'DISMISSED_ANNOUNCEMENTS',
-        JSON.stringify(['single-sign-on-intro']),
-      );
       cy.visit(
         '/health-care/health-questionnaires/questionnaires/answer-questions/demographics?skip',
       );

--- a/src/applications/healthcare/questionnaire/tests/e2e/01.questionnaire.demographics.phoneNumbers.cypress.spec.js
+++ b/src/applications/healthcare/questionnaire/tests/e2e/01.questionnaire.demographics.phoneNumbers.cypress.spec.js
@@ -1,3 +1,4 @@
+import disableFTUXModals from '~/platform/user/tests/disableFTUXModals';
 import basicUser from './fixtures/users/user-basic.js';
 
 describe('healthcare questionnaire -- demographics -- phone numbers', () => {
@@ -7,10 +8,7 @@ describe('healthcare questionnaire -- demographics -- phone numbers', () => {
     ).then(async features => {
       cy.route('GET', '/v0/feature_toggles*', features);
       cy.login(basicUser);
-      window.localStorage.setItem(
-        'DISMISSED_ANNOUNCEMENTS',
-        JSON.stringify(['single-sign-on-intro']),
-      );
+      disableFTUXModals();
       cy.visit(
         '/health-care/health-questionnaires/questionnaires/answer-questions/demographics?skip',
       );

--- a/src/applications/healthcare/questionnaire/tests/e2e/03.questionnaire.landing.page.accessibility.cypress.spec.js
+++ b/src/applications/healthcare/questionnaire/tests/e2e/03.questionnaire.landing.page.accessibility.cypress.spec.js
@@ -1,3 +1,4 @@
+import disableFTUXModals from '~/platform/user/tests/disableFTUXModals';
 import basicUser from './fixtures/users/user-basic.js';
 
 describe('healthcare questionnaire -- landing page --', () => {
@@ -7,10 +8,7 @@ describe('healthcare questionnaire -- landing page --', () => {
     ).then(async features => {
       cy.route('GET', '/v0/feature_toggles*', features);
       cy.login(basicUser);
-      window.localStorage.setItem(
-        'DISMISSED_ANNOUNCEMENTS',
-        JSON.stringify(['single-sign-on-intro']),
-      );
+      disableFTUXModals();
       cy.visit(
         '/health-care/health-questionnaires/questionnaires/answer-questions/introduction?skip',
       );

--- a/src/applications/personalization/profile/tests/e2e/address-validation/setup.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/setup.js
@@ -1,3 +1,4 @@
+import disableFTUXModals from '~/platform/user/tests/disableFTUXModals';
 import { PROFILE_PATHS } from '@@profile/constants';
 import { createUserResponse } from './user';
 import { createAddressValidationResponse } from './addressValidation';
@@ -7,10 +8,7 @@ import receivedTransaction from 'applications/personalization/profile/tests/fixt
 import finishedTransaction from 'applications/personalization/profile/tests/fixtures/transactions/finished-transaction.json';
 
 export const setUp = type => {
-  window.localStorage.setItem(
-    'DISMISSED_ANNOUNCEMENTS',
-    JSON.stringify(['single-sign-on-intro']),
-  );
+  disableFTUXModals();
 
   cy.login(mockUser);
   cy.visit(PROFILE_PATHS.PERSONAL_INFORMATION);

--- a/src/applications/personalization/profile/tests/e2e/profile.connected-apps.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile.connected-apps.cypress.spec.js
@@ -1,3 +1,4 @@
+import disableFTUXModals from '~/platform/user/tests/disableFTUXModals';
 import { PROFILE_PATHS } from '../../constants';
 import mockUser from '../fixtures/users/user-36.json';
 import mockConnectedApps from '../fixtures/connected-apps/mock-connected-apps.json';
@@ -80,10 +81,7 @@ function disconnectApps(mobile = false) {
 
 describe('Connected applications', () => {
   beforeEach(() => {
-    window.localStorage.setItem(
-      'DISMISSED_ANNOUNCEMENTS',
-      JSON.stringify(['single-sign-on-intro']),
-    );
+    disableFTUXModals();
     cy.login(mockUser);
     // login() calls cy.server() so we can now mock routes
   });

--- a/src/applications/personalization/profile/tests/e2e/profile.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile.cypress.spec.js
@@ -1,3 +1,4 @@
+import disableFTUXModals from '~/platform/user/tests/disableFTUXModals';
 import { PROFILE_PATHS } from '../../constants';
 
 import mockUser from '../fixtures/users/user-36.json';
@@ -133,10 +134,7 @@ function checkAllPages(mobile = false) {
 
 describe('Profile', () => {
   beforeEach(() => {
-    window.localStorage.setItem(
-      'DISMISSED_ANNOUNCEMENTS',
-      JSON.stringify(['single-sign-on-intro']),
-    );
+    disableFTUXModals();
     cy.login(mockUser);
     // login() calls cy.server() so we can now mock routes
     cy.route('GET', '/v0/ppiu/payment_information', mockPaymentInfo);

--- a/src/applications/personalization/profile/tests/e2e/profile.direct-deposit.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile.direct-deposit.cypress.spec.js
@@ -1,3 +1,4 @@
+import disableFTUXModals from '~/platform/user/tests/disableFTUXModals';
 import { PROFILE_PATHS } from '../../constants';
 
 import mockUserNotInEVSS from '../fixtures/users/user-non-vet.json';
@@ -40,10 +41,7 @@ describe('Direct Deposit', () => {
   }
 
   beforeEach(() => {
-    window.localStorage.setItem(
-      'DISMISSED_ANNOUNCEMENTS',
-      JSON.stringify(['single-sign-on-intro']),
-    );
+    disableFTUXModals();
     cy.login();
   });
   it('should be blocked if the user is not in EVSS', () => {

--- a/src/applications/personalization/profile/tests/e2e/profile.loa1.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile.loa1.cypress.spec.js
@@ -1,13 +1,11 @@
+import disableFTUXModals from '~/platform/user/tests/disableFTUXModals';
 import { PROFILE_PATHS } from '../../constants';
 
 import mockLOA1User from '../fixtures/users/user-loa1.json';
 
 describe('LOA1 users', () => {
   beforeEach(() => {
-    window.localStorage.setItem(
-      'DISMISSED_ANNOUNCEMENTS',
-      JSON.stringify(['single-sign-on-intro']),
-    );
+    disableFTUXModals();
     cy.login(mockLOA1User);
     // login() calls cy.server() so we can now mock routes
   });

--- a/src/applications/personalization/profile/tests/e2e/profile.mpi-error.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile.mpi-error.cypress.spec.js
@@ -1,3 +1,4 @@
+import disableFTUXModals from '~/platform/user/tests/disableFTUXModals';
 import { PROFILE_PATHS } from '../../constants';
 
 import mockMPIErrorUser from '../fixtures/users/user-mpi-error.json';
@@ -77,10 +78,7 @@ function test(mobile = false) {
 
 describe('When user is LOA3 with 2FA turned on but we cannot connect to MPI', () => {
   beforeEach(() => {
-    window.localStorage.setItem(
-      'DISMISSED_ANNOUNCEMENTS',
-      JSON.stringify(['single-sign-on-intro']),
-    );
+    disableFTUXModals();
     cy.login(mockMPIErrorUser);
     // login() calls cy.server() so we can now mock routes
   });

--- a/src/applications/personalization/profile/tests/e2e/profile.not-in-mpi-error.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile.not-in-mpi-error.cypress.spec.js
@@ -1,3 +1,4 @@
+import disableFTUXModals from '~/platform/user/tests/disableFTUXModals';
 import { PROFILE_PATHS } from '../../constants';
 
 import mockUserNotInMPI from '../fixtures/users/user-not-in-mpi.json';
@@ -77,10 +78,7 @@ function test(mobile = false) {
 
 describe('When user is LOA3 with 2FA turned on but we cannot connect to MPI', () => {
   beforeEach(() => {
-    window.localStorage.setItem(
-      'DISMISSED_ANNOUNCEMENTS',
-      JSON.stringify(['single-sign-on-intro']),
-    );
+    disableFTUXModals();
     cy.login(mockUserNotInMPI);
     // login() calls cy.server() so we can now mock routes
   });

--- a/src/applications/personalization/profile/tests/e2e/profile.personal-and-contact-information-fields-check.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile.personal-and-contact-information-fields-check.cypress.spec.js
@@ -1,3 +1,4 @@
+import disableFTUXModals from '~/platform/user/tests/disableFTUXModals';
 import { PROFILE_PATHS } from '../../constants';
 
 import { mockUser } from '../fixtures/users/user.js';
@@ -6,11 +7,7 @@ import mockServiceHistory from '../fixtures/service-history-success.json';
 import mockFullName from '../fixtures/full-name-success.json';
 
 const setup = () => {
-  window.localStorage.setItem(
-    'DISMISSED_ANNOUNCEMENTS',
-    JSON.stringify(['single-sign-on-intro']),
-  );
-
+  disableFTUXModals();
   cy.login(mockUser);
   cy.route('GET', 'v0/profile/personal_information', mockPersonalInformation);
   cy.route('GET', 'v0/profile/service_history', mockServiceHistory);

--- a/src/applications/personalization/profile/tests/e2e/profile.personal-and-contact-information-modals.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile.personal-and-contact-information-modals.cypress.spec.js
@@ -1,12 +1,11 @@
+import disableFTUXModals from '~/platform/user/tests/disableFTUXModals';
+
 import { PROFILE_PATHS } from '../../constants';
 
 import { mockUser } from '../fixtures/users/user.js';
 
 const setup = (mobile = false) => {
-  window.localStorage.setItem(
-    'DISMISSED_ANNOUNCEMENTS',
-    JSON.stringify(['single-sign-on-intro']),
-  );
+  disableFTUXModals();
 
   if (mobile) {
     cy.viewport('iphone-4');

--- a/src/applications/personalization/profile/tests/e2e/profile.personal-and-contact-information-vap-error.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile.personal-and-contact-information-vap-error.cypress.spec.js
@@ -1,3 +1,5 @@
+import disableFTUXModals from '~/platform/user/tests/disableFTUXModals';
+
 import { PROFILE_PATHS } from '../../constants';
 
 import { mockUser } from '../fixtures/users/user-vap-error.js';
@@ -7,10 +9,7 @@ import mockFullName from '../fixtures/full-name-success.json';
 import mockPaymentInfoNotEligible from '../fixtures/payment-information/direct-deposit-is-not-eligible.json';
 
 const setup = () => {
-  window.localStorage.setItem(
-    'DISMISSED_ANNOUNCEMENTS',
-    JSON.stringify(['single-sign-on-intro']),
-  );
+  disableFTUXModals();
 
   cy.login(mockUser);
   cy.route('GET', 'v0/profile/personal_information', mockPersonalInformation);

--- a/src/applications/personalization/profile/tests/e2e/profile.personal-and-contact-mailing-address.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile.personal-and-contact-mailing-address.cypress.spec.js
@@ -1,11 +1,9 @@
+import disableFTUXModals from '~/platform/user/tests/disableFTUXModals';
 import { PROFILE_PATHS } from '../../constants';
 import mockUser from '../fixtures/users/user-36.json';
 
 const setup = (mobile = false) => {
-  window.localStorage.setItem(
-    'DISMISSED_ANNOUNCEMENTS',
-    JSON.stringify(['single-sign-on-intro']),
-  );
+  disableFTUXModals();
 
   if (mobile) {
     cy.viewport('iphone-4');

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/tests/index.cypress.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/tests/index.cypress.spec.js
@@ -1,3 +1,4 @@
+import disableFTUXModals from '~/platform/user/tests/disableFTUXModals';
 import cernerUser from '../../fixtures/user/cerner.json';
 import notCernerUser from '../../fixtures/user/notCerner.json';
 
@@ -11,10 +12,7 @@ const setup = ({ authenticated, isCerner } = {}) => {
     cy.route('GET', '/v0/feature_toggles*', features);
 
     // Clear announcements.
-    window.localStorage.setItem(
-      'DISMISSED_ANNOUNCEMENTS',
-      JSON.stringify(['single-sign-on-intro']),
-    );
+    disableFTUXModals();
 
     // Navigate straight to the test URL if unauth.
     if (!authenticated) {

--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -1,6 +1,7 @@
 import { join, sep } from 'path';
 
 import get from 'platform/utilities/data/get';
+import disableFTUXModals from '~/platform/user/tests/disableFTUXModals';
 
 const APP_SELECTOR = '#react-root';
 const ARRAY_ITEM_SELECTOR =
@@ -517,7 +518,7 @@ const testForm = testConfig => {
     // so those have to be set up _before each_ test.
     beforeEach(() => {
       // Dismiss any announcements.
-      window.localStorage.setItem('DISMISSED_ANNOUNCEMENTS', '*');
+      disableFTUXModals();
 
       cy.wrap(arrayPages).as('arrayPages');
 

--- a/src/platform/user/tests/disableFTUXModals.js
+++ b/src/platform/user/tests/disableFTUXModals.js
@@ -1,4 +1,6 @@
 // make sure no first-time UX modals are in the way
-export function disableFTUXModals() {
+const disableFTUXModals = () => {
   window.localStorage.setItem('DISMISSED_ANNOUNCEMENTS', '*');
-}
+};
+
+export default disableFTUXModals;

--- a/src/platform/user/tests/disableFTUXModals.js
+++ b/src/platform/user/tests/disableFTUXModals.js
@@ -1,0 +1,4 @@
+// make sure no first-time UX modals are in the way
+export function disableFTUXModals() {
+  window.localStorage.setItem('DISMISSED_ANNOUNCEMENTS', '*');
+}


### PR DESCRIPTION
## Description
In many Cypress tests we have code like this that is used to make sure FTUX (first-time user-experience) modals do no appear:

```
export function mockLocalStorage() {
  // make sure no first-time UX modals are in the way
  window.localStorage.setItem(
    'DISMISSED_ANNOUNCEMENTS',
    JSON.stringify(['single-sign-on-intro', 'find-benefits-intro']),
  );
}
```
We should create a helper function to not repeat this code.

## Testing done
All tests still pass.

## Acceptance criteria
- [x] Create a helper function to not repeat code that dismisses modals

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
