### PR TITLE
Add context to address suggestion failure

### DIFF
--- a/src/platform/user/profile/vap-svc/actions/transactions.js
+++ b/src/platform/user/profile/vap-svc/actions/transactions.js
@@ -1,5 +1,3 @@
-import * as Sentry from '@sentry/browser';
-
 import { apiRequest } from '~/platform/utilities/api';
 import { refreshProfile } from '~/platform/user/profile/actions';
 import recordEvent from '~/platform/monitoring/record-event';


### PR DESCRIPTION
## Description
This PR adds some context as to why we are sometimes seeing `undefined_undefined` in GA for address suggestions. When the apiRequest comes back with a 500 (or similar error), we won't have access to the `error.errors` object. This PR adds a bit more descriptive string than merely `undefined`.

## Testing done


## Screenshots


## Acceptance criteria
- [x] Understand why we were seeing `undefined_undefined` and add more descriptive string
- [x] Remove Sentry error logging

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
