### PR TITLE
[17725] Fix calendar min-width wrapping

### DIFF
--- a/src/applications/vaos/new-appointment/sass/_calendar.scss
+++ b/src/applications/vaos/new-appointment/sass/_calendar.scss
@@ -74,7 +74,7 @@
   background-color: $color-gray-lightest;
   border: 1px solid $color-gray-medium;
   border-radius: 5px;
-  padding: 5px;
+  padding: 12px;
   margin: 0;
 
   &:hover {

--- a/src/applications/vaos/new-appointment/sass/_calendar.scss
+++ b/src/applications/vaos/new-appointment/sass/_calendar.scss
@@ -74,7 +74,7 @@
   background-color: $color-gray-lightest;
   border: 1px solid $color-gray-medium;
   border-radius: 5px;
-  padding: 12px;
+  padding: 5px;
   margin: 0;
 
   &:hover {
@@ -102,7 +102,7 @@
 }
 
 .vaos-calendar__nav h2 {
-  min-width: 245px;
+  white-space: nowrap;
 }
 
 .vaos-calendar__nav-links-button {


### PR DESCRIPTION
## Description
The calendar is being cut off by the browser window at ~340px. Our smallest breakpoint is 320px so we should support that at a minimum.
Saw this on staging, Chrome Version 87.0.4280.88 (Official Build) (x86_64), zoom level 100%, cache cleared.

## Testing done
Visual responsive browser testing

## Screenshots
![image](https://user-images.githubusercontent.com/8315447/103315354-53fe7e00-49f3-11eb-87bc-58fd601f3876.png)
![image](https://user-images.githubusercontent.com/8315447/103315363-5b258c00-49f3-11eb-9ea9-eeccd07cb829.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
