### PR TITLE
Update PreSubmitSignature.jsx

### DIFF
--- a/src/applications/financial-status-report/components/PreSubmitSignature.jsx
+++ b/src/applications/financial-status-report/components/PreSubmitSignature.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import ErrorableCheckbox from '@department-of-veterans-affairs/formation-react/ErrorableCheckbox';
+import Checkbox from '@department-of-veterans-affairs/formation-react/Checkbox';
 
 const PreSubmitSignature = ({ formData }) => {
   const fullName = Object.values(formData?.personalData?.fullName)
@@ -26,7 +26,7 @@ const PreSubmitSignature = ({ formData }) => {
         value={veteranName}
         onChange={event => setVeteranName(event.target.value)}
       />
-      <ErrorableCheckbox
+      <Checkbox
         onValueChange={value => setIsChecked(value)}
         label="I certify the information above is correct and true to the best of my knowledge and belief."
         errorMessage={'Must certify by checking box'}


### PR DESCRIPTION
## Description
In https://github.com/department-of-veterans-affairs/vets-website/pull/15587, I updated all `Errorable` components to remove that word. I believe this was added after I branched from `master`, so my PR missed it.

To find and replace all instances of `Errorable`, I ran the following: `rg Errorable --files-with-matches | xargs -I {} sed -Ei 's/Errorable//g' {}`

## Testing done
Linting