### PR TITLE
Tweaks to "browse by audience" of Resources homepage

### DIFF
--- a/src/site/layouts/basic_landing_page.drupal.liquid
+++ b/src/site/layouts/basic_landing_page.drupal.liquid
@@ -58,6 +58,20 @@
       {% if buildtype != 'vagovprod' %}
 
         {% if audienceTags.length > 0 %}
+
+          <div class="usa-alert usa-alert-info" role="alert">
+            <div class="usa-alert-body">
+                <h3 class="usa-alert-heading">
+                    We're currently in beta testing
+                </h3>
+                <div class="processed-content">
+                  <div itemprop="text">
+                    <p>Welcome to resources and support, a new part of <a href="/">VA.gov</a>. We'll be adding more articles and topics in the weeks and months ahead, so please check back often.</p>
+                  </div>
+                </div>
+            </div>
+          </div>
+
           <h2>Browse by audience</h2>
           <ul class="usa-unstyled-list">
 

--- a/src/site/layouts/basic_landing_page.drupal.liquid
+++ b/src/site/layouts/basic_landing_page.drupal.liquid
@@ -66,7 +66,7 @@
             {% for audienceTag in audienceTags %}
               {% if forloop.index <= pageSize %}
                 <li class="vads-u-margin-y--2">
-                  <a class="vads-u-font-weight--bold vads-u-text-decoration--none" href="{{ audienceTag.path.alias }}/">
+                  <a class="vads-u-font-weight--bold vads-u-text-decoration--none" href="{{ audienceTag.entityUrl.path }}/">
                     {{ audienceTag.name }} <i role="presentation" aria-hidden="true" class="fa fa-chevron-right vads-u-margin-left--1"></i>
                   </a>
                 </li>

--- a/src/site/stages/build/drupal/graphql/taxonomy-fragments/GetTaxonomies.graphql.js
+++ b/src/site/stages/build/drupal/graphql/taxonomy-fragments/GetTaxonomies.graphql.js
@@ -7,6 +7,7 @@ module.exports = `
           path
         }
         name
+        fieldAudienceRsHomepage
       }
 
       ... on TaxonomyTermAudienceNonBeneficiaries {
@@ -14,6 +15,7 @@ module.exports = `
           path
         }
         name
+        fieldAudienceRsHomepage
       }
 
       ... on TaxonomyTermLcCategories {


### PR DESCRIPTION
## Description
- Fixes the URL for the audience tag
- Adds back the beta banner
- Adds forgotten GraphQL attribute `fieldAudienceRsHomepage`

## Testing done
Visually confirmed changes using http://localhost:3001/preview?nodeId=8296

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/104515415-c741eb80-55c0-11eb-97e5-ba46cb55791c.png)

## Acceptance criteria
- [ ] "Browse by audience" section is correct

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
