### PR TITLE
Restyle ReviewCardField titles

### DIFF
--- a/src/platform/forms-system/src/js/components/ReviewCardField.jsx
+++ b/src/platform/forms-system/src/js/components/ReviewCardField.jsx
@@ -153,7 +153,6 @@ export default class ReviewCardField extends React.Component {
       'vads-u-margin-top--1',
       'vads-u-margin-bottom--2p5',
       'vads-u-margin-x--0',
-      'vads-u-font-size--h4',
     ].join(' ');
 
     const updateButtonClasses = [


### PR DESCRIPTION
## Description
Per @CrystabelReiter, I removed the H4 styling override on the `ReviewCardField` card title.

## Testing done
:eyes: 

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/103577532-db337200-4e89-11eb-962d-bb0149332205.png)
