### PR TITLE
Update app disconnect copy in connected-apps

### DIFF
--- a/src/applications/personalization/profile/components/connected-apps/AppDeletedAlert.jsx
+++ b/src/applications/personalization/profile/components/connected-apps/AppDeletedAlert.jsx
@@ -5,13 +5,37 @@ import { focusElement } from 'platform/utilities/ui';
 
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
-export const AppDeletedAlert = props => {
+export const AppDeletedAlert = ({
+  dismissAlert,
+  id,
+  privacyPolicies,
+  title,
+}) => {
   useEffect(() => {
     focusElement('[data-focus-target]');
   }, []);
-
-  const { id, title, dismissAlert } = props;
-  const alertMessage = `We’ve disconnected ${title}. This app can’t access any new information from your VA.gov profile. Some apps may still store information you’ve already shared. If you’d like to ask the app to delete any stored information, contact the app’s support.`;
+  const privacyLink = (
+    <a
+      href={`${privacyPolicies[title]}`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      privacy policy
+    </a>
+  );
+  const alertMessage = (
+    <span>
+      We’ve disconnected {title}. This app can’t access any new information from
+      your VA.gov profile, but{' '}
+      <strong>
+        some apps may still store information you’ve already shared.
+      </strong>{' '}
+      To learn about how this app stores your information, including what
+      information it stores, if any, and what steps are available to you, review{' '}
+      {title}
+      's {privacyLink}.
+    </span>
+  );
   const headline = `We’ve disconnected ${title}`;
   return (
     <div tabIndex="-1" data-focus-target className="vads-u-margin-y--4">
@@ -29,4 +53,5 @@ AppDeletedAlert.propTypes = {
   id: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   dismissAlert: PropTypes.func.isRequired,
+  privacyPolicies: PropTypes.object.isRequired,
 };

--- a/src/applications/personalization/profile/components/connected-apps/ConnectedApp.jsx
+++ b/src/applications/personalization/profile/components/connected-apps/ConnectedApp.jsx
@@ -19,7 +19,7 @@ export class ConnectedApp extends Component {
   };
 
   confirmDelete = () => {
-    this.props.confirmDelete(this.props.id);
+    this.props.confirmDelete(this.props.id, this.props.attributes?.title);
   };
 
   render() {

--- a/src/applications/personalization/profile/components/connected-apps/ConnectedApps.jsx
+++ b/src/applications/personalization/profile/components/connected-apps/ConnectedApps.jsx
@@ -9,6 +9,7 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation-react/Lo
 import {
   deleteConnectedApp,
   dismissDeletedAppAlert,
+  getPrivacyPolicy,
   loadConnectedApps,
 } from '@@profile/components/connected-apps/actions';
 import recordEvent from 'platform/monitoring/record-event';
@@ -29,7 +30,8 @@ export class ConnectedApps extends Component {
     }
   }
 
-  confirmDelete = appId => {
+  confirmDelete = (appId, appTitle) => {
+    this.props.getPrivacyPolicy(appTitle);
     this.props.deleteConnectedApp(appId);
   };
 
@@ -38,7 +40,7 @@ export class ConnectedApps extends Component {
   };
 
   render() {
-    const { apps, loading, errors } = this.props;
+    const { apps, loading, errors, privacyPolicies } = this.props;
     const deletedApps = apps ? apps.filter(app => app.deleted) : [];
     const activeApps = apps ? apps.filter(app => !app.deleted) : [];
 
@@ -109,6 +111,7 @@ export class ConnectedApps extends Component {
             title={app?.attributes?.title}
             key={app.id}
             dismissAlert={this.dismissAlert}
+            privacyPolicies={privacyPolicies}
           />
         ))}
 
@@ -209,6 +212,7 @@ const mapDispatchToProps = {
   loadConnectedApps,
   deleteConnectedApp,
   dismissDeletedAppAlert,
+  getPrivacyPolicy,
 };
 
 ConnectedApps.propTypes = {

--- a/src/applications/personalization/profile/components/connected-apps/ConnectedApps.jsx
+++ b/src/applications/personalization/profile/components/connected-apps/ConnectedApps.jsx
@@ -238,8 +238,10 @@ ConnectedApps.propTypes = {
   loadConnectedApps: PropTypes.func.isRequired,
   deleteConnectedApp: PropTypes.func.isRequired,
   dismissDeletedAppAlert: PropTypes.func.isRequired,
+  getPrivacyPolicy: PropTypes.func.isRequired,
   loading: PropTypes.bool,
   errors: PropTypes.array,
+  privacyPolicies: PropTypes.object,
 };
 
 export default connect(

--- a/src/applications/personalization/profile/components/connected-apps/actions/index.js
+++ b/src/applications/personalization/profile/components/connected-apps/actions/index.js
@@ -16,8 +16,13 @@ export const FINISHED_DELETING_CONNECTED_APP =
   'connected-apps/FINISHED_DELETING_CONNECTED_APP';
 export const DELETED_APP_ALERT_DISMISSED =
   'connected-apps/DELETED_APP_ALERT_DISMISSED';
+export const FINISHED_FETCHING_PRIVACY_POLICY =
+  'connected-apps/FINISHED_FETCHING_PRIVACY_POLICY';
+export const ERROR_FETCHING_PRIVACY_POLICY =
+  'connected-apps/ERROR_FETCHING_PRIVACY_POLICY';
 
 const grantsUrl = '/profile/connected_applications';
+const appsUrl = '/apps/v0/directory';
 
 export function loadConnectedApps() {
   return async dispatch => {
@@ -92,4 +97,16 @@ export function deleteConnectedApp(appId) {
 export function dismissDeletedAppAlert(appId) {
   return async dispatch =>
     dispatch({ type: DELETED_APP_ALERT_DISMISSED, appId });
+}
+
+export function getPrivacyPolicy(appTitle) {
+  return async dispatch => {
+    await apiRequest(`${appsUrl}/${appTitle}`, { apiVersion: 'services' })
+      .then(({ data }) => {
+        dispatch({ type: FINISHED_FETCHING_PRIVACY_POLICY, appTitle, data });
+      })
+      .catch(({ errors }) => {
+        dispatch({ type: ERROR_FETCHING_PRIVACY_POLICY, appTitle, errors });
+      });
+  };
 }

--- a/src/applications/personalization/profile/components/connected-apps/reducers/connectedApps.js
+++ b/src/applications/personalization/profile/components/connected-apps/reducers/connectedApps.js
@@ -6,11 +6,14 @@ import {
   ERROR_DELETING_CONNECTED_APP,
   FINISHED_DELETING_CONNECTED_APP,
   DELETED_APP_ALERT_DISMISSED,
+  FINISHED_FETCHING_PRIVACY_POLICY,
+  ERROR_FETCHING_PRIVACY_POLICY,
 } from '../actions';
 
 const initialState = {
   apps: [],
   errors: [],
+  privacyPolicies: {},
   loading: false,
 };
 
@@ -58,6 +61,18 @@ export default (state = initialState, action) => {
     case DELETED_APP_ALERT_DISMISSED: {
       const apps = state.apps.filter(app => app.id !== action.appId);
       return { ...state, apps };
+    }
+
+    case FINISHED_FETCHING_PRIVACY_POLICY: {
+      const privacyPolicies = {
+        ...state.privacyPolicies,
+        [action.appTitle]: action.data.privacyUrl,
+      };
+      return { ...state, privacyPolicies, errors: [] };
+    }
+
+    case ERROR_FETCHING_PRIVACY_POLICY: {
+      return { ...state, errors: action.errors };
     }
 
     default:

--- a/src/applications/personalization/profile/tests/components/connected-apps/AppDeletedAlert.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/connected-apps/AppDeletedAlert.unit.spec.jsx
@@ -6,12 +6,23 @@ import { AppDeletedAlert } from '../../../components/connected-apps/AppDeletedAl
 
 describe('<AppDeletedAlert>', () => {
   it('renders correctly', () => {
-    const wrapper = mount(<AppDeletedAlert />);
+    const privacyUrl = 'https://www.apple.com/legal/privacy/';
+    const defaultProps = {
+      id: '',
+      title: 'Apple Health',
+      dismissAlert: () => {},
+      privacyPolicies: {
+        'Apple Health': privacyUrl,
+      },
+    };
+    const wrapper = mount(<AppDeletedAlert {...defaultProps} />);
     const text = wrapper.text();
 
     expect(text).to.include(
       'This app can’t access any new information from your VA.gov profile',
     );
+
+    expect(wrapper.find('a').props().href).to.equal(privacyUrl);
 
     wrapper.unmount();
   });

--- a/src/applications/personalization/profile/tests/components/connected-apps/ConnectedApps.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/connected-apps/ConnectedApps.unit.spec.jsx
@@ -25,6 +25,7 @@ describe('<ConnectedApps>', () => {
       loadConnectedApps: () => {},
       deleteConnectedApp: () => {},
       dismissDeletedAppAlert: () => {},
+      getPrivacyPolicy: () => {},
     };
 
     const wrapper = shallow(<ConnectedApps {...defaultProps} />);
@@ -47,9 +48,11 @@ describe('<ConnectedApps>', () => {
     const defaultProps = {
       apps: [{ deleted: true }, { deleted: true }],
       loading: false,
+      privacyPolicies: {},
       loadConnectedApps: () => {},
       deleteConnectedApp: () => {},
       dismissDeletedAppAlert: () => {},
+      getPrivacyPolicy: () => {},
     };
 
     const wrapper = mount(<ConnectedApps {...defaultProps} />);
@@ -86,6 +89,7 @@ describe('<ConnectedApps>', () => {
       loadConnectedApps: () => {},
       deleteConnectedApp: () => {},
       dismissDeletedAppAlert: () => {},
+      getPrivacyPolicy: () => {},
     };
 
     const wrapper = mount(<ConnectedApps {...defaultProps} />);
@@ -107,9 +111,11 @@ describe('<ConnectedApps>', () => {
     const defaultProps = {
       apps: [{ deleted: true }, { deleted: true }],
       loading: true,
+      privacyPolicies: {},
       loadConnectedApps: () => {},
       deleteConnectedApp: () => {},
       dismissDeletedAppAlert: () => {},
+      getPrivacyPolicy: () => {},
     };
 
     const wrapper = mount(<ConnectedApps {...defaultProps} />);

--- a/src/applications/personalization/profile/tests/components/connected-apps/reducer.unit.spec.js
+++ b/src/applications/personalization/profile/tests/components/connected-apps/reducer.unit.spec.js
@@ -6,6 +6,8 @@ import {
   DELETING_CONNECTED_APP,
   ERROR_LOADING_CONNECTED_APPS,
   ERROR_DELETING_CONNECTED_APP,
+  ERROR_FETCHING_PRIVACY_POLICY,
+  FINISHED_FETCHING_PRIVACY_POLICY,
   FINISHED_LOADING_CONNECTED_APPS,
   FINISHED_DELETING_CONNECTED_APP,
   LOADING_CONNECTED_APPS,
@@ -19,6 +21,7 @@ describe('Connected Apps reducer', () => {
       apps: [],
       errors: [],
       loading: false,
+      privacyPolicies: {},
     });
   });
 
@@ -29,6 +32,7 @@ describe('Connected Apps reducer', () => {
       apps: [],
       errors: [],
       loading: true,
+      privacyPolicies: {},
     });
   });
 
@@ -39,6 +43,7 @@ describe('Connected Apps reducer', () => {
       apps: ['hello'],
       errors: [],
       loading: false,
+      privacyPolicies: {},
     });
   });
 
@@ -49,6 +54,7 @@ describe('Connected Apps reducer', () => {
       apps: [],
       errors: ['hello'],
       loading: false,
+      privacyPolicies: {},
     });
   });
 
@@ -59,6 +65,7 @@ describe('Connected Apps reducer', () => {
       deleting: false,
       errors: [],
       loading: false,
+      privacyPolicies: {},
     };
     const state = reducer(prevState, action);
     expect(state).to.be.deep.equal({
@@ -66,6 +73,7 @@ describe('Connected Apps reducer', () => {
       deleting: false,
       errors: [],
       loading: false,
+      privacyPolicies: {},
     });
   });
 
@@ -82,6 +90,7 @@ describe('Connected Apps reducer', () => {
       ],
       errors: [],
       loading: false,
+      privacyPolicies: {},
     };
     const state = reducer(prevState, action);
     expect(state).to.be.deep.equal({
@@ -91,6 +100,7 @@ describe('Connected Apps reducer', () => {
       ],
       errors: [],
       loading: false,
+      privacyPolicies: {},
     });
   });
 
@@ -103,6 +113,7 @@ describe('Connected Apps reducer', () => {
       ],
       errors: [],
       loading: false,
+      privacyPolicies: {},
     };
     const state = reducer(prevState, action);
     expect(state).to.be.deep.equal({
@@ -112,6 +123,7 @@ describe('Connected Apps reducer', () => {
       ],
       errors: [],
       loading: false,
+      privacyPolicies: {},
     });
   });
 
@@ -121,12 +133,48 @@ describe('Connected Apps reducer', () => {
       apps: [{ id: '1' }, { id: '2' }],
       errors: [],
       loading: false,
+      privacyPolicies: {},
     };
     const state = reducer(prevState, action);
     expect(state).to.be.deep.equal({
       apps: [{ id: '2' }],
       errors: [],
       loading: false,
+      privacyPolicies: {},
+    });
+  });
+
+  it('handles the action type FINISHED_FETCHING_PRIVACY_POLICY', () => {
+    const action = {
+      appTitle: 'Apple Health',
+      data: { privacyUrl: 'https://www.apple.com/legal/privacy/' },
+      type: FINISHED_FETCHING_PRIVACY_POLICY,
+    };
+    const prevState = {
+      apps: [],
+      errors: [],
+      loading: false,
+      privacyPolicies: {},
+    };
+    const state = reducer(prevState, action);
+    expect(state).to.be.deep.equal({
+      apps: [],
+      errors: [],
+      loading: false,
+      privacyPolicies: {
+        'Apple Health': 'https://www.apple.com/legal/privacy/',
+      },
+    });
+  });
+
+  it('handles the action type ERROR_FETCHING_PRIVACY_POLICY', () => {
+    const action = { errors: ['hello'], type: ERROR_FETCHING_PRIVACY_POLICY };
+    const state = reducer(undefined, action);
+    expect(state).to.be.deep.equal({
+      apps: [],
+      errors: ['hello'],
+      loading: false,
+      privacyPolicies: {},
     });
   });
 });


### PR DESCRIPTION
## Description

This PR updates the copy in the alert for disconnecting third party applications. The privacy policy url is fetched from the Apps API service. 

## Tickets

[4003](https://vajira.max.gov/browse/API-4003)

## Testing done

- local testing with demo apps in profile
- updated unit tests

## Screenshots

<img width="654" alt="Screen Shot 2021-01-14 at 11 50 02 AM" src="https://user-images.githubusercontent.com/9746156/104641474-a92ac880-565e-11eb-84d3-381e4006c27f.png">

## Acceptance criteria
- [x] Updated copy in third party app disconnect alert

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
