### PR TITLE
Add 'back to top' button to all  Resources and Support article-types

### DIFF
--- a/src/site/layouts/checklist.drupal.liquid
+++ b/src/site/layouts/checklist.drupal.liquid
@@ -113,6 +113,7 @@
       </div>
     </div>
   </main>
+  {% include "src/site/components/up_to_top_button.html" %}
 </div>
 
 {% include "src/site/includes/footer.html" %}

--- a/src/site/layouts/media_list_images.drupal.liquid
+++ b/src/site/layouts/media_list_images.drupal.liquid
@@ -52,7 +52,7 @@
                         {% endif %}
                         <!-- Images List -->
                         <dl class="usa-unstyled-list">
-                            {% include "src/site/includes/images_list_with_additional_info_component.drupal.liquid" 
+                            {% include "src/site/includes/images_list_with_additional_info_component.drupal.liquid"
                             with images = fieldMediaListImages.entity.fieldImages %}
                         </dl>
                         <!-- Repeated buttons -->
@@ -89,6 +89,7 @@
             </div>
         </div>
     </main>
+    {% include "src/site/components/up_to_top_button.html" %}
 </div>
 
 {% include "src/site/includes/footer.html" %}

--- a/src/site/layouts/media_list_videos.drupal.liquid
+++ b/src/site/layouts/media_list_videos.drupal.liquid
@@ -95,6 +95,7 @@
       </div>
     </div>
   </main>
+  {% include "src/site/components/up_to_top_button.html" %}
 </div>
 
 {% include "src/site/includes/footer.html" %}

--- a/src/site/layouts/q_a.drupal.liquid
+++ b/src/site/layouts/q_a.drupal.liquid
@@ -70,6 +70,7 @@
       </div>
     </div>
   </main>
+  {% include "src/site/components/up_to_top_button.html" %}
 </div>
 
 {% include "src/site/includes/footer.html" %}

--- a/src/site/layouts/step_by_step.drupal.liquid
+++ b/src/site/layouts/step_by_step.drupal.liquid
@@ -59,7 +59,7 @@
                     <!-- Step wysiyg -->
                     {{ fieldStep.entity.fieldWysiwyg.processed }}
                     <!-- mobile template, hide ghost alerts -->
-                    {% if fieldStep.entity.fieldMedia.entity.thumbnail != empty or fieldStep.entity.fieldAlert.entity.fieldAlertBlockReference != empty   
+                    {% if fieldStep.entity.fieldMedia.entity.thumbnail != empty or fieldStep.entity.fieldAlert.entity.fieldAlertBlockReference != empty
                     %}
                       <div class="form-expanding-group additional-info-container medium-screen:vads-u-display--none">
                         <span class="additional-info-title">Show details</span>
@@ -76,7 +76,7 @@
                     {% endif %}
                     <!-- desktop -->
                     <span class="vads-u-display--none medium-screen:vads-u-display--block">
-                      {% if fieldStep.entity.fieldAlert.entity.fieldAlertBlockReference != empty   
+                      {% if fieldStep.entity.fieldAlert.entity.fieldAlertBlockReference != empty
                       %}
                         <div class="vads-u-margin--1p5">
                           {% include "src/site/paragraphs/alert_single.drupal.liquid" with entity = fieldStep.entity.fieldAlert.entity %}
@@ -129,6 +129,7 @@
       </div>
     </div>
   </main>
+  {% include "src/site/components/up_to_top_button.html" %}
 </div>
 
 {% include "src/site/includes/footer.html" %}

--- a/src/site/layouts/support_resources_article_listing.drupal.liquid
+++ b/src/site/layouts/support_resources_article_listing.drupal.liquid
@@ -47,6 +47,7 @@
       </div>
     </div>
   </main>
+  {% include "src/site/components/up_to_top_button.html" %}
 </div>
 
 {% include "src/site/includes/footer.html" %}

--- a/src/site/layouts/support_resources_detail_page.drupal.liquid
+++ b/src/site/layouts/support_resources_detail_page.drupal.liquid
@@ -91,6 +91,7 @@
       </div>
     </div>
   </main>
+  {% include "src/site/components/up_to_top_button.html" %}
 </div>
 
 {% include "src/site/includes/footer.html" %}


### PR DESCRIPTION
## Description
This PR adds the "Scroll to top" button onto all of the article types in the Resources and Support website section. Currently it is only on the Multiple FAQ article type.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/16369

## Testing done
I included the component on each R&S page-type, did a `yarn build:content`, then navigated to an instance of each type of page and confirmed the scroll-top button is there and works.

I tested on -

1. `http://localhost:3001/resources/get-a-premium-my-healthevet-account/` (About)
2. `http://localhost:3001/resources/how-to-get-a-premium-ds-logon-account-online/` (Step by step)
3. `http://localhost:3001/resources/how-can-i-find-a-va-facility/` (Single QA)

We don't have any published articles for image lists or the checklist AFAIK so I couldn't test on those directly. But those will be tested in preview prior to publish anyway.

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/103562171-9f4bdd00-4e88-11eb-8a5f-a6ca23996194.png)

## Acceptance criteria
- [ ] Scroll-to-top button exists

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
