### PR TITLE
Replace old help desk number

### DIFF
--- a/src/platform/static-data/CallHRC.jsx
+++ b/src/platform/static-data/CallHRC.jsx
@@ -8,7 +8,7 @@ export default function CallHRC({ startSentence }) {
   return (
     <span>
       {startSentence ? 'Call' : 'call'} us at{' '}
-      <a href="tel:18555747286">855-574-7286</a>.<br />
+      <Telephone contact={CONTACTS.HELP_DESK} />.<br />
       If you have hearing loss, call TTY:{' '}
       <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
     </span>


### PR DESCRIPTION
## Description

The old help desk number `855-574-7286` is outdated and needs to be replaced with `800-698-2411`

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/18345
- https://dsva.slack.com/archives/CBU0KDSB1/p1610393236325800

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] Old help desk number should not exist in the code base

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
