### PR TITLE
[Development] Change restart wizard button to a link

### DIFF
--- a/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
@@ -24,6 +24,7 @@ import {
 } from '../actions';
 import { higherLevelReviewFeature, scrollToTop } from '../helpers';
 import {
+  BASE_URL,
   SAVED_CLAIM_TYPE,
   SUPPLEMENTAL_CLAIM_URL,
   FACILITY_LOCATOR_URL,
@@ -201,16 +202,19 @@ export class IntroductionPage extends React.Component {
               </h2>
               <p className="vads-u-margin-top--2">
                 if you don’t think this is the right form for you,{' '}
-                <button
+                <a
+                  href={BASE_URL}
                   className="va-button-link"
-                  onClick={() => {
+                  onClick={event => {
+                    // prevent reload, but allow opening a new tab
+                    event.preventDefault();
                     this.setWizardStatus(WIZARD_STATUS_NOT_STARTED);
                     this.setPageFocus();
                     recordEvent({ event: 'howToWizard-start-over' });
                   }}
                 >
                   go back and answer questions again
-                </button>
+                </a>
                 .
               </p>
               <ol>


### PR DESCRIPTION
## Description

The restart wizard link was originally a button that appeared as a link. Since all it was doing was clearing the sessionStorage, it made sense to make it a button. But since it's appearance is a link, users may attempt to use the "link" to open a new tab. This PR changes it to a link.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/17740

## Testing done

Manual

## Screenshots

N/A (no appearance change)

## Acceptance criteria
- [x] Restart wizard is a link that can be used to open a new tab

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
