### PR TITLE
Moved creation of BUILD.txt to archive step.

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -177,8 +177,6 @@ def checkForBrokenLinks(String buildLogPath, String envName, Boolean contentOnly
 }
 
 def build(String ref, dockerContainer, String assetSource, String envName, Boolean useCache, Boolean contentOnlyBuild) {
-  def long buildtime = System.currentTimeMillis() / 1000L;
-  def buildDetails = buildDetails(envName, ref, buildtime)
   // Use Drupal prod for all environments
   def drupalAddress = DRUPAL_ADDRESSES.get('vagovprod')
   def drupalCred = DRUPAL_CREDENTIALS.get('vagovprod')
@@ -191,15 +189,13 @@ def build(String ref, dockerContainer, String assetSource, String envName, Boole
       sh "cd /application && jenkins/build.sh --envName ${envName} --assetSource ${assetSource} --drupalAddress ${drupalAddress} ${drupalMode} --buildLog ${buildLogPath} --verbose"
 
       if (envName == 'vagovprod') {
-	checkForBrokenLinks(buildLogPath, envName, contentOnlyBuild)
+        checkForBrokenLinks(buildLogPath, envName, contentOnlyBuild)
       }
 
       // Find any missing query flags in the log
       if (envName == 'vagovprod') {
         findMissingQueryFlags(buildLogPath, envName)
       }
-
-      sh "cd /application && echo \"${buildDetails}\" > build/${envName}/BUILD.txt"
     }
   }
 }
@@ -278,9 +274,13 @@ def prearchiveAll(dockerContainer) {
 }
 
 def archive(dockerContainer, String ref, String envName) {
+  def long buildtime = System.currentTimeMillis() / 1000L;
+  def buildDetails = buildDetails(envName, ref, buildtime)
+
   dockerContainer.inside(DOCKER_ARGS) {
     withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'vetsgov-website-builds-s3-upload',
                      usernameVariable: 'AWS_ACCESS_KEY', passwordVariable: 'AWS_SECRET_KEY']]) {
+      sh "echo \"${buildDetails}\" > /application/build/${envName}/BUILD.txt"
       sh "tar -C /application/build/${envName} -cf /application/build/${envName}.tar.bz2 ."
       sh "aws s3 cp /application/build/${envName}.tar.bz2 s3://vetsgov-website-builds-s3-upload/${ref}/${envName}.tar.bz2 --acl public-read --region us-gov-west-1 --quiet"
     }


### PR DESCRIPTION
## Description
Recent changes introduced an extra build to correctly set the S3 asset paths after E2E tests and before deploy (#15659). However, this may be overwriting the BUILD.txt, and without that file, the build is failing to deploy. This moves the creation of BUILD.txt to a later step (archive) to prevent it from getting overwritten.

The dev deploy was discovered to have failed in [this Slack thread](https://dsva.slack.com/archives/C37M86Y8G/p1610989806015400).

## Testing done
Build passes. Will observe the effects on a dev deploy after merge.

## Acceptance criteria
- [ ] Builds should contain a BUILD.txt.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
