### PR TITLE
Remove unneeded )}

### DIFF
--- a/src/platform/forms-system/src/js/widgets/SelectWidget.jsx
+++ b/src/platform/forms-system/src/js/widgets/SelectWidget.jsx
@@ -58,7 +58,6 @@ function SelectWidget({
           {labels[option.value] || option.label}
         </option>
       ))}
-      )}
     </select>
   );
 }


### PR DESCRIPTION
## Description
We sometimes see `)}` in the DOM tree that should not be there. This PR removes it.

Relevant [TICKET](https://github.com/department-of-veterans-affairs/va.gov-team/issues/10576)

## Testing done
All looks good locally.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/103813766-d7385900-501d-11eb-9a2a-96868c254fc1.png)

![image](https://user-images.githubusercontent.com/14869324/103813773-da334980-501d-11eb-8b2a-ccf7bfacf36a.png)

## Acceptance criteria
- [x] Remove unneeded `)}`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
