### PR TITLE
Make user confirm address if the suggested state does not match input state

### DIFF
--- a/src/applications/personalization/profile/tests/e2e/address-validation/confirm-state-diff.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/confirm-state-diff.cypress.spec.js
@@ -1,0 +1,24 @@
+import { setUp } from 'applications/personalization/profile/tests/e2e/address-validation/setup';
+
+describe('Personal and contact information', () => {
+  describe('when user-input state does not match suggested address state', () => {
+    it('should ask the user to confirm their address', () => {
+      // This will return a single confirmed, high confidence address from the
+      // validation API with a stateCode of 'CA'...
+      setUp('valid-address');
+
+      // ...so we'll set our address's state as 'CO'...
+      cy.findByLabelText(/^State/).select('CO');
+
+      cy.findByTestId('save-edit-button').click({
+        force: true,
+      });
+
+      // ...and expect to be asked to confirm our address
+      cy.findByTestId('mailingAddress').should(
+        'contain',
+        'Please confirm your address',
+      );
+    });
+  });
+});

--- a/src/applications/personalization/profile/tests/e2e/address-validation/setup.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/setup.js
@@ -3,9 +3,9 @@ import { PROFILE_PATHS } from '@@profile/constants';
 import { createUserResponse } from './user';
 import { createAddressValidationResponse } from './addressValidation';
 
-import mockUser from 'applications/personalization/profile/tests/fixtures/users/user-36.json';
-import receivedTransaction from 'applications/personalization/profile/tests/fixtures/transactions/received-transaction.json';
-import finishedTransaction from 'applications/personalization/profile/tests/fixtures/transactions/finished-transaction.json';
+import mockUser from '~/applications/personalization/profile/tests/fixtures/users/user-36.json';
+import receivedTransaction from '~/applications/personalization/profile/tests/fixtures/transactions/received-transaction.json';
+import finishedTransaction from '~/applications/personalization/profile/tests/fixtures/transactions/finished-transaction.json';
 
 export const setUp = type => {
   disableFTUXModals();

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -241,15 +241,23 @@ export const getValidationMessageKey = (
 // address validation modal will _not_ be shown to the user is if the validation
 // API came back with one valid address suggestion that it is very confident is
 // the address the user entered.
-export const showAddressValidationModal = suggestedAddresses => {
-  // pull the addressMetaData prop off the first suggestedAddresses element
-  const [{ addressMetaData } = {}] = suggestedAddresses;
+export const showAddressValidationModal = (
+  suggestedAddresses,
+  userInputAddress,
+) => {
+  // pull the first address off of the suggestedAddresses array
+  const [firstSuggestedAddress] = suggestedAddresses;
+  const {
+    addressMetaData: firstSuggestedAddressMetadata,
+  } = firstSuggestedAddress;
 
   if (
     suggestedAddresses.length === 1 &&
-    addressMetaData.confidenceScore > 90 &&
-    (addressMetaData.deliveryPointValidation === CONFIRMED ||
-      addressMetaData.addressType?.toLowerCase() === 'international')
+    firstSuggestedAddress.stateCode === userInputAddress.stateCode &&
+    firstSuggestedAddressMetadata.confidenceScore > 90 &&
+    (firstSuggestedAddressMetadata.deliveryPointValidation === CONFIRMED ||
+      firstSuggestedAddressMetadata.addressType?.toLowerCase() ===
+        'international')
   ) {
     return false;
   }

--- a/src/platform/user/profile/vap-svc/actions/transactions.js
+++ b/src/platform/user/profile/vap-svc/actions/transactions.js
@@ -214,16 +214,16 @@ export const validateAddress = (
   route,
   method,
   fieldName,
-  payload,
+  inputAddress,
   analyticsSectionName,
 ) => async dispatch => {
-  const userEnteredAddress = { address: { ...payload } };
+  const userEnteredAddress = { ...inputAddress };
   dispatch({
     type: ADDRESS_VALIDATION_INITIALIZE,
     fieldName,
   });
   const options = {
-    body: JSON.stringify(userEnteredAddress),
+    body: JSON.stringify({ address: userEnteredAddress }),
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -250,7 +250,7 @@ export const validateAddress = (
           fieldName === FIELD_NAMES.MAILING_ADDRESS
             ? ADDRESS_POU.CORRESPONDENCE
             : ADDRESS_POU.RESIDENCE,
-        id: payload.id || null,
+        id: inputAddress.id || null,
       }));
     const confirmedSuggestions = suggestedAddresses.filter(
       suggestion =>
@@ -267,13 +267,16 @@ export const validateAddress = (
 
     if (!confirmedSuggestions.length && validationKey) {
       // if there are no confirmed suggestions and user can override, fall back to submitted address
-      selectedAddress = userEnteredAddress.address;
+      selectedAddress = userEnteredAddress;
     }
 
     // we use the unfiltered list of suggested addresses to determine if we need
     // to show the modal because the only time we will skip the modal is if one
     // and only one confirmed address came back from the API
-    const showModal = showAddressValidationModal(suggestedAddresses);
+    const showModal = showAddressValidationModal(
+      suggestedAddresses,
+      userEnteredAddress,
+    );
 
     let selectedAddressId = null;
     if (showModal) {
@@ -294,7 +297,7 @@ export const validateAddress = (
     if (showModal) {
       return dispatch({
         type: ADDRESS_VALIDATION_CONFIRM,
-        addressFromUser: userEnteredAddress.address, // need to use the address with iso3 code added to it
+        addressFromUser: userEnteredAddress, // need to use the address with iso3 code added to it
         addressValidationType: fieldName,
         selectedAddress,
         suggestedAddresses,
@@ -342,7 +345,7 @@ export const validateAddress = (
     return dispatch({
       type: ADDRESS_VALIDATION_ERROR,
       addressValidationError: true,
-      addressFromUser: { ...payload },
+      addressFromUser: { ...inputAddress },
       fieldName,
       error,
     });

--- a/src/platform/user/profile/vap-svc/tests/helpers/addressValidationMessages.unit.spec.js
+++ b/src/platform/user/profile/vap-svc/tests/helpers/addressValidationMessages.unit.spec.js
@@ -101,18 +101,16 @@ describe('showAddressValidationModal', () => {
   it('returns true with multiple suggestions', () => {
     const suggestedAddresses = [
       {
-        address: {
-          addressLine1: '400 N 65th St',
-          addressType: 'DOMESTIC',
-          city: 'Seattle',
-          countryName: 'USA',
-          countryCodeIso3: 'USA',
-          countyCode: '53033',
-          countyName: 'King',
-          stateCode: 'WA',
-          zipCode: '98103',
-          zipCodeSuffix: '5252',
-        },
+        addressLine1: '400 N 65th St',
+        addressType: 'DOMESTIC',
+        city: 'Seattle',
+        countryName: 'USA',
+        countryCodeIso3: 'USA',
+        countyCode: '53033',
+        countyName: 'King',
+        stateCode: 'WA',
+        zipCode: '98103',
+        zipCodeSuffix: '5252',
         addressMetaData: {
           confidenceScore: 79.0,
           addressType: 'Domestic',
@@ -120,18 +118,16 @@ describe('showAddressValidationModal', () => {
         },
       },
       {
-        address: {
-          addressLine1: '400 NE 65th St',
-          addressType: 'DOMESTIC',
-          city: 'Seattle',
-          countryName: 'USA',
-          countryCodeIso3: 'USA',
-          countyCode: '53033',
-          countyName: 'King',
-          stateCode: 'WA',
-          zipCode: '98115',
-          zipCodeSuffix: '6463',
-        },
+        addressLine1: '400 NE 65th St',
+        addressType: 'DOMESTIC',
+        city: 'Seattle',
+        countryName: 'USA',
+        countryCodeIso3: 'USA',
+        countyCode: '53033',
+        countyName: 'King',
+        stateCode: 'WA',
+        zipCode: '98115',
+        zipCodeSuffix: '6463',
         addressMetaData: {
           confidenceScore: 98.0,
           addressType: 'Domestic',
@@ -141,24 +137,36 @@ describe('showAddressValidationModal', () => {
         },
       },
     ];
-    expect(showAddressValidationModal(suggestedAddresses)).to.equal(true);
+    const userInputAddress = {
+      addressLine1: '400 north 65th',
+      addressType: 'DOMESTIC',
+      city: 'Seattle',
+      countryName: 'USA',
+      countryCodeIso3: 'USA',
+      countyCode: '53033',
+      countyName: 'King',
+      stateCode: 'WA',
+      zipCode: '98103',
+      zipCodeSuffix: '5252',
+    };
+    expect(
+      showAddressValidationModal(suggestedAddresses, userInputAddress),
+    ).to.equal(true);
   });
 
-  it("returns false with single CONFIRMED suggestion that's over 90 confidence score", () => {
+  it('returns false when there is a single CONFIRMED domestic address with a confidence score > 90 and whose state matches the user-submitted state', () => {
     const suggestedAddresses = [
       {
-        address: {
-          addressLine1: '400 N 65th St',
-          addressType: 'DOMESTIC',
-          city: 'Seattle',
-          countryName: 'USA',
-          countryCodeIso3: 'USA',
-          countyCode: '53033',
-          countyName: 'King',
-          stateCode: 'WA',
-          zipCode: '98103',
-          zipCodeSuffix: '5252',
-        },
+        addressLine1: '400 N 65th St',
+        addressType: 'DOMESTIC',
+        city: 'Seattle',
+        countryName: 'USA',
+        countryCodeIso3: 'USA',
+        countyCode: '53033',
+        countyName: 'King',
+        stateCode: 'WA',
+        zipCode: '98103',
+        zipCodeSuffix: '5252',
         addressMetaData: {
           confidenceScore: 91.0,
           addressType: 'Domestic',
@@ -166,24 +174,73 @@ describe('showAddressValidationModal', () => {
         },
       },
     ];
-    expect(showAddressValidationModal(suggestedAddresses)).to.equal(false);
+    const userInputAddress = {
+      addressLine1: '400 north 65th',
+      addressType: 'DOMESTIC',
+      city: 'Seattle',
+      countryName: 'USA',
+      countryCodeIso3: 'USA',
+      countyCode: '53033',
+      countyName: 'King',
+      stateCode: 'WA',
+      zipCode: '98103',
+      zipCodeSuffix: '5252',
+    };
+    expect(
+      showAddressValidationModal(suggestedAddresses, userInputAddress),
+    ).to.equal(false);
+  });
+
+  it('returns true when there is a single CONFIRMED domestic address with a confidence score > 90 but whose state does not match the user-submitted state', () => {
+    const suggestedAddresses = [
+      {
+        addressLine1: '400 N 65th St',
+        addressType: 'DOMESTIC',
+        city: 'Seattle',
+        countryName: 'USA',
+        countryCodeIso3: 'USA',
+        countyCode: '53033',
+        countyName: 'King',
+        stateCode: 'WI',
+        zipCode: '98103',
+        zipCodeSuffix: '5252',
+        addressMetaData: {
+          confidenceScore: 91.0,
+          addressType: 'Domestic',
+          deliveryPointValidation: 'CONFIRMED',
+        },
+      },
+    ];
+    const userInputAddress = {
+      addressLine1: '400 north 65th',
+      addressType: 'DOMESTIC',
+      city: 'Seattle',
+      countryName: 'USA',
+      countryCodeIso3: 'USA',
+      countyCode: '53033',
+      countyName: 'King',
+      stateCode: 'WA',
+      zipCode: '98103',
+      zipCodeSuffix: '5252',
+    };
+    expect(
+      showAddressValidationModal(suggestedAddresses, userInputAddress),
+    ).to.equal(true);
   });
 
   it("returns true with single deliverable suggestion that's under 90 confidence", () => {
     const suggestedAddresses = [
       {
-        address: {
-          addressLine1: '400 N 65th St',
-          addressType: 'DOMESTIC',
-          city: 'Seattle',
-          countryName: 'USA',
-          countryCodeIso3: 'USA',
-          countyCode: '53033',
-          countyName: 'King',
-          stateCode: 'WA',
-          zipCode: '98103',
-          zipCodeSuffix: '5252',
-        },
+        addressLine1: '400 N 65th St',
+        addressType: 'DOMESTIC',
+        city: 'Seattle',
+        countryName: 'USA',
+        countryCodeIso3: 'USA',
+        countyCode: '53033',
+        countyName: 'King',
+        stateCode: 'WA',
+        zipCode: '98103',
+        zipCodeSuffix: '5252',
         addressMetaData: {
           confidenceScore: 87.0,
           addressType: 'Domestic',
@@ -191,24 +248,36 @@ describe('showAddressValidationModal', () => {
         },
       },
     ];
-    expect(showAddressValidationModal(suggestedAddresses)).to.equal(true);
+    const userInputAddress = {
+      addressLine1: '400 north 65th',
+      addressType: 'DOMESTIC',
+      city: 'Seattle',
+      countryName: 'USA',
+      countryCodeIso3: 'USA',
+      countyCode: '53033',
+      countyName: 'King',
+      stateCode: 'WA',
+      zipCode: '98103',
+      zipCodeSuffix: '5252',
+    };
+    expect(
+      showAddressValidationModal(suggestedAddresses, userInputAddress),
+    ).to.equal(true);
   });
 
   it('returns true with single suggestion over 90 confidence but undeliverable', () => {
     const suggestedAddresses = [
       {
-        address: {
-          addressLine1: '400 N 65th St',
-          addressType: 'DOMESTIC',
-          city: 'Seattle',
-          countryName: 'USA',
-          countryCodeIso3: 'USA',
-          countyCode: '53033',
-          countyName: 'King',
-          stateCode: 'WA',
-          zipCode: '98103',
-          zipCodeSuffix: '5252',
-        },
+        addressLine1: '400 N 65th St',
+        addressType: 'DOMESTIC',
+        city: 'Seattle',
+        countryName: 'USA',
+        countryCodeIso3: 'USA',
+        countyCode: '53033',
+        countyName: 'King',
+        stateCode: 'WA',
+        zipCode: '98103',
+        zipCodeSuffix: '5252',
         addressMetaData: {
           confidenceScore: 91.0,
           addressType: 'Domestic',
@@ -216,6 +285,20 @@ describe('showAddressValidationModal', () => {
         },
       },
     ];
-    expect(showAddressValidationModal(suggestedAddresses)).to.equal(true);
+    const userInputAddress = {
+      addressLine1: '400 north 65th',
+      addressType: 'DOMESTIC',
+      city: 'Seattle',
+      countryName: 'USA',
+      countryCodeIso3: 'USA',
+      countyCode: '53033',
+      countyName: 'King',
+      stateCode: 'WA',
+      zipCode: '98103',
+      zipCodeSuffix: '5252',
+    };
+    expect(
+      showAddressValidationModal(suggestedAddresses, userInputAddress),
+    ).to.equal(true);
   });
 });


### PR DESCRIPTION
## Description
With this change we will start having users confirm their address if suggested address's state does not match the state they entered.

## Testing done
New Cypress test and unit tests

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs