### PR TITLE
Updated conditional in metalsmith Drupal build

### DIFF
--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -221,7 +221,7 @@ async function loadDrupal(buildOptions) {
   }
 
   const contentTimer = `Total time to load content from ${
-    USE_CMS_EXPORT_BUILD_ARG ? 'CMS export' : 'GraphQL'
+    buildOptions[USE_CMS_EXPORT_BUILD_ARG] ? 'CMS export' : 'GraphQL'
   }`;
 
   console.time(contentTimer);


### PR DESCRIPTION
## Description
There was a conditional in the metalsmith build output text about the timing of content download. It was checking against a local variable, I just updated it to check against the build option
