### PR TITLE
[526/BDD]: Skip Inflection Header for SIP

### DIFF
--- a/src/platform/forms/constants.js
+++ b/src/platform/forms/constants.js
@@ -26,3 +26,7 @@ export const VA_FORM_IDS = Object.freeze({
   FORM_21_22: '21-22',
   FORM_5655: '5655',
 });
+
+export const VA_FORM_IDS_SKIP_INFLECTION = Object.freeze([
+  VA_FORM_IDS.FORM_21_526EZ,
+]);

--- a/src/platform/forms/save-in-progress/api.js
+++ b/src/platform/forms/save-in-progress/api.js
@@ -66,7 +66,6 @@ export function saveFormApi(
   if (VA_FORM_IDS_SKIP_INFLECTION.includes(formId)) {
     delete saveFormApiHeaders['X-Key-Inflection'];
   }
-  debugger
 
   return fetch(`${environment.API_URL}/v0/in_progress_forms/${formId}`, {
     method: 'PUT',

--- a/src/platform/forms/save-in-progress/api.js
+++ b/src/platform/forms/save-in-progress/api.js
@@ -4,6 +4,7 @@ import environment from '../../utilities/environment';
 import localStorage from '../../utilities/storage/localStorage';
 import { fetchAndUpdateSessionExpiration as fetch } from '../../utilities/api';
 import { sanitizeForm } from '../helpers';
+import { VA_FORM_IDS_SKIP_INFLECTION } from '../constants';
 
 export function removeFormApi(formId) {
   const csrfTokenStored = localStorage.getItem('csrfToken');
@@ -56,16 +57,21 @@ export function saveFormApi(
     formData,
   });
   const csrfTokenStored = localStorage.getItem('csrfToken');
+  const saveFormApiHeaders = {
+    'Content-Type': 'application/json',
+    'X-Key-Inflection': 'camel',
+    'Source-App-Name': window.appName,
+    'X-CSRF-Token': csrfTokenStored,
+  };
+  if (VA_FORM_IDS_SKIP_INFLECTION.includes(formId)) {
+    delete saveFormApiHeaders['X-Key-Inflection'];
+  }
+  debugger
 
   return fetch(`${environment.API_URL}/v0/in_progress_forms/${formId}`, {
     method: 'PUT',
     credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Key-Inflection': 'camel',
-      'Source-App-Name': window.appName,
-      'X-CSRF-Token': csrfTokenStored,
-    },
+    headers: saveFormApiHeaders,
     body,
   })
     .then(res => {


### PR DESCRIPTION
## Description
Due to a significant issue with disability names that have special characters, we need to not pass the inflection camel header for the 526/BDD forms. This PR adds the ability to skip the header for specific form IDs.

## Acceptance criteria
- [x] Inflection header not provided for 526/BDD forms