### PR TITLE
Typeahead Screen Reader Rework - 16965

### DIFF
--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 
 import { fetchSearchResults } from '../actions';
 import { formatResponseString } from '../utils';
@@ -115,16 +117,27 @@ class SearchApp extends React.Component {
         'nav-path': `Recommended Results -> ${strippedTitle}`,
       });
     }
+
+    const bestBetPosition = index + 1;
+    const normalResultPosition =
+      index + (this.props.search?.recommendedResults?.length || 0) + 1;
+    const searchResultPosition = bestBet
+      ? bestBetPosition
+      : normalResultPosition;
+
     recordEvent({
       event: 'onsite-search-results-click',
       'search-page-path': document.location.pathname,
       'search-query': this.state.userInput,
-      'search-results-position': index + 1,
+      'search-results-pagination-current-page': this.props.search?.currentPage,
+      'search-results-position': searchResultPosition,
       'search-results-total-count': this.props.search?.totalEntries,
       'search-results-total-pages': Math.ceil(
-        this.props.search?.results?.length / 10,
+        this.props.search?.totalEntries / 10,
       ),
       'search-selection': 'All VA.gov',
+      'search-results-top-recommendation': bestBet,
+      'search-typeahead-enabled': this.props.searchTypeaheadEnabled,
     });
   };
 
@@ -187,8 +200,8 @@ class SearchApp extends React.Component {
             Our top recommendations for you
           </h4>
           <ul className="results-list">
-            {recommendedResults.map(r =>
-              this.renderWebResult(r, 'description', true),
+            {recommendedResults.map((result, index) =>
+              this.renderWebResult(result, 'description', true, index),
             )}
           </ul>
           <hr />
@@ -399,10 +412,12 @@ class SearchApp extends React.Component {
   }
 }
 
-function mapStateToProps(state) {
-  const { search } = state;
-  return { search };
-}
+const mapStateToProps = state => ({
+  search: state.search,
+  searchTypeaheadEnabled: toggleValues(state)[
+    FEATURE_FLAG_NAMES.searchTypeaheadEnabled
+  ],
+});
 
 const mapDispatchToProps = {
   fetchSearchResults,

--- a/src/platform/site-wide/user-nav/components/SearchMenu.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchMenu.jsx
@@ -54,6 +54,19 @@ export class SearchMenu extends React.Component {
     }
   }
 
+  isUserInputValid = () => {
+    const { userInput } = this.state;
+
+    // check to make sure user input isn't empty
+    const isCorrectLength =
+      userInput && userInput.replace(/\s/g, '').length > 0;
+    if (!isCorrectLength) {
+      return false;
+    }
+    // this will likely expand in the future
+    return true;
+  };
+
   getSuggestions = async () => {
     const { userInput } = this.state;
 
@@ -103,7 +116,7 @@ export class SearchMenu extends React.Component {
       return;
     }
 
-    // update our highlighted suggestion for search logging
+    // keep track of the index of the highlighted suggestion so we can use it to fire off a search / log events
     this.setState({ highlightedIndex: state.highlightedIndex });
   };
 
@@ -124,6 +137,12 @@ export class SearchMenu extends React.Component {
   // handle event logging and fire off a search query
   handleSearchEvent = suggestion => {
     const { suggestions, userInput } = this.state;
+    const { isUserInputValid } = this;
+
+    // if the user tries to search with an empty input, escape early
+    if (!isUserInputValid) {
+      return;
+    }
 
     // event logging, note suggestion will be undefined during a userInput search
     recordEvent({
@@ -162,10 +181,8 @@ export class SearchMenu extends React.Component {
       handleInputChange,
       handleSearchEvent,
       handleKeyUp,
+      isUserInputValid,
     } = this;
-
-    // check to make sure user input is valid
-    const validUserInput = userInput && userInput.replace(/\s/g, '').length > 0;
 
     const highlightedSuggestion =
       'suggestion-highlighted vads-u-background-color--primary-alt-light vads-u-margin-x--0 vads-u-margin-top--0p5 vads-u-margin-bottom--0  vads-u-padding--1 vads-u-width--full';
@@ -199,7 +216,7 @@ export class SearchMenu extends React.Component {
             />
             <button
               type="submit"
-              disabled={!validUserInput}
+              disabled={!isUserInputValid}
               className="vads-u-margin-left--0p25 vads-u-margin-right--0p5 "
             >
               <IconSearch color="#fff" />
@@ -251,7 +268,7 @@ export class SearchMenu extends React.Component {
               />
               <button
                 type="submit"
-                disabled={!validUserInput}
+                disabled={!isUserInputValid}
                 className="vads-u-margin-left--0p5 vads-u-margin-y--1 vads-u-margin-right--1 vads-u-flex--1"
                 onClick={() => handleSearchEvent()}
                 onFocus={() => this.setState({ suggestions: [] })}
@@ -279,7 +296,6 @@ export class SearchMenu extends React.Component {
                       aria-selected={JSON.stringify(
                         selectedItem === suggestion,
                       )}
-                      data-index={index}
                       className={
                         highlightedIndex === index
                           ? highlightedSuggestion

--- a/src/platform/site-wide/user-nav/components/SearchMenu.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchMenu.jsx
@@ -17,7 +17,6 @@ import DropDownPanel from '@department-of-veterans-affairs/formation-react/DropD
 export const searchGovSuggestionEndpoint = 'https://search.usa.gov/sayt';
 
 const ENTER_KEY = 13;
-const ESCAPE_KEY = 27;
 
 export class SearchMenu extends React.Component {
   constructor(props) {
@@ -29,15 +28,21 @@ export class SearchMenu extends React.Component {
     this.state = {
       userInput: '',
       suggestions: [],
+      highlightedIndex: null,
     };
   }
+
   componentDidUpdate(prevProps, prevState) {
     const { userInput } = this.state;
+    const { searchTypeaheadEnabled } = this.props;
 
+    // if userInput has changed, fetch suggestions for the typeahead experience
     const inputChanged = prevState.userInput !== userInput;
-    if (inputChanged) {
+    if (inputChanged && searchTypeaheadEnabled) {
       this.getSuggestions();
     }
+
+    // event logging for phased typeahead rollout
     if (
       !prevProps.searchTypeaheadEnabled &&
       this.props.searchTypeaheadEnabled
@@ -49,9 +54,10 @@ export class SearchMenu extends React.Component {
     }
   }
 
-  async getSuggestions() {
+  getSuggestions = async () => {
     const { userInput } = this.state;
 
+    // end early / clear suggestions if user input is too short
     if (userInput?.length <= 2) {
       if (this.state.suggestions.length > 0) {
         this.setState({ suggestions: [] });
@@ -59,7 +65,11 @@ export class SearchMenu extends React.Component {
 
       return;
     }
+
+    // encode user input for query to suggestions url
     const encodedInput = encodeURIComponent(userInput);
+
+    // fetch suggestions
     try {
       const response = await fetch(
         `${searchGovSuggestionEndpoint}?=&name=va&q=${encodedInput}`,
@@ -67,57 +77,95 @@ export class SearchMenu extends React.Component {
 
       const suggestions = await response.json();
       this.setState({ suggestions });
+
+      // if we fail to fetch suggestions
     } catch (error) {
       Sentry.captureException(error);
     }
-  }
+  };
 
   handleInputChange = event => {
     this.setState({ userInput: event.target.value });
   };
 
-  handleKeyUp = event => {
-    if (
-      (event.which || event.keyCode) === ENTER_KEY &&
-      document.getElementById('query') === document.activeElement
-    ) {
-      this.handleSearchEvent();
+  // function to control state changes within the downshift component
+  handelDownshiftStateChange = (changes, state) => {
+    // when a user presses the escape key, clear suggestions and close the dropdown
+    if (changes.type === Downshift.stateChangeTypes.keyDownEscape) {
+      this.setState({
+        highlightedIndex: null,
+        suggestions: [],
+      });
       return;
     }
-    if ((event.which || event.keyCode) === ESCAPE_KEY) {
-      this.props.clickHandler();
+    // when a user presses the enter key, exit early to prevent out highlighted suggestion being cleared
+    if (changes.type === Downshift.stateChangeTypes.keyDownEnter) {
+      return;
+    }
+
+    // update our highlighted suggestion for search logging
+    this.setState({ highlightedIndex: state.highlightedIndex });
+  };
+
+  // function to handle searches kicked off by key presses
+  handleKeyUp = event => {
+    const { highlightedIndex, suggestions } = this.state;
+
+    // kick off a search when an enter key is pressed
+    if ((event.which || event.keyCode) === ENTER_KEY) {
+      // if our highlighted index is null, search using the userInput (pass in undefined)
+      // otherwise pass in our chosen suggestion
+      const query =
+        highlightedIndex !== null ? suggestions[highlightedIndex] : undefined;
+      this.handleSearchEvent(query);
     }
   };
 
+  // handle event logging and fire off a search query
   handleSearchEvent = suggestion => {
+    const { suggestions, userInput } = this.state;
+
+    // event logging, note suggestion will be undefined during a userInput search
     recordEvent({
       event: 'view_search_results',
       'search-page-path': document.location.pathname,
-      'search-query': this.state.userInput,
+      'search-query': userInput,
       'search-results-total-count': undefined,
       'search-results-total-pages': undefined,
       'search-selection': 'All VA.gov',
       'search-typeahead-enabled': this.props.searchTypeaheadEnabled,
       'type-ahead-option-keyword-selected': suggestion,
       'type-ahead-option-position': suggestion
-        ? this.state.suggestions.indexOf(suggestion) + 1
+        ? suggestions.indexOf(suggestion) + 1
         : undefined,
-      'type-ahead-options-list': this.state.suggestions,
+      'type-ahead-options-list': suggestions,
     });
 
-    const query = suggestion || this.state.userInput;
+    // unifier to let the same function be used if we are searching from a userInput or a suggestion
+    const query = suggestion || userInput;
 
+    // create a search url
     const searchUrl = replaceWithStagingDomain(
       `https://www.va.gov/search/?query=${encodeURIComponent(query)}`,
     );
 
+    // relocate to search results, preserving history
     window.location.assign(searchUrl);
   };
 
   makeForm = () => {
-    const validUserInput =
-      this.state.userInput &&
-      this.state.userInput.replace(/\s/g, '').length > 0;
+    const { suggestions, userInput } = this.state;
+    const { searchTypeaheadEnabled } = this.props;
+    const {
+      getSuggestions,
+      handelDownshiftStateChange,
+      handleInputChange,
+      handleSearchEvent,
+      handleKeyUp,
+    } = this;
+
+    // check to make sure user input is valid
+    const validUserInput = userInput && userInput.replace(/\s/g, '').length > 0;
 
     const highlightedSuggestion =
       'suggestion-highlighted vads-u-background-color--primary-alt-light vads-u-margin-x--0 vads-u-margin-top--0p5 vads-u-margin-bottom--0  vads-u-padding--1 vads-u-width--full';
@@ -125,13 +173,14 @@ export class SearchMenu extends React.Component {
     const regularSuggestion =
       'suggestion vads-u-margin-x--0 vads-u-margin-top--0p5 vads-u-margin-bottom--0 vads-u-padding--1 vads-u-width--full';
 
-    if (!this.props.searchTypeaheadEnabled) {
+    // default search experience
+    if (!searchTypeaheadEnabled) {
       return (
         <form
           acceptCharset="UTF-8"
           onSubmit={event => {
             event.preventDefault();
-            this.handleSearchEvent();
+            handleSearchEvent();
           }}
         >
           <label htmlFor="query" className="usa-sr-only">
@@ -146,7 +195,7 @@ export class SearchMenu extends React.Component {
               id="query"
               name="query"
               type="text"
-              onChange={this.handleInputChange}
+              onChange={handleInputChange}
             />
             <button
               type="submit"
@@ -161,13 +210,14 @@ export class SearchMenu extends React.Component {
       );
     }
 
+    // typeahead search experience
     return (
       <Downshift
-        inputValue={this.state.userInput}
-        onSelect={item => this.handleSearchEvent(item)}
+        inputValue={userInput}
+        isOpen={suggestions.length > 0}
         itemToString={item => item}
-        onKeyUp={this.handleKeyUp}
-        isOpen={this.state.suggestions.length > 0}
+        onStateChange={handelDownshiftStateChange}
+        onSelect={suggestion => handleSearchEvent(suggestion)}
       >
         {({
           getInputProps,
@@ -190,19 +240,21 @@ export class SearchMenu extends React.Component {
                 className="usagov-search-autocomplete  vads-u-flex--4 vads-u-margin-left--1 vads-u-margin-right--0p5 vads-u-margin-y--1  vads-u-width--full"
                 name="query"
                 aria-controls={isOpen ? 'suggestions-list' : undefined}
+                onFocus={getSuggestions}
+                onKeyUp={handleKeyUp}
                 {...getInputProps({
                   type: 'text',
-                  onChange: this.handleInputChange,
+                  onChange: handleInputChange,
                   'aria-labelledby': 'site-search-label',
                   id: 'query',
-                  onKeyUp: this.handleKeyUp,
                 })}
               />
               <button
                 type="submit"
                 disabled={!validUserInput}
                 className="vads-u-margin-left--0p5 vads-u-margin-y--1 vads-u-margin-right--1 vads-u-flex--1"
-                onClick={() => this.handleSearchEvent()}
+                onClick={() => handleSearchEvent()}
+                onFocus={() => this.setState({ suggestions: [] })}
               >
                 <IconSearch color="#fff" />
                 <span className="usa-sr-only">Search</span>
@@ -215,10 +267,10 @@ export class SearchMenu extends React.Component {
                 role="listbox"
                 aria-label="suggestions-list"
               >
-                {this.state.suggestions?.map((suggestion, index) => {
+                {suggestions?.map((suggestion, index) => {
                   const formattedSuggestion = suggestion.replace(
-                    this.state.userInput,
-                    `<strong>${escape(this.state.userInput)}</strong>`,
+                    userInput,
+                    `<strong>${escape(userInput)}</strong>`,
                   );
                   return (
                     <li
@@ -227,12 +279,14 @@ export class SearchMenu extends React.Component {
                       aria-selected={JSON.stringify(
                         selectedItem === suggestion,
                       )}
+                      data-index={index}
                       className={
                         highlightedIndex === index
                           ? highlightedSuggestion
                           : regularSuggestion
                       }
                       {...getItemProps({ item: suggestion })}
+                      // this line is used to show the suggestion with the user's input in BOLD
                       // eslint-disable-next-line react/no-danger
                       dangerouslySetInnerHTML={{
                         __html: formattedSuggestion,
@@ -249,8 +303,11 @@ export class SearchMenu extends React.Component {
   };
 
   render() {
+    const { makeForm } = this;
+    const { cssClass, clickHandler, isOpen } = this.props;
+
     const buttonClasses = classNames(
-      this.props.cssClass,
+      cssClass,
       'va-btn-withicon',
       'va-dropdown-trigger',
     );
@@ -261,14 +318,14 @@ export class SearchMenu extends React.Component {
       <DropDownPanel
         onClick={() => recordEvent({ event: 'nav-jumplink-click' })}
         buttonText="Search"
-        clickHandler={this.props.clickHandler}
+        clickHandler={clickHandler}
         dropdownPanelClassNames="vads-u-padding--0 vads-u-margin--0"
         cssClass={buttonClasses}
         id="search"
         icon={icon}
-        isOpen={this.props.isOpen}
+        isOpen={isOpen}
       >
-        {this.makeForm()}
+        {makeForm()}
       </DropDownPanel>
     );
   }


### PR DESCRIPTION
## Description
This update brings the typeahead experience in line with the 508 recommended user flows

## Testing done
Manual and Unit tests:

Typeahead experience tested:
1. User can enter input and press enter key to search
2. User can enter input and click search button to search
3. User can enter input, and click on a suggestion from the dropdown to search
4. User can enter input, use the arrow keys to select a suggestion and press enter to search
5. Tabbing to the search button closes the suggestions list
6. Back-tabbing from the search button to the input field re-fetches suggestions and displays them
7. User can press escape key anywhere inside search experience to close the suggestions list

Default Search cases tested:
1. User can enter input and press enter to search
2. User can enter input and click search button to search

## Screenshots
N/A

## Acceptance criteria
- [X] See above tests

## Relevant Links
https://github.com/department-of-veterans-affairs/va.gov-team/issues/16965

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
