### PR TITLE
[Development] Add Analytics to HLR error alerts

### DIFF
--- a/src/applications/disability-benefits/996/actions/index.js
+++ b/src/applications/disability-benefits/996/actions/index.js
@@ -24,7 +24,7 @@ export const getContestableIssues = props => {
     if (!foundBenefitType || !foundBenefitType?.isSupported) {
       return Promise.reject({
         error: 'invalidBenefitType',
-        type: foundBenefitType?.label || 'Unknown',
+        type: foundBenefitType?.label || benefitType || 'Unknown',
       }).catch(errors =>
         dispatch({
           type: FETCH_CONTESTABLE_ISSUES_FAILED,

--- a/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
@@ -99,12 +99,16 @@ export class IntroductionPage extends React.Component {
   };
 
   getCallToActionContent = () => {
-    const { route, contestableIssues } = this.props;
+    const { route, contestableIssues, delay = 250 } = this.props;
 
     if (contestableIssues?.error) {
-      return showContestableIssueError(contestableIssues.error);
+      return showContestableIssueError(contestableIssues, delay);
     }
-    if (contestableIssues?.status === FETCH_CONTESTABLE_ISSUES_INIT) {
+
+    if (
+      (contestableIssues?.status || '') === '' ||
+      contestableIssues?.status === FETCH_CONTESTABLE_ISSUES_INIT
+    ) {
       return (
         <LoadingIndicator
           setFocus
@@ -112,19 +116,33 @@ export class IntroductionPage extends React.Component {
         />
       );
     }
+
     const { formId, prefillEnabled, savedFormMessages } = route.formConfig;
-    return contestableIssues?.issues?.length > 0 ? (
-      <SaveInProgressIntro
-        formId={formId}
-        prefillEnabled={prefillEnabled}
-        messages={savedFormMessages}
-        pageList={route.pageList}
-        startText="Start the Request for a Higher-Level Review"
-        gaStartEventName="decision-reviews-va20-0996-start-form"
-      />
-    ) : (
-      noContestableIssuesFound
-    );
+
+    if (contestableIssues?.issues?.length > 0) {
+      return (
+        <SaveInProgressIntro
+          formId={formId}
+          prefillEnabled={prefillEnabled}
+          messages={savedFormMessages}
+          pageList={route.pageList}
+          startText="Start the Request for a Higher-Level Review"
+          gaStartEventName="decision-reviews-va20-0996-start-form"
+        />
+      );
+    }
+
+    recordEvent({
+      event: 'visible-alert-box',
+      'alert-box-type': 'warning',
+      'alert-box-heading':
+        'We don’t have any issues on file for you that are eligible for a Higher-Level Review',
+      'error-key': contestableIssues?.status || '',
+      'alert-box-full-width': false,
+      'alert-box-background-only': false,
+      'alert-box-closeable': false,
+    });
+    return noContestableIssuesFound;
   };
 
   setWizardStatus = value => {

--- a/src/applications/disability-benefits/996/content/contestableIssueAlerts.jsx
+++ b/src/applications/disability-benefits/996/content/contestableIssueAlerts.jsx
@@ -4,6 +4,8 @@ import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
+import recordEvent from 'platform/monitoring/record-event';
+
 import { disabilitiesExplanationAlert } from './contestedIssues';
 import { PROFILE_URL, HLR_INFO_URL } from '../constants';
 
@@ -35,13 +37,37 @@ export const noContestableIssuesFound = (
   />
 );
 
-export const showContestableIssueError = ({ error, type } = {}) => {
-  const headline =
-    error === 'invalidBenefitType'
-      ? `We don’t support this benefit type`
-      : 'We can’t load your issues';
-  const content =
-    error === 'invalidBenefitType' ? benefitError(type) : networkError;
+let timeoutId;
+
+export const showContestableIssueError = ({ error, status } = {}, delay) => {
+  const invalidBenefitType = error.error === 'invalidBenefitType';
+  const headline = invalidBenefitType
+    ? `We don’t support this benefit type`
+    : 'We can’t load your issues';
+  const content = invalidBenefitType ? benefitError(error?.type) : networkError;
+
+  const record = () =>
+    recordEvent({
+      event: 'visible-alert-box',
+      'alert-box-type': 'error',
+      'alert-box-heading': headline,
+      'alert-box-subheading': invalidBenefitType
+        ? `${error?.type} not supported`
+        : 'network error',
+      'error-key': status,
+      'alert-box-full-width': false,
+      'alert-box-background-only': false,
+      'alert-box-closeable': false,
+    });
+
+  // Using a debounce method to prevent duplication (2 alerts on intro page)
+  // Not using platform debounce function since it doesn't behave as expected
+  clearTimeout(timeoutId);
+  if (delay) {
+    timeoutId = setTimeout(record(), delay);
+  } else {
+    record(); // no delay in unit tests
+  }
   return <AlertBox status="error" headline={headline} content={content} />;
 };
 

--- a/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
@@ -52,10 +52,13 @@ const globalWin = {
 
 describe('IntroductionPage', () => {
   let oldWindow;
+  let gaData;
   beforeEach(() => {
     oldWindow = global.window;
     global.window = Object.create(global.window);
     Object.assign(global.window, globalWin);
+    global.window.dataLayer = [];
+    gaData = global.window.dataLayer;
   });
   afterEach(() => {
     global.window = oldWindow;
@@ -106,40 +109,48 @@ describe('IntroductionPage', () => {
 
   it('should render alert showing a server error', () => {
     sessionStorage.setItem(WIZARD_STATUS, WIZARD_STATUS_COMPLETE);
+    const errorMessage = 'We can’t load your issues';
     const props = {
       ...defaultProps,
       contestableIssues: {
         issues: [],
         status: '',
         error: {
-          errors: [{ title: 'We can’t load your issues' }],
+          errors: [{ title: errorMessage }],
         },
       },
+      delay: 0,
     };
 
     const tree = shallow(<IntroductionPage {...props} />);
 
     const AlertBox = tree.find('AlertBox').first();
-    expect(AlertBox.render().text()).to.include('can’t load your issues');
+    expect(AlertBox.render().text()).to.include(errorMessage);
+    const recordedEvent = gaData[gaData.length - 1];
+    expect(recordedEvent.event).to.equal('visible-alert-box');
+    expect(recordedEvent['alert-box-heading']).to.include(errorMessage);
     tree.unmount();
   });
   it('should render alert showing no contestable issues', () => {
     sessionStorage.setItem(WIZARD_STATUS, WIZARD_STATUS_COMPLETE);
+    const errorMessage = 'don’t have any issues on file for you';
     const props = {
       ...defaultProps,
       contestableIssues: {
         issues: [],
-        status: '',
+        status: 'done',
         error: '',
       },
+      delay: 0,
     };
 
     const tree = shallow(<IntroductionPage {...props} />);
 
     const AlertBox = tree.find('AlertBox').first();
-    expect(AlertBox.render().text()).to.include(
-      'don’t have any issues on file for you',
-    );
+    expect(AlertBox.render().text()).to.include(errorMessage);
+    const recordedEvent = gaData[gaData.length - 1];
+    expect(recordedEvent.event).to.equal('visible-alert-box');
+    expect(recordedEvent['alert-box-heading']).to.include(errorMessage);
     tree.unmount();
   });
   it('should render start button', () => {
@@ -148,7 +159,7 @@ describe('IntroductionPage', () => {
       ...defaultProps,
       contestableIssues: {
         issues: [{}],
-        status: '',
+        status: 'done',
         error: '',
       },
     };
@@ -167,7 +178,7 @@ describe('IntroductionPage', () => {
       ...defaultProps,
       contestableIssues: {
         issues: [{}],
-        status: '',
+        status: 'done',
         error: '',
       },
     };
@@ -208,7 +219,7 @@ describe('IntroductionPage', () => {
       ...defaultProps,
       contestableIssues: {
         issues: [{}],
-        status: '',
+        status: 'done',
         error: '',
       },
     };


### PR DESCRIPTION
## Description

When Higher-Level Review contestable issues are loaded, there is a possibility of seeing a loading error alert, or an alert letting the user know they don't have any contestable issues. This PR adds GA events for when these error messages are shown.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/3825#issuecomment-756300765

## Testing done

Updated unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] GA event recorded for failed contestable issue loading
- [x] GA event recorded for user with no eligible contestable issues

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
