### PR TITLE
update facility not listed wording

### DIFF
--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesNotShown.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesNotShown.jsx
@@ -104,7 +104,9 @@ export default function FacilitiesNotShown({
               </li>
             ))}
           </ul>
-          <strong>What you can do</strong>
+          <h3 className="vads-u-font-size--h4 vads-u-margin-top--2 vads-u-margin-bottom--1">
+            What you can do
+          </h3>
           <p className="vads-u-margin-top--4">
             Call the facility directly to schedule your appointment,{' '}
             <strong>or </strong>

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesNotShown.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesNotShown.jsx
@@ -107,7 +107,7 @@ export default function FacilitiesNotShown({
           <h3 className="vads-u-font-size--h4 vads-u-margin-top--2 vads-u-margin-bottom--1">
             What you can do
           </h3>
-          <p className="vads-u-margin-top--4">
+          <p className="vads-u-margin-top--0">
             Call the facility directly to schedule your appointment,{' '}
             <strong>or </strong>
             <a

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesNotShown.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesNotShown.jsx
@@ -77,8 +77,7 @@ export default function FacilitiesNotShown({
         {trigger}
         <div className="additional-info-content">
           <p id="vaos-unsupported-label">
-            Some facilities don’t offer online scheduling. You can call them
-            directly to schedule your appointment.
+            The facilities below don’t offer online scheduling for this care.
           </p>
           <ul
             className="usa-unstyled-list"
@@ -105,7 +104,10 @@ export default function FacilitiesNotShown({
               </li>
             ))}
           </ul>
+          <strong>What you can do</strong>
           <p className="vads-u-margin-top--4">
+            Call the facility directly to schedule your appointment,{' '}
+            <strong>or </strong>
             <a
               href="/find-locations"
               target="_blank"
@@ -116,8 +118,9 @@ export default function FacilitiesNotShown({
                 })
               }
             >
-              Or, find a different VA location
+              search for a different VA location
             </a>
+            .
           </p>
         </div>
       </ExpandingGroup>


### PR DESCRIPTION
## Description
On the Facility Selection page, update copy to clarify online scheduling isn't currently available for specific type of care.

## Testing done
Local and Unit

## Screenshots
<img width="460" alt="Screen Shot 2020-12-22 at 3 45 01 PM" src="https://user-images.githubusercontent.com/8315447/102931995-79c4d980-446d-11eb-900e-f7fdd0e03b39.png">
<img width="644" alt="Screen Shot 2020-12-22 at 3 45 09 PM" src="https://user-images.githubusercontent.com/8315447/102932005-7df0f700-446d-11eb-81b0-cc5e4f1e9d09.png">
<img width="258" alt="Screen Shot 2020-12-22 at 3 46 09 PM" src="https://user-images.githubusercontent.com/8315447/102932011-7fbaba80-446d-11eb-852e-afac57902161.png">
<img width="258" alt="Screen Shot 2020-12-22 at 3 46 19 PM" src="https://user-images.githubusercontent.com/8315447/102932014-81847e00-446d-11eb-8ff3-14f57fcc0a36.png">

## Acceptance criteria
- [ ]  DESIGN - All desktop, tablet, and mobile designs match the specs:
Mobile: https://adhoc.invisionapp.com/share/W8ZLYPI2S53#/screens/439374108
Tablet/Desktop: https://adhoc.invisionapp.com/share/W8ZLYPI2S53#/screens/439625520
- [ ] Intro copy displays above the list
`The facilities below don’t offer online scheduling for this care.`
- [ ] Additional copy displays below the facility list
`What you can do
Call the facility directly to schedule your appointment, or search for a different VA location.`
- [ ] "search for a different VA location" links to Facility Locator and opens in a new tab

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
