### PR TITLE
Rough-draft of DD4EDU on Direct Deposit v2

### DIFF
--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -250,7 +250,7 @@ const mapStateToProps = state => {
   const shouldFetchCNPDirectDepositInformation =
     isEvssAvailable && is2faEnabled;
   const shouldFetchEDUDirectDepositInformation =
-    showDirectDepositV2(state) && is2faEnabled;
+    !!showDirectDepositV2(state) && is2faEnabled;
   const currentlyLoggedIn = isLoggedIn(state);
   const isLOA1 = isLOA1Selector(state);
   const isLOA3 = isLOA3Selector(state);

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
@@ -37,7 +37,7 @@ import ProfileInfoTable from '../ProfileInfoTable';
 
 import prefixUtilityClasses from '~/platform/utilities/prefix-utility-classes';
 
-export const DirectDepositCNP = ({
+export const BankInfoCNP = ({
   isLOA3,
   isDirectDepositSetUp,
   is2faEnabled,
@@ -160,7 +160,9 @@ export const DirectDepositCNP = ({
       </dl>
       <button
         className={classes.editButton}
-        aria-label={'Edit your direct deposit bank information'}
+        aria-label={
+          'Edit your direct deposit for disability compensation and pension benefits bank information'
+        }
         ref={editBankInfoButton}
         onClick={() => {
           recordEvent({
@@ -372,7 +374,7 @@ export const DirectDepositCNP = ({
   }
 };
 
-DirectDepositCNP.propTypes = {
+BankInfoCNP.propTypes = {
   isLOA3: PropTypes.bool.isRequired,
   is2faEnabled: PropTypes.bool.isRequired,
   directDepositAccountInfo: PropTypes.shape({
@@ -409,4 +411,4 @@ const mapDispatchToProps = {
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-)(DirectDepositCNP);
+)(BankInfoCNP);

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoCNPv2.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoCNPv2.jsx
@@ -34,7 +34,7 @@ import ProfileInfoTable from '../ProfileInfoTable';
 
 import prefixUtilityClasses from '~/platform/utilities/prefix-utility-classes';
 
-export const DirectDepositCNP = ({
+export const BankInfoCNP = ({
   isLOA3,
   isDirectDepositSetUp,
   is2faEnabled,
@@ -141,7 +141,9 @@ export const DirectDepositCNP = ({
       </dl>
       <button
         className={classes.editButton}
-        aria-label={'Edit your direct deposit bank information'}
+        aria-label={
+          'Edit your direct deposit for disability compensation and pension benefits bank information'
+        }
         ref={editBankInfoButton}
         onClick={() => {
           recordEvent({
@@ -319,7 +321,7 @@ export const DirectDepositCNP = ({
   }
 };
 
-DirectDepositCNP.propTypes = {
+BankInfoCNP.propTypes = {
   isLOA3: PropTypes.bool.isRequired,
   is2faEnabled: PropTypes.bool.isRequired,
   directDepositAccountInfo: PropTypes.shape({
@@ -356,4 +358,4 @@ const mapDispatchToProps = {
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-)(DirectDepositCNP);
+)(BankInfoCNP);

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoCNPv2.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoCNPv2.jsx
@@ -6,6 +6,9 @@ import { connect } from 'react-redux';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 import recordEvent from '~/platform/monitoring/record-event';
 import { isAuthenticatedWithSSOe } from '~/platform/user/authentication/selectors';
@@ -22,6 +25,7 @@ import {
 } from '@@profile/actions/paymentInformation';
 import {
   cnpDirectDepositAccountInformation,
+  cnpDirectDepositAddressIsSetUp,
   cnpDirectDepositInformation,
   cnpDirectDepositIsSetUp,
   cnpDirectDepositUiState as directDepositUiStateSelector,
@@ -37,6 +41,7 @@ import prefixUtilityClasses from '~/platform/utilities/prefix-utility-classes';
 export const BankInfoCNP = ({
   isLOA3,
   isDirectDepositSetUp,
+  isEligibleToSetUpDirectDeposit,
   is2faEnabled,
   directDepositAccountInfo,
   directDepositUiState,
@@ -177,6 +182,35 @@ export const BankInfoCNP = ({
     </button>
   );
 
+  // When not eligible for DD for CNP
+  const notEligibleContent = (
+    <>
+      <p className="vads-u-margin-top--0">
+        Our records show that you‘re not receiving disability compensation or
+        pension payments. If you think this is an error, please call us at{' '}
+        <Telephone contact={CONTACTS.VA_BENEFITS} />.
+      </p>
+      <p>
+        <a
+          target="_blank"
+          rel="noopener noreferrer"
+          href="https://www.va.gov/disability/eligibility/"
+        >
+          Find out if you‘re eligible for VA disability benefits
+        </a>
+      </p>
+      <p className="vads-u-margin-bottom--0">
+        <a
+          target="_blank"
+          rel="noopener noreferrer"
+          href="https://www.va.gov/pension/eligibility/"
+        >
+          Find out if you‘re eligible for VA pension benefits
+        </a>
+      </p>
+    </>
+  );
+
   // When editing/setting up direct deposit, we'll show a form that accepts bank
   // account information
   const editingBankInfoContent = (
@@ -220,7 +254,10 @@ export const BankInfoCNP = ({
     if (isDirectDepositSetUp) {
       return bankInfoContent;
     }
-    return notSetUpContent;
+    if (isEligibleToSetUpDirectDeposit) {
+      return notSetUpContent;
+    }
+    return notEligibleContent;
   };
 
   const directDepositData = [
@@ -331,6 +368,7 @@ BankInfoCNP.propTypes = {
     financialInstitutionRoutingNumber: PropTypes.string.isRequired,
   }),
   isDirectDepositSetUp: PropTypes.bool.isRequired,
+  isEligibleToSetUpDirectDeposit: PropTypes.bool.isRequired,
   directDepositUiState: PropTypes.shape({
     isEditing: PropTypes.bool.isRequired,
     isSaving: PropTypes.bool.isRequired,
@@ -345,6 +383,7 @@ export const mapStateToProps = state => ({
   directDepositAccountInfo: cnpDirectDepositAccountInformation(state),
   directDepositInfo: cnpDirectDepositInformation(state),
   isDirectDepositSetUp: cnpDirectDepositIsSetUp(state),
+  isEligibleToSetUpDirectDeposit: cnpDirectDepositAddressIsSetUp(state),
   directDepositUiState: directDepositUiStateSelector(state),
   is2faEnabled: isMultifactorEnabled(state),
   isAuthenticatedWithSSOe: isAuthenticatedWithSSOe(state),

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
@@ -162,16 +162,16 @@ export const DirectDepositEDU = ({
 
   // When direct deposit is not set up
   const notSetUpContent = (
-    <div>
-      <p>
+    <>
+      <p className="vads-u-margin-top--0">
         Our records show that you‘re not receiving education benefit payments.
         If you think this is an error, please call us at{' '}
         <Telephone contact={CONTACTS.HELP_DESK} />.
       </p>
-      <p>
+      <p className="vads-u-margin-bottom--0">
         <a>Find out if you‘re eligible for VA education benefits</a>
       </p>
-    </div>
+    </>
   );
 
   // When editing bank info, we'll show a form that accepts bank account

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
@@ -1,0 +1,358 @@
+import React, { useEffect, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Prompt } from 'react-router-dom';
+import { connect } from 'react-redux';
+
+import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
+import Modal from '@department-of-veterans-affairs/formation-react/Modal';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
+
+import recordEvent from '~/platform/monitoring/record-event';
+import { isAuthenticatedWithSSOe } from '~/platform/user/authentication/selectors';
+import { mfa } from '~/platform/user/authentication/utilities';
+
+import {
+  isLOA3 as isLOA3Selector,
+  isMultifactorEnabled,
+} from '~/platform/user/selectors';
+import { usePrevious } from '~/platform/utilities/react-hooks';
+import {
+  editEDUPaymentInformationToggled,
+  saveEDUPaymentInformation as savePaymentInformationAction,
+} from '@@profile/actions/paymentInformation';
+import {
+  eduDirectDepositAccountInformation,
+  eduDirectDepositInformation,
+  eduDirectDepositIsSetUp,
+  eduDirectDepositUiState as directDepositUiStateSelector,
+} from '@@profile/selectors';
+
+import BankInfoForm from './BankInfoForm';
+
+import PaymentInformationEditError from './PaymentInformationEditModalError';
+import ProfileInfoTable from '../ProfileInfoTable';
+
+import prefixUtilityClasses from '~/platform/utilities/prefix-utility-classes';
+
+export const DirectDepositEDU = ({
+  isLOA3,
+  isDirectDepositSetUp,
+  is2faEnabled,
+  directDepositAccountInfo,
+  directDepositUiState,
+  saveBankInformation,
+  toggleEditState,
+}) => {
+  const editBankInfoButton = useRef();
+  const [formData, setFormData] = useState({});
+  const [showConfirmCancelModal, setShowConfirmCancelModal] = useState(false);
+  const wasEditingBankInfo = usePrevious(directDepositUiState.isEditing);
+
+  const isEditingBankInfo = directDepositUiState.isEditing;
+  const saveError = directDepositUiState.responseError;
+
+  const { accountNumber, accountType, routingNumber } = formData;
+  const isEmptyForm = !accountNumber && !accountType && !routingNumber;
+
+  const showSetup2FactorAuthentication = isLOA3 && !is2faEnabled;
+
+  // when we enter and exit edit mode...
+  useEffect(
+    () => {
+      if (wasEditingBankInfo && !isEditingBankInfo) {
+        // clear the form data when exiting edit mode so it's blank when the
+        // edit form is shown again
+        setFormData({});
+        // focus the edit button when we exit edit mode
+        editBankInfoButton.current.focus();
+      }
+    },
+    [isEditingBankInfo, wasEditingBankInfo],
+  );
+
+  useEffect(
+    () => {
+      // Show alert when navigating away
+      if (!isEmptyForm) {
+        window.onbeforeunload = () => true;
+        return;
+      }
+
+      window.onbeforeunload = undefined;
+    },
+    [isEmptyForm],
+  );
+
+  const saveBankInfo = () => {
+    const payload = {
+      financialInstitutionRoutingNumber: formData.routingNumber,
+      accountNumber: formData.accountNumber,
+      accountType: formData.accountType,
+    };
+    saveBankInformation(payload);
+  };
+
+  const bankInfoClasses = prefixUtilityClasses(
+    [
+      'display--flex',
+      'align-items--flex-start',
+      'flex-direction--row',
+      'justify-content--space-between',
+    ],
+    'medium',
+  );
+
+  const editButtonClasses = [
+    'va-button-link',
+    ...prefixUtilityClasses(['margin-top--1p5']),
+  ];
+
+  const editButtonClassesMedium = prefixUtilityClasses(
+    ['flex--auto', 'margin-top--0'],
+    'medium',
+  );
+
+  const classes = {
+    bankInfo: [...bankInfoClasses].join(' '),
+    editButton: [...editButtonClasses, ...editButtonClassesMedium].join(' '),
+  };
+
+  const closeDDForm = () => {
+    if (!isEmptyForm) {
+      setShowConfirmCancelModal(true);
+      return;
+    }
+
+    toggleEditState();
+  };
+
+  // When direct deposit is set up we will show the current bank info
+  const bankInfoContent = (
+    <div className={classes.bankInfo}>
+      <dl className="vads-u-margin-y--0 vads-u-line-height--6">
+        <dt className="sr-only">Bank name:</dt>
+        <dd>{directDepositAccountInfo?.financialInstitutionName}</dd>
+        <dt className="sr-only">Bank account number:</dt>
+        <dd>{directDepositAccountInfo?.accountNumber}</dd>
+        <dt className="sr-only">Bank account type:</dt>
+        <dd>{`${directDepositAccountInfo?.accountType} account`}</dd>
+      </dl>
+      <button
+        className={classes.editButton}
+        aria-label={
+          'Edit your direct deposit for education benefits bank information'
+        }
+        ref={editBankInfoButton}
+        onClick={() => {
+          recordEvent({
+            event: 'profile-navigation',
+            'profile-action': 'edit-link',
+            'profile-section': 'edu-direct-deposit-information',
+          });
+          toggleEditState();
+        }}
+      >
+        Edit
+      </button>
+    </div>
+  );
+
+  // When direct deposit is not set up
+  const notSetUpContent = (
+    <div>
+      <p>
+        Our records show that you‘re not receiving education benefit payments.
+        If you think this is an error, please call us at{' '}
+        <Telephone contact={CONTACTS.HELP_DESK} />.
+      </p>
+      <p>
+        <a>Find out if you‘re eligible for VA education benefits</a>
+      </p>
+    </div>
+  );
+
+  // When editing bank info, we'll show a form that accepts bank account
+  // information
+  const editingBankInfoContent = (
+    <>
+      <div id="errors" role="alert" aria-atomic="true">
+        {!!saveError && (
+          <PaymentInformationEditError
+            responseError={saveError}
+            className="vads-u-margin-top--0 vads-u-margin-bottom--2"
+          />
+        )}
+      </div>
+      <p className="vads-u-margin-top--0">
+        Please enter your bank’s routing and account numbers and your account
+        type.
+      </p>
+      <div className="vads-u-margin-bottom--2">
+        <AdditionalInfo triggerText="Where can I find these numbers?">
+          <img
+            src="/img/direct-deposit-check-guide.png"
+            alt="On a personal check, find your bank’s 9-digit routing number listed along the bottom-left edge, and your account number listed beside that."
+          />
+        </AdditionalInfo>
+      </div>
+      <BankInfoForm
+        formChange={data => setFormData(data)}
+        formData={formData}
+        formSubmit={saveBankInfo}
+        isSaving={directDepositUiState.isSaving}
+        onClose={closeDDForm}
+        cancelButtonClasses={['va-button-link', 'vads-u-margin-left--1']}
+      />
+    </>
+  );
+
+  // Helper that determines which data to show in the top row of the table
+  const getBankInfo = () => {
+    if (directDepositUiState.isEditing) {
+      return editingBankInfoContent;
+    }
+    if (isDirectDepositSetUp) {
+      return bankInfoContent;
+    }
+    return notSetUpContent;
+  };
+
+  const directDepositData = [
+    // the table can show multiple states so we set its value with the
+    // getBankInfo() helper
+    {
+      title: 'Account',
+      value: getBankInfo(),
+    },
+  ];
+
+  const mfaHandler = isAuthenticatedWithSSO => {
+    recordEvent({ event: 'multifactor-link-clicked' });
+    mfa(isAuthenticatedWithSSO ? 'v1' : 'v0');
+  };
+
+  // Render nothing if the user is not LOA3.
+  // This entire component should never be rendered in that case; this just
+  // serves as another layer of protection.
+  if (!isLOA3) {
+    return null;
+  }
+
+  if (showSetup2FactorAuthentication) {
+    return (
+      <AlertBox
+        className="vads-u-margin-bottom--2"
+        headline="You’ll need to set up 2-factor authentication before you can edit your direct deposit information."
+        content={
+          <>
+            <p>
+              We require this to help protect your bank account information and
+              prevent fraud.
+            </p>
+            <p>
+              Authentication gives you an extra layer of security by letting you
+              into your account only after you've signed in with a password and
+              a 6-digit code sent directly to your mobile or home phone. This
+              helps to make sure that no one but you can access your account -
+              even if they get your password.
+            </p>
+            <button
+              type="button"
+              className="usa-button-primary va-button-primary"
+              onClick={() => mfaHandler(isAuthenticatedWithSSOe)}
+            >
+              Set up 2-factor authentication
+            </button>
+          </>
+        }
+        status="continue"
+        isVisible
+      />
+    );
+  } else {
+    return (
+      <>
+        <Modal
+          title={'Are you sure?'}
+          status="warning"
+          visible={showConfirmCancelModal}
+          onClose={() => {
+            setShowConfirmCancelModal(false);
+          }}
+        >
+          <p>
+            {' '}
+            {`You haven’t finished editing your direct deposit information. If you cancel, your in-progress work won’t be saved.`}
+          </p>
+          <button
+            className="usa-button-secondary"
+            onClick={() => {
+              setShowConfirmCancelModal(false);
+            }}
+          >
+            Continue Editing
+          </button>
+          <button
+            onClick={() => {
+              setShowConfirmCancelModal(false);
+              toggleEditState();
+            }}
+          >
+            Cancel
+          </button>
+        </Modal>
+        <Prompt
+          message="Are you sure you want to leave? If you leave, your in-progress work won’t be saved."
+          when={!isEmptyForm}
+        />
+        <ProfileInfoTable
+          className="vads-u-margin-y--2 medium-screen:vads-u-margin-y--4"
+          title="Education benefits"
+          data={directDepositData}
+        />
+      </>
+    );
+  }
+};
+
+DirectDepositEDU.propTypes = {
+  isLOA3: PropTypes.bool.isRequired,
+  is2faEnabled: PropTypes.bool.isRequired,
+  directDepositAccountInfo: PropTypes.shape({
+    accountNumber: PropTypes.string.isRequired,
+    accountType: PropTypes.string.isRequired,
+    financialInstitutionName: PropTypes.string,
+    financialInstitutionRoutingNumber: PropTypes.string.isRequired,
+  }),
+  isDirectDepositSetUp: PropTypes.bool.isRequired,
+  directDepositUiState: PropTypes.shape({
+    isEditing: PropTypes.bool.isRequired,
+    isSaving: PropTypes.bool.isRequired,
+    responseError: PropTypes.string,
+  }),
+  saveBankInformation: PropTypes.func.isRequired,
+  toggleEditState: PropTypes.func.isRequired,
+};
+
+export const mapStateToProps = state => ({
+  isLOA3: isLOA3Selector(state),
+  directDepositAccountInfo: eduDirectDepositAccountInformation(state),
+  directDepositInfo: eduDirectDepositInformation(state),
+  isDirectDepositSetUp: eduDirectDepositIsSetUp(state),
+  directDepositUiState: directDepositUiStateSelector(state),
+  is2faEnabled: isMultifactorEnabled(state),
+  isAuthenticatedWithSSOe: isAuthenticatedWithSSOe(state),
+});
+
+const mapDispatchToProps = {
+  saveBankInformation: savePaymentInformationAction,
+  toggleEditState: editEDUPaymentInformationToggled,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(DirectDepositEDU);

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
@@ -169,7 +169,13 @@ export const DirectDepositEDU = ({
         <Telephone contact={CONTACTS.VA_BENEFITS} />.
       </p>
       <p className="vads-u-margin-bottom--0">
-        <a>Find out if you‘re eligible for VA education benefits</a>
+        <a
+          target="_blank"
+          rel="noopener noreferrer"
+          href="https://www.va.gov/education/eligibility/"
+        >
+          Find out if you‘re eligible for VA education benefits
+        </a>
       </p>
     </>
   );

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
@@ -166,7 +166,7 @@ export const DirectDepositEDU = ({
       <p className="vads-u-margin-top--0">
         Our records show that you‘re not receiving education benefit payments.
         If you think this is an error, please call us at{' '}
-        <Telephone contact={CONTACTS.HELP_DESK} />.
+        <Telephone contact={CONTACTS.VA_BENEFITS} />.
       </p>
       <p className="vads-u-margin-bottom--0">
         <a>Find out if you‘re eligible for VA education benefits</a>

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
@@ -160,8 +160,8 @@ export const DirectDepositEDU = ({
     </div>
   );
 
-  // When direct deposit is not set up
-  const notSetUpContent = (
+  // When not eligible for DD for EDU
+  const notEligibleContent = (
     <>
       <p className="vads-u-margin-top--0">
         Our records show that you‘re not receiving education benefit payments.
@@ -223,7 +223,7 @@ export const DirectDepositEDU = ({
     if (isDirectDepositSetUp) {
       return bankInfoContent;
     }
-    return notSetUpContent;
+    return notEligibleContent;
   };
 
   const directDepositData = [

--- a/src/applications/personalization/profile/components/direct-deposit/DirectDepositV2.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/DirectDepositV2.jsx
@@ -12,6 +12,7 @@ import { handleDowntimeForSection } from '../alerts/DowntimeBanner';
 import FraudVictimAlert from './FraudVictimAlert';
 import PaymentHistory from './PaymentHistory';
 import BankInfoCNPv2 from './BankInfoCNPv2';
+import BankInfoEDU from './BankInfoEDU';
 
 const DirectDeposit = () => {
   // const [showSaveSucceededAlert, setShowSaveSucceededAlert] = React.useState(
@@ -78,6 +79,7 @@ const DirectDeposit = () => {
       >
         <BankInfoCNPv2 />
       </DowntimeNotification>
+      <BankInfoEDU />
       <PaymentHistory />
       <FraudVictimAlert />
     </>

--- a/src/applications/personalization/profile/selectors.js
+++ b/src/applications/personalization/profile/selectors.js
@@ -35,8 +35,20 @@ export const eduDirectDepositIsSetUp = state =>
 export const cnpDirectDepositLoadError = state =>
   cnpDirectDepositInformation(state)?.error;
 
-export const eduDirectDepositLoadError = state =>
-  eduDirectDepositInformation(state)?.error;
+// If the error is a 403 error, we will treat it like a no-data state, not an
+// error.
+export const eduDirectDepositLoadError = state => {
+  const error = eduDirectDepositInformation(state)?.error;
+  if (error?.errors instanceof Array) {
+    error.errors = error.errors.filter(err => {
+      return err.code !== '403';
+    });
+    if (!error.errors.length) {
+      return undefined;
+    }
+  }
+  return error;
+};
 
 export const cnpDirectDepositAddressInformation = state =>
   cnpDirectDepositInformation(state)?.responses?.[0]?.paymentAddress;

--- a/src/applications/personalization/profile/selectors.js
+++ b/src/applications/personalization/profile/selectors.js
@@ -24,7 +24,7 @@ export const cnpDirectDepositAccountInformation = state =>
   cnpDirectDepositBankInfo(cnpDirectDepositInformation(state));
 
 export const eduDirectDepositAccountInformation = state =>
-  eduDirectDepositInformation(state).paymentAccount;
+  eduDirectDepositInformation(state)?.paymentAccount;
 
 export const cnpDirectDepositIsSetUp = state =>
   isSignedUpForCNPDirectDeposit(cnpDirectDepositInformation(state));

--- a/src/applications/personalization/profile/tests/components/Profile.unit.spec.js
+++ b/src/applications/personalization/profile/tests/components/Profile.unit.spec.js
@@ -215,6 +215,7 @@ describe('mapStateToProps', () => {
       'isInMVI',
       'isLOA3',
       'shouldFetchCNPDirectDepositInformation',
+      'shouldFetchEDUDirectDepositInformation',
       'shouldShowDirectDeposit',
       'isDowntimeWarningDismissed',
     ];

--- a/src/applications/personalization/profile/tests/selectors.unit.spec.js
+++ b/src/applications/personalization/profile/tests/selectors.unit.spec.js
@@ -340,9 +340,13 @@ describe('profile selectors', () => {
   });
 
   describe('eduDirectDepositLoadError', () => {
-    it('returns the error if it exists', () => {
+    it('returns any non-403 errors that exist', () => {
       const error = {
-        code: '123',
+        errors: [
+          {
+            code: '401',
+          },
+        ],
       };
       const state = {
         vaProfile: {
@@ -353,6 +357,49 @@ describe('profile selectors', () => {
       };
 
       expect(selectors.eduDirectDepositLoadError(state)).to.deep.equal(error);
+
+      state.vaProfile.eduPaymentInformation.error.errors.push({
+        code: '403',
+      });
+
+      expect(selectors.eduDirectDepositLoadError(state)).to.deep.equal(error);
+    });
+    it('returns the error if it is not an object with an errors array', () => {
+      const error = {
+        code: '500',
+      };
+      const state = {
+        vaProfile: {
+          eduPaymentInformation: {
+            error,
+          },
+        },
+      };
+      expect(selectors.eduDirectDepositLoadError(state)).to.deep.equal(error);
+    });
+    it('returns undefined if the error data only contains 403 errors', () => {
+      const error = {
+        errors: [
+          {
+            code: '403',
+          },
+        ],
+      };
+      const state = {
+        vaProfile: {
+          eduPaymentInformation: {
+            error,
+          },
+        },
+      };
+
+      expect(selectors.eduDirectDepositLoadError(state)).to.be.undefined;
+
+      state.vaProfile.eduPaymentInformation.error.errors.push({
+        code: '403',
+      });
+
+      expect(selectors.eduDirectDepositLoadError(state)).to.be.undefined;
     });
 
     it('returns `undefined` when there is no error', () => {

--- a/src/applications/personalization/profile/util/index.js
+++ b/src/applications/personalization/profile/util/index.js
@@ -75,7 +75,7 @@ export const cnpDirectDepositBankInfo = apiData => {
 };
 
 export const eduDirectDepositAccountNumber = apiData => {
-  return apiData.accountNumber;
+  return apiData?.accountNumber;
 };
 
 const cnpDirectDepositAddressInfo = apiData => {


### PR DESCRIPTION
## Description
Still much to do, but this gets the Direct Deposit for EDU feature on the new Direct Deposit section of the Profile.

- [x] confirm that this has no effect on Direct Deposit v1 (when the `ch33_dd_profile` feature flag is off) **confirmed locally that user 1 sees their DD4CNP just fine and the new endpoint is not called when the feature flag is off**
- [ ] make the "update complete" alert to show and hide properly
- [ ] only show a single "set up 2FA" CTA, rather than one for each DD component
- [ ] since both new API endpoints need to be updated to provide the functionality we need, write Cypress tests that use a mock API to confirm things work

## Testing done
Local + new tests for updated selector functionality.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs