### PR TITLE
[508] Add custom radio & yesNo widget props

### DIFF
--- a/src/platform/forms-system/src/js/widgets/RadioWidget.jsx
+++ b/src/platform/forms-system/src/js/widgets/RadioWidget.jsx
@@ -9,7 +9,12 @@ export default function RadioWidget({
   onChange,
   id,
 }) {
-  const { enumOptions, labels = {}, nestedContent = {} } = options;
+  const {
+    enumOptions,
+    labels = {},
+    nestedContent = {},
+    widgetProps = {},
+  } = options;
 
   // nested content could be a component or just jsx/text
   let content = nestedContent[value];
@@ -32,6 +37,7 @@ export default function RadioWidget({
               value={option.value}
               disabled={disabled}
               onChange={_ => onChange(option.value)}
+              {...widgetProps[option.value] || {}}
             />
             <label htmlFor={`${id}_${i}`}>
               {labels[option.value] || option.label}

--- a/src/platform/forms-system/src/js/widgets/YesNoWidget.jsx
+++ b/src/platform/forms-system/src/js/widgets/YesNoWidget.jsx
@@ -7,7 +7,7 @@ export default function YesNoWidget({
   onChange,
   options = {},
 }) {
-  const { yesNoReverse = false, labels = {} } = options;
+  const { yesNoReverse = false, labels = {}, widgetProps = {} } = options;
   const yesValue = !yesNoReverse;
   const noValue = !yesValue;
   return (
@@ -20,6 +20,7 @@ export default function YesNoWidget({
         value="Y"
         disabled={disabled}
         onChange={_ => onChange(yesValue)}
+        {...widgetProps.Y || {}}
       />
       <label htmlFor={`${id}Yes`}>{labels.Y || 'Yes'}</label>
       <input
@@ -30,6 +31,7 @@ export default function YesNoWidget({
         value="N"
         disabled={disabled}
         onChange={_ => onChange(noValue)}
+        {...widgetProps.N || {}}
       />
       <label htmlFor={`${id}No`}>{labels.N || 'No'}</label>
     </div>

--- a/src/platform/forms-system/test/js/widgets/RadioWidget.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/widgets/RadioWidget.unit.spec.jsx
@@ -118,4 +118,22 @@ describe('Schemaform <RadioWidget>', () => {
 
     expect(tree.text()).not.to.contain('Nested');
   });
+  it('should add custom props', () => {
+    const onChange = sinon.spy();
+    const options = {
+      enumOptions: [
+        { label: 'Testing', value: '1' },
+        { label: 'Testing2', value: '2' },
+      ],
+      widgetProps: {
+        1: { 'data-test': 'first' },
+        2: { 'data-test': 'second' },
+      },
+    };
+    const tree = SkinDeep.shallowRender(
+      <RadioWidget value onChange={onChange} options={options} />,
+    );
+    expect(tree.everySubTree('input')[0].props['data-test']).to.equal('first');
+    expect(tree.everySubTree('input')[1].props['data-test']).to.equal('second');
+  });
 });

--- a/src/platform/forms-system/test/js/widgets/YesNoWidget.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/widgets/YesNoWidget.unit.spec.jsx
@@ -79,4 +79,27 @@ describe('Schemaform <YesNoWidget>', () => {
     expect(tree.everySubTree('input')[0].props.checked).to.be.false;
     expect(tree.everySubTree('input')[1].props.checked).to.be.true;
   });
+  it('should add custom props', () => {
+    const onChange = sinon.spy();
+    const tree = SkinDeep.shallowRender(
+      <YesNoWidget
+        value
+        options={{
+          yesNoReverse: true,
+          widgetProps: {
+            Y: { 'data-test': 'yes-input' },
+            N: { 'data-test': 'no-input' },
+          },
+        }}
+        onChange={onChange}
+      />,
+    );
+
+    expect(tree.everySubTree('input')[0].props['data-test']).to.equal(
+      'yes-input',
+    );
+    expect(tree.everySubTree('input')[1].props['data-test']).to.equal(
+      'no-input',
+    );
+  });
 });


### PR DESCRIPTION
## Description

When a user selects a radio button (radio or yesNo widget), additional context may need to be associated with the selection to make screenreader users aware of important information.

This PR allows adding custom properties (`widgetProps`) to the radio input using the `ui:options` object in the `uiSchema`.

The `widgetProps` object targets the input using the option value (see examples).

### Examples

<details><summary>yesNo widget</summary>

<!-- leave a blank line above -->
```js
{
  schema: {
    type: 'object',
    properties: {
      hasPet: {
        type: 'boolean'
      },
      petName: {
        type: 'string'
      }
    }
  },
  uiSchema: {
    hasPet: {
      'ui:title': 'Do you have a pet?'
      'ui:widget': 'yesNo',
      'ui:options': {
        widgetProps: {
          Y: { 'aria-describedby': 'some_id' },
          N: { 'aria-describedby': 'different_id' },
        }
      }
    },
    petName: {
      'ui:title': 'What is your pet‘s name?',
      'ui:options': {
        expandUnder: 'hasPet',
        expandUnderCondition: true
      }
    }
  }
}
```
</details>

<details><summary>radio widget</summary>

<!-- leave a blank line above -->
```js
page1: {
  path: 'first-page',
  title: 'First Page',
  uiSchema: {
    myField: {
      'ui:title': 'My field label',
      'ui:widget': 'radio',
      'ui:options': {
        widgetProps: {
          'First option': { 'aria-describedby': 'some_id_1' },
          'Second option': { 'aria-describedby': 'some_id_2' },
        }
      }
    }
  },
  schema: {
    type: 'object',
    properties: {
      myField: {
        type: 'string',
        'enum': [
          'First option',
          'Second option'
        ]
      }
    }
  }
}
```
</details>

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/316
- Docs: https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/571

## Testing done

Added widget unit tests

## Screenshots

<details><summary>Before</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-01-08 at 11 43 51 AM](https://user-images.githubusercontent.com/136959/104057615-139fbc80-51b8-11eb-9150-19d261a4dd42.png)</details>

<details><summary>After</summary>

<!-- leave a blank line above -->
Adding `aria-describedby` to the "Yes" radio button only

```js
sameOffice: {
  'ui:title': OfficeForReviewLabel,
  'ui:widget': 'yesNo',
  'ui:options': {
    widgetProps: {
      Y: {
        'aria-describedby': 'same-office-description',
      },
    },
  },
},
```

![Screen Shot 2021-01-08 at 11 44 40 AM](https://user-images.githubusercontent.com/136959/104057612-13072600-51b8-11eb-9db7-97f0eddd5dc4.png)</details>

## Acceptance criteria
- [x] Custom properties can be added to the radio & yesNo widgets

## Definition of done
- [ ] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
