### PR TITLE
DT-11453 Updating related to data source.

### DIFF
--- a/src/applications/find-forms/components/SearchResult.jsx
+++ b/src/applications/find-forms/components/SearchResult.jsx
@@ -37,7 +37,7 @@ const SearchResult = ({ form }) => {
       formToolUrl,
       formDetailsUrl,
       lastRevisionOn,
-      relatedForms,
+      benefitCategories,
       title,
       url,
     },
@@ -62,10 +62,10 @@ const SearchResult = ({ form }) => {
         {lastRevision}
       </dd>
 
-      {relatedForms.length > 0 ? (
+      {benefitCategories && benefitCategories.length > 0 ? (
         <dd className="vads-u-margin-y--1 vads-u-margin-y--1">
           <dfn className="vads-u-font-weight--bold">Related to:</dfn>{' '}
-          {relatedForms.join(', ')}
+          {benefitCategories.map(f => f.name).join(', ')}
         </dd>
       ) : null}
 

--- a/src/applications/find-forms/prop-types.js
+++ b/src/applications/find-forms/prop-types.js
@@ -2,16 +2,25 @@ import PropTypes from 'prop-types';
 
 const Form = PropTypes.shape({
   id: PropTypes.string.isRequired,
+  type: PropTypes.string,
   attributes: PropTypes.shape({
     formName: PropTypes.string.isRequired, // same as id
-    title: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,
-    validPdf: PropTypes.bool,
-    validPDF: PropTypes.bool,
+    title: PropTypes.string.isRequired,
     lastRevisionOn: PropTypes.string,
     firstIssuedOn: PropTypes.string, // always null; meaningless property
-    sha: PropTypes.string,
     pages: PropTypes.number,
+    sha256: PropTypes.string,
+    validPdf: PropTypes.bool,
+    formUsage: PropTypes.string,
+    formToolIntro: PropTypes.string,
+    formToolUrl: PropTypes.string,
+    formDetailsUrl: PropTypes.string,
+    formType: PropTypes.string,
+    language: PropTypes.string,
+    deletedAt: PropTypes.string,
+    relatedForms: PropTypes.array,
+    benefitCategories: PropTypes.array,
   }).isRequired,
 });
 


### PR DESCRIPTION
## Description
"Related To" text was pulling from the wrong data source.

## Testing done
Spun up local env and searched _Caregivers_ and _health_ within the component to see the results populate.
Ran all unit tests and e2e tests locally to make sure they passed. 

## Acceptance criteria
- [x] Related To field is pulling from the correct data source.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
