### PR TITLE
Make the log level for unit tests `debug` by default

### DIFF
--- a/script/run-unit-test.js
+++ b/script/run-unit-test.js
@@ -7,7 +7,7 @@ const { runCommand } = require('./utils');
 const defaultPath = './src/**/*.unit.spec.js?(x)';
 
 const COMMAND_LINE_OPTIONS_DEFINITIONS = [
-  { name: 'log-level', type: String, defaultValue: 'log' },
+  { name: 'log-level', type: String, defaultValue: 'debug' },
   { name: 'app-folder', type: String, defaultValue: null },
   { name: 'coverage', type: Boolean, defaultValue: false },
   { name: 'reporter', type: String, defaultValue: null },


### PR DESCRIPTION
## Description
When using React Testing Library in unit tests, any errors that are thrown in a component are squelched by React's own _especially_ unhelpful error message: `Error: An error was thrown inside one of your components, but React doesn't know what it was.` I discovered that `log-level` is an option. Setting it to debug logs the original error message. Rather than make folks remember this, I figured we'd just set it to `debug` by default.