### PR TITLE
View Payments Revert case check

### DIFF
--- a/src/applications/static-pages/view-payment-history/ViewPaymentHistoryCTA.js
+++ b/src/applications/static-pages/view-payment-history/ViewPaymentHistoryCTA.js
@@ -17,7 +17,7 @@ const ViewPaymentHistoryCTA = props => {
   const { includedInFlipper, isLoggedIn, isProfileLoading } = props;
   if (includedInFlipper === undefined || isProfileLoading) {
     return <LoadingIndicator message="Loading..." />;
-  } else if (includedInFlipper === false && isLoggedIn === false) {
+  } else if (includedInFlipper === false) {
     alertContent = (
       <>
         <p>


### PR DESCRIPTION
## Description
This pull request reverts the logic for one of the cases covered in the view payments CTA because it introduced a bug where if the feature toggle was off, but a user was logged in, they'd bypass the toggle. 

## Testing done
- local, cases tested:
  - Logged out, feature disabled for everyone
  - Logged in, feature disabled for everyone
  - Logged in but not on whitelist

## Acceptance criteria
- [x] all cases pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
