### PR TITLE
Add new sorting for r&s search

### DIFF
--- a/src/applications/resources-and-support/hooks/useGetSearchResults.js
+++ b/src/applications/resources-and-support/hooks/useGetSearchResults.js
@@ -79,7 +79,7 @@ export default function useGetSearchResults(articles, query, page) {
         orderedResults = orderBy(
           filteredArticles,
           ['keywordsCountsTitle', 'keywordsCountsDescription', 'title'],
-          ['desc', 'desc', 'desc'],
+          ['desc', 'desc', 'asc'],
         );
       }
 

--- a/src/applications/resources-and-support/hooks/useGetSearchResults.js
+++ b/src/applications/resources-and-support/hooks/useGetSearchResults.js
@@ -1,6 +1,6 @@
 // Node modules.
 import { useEffect, useState } from 'react';
-import { map, orderBy, reduce } from 'lodash';
+import { orderBy } from 'lodash';
 // Relative imports.
 import environment from 'platform/utilities/environment';
 import recordEvent from 'platform/monitoring/record-event';
@@ -56,19 +56,20 @@ export default function useGetSearchResults(articles, query, page) {
           ...article,
 
           // Number of times a keyword is found in the article's title.
-          keywordsCountsTitle: keywords?.reduce((keywordInstances, keyword) => {
-            keywordInstances +=
-              article.title.toLowerCase()?.split(keyword)?.length || 0;
-            return keywordInstances - 1;
-          }, 0),
+          keywordsCountsTitle: keywords?.reduce(
+            (keywordInstances, keyword) =>
+              keywordInstances +
+              article.title.toLowerCase()?.split(keyword)?.length -
+              1,
+            0,
+          ),
 
           // Number of times a keyword is found in the article's description.
           keywordsCountsDescription: keywords?.reduce(
-            (keywordInstances, keyword) => {
-              keywordInstances +=
-                article.description.toLowerCase()?.split(keyword)?.length || 0;
-              return keywordInstances - 1;
-            },
+            (keywordInstances, keyword) =>
+              keywordInstances +
+              article.description.toLowerCase()?.split(keyword)?.length -
+              1,
             0,
           ),
         }));

--- a/src/applications/resources-and-support/hooks/useGetSearchResults.js
+++ b/src/applications/resources-and-support/hooks/useGetSearchResults.js
@@ -1,9 +1,10 @@
 // Node modules.
 import { useEffect, useState } from 'react';
-import sortBy from 'lodash/sortBy';
+import { map, orderBy, reduce } from 'lodash';
 // Relative imports.
-import { SEARCH_IGNORE_LIST } from '../constants';
+import environment from 'platform/utilities/environment';
 import recordEvent from 'platform/monitoring/record-event';
+import { SEARCH_IGNORE_LIST } from '../constants';
 
 export default function useGetSearchResults(articles, query, page) {
   const [results, setResults] = useState([]);
@@ -33,7 +34,7 @@ export default function useGetSearchResults(articles, query, page) {
           return keyword;
         });
 
-      const filteredArticles = articles.filter(article => {
+      let filteredArticles = articles.filter(article => {
         const articleTitleKeywords = article.title.toLowerCase().split(' ');
 
         return keywords.some(keyword => {
@@ -43,7 +44,44 @@ export default function useGetSearchResults(articles, query, page) {
         });
       });
 
-      const orderedResults = sortBy(filteredArticles, 'title');
+      let orderedResults = [];
+
+      // Keep legacy sorting on production.
+      if (environment.isProduction()) {
+        orderedResults = orderBy(filteredArticles, 'title');
+
+        // Experiment with new sorting on non-prod envs.
+      } else {
+        filteredArticles = filteredArticles?.map(article => ({
+          ...article,
+
+          // Number of times a keyword is found in the article's title.
+          keywordsCountsTitle: keywords?.reduce((keywordInstances, keyword) => {
+            keywordInstances +=
+              article.title.toLowerCase()?.split(keyword)?.length || 0;
+            return keywordInstances - 1;
+          }, 0),
+
+          // Number of times a keyword is found in the article's description.
+          keywordsCountsDescription: keywords?.reduce(
+            (keywordInstances, keyword) => {
+              keywordInstances +=
+                article.description.toLowerCase()?.split(keyword)?.length || 0;
+              return keywordInstances - 1;
+            },
+            0,
+          ),
+        }));
+
+        // Sort first by query word instances found in title descending
+        // Sort ties then by query word instances found in description descending
+        // Sort ties then by alphabetical descending
+        orderedResults = orderBy(
+          filteredArticles,
+          ['keywordsCountsTitle', 'keywordsCountsDescription', 'title'],
+          ['desc', 'desc', 'desc'],
+        );
+      }
 
       // Track R&S search results.
       recordEvent({


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/16915

This PR adds experimental sorting for R&S search on non-prod envs.

1. Sort first by query word instances found in title descending
2. Sort ties then by query word instances found in body descending
3. Sort ties then by alphabetical descending
4. Hide new sorting logic on production

## Testing done
N/A

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/102647577-2e37c600-4123-11eb-938a-78b384c8157b.png)

## Acceptance criteria
- [x] Update sorting for R&S search on non-prod envs.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
