### PR TITLE
[Development] Add HLR office of review edit aria-label

### DIFF
--- a/src/applications/disability-benefits/996/pages/sameOffice.js
+++ b/src/applications/disability-benefits/996/pages/sameOffice.js
@@ -5,6 +5,9 @@ import {
 
 const sameOfficePage = {
   uiSchema: {
+    'ui:options': {
+      ariaLabelForEditButtonOnReview: 'Edit office of review',
+    },
     'view:sameOfficeInfo': {
       'ui:title': ' ',
       'ui:description': OfficeForReviewContent,


### PR DESCRIPTION
## Description

Add Higher-Level Review office for review edit button (review & submit page) `aria-label`.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/17824#issuecomment-758023497

## Testing done

N/A (manually checked)

## Screenshots

<details><summary>Edit button</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-01-11 at 10 05 19 AM](https://user-images.githubusercontent.com/136959/104205931-944afc80-53f4-11eb-9e08-8c2b5231731d.png)</details>

## Acceptance criteria
- [x] Appropriate `aria-label` on office of review edit button

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
