### PR TITLE
COVID-19 vaccines search on FL

### DIFF
--- a/src/applications/facility-locator/actions/index.js
+++ b/src/applications/facility-locator/actions/index.js
@@ -24,6 +24,7 @@ import {
 
 import mbxGeo from '@mapbox/mapbox-sdk/services/geocoding';
 import { distBetween } from '../utils/facilityDistance';
+import { radiusFromBoundingBox } from '../config';
 
 const mbxClient = mbxGeo(mapboxClient);
 /**
@@ -277,12 +278,7 @@ export const genBBoxFromAddress = query => {
           ];
         }
 
-        const radius = distBetween(
-          features[0].bbox[1],
-          features[0].bbox[0],
-          features[0].bbox[3],
-          features[0].bbox[2],
-        );
+        const radius = radiusFromBoundingBox(features);
 
         dispatch({
           type: SEARCH_QUERY_UPDATED,

--- a/src/applications/facility-locator/actions/index.js
+++ b/src/applications/facility-locator/actions/index.js
@@ -23,8 +23,7 @@ import {
 } from '../constants';
 
 import mbxGeo from '@mapbox/mapbox-sdk/services/geocoding';
-import { distBetween } from '../utils/facilityDistance';
-import { radiusFromBoundingBox } from '../config';
+import { distBetween, radiusFromBoundingBox } from '../utils/facilityDistance';
 
 const mbxClient = mbxGeo(mapboxClient);
 /**

--- a/src/applications/facility-locator/config.js
+++ b/src/applications/facility-locator/config.js
@@ -1,7 +1,8 @@
 import environment from 'platform/utilities/environment';
 import compact from 'lodash/compact';
-import { LocationType, FacilityType } from './constants';
+import { LocationType, FacilityType, MIN_RADIUS } from './constants';
 import manifest from './manifest.json';
+import { distBetween } from './utils/facilityDistance';
 
 // Base URL to be used in API requests.
 export const api = {
@@ -194,4 +195,17 @@ export const facilityTypesOptions = {
   [LocationType.BENEFITS]: 'VA benefits',
   [LocationType.CEMETARY]: 'VA cemeteries',
   [LocationType.VET_CENTER]: 'Vet Centers',
+};
+
+export const radiusFromBoundingBox = fbox => {
+  let radius = distBetween(
+    fbox[0].bbox[1],
+    fbox[0].bbox[0],
+    fbox[0].bbox[3],
+    fbox[0].bbox[2],
+  );
+
+  if (radius < MIN_RADIUS) radius = MIN_RADIUS;
+
+  return radius;
 };

--- a/src/applications/facility-locator/config.js
+++ b/src/applications/facility-locator/config.js
@@ -126,6 +126,7 @@ export const healthServices = {
   MentalHealthCare: 'Mental health care',
   DentalServices: 'Dental services',
   UrgentCare: 'Urgent care',
+  Covid19Vaccine: 'COVID-19 vaccines',
   EmergencyCare: 'Emergency care',
   Audiology: 'Audiology',
   Cardiology: 'Cardiology',

--- a/src/applications/facility-locator/config.js
+++ b/src/applications/facility-locator/config.js
@@ -1,8 +1,7 @@
 import environment from 'platform/utilities/environment';
 import compact from 'lodash/compact';
-import { LocationType, FacilityType, MIN_RADIUS } from './constants';
+import { LocationType, FacilityType } from './constants';
 import manifest from './manifest.json';
-import { distBetween } from './utils/facilityDistance';
 
 // Base URL to be used in API requests.
 export const api = {
@@ -195,17 +194,4 @@ export const facilityTypesOptions = {
   [LocationType.BENEFITS]: 'VA benefits',
   [LocationType.CEMETARY]: 'VA cemeteries',
   [LocationType.VET_CENTER]: 'Vet Centers',
-};
-
-export const radiusFromBoundingBox = fbox => {
-  let radius = distBetween(
-    fbox[0].bbox[1],
-    fbox[0].bbox[0],
-    fbox[0].bbox[3],
-    fbox[0].bbox[2],
-  );
-
-  if (radius < MIN_RADIUS) radius = MIN_RADIUS;
-
-  return radius;
 };

--- a/src/applications/facility-locator/constants/index.js
+++ b/src/applications/facility-locator/constants/index.js
@@ -118,3 +118,8 @@ export const TypeList = ['place', 'region', 'postcode', 'locality'];
  * Max search area in miles
  */
 export const MAX_SEARCH_AREA = 500;
+
+/**
+ * Min radius search area in miles
+ */
+export const MIN_RADIUS = 10;

--- a/src/applications/facility-locator/tests/helpers/radiusFromBoundingBox.unit.spec.js
+++ b/src/applications/facility-locator/tests/helpers/radiusFromBoundingBox.unit.spec.js
@@ -1,0 +1,30 @@
+import { expect } from 'chai';
+import { radiusFromBoundingBox } from '../../utils/facilityDistance';
+import { MIN_RADIUS } from '../../constants';
+
+describe('radiusFromBoundingBox', () => {
+  it('should return a valid computed radius - Dallas', () => {
+    const testDallasFeatureBbox = [
+      {
+        bbox: [
+          -97.04103101,
+          32.6185720016946,
+          -96.5555139885032,
+          33.016494008014,
+        ],
+      },
+    ];
+    const testRad = radiusFromBoundingBox(testDallasFeatureBbox);
+    expect(testRad > MIN_RADIUS).to.eql(true);
+  });
+
+  it('should return a default 10 miles radius - zip 92052', () => {
+    const testDallasFeatureBbox = [
+      {
+        bbox: [-117.357412, 33.21172839552, -117.35718939552, 33.21189160448],
+      },
+    ];
+    const testRad = radiusFromBoundingBox(testDallasFeatureBbox);
+    expect(testRad === MIN_RADIUS).to.eql(true);
+  });
+});

--- a/src/applications/facility-locator/tests/helpers/radiusFromBoundingBox.unit.spec.js
+++ b/src/applications/facility-locator/tests/helpers/radiusFromBoundingBox.unit.spec.js
@@ -19,12 +19,12 @@ describe('radiusFromBoundingBox', () => {
   });
 
   it('should return a default 10 miles radius - zip 92052', () => {
-    const testDallasFeatureBbox = [
+    const testZip92052Bbox = [
       {
         bbox: [-117.357412, 33.21172839552, -117.35718939552, 33.21189160448],
       },
     ];
-    const testRad = radiusFromBoundingBox(testDallasFeatureBbox);
+    const testRad = radiusFromBoundingBox(testZip92052Bbox);
     expect(testRad === MIN_RADIUS).to.eql(true);
   });
 });

--- a/src/applications/facility-locator/utils/facilityDistance.js
+++ b/src/applications/facility-locator/utils/facilityDistance.js
@@ -1,3 +1,5 @@
+import { MIN_RADIUS } from '../constants';
+
 function toRadians(value) {
   return (value * Math.PI) / 180;
 }
@@ -17,3 +19,16 @@ export function distBetween(lat1, lng1, lat2, lng2) {
 
   return R * c;
 }
+
+export const radiusFromBoundingBox = fbox => {
+  let radius = distBetween(
+    fbox[0].bbox[1],
+    fbox[0].bbox[0],
+    fbox[0].bbox[3],
+    fbox[0].bbox[2],
+  );
+
+  if (radius < MIN_RADIUS) radius = MIN_RADIUS;
+
+  return Math.max(radius, MIN_RADIUS);
+};


### PR DESCRIPTION
## Description
issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/17226

## Testing done


## Screenshots


## Acceptance criteria
- [ ] A Veteran can select `COVID-19 vaccines` as service type when the facility type = `VA health`
- [ ] When a Veteran selects `COVID-19 vaccines` as a service type, the search results contain only facilities with COVID-19 vaccines as a service 
- [ ] When a Veteran selects `COVID-19 vaccines` as a service type, cards are consistent with current experience except 
      - Add the alert "COVID-19 vaccines at the VA"
      - Remove mental health phone number
- [ ] Blue "COVID-19 vaccines at the VA" button links to https://www.va.gov/health-care/covid-19-vaccine/
- [ ] Blue "COVID-19 vaccines at the VA" button appears **above** the phone number'
- [ ] When available, the facility operating status appears **below** the phone number
- [ ] Implementation is consistent with design
- [ ] Alert shows only if `COVID-19 vaccines` has been selected as Service type
- [ ] When Service type = `All VA health services`, the alert does not display

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
