### PR TITLE
Testing --use-cms-export DO NOT MERGE

### DIFF
--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -39,6 +39,6 @@ done
 # exit code.  In this case, if the build command fails, the tee
 # command won't trick Jenkins into thinking the step passed.
 set -o pipefail
-npm --no-color run build -- --buildtype="$envName" --asset-source="$assetSource" --drupal-address="$drupalAddress" "$pullDrupal" 2>&1 | tee "$buildLog"
+npm --no-color run build -- --buildtype="$envName" --asset-source="$assetSource" --drupal-address="$drupalAddress" "$pullDrupal" --use-cms-export 2>&1 | tee "$buildLog"
 
 exit $?


### PR DESCRIPTION
# This PR is for testing the cms-export build in a review environment. DO NOT MERGE!

## Acceptance criteria
- [ ] cms-export is used for build, review environment has cms-exported/transformed content

