### PR TITLE
Comparison Tool: Horizontal gold line appears when using Safari

### DIFF
--- a/src/applications/gi/components/Modal.jsx
+++ b/src/applications/gi/components/Modal.jsx
@@ -73,7 +73,7 @@ class Modal extends React.Component {
       }
     }
   };
-  handeFocusOnMac = event => {
+  handeFocusOnSafari = event => {
     if (event.target.matches('button')) {
       event.target.focus();
     }

--- a/src/applications/gi/components/Modal.jsx
+++ b/src/applications/gi/components/Modal.jsx
@@ -6,6 +6,9 @@ import { focusElement } from 'platform/utilities/ui';
 const ESCAPE_KEY = 27;
 const TAB_KEY = 9;
 
+const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+const isFirefox = typeof InstallTrigger !== 'undefined';
+
 class Modal extends React.Component {
   constructor(props) {
     super(props);
@@ -13,7 +16,9 @@ class Modal extends React.Component {
   }
 
   componentDidMount() {
-    document.addEventListener('click', this.handeFocusOnSafari, true);
+    if (isSafari || isFirefox) {
+      document.addEventListener('click', this.handeFocusOnSafariFirefox, true);
+    }
     if (this.props.visible) {
       this.setupModal();
     }
@@ -23,7 +28,13 @@ class Modal extends React.Component {
     if (!prevProps.visible && this.props.visible) {
       this.setupModal();
     } else if (prevProps.visible && !this.props.visible) {
-      document.removeEventListener('click', this.handeFocusOnSafari, true);
+      if (isSafari || isFirefox) {
+        document.removeEventListener(
+          'click',
+          this.handeFocusOnSafariFirefox,
+          true,
+        );
+      }
       this.teardownModal();
     }
   }
@@ -73,7 +84,7 @@ class Modal extends React.Component {
       }
     }
   };
-  handeFocusOnSafari = event => {
+  handeFocusOnSafariFirefox = event => {
     if (event.target.matches('button')) {
       event.target.focus();
     }

--- a/src/applications/gi/components/Modal.jsx
+++ b/src/applications/gi/components/Modal.jsx
@@ -13,13 +13,17 @@ class Modal extends React.Component {
   }
 
   componentDidMount() {
-    if (this.props.visible) this.setupModal();
+    document.addEventListener('click', this.handeFocusOnSafari, true);
+    if (this.props.visible) {
+      this.setupModal();
+    }
   }
 
   componentDidUpdate(prevProps) {
     if (!prevProps.visible && this.props.visible) {
       this.setupModal();
     } else if (prevProps.visible && !this.props.visible) {
+      document.removeEventListener('click', this.handeFocusOnSafari, true);
       this.teardownModal();
     }
   }
@@ -69,7 +73,11 @@ class Modal extends React.Component {
       }
     }
   };
-
+  handeFocusOnMac = event => {
+    if (event.target.matches('button')) {
+      event.target.focus();
+    }
+  };
   handleClose = e => {
     e.preventDefault();
     this.props.onClose();


### PR DESCRIPTION
## Description
When a Safari user closes a modal in the Comparison Tool, a horizontal gold line appears on the page. This line should not appear.
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/17905
## Testing done
local testing

## Screenshots

https://user-images.githubusercontent.com/50601724/103799828-9e968080-5019-11eb-8b0f-5bae6fc6f3d4.mov

## Acceptance criteria
- [x] focus is on button and not body causing gold line

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
