### PR TITLE
Convert add to calendar tests to RTL

### DIFF
--- a/src/applications/vaos/components/AddToCalendar.jsx
+++ b/src/applications/vaos/components/AddToCalendar.jsx
@@ -31,7 +31,7 @@ function formatDescription(description) {
   return chunked.join('\r\n\t');
 }
 
-export function generateICS(
+function generateICS(
   summary,
   description,
   location,

--- a/src/applications/vaos/tests/components/AddToCalendar.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/AddToCalendar.unit.spec.jsx
@@ -1,59 +1,88 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 import moment from '../../lib/moment-tz.js';
 
-import AddToCalendar, { generateICS } from '../../components/AddToCalendar';
+import AddToCalendar from '../../components/AddToCalendar';
+import userEvent from '@testing-library/user-event';
 
 describe('VAOS <AddToCalendar>', () => {
-  describe('Add VA appointment to calendar', () => {
-    const tree = shallow(
+  it('should render link with calendar info', () => {
+    const startDateTime = moment('2020-01-02');
+    const screen = render(
       <AddToCalendar
         summary="VA Appointment"
         description="Follow-up/Routine: some description"
         location="A location"
         duration={60}
-        startDateTime={moment('2020-01-02').toDate()}
+        startDateTime={startDateTime.toDate()}
       />,
     );
 
-    const link = tree.find('a');
-
-    it('should render', () => {
-      expect(tree.exists()).to.be.true;
-    });
-
-    it('should contain valid ICS end command', () => {
-      expect(link.props().href).to.contain(encodeURIComponent('END:VCALENDAR'));
-    });
-
-    it('should contain description', () => {
-      expect(link.props().href).to.contain(
-        encodeURIComponent('some description'),
-      );
-    });
-
-    it('should download ICS commands to a file named "VA_Appointment.ics"', () => {
-      expect(link.props().download).to.equal('VA_Appointment.ics');
-    });
-
-    it('should have an aria label', () => {
-      expect(link.props()['aria-label']).to.equal(
-        `Add January 2, 2020 appointment to your calendar`,
-      );
-    });
-
-    tree.unmount();
+    expect(screen.getByRole('link')).to.contain.text('Add to calendar');
+    expect(screen.getByRole('link')).to.have.attribute(
+      'download',
+      'VA_Appointment.ics',
+    );
+    expect(screen.getByRole('link')).to.have.attribute(
+      'aria-label',
+      `Add January 2, 2020 appointment to your calendar`,
+    );
+    const ics = decodeURIComponent(
+      screen
+        .getByRole('link')
+        .getAttribute('href')
+        .replace('data:text/calendar;charset=utf-8,', ''),
+    );
+    expect(ics).to.contain('PRODID:VA');
+    expect(ics).to.contain('UID:');
+    expect(ics).to.contain('SUMMARY:VA Appointment');
+    expect(ics).to.contain('DESCRIPTION:Follow-up/Routine: some description');
+    expect(ics).to.contain('LOCATION:A location');
+    expect(ics).to.contain(
+      `DTSTAMP:${startDateTime.format('YYYYMMDDTHHmmss')}`,
+    );
+    expect(ics).to.contain(
+      `DTSTART:${startDateTime.format('YYYYMMDDTHHmmss')}`,
+    );
+    expect(ics).to.contain(
+      `DTEND:${startDateTime
+        .clone()
+        .add(60, 'minutes')
+        .format('YYYYMMDDTHHmmss')}`,
+    );
   });
 
-  describe('Add appointment request to calendar in IE', () => {
+  it('should propertly format long descriptions', () => {
+    const startDateTime = moment('2020-01-02');
+    const screen = render(
+      <AddToCalendar
+        summary="VA Appointment"
+        description="Testing long line descriptions Testing long descriptions Testing long descriptions Testing long descriptions Testing long descriptions Testing long descriptions Testing long descriptions Testing long descriptions"
+        location="A location"
+        duration={60}
+        startDateTime={startDateTime.toDate()}
+      />,
+    );
+
+    const ics = decodeURIComponent(
+      screen
+        .getByRole('link')
+        .getAttribute('href')
+        .replace('data:text/calendar;charset=utf-8,', ''),
+    );
+    expect(ics).to.contain(
+      'DESCRIPTION:Testing long line descriptions Testing long descriptions Testi\r\n\tng long descriptions Testing long descriptions Testing long descriptions T\r\n\testing long descriptions Testing long descriptions Testing long descriptio\r\n\tns\n',
+    );
+  });
+  it('should download ICS file via blob in IE', () => {
     const oldValue = window.navigator.msSaveOrOpenBlob;
     Object.defineProperty(window.navigator, 'msSaveOrOpenBlob', {
       value: sinon.spy(),
       writable: true,
     });
-    const tree = shallow(
+    const screen = render(
       <AddToCalendar
         summary="VA Appointment"
         description="Some description"
@@ -63,101 +92,21 @@ describe('VAOS <AddToCalendar>', () => {
       />,
     );
 
-    const button = tree.find('button');
+    expect(screen.getByRole('button')).to.contain.text('Add to calendar');
 
-    it('should render', () => {
-      expect(button.exists()).to.be.true;
+    Object.defineProperty(window.navigator, 'msSaveOrOpenBlob', {
+      value: sinon.spy(),
     });
 
-    it('should download ICS file on click', async () => {
-      Object.defineProperty(window.navigator, 'msSaveOrOpenBlob', {
-        value: sinon.spy(),
-      });
-      button.props().onClick();
-      const filename = window.navigator.msSaveOrOpenBlob.firstCall.args[1];
-      expect(window.navigator.msSaveOrOpenBlob.called).to.be.true;
-      expect(filename).to.equal('VA_Appointment.ics');
-    });
+    userEvent.click(screen.getByRole('button'));
 
-    it('should have an aria label', () => {
-      expect(button.props()['aria-label']).to.equal(
-        `Add January 2, 2020 appointment to your calendar`,
-      );
-    });
+    const filename = window.navigator.msSaveOrOpenBlob.firstCall.args[1];
+    expect(window.navigator.msSaveOrOpenBlob.called).to.be.true;
+    expect(filename).to.equal('VA_Appointment.ics');
 
-    tree.unmount();
     Object.defineProperty(window.navigator, 'msSaveOrOpenBlob', {
       value: oldValue,
       writable: true,
-    });
-  });
-  describe('generateICS', () => {
-    const now = moment();
-    it('should generate valid ICS calendar commands', () => {
-      const momentDate = moment(now);
-      const dtStamp = momentDate.format('YYYYMMDDTHHmmss');
-      const dtStart = momentDate.format('YYYYMMDDTHHmmss');
-      const dtEnd = momentDate
-        .clone()
-        .add(60, 'minutes')
-        .format('YYYYMMDDTHHmmss');
-
-      const ics = generateICS(
-        'Community Care',
-        '. ',
-        'Address 1 City, State Zip',
-        dtStart,
-        dtEnd,
-      );
-      expect(ics).to.contain('BEGIN:VCALENDAR');
-      expect(ics).to.contain('VERSION:2.0');
-      expect(ics).to.contain('PRODID:VA');
-      expect(ics).to.contain('BEGIN:VEVENT');
-      expect(ics).to.contain('UID:');
-      expect(ics).to.contain('SUMMARY:Community Care');
-      expect(ics).to.contain('DESCRIPTION:. ');
-      expect(ics).to.contain('LOCATION:Address 1 City, State Zip');
-      expect(ics).to.contain(`DTSTAMP:${dtStamp}`);
-      expect(ics).to.contain(`DTSTART:${dtStart}`);
-      expect(ics).to.contain(`DTEND:${dtEnd}`);
-      expect(ics).to.contain('END:VEVENT');
-      expect(ics).to.contain('END:VCALENDAR');
-    });
-    it('should properly chunk long descriptions', () => {
-      const momentDate = moment(now);
-      const dtStamp = momentDate.format('YYYYMMDDTHHmmss');
-      const dtStart = momentDate.format('YYYYMMDDTHHmmss');
-      const dtEnd = momentDate
-        .clone()
-        .add(60, 'minutes')
-        .format('YYYYMMDDTHHmmss');
-      const description = `Testing long line descriptions
-Testing long descriptions Testing long descriptions Testing long descriptions
-Testing long descriptions Testing long descriptions Testing long descriptions
-Testing long descriptions`;
-
-      const ics = generateICS(
-        'Community Care',
-        description,
-        'Address 1 City, State Zip',
-        dtStart,
-        dtEnd,
-      );
-      expect(ics).to.contain('BEGIN:VCALENDAR');
-      expect(ics).to.contain('VERSION:2.0');
-      expect(ics).to.contain('PRODID:VA');
-      expect(ics).to.contain('BEGIN:VEVENT');
-      expect(ics).to.contain('UID:');
-      expect(ics).to.contain('SUMMARY:Community Care');
-      expect(ics).to.contain(
-        'DESCRIPTION:Testing long line descriptions\\nTesting long descriptions Test\r\n\ting long descriptions Testing long descriptions\\nTesting long descriptions\r\n\t Testing long descriptions Testing long descriptions\\nTesting long descrip\r\n\ttions',
-      );
-      expect(ics).to.contain('LOCATION:Address 1 City, State Zip');
-      expect(ics).to.contain(`DTSTAMP:${dtStamp}`);
-      expect(ics).to.contain(`DTSTART:${dtStart}`);
-      expect(ics).to.contain(`DTEND:${dtEnd}`);
-      expect(ics).to.contain('END:VEVENT');
-      expect(ics).to.contain('END:VCALENDAR');
     });
   });
 });


### PR DESCRIPTION
## Description
This converts the AddToCalendar component tests to RTL.

## Testing done
Unit testing

## Acceptance criteria
- [ ] Build passes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
