### PR TITLE
Revert "Remove 'authenticated with sso' param from MHV URL helper (#1…

### DIFF
--- a/src/applications/financial-status-report/components/PreSubmitSignature.jsx
+++ b/src/applications/financial-status-report/components/PreSubmitSignature.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import ErrorableCheckbox from '@department-of-veterans-affairs/formation-react/ErrorableCheckbox';
+import Checkbox from '@department-of-veterans-affairs/formation-react/Checkbox';
 
 const PreSubmitSignature = ({ formData }) => {
   const fullName = Object.values(formData?.personalData?.fullName)
@@ -26,7 +26,7 @@ const PreSubmitSignature = ({ formData }) => {
         value={veteranName}
         onChange={event => setVeteranName(event.target.value)}
       />
-      <ErrorableCheckbox
+      <Checkbox
         onValueChange={value => setIsChecked(value)}
         label="I certify the information above is correct and true to the best of my knowledge and belief."
         errorMessage={'Must certify by checking box'}

--- a/src/applications/personalization/dashboard/components/ManageYourVAHealthCare.jsx
+++ b/src/applications/personalization/dashboard/components/ManageYourVAHealthCare.jsx
@@ -8,6 +8,7 @@ import {
 } from 'platform/monitoring/DowntimeNotification';
 import { getMedicalCenterNameByID } from 'platform/utilities/medical-centers/medical-centers';
 import backendServices from 'platform/user/profile/constants/backendServices';
+import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 import {
   isVAPatient as isVAPatientSelector,
   selectCernerAppointmentsFacilities,
@@ -59,6 +60,7 @@ const ManageYourVAHealthCare = ({
   appointmentFacilityNames,
   messagingFacilityNames,
   prescriptionFacilityNames,
+  authenticatedWithSSOe,
   enrollmentDate,
   isInESR,
   preferredFacility,
@@ -118,7 +120,10 @@ const ManageYourVAHealthCare = ({
       </DowntimeNotification>
     )}
     {showCernerMessagingWidget && (
-      <CernerSecureMessagingWidget facilityNames={messagingFacilityNames} />
+      <CernerSecureMessagingWidget
+        facilityNames={messagingFacilityNames}
+        authenticatedWithSSOe={authenticatedWithSSOe}
+      />
     )}
 
     {!showCernerPrescriptionWidget && (
@@ -134,7 +139,10 @@ const ManageYourVAHealthCare = ({
       </DowntimeNotification>
     )}
     {showCernerPrescriptionWidget && (
-      <CernerPrescriptionsWidget facilityNames={prescriptionFacilityNames} />
+      <CernerPrescriptionsWidget
+        facilityNames={prescriptionFacilityNames}
+        authenticatedWithSSOe={authenticatedWithSSOe}
+      />
     )}
 
     {showNonCernerAppointmentWidget && <ScheduleAnAppointmentWidget />}
@@ -199,6 +207,7 @@ const mapStateToProps = state => {
     appointmentFacilityNames,
     messagingFacilityNames,
     prescriptionFacilityNames,
+    authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
   };
 };
 

--- a/src/applications/personalization/dashboard/components/cerner-widgets.js
+++ b/src/applications/personalization/dashboard/components/cerner-widgets.js
@@ -96,27 +96,36 @@ export const CernerScheduleAnAppointmentWidget = ({ facilityNames }) => (
   </div>
 );
 
-export const CernerSecureMessagingWidget = ({ facilityNames }) => (
+export const CernerSecureMessagingWidget = ({
+  facilityNames,
+  authenticatedWithSSOe,
+}) => (
   <div data-testid="cerner-messaging-widget">
     <h3>Send or receive a secure message</h3>
     <CernerAlertBox
       primaryCtaButtonUrl={getCernerURL('/pages/messaging/inbox')}
       primaryCtaText="Send a secure message to a provider at:"
       secondaryCtaButtonText="Go to My HealtheVet"
-      secondaryCtaButtonUrl={mhvUrl('secure-messaging')}
+      secondaryCtaButtonUrl={mhvUrl(authenticatedWithSSOe, 'secure-messaging')}
       facilityNames={facilityNames}
     />
   </div>
 );
 
-export const CernerPrescriptionsWidget = ({ facilityNames }) => (
+export const CernerPrescriptionsWidget = ({
+  facilityNames,
+  authenticatedWithSSOe,
+}) => (
   <div data-testid="cerner-prescription-widget">
     <h3>Refill and track prescriptions</h3>
     <CernerAlertBox
       primaryCtaButtonUrl={getCernerURL('/pages/medications/current')}
       primaryCtaText="Refill prescriptions from:"
       secondaryCtaButtonText="Go to My HealtheVet"
-      secondaryCtaButtonUrl={mhvUrl('web/myhealthevet/refill-prescriptions')}
+      secondaryCtaButtonUrl={mhvUrl(
+        authenticatedWithSSOe,
+        'web/myhealthevet/refill-prescriptions',
+      )}
       facilityNames={facilityNames}
     />
   </div>

--- a/src/applications/personalization/dashboard/containers/MessagingWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/MessagingWidget.jsx
@@ -7,6 +7,7 @@ import { formattedDate } from '../utils/helpers';
 import backendServices from 'platform/user/profile/constants/backendServices';
 import { fetchFolder, fetchRecipients } from '../actions/messaging';
 import { recordDashboardClick } from '../helpers';
+import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 
 class MessagingWidget extends React.Component {
@@ -18,7 +19,11 @@ class MessagingWidget extends React.Component {
   }
 
   render() {
-    const { canAccessMessaging, recipients } = this.props;
+    const {
+      canAccessMessaging,
+      recipients,
+      authenticatedWithSSOe,
+    } = this.props;
 
     if (!canAccessMessaging || (recipients && recipients.length === 0)) {
       // do not show widget if user is not a VA patient
@@ -72,7 +77,7 @@ class MessagingWidget extends React.Component {
         {content}
         <p>
           <a
-            href={mhvUrl('secure-messaging')}
+            href={mhvUrl(authenticatedWithSSOe, 'secure-messaging')}
             onClick={recordDashboardClick('view-all-messages')}
             rel="noopener noreferrer"
             target="_blank"
@@ -102,6 +107,7 @@ const mapStateToProps = state => {
     recipients: msgState.recipients.data,
     pagination,
     canAccessMessaging,
+    authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
   };
 };
 

--- a/src/applications/personalization/dashboard/containers/PrescriptionsWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/PrescriptionsWidget.jsx
@@ -9,6 +9,7 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation-react/Lo
 import { recordDashboardClick } from '../helpers';
 import PrescriptionCard from '../components/PrescriptionCard';
 import CallVBACenter from 'platform/static-data/CallVBACenter';
+import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 
 class PrescriptionsWidget extends React.Component {
@@ -22,7 +23,7 @@ class PrescriptionsWidget extends React.Component {
   }
 
   render() {
-    const { canAccessRx } = this.props;
+    const { canAccessRx, authenticatedWithSSOe } = this.props;
     if (!canAccessRx) {
       return null;
     }
@@ -66,7 +67,10 @@ class PrescriptionsWidget extends React.Component {
         <div>{content}</div>
         <p>
           <a
-            href={mhvUrl('web/myhealthevet/refill-prescriptions')}
+            href={mhvUrl(
+              authenticatedWithSSOe,
+              'web/myhealthevet/refill-prescriptions',
+            )}
             onClick={recordDashboardClick('view-all-prescriptions')}
             rel="noopener noreferrer"
             target="_blank"
@@ -107,6 +111,7 @@ const mapStateToProps = state => {
     ...rxState.prescriptions.active,
     prescriptions,
     canAccessRx,
+    authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
   };
 };
 

--- a/src/applications/personalization/dashboard/tests/components/cerner-widgets.unit.spec.js
+++ b/src/applications/personalization/dashboard/tests/components/cerner-widgets.unit.spec.js
@@ -43,7 +43,7 @@ describe('Prescriptions Widget', () => {
       name: /Go to My HealtheVet/i,
     });
     expect(ctaButton.href).to.contain(
-      'https://int.eauth.va.gov/mhv-portal-web/eauth?deeplinking=prescription_refill',
+      'https://mhv-syst.myhealth.va.gov/mhv-portal-web/web/myhealthevet/refill-prescription',
     );
   });
 });
@@ -128,7 +128,7 @@ describe('Secure Messaging Widget', () => {
       name: /Go to My HealtheVet/i,
     });
     expect(ctaButton.href).to.contain(
-      'https://int.eauth.va.gov/mhv-portal-web/eauth?deeplinking=secure_messaging',
+      'https://mhv-syst.myhealth.va.gov/mhv-portal-web/secure-messaging',
     );
   });
 });

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
@@ -9,8 +9,13 @@ import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
 import { selectPatientFacilities } from 'platform/user/selectors';
+import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 
-export const App = ({ facilities, showNewGetMedicalRecordsPage }) => {
+export const App = ({
+  facilities,
+  showNewGetMedicalRecordsPage,
+  authenticatedWithSSOe,
+}) => {
   if (!showNewGetMedicalRecordsPage) {
     return <LegacyContent />;
   }
@@ -22,6 +27,7 @@ export const App = ({ facilities, showNewGetMedicalRecordsPage }) => {
       <AuthContent
         cernerFacilities={cernerFacilities}
         otherFacilities={otherFacilities}
+        authenticatedWithSSOe={authenticatedWithSSOe}
       />
     );
   }
@@ -31,6 +37,7 @@ export const App = ({ facilities, showNewGetMedicalRecordsPage }) => {
 
 App.propTypes = {
   // From mapStateToProps.
+  authenticatedWithSSOe: PropTypes.bool,
   facilities: PropTypes.arrayOf(
     PropTypes.shape({
       facilityId: PropTypes.string.isRequired,
@@ -47,6 +54,7 @@ App.propTypes = {
 
 const mapStateToProps = state => ({
   facilities: selectPatientFacilities(state),
+  authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
   showNewGetMedicalRecordsPage:
     state?.featureToggles?.[featureFlagNames.showNewGetMedicalRecordsPage],
 });

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.js
@@ -9,7 +9,11 @@ import CernerCallToAction from '../../../components/CernerCallToAction';
 import { getCernerURL } from 'platform/utilities/cerner';
 import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 
-const AuthContent = ({ cernerFacilities, otherFacilities }) => (
+const AuthContent = ({
+  authenticatedWithSSOe,
+  cernerFacilities,
+  otherFacilities,
+}) => (
   <>
     <h2 className="vads-u-margin-bottom--2 vads-u-font-size--lg">
       On this page:
@@ -29,7 +33,7 @@ const AuthContent = ({ cernerFacilities, otherFacilities }) => (
       cernerFacilities={cernerFacilities}
       otherFacilities={otherFacilities}
       linksHeaderText="Get your medical records from:"
-      myHealtheVetLink={mhvUrl('download-my-data')}
+      myHealtheVetLink={mhvUrl(authenticatedWithSSOe, 'download-my-data')}
       myVAHealthLink={getCernerURL(
         '/pages/health_record/clinical_documents/sharing',
       )}
@@ -321,6 +325,7 @@ const AuthContent = ({ cernerFacilities, otherFacilities }) => (
 );
 
 AuthContent.propTypes = {
+  authenticatedWithSSOe: PropTypes.bool.isRequired,
   cernerfacilities: PropTypes.arrayOf(
     PropTypes.shape({
       facilityId: PropTypes.string.isRequired,

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.js
@@ -9,8 +9,13 @@ import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
 import { selectPatientFacilities } from 'platform/user/selectors';
+import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 
-export const App = ({ facilities, showNewRefillTrackPrescriptionsPage }) => {
+export const App = ({
+  facilities,
+  showNewRefillTrackPrescriptionsPage,
+  authenticatedWithSSOe,
+}) => {
   if (!showNewRefillTrackPrescriptionsPage) {
     return <LegacyContent />;
   }
@@ -22,6 +27,7 @@ export const App = ({ facilities, showNewRefillTrackPrescriptionsPage }) => {
       <AuthContent
         cernerFacilities={cernerFacilities}
         otherFacilities={otherFacilities}
+        authenticatedWithSSOe={authenticatedWithSSOe}
       />
     );
   }
@@ -31,6 +37,7 @@ export const App = ({ facilities, showNewRefillTrackPrescriptionsPage }) => {
 
 App.propTypes = {
   // From mapStateToProps.
+  authenticatedWithSSOe: PropTypes.bool,
   facilities: PropTypes.arrayOf(
     PropTypes.shape({
       facilityId: PropTypes.string.isRequired,
@@ -47,6 +54,7 @@ App.propTypes = {
 
 const mapStateToProps = state => ({
   facilities: selectPatientFacilities(state),
+  authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
   showNewRefillTrackPrescriptionsPage:
     state?.featureToggles?.[
       featureFlagNames.showNewRefillTrackPrescriptionsPage

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/AuthContent/index.js
@@ -9,13 +9,20 @@ import CernerCallToAction from '../../../components/CernerCallToAction';
 import { getCernerURL } from 'platform/utilities/cerner';
 import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 
-export const AuthContent = ({ cernerFacilities, otherFacilities }) => (
+export const AuthContent = ({
+  authenticatedWithSSOe,
+  cernerFacilities,
+  otherFacilities,
+}) => (
   <>
     <CernerCallToAction
       cernerFacilities={cernerFacilities}
       otherFacilities={otherFacilities}
       linksHeaderText="Refill prescriptions from:"
-      myHealtheVetLink={mhvUrl('web/myhealthevet/refill-prescriptions')}
+      myHealtheVetLink={mhvUrl(
+        authenticatedWithSSOe,
+        'web/myhealthevet/refill-prescriptions',
+      )}
       myVAHealthLink={getCernerURL('/pages/medications/current')}
     />
     <div>
@@ -406,6 +413,7 @@ export const AuthContent = ({ cernerFacilities, otherFacilities }) => (
 );
 
 AuthContent.propTypes = {
+  authenticatedWithSSOe: PropTypes.bool.isRequired,
   cernerfacilities: PropTypes.arrayOf(
     PropTypes.shape({
       facilityId: PropTypes.string.isRequired,

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.js
@@ -9,8 +9,13 @@ import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
 import { selectPatientFacilities } from 'platform/user/selectors';
+import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 
-export const App = ({ facilities, showNewSecureMessagingPage }) => {
+export const App = ({
+  facilities,
+  showNewSecureMessagingPage,
+  authenticatedWithSSOe,
+}) => {
   if (!showNewSecureMessagingPage) {
     return <LegacyContent />;
   }
@@ -22,6 +27,7 @@ export const App = ({ facilities, showNewSecureMessagingPage }) => {
       <AuthContent
         cernerFacilities={cernerFacilities}
         otherFacilities={otherFacilities}
+        authenticatedWithSSOe={authenticatedWithSSOe}
       />
     );
   }
@@ -31,6 +37,7 @@ export const App = ({ facilities, showNewSecureMessagingPage }) => {
 
 App.propTypes = {
   // From mapStateToProps.
+  authenticatedWithSSOe: PropTypes.bool,
   facilities: PropTypes.arrayOf(
     PropTypes.shape({
       facilityId: PropTypes.string.isRequired,
@@ -47,6 +54,7 @@ App.propTypes = {
 
 const mapStateToProps = state => ({
   facilities: selectPatientFacilities(state),
+  authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
   showNewSecureMessagingPage:
     state?.featureToggles?.[featureFlagNames.showNewSecureMessagingPage],
 });

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/AuthContent/index.js
@@ -6,14 +6,18 @@ import CernerCallToAction from '../../../components/CernerCallToAction';
 import { getCernerURL } from 'platform/utilities/cerner';
 import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 
-export const AuthContent = ({ cernerFacilities, otherFacilities }) => (
+export const AuthContent = ({
+  authenticatedWithSSOe,
+  cernerFacilities,
+  otherFacilities,
+}) => (
   <>
     <h2 id="send-or-receive-secure-mess">Send or receive a secure message</h2>
     <CernerCallToAction
       cernerFacilities={cernerFacilities}
       otherFacilities={otherFacilities}
       linksHeaderText="Send a secure message to a provider at:"
-      myHealtheVetLink={mhvUrl('secure-messaging')}
+      myHealtheVetLink={mhvUrl(authenticatedWithSSOe, 'secure-messaging')}
       myVAHealthLink={getCernerURL('/pages/messaging/inbox')}
     />
     <div>
@@ -328,6 +332,7 @@ export const AuthContent = ({ cernerFacilities, otherFacilities }) => (
 );
 
 AuthContent.propTypes = {
+  authenticatedWithSSOe: PropTypes.bool.isRequired,
   cernerfacilities: PropTypes.arrayOf(
     PropTypes.shape({
       facilityId: PropTypes.string.isRequired,

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.js
@@ -9,8 +9,13 @@ import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
 import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
 import { selectPatientFacilities } from 'platform/user/selectors';
+import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 
-export const App = ({ facilities, showNewViewTestLabResultsPage }) => {
+export const App = ({
+  facilities,
+  showNewViewTestLabResultsPage,
+  authenticatedWithSSOe,
+}) => {
   if (!showNewViewTestLabResultsPage) {
     return <LegacyContent />;
   }
@@ -22,6 +27,7 @@ export const App = ({ facilities, showNewViewTestLabResultsPage }) => {
       <AuthContent
         cernerFacilities={cernerFacilities}
         otherFacilities={otherFacilities}
+        authenticatedWithSSOe={authenticatedWithSSOe}
       />
     );
   }
@@ -31,6 +37,7 @@ export const App = ({ facilities, showNewViewTestLabResultsPage }) => {
 
 App.propTypes = {
   // From mapStateToProps.
+  authenticatedWithSSOe: PropTypes.bool,
   facilities: PropTypes.arrayOf(
     PropTypes.shape({
       facilityId: PropTypes.string.isRequired,
@@ -47,6 +54,7 @@ App.propTypes = {
 
 const mapStateToProps = state => ({
   facilities: selectPatientFacilities(state),
+  authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
   showNewViewTestLabResultsPage:
     state?.featureToggles?.[featureFlagNames.showNewViewTestLabResultsPage],
 });

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/AuthContent/index.js
@@ -9,13 +9,17 @@ import CernerCallToAction from '../../../components/CernerCallToAction';
 import { getCernerURL } from 'platform/utilities/cerner';
 import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 
-export const AuthContent = ({ cernerFacilities, otherFacilities }) => (
+export const AuthContent = ({
+  authenticatedWithSSOe,
+  cernerFacilities,
+  otherFacilities,
+}) => (
   <>
     <CernerCallToAction
       cernerFacilities={cernerFacilities}
       otherFacilities={otherFacilities}
       linksHeaderText="View lab and test results from:"
-      myHealtheVetLink={mhvUrl('labs-tests')}
+      myHealtheVetLink={mhvUrl(authenticatedWithSSOe, 'labs-tests')}
       myVAHealthLink={getCernerURL('/pages/health_record/results/labs')}
     />
     <div>
@@ -324,6 +328,7 @@ export const AuthContent = ({ cernerFacilities, otherFacilities }) => (
 );
 
 AuthContent.propTypes = {
+  authenticatedWithSSOe: PropTypes.bool.isRequired,
   cernerfacilities: PropTypes.arrayOf(
     PropTypes.shape({
       facilityId: PropTypes.string.isRequired,

--- a/src/applications/validate-mhv-account/containers/Main.jsx
+++ b/src/applications/validate-mhv-account/containers/Main.jsx
@@ -5,6 +5,7 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation-react/Lo
 
 import { isLoggedIn, selectProfile } from 'platform/user/selectors';
 import get from 'platform/utilities/data/get';
+import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 import { ACCOUNT_STATES, MHV_ACCOUNT_LEVELS } from './../constants';
 
@@ -23,6 +24,7 @@ class Main extends React.Component {
       mhvAccount,
       profile,
       router,
+      authenticatedWithSSOe,
     } = this.props;
 
     const pathname = location.pathname;
@@ -51,7 +53,7 @@ class Main extends React.Component {
 
       if (accountLevelChanged || accountStateChanged) {
         if (this.hasMHVAccess()) {
-          window.location = mhvUrl('home');
+          window.location = mhvUrl(authenticatedWithSSOe, 'home');
         } else {
           router.replace('/');
         }
@@ -109,6 +111,7 @@ const mapStateToProps = (state, ownProps) => {
     loadingProfile: loading,
     mhvAccount,
     profile,
+    authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
   };
 };
 

--- a/src/applications/validate-mhv-account/containers/ValidateMHVAccount.jsx
+++ b/src/applications/validate-mhv-account/containers/ValidateMHVAccount.jsx
@@ -76,7 +76,7 @@ class ValidateMHVAccount extends React.Component {
       router.replace(`error/needs-va-patient`);
       return;
     }
-    window.location = mhvUrl('home');
+    window.location = mhvUrl(true, 'home');
   };
 
   redirect = () => {
@@ -147,7 +147,7 @@ class ValidateMHVAccount extends React.Component {
       accountLevel === MHV_ACCOUNT_LEVELS.PREMIUM ||
       accountLevel === MHV_ACCOUNT_LEVELS.ADVANCED
     ) {
-      window.location = mhvUrl('home');
+      window.location = mhvUrl(false, 'home');
     } else if (accountLevel === MHV_ACCOUNT_LEVELS.BASIC) {
       router.replace('upgrade-account');
     } else {

--- a/src/platform/site-wide/cta-widget/helpers.js
+++ b/src/platform/site-wide/cta-widget/helpers.js
@@ -84,36 +84,39 @@ export const mhvToolName = appId => {
   return null;
 };
 
-export const toolUrl = appId => {
+export const toolUrl = (appId, authenticatedWithSSOe = false) => {
   switch (appId) {
     case widgetTypes.HEALTH_RECORDS:
       return {
-        url: mhvUrl('download-my-data'),
+        url: mhvUrl(authenticatedWithSSOe, 'download-my-data'),
         redirect: false,
       };
 
     case widgetTypes.RX:
       return {
-        url: mhvUrl('web/myhealthevet/refill-prescriptions'),
+        url: mhvUrl(
+          authenticatedWithSSOe,
+          'web/myhealthevet/refill-prescriptions',
+        ),
         redirect: false,
       };
 
     case widgetTypes.MESSAGING:
       return {
-        url: mhvUrl('secure-messaging'),
+        url: mhvUrl(authenticatedWithSSOe, 'secure-messaging'),
         redirect: false,
       };
 
     case widgetTypes.VIEW_APPOINTMENTS:
     case widgetTypes.SCHEDULE_APPOINTMENTS:
       return {
-        url: mhvUrl('appointments'),
+        url: mhvUrl(authenticatedWithSSOe, 'appointments'),
         redirect: false,
       };
 
     case widgetTypes.LAB_AND_TEST_RESULTS:
       return {
-        url: mhvUrl('labs-tests'),
+        url: mhvUrl(authenticatedWithSSOe, 'labs-tests'),
         redirect: false,
       };
 

--- a/src/platform/site-wide/cta-widget/tests/helpers.unit.spec.js
+++ b/src/platform/site-wide/cta-widget/tests/helpers.unit.spec.js
@@ -52,30 +52,30 @@ describe('CTA helpers', () => {
   describe('A signed-in non-SSO user', () => {
     it('Download my data', () => {
       expect(toolUrl(widgetTypes.HEALTH_RECORDS).url).to.equal(
-        'https://int.eauth.va.gov/mhv-portal-web/eauth?deeplinking=download_my_data',
+        'https://mhv-syst.myhealth.va.gov/mhv-portal-web/download-my-data',
       );
     });
     it('Prescription Refill', () => {
       expect(toolUrl(widgetTypes.RX).url).to.equal(
-        'https://int.eauth.va.gov/mhv-portal-web/eauth?deeplinking=prescription_refill',
+        'https://mhv-syst.myhealth.va.gov/mhv-portal-web/web/myhealthevet/refill-prescriptions',
       );
     });
     it('Secure Messaging', () => {
       expect(toolUrl(widgetTypes.MESSAGING).url).to.equal(
-        'https://int.eauth.va.gov/mhv-portal-web/eauth?deeplinking=secure_messaging',
+        'https://mhv-syst.myhealth.va.gov/mhv-portal-web/secure-messaging',
       );
     });
     it('Appointments', () => {
       expect(toolUrl(widgetTypes.VIEW_APPOINTMENTS).url).to.equal(
-        'https://int.eauth.va.gov/mhv-portal-web/eauth?deeplinking=appointments',
+        'https://mhv-syst.myhealth.va.gov/mhv-portal-web/appointments',
       );
       expect(toolUrl(widgetTypes.SCHEDULE_APPOINTMENTS).url).to.equal(
-        'https://int.eauth.va.gov/mhv-portal-web/eauth?deeplinking=appointments',
+        'https://mhv-syst.myhealth.va.gov/mhv-portal-web/appointments',
       );
     });
     it('Lab Tests', () => {
       expect(toolUrl(widgetTypes.LAB_AND_TEST_RESULTS).url).to.equal(
-        'https://int.eauth.va.gov/mhv-portal-web/eauth',
+        'https://mhv-syst.myhealth.va.gov/mhv-portal-web/labs-tests',
       );
     });
   });

--- a/src/platform/site-wide/mhv/tests/utilities.unit.spec.js
+++ b/src/platform/site-wide/mhv/tests/utilities.unit.spec.js
@@ -4,26 +4,44 @@ import { mhvUrl } from '../utilities';
 
 describe('mhvUrl', () => {
   it('should normalize path', () => {
-    expect(mhvUrl('/home')).to.equal(
-      'https://int.eauth.va.gov/mhv-portal-web/eauth',
+    expect(mhvUrl(false, '/home')).to.equal(
+      'https://mhv-syst.myhealth.va.gov/mhv-portal-web/home',
     );
   });
 
   it('should map SSOe paths', () => {
-    expect(mhvUrl('home')).to.equal(
+    expect(mhvUrl(true, 'home')).to.equal(
       'https://int.eauth.va.gov/mhv-portal-web/eauth',
     );
-    expect(mhvUrl('download-my-data')).to.equal(
+    expect(mhvUrl(true, 'download-my-data')).to.equal(
       'https://int.eauth.va.gov/mhv-portal-web/eauth?deeplinking=download_my_data',
     );
-    expect(mhvUrl('web/myhealthevet/refill-prescriptions')).to.equal(
+    expect(mhvUrl(true, 'web/myhealthevet/refill-prescriptions')).to.equal(
       'https://int.eauth.va.gov/mhv-portal-web/eauth?deeplinking=prescription_refill',
     );
-    expect(mhvUrl('secure-messaging')).to.equal(
+    expect(mhvUrl(true, 'secure-messaging')).to.equal(
       'https://int.eauth.va.gov/mhv-portal-web/eauth?deeplinking=secure_messaging',
     );
-    expect(mhvUrl('appointments')).to.equal(
+    expect(mhvUrl(true, 'appointments')).to.equal(
       'https://int.eauth.va.gov/mhv-portal-web/eauth?deeplinking=appointments',
+    );
+  });
+
+  it('should map non-SSOe paths', () => {
+    expect(mhvUrl(false, 'home')).to.equal(
+      'https://mhv-syst.myhealth.va.gov/mhv-portal-web/home',
+    );
+    expect(mhvUrl(false, 'download-my-data')).to.equal(
+      'https://mhv-syst.myhealth.va.gov/mhv-portal-web/download-my-data',
+    );
+    expect(mhvUrl(false, 'web/myhealthevet/refill-prescriptions')).to.equal(
+      'https://mhv-syst.myhealth.va.gov/mhv-portal-web/web/myhealthevet/refill-prescriptions',
+    );
+    expect(mhvUrl(false, 'secure-messaging')).to.equal(
+      'https://mhv-syst.myhealth.va.gov/mhv-portal-web/secure-messaging',
+    );
+    expect(mhvUrl(false, 'appointments')).to.equal(
+      'https://mhv-syst.myhealth.va.gov/mhv-portal-web/appointments',
     );
   });
 });

--- a/src/platform/site-wide/mhv/utilities.js
+++ b/src/platform/site-wide/mhv/utilities.js
@@ -2,6 +2,7 @@ import environment from 'platform/utilities/environment';
 import { eauthEnvironmentPrefixes } from 'platform/utilities/sso/constants';
 
 const eauthPrefix = eauthEnvironmentPrefixes[environment.BUILDTYPE];
+const mhvPrefix = environment.isProduction() ? 'www' : 'mhv-syst';
 
 // TODO: Update labs-and-tests route once deep link is provided
 const mhvToEauthRoutes = {
@@ -14,12 +15,17 @@ const mhvToEauthRoutes = {
   'labs-tests': 'eauth',
 };
 
-// An MHV URL is a function that accepts an MHV URL path as a parameter.
-function mhvUrl(path) {
+// An MHV URL is a function of the following parameters:
+// 1. Whether this is a production or staging environment
+// 2. Whether the current user is authenticated with SSOe
+// 3. The specific MHV path being accessed
+function mhvUrl(authenticatedWithSSOe, path) {
   const normPath = path.startsWith('/') ? path.substring(1) : path;
-  const eauthDeepLink = mhvToEauthRoutes[normPath];
-
-  return `https://${eauthPrefix}eauth.va.gov/mhv-portal-web/${eauthDeepLink}`;
+  if (authenticatedWithSSOe) {
+    const eauthDeepLink = mhvToEauthRoutes[normPath];
+    return `https://${eauthPrefix}eauth.va.gov/mhv-portal-web/${eauthDeepLink}`;
+  }
+  return `https://${mhvPrefix}.myhealth.va.gov/mhv-portal-web/${normPath}`;
 }
 
 // TODO: This function is NOT SSOe-aware and is a candidate for removal


### PR DESCRIPTION
…5562)"

This reverts commit 0198171528dd1b81bcb367dacfbd83fae5f9f44d.



## Description
Per the request of the MHV team, we need to revert the work we did with sending all users to the "eauth" domain. 

https://github.com/department-of-veterans-affairs/va.gov-team/issues/17318

## Testing done
Did not test since this is just a direct revert. MHV will confirm that it's been reverted okay.

## Screenshots
N/A

## Acceptance criteria
- [ ] "eauth" domain is only used for SSO users

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
