### PR TITLE
Keep same address id and default to USA when clearing home address

### DIFF
--- a/src/platform/user/profile/vap-svc/containers/CopyMailingAddress.jsx
+++ b/src/platform/user/profile/vap-svc/containers/CopyMailingAddress.jsx
@@ -51,6 +51,9 @@ class CopyMailingAddress extends React.Component {
     // If mailing + home addresses are the same, clear the home address
     if (this.areHomeMailingAddressesEqual()) {
       const clearedHomeAddress = mapValues(mailingAddress, () => null);
+
+      // We need the id to remain the same to prevent POST calls
+      clearedHomeAddress.id = mailingAddress.id;
       copyMailingAddress(clearedHomeAddress);
       return;
     }

--- a/src/platform/user/profile/vap-svc/containers/CopyMailingAddress.jsx
+++ b/src/platform/user/profile/vap-svc/containers/CopyMailingAddress.jsx
@@ -53,7 +53,7 @@ class CopyMailingAddress extends React.Component {
       const clearedHomeAddress = mapValues(mailingAddress, () => null);
 
       // We need the id to remain the same to prevent POST calls
-      clearedHomeAddress.id = mailingAddress.id;
+      clearedHomeAddress.id = mailingAddress.id || null;
       copyMailingAddress(clearedHomeAddress);
       return;
     }

--- a/src/platform/user/profile/vap-svc/containers/CopyMailingAddress.jsx
+++ b/src/platform/user/profile/vap-svc/containers/CopyMailingAddress.jsx
@@ -7,7 +7,7 @@ import pickBy from 'lodash/pickBy';
 import mapValues from 'lodash/mapValues';
 import { isEmptyAddress } from 'platform/forms/address/helpers';
 
-import { FIELD_NAMES } from '../constants';
+import { FIELD_NAMES, USA } from '@@vap-svc/constants';
 
 import { selectVAPContactInfoField, selectEditedFormField } from '../selectors';
 
@@ -54,8 +54,7 @@ class CopyMailingAddress extends React.Component {
 
       // We need the id to remain the same to prevent POST calls
       clearedHomeAddress.id = mailingAddress.id || null;
-      clearedHomeAddress.countryCodeIso3 =
-        mailingAddress.countryCodeIso3 || null;
+      clearedHomeAddress.countryCodeIso3 = USA.COUNTRY_ISO3_CODE;
 
       copyMailingAddress(clearedHomeAddress);
       return;

--- a/src/platform/user/profile/vap-svc/containers/CopyMailingAddress.jsx
+++ b/src/platform/user/profile/vap-svc/containers/CopyMailingAddress.jsx
@@ -54,6 +54,9 @@ class CopyMailingAddress extends React.Component {
 
       // We need the id to remain the same to prevent POST calls
       clearedHomeAddress.id = mailingAddress.id || null;
+      clearedHomeAddress.countryCodeIso3 =
+        mailingAddress.countryCodeIso3 || null;
+
       copyMailingAddress(clearedHomeAddress);
       return;
     }


### PR DESCRIPTION
## Description
We were wiping out the `id` on the address when clearing the form. Upon saving the address, it was thus treated as a POST rather than a PUT. 

## Testing done


## Screenshots


## Acceptance criteria
- [x] Ensure we do not wipe out the address id when clearing the form

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
