### PR TITLE
Increase retries in mocha from 3 to 5 (#16941)

### DIFF
--- a/script/run-unit-test.js
+++ b/script/run-unit-test.js
@@ -44,7 +44,7 @@ if (options.help) {
 }
 
 const mochaPath = `BABEL_ENV=test mocha ${reporterOption}`;
-const coveragePath = `NODE_ENV=test nyc --all ${coverageInclude} --reporter=lcov --reporter=text --reporter=json-summary mocha --reporter mocha-junit-reporter --no-color --retries 3`;
+const coveragePath = `NODE_ENV=test nyc --all ${coverageInclude} --reporter=lcov --reporter=text --reporter=json-summary mocha --reporter mocha-junit-reporter --no-color --retries 5`;
 const testRunner = options.coverage ? coveragePath : mochaPath;
 const configFile = 'config/mocha.json';
 


### PR DESCRIPTION
## Description
Increase retries in mocha from 3 to 5 (may help with flaky tests).

## Testing done
Successful CI unit test run

## Screenshots
N/A

## Acceptance criteria
- [ ] Number of retries increased to 5

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
