### PR TITLE
Feature/17317 accessibility issues on show more pattern for provider selection

### DIFF
--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
@@ -250,7 +250,7 @@ function ProviderSelectionField({
                     </button>
                   </p>
                 )}
-                <p role="status">
+                <p role="status" aria-live="polite" aria-atomic="true">
                   Displaying 1 to {currentlyShownProvidersList.length} of{' '}
                   {communityCareProviderList.length} providers
                 </p>
@@ -317,8 +317,6 @@ function ProviderSelectionField({
             {providersListLength < communityCareProviderList.length && (
               <>
                 <button
-                  aria-live="polite"
-                  aria-atomic="true"
                   type="button"
                   className="additional-info-button va-button-link vads-u-display--block vads-u-margin-right--2"
                   onClick={() => {

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
@@ -328,7 +328,9 @@ function ProviderSelectionField({
                   type="button"
                   className="additional-info-button va-button-link vads-u-display--block vads-u-margin-right--2"
                   onClick={() => {
-                    setProvidersListLength(providersListLength + 5);
+                    setProvidersListLength(
+                      providersListLength + INITIAL_PROVIDER_DISPLAY_COUNT,
+                    );
                     recordEvent({
                       event: `${GA_PREFIX}-provider-list-paginate`,
                     });

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
@@ -89,6 +89,20 @@ function ProviderSelectionField({
     [formData],
   );
 
+  useEffect(
+    () => {
+      if (
+        showProvidersList &&
+        providersListLength > INITIAL_PROVIDER_DISPLAY_COUNT
+      ) {
+        scrollAndFocus(
+          `#provider_${providersListLength - INITIAL_PROVIDER_DISPLAY_COUNT}`,
+        );
+      }
+    },
+    [providersListLength],
+  );
+
   return (
     <div className="vads-u-background-color--gray-lightest small-screen:vads-u-padding--2 medium-screen:vads-u-padding--3">
       {!showProvidersList &&
@@ -127,7 +141,11 @@ function ProviderSelectionField({
               )}{' '}
               miles
             </span>
-            <div className="vads-u-display--flex">
+            <div
+              className="vads-u-display--flex"
+              aria-atomic="true"
+              aria-live="assertive"
+            >
               <button
                 type="button"
                 className="vaos-appts__cancel-btn va-button-link vads-u-margin--0 vads-u-flex--0 vads-u-margin-right--2"
@@ -242,17 +260,22 @@ function ProviderSelectionField({
                   const { name } = provider;
                   const checked = provider.id === checkedProvider;
                   return (
-                    <div className="form-radio-buttons" key={provider.id}>
+                    <div
+                      className="form-radio-buttons"
+                      key={provider.id}
+                      aria-atomic="true"
+                      aria-live="assertive"
+                    >
                       <input
                         type="radio"
                         checked={checked}
-                        id={`${idSchema.$id}_${provider.id}`}
+                        id={`provider_${providerIndex}`}
                         name={`${idSchema.$id}`}
                         value={provider.id}
                         onChange={_ => setCheckedProvider(provider.id)}
                         disabled={loadingProviders}
                       />
-                      <label htmlFor={`${idSchema.$id}_${provider.id}`}>
+                      <label htmlFor={`provider_${providerIndex}`}>
                         <span className="vads-u-display--block vads-u-font-weight--bold">
                           {name}
                         </span>
@@ -300,6 +323,8 @@ function ProviderSelectionField({
             {providersListLength < communityCareProviderList.length && (
               <>
                 <button
+                  aria-atomic="true"
+                  aria-live="assertive"
                   type="button"
                   className="additional-info-button va-button-link vads-u-display--block vads-u-margin-right--2"
                   onClick={() => {
@@ -309,6 +334,7 @@ function ProviderSelectionField({
                     });
                   }}
                 >
+                  <span className="sr-only">show</span>
                   <span className="va-button-link">
                     +{' '}
                     {Math.min(

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
@@ -96,7 +96,9 @@ function ProviderSelectionField({
         providersListLength > INITIAL_PROVIDER_DISPLAY_COUNT
       ) {
         scrollAndFocus(
-          `#provider_${providersListLength - INITIAL_PROVIDER_DISPLAY_COUNT}`,
+          `#provider_${providersListLength -
+            INITIAL_PROVIDER_DISPLAY_COUNT +
+            1}`,
         );
       }
     },
@@ -259,6 +261,7 @@ function ProviderSelectionField({
                 {currentlyShownProvidersList.map((provider, providerIndex) => {
                   const { name } = provider;
                   const checked = provider.id === checkedProvider;
+                  const providerPosition = providerIndex + 1;
                   return (
                     <div
                       className="form-radio-buttons"
@@ -269,13 +272,13 @@ function ProviderSelectionField({
                       <input
                         type="radio"
                         checked={checked}
-                        id={`provider_${providerIndex}`}
+                        id={`provider_${providerPosition}`}
                         name={`${idSchema.$id}`}
                         value={provider.id}
                         onChange={_ => setCheckedProvider(provider.id)}
                         disabled={loadingProviders}
                       />
-                      <label htmlFor={`provider_${providerIndex}`}>
+                      <label htmlFor={`provider_${providerPosition}`}>
                         <span className="vads-u-display--block vads-u-font-weight--bold">
                           {name}
                         </span>
@@ -299,7 +302,7 @@ function ProviderSelectionField({
                             setShowProvidersList(false);
                             recordEvent({
                               event: `${GA_PREFIX}-order-position-provider-selection`,
-                              providerPosition: providerIndex + 1,
+                              providerPosition: { providerPosition },
                             });
                           }}
                         >

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
@@ -96,7 +96,7 @@ function ProviderSelectionField({
         providersListLength > INITIAL_PROVIDER_DISPLAY_COUNT
       ) {
         scrollAndFocus(
-          `#provider_${providersListLength -
+          `#${idSchema.$id}_${providersListLength -
             INITIAL_PROVIDER_DISPLAY_COUNT +
             1}`,
         );
@@ -143,11 +143,7 @@ function ProviderSelectionField({
               )}{' '}
               miles
             </span>
-            <div
-              className="vads-u-display--flex"
-              aria-atomic="true"
-              aria-live="assertive"
-            >
+            <div className="vads-u-display--flex">
               <button
                 type="button"
                 className="vaos-appts__cancel-btn va-button-link vads-u-margin--0 vads-u-flex--0 vads-u-margin-right--2"
@@ -254,7 +250,7 @@ function ProviderSelectionField({
                     </button>
                   </p>
                 )}
-                <p>
+                <p role="status">
                   Displaying 1 to {currentlyShownProvidersList.length} of{' '}
                   {communityCareProviderList.length} providers
                 </p>
@@ -263,22 +259,17 @@ function ProviderSelectionField({
                   const checked = provider.id === checkedProvider;
                   const providerPosition = providerIndex + 1;
                   return (
-                    <div
-                      className="form-radio-buttons"
-                      key={provider.id}
-                      aria-atomic="true"
-                      aria-live="assertive"
-                    >
+                    <div className="form-radio-buttons" key={provider.id}>
                       <input
                         type="radio"
                         checked={checked}
-                        id={`provider_${providerPosition}`}
+                        id={`${idSchema.$id}_${providerPosition}`}
                         name={`${idSchema.$id}`}
                         value={provider.id}
                         onChange={_ => setCheckedProvider(provider.id)}
                         disabled={loadingProviders}
                       />
-                      <label htmlFor={`provider_${providerPosition}`}>
+                      <label htmlFor={`${idSchema.$id}_${providerPosition}`}>
                         <span className="vads-u-display--block vads-u-font-weight--bold">
                           {name}
                         </span>
@@ -302,7 +293,7 @@ function ProviderSelectionField({
                             setShowProvidersList(false);
                             recordEvent({
                               event: `${GA_PREFIX}-order-position-provider-selection`,
-                              providerPosition: { providerPosition },
+                              providerPosition,
                             });
                           }}
                         >
@@ -326,8 +317,8 @@ function ProviderSelectionField({
             {providersListLength < communityCareProviderList.length && (
               <>
                 <button
+                  aria-live="polite"
                   aria-atomic="true"
-                  aria-live="assertive"
                   type="button"
                   className="additional-info-button va-button-link vads-u-display--block vads-u-margin-right--2"
                   onClick={() => {

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/RemoveProviderModal.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/RemoveProviderModal.jsx
@@ -30,6 +30,7 @@ export default function RemoveProviderModal({ onClose, provider, address }) {
         className="usa-button-secondary"
         type="button"
         onClick={() => onClose(false)}
+        aria-label="Cancel removing the selected provider"
       >
         Cancel
       </button>

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesRadioWidget.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesRadioWidget.jsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { FACILITY_SORT_METHODS } from '../../../utils/constants';
+import { scrollAndFocus } from '../../../utils/scrollAndFocus';
 
 const INITIAL_FACILITY_DISPLAY_COUNT = 5;
 
@@ -24,20 +25,30 @@ export default function FacilitiesRadioWidget({
     selectedIndex >= INITIAL_FACILITY_DISPLAY_COUNT,
   );
 
+  // currently shown facility list
   const displayedOptions = displayAll
     ? enumOptions
     : enumOptions.slice(0, INITIAL_FACILITY_DISPLAY_COUNT);
-
+  // remaining facilities count
   const hiddenCount =
     enumOptions.length > INITIAL_FACILITY_DISPLAY_COUNT
       ? enumOptions.length - INITIAL_FACILITY_DISPLAY_COUNT
       : 0;
 
+  useEffect(
+    () => {
+      if (displayedOptions.length > INITIAL_FACILITY_DISPLAY_COUNT) {
+        scrollAndFocus(`#facility_${INITIAL_FACILITY_DISPLAY_COUNT}`);
+      }
+    },
+    [displayedOptions.length, displayAll],
+  );
+
   return (
     <div>
-      {displayedOptions.map((option, i) => {
-        const { id, name, address, legacyVAR } = option?.label;
-        const checked = option.value === value;
+      {displayedOptions.map((facility, facilityIndex) => {
+        const { id, name, address, legacyVAR } = facility?.label;
+        const checked = facility.value === value;
         let distance;
 
         if (sortMethod === FACILITY_SORT_METHODS.distanceFromResidential) {
@@ -49,17 +60,22 @@ export default function FacilitiesRadioWidget({
         }
 
         return (
-          <div className="form-radio-buttons" key={option.value}>
+          <div
+            className="form-radio-buttons"
+            key={facility.value}
+            aria-atomic="true"
+            aria-live="assertive"
+          >
             <input
               type="radio"
               checked={checked}
-              id={`${id}_${i}`}
+              id={`facility_${facilityIndex}`}
               name={`${id}`}
-              value={option.value}
-              onChange={_ => onChange(option.value)}
+              value={facility.value}
+              onChange={_ => onChange(facility.value)}
               disabled={loadingEligibility}
             />
-            <label htmlFor={`${id}_${i}`}>
+            <label htmlFor={`facility_${facilityIndex}`}>
               <span className="vads-u-display--block vads-u-font-weight--bold">
                 {name}
               </span>
@@ -81,8 +97,13 @@ export default function FacilitiesRadioWidget({
           <button
             type="button"
             className="additional-info-button va-button-link vads-u-display--block"
-            onClick={() => setDisplayAll(!displayAll)}
+            aria-atomic="true"
+            aria-live="assertive"
+            onClick={() => {
+              setDisplayAll(!displayAll);
+            }}
           >
+            <span className="sr-only">show</span>
             <span className="va-button-link">
               {`+ ${hiddenCount} more location${hiddenCount === 1 ? '' : 's'}`}
             </span>

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesRadioWidget.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesRadioWidget.jsx
@@ -34,11 +34,10 @@ export default function FacilitiesRadioWidget({
     enumOptions.length > INITIAL_FACILITY_DISPLAY_COUNT
       ? enumOptions.length - INITIAL_FACILITY_DISPLAY_COUNT
       : 0;
-
   useEffect(
     () => {
       if (displayedOptions.length > INITIAL_FACILITY_DISPLAY_COUNT) {
-        scrollAndFocus(`#facility_${INITIAL_FACILITY_DISPLAY_COUNT}`);
+        scrollAndFocus(`#facility_${INITIAL_FACILITY_DISPLAY_COUNT + 1}`);
       }
     },
     [displayedOptions.length, displayAll],
@@ -58,6 +57,7 @@ export default function FacilitiesRadioWidget({
         ) {
           distance = legacyVAR?.distanceFromCurrentLocation;
         }
+        const facilityPosition = facilityIndex + 1;
 
         return (
           <div
@@ -69,13 +69,13 @@ export default function FacilitiesRadioWidget({
             <input
               type="radio"
               checked={checked}
-              id={`facility_${facilityIndex}`}
+              id={`facility_${facilityPosition}`}
               name={`${id}`}
               value={facility.value}
               onChange={_ => onChange(facility.value)}
               disabled={loadingEligibility}
             />
-            <label htmlFor={`facility_${facilityIndex}`}>
+            <label htmlFor={`facility_${facilityPosition}`}>
               <span className="vads-u-display--block vads-u-font-weight--bold">
                 {name}
               </span>

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesRadioWidget.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesRadioWidget.jsx
@@ -37,7 +37,11 @@ export default function FacilitiesRadioWidget({
   useEffect(
     () => {
       if (displayedOptions.length > INITIAL_FACILITY_DISPLAY_COUNT) {
-        scrollAndFocus(`#facility_${INITIAL_FACILITY_DISPLAY_COUNT + 1}`);
+        scrollAndFocus(
+          `#${
+            enumOptions[INITIAL_FACILITY_DISPLAY_COUNT].label.id
+          }_${INITIAL_FACILITY_DISPLAY_COUNT + 1}`,
+        );
       }
     },
     [displayedOptions.length, displayAll],
@@ -45,9 +49,9 @@ export default function FacilitiesRadioWidget({
 
   return (
     <div>
-      {displayedOptions.map((facility, facilityIndex) => {
-        const { id, name, address, legacyVAR } = facility?.label;
-        const checked = facility.value === value;
+      {displayedOptions.map((option, i) => {
+        const { id, name, address, legacyVAR } = option?.label;
+        const checked = option.value === value;
         let distance;
 
         if (sortMethod === FACILITY_SORT_METHODS.distanceFromResidential) {
@@ -57,25 +61,20 @@ export default function FacilitiesRadioWidget({
         ) {
           distance = legacyVAR?.distanceFromCurrentLocation;
         }
-        const facilityPosition = facilityIndex + 1;
+        const facilityPosition = i + 1;
 
         return (
-          <div
-            className="form-radio-buttons"
-            key={facility.value}
-            aria-atomic="true"
-            aria-live="assertive"
-          >
+          <div className="form-radio-buttons" key={option.value}>
             <input
               type="radio"
               checked={checked}
-              id={`facility_${facilityPosition}`}
+              id={`${id}_${facilityPosition}`}
               name={`${id}`}
-              value={facility.value}
-              onChange={_ => onChange(facility.value)}
+              value={option.value}
+              onChange={_ => onChange(option.value)}
               disabled={loadingEligibility}
             />
-            <label htmlFor={`facility_${facilityPosition}`}>
+            <label htmlFor={`${id}_${facilityPosition}`}>
               <span className="vads-u-display--block vads-u-font-weight--bold">
                 {name}
               </span>
@@ -97,8 +96,6 @@ export default function FacilitiesRadioWidget({
           <button
             type="button"
             className="additional-info-button va-button-link vads-u-display--block"
-            aria-atomic="true"
-            aria-live="assertive"
             onClick={() => {
               setDisplayAll(!displayAll);
             }}

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
@@ -188,17 +188,19 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
     expect(await screen.findByText(/displaying 1 to 10 of 16 providers/i)).to
       .exist;
     expect((await screen.findAllByRole('radio')).length).to.equal(12);
+    expect(document.activeElement.id).to.equal('provider_6');
 
     userEvent.click(await screen.findByText(/\+ 5 more providers/i));
     expect(await screen.findByText(/displaying 1 to 15 of 16 providers/i)).to
       .exist;
     expect((await screen.findAllByRole('radio')).length).to.equal(17);
+    expect(document.activeElement.id).to.equal('provider_11');
 
     userEvent.click(await screen.findByText(/\+ 1 more providers/i));
     expect(await screen.findByText(/displaying 1 to 16 of 16 providers/i)).to
       .exist;
     expect((await screen.findAllByRole('radio')).length).to.equal(18);
-
+    expect(document.activeElement.id).to.equal('provider_16');
     // Choose Provider
     userEvent.click(await screen.findByText(/AJADI, ADEDIWURA/i));
     userEvent.click(

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
@@ -188,19 +188,19 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
     expect(await screen.findByText(/displaying 1 to 10 of 16 providers/i)).to
       .exist;
     expect((await screen.findAllByRole('radio')).length).to.equal(12);
-    expect(document.activeElement.id).to.equal('provider_6');
+    expect(document.activeElement.id).to.equal('root_communityCareProvider_6');
 
     userEvent.click(await screen.findByText(/\+ 5 more providers/i));
     expect(await screen.findByText(/displaying 1 to 15 of 16 providers/i)).to
       .exist;
     expect((await screen.findAllByRole('radio')).length).to.equal(17);
-    expect(document.activeElement.id).to.equal('provider_11');
+    expect(document.activeElement.id).to.equal('root_communityCareProvider_11');
 
     userEvent.click(await screen.findByText(/\+ 1 more providers/i));
     expect(await screen.findByText(/displaying 1 to 16 of 16 providers/i)).to
       .exist;
     expect((await screen.findAllByRole('radio')).length).to.equal(18);
-    expect(document.activeElement.id).to.equal('provider_16');
+    expect(document.activeElement.id).to.equal('root_communityCareProvider_16');
     // Choose Provider
     userEvent.click(await screen.findByText(/AJADI, ADEDIWURA/i));
     userEvent.click(

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.multi.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.multi.unit.spec.jsx
@@ -193,7 +193,7 @@ describe('VAOS integration: VA flat facility page - multiple facilities', () => 
 
     // Should show 6th facility
     expect(screen.baseElement).to.contain.text('Fake facility name 6');
-    expect(document.activeElement.id).to.equal('facility_6');
+    expect(document.activeElement.id).to.equal('var984_6');
 
     // Should validation message if no facility selected
     fireEvent.click(screen.getByText(/Continue/));

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.multi.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.multi.unit.spec.jsx
@@ -193,6 +193,7 @@ describe('VAOS integration: VA flat facility page - multiple facilities', () => 
 
     // Should show 6th facility
     expect(screen.baseElement).to.contain.text('Fake facility name 6');
+    expect(document.activeElement.id).to.equal('facility_6');
 
     // Should validation message if no facility selected
     fireEvent.click(screen.getByText(/Continue/));


### PR DESCRIPTION
## Description
When clicking on the "more provider" link it currently does not focus first next set of providers. The same is also missing from the "more locations" link in the facility selection page

## Testing done
local and unit test

## Screenshots
![image](https://user-images.githubusercontent.com/54327023/102510180-56f18a00-4055-11eb-9413-b1372b7bd4c9.png)


## Acceptance criteria
- [ ] have focus on the first next set of providers
- [ ] add aria-label as needed
- [ ] add .sr-only to visually hide text from screen but read out loud by screen reader

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
