### PR TITLE
removed color output from cypress in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,7 +77,7 @@ node('vetsgov-general-purpose') {
           },
 
           cypress: {
-            sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p cypress up -d && docker-compose -p cypress run --rm --entrypoint=npm -e CI=true vets-website --no-color NO_COLOR=1 run cy:test:docker"
+            sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p cypress up -d && docker-compose -p cypress run --rm --entrypoint=npm -e CI=true -e NO_COLOR=1 vets-website --no-color run cy:test:docker"
           }
         )
       } catch (error) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,7 +77,7 @@ node('vetsgov-general-purpose') {
           },
 
           cypress: {
-            sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p cypress up -d && docker-compose -p cypress run --rm --entrypoint=npm -e CI=true vets-website --no-color run cy:test:docker"
+            sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p cypress up -d && docker-compose -p cypress run --rm --entrypoint=npm -e CI=true NO_COLOR=1 vets-website --no-color run cy:test:docker"
           }
         )
       } catch (error) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,7 +77,7 @@ node('vetsgov-general-purpose') {
           },
 
           cypress: {
-            sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p cypress up -d && docker-compose -p cypress run --rm --entrypoint=npm -e CI=true NO_COLOR=1 vets-website --no-color run cy:test:docker"
+            sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p cypress up -d && docker-compose -p cypress run --rm --entrypoint=npm -e CI=true vets-website --no-color NO_COLOR=1 run cy:test:docker"
           }
         )
       } catch (error) {


### PR DESCRIPTION
## Description
Color output in Cypress is clogging up the output in CI, so trying to disabled it.

## Testing done
[Current output with color codes](http://jenkins.vfs.va.gov/blue/rest/organizations/jenkins/pipelines/testing/pipelines/vets-website/branches/master/runs/9755/nodes/153/steps/156/log/?start=0)

[Output with color codes removed](http://jenkins.vfs.va.gov/blue/rest/organizations/jenkins/pipelines/testing/pipelines/vets-website/branches/fix%252Fremove-colors-from-cypress-tests/runs/4/nodes/153/steps/156/log/?start=0)