### PR TITLE
Dt 11625 Deleted Forms message

### DIFF
--- a/src/applications/find-forms/actions/index.js
+++ b/src/applications/find-forms/actions/index.js
@@ -22,9 +22,9 @@ export const fetchFormsFailure = error => ({
   type: FETCH_FORMS_FAILURE,
 });
 
-export const fetchFormsSuccess = (results, allFormsTombstone) => ({
+export const fetchFormsSuccess = (results, hasOnlyRetiredForms) => ({
   results,
-  allFormsTombstone,
+  hasOnlyRetiredForms,
   type: FETCH_FORMS_SUCCESS,
 });
 
@@ -69,7 +69,7 @@ export const fetchFormsThunk = (query, options = {}) => async dispatch => {
     dispatch(
       fetchFormsSuccess(
         resultsDetails.results,
-        resultsDetails.allFormsTombstone,
+        resultsDetails.hasOnlyRetiredForms,
       ),
     );
   } catch (error) {

--- a/src/applications/find-forms/actions/index.js
+++ b/src/applications/find-forms/actions/index.js
@@ -22,8 +22,9 @@ export const fetchFormsFailure = error => ({
   type: FETCH_FORMS_FAILURE,
 });
 
-export const fetchFormsSuccess = results => ({
+export const fetchFormsSuccess = (results, allFormsTombstone) => ({
   results,
+  allFormsTombstone,
   type: FETCH_FORMS_SUCCESS,
 });
 
@@ -62,10 +63,15 @@ export const fetchFormsThunk = (query, options = {}) => async dispatch => {
 
   try {
     // Attempt to make the API request to retreive forms.
-    const results = await fetchFormsApi(query, { mockRequest });
+    const resultsDetails = await fetchFormsApi(query, { mockRequest });
 
     // If we are here, the API request succeeded.
-    dispatch(fetchFormsSuccess(results));
+    dispatch(
+      fetchFormsSuccess(
+        resultsDetails.results,
+        resultsDetails.allFormsTombstone,
+      ),
+    );
   } catch (error) {
     // If we are here, the API request failed.
     dispatch(

--- a/src/applications/find-forms/api/index.js
+++ b/src/applications/find-forms/api/index.js
@@ -26,11 +26,16 @@ export const fetchFormsApi = async (query, options = {}) => {
 
   const forms = response?.data;
   const onlyValidForms = forms?.filter(
-    form => form.attributes?.validPDF || form.attributes?.validPdf,
+    form =>
+      (form.attributes?.validPDF || form.attributes?.validPdf) &&
+      form.attributes?.deletedAt === null,
   );
 
+  // checks to see if all the forms in the results have been tombstone/ deleted.
+  const allFormsTombstone = forms?.length > 0 && onlyValidForms?.length === 0;
+
   const potentialServerIssue =
-    (query === '' || query === '10-10ez') && onlyValidForms.length === 0;
+    (query === '' || query === '10-10ez') && onlyValidForms?.length === 0;
 
   if (potentialServerIssue) {
     // A query-less search should always include hundreds of results, and a
@@ -44,5 +49,8 @@ export const fetchFormsApi = async (query, options = {}) => {
     });
   }
 
-  return sortBy(onlyValidForms, 'id');
+  return {
+    allFormsTombstone,
+    results: sortBy(onlyValidForms, 'id'),
+  };
 };

--- a/src/applications/find-forms/api/index.js
+++ b/src/applications/find-forms/api/index.js
@@ -28,11 +28,13 @@ export const fetchFormsApi = async (query, options = {}) => {
   const onlyValidForms = forms?.filter(
     form =>
       (form.attributes?.validPDF || form.attributes?.validPdf) &&
-      form.attributes?.deletedAt === null,
+      (form.attributes?.deletedAt === null ||
+        form.attributes?.deletedAt === undefined ||
+        form.attributes?.deletedAt.length === 0),
   );
 
   // checks to see if all the forms in the results have been tombstone/ deleted.
-  const allFormsTombstone = forms?.length > 0 && onlyValidForms?.length === 0;
+  const hasOnlyRetiredForms = forms?.length > 0 && onlyValidForms?.length === 0;
 
   const potentialServerIssue =
     (query === '' || query === '10-10ez') && onlyValidForms?.length === 0;
@@ -50,7 +52,7 @@ export const fetchFormsApi = async (query, options = {}) => {
   }
 
   return {
-    allFormsTombstone,
+    hasOnlyRetiredForms,
     results: sortBy(onlyValidForms, 'id'),
   };
 };

--- a/src/applications/find-forms/containers/SearchResults.jsx
+++ b/src/applications/find-forms/containers/SearchResults.jsx
@@ -24,6 +24,7 @@ export class SearchResults extends Component {
     page: PropTypes.number.isRequired,
     query: PropTypes.string.isRequired,
     results: PropTypes.arrayOf(customPropTypes.Form.isRequired),
+    allFormsTombstone: PropTypes.bool.isRequired,
     startIndex: PropTypes.number.isRequired,
     showFindFormsResultsLinkToFormDetailPages: PropTypes.bool.isRequired,
     // From mapDispatchToProps.
@@ -63,6 +64,7 @@ export class SearchResults extends Component {
       page,
       query,
       results,
+      allFormsTombstone,
       showFindFormsResultsLinkToFormDetailPages,
       startIndex,
     } = this.props;
@@ -87,6 +89,19 @@ export class SearchResults extends Component {
     if (!results) {
       return null;
     }
+
+    // Show UX friendly message if all forms are tombstone/ deleted in the results returned.
+    if (allFormsTombstone)
+      return (
+        <h2
+          className="vads-u-font-size--base vads-u-line-height--3 vads-u-font-family--sans
+    vads-u-margin-top--1p5 vads-u-font-weight--normal"
+          data-forms-focus
+        >
+          The form you're looking for has been retired or is no longer valid,
+          and has been removed from the VA forms database.
+        </h2>
+      );
 
     // Show no results found message.
     if (!results.length) {
@@ -169,6 +184,7 @@ const mapStateToProps = state => ({
   page: getFindFormsAppState(state).page,
   query: getFindFormsAppState(state).query,
   results: getFindFormsAppState(state).results,
+  allFormsTombstone: getFindFormsAppState(state).allFormsTombstone,
   startIndex: getFindFormsAppState(state).startIndex,
   showFindFormsResultsLinkToFormDetailPages: mvpEnhancements(state),
 });

--- a/src/applications/find-forms/containers/SearchResults.jsx
+++ b/src/applications/find-forms/containers/SearchResults.jsx
@@ -24,7 +24,7 @@ export class SearchResults extends Component {
     page: PropTypes.number.isRequired,
     query: PropTypes.string.isRequired,
     results: PropTypes.arrayOf(customPropTypes.Form.isRequired),
-    allFormsTombstone: PropTypes.bool.isRequired,
+    hasOnlyRetiredForms: PropTypes.bool.isRequired,
     startIndex: PropTypes.number.isRequired,
     showFindFormsResultsLinkToFormDetailPages: PropTypes.bool.isRequired,
     // From mapDispatchToProps.
@@ -64,7 +64,7 @@ export class SearchResults extends Component {
       page,
       query,
       results,
-      allFormsTombstone,
+      hasOnlyRetiredForms,
       showFindFormsResultsLinkToFormDetailPages,
       startIndex,
     } = this.props;
@@ -91,7 +91,7 @@ export class SearchResults extends Component {
     }
 
     // Show UX friendly message if all forms are tombstone/ deleted in the results returned.
-    if (allFormsTombstone)
+    if (hasOnlyRetiredForms)
       return (
         <h2
           className="vads-u-font-size--base vads-u-line-height--3 vads-u-font-family--sans
@@ -184,7 +184,7 @@ const mapStateToProps = state => ({
   page: getFindFormsAppState(state).page,
   query: getFindFormsAppState(state).query,
   results: getFindFormsAppState(state).results,
-  allFormsTombstone: getFindFormsAppState(state).allFormsTombstone,
+  hasOnlyRetiredForms: getFindFormsAppState(state).hasOnlyRetiredForms,
   startIndex: getFindFormsAppState(state).startIndex,
   showFindFormsResultsLinkToFormDetailPages: mvpEnhancements(state),
 });

--- a/src/applications/find-forms/reducers/findVAFormsReducer.js
+++ b/src/applications/find-forms/reducers/findVAFormsReducer.js
@@ -12,6 +12,7 @@ const initialState = {
   page: 1,
   query: '',
   results: null,
+  allFormsTombstone: false,
   startIndex: 0,
 };
 
@@ -24,7 +25,12 @@ export default (state = initialState, action) => {
       return { ...state, error: action.error, fetching: false };
     }
     case FETCH_FORMS_SUCCESS: {
-      return { ...state, fetching: false, results: action.results };
+      return {
+        ...state,
+        fetching: false,
+        allFormsTombstone: action.allFormsTombstone,
+        results: action.results,
+      };
     }
     case UPDATE_PAGINATION: {
       return { ...state, page: action.page, startIndex: action.startIndex };

--- a/src/applications/find-forms/reducers/findVAFormsReducer.js
+++ b/src/applications/find-forms/reducers/findVAFormsReducer.js
@@ -12,7 +12,7 @@ const initialState = {
   page: 1,
   query: '',
   results: null,
-  allFormsTombstone: false,
+  hasOnlyRetiredForms: false,
   startIndex: 0,
 };
 
@@ -28,7 +28,7 @@ export default (state = initialState, action) => {
       return {
         ...state,
         fetching: false,
-        allFormsTombstone: action.allFormsTombstone,
+        hasOnlyRetiredForms: action.hasOnlyRetiredForms,
         results: action.results,
       };
     }

--- a/src/applications/find-forms/tests/actions/index.unit.spec.js
+++ b/src/applications/find-forms/tests/actions/index.unit.spec.js
@@ -43,11 +43,11 @@ describe('Find VA Forms actions', () => {
   describe('fetchFormsSuccess', () => {
     it('should return an action in the shape we expect', () => {
       const results = [];
-      const allFormsTombstone = false;
-      const action = fetchFormsSuccess(results, allFormsTombstone);
+      const hasOnlyRetiredForms = false;
+      const action = fetchFormsSuccess(results, hasOnlyRetiredForms);
 
       expect(action).to.be.deep.equal({
-        allFormsTombstone,
+        hasOnlyRetiredForms,
         results,
         type: FETCH_FORMS_SUCCESS,
       });

--- a/src/applications/find-forms/tests/actions/index.unit.spec.js
+++ b/src/applications/find-forms/tests/actions/index.unit.spec.js
@@ -43,9 +43,11 @@ describe('Find VA Forms actions', () => {
   describe('fetchFormsSuccess', () => {
     it('should return an action in the shape we expect', () => {
       const results = [];
-      const action = fetchFormsSuccess(results);
+      const allFormsTombstone = false;
+      const action = fetchFormsSuccess(results, allFormsTombstone);
 
       expect(action).to.be.deep.equal({
+        allFormsTombstone,
         results,
         type: FETCH_FORMS_SUCCESS,
       });

--- a/src/applications/find-forms/tests/reducers/findVAFormsReducer.unit.spec.js
+++ b/src/applications/find-forms/tests/reducers/findVAFormsReducer.unit.spec.js
@@ -15,7 +15,7 @@ describe('Find VA Forms reducer: findVAFormsReducer', () => {
       page: 1,
       query: '',
       results: null,
-      allFormsTombstone: false,
+      hasOnlyRetiredForms: false,
       startIndex: 0,
     });
   });
@@ -30,7 +30,7 @@ describe('Find VA Forms reducer: findVAFormsReducer', () => {
       page: 1,
       query: 'testing',
       results: null,
-      allFormsTombstone: false,
+      hasOnlyRetiredForms: false,
       startIndex: 0,
     });
   });
@@ -43,7 +43,7 @@ describe('Find VA Forms reducer: findVAFormsReducer', () => {
     const action = {
       type: FETCH_FORMS_SUCCESS,
       results: [],
-      allFormsTombstone: false,
+      hasOnlyRetiredForms: false,
     };
     const state = findVAFormsReducer(initialState, action);
 

--- a/src/applications/find-forms/tests/reducers/findVAFormsReducer.unit.spec.js
+++ b/src/applications/find-forms/tests/reducers/findVAFormsReducer.unit.spec.js
@@ -15,6 +15,7 @@ describe('Find VA Forms reducer: findVAFormsReducer', () => {
       page: 1,
       query: '',
       results: null,
+      allFormsTombstone: false,
       startIndex: 0,
     });
   });
@@ -29,6 +30,7 @@ describe('Find VA Forms reducer: findVAFormsReducer', () => {
       page: 1,
       query: 'testing',
       results: null,
+      allFormsTombstone: false,
       startIndex: 0,
     });
   });
@@ -38,7 +40,11 @@ describe('Find VA Forms reducer: findVAFormsReducer', () => {
       fetching: true,
       results: null,
     };
-    const action = { type: FETCH_FORMS_SUCCESS, results: [] };
+    const action = {
+      type: FETCH_FORMS_SUCCESS,
+      results: [],
+      allFormsTombstone: false,
+    };
     const state = findVAFormsReducer(initialState, action);
 
     expect(state.fetching).to.be.false;

--- a/src/applications/find-forms/tests/widgets/createInvalidPdfAlert.unit.spec.js
+++ b/src/applications/find-forms/tests/widgets/createInvalidPdfAlert.unit.spec.js
@@ -69,7 +69,7 @@ describe('createInvalidPdfAlert', () => {
   });
 
   it('does not show an alert banner for valid forms', async () => {
-    const link2 = {
+    const link = {
       click: sinon.stub(),
       removeEventListener: sinon.stub(),
       href: 'https://www.va.gov/vaforms/medical/pdf/10-10EZ-fillable.pdf',
@@ -79,15 +79,15 @@ describe('createInvalidPdfAlert', () => {
       remove: sinon.stub(),
     };
 
-    const event2 = {
-      target: link2,
+    const event = {
+      target: link,
       preventDefault: sinon.stub(),
     };
 
-    await onDownloadLinkClick(event2);
+    await onDownloadLinkClick(event);
 
-    expect(link2.remove.called).to.be.false;
-    expect(link2.removeEventListener.called).to.be.true;
-    expect(link2.click.called).to.be.true;
+    expect(link.remove.called).to.be.false;
+    expect(link.removeEventListener.called).to.be.true;
+    expect(link.click.called).to.be.true;
   });
 });

--- a/src/applications/find-forms/tests/widgets/createInvalidPdfAlert.unit.spec.js
+++ b/src/applications/find-forms/tests/widgets/createInvalidPdfAlert.unit.spec.js
@@ -17,12 +17,18 @@ describe('createInvalidPdfAlert', () => {
         {
           id: '10-10EZ',
           type: 'va_form',
-          attributes: { validPdf: true },
+          attributes: {
+            deletedAt: null,
+            validPdf: true,
+          },
         },
         {
           id: 'VA0927b',
           type: 'va_form',
-          attributes: { validPdf: false },
+          attributes: {
+            deletedAt: '2020-08-18T00:00:00.000Z',
+            validPdf: false,
+          },
         },
       ],
     });
@@ -35,7 +41,7 @@ describe('createInvalidPdfAlert', () => {
   it('shows an alert banner for invalid forms', async () => {
     const link = {
       click: sinon.stub(),
-      href: 'https://www.va.gov/vaforms/medical/pdf/10-10EZ-fillable.pdf',
+      href: 'https://www.va.gov/vaforms/va/pdf/VA0927b.pdf',
       dataset: {
         formNumber: 'VA0927b',
       },
@@ -62,8 +68,8 @@ describe('createInvalidPdfAlert', () => {
     expect(link.remove.called).to.be.true;
   });
 
-  it('shows an alert banner for invalid forms', async () => {
-    const link = {
+  it('does not show an alert banner for valid forms', async () => {
+    const link2 = {
       click: sinon.stub(),
       removeEventListener: sinon.stub(),
       href: 'https://www.va.gov/vaforms/medical/pdf/10-10EZ-fillable.pdf',
@@ -73,15 +79,15 @@ describe('createInvalidPdfAlert', () => {
       remove: sinon.stub(),
     };
 
-    const event = {
-      target: link,
+    const event2 = {
+      target: link2,
       preventDefault: sinon.stub(),
     };
 
-    await onDownloadLinkClick(event);
+    await onDownloadLinkClick(event2);
 
-    expect(link.remove.called).to.be.false;
-    expect(link.removeEventListener.called).to.be.true;
-    expect(link.click.called).to.be.true;
+    expect(link2.remove.called).to.be.false;
+    expect(link2.removeEventListener.called).to.be.true;
+    expect(link2.click.called).to.be.true;
   });
 });

--- a/src/applications/find-forms/widgets/createInvalidPdfAlert.js
+++ b/src/applications/find-forms/widgets/createInvalidPdfAlert.js
@@ -43,7 +43,7 @@ export async function onDownloadLinkClick(event) {
 
   try {
     const forms = await fetchFormsApi(formNumber);
-    form = forms.find(f => f.id === formNumber);
+    form = forms.results.find(f => f.id === formNumber);
     formPdfIsValid = form?.attributes.validPdf;
   } catch (err) {
     // Todo


### PR DESCRIPTION
## Description
Added a message to show in the event that all forms are deleted/ tombstone in the results queried.

## Testing done
Ran e2e, Unit, and http://localhost:3001/find-forms/?q=22-8873 query. 

## Screenshots
![Screen Shot 2020-12-30 at 10 45 59 AM](https://user-images.githubusercontent.com/26075258/103365488-274b7480-4a8e-11eb-8ad1-3a7ae585af25.png)


## Acceptance criteria
- [x] User friendly message renders when edge case is met. 

## Definition of done
- [x] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
