### PR TITLE
First draft of DD4EDU working

### DIFF
--- a/src/applications/personalization/profile/actions/paymentInformation.js
+++ b/src/applications/personalization/profile/actions/paymentInformation.js
@@ -252,10 +252,10 @@ export function saveEDUPaymentInformation(
       });
       dispatch({
         type: EDU_PAYMENT_INFORMATION_SAVE_SUCCEEDED,
-        response,
+        response: {
+          paymentAccount: response,
+        },
       });
-      // TODO: we might need to immediately fetch the updated bank info here
-      // since that is not part of the response after a successful save
     }
   };
 }

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
@@ -164,7 +164,7 @@ export const DirectDepositEDU = ({
   const notEligibleContent = (
     <>
       <p className="vads-u-margin-top--0">
-        Our records show that you‘re not receiving education benefit payments.
+        Our records show that you’re not receiving education benefit payments.
         If you think this is an error, please call us at{' '}
         <Telephone contact={CONTACTS.VA_BENEFITS} />.
       </p>
@@ -174,7 +174,7 @@ export const DirectDepositEDU = ({
           rel="noopener noreferrer"
           href="https://www.va.gov/education/eligibility/"
         >
-          Find out if you‘re eligible for VA education benefits
+          Find out if you’re eligible for VA education benefits
         </a>
       </p>
     </>

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
@@ -330,7 +330,7 @@ DirectDepositEDU.propTypes = {
   directDepositAccountInfo: PropTypes.shape({
     accountNumber: PropTypes.string.isRequired,
     accountType: PropTypes.string.isRequired,
-    financialInstitutionName: PropTypes.string,
+    financialInstitutionName: PropTypes.string.isRequired,
     financialInstitutionRoutingNumber: PropTypes.string.isRequired,
   }),
   isDirectDepositSetUp: PropTypes.bool.isRequired,

--- a/src/applications/personalization/profile/components/direct-deposit/DirectDepositV2.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/DirectDepositV2.jsx
@@ -83,7 +83,7 @@ const DirectDeposit = ({ cnpUiState, eduUiState }) => {
         >
           {!!recentlySavedBankInfo && (
             <AlertBox
-              status="success"
+              status={ALERT_TYPE.SUCCESS}
               backgroundOnly
               className="vads-u-margin-top--0 vads-u-margin-bottom--2"
               scrollOnShow

--- a/src/applications/personalization/profile/components/direct-deposit/DirectDepositV2.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/DirectDepositV2.jsx
@@ -33,6 +33,12 @@ const DirectDeposit = ({ cnpUiState, eduUiState }) => {
   const wasSavingEDUBankInfo = usePrevious(eduUiState.isSaving);
   const eduSaveError = eduUiState.responseError;
 
+  const removeBankInfoUpdatedAlert = () => {
+    setTimeout(() => {
+      setRecentlySavedBankInfo('');
+    }, 6000);
+  };
+
   React.useEffect(() => {
     focusElement('[data-focus-target]');
     document.title = `Direct Deposit | Veterans Affairs`;
@@ -43,9 +49,7 @@ const DirectDeposit = ({ cnpUiState, eduUiState }) => {
     () => {
       if (wasSavingCNPBankInfo && !isSavingCNPBankInfo && !cnpSaveError) {
         setRecentlySavedBankInfo('compensation and pension benefits');
-        setTimeout(() => {
-          setRecentlySavedBankInfo('');
-        }, 6000);
+        removeBankInfoUpdatedAlert();
       }
     },
     [wasSavingCNPBankInfo, isSavingCNPBankInfo, cnpSaveError],
@@ -56,9 +60,7 @@ const DirectDeposit = ({ cnpUiState, eduUiState }) => {
     () => {
       if (wasSavingEDUBankInfo && !isSavingEDUBankInfo && !eduSaveError) {
         setRecentlySavedBankInfo('education benefits');
-        setTimeout(() => {
-          setRecentlySavedBankInfo('');
-        }, 6000);
+        removeBankInfoUpdatedAlert();
       }
     },
     [wasSavingEDUBankInfo, isSavingEDUBankInfo, eduSaveError],

--- a/src/applications/personalization/profile/components/direct-deposit/DirectDepositV2.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/DirectDepositV2.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
-import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import AlertBox, {
+  ALERT_TYPE,
+} from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 import DowntimeNotification, {
   externalServices,
@@ -79,9 +81,9 @@ const DirectDeposit = () => {
       >
         <BankInfoCNPv2 />
       </DowntimeNotification>
+      <FraudVictimAlert status={ALERT_TYPE.INFO} />
       <BankInfoEDU />
       <PaymentHistory />
-      <FraudVictimAlert />
     </>
   );
 };

--- a/src/applications/personalization/profile/components/direct-deposit/DirectDepositV2.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/DirectDepositV2.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 import AlertBox, {
   ALERT_TYPE,
@@ -6,8 +7,14 @@ import AlertBox, {
 
 import DowntimeNotification, {
   externalServices,
-} from 'platform/monitoring/DowntimeNotification';
-import { focusElement } from 'platform/utilities/ui';
+} from '~/platform/monitoring/DowntimeNotification';
+import { focusElement } from '~/platform/utilities/ui';
+import { usePrevious } from '~/platform/utilities/react-hooks';
+
+import {
+  cnpDirectDepositUiState,
+  eduDirectDepositUiState,
+} from '@@profile/selectors';
 
 import { handleDowntimeForSection } from '../alerts/DowntimeBanner';
 
@@ -16,31 +23,46 @@ import PaymentHistory from './PaymentHistory';
 import BankInfoCNPv2 from './BankInfoCNPv2';
 import BankInfoEDU from './BankInfoEDU';
 
-const DirectDeposit = () => {
-  // const [showSaveSucceededAlert, setShowSaveSucceededAlert] = React.useState(
-  //   false,
-  // );
+const DirectDeposit = ({ cnpUiState, eduUiState }) => {
+  const [recentlySavedBankInfo, setRecentlySavedBankInfo] = React.useState('');
 
-  // const isSavingBankInfo = directDepositUiState.isSaving;
-  // const wasSavingBankInfo = usePrevious(directDepositUiState.isSaving);
+  const isSavingCNPBankInfo = cnpUiState.isSaving;
+  const wasSavingCNPBankInfo = usePrevious(cnpUiState.isSaving);
+  const cnpSaveError = cnpUiState.responseError;
+  const isSavingEDUBankInfo = eduUiState.isSaving;
+  const wasSavingEDUBankInfo = usePrevious(eduUiState.isSaving);
+  const eduSaveError = eduUiState.responseError;
 
   React.useEffect(() => {
     focusElement('[data-focus-target]');
     document.title = `Direct Deposit | Veterans Affairs`;
   }, []);
 
-  // show the user a success alert after their bank info has saved
-  // React.useEffect(
-  //   () => {
-  //     if (wasSavingBankInfo && !isSavingBankInfo && !saveError) {
-  //       setShowSaveSucceededAlert(true);
-  //       setTimeout(() => {
-  //         setShowSaveSucceededAlert(false);
-  //       }, 6000);
-  //     }
-  //   },
-  //   [wasSavingBankInfo, isSavingBankInfo, saveError],
-  // );
+  // show the user a success alert after their CNP bank info has saved
+  React.useEffect(
+    () => {
+      if (wasSavingCNPBankInfo && !isSavingCNPBankInfo && !cnpSaveError) {
+        setRecentlySavedBankInfo('compensation and pension benefits');
+        setTimeout(() => {
+          setRecentlySavedBankInfo('');
+        }, 6000);
+      }
+    },
+    [wasSavingCNPBankInfo, isSavingCNPBankInfo, cnpSaveError],
+  );
+
+  // show the user a success alert after their EDU bank info has saved
+  React.useEffect(
+    () => {
+      if (wasSavingEDUBankInfo && !isSavingEDUBankInfo && !eduSaveError) {
+        setRecentlySavedBankInfo('education benefits');
+        setTimeout(() => {
+          setRecentlySavedBankInfo('');
+        }, 6000);
+      }
+    },
+    [wasSavingEDUBankInfo, isSavingEDUBankInfo, eduSaveError],
+  );
 
   return (
     <>
@@ -59,16 +81,18 @@ const DirectDeposit = () => {
           transitionEnterTimeout={500}
           transitionLeaveTimeout={500}
         >
-          {/* TODO: only show this if we just completed an update */}
-          <AlertBox
-            status="success"
-            backgroundOnly
-            className="vads-u-margin-top--0 vads-u-margin-bottom--2"
-            scrollOnShow
-          >
-            We’ve updated your bank account information for your{' '}
-            <strong>compensation and pension benefits</strong>
-          </AlertBox>
+          {!!recentlySavedBankInfo && (
+            <AlertBox
+              status="success"
+              backgroundOnly
+              className="vads-u-margin-top--0 vads-u-margin-bottom--2"
+              scrollOnShow
+            >
+              We’ve updated your bank account information for your{' '}
+              <strong>{recentlySavedBankInfo}</strong> and your next payment
+              will go to your new account.
+            </AlertBox>
+          )}
         </ReactCSSTransitionGroup>
       </div>
 
@@ -88,4 +112,11 @@ const DirectDeposit = () => {
   );
 };
 
-export default DirectDeposit;
+const mapStateToProps = state => {
+  return {
+    cnpUiState: cnpDirectDepositUiState(state),
+    eduUiState: eduDirectDepositUiState(state),
+  };
+};
+
+export default connect(mapStateToProps)(DirectDeposit);

--- a/src/applications/personalization/profile/components/direct-deposit/FraudVictimAlert.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/FraudVictimAlert.jsx
@@ -7,7 +7,7 @@ import Telephone, {
   PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
-const FraudVictimAlert = ({ status = ALERT_TYPE.CONTIUNE }) => (
+const FraudVictimAlert = ({ status = ALERT_TYPE.CONTINUE }) => (
   <AlertBox
     className="vads-u-margin-y--2 medium-screen:vads-u-margin-y--4"
     backgroundOnly

--- a/src/applications/personalization/profile/components/direct-deposit/FraudVictimAlert.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/FraudVictimAlert.jsx
@@ -1,14 +1,17 @@
 import React from 'react';
-import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import AlertBox, {
+  ALERT_TYPE,
+} from '@department-of-veterans-affairs/formation-react/AlertBox';
 import Telephone, {
   CONTACTS,
   PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
-const FraudVictimAlert = () => (
+const FraudVictimAlert = ({ status = ALERT_TYPE.CONTIUNE }) => (
   <AlertBox
     className="vads-u-margin-y--2 medium-screen:vads-u-margin-y--4"
     backgroundOnly
+    status={status}
   >
     <strong>Note:</strong> If you think you’ve been the victim of bank fraud,
     please call us at{' '}


### PR DESCRIPTION
## Description
Note: this will _not_ work fully until the API has been updated.

- the bank name will not show up in the DD4EDU section until https://github.com/department-of-veterans-affairs/va.gov-team/issues/17294 has been completed.
- bank info updates will likely crash the up until https://github.com/department-of-veterans-affairs/va.gov-team/issues/17292 has been completed.

## Testing done
Local. Will be adding Cypress tests to ensure:
- the Direct Deposit section is shown and hidden when this new feature is enabled. We already have good coverage for this, but the logic has changed as we will need to also show the Direct Deposit section when the user is _not_ eligible for DD4CNP but they do have DD4EDU set up.
- the "not eligible" state is shown correctly
- bank info updates are handled correctly (both happy and sad path)

## Screenshots
This GIF was recorded in Safari while mocking the response from the GET and PUT calls to `ch33_bank_accounts`. It shows:
- the Direct Deposit section shows both CNP and EDU bank info
- updates to EDU bank info works when the endpoint responds correctly and the success alert is shown at the top of the screen
- updates to the CNP bank info still works

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs