### PR TITLE
18255 - 686 update net worth value

### DIFF
--- a/src/applications/disability-benefits/686c-674/config/chapters/household-income/helpers.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/household-income/helpers.js
@@ -20,7 +20,7 @@ export const netWorthCalculation = (
 
 export const netWorthTitle = (
   <p>
-    Did the household have a <strong>net worth</strong> greater than $129,094 in
+    Did the household have a <strong>net worth</strong> greater than $130,733 in
     the last tax year?
   </p>
 );

--- a/src/applications/disability-benefits/686c-674/config/chapters/household-income/helpers.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/household-income/helpers.js
@@ -1,5 +1,6 @@
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 import React from 'react';
+import { NETWORTH_VALUE } from '../../constants';
 
 export const netWorthCalculation = (
   <>
@@ -20,7 +21,7 @@ export const netWorthCalculation = (
 
 export const netWorthTitle = (
   <p>
-    Did the household have a <strong>net worth</strong> greater than $130,733 in
-    the last tax year?
+    Did the household have a <strong>net worth</strong> greater than $
+    {NETWORTH_VALUE} in the last tax year?
   </p>
 );

--- a/src/applications/disability-benefits/686c-674/config/constants.js
+++ b/src/applications/disability-benefits/686c-674/config/constants.js
@@ -17,3 +17,5 @@ export const MARRIAGE_TYPES = {
   proxy: 'PROXY',
   other: 'OTHER',
 };
+
+export const NETWORTH_VALUE = '130,733';


### PR DESCRIPTION
## Description
This pull request updates the value for net worth in the 686 form flow from 129,094 to 130,733.

## Testing done
- local

## Screenshots
<img width="550" alt="Screen Shot 2021-01-07 at 3 57 46 PM" src="https://user-images.githubusercontent.com/15097156/103944335-7bdf9700-5101-11eb-90c8-d6d03bae0376.png">


## Acceptance criteria
- [x] value has been updated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
