### PR TITLE
Hotfix - Removes attachStacktrace property on Sentry

### DIFF
--- a/src/platform/monitoring/sentry.js
+++ b/src/platform/monitoring/sentry.js
@@ -19,7 +19,6 @@ if (trackErrors) {
       // https://github.com/getsentry/sentry/issues/5267
       /Blocked a frame with origin/,
     ],
-    attachStacktrace: true,
   });
   Sentry.setTag('source', 'unknown');
   Sentry.configureScope(scope => {


### PR DESCRIPTION
## Description
Jeff Balboni mentioned that [Sentry message grouping was broken](https://dsva.slack.com/archives/CBU0KDSB1/p1608659872244600) (mostly in VAOS) because of adding the `attachStacktrace` property in Sentry's initialization would not allow grouping events logged with captureMessage together.

## Testing done
Manual

## Screenshots


## Acceptance criteria
- [x] Sentry's message grouping in platform-web returns to normal
- [x] `attachStacktrace` property is removed from Sentry's initialization

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
