### PR TITLE
[Development;508] HLR: Add aria-label to profile link

### DIFF
--- a/src/applications/disability-benefits/996/components/ReviewDescription.jsx
+++ b/src/applications/disability-benefits/996/components/ReviewDescription.jsx
@@ -49,6 +49,7 @@ const ReviewDescription = ({ profile }) => {
           target="_blank"
           rel="noopener noreferrer"
           className="vads-u-margin-right--1"
+          aria-label="Edit contact information on profile"
         >
           Edit on Profile
         </a>


### PR DESCRIPTION
## Description

Add `aria-label` to profile link to provide better context for a screenreader

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/17824

## Testing done

N/A

## Screenshots

![Screen Shot 2021-01-06 at 12 18 11 PM](https://user-images.githubusercontent.com/136959/103805645-7dce2b00-5019-11eb-9e63-7b92289ea4fb.png)

## Acceptance criteria
- [x] Profile link includes an `aria-label`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
