### PR TITLE
Add missing webpackChunkName magic comments

### DIFF
--- a/src/applications/find-forms/createFindVaForms.js
+++ b/src/applications/find-forms/createFindVaForms.js
@@ -16,8 +16,8 @@ export default (store, widgetType) => {
     return;
   }
 
-  // webpackChunkName: "find-va-forms"
-  import('./find-va-forms-entry').then(module => {
+  import(/* webpackChunkName: "find-va-forms" */
+  './find-va-forms-entry').then(module => {
     const { FindVaForms } = module.default;
     ReactDOM.render(
       <Provider store={store}>

--- a/src/applications/health-care-questionnaire/list/api/index.js
+++ b/src/applications/health-care-questionnaire/list/api/index.js
@@ -9,9 +9,11 @@ const loadQuestionnaires = async () => {
   if (USE_MOCK_DATA) {
     promise = new Promise(resolve => {
       setTimeout(() => {
-        import('./my-questionnaires.sample.json').then(module => {
-          resolve(module.default);
-        });
+        import(/* webpackChunkName: "my-questionnaires-sample-json" */ './my-questionnaires.sample.json').then(
+          module => {
+            resolve(module.default);
+          },
+        );
       }, 1000);
     });
   } else {

--- a/src/applications/health-care-questionnaire/questionnaire/api/index.js
+++ b/src/applications/health-care-questionnaire/questionnaire/api/index.js
@@ -8,11 +8,9 @@ const loadAppointment = async () => {
   if (USE_MOCK_DATA) {
     promise = new Promise(resolve => {
       setTimeout(() => {
-        import(/* webpackChunkName: "appointment-data" */ './appointment-data.json').then(
-          module => {
-            resolve(module.default);
-          },
-        );
+        import('./appointment-data.json').then(module => {
+          resolve(module.default);
+        });
       }, 0);
     });
   } else {

--- a/src/applications/health-care-questionnaire/questionnaire/api/index.js
+++ b/src/applications/health-care-questionnaire/questionnaire/api/index.js
@@ -8,9 +8,11 @@ const loadAppointment = async () => {
   if (USE_MOCK_DATA) {
     promise = new Promise(resolve => {
       setTimeout(() => {
-        import('./appointment-data.json').then(module => {
-          resolve(module.default);
-        });
+        import(/* webpackChunkName: "appointment-data" */ './appointment-data.json').then(
+          module => {
+            resolve(module.default);
+          },
+        );
       }, 0);
     });
   } else {

--- a/src/applications/personalization/dashboard-2/components/DashboardWrapper.jsx
+++ b/src/applications/personalization/dashboard-2/components/DashboardWrapper.jsx
@@ -6,10 +6,10 @@ import localStorage from 'platform/utilities/storage/localStorage';
 import { selectShowDashboard2 } from '../selectors';
 
 const DashboardV1 = React.lazy(() => {
-  return import('../../dashboard/components/Dashboard');
+  return import(/* webpackChunkName: "dashboard-1" */ '../../dashboard/components/Dashboard');
 });
 const DashboardV2 = React.lazy(() => {
-  return import('./Dashboard');
+  return import(/* webpackChunkName: "dashboard-2" */ './Dashboard');
 });
 
 // The root component for the My VA Dashboard app that lives at /my-va

--- a/src/applications/post-911-gib-status/createPost911GiBillStatusWidget.jsx
+++ b/src/applications/post-911-gib-status/createPost911GiBillStatusWidget.jsx
@@ -16,14 +16,15 @@ export default (store, widgetType) => {
     return;
   }
 
-  // webpackChunkName: "gibs-status-availability-widget"
-  import('./containers/ServiceAvailabilityBanner').then(module => {
-    const ServiceAvailabilityBanner = module.default;
-    ReactDOM.render(
-      <Provider store={store}>
-        <ServiceAvailabilityBanner />
-      </Provider>,
-      root,
-    );
-  });
+  import(/* webpackChunkName: "gibs-status-availability-widget" */ './containers/ServiceAvailabilityBanner').then(
+    module => {
+      const ServiceAvailabilityBanner = module.default;
+      ReactDOM.render(
+        <Provider store={store}>
+          <ServiceAvailabilityBanner />
+        </Provider>,
+        root,
+      );
+    },
+  );
 };

--- a/src/applications/static-pages/view-payment-history/createViewPaymentHistoryCTA.js
+++ b/src/applications/static-pages/view-payment-history/createViewPaymentHistoryCTA.js
@@ -6,14 +6,16 @@ import { Provider } from 'react-redux';
 export default function createViewPaymentHistoryCTA(store, widgetType) {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
   if (root) {
-    import('./ViewPaymentHistoryCTA').then(module => {
-      const ViewPaymentHistoryCTA = module.default;
-      ReactDOM.render(
-        <Provider store={store}>
-          <ViewPaymentHistoryCTA />
-        </Provider>,
-        root,
-      );
-    });
+    import(/* webpackChunkName: "view-payment-history-cta" */ './ViewPaymentHistoryCTA').then(
+      module => {
+        const ViewPaymentHistoryCTA = module.default;
+        ReactDOM.render(
+          <Provider store={store}>
+            <ViewPaymentHistoryCTA />
+          </Provider>,
+          root,
+        );
+      },
+    );
   }
 }

--- a/src/applications/static-pages/vre-chapter31/createChapter31CTA.js
+++ b/src/applications/static-pages/vre-chapter31/createChapter31CTA.js
@@ -6,14 +6,16 @@ import { Provider } from 'react-redux';
 export default function createChapter31CTA(store, widgetType) {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
   if (root) {
-    import('./Chapter31CTA').then(module => {
-      const Chapter31CTA = module.default;
-      ReactDOM.render(
-        <Provider store={store}>
-          <Chapter31CTA />
-        </Provider>,
-        root,
-      );
-    });
+    import(/* webpackChunkName: "chapter-31-cta" */ './Chapter31CTA').then(
+      module => {
+        const Chapter31CTA = module.default;
+        ReactDOM.render(
+          <Provider store={store}>
+            <Chapter31CTA />
+          </Provider>,
+          root,
+        );
+      },
+    );
   }
 }

--- a/src/applications/static-pages/vre-chapter36/createChapter36CTA.js
+++ b/src/applications/static-pages/vre-chapter36/createChapter36CTA.js
@@ -6,14 +6,16 @@ import { Provider } from 'react-redux';
 export default function createChapter36CTA(store, widgetType) {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
   if (root) {
-    import('./Chapter36CTA').then(module => {
-      const Chapter36CTA = module.default;
-      ReactDOM.render(
-        <Provider store={store}>
-          <Chapter36CTA />
-        </Provider>,
-        root,
-      );
-    });
+    import(/* webpackChunkName: "chapter-36-cta" */ './Chapter36CTA').then(
+      module => {
+        const Chapter36CTA = module.default;
+        ReactDOM.render(
+          <Provider store={store}>
+            <Chapter36CTA />
+          </Provider>,
+          root,
+        );
+      },
+    );
   }
 }

--- a/src/applications/third-party-app-directory/createThirdPartyApps.js
+++ b/src/applications/third-party-app-directory/createThirdPartyApps.js
@@ -15,14 +15,15 @@ export default (store, widgetType) => {
     return;
   }
 
-  // webpackChunkName: "third-party-app-directory"
-  import('./third-party-apps-entry').then(module => {
-    const { App } = module.default;
-    ReactDOM.render(
-      <Provider store={store}>
-        <App />
-      </Provider>,
-      root,
-    );
-  });
+  import(/* webpackChunkName: "third-party-app-directory" */ './third-party-apps-entry').then(
+    module => {
+      const { App } = module.default;
+      ReactDOM.render(
+        <Provider store={store}>
+          <App />
+        </Provider>,
+        root,
+      );
+    },
+  );
 };

--- a/src/applications/vaos/services/utils.js
+++ b/src/applications/vaos/services/utils.js
@@ -53,7 +53,8 @@ export async function apiRequestWithMocks(url, options, ...rest) {
   /* istanbul ignore if  */
   if (USE_MOCK_DATA) {
     // This needs to be lazy loaded to keep it out of the main bundle
-    const handlers = (await import('./mocks')).default;
+    const handlers = (await import(/* webpackChunkName: "mocks" */ './mocks'))
+      .default;
 
     // find a matching handler by method and path checks
     const match = handlers.find(handler => {

--- a/src/applications/vaos/services/utils.js
+++ b/src/applications/vaos/services/utils.js
@@ -53,8 +53,7 @@ export async function apiRequestWithMocks(url, options, ...rest) {
   /* istanbul ignore if  */
   if (USE_MOCK_DATA) {
     // This needs to be lazy loaded to keep it out of the main bundle
-    const handlers = (await import(/* webpackChunkName: "mocks" */ './mocks'))
-      .default;
+    const handlers = (await import('./mocks')).default;
 
     // find a matching handler by method and path checks
     const match = handlers.find(handler => {


### PR DESCRIPTION
## Description

Add/update `webpackChunkName` [magic comments](https://webpack.js.org/api/module-methods/#magic-comments)

### More context

Webpack supports "magic comments."

>Inline comments to make features work. By adding comments to the import, we can do things such as name our chunk or select different modes.  - https://webpack.js.org/api/module-methods/#magic-comments

While inspecting the webpack build, I noticed there were some bundle files that had unintuitive names, like (`0.entry.js`, `1.entry.js`, `2.entry.js`, `3.entry.js`). We already use the `webpackChunkName` magic comment for some dynamic imports, and this PR adds/updates the `webpackChunkName` to some dynamic imports. 

## Testing done

CI

## Links

- https://dsva.slack.com/archives/CQH357ZTP/p1600876610006000
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/8983

## Acceptance criteria
- [x] CI passes
- [ ] bundle filenames are updated from unintuitive names like `1.entry.js` to `dashboard.entry.js`

## Definition of done
- [ ] Documentation has been updated, if applicable
