### PR TITLE
Update to formation 7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -275,7 +275,7 @@
   "private": true,
   "dependencies": {
     "@department-of-veterans-affairs/formation": "6.10.3",
-    "@department-of-veterans-affairs/formation-react": "6.0.2",
+    "@department-of-veterans-affairs/formation-react": "7.0.0",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "@fortawesome/fontawesome-free": "^5.6.3",
     "@mapbox/mapbox-sdk": "^0.10.0",

--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import ErrorableCheckbox from '@department-of-veterans-affairs/formation-react/ErrorableCheckbox';
+import Checkbox from '@department-of-veterans-affairs/formation-react/Checkbox';
 
 import SignatureInput from './SignatureInput';
 
@@ -56,7 +56,7 @@ const SignatureCheckbox = ({
         hasSubmit={hasSubmit}
       />
 
-      <ErrorableCheckbox
+      <Checkbox
         onValueChange={value => setIsChecked(value)}
         label="I certify the information above is correct and true to the best of my knowledge and belief."
         errorMessage={hasError && 'Must certify by checking box'}

--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import ErrorableTextInput from '@department-of-veterans-affairs/formation-react/ErrorableTextInput';
+import TextInput from '@department-of-veterans-affairs/formation-react/TextInput';
 
 const SignatureInput = ({
   fullName,
@@ -67,7 +67,7 @@ const SignatureInput = ({
   );
 
   return (
-    <ErrorableTextInput
+    <TextInput
       additionalClass="signature-input"
       label={label}
       required={required}

--- a/src/applications/claims-status/components/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/AddFilesForm.jsx
@@ -4,10 +4,10 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router';
 import Scroll from 'react-scroll';
 
-import ErrorableFileInput from '@department-of-veterans-affairs/formation-react/ErrorableFileInput';
-import ErrorableSelect from '@department-of-veterans-affairs/formation-react/ErrorableSelect';
-import ErrorableCheckbox from '@department-of-veterans-affairs/formation-react/ErrorableCheckbox';
-import ErrorableTextInput from '@department-of-veterans-affairs/formation-react/ErrorableTextInput';
+import FileInput from '@department-of-veterans-affairs/formation-react/FileInput';
+import Select from '@department-of-veterans-affairs/formation-react/Select';
+import Checkbox from '@department-of-veterans-affairs/formation-react/Checkbox';
+import TextInput from '@department-of-veterans-affairs/formation-react/TextInput';
 
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
 
@@ -161,7 +161,7 @@ class AddFilesForm extends React.Component {
         </div>
         <Element name="filesList" />
         <div>
-          <ErrorableFileInput
+          <FileInput
             errorMessage={this.getErrorMessage()}
             label={
               <span className="claims-upload-input-title">
@@ -209,7 +209,7 @@ class AddFilesForm extends React.Component {
                       able to view the document, we will need the password to
                       decrypt it.
                     </p>
-                    <ErrorableTextInput
+                    <TextInput
                       required
                       errorMessage={
                         validateIfDirty(password, isNotBlank)
@@ -229,7 +229,7 @@ class AddFilesForm extends React.Component {
                   </>
                 )}
                 <div className="clearfix" />
-                <ErrorableSelect
+                <Select
                   required
                   errorMessage={
                     validateIfDirty(docType, isNotBlank)
@@ -249,7 +249,7 @@ class AddFilesForm extends React.Component {
             </div>
           ),
         )}
-        <ErrorableCheckbox
+        <Checkbox
           onValueChange={checked => {
             this.setState({ checked });
           }}

--- a/src/applications/claims-status/containers/AskVAPage.jsx
+++ b/src/applications/claims-status/containers/AskVAPage.jsx
@@ -6,7 +6,7 @@ import { setUpPage } from '../utils/page';
 
 import AskVAQuestions from '../components/AskVAQuestions';
 import ClaimsBreadcrumbs from '../components/ClaimsBreadcrumbs';
-import ErrorableCheckbox from '@department-of-veterans-affairs/formation-react/ErrorableCheckbox';
+import Checkbox from '@department-of-veterans-affairs/formation-react/Checkbox';
 
 class AskVAPage extends React.Component {
   constructor() {
@@ -80,7 +80,7 @@ class AskVAPage extends React.Component {
                 <li>The date benefits will begin if we approve your claim</li>
               </ul>
               <div className="usa-alert usa-alert-info background-color-only claims-alert">
-                <ErrorableCheckbox
+                <Checkbox
                   className="claims-alert-checkbox"
                   checked={this.state.submittedDocs}
                   onValueChange={update => this.setSubmittedDocs(update)}

--- a/src/applications/claims-status/tests/components/AddFilesForm.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/AddFilesForm.unit.spec.jsx
@@ -28,7 +28,7 @@ describe('<AddFilesForm>', () => {
         onDirtyFields={onDirtyFields}
       />,
     );
-    expect(tree.everySubTree('ErrorableFileInput')).not.to.be.empty;
+    expect(tree.everySubTree('FileInput')).not.to.be.empty;
     expect(tree.everySubTree('Modal')[0].props.visible).to.be.undefined;
     expect(tree.everySubTree('Modal')[1].props.visible).to.be.undefined;
   });
@@ -348,6 +348,6 @@ describe('<AddFilesForm>', () => {
       />,
     );
     expect(tree.getMountedInstance().state.errorMessage).to.be.null;
-    expect(tree.subTree('ErrorableTextInput')).to.exist;
+    expect(tree.subTree('TextInput')).to.exist;
   });
 });

--- a/src/applications/claims-status/tests/components/AskVAPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/AskVAPage.unit.spec.jsx
@@ -37,7 +37,7 @@ describe('<AskVAPage>', () => {
       />,
     );
 
-    tree.subTree('ErrorableCheckbox').props.onValueChange(true);
+    tree.subTree('Checkbox').props.onValueChange(true);
     expect(tree.everySubTree('button')[0].props.disabled).to.be.null;
   });
 
@@ -76,7 +76,7 @@ describe('<AskVAPage>', () => {
       />,
     );
 
-    tree.subTree('ErrorableCheckbox').props.onValueChange(true);
+    tree.subTree('Checkbox').props.onValueChange(true);
     tree.subTree('button').props.onClick();
     expect(submitRequest.called).to.be.true;
   });

--- a/src/applications/disability-benefits/996/wizard/pages/claimType.jsx
+++ b/src/applications/disability-benefits/996/wizard/pages/claimType.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
+import RadioButtons from '@department-of-veterans-affairs/formation-react/RadioButtons';
 import recordEvent from 'platform/monitoring/record-event';
 
 import { SAVED_CLAIM_TYPE } from '../../constants';
@@ -45,7 +45,7 @@ const ClaimType = ({ setPageState, state = {} }) => {
   };
 
   return (
-    <ErrorableRadioButtons
+    <RadioButtons
       name={name}
       label={label}
       id={name}

--- a/src/applications/disability-benefits/996/wizard/pages/legacyChoice.jsx
+++ b/src/applications/disability-benefits/996/wizard/pages/legacyChoice.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
+import RadioButtons from '@department-of-veterans-affairs/formation-react/RadioButtons';
 import recordEvent from 'platform/monitoring/record-event';
 
 import pageNames from './pageNames';
@@ -31,7 +31,7 @@ const name = 'higher-level-review-legacy';
 
 const LegacyChoice = ({ setPageState, state = {} }) => {
   return (
-    <ErrorableRadioButtons
+    <RadioButtons
       name={name}
       id={name}
       label={label}

--- a/src/applications/disability-benefits/wizard/pages/appeals.jsx
+++ b/src/applications/disability-benefits/wizard/pages/appeals.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
+import RadioButtons from '@department-of-veterans-affairs/formation-react/RadioButtons';
 import { pageNames } from './pageList';
 
 const options = [
@@ -15,7 +15,7 @@ const options = [
 ];
 
 const AppealsPage = ({ setPageState, state = {} }) => (
-  <ErrorableRadioButtons
+  <RadioButtons
     name={`${pageNames.appeals}-option`}
     label="Are you filing a new claim or are you disagreeing with a VA decision on an earlier claim?"
     id={`${pageNames.appeals}-option`}

--- a/src/applications/disability-benefits/wizard/pages/bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/bdd.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import moment from 'moment';
-import ErrorableDate from '@department-of-veterans-affairs/formation-react/ErrorableDate';
+import Date from '@department-of-veterans-affairs/formation-react/Date';
 import { pageNames } from './pageList';
 
 import unableToFileBDDProduction from './unable-to-file-bdd-production';
@@ -85,7 +85,7 @@ const BDDPage = ({ setPageState, state = defaultState, allowBDD }) => {
   };
 
   return (
-    <ErrorableDate
+    <Date
       label="Date or anticipated date of release from active duty"
       onValueChange={onChange}
       name="discharge-date"

--- a/src/applications/disability-benefits/wizard/pages/disagreeing.jsx
+++ b/src/applications/disability-benefits/wizard/pages/disagreeing.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import moment from 'moment';
-import ErrorableDate from '@department-of-veterans-affairs/formation-react/ErrorableDate';
+import Date from '@department-of-veterans-affairs/formation-react/Date';
 import { pageNames } from './pageList';
 
 // Figure out which page to go to based on the date entered
@@ -47,7 +47,7 @@ const DisagreeingPage = ({ setPageState, state = defaultState }) => {
       isDateComplete(pageState) ? findNextPage(pageState) : undefined,
     );
   return (
-    <ErrorableDate
+    <Date
       label="What’s the date of VA’s decision?"
       onValueChange={onChange}
       name="decision-date"

--- a/src/applications/disability-benefits/wizard/pages/start.jsx
+++ b/src/applications/disability-benefits/wizard/pages/start.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
+import RadioButtons from '@department-of-veterans-affairs/formation-react/RadioButtons';
 import { pageNames } from './pageList';
 
 const options = [
@@ -8,7 +8,7 @@ const options = [
 ];
 
 const StartPage = ({ setPageState, state = {} }) => (
-  <ErrorableRadioButtons
+  <RadioButtons
     name={`${pageNames.start}-option`}
     label="Are you currently on active duty?"
     id={`${pageNames.start}-option`}

--- a/src/applications/discharge-wizard/components/FormQuestions.jsx
+++ b/src/applications/discharge-wizard/components/FormQuestions.jsx
@@ -5,8 +5,8 @@ import { Link } from 'react-router';
 import Scroll from 'react-scroll';
 
 import recordEvent from 'platform/monitoring/record-event';
-import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
-import ErrorableSelect from '@department-of-veterans-affairs/formation-react/ErrorableSelect';
+import RadioButtons from '@department-of-veterans-affairs/formation-react/RadioButtons';
+import Select from '@department-of-veterans-affairs/formation-react/Select';
 import { months } from 'platform/static-data/options-for-select.js';
 import { focusElement } from 'platform/utilities/ui';
 import {
@@ -118,7 +118,7 @@ class FormQuestions extends React.Component {
         }}
       >
         <Element name={name} />
-        <ErrorableRadioButtons {...radioButtonProps} />
+        <RadioButtons {...radioButtonProps} />
       </div>
     );
   }
@@ -229,7 +229,7 @@ class FormQuestions extends React.Component {
         }}
       >
         <Element name={key} />
-        <ErrorableSelect
+        <Select
           autocomplete="false"
           label={label}
           name={key}
@@ -266,7 +266,7 @@ class FormQuestions extends React.Component {
         }}
       >
         <Element name={key} />
-        <ErrorableSelect
+        <Select
           autocomplete="false"
           label={monthLabel}
           name={key}

--- a/src/applications/edu-benefits/components/EducationWizard.jsx
+++ b/src/applications/edu-benefits/components/EducationWizard.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import _ from 'lodash/fp';
 import classNames from 'classnames';
 import recordEvent from 'platform/monitoring/record-event';
-import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
+import RadioButtons from '@department-of-veterans-affairs/formation-react/RadioButtons';
 import {
   WIZARD_STATUS,
   WIZARD_STATUS_COMPLETE,
@@ -181,7 +181,7 @@ export default class EducationWizard extends React.Component {
         </button>
         <div className={contentClasses} id="wizardOptions">
           <div className="wizard-content-inner">
-            <ErrorableRadioButtons
+            <RadioButtons
               additionalFieldsetClass="wizard-fieldset"
               name="newBenefit"
               id="newBenefit"
@@ -193,7 +193,7 @@ export default class EducationWizard extends React.Component {
               label="Are you applying for a benefit or updating your program or place of training?"
             />
             {newBenefit === 'yes' && (
-              <ErrorableRadioButtons
+              <RadioButtons
                 additionalFieldsetClass="wizard-fieldset"
                 name="serviceBenefitBasedOn"
                 id="serviceBenefitBasedOn"
@@ -209,7 +209,7 @@ export default class EducationWizard extends React.Component {
               />
             )}
             {newBenefit === 'no' && (
-              <ErrorableRadioButtons
+              <RadioButtons
                 additionalFieldsetClass="wizard-fieldset"
                 name="transferredEduBenefits"
                 id="transferredEduBenefits"
@@ -236,7 +236,7 @@ export default class EducationWizard extends React.Component {
               />
             )}
             {serviceBenefitBasedOn === 'own' && (
-              <ErrorableRadioButtons
+              <RadioButtons
                 additionalFieldsetClass="wizard-fieldset"
                 name="nationalCallToService"
                 id="nationalCallToService"
@@ -258,7 +258,7 @@ export default class EducationWizard extends React.Component {
             )}
             {serviceBenefitBasedOn === 'own' &&
               nationalCallToService === 'no' && (
-                <ErrorableRadioButtons
+                <RadioButtons
                   additionalFieldsetClass="wizard-fieldset"
                   name="vetTecBenefit"
                   id="vetTecBenefit"
@@ -279,7 +279,7 @@ export default class EducationWizard extends React.Component {
                 />
               )}
             {serviceBenefitBasedOn === 'other' && (
-              <ErrorableRadioButtons
+              <RadioButtons
                 additionalFieldsetClass="wizard-fieldset"
                 name="sponsorDeceasedDisabledMIA"
                 id="sponsorDeceasedDisabledMIA"
@@ -295,7 +295,7 @@ export default class EducationWizard extends React.Component {
               />
             )}
             {sponsorDeceasedDisabledMIA === 'no' && (
-              <ErrorableRadioButtons
+              <RadioButtons
                 name="sponsorTransferredBenefits"
                 id="sponsorTransferredBenefits"
                 options={[
@@ -432,7 +432,7 @@ export default class EducationWizard extends React.Component {
                   </ul>
                 </div>
 
-                <ErrorableRadioButtons
+                <RadioButtons
                   additionalFieldsetClass="wizard-fieldset"
                   name="applyForScholarship"
                   id="applyForScholarship"

--- a/src/applications/edu-benefits/feedback-tool/components/SchoolSelectField.jsx
+++ b/src/applications/edu-benefits/feedback-tool/components/SchoolSelectField.jsx
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import classNames from 'classnames';
 import Pagination from '@department-of-veterans-affairs/formation-react/Pagination';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
-import ErrorableCheckbox from '@department-of-veterans-affairs/formation-react/ErrorableCheckbox';
+import Checkbox from '@department-of-veterans-affairs/formation-react/Checkbox';
 import Scroll from 'react-scroll';
 import { connect } from 'react-redux';
 import {
@@ -310,7 +310,7 @@ export class SchoolSelectField extends React.Component {
               </div>
             </div>
           </div>
-          <ErrorableCheckbox
+          <Checkbox
             checked={manualSchoolEntryChecked}
             onValueChange={() =>
               this.handleManualSchoolEntryToggled(manualSchoolEntryChecked)

--- a/src/applications/edu-benefits/tests/components/EducationWizard.unit.spec.jsx
+++ b/src/applications/edu-benefits/tests/components/EducationWizard.unit.spec.jsx
@@ -24,7 +24,7 @@ describe('<EducationWizard>', () => {
     const tree = mount(<EducationWizard />);
     tree.setState({ open: true });
     expect(tree.find('button').length).to.eq(1);
-    expect(tree.find('ErrorableRadioButtons').length).to.eq(1);
+    expect(tree.find('RadioButtons').length).to.eq(1);
     tree.unmount();
   });
   it('should show own service question for new benefit', () => {

--- a/src/applications/edu-benefits/wizard/pages/ClaimingBenefitOwnService.jsx
+++ b/src/applications/edu-benefits/wizard/pages/ClaimingBenefitOwnService.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { pageNames } from './pageList';
-import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
+import RadioButtons from '@department-of-veterans-affairs/formation-react/RadioButtons';
 import { formIdSuffixes } from 'applications/static-pages/wizard/';
 
 const claimingBenefitOwnServiceOptions = [
@@ -14,7 +14,7 @@ const ClaimingBenefitOwnService = ({
   setReferredBenefit,
 }) => (
   <div>
-    <ErrorableRadioButtons
+    <RadioButtons
       name={`${pageNames.claimingBenefitOwnService}`}
       label="Are you a Veteran or service member claiming a benefit based on your own service?"
       id={`${pageNames.claimingBenefitOwnService}`}

--- a/src/applications/edu-benefits/wizard/pages/NationalCallToService.jsx
+++ b/src/applications/edu-benefits/wizard/pages/NationalCallToService.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
+import RadioButtons from '@department-of-veterans-affairs/formation-react/RadioButtons';
 import { pageNames } from './pageList';
 
 const nationalCallToServiceOptions = [
@@ -12,7 +12,7 @@ const NationalCallToService = ({
   getPageStateFromPageName,
   state = {},
 }) => (
-  <ErrorableRadioButtons
+  <RadioButtons
     name={`${pageNames.nationalCallToService}`}
     label={
       <span>

--- a/src/applications/edu-benefits/wizard/pages/NewBenefit.jsx
+++ b/src/applications/edu-benefits/wizard/pages/NewBenefit.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
+import RadioButtons from '@department-of-veterans-affairs/formation-react/RadioButtons';
 import { pageNames } from './pageList';
 import { formIdSuffixes } from 'applications/static-pages/wizard/';
 
@@ -30,7 +30,7 @@ const NewBenefit = ({
   state = {},
   setReferredBenefit,
 }) => (
-  <ErrorableRadioButtons
+  <RadioButtons
     name={`${pageNames.newBenefit}`}
     label="Are you applying for a benefit or updating your program or place of training?"
     id={`${pageNames.newBenefit}`}

--- a/src/applications/edu-benefits/wizard/pages/STEMScholarship.jsx
+++ b/src/applications/edu-benefits/wizard/pages/STEMScholarship.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
+import RadioButtons from '@department-of-veterans-affairs/formation-react/RadioButtons';
 import { pageNames } from './pageList';
 import recordEvent from 'platform/monitoring/record-event';
 import { formIdSuffixes } from 'applications/static-pages/wizard/';
@@ -69,7 +69,7 @@ const STEMScholarship = ({ setPageState, state = {}, setReferredBenefit }) => {
         </li>
       </ul>
 
-      <ErrorableRadioButtons
+      <RadioButtons
         additionalFieldsetClass="wizard-fieldset"
         name={`${pageNames.STEMScholarship}`}
         id={`${pageNames.STEMScholarship}`}

--- a/src/applications/edu-benefits/wizard/pages/SponsorDeceased.jsx
+++ b/src/applications/edu-benefits/wizard/pages/SponsorDeceased.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
+import RadioButtons from '@department-of-veterans-affairs/formation-react/RadioButtons';
 import { pageNames } from './pageList';
 import { formIdSuffixes } from 'applications/static-pages/wizard/';
 
@@ -14,7 +14,7 @@ const SponsorDeceased = ({
   state = {},
   setReferredBenefit,
 }) => (
-  <ErrorableRadioButtons
+  <RadioButtons
     name={`${pageNames.sponsorDeceased}`}
     label="Is your sponsor deceased, 100% permanently disabled, MIA, or a POW?"
     id={`${pageNames.sponsorDeceased}`}

--- a/src/applications/edu-benefits/wizard/pages/TransferredBenefits.jsx
+++ b/src/applications/edu-benefits/wizard/pages/TransferredBenefits.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
+import RadioButtons from '@department-of-veterans-affairs/formation-react/RadioButtons';
 import { pageNames } from './pageList';
 import { formIdSuffixes } from 'applications/static-pages/wizard/';
 
@@ -40,7 +40,7 @@ const TransferredBenefits = ({
   );
 
   return (
-    <ErrorableRadioButtons
+    <RadioButtons
       name={`${pageNames.transferredBenefits}`}
       label={
         sponsorDeceasedAnswer === 'no'

--- a/src/applications/edu-benefits/wizard/pages/VetTec.jsx
+++ b/src/applications/edu-benefits/wizard/pages/VetTec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
+import RadioButtons from '@department-of-veterans-affairs/formation-react/RadioButtons';
 import { pageNames } from './pageList';
 import { formIdSuffixes } from 'applications/static-pages/wizard/';
 
@@ -14,7 +14,7 @@ const VetTec = ({
   state = {},
   setReferredBenefit,
 }) => (
-  <ErrorableRadioButtons
+  <RadioButtons
     name={`${pageNames.vetTec}`}
     label={
       <span>

--- a/src/applications/financial-status-report/components/FileUploader.jsx
+++ b/src/applications/financial-status-report/components/FileUploader.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import Scroll from 'react-scroll';
-import ErrorableFileInput from '@department-of-veterans-affairs/formation-react/ErrorableFileInput';
+import FileInput from '@department-of-veterans-affairs/formation-react/FileInput';
 import { checkForEncryptedPdf } from 'platform/forms-system/src/js/utilities/file';
 import { getScrollOptions } from 'platform/utilities/ui';
 import {
@@ -75,7 +75,7 @@ const FileUploader = ({ files, requestLockedPdfPassword, onAddFile }) => {
         <strong>Maximum file size: </strong>
       </div>
       <div>50MB</div>
-      <ErrorableFileInput
+      <FileInput
         errorMessage={errorMessage}
         onChange={handleChange}
         buttonText="Add files"

--- a/src/applications/gi/components/profile/EstimateYourBenefitsForm.jsx
+++ b/src/applications/gi/components/profile/EstimateYourBenefitsForm.jsx
@@ -5,7 +5,7 @@ import { scroller } from 'react-scroll';
 import classNames from 'classnames';
 
 import ExpandingGroup from '@department-of-veterans-affairs/formation-react/ExpandingGroup';
-import ErrorableTextInput from '@department-of-veterans-affairs/formation-react/ErrorableTextInput';
+import TextInput from '@department-of-veterans-affairs/formation-react/TextInput';
 import recordEvent from 'platform/monitoring/record-event';
 import { getScrollOptions, focusElement } from 'platform/utilities/ui';
 import AlertBox from '../AlertBox';
@@ -862,7 +862,7 @@ class EstimateYourBenefitsForm extends React.Component {
 
         zipcodeInput = (
           <div name="beneficiary-zip-question">
-            <ErrorableTextInput
+            <TextInput
               autoFocus
               errorMessage={errorMessageCheck}
               label={label}

--- a/src/applications/personalization/preferences/components/PreferenceOption.jsx
+++ b/src/applications/personalization/preferences/components/PreferenceOption.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import ErrorableCheckbox from '@department-of-veterans-affairs/formation-react/ErrorableCheckbox';
+import Checkbox from '@department-of-veterans-affairs/formation-react/Checkbox';
 
 export default ({ item, onChange, checked }) => {
   const itemId = item.shortTitle
@@ -15,7 +15,7 @@ export default ({ item, onChange, checked }) => {
         <h5 id={`itemTitle${itemId}`} className="title-item">
           {item.shortTitle || item.title}
         </h5>
-        <ErrorableCheckbox
+        <Checkbox
           name={item.code}
           checked={checked}
           ariaLabelledBy={`itemTitle${itemId}`}

--- a/src/applications/personalization/preferences/tests/containers/SetPreferences.unit.spec.jsx
+++ b/src/applications/personalization/preferences/tests/containers/SetPreferences.unit.spec.jsx
@@ -57,7 +57,7 @@ describe('<SetPreferences>', () => {
 
     const component = mount(<SetPreferences {...props} />);
     component
-      .find('ErrorableCheckbox')
+      .find('Checkbox')
       .first()
       .simulate('click'); // TODO: update test
     // expect(setPreference.args[0][0]).to.equal('healthcare');

--- a/src/applications/post-911-gib-status/components/EducationWizard.jsx
+++ b/src/applications/post-911-gib-status/components/EducationWizard.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
+import RadioButtons from '@department-of-veterans-affairs/formation-react/RadioButtons';
 
 export default class EducationWizard extends React.Component {
   constructor(props) {
@@ -74,7 +74,7 @@ export default class EducationWizard extends React.Component {
               if (shouldDisplayQuestion) {
                 if (options) {
                   return (
-                    <ErrorableRadioButtons
+                    <RadioButtons
                       additionalFieldsetClass="wizard-fieldset"
                       name={type}
                       id={type}

--- a/src/applications/post-911-gib-status/tests/components/EducationWizard.unit.spec.jsx
+++ b/src/applications/post-911-gib-status/tests/components/EducationWizard.unit.spec.jsx
@@ -6,9 +6,7 @@ import EducationWizard from '../../components/EducationWizard';
 import wizardConfig from '../../utils/wizardConfig';
 
 function getQuestion(tree, name) {
-  return tree
-    .everySubTree('ErrorableRadioButtons')
-    .find(i => i.props.name === name);
+  return tree.everySubTree('RadioButtons').find(i => i.props.name === name);
 }
 
 function answerQuestion(tree, name, value) {
@@ -42,7 +40,7 @@ describe('<EducationWizard>', () => {
     expect(tree.subTree('#wizardOptions').props.className).not.to.contain(
       'wizard-content-closed',
     );
-    expect(tree.everySubTree('ErrorableRadioButtons')).not.to.be.empty;
+    expect(tree.everySubTree('RadioButtons')).not.to.be.empty;
   });
   it('should show next relevant question', () => {
     const tree = SkinDeep.shallowRender(

--- a/src/applications/veteran-id-card/containers/EmailCapture.jsx
+++ b/src/applications/veteran-id-card/containers/EmailCapture.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { submitEmail, setEmail } from '../actions';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
-import ErrorableTextInput from '@department-of-veterans-affairs/formation-react/ErrorableTextInput';
+import TextInput from '@department-of-veterans-affairs/formation-react/TextInput';
 
 class EmailCapture extends React.Component {
   constructor(props) {
@@ -53,7 +53,7 @@ class EmailCapture extends React.Component {
             <a href="/privacy-policy/">See our privacy policy</a>
           </p>
           <form onSubmit={this.handleSubmit}>
-            <ErrorableTextInput
+            <TextInput
               errorMessage={this.props.errors && this.props.errors[0].title}
               label={<span>Email address</span>}
               name="email"

--- a/src/applications/vre/28-1900/wizard/pages/service-member/01-yesHonorableDischarge.jsx
+++ b/src/applications/vre/28-1900/wizard/pages/service-member/01-yesHonorableDischarge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
+import RadioButtons from '@department-of-veterans-affairs/formation-react/RadioButtons';
 import { serviceMemberPathPageNames } from '../pageList';
 import { handleChangeAndPageSet } from '../helpers';
 
@@ -9,7 +9,7 @@ const options = [
 ];
 
 const yesHonorableDischargeSM = ({ setPageState, state = {} }) => (
-  <ErrorableRadioButtons
+  <RadioButtons
     name={`${serviceMemberPathPageNames.yesHonorableDischargeSM}-option`}
     label={
       <p>

--- a/src/applications/vre/28-1900/wizard/pages/service-member/02-noVaMemorandum.jsx
+++ b/src/applications/vre/28-1900/wizard/pages/service-member/02-noVaMemorandum.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
+import RadioButtons from '@department-of-veterans-affairs/formation-react/RadioButtons';
 import { serviceMemberPathPageNames } from '../pageList';
 import { handleChangeAndPageSet } from '../helpers';
 
@@ -9,7 +9,7 @@ const options = [
 ];
 
 const noVaMemorandum = ({ setPageState, state = {} }) => (
-  <ErrorableRadioButtons
+  <RadioButtons
     name={`${serviceMemberPathPageNames.noVaMemorandum}-option`}
     label={
       <p>

--- a/src/applications/vre/28-1900/wizard/pages/service-member/isServiceMember.jsx
+++ b/src/applications/vre/28-1900/wizard/pages/service-member/isServiceMember.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
+import RadioButtons from '@department-of-veterans-affairs/formation-react/RadioButtons';
 import { serviceMemberPathPageNames } from '../pageList';
 import { handleChangeAndPageSet } from '../helpers';
 
@@ -9,7 +9,7 @@ const options = [
 ];
 
 const isServiceMember = ({ setPageState, state = {} }) => (
-  <ErrorableRadioButtons
+  <RadioButtons
     name={`${serviceMemberPathPageNames.isServiceMember}-option`}
     label="Do you expect to receive an honorable discharge?"
     id={`${serviceMemberPathPageNames.isServiceMember}-option`}

--- a/src/applications/vre/28-1900/wizard/pages/start.jsx
+++ b/src/applications/vre/28-1900/wizard/pages/start.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
+import RadioButtons from '@department-of-veterans-affairs/formation-react/RadioButtons';
 import {
   startingPageName,
   veteranPathPageNames,
@@ -18,7 +18,7 @@ const options = [
 ];
 
 const StartPage = ({ setPageState, state = {} }) => (
-  <ErrorableRadioButtons
+  <RadioButtons
     name={`${startingPageName.start}-option`}
     label="Which of these describes you?"
     id={`${startingPageName.start}-option`}

--- a/src/applications/vre/28-1900/wizard/pages/veteran/01-yesHonorableDischarge.jsx
+++ b/src/applications/vre/28-1900/wizard/pages/veteran/01-yesHonorableDischarge.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
+import RadioButtons from '@department-of-veterans-affairs/formation-react/RadioButtons';
 import { veteranPathPageNames } from '../pageList';
 import { handleChangeAndPageSet } from '../helpers';
 
@@ -9,7 +9,7 @@ const options = [
 ];
 
 const yesHonorableDischarge = ({ setPageState, state = {} }) => (
-  <ErrorableRadioButtons
+  <RadioButtons
     name={`${veteranPathPageNames.yesHonorableDischarge}-option`}
     label={
       <p>

--- a/src/applications/vre/28-1900/wizard/pages/veteran/isVeteran.jsx
+++ b/src/applications/vre/28-1900/wizard/pages/veteran/isVeteran.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
+import RadioButtons from '@department-of-veterans-affairs/formation-react/RadioButtons';
 import { veteranPathPageNames } from '../pageList';
 import { handleChangeAndPageSet } from '../helpers';
 
@@ -9,7 +9,7 @@ const options = [
 ];
 
 const isVeteran = ({ setPageState, state = {} }) => (
-  <ErrorableRadioButtons
+  <RadioButtons
     name={`${veteranPathPageNames.isVeteran}-option`}
     label={
       <p>

--- a/src/applications/vre/28-8832/wizard/pages/BeginFormNow.jsx
+++ b/src/applications/vre/28-8832/wizard/pages/BeginFormNow.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import recordEvent from 'platform/monitoring/record-event';
-import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
+import RadioButtons from '@department-of-veterans-affairs/formation-react/RadioButtons';
 import { pageNames } from './pageList';
 
 const options = [
@@ -26,7 +26,7 @@ const BeginFormNow = ({ setPageState, state = {} }) => {
     setPageState({ selected: value }, value);
   };
   return (
-    <ErrorableRadioButtons
+    <RadioButtons
       name="begin-form-now"
       label="Would you like to apply for career planning and guidance benefits now?"
       options={options}

--- a/src/applications/vre/28-8832/wizard/pages/DischargeStatus.jsx
+++ b/src/applications/vre/28-8832/wizard/pages/DischargeStatus.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import recordEvent from 'platform/monitoring/record-event';
-import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
+import RadioButtons from '@department-of-veterans-affairs/formation-react/RadioButtons';
 import { pageNames } from './pageList';
 
 const options = [
@@ -27,7 +27,7 @@ const DischargeStatus = ({ setPageState, state = {} }) => {
   };
 
   return (
-    <ErrorableRadioButtons
+    <RadioButtons
       name="discharge-status"
       label="Have you or your sponsor been discharged form active-duty service in the last year, or do you have less than 6 months until discharge?"
       options={options}

--- a/src/applications/vre/28-8832/wizard/pages/Start.jsx
+++ b/src/applications/vre/28-8832/wizard/pages/Start.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import recordEvent from 'platform/monitoring/record-event';
-import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
+import RadioButtons from '@department-of-veterans-affairs/formation-react/RadioButtons';
 import { pageNames } from './pageList';
 
 const options = [
@@ -45,7 +45,7 @@ const StartPage = ({ setPageState, state = {} }) => {
   };
 
   return (
-    <ErrorableRadioButtons
+    <RadioButtons
       additionalFieldsetClass="vads-u-margin-top--1"
       name="claimant-relationship"
       label="Which of these best describes you?"

--- a/src/applications/vre/28-8832/wizard/pages/VREBenefits.jsx
+++ b/src/applications/vre/28-8832/wizard/pages/VREBenefits.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import recordEvent from 'platform/monitoring/record-event';
-import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
+import RadioButtons from '@department-of-veterans-affairs/formation-react/RadioButtons';
 import { pageNames } from './pageList';
 
 const options = [
@@ -26,7 +26,7 @@ const VREBenefits = ({ setPageState, state = {} }) => {
     setPageState({ selected: value }, value);
   };
   return (
-    <ErrorableRadioButtons
+    <RadioButtons
       name="vre-benefits"
       label="Are you receiving Chapter 31 Veteran Readiness and Employment (VR&E) benefits?"
       options={options}

--- a/src/applications/vre/28-8832/wizard/pages/VaEducationBenefits.jsx
+++ b/src/applications/vre/28-8832/wizard/pages/VaEducationBenefits.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import recordEvent from 'platform/monitoring/record-event';
-import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
+import RadioButtons from '@department-of-veterans-affairs/formation-react/RadioButtons';
 import { pageNames } from './pageList';
 
 const options = [
@@ -26,7 +26,7 @@ const EducationBenefits = ({ setPageState, state = {} }) => {
     setPageState({ selected: value }, value);
   };
   return (
-    <ErrorableRadioButtons
+    <RadioButtons
       name="education-benefits"
       label="Are you using VA education benefits to go to school?"
       options={options}

--- a/src/applications/yellow-ribbon/containers/SearchForm/index.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchForm/index.jsx
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import map from 'lodash/map';
 import { connect } from 'react-redux';
 // Relative imports.
-import ErrorableCheckbox from '@department-of-veterans-affairs/formation-react/ErrorableCheckbox';
+import Checkbox from '@department-of-veterans-affairs/formation-react/Checkbox';
 import { states as STATES } from 'vets-json-schema/dist/constants.json';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { fetchResultsThunk } from '../../actions';
@@ -195,7 +195,7 @@ export class SearchForm extends Component {
 
         <div>
           {/* Unlimited Contribution Amount */}
-          <ErrorableCheckbox
+          <Checkbox
             checked={contributionAmount === 'unlimited'}
             label="Only show schools that provide maximum funding (tuition that's left after your Post-9/11 GI Bill)"
             onValueChange={onCheckboxChange('contributionAmount')}
@@ -203,7 +203,7 @@ export class SearchForm extends Component {
           />
 
           {/* Unlimited Number of Students */}
-          <ErrorableCheckbox
+          <Checkbox
             checked={numberOfStudents === 'unlimited'}
             label="Only show schools that provide funding to all eligible students"
             onValueChange={onCheckboxChange('numberOfStudents')}

--- a/src/platform/forms-system/src/js/utilities/file/ShowPdfPassword.jsx
+++ b/src/platform/forms-system/src/js/utilities/file/ShowPdfPassword.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import ErrorableTextInput from '@department-of-veterans-affairs/formation-react/ErrorableTextInput';
+import TextInput from '@department-of-veterans-affairs/formation-react/TextInput';
 
 const ShowPdfPassword = ({ file, index, onSubmitPassword }) => {
   const [fieldObj, setFieldObj] = useState({
@@ -11,7 +11,7 @@ const ShowPdfPassword = ({ file, index, onSubmitPassword }) => {
   const showError = fieldObj.dirty && !fieldObj.value;
   return (
     <div className="vads-u-margin-bottom--2">
-      <ErrorableTextInput
+      <TextInput
         label={'PDF password'}
         errorMessage={
           showError && 'Please provide a password to decrypt this file'

--- a/src/platform/forms/components/PrivacyAgreement.jsx
+++ b/src/platform/forms/components/PrivacyAgreement.jsx
@@ -1,11 +1,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import ErrorableCheckbox from '@department-of-veterans-affairs/formation-react/ErrorableCheckbox';
+import Checkbox from '@department-of-veterans-affairs/formation-react/Checkbox';
 
 export default function PrivacyAgreement({ onChange, checked, showError }) {
   return (
     <div>
-      <ErrorableCheckbox
+      <Checkbox
         required
         checked={checked}
         onValueChange={onChange}

--- a/src/platform/forms/components/review/PreSubmitSection.jsx
+++ b/src/platform/forms/components/review/PreSubmitSection.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 // formation
-import ErrorableCheckbox from '@department-of-veterans-affairs/formation-react/ErrorableCheckbox';
+import Checkbox from '@department-of-veterans-affairs/formation-react/Checkbox';
 
 // platform - forms - selectors
 import { preSubmitSelector } from 'platform/forms/selectors/review';
@@ -37,7 +37,7 @@ export function PreSubmitSection(props) {
         <div>
           {preSubmit.notice}
           {preSubmit.required && (
-            <ErrorableCheckbox
+            <Checkbox
               required
               checked={checked}
               onValueChange={value => setPreSubmit(preSubmit?.field, value)}

--- a/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
-import ErrorableTextArea from '@department-of-veterans-affairs/formation-react/ErrorableTextArea';
-import ErrorableSelect from '@department-of-veterans-affairs/formation-react/ErrorableSelect';
+import TextArea from '@department-of-veterans-affairs/formation-react/TextArea';
+import Select from '@department-of-veterans-affairs/formation-react/Select';
 
 import environment from 'platform/utilities/environment';
 import { getActivePages } from 'platform/forms-system/src/js/helpers';
@@ -86,7 +86,7 @@ const SipsDevModal = props => {
         onClose={() => toggleModal(false)}
       >
         <>
-          <ErrorableTextArea
+          <TextArea
             errorMessage={errorMessage}
             label="Form data"
             name="sips_data"
@@ -94,7 +94,7 @@ const SipsDevModal = props => {
             field={{ value: sipsData }}
             onValueChange={field => handleChange(field.value)}
           />
-          <ErrorableSelect
+          <Select
             label="Return url"
             name="sips_url"
             options={availablePaths}

--- a/src/platform/user/profile/vap-svc/containers/ReceiveTextMessages.jsx
+++ b/src/platform/user/profile/vap-svc/containers/ReceiveTextMessages.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import ErrorableCheckbox from '@department-of-veterans-affairs/formation-react/ErrorableCheckbox';
+import Checkbox from '@department-of-veterans-affairs/formation-react/Checkbox';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import {
   isVAPatient,
@@ -89,7 +89,7 @@ class ReceiveTextMessages extends React.Component {
     return (
       <div className="receive-text-messages">
         <div className="form-checkbox-buttons">
-          <ErrorableCheckbox
+          <Checkbox
             checked={
               !!this.props.profile.vapContactInfo.mobilePhone.isTextPermitted
             }

--- a/src/platform/user/profile/vap-svc/tests/containers/ReceiveTextMessages.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/containers/ReceiveTextMessages.unit.spec.jsx
@@ -50,7 +50,7 @@ describe('<ReceiveTextMessages/>', () => {
 
   it('renders the checkbox when conditions do allow checkbox to be rendered', () => {
     const component = enzyme.shallow(<ReceiveTextMessages {...props} />);
-    const errorableCheckbox = component.find('ErrorableCheckbox');
+    const errorableCheckbox = component.find('Checkbox');
     expect(errorableCheckbox, 'the checkbox rendered').to.have.lengthOf(1);
     component.unmount();
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1274,10 +1274,10 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@department-of-veterans-affairs/formation-react@6.0.2":
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation-react/-/formation-react-6.0.2.tgz#213a4e521a6eca551e722b15fa9351f80b5c8879"
-  integrity sha512-qtS2i1n2ltbD1TSD9+PsBAtchwJCAlQn7C/1gYyUIkKQZriu7T6vyVIp2TNkdszm80NhHEp9YQmfHnpB4kZwsg==
+"@department-of-veterans-affairs/formation-react@7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation-react/-/formation-react-7.0.0.tgz#8b27506cf665c8a0640417d0c3473d21413a570e"
+  integrity sha512-Sdbqv8VhHv8GB4Gk2zMI+Imwwn7xhR7AOeclAMNrMvEZQZSsEPd3swShRYQ2u9elmE+ifY5WHVWiC/2ZULckiQ==
   dependencies:
     classnames "^2.2.6"
     lodash "^4.17.15"


### PR DESCRIPTION
## Description
The only change is removing `Errorable` from the component names since it was causing confusion.

The command I ran to replace all instances of `Errorable` was: `rg Errorable --files-with-matches | xargs -I {} sed -Ei 's/Errorable//g' {}`.

I first verified that all `Errorable*` components were coming from `formation-react` with:
```sh
diff <(rg "Errorable(\w+)" ../veteran-facing-services-tools/packages/formation-react/ --only-matching --no-heading --no-filename --no-line-number | sort | uniq) <(rg "Errorable\w+" --only-matching --no-heading --no-line-number --no-filename | sort | uniq)
```
This looks for `Errorable*` in `formation-react` and lists the unique component names, looks for `Errorable*` in `vets-website` and compares the unique names against those in `formation-react`. They're all the same. (Fun fact: `formation-react` has three `Errorable` components which are not used in `vets-website`. :shrug: )

I then made sure that there were no instances of `Errorable*` defined outside of an `import .* from '@department-of-veterans-affairs/formation-react/.*'` (though I no longer have the command I used... :confused: ).

## Testing done
Linting + unit tests.