### PR TITLE
Use residentialAddress

### DIFF
--- a/src/platform/user/profile/vap-svc/containers/CopyMailingAddress.jsx
+++ b/src/platform/user/profile/vap-svc/containers/CopyMailingAddress.jsx
@@ -46,14 +46,18 @@ class CopyMailingAddress extends React.Component {
   };
 
   onChange = () => {
-    const { copyMailingAddress, mailingAddress } = this.props;
+    const {
+      copyMailingAddress,
+      mailingAddress,
+      residentialAddress,
+    } = this.props;
 
     // If mailing + home addresses are the same, clear the home address
     if (this.areHomeMailingAddressesEqual()) {
       const clearedHomeAddress = mapValues(mailingAddress, () => null);
 
       // We need the id to remain the same to prevent POST calls
-      clearedHomeAddress.id = mailingAddress.id || null;
+      clearedHomeAddress.id = residentialAddress.id || null;
       clearedHomeAddress.countryCodeIso3 = USA.COUNTRY_ISO3_CODE;
 
       copyMailingAddress(clearedHomeAddress);


### PR DESCRIPTION
## Description
We need to keep the same id on the residential address when making an update. I had accidentally referenced the mailingAddress id which is incorrect in this case,


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
