### PR TITLE
Kelsonic 17514 create clp template + graphql query boilerplate

### DIFF
--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -1,0 +1,35 @@
+{% include "src/site/includes/header.html" with drupalTags = true %}
+{% include "src/site/includes/alerts.drupal.liquid" %}
+{% include "src/site/includes/preview-edit.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with constructLcBreadcrumbs = true titleInclude = false %}
+
+<div id="content" class="interior" data-template="node-campaign_landing_page">
+  <main class="va-l-detail-page">
+    <div class="usa-grid usa-grid-full">
+      <div class="usa-width-three-fourths">
+        <!-- Draft status -->
+        {% if !entityPublished %}
+          <div class="usa-alert usa-alert-info">
+            <div class="usa-alert-body">
+              <p class="usa-alert-text">You are viewing a draft.</p>
+            </div>
+          </div>
+        {% endif %}
+
+        <article class="usa-content">
+          <!-- Title -->
+          <h1>{{ title }}</h1>
+        </article>
+
+        <!-- Last Updated -->
+        <div class="last-updated usa-content">
+          Last updated: <time
+            datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
+
+{% include "src/site/includes/footer.html" %}
+{% include "src/site/includes/debug.drupal.liquid" %}

--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -8,7 +8,7 @@ const bannerAlertsQuery = require('./bannerAlerts.graphql');
 const basicLandingPage = require('./nodeBasicLandingPage.graphql');
 const benefitListingPage = require('./benefitListingPage.graphql');
 const bioPage = require('./bioPage.graphql');
-const campaignLandingPage = require('./nodeCampaignLandingPage.graphql');
+const nodeCampaignLandingPage = require('./nodeCampaignLandingPage.graphql');
 const checklistPage = require('./nodeChecklist.graphql');
 const eventListingPage = require('./eventListingPage.graphql');
 const eventPage = require('./eventPage.graphql');
@@ -89,7 +89,7 @@ const buildQuery = ({ useTomeSync }) => {
   ${mediaListVideos}
   ${supportResourcesDetailPage}
   ${basicLandingPage}
-  ${campaignLandingPage}
+  ${nodeCampaignLandingPage}
 `;
 
   const todayQueryVar = useTomeSync ? '' : '$today: String!,';

--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -8,6 +8,7 @@ const bannerAlertsQuery = require('./bannerAlerts.graphql');
 const basicLandingPage = require('./nodeBasicLandingPage.graphql');
 const benefitListingPage = require('./benefitListingPage.graphql');
 const bioPage = require('./bioPage.graphql');
+const campaignLandingPage = require('./nodeCampaignLandingPage.graphql');
 const checklistPage = require('./nodeChecklist.graphql');
 const eventListingPage = require('./eventListingPage.graphql');
 const eventPage = require('./eventPage.graphql');
@@ -88,6 +89,7 @@ const buildQuery = ({ useTomeSync }) => {
   ${mediaListVideos}
   ${supportResourcesDetailPage}
   ${basicLandingPage}
+  ${campaignLandingPage}
 `;
 
   const todayQueryVar = useTomeSync ? '' : '$today: String!,';
@@ -128,6 +130,7 @@ const buildQuery = ({ useTomeSync }) => {
         ... nodeMediaListVideos
         ... nodeSupportResourcesDetailPage
         ... nodeBasicLandingPage
+        ... nodeCampaignLandingPage
       }
     }`;
 

--- a/src/site/stages/build/drupal/graphql/GetLatestPageById.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetLatestPageById.graphql.js
@@ -16,6 +16,7 @@ const icsFileQuery = require('./file-fragments/ics.file.graphql');
 const menuLinksQuery = require('./navigation-fragments/menuLinks.nav.graphql');
 const newsStoryPage = require('./newStoryPage.graphql');
 const nodeBasicLandingPage = require('./nodeBasicLandingPage.graphql');
+const nodeCampaignLandingPage = require('./nodeCampaignLandingPage.graphql');
 const nodeChecklist = require('./nodeChecklist.graphql');
 const nodeMediaListImages = require('./nodeMediaListImages.graphql');
 const nodeMediaListVideos = require('./nodeMediaListVideos.graphql');
@@ -63,6 +64,7 @@ module.exports = `
   ${nodeMediaListVideos}
   ${nodeSupportResourcesDetailPage}
   ${nodeBasicLandingPage}
+  ${nodeCampaignLandingPage}
 
   query GetLatestPageById($id: String!, $today: String!, $onlyPublishedContent: Boolean!) {
     nodes: nodeQuery(revisions: LATEST, filter: {
@@ -90,6 +92,7 @@ module.exports = `
         ... nodeMediaListVideos
         ... nodeSupportResourcesDetailPage
         ... nodeBasicLandingPage
+        ... nodeCampaignLandingPage
       }
     }
     ${icsFileQuery}

--- a/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
@@ -1,6 +1,6 @@
 const entityElementsFromPages = require('./entityElementsForPages.graphql');
 
-const fragment = `
+module.exports = `
   fragment nodeCampaignLandingPage on NodeCampaignLandingPage {
     ${entityElementsFromPages}
     changed

--- a/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
@@ -17,7 +17,6 @@ const fragment = `
           fieldLink {
             uri
             title
-            options
           }
           fieldMetatags
           fieldSocialMediaLinks {
@@ -45,7 +44,6 @@ const fragment = `
                 fieldLink {
                   uri
                   title
-                  options
                 }
                 fieldMetatags
                 fieldSocialMediaLinks {
@@ -84,7 +82,6 @@ const fragment = `
           fieldLink {
             uri
             title
-            options
           }
           fieldMetatags
           fieldSocialMediaLinks {
@@ -134,7 +131,6 @@ const fragment = `
                 fieldLink {
                   uri
                   title
-                  options
                 }
                 fieldMetatags
                 fieldSocialMediaLinks {
@@ -181,7 +177,6 @@ const fragment = `
           fieldLink {
             uri
             title
-            options
           }
           fieldListing {
             entity {
@@ -200,7 +195,6 @@ const fragment = `
                       fieldLink {
                         uri
                         title
-                        options
                       }
                       fieldMetatags
                       fieldSocialMediaLinks {
@@ -234,7 +228,6 @@ const fragment = `
                             fieldLink {
                               uri
                               title
-                              options
                             }
                             fieldMetatags
                             fieldSocialMediaLinks {
@@ -283,7 +276,6 @@ const fragment = `
           fieldUrlOfAnOnlineEvent {
             uri
             title
-            options
           }
         }
       }
@@ -298,7 +290,6 @@ const fragment = `
           fieldButtonLink {
             uri
             title
-            options
           }
         }
       }
@@ -338,7 +329,6 @@ const fragment = `
           fieldMediaExternalFile {
             uri
             title
-            options
           }
           fieldMediaInLibrary
           fieldMimeType
@@ -356,7 +346,6 @@ const fragment = `
                 fieldLink {
                   uri
                   title
-                  options
                 }
                 fieldSocialMediaLinks {
                   platform
@@ -379,7 +368,6 @@ const fragment = `
           fieldButtonLink {
             uri
             title
-            options
           }
         }
       }
@@ -397,7 +385,6 @@ const fragment = `
           fieldButtonLink {
             uri
             title
-            options
           }
         }
       }
@@ -413,7 +400,6 @@ const fragment = `
           fieldLink {
             uri
             title
-            options
           }
           fieldLinkSummary
         }
@@ -423,7 +409,6 @@ const fragment = `
     fieldClpStoriesCta {
       uri
       title
-      options
     }
     fieldClpStoriesHeader
     fieldClpStoriesIntro
@@ -440,7 +425,6 @@ const fragment = `
                 fieldLink {
                   uri
                   title
-                  options
                 }
                 fieldLinkSummary
               }
@@ -476,7 +460,6 @@ const fragment = `
           fieldButtonLink {
             uri
             title
-            options
           }
         }
       }
@@ -516,7 +499,6 @@ const fragment = `
                 fieldLink {
                   uri
                   title
-                  options
                 }
                 fieldSocialMediaLinks {
                   platform
@@ -535,7 +517,6 @@ const fragment = `
                 fieldLink {
                   uri
                   title
-                  options
                 }
                 fieldLinkSummary
               }
@@ -591,7 +572,6 @@ const fragment = `
           fieldButtonLink {
             uri
             title
-            options
           }
         }
       }
@@ -606,7 +586,6 @@ const fragment = `
           fieldButtonLink {
             uri
             title
-            options
           }
         }
       }

--- a/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
@@ -1,0 +1,615 @@
+const entityElementsFromPages = require('./entityElementsForPages.graphql');
+
+const fragment = `
+  fragment nodeCampaignLandingPage on NodeCampaignLandingPage {
+    ${entityElementsFromPages}
+    changed
+    entityId
+    title
+    fieldAdministration {
+      entity {
+        ... on TaxonomyTermAdministration {
+          fieldAcronym
+          fieldDescription
+          fieldEmailUpdatesLinkText
+          fieldEmailUpdatesUrl
+          fieldIntroText
+          fieldLink {
+            uri
+            title
+            options
+          }
+          fieldMetatags
+          fieldSocialMediaLinks {
+            platform
+            value
+            platformValues
+          }
+        }
+      }
+    }
+    fieldBenefitCategories {
+      entity {
+        entityType
+        entityBundle
+        entityId
+        ... on NodeLandingPage {
+          fieldAdministration {
+            entity {
+              ... on TaxonomyTermAdministration {
+                fieldAcronym
+                fieldDescription
+                fieldEmailUpdatesLinkText
+                fieldEmailUpdatesUrl
+                fieldIntroText
+                fieldLink {
+                  uri
+                  title
+                  options
+                }
+                fieldMetatags
+                fieldSocialMediaLinks {
+                  platform
+                  value
+                  platformValues
+                }
+              }
+            }
+          }
+          fieldDescription
+        }
+      }
+    }
+    fieldClpAudience {
+      entity {
+        entityType
+        entityBundle
+        entityId
+        ... on TaxonomyTermAudienceTags {
+          name
+        }
+      }
+    }
+    fieldClpConnectWithUs {
+      entity {
+        entityType
+        entityBundle
+        entityId
+        ... on TaxonomyTermAdministration {
+          fieldAcronym
+          fieldDescription
+          fieldEmailUpdatesLinkText
+          fieldEmailUpdatesUrl
+          fieldIntroText
+          fieldLink {
+            uri
+            title
+            options
+          }
+          fieldMetatags
+          fieldSocialMediaLinks {
+            platform
+            value
+            platformValues
+          }
+        }
+      }
+    }
+    fieldClpEventsHeader
+    fieldClpEventsPanel
+    fieldClpEventsReferences {
+      entity {
+        entityType
+        entityBundle
+        entityId
+        ... on NodeEvent {
+          fieldAdditionalInformationAbo {
+            value
+            format
+            processed
+          }
+          fieldAddress {
+            langcode
+            countryCode
+            administrativeArea
+            locality
+            dependentLocality
+            postalCode
+            sortingCode
+            addressLine1
+            addressLine2
+            organization
+            givenName
+            additionalName
+            familyName
+          }
+          fieldAdministration {
+            entity {
+              ... on TaxonomyTermAdministration {
+                fieldAcronym
+                fieldDescription
+                fieldEmailUpdatesLinkText
+                fieldEmailUpdatesUrl
+                fieldIntroText
+                fieldLink {
+                  uri
+                  title
+                  options
+                }
+                fieldMetatags
+                fieldSocialMediaLinks {
+                  platform
+                  value
+                  platformValues
+                }
+              }
+            }
+          }
+          fieldBody {
+            value
+            format
+            processed
+          }
+          fieldDate {
+            value
+            startDate
+            endValue
+            endDate
+          }
+          fieldDatetimeRangeTimezone {
+            value
+            startTime
+            endValue
+            endTime
+            duration
+            rrule
+            rruleIndex
+            timezone
+          }
+          fieldDescription
+          fieldEventCost
+          fieldEventCta
+          fieldEventRegistrationrequired
+          fieldFacilityLocation {
+            entity {
+              entityType
+              entityBundle
+              entityId
+            }
+          }
+          fieldFeatured
+          fieldLink {
+            uri
+            title
+            options
+          }
+          fieldListing {
+            entity {
+              entityType
+              entityBundle
+              entityId
+              ... on NodeEventListing {
+                fieldAdministration {
+                  entity {
+                    ... on TaxonomyTermAdministration {
+                      fieldAcronym
+                      fieldDescription
+                      fieldEmailUpdatesLinkText
+                      fieldEmailUpdatesUrl
+                      fieldIntroText
+                      fieldLink {
+                        uri
+                        title
+                        options
+                      }
+                      fieldMetatags
+                      fieldSocialMediaLinks {
+                        platform
+                        value
+                        platformValues
+                      }
+                    }
+                  }
+                }
+                fieldDescription
+                fieldIntroText
+                fieldMetaTitle
+                fieldOffice {
+                  entity {
+                    entityType
+                    entityBundle
+                    entityId
+                    ... on NodeOffice {
+                      fieldAdministration {
+                        entity {
+                          entityType
+                          entityBundle
+                          entityId
+                          ... on TaxonomyTermAdministration {
+                            fieldAcronym
+                            fieldDescription
+                            fieldEmailUpdatesLinkText
+                            fieldEmailUpdatesUrl
+                            fieldIntroText
+                            fieldLink {
+                              uri
+                              title
+                              options
+                            }
+                            fieldMetatags
+                            fieldSocialMediaLinks {
+                              platform
+                              value
+                              platformValues
+                            }
+                          }
+                        }
+                      }
+                      fieldBody {
+                        value
+                        format
+                        processed
+                      }
+                      fieldDescription
+                      fieldMetaTags
+                      fieldMetaTitle
+                    }
+                  }
+                }
+              }
+            }
+          }
+          fieldLocationHumanreadable
+          fieldLocationType
+          fieldMedia {
+            entity {
+              entityType
+              entityBundle
+              entityId
+              ... on Media {
+                thumbnail {
+                  height
+                  width
+                  url
+                  targetId
+                  alt
+                  title
+                }
+              }
+            }
+          }
+          fieldMetaTags
+          fieldOrder
+          fieldUrlOfAnOnlineEvent {
+            uri
+            title
+            options
+          }
+        }
+      }
+    }
+    fieldClpFaqCta {
+      entity {
+        entityType
+        entityBundle
+        entityId
+        ... on ParagraphButton {
+          fieldButtonLabel
+          fieldButtonLink {
+            uri
+            title
+            options
+          }
+        }
+      }
+    }
+    fieldClpFaqPanel
+    fieldClpFaqParagraphs {
+      entity {
+        entityType
+        entityBundle
+        entityId
+        ... on ParagraphQA {
+          fieldAnswer {
+            entity {
+              entityType
+              entityBundle
+              entityId
+              ... on ParagraphWysiwyg {
+                fieldWysiwyg {
+                  value
+                  format
+                  processed
+                }
+              }
+            }
+          }
+          fieldQuestion
+        }
+      }
+    }
+    fieldClpResources {
+      entity {
+        entityType
+        entityBundle
+        entityId
+        ... on MediaDocumentExternal {
+          fieldDescription
+          fieldMediaExternalFile {
+            uri
+            title
+            options
+          }
+          fieldMediaInLibrary
+          fieldMimeType
+          fieldOwner {
+            entity {
+              entityType
+              entityBundle
+              entityId
+              ... on TaxonomyTermAdministration {
+                fieldAcronym
+                fieldDescription
+                fieldEmailUpdatesLinkText
+                fieldEmailUpdatesUrl
+                fieldIntroText
+                fieldLink {
+                  uri
+                  title
+                  options
+                }
+                fieldSocialMediaLinks {
+                  platform
+                  value
+                  platformValues
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    fieldClpResourcesCta {
+      entity {
+        entityType
+        entityBundle
+        entityId
+        ... on ParagraphButton {
+          fieldButtonLabel
+          fieldButtonLink {
+            uri
+            title
+            options
+          }
+        }
+      }
+    }
+    fieldClpResourcesHeader
+    fieldClpResourcesIntroText
+    fieldClpResourcesPanel
+    fieldClpSpotlightCta {
+      entity {
+        entityType
+        entityBundle
+        entityId
+        ... on ParagraphButton {
+          fieldButtonLabel
+          fieldButtonLink {
+            uri
+            title
+            options
+          }
+        }
+      }
+    }
+    fieldClpSpotlightHeader
+    fieldClpSpotlightIntroText
+    fieldClpSpotlightLinkTeasers {
+      entity {
+        entityType
+        entityBundle
+        entityId
+        ... on ParagraphLinkTeaser {
+          fieldLink {
+            uri
+            title
+            options
+          }
+          fieldLinkSummary
+        }
+      }
+    }
+    fieldClpSpotlightPanel
+    fieldClpStoriesCta {
+      uri
+      title
+      options
+    }
+    fieldClpStoriesHeader
+    fieldClpStoriesIntro
+    fieldClpStoriesPanel
+    fieldClpStoriesTeasers {
+      entity {
+        entityType
+        entityBundle
+        entityId
+        ... on ParagraphLinkTeaserWithImage {
+          fieldLinkTeaser {
+            entity {
+              ... on ParagraphLinkTeaser {
+                fieldLink {
+                  uri
+                  title
+                  options
+                }
+                fieldLinkSummary
+              }
+            }
+          }
+          fieldMedia {
+            entity {
+              ... on Media {
+                name
+                thumbnail {
+                  height
+                  width
+                  url
+                  targetId
+                  alt
+                  title
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    fieldClpVideoPanel
+    fieldClpVideoPanelHeader
+    fieldClpVideoPanelMoreVideo {
+      entity {
+        entityType
+        entityBundle
+        entityId
+        ... on ParagraphButton {
+          fieldButtonLabel
+          fieldButtonLink {
+            uri
+            title
+            options
+          }
+        }
+      }
+    }
+    fieldClpWhatYouCanDoHeader
+    fieldClpWhatYouCanDoIntro
+    fieldClpWhatYouCanDoPromos {
+      entity {
+        entityType
+        entityBundle
+        entityId
+        ... on BlockContentPromo {
+          fieldImage {
+            entity {
+              ... on Media {
+                name
+                thumbnail {
+                  height
+                  width
+                  url
+                  targetId
+                  alt
+                  title
+                }
+              }
+            }
+          }
+          fieldInstructions
+          fieldOwner {
+            entity {
+              ... on TaxonomyTermAdministration {
+                fieldAcronym
+                fieldDescription
+                fieldEmailUpdatesLinkText
+                fieldEmailUpdatesUrl
+                fieldIntroText
+                fieldLink {
+                  uri
+                  title
+                  options
+                }
+                fieldSocialMediaLinks {
+                  platform
+                  value
+                  platformValues
+                }
+              }
+            }
+          }
+          fieldPromoLink {
+            entity {
+              entityType
+              entityBundle
+              entityId
+              ... on ParagraphLinkTeaser {
+                fieldLink {
+                  uri
+                  title
+                  options
+                }
+                fieldLinkSummary
+              }
+            }
+          }
+        }
+      }
+    }
+    fieldClpWhyThisMatters
+    fieldHeroBlurb
+    fieldHeroImage {
+      entity {
+        entityType
+        entityBundle
+        entityId
+        ... on MediaImage {
+          image {
+            height
+            width
+            url
+            targetId
+            alt
+            title
+          }
+        }
+      }
+    }
+    fieldMedia {
+      entity {
+        entityType
+        entityBundle
+        entityId
+        ... on MediaVideo {
+          name
+          thumbnail {
+            height
+            width
+            url
+            targetId
+            alt
+            title
+          }
+        }
+      }
+    }
+    fieldPrimaryCallToAction {
+      entity {
+        entityType
+        entityBundle
+        entityId
+        ... on ParagraphButton {
+          fieldButtonLabel
+          fieldButtonLink {
+            uri
+            title
+            options
+          }
+        }
+      }
+    }
+    fieldSecondaryCallToAction {
+      entity {
+        entityType
+        entityBundle
+        entityId
+        ... on ParagraphButton {
+          fieldButtonLabel
+          fieldButtonLink {
+            uri
+            title
+            options
+          }
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/17514

This PR adds the full graphql query for CLP and a boilerplate for the template so that we can work on building out the template.

## Testing done
Locally

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/104633721-cfe7ff80-565c-11eb-9200-44229088cb49.png)

## Acceptance criteria
- [x] adds the full graphql query for CLP and a boilerplate for the template so that we can work on building out the template.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
