### PR TITLE
Update direct deposit update error alert

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
@@ -32,7 +32,7 @@ import {
 
 import BankInfoForm from './BankInfoForm';
 
-import PaymentInformationEditError from './PaymentInformationEditModalError';
+import PaymentInformationEditError from './PaymentInformationEditError';
 import ProfileInfoTable from '../ProfileInfoTable';
 
 import prefixUtilityClasses from '~/platform/utilities/prefix-utility-classes';

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoCNPv2.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoCNPv2.jsx
@@ -33,7 +33,7 @@ import {
 
 import BankInfoForm from './BankInfoForm';
 
-import PaymentInformationEditError from './PaymentInformationEditModalError';
+import PaymentInformationEditError from './PaymentInformationEditError';
 import ProfileInfoTable from '../ProfileInfoTable';
 
 import prefixUtilityClasses from '~/platform/utilities/prefix-utility-classes';

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
@@ -32,7 +32,7 @@ import {
 
 import BankInfoForm from './BankInfoForm';
 
-import PaymentInformationEditError from './PaymentInformationEditModalError';
+import PaymentInformationEditError from './PaymentInformationEditError';
 import ProfileInfoTable from '../ProfileInfoTable';
 
 import prefixUtilityClasses from '~/platform/utilities/prefix-utility-classes';

--- a/src/applications/personalization/profile/components/direct-deposit/PaymentInformationEditError.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/PaymentInformationEditError.jsx
@@ -82,47 +82,31 @@ function GenericError() {
 // Since we don't know what the error message looks like when there's a problem
 // with the user's home address, we'll use a single error message for any and
 // all address-related errors
-function UpdateAddressError({ closeModal }) {
+function UpdateAddressError() {
   return (
     <p>
       We’re sorry. We couldn’t update your direct deposit bank information
       because your mailing address is missing or invalid. Please go back to{' '}
-      <a
-        href="/profile/#contact-information"
-        onClick={() => {
-          closeModal();
-        }}
-      >
-        your profile
-      </a>{' '}
-      and fill in this required information.
+      <a href="/profile/personal-information">your profile</a> and fill in this
+      required information.
     </p>
   );
 }
 
-function UpdatePhoneNumberError({ closeModal, phoneNumberType = 'home' }) {
+function UpdatePhoneNumberError({ phoneNumberType = 'home' }) {
   return (
     <p>
       We’re sorry. We couldn’t update your direct deposit bank information
       because your {phoneNumberType} phone number is missing or invalid. Please
-      go back to{' '}
-      <a
-        href="/profile/#contact-information"
-        onClick={() => {
-          closeModal();
-        }}
-      >
-        your profile
-      </a>{' '}
-      and fill in this required information.
+      go back to <a href="/profile/personal-information">your profile</a> and
+      fill in this required information.
     </p>
   );
 }
 
-export default function PaymentInformationEditModalError({
+export default function PaymentInformationEditError({
   responseError,
   className,
-  closeModal = () => {},
 }) {
   let content = <GenericError error={responseError} />;
   let headline = 'We couldn’t update your bank information';
@@ -141,21 +125,11 @@ export default function PaymentInformationEditModalError({
     } else if (hasInvalidRoutingNumberError(errors)) {
       content = <InvalidRoutingNumber />;
     } else if (hasInvalidAddressError(errors)) {
-      content = <UpdateAddressError closeModal={closeModal} />;
+      content = <UpdateAddressError />;
     } else if (hasInvalidHomePhoneNumberError(errors)) {
-      content = (
-        <UpdatePhoneNumberError
-          closeModal={closeModal}
-          phoneNumberType="home"
-        />
-      );
+      content = <UpdatePhoneNumberError phoneNumberType="home" />;
     } else if (hasInvalidWorkPhoneNumberError(errors)) {
-      content = (
-        <UpdatePhoneNumberError
-          closeModal={closeModal}
-          phoneNumberType="work"
-        />
-      );
+      content = <UpdatePhoneNumberError phoneNumberType="work" />;
     }
   }
 

--- a/src/applications/personalization/profile/reducers/vaProfile.js
+++ b/src/applications/personalization/profile/reducers/vaProfile.js
@@ -97,13 +97,11 @@ function vaProfile(state = initialState, action) {
       );
     }
 
+    case EDU_PAYMENT_INFORMATION_SAVE_SUCCEEDED:
     case EDU_PAYMENT_INFORMATION_FETCH_SUCCEEDED: {
-      const newState = set('eduPaymentInformation', action.response, state);
-      return set('eduPaymentInformationUiState.isEditing', false, newState);
-    }
-
-    case EDU_PAYMENT_INFORMATION_SAVE_SUCCEEDED: {
-      return set('eduPaymentInformationUiState.isSaving', false, state);
+      let newState = set('eduPaymentInformation', action.response, state);
+      newState = set('eduPaymentInformationUiState.isEditing', false, newState);
+      return set('eduPaymentInformationUiState.isSaving', false, newState);
     }
 
     case EDU_PAYMENT_INFORMATION_EDIT_TOGGLED: {

--- a/src/applications/personalization/profile/tests/components/direct-deposit/PaymentInformationEditError.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/direct-deposit/PaymentInformationEditError.unit.spec.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
 
-import PaymentInformationEditModalError from '@@profile/components/direct-deposit/PaymentInformationEditModalError';
+import PaymentInformationEditError from '@@profile/components/direct-deposit/PaymentInformationEditError';
 
-describe('<PaymentInformationEditModalError />', () => {
+describe('<PaymentInformationEditError />', () => {
   const checksumError = {
     errors: [
       {
@@ -206,9 +206,7 @@ describe('<PaymentInformationEditModalError />', () => {
 
   it('renders', () => {
     const wrapper = shallow(
-      <PaymentInformationEditModalError
-        responseError={{ error: genericError }}
-      />,
+      <PaymentInformationEditError responseError={{ error: genericError }} />,
     );
     expect(wrapper.html()).to.not.be.empty;
     wrapper.unmount();
@@ -216,9 +214,7 @@ describe('<PaymentInformationEditModalError />', () => {
 
   it('renders the default error when it gets an unrecognized error message', () => {
     const wrapper = shallow(
-      <PaymentInformationEditModalError
-        responseError={{ error: genericError }}
-      />,
+      <PaymentInformationEditError responseError={{ error: genericError }} />,
     );
     expect(wrapper.html()).to.contain(
       'We’re sorry. We couldn’t update your payment information. Please try again later.',
@@ -228,9 +224,7 @@ describe('<PaymentInformationEditModalError />', () => {
 
   it('renders the invalid routing number error', () => {
     let wrapper = shallow(
-      <PaymentInformationEditModalError
-        responseError={{ error: checksumError }}
-      />,
+      <PaymentInformationEditError responseError={{ error: checksumError }} />,
     );
     expect(wrapper.html()).to.contain(
       'We couldn’t find a bank linked to this routing number. Please check your bank’s 9-digit routing number and enter it again.',
@@ -238,7 +232,7 @@ describe('<PaymentInformationEditModalError />', () => {
     wrapper.unmount();
 
     wrapper = shallow(
-      <PaymentInformationEditModalError
+      <PaymentInformationEditError
         responseError={{ error: invalidRoutingNumberError }}
       />,
     );
@@ -250,7 +244,7 @@ describe('<PaymentInformationEditModalError />', () => {
 
   it('renders the flagged/locked account error', () => {
     let wrapper = shallow(
-      <PaymentInformationEditModalError
+      <PaymentInformationEditError
         responseError={{ error: accountFlaggedError }}
       />,
     );
@@ -260,7 +254,7 @@ describe('<PaymentInformationEditModalError />', () => {
     wrapper.unmount();
 
     wrapper = shallow(
-      <PaymentInformationEditModalError
+      <PaymentInformationEditError
         responseError={{ error: restrictionIndicatorsPresentError }}
       />,
     );
@@ -272,7 +266,7 @@ describe('<PaymentInformationEditModalError />', () => {
 
   it('renders the flagged routing number error', () => {
     const wrapper = shallow(
-      <PaymentInformationEditModalError
+      <PaymentInformationEditError
         responseError={{ error: routingNumberFlaggedError }}
       />,
     );
@@ -284,41 +278,41 @@ describe('<PaymentInformationEditModalError />', () => {
 
   it('renders an error message prompting the user to update their address', () => {
     const wrapper = shallow(
-      <PaymentInformationEditModalError
+      <PaymentInformationEditError
         responseError={{ error: badAddressError }}
       />,
     );
     expect(wrapper.html()).to.contain(
-      'We’re sorry. We couldn’t update your direct deposit bank information because your mailing address is missing or invalid. Please go back to <a href="/profile/#contact-information">your profile</a> and fill in this required information.',
+      'We’re sorry. We couldn’t update your direct deposit bank information because your mailing address is missing or invalid. Please go back to <a href="/profile/personal-information">your profile</a> and fill in this required information.',
     );
     wrapper.unmount();
   });
 
   it('renders the bad phone number error messages', () => {
     let wrapper = shallow(
-      <PaymentInformationEditModalError
+      <PaymentInformationEditError
         responseError={{ error: badWorkPhoneNumberError }}
       />,
     );
     expect(wrapper.html()).to.contain(
-      'We’re sorry. We couldn’t update your direct deposit bank information because your work phone number is missing or invalid. Please go back to <a href="/profile/#contact-information">your profile</a> and fill in this required information.',
+      'We’re sorry. We couldn’t update your direct deposit bank information because your work phone number is missing or invalid. Please go back to <a href="/profile/personal-information">your profile</a> and fill in this required information.',
     );
     wrapper.unmount();
 
     wrapper = shallow(
-      <PaymentInformationEditModalError
+      <PaymentInformationEditError
         responseError={{ error: badHomeAreaCodeError }}
       />,
     );
     expect(wrapper.html()).to.contain(
-      'We’re sorry. We couldn’t update your direct deposit bank information because your home phone number is missing or invalid. Please go back to <a href="/profile/#contact-information">your profile</a> and fill in this required information.',
+      'We’re sorry. We couldn’t update your direct deposit bank information because your home phone number is missing or invalid. Please go back to <a href="/profile/personal-information">your profile</a> and fill in this required information.',
     );
     wrapper.unmount();
   });
 
   it('renders the default error when an upstream error occurs', () => {
     const wrapper = shallow(
-      <PaymentInformationEditModalError responseError={upstreamError} />,
+      <PaymentInformationEditError responseError={upstreamError} />,
     );
     expect(wrapper.html()).to.contain(
       'We’re sorry. We couldn’t update your payment information. Please try again later.',


### PR DESCRIPTION
## Description
- stop directing people to the old contact info URL (the Profile still supported this old URL but since Profile v1 is long dead this was due for an update)
- stop using "modal" in the name of the error alert
- we also do not need the optional `closeModal` callback anymore

In addition to this cleanup, this PR also updates the DD4EDU reducer logic to update the current bank info after a successful update call. The API doesn't actually return the required data yet, [but it will](https://github.com/department-of-veterans-affairs/va.gov-team/issues/17292).

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs