### PR TITLE
DT-17678 508-2 fixing ux and screen reader visibility.

### DIFF
--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -121,12 +121,10 @@
             <ul class="usa-unstyled-list">
             {% for vaForm in fieldVaFormRelatedForms %}
               <li>
-                <hgroup>
                   <h3>VA Form {{ vaForm.entity.fieldVaFormNumber }}</h3>
-                  <h4 class="vads-u-margin-top--0">
-                    Form name: {{ vaForm.entity.fieldVaFormName }}
-                  </h4>
-                </hgroup>
+                  <p class="vads-u-margin-top--0 vads-u-font-size--h4 vads-u-font-weight--bold">
+                    <dfn class="vads-u-visibility--screen-reader">Form name:</dfn> {{ vaForm.entity.fieldVaFormName }}
+                  </p>
 
                 {{ vaForm.entity.fieldVaFormUsage.processed }}
 


### PR DESCRIPTION
## Description
Removed _Form Name_ UX visible text and applied that only to screen readers.

## Testing done
Ran and built branch locally http://localhost:3001/find-forms/about-form-21p-0969/ .
I used the mac voice over commands to read the hold page.

## Screenshots
![Screen Shot 2020-12-22 at 11 08 57 AM](https://user-images.githubusercontent.com/26075258/102909113-7a964500-4446-11eb-8338-b90366329451.png)


## Acceptance criteria
- [x] Screen reader reads form title only once and its visible to screen reader while being invisible to visual user.  

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
