### PR TITLE
Update GA strings for CNP

### DIFF
--- a/src/applications/personalization/profile/actions/paymentInformation.js
+++ b/src/applications/personalization/profile/actions/paymentInformation.js
@@ -4,9 +4,9 @@ import {
   isEligibleForCNPDirectDeposit,
   isSignedUpForCNPDirectDeposit,
   isSignedUpForEDUDirectDeposit,
+  cnpPrefix,
 } from '../util';
 import recordAnalyticsEvent from 'platform/monitoring/record-event';
-import environment from 'platform/utilities/environment';
 
 export const CNP_PAYMENT_INFORMATION_FETCH_STARTED =
   'CNP_PAYMENT_INFORMATION_FETCH_STARTED';
@@ -42,13 +42,11 @@ export const EDU_PAYMENT_INFORMATION_SAVE_SUCCEEDED =
 export const EDU_PAYMENT_INFORMATION_SAVE_FAILED =
   'EDU_PAYMENT_INFORMATION_SAVE_FAILED';
 
-const isProd = () => (!environment.isProduction() ? 'cnp-' : '');
-
 export function fetchCNPPaymentInformation(recordEvent = recordAnalyticsEvent) {
   return async dispatch => {
     dispatch({ type: CNP_PAYMENT_INFORMATION_FETCH_STARTED });
 
-    recordEvent({ event: `profile-get-${isProd}direct-deposit-started` });
+    recordEvent({ event: `profile-get-${cnpPrefix}direct-deposit-started` });
     const response = await getData('/ppiu/payment_information');
 
     // sample error when getting payment information
@@ -65,14 +63,14 @@ export function fetchCNPPaymentInformation(recordEvent = recordAnalyticsEvent) {
     // };
 
     if (response.error) {
-      recordEvent({ event: `profile-get-${isProd}direct-deposit-failed` });
+      recordEvent({ event: `profile-get-${cnpPrefix}direct-deposit-failed` });
       dispatch({
         type: CNP_PAYMENT_INFORMATION_FETCH_FAILED,
         response,
       });
     } else {
       recordEvent({
-        event: `profile-get-${isProd}direct-deposit-retrieved`,
+        event: `profile-get-${cnpPrefix}direct-deposit-retrieved`,
         // The API might report an empty payment address for some folks who are
         // already enrolled in direct deposit. But we want to make sure we
         // always treat those who are signed up as being eligible. Therefore
@@ -162,7 +160,7 @@ export function saveCNPPaymentInformation(
     } else {
       recordEvent({
         event: 'profile-transaction',
-        'profile-section': `${isProd}direct-deposit-information`,
+        'profile-section': `${cnpPrefix}direct-deposit-information`,
       });
       dispatch({
         type: CNP_PAYMENT_INFORMATION_SAVE_SUCCEEDED,

--- a/src/applications/personalization/profile/actions/paymentInformation.js
+++ b/src/applications/personalization/profile/actions/paymentInformation.js
@@ -6,6 +6,7 @@ import {
   isSignedUpForEDUDirectDeposit,
 } from '../util';
 import recordAnalyticsEvent from 'platform/monitoring/record-event';
+import environment from 'platform/utilities/environment';
 
 export const CNP_PAYMENT_INFORMATION_FETCH_STARTED =
   'CNP_PAYMENT_INFORMATION_FETCH_STARTED';
@@ -41,11 +42,13 @@ export const EDU_PAYMENT_INFORMATION_SAVE_SUCCEEDED =
 export const EDU_PAYMENT_INFORMATION_SAVE_FAILED =
   'EDU_PAYMENT_INFORMATION_SAVE_FAILED';
 
+const isProd = () => (!environment.isProduction() ? 'cnp-' : '');
+
 export function fetchCNPPaymentInformation(recordEvent = recordAnalyticsEvent) {
   return async dispatch => {
     dispatch({ type: CNP_PAYMENT_INFORMATION_FETCH_STARTED });
 
-    recordEvent({ event: 'profile-get-direct-deposit-started' });
+    recordEvent({ event: `profile-get-${isProd}direct-deposit-started` });
     const response = await getData('/ppiu/payment_information');
 
     // sample error when getting payment information
@@ -62,14 +65,14 @@ export function fetchCNPPaymentInformation(recordEvent = recordAnalyticsEvent) {
     // };
 
     if (response.error) {
-      recordEvent({ event: 'profile-get-direct-deposit-failed' });
+      recordEvent({ event: `profile-get-${isProd}direct-deposit-failed` });
       dispatch({
         type: CNP_PAYMENT_INFORMATION_FETCH_FAILED,
         response,
       });
     } else {
       recordEvent({
-        event: 'profile-get-direct-deposit-retrieved',
+        event: `profile-get-${isProd}direct-deposit-retrieved`,
         // The API might report an empty payment address for some folks who are
         // already enrolled in direct deposit. But we want to make sure we
         // always treat those who are signed up as being eligible. Therefore
@@ -159,7 +162,7 @@ export function saveCNPPaymentInformation(
     } else {
       recordEvent({
         event: 'profile-transaction',
-        'profile-section': 'direct-deposit-information',
+        'profile-section': `${isProd}direct-deposit-information`,
       });
       dispatch({
         type: CNP_PAYMENT_INFORMATION_SAVE_SUCCEEDED,

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
@@ -18,7 +18,9 @@ import {
   isLOA3 as isLOA3Selector,
   isMultifactorEnabled,
 } from '~/platform/user/selectors';
+import environment from 'platform/utilities/environment';
 import { usePrevious } from '~/platform/utilities/react-hooks';
+
 import {
   editCNPPaymentInformationToggled,
   saveCNPPaymentInformation as savePaymentInformationAction,
@@ -147,6 +149,8 @@ export const BankInfoCNP = ({
     toggleEditState();
   };
 
+  const isProd = () => (!environment.isProduction() ? 'cnp-' : '');
+
   // When direct deposit is already set up we will show the current bank info
   const bankInfoContent = (
     <div className={classes.bankInfo}>
@@ -168,7 +172,7 @@ export const BankInfoCNP = ({
           recordEvent({
             event: 'profile-navigation',
             'profile-action': 'edit-link',
-            'profile-section': 'direct-deposit-information',
+            'profile-section': `${isProd}direct-deposit-information`,
           });
           toggleEditState();
         }}
@@ -187,7 +191,7 @@ export const BankInfoCNP = ({
         recordEvent({
           event: 'profile-navigation',
           'profile-action': 'add-link',
-          'profile-section': 'direct-deposit-information',
+          'profile-section': `${isProd}direct-deposit-information`,
         });
         toggleEditState();
       }}

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
@@ -18,7 +18,6 @@ import {
   isLOA3 as isLOA3Selector,
   isMultifactorEnabled,
 } from '~/platform/user/selectors';
-import environment from 'platform/utilities/environment';
 import { usePrevious } from '~/platform/utilities/react-hooks';
 
 import {
@@ -31,6 +30,8 @@ import {
   cnpDirectDepositIsSetUp,
   cnpDirectDepositUiState as directDepositUiStateSelector,
 } from '@@profile/selectors';
+
+import { cnpPrefix } from '@@profile/util';
 
 import BankInfoForm from './BankInfoForm';
 
@@ -149,8 +150,6 @@ export const BankInfoCNP = ({
     toggleEditState();
   };
 
-  const isProd = () => (!environment.isProduction() ? 'cnp-' : '');
-
   // When direct deposit is already set up we will show the current bank info
   const bankInfoContent = (
     <div className={classes.bankInfo}>
@@ -172,7 +171,7 @@ export const BankInfoCNP = ({
           recordEvent({
             event: 'profile-navigation',
             'profile-action': 'edit-link',
-            'profile-section': `${isProd}direct-deposit-information`,
+            'profile-section': `${cnpPrefix}direct-deposit-information`,
           });
           toggleEditState();
         }}
@@ -191,7 +190,7 @@ export const BankInfoCNP = ({
         recordEvent({
           event: 'profile-navigation',
           'profile-action': 'add-link',
-          'profile-section': `${isProd}direct-deposit-information`,
+          'profile-section': `${cnpPrefix}direct-deposit-information`,
         });
         toggleEditState();
       }}

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoCNPv2.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoCNPv2.jsx
@@ -154,7 +154,7 @@ export const BankInfoCNP = ({
           recordEvent({
             event: 'profile-navigation',
             'profile-action': 'edit-link',
-            'profile-section': 'direct-deposit-information',
+            'profile-section': 'cnp-direct-deposit-information',
           });
           toggleEditState();
         }}
@@ -173,7 +173,7 @@ export const BankInfoCNP = ({
         recordEvent({
           event: 'profile-navigation',
           'profile-action': 'add-link',
-          'profile-section': 'direct-deposit-information',
+          'profile-section': 'cnp-direct-deposit-information',
         });
         toggleEditState();
       }}

--- a/src/applications/personalization/profile/tests/actions/paymentInformation.unit.spec.js
+++ b/src/applications/personalization/profile/tests/actions/paymentInformation.unit.spec.js
@@ -129,10 +129,10 @@ describe('actions/paymentInformation', () => {
 
         it('reports the correct data to Google Analytics', () => {
           expect(recordEventSpy.firstCall.args[0].event).to.equal(
-            'profile-get-direct-deposit-started',
+            'profile-get-cnp-direct-deposit-started',
           );
           expect(recordEventSpy.secondCall.args[0].event).to.equal(
-            'profile-get-direct-deposit-retrieved',
+            'profile-get-cnp-direct-deposit-retrieved',
           );
           expect(
             recordEventSpy.secondCall.args[0]['direct-deposit-setup-eligible'],
@@ -201,10 +201,10 @@ describe('actions/paymentInformation', () => {
 
         it('reports the correct data to Google Analytics', () => {
           expect(recordEventSpy.firstCall.args[0].event).to.equal(
-            'profile-get-direct-deposit-started',
+            'profile-get-cnp-direct-deposit-started',
           );
           expect(recordEventSpy.secondCall.args[0].event).to.equal(
-            'profile-get-direct-deposit-retrieved',
+            'profile-get-cnp-direct-deposit-retrieved',
           );
           expect(
             recordEventSpy.secondCall.args[0]['direct-deposit-setup-eligible'],
@@ -273,10 +273,10 @@ describe('actions/paymentInformation', () => {
 
         it('reports the correct data to Google Analytics', () => {
           expect(recordEventSpy.firstCall.args[0].event).to.equal(
-            'profile-get-direct-deposit-started',
+            'profile-get-cnp-direct-deposit-started',
           );
           expect(recordEventSpy.secondCall.args[0].event).to.equal(
-            'profile-get-direct-deposit-retrieved',
+            'profile-get-cnp-direct-deposit-retrieved',
           );
           expect(
             recordEventSpy.secondCall.args[0]['direct-deposit-setup-eligible'],
@@ -350,7 +350,7 @@ describe('actions/paymentInformation', () => {
             'profile-transaction',
           );
           expect(recordEventSpy.firstCall.args[0]['profile-section']).to.equal(
-            'direct-deposit-information',
+            'cnp-direct-deposit-information',
           );
         });
       });
@@ -390,7 +390,7 @@ describe('actions/paymentInformation', () => {
           expect(recordEventSpy.firstCall.args[0]).to.deep.equal({
             event: 'profile-edit-failure',
             'profile-action': 'save-failure',
-            'profile-section': 'direct-deposit-information',
+            'profile-section': 'cnp-direct-deposit-information',
             'error-key': 'routing-number-flagged-for-fraud-error-update',
           });
         });

--- a/src/applications/personalization/profile/tests/util/index.unit.spec.js
+++ b/src/applications/personalization/profile/tests/util/index.unit.spec.js
@@ -12,7 +12,7 @@ describe('profile utils', () => {
     const createEventDataObjectWithError = error => ({
       event: 'profile-edit-failure',
       'profile-action': 'save-failure',
-      'profile-section': 'direct-deposit-information',
+      'profile-section': 'cnp-direct-deposit-information',
       'error-key': error,
     });
     const defaultDataObject = createEventDataObjectWithError(

--- a/src/applications/personalization/profile/util/index.js
+++ b/src/applications/personalization/profile/util/index.js
@@ -1,4 +1,5 @@
 import { apiRequest } from 'platform/utilities/api';
+import environment from 'platform/utilities/environment';
 
 // possible values for the `key` property on error messages we get from the server
 const ACCOUNT_FLAGGED_FOR_FRAUD_KEY = 'cnp.payment.flashes.on.record.message';
@@ -21,6 +22,8 @@ const GA_ERROR_KEY_INVALID_ROUTING_NUMBER = 'invalid-routing-number-error';
 const GA_ERROR_KEY_PAYMENT_RESTRICTIONS =
   'payment-restriction-indicators-error';
 const GA_ERROR_KEY_DEFAULT = 'other-error';
+
+export const cnpPrefix = !environment.isProduction() ? 'cnp-' : '';
 
 export async function getData(apiRoute, options) {
   try {
@@ -127,7 +130,7 @@ export const createCNPDirectDepositAnalyticsDataObject = (
   return {
     event: 'profile-edit-failure',
     'profile-action': 'save-failure',
-    'profile-section': 'direct-deposit-information',
+    'profile-section': `${cnpPrefix}direct-deposit-information`,
     [key]: errorCode,
   };
 };


### PR DESCRIPTION
Based on [this ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/16904), we should update some of our existing Direct Deposit-related GA strings to be specific to Direct Deposit for Comp and Pen.

This PR applies this change to non-prod envs first and confirm that things look good on the GA side.

Before we merge this into `master` to deploy to staging we should confirm with @bmcgrady-ep that they are ready for the new events, but based on [his comment here](https://github.com/department-of-veterans-affairs/va.gov-team/issues/16904#issuecomment-756294678) I think we are good to go!

## Acceptance Criteria

These are the specific strings that would have to change:

`recordEvent({ event: 'profile-get-direct-deposit-started' });`

becomes:

`recordEvent({ event: 'profile-get-cnp-direct-deposit-started' });`

---

`recordEvent({ event: 'profile-get-direct-deposit-failed' });`

becomes:

`recordEvent({ event: 'profile-get-cnp-direct-deposit-failed' });`

---

```
recordEvent({
  event: 'profile-get-direct-deposit-retrieved',
  'direct-deposit-setup-eligible': true|false,
  'direct-deposit-setup-complete': true|false,
})
```

becomes:

```
recordEvent({
  event: 'profile-get-cnp-direct-deposit-retrieved',
  'direct-deposit-setup-eligible': true|false,
  'direct-deposit-setup-complete': true|false,
})
```

(We could also change the 2nd and 3rd keys if you wanted)

---

```
recordEvent({
  event: 'profile-edit-failure',
  'profile-action': 'save-failure',
  'profile-section': 'direct-deposit-information',
  'error-key': errorCode,
})
```

becomes:

```
recordEvent({
  event: 'profile-edit-failure',
  'profile-action': 'save-failure',
  'profile-section': 'cnp-direct-deposit-information',
  'error-key': errorCode,
})
```

---

```
recordEvent({
  event: 'profile-transaction',
  'profile-section': 'direct-deposit-information',
})
```

becomes:

```
recordEvent({
  event: 'profile-transaction',
  'profile-section': 'cnp-direct-deposit-information',
})
```

---

```
recordEvent({
  event: 'profile-navigation',
  'profile-action': 'add-link',
  'profile-section': 'direct-deposit-information',
})
```

becomes:

```
recordEvent({
  event: 'profile-navigation',
  'profile-action': 'add-link',
  'profile-section': 'cnp-direct-deposit-information',
})
```

---

```
recordEvent({
  event: 'profile-navigation',
  'profile-action': 'edit-link',
  'profile-section': 'direct-deposit-information',
})
```

becomes:

```
recordEvent({
  event: 'profile-navigation',
  'profile-action': 'edit-link',
  'profile-section': 'cnp-direct-deposit-information',
})
```
## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
