### PR TITLE
[Development] Fix radio focus management

### DIFF
--- a/src/platform/forms-system/src/js/widgets/RadioWidget.jsx
+++ b/src/platform/forms-system/src/js/widgets/RadioWidget.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import ExpandingGroup from '../components/ExpandingGroup';
+import { focusElement } from '../utilities/ui';
 
 export default function RadioWidget({
   options,
@@ -10,12 +11,20 @@ export default function RadioWidget({
   id,
 }) {
   const { enumOptions, labels = {}, nestedContent = {} } = options;
+  const focusedElement = document?.activeElement?.id;
 
   // nested content could be a component or just jsx/text
   let content = nestedContent[value];
   if (typeof content === 'function') {
     const NestedContent = content;
     content = <NestedContent />;
+  }
+
+  if (focusedElement) {
+    // focus is intermittently lost
+    setTimeout(() => {
+      focusElement(`#${focusedElement}`);
+    });
   }
 
   return (


### PR DESCRIPTION
## Description

While testing HLR's informal conference radio button choices, focus is intermittently lost while re-rendering content below the group - see the video in the related ticket

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/17766

## Testing done

Manual testing

## Screenshots

![focus](https://user-images.githubusercontent.com/136959/102796373-c75d1b80-4373-11eb-9a97-4ef6229ad1de.gif)

## Acceptance criteria
- [x] Focus is maintained within the radio button group

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
