### PR TITLE
[17524] Add Load Providers Alert

### DIFF
--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/LoadProvidersAlert.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/LoadProvidersAlert.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+
+export default function LoadProvidersAlert() {
+  const headline = `We can’t load provider information`;
+  return (
+    <AlertBox
+      status="error"
+      headline={headline}
+      className="vads-u-margin-top--3"
+      content={
+        <>
+          <p>
+            We’re sorry. Something went wrong on our end. To request this
+            appointment, you can: <br />
+          </p>
+          <ul>
+            <li>
+              Call your VA or community care facility.{' '}
+              <a
+                href="/find-locations"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Find your health facility’s phone number
+              </a>
+              , <strong>or</strong>
+            </li>
+            <li>
+              Continue your request without choosing a provider. We’ll contact
+              you about about a provider.
+            </li>
+          </ul>
+        </>
+      }
+    />
+  );
+}

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
@@ -11,10 +11,10 @@ import {
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import { distanceBetween } from '../../../utils/address';
 import { scrollAndFocus } from '../../../utils/scrollAndFocus';
-import ErrorMessage from '../../../components/ErrorMessage';
 import RemoveProviderModal from './RemoveProviderModal';
 import recordEvent from 'platform/monitoring/record-event';
 import NoProvidersAlert from './NoProvidersAlert';
+import LoadProvidersAlert from './LoadProvidersAlert';
 
 const INITIAL_PROVIDER_DISPLAY_COUNT = 5;
 
@@ -220,7 +220,7 @@ function ProviderSelectionField({
           )}
           {requestStatus === FETCH_STATUS.failed && (
             <div className="vads-u-padding-bottom--2">
-              <ErrorMessage />
+              <LoadProvidersAlert />
             </div>
           )}
           {!loadingLocations &&

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
@@ -312,12 +312,12 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
     userEvent.click(await screen.findByText(/Choose a provider/i));
     expect(
       await screen.findByRole('heading', {
-        name: /we’re sorry\. we’ve run into a problem/i,
+        name: /We can’t load provider information/i,
       }),
     );
     expect(
       await screen.findByText(
-        /something went wrong on our end. please try again later./i,
+        /We’re sorry. Something went wrong on our end. To request this appointment, you can:/i,
       ),
     );
   });


### PR DESCRIPTION
## Description
When a technical issue causes list of providers not to load, provide messaging to user.

## Testing done
Local and Unit

## Screenshots
![image](https://user-images.githubusercontent.com/8315447/104488529-79b38780-559c-11eb-8370-935458ebefa3.png)

## Acceptance criteria
- [ ] Update is behind VA Online Scheduling Provider Selection feature flag
- [ ] If can't load providers due to technical error, display alert
 >"Find your health facility’s phone number" links to Facility Locator and opens in a new tab
- [ ] DESIGN - All desktop, tablet, and mobile design match the specs: TBD
- [ ] CONTENT - All copy matches content guidance:
> We can’t load provider information
> We’re sorry. Something went wrong on our end. To request this appointment, you can:

> Call your VA or community care facility. Find your health facility’s phone number, or
> Continue your request without choosing a provider. We’ll contact you about a provider.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
