### PR TITLE
Add form-checkbox wrapping class + remove h3 styling for section headers

### DIFF
--- a/src/site/layouts/checklist.drupal.liquid
+++ b/src/site/layouts/checklist.drupal.liquid
@@ -49,7 +49,7 @@
 
               <!-- Checklist section header -->
               {% if checklistSection.entity.fieldSectionHeader %}
-                <h2 class="vads-u-font-size--h3">{{ checklistSection.entity.fieldSectionHeader }}</h2>
+                <h2>{{ checklistSection.entity.fieldSectionHeader }}</h2>
               {% endif %}
 
               <!-- Checklist section intro -->
@@ -66,7 +66,7 @@
                   {% assign checkboxId = "checkbox-" | append: listchecklistItemIndex %}
 
                   <!-- Checklist item -->
-                  <li>
+                  <li class="form-checkbox">
                     <input type="checkbox" id="{{ checkboxId }}" name="{{ checkboxId }}">
                     <label for="{{ checkboxId }}">{{ checklistItem }}</label>
                   </li>


### PR DESCRIPTION
## Description
**Issue/relevant comment**: https://github.com/department-of-veterans-affairs/va.gov-team/issues/15617#issuecomment-758881763

This PR adds `form-checkbox` wrapping class to checkboxes + removes h3 styling for section headers.

Test on http://localhost:3001/preview?nodeId=6924

## Testing done
Locally

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/104365266-07c43b00-54d5-11eb-8586-067fd6e4eceb.png)

## Acceptance criteria
- [x] adds `form-checkbox` wrapping class to checkboxes + removes h3 styling for section headers

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
