### PR TITLE
Disable failing Facility Locator Cypress test

### DIFF
--- a/src/applications/facility-locator/tests/e2e/search.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/search.cypress.spec.js
@@ -28,7 +28,7 @@ Cypress.Commands.add('verifyOptions', () => {
   cy.get('#service-type-dropdown').should('not.have', 'disabled');
 });
 
-describe('Facility search', () => {
+describe.skip('Facility search', () => {
   before(() => {
     cy.syncFixtures({
       constants: path.join(__dirname, '..', '..', 'constants'),


### PR DESCRIPTION
## Description
This test is being disabled because it fails on Jenkins. The test hangs indefinitely until the build is terminated. Examples of failures: 
- http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fvets-website/detail/17240-hlr-fixes/1/pipeline/156/
- http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fvets-website/detail/eph-dd-gating-tests/1/pipeline/156

## Testing done
- Test is skipped.

## Acceptance criteria
- [ ] Test is skipped on CI.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
