### PR TITLE
Always deploy to dev + staging at the end of a build on the main branch

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -45,8 +45,7 @@ def isReviewable() {
 def isDeployable() {
   return (IS_DEV_BRANCH ||
           IS_STAGING_BRANCH) &&
-    !env.CHANGE_TARGET &&
-    !currentBuild.nextBuild // if there's a later build on this job (branch), don't deploy
+    !env.CHANGE_TARGET
 }
 
 def shouldBail() {


### PR DESCRIPTION
## Description
Our CI takes longer to run during busy days (close to an hour) and our CI has logic to cancel deploys to dev/staging if there is a later build running on master than the current build. This causes dev/staging to go long periods of time without a deployment, sometimes all day, and is confusing for the team.

Since dev/staging deploys are much faster than they use to be (reducing cost of resources and risk of race conditions) and the change itself is trivial, this PR changes that behavior to always deploy to dev/staging at the end of a master build, regardless of if there is a later master build than the current.

## Testing done
This affects CI so is not easily testable 

## Screenshots
N/A

## Acceptance criteria
- [ ] Dev/staging are updated more often

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
