### PR TITLE
[Development] Add PDF max upload size option

### DIFF
--- a/src/platform/forms-system/src/js/actions.js
+++ b/src/platform/forms-system/src/js/actions.js
@@ -251,7 +251,6 @@ export function uploadFile(
       onError();
       return null;
     }
-
     if (password) {
       onChange({ name: file.name, uploading: true, password });
     } else {

--- a/src/platform/forms-system/src/js/actions.js
+++ b/src/platform/forms-system/src/js/actions.js
@@ -210,22 +210,6 @@ export function uploadFile(
   // This item should have been set in any previous API calls
   const csrfTokenStored = localStorage.getItem('csrfToken');
   return (dispatch, getState) => {
-    // we limit file types, but it’s not respected on mobile and desktop
-    // users can bypass it without much effort
-    if (
-      !uiOptions.fileTypes.some(fileType =>
-        file.name.toLowerCase().endsWith(fileType.toLowerCase()),
-      )
-    ) {
-      onChange({
-        name: file.name,
-        errorMessage: 'File is not one of the allowed types',
-      });
-
-      onError();
-      return null;
-    }
-
     // PDFs may have a different max size based on where it is being uploaded
     // (form 526 & claim status)
     const maxSize =
@@ -246,6 +230,22 @@ export function uploadFile(
       onChange({
         name: file.name,
         errorMessage: 'File is too small to be uploaded',
+      });
+
+      onError();
+      return null;
+    }
+
+    // we limit file types, but it’s not respected on mobile and desktop
+    // users can bypass it without much effort
+    if (
+      !uiOptions.fileTypes.some(fileType =>
+        file.name.toLowerCase().endsWith(fileType.toLowerCase()),
+      )
+    ) {
+      onChange({
+        name: file.name,
+        errorMessage: 'File is not one of the allowed types',
       });
 
       onError();

--- a/src/platform/forms-system/src/js/actions.js
+++ b/src/platform/forms-system/src/js/actions.js
@@ -210,7 +210,29 @@ export function uploadFile(
   // This item should have been set in any previous API calls
   const csrfTokenStored = localStorage.getItem('csrfToken');
   return (dispatch, getState) => {
-    if (file.size > uiOptions.maxSize) {
+    // we limit file types, but it’s not respected on mobile and desktop
+    // users can bypass it without much effort
+    if (
+      !uiOptions.fileTypes.some(fileType =>
+        file.name.toLowerCase().endsWith(fileType.toLowerCase()),
+      )
+    ) {
+      onChange({
+        name: file.name,
+        errorMessage: 'File is not one of the allowed types',
+      });
+
+      onError();
+      return null;
+    }
+
+    // PDFs may have a different max size based on where it is being uploaded
+    // (form 526 & claim status)
+    const maxSize =
+      (file.name.toLowerCase().endsWith('pdf') && uiOptions.maxPdfSize) ||
+      uiOptions.maxSize;
+
+    if (file.size > maxSize) {
       onChange({
         name: file.name,
         errorMessage: 'File is too large to be uploaded',
@@ -230,21 +252,6 @@ export function uploadFile(
       return null;
     }
 
-    // we limit file types, but it’s not respected on mobile and desktop
-    // users can bypass it without much effort
-    if (
-      !uiOptions.fileTypes.some(fileType =>
-        file.name.toLowerCase().endsWith(fileType.toLowerCase()),
-      )
-    ) {
-      onChange({
-        name: file.name,
-        errorMessage: 'File is not one of the allowed types',
-      });
-
-      onError();
-      return null;
-    }
     if (password) {
       onChange({ name: file.name, uploading: true, password });
     } else {


### PR DESCRIPTION
## Description

Form 526 allows active service members to upload their service treatment records (STR) when filing for a Benefits Delivery at Discharge (BDD). These files can be in excess of 95 MB in size. EVSS has raised the size limit of these uploaded files to 150 MB, so this PR modifies the platform upload code to allow uploading different sized PDFs. We only want to allow large PDFs and not allow 150MB images to be uploaded.

A feature flag will be checked and control these changes within the form and claim status tool.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/16003 (FE)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/16004 (BE)
- https://github.com/department-of-veterans-affairs/devops/pull/7990
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/17643 (feature flag)

## Testing done

Updated unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Allow uploading different sized PDF vs other file types

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
