### PR TITLE
Show "not all data available" when DD4EDU call fails

### DIFF
--- a/src/applications/personalization/profile/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile/components/ProfileWrapper.jsx
@@ -10,6 +10,7 @@ import { selectProfile } from '~/platform/user/selectors';
 
 import {
   cnpDirectDepositLoadError,
+  eduDirectDepositLoadError,
   fullNameLoadError,
   militaryInformationLoadError,
   personalInformationLoadError,
@@ -118,6 +119,7 @@ const mapStateToProps = state => {
     hero: state.vaProfile?.hero,
     showNotAllDataAvailableError:
       !!cnpDirectDepositLoadError(state) ||
+      !!eduDirectDepositLoadError(state) ||
       !!fullNameLoadError(state) ||
       !!personalInformationLoadError(state) ||
       (!!militaryInformationLoadError(state) && !invalidVeteranStatus),

--- a/src/applications/personalization/profile/msw-mocks.js
+++ b/src/applications/personalization/profile/msw-mocks.js
@@ -2,6 +2,7 @@ import { rest } from 'msw';
 import environment from 'platform/utilities/environment';
 
 import mockDD4CNPSuccess from './tests/fixtures/dd4cnp/dd4cnp-is-set-up.json';
+import mockDD4EDUSuccess from './tests/fixtures/dd4edu/dd4edu-enrolled.json';
 
 import mockMHVHasAccepted from './tests/fixtures/mhv-has-accepted.json';
 
@@ -1711,6 +1712,9 @@ export const allProfileEndpointsLoaded = [
   rest.get(`${prefix}/v0/ppiu/payment_information`, (req, res, ctx) => {
     return res(ctx.json(mockDD4CNPSuccess));
   }),
+  rest.get(`${prefix}/v0/profile/ch33_bank_accounts`, (req, res, ctx) => {
+    return res(ctx.json(mockDD4EDUSuccess));
+  }),
 ];
 
 export const getFullNameFailure = [
@@ -1739,6 +1743,12 @@ export const getServiceHistory401 = [
 
 export const getDD4CNPFailure = [
   rest.get(`${prefix}/v0/ppiu/payment_information`, (req, res, ctx) => {
+    return res(ctx.status(401), ctx.json(mock401));
+  }),
+];
+
+export const getDD4EDUFailure = [
+  rest.get(`${prefix}/v0/profile/ch33_bank_accounts`, (req, res, ctx) => {
     return res(ctx.status(401), ctx.json(mock401));
   }),
 ];

--- a/src/applications/personalization/profile/tests/components/alerts/Profile.data-unavailable-error.unit.spec.js
+++ b/src/applications/personalization/profile/tests/components/alerts/Profile.data-unavailable-error.unit.spec.js
@@ -18,6 +18,10 @@ const ALERT_ID = 'not-all-data-available-error';
 // Returns the Redux state needed by the Profile and its child components
 function createBasicInitialState() {
   return {
+    // TODO: delete the `featureToggles` when DD4EDU is no longer behind a
+    // feature flag
+    // eslint-disable-next-line camelcase
+    featureToggles: { ch33_dd_profile: true },
     scheduledDowntime: {
       globalDowntime: null,
       isReady: true,
@@ -90,7 +94,7 @@ async function errorAppearsOnAllPages(
   });
 }
 
-async function hideErrorNonVet(
+async function errorIsNotShownOnAnyPage(
   pageNames = [
     PROFILE_PATH_NAMES.MILITARY_INFORMATION,
     PROFILE_PATH_NAMES.DIRECT_DEPOSIT,
@@ -143,13 +147,13 @@ describe('Profile "Not all data available" error', () => {
   it('should not be shown if there is a 500 error with the `GET service_history` endpoint and the user is not a vet', async () => {
     server.use(...mocks.getServiceHistory500);
 
-    await hideErrorNonVet();
+    await errorIsNotShownOnAnyPage();
   });
 
   it('should not be shown if there is a 401 error with the `GET service_history` endpoint and the user is not a vet', async () => {
     server.use(...mocks.getServiceHistory401);
 
-    await hideErrorNonVet();
+    await errorIsNotShownOnAnyPage();
   });
 
   it('should be shown on all pages if there is an error with the `GET full_name` endpoint', async () => {
@@ -176,8 +180,19 @@ describe('Profile "Not all data available" error', () => {
     await errorAppearsOnAllPages();
   });
 
-  it('should be shown on all pages if there is an error with the `GET payment_information` endpoint`', async () => {
+  it('should be shown on all pages if there is an error with the DD4CNP `GET payment_information` endpoint`', async () => {
     server.use(...mocks.getDD4CNPFailure);
+
+    // don't check for the error on the direct deposit page since that page is unavailable when the `GET payment_information` endpoint fails
+    await errorAppearsOnAllPages([
+      PROFILE_PATH_NAMES.MILITARY_INFORMATION,
+      PROFILE_PATH_NAMES.ACCOUNT_SECURITY,
+      PROFILE_PATH_NAMES.CONNECTED_APPLICATIONS,
+    ]);
+  });
+
+  it('should be shown on all pages if there is an error with the DD4EDU `GET ch33_bank_accounts` endpoint`', async () => {
+    server.use(...mocks.getDD4EDUFailure);
 
     // don't check for the error on the direct deposit page since that page is unavailable when the `GET payment_information` endpoint fails
     await errorAppearsOnAllPages([


### PR DESCRIPTION
## Description
We need to show the standard "not all data available" error alert on the Profile when we get an error calling the DD4EDU endpoint

## Testing done
Added a test for this case.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs