### PR TITLE
[Development] Prevent legend wrapping alert

### DIFF
--- a/src/applications/disability-benefits/996/pages/contestedIssues.js
+++ b/src/applications/disability-benefits/996/pages/contestedIssues.js
@@ -50,8 +50,10 @@ const contestedIssuesPage = {
       },
     },
     sameOfficeAlert: {
-      'ui:title': OfficeForReviewAlert,
+      'ui:title': '', // prevent alert from being added to a legend
+      'ui:description': OfficeForReviewAlert,
       'ui:options': {
+        forceDivWrapper: true,
         hideIf: formData =>
           formData?.sameOffice !== true || hasNoContestedIssues(formData),
       },


### PR DESCRIPTION
## Description

The same office alert was wrapped in a `legend` inside a `fieldset` both of which are nested inside another `fieldset`. The content contains no form elements, so moving the component to the description wraps the alert in a `div`. Better for a11y.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/17240

## Testing done

Unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Page passes a11y checks

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
