### PR TITLE
STEM: Create automated decision feature flag#13829 Front end

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -47,6 +47,7 @@ export default Object.freeze({
   showEduBenefits5490Wizard: 'show_edu_benefits_5490_wizard',
   showEduBenefits1990EWizard: 'show_edu_benefits_1990e_wizard',
   showEduBenefits1990Wizard: 'show_edu_benefits_1990_wizard',
+  stemAutomatedDecision: 'stem_automated_decision',
   stemSCOEmail: 'stem_sco_email',
   showHealthcareExperienceQuestionnaire:
     'showHealthcareExperienceQuestionnaire',


### PR DESCRIPTION
## Description
As a developer, I need a way to toggle the automated decision functionality, so that it can be turned on/off in environments as needed.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/13829

back end PR: https://github.com/department-of-veterans-affairs/vets-api/pull/5561
## Testing done
local testing

## Screenshots
![Screen Shot 2020-12-22 at 7 11 48 AM](https://user-images.githubusercontent.com/50601724/102887460-04cdb180-4425-11eb-8cb5-777cbca98b0a.png)


## Acceptance criteria
- [x] The Feature Flag stem_automated_decision is available to be used for the submission enhancements.
- [x] The Feature Flag stem_automated_decision description is: "Add automated decision to 10203 application workflow"
- [x] The Feature Flag is created and available in all environments.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
