### PR TITLE
[Drupal] Output the page path during common runtime error

### DIFF
--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -194,12 +194,17 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
  * @return nothing
  */
 function addGetUpdatesFields(page, pages) {
-  const regionPage = pages.find(
-    p =>
-      p.entityUrl
-        ? p.entityUrl.path === page.entityUrl.breadcrumb[1].url.path
-        : false,
-  );
+  const regionPageUrlPath = page.entityUrl.breadcrumb[1]?.url?.path;
+
+  if (!regionPageUrlPath) {
+    throw new Error(
+      `CMS error while building breadcrumbs: "${
+        page.entityUrl.path
+      }" is missing reference to a parent or grandparent.`,
+    );
+  }
+
+  const regionPage = pages.find(p => p.entityUrl.path === regionPageUrlPath);
 
   if (regionPage) {
     page.fieldLinks = regionPage.fieldLinks;


### PR DESCRIPTION
## Description
Per the issue, a common error seen during CMS dev is when a page doesn't have its parent/grandparent set up. This fails the whole build and it's hard to hunt down the page that is causing the issue. This PR adds the page path into the output to make it clear which page it is.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/18620

## Testing done
Modified local Drupal data to recreate error then confirmed output

## Screenshots

![image](https://user-images.githubusercontent.com/1915775/104782583-73670c00-5752-11eb-8cfa-6367f00f98a3.png)


## Acceptance criteria
- [ ] Page path is outputted during breadcrumb error

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
