### PR TITLE
17884 data layer updates

### DIFF
--- a/src/applications/static-pages/vre-chapter31/Chapter31CTA.js
+++ b/src/applications/static-pages/vre-chapter31/Chapter31CTA.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
+import recordEvent from 'platform/monitoring/record-event';
 
 import Chapter31Content from './buildChapter31Content';
 
@@ -15,8 +16,16 @@ const Chapter31CTA = props => {
   if (props.includedInFlipper === undefined) {
     content = <LoadingIndicator message="Loading..." />;
   } else if (props.includedInFlipper === false) {
+    recordEvent({
+      event: 'phased-roll-out-disabled',
+      'product-description': 'Chapter 31',
+    });
     content = <Chapter31Content page={currentURL[5]} track={currentURL[6]} />;
   } else {
+    recordEvent({
+      event: 'phased-roll-out-enabled',
+      'product-description': 'Chapter 31',
+    });
     content = (
       <>
         <a

--- a/src/applications/static-pages/vre-chapter36/Chapter36CTA.js
+++ b/src/applications/static-pages/vre-chapter36/Chapter36CTA.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
-
+import recordEvent from 'platform/monitoring/record-event';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 
 import EbenefitsLink from 'platform/site-wide/ebenefits/containers/EbenefitsLink';
@@ -31,6 +31,10 @@ const Chapter36CTA = props => {
   if (props.includedInFlipper === undefined) {
     content = <LoadingIndicator message="Loading..." />;
   } else if (props.includedInFlipper === false) {
+    recordEvent({
+      event: 'phased-roll-out-disabled',
+      'product-description': 'Chapter 36',
+    });
     content = (
       <>
         {header}
@@ -89,6 +93,10 @@ const Chapter36CTA = props => {
       </>
     );
   } else {
+    recordEvent({
+      event: 'phased-roll-out-enabled',
+      'product-description': 'Chapter 36',
+    });
     content = (
       <>
         {!isEducationAndCareerPage ? <h2>How do I apply?</h2> : null}

--- a/src/applications/vre/28-1900/config/form.js
+++ b/src/applications/vre/28-1900/config/form.js
@@ -18,7 +18,7 @@ const formConfig = {
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
   submitUrl: `${environment.API_URL}/v0/veteran_readiness_employment_claims`,
-  trackingPrefix: '28-1900-chapter-31-',
+  trackingPrefix: 'careers-employment-28-1900--',
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
   preSubmitInfo: PreSubmitInfo,

--- a/src/applications/vre/28-8832/config/form.js
+++ b/src/applications/vre/28-8832/config/form.js
@@ -25,7 +25,7 @@ const formConfig = {
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
   submitUrl: `${environment.API_URL}/v0/education_career_counseling_claims`,
-  trackingPrefix: '28-8832-planning-and-career-guidance-',
+  trackingPrefix: 'careers-employment-28-8832--',
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
   transformForSubmit: transform,


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/17884)

This PR is to make a few updates to the analytics data layer for CH31 and CH36. The updates are 

- Two new events that need to be fired for each CH31 and CH36 when the flipper toggle is flipped to tell what group the user is in.
- Updates to the tracking prefixes for the CH31 and CH36 forms 

## Testing done
tested locally using dataSlayer in firefox

## Screenshots

<img width="437" alt="Screen Shot 2020-12-28 at 1 58 10 PM" src="https://user-images.githubusercontent.com/1899695/103245358-c64c6100-4914-11eb-80fc-79755125d930.png">

<img width="438" alt="Screen Shot 2020-12-28 at 1 56 22 PM" src="https://user-images.githubusercontent.com/1899695/103245363-cba9ab80-4914-11eb-9082-528376dff4dc.png">

## Acceptance criteria
- [x] Make the above changes to the data layers for CH36 and CH31
- [x] Submit a PR for the changes
