### PR TITLE
Update GA with analyticsSectionName

### DIFF
--- a/src/platform/user/profile/vap-svc/actions/transactions.js
+++ b/src/platform/user/profile/vap-svc/actions/transactions.js
@@ -5,7 +5,13 @@ import { refreshProfile } from '~/platform/user/profile/actions';
 import recordEvent from '~/platform/monitoring/record-event';
 import { inferAddressType } from '~/applications/letters/utils/helpers';
 
-import { FIELD_NAMES, ADDRESS_POU } from '@@vap-svc/constants';
+import {
+  ANALYTICS_ADDRESS_FIELD_NAMES,
+  ANALYTICS_FIELD_MAP,
+  ANALYTICS_PHONE_FIELD_NAMES,
+  ADDRESS_POU,
+  FIELD_NAMES,
+} from '@@vap-svc/constants';
 
 import { showAddressValidationModal } from '../../utilities';
 
@@ -132,13 +138,23 @@ export function refreshTransaction(
             transactionRefreshed?.data?.attributes?.metadata?.[0] ?? {};
           const errorCode = errorMetadata.code ?? 'unknown-code';
           const errorKey = errorMetadata.key ?? 'unknown-key';
-          const addressSection =
-            analyticsSectionName === FIELD_NAMES.MAILING_ADDRESS ||
-            analyticsSectionName === FIELD_NAMES.RESIDENTIAL_ADDRESS;
 
-          const errorSection = addressSection
-            ? 'address'
-            : analyticsSectionName;
+          const addressNames = Object.values(ANALYTICS_ADDRESS_FIELD_NAMES);
+          const phoneNames = Object.values(ANALYTICS_PHONE_FIELD_NAMES);
+          let errorSection;
+
+          if (addressNames.includes(analyticsSectionName)) {
+            errorSection = 'address';
+          }
+
+          if (phoneNames.includes(analyticsSectionName)) {
+            errorSection = 'phone';
+          }
+
+          if (analyticsSectionName === ANALYTICS_FIELD_MAP.email) {
+            errorSection = 'email';
+          }
+
           recordEvent({
             event: 'profile-edit-failure',
             'profile-action': 'save-failure',

--- a/src/platform/user/profile/vap-svc/actions/transactions.js
+++ b/src/platform/user/profile/vap-svc/actions/transactions.js
@@ -132,11 +132,18 @@ export function refreshTransaction(
             transactionRefreshed?.data?.attributes?.metadata?.[0] ?? {};
           const errorCode = errorMetadata.code ?? 'unknown-code';
           const errorKey = errorMetadata.key ?? 'unknown-key';
+          const addressSection =
+            analyticsSectionName === FIELD_NAMES.MAILING_ADDRESS ||
+            analyticsSectionName === FIELD_NAMES.RESIDENTIAL_ADDRESS;
+
+          const errorSection = addressSection
+            ? 'address'
+            : analyticsSectionName;
           recordEvent({
             event: 'profile-edit-failure',
             'profile-action': 'save-failure',
             'profile-section': analyticsSectionName,
-            'error-key': `${errorCode}_${errorKey}-address-save-failure`,
+            'error-key': `${errorCode}_${errorKey}-${errorSection}-save-failure`,
           });
           recordEvent({
             'error-key': undefined,

--- a/src/platform/user/profile/vap-svc/actions/transactions.js
+++ b/src/platform/user/profile/vap-svc/actions/transactions.js
@@ -141,25 +141,25 @@ export function refreshTransaction(
 
           const addressNames = Object.values(ANALYTICS_ADDRESS_FIELD_NAMES);
           const phoneNames = Object.values(ANALYTICS_PHONE_FIELD_NAMES);
-          let errorSection;
+          let sectionName = analyticsSectionName;
 
           if (addressNames.includes(analyticsSectionName)) {
-            errorSection = 'address';
+            sectionName = 'address';
           }
 
           if (phoneNames.includes(analyticsSectionName)) {
-            errorSection = 'phone';
+            sectionName = 'phone';
           }
 
           if (analyticsSectionName === ANALYTICS_FIELD_MAP.email) {
-            errorSection = 'email';
+            sectionName = 'email';
           }
 
           recordEvent({
             event: 'profile-edit-failure',
             'profile-action': 'save-failure',
             'profile-section': analyticsSectionName,
-            'error-key': `${errorCode}_${errorKey}-${errorSection}-save-failure`,
+            'error-key': `${errorCode}_${errorKey}-${sectionName}-save-failure`,
           });
           recordEvent({
             'error-key': undefined,

--- a/src/platform/user/profile/vap-svc/actions/transactions.js
+++ b/src/platform/user/profile/vap-svc/actions/transactions.js
@@ -5,13 +5,7 @@ import { refreshProfile } from '~/platform/user/profile/actions';
 import recordEvent from '~/platform/monitoring/record-event';
 import { inferAddressType } from '~/applications/letters/utils/helpers';
 
-import {
-  ANALYTICS_ADDRESS_FIELD_NAMES,
-  ANALYTICS_FIELD_MAP,
-  ANALYTICS_PHONE_FIELD_NAMES,
-  ADDRESS_POU,
-  FIELD_NAMES,
-} from '@@vap-svc/constants';
+import { ADDRESS_POU, FIELD_NAMES } from '@@vap-svc/constants';
 
 import { showAddressValidationModal } from '../../utilities';
 
@@ -139,27 +133,11 @@ export function refreshTransaction(
           const errorCode = errorMetadata.code ?? 'unknown-code';
           const errorKey = errorMetadata.key ?? 'unknown-key';
 
-          const addressNames = Object.values(ANALYTICS_ADDRESS_FIELD_NAMES);
-          const phoneNames = Object.values(ANALYTICS_PHONE_FIELD_NAMES);
-          let sectionName = analyticsSectionName;
-
-          if (addressNames.includes(analyticsSectionName)) {
-            sectionName = 'address';
-          }
-
-          if (phoneNames.includes(analyticsSectionName)) {
-            sectionName = 'phone';
-          }
-
-          if (analyticsSectionName === ANALYTICS_FIELD_MAP.email) {
-            sectionName = 'email';
-          }
-
           recordEvent({
             event: 'profile-edit-failure',
             'profile-action': 'save-failure',
             'profile-section': analyticsSectionName,
-            'error-key': `${errorCode}_${errorKey}-${sectionName}-save-failure`,
+            'error-key': `${errorCode}_${errorKey}-${analyticsSectionName}-save-failure`,
           });
           recordEvent({
             'error-key': undefined,

--- a/src/platform/user/profile/vap-svc/constants/index.js
+++ b/src/platform/user/profile/vap-svc/constants/index.js
@@ -90,6 +90,20 @@ export const ANALYTICS_FIELD_MAP = {
   smsOptout: 'sms-optout',
 };
 
+export const ANALYTICS_ADDRESS_FIELD_NAMES = {
+  mailingAddress: 'mailing-address',
+  residentialAddress: 'home-address',
+};
+
+export const ANALYTICS_PHONE_FIELD_NAMES = {
+  primaryTelephone: 'primary-telephone',
+  alternateTelephone: 'alternative-telephone',
+  homePhone: 'home-telephone',
+  mobilePhone: 'mobile-telephone',
+  workPhone: 'work-telephone',
+  faxNumber: 'fax-telephone',
+};
+
 export const API_ROUTES = {
   INIT_VAP_SERVICE_ID: '/profile/initialize_vet360_id',
   TELEPHONES: '/profile/telephones',

--- a/src/platform/user/profile/vap-svc/constants/index.js
+++ b/src/platform/user/profile/vap-svc/constants/index.js
@@ -90,20 +90,6 @@ export const ANALYTICS_FIELD_MAP = {
   smsOptout: 'sms-optout',
 };
 
-export const ANALYTICS_ADDRESS_FIELD_NAMES = {
-  mailingAddress: 'mailing-address',
-  residentialAddress: 'home-address',
-};
-
-export const ANALYTICS_PHONE_FIELD_NAMES = {
-  primaryTelephone: 'primary-telephone',
-  alternateTelephone: 'alternative-telephone',
-  homePhone: 'home-telephone',
-  mobilePhone: 'mobile-telephone',
-  workPhone: 'work-telephone',
-  faxNumber: 'fax-telephone',
-};
-
 export const API_ROUTES = {
   INIT_VAP_SERVICE_ID: '/profile/initialize_vet360_id',
   TELEPHONES: '/profile/telephones',


### PR DESCRIPTION
## Description
When a VA PRofile transaction fails, we are always recording the `error-key` with an `address-save-failure` suffix without checking to see if it actually _was_ address that failed:


## Acceptance criteria
- [x] continue using this suffix if the transaction was an address save failure so we don't mess up our GA stats
- [x] use different suffixes if phone numbers or email addresses fail to save

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
