### PR TITLE
[Development] Add 526 wizard reset unit tests

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -98,7 +98,7 @@ class IntroductionPage extends React.Component {
             if you don’t think this is the right form for you,{' '}
             <a
               href={
-                this.props.show526Wizard
+                this.props.showWizard
                   ? DISABILITY_526_V2_ROOT_URL
                   : '/disability/how-to-file-claim/'
               }
@@ -285,6 +285,7 @@ IntroductionPage.propTypes = {
   }).isRequired,
   user: PropTypes.shape({}),
   allowOriginalClaim: PropTypes.bool,
+  showWizard: PropTypes.bool,
   isBDDForm: PropTypes.bool,
 };
 

--- a/src/applications/disability-benefits/all-claims/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -3,7 +3,12 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 
 import ConfirmationPage from '../../containers/ConfirmationPage';
-import { submissionStatuses } from '../../constants';
+import {
+  submissionStatuses,
+  WIZARD_STATUS,
+  FORM_STATUS_BDD,
+  SAVED_SEPARATION_DATE,
+} from '../../constants';
 
 describe('Disability Benefits 526EZ <ConfirmationPage>', () => {
   const defaultProps = {
@@ -102,6 +107,18 @@ describe('Disability Benefits 526EZ <ConfirmationPage>', () => {
 
     const tree = shallow(<ConfirmationPage {...props} />);
     expect(tree.find('#note-email').length).to.equal(0);
+    tree.unmount();
+  });
+  it('should reset wizard state & values', () => {
+    sessionStorage.setItem(WIZARD_STATUS, 'a');
+    sessionStorage.setItem(FORM_STATUS_BDD, 'b');
+    sessionStorage.setItem(SAVED_SEPARATION_DATE, 'c');
+
+    const tree = testPage(submissionStatuses.succeeded);
+    expect(tree.text()).to.contain('Claim ID number');
+    expect(sessionStorage.getItem(WIZARD_STATUS)).to.be.null;
+    expect(sessionStorage.getItem(FORM_STATUS_BDD)).to.be.null;
+    expect(sessionStorage.getItem(SAVED_SEPARATION_DATE)).to.be.null;
     tree.unmount();
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
@@ -9,6 +9,7 @@ import {
   PAGE_TITLES,
   START_TEXT,
   SAVED_SEPARATION_DATE,
+  DISABILITY_526_V2_ROOT_URL,
 } from '../../constants';
 
 describe('<IntroductionPage/>', () => {
@@ -110,6 +111,20 @@ describe('<IntroductionPage/>', () => {
     ).to.equal(0);
     expect(wrapper.find('FormTitle').length).to.equal(1);
     expect(wrapper.find('FileOriginalClaimPage').length).to.equal(1);
+    wrapper.unmount();
+  });
+  it('should render reset wizard link to info page', () => {
+    const wrapper = shallow(<IntroductionPage {...defaultProps} />);
+    expect(wrapper.find('.va-button-link').props().href).to.contain(
+      'how-to-file-claim',
+    );
+    wrapper.unmount();
+  });
+  it('should render reset wizard link to intro page', () => {
+    const wrapper = shallow(<IntroductionPage {...defaultProps} showWizard />);
+    expect(wrapper.find('.va-button-link').props().href).to.equal(
+      DISABILITY_526_V2_ROOT_URL,
+    );
     wrapper.unmount();
   });
 });


### PR DESCRIPTION
## Description

Missing unit tests for recent update that adds a wizard reset link.

Related: https://github.com/department-of-veterans-affairs/vets-website/pull/15661

## Testing done

Unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Unit tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
