### PR TITLE
turned on mock data for staging

### DIFF
--- a/src/applications/health-care-questionnaire/questionnaire/api/load-appointments.js
+++ b/src/applications/health-care-questionnaire/questionnaire/api/load-appointments.js
@@ -1,7 +1,8 @@
 import { apiRequest } from 'platform/utilities/api';
 import environment from 'platform/utilities/environment';
 
-const USE_MOCK_DATA = window.Cypress || environment.isLocalhost();
+const USE_MOCK_DATA =
+  window.Cypress || environment.isLocalhost() || environment.isStaging();
 
 const loadAppointment = async id => {
   let promise;


### PR DESCRIPTION
## Description
In attempting to validate [dynamic titles](https://github.com/department-of-veterans-affairs/va.gov-team/issues/16579), the data for the appointment needs to be dynamic and since the API is not returning dynamic data yet, this PR turns on mock data for staging. 
