### PR TITLE
[Development; 508] HLR accessibility fixes

### DIFF
--- a/src/applications/disability-benefits/996/config/form.js
+++ b/src/applications/disability-benefits/996/config/form.js
@@ -118,9 +118,6 @@ const formConfig = {
           path: 'office-of-review',
           uiSchema: sameOffice.uiSchema,
           schema: sameOffice.schema,
-          initialData: {
-            sameOffice: false,
-          },
         },
       },
     },

--- a/src/applications/disability-benefits/996/content/InformalConference.jsx
+++ b/src/applications/disability-benefits/996/content/InformalConference.jsx
@@ -25,14 +25,8 @@ export const informalConferenceLabels = {
   rep: 'Yes, call my representative',
 };
 
-export const ContactRepresentativeTitle = 'Representative’s information';
-
-// direct <p> will have all margins removed, so it's nested here:
-export const ContactRepresentativeDescription = (
-  <div className="vads-u-margin-bottom--4">
-    <p>Please provide your representative’s contact information.</p>
-  </div>
-);
+export const ContactRepresentativeTitle =
+  'Provide your representative’s contact information.';
 
 export const RepresentativeNameTitle = 'Representative’s name';
 

--- a/src/applications/disability-benefits/996/content/InformalConference.jsx
+++ b/src/applications/disability-benefits/996/content/InformalConference.jsx
@@ -8,7 +8,7 @@ export const InformalConferenceDescription = (
       and the reviewer to discuss why you think the decision should be changed
       and identify factual errors.
     </p>
-    <p className="vads-u-margin-bottom--3">
+    <p id="choose-conference-notice" className="vads-u-margin-bottom--3">
       If you request an informal conference, the reviewer will call you or your
       representative. You can request only one informal conference for each
       Higher-Level Review request.

--- a/src/applications/disability-benefits/996/content/OfficeForReview.jsx
+++ b/src/applications/disability-benefits/996/content/OfficeForReview.jsx
@@ -5,14 +5,13 @@ export const OfficeForReviewLabel = `If available, would you like to have the
 
 export const OfficeForReviewContent = (
   <>
-    <h3 className="vads-u-font-size--h5">Office of review</h3>
     <p className="vads-u-margin-top--2">
       You have the right to request the same office conduct the review. VA may
       be unable to grant this request. In either scenario, your case will be
       looked at by a different individual and considered separately from your
       original decision.
     </p>
-    <p>
+    <p id="same-office-notice">
       <strong>
         If we cannot fulfill your request, we will notify you at the time the
         Higher-Level Review decision is made.

--- a/src/applications/disability-benefits/996/pages/informalConference.js
+++ b/src/applications/disability-benefits/996/pages/informalConference.js
@@ -27,6 +27,10 @@ const informalConference = {
           }
           return schema;
         },
+        widgetProps: {
+          me: { 'aria-describedby': 'choose-conference-notice' },
+          rep: { 'aria-describedby': 'choose-conference-notice' },
+        },
       },
       'ui:errorMessages': {
         required: errorMessages.informalConferenceContactChoice,

--- a/src/applications/disability-benefits/996/pages/informalConferenceRep.js
+++ b/src/applications/disability-benefits/996/pages/informalConferenceRep.js
@@ -5,7 +5,6 @@ import { errorMessages } from '../constants';
 
 import {
   ContactRepresentativeTitle,
-  ContactRepresentativeDescription,
   RepresentativeNameTitle,
   RepresentativePhoneTitle,
 } from '../content/InformalConference';
@@ -18,7 +17,6 @@ export default {
     },
     informalConferenceRep: {
       'ui:title': ContactRepresentativeTitle,
-      'ui:description': ContactRepresentativeDescription,
       name: {
         'ui:title': RepresentativeNameTitle,
         'ui:required': formData => formData?.informalConference === 'rep',

--- a/src/applications/disability-benefits/996/pages/sameOffice.js
+++ b/src/applications/disability-benefits/996/pages/sameOffice.js
@@ -15,6 +15,14 @@ const sameOfficePage = {
     sameOffice: {
       'ui:title': OfficeForReviewLabel,
       'ui:widget': 'yesNo',
+      'ui:required': () => true,
+      'ui:options': {
+        widgetProps: {
+          Y: {
+            'aria-describedby': 'same-office-notice',
+          },
+        },
+      },
     },
   },
 


### PR DESCRIPTION
## Description

In the Higher-Level Review a11y audit, some changes were discussed to improve screenreader accessibility. In this PR,

1. Added an `aria-describedby` reference to the same office "Yes" radio to provide the screenreader user important context.
2. Added an `aria-describedby` reference to the two "Yes" choices on the informal conference selection page to provide the screenreader user important context.
3. Removed unnecessary sentence on the representative info page.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/17240
- https://github.com/department-of-veterans-affairs/vets-website/pull/15586
- Design discussion: https://docs.google.com/presentation/d/1g4q6xlUS7BvVsiCmcVqGe4675h6KaYPhitL1jii9WvQ/edit?ts=5ff73edc#slide=id.gb3bdba4c8d_0_16

## Testing done

Unit tests

## Screenshots

<details><summary>Same office changes</summary>

<!-- leave a blank line above -->
Notice: `same-office-notice` ID and it's `aria-describedby` reference in the "Yes" input

![Screen Shot 2021-01-08 at 3 29 38 PM](https://user-images.githubusercontent.com/136959/104070823-6768d080-51cd-11eb-8474-0aa44923acbc.png)</details>

<details><summary>Informal conference changes</summary>

<!-- leave a blank line above -->
Notice the `choose-conference-notice` ID and it's `aria-describedby` reference in both "Yes, call..." radio inputs.

![Screen Shot 2021-01-08 at 3 55 19 PM](https://user-images.githubusercontent.com/136959/104070903-941ce800-51cd-11eb-88d4-14f64b5f761a.png)</details>

<details><summary>Informal conference representative changes</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-01-08 at 4 00 19 PM](https://user-images.githubusercontent.com/136959/104071020-d47c6600-51cd-11eb-99a3-94fd7ce8057b.png)</details>

## Acceptance criteria
- [x] Referenced `aria-describedby` content is read to the screenreader user when they make the related selection
- [x] Reduce cognitive load on representative contact info page. 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
