### PR TITLE
508-defect-3 [SCREENREADER]: STEM Standalone - Links that open in new tab do not alert user that a new tab will be opened

### DIFF
--- a/src/applications/edu-benefits/10203/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/10203/containers/IntroductionPage.jsx
@@ -127,6 +127,7 @@ export class IntroductionPage extends React.Component {
                         You've already earned a STEM bachelor’s degree and are
                         pursuing a teaching certification.{' '}
                         <a
+                          aria-label="See eligible degree programs, opening in new tab"
                           href="https://benefits.va.gov/gibill/docs/fgib/STEM_Program_List.pdf"
                           rel="noopener noreferrer"
                           target="_blank"

--- a/src/applications/edu-benefits/10203/content/benefitSelection.jsx
+++ b/src/applications/edu-benefits/10203/content/benefitSelection.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export const benefitsLabels = {
   chapter33: (
-    <span aria-label="Post-9/11 GI Bill (Chapter 33)">
+    <p>
       Post-9/11 GI Bill (Chapter 33)
       <br />
       <a
@@ -12,11 +12,11 @@ export const benefitsLabels = {
       >
         Learn more
       </a>
-    </span>
+    </p>
   ),
   // 1995-STEM related
   fryScholarship: (
-    <span aria-label="Fry Scholarship (Chapter 33)">
+    <p>
       Fry Scholarship (Chapter 33)
       <br />
       <a
@@ -26,10 +26,10 @@ export const benefitsLabels = {
       >
         Learn more
       </a>
-    </span>
+    </p>
   ),
   chapter30: (
-    <span aria-label="Montgomery GI Bill (MGIB-AD, Chapter 30)">
+    <p>
       Montgomery GI Bill (MGIB-AD, Chapter 30)
       <br />
       <a
@@ -39,10 +39,10 @@ export const benefitsLabels = {
       >
         Learn more
       </a>
-    </span>
+    </p>
   ),
   chapter1606: (
-    <span aria-label="Montgomery GI Bill Selected Reserve (MGIB-SR, Chapter 1606)">
+    <p>
       Montgomery GI Bill Selected Reserve (MGIB-SR, Chapter 1606)
       <br />
       <a
@@ -52,10 +52,10 @@ export const benefitsLabels = {
       >
         Learn more
       </a>
-    </span>
+    </p>
   ),
   transferOfEntitlement: (
-    <span aria-label="Transfer of Entitlement Program (TOE)">
+    <p>
       Transfer of Entitlement Program (TOE)
       <br />
       <a
@@ -65,10 +65,10 @@ export const benefitsLabels = {
       >
         Learn more
       </a>
-    </span>
+    </p>
   ),
   chapter32: (
-    <span aria-label="Post-Vietnam Era Veterans’ Educational Assistance Program">
+    <p>
       Post-Vietnam Era Veterans’ Educational Assistance Program
       <br />
       (VEAP, Chapter 32)
@@ -80,6 +80,6 @@ export const benefitsLabels = {
       >
         Learn more
       </a>
-    </span>
+    </p>
   ),
 };

--- a/src/applications/edu-benefits/10203/content/benefitSelection.jsx
+++ b/src/applications/edu-benefits/10203/content/benefitSelection.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export const benefitsLabels = {
   chapter33: (
-    <p aria-label="Post-9/11 GI Bill (Chapter 33)">
+    <span aria-label="Post-9/11 GI Bill (Chapter 33)">
       Post-9/11 GI Bill (Chapter 33)
       <br />
       <a
@@ -12,11 +12,11 @@ export const benefitsLabels = {
       >
         Learn more
       </a>
-    </p>
+    </span>
   ),
   // 1995-STEM related
   fryScholarship: (
-    <p aria-label="Fry Scholarship (Chapter 33)">
+    <span aria-label="Fry Scholarship (Chapter 33)">
       Fry Scholarship (Chapter 33)
       <br />
       <a
@@ -26,10 +26,10 @@ export const benefitsLabels = {
       >
         Learn more
       </a>
-    </p>
+    </span>
   ),
   chapter30: (
-    <p aria-label="Montgomery GI Bill (MGIB-AD, Chapter 30)">
+    <span aria-label="Montgomery GI Bill (MGIB-AD, Chapter 30)">
       Montgomery GI Bill (MGIB-AD, Chapter 30)
       <br />
       <a
@@ -39,10 +39,10 @@ export const benefitsLabels = {
       >
         Learn more
       </a>
-    </p>
+    </span>
   ),
   chapter1606: (
-    <p aria-label="Montgomery GI Bill Selected Reserve (MGIB-SR, Chapter 1606)">
+    <span aria-label="Montgomery GI Bill Selected Reserve (MGIB-SR, Chapter 1606)">
       Montgomery GI Bill Selected Reserve (MGIB-SR, Chapter 1606)
       <br />
       <a
@@ -52,10 +52,10 @@ export const benefitsLabels = {
       >
         Learn more
       </a>
-    </p>
+    </span>
   ),
   transferOfEntitlement: (
-    <p aria-label="Transfer of Entitlement Program (TOE)">
+    <span aria-label="Transfer of Entitlement Program (TOE)">
       Transfer of Entitlement Program (TOE)
       <br />
       <a
@@ -65,10 +65,10 @@ export const benefitsLabels = {
       >
         Learn more
       </a>
-    </p>
+    </span>
   ),
   chapter32: (
-    <p aria-label="Post-Vietnam Era Veterans’ Educational Assistance Program">
+    <span aria-label="Post-Vietnam Era Veterans’ Educational Assistance Program">
       Post-Vietnam Era Veterans’ Educational Assistance Program
       <br />
       (VEAP, Chapter 32)
@@ -80,6 +80,6 @@ export const benefitsLabels = {
       >
         Learn more
       </a>
-    </p>
+    </span>
   ),
 };

--- a/src/applications/edu-benefits/10203/content/benefitSelection.jsx
+++ b/src/applications/edu-benefits/10203/content/benefitSelection.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 
 export const benefitsLabels = {
   chapter33: (
-    <p>
+    <p aria-label="Post-9/11 GI Bill (Chapter 33)">
       Post-9/11 GI Bill (Chapter 33)
       <br />
       <a
-        aria-label="Learn more about Post-9/11 benefits"
+        aria-label="Learn more about Post-9/11 benefits, opening in new tab"
         href="/education/about-gi-bill-benefits/post-9-11/"
         target="_blank"
       >
@@ -16,11 +16,11 @@ export const benefitsLabels = {
   ),
   // 1995-STEM related
   fryScholarship: (
-    <p>
+    <p aria-label="Fry Scholarship (Chapter 33)">
       Fry Scholarship (Chapter 33)
       <br />
       <a
-        aria-label="Learn more about Fry Scholarship benefits"
+        aria-label="Learn more about Fry Scholarship benefits, opening in new tab"
         href="/education/survivor-dependent-benefits/fry-scholarship/"
         target="_blank"
       >
@@ -29,11 +29,11 @@ export const benefitsLabels = {
     </p>
   ),
   chapter30: (
-    <p>
+    <p aria-label="Montgomery GI Bill (MGIB-AD, Chapter 30)">
       Montgomery GI Bill (MGIB-AD, Chapter 30)
       <br />
       <a
-        aria-label="Learn more about Montgomery GI Bill benefits"
+        aria-label="Learn more about Montgomery GI Bill benefits, opening in new tab"
         href="/education/about-gi-bill-benefits/montgomery-active-duty/"
         target="_blank"
       >
@@ -42,11 +42,11 @@ export const benefitsLabels = {
     </p>
   ),
   chapter1606: (
-    <p>
+    <p aria-label="Montgomery GI Bill Selected Reserve (MGIB-SR, Chapter 1606)">
       Montgomery GI Bill Selected Reserve (MGIB-SR, Chapter 1606)
       <br />
       <a
-        aria-label="Learn more about Montgomery GI Bill Selected Reserve benefits"
+        aria-label="Learn more about Montgomery GI Bill Selected Reserve benefits, opening in new tab"
         href="/education/about-gi-bill-benefits/montgomery-selected-reserve/"
         target="_blank"
       >
@@ -55,11 +55,11 @@ export const benefitsLabels = {
     </p>
   ),
   transferOfEntitlement: (
-    <p>
+    <p aria-label="Transfer of Entitlement Program (TOE)">
       Transfer of Entitlement Program (TOE)
       <br />
       <a
-        aria-label="Learn more about Transfer of Entitlement Program benefits"
+        aria-label="Learn more about Transfer of Entitlement Program benefits, opening in new tab"
         href="/education/transfer-post-9-11-gi-bill-benefits/"
         target="_blank"
       >
@@ -68,13 +68,13 @@ export const benefitsLabels = {
     </p>
   ),
   chapter32: (
-    <p>
+    <p aria-label="Post-Vietnam Era Veterans’ Educational Assistance Program">
       Post-Vietnam Era Veterans’ Educational Assistance Program
       <br />
       (VEAP, Chapter 32)
       <br />
       <a
-        aria-label="Learn more about Post-Vietnam Era Veterans’ Educational Assistance Program benefits"
+        aria-label="Learn more about Post-Vietnam Era Veterans’ Educational Assistance Program benefits, opening in new tab"
         href="/education/other-va-education-benefits/veap/"
         target="_blank"
       >

--- a/src/applications/edu-benefits/10203/content/directDeposit.jsx
+++ b/src/applications/edu-benefits/10203/content/directDeposit.jsx
@@ -56,6 +56,7 @@ export const bankInfoHelpText = (
         <li>
           Apply at{' '}
           <a
+            aria-label="www.usdirectexpress.com, opening in new tab"
             href="https://www.usdirectexpress.com/"
             target="_blank"
             rel="noopener noreferrer"

--- a/src/applications/edu-benefits/10203/content/stemEligibility.jsx
+++ b/src/applications/edu-benefits/10203/content/stemEligibility.jsx
@@ -4,6 +4,7 @@ export const eligiblePrograms = () => {
   return (
     <div>
       <a
+        aria-label="See eligible degree programs, opening in new tab"
         href="https://benefits.va.gov/gibill/docs/fgib/STEM_Program_List.pdf"
         target="_blank"
         rel="noopener noreferrer"

--- a/src/applications/edu-benefits/10203/content/stemEligibility.jsx
+++ b/src/applications/edu-benefits/10203/content/stemEligibility.jsx
@@ -19,6 +19,7 @@ export const checkBenefit = () => {
   return (
     <div>
       <a
+        aria-label="Check your remaining benefits, opening in new tab"
         href="https://www.va.gov/education/gi-bill/post-9-11/ch-33-benefit/"
         target="_blank"
         rel="noopener noreferrer"

--- a/src/platform/forms/preSubmitInfo.js
+++ b/src/platform/forms/preSubmitInfo.js
@@ -12,9 +12,13 @@ export default {
   ),
   field: 'privacyAgreementAccepted',
   label: (
-    <span>
+    <span aria-label="I have read and accept the privacy policy">
       I have read and accept the{' '}
-      <a target="_blank" href="/privacy-policy/">
+      <a
+        aria-label="Privacy policy, will open in new tab"
+        target="_blank"
+        href="/privacy-policy/"
+      >
         privacy policy
       </a>
     </span>

--- a/src/platform/forms/preSubmitInfo.js
+++ b/src/platform/forms/preSubmitInfo.js
@@ -12,7 +12,7 @@ export default {
   ),
   field: 'privacyAgreementAccepted',
   label: (
-    <span aria-label="I have read and accept the privacy policy">
+    <span>
       I have read and accept the{' '}
       <a
         aria-label="Privacy policy, will open in new tab"


### PR DESCRIPTION
## Description
As a screen reader who cannot see and uses the keyboard to navigate, when tabbing to various links in the form, they do not announce to the user that they open in a new tab. User might think the links will exit the user from the form.
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/18247
## Testing done
Local Test
Mac - Apple Voiceover
Windows - JAWS

## Screenshots


## Acceptance criteria
- [x] Add hidden screen reader only text to link text that announces it opening in a new window or give link aria-label that includes text that announces opening in a new window

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
