### PR TITLE
Sanlouise 17279 update vapsvc readme

### DIFF
--- a/src/platform/user/profile/vap-svc/README.md
+++ b/src/platform/user/profile/vap-svc/README.md
@@ -23,7 +23,7 @@ Follow these steps to get started in your own application:
 This should hopefully be all you need to know to work with VA Profile Service, but there's more information below in case you would like to become familiar with how the components work.
 
 ## VA Profile Service Reducer (vapService)
-The VA Profile Service reducer is necessary in order to manage transactions (more on that below), as well as certain interactions with the UI (opening an edit-modal after a user clicks "edit", for example.) It contains the following fields-
+The VA Profile Service reducer is necessary in order to manage transactions (more on that below), as well as certain interactions with the UI (opening an edit-modal after a user clicks "edit", for example.) It contains the following properties-
 
 1. `modal`
     - A string value indicating which field's edit-modal should be visible.
@@ -40,6 +40,14 @@ The VA Profile Service reducer is necessary in order to manage transactions (mor
     - An array of transaction IDs, each one corresponding to a request at `/v0/profile/person/status/{transaction_id}`. This is effectively used to prevent the API from being hit quicker than it can respond while we are polling for transaction updates.
 5. `metadata`
     - Anything else about the transactions data. Currently, it contains only a `mostRecentErroredTransactionId` property, which is used to render error messaging for the most recent rejected transaction. It is necessary because transactions aren't timestamped.
+6. `hasUnsavedEdits`
+    - A boolean used to indicate whether the user has any form field updates that have not yet been successfully saved.
+7. `initialFormFields`
+    - The value of initialFormFields is set to an empty object if the user has not yet filled out any contact information and otherwise includes any already saved contact information. The value is set when `UPDATE_PROFILE_FORM_FIELD` is triggered upon initial opening of the edit modal / rendering of the edit view.
+8. `addressValidation`
+    - Is an object set to `initialAddressValidationState` upon initialization and when the address validation modal is opened, and updated based on whether the address validation went through successfully (`ADDRESS_VALIDATION_CONFIRM`) or with an error (`ADDRESS_VALIDATION_ERROR`).
+9. `transactionStatus`
+    - A string that is either `RECEIVED`, `COMPLETED_SUCCESS` or `COMPLETED_FAILURE`.
 
 ## Transactions
 When a request to update a field is sent to VA Profile Service (via `PUT`, or `POST` if the field is empty), VA Profile Service does not respond with the updated record from a database as you would expect from a typical API. Instead, it responds with data on how to look up the progress of the update, information referred to as a "transaction." For example, a request to update an email would return a transaction that looks like:
@@ -56,7 +64,7 @@ When a request to update a field is sent to VA Profile Service (via `PUT`, or `P
 }
 ```
 
-The `transaction_status` property set to `RECEIVED` indicates that VA Profile Service has enqueued the update, but it has not finished processing. The `transaction_id` can then be used to look up that update at a later time via `/v0/profile/person/status/{transaction_id}`. At some point, the `transaction_status` will indicate whether the update was successful or rejected. If it is rejected, there will be a `metadata` property containing a list of errors. The Swagger docs contain [more info](https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/api-reference/#/profile/postVapsvcEmailAddress) on this.
+The `transaction_status` property set to `RECEIVED` indicates that VA Profile Service has enqueued the update, but it has not finished processing. The `transaction_id` can then be used to look up that update at a later time via `/v0/profile/person/status/{transaction_id}`. At some point, the `transaction_status` will indicate whether the update was successful or rejected. If it is rejected, there will be a `metadata` property containing a list of errors. The Swagger docs contain [more info](https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/api-reference/#/profile/postVet360EmailAddress) on this.
 
 A note here about the `type` property - that field indicates whether the transaction pertains to an email, address, or telephone number. In the case of an address, you are not provided with an identifier to determine whether the transaction is for a residential or mailing address. This information must be managed by the Front-End in memory.
 

--- a/src/platform/user/profile/vap-svc/README.md
+++ b/src/platform/user/profile/vap-svc/README.md
@@ -1,6 +1,6 @@
-This directory contains the React components and state management for interfacing with Vet360, a VA service that processes updates by updating the field in multiple data sources. The work here has been extracted from the Profile application to be easily imported into other applications, and is warranted because the Vet360 data flow operates via "transactions", which is more complex than the more common model of an API responding directly to a request with the updated record or errors.
+This directory contains the React components and state management for interfacing with VA Profile Service (AKA vap-svc, vapService, VAPService in the application), a VA service that processes updates by updating the field in multiple data sources. The work here has been extracted from the Profile application to be easily imported into other applications, and is warranted because the VA Profile Service data flow operates via "transactions", which is more complex than the more common model of an API responding directly to a request with the updated record or errors.
 
-Currently, Vet360's scope is limited to veteran contact information, which consists of the following fields:
+Currently, VA Profile Service's scope is limited to veteran contact information, which consists of the following fields:
 
 - Email
 - Home Phone
@@ -11,19 +11,19 @@ Currently, Vet360's scope is limited to veteran contact information, which consi
 - Residential Address
 
 ## Getting started
-The [Profile](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/applications/personalization/profile360) application serves as an example for how to use this work.
+The [Profile](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/applications/personalization/profile) application serves as an example for how to use this work.
 
 Follow these steps to get started in your own application:
 
-1. Import and initialize the Vet360 reducer into the Redux store as `vet360`.
-    - In the Profile, this looks like - `export default { vaProfile, vet360 };`
+1. Import and initialize the VA Profile Service reducer into the Redux store as `vapService`.
+    - In the Profile, this looks like - `export default { vaProfile, vapService };`
 2. Import and render the components or containers useful for your application.
-    - The `vet360/components` directory contains components that internally wrap containers so that they can be freely rendered standalone without any props or setup involved.
+    - The `vap-svc/components` directory contains components that internally wrap containers so that they can be freely rendered standalone without any props or setup involved.
 
-This should hopefully be all you need to know to work with Vet360, but there's more information below in case you would like to become familiar with how the components work.
+This should hopefully be all you need to know to work with VA Profile Service, but there's more information below in case you would like to become familiar with how the components work.
 
-## Vet360 Reducer
-The Vet360 reducer is necessary in order to manage transactions (more on that below), as well as certain interactions with the UI (opening an edit-modal after a user clicks "edit", for example.) It contains the following fields-
+## VA Profile Service Reducer (vapService)
+The VA Profile Service reducer is necessary in order to manage transactions (more on that below), as well as certain interactions with the UI (opening an edit-modal after a user clicks "edit", for example.) It contains the following fields-
 
 1. `modal`
     - A string value indicating which field's edit-modal should be visible.
@@ -42,7 +42,7 @@ The Vet360 reducer is necessary in order to manage transactions (more on that be
     - Anything else about the transactions data. Currently, it contains only a `mostRecentErroredTransactionId` property, which is used to render error messaging for the most recent rejected transaction. It is necessary because transactions aren't timestamped.
 
 ## Transactions
-When a request to update a field is sent to Vet360 (via `PUT`, or `POST` if the field is empty), Vet360 does not respond with the updated record from a database as you would expect from a typical API. Instead, it responds with data on how to look up the progress of the update, information referred to as a "transaction." For example, a request to update an email would return a transaction that looks like:
+When a request to update a field is sent to VA Profile Service (via `PUT`, or `POST` if the field is empty), VA Profile Service does not respond with the updated record from a database as you would expect from a typical API. Instead, it responds with data on how to look up the progress of the update, information referred to as a "transaction." For example, a request to update an email would return a transaction that looks like:
 
 ```json
 {
@@ -50,18 +50,18 @@ When a request to update a field is sent to Vet360 (via `PUT`, or `POST` if the 
     "attributes": {
       "transaction_status": "RECEIVED",
       "transaction_id": "786efe0e-fd20-4da2-9019-0c00540dba4d",
-      "type": "AsyncTransaction::Vet360::EmailTransaction"
+      "type": "AsyncTransaction::vet360::EmailTransaction"
     }
   }
 }
 ```
 
-The `transaction_status` property set to `RECEIVED` indicates that Vet360 has enqueued the update, but it has not finished processing. The `transaction_id` can then be used to look up that update at a later time via `/v0/profile/person/status/{transaction_id}`. At some point, the `transaction_status` will indicate whether the update was successful or rejected. If it is rejected, there will be a `metadata` property containing a list of errors. The Swagger docs contain [more info](https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/api-reference/#/profile/postVet360EmailAddress) on this.
+The `transaction_status` property set to `RECEIVED` indicates that VA Profile Service has enqueued the update, but it has not finished processing. The `transaction_id` can then be used to look up that update at a later time via `/v0/profile/person/status/{transaction_id}`. At some point, the `transaction_status` will indicate whether the update was successful or rejected. If it is rejected, there will be a `metadata` property containing a list of errors. The Swagger docs contain [more info](https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/api-reference/#/profile/postVapsvcEmailAddress) on this.
 
 A note here about the `type` property - that field indicates whether the transaction pertains to an email, address, or telephone number. In the case of an address, you are not provided with an identifier to determine whether the transaction is for a residential or mailing address. This information must be managed by the Front-End in memory.
 
 ### Errors
-Most errors are returned by Vet360 during a transaction lookup along with a `transaction_status` indicating that the update was rejected. However, some errors are returned directly, similar to a traditional API response. These errors are -
+Most errors are returned by VA Profile Service during a transaction lookup along with a `transaction_status` indicating that the update was rejected. However, some errors are returned directly, similar to a traditional API response. These errors are -
 
 1. An address was said to be invalid
 2. The veteran is deceased

--- a/src/platform/user/profile/vap-svc/README.md
+++ b/src/platform/user/profile/vap-svc/README.md
@@ -60,7 +60,7 @@ When a request to update a field is sent to VA Profile Service (via `PUT`, or `P
     "attributes": {
       "transaction_status": "RECEIVED",
       "transaction_id": "786efe0e-fd20-4da2-9019-0c00540dba4d",
-      "type": "AsyncTransaction::vet360::EmailTransaction"
+      "type": "AsyncTransaction::Vet360::EmailTransaction"
     }
   }
 }
@@ -69,6 +69,8 @@ When a request to update a field is sent to VA Profile Service (via `PUT`, or `P
 The `transaction_status` property set to `RECEIVED` indicates that VA Profile Service has enqueued the update, but it has not finished processing. The `transaction_id` can then be used to look up that update at a later time via `/v0/profile/person/status/{transaction_id}`. At some point, the `transaction_status` will indicate whether the update was successful or rejected. If it is rejected, there will be a `metadata` property containing a list of errors. The Swagger docs contain [more info](https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/api-reference/#/profile/postVet360EmailAddress) on this.
 
 A note here about the `type` property - that field indicates whether the transaction pertains to an email, address, or telephone number. In the case of an address, you are not provided with an identifier to determine whether the transaction is for a residential or mailing address. This information must be managed by the Front-End in memory.
+
+Note that we're still getting vet360 data back from the API, as it has not yet been renamed to reference VA Profile Service.
 
 ### Errors
 Most errors are returned by VA Profile Service during a transaction lookup along with a `transaction_status` indicating that the update was rejected. However, some errors are returned directly, similar to a traditional API response. These errors are -

--- a/src/platform/user/profile/vap-svc/README.md
+++ b/src/platform/user/profile/vap-svc/README.md
@@ -47,8 +47,9 @@ The VA Profile Service reducer is necessary in order to manage transactions (mor
 9. `hasUnsavedEdits`
     - A boolean used to indicate whether the user has any form field updates that have not yet been successfully saved.
 10. `addressValidation`
-    - Is an object set to `initialAddressValidationState` when the address validation modal is opened, and updated based on whether the address validation went through successfully (`ADDRESS_VALIDATION_CONFIRM`) or with an error (`ADDRESS_VALIDATION_ERROR`).
+    - When the `validateAddress` thunk is triggered, it will set `addressValidation` equal to `initialAddressValidationState`.
     - The logic whether to show the address validation modal can be found in `src/platform/user/profile/vap-svc/util/index.js`.
+    - When the address validation modal is opened, the values on `addressValidation` are set to their respective values based on whether we get confirmed suggested addresses back or whether there was an error.
 
 ## Transactions
 When a request to update a field is sent to VA Profile Service (via `PUT`, or `POST` if the field is empty), VA Profile Service does not respond with the updated record from a database as you would expect from a typical API. Instead, it responds with data on how to look up the progress of the update, information referred to as a "transaction." For example, a request to update an email would return a transaction that looks like:

--- a/src/platform/user/profile/vap-svc/README.md
+++ b/src/platform/user/profile/vap-svc/README.md
@@ -27,27 +27,28 @@ The VA Profile Service reducer is necessary in order to manage transactions (mor
 
 1. `modal`
     - A string value indicating which field's edit-modal should be visible.
-2. `formFields`
+2. `initialFormFields`
+    - The value of initialFormFields is set to an empty object if the user has not yet filled out any contact information and otherwise includes any already saved contact information. The value is set when `UPDATE_PROFILE_FORM_FIELD` is triggered upon initial opening of the edit modal / rendering of the edit view.
+3. `formFields`
     - Information for the modals to manage their state in the UI, including the edited form value and validation errors.
-2. `transactions`
+4. `transactions`
     - An array of transactions, all of which will pertain to updates that are either pending (status of `RECEIVED`) or rejected. Successful transactions are automatically removed from state after the user profile is refreshed.
     - The `fetchTransactions` action will populate this property with all transactions for a particular user.
-3. `fieldTransactionMap`
+5. `transactionStatus`
+    - A string that is either `RECEIVED`, `COMPLETED_SUCCESS` or `COMPLETED_FAILURE`.
+6. `fieldTransactionMap`
     - An object, where each field-name (`mailingAddress`, `emailAddress`, etc) is used to look up whether there is an update request for a field. If there is pending request, then `fieldTransactionMap[FIELD_NAME].isPending` will be `true`. If there is direct error, then `isFailed` will be true and `error` will contain information from the API. If we there is an active transaction for that field, then `fieldTransactionMap[FIELD_NAME].transactionId` can be used to look up that transaction in the `transactions` property. This is necessary because a transaction only contains enough information to determine the update category (address, email address, or phone number) via its `type` rather then the specific field that it corresponds.
     - A transaction may exist in the `transactions` array but without a field-mapping in the `fieldTransactionMap` if transactions are found via the `fetchTransactions` action.
     - If there is no active transaction for a field or the specific field can't be determined because of the reason described above, then the value for a field will be `undefined`.
-4. `transactionsAwaitingUpdate`
+7. `transactionsAwaitingUpdate`
     - An array of transaction IDs, each one corresponding to a request at `/v0/profile/person/status/{transaction_id}`. This is effectively used to prevent the API from being hit quicker than it can respond while we are polling for transaction updates.
-5. `metadata`
+8. `metadata`
     - Anything else about the transactions data. Currently, it contains only a `mostRecentErroredTransactionId` property, which is used to render error messaging for the most recent rejected transaction. It is necessary because transactions aren't timestamped.
-6. `hasUnsavedEdits`
+9. `hasUnsavedEdits`
     - A boolean used to indicate whether the user has any form field updates that have not yet been successfully saved.
-7. `initialFormFields`
-    - The value of initialFormFields is set to an empty object if the user has not yet filled out any contact information and otherwise includes any already saved contact information. The value is set when `UPDATE_PROFILE_FORM_FIELD` is triggered upon initial opening of the edit modal / rendering of the edit view.
-8. `addressValidation`
-    - Is an object set to `initialAddressValidationState` upon initialization and when the address validation modal is opened, and updated based on whether the address validation went through successfully (`ADDRESS_VALIDATION_CONFIRM`) or with an error (`ADDRESS_VALIDATION_ERROR`).
-9. `transactionStatus`
-    - A string that is either `RECEIVED`, `COMPLETED_SUCCESS` or `COMPLETED_FAILURE`.
+10. `addressValidation`
+    - Is an object set to `initialAddressValidationState` when the address validation modal is opened, and updated based on whether the address validation went through successfully (`ADDRESS_VALIDATION_CONFIRM`) or with an error (`ADDRESS_VALIDATION_ERROR`).
+    - The logic whether to show the address validation modal can be found in `src/platform/user/profile/vap-svc/util/index.js`.
 
 ## Transactions
 When a request to update a field is sent to VA Profile Service (via `PUT`, or `POST` if the field is empty), VA Profile Service does not respond with the updated record from a database as you would expect from a typical API. Instead, it responds with data on how to look up the progress of the update, information referred to as a "transaction." For example, a request to update an email would return a transaction that looks like:

--- a/src/platform/user/profile/vap-svc/README.md
+++ b/src/platform/user/profile/vap-svc/README.md
@@ -1,4 +1,4 @@
-This directory contains the React components and state management for interfacing with VA Profile Service (AKA vap-svc, vapService, VAPService in the application), a VA service that processes updates by updating the field in multiple data sources. The work here has been extracted from the Profile application to be easily imported into other applications, and is warranted because the VA Profile Service data flow operates via "transactions", which is more complex than the more common model of an API responding directly to a request with the updated record or errors.
+This directory contains the React components and state management for interfacing with VA Profile Service (AKA vap, vap-svc, vapService, VAPService in the application), a VA service that processes updates by updating the field in multiple data sources. The work here has been extracted from the Profile application to be easily imported into other applications, and is warranted because the VA Profile Service data flow operates via "transactions", which is more complex than the more common model of an API responding directly to a request with the updated record or errors.
 
 Currently, VA Profile Service's scope is limited to veteran contact information, which consists of the following fields:
 
@@ -22,11 +22,13 @@ Follow these steps to get started in your own application:
 
 This should hopefully be all you need to know to work with VA Profile Service, but there's more information below in case you would like to become familiar with how the components work.
 
+At the moment of writing, `letters` is the only application that is already using vap-svc components. An example can be found here, were we use `MailingAddress`: `src/applications/letters/containers/AddressSection.jsx`.
+
 ## VA Profile Service Reducer (vapService)
-The VA Profile Service reducer is necessary in order to manage transactions (more on that below), as well as certain interactions with the UI (opening an edit-modal after a user clicks "edit", for example.) It contains the following properties-
+The VA Profile Service reducer is necessary in order to manage transactions (more on that below), as well as certain interactions with the UI (opening an edit-modal or edit view after a user clicks "edit", for example.) It contains the following properties-
 
 1. `modal`
-    - A string value indicating which field's edit-modal should be visible.
+    - A string value indicating which field is being edited.
 2. `initialFormFields`
     - The value of initialFormFields is set to an empty object if the user has not yet filled out any contact information and otherwise includes any already saved contact information. The value is set when `UPDATE_PROFILE_FORM_FIELD` is triggered upon initial opening of the edit modal / rendering of the edit view.
 3. `formFields`
@@ -41,7 +43,7 @@ The VA Profile Service reducer is necessary in order to manage transactions (mor
     - A transaction may exist in the `transactions` array but without a field-mapping in the `fieldTransactionMap` if transactions are found via the `fetchTransactions` action.
     - If there is no active transaction for a field or the specific field can't be determined because of the reason described above, then the value for a field will be `undefined`.
 7. `transactionsAwaitingUpdate`
-    - An array of transaction IDs, each one corresponding to a request at `/v0/profile/person/status/{transaction_id}`. This is effectively used to prevent the API from being hit quicker than it can respond while we are polling for transaction updates.
+    - An array of transaction IDs, each one corresponding to a request at `/v0/profile/status/{transaction_id}`. This is effectively used to prevent the API from being hit quicker than it can respond while we are polling for transaction updates.
 8. `metadata`
     - Anything else about the transactions data. Currently, it contains only a `mostRecentErroredTransactionId` property, which is used to render error messaging for the most recent rejected transaction. It is necessary because transactions aren't timestamped.
 9. `hasUnsavedEdits`


### PR DESCRIPTION
[TICKET ](https://github.com/department-of-veterans-affairs/va.gov-team/issues/17279)

## Description
We needed to update this README as we have switched to reference VA Profile Service instead of Vet360 on the FE, and have added properties to the VA Profile Service reducer.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
