### PR TITLE
[Development] HLR: Add a11y ref to start button

### DIFF
--- a/src/applications/disability-benefits/996/wizard/pages/legacyNo.jsx
+++ b/src/applications/disability-benefits/996/wizard/pages/legacyNo.jsx
@@ -16,39 +16,42 @@ const LegacyNo = ({ setWizardStatus }) => {
   });
   return (
     <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
-      You can request a Higher-Level Review online using{' '}
-      <strong>VA Form 20-0996</strong>.
-      <p>
-        <button
-          onClick={() => {
-            recordEvent({
-              event: 'howToWizard-hidden',
-              'reason-for-hidden-wizard': 'wizard completed, starting form',
-            });
-            recordEvent({
-              event: 'cta-button-click',
-              'button-type': 'primary',
-              'button-click-label': 'Request a Higher-Level Review online',
-            });
-            setWizardStatus(WIZARD_STATUS_COMPLETE);
-          }}
-          className="usa-button-primary va-button-primary"
-        >
-          Request a Higher-Level Review online
-        </button>
+      <p className="vads-u-margin-top--0">
+        You can request a Higher-Level Review online using{' '}
+        <strong>VA Form 20-0996</strong>.
       </p>
-      <a
-        href={HLR_INFO_URL}
+      <button
         onClick={() => {
           recordEvent({
-            event: 'howToWizard-alert-link-click',
-            'howToWizard-alert-link-click-label':
-              'Learn about other ways you can request a Higher-Level Review',
+            event: 'howToWizard-hidden',
+            'reason-for-hidden-wizard': 'wizard completed, starting form',
           });
+          recordEvent({
+            event: 'cta-button-click',
+            'button-type': 'primary',
+            'button-click-label': 'Request a Higher-Level Review online',
+          });
+          setWizardStatus(WIZARD_STATUS_COMPLETE);
         }}
+        className="usa-button-primary va-button-primary"
+        aria-describedby="other_ways_to_request_hlr"
       >
-        Learn about other ways you can request a Higher-Level Review
-      </a>
+        Request a Higher-Level Review online
+      </button>
+      <p id="other_ways_to_request_hlr" className="vads-u-margin-bottom--0">
+        <a
+          href={HLR_INFO_URL}
+          onClick={() => {
+            recordEvent({
+              event: 'howToWizard-alert-link-click',
+              'howToWizard-alert-link-click-label':
+                'Learn about other ways you can request a Higher-Level Review',
+            });
+          }}
+        >
+          Learn about other ways you can request a Higher-Level Review
+        </a>
+      </p>
     </div>
   );
 };


### PR DESCRIPTION
## Description

Include `aria-describedby` on the form start button so the screen reader user knows there is a link with additional information below the button.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/16148

## Testing done

Unit tests

## Screenshots

![Screen Shot 2020-12-16 at 4 01 42 PM](https://user-images.githubusercontent.com/136959/102411745-0b3cd300-3fb8-11eb-8c44-d8382f516455.png)

## Acceptance criteria
- [x] Button includes an `aria-describedby` pointing to the link to the HLR info page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
