### PR TITLE
Removed secondary SCO info

### DIFF
--- a/src/applications/gi/components/profile/ContactInformation.jsx
+++ b/src/applications/gi/components/profile/ContactInformation.jsx
@@ -18,10 +18,6 @@ export const ContactInformation = ({ institution }) => {
     SCO => SCO.priority.toUpperCase() === 'PRIMARY',
   );
 
-  const secondarySCOs = versionedSchoolCertifyingOfficials.filter(
-    SCO => SCO.priority.toUpperCase() === 'SECONDARY',
-  );
-
   const renderPhysicalAddress = () =>
     institution.physicalAddress1 && (
       <div className="vads-l-row vads-u-margin-top--2p5 vads-u-margin-bottom--4">
@@ -146,37 +142,11 @@ export const ContactInformation = ({ institution }) => {
       </div>
     );
 
-  const renderSecondarySCOs = () =>
-    secondarySCOs.length > 0 && (
-      <div className="vads-l-row vads-u-margin-y--2">
-        <div className="vads-l-col--12 medium-screen:vads-l-col--3">
-          <h4
-            id="secondary-contact-header"
-            className="contact-heading vads-u-font-family--sans vads-u-margin--0"
-          >
-            Secondary
-          </h4>
-        </div>
-        <div className="vads-l-col--9">
-          <div className="vads-l-grid-container--full">
-            <ul
-              className="vads-l-row sco-list vads-u-margin--0 secondary-sco-list"
-              aria-labelledby="secondary-contact-header"
-            >
-              {secondarySCOs.map((sco, index) => ScoContact(sco, index))}
-            </ul>
-          </div>
-        </div>
-      </div>
-    );
-
   const renderSCOContactInfoSection = () =>
     versionedSchoolCertifyingOfficials.length > 0 && (
       <div>
         {renderSCOHeader()}
         {renderPrimarySCOs()}
-        {primarySCOs.length > 0 && secondarySCOs.length > 0 && <hr />}
-        {renderSecondarySCOs()}
       </div>
     );
 

--- a/src/applications/gi/components/profile/ContactInformation.jsx
+++ b/src/applications/gi/components/profile/ContactInformation.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 
 import { ScoContact } from './ScoContact';
 import { phoneInfo } from '../../utils/helpers';
+import environment from 'platform/utilities/environment';
 
 export const ContactInformation = ({ institution }) => {
   const firstProgram = _.get(institution, 'programs[0]', {});
@@ -16,6 +17,10 @@ export const ContactInformation = ({ institution }) => {
 
   const primarySCOs = versionedSchoolCertifyingOfficials.filter(
     SCO => SCO.priority.toUpperCase() === 'PRIMARY',
+  );
+
+  const secondarySCOs = versionedSchoolCertifyingOfficials.filter(
+    SCO => SCO.priority.toUpperCase() === 'SECONDARY',
   );
 
   const renderPhysicalAddress = () =>
@@ -142,11 +147,39 @@ export const ContactInformation = ({ institution }) => {
       </div>
     );
 
+  const renderSecondarySCOs = () =>
+    secondarySCOs.length > 0 && (
+      <div className="vads-l-row vads-u-margin-y--2">
+        <div className="vads-l-col--12 medium-screen:vads-l-col--3">
+          <h4
+            id="secondary-contact-header"
+            className="contact-heading vads-u-font-family--sans vads-u-margin--0"
+          >
+            Secondary
+          </h4>
+        </div>
+        <div className="vads-l-col--9">
+          <div className="vads-l-grid-container--full">
+            <ul
+              className="vads-l-row sco-list vads-u-margin--0 secondary-sco-list"
+              aria-labelledby="secondary-contact-header"
+            >
+              {secondarySCOs.map((sco, index) => ScoContact(sco, index))}
+            </ul>
+          </div>
+        </div>
+      </div>
+    );
+
   const renderSCOContactInfoSection = () =>
     versionedSchoolCertifyingOfficials.length > 0 && (
       <div>
         {renderSCOHeader()}
         {renderPrimarySCOs()}
+        {environment.isProduction() &&
+          primarySCOs.length > 0 &&
+          secondarySCOs.length > 0 && <hr />}
+        {environment.isProduction() && renderSecondarySCOs()}
       </div>
     );
 

--- a/src/applications/gi/tests/components/profile/ContactInformation.unit.spec.jsx
+++ b/src/applications/gi/tests/components/profile/ContactInformation.unit.spec.jsx
@@ -66,10 +66,4 @@ describe('<ContactInformation>', () => {
     expect(wrapper.find('.primary-sco-list li').length).to.eq(2);
     wrapper.unmount();
   });
-
-  it('should display secondary SCOs', () => {
-    const wrapper = shallow(<ContactInformation institution={institution} />);
-    expect(wrapper.find('.secondary-sco-list li').length).to.eq(2);
-    wrapper.unmount();
-  });
 });


### PR DESCRIPTION
## Description
As an Education Services Team Member, I need to see the secondary SCO information removed from the profile page, so that users contact the correct person.
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/18307
## Testing done
local testing 

## Screenshots
![Screen Shot 2021-01-15 at 2 32 28 PM](https://user-images.githubusercontent.com/50601724/104770565-c20aab00-573e-11eb-8fdf-3d6f36597d7e.png)


## Acceptance criteria
- [x] The "secondary" SCO section and all SCOs not of type "Primary" are not displayed on the CT profile page.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
