### PR TITLE
Fix side nav focus outline on links

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-side-nav.scss
+++ b/src/platform/site-wide/sass/modules/_m-side-nav.scss
@@ -242,4 +242,8 @@ $side-nav-color-dark: #323a45;
       }
     }
   }
+
+  #va-sidenav-ul-container [href]:focus {
+    outline-offset: -2px;
+  }
 }


### PR DESCRIPTION
## Description
issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/8975

## Screenshots
<img width="380" alt="Screen Shot 2021-01-06 at 6 26 47 PM" src="https://user-images.githubusercontent.com/100468/103835787-c9e69300-504c-11eb-9767-fc7d272fafee.png">
<img width="432" alt="Screen Shot 2021-01-06 at 6 26 51 PM" src="https://user-images.githubusercontent.com/100468/103835789-cbb05680-504c-11eb-9ec0-fd486c019cbc.png">


## Acceptance criteria
- [x] As a keyboard user, I want to know with certainty where the focused area is, and for it to be a consistent cue across the site.


## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
