### PR TITLE
[Development] Fix HLR content issues

### DIFF
--- a/src/applications/disability-benefits/996/constants.js
+++ b/src/applications/disability-benefits/996/constants.js
@@ -20,7 +20,7 @@ export const PROFILE_URL = '/profile';
 
 // 8622 is the ID of the <li> wrapping the "Find addresses for other benefit
 // types" accordion
-export const BENEFIT_OFFICES_URL = `${HLR_INFO_URL}/#8622`;
+export const BENEFIT_OFFICES_URL = `${HLR_INFO_URL}#8622`;
 
 export const CONTESTABLE_ISSUES_API =
   '/higher_level_reviews/contestable_issues/';

--- a/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
@@ -283,7 +283,7 @@ export class IntroductionPage extends React.Component {
                   <p>
                     Our goal for completing a Higher-Level Review is 125 days. A
                     review might take longer if we need to get records or
-                    schedule a new exam to correct the error.
+                    schedule a new exam to correct an error.
                   </p>
                 </li>
                 <li className="process-step list-four">

--- a/src/applications/disability-benefits/996/content/contestedIssues.jsx
+++ b/src/applications/disability-benefits/996/content/contestedIssues.jsx
@@ -93,8 +93,8 @@ const disabilitiesList = (
         fill out VA Form 20-0996 and submit it by mail or in person.
       </li>
       <li>
-        The issue or decision isn’t our system yet. You’ll need to fill VA Form
-        20-0996 and submit it by mail or in person.
+        The issue or decision isn’t our system yet. You’ll need to fill out VA
+        Form 20-0996 and submit it by mail or in person.
       </li>
       <li>
         You and another surviving dependent of the Veteran are applying for the


### PR DESCRIPTION
## Description

This PR fixes issues that arouse from a Higher-Level Review content review - changing "the" to "an", and adding "out". Also discovered was an anchor link that included double slashes `//` which appeared to work locally, but not in staging.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/16210#issuecomment-749250169

## Testing done

N/A (manual)

## Screenshots

N/A

## Acceptance criteria
- [x] Fix anchor link
- [x] Update content issues

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
