### PR TITLE
[Development;508] HLR: Add aria-label to issue edit on review & submit page

### DIFF
--- a/src/applications/disability-benefits/996/pages/contestedIssues.js
+++ b/src/applications/disability-benefits/996/pages/contestedIssues.js
@@ -11,6 +11,9 @@ import { SELECTED } from '../constants';
 const contestedIssuesPage = {
   uiSchema: {
     'ui:title': ContestedIssuesTitle,
+    'ui:options': {
+      ariaLabelForEditButtonOnReview: 'Edit issues eligible for review',
+    },
     contestedIssues: {
       'ui:title': ' ',
       'ui:field': 'StringField',


### PR DESCRIPTION
## Description

On the review & submit page of the Higher-Level Review form, the issues eligible for review accordion includes an edit button with an `aria-label` that is missing the title ("Edit ") of the group. This PR uses a `ui:option` to change the `aria-label` to "Edit issues eligible for review".

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/17824
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/17240

## Testing done

N/A

## Screenshots

![Screen Shot 2021-01-07 at 11 01 28 AM](https://user-images.githubusercontent.com/136959/103921140-bdf3e300-50d7-11eb-8fa6-40209adbff34.png)

## Acceptance criteria
- [x] Screenreader is provided a better label for the eligible issues edit button

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
