### PR TITLE
[Development] Fix 526 UI bug

### DIFF
--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -17,6 +17,14 @@
   white-space: nowrap;
 }
 
+.clearfix:after {
+  content: " ";
+  visibility: hidden;
+  display: block;
+  height: 0;
+  clear: both;
+}
+
 ul.original-disability-list {
   li {
     margin-bottom: 0;

--- a/src/applications/disability-benefits/wizard/pages/bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/bdd.jsx
@@ -87,16 +87,18 @@ const BDDPage = ({ setPageState, state = defaultState, allowBDD }) => {
   };
 
   return (
-    <Date
-      label={label}
-      onValueChange={onChange}
-      name="discharge-date"
-      date={state}
-      validation={{
-        valid: isDateInFuture(state),
-        message: 'Your separation date must be in the future',
-      }}
-    />
+    <div className="clearfix">
+      <Date
+        label={label}
+        onValueChange={onChange}
+        name="discharge-date"
+        date={state}
+        validation={{
+          valid: isDateInFuture(state),
+          message: 'Your separation date must be in the future',
+        }}
+      />
+    </div>
   );
 };
 


### PR DESCRIPTION
## Description

In the Form 526 wizard, the date component `float` styling is not cleared causing the content after it to not be properly placed. This PR adds a clearfix class name to the CSS to fix it.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/17679

## Testing done

Visual

## Screenshots

<details><summary>Problem</summary>

<!-- leave a blank line above -->
![](https://user-images.githubusercontent.com/53942725/102540719-6e446d80-407d-11eb-93da-3975abcc44ff.png)</details>

<details><summary>Fixed</summary>

<!-- leave a blank line above -->
![](https://user-images.githubusercontent.com/53942725/102540684-6258ab80-407d-11eb-998e-b58b6a43a72b.png)</details>

## Acceptance criteria
- [x] Button alignment in Form 526 wizard has been fixed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
