### PR TITLE
Remove 'authenticated with sso' param from MHV URL helper

### DIFF
--- a/src/applications/personalization/dashboard/components/ManageYourVAHealthCare.jsx
+++ b/src/applications/personalization/dashboard/components/ManageYourVAHealthCare.jsx
@@ -8,7 +8,6 @@ import {
 } from 'platform/monitoring/DowntimeNotification';
 import { getMedicalCenterNameByID } from 'platform/utilities/medical-centers/medical-centers';
 import backendServices from 'platform/user/profile/constants/backendServices';
-import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 import {
   isVAPatient as isVAPatientSelector,
   selectCernerAppointmentsFacilities,
@@ -60,7 +59,6 @@ const ManageYourVAHealthCare = ({
   appointmentFacilityNames,
   messagingFacilityNames,
   prescriptionFacilityNames,
-  authenticatedWithSSOe,
   enrollmentDate,
   isInESR,
   preferredFacility,
@@ -120,10 +118,7 @@ const ManageYourVAHealthCare = ({
       </DowntimeNotification>
     )}
     {showCernerMessagingWidget && (
-      <CernerSecureMessagingWidget
-        facilityNames={messagingFacilityNames}
-        authenticatedWithSSOe={authenticatedWithSSOe}
-      />
+      <CernerSecureMessagingWidget facilityNames={messagingFacilityNames} />
     )}
 
     {!showCernerPrescriptionWidget && (
@@ -139,10 +134,7 @@ const ManageYourVAHealthCare = ({
       </DowntimeNotification>
     )}
     {showCernerPrescriptionWidget && (
-      <CernerPrescriptionsWidget
-        facilityNames={prescriptionFacilityNames}
-        authenticatedWithSSOe={authenticatedWithSSOe}
-      />
+      <CernerPrescriptionsWidget facilityNames={prescriptionFacilityNames} />
     )}
 
     {showNonCernerAppointmentWidget && <ScheduleAnAppointmentWidget />}
@@ -207,7 +199,6 @@ const mapStateToProps = state => {
     appointmentFacilityNames,
     messagingFacilityNames,
     prescriptionFacilityNames,
-    authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
   };
 };
 

--- a/src/applications/personalization/dashboard/components/cerner-widgets.js
+++ b/src/applications/personalization/dashboard/components/cerner-widgets.js
@@ -96,36 +96,27 @@ export const CernerScheduleAnAppointmentWidget = ({ facilityNames }) => (
   </div>
 );
 
-export const CernerSecureMessagingWidget = ({
-  facilityNames,
-  authenticatedWithSSOe,
-}) => (
+export const CernerSecureMessagingWidget = ({ facilityNames }) => (
   <div data-testid="cerner-messaging-widget">
     <h3>Send or receive a secure message</h3>
     <CernerAlertBox
       primaryCtaButtonUrl={getCernerURL('/pages/messaging/inbox')}
       primaryCtaText="Send a secure message to a provider at:"
       secondaryCtaButtonText="Go to My HealtheVet"
-      secondaryCtaButtonUrl={mhvUrl(authenticatedWithSSOe, 'secure-messaging')}
+      secondaryCtaButtonUrl={mhvUrl('secure-messaging')}
       facilityNames={facilityNames}
     />
   </div>
 );
 
-export const CernerPrescriptionsWidget = ({
-  facilityNames,
-  authenticatedWithSSOe,
-}) => (
+export const CernerPrescriptionsWidget = ({ facilityNames }) => (
   <div data-testid="cerner-prescription-widget">
     <h3>Refill and track prescriptions</h3>
     <CernerAlertBox
       primaryCtaButtonUrl={getCernerURL('/pages/medications/current')}
       primaryCtaText="Refill prescriptions from:"
       secondaryCtaButtonText="Go to My HealtheVet"
-      secondaryCtaButtonUrl={mhvUrl(
-        authenticatedWithSSOe,
-        'web/myhealthevet/refill-prescriptions',
-      )}
+      secondaryCtaButtonUrl={mhvUrl('web/myhealthevet/refill-prescriptions')}
       facilityNames={facilityNames}
     />
   </div>

--- a/src/applications/personalization/dashboard/containers/MessagingWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/MessagingWidget.jsx
@@ -7,7 +7,6 @@ import { formattedDate } from '../utils/helpers';
 import backendServices from 'platform/user/profile/constants/backendServices';
 import { fetchFolder, fetchRecipients } from '../actions/messaging';
 import { recordDashboardClick } from '../helpers';
-import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 
 class MessagingWidget extends React.Component {
@@ -19,11 +18,7 @@ class MessagingWidget extends React.Component {
   }
 
   render() {
-    const {
-      canAccessMessaging,
-      recipients,
-      authenticatedWithSSOe,
-    } = this.props;
+    const { canAccessMessaging, recipients } = this.props;
 
     if (!canAccessMessaging || (recipients && recipients.length === 0)) {
       // do not show widget if user is not a VA patient
@@ -77,7 +72,7 @@ class MessagingWidget extends React.Component {
         {content}
         <p>
           <a
-            href={mhvUrl(authenticatedWithSSOe, 'secure-messaging')}
+            href={mhvUrl('secure-messaging')}
             onClick={recordDashboardClick('view-all-messages')}
             rel="noopener noreferrer"
             target="_blank"
@@ -107,7 +102,6 @@ const mapStateToProps = state => {
     recipients: msgState.recipients.data,
     pagination,
     canAccessMessaging,
-    authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
   };
 };
 

--- a/src/applications/personalization/dashboard/containers/PrescriptionsWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/PrescriptionsWidget.jsx
@@ -9,7 +9,6 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation-react/Lo
 import { recordDashboardClick } from '../helpers';
 import PrescriptionCard from '../components/PrescriptionCard';
 import CallVBACenter from 'platform/static-data/CallVBACenter';
-import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 
 class PrescriptionsWidget extends React.Component {
@@ -23,7 +22,7 @@ class PrescriptionsWidget extends React.Component {
   }
 
   render() {
-    const { canAccessRx, authenticatedWithSSOe } = this.props;
+    const { canAccessRx } = this.props;
     if (!canAccessRx) {
       return null;
     }
@@ -67,10 +66,7 @@ class PrescriptionsWidget extends React.Component {
         <div>{content}</div>
         <p>
           <a
-            href={mhvUrl(
-              authenticatedWithSSOe,
-              'web/myhealthevet/refill-prescriptions',
-            )}
+            href={mhvUrl('web/myhealthevet/refill-prescriptions')}
             onClick={recordDashboardClick('view-all-prescriptions')}
             rel="noopener noreferrer"
             target="_blank"
@@ -111,7 +107,6 @@ const mapStateToProps = state => {
     ...rxState.prescriptions.active,
     prescriptions,
     canAccessRx,
-    authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
   };
 };
 

--- a/src/applications/personalization/dashboard/tests/components/cerner-widgets.unit.spec.js
+++ b/src/applications/personalization/dashboard/tests/components/cerner-widgets.unit.spec.js
@@ -43,7 +43,7 @@ describe('Prescriptions Widget', () => {
       name: /Go to My HealtheVet/i,
     });
     expect(ctaButton.href).to.contain(
-      'https://mhv-syst.myhealth.va.gov/mhv-portal-web/web/myhealthevet/refill-prescription',
+      'https://int.eauth.va.gov/mhv-portal-web/eauth?deeplinking=prescription_refill',
     );
   });
 });
@@ -128,7 +128,7 @@ describe('Secure Messaging Widget', () => {
       name: /Go to My HealtheVet/i,
     });
     expect(ctaButton.href).to.contain(
-      'https://mhv-syst.myhealth.va.gov/mhv-portal-web/secure-messaging',
+      'https://int.eauth.va.gov/mhv-portal-web/eauth?deeplinking=secure_messaging',
     );
   });
 });

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
@@ -9,13 +9,8 @@ import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
 import { selectPatientFacilities } from 'platform/user/selectors';
-import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 
-export const App = ({
-  facilities,
-  showNewGetMedicalRecordsPage,
-  authenticatedWithSSOe,
-}) => {
+export const App = ({ facilities, showNewGetMedicalRecordsPage }) => {
   if (!showNewGetMedicalRecordsPage) {
     return <LegacyContent />;
   }
@@ -27,7 +22,6 @@ export const App = ({
       <AuthContent
         cernerFacilities={cernerFacilities}
         otherFacilities={otherFacilities}
-        authenticatedWithSSOe={authenticatedWithSSOe}
       />
     );
   }
@@ -37,7 +31,6 @@ export const App = ({
 
 App.propTypes = {
   // From mapStateToProps.
-  authenticatedWithSSOe: PropTypes.bool,
   facilities: PropTypes.arrayOf(
     PropTypes.shape({
       facilityId: PropTypes.string.isRequired,
@@ -54,7 +47,6 @@ App.propTypes = {
 
 const mapStateToProps = state => ({
   facilities: selectPatientFacilities(state),
-  authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
   showNewGetMedicalRecordsPage:
     state?.featureToggles?.[featureFlagNames.showNewGetMedicalRecordsPage],
 });

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.js
@@ -9,11 +9,7 @@ import CernerCallToAction from '../../../components/CernerCallToAction';
 import { getCernerURL } from 'platform/utilities/cerner';
 import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 
-const AuthContent = ({
-  authenticatedWithSSOe,
-  cernerFacilities,
-  otherFacilities,
-}) => (
+const AuthContent = ({ cernerFacilities, otherFacilities }) => (
   <>
     <h2 className="vads-u-margin-bottom--2 vads-u-font-size--lg">
       On this page:
@@ -33,7 +29,7 @@ const AuthContent = ({
       cernerFacilities={cernerFacilities}
       otherFacilities={otherFacilities}
       linksHeaderText="Get your medical records from:"
-      myHealtheVetLink={mhvUrl(authenticatedWithSSOe, 'download-my-data')}
+      myHealtheVetLink={mhvUrl('download-my-data')}
       myVAHealthLink={getCernerURL(
         '/pages/health_record/clinical_documents/sharing',
       )}
@@ -325,7 +321,6 @@ const AuthContent = ({
 );
 
 AuthContent.propTypes = {
-  authenticatedWithSSOe: PropTypes.bool.isRequired,
   cernerfacilities: PropTypes.arrayOf(
     PropTypes.shape({
       facilityId: PropTypes.string.isRequired,

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.js
@@ -9,13 +9,8 @@ import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
 import { selectPatientFacilities } from 'platform/user/selectors';
-import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 
-export const App = ({
-  facilities,
-  showNewRefillTrackPrescriptionsPage,
-  authenticatedWithSSOe,
-}) => {
+export const App = ({ facilities, showNewRefillTrackPrescriptionsPage }) => {
   if (!showNewRefillTrackPrescriptionsPage) {
     return <LegacyContent />;
   }
@@ -27,7 +22,6 @@ export const App = ({
       <AuthContent
         cernerFacilities={cernerFacilities}
         otherFacilities={otherFacilities}
-        authenticatedWithSSOe={authenticatedWithSSOe}
       />
     );
   }
@@ -37,7 +31,6 @@ export const App = ({
 
 App.propTypes = {
   // From mapStateToProps.
-  authenticatedWithSSOe: PropTypes.bool,
   facilities: PropTypes.arrayOf(
     PropTypes.shape({
       facilityId: PropTypes.string.isRequired,
@@ -54,7 +47,6 @@ App.propTypes = {
 
 const mapStateToProps = state => ({
   facilities: selectPatientFacilities(state),
-  authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
   showNewRefillTrackPrescriptionsPage:
     state?.featureToggles?.[
       featureFlagNames.showNewRefillTrackPrescriptionsPage

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/AuthContent/index.js
@@ -9,20 +9,13 @@ import CernerCallToAction from '../../../components/CernerCallToAction';
 import { getCernerURL } from 'platform/utilities/cerner';
 import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 
-export const AuthContent = ({
-  authenticatedWithSSOe,
-  cernerFacilities,
-  otherFacilities,
-}) => (
+export const AuthContent = ({ cernerFacilities, otherFacilities }) => (
   <>
     <CernerCallToAction
       cernerFacilities={cernerFacilities}
       otherFacilities={otherFacilities}
       linksHeaderText="Refill prescriptions from:"
-      myHealtheVetLink={mhvUrl(
-        authenticatedWithSSOe,
-        'web/myhealthevet/refill-prescriptions',
-      )}
+      myHealtheVetLink={mhvUrl('web/myhealthevet/refill-prescriptions')}
       myVAHealthLink={getCernerURL('/pages/medications/current')}
     />
     <div>
@@ -413,7 +406,6 @@ export const AuthContent = ({
 );
 
 AuthContent.propTypes = {
-  authenticatedWithSSOe: PropTypes.bool.isRequired,
   cernerfacilities: PropTypes.arrayOf(
     PropTypes.shape({
       facilityId: PropTypes.string.isRequired,

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.js
@@ -9,13 +9,8 @@ import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
 import { selectPatientFacilities } from 'platform/user/selectors';
-import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 
-export const App = ({
-  facilities,
-  showNewSecureMessagingPage,
-  authenticatedWithSSOe,
-}) => {
+export const App = ({ facilities, showNewSecureMessagingPage }) => {
   if (!showNewSecureMessagingPage) {
     return <LegacyContent />;
   }
@@ -27,7 +22,6 @@ export const App = ({
       <AuthContent
         cernerFacilities={cernerFacilities}
         otherFacilities={otherFacilities}
-        authenticatedWithSSOe={authenticatedWithSSOe}
       />
     );
   }
@@ -37,7 +31,6 @@ export const App = ({
 
 App.propTypes = {
   // From mapStateToProps.
-  authenticatedWithSSOe: PropTypes.bool,
   facilities: PropTypes.arrayOf(
     PropTypes.shape({
       facilityId: PropTypes.string.isRequired,
@@ -54,7 +47,6 @@ App.propTypes = {
 
 const mapStateToProps = state => ({
   facilities: selectPatientFacilities(state),
-  authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
   showNewSecureMessagingPage:
     state?.featureToggles?.[featureFlagNames.showNewSecureMessagingPage],
 });

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/AuthContent/index.js
@@ -6,18 +6,14 @@ import CernerCallToAction from '../../../components/CernerCallToAction';
 import { getCernerURL } from 'platform/utilities/cerner';
 import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 
-export const AuthContent = ({
-  authenticatedWithSSOe,
-  cernerFacilities,
-  otherFacilities,
-}) => (
+export const AuthContent = ({ cernerFacilities, otherFacilities }) => (
   <>
     <h2 id="send-or-receive-secure-mess">Send or receive a secure message</h2>
     <CernerCallToAction
       cernerFacilities={cernerFacilities}
       otherFacilities={otherFacilities}
       linksHeaderText="Send a secure message to a provider at:"
-      myHealtheVetLink={mhvUrl(authenticatedWithSSOe, 'secure-messaging')}
+      myHealtheVetLink={mhvUrl('secure-messaging')}
       myVAHealthLink={getCernerURL('/pages/messaging/inbox')}
     />
     <div>
@@ -332,7 +328,6 @@ export const AuthContent = ({
 );
 
 AuthContent.propTypes = {
-  authenticatedWithSSOe: PropTypes.bool.isRequired,
   cernerfacilities: PropTypes.arrayOf(
     PropTypes.shape({
       facilityId: PropTypes.string.isRequired,

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.js
@@ -9,13 +9,8 @@ import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
 import { selectPatientFacilities } from 'platform/user/selectors';
-import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 
-export const App = ({
-  facilities,
-  showNewViewTestLabResultsPage,
-  authenticatedWithSSOe,
-}) => {
+export const App = ({ facilities, showNewViewTestLabResultsPage }) => {
   if (!showNewViewTestLabResultsPage) {
     return <LegacyContent />;
   }
@@ -27,7 +22,6 @@ export const App = ({
       <AuthContent
         cernerFacilities={cernerFacilities}
         otherFacilities={otherFacilities}
-        authenticatedWithSSOe={authenticatedWithSSOe}
       />
     );
   }
@@ -37,7 +31,6 @@ export const App = ({
 
 App.propTypes = {
   // From mapStateToProps.
-  authenticatedWithSSOe: PropTypes.bool,
   facilities: PropTypes.arrayOf(
     PropTypes.shape({
       facilityId: PropTypes.string.isRequired,
@@ -54,7 +47,6 @@ App.propTypes = {
 
 const mapStateToProps = state => ({
   facilities: selectPatientFacilities(state),
-  authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
   showNewViewTestLabResultsPage:
     state?.featureToggles?.[featureFlagNames.showNewViewTestLabResultsPage],
 });

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/AuthContent/index.js
@@ -9,17 +9,13 @@ import CernerCallToAction from '../../../components/CernerCallToAction';
 import { getCernerURL } from 'platform/utilities/cerner';
 import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 
-export const AuthContent = ({
-  authenticatedWithSSOe,
-  cernerFacilities,
-  otherFacilities,
-}) => (
+export const AuthContent = ({ cernerFacilities, otherFacilities }) => (
   <>
     <CernerCallToAction
       cernerFacilities={cernerFacilities}
       otherFacilities={otherFacilities}
       linksHeaderText="View lab and test results from:"
-      myHealtheVetLink={mhvUrl(authenticatedWithSSOe, 'labs-tests')}
+      myHealtheVetLink={mhvUrl('labs-tests')}
       myVAHealthLink={getCernerURL('/pages/health_record/results/labs')}
     />
     <div>
@@ -328,7 +324,6 @@ export const AuthContent = ({
 );
 
 AuthContent.propTypes = {
-  authenticatedWithSSOe: PropTypes.bool.isRequired,
   cernerfacilities: PropTypes.arrayOf(
     PropTypes.shape({
       facilityId: PropTypes.string.isRequired,

--- a/src/applications/validate-mhv-account/containers/Main.jsx
+++ b/src/applications/validate-mhv-account/containers/Main.jsx
@@ -5,7 +5,6 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation-react/Lo
 
 import { isLoggedIn, selectProfile } from 'platform/user/selectors';
 import get from 'platform/utilities/data/get';
-import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 import { ACCOUNT_STATES, MHV_ACCOUNT_LEVELS } from './../constants';
 
@@ -24,7 +23,6 @@ class Main extends React.Component {
       mhvAccount,
       profile,
       router,
-      authenticatedWithSSOe,
     } = this.props;
 
     const pathname = location.pathname;
@@ -53,7 +51,7 @@ class Main extends React.Component {
 
       if (accountLevelChanged || accountStateChanged) {
         if (this.hasMHVAccess()) {
-          window.location = mhvUrl(authenticatedWithSSOe, 'home');
+          window.location = mhvUrl('home');
         } else {
           router.replace('/');
         }
@@ -111,7 +109,6 @@ const mapStateToProps = (state, ownProps) => {
     loadingProfile: loading,
     mhvAccount,
     profile,
-    authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
   };
 };
 

--- a/src/applications/validate-mhv-account/containers/ValidateMHVAccount.jsx
+++ b/src/applications/validate-mhv-account/containers/ValidateMHVAccount.jsx
@@ -76,7 +76,7 @@ class ValidateMHVAccount extends React.Component {
       router.replace(`error/needs-va-patient`);
       return;
     }
-    window.location = mhvUrl(true, 'home');
+    window.location = mhvUrl('home');
   };
 
   redirect = () => {
@@ -147,7 +147,7 @@ class ValidateMHVAccount extends React.Component {
       accountLevel === MHV_ACCOUNT_LEVELS.PREMIUM ||
       accountLevel === MHV_ACCOUNT_LEVELS.ADVANCED
     ) {
-      window.location = mhvUrl(false, 'home');
+      window.location = mhvUrl('home');
     } else if (accountLevel === MHV_ACCOUNT_LEVELS.BASIC) {
       router.replace('upgrade-account');
     } else {

--- a/src/platform/site-wide/cta-widget/helpers.js
+++ b/src/platform/site-wide/cta-widget/helpers.js
@@ -84,39 +84,36 @@ export const mhvToolName = appId => {
   return null;
 };
 
-export const toolUrl = (appId, authenticatedWithSSOe = false) => {
+export const toolUrl = appId => {
   switch (appId) {
     case widgetTypes.HEALTH_RECORDS:
       return {
-        url: mhvUrl(authenticatedWithSSOe, 'download-my-data'),
+        url: mhvUrl('download-my-data'),
         redirect: false,
       };
 
     case widgetTypes.RX:
       return {
-        url: mhvUrl(
-          authenticatedWithSSOe,
-          'web/myhealthevet/refill-prescriptions',
-        ),
+        url: mhvUrl('web/myhealthevet/refill-prescriptions'),
         redirect: false,
       };
 
     case widgetTypes.MESSAGING:
       return {
-        url: mhvUrl(authenticatedWithSSOe, 'secure-messaging'),
+        url: mhvUrl('secure-messaging'),
         redirect: false,
       };
 
     case widgetTypes.VIEW_APPOINTMENTS:
     case widgetTypes.SCHEDULE_APPOINTMENTS:
       return {
-        url: mhvUrl(authenticatedWithSSOe, 'appointments'),
+        url: mhvUrl('appointments'),
         redirect: false,
       };
 
     case widgetTypes.LAB_AND_TEST_RESULTS:
       return {
-        url: mhvUrl(authenticatedWithSSOe, 'labs-tests'),
+        url: mhvUrl('labs-tests'),
         redirect: false,
       };
 

--- a/src/platform/site-wide/cta-widget/tests/helpers.unit.spec.js
+++ b/src/platform/site-wide/cta-widget/tests/helpers.unit.spec.js
@@ -52,30 +52,30 @@ describe('CTA helpers', () => {
   describe('A signed-in non-SSO user', () => {
     it('Download my data', () => {
       expect(toolUrl(widgetTypes.HEALTH_RECORDS).url).to.equal(
-        'https://mhv-syst.myhealth.va.gov/mhv-portal-web/download-my-data',
+        'https://int.eauth.va.gov/mhv-portal-web/eauth?deeplinking=download_my_data',
       );
     });
     it('Prescription Refill', () => {
       expect(toolUrl(widgetTypes.RX).url).to.equal(
-        'https://mhv-syst.myhealth.va.gov/mhv-portal-web/web/myhealthevet/refill-prescriptions',
+        'https://int.eauth.va.gov/mhv-portal-web/eauth?deeplinking=prescription_refill',
       );
     });
     it('Secure Messaging', () => {
       expect(toolUrl(widgetTypes.MESSAGING).url).to.equal(
-        'https://mhv-syst.myhealth.va.gov/mhv-portal-web/secure-messaging',
+        'https://int.eauth.va.gov/mhv-portal-web/eauth?deeplinking=secure_messaging',
       );
     });
     it('Appointments', () => {
       expect(toolUrl(widgetTypes.VIEW_APPOINTMENTS).url).to.equal(
-        'https://mhv-syst.myhealth.va.gov/mhv-portal-web/appointments',
+        'https://int.eauth.va.gov/mhv-portal-web/eauth?deeplinking=appointments',
       );
       expect(toolUrl(widgetTypes.SCHEDULE_APPOINTMENTS).url).to.equal(
-        'https://mhv-syst.myhealth.va.gov/mhv-portal-web/appointments',
+        'https://int.eauth.va.gov/mhv-portal-web/eauth?deeplinking=appointments',
       );
     });
     it('Lab Tests', () => {
       expect(toolUrl(widgetTypes.LAB_AND_TEST_RESULTS).url).to.equal(
-        'https://mhv-syst.myhealth.va.gov/mhv-portal-web/labs-tests',
+        'https://int.eauth.va.gov/mhv-portal-web/eauth',
       );
     });
   });

--- a/src/platform/site-wide/mhv/tests/utilities.unit.spec.js
+++ b/src/platform/site-wide/mhv/tests/utilities.unit.spec.js
@@ -4,44 +4,26 @@ import { mhvUrl } from '../utilities';
 
 describe('mhvUrl', () => {
   it('should normalize path', () => {
-    expect(mhvUrl(false, '/home')).to.equal(
-      'https://mhv-syst.myhealth.va.gov/mhv-portal-web/home',
+    expect(mhvUrl('/home')).to.equal(
+      'https://int.eauth.va.gov/mhv-portal-web/eauth',
     );
   });
 
   it('should map SSOe paths', () => {
-    expect(mhvUrl(true, 'home')).to.equal(
+    expect(mhvUrl('home')).to.equal(
       'https://int.eauth.va.gov/mhv-portal-web/eauth',
     );
-    expect(mhvUrl(true, 'download-my-data')).to.equal(
+    expect(mhvUrl('download-my-data')).to.equal(
       'https://int.eauth.va.gov/mhv-portal-web/eauth?deeplinking=download_my_data',
     );
-    expect(mhvUrl(true, 'web/myhealthevet/refill-prescriptions')).to.equal(
+    expect(mhvUrl('web/myhealthevet/refill-prescriptions')).to.equal(
       'https://int.eauth.va.gov/mhv-portal-web/eauth?deeplinking=prescription_refill',
     );
-    expect(mhvUrl(true, 'secure-messaging')).to.equal(
+    expect(mhvUrl('secure-messaging')).to.equal(
       'https://int.eauth.va.gov/mhv-portal-web/eauth?deeplinking=secure_messaging',
     );
-    expect(mhvUrl(true, 'appointments')).to.equal(
+    expect(mhvUrl('appointments')).to.equal(
       'https://int.eauth.va.gov/mhv-portal-web/eauth?deeplinking=appointments',
-    );
-  });
-
-  it('should map non-SSOe paths', () => {
-    expect(mhvUrl(false, 'home')).to.equal(
-      'https://mhv-syst.myhealth.va.gov/mhv-portal-web/home',
-    );
-    expect(mhvUrl(false, 'download-my-data')).to.equal(
-      'https://mhv-syst.myhealth.va.gov/mhv-portal-web/download-my-data',
-    );
-    expect(mhvUrl(false, 'web/myhealthevet/refill-prescriptions')).to.equal(
-      'https://mhv-syst.myhealth.va.gov/mhv-portal-web/web/myhealthevet/refill-prescriptions',
-    );
-    expect(mhvUrl(false, 'secure-messaging')).to.equal(
-      'https://mhv-syst.myhealth.va.gov/mhv-portal-web/secure-messaging',
-    );
-    expect(mhvUrl(false, 'appointments')).to.equal(
-      'https://mhv-syst.myhealth.va.gov/mhv-portal-web/appointments',
     );
   });
 });

--- a/src/platform/site-wide/mhv/utilities.js
+++ b/src/platform/site-wide/mhv/utilities.js
@@ -2,7 +2,6 @@ import environment from 'platform/utilities/environment';
 import { eauthEnvironmentPrefixes } from 'platform/utilities/sso/constants';
 
 const eauthPrefix = eauthEnvironmentPrefixes[environment.BUILDTYPE];
-const mhvPrefix = environment.isProduction() ? 'www' : 'mhv-syst';
 
 // TODO: Update labs-and-tests route once deep link is provided
 const mhvToEauthRoutes = {
@@ -19,13 +18,11 @@ const mhvToEauthRoutes = {
 // 1. Whether this is a production or staging environment
 // 2. Whether the current user is authenticated with SSOe
 // 3. The specific MHV path being accessed
-function mhvUrl(authenticatedWithSSOe, path) {
+function mhvUrl(path) {
   const normPath = path.startsWith('/') ? path.substring(1) : path;
-  if (authenticatedWithSSOe) {
-    const eauthDeepLink = mhvToEauthRoutes[normPath];
-    return `https://${eauthPrefix}eauth.va.gov/mhv-portal-web/${eauthDeepLink}`;
-  }
-  return `https://${mhvPrefix}.myhealth.va.gov/mhv-portal-web/${normPath}`;
+  const eauthDeepLink = mhvToEauthRoutes[normPath];
+
+  return `https://${eauthPrefix}eauth.va.gov/mhv-portal-web/${eauthDeepLink}`;
 }
 
 // TODO: This function is NOT SSOe-aware and is a candidate for removal

--- a/src/platform/site-wide/mhv/utilities.js
+++ b/src/platform/site-wide/mhv/utilities.js
@@ -14,10 +14,7 @@ const mhvToEauthRoutes = {
   'labs-tests': 'eauth',
 };
 
-// An MHV URL is a function of the following parameters:
-// 1. Whether this is a production or staging environment
-// 2. Whether the current user is authenticated with SSOe
-// 3. The specific MHV path being accessed
+// An MHV URL is a function that accepts an MHV URL path as a parameter.
 function mhvUrl(path) {
   const normPath = path.startsWith('/') ? path.substring(1) : path;
   const eauthDeepLink = mhvToEauthRoutes[normPath];


### PR DESCRIPTION
## Description
A contact at MHV has expressed to us that we should always be linking to their "eauth" domain, regardless of SSOe status. This PR makes that update to our utility function and removes the unused parameter from the calls to that function.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/17318

## Testing done
Visited health care portals and confirmed that the eauth MHV URLs are being used correctly

## Screenshots
### RX
![image](https://user-images.githubusercontent.com/1915775/104196026-54cee100-53f1-11eb-8435-0ffc24f38c98.png)

### Messaging
![image](https://user-images.githubusercontent.com/1915775/104196191-7d56db00-53f1-11eb-8051-366bfdfe13b0.png)

### Lab tests
![image](https://user-images.githubusercontent.com/1915775/104196330-a5463e80-53f1-11eb-977a-2949769861b5.png)

### Records
![image](https://user-images.githubusercontent.com/1915775/104196391-b8f1a500-53f1-11eb-9a8b-0f490e17d689.png)


## Acceptance criteria
- [ ] User always lands on the "eauth" domain

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
