### PR TITLE
[Resources and Support] Add 'browse by audience' section into homepage

### DIFF
--- a/src/site/layouts/basic_landing_page.drupal.liquid
+++ b/src/site/layouts/basic_landing_page.drupal.liquid
@@ -53,15 +53,40 @@
           {% if audienceTags != empty %}
             <h2>Browse by audience</h2>
             <ul class="usa-unstyled-list">
+
+              {% assign pageSize = 5 %}
+
               {% for audienceTag in audienceTags %}
-                <li class="vads-u-margin-y--2">
-                  <a class="vads-u-font-weight--bold vads-u-text-decoration--none" href="{{ audienceTag.path.alias }}/">
-                    {{ audienceTag.name }}
-                    <i role="presentation" aria-hidden="true" class="fa fa-chevron-right vads-u-margin-left--1"> </i>
-                  </a>
-                </li>
+                {% if forloop.index <= pageSize %}
+                  <li class="vads-u-margin-y--2">
+                    <a class="vads-u-font-weight--bold vads-u-text-decoration--none" href="{{ audienceTag.path.alias }}/">
+                      {{ audienceTag.name }}
+                      <i role="presentation" aria-hidden="true" class="fa fa-chevron-right vads-u-margin-left--1"> </i>
+                    </a>
+                  </li>
+                {% endif %}
               {% endfor %}
-            </ul>
+
+              {% if audienceTags.length > pageSize %}
+                <div class="form-expanding-group additional-info-container vads-u-margin-y--2p5">
+                  <div class="additional-info-title">Show more</div>
+                  {% assign remainingAudienceTags = audienceTags | sliceArrayFromStart: pageSize %}
+                  <span>
+                      <div class="additional-info-content">
+                        <ul class="usa-unstyled-list">
+                          {% for audienceTag in remainingAudienceTags %}
+                            <li class="vads-u-margin-y--2">
+                              <a class="vads-u-font-weight--bold vads-u-text-decoration--none" href="{{ audienceTag.path.alias }}/">
+                                {{ audienceTag.name }}
+                                <i role="presentation" aria-hidden="true" class="fa fa-chevron-right vads-u-margin-left--1"> </i>
+                              </a>
+                            </li>
+                          {% endfor %}
+                        </ul>
+                      </div>
+                  </span>
+              </div>
+            {% endif %}
           {% endif %}
 
           <!-- Content blocks -->

--- a/src/site/layouts/basic_landing_page.drupal.liquid
+++ b/src/site/layouts/basic_landing_page.drupal.liquid
@@ -50,6 +50,20 @@
             {% include "src/site/includes/support_resources_search_bar.drupal.liquid" %}
           </div>
 
+          {% if audienceTags != empty %}
+            <h2>Browse by audience</h2>
+            <ul class="usa-unstyled-list">
+              {% for audienceTag in audienceTags %}
+                <li class="vads-u-margin-y--2">
+                  <a class="vads-u-font-weight--bold vads-u-text-decoration--none" href="{{ audienceTag.path.alias }}/">
+                    {{ audienceTag.name }}
+                    <i role="presentation" aria-hidden="true" class="fa fa-chevron-right vads-u-margin-left--1"> </i>
+                  </a>
+                </li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+
           <!-- Content blocks -->
           {% for block in fieldContentBlock %}
             {% assign bundleComponent = "src/site/paragraphs/" | append: block.entity.entityBundle %}

--- a/src/site/layouts/basic_landing_page.drupal.liquid
+++ b/src/site/layouts/basic_landing_page.drupal.liquid
@@ -50,6 +50,19 @@
             {% include "src/site/includes/support_resources_search_bar.drupal.liquid" %}
           </div>
 
+          <div class="usa-alert usa-alert-info" role="alert">
+            <div class="usa-alert-body">
+                <h3 class="usa-alert-heading">
+                    We're currently in beta testing
+                </h3>
+                <div class="processed-content">
+                  <div itemprop="text">
+                    <p>Welcome to resources and support, a new part of <a href="/">VA.gov</a>. We'll be adding more articles and topics in the weeks and months ahead, so please check back often.</p>
+                  </div>
+                </div>
+            </div>
+          </div>
+
           {% if audienceTags != empty %}
             <h2>Browse by audience</h2>
             <ul class="usa-unstyled-list">

--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -33,6 +33,7 @@ const qaPage = require('./nodeQa.graphql');
 const sidebarQuery = require('./navigation-fragments/sidebar.nav.graphql');
 const stepByStepPage = require('./nodeStepByStep.graphql');
 const storyListingPage = require('./storyListingPage.graphql');
+const taxonomiesQuery = require('./taxonomy-fragments/GetTaxonomies.graphql');
 const supportResourcesDetailPage = require('./nodeSupportResourcesDetailPage.graphql');
 const vaFormPage = require('./vaFormPage.graphql');
 const vamcOperatingStatusAndAlerts = require('./vamcOperatingStatusAndAlerts.graphql');
@@ -154,6 +155,7 @@ const buildQuery = ({ useTomeSync }) => {
         : ''
     }
     ${menuLinksQuery}
+    ${taxonomiesQuery}
   }
 `;
 

--- a/src/site/stages/build/drupal/graphql/GetLatestPageById.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetLatestPageById.graphql.js
@@ -24,6 +24,7 @@ const nodeStepByStep = require('./nodeStepByStep.graphql');
 const nodeSupportResourcesDetailPage = require('./nodeSupportResourcesDetailPage.graphql');
 const pressReleasePage = require('./pressReleasePage.graphql');
 const sidebarQuery = require('./navigation-fragments/sidebar.nav.graphql');
+const taxonomiesQuery = require('./taxonomy-fragments/GetTaxonomies.graphql');
 const vaFormPage = require('./vaFormPage.graphql');
 const vamcOperatingStatusAndAlerts = require('./vamcOperatingStatusAndAlerts.graphql');
 
@@ -102,6 +103,7 @@ module.exports = `
         : ''
     }
     ${menuLinksQuery}
+    ${taxonomiesQuery}
   }
 `;
 

--- a/src/site/stages/build/drupal/graphql/taxonomy-fragments/GetTaxonomies.graphql.js
+++ b/src/site/stages/build/drupal/graphql/taxonomy-fragments/GetTaxonomies.graphql.js
@@ -1,0 +1,17 @@
+module.exports = `
+  allTaxonomies: taxonomyTermQuery(limit: 1000) {
+    entities {
+      entityBundle
+      ... on TaxonomyTermAudienceBeneficiaries {
+        fieldAudienceRsHomepage
+        name
+        path {
+          alias
+          pid
+          langcode
+          pathauto
+        }
+      }
+    }
+  }
+`

--- a/src/site/stages/build/drupal/graphql/taxonomy-fragments/GetTaxonomies.graphql.js
+++ b/src/site/stages/build/drupal/graphql/taxonomy-fragments/GetTaxonomies.graphql.js
@@ -2,16 +2,20 @@ module.exports = `
   allTaxonomies: taxonomyTermQuery(limit: 1000) {
     entities {
       entityBundle
+      ... on TaxonomyTermAudienceNonBeneficiaries {
+        fieldAudienceRsHomepage
+        name
+        path {
+          alias
+        }
+      }
       ... on TaxonomyTermAudienceBeneficiaries {
         fieldAudienceRsHomepage
         name
         path {
           alias
-          pid
-          langcode
-          pathauto
         }
       }
     }
   }
-`
+`;

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -252,9 +252,16 @@ function mergeTaxonomiesIntoResourcesAndSupportHomepage(
   resourcesAndSupportHomepage,
   allTaxonomies,
 ) {
-  const audienceTags = allTaxonomies.entities
-    .filter(taxonomy => taxonomy.entityBundle === 'audience_beneficiaries')
+  const audienceBundles = new Set([
+    'audience_beneficiaries',
+    'audience_non_beneficiaries',
+  ]);
+
+  const audienceTagsUnsorted = allTaxonomies.entities
+    .filter(taxonomy => audienceBundles.has(taxonomy.entityBundle))
     .filter(audienceTag => audienceTag.fieldAudienceRsHomepage);
+
+  const audienceTags = _.sortBy(audienceTagsUnsorted, 'name');
 
   return {
     ...resourcesAndSupportHomepage,

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -253,9 +253,7 @@ function mergeTaxonomiesIntoResourcesAndSupportHomepage(
   allTaxonomies,
 ) {
   const audienceTags = allTaxonomies.entities
-    .filter(taxonomy => {
-      return taxonomy.entityBundle === 'audience_beneficiaries';
-    })
+    .filter(taxonomy => taxonomy.entityBundle === 'audience_beneficiaries')
     .filter(audienceTag => audienceTag.fieldAudienceRsHomepage);
 
   return {

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -286,7 +286,9 @@ function compilePage(page, contentData) {
       alerts: alertsItem = {},
       bannerAlerts: bannerAlertsItem = {},
       outreachSidebarQuery: outreachSidebarNav = {},
-      allTaxonomies = [],
+      allTaxonomies = {
+        entities: [],
+      },
     },
   } = contentData;
 

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -248,6 +248,22 @@ function getFacilitySidebar(page, contentData) {
   return { links: [] };
 }
 
+function mergeTaxonomiesIntoResourcesAndSupportHomepage(
+  resourcesAndSupportHomepage,
+  allTaxonomies,
+) {
+  const audienceTags = allTaxonomies.entities
+    .filter(taxonomy => {
+      return taxonomy.entityBundle === 'audience_beneficiaries';
+    })
+    .filter(audienceTag => audienceTag.fieldAudienceRsHomepage);
+
+  return {
+    ...resourcesAndSupportHomepage,
+    audienceTags,
+  };
+}
+
 function compilePage(page, contentData) {
   const {
     data: {
@@ -265,6 +281,7 @@ function compilePage(page, contentData) {
       alerts: alertsItem = {},
       bannerAlerts: bannerAlertsItem = {},
       outreachSidebarQuery: outreachSidebarNav = {},
+      allTaxonomies = [],
     },
   } = contentData;
 
@@ -386,6 +403,13 @@ function compilePage(page, contentData) {
         pageId,
       );
       break;
+  }
+
+  if (entityUrl.path === '/resources') {
+    pageCompiled = mergeTaxonomiesIntoResourcesAndSupportHomepage(
+      pageCompiled,
+      allTaxonomies,
+    );
   }
 
   return pageCompiled;


### PR DESCRIPTION
## Description
This PR adds a "Browse by audience" section onto the Resources and Support homepage at `/resources/`. This section is not represented the R&S homepage's content model. Instead, per the direct of the CMS team, we need a separate GraphQL query to pull in the list of "audience tags" which should be merged into the R&S homepage's content model. 

https://github.com/department-of-veterans-affairs/va.gov-team/issues/17276
## Testing done
I tested against http://localhost:3001/preview?nodeId=8296, which is the preview of `/resources/`.

## Screenshots

### Collapsed
Only five audience tags are shown by default
![image](https://user-images.githubusercontent.com/1915775/103799527-32b41800-5019-11eb-8676-0308657d771c.png)

### Expanded
The rest need to be expanded via the "show more" button
![image](https://user-images.githubusercontent.com/1915775/103799547-3e074380-5019-11eb-8a17-a192e674a8a1.png)


## Acceptance criteria
- [ ] R&S has a "Browse by audience" section

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
