### PR TITLE
update "save succeeded" messages

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoForm.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoForm.jsx
@@ -30,21 +30,21 @@ export const uiSchema = {
     'ui:title':
       'Routing number (Your bank’s name will appear after you add the 9-digit routing number)',
     'ui:errorMessages': {
-      pattern: 'Please enter the bank’s 9-digit routing number.',
-      required: 'Please enter the bank’s 9-digit routing number.',
+      pattern: 'Please enter the bank’s 9-digit routing number',
+      required: 'Please enter the bank’s 9-digit routing number',
     },
   },
   accountNumber: {
     'ui:title': 'Account number (This should be no more than 17 digits)',
     'ui:errorMessages': {
-      pattern: 'Please enter your account number.',
-      required: 'Please enter your account number.',
+      pattern: 'Please enter your account number',
+      required: 'Please enter your account number',
     },
   },
   accountType: {
     'ui:title': 'Account type',
     'ui:errorMessages': {
-      required: 'Please select the type that best describes the account.',
+      required: 'Please select the type that best describes the account',
     },
   },
 };

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoForm.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoForm.jsx
@@ -30,8 +30,8 @@ export const uiSchema = {
     'ui:title':
       'Routing number (Your bank’s name will appear after you add the 9-digit routing number)',
     'ui:errorMessages': {
-      pattern: 'Please enter the bank’s 9-digit routing number',
-      required: 'Please enter the bank’s 9-digit routing number',
+      pattern: 'Please enter your bank’s 9-digit routing number',
+      required: 'Please enter your bank’s 9-digit routing number',
     },
   },
   accountNumber: {
@@ -44,7 +44,7 @@ export const uiSchema = {
   accountType: {
     'ui:title': 'Account type',
     'ui:errorMessages': {
-      required: 'Please select the type that best describes the account',
+      required: 'Please select the type that best describes your account',
     },
   },
 };

--- a/src/applications/personalization/profile/components/direct-deposit/DirectDepositV2.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/DirectDepositV2.jsx
@@ -29,6 +29,40 @@ import PaymentHistory from './PaymentHistory';
 import BankInfoCNPv2 from './BankInfoCNPv2';
 import BankInfoEDU from './BankInfoEDU';
 
+const benefitTypes = {
+  CNP: 'compensation and pension benefits',
+  EDU: 'education benefits',
+};
+
+const SuccessMessage = ({ benefit }) => {
+  let content = null;
+  switch (benefit) {
+    case benefitTypes.CNP:
+      content = (
+        <>
+          We’ve updated your bank account information for your{' '}
+          <strong>compensation and pension benefits</strong>. This change should
+          take place immediately.
+        </>
+      );
+      break;
+    case benefitTypes.EDU:
+      content = (
+        <>
+          We’ve updated your bank account information for your{' '}
+          <strong>education benefits</strong>. Your next payment will be
+          deposited into your new account.
+        </>
+      );
+      break;
+
+    default:
+      break;
+  }
+
+  return content;
+};
+
 const DirectDeposit = ({
   cnpUiState,
   eduUiState,
@@ -36,7 +70,10 @@ const DirectDeposit = ({
   isAuthenticatedWithSSOe,
   isLOA3,
 }) => {
-  const [recentlySavedBankInfo, setRecentlySavedBankInfo] = React.useState('');
+  const [
+    recentlySavedBankInfo,
+    setRecentlySavedBankInfoForBenefit,
+  ] = React.useState('');
 
   const isSavingCNPBankInfo = cnpUiState.isSaving;
   const wasSavingCNPBankInfo = usePrevious(cnpUiState.isSaving);
@@ -54,7 +91,7 @@ const DirectDeposit = ({
   const removeBankInfoUpdatedAlert = React.useCallback(
     () => {
       setTimeout(() => {
-        setRecentlySavedBankInfo('');
+        setRecentlySavedBankInfoForBenefit('');
       }, bankInfoUpdatedAlertSettings.TIMEOUT);
     },
     [bankInfoUpdatedAlertSettings],
@@ -69,7 +106,7 @@ const DirectDeposit = ({
   React.useEffect(
     () => {
       if (wasSavingCNPBankInfo && !isSavingCNPBankInfo && !cnpSaveError) {
-        setRecentlySavedBankInfo('compensation and pension benefits');
+        setRecentlySavedBankInfoForBenefit(benefitTypes.CNP);
         removeBankInfoUpdatedAlert();
       }
     },
@@ -85,7 +122,7 @@ const DirectDeposit = ({
   React.useEffect(
     () => {
       if (wasSavingEDUBankInfo && !isSavingEDUBankInfo && !eduSaveError) {
-        setRecentlySavedBankInfo('education benefits');
+        setRecentlySavedBankInfoForBenefit(benefitTypes.EDU);
         removeBankInfoUpdatedAlert();
       }
     },
@@ -122,9 +159,7 @@ const DirectDeposit = ({
                 className="vads-u-margin-top--0 vads-u-margin-bottom--2"
                 scrollOnShow
               >
-                We’ve updated your bank account information for your{' '}
-                <strong>{recentlySavedBankInfo}</strong> and your next payment
-                will go to your new account.
+                <SuccessMessage benefit={recentlySavedBankInfo} />
               </AlertBox>
             </div>
           )}


### PR DESCRIPTION
## Description
Implement feedback from Jim on the DD for EDU feature.

## Testing done
Existing tests are flexible enough to still pass.

## Screenshots


## Acceptance criteria
- [x] Change success message for C&P change to, "We’ve updated your bank account information for your compensation and pension benefits. This change should take place immediately."
- [x] Change success message for EDU change to, "We’ve updated your bank account information for your education benefits. Your next payment will be deposited into your new account."
- [x] Remove periods from all field validation error labels; e.g. "Please enter your account number"
- [x] In "Please enter the bank’s 9-digit routing number," change "the" to "your"
- [x] For consistency, change "the" to "your" in "Please select the type that best describes the account"

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs