### PR TITLE
18254: Critical information is not available to the user with keyboard navigation

### DIFF
--- a/src/applications/edu-benefits/10203/containers/ConfirmEligibilityView.jsx
+++ b/src/applications/edu-benefits/10203/containers/ConfirmEligibilityView.jsx
@@ -152,14 +152,14 @@ export class ConfirmEligibilityView extends React.Component {
           {this.renderChecks()}
           {this.renderConfirmEligibility()}
         </div>
-        <div className="vads-u-padding-y--4">
+        {/*  eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+        <div className="vads-u-padding-y--4" tabIndex="0">
           <b>
             You must meet the above requirements to qualify for the scholarship.
           </b>{' '}
           Please consider that ineligible applications delay the processing of
           benefits for eligible applicants.
         </div>
-
         <div>
           <div className="vads-u-margin-top--neg2">
             <ExitApplicationButton

--- a/src/applications/edu-benefits/10203/content/directDeposit.jsx
+++ b/src/applications/edu-benefits/10203/content/directDeposit.jsx
@@ -3,7 +3,8 @@ import AdditionalInfo from '@department-of-veterans-affairs/formation-react/Addi
 
 export const directDepositDescription = () => {
   return (
-    <div>
+    /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */
+    <div tabIndex="0">
       <p>
         We make payments only through direct deposit, also called electronic
         funds transfer (EFT). If you’re approved for the Rogers STEM
@@ -44,45 +45,49 @@ export const bankInfoHelpText = (
     triggerText="What if I don't have a bank account or don't want to use direct deposit?"
     onClick={gaBankInfoHelpText}
   >
-    <p>
-      The Department of the Treasury requires all federal benefit payments be
-      made by electronic funds transfer (EFT), also called direct deposit.
-    </p>
-    <p>
-      If you don’t have a bank account, or don’t wish to provide your bank
-      account information, you must receive your payment through Direct Express
-      Debit MasterCard. To request a Direct Express Debit MasterCard:
-      <ul>
-        <li>
-          Apply at{' '}
-          <a
-            aria-label="www.usdirectexpress.com, opening in new tab"
-            href="https://www.usdirectexpress.com/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+    {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+    <div tabIndex="0">
+      <p>
+        The Department of the Treasury requires all federal benefit payments be
+        made by electronic funds transfer (EFT), also called direct deposit.
+      </p>
+      <p>
+        If you don’t have a bank account, or don’t wish to provide your bank
+        account information, you must receive your payment through Direct
+        Express Debit MasterCard. To request a Direct Express Debit MasterCard:
+        <ul>
+          <li>
+            Apply at{' '}
+            <a
+              aria-label="www.usdirectexpress.com, opening in new tab"
+              href="https://www.usdirectexpress.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {' '}
+              www.usdirectexpress.com
+            </a>{' '}
+            <b>or</b>
+          </li>
+          <li>
             {' '}
-            www.usdirectexpress.com
-          </a>{' '}
-          <b>or</b>
-        </li>
-        <li>
-          {' '}
-          Call{' '}
-          <a className="help-phone-number-link" href="tel:1-800-333-1795">
-            800-333-1795
-          </a>
-        </li>
-      </ul>
-    </p>
-    <p>
-      If you choose not to enroll, you’ll need to call the Department of the
-      Treasury at{' '}
-      <a className="help-phone-number-link" href="tel:1-888-224-2950">
-        888-224-2950
-      </a>{' '}
-      and speak to a representative handling waiver requests. They’ll encourage
-      you to participate in EFT and address any questions or concerns you have.
-    </p>
+            Call{' '}
+            <a className="help-phone-number-link" href="tel:1-800-333-1795">
+              800-333-1795
+            </a>
+          </li>
+        </ul>
+      </p>
+      <p>
+        If you choose not to enroll, you’ll need to call the Department of the
+        Treasury at{' '}
+        <a className="help-phone-number-link" href="tel:1-888-224-2950">
+          888-224-2950
+        </a>{' '}
+        and speak to a representative handling waiver requests. They’ll
+        encourage you to participate in EFT and address any questions or
+        concerns you have.
+      </p>
+    </div>
   </AdditionalInfo>
 );


### PR DESCRIPTION
## Description
Multiple critical text sections of the form which provides information to the user is not available to a user who relies on keyboard navigation and a screen reader to announce important information

## Testing done
Testing passes locally

## Screenshots
<img width="581" alt="Screen Shot 2021-01-15 at 2 13 14 PM" src="https://user-images.githubusercontent.com/48804834/104768562-e44ef980-573b-11eb-96e9-7b28bc9beebd.png">
<img width="558" alt="Screen Shot 2021-01-15 at 2 13 26 PM" src="https://user-images.githubusercontent.com/48804834/104768643-00529b00-573c-11eb-8845-56acb8114ab5.png">
<img width="749" alt="Screen Shot 2021-01-15 at 2 12 31 PM" src="https://user-images.githubusercontent.com/48804834/104768573-e87b1700-573b-11eb-9f89-f4f0d1ed6c27.png">




## Acceptance criteria
 Add tabindex="0" to the following sections (tabindex="0" is already used in some places in the form)
- [x] Step 3 of 6 (Not qualified): "You must meet the above requirements to qualify for the scholarship" section is not announced
- [x] Step 5 of 6: Direct Deposit Text block is not announced with keyboard navigation
- [x] Step 5 of 6: "What if I don't have a bank account" expandable section content is not announced

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
