### PR TITLE
Cache CC provider list

### DIFF
--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
@@ -60,13 +60,15 @@ function ProviderSelectionField({
 
   useEffect(
     () => {
-      if (sortMethod === FACILITY_SORT_METHODS.distanceFromCurrentLocation) {
-        requestProvidersList(currentLocation);
-      } else {
-        requestProvidersList(address);
+      if (showProvidersList) {
+        requestProvidersList(
+          sortMethod === FACILITY_SORT_METHODS.distanceFromCurrentLocation
+            ? currentLocation
+            : address,
+        );
       }
     },
-    [sortMethod],
+    [sortMethod, showProvidersList],
   );
 
   useEffect(

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
@@ -60,15 +60,13 @@ function ProviderSelectionField({
 
   useEffect(
     () => {
-      if (showProvidersList) {
-        requestProvidersList(
-          sortMethod === FACILITY_SORT_METHODS.distanceFromCurrentLocation
-            ? currentLocation
-            : address,
-        );
+      if (sortMethod === FACILITY_SORT_METHODS.distanceFromCurrentLocation) {
+        requestProvidersList(currentLocation);
+      } else {
+        requestProvidersList(address);
       }
     },
-    [sortMethod, showProvidersList],
+    [sortMethod],
   );
 
   useEffect(

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -1174,23 +1174,7 @@ export function requestProvidersList(address) {
       const communityCareProviders = newAppointment.communityCareProviders;
       const sortMethod = newAppointment.ccProviderPageSortMethod;
       const typeOfCare = getTypeOfCare(newAppointment.data);
-      let location;
-
-      if (sortMethod === FACILITY_SORT_METHODS.distanceFromResidential) {
-        location = 'residential';
-      } else {
-        const stringifyCoord = coord =>
-          coord
-            .toString()
-            .replace('-', '')
-            .replace('.', '');
-
-        location = `${stringifyCoord(address.latitude)}_${stringifyCoord(
-          address.longitude,
-        )}`;
-      }
-
-      const key = `${location}_${typeOfCare.id}`;
+      const key = `${sortMethod.replace('distanceFrom', '')}_${typeOfCare.id}`;
       let typeOfCareProviders = communityCareProviders[key];
 
       dispatch({

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -1179,15 +1179,15 @@ export function requestProvidersList(address) {
       if (sortMethod === FACILITY_SORT_METHODS.distanceFromResidential) {
         location = 'residential';
       } else {
-        const stringifyCoordinate = coord =>
+        const stringifyCoord = coord =>
           coord
             .toString()
             .replace('-', '')
             .replace('.', '');
 
-        location = `${stringifyCoordinate(
-          address.latitude,
-        )}_${stringifyCoordinate(address.longitude)}`;
+        location = `${stringifyCoord(address.latitude)}_${stringifyCoord(
+          address.longitude,
+        )}`;
       }
 
       const key = `${location}_${typeOfCare.id}`;

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -1174,8 +1174,8 @@ export function requestProvidersList(address) {
       const communityCareProviders = newAppointment.communityCareProviders;
       const sortMethod = newAppointment.ccProviderPageSortMethod;
       const typeOfCare = getTypeOfCare(newAppointment.data);
-      const key = `${sortMethod.replace('distanceFrom', '')}_${typeOfCare.id}`;
-      let typeOfCareProviders = communityCareProviders[key];
+      let typeOfCareProviders =
+        communityCareProviders[`${sortMethod}_${typeOfCare.ccId}`];
 
       dispatch({
         type: FORM_REQUESTED_PROVIDERS,
@@ -1191,7 +1191,6 @@ export function requestProvidersList(address) {
       dispatch({
         type: FORM_REQUESTED_PROVIDERS_SUCCEEDED,
         typeOfCareProviders,
-        key,
         address,
       });
     } catch (e) {

--- a/src/applications/vaos/new-appointment/redux/reducer.js
+++ b/src/applications/vaos/new-appointment/redux/reducer.js
@@ -1132,14 +1132,12 @@ export default function formReducer(state = initialState, action) {
       };
     }
     case FORM_REQUESTED_PROVIDERS_SUCCEEDED: {
-      const { address, typeOfCareProviders, key } = action;
-
-      const sortMethod = state.ccProviderPageSortMethod
-        ? state.ccProviderPageSortMethod
-        : FACILITY_SORT_METHODS.distanceFromResidential;
+      const { address, typeOfCareProviders } = action;
+      const { ccProviderPageSortMethod: sortMethod, data } = state;
+      const cacheKey = `${sortMethod}_${getTypeOfCare(data)?.ccId}`;
 
       const communityCareProviderList =
-        state.communityCareProviders[key] ||
+        state.communityCareProviders[cacheKey] ||
         typeOfCareProviders
           .map(facility => {
             const distance = distanceBetween(
@@ -1160,7 +1158,7 @@ export default function formReducer(state = initialState, action) {
         requestStatus: FETCH_STATUS.succeeded,
         communityCareProviders: {
           ...state.communityCareProviders,
-          [key]: communityCareProviderList,
+          [cacheKey]: communityCareProviderList,
         },
         communityCareProviderList,
       };

--- a/src/applications/vaos/new-appointment/redux/reducer.js
+++ b/src/applications/vaos/new-appointment/redux/reducer.js
@@ -118,7 +118,6 @@ const initialState = {
   hideUpdateAddressAlert: false,
   requestLocationStatus: FETCH_STATUS.notStarted,
   communityCareProviders: {},
-  communityCareProviderList: [],
   requestStatus: FETCH_STATUS.notStarted,
   currentLocation: {},
   ccProviderPageSortMethod: FACILITY_SORT_METHODS.distanceFromResidential,
@@ -1136,7 +1135,7 @@ export default function formReducer(state = initialState, action) {
       const { ccProviderPageSortMethod: sortMethod, data } = state;
       const cacheKey = `${sortMethod}_${getTypeOfCare(data)?.ccId}`;
 
-      const communityCareProviderList =
+      const providers =
         state.communityCareProviders[cacheKey] ||
         typeOfCareProviders
           .map(facility => {
@@ -1158,9 +1157,8 @@ export default function formReducer(state = initialState, action) {
         requestStatus: FETCH_STATUS.succeeded,
         communityCareProviders: {
           ...state.communityCareProviders,
-          [cacheKey]: communityCareProviderList,
+          [cacheKey]: providers,
         },
-        communityCareProviderList,
       };
     }
     case FORM_REQUESTED_PROVIDERS_FAILED: {

--- a/src/applications/vaos/new-appointment/redux/reducer.js
+++ b/src/applications/vaos/new-appointment/redux/reducer.js
@@ -117,6 +117,7 @@ const initialState = {
   isCCEligible: false,
   hideUpdateAddressAlert: false,
   requestLocationStatus: FETCH_STATUS.notStarted,
+  communityCareProviders: {},
   communityCareProviderList: [],
   requestStatus: FETCH_STATUS.notStarted,
   currentLocation: {},
@@ -1131,30 +1132,36 @@ export default function formReducer(state = initialState, action) {
       };
     }
     case FORM_REQUESTED_PROVIDERS_SUCCEEDED: {
-      let communityCareProviderList = action.communityCareProviderList;
-      const address = action.address;
+      const { address, typeOfCareProviders, key } = action;
 
       const sortMethod = state.ccProviderPageSortMethod
         ? state.ccProviderPageSortMethod
         : FACILITY_SORT_METHODS.distanceFromResidential;
-      communityCareProviderList = communityCareProviderList
-        .map(facility => {
-          const distance = distanceBetween(
-            address.latitude,
-            address.longitude,
-            facility.position.latitude,
-            facility.position.longitude,
-          );
-          return {
-            ...facility,
-            [sortMethod]: distance,
-          };
-        })
-        .sort((a, b) => a[sortMethod] - b[sortMethod]);
+
+      const communityCareProviderList =
+        state.communityCareProviders[key] ||
+        typeOfCareProviders
+          .map(facility => {
+            const distance = distanceBetween(
+              address.latitude,
+              address.longitude,
+              facility.position.latitude,
+              facility.position.longitude,
+            );
+            return {
+              ...facility,
+              [sortMethod]: distance,
+            };
+          })
+          .sort((a, b) => a[sortMethod] - b[sortMethod]);
 
       return {
         ...state,
         requestStatus: FETCH_STATUS.succeeded,
+        communityCareProviders: {
+          ...state.communityCareProviders,
+          [key]: communityCareProviderList,
+        },
         communityCareProviderList,
       };
     }

--- a/src/applications/vaos/new-appointment/redux/selectors.js
+++ b/src/applications/vaos/new-appointment/redux/selectors.js
@@ -251,19 +251,24 @@ export function selectCernerOrgIds(state) {
 
 export function selectProviderSelectionInfo(state) {
   const {
-    communityCareProviderList,
+    communityCareProviders,
+    data,
     requestStatus,
     requestLocationStatus,
     currentLocation,
-    ccProviderPageSortMethod,
+    ccProviderPageSortMethod: sortMethod,
   } = getNewAppointment(state);
+
+  const typeOfCareId = getTypeOfCare(data).ccId;
+
   return {
     address: selectVAPResidentialAddress(state),
-    communityCareProviderList,
+    communityCareProviderList:
+      communityCareProviders[`${sortMethod}_${typeOfCareId}`] || [],
     requestStatus,
     requestLocationStatus,
     currentLocation,
-    sortMethod: ccProviderPageSortMethod,
+    sortMethod,
   };
 }
 

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
@@ -442,7 +442,6 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
     userEvent.click(await screen.findByText(/more providers$/i));
     userEvent.click(await screen.findByText(/more providers$/i));
     userEvent.click(await screen.findByText(/more providers$/i));
-    userEvent.click(await screen.findByText(/more providers$/i));
 
     const miles = screen.queryAllByText(/miles$/);
 


### PR DESCRIPTION
## Description
Caches results of CC provider list, instead of re-fetching every time user switches between residential address and geolocation.

## Testing done
Local and unit

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
