### PR TITLE
Restore missing intro text to VAMC home page in cms-export builds

### DIFF
--- a/src/site/layouts/tests/vamc/location_home.cypress.spec.js
+++ b/src/site/layouts/tests/vamc/location_home.cypress.spec.js
@@ -80,7 +80,7 @@ Cypress.Commands.add('checkElements', (page, isMobile) => {
 });
 
 describe('VAMC location home page', () => {
-  before(() => {
+  before(function() {
     if (Cypress.env('CIRCLECI')) this.skip();
     cy.syncFixtures({
       fixtures: path.join(__dirname, 'fixtures'),

--- a/src/site/stages/build/process-cms-exports/schemas/input/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/node-health_care_region_page.js
@@ -19,6 +19,7 @@ module.exports = {
     status: { $ref: 'GenericNestedBoolean' },
     path: { $ref: 'RawPath' },
     metatag: { $ref: 'RawMetaTags' },
+    field_intro_text: { $ref: 'GenericNestedString' },
     field_nickname_for_this_facility: { $ref: 'GenericNestedString' },
     field_link_facility_emerg_list: {
       type: 'array',
@@ -49,6 +50,7 @@ module.exports = {
     'status',
     'path',
     'metatag',
+    'field_intro_text',
     // Turns out this sometimes just isn't there
     // 'field_link_facility_emerg_list',
     'field_nickname_for_this_facility',

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
@@ -95,6 +95,7 @@ module.exports = {
     entityBundle: { enum: ['health_care_region_page'] },
     title: { type: 'string' },
     entityUrl: { $ref: 'EntityUrl' },
+    fieldIntroText: { type: ['string', 'null'] },
     fieldGovdeliveryIdEmerg: { type: 'string' },
     fieldGovdeliveryIdNews: { type: 'string' },
     fieldOperatingStatus: socialMediaSchema,
@@ -158,6 +159,7 @@ module.exports = {
   },
   required: [
     'title',
+    'fieldIntroText',
     'fieldGovdeliveryIdEmerg',
     'fieldGovdeliveryIdNews',
     'fieldOperatingStatus',

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
@@ -20,6 +20,7 @@ const transform = ({
   title,
   status,
   metatag: { value: metaTags },
+  fieldIntroText,
   fieldGovdeliveryIdEmerg,
   fieldGovdeliveryIdNews,
   fieldOperatingStatus,
@@ -36,6 +37,7 @@ const transform = ({
   entityPublished: isPublished(getDrupalValue(status)),
   entityLabel: getDrupalValue(title),
   title: getDrupalValue(title),
+  fieldIntroText: getDrupalValue(fieldIntroText),
   fieldGovdeliveryIdEmerg: getDrupalValue(fieldGovdeliveryIdEmerg),
   fieldGovdeliveryIdNews: getDrupalValue(fieldGovdeliveryIdNews),
   fieldOperatingStatus: fieldOperatingStatus[0]
@@ -330,6 +332,7 @@ module.exports = {
     'title',
     'status',
     'path',
+    'field_intro_text',
     'field_govdelivery_id_emerg',
     'field_govdelivery_id_news',
     'field_link_facility_emerg_list',


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/va.gov-team/issues/18167

## Acceptance criteria
- [x] Intro text appears on /pittsburgh-health-care page in cms-export build

