### PR TITLE
Preventative fix exception error

### DIFF
--- a/src/platform/user/profile/vap-svc/containers/CopyMailingAddress.jsx
+++ b/src/platform/user/profile/vap-svc/containers/CopyMailingAddress.jsx
@@ -57,7 +57,7 @@ class CopyMailingAddress extends React.Component {
       const clearedHomeAddress = mapValues(mailingAddress, () => null);
 
       // We need the id to remain the same to prevent POST calls
-      clearedHomeAddress.id = residentialAddress.id || null;
+      clearedHomeAddress.id = residentialAddress?.id || null;
       clearedHomeAddress.countryCodeIso3 = USA.COUNTRY_ISO3_CODE;
 
       copyMailingAddress(clearedHomeAddress);


### PR DESCRIPTION
## Description
This is a preventative fix - in case the `residentialAddress` is null we don't want to throw an error.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
