### PR TITLE
Added webpack file hashes back to stop Sentry alerts

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -30,6 +30,8 @@ const generateWebpackDevConfig = require('./webpack.dev.config.js');
 const getAbsolutePath = relativePath =>
   path.join(__dirname, '../', relativePath);
 
+const timestamp = new Date().getTime();
+
 const sharedModules = [
   getAbsolutePath('src/platform/polyfills'),
   'react',
@@ -101,6 +103,11 @@ module.exports = env => {
     ENVIRONMENTS.VAGOVPROD,
   ].includes(buildOptions.buildtype);
 
+  const useHashFilenames = [
+    ENVIRONMENTS.VAGOVSTAGING,
+    ENVIRONMENTS.VAGOVPROD,
+  ].includes(buildOptions.buildtype);
+
   // enable css sourcemaps for all non-localhost builds
   // or if build options include local-css-sourcemaps or entry
   const enableCSSSourcemaps =
@@ -116,8 +123,12 @@ module.exports = env => {
     output: {
       path: outputPath,
       publicPath: '/generated/',
-      filename: '[name].entry.js',
-      chunkFilename: '[name].entry.js',
+      filename: !useHashFilenames
+        ? '[name].entry.js'
+        : `[name].entry.[chunkhash]-${timestamp}.js`,
+      chunkFilename: !useHashFilenames
+        ? '[name].entry.js'
+        : `[name].entry.[chunkhash]-${timestamp}.js`,
     },
     module: {
       rules: [
@@ -253,7 +264,9 @@ module.exports = env => {
 
           if (isMedalliaStyleFile && isStaging) return `[name].css`;
 
-          return `[name].css`;
+          return useHashFilenames
+            ? `[name].[contenthash]-${timestamp}.css`
+            : `[name].css`;
         },
       }),
 


### PR DESCRIPTION
File hash removal exposed a caching issue with lazy loaded React components and flooded Sentry with alerts. We're temporarily switching the hashes back on until we can manually hash the lazy loaded files.