### PR TITLE
Adds metatags for og:image:alt and twitter:image:alt.

### DIFF
--- a/src/site/stages/build/process-cms-exports/transformers/helpers.js
+++ b/src/site/stages/build/process-cms-exports/transformers/helpers.js
@@ -236,12 +236,18 @@ module.exports = {
       createMetaTag('MetaValue', 'keywords', metaTags.keywords),
       createMetaTag('MetaProperty', 'og:description', metaTags.og_description),
       createMetaTag('MetaValue', 'twitter:image', metaTags.twitter_cards_image),
+      createMetaTag(
+        'MetaValue',
+        'twitter:image:alt',
+        metaTags.twitter_cards_image_alt,
+      ),
       createMetaTag('MetaProperty', 'og:image', metaTags.og_image_0),
       createMetaTag(
         'MetaProperty',
         'og:image:height',
         metaTags.og_image_height,
       ),
+      createMetaTag('MetaProperty', 'og:image:alt', metaTags.og_image_alt),
     ].filter(t => t.value);
   },
 


### PR DESCRIPTION
## Description
See #15645 (and department-of-veterans-affairs/va.gov-cms#3563).

This adds support for these two metatags.

I'm new here and I apologize for anything I am doing wrong 😅 

## Testing done
Actually currently working on this.  I'm new to the repo, so I'm working to acquaint myself generally with everything as well as the specifics of this issue.

## Screenshots


## Acceptance criteria
- [ ] when made available by the backend, the `og:image:alt` metatag is appropriately populated in the frontend
- [ ] when made available by the backend, the `twitter:image:alt` metatag is appropriately populated in the frontend

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
