### PR TITLE
Added edu_form_omb_and_expiration feature flag to front end

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -75,4 +75,5 @@ export default Object.freeze({
   showFindFormsResultsLinkToFormDetailPages: 'find_forms_mvp_enhancement',
   multipleAddress1010ez: 'multiple_address_10_10ez',
   evssUploadLimit150Mb: 'evss_upload_limit_150mb',
+  eduFormOmbAndExpiration: 'edu_form_omb_and_expiration',
 });


### PR DESCRIPTION
## Description
As a developer, I need to create a feature flag for the form OMB content so that it is not displayed in production as development is completed.
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/18293

Backend PR: https://github.com/department-of-veterans-affairs/vets-api/pull/5686
## Testing done
local testing

## Screenshots


## Acceptance criteria
- [x] The Feature Flag edu_form_omb_and_expiration is available to be used for the form OMB content updates.
- [x] The Feature Flag description is: "Update OMB # and expiration dates for forms"

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
