### PR TITLE
[Development] Fix 526 Cypress wizard tests

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
@@ -47,7 +47,9 @@ const testConfig = createTestConfig(
               SAVED_SEPARATION_DATE,
               todayPlus120.join('-'),
             );
-            cy.get('[type="radio"][value="bdd"]').click();
+            cy.get('[type="radio"][value="bdd"]').check({
+              waitForAnimations: true,
+            });
             cy.get('select[name="discharge-dateMonth"]').select(
               todayPlus120[1],
             );
@@ -56,11 +58,15 @@ const testConfig = createTestConfig(
               .clear()
               .type(todayPlus120[0]);
           } else {
-            cy.get('[type="radio"][value="appeals"]').click();
-            cy.get('[type="radio"][value="file-claim"]').click();
+            cy.get('[type="radio"][value="appeals"]').check({
+              waitForAnimations: true,
+            });
+            cy.get('[type="radio"][value="file-claim"]').check({
+              waitForAnimations: true,
+            });
           }
           // close wizard & render intro page content
-          cy.get('.va-button-primary').click();
+          cy.get('.va-button-primary').click({ waitForAnimations: true });
           // Start form
           cy.findAllByText(/start/i, { selector: 'button' })
             .first()


### PR DESCRIPTION
## Description

Another attempt to fix the Form 526 wizard specific Cypress tests. Added `waitForAnimation` option and switched to using `check` instead of `click`

Related:
- https://github.com/department-of-veterans-affairs/vets-website/pull/15685
- https://github.com/department-of-veterans-affairs/vets-website/pull/15697
- https://dsva.slack.com/archives/C5HP4GN3F/p1611069194021400

## Testing done

Cypress e2e tests

## Screenshots

N/A

## Acceptance criteria
- [x] Consistently passing 526 wizard Cypress tests

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
