### PR TITLE
[DESIGN]: GIBCT EYB - CONSIDER shortening margin between benefit headers on college, OTJ profiles#14424

### DIFF
--- a/src/applications/gi/components/profile/EstimatedBenefits.jsx
+++ b/src/applications/gi/components/profile/EstimatedBenefits.jsx
@@ -45,13 +45,18 @@ const CalculatorResultRow = ({
   bold,
   visible,
   screenReaderSpan,
+  eybH4,
 }) =>
   visible ? (
     <li
       id={`calculator-result-row-${createId(id == null ? label : id)}`}
-      className={classNames('row', 'calculator-result', {
-        'vads-u-font-weight--bold': bold,
-      })}
+      className={
+        eybH4
+          ? 'vads-u-margin-bottom--neg0p5 eyb-h4 row calculator-result'
+          : classNames('row', 'calculator-result', {
+              'vads-u-font-weight--bold': bold,
+            })
+      }
     >
       {header ? (
         <h4 className="small-6 columns">{label}:</h4>
@@ -173,30 +178,27 @@ export const EstimatedBenefits = ({ profile, outputs, calculator }) => (
         aria-label="Total paid to you"
         role="list"
       >
-        <div className="vads-u-margin-bottom--neg0p5 eyb-h4">
-          <CalculatorResultRow
-            label="Housing allowance"
-            value={outputs.housingAllowance.value}
-            visible={outputs.housingAllowance.visible}
-            screenReaderSpan={month}
-          />
-        </div>
-        <div className="vads-u-margin-bottom--neg0p5 eyb-h4">
-          <CalculatorResultRow
-            label="Book stipend"
-            value={outputs.bookStipend.value}
-            visible={outputs.bookStipend.visible}
-            screenReaderSpan={profile.attributes.type === 'ojt' ? month : year}
-          />
-        </div>
-        <div className="eyb-h4">
-          <CalculatorResultRow
-            label="Total paid to you"
-            value={outputs.totalPaidToYou.value}
-            bold
-            visible={outputs.totalPaidToYou.visible}
-          />
-        </div>
+        <CalculatorResultRow
+          label="Housing allowance"
+          value={outputs.housingAllowance.value}
+          visible={outputs.housingAllowance.visible}
+          screenReaderSpan={month}
+          eybH4
+        />
+        <CalculatorResultRow
+          label="Book stipend"
+          value={outputs.bookStipend.value}
+          visible={outputs.bookStipend.visible}
+          screenReaderSpan={profile.attributes.type === 'ojt' ? month : year}
+          eybH4
+        />
+        <CalculatorResultRow
+          label="Total paid to you"
+          value={outputs.totalPaidToYou.value}
+          bold
+          visible={outputs.totalPaidToYou.visible}
+          eybH4
+        />
       </ul>
     </div>
     <hr aria-hidden="true" />

--- a/src/applications/gi/components/profile/EstimatedBenefits.jsx
+++ b/src/applications/gi/components/profile/EstimatedBenefits.jsx
@@ -173,27 +173,30 @@ export const EstimatedBenefits = ({ profile, outputs, calculator }) => (
         aria-label="Total paid to you"
         role="list"
       >
-        <CalculatorResultRow
-          label="Housing allowance"
-          value={outputs.housingAllowance.value}
-          visible={outputs.housingAllowance.visible}
-          screenReaderSpan={month}
-          header
-        />
-        <CalculatorResultRow
-          label="Book stipend"
-          value={outputs.bookStipend.value}
-          visible={outputs.bookStipend.visible}
-          screenReaderSpan={profile.attributes.type === 'ojt' ? month : year}
-          header
-        />
-        <CalculatorResultRow
-          label="Total paid to you"
-          value={outputs.totalPaidToYou.value}
-          bold
-          visible={outputs.totalPaidToYou.visible}
-          header
-        />
+        <div className="vads-u-margin-bottom--neg0p5 eyb-h4">
+          <CalculatorResultRow
+            label="Housing allowance"
+            value={outputs.housingAllowance.value}
+            visible={outputs.housingAllowance.visible}
+            screenReaderSpan={month}
+          />
+        </div>
+        <div className="vads-u-margin-bottom--neg0p5 eyb-h4">
+          <CalculatorResultRow
+            label="Book stipend"
+            value={outputs.bookStipend.value}
+            visible={outputs.bookStipend.visible}
+            screenReaderSpan={profile.attributes.type === 'ojt' ? month : year}
+          />
+        </div>
+        <div className="eyb-h4">
+          <CalculatorResultRow
+            label="Total paid to you"
+            value={outputs.totalPaidToYou.value}
+            bold
+            visible={outputs.totalPaidToYou.visible}
+          />
+        </div>
       </ul>
     </div>
     <hr aria-hidden="true" />

--- a/src/applications/gi/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi/sass/partials/_gi-profile-page.scss
@@ -197,7 +197,7 @@
     margin-top: 1px;
   }
 
-  .category-ratings-accordion-headings{
+  .category-ratings-accordion-headings {
     margin-bottom: 9px;
     padding-top: 2rem;
     padding-left: 1rem;
@@ -281,6 +281,12 @@
     .calculator-result {
       margin-top: 1.6rem;
     }
+  }
+  .eyb-h4 {
+    font-family: "Bitter", "Georgia", "Cambria", "Times New Roman", "Times",
+      serif;
+    font-size: 1.7rem;
+    font-weight: 700;
   }
 
   .per-term-section {


### PR DESCRIPTION
## Description
As a user, I want to skim the benefit headings quickly.
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/14424
## Testing done
local testing

## Screenshots
![Screen Shot 2020-12-17 at 2 17 42 PM](https://user-images.githubusercontent.com/50601724/102534970-89ab7a80-4075-11eb-8036-7bc1246ca98e.png)
![Screen Shot 2020-12-17 at 2 17 17 PM](https://user-images.githubusercontent.com/50601724/102534977-8b753e00-4075-11eb-892f-5e4971b985f8.png)


## Acceptance criteria
- [x] Heading margins are shortened, or design agrees this is not an issue

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
