### PR TITLE
Update footer link styles

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-footer.scss
+++ b/src/platform/site-wide/sass/modules/_m-footer.scss
@@ -102,10 +102,13 @@
       > a {
         display: inline-block;
         color: $color-white;
-        text-decoration: none;
         font-size: 1em;
         font-weight: 400;
         margin: .25em 0;
+
+        &:hover {
+          color: $color-gold !important;
+        }
       }
     }
   }


### PR DESCRIPTION
## Description
[TICKET](https://github.com/department-of-veterans-affairs/va.gov-team/issues/3179)

This PR adds underline and hover styling to links in the footer. The underline should help as a visual indication that the `a` tags are indeed links. Links on smaller screens are affected.

Per the ticket:

```
- As a user, I want to view links in the footer of VA.gov and visually understand what items are links.
- As a mouse user, I want to hover over links in the footer of VA.gov and visually understand which items are interactive, regardless of browser viewport width.
```

## Testing done
Looks good locally.

## Screenshots

BEFORE:
![image](https://user-images.githubusercontent.com/14869324/104650129-f9138a80-5672-11eb-8267-4b2e508b254c.png)

AFTER:
![image](https://user-images.githubusercontent.com/14869324/104650074-e8fbab00-5672-11eb-880a-65db177270c2.png)

## Acceptance criteria
- [x] For links on small screens, add underline and hover effect

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
