### PR TITLE
Updated all Pact Broker operations to use basic auth.

### DIFF
--- a/script/can-i-deploy.js
+++ b/script/can-i-deploy.js
@@ -24,6 +24,8 @@ const PactBrokerClient = require('../src/platform/testing/contract/client');
 const checkDeployability = async (retries = 3, timeout = 30) => {
   const pactBrokerClient = new PactBrokerClient({
     url: process.env.PACT_BROKER_BASE_URL,
+    username: process.env.PACT_BROKER_BASIC_AUTH_USERNAME,
+    password: process.env.PACT_BROKER_BASIC_AUTH_PASSWORD,
   });
 
   const pactsFolder = path.resolve(__dirname, '../pacts');

--- a/src/platform/testing/contract/client.js
+++ b/src/platform/testing/contract/client.js
@@ -246,7 +246,7 @@ module.exports = class PactBrokerClient {
    * @return {Object} Verification result for the consumer.
    */
   getVerificationStatus = async ({ consumer, version, tag, url }) => {
-    const response = await fetch(url);
+    const response = await fetch(url, { headers: this.authHeader });
 
     if (!response.ok) {
       throw new Error(


### PR DESCRIPTION
## Description

Due to security concerns, the Pact Broker UI as a whole is now protected with basic auth, which includes read operations that did not require auth before.

In accordance with those changes, we're updating the previously unauth'd GET requests to include the auth headers.

## Testing done
Pact processes in CI pipeline pass.

## Acceptance criteria
- [ ] Pact Broker operations should continue to work.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
