### PR TITLE
Remove top margin on contact info edit error alert

### DIFF
--- a/src/applications/personalization/profile/components/personal-information/ContactInformationEditView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationEditView.jsx
@@ -254,11 +254,7 @@ export class ContactInformationEditView extends Component {
       <>
         {error && (
           <div
-            // Using negative top margin rather than removing the margin in the
-            // VAPServiceEditModalErrorMessage component itself because that
-            // component is used elsewhere and might need the margin in other
-            // situations
-            className="vads-u-margin-bottom--2 vads-u-margin-top--neg3"
+            className="vads-u-margin-bottom--2"
             data-testid="edit-error-alert"
           >
             <VAPServiceEditModalErrorMessage

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationEditView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationEditView.jsx
@@ -254,7 +254,11 @@ export class ContactInformationEditView extends Component {
       <>
         {error && (
           <div
-            className="vads-u-margin-bottom--1"
+            // Using negative top margin rather than removing the margin in the
+            // VAPServiceEditModalErrorMessage component itself because that
+            // component is used elsewhere and might need the margin in other
+            // situations
+            className="vads-u-margin-bottom--2 vads-u-margin-top--neg3"
             data-testid="edit-error-alert"
           >
             <VAPServiceEditModalErrorMessage

--- a/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage.jsx
+++ b/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage.jsx
@@ -66,6 +66,7 @@ export default function VAPServiceEditModalErrorMessage({
 
   return (
     <AlertBox
+      className="vads-u-margin-top--0"
       content={<div className="columns">{content}</div>}
       isVisible
       onCloseAlert={clearErrors}


### PR DESCRIPTION
## Description
Also increased the bottom margin a bit

## Testing done
Local

## Screenshots
<img width="610" alt="Screen Shot 2021-01-13 at 5 21 09 PM" src="https://user-images.githubusercontent.com/20728956/104532097-57356480-55c4-11eb-8186-af7160a017aa.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs