### PR TITLE
[Development] Clear BDD status for e2e tests

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
@@ -7,7 +7,11 @@ import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-test
 import formConfig from '../config/form';
 import manifest from '../manifest.json';
 import { mockItf } from './all-claims.cypress.helpers';
-import { WIZARD_STATUS, SAVED_SEPARATION_DATE } from '../constants';
+import {
+  WIZARD_STATUS,
+  FORM_STATUS_BDD,
+  SAVED_SEPARATION_DATE,
+} from '../constants';
 
 const todayPlus120 = moment()
   .add(120, 'days')
@@ -163,6 +167,7 @@ const testConfig = createTestConfig(
       // but without view:selected, since that's not pre-filled
       cy.get('@testData').then(data => {
         window.sessionStorage.removeItem(WIZARD_STATUS);
+        window.sessionStorage.removeItem(FORM_STATUS_BDD);
         const sanitizedRatedDisabilities = (data.ratedDisabilities || []).map(
           ({ 'view:selected': _, ...obj }) => obj,
         );


### PR DESCRIPTION
## Description

Form 526 Cypress e2e tests are regularly failing. It appears to be a sessionStorage flag not being cleared properly before tests start - they are cleared on the confirmation page, so it is not completely clear why the `full-781-781a-8930-test.json` test is failing, but this change seemed to fix it.

## Testing done

Cypress e2e

## Screenshots

![Screen Shot 2021-01-18 at 9 23 06 AM](https://user-images.githubusercontent.com/136959/104955815-6e8f9b80-5990-11eb-9d84-cc8d5306991d.png)

## Acceptance criteria
- [x] Cypress e2e tests are passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
