### PR TITLE
Update hawaii travel question

### DIFF
--- a/src/applications/coronavirus-screener/config/questions.jsx
+++ b/src/applications/coronavirus-screener/config/questions.jsx
@@ -125,34 +125,32 @@ export const questions = [
   {
     id: 'travel-459',
     text: {
-      en: 'In the past 14 days, have you traveled outside of Hawaii?',
-      es: 'En los últimos 14 días, ¿ha viajado fuera de Hawái?',
+      en: 'In the past 14 days, have you traveled off island?',
+      es: 'En los últimos 14 días, ¿ha viajado fuera de la isla?',
     },
     customId: ['459'],
   },
   {
     id: 'travel-459GE',
     text: {
-      en: 'In the past 14 days, have you traveled outside of Guam?',
-      es: 'En los últimos 14 días, ¿ha viajado fuera de Guam?',
+      en: 'In the past 14 days, have you traveled off island?',
+      es: 'En los últimos 14 días, ¿ha viajado fuera de la isla?',
     },
     customId: ['459GE'],
   },
   {
     id: 'travel-459GF',
     text: {
-      en: 'In the past 14 days, have you traveled outside of American Samoa?',
-      es: 'En los últimos 14 días, ¿ha viajado fuera de Samoa Americana?',
+      en: 'In the past 14 days, have you traveled off island?',
+      es: 'En los últimos 14 días, ¿ha viajado fuera de la isla?',
     },
     customId: ['459GF'],
   },
   {
     id: 'travel-459GH',
     text: {
-      en:
-        'In the past 14 days, have you traveled outside of the Northern Mariana Islands?',
-      es:
-        'En los últimos 14 días, ¿ha viajado fuera de las Islas Marianas de Norte?',
+      en: 'In the past 14 days, have you traveled off island?',
+      es: 'En los últimos 14 días, ¿ha viajado fuera de la isla?',
     },
     customId: ['459GH'],
   },


### PR DESCRIPTION
## Description
Per request of facility.
Though content is the same for all Hawaii CBOCs (Guam, America Samoa, etc...), keeping the separate nodes in `config.jsx` in case we need to re-customize in the future.

## Testing done
Unit & manual

## Screenshots
<img width="1214" alt="Screen Shot 2020-12-21 at 12 45 08 PM" src="https://user-images.githubusercontent.com/7645362/102806203-6987fe00-438a-11eb-8aa9-6512388bc869.png">


## Acceptance criteria
- [ ] See new content when navigating to ../covidscreen/459, ../covidscreen/459GE, ../covidscreen/459GF, ../covidscreen/459GH 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
