### PR TITLE
Mc chp36 loa flow fix

### DIFF
--- a/src/applications/vre/28-8832/config/chapters/claimant-information/claimantInformation.js
+++ b/src/applications/vre/28-8832/config/chapters/claimant-information/claimantInformation.js
@@ -2,9 +2,7 @@ import React from 'react';
 import merge from 'lodash/merge';
 import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
-import { hasSession } from 'platform/user/profile/utilities';
 import { claimantInformation } from '../../utilities';
-import { LOA_LEVEL_REQUIRED } from '../../../constants';
 
 export const schema = claimantInformation;
 
@@ -12,8 +10,7 @@ export const uiSchema = {
   fullName: {
     first: {
       'ui:title': 'First name',
-      'ui:required': formData =>
-        !hasSession() || formData.loa !== LOA_LEVEL_REQUIRED,
+      'ui:required': () => true,
     },
     middle: {
       'ui:title': 'Middle name',
@@ -23,8 +20,7 @@ export const uiSchema = {
     },
     last: {
       'ui:title': 'Last name',
-      'ui:required': formData =>
-        !hasSession() || formData.loa !== LOA_LEVEL_REQUIRED,
+      'ui:required': () => true,
     },
     suffix: {
       'ui:title': 'Suffix',
@@ -36,8 +32,7 @@ export const uiSchema = {
   },
   ssn: {
     ...ssnUI,
-    'ui:required': formData =>
-      !hasSession() || formData.loa !== LOA_LEVEL_REQUIRED,
+    'ui:required': () => true,
   },
   VAFileNumber: {
     'ui:title': (
@@ -55,7 +50,6 @@ export const uiSchema = {
     },
   },
   dateOfBirth: merge(currentOrPastDateUI('Date of birth'), {
-    'ui:required': formData =>
-      !hasSession() || formData.loa !== LOA_LEVEL_REQUIRED,
+    'ui:required': () => true,
   }),
 };

--- a/src/applications/vre/28-8832/config/form.js
+++ b/src/applications/vre/28-8832/config/form.js
@@ -8,16 +8,13 @@ import ConfirmationPage from '../containers/ConfirmationPage';
 import { statusSelection } from './chapters/status-selection';
 import { veteranInformation } from './chapters/veteran-information';
 import GetFormHelp from '../components/GetFormHelp';
-import ReadOnlyUserDescription from '../components/ReadOnlyUserDescription';
 import PreSubmitInfo from '../components/PreSubmitInfo';
 
 import {
   claimantInformation,
   claimantAddress,
-  staticClaimantInformation,
 } from './chapters/claimant-information';
 import { isDependent, transform } from './helpers';
-import { LOA_LEVEL_REQUIRED } from '../constants';
 import manifest from '../manifest.json';
 
 const formConfig = {
@@ -56,26 +53,25 @@ const formConfig = {
   chapters: {
     claimantInformation: {
       title: 'Applicant Information',
-      reviewDescription: ReadOnlyUserDescription,
+      // TODO: possibly re-added some time down later
+      // reviewDescription: ReadOnlyUserDescription,
       pages: {
         claimantInformation: {
-          depends: formData => {
-            return formData.loa !== LOA_LEVEL_REQUIRED;
-          },
-          path: 'basic-information',
+          path: 'claimant-information',
           title: 'Applicant Information',
           uiSchema: claimantInformation.uiSchema,
           schema: claimantInformation.schema,
         },
-        claimantStaticInformation: {
-          depends: formData => {
-            return formData.loa === LOA_LEVEL_REQUIRED;
-          },
-          path: 'claimant-information',
-          title: 'Applicant Information',
-          uiSchema: staticClaimantInformation.uiSchema,
-          schema: staticClaimantInformation.schema,
-        },
+        // TODO: possibly re-added some time later
+        // claimantStaticInformation: {
+        //   depends: formData => {
+        //     return formData.loa === LOA_LEVEL_REQUIRED;
+        //   },
+        //   path: 'claimant-information',
+        //   title: 'Applicant Information',
+        //   uiSchema: staticClaimantInformation.uiSchema,
+        //   schema: staticClaimantInformation.schema,
+        // },
         claimantAddress: {
           path: 'claimant-address',
           title: 'Applicant Address',

--- a/src/applications/vre/28-8832/config/helpers.js
+++ b/src/applications/vre/28-8832/config/helpers.js
@@ -41,7 +41,9 @@ const reformatData = form => {
     },
     claimantAddress,
     veteranFullName: veteranName,
-    veteranSocialSecurityNumber: veteranInformation.ssn,
+    veteranSocialSecurityNumber: isVeteran(form.data)
+      ? ssn
+      : veteranInformation.ssn,
     status,
   };
 };

--- a/src/applications/vre/28-8832/containers/IntroductionPage.jsx
+++ b/src/applications/vre/28-8832/containers/IntroductionPage.jsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useState } from 'react';
-import { connect } from 'react-redux';
+import React, { useEffect } from 'react';
 import AlertBox, {
   ALERT_TYPE,
 } from '@department-of-veterans-affairs/formation-react/AlertBox';
@@ -7,8 +6,6 @@ import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
 import { focusElement } from 'platform/utilities/ui';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
-import { getEligiblePages } from 'platform/forms-system/src/js/routing';
-import { setData } from 'platform/forms-system/src/js/actions';
 import recordEvent from 'platform/monitoring/record-event';
 import {
   CHAPTER_31_ROOT_URL,
@@ -18,35 +15,9 @@ import {
 
 const IntroductionPage = props => {
   // focus on element
-  const [pageList, setPageList] = useState(props.route.pageList);
   useEffect(() => {
     focusElement('h1');
   }, []);
-
-  // build pagelist
-  const { form, route, loa } = props;
-
-  useEffect(
-    () => {
-      const authCheckedFormData = {
-        ...form.data,
-        loa,
-      };
-      // Wait for action to finish then continue
-      const awaitedUpdate = async () => {
-        return props.setData(authCheckedFormData);
-      };
-      awaitedUpdate().then(formData => {
-        const filteredPageList = getEligiblePages(
-          route.pageList,
-          formData.data,
-          '/introduction',
-        );
-        setPageList(filteredPageList.pages);
-      });
-    },
-    [loa],
-  );
 
   return (
     <div className="schemaform-intro">
@@ -57,7 +28,7 @@ const IntroductionPage = props => {
       <SaveInProgressIntro
         prefillEnabled={props.route.formConfig.prefillEnabled}
         messages={props.route.formConfig.savedFormMessages}
-        pageList={pageList}
+        pageList={props.route.pageList}
         downtime={props.route.formConfig.downtime}
         startText="Apply for career planning and guidance"
       >
@@ -164,16 +135,4 @@ const IntroductionPage = props => {
   );
 };
 
-const mapStateToProps = state => ({
-  form: state?.form,
-  loa: state?.user?.profile?.loa?.current,
-});
-
-const mapDispatchToProps = {
-  setData,
-};
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(IntroductionPage);
+export default IntroductionPage;

--- a/src/applications/vre/28-8832/tests/config/claimant-information/static-claimant-information.unit.spec.jsx
+++ b/src/applications/vre/28-8832/tests/config/claimant-information/static-claimant-information.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { mount } from 'enzyme';
 import staticClaimantInformation from '../../../config/chapters/claimant-information/staticClaimantComponent.jsx';
 
-describe('Chapter 36 Static Claimant Information', () => {
+describe.skip('Chapter 36 Static Claimant Information', () => {
   const mockUser = {
     gender: 'M',
     dob: '12-12-20',


### PR DESCRIPTION
## Description
A bug was found in production for the chapter 36 form, where LOA1 users would hit the biographical data page, see nothing, click next, and then land back on the introduction page for the form. The issue stems from a discrepancy in the value of the `returnUrl` the frontend receives from SiP data, and the url of the page LOA1 users were meant to see. For the time being, we have decided to remove the biographical data card, and rely on prefill to handle profile data. 

## Testing done
- local, all tests pass
- tested un-auth'd users, LOA1, and LOA3 users

## Screenshots
<details><summary>Logged in user with bio fields shown</summary>

<img width="910" alt="Screen Shot 2021-01-11 at 6 24 20 PM" src="https://user-images.githubusercontent.com/15097156/104250220-1a8a3180-543b-11eb-8361-5dbaef500087.png">
</details>

## Acceptance criteria
- [x] tests pass
- [x] all users see form fields for bio data

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
