### PR TITLE
[Development] HLR production readiness

### DIFF
--- a/src/applications/disability-benefits/996/manifest.json
+++ b/src/applications/disability-benefits/996/manifest.json
@@ -2,6 +2,5 @@
   "appName": "Request for Higher-Level Review",
   "entryFile": "./form-entry.jsx",
   "entryName": "0996-higher-level-review",
-  "rootUrl": "/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996",
-  "e2eTestsDisabled": true
+  "rootUrl": "/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996"
 }

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -288,7 +288,7 @@
           "path": "decision-reviews"
         },
         {
-          "name": "Higher-Level Review",
+          "name": "Higher-Level Reviews",
           "path": "decision-reviews/higher-level-review/"
         },
         {


### PR DESCRIPTION
## Description

This PR enabled e2e tests for HLR & fixes the breadcrumb to match the page title of https://staging.va.gov/decision-reviews/higher-level-review/ (which includes an `s`).

Related
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/3822
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/17240

## Testing done

Cypress e2e tests all pass locally

## Screenshots

N/A

## Acceptance criteria
- [x] Cypress tests running in production
- [x] Fix spelling error in breadcrumb

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
