### PR TITLE
Revert military checkbox change

### DIFF
--- a/src/applications/personalization/profile/util/contact-information.js
+++ b/src/applications/personalization/profile/util/contact-information.js
@@ -1,9 +1,16 @@
 import pickBy from 'lodash/pickBy';
-import { ADDRESS_POU, ADDRESS_TYPES, USA } from '@@vap-svc/constants';
+import { ADDRESS_DATA, ADDRESS_POU, USA } from '@@vap-svc/constants';
 
-const isOverseasMilitaryMailingAddress = data =>
-  data?.addressPou === ADDRESS_POU.CORRESPONDENCE &&
-  data?.addressType === ADDRESS_TYPES.OVERSEAS_MILITARY;
+const isOverseasMilitaryMailingAddress = data => {
+  if (
+    data?.addressPou === ADDRESS_POU.CORRESPONDENCE &&
+    ADDRESS_DATA.militaryStates.includes(data?.stateCode) &&
+    ADDRESS_DATA.militaryCities.includes(data?.city)
+  ) {
+    return true;
+  }
+  return false;
+};
 
 /**
  * Helper function that calls other helpers to:

--- a/src/applications/personalization/profile/util/contact-information.js
+++ b/src/applications/personalization/profile/util/contact-information.js
@@ -1,17 +1,10 @@
 import pickBy from 'lodash/pickBy';
-import { ADDRESS_POU, USA } from '@@vap-svc/constants';
+import { USA } from '@@vap-svc/constants';
 import ADDRESS_DATA from '~/platform/forms/address/data';
 
-const isOverseasMilitaryMailingAddress = data => {
-  if (
-    data?.addressPou === ADDRESS_POU.CORRESPONDENCE &&
-    ADDRESS_DATA.militaryStates.includes(data?.stateCode) &&
-    ADDRESS_DATA.militaryCities.includes(data?.city)
-  ) {
-    return true;
-  }
-  return false;
-};
+const isOverseasMilitaryMailingAddress = data =>
+  ADDRESS_DATA.militaryStates.includes(data?.stateCode) &&
+  ADDRESS_DATA.militaryCities.includes(data?.city);
 
 /**
  * Helper function that calls other helpers to:

--- a/src/applications/personalization/profile/util/contact-information.js
+++ b/src/applications/personalization/profile/util/contact-information.js
@@ -1,5 +1,6 @@
 import pickBy from 'lodash/pickBy';
-import { ADDRESS_DATA, ADDRESS_POU, USA } from '@@vap-svc/constants';
+import { ADDRESS_POU, USA } from '@@vap-svc/constants';
+import ADDRESS_DATA from '~/platform/forms/address/data';
 
 const isOverseasMilitaryMailingAddress = data => {
   if (


### PR DESCRIPTION
## Description
In my [previous PR](https://github.com/department-of-veterans-affairs/vets-website/pull/15273/commits/19e7e539c0cf3abd37be933570d69bbe6379c8a1#diff-92b25a7a1d40a82d15bf07b2677f3c37265937bb4865952e1b6ce8f33a30a396L10) I changed the logic as to when to check the military address checkbox. I assumed the address type would come back as OVERSEAS_MILITARY, but it comes back as DOMESTIC. This PR changes teh logic back to how it was prior to that PR.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
