### PR TITLE
Correct 1010EZ link label

### DIFF
--- a/src/applications/caregivers/containers/IntroductionPage.jsx
+++ b/src/applications/caregivers/containers/IntroductionPage.jsx
@@ -156,7 +156,7 @@ const IntroductionPage = ({ route, router }) => {
               >
                 {links.applyVAHealthCare.label}
               </a>
-              (VA Form 10-10CG).
+              (VA Form 10-10EZ).
             </p>
           </li>
 


### PR DESCRIPTION
## Description
Correct 1010EZ label from 1010CG to 1010EZ as per [ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/17848)

## Testing done
Visual testing

## Screenshots
![Screen Shot 2021-01-05 at 11 36 41 AM](https://user-images.githubusercontent.com/23741323/103672493-61af8880-4f4a-11eb-9368-ee6b71049476.png)


## Acceptance criteria
- [x] Correct 1010EZ label from 1010CG to 1010EZ

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
