### PR TITLE
Add underline and move a into h3

### DIFF
--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -157,7 +157,6 @@
                   <li>
                     <h3 class="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-font-family--sans">
                       <a
-                        class="vads-u-text-decoration--none"
                         href="{{ vaFormLinkTeaser.entity.fieldLink.url.path }}"
                         onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': '{{ vaFormLinkTeaser.entity.fieldLink.title | escape }}', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })">
                         {{ vaFormLinkTeaser.entity.fieldLink.title }}
@@ -171,7 +170,6 @@
                 <li>
                   <h3 class="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-font-family--sans">
                     <a
-                      class="vads-u-text-decoration--none"
                       href="/change-direct-deposit"
                       onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Change your direct deposit information', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })">
                       Change your direct deposit information
@@ -182,7 +180,6 @@
                 <li>
                   <h3 class="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-font-family--sans">
                     <a
-                      class="vads-u-text-decoration--none"
                       href="/change-address"
                       onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Change your address', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })">
                       Change your address
@@ -193,7 +190,6 @@
                 <li>
                   <h3 class="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-font-family--sans">
                     <a
-                      class="vads-u-text-decoration--none"
                       href="/records/get-military-service-records/"
                       onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Request your military records, including DD214', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })">
                       Request your military records, including DD214
@@ -204,7 +200,6 @@
                 <li>
                   <h3 class="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-font-family--sans">
                     <a
-                      class="vads-u-text-decoration--none"
                       href="/records/"
                       onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Get your VA records and documents online', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })">
                       Get your VA records and documents online

--- a/src/site/paragraphs/linkTeaser.drupal.liquid
+++ b/src/site/paragraphs/linkTeaser.drupal.liquid
@@ -38,13 +38,14 @@
         <a href="{{link.url.path}}" class="vads-u-text-decoration--underline"
           {% if linkTeaser.options["target"] %}
             target="{{ linkTeaser.options["target"] }}"
+            rel="noopener noreferrer"
           {% endif %}
         >
           {{ link.title }}
         </a>
       </{{ header }}>
       {% if parentFieldName === "field_spokes" %}
-          <img class="all-link-arrow" src="/img/arrow-right-blue.svg" alt="right-arrow">
+          <img class="all-link-arrow" src="/img/arrow-right-blue.svg" alt="Blue arrow pointing right">
       {% endif %}
     {% endif %}
     {% if linkTeaser.fieldLinkSummary != empty %}

--- a/src/site/paragraphs/linkTeaser.drupal.liquid
+++ b/src/site/paragraphs/linkTeaser.drupal.liquid
@@ -36,8 +36,10 @@
     {% if link.title != empty %}
       <{{ header }} class="{{ headerClass }}">
         <a href="{{link.url.path}}" class="vads-u-text-decoration--underline"
-            {% if linkTeaser.options["target"] %}target="{{ linkTeaser.options["target"] }}"{% endif %}
-            >
+          {% if linkTeaser.options["target"] %}
+            target="{{ linkTeaser.options["target"] }}"
+          {% endif %}
+        >
           {{ link.title }}
         </a>
       </{{ header }}>

--- a/src/site/paragraphs/linkTeaser.drupal.liquid
+++ b/src/site/paragraphs/linkTeaser.drupal.liquid
@@ -33,16 +33,18 @@
   data-links-list-header="{{ link.title | escape }}"
   data-links-list-section-header="{{ section_header | escape }}"
   {% if parentFieldName === 'field_spokes' %}class="hub-page-link-list__item"{% endif %}>
-    <a href="{{link.url.path}}"
-      {% if linkTeaser.options["target"] %}target="{{ linkTeaser.options["target"] }}"{% endif %}
-      >
-        {% if link.title != empty %}
-            <{{ header }} class="{{ headerClass }}">{{ link.title }}</{{ header }}>
-            {% if parentFieldName === "field_spokes" %}
-                <img class="all-link-arrow" src="/img/arrow-right-blue.svg" alt="right-arrow">
-            {% endif %}
-        {% endif %}
-    </a>
+    {% if link.title != empty %}
+      <{{ header }} class="{{ headerClass }}">
+        <a href="{{link.url.path}}" class="vads-u-text-decoration--underline"
+            {% if linkTeaser.options["target"] %}target="{{ linkTeaser.options["target"] }}"{% endif %}
+            >
+          {{ link.title }}
+        </a>
+      </{{ header }}>
+      {% if parentFieldName === "field_spokes" %}
+          <img class="all-link-arrow" src="/img/arrow-right-blue.svg" alt="right-arrow">
+      {% endif %}
+    {% endif %}
     {% if linkTeaser.fieldLinkSummary != empty %}
         <p class="va-nav-linkslist-description">{{ linkTeaser.fieldLinkSummary }}</p>
     {% endif %}


### PR DESCRIPTION
## Description
[TICKET](https://github.com/department-of-veterans-affairs/va.gov-team/issues/3556)

This PR:
1) moves the `a` tag within the `h3`, or `b` on pages that use the linkTeaser.
2) ensures that the `a` tag in the linkTeaser is underlined, even when it's not active
3) ensures that the `a` tags on the form detail page are also underlined -- PLEASE CONFIRM DESIRABILITY (@ncksllvn or maybe someone else on the pw team?), I changed it since it seemed to follow the same UI as what's rendered through the linkTeaser  

## Testing done
Looks good locally

## Screenshots

### FORM DETAIL PAGE (PLEASE CONFIRM DESIRABILITY)
![image](https://user-images.githubusercontent.com/14869324/105075613-372ff600-5a47-11eb-939b-a9143cfec9fb.png)

### /health-care
![image](https://user-images.githubusercontent.com/14869324/105075735-62b2e080-5a47-11eb-96b6-6e0174f0665a.png)

### /health-care/about-va-health-benefits/ 
![image](https://user-images.githubusercontent.com/14869324/105075818-7fe7af00-5a47-11eb-87cd-98190e8df045.png)

## Acceptance criteria
- [x] Add underline to links
- [x] Move `a` tag within `h3`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
