### PR TITLE
[GraphQL] Expand GraphQL query to not include any fragments

### DIFF
--- a/src/site/stages/build/drupal/graphql/taxonomy-fragments/GetTaxonomies.graphql.js
+++ b/src/site/stages/build/drupal/graphql/taxonomy-fragments/GetTaxonomies.graphql.js
@@ -2,9 +2,26 @@ module.exports = `
   allTaxonomies: taxonomyTermQuery(limit: 1000) {
     entities {
       entityBundle
-      ... taxonomyTermAudienceBeneficiaries
-      ... taxonomyTermAudienceNonBeneficiaries
-      ... taxonomyTermLcCategories
+      ... on TaxonomyTermAudienceBeneficiaries {
+        entityUrl {
+          path
+        }
+        name
+      }
+
+      ... on TaxonomyTermAudienceNonBeneficiaries {
+        entityUrl {
+          path
+        }
+        name
+      }
+
+      ... on TaxonomyTermLcCategories {
+        entityUrl {
+          path
+        }
+        name
+      }
     }
   }
 `;


### PR DESCRIPTION
## Description
TIL that in our "non-node query", which is the GraphQL query used by transformers (content data that transformers doesn't include so we still need to get it via GraphQL), we cannot use GraphQL fragments because they are not included as part of the "non-node query." 

## Testing done
Previewed http://localhost:3001/preview?nodeId=8296 with the modified GraphQL query to ensure it still functions w/o fragments.

## Screenshots
n/a

## Acceptance criteria
- [ ] Content Export build works again

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
