### PR TITLE
[KEYBOARD] Prevent focus shift after edit

### DIFF
--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -43,7 +43,11 @@ export default class ReviewCollapsibleChapter extends React.Component {
   handleEdit(key, editing, index = null) {
     this.props.onEdit(key, editing, index);
     this.scrollToPage(`${key}${index === null ? '' : index}`);
-    this.focusOnPage(`${key}${index === null ? '' : index}`);
+    if (editing) {
+      // pressing "Update page" will call handleSubmit, which moves focus from
+      // the edit button to the this target
+      this.focusOnPage(`${key}${index === null ? '' : index}`);
+    }
   }
 
   handleSubmit = (formData, key, path = null, index = null) => {


### PR DESCRIPTION
## Description

After updating content on the review & submit page, keyboard focus should be applied to the section's edit button. In this instance, focus is set on the edit button, but the submit handler is also called which shifts focus to the first `p`, `legend` or `label`.

This PR ensures that edit mode shifts focus to the first `p`, `legend` or `label` and after updating the focus stays on the edit button.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/17825

## Testing done

Manual testing - no unit tests for focus management found

Steps to test:
1. Go to http://localhost:3001/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996
1. Log into `vetsgov+test238@id.me` ([test user doc](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/Administrative/vagov-users/staging-test-accounts-HLR.docx))
1. Get to the review & submit page
1. Open the "Issues eligible for review" accordion
1. Focus on the "Edit" button and press <kbd>Enter</kbd>
1. Note that the focus is on the `legend` (`document.activeElement` in the console).
1. <kbd>Tab</kbd> down to the "Update page" button and press <kbd>Enter</kbd>
1. Note that the "Edit" button has focus
1. Test other accordion sections to ensure focus is returned to the "Edit" button after updating

## Screenshots

<details><summary>Focus management changes after this PR</summary>

<!-- leave a blank line above -->
![focus-on-edit](https://user-images.githubusercontent.com/136959/103831749-5d669680-5042-11eb-8fae-b54ab3aa2ed7.gif)</details>

## Acceptance criteria
- [x] Focus on edit after updating page in review & submit accordion

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
