### PR TITLE
update the availability text in the footer

### DIFF
--- a/src/applications/vaos/components/NeedHelp.jsx
+++ b/src/applications/vaos/components/NeedHelp.jsx
@@ -31,7 +31,7 @@ export default function NeedHelp() {
         For questions about joining a VA Video Connect appointment, please call{' '}
         <Telephone contact="8666513180" /> (TTY:{' '}
         <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
-        ). We’re here Monday through Saturday, 7:00 a.m. to 11:00 p.m. ET.
+        ). We’re here 24/7.
       </p>
       <p className="vads-u-margin-top--0">
         <a

--- a/src/applications/vaos/tests/components/NeedHelp.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/NeedHelp.unit.spec.jsx
@@ -22,5 +22,6 @@ describe('VAOS <NeedHelp>', () => {
       'href',
       'https://veteran.apps.va.gov/feedback-web/v1/?appId=85870ADC-CC55-405E-9AC3-976A92BBBBEE',
     );
+    expect(screen.getByText(/We’re here 24\/7/i)).to.exist;
   });
 });


### PR DESCRIPTION
## Description
change the last sentence in the footer to read "We’re here 24/7."

## Testing done
local and unit test

## Screenshots
![image](https://user-images.githubusercontent.com/54327023/103697839-7aca3080-4f6e-11eb-82d5-c18cc6806929.png)


## Acceptance criteria
- [ ] change footer text from "We’re here Monday through Saturday, 7:00 a.m. to 11:00 p.m. ET. " to "We’re here 24/7."

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
