### PR TITLE
[Development] 526 Reset wizard on intro & confirmation pages

### DIFF
--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -20,6 +20,9 @@ import WizardContainer from './containers/WizardContainer';
 import { WIZARD_STATUS } from './constants';
 import { show526Wizard, isBDD, getPageTitle } from './utils';
 
+import scrollToTop from 'platform/utilities/ui/scrollToTop';
+import { focusElement } from 'platform/utilities/ui';
+
 const wrapInBreadcrumb = (title, component) => (
   <>
     <Breadcrumbs>
@@ -69,13 +72,22 @@ export const Form526Entry = ({
   document.title = title;
 
   const setWizardStatus = value => {
-    window.sessionStorage.setItem(WIZARD_STATUS, value);
+    sessionStorage.setItem(WIZARD_STATUS, value);
     setWizardState(value);
+  };
+
+  // start focus on breadcrumb nav when wizard is visible
+  const setPageFocus = focusTarget => {
+    focusElement(focusTarget);
+    scrollToTop();
   };
 
   useEffect(() => {
     if (defaultWizardState === WIZARD_STATUS_COMPLETE) {
+      setPageFocus('h1');
       setWizardStatus(WIZARD_STATUS_COMPLETE);
+    } else if (defaultWizardState === WIZARD_STATUS_NOT_STARTED) {
+      setPageFocus('.va-nav-breadcrumbs-list');
     }
   });
   if (showWizard && wizardState !== WIZARD_STATUS_COMPLETE) {

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -7,19 +7,26 @@ import Telephone, {
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
 import { focusElement } from 'platform/utilities/ui';
+import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 import { selectAvailableServices } from 'platform/user/selectors';
+import recordEvent from 'platform/monitoring/record-event';
 
 import { itfNotice } from '../content/introductionPage';
 import { originalClaimsFeature } from '../config/selectors';
 import fileOriginalClaimPage from '../../wizard/pages/file-original-claim';
 import { isBDD, getPageTitle, getStartText } from '../utils';
-import { BDD_INFO_URL } from '../constants';
+import {
+  BDD_INFO_URL,
+  DISABILITY_526_V2_ROOT_URL,
+  WIZARD_STATUS,
+} from '../constants';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {
     focusElement('h1');
+    scrollToTop();
   }
 
   render() {
@@ -87,6 +94,20 @@ class IntroductionPage extends React.Component {
         {itfNotice}
         <h2 className="vads-u-font-size--h4">{subwayTitle}</h2>
         <div className="process schemaform-process">
+          <p className="vads-u-margin-top--0">
+            if you don’t think this is the right form for you,{' '}
+            <a
+              href={DISABILITY_526_V2_ROOT_URL}
+              className="va-button-link"
+              onClick={() => {
+                sessionStorage.removeItem(WIZARD_STATUS);
+                recordEvent({ event: 'howToWizard-start-over' });
+              }}
+            >
+              go back and answer questions again
+            </a>
+            .
+          </p>
           <ol>
             <li className="process-step list-one">
               <h3 className="vads-u-font-size--h4">Prepare</h3>

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -16,7 +16,7 @@ import recordEvent from 'platform/monitoring/record-event';
 import { itfNotice } from '../content/introductionPage';
 import { originalClaimsFeature } from '../config/selectors';
 import fileOriginalClaimPage from '../../wizard/pages/file-original-claim';
-import { isBDD, getPageTitle, getStartText } from '../utils';
+import { show526Wizard, isBDD, getPageTitle, getStartText } from '../utils';
 import {
   BDD_INFO_URL,
   DISABILITY_526_V2_ROOT_URL,
@@ -97,7 +97,11 @@ class IntroductionPage extends React.Component {
           <p className="vads-u-margin-top--0">
             if you don’t think this is the right form for you,{' '}
             <a
-              href={DISABILITY_526_V2_ROOT_URL}
+              href={
+                this.props.show526Wizard
+                  ? DISABILITY_526_V2_ROOT_URL
+                  : '/disability/how-to-file-claim/'
+              }
               className="va-button-link"
               onClick={() => {
                 sessionStorage.removeItem(WIZARD_STATUS);
@@ -267,6 +271,7 @@ const mapStateToProps = state => ({
   formId: state.form.formId,
   user: state.user,
   allowOriginalClaim: originalClaimsFeature(state),
+  showWizard: show526Wizard(state),
   isBDDForm: isBDD(state?.form?.data),
 });
 

--- a/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
@@ -4,7 +4,12 @@ import Scroll from 'react-scroll';
 
 import { focusElement } from 'platform/utilities/ui';
 
-import { submissionStatuses } from '../constants';
+import {
+  submissionStatuses,
+  WIZARD_STATUS,
+  FORM_STATUS_BDD,
+  SAVED_SEPARATION_DATE,
+} from '../constants';
 import {
   retryableErrorContent,
   successfulSubmitContent,
@@ -32,6 +37,11 @@ export default class ConfirmationPage extends React.Component {
   }
 
   render() {
+    // Reset everything
+    sessionStorage.removeItem(WIZARD_STATUS);
+    sessionStorage.removeItem(FORM_STATUS_BDD);
+    sessionStorage.removeItem(SAVED_SEPARATION_DATE);
+
     switch (this.props.submissionStatus) {
       case submissionStatuses.succeeded:
         return successfulSubmitContent(this.props);

--- a/src/applications/disability-benefits/all-claims/containers/WizardContainer.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/WizardContainer.jsx
@@ -35,7 +35,7 @@ const WizardContainer = ({ setWizardStatus }) => (
         />
         <h2>Already know this is the right form?</h2>
         <p>
-          If you know VA Form 21-526EZ is correct, or if you were directd to
+          If you know VA Form 21-526EZ is correct, or if you were directed to
           complete this application, you can go straight to the application
           without answering the questions above.
         </p>


### PR DESCRIPTION
## Description

Adding a link to reset the wizard on the introduction page. This link removes the wizard "completed" flag so it displays and reloads the appropriate page: Info or Introduction page depending on the feature flag.

Additionally, all storage flags - set by the wizard - are cleared once the Veteran reaches the confirmation page.

Added on one typo fix within the wizard

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/17680

## Testing done

Updated unit tests

## Screenshots

![Screen Shot 2021-01-15 at 9 46 54 AM](https://user-images.githubusercontent.com/136959/104747858-a095c900-5716-11eb-8e60-5c31de64e3d4.png)

## Acceptance criteria
- [x] Link to reset the wizard appears on intro page
- Reset link redirects to:
  - [x] Info page (`/disability/how-to-file-claim/`) when wizard is not set to show on intro page
  - [x] Introduction page when wizard does appear on intro page 
- [x] Confirmation page clears all wizard settings

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
