### PR TITLE
Update payments link

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
@@ -10,7 +10,6 @@ import Modal from '@department-of-veterans-affairs/formation-react/Modal';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 import recordEvent from '~/platform/monitoring/record-event';
-import EbenefitsLink from '~/platform/site-wide/ebenefits/containers/EbenefitsLink';
 
 import { isLOA3 as isLOA3Selector } from '~/platform/user/selectors';
 import { usePrevious } from '~/platform/utilities/react-hooks';
@@ -250,9 +249,9 @@ export const BankInfoCNP = ({
       data.push({
         title: 'Payment history',
         value: (
-          <EbenefitsLink path="ebenefits/about/feature?feature=payment-history">
+          <a href="/va-payment-history/payments/" target="_blank">
             View your payment history
-          </EbenefitsLink>
+          </a>
         ),
       });
     }

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
@@ -249,9 +249,7 @@ export const BankInfoCNP = ({
       data.push({
         title: 'Payment history',
         value: (
-          <a href="/va-payment-history/payments/" target="_blank">
-            View your payment history
-          </a>
+          <a href="/va-payment-history/payments/">View your payment history</a>
         ),
       });
     }

--- a/src/applications/personalization/profile/components/direct-deposit/PaymentHistory.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/PaymentHistory.jsx
@@ -10,9 +10,7 @@ function PaymentHistory() {
             Check your payment history for your VA disability compensation,
             pension, and education benefits
           </p>
-          <a href="/va-payment-history/payments/" target="_blank">
-            View your payment history
-          </a>
+          <a href="/va-payment-history/payments/">View your payment history</a>
         </>
       ),
     },

--- a/src/applications/personalization/profile/components/direct-deposit/PaymentHistory.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/PaymentHistory.jsx
@@ -1,7 +1,4 @@
 import React from 'react';
-
-import EbenefitsLink from '~/platform/site-wide/ebenefits/containers/EbenefitsLink';
-
 import ProfileInfoTable from '../ProfileInfoTable';
 
 function PaymentHistory() {
@@ -13,9 +10,9 @@ function PaymentHistory() {
             Check your payment history for your VA disability compensation,
             pension, and education benefits
           </p>
-          <EbenefitsLink path="ebenefits/about/feature?feature=payment-history">
+          <a href="/va-payment-history/payments/" target="_blank">
             View your payment history
-          </EbenefitsLink>
+          </a>
         </>
       ),
     },


### PR DESCRIPTION
## Description
Now that the payment history tool is live on VA.gov, we need to update the View Payment History in the Direct Deposit tab of profile. We have it linking to eBenefits, so now we can link it to the page on VA.gov. We need to change the location of the View Payment History link to https://www.va.gov/va-payment-history/payments/.

## Testing done
Link redirects to the correct page in a new tab.

## Acceptance criteria
- [x] Update link to navigate to `/va-payment-history/payments/`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
