### PR TITLE
Fix for incorrect MHV URL when presented alongside Cerner URL

### DIFF
--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
@@ -9,8 +9,13 @@ import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
 import { selectPatientFacilities } from 'platform/user/selectors';
+import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 
-export const App = ({ facilities, showNewGetMedicalRecordsPage }) => {
+export const App = ({
+  facilities,
+  showNewGetMedicalRecordsPage,
+  authenticatedWithSSOe,
+}) => {
   if (!showNewGetMedicalRecordsPage) {
     return <LegacyContent />;
   }
@@ -22,6 +27,7 @@ export const App = ({ facilities, showNewGetMedicalRecordsPage }) => {
       <AuthContent
         cernerFacilities={cernerFacilities}
         otherFacilities={otherFacilities}
+        authenticatedWithSSOe={authenticatedWithSSOe}
       />
     );
   }
@@ -47,6 +53,7 @@ App.propTypes = {
 
 const mapStateToProps = state => ({
   facilities: selectPatientFacilities(state),
+  authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
   showNewGetMedicalRecordsPage:
     state?.featureToggles?.[featureFlagNames.showNewGetMedicalRecordsPage],
 });

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
@@ -37,6 +37,7 @@ export const App = ({
 
 App.propTypes = {
   // From mapStateToProps.
+  authenticatedWithSSOe: PropTypes.bool,
   facilities: PropTypes.arrayOf(
     PropTypes.shape({
       facilityId: PropTypes.string.isRequired,

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.js
@@ -325,6 +325,7 @@ const AuthContent = ({
 );
 
 AuthContent.propTypes = {
+  authenticatedWithSSOe: PropTypes.bool.isRequired,
   cernerfacilities: PropTypes.arrayOf(
     PropTypes.shape({
       facilityId: PropTypes.string.isRequired,

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.js
@@ -7,8 +7,13 @@ import Telephone, {
 // Relative imports.
 import CernerCallToAction from '../../../components/CernerCallToAction';
 import { getCernerURL } from 'platform/utilities/cerner';
+import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 
-const AuthContent = ({ cernerFacilities, otherFacilities }) => (
+const AuthContent = ({
+  authenticatedWithSSOe,
+  cernerFacilities,
+  otherFacilities,
+}) => (
   <>
     <h2 className="vads-u-margin-bottom--2 vads-u-font-size--lg">
       On this page:
@@ -28,7 +33,7 @@ const AuthContent = ({ cernerFacilities, otherFacilities }) => (
       cernerFacilities={cernerFacilities}
       otherFacilities={otherFacilities}
       linksHeaderText="Get your medical records from:"
-      myHealtheVetLink="https://sqa.eauth.va.gov/mhv-portal-web/eauth?deeplinking=download_my_data"
+      myHealtheVetLink={mhvUrl(authenticatedWithSSOe, 'download-my-data')}
       myVAHealthLink={getCernerURL(
         '/pages/health_record/clinical_documents/sharing',
       )}

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.js
@@ -9,8 +9,13 @@ import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
 import { selectPatientFacilities } from 'platform/user/selectors';
+import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 
-export const App = ({ facilities, showNewRefillTrackPrescriptionsPage }) => {
+export const App = ({
+  facilities,
+  showNewRefillTrackPrescriptionsPage,
+  authenticatedWithSSOe,
+}) => {
   if (!showNewRefillTrackPrescriptionsPage) {
     return <LegacyContent />;
   }
@@ -22,6 +27,7 @@ export const App = ({ facilities, showNewRefillTrackPrescriptionsPage }) => {
       <AuthContent
         cernerFacilities={cernerFacilities}
         otherFacilities={otherFacilities}
+        authenticatedWithSSOe={authenticatedWithSSOe}
       />
     );
   }
@@ -47,6 +53,7 @@ App.propTypes = {
 
 const mapStateToProps = state => ({
   facilities: selectPatientFacilities(state),
+  authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
   showNewRefillTrackPrescriptionsPage:
     state?.featureToggles?.[
       featureFlagNames.showNewRefillTrackPrescriptionsPage

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.js
@@ -37,6 +37,7 @@ export const App = ({
 
 App.propTypes = {
   // From mapStateToProps.
+  authenticatedWithSSOe: PropTypes.bool,
   facilities: PropTypes.arrayOf(
     PropTypes.shape({
       facilityId: PropTypes.string.isRequired,

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/AuthContent/index.js
@@ -7,14 +7,22 @@ import Telephone, {
 // Relative imports.
 import CernerCallToAction from '../../../components/CernerCallToAction';
 import { getCernerURL } from 'platform/utilities/cerner';
+import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 
-export const AuthContent = ({ cernerFacilities, otherFacilities }) => (
+export const AuthContent = ({
+  authenticatedWithSSOe,
+  cernerFacilities,
+  otherFacilities,
+}) => (
   <>
     <CernerCallToAction
       cernerFacilities={cernerFacilities}
       otherFacilities={otherFacilities}
       linksHeaderText="Refill prescriptions from:"
-      myHealtheVetLink="https://sqa.eauth.va.gov/mhv-portal-web/eauth?deeplinking=prescription_refill"
+      myHealtheVetLink={mhvUrl(
+        authenticatedWithSSOe,
+        'web/myhealthevet/refill-prescriptions',
+      )}
       myVAHealthLink={getCernerURL('/pages/medications/current')}
     />
     <div>

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/AuthContent/index.js
@@ -413,6 +413,7 @@ export const AuthContent = ({
 );
 
 AuthContent.propTypes = {
+  authenticatedWithSSOe: PropTypes.bool.isRequired,
   cernerfacilities: PropTypes.arrayOf(
     PropTypes.shape({
       facilityId: PropTypes.string.isRequired,

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.js
@@ -37,6 +37,7 @@ export const App = ({
 
 App.propTypes = {
   // From mapStateToProps.
+  authenticatedWithSSOe: PropTypes.bool,
   facilities: PropTypes.arrayOf(
     PropTypes.shape({
       facilityId: PropTypes.string.isRequired,

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.js
@@ -9,8 +9,13 @@ import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
 import { selectPatientFacilities } from 'platform/user/selectors';
+import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 
-export const App = ({ facilities, showNewSecureMessagingPage }) => {
+export const App = ({
+  facilities,
+  showNewSecureMessagingPage,
+  authenticatedWithSSOe,
+}) => {
   if (!showNewSecureMessagingPage) {
     return <LegacyContent />;
   }
@@ -22,6 +27,7 @@ export const App = ({ facilities, showNewSecureMessagingPage }) => {
       <AuthContent
         cernerFacilities={cernerFacilities}
         otherFacilities={otherFacilities}
+        authenticatedWithSSOe={authenticatedWithSSOe}
       />
     );
   }
@@ -47,6 +53,7 @@ App.propTypes = {
 
 const mapStateToProps = state => ({
   facilities: selectPatientFacilities(state),
+  authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
   showNewSecureMessagingPage:
     state?.featureToggles?.[featureFlagNames.showNewSecureMessagingPage],
 });

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/AuthContent/index.js
@@ -4,15 +4,20 @@ import PropTypes from 'prop-types';
 // Relative imports.
 import CernerCallToAction from '../../../components/CernerCallToAction';
 import { getCernerURL } from 'platform/utilities/cerner';
+import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 
-export const AuthContent = ({ cernerFacilities, otherFacilities }) => (
+export const AuthContent = ({
+  authenticatedWithSSOe,
+  cernerFacilities,
+  otherFacilities,
+}) => (
   <>
     <h2 id="send-or-receive-secure-mess">Send or receive a secure message</h2>
     <CernerCallToAction
       cernerFacilities={cernerFacilities}
       otherFacilities={otherFacilities}
       linksHeaderText="Send a secure message to a provider at:"
-      myHealtheVetLink="https://sqa.eauth.va.gov/mhv-portal-web/eauth?deeplinking=secure_messaging"
+      myHealtheVetLink={mhvUrl(authenticatedWithSSOe, 'secure-messaging')}
       myVAHealthLink={getCernerURL('/pages/messaging/inbox')}
     />
     <div>

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/AuthContent/index.js
@@ -332,6 +332,7 @@ export const AuthContent = ({
 );
 
 AuthContent.propTypes = {
+  authenticatedWithSSOe: PropTypes.bool.isRequired,
   cernerfacilities: PropTypes.arrayOf(
     PropTypes.shape({
       facilityId: PropTypes.string.isRequired,

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.js
@@ -37,6 +37,7 @@ export const App = ({
 
 App.propTypes = {
   // From mapStateToProps.
+  authenticatedWithSSOe: PropTypes.bool,
   facilities: PropTypes.arrayOf(
     PropTypes.shape({
       facilityId: PropTypes.string.isRequired,

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.js
@@ -9,8 +9,13 @@ import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
 import { selectPatientFacilities } from 'platform/user/selectors';
+import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 
-export const App = ({ facilities, showNewViewTestLabResultsPage }) => {
+export const App = ({
+  facilities,
+  showNewViewTestLabResultsPage,
+  authenticatedWithSSOe,
+}) => {
   if (!showNewViewTestLabResultsPage) {
     return <LegacyContent />;
   }
@@ -22,6 +27,7 @@ export const App = ({ facilities, showNewViewTestLabResultsPage }) => {
       <AuthContent
         cernerFacilities={cernerFacilities}
         otherFacilities={otherFacilities}
+        authenticatedWithSSOe={authenticatedWithSSOe}
       />
     );
   }
@@ -47,6 +53,7 @@ App.propTypes = {
 
 const mapStateToProps = state => ({
   facilities: selectPatientFacilities(state),
+  authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
   showNewViewTestLabResultsPage:
     state?.featureToggles?.[featureFlagNames.showNewViewTestLabResultsPage],
 });

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/AuthContent/index.js
@@ -328,6 +328,7 @@ export const AuthContent = ({
 );
 
 AuthContent.propTypes = {
+  authenticatedWithSSOe: PropTypes.bool.isRequired,
   cernerfacilities: PropTypes.arrayOf(
     PropTypes.shape({
       facilityId: PropTypes.string.isRequired,

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/AuthContent/index.js
@@ -7,14 +7,19 @@ import Telephone, {
 // Relative imports.
 import CernerCallToAction from '../../../components/CernerCallToAction';
 import { getCernerURL } from 'platform/utilities/cerner';
+import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 
-export const AuthContent = ({ cernerFacilities, otherFacilities }) => (
+export const AuthContent = ({
+  authenticatedWithSSOe,
+  cernerFacilities,
+  otherFacilities,
+}) => (
   <>
     <CernerCallToAction
       cernerFacilities={cernerFacilities}
       otherFacilities={otherFacilities}
       linksHeaderText="View lab and test results from:"
-      myHealtheVetLink="https://sqa.eauth.va.gov/mhv-portal-web/eauth"
+      myHealtheVetLink={mhvUrl(authenticatedWithSSOe, 'labs-tests')}
       myVAHealthLink={getCernerURL('/pages/health_record/results/labs')}
     />
     <div>

--- a/src/platform/site-wide/mhv/utilities.js
+++ b/src/platform/site-wide/mhv/utilities.js
@@ -2,7 +2,7 @@ import environment from 'platform/utilities/environment';
 import { eauthEnvironmentPrefixes } from 'platform/utilities/sso/constants';
 
 const eauthPrefix = eauthEnvironmentPrefixes[environment.BUILDTYPE];
-const mhvPrefix = environment.isProduction() ? 'www' : 'mhv-syst';
+// const mhvPrefix = environment.isProduction() ? 'www' : 'mhv-syst';
 
 // TODO: Update labs-and-tests route once deep link is provided
 const mhvToEauthRoutes = {
@@ -21,11 +21,8 @@ const mhvToEauthRoutes = {
 // 3. The specific MHV path being accessed
 function mhvUrl(authenticatedWithSSOe, path) {
   const normPath = path.startsWith('/') ? path.substring(1) : path;
-  if (authenticatedWithSSOe) {
-    const eauthDeepLink = mhvToEauthRoutes[normPath];
-    return `https://${eauthPrefix}eauth.va.gov/mhv-portal-web/${eauthDeepLink}`;
-  }
-  return `https://${mhvPrefix}.myhealth.va.gov/mhv-portal-web/${normPath}`;
+  const eauthDeepLink = mhvToEauthRoutes[normPath];
+  return `https://${eauthPrefix}eauth.va.gov/mhv-portal-web/${eauthDeepLink}`;
 }
 
 // TODO: This function is NOT SSOe-aware and is a candidate for removal

--- a/src/platform/site-wide/mhv/utilities.js
+++ b/src/platform/site-wide/mhv/utilities.js
@@ -2,7 +2,7 @@ import environment from 'platform/utilities/environment';
 import { eauthEnvironmentPrefixes } from 'platform/utilities/sso/constants';
 
 const eauthPrefix = eauthEnvironmentPrefixes[environment.BUILDTYPE];
-// const mhvPrefix = environment.isProduction() ? 'www' : 'mhv-syst';
+const mhvPrefix = environment.isProduction() ? 'www' : 'mhv-syst';
 
 // TODO: Update labs-and-tests route once deep link is provided
 const mhvToEauthRoutes = {
@@ -21,8 +21,11 @@ const mhvToEauthRoutes = {
 // 3. The specific MHV path being accessed
 function mhvUrl(authenticatedWithSSOe, path) {
   const normPath = path.startsWith('/') ? path.substring(1) : path;
-  const eauthDeepLink = mhvToEauthRoutes[normPath];
-  return `https://${eauthPrefix}eauth.va.gov/mhv-portal-web/${eauthDeepLink}`;
+  if (authenticatedWithSSOe) {
+    const eauthDeepLink = mhvToEauthRoutes[normPath];
+    return `https://${eauthPrefix}eauth.va.gov/mhv-portal-web/${eauthDeepLink}`;
+  }
+  return `https://${mhvPrefix}.myhealth.va.gov/mhv-portal-web/${normPath}`;
 }
 
 // TODO: This function is NOT SSOe-aware and is a candidate for removal


### PR DESCRIPTION
## Description
It would appear that when a user has the option of going to Cerner's system OR MHV's, we show the wrong link to MHV's system. This PR adjusts this behavior by using our MHV utility function for deriving their tool URL. 

https://github.com/department-of-veterans-affairs/va.gov-team/issues/17318

## Testing done
I logged in locally, then hardcoded some facilities onto the user profile so that every user would have a Cerner and non-Cerner facility. Then I navigated to each of the health care portals, hovered over the rendered MHV link, and confirmed that the URL was correct.

- `/health-care/get-medical-records/`
- `/health-care/refill-track-prescriptions/`
- `/health-care/secure-messaging/`
- `/health-care/view-test-and-lab-results/`

## Screenshots
Notice the URL on hover is the correct MHV environment
![image](https://user-images.githubusercontent.com/1915775/103376598-14936880-4aab-11eb-800b-c51fb9c4c571.png)


## Acceptance criteria
- [ ] Issue reported by contact at MHV is resolved

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
