### PR TITLE
[Development] HLR: Split up informal conference form

### DIFF
--- a/src/applications/disability-benefits/996/config/form.js
+++ b/src/applications/disability-benefits/996/config/form.js
@@ -20,6 +20,8 @@ import veteranInformation from '../pages/veteranInformation';
 import contactInfo from '../pages/contactInformation';
 import contestedIssuesPage from '../pages/contestedIssues';
 import informalConference from '../pages/informalConference';
+import informalConferenceRep from '../pages/informalConferenceRep';
+import informalConferenceTimes from '../pages/informalConferenceTimes';
 
 import { errorMessages } from '../constants';
 // import initialData from '../tests/schema/initialData';
@@ -111,10 +113,24 @@ const formConfig = {
       title: 'Request an informal conference',
       pages: {
         requestConference: {
-          path: 'request-informal-conference',
+          path: 'informal-conference',
           title: 'Request an informal conference',
           uiSchema: informalConference.uiSchema,
           schema: informalConference.schema,
+        },
+        representativeInfo: {
+          path: 'informal-conference/representative-information',
+          title: 'Representative’s information',
+          depends: formData => formData?.informalConference === 'rep',
+          uiSchema: informalConferenceRep.uiSchema,
+          schema: informalConferenceRep.schema,
+        },
+        availability: {
+          path: 'informal-conference/availability',
+          title: 'Scheduling availability',
+          depends: formData => formData?.informalConference !== 'no',
+          uiSchema: informalConferenceTimes.uiSchema,
+          schema: informalConferenceTimes.schema,
         },
       },
     },

--- a/src/applications/disability-benefits/996/content/InformalConference.jsx
+++ b/src/applications/disability-benefits/996/content/InformalConference.jsx
@@ -1,19 +1,17 @@
 import React from 'react';
-import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 export const InformalConferenceDescription = (
   <>
     <p>
-      You or your accredited representative (claims agent, attorney, or Veterans
-      Service Organization) can request an informal conference with the reviewer
-      assigned to your Higher-Level Review. During this conference you or your
-      representative will have the chance to discuss why you think the decision
-      should be changed and identify factual errors.
+      An informal conference is a phone call between you or your accredited
+      representative (claims agent, attorney, or Veterans Service Organization)
+      and the reviewer to discuss why you think the decision should be changed
+      and identify factual errors.
     </p>
     <p className="vads-u-margin-bottom--3">
       If you request an informal conference, the reviewer will call you or your
-      representative. You can request only one informal conference for your
-      Higher-Level Review.
+      representative. You can request only one informal conference for each
+      Higher-Level Review request.
     </p>
   </>
 );
@@ -27,8 +25,13 @@ export const informalConferenceLabels = {
   rep: 'Yes, call my representative',
 };
 
+export const ContactRepresentativeTitle = 'Representative’s information';
+
+// direct <p> will have all margins removed, so it's nested here:
 export const ContactRepresentativeDescription = (
-  <p>Please provide your representative’s contact information.</p>
+  <div className="vads-u-margin-bottom--4">
+    <p>Please provide your representative’s contact information.</p>
+  </div>
 );
 
 export const RepresentativeNameTitle = 'Representative’s name';
@@ -42,14 +45,31 @@ const contacts = (
     <span className="contact-choice selected-me">you</span>
   </>
 );
-export const InformalConferenceTimes = (
+
+export const InformalConferenceTimesTitle = (
   <>
-    <strong>We’ll call {contacts} to schedule an informal conference.</strong>
-    <p>Please provide 1 or 2 preferred times for a call.</p>
+    <h3 className="vads-u-font-size--h5 vads-u-margin-top--0">
+      <span className="contact-choice selected-rep">
+        Your representative’s availability
+      </span>
+      <span className="contact-choice selected-me">Your availability</span>
+    </h3>
+    <p>
+      First we’ll call {contacts} to schedule the informal conference. Please
+      indicate <span className="contact-choice selected-me">your</span>
+      <span className="contact-choice selected-rep">their</span> availability by
+      providing 1 or 2 preferred times for a call.
+    </p>
+    <p>
+      <strong>We’ll make two attempts to call {contacts}.</strong> If no one
+      answers, we’ll leave a voice mail and a number for {contacts} to return
+      the call. If we aren’t able to get in touch with {contacts} after 2
+      attempts, we’ll proceed with the Higher-Level Review.
+    </p>
   </>
 );
 
-export const informalConferenceTimeTitles = {
+export const informalConferenceTimeSelectTitles = {
   first: <>Choose the best time for us to call {contacts}</>,
   second: 'Choose another time for us to call',
 };
@@ -59,23 +79,4 @@ export const informalConferenceTimeAllLabels = {
   time1000to1230: '10:00 a.m. to 12:30 p.m. ET',
   time1230to1400: '12:30 p.m. to 2:00 p.m. ET',
   time1400to1630: '2:00 p.m. to 4:30 p.m. ET',
-};
-
-export const InformalConferenceAvailability = contact => (
-  <span className="time-contact">
-    {contact === 'me' ? 'My' : 'Representative’s'} availability for scheduling
-  </span>
-);
-
-export const AttemptsInfoAlert = ({ isRep }) => {
-  const contact = isRep ? 'them' : 'you';
-  return (
-    <AlertBox
-      status="info"
-      headline={`We’ll call ${isRep ? 'your representative' : 'you'} 2 times`}
-      content={`Each time we call, we’ll leave a voice mail and a number for
-      ${contact} to return the call. If we aren’t able to get in touch with
-      ${contact} after 2 attempts, we’ll proceed with the Higher-Level Review.`}
-    />
-  );
 };

--- a/src/applications/disability-benefits/996/pages/informalConference.js
+++ b/src/applications/disability-benefits/996/pages/informalConference.js
@@ -1,23 +1,9 @@
-import PhoneNumberWidget from 'platform/forms-system/src/js/widgets/PhoneNumberWidget';
-import PhoneNumberReviewWidget from 'platform/forms-system/src/js/review/PhoneNumberWidget';
-
-import {
-  checkConferenceTimes,
-  isFirstConferenceTimeEmpty,
-} from '../validations';
 import { errorMessages } from '../constants';
 
 import {
   InformalConferenceDescription,
   InformalConferenceTitle,
-  informalConferenceTimeTitles,
   informalConferenceLabels,
-  informalConferenceTimeAllLabels,
-  ContactRepresentativeDescription,
-  RepresentativeNameTitle,
-  RepresentativePhoneTitle,
-  InformalConferenceTimes,
-  AttemptsInfoAlert,
 } from '../content/InformalConference';
 
 const informalConference = {
@@ -46,112 +32,6 @@ const informalConference = {
         required: errorMessages.informalConferenceContactChoice,
       },
     },
-    informalConferenceRep: {
-      'ui:title': '',
-      'ui:options': {
-        hideIf: formData => formData?.informalConference !== 'rep',
-        expandUnder: 'informalConference',
-      },
-      'view:ContactRepresentativeInfo': {
-        'ui:title': '',
-        'ui:description': ContactRepresentativeDescription,
-      },
-      name: {
-        'ui:title': RepresentativeNameTitle,
-        'ui:required': formData => formData?.informalConference === 'rep',
-        'ui:errorMessages': {
-          required: errorMessages.informalConferenceContactName,
-        },
-        'ui:options': {
-          hideIf: formData => formData?.informalConference !== 'rep',
-        },
-      },
-      phone: {
-        'ui:title': RepresentativePhoneTitle,
-        'ui:widget': PhoneNumberWidget,
-        'ui:reviewWidget': PhoneNumberReviewWidget,
-        'ui:required': formData => formData?.informalConference === 'rep',
-        'ui:errorMessages': {
-          pattern: errorMessages.informalConferenceContactPhonePattern,
-          required: errorMessages.informalConferenceContactPhone,
-        },
-        'ui:options': {
-          hideIf: formData => formData?.informalConference !== 'rep',
-        },
-      },
-    },
-    informalConferenceTimes: {
-      'ui:title': InformalConferenceTimes,
-      'ui:options': {
-        showFieldLabel: true,
-        hideIf: formData => formData?.informalConference === 'no',
-        expandUnder: 'informalConference',
-        forceDivWrapper: true,
-        updateSchema: formData => {
-          const time1Setting = formData?.informalConferenceTimes?.time1 || '';
-          const time2Setting = formData?.informalConferenceTimes?.time2 || '';
-          const enums = Object.keys(informalConferenceTimeAllLabels);
-          const enumNames = Object.values(informalConferenceTimeAllLabels);
-          return {
-            type: 'object',
-            properties: {
-              time1: {
-                type: 'string',
-                enum: enums.filter(val => val !== time2Setting),
-                enumNames: enumNames.filter(
-                  label =>
-                    label !== informalConferenceTimeAllLabels[time2Setting],
-                ),
-              },
-              time2: {
-                type: 'string',
-                enum: enums.filter(val => val !== time1Setting),
-                enumNames: enumNames.filter(
-                  label =>
-                    label !== informalConferenceTimeAllLabels[time1Setting],
-                ),
-              },
-            },
-          };
-        },
-      },
-      time1: {
-        'ui:title': informalConferenceTimeTitles.first,
-        'ui:required': formData => formData?.informalConference !== 'no',
-        'ui:validations': [checkConferenceTimes],
-        'ui:errorMessages': {
-          required: errorMessages.informalConferenceTimes,
-        },
-      },
-      time2: {
-        'ui:title': informalConferenceTimeTitles.second,
-        'ui:options': {
-          hideEmptyValueInReview: true,
-        },
-      },
-    },
-    'view:alert': {
-      'ui:title': '',
-      'view:contactYou': {
-        'ui:title': ' ',
-        'ui:description': AttemptsInfoAlert,
-        'ui:options': {
-          hideIf: formData => formData?.informalConference !== 'me',
-          forceDivWrapper: true,
-        },
-      },
-      'view:contactRepresentative': {
-        'ui:title': '',
-        'ui:description': () => AttemptsInfoAlert({ isRep: true }),
-        'ui:options': {
-          hideIf: formData => formData?.informalConference !== 'rep',
-        },
-      },
-      'ui:options': {
-        hideIf: isFirstConferenceTimeEmpty,
-        expandUnder: 'informalConference',
-      },
-    },
   },
   schema: {
     type: 'object',
@@ -160,45 +40,6 @@ const informalConference = {
       informalConference: {
         type: 'string',
         enum: ['no', 'me', 'rep'],
-      },
-      informalConferenceRep: {
-        type: 'object',
-        properties: {
-          'view:ContactRepresentativeInfo': {
-            type: 'object',
-            properties: {},
-          },
-          name: {
-            type: 'string',
-          },
-          phone: {
-            type: 'string',
-          },
-        },
-      },
-      informalConferenceTimes: {
-        type: 'object',
-        properties: {
-          time1: {
-            type: 'string',
-          },
-          time2: {
-            type: 'string',
-          },
-        },
-      },
-      'view:alert': {
-        type: 'object',
-        properties: {
-          'view:contactYou': {
-            type: 'object',
-            properties: {},
-          },
-          'view:contactRepresentative': {
-            type: 'object',
-            properties: {},
-          },
-        },
       },
     },
   },

--- a/src/applications/disability-benefits/996/pages/informalConferenceRep.js
+++ b/src/applications/disability-benefits/996/pages/informalConferenceRep.js
@@ -1,0 +1,62 @@
+import PhoneNumberWidget from 'platform/forms-system/src/js/widgets/PhoneNumberWidget';
+import PhoneNumberReviewWidget from 'platform/forms-system/src/js/review/PhoneNumberWidget';
+
+import { errorMessages } from '../constants';
+
+import {
+  ContactRepresentativeTitle,
+  ContactRepresentativeDescription,
+  RepresentativeNameTitle,
+  RepresentativePhoneTitle,
+} from '../content/InformalConference';
+
+export default {
+  uiSchema: {
+    'ui:title': ' ',
+    'ui:options': {
+      forceDivWrapper: true,
+    },
+    informalConferenceRep: {
+      'ui:title': ContactRepresentativeTitle,
+      'ui:description': ContactRepresentativeDescription,
+      name: {
+        'ui:title': RepresentativeNameTitle,
+        'ui:required': formData => formData?.informalConference === 'rep',
+        'ui:errorMessages': {
+          required: errorMessages.informalConferenceContactName,
+        },
+      },
+      phone: {
+        'ui:title': RepresentativePhoneTitle,
+        'ui:widget': PhoneNumberWidget,
+        'ui:reviewWidget': PhoneNumberReviewWidget,
+        'ui:required': formData => formData?.informalConference === 'rep',
+        'ui:errorMessages': {
+          pattern: errorMessages.informalConferenceContactPhonePattern,
+          required: errorMessages.informalConferenceContactPhone,
+        },
+      },
+    },
+  },
+  schema: {
+    type: 'object',
+    required: ['informalConference'],
+    properties: {
+      informalConferenceRep: {
+        type: 'object',
+        properties: {
+          'view:ContactRepresentativeInfo': {
+            type: 'object',
+            properties: {},
+          },
+          name: {
+            type: 'string',
+          },
+          phone: {
+            type: 'string',
+          },
+        },
+      },
+    },
+  },
+};

--- a/src/applications/disability-benefits/996/pages/informalConferenceTimes.js
+++ b/src/applications/disability-benefits/996/pages/informalConferenceTimes.js
@@ -1,0 +1,81 @@
+import { checkConferenceTimes } from '../validations';
+import { errorMessages } from '../constants';
+
+import {
+  InformalConferenceTimesTitle,
+  informalConferenceTimeSelectTitles,
+  informalConferenceTimeAllLabels,
+} from '../content/InformalConference';
+
+export default {
+  uiSchema: {
+    'ui:description': InformalConferenceTimesTitle,
+    'ui:options': {
+      forceDivWrapper: true,
+    },
+    informalConferenceTimes: {
+      'ui:title': ' ',
+      'ui:options': {
+        showFieldLabel: true,
+        forceDivWrapper: true,
+        updateSchema: formData => {
+          const time1Setting = formData?.informalConferenceTimes?.time1 || '';
+          const time2Setting = formData?.informalConferenceTimes?.time2 || '';
+          const enums = Object.keys(informalConferenceTimeAllLabels);
+          const enumNames = Object.values(informalConferenceTimeAllLabels);
+          return {
+            type: 'object',
+            properties: {
+              time1: {
+                type: 'string',
+                enum: enums.filter(val => val !== time2Setting),
+                enumNames: enumNames.filter(
+                  label =>
+                    label !== informalConferenceTimeAllLabels[time2Setting],
+                ),
+              },
+              time2: {
+                type: 'string',
+                enum: enums.filter(val => val !== time1Setting),
+                enumNames: enumNames.filter(
+                  label =>
+                    label !== informalConferenceTimeAllLabels[time1Setting],
+                ),
+              },
+            },
+          };
+        },
+      },
+      time1: {
+        'ui:title': informalConferenceTimeSelectTitles.first,
+        'ui:required': formData => formData?.informalConference !== 'no',
+        'ui:validations': [checkConferenceTimes],
+        'ui:errorMessages': {
+          required: errorMessages.informalConferenceTimes,
+        },
+      },
+      time2: {
+        'ui:title': informalConferenceTimeSelectTitles.second,
+        'ui:options': {
+          hideEmptyValueInReview: true,
+        },
+      },
+    },
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      informalConferenceTimes: {
+        type: 'object',
+        properties: {
+          time1: {
+            type: 'string',
+          },
+          time2: {
+            type: 'string',
+          },
+        },
+      },
+    },
+  },
+};

--- a/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
+++ b/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
@@ -173,37 +173,17 @@ article[data-contact-choice="me"] .contact-choice.selected-me {
   display: inline-block;
 }
 
-article[data-location="request-informal-conference"] {
-  .schemaform-block-header {
-    margin-bottom: 1.5em;
+article[data-location="informal-conference/representative-information"] {
+  .schemaform-field-container {
+    margin-top: 0;
+  }
+}
+
+article[data-location="informal-conference/availability"] {
+  #root_informalConferenceTimes_time2-label {
+    margin-top: 2rem;
   }
 
-  .form-expanding-group-open {
-    .schemaform-field-template,
-    .schemaform-field-container {
-      margin-top: 1em;
-    }
-  }
-
-  /* Remove extra spacing between form elements */
-  .form-expanding-group {
-    .schemaform-first-field,
-    .usa-input-error {
-      margin-top: 0;
-    }
-
-    .schemaform-block-header {
-      margin-bottom: 0;
-    }
-  }
-
-  .schemaform-label.usa-input-error-label {
-    font-weight: bold;
-  }
-
-  .form-checkbox label {
-    margin-top: 1em;
-  }
 }
 
 /* Step 4 Review Application */

--- a/src/applications/disability-benefits/996/tests/content/InformalConferenceRep.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/content/InformalConferenceRep.unit.spec.jsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import ReactTestUtils from 'react-dom/test-utils';
+
+import {
+  DefinitionTester,
+  submitForm,
+  getFormDOM,
+} from 'platform/testing/unit/schemaform-utils';
+
+import { $, $$ } from '../../helpers';
+
+import formConfig from '../../config/form';
+import informalConferenceRep from '../../pages/informalConferenceRep';
+
+const { schema, uiSchema } = informalConferenceRep;
+
+describe('Higher-Level Review 0996 informal conference representative', () => {
+  const data = {
+    informalConference: 'rep',
+    informalConferenceRep: {
+      name: 'John Doe',
+      phone: '8005551212',
+    },
+  };
+
+  it('should render informal conference representative form', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        data={{}}
+        formData={{}}
+        uiSchema={uiSchema}
+      />,
+    );
+
+    const formDOM = getFormDOM(form);
+    expect($$('input[type="text"]', formDOM).length).to.equal(1);
+    expect($$('input[type="tel"]', formDOM).length).to.equal(1);
+  });
+
+  it('should show the call representative name & phone info', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        data={{
+          informalConference: 'rep',
+          informalConferenceRep: {
+            name: 'John Doe',
+            phone: '800-555-1212',
+          },
+        }}
+        formData={{}}
+        uiSchema={uiSchema}
+      />,
+    );
+
+    const formDOM = getFormDOM(form);
+    expect($('input[type="text"]', formDOM).value).to.equal('John Doe');
+    expect($('input[type="tel"]', formDOM).value).to.equal('800-555-1212');
+  });
+
+  it('prevents submit when informal conference is not selected', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        onSubmit={onSubmit}
+        schema={schema}
+        data={{
+          // needed to set name/phone as required
+          informalConference: 'rep',
+        }}
+        formData={{}}
+        uiSchema={uiSchema}
+      />,
+    );
+
+    const formDOM = getFormDOM(form);
+    submitForm(form);
+    expect($$('.usa-input-error', formDOM).length).to.equal(2);
+    expect(onSubmit.called).not.to.be.true;
+  });
+
+  it('successfully submits when a rep info is entered', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        onSubmit={onSubmit}
+        schema={schema}
+        data={data}
+        formData={data}
+        uiSchema={uiSchema}
+      />,
+    );
+
+    const formDOM = getFormDOM(form);
+    submitForm(form);
+    expect($$('.usa-input-error', formDOM).length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+  });
+});

--- a/src/applications/disability-benefits/996/tests/content/InformalConferenceTimes.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/content/InformalConferenceTimes.unit.spec.jsx
@@ -12,12 +12,12 @@ import {
 import { $$ } from '../../helpers';
 
 import formConfig from '../../config/form';
-import informalConference from '../../pages/informalConference';
+import informalConferenceTimes from '../../pages/informalConferenceTimes';
 
-const { schema, uiSchema } = informalConference;
+const { schema, uiSchema } = informalConferenceTimes;
 
-describe('Higher-Level Review 0996 informal conference', () => {
-  it('should render informal conference form', () => {
+describe('Higher-Level Review 0996 informal conference times', () => {
+  it('should render informal conference times form', () => {
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
         definitions={formConfig.defaultDefinitions}
@@ -29,18 +29,46 @@ describe('Higher-Level Review 0996 informal conference', () => {
     );
 
     const formDOM = getFormDOM(form);
-    expect($$('input[type="radio"]', formDOM).length).to.equal(3);
+    expect($$('select', formDOM).length).to.equal(2);
   });
 
-  /* Successful submits */
-  it('successfully submits when no informal conference is selected', () => {
+  /* Successful submit */
+  it('successfully submits when one time is selected', () => {
     const onSubmit = sinon.spy();
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
         definitions={formConfig.defaultDefinitions}
         onSubmit={onSubmit}
         schema={schema}
-        data={{ informalConference: 'no' }}
+        data={{
+          informalConferenceTimes: {
+            time1: 'time1000to1230',
+          },
+        }}
+        formData={{}}
+        uiSchema={uiSchema}
+      />,
+    );
+
+    const formDOM = getFormDOM(form);
+    submitForm(form);
+    expect($$('.usa-input-error', formDOM).length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+  });
+
+  it('successfully submits when two times are selected', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        onSubmit={onSubmit}
+        schema={schema}
+        data={{
+          informalConferenceTimes: {
+            time1: 'time1000to1230',
+            time2: 'time1230to1400',
+          },
+        }}
         formData={{}}
         uiSchema={uiSchema}
       />,
@@ -53,7 +81,7 @@ describe('Higher-Level Review 0996 informal conference', () => {
   });
 
   /* Unsuccessful submits */
-  it('prevents submit when informal conference is not selected', () => {
+  it('prevents submit when no time is selected', () => {
     const onSubmit = sinon.spy();
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester


### PR DESCRIPTION
## Description

In the Higher-Level Review informal conference page, after making an informal conference choice for yourself additional fields are revealed asking for your time availability. When your representative is selected, additional fields ask for your representatives name, phone number and time availability. These additional fields are all contained on the page and may lead to cognitive overload. Additionally, all form fields are contained within a single fieldset making the screenreader unable to discern the sections of the form.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/18049
- https://github.com/department-of-veterans-affairs/vets-website/pull/15448#issuecomment-749136340
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/17766#issuecomment-752989375
- Design: https://vsateams.invisionapp.com/share/JHZTPGYBEYV#/441441502_HLR-Request-Informal-Conference-2-Who-To-Call

## Testing done

Updated unit tests
Verified Cypress test passing

## Screenshots

<details><summary>Informal conference choices</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-01-04 at 2 05 27 PM](https://user-images.githubusercontent.com/136959/103584372-c6b1a280-4ea6-11eb-9b9e-627fd74850f0.png)</details>

<details><summary>Representative information page</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-01-04 at 2 05 13 PM](https://user-images.githubusercontent.com/136959/103584374-c74a3900-4ea6-11eb-9063-bc87f1f31eab.png)</details>

<details><summary>Informal conference time selection</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-01-04 at 2 04 43 PM](https://user-images.githubusercontent.com/136959/103584376-c74a3900-4ea6-11eb-8cef-3451d324ab75.png)</details>

<details><summary>Review & Submit changes</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-01-04 at 2 11 14 PM](https://user-images.githubusercontent.com/136959/103584370-c4e7df00-4ea6-11eb-8108-82d29b3ad428.png)</details>

## Acceptance criteria
- [x] Informal conference choice page
- [x] Informal conference representative info page
- [x] Informal conference availability selection page
- [x] accessibility testing of each page done

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
