### PR TITLE
Deactivate additional-linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,12 +109,12 @@ jobs:
       - checkout
       - run: yarn security-check
 
-  additional-linting:
-    executor: circleci-node
-    steps:
-      - checkout
-      - yarn-install-cache
-      - run: npm run lint:circle
+  # additional-linting:
+  #   executor: circleci-node
+  #   steps:
+  #     - checkout
+  #     - yarn-install-cache
+  #     - run: npm run lint:circle
 
   build:
     executor: circleci-node
@@ -289,6 +289,6 @@ workflows:
       - e2e-test:
           requires:
             - build-e2e
-  additional-linting:
-    jobs:
-      - additional-linting
+  # additional-linting:
+  #   jobs:
+  #     - additional-linting


### PR DESCRIPTION
## Description
We are deactivating `additional-linting` which is the test enviroment for the linting rules in circle. We currently do not have any linting rules to be tested, however, this job is taking up spots in the queue.

## Testing done
Locally

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
