### PR TITLE
Stop checking status of failed VA Profile transactions from the validation view

### DIFF
--- a/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
+++ b/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
@@ -40,6 +40,13 @@ class AddressValidationView extends React.Component {
         window.VetsGov.pollTimeout || 1000,
       );
     }
+    // if the transaction is no longer pending, stop refreshing it
+    if (
+      isPendingTransaction(prevProps.transaction) &&
+      !isPendingTransaction(this.props.transaction)
+    ) {
+      window.clearInterval(this.interval);
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
## Description
We already stopped checking on the status of failed VA Profile transactions from the edit view, but we were _not_ killing the interval that checked the transaction status from the _validation_ view. So if an address update failed from the address validation screen we continued to check on the transaction status every second, making needless API calls and recording lots of duplicate "Address save failure" events in Google Analytics.

## Testing done
Local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs