### PR TITLE
Add proof of concept age check to VAOS

### DIFF
--- a/src/applications/vaos/project-cheetah/components/InfoPage.jsx
+++ b/src/applications/vaos/project-cheetah/components/InfoPage.jsx
@@ -6,7 +6,7 @@ import FormButtons from '../../components/FormButtons';
 import { scrollAndFocus } from '../../utils/scrollAndFocus';
 
 const pageKey = 'info';
-const pageTitle = 'Info';
+const pageTitle = 'Project Cheetah booking information';
 
 function InfoPage({
   pageChangeInProgress,
@@ -22,6 +22,30 @@ function InfoPage({
   return (
     <div>
       <h1>{pageTitle}</h1>
+      <div className="process schemaform-process">
+        <ol>
+          <li className="process-step list-one">
+            <h2 className="vads-u-padding-y--0p25">
+              Create a project cheetah appointment online
+            </h2>
+          </li>
+          <li className="process-step list-two">
+            <h2 className="vads-u-padding-y--0p25">
+              Arrive at VA facility for your first appointment
+            </h2>
+          </li>
+          <li className="process-step list-three">
+            <h2 className="vads-u-padding-y--0p25">
+              Create a follow-up appointment with VA staff
+            </h2>
+          </li>
+          <li className="process-step list-four">
+            <h2 className="vads-u-padding-y--0p25">
+              Arrive at VA facility for your second appointment
+            </h2>
+          </li>
+        </ol>
+      </div>
       <FormButtons
         backBeforeText=""
         backButtonText="Cancel"

--- a/src/applications/vaos/project-cheetah/index.jsx
+++ b/src/applications/vaos/project-cheetah/index.jsx
@@ -1,10 +1,13 @@
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
-import { Switch, Route, useRouteMatch, useHistory } from 'react-router-dom';
 import {
-  selectFeatureToggleLoading,
-  selectFeatureProjectCheetah,
-} from '../redux/selectors';
+  Switch,
+  Route,
+  useRouteMatch,
+  Link,
+  useHistory,
+} from 'react-router-dom';
+import { selectAllowProjectCheetahBookings } from './redux/selectors';
 import projectCheetahReducer from './redux/reducer';
 import FormLayout from './components/FormLayout';
 import InfoPage from './components/InfoPage';
@@ -12,19 +15,43 @@ import SelectDate1Page from './components/SelectDate1Page';
 import SelectDate2Page from './components/SelectDate2Page';
 import ReviewPage from './components/ReviewPage';
 import ConfirmationPage from './components/ConfirmationPage';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import FullWidthLayout from '../components/FullWidthLayout';
+import Breadcrumbs from '../components/Breadcrumbs';
+import { selectFeatureProjectCheetah } from '../redux/selectors';
 
-export function NewBookingSection({ allowBookings }) {
+export function NewBookingSection({ allowBookings, featureProjectCheetah }) {
   const match = useRouteMatch();
   const history = useHistory();
 
   useEffect(
     () => {
-      if (!allowBookings) {
+      if (!featureProjectCheetah) {
         history.push('/');
       }
     },
-    [allowBookings, history],
+    [featureProjectCheetah, history],
   );
+
+  if (!allowBookings) {
+    return (
+      <FullWidthLayout>
+        <Breadcrumbs>
+          <Link to="new-project-cheetah-booking">Project Cheetah Booking</Link>
+        </Breadcrumbs>
+        <AlertBox
+          headline="Please contact your VA facility"
+          status="warning"
+          className="vads-u-margin-top--0p5 vads-u-margin-bottom--4"
+          isVisible
+        >
+          You should contact your doctor or the{' '}
+          <a href="/find-locations">nearest VA facility</a> if you have
+          questions about project cheetah.
+        </AlertBox>
+      </FullWidthLayout>
+    );
+  }
 
   return (
     <FormLayout>
@@ -52,8 +79,8 @@ export function NewBookingSection({ allowBookings }) {
 
 function mapStateToProps(state) {
   return {
-    allowBookings:
-      !selectFeatureToggleLoading(state) && selectFeatureProjectCheetah(state),
+    featureProjectCheetah: selectFeatureProjectCheetah(state),
+    allowBookings: selectAllowProjectCheetahBookings(state),
   };
 }
 

--- a/src/applications/vaos/project-cheetah/redux/selectors.js
+++ b/src/applications/vaos/project-cheetah/redux/selectors.js
@@ -1,3 +1,6 @@
+import moment from 'moment';
+import { selectProfile } from 'platform/user/selectors';
+
 export function selectProjectCheetah(state) {
   return state.projectCheetah;
 }
@@ -17,4 +20,8 @@ export function getProjectCheetahFormPageInfo(state, pageKey) {
     data: newBooking.data,
     pageChangeInProgress: newBooking.pageChangeInProgress,
   };
+}
+
+export function selectAllowProjectCheetahBookings(state) {
+  return moment().diff(moment(selectProfile(state).dob), 'years') >= 65;
 }

--- a/src/platform/testing/local-dev-mock-api/common.js
+++ b/src/platform/testing/local-dev-mock-api/common.js
@@ -76,6 +76,7 @@ const responses = {
         { name: 'vaOnlineSchedulingExpressCareNew', value: true },
         { name: 'vaOnlineSchedulingFlatFacilityPage', value: true },
         { name: 'vaOnlineSchedulingProviderSelection', value: true },
+        { name: 'vaOnlineSchedulingCheetah', value: true },
         { name: 'vaGlobalDowntimeNotification', value: false },
         { name: 'ssoe', value: true },
         { name: 'ssoeInbound', value: false },


### PR DESCRIPTION
## Description
Here's a PoC age check in VAOS for the project cheetah flow.

## Testing done
Local testing

## Screenshots
If you meet the age criteria:
![Screen Shot 2020-12-21 at 4 12 35 PM](https://user-images.githubusercontent.com/634932/102822644-7f57ec00-43a7-11eb-828b-3ce4cf6a56b0.png)

If you don't meet the age criteria:
![Screen Shot 2020-12-21 at 4 12 18 PM](https://user-images.githubusercontent.com/634932/102822646-7f57ec00-43a7-11eb-81b2-82fa7c187b1c.png)


## Acceptance criteria
- [ ] Age check works

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
