### PR TITLE
Add href and ariaLabel to 711

### DIFF
--- a/src/platform/landing-pages/header-footer-data.json
+++ b/src/platform/landing-pages/header-footer-data.json
@@ -217,7 +217,9 @@
       "title": "800-698-2411"
     },
     {
+      "ariaLabel": "TTY: 7 1 1.",
       "column": 4,
+      "href": "tel:+1711",
       "order": 4,
       "target": null,
       "title": "TTY: 711"

--- a/src/platform/site-wide/va-footer/helpers.jsx
+++ b/src/platform/site-wide/va-footer/helpers.jsx
@@ -31,6 +31,7 @@ const renderInnerTag = (link, captureEvent) => (
     ) : null}
     {link.href ? (
       <a
+        aria-label={link.ariaLabel}
         href={link.href}
         onClick={captureEvent}
         target={link.target}
@@ -67,6 +68,7 @@ function generateSuperLinks(groupedList) {
       {orderBy(groupedList.bottom_rail, 'order', 'asc').map(link => (
         <li key={`${link.order}`}>
           <a
+            aria-label={link.ariaLabel}
             href={link.href}
             onClick={captureEvent}
             target={link.target}

--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -216,7 +216,9 @@
     "title": "800-698-2411"
   },
   {
+    "ariaLabel": "TTY: 7 1 1.",
     "column": 4,
+    "href": "tel:+1711",
     "order": 4,
     "target": null,
     "title": "TTY: 711"


### PR DESCRIPTION
## Description
[TICKET](https://github.com/department-of-veterans-affairs/va.gov-team/issues/18151)

This PR adds the link and aria-label to the 711 number in the footer, not to the right rail.

We need an update to the CMS to support adding an aria-label to the right rail.

The TTY link in the right rail isn't able to be linked right now, because the template does not support it without a `service.fieldPhoneNumber`, which that TTY number doesn't have. See my comment on the ticket.

## Testing done
Works well locally.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/104616534-9fe23180-5647-11eb-8aaf-05c4d5a7c79f.png)

## Acceptance criteria
- [x] Ensure 711 has `href` and `aria-label` in the footer
- [ ] Ensure 711 has `href` and `aria-label` in the right rail

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
