### PR TITLE
Fixed VAOS cypress tests, enabled unit test

### DIFF
--- a/src/applications/vaos/tests/e2e/va-appointment.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/va-appointment.cypress.spec.js
@@ -8,7 +8,7 @@ import * as newApptTests from './vaos-cypress-schedule-appointment-helpers';
 describe('VAOS direct schedule flow', () => {
   beforeEach(() => {});
 
-  it.skip('should submit form', () => {
+  it('should submit form', () => {
     initAppointmentListMock();
     initVAAppointmentMock();
     cy.visit('health-care/schedule-view-va-appointments/appointments/');
@@ -59,6 +59,8 @@ describe('VAOS direct schedule flow', () => {
       expect(request).to.have.property(
         'desiredDate',
         `${moment()
+          .add(1, 'month')
+          .startOf('month')
           .add(4, 'days')
           .startOf('day')
           .format('YYYY-MM-DD')}T00:00:00+00:00`,
@@ -79,7 +81,7 @@ describe('VAOS direct schedule flow', () => {
     newApptTests.confirmationPageTest(additionalInfo);
   });
 
-  it.skip('should submit form with an eye care type of care', () => {
+  it('should submit form with an eye care type of care', () => {
     initAppointmentListMock();
     initVAAppointmentMock();
     cy.visit('health-care/schedule-view-va-appointments/appointments/');
@@ -130,6 +132,8 @@ describe('VAOS direct schedule flow', () => {
       expect(request).to.have.property(
         'desiredDate',
         `${moment()
+          .add(1, 'month')
+          .startOf('month')
           .add(4, 'days')
           .startOf('day')
           .format('YYYY-MM-DD')}T00:00:00+00:00`,
@@ -146,7 +150,7 @@ describe('VAOS direct schedule flow', () => {
     newApptTests.confirmationPageTest(additionalInfo);
   });
 
-  it.skip('should submit form with a sleep care type of care', () => {
+  it('should submit form with a sleep care type of care', () => {
     initAppointmentListMock();
     initVAAppointmentMock();
     cy.visit('health-care/schedule-view-va-appointments/appointments/');
@@ -197,6 +201,8 @@ describe('VAOS direct schedule flow', () => {
       expect(request).to.have.property(
         'desiredDate',
         `${moment()
+          .add(1, 'month')
+          .startOf('month')
           .add(4, 'days')
           .startOf('day')
           .format('YYYY-MM-DD')}T00:00:00+00:00`,

--- a/src/applications/vaos/tests/e2e/vaos-cypress-schedule-appointment-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-cypress-schedule-appointment-helpers.js
@@ -33,7 +33,11 @@ export function choosePreferredDateTest() {
   cy.url().should('include', '/preferred-date');
   cy.axeCheck();
 
-  const preferredDate = today.clone().add(4, 'days');
+  const preferredDate = today
+    .clone()
+    .add(1, 'month')
+    .startOf('month')
+    .add(4, 'days');
 
   cy.findByLabelText('Month').select(preferredDate.format('MMM'));
   cy.findByLabelText('Day').select(preferredDate.format('D'));
@@ -43,7 +47,6 @@ export function choosePreferredDateTest() {
 
 export function selectTimeSlotTest() {
   cy.url().should('include', '/select-date');
-  cy.findByText(/Next/).click();
   cy.get(
     '.vaos-calendar__calendars button[id^="date-cell"]:not([disabled])',
   ).click();

--- a/src/applications/vaos/tests/new-appointment/components/DateTimeRequestPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/DateTimeRequestPage.unit.spec.jsx
@@ -362,7 +362,7 @@ describe('VAOS <DateTimeRequestPage>', () => {
     });
   });
 
-  it.skip('should not allow selections after max date', async () => {
+  it('should not allow selections after max date', async () => {
     const store = createTestStore({
       newAppointment: {
         data: {


### PR DESCRIPTION
## Description
Due to a bug we fixed on the calendar recently, our direct schedule Cypress tests started failing during the last four days of the month. This updates the date logic to hopefully work consistently across all days of the month.

## Testing done
Local testing

## Acceptance criteria
- [ ] Build passes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
