### PR TITLE
Fix new race conditions in facility locator Cypress spec

### DIFF
--- a/src/applications/facility-locator/tests/e2e/mobile.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/mobile.cypress.spec.js
@@ -57,28 +57,26 @@ describe('Mobile', () => {
     });
   });
 
-  for(let i = 0; i < 50; i++) {
-    it('should render in mobile layouts and tabs actions work', () => {
-      cy.visit('/find-locations');
-      cy.injectAxe();
+  it('should render in mobile layouts and tabs actions work', () => {
+    cy.visit('/find-locations');
+    cy.injectAxe();
 
-      // iPhone X
-      cy.viewport(400, 812);
-      cy.checkSearch();
+    // iPhone X
+    cy.viewport(400, 812);
+    cy.checkSearch();
 
-      // iPhone 6/7/8 plus
-      cy.viewport(414, 736);
-      cy.checkSearch();
+    // iPhone 6/7/8 plus
+    cy.viewport(414, 736);
+    cy.checkSearch();
 
-      // Pixel 2
-      cy.viewport(411, 731);
-      cy.checkSearch();
+    // Pixel 2
+    cy.viewport(411, 731);
+    cy.checkSearch();
 
-      // Galaxy S5/Moto
-      cy.viewport(360, 640);
-      cy.checkSearch();
-    });
-  }
+    // Galaxy S5/Moto
+    cy.viewport(360, 640);
+    cy.checkSearch();
+  });
 
   it('should render the appropriate elements at each breakpoint', () => {
     cy.visit('/find-locations');

--- a/src/applications/facility-locator/tests/e2e/mobile.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/mobile.cypress.spec.js
@@ -11,7 +11,8 @@ Cypress.Commands.add('checkSearch', () => {
     .should('not.be.disabled')
     .clear({ force: true });
 
-  // This forEach loop is a workaround to a typing bug in Cypress.
+  // This forEach loop is a workaround to a typing bug in Cypress:
+  // https://github.com/cypress-io/cypress/issues/5480
   // Upgrading to Cypress 6.1 should fix this bug and allow us
   // to remove the loop.
   [...city].forEach(char => {
@@ -57,28 +58,26 @@ describe('Mobile', () => {
     });
   });
 
-  for (let i = 0; i < 50; i++) {
-    it('should render in mobile layouts and tabs actions work', () => {
-      cy.visit('/find-locations');
-      cy.injectAxe();
+  it('should render in mobile layouts and tabs actions work', () => {
+    cy.visit('/find-locations');
+    cy.injectAxe();
 
-      // iPhone X
-      cy.viewport(400, 812);
-      cy.checkSearch();
+    // iPhone X
+    cy.viewport(400, 812);
+    cy.checkSearch();
 
-      // iPhone 6/7/8 plus
-      cy.viewport(414, 736);
-      cy.checkSearch();
+    // iPhone 6/7/8 plus
+    cy.viewport(414, 736);
+    cy.checkSearch();
 
-      // Pixel 2
-      cy.viewport(411, 731);
-      cy.checkSearch();
+    // Pixel 2
+    cy.viewport(411, 731);
+    cy.checkSearch();
 
-      // Galaxy S5/Moto
-      cy.viewport(360, 640);
-      cy.checkSearch();
-    });
-  }
+    // Galaxy S5/Moto
+    cy.viewport(360, 640);
+    cy.checkSearch();
+  });
 
   it('should render the appropriate elements at each breakpoint', () => {
     cy.visit('/find-locations');

--- a/src/applications/facility-locator/tests/e2e/mobile.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/mobile.cypress.spec.js
@@ -8,11 +8,16 @@ Cypress.Commands.add('checkSearch', () => {
   // Search
   cy.get('#street-city-state-zip', { timeout: 10000 })
     .should('exist')
-    .clear();
+    .should('not.be.disabled')
+    .clear({ waitForAnimations: true, force: true });
+
+  // This forEach loop is a workaround to a typing bug in Cypress.
+  // Upgrading to Cypress 6.1 should fix this bug and allow us
+  // to remove the loop.
   [...city].forEach(char => {
     cy.get('#street-city-state-zip')
       .should('not.be.disabled')
-      .type(char, { waitForAnimations: true, force: true });
+      .type(char, { waitForAnimations: true });
   });
   cy.get('#facility-type-dropdown').select('VA health');
   cy.get('#facility-search').click();
@@ -30,7 +35,7 @@ Cypress.Commands.add('checkSearch', () => {
   // Switch tab map
   cy.get('#react-tabs-2')
     .should('not.be.disabled')
-    .click({ waitForAnimations: true, force: true });
+    .click({ waitForAnimations: true });
 
   // Ensure map is visible
   cy.get('#mapbox-gl-container').should('be.visible');
@@ -52,26 +57,28 @@ describe('Mobile', () => {
     });
   });
 
-  it('should render in mobile layouts and tabs actions work', () => {
-    cy.visit('/find-locations');
-    cy.injectAxe();
+  for(let i = 0; i < 50; i++) {
+    it('should render in mobile layouts and tabs actions work', () => {
+      cy.visit('/find-locations');
+      cy.injectAxe();
 
-    // iPhone X
-    cy.viewport(400, 812);
-    cy.checkSearch();
+      // iPhone X
+      cy.viewport(400, 812);
+      cy.checkSearch();
 
-    // iPhone 6/7/8 plus
-    cy.viewport(414, 736);
-    cy.checkSearch();
+      // iPhone 6/7/8 plus
+      cy.viewport(414, 736);
+      cy.checkSearch();
 
-    // Pixel 2
-    cy.viewport(411, 731);
-    cy.checkSearch();
+      // Pixel 2
+      cy.viewport(411, 731);
+      cy.checkSearch();
 
-    // Galaxy S5/Moto
-    cy.viewport(360, 640);
-    cy.checkSearch();
-  });
+      // Galaxy S5/Moto
+      cy.viewport(360, 640);
+      cy.checkSearch();
+    });
+  }
 
   it('should render the appropriate elements at each breakpoint', () => {
     cy.visit('/find-locations');

--- a/src/applications/facility-locator/tests/e2e/mobile.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/mobile.cypress.spec.js
@@ -52,28 +52,26 @@ describe('Mobile', () => {
     });
   });
 
-  for(let i = 0; i < 30; i++) {
-    it('should render in mobile layouts and tabs actions work', () => {
-      cy.visit('/find-locations');
-      cy.injectAxe();
+  it('should render in mobile layouts and tabs actions work', () => {
+    cy.visit('/find-locations');
+    cy.injectAxe();
 
-      // iPhone X
-      cy.viewport(400, 812);
-      cy.checkSearch();
+    // iPhone X
+    cy.viewport(400, 812);
+    cy.checkSearch();
 
-      // iPhone 6/7/8 plus
-      cy.viewport(414, 736);
-      cy.checkSearch();
+    // iPhone 6/7/8 plus
+    cy.viewport(414, 736);
+    cy.checkSearch();
 
-      // Pixel 2
-      cy.viewport(411, 731);
-      cy.checkSearch();
+    // Pixel 2
+    cy.viewport(411, 731);
+    cy.checkSearch();
 
-      // Galaxy S5/Moto
-      cy.viewport(360, 640);
-      cy.checkSearch();
-    });
-  }
+    // Galaxy S5/Moto
+    cy.viewport(360, 640);
+    cy.checkSearch();
+  });
 
   it('should render the appropriate elements at each breakpoint', () => {
     cy.visit('/find-locations');

--- a/src/applications/facility-locator/tests/e2e/mobile.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/mobile.cypress.spec.js
@@ -6,10 +6,13 @@ Cypress.Commands.add('checkSearch', () => {
   cy.axeCheck();
 
   // Search
+  cy.get('#street-city-state-zip', { timeout: 10000 })
+    .should('exist')
+    .clear();
   [...city].forEach(char => {
     cy.get('#street-city-state-zip')
       .should('not.be.disabled')
-      .type(char);
+      .type(char, { waitForAnimations: true, force: true });
   });
   cy.get('#facility-type-dropdown').select('VA health');
   cy.get('#facility-search').click();
@@ -49,26 +52,28 @@ describe('Mobile', () => {
     });
   });
 
-  it('should render in mobile layouts and tabs actions work', () => {
-    cy.visit('/find-locations');
-    cy.injectAxe();
+  for(let i = 0; i < 30; i++) {
+    it('should render in mobile layouts and tabs actions work', () => {
+      cy.visit('/find-locations');
+      cy.injectAxe();
 
-    // iPhone X
-    cy.viewport(400, 812);
-    cy.checkSearch();
+      // iPhone X
+      cy.viewport(400, 812);
+      cy.checkSearch();
 
-    // iPhone 6/7/8 plus
-    cy.viewport(414, 736);
-    cy.checkSearch();
+      // iPhone 6/7/8 plus
+      cy.viewport(414, 736);
+      cy.checkSearch();
 
-    // Pixel 2
-    cy.viewport(411, 731);
-    cy.checkSearch();
+      // Pixel 2
+      cy.viewport(411, 731);
+      cy.checkSearch();
 
-    // Galaxy S5/Moto
-    cy.viewport(360, 640);
-    cy.checkSearch();
-  });
+      // Galaxy S5/Moto
+      cy.viewport(360, 640);
+      cy.checkSearch();
+    });
+  }
 
   it('should render the appropriate elements at each breakpoint', () => {
     cy.visit('/find-locations');

--- a/src/applications/facility-locator/tests/e2e/mobile.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/mobile.cypress.spec.js
@@ -9,7 +9,7 @@ Cypress.Commands.add('checkSearch', () => {
   cy.get('#street-city-state-zip', { timeout: 10000 })
     .should('exist')
     .should('not.be.disabled')
-    .clear({ waitForAnimations: true, force: true });
+    .clear({ force: true });
 
   // This forEach loop is a workaround to a typing bug in Cypress.
   // Upgrading to Cypress 6.1 should fix this bug and allow us
@@ -17,7 +17,7 @@ Cypress.Commands.add('checkSearch', () => {
   [...city].forEach(char => {
     cy.get('#street-city-state-zip')
       .should('not.be.disabled')
-      .type(char, { waitForAnimations: true });
+      .type(char, { force: true });
   });
   cy.get('#facility-type-dropdown').select('VA health');
   cy.get('#facility-search').click();
@@ -57,26 +57,28 @@ describe('Mobile', () => {
     });
   });
 
-  it('should render in mobile layouts and tabs actions work', () => {
-    cy.visit('/find-locations');
-    cy.injectAxe();
+  for (let i = 0; i < 50; i++) {
+    it('should render in mobile layouts and tabs actions work', () => {
+      cy.visit('/find-locations');
+      cy.injectAxe();
 
-    // iPhone X
-    cy.viewport(400, 812);
-    cy.checkSearch();
+      // iPhone X
+      cy.viewport(400, 812);
+      cy.checkSearch();
 
-    // iPhone 6/7/8 plus
-    cy.viewport(414, 736);
-    cy.checkSearch();
+      // iPhone 6/7/8 plus
+      cy.viewport(414, 736);
+      cy.checkSearch();
 
-    // Pixel 2
-    cy.viewport(411, 731);
-    cy.checkSearch();
+      // Pixel 2
+      cy.viewport(411, 731);
+      cy.checkSearch();
 
-    // Galaxy S5/Moto
-    cy.viewport(360, 640);
-    cy.checkSearch();
-  });
+      // Galaxy S5/Moto
+      cy.viewport(360, 640);
+      cy.checkSearch();
+    });
+  }
 
   it('should render the appropriate elements at each breakpoint', () => {
     cy.visit('/find-locations');


### PR DESCRIPTION
## Description
The fixes in [this recent PR](https://github.com/department-of-veterans-affairs/vets-website/pull/15503) exposed new race conditions in the affected Cypress tests. This PR handles the remaining race conditions.

## Testing done
- This test was run 30 times locally (both in the browser and headless) without any failures.

## Acceptance criteria
- [ ] Tests pass locally and on CI.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
