### PR TITLE
Fix "DD not set up" view state

### DIFF
--- a/src/applications/debt-letters/const/deduction-codes/index.js
+++ b/src/applications/debt-letters/const/deduction-codes/index.js
@@ -160,7 +160,7 @@ export const renderWhyMightIHaveThisDebt = deductionCode => {
               status.
             </li>
             <li>
-              You‘ve received two payments for the same compensation and pension
+              You’ve received two payments for the same compensation and pension
               benefits.
             </li>
             <li>You didn’t let us know of additional income you might have.</li>

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoCNPv2.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoCNPv2.jsx
@@ -176,7 +176,7 @@ export const BankInfoCNP = ({
   const notEligibleContent = (
     <>
       <p className="vads-u-margin-top--0">
-        Our records show that you‘re not receiving disability compensation or
+        Our records show that you’re not receiving disability compensation or
         pension payments. If you think this is an error, please call us at{' '}
         <Telephone contact={CONTACTS.VA_BENEFITS} />.
       </p>
@@ -186,7 +186,7 @@ export const BankInfoCNP = ({
           rel="noopener noreferrer"
           href="https://www.va.gov/disability/eligibility/"
         >
-          Find out if you‘re eligible for VA disability benefits
+          Find out if you’re eligible for VA disability benefits
         </a>
       </p>
       <p className="vads-u-margin-bottom--0">
@@ -195,7 +195,7 @@ export const BankInfoCNP = ({
           rel="noopener noreferrer"
           href="https://www.va.gov/pension/eligibility/"
         >
-          Find out if you‘re eligible for VA pension benefits
+          Find out if you’re eligible for VA pension benefits
         </a>
       </p>
     </>
@@ -250,14 +250,17 @@ export const BankInfoCNP = ({
     return notEligibleContent;
   };
 
-  const directDepositData = [
-    // the table can show multiple states so we set its value with the
-    // getBankInfo() helper
-    {
-      title: 'Account',
+  const directDepositData = () => {
+    const data = {
+      // the table can show multiple states so we set its value with the
+      // getBankInfo() helper
       value: getBankInfo(),
-    },
-  ];
+    };
+    if (isEligibleToSetUpDirectDeposit || isDirectDepositSetUp) {
+      data.title = 'Account';
+    }
+    return [data];
+  };
 
   // Render nothing if the user is not LOA3.
   // This entire component should never be rendered in that case; this just
@@ -304,7 +307,7 @@ export const BankInfoCNP = ({
       <ProfileInfoTable
         className="vads-u-margin-y--2 medium-screen:vads-u-margin-y--4"
         title="Disability compensation and pension benefits"
-        data={directDepositData}
+        data={directDepositData()}
       />
     </>
   );

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
@@ -217,14 +217,17 @@ export const DirectDepositEDU = ({
     return notEligibleContent;
   };
 
-  const directDepositData = [
-    // the table can show multiple states so we set its value with the
-    // getBankInfo() helper
-    {
-      title: 'Account',
+  const directDepositData = () => {
+    const data = {
+      // the table can show multiple states so we set its value with the
+      // getBankInfo() helper
       value: getBankInfo(),
-    },
-  ];
+    };
+    if (isDirectDepositSetUp) {
+      data.title = 'Account';
+    }
+    return [data];
+  };
 
   // Render nothing if the user is not LOA3.
   // This entire component should never be rendered in that case; this just
@@ -271,7 +274,7 @@ export const DirectDepositEDU = ({
       <ProfileInfoTable
         className="vads-u-margin-y--2 medium-screen:vads-u-margin-y--4"
         title="Education benefits"
-        data={directDepositData}
+        data={directDepositData()}
       />
     </>
   );


### PR DESCRIPTION
## Description
Make it a single-column table (remove the "Account" label in the left hand column) when the user is not eligible/is not receiving those benefits.

Also replace some single open quotes with single close quotes
Also set up skeleton tests for when a single DD endpoint fails but the user qualifies for the _other_ DD

## Testing done


## Screenshots
BEFORE
<img width="724" alt="Screen Shot 2021-01-11 at 9 44 41 AM" src="https://user-images.githubusercontent.com/20728956/104223570-ab8be900-53f8-11eb-838c-4e9e6247d83b.png">

AFTER
<img width="728" alt="Screen Shot 2021-01-11 at 10 02 24 AM" src="https://user-images.githubusercontent.com/20728956/104223588-b181ca00-53f8-11eb-8663-cdfc2c012e1b.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs