### PR TITLE
[Development] Record submit response details on error

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/submitForm.js
+++ b/src/applications/disability-benefits/all-claims/config/submitForm.js
@@ -45,7 +45,7 @@ const submitFormFor = eventName =>
           } else {
             error = new Error(`vets_server_error: ${req.statusText}`);
           }
-          error.statusText = req.statusText;
+          error.statusText = req.details;
           clearTimeout(timer);
           reject(error);
         }

--- a/src/applications/disability-benefits/all-claims/config/submitForm.js
+++ b/src/applications/disability-benefits/all-claims/config/submitForm.js
@@ -53,21 +53,21 @@ const submitFormFor = eventName =>
 
       req.addEventListener('error', () => {
         const error = new Error('client_error: Network request failed');
-        error.statusText = req.statusText;
+        error.statusText = req.details;
         clearTimeout(timer);
         reject(error);
       });
 
       req.addEventListener('abort', () => {
         const error = new Error('client_error: Request aborted');
-        error.statusText = req.statusText;
+        error.statusText = req.details;
         clearTimeout(timer);
         reject(error);
       });
 
       req.addEventListener('timeout', () => {
         const error = new Error('client_error: Request timed out');
-        error.statusText = req.statusText;
+        error.statusText = req.details;
         clearTimeout(timer);
         reject(error);
       });


### PR DESCRIPTION
## Description

On 526 submission, error `statusText` is used in the error message. If we use the response `details`, more information will be available in Sentry.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/15689#issuecomment-752252130

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] Store response details in error message

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
