### PR TITLE
[Development] Move HLR availability title into legend

### DIFF
--- a/src/applications/disability-benefits/996/content/InformalConference.jsx
+++ b/src/applications/disability-benefits/996/content/InformalConference.jsx
@@ -42,12 +42,17 @@ const contacts = (
 
 export const InformalConferenceTimesTitle = (
   <>
-    <h3 className="vads-u-font-size--h5 vads-u-margin-top--0">
-      <span className="contact-choice selected-rep">
-        Your representative’s availability
-      </span>
-      <span className="contact-choice selected-me">Your availability</span>
-    </h3>
+    <span className="contact-choice selected-rep vads-u-font-size--sm">
+      Please indicate your representative’s availability
+    </span>
+    <span className="contact-choice selected-me vads-u-font-size--sm">
+      Please indicate your availability
+    </span>
+  </>
+);
+
+export const InformalConferenceTimesDescription = (
+  <>
     <p>
       First we’ll call {contacts} to schedule the informal conference. Please
       indicate <span className="contact-choice selected-me">your</span>

--- a/src/applications/disability-benefits/996/pages/informalConferenceTimes.js
+++ b/src/applications/disability-benefits/996/pages/informalConferenceTimes.js
@@ -3,16 +3,15 @@ import { errorMessages } from '../constants';
 
 import {
   InformalConferenceTimesTitle,
+  InformalConferenceTimesDescription,
   informalConferenceTimeSelectTitles,
   informalConferenceTimeAllLabels,
 } from '../content/InformalConference';
 
 export default {
   uiSchema: {
-    'ui:description': InformalConferenceTimesTitle,
-    'ui:options': {
-      forceDivWrapper: true,
-    },
+    'ui:title': InformalConferenceTimesTitle,
+    'ui:description': InformalConferenceTimesDescription,
     informalConferenceTimes: {
       'ui:title': ' ',
       'ui:options': {


### PR DESCRIPTION
## Description

The Higher-Level Review informal conference availability page needs to include a wrapping `<fieldset>` with `<legend>`. This PR shuffles content around to match the requested changes.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/16224#issuecomment-758018278

## Testing done

N/A

## Screenshots

<details><summary>Availability title in legend</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-01-11 at 9 50 37 AM](https://user-images.githubusercontent.com/136959/104204118-898f6800-53f2-11eb-95c1-8dce8d6c0e8d.png)</details>

## Acceptance criteria
- [x] Availability form elements wrapped in `<fieldset>` and includes `<legend>`.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
