### PR TITLE
Enable Facility Locator mobile E2E test

### DIFF
--- a/src/applications/facility-locator/tests/e2e/mobile.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/mobile.cypress.spec.js
@@ -58,28 +58,26 @@ describe('Mobile', () => {
     });
   });
 
-  for (let i = 0; i < 50; i++) {
-    it('should render in mobile layouts and tabs actions work', () => {
-      cy.visit('/find-locations');
-      cy.injectAxe();
+  it('should render in mobile layouts and tabs actions work', () => {
+    cy.visit('/find-locations');
+    cy.injectAxe();
 
-      // iPhone X
-      cy.viewport(400, 812);
-      cy.checkSearch();
+    // iPhone X
+    cy.viewport(400, 812);
+    cy.checkSearch();
 
-      // iPhone 6/7/8 plus
-      cy.viewport(414, 736);
-      cy.checkSearch();
+    // iPhone 6/7/8 plus
+    cy.viewport(414, 736);
+    cy.checkSearch();
 
-      // Pixel 2
-      cy.viewport(411, 731);
-      cy.checkSearch();
+    // Pixel 2
+    cy.viewport(411, 731);
+    cy.checkSearch();
 
-      // Galaxy S5/Moto
-      cy.viewport(360, 640);
-      cy.checkSearch();
-    });
-  }
+    // Galaxy S5/Moto
+    cy.viewport(360, 640);
+    cy.checkSearch();
+  });
 
   it('should render the appropriate elements at each breakpoint', () => {
     cy.visit('/find-locations');

--- a/src/applications/facility-locator/tests/e2e/mobile.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/mobile.cypress.spec.js
@@ -51,33 +51,35 @@ Cypress.Commands.add('checkSearch', () => {
   cy.get('#street-city-state-zip').clear();
 });
 
-describe.skip('Mobile', () => {
+describe('Mobile', () => {
   before(() => {
     cy.syncFixtures({
       constants: path.join(__dirname, '..', '..', 'constants'),
     });
   });
 
-  it('should render in mobile layouts and tabs actions work', () => {
-    cy.visit('/find-locations');
-    cy.injectAxe();
+  for (let i = 0; i < 50; i++) {
+    it('should render in mobile layouts and tabs actions work', () => {
+      cy.visit('/find-locations');
+      cy.injectAxe();
 
-    // iPhone X
-    cy.viewport(400, 812);
-    cy.checkSearch();
+      // iPhone X
+      cy.viewport(400, 812);
+      cy.checkSearch();
 
-    // iPhone 6/7/8 plus
-    cy.viewport(414, 736);
-    cy.checkSearch();
+      // iPhone 6/7/8 plus
+      cy.viewport(414, 736);
+      cy.checkSearch();
 
-    // Pixel 2
-    cy.viewport(411, 731);
-    cy.checkSearch();
+      // Pixel 2
+      cy.viewport(411, 731);
+      cy.checkSearch();
 
-    // Galaxy S5/Moto
-    cy.viewport(360, 640);
-    cy.checkSearch();
-  });
+      // Galaxy S5/Moto
+      cy.viewport(360, 640);
+      cy.checkSearch();
+    });
+  }
 
   it('should render the appropriate elements at each breakpoint', () => {
     cy.visit('/find-locations');


### PR DESCRIPTION
## Description
This spec was disabled recently due to flakiness/failures. A [recent PR](https://github.com/department-of-veterans-affairs/vets-website/pull/15510) fixed the flakiness, so this test can be re-enabled.

## Testing done
- Ran test on CI 50 times without any failures

## Screenshots


## Acceptance criteria
- [ ] Test passes locally and on CI

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
