### PR TITLE
[Development] Add GA events to 526 wizard

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -42,7 +42,7 @@ class IntroductionPage extends React.Component {
     const pageTitle = getPageTitle(isBDDForm);
     const startText = getStartText(isBDDForm);
 
-    // Remove this once we original claims feature toggle is set to 100%
+    // Remove this once form526_original_claims feature flag is removed
     if (!allowContinue) {
       return (
         <div className="schemaform-intro">

--- a/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
@@ -5,6 +5,8 @@ import Telephone, {
   PATTERNS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
 
+import recordEvent from 'platform/monitoring/record-event';
+
 import { getPageTitle } from '../utils';
 
 const Alert = ({ content }) => (
@@ -33,6 +35,15 @@ export const MissingServices = ({ title }) => {
       </p>
     </>
   );
+  recordEvent({
+    event: 'visible-alert-box',
+    'alert-box-type': 'warning',
+    'alert-box-heading': title,
+    'error-key': 'missing_526_or_original_claims_service',
+    'alert-box-full-width': false,
+    'alert-box-background-only': false,
+    'alert-box-closeable': false,
+  });
   return <Alert content={content} />;
 };
 
@@ -64,5 +75,14 @@ export const MissingId = ({ title }) => {
       </p>
     </>
   );
+  recordEvent({
+    event: 'visible-alert-box',
+    'alert-box-type': 'warning',
+    'alert-box-heading': title,
+    'error-key': 'missing_edipi_or_birls_id',
+    'alert-box-full-width': false,
+    'alert-box-background-only': false,
+    'alert-box-closeable': false,
+  });
   return <Alert content={content} />;
 };

--- a/src/applications/disability-benefits/all-claims/containers/WizardContainer.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/WizardContainer.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import recordEvent from 'platform/monitoring/record-event';
 import FormFooter from 'platform/forms/components/FormFooter';
 import Wizard, {
   WIZARD_STATUS_COMPLETE,
@@ -55,6 +56,7 @@ const WizardContainer = ({ setWizardStatus }) => {
             className="va-button-link vads-u-display--inline-block vads-u-margin-bottom--3 skip-wizard-link"
             onClick={e => {
               e.preventDefault();
+              recordEvent({ event: 'howToWizard-skip' });
               setWizardStatus(WIZARD_STATUS_COMPLETE);
             }}
           >

--- a/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
@@ -31,6 +31,8 @@ const fakeSipsIntro = user => {
 };
 
 describe('Form 526EZ Entry Page', () => {
+  let gaData;
+  const getLastEvent = (index = -1) => gaData[gaData.length + index];
   const testPage = ({
     verified = false,
     currentlyLoggedIn = true,
@@ -75,6 +77,8 @@ describe('Form 526EZ Entry Page', () => {
       }),
       initialState,
     );
+    window.dataLayer = [];
+    gaData = global.window.dataLayer;
     return mount(
       <Provider store={fakeStore}>
         <Form526Entry
@@ -114,6 +118,9 @@ describe('Form 526EZ Entry Page', () => {
     expect(tree.find('h1')).to.have.lengthOf(1);
     expect(tree.find('AlertBox')).to.have.lengthOf(1);
     expect(tree.find('AlertBox').text()).to.contain('BIRLS ID');
+    const recordedEvent = getLastEvent();
+    expect(recordedEvent.event).to.equal('visible-alert-box');
+    expect(recordedEvent['error-key']).to.include('birls_id');
     tree.unmount();
   });
 
@@ -130,6 +137,9 @@ describe('Form 526EZ Entry Page', () => {
     expect(tree.find('h1')).to.have.lengthOf(1);
     expect(tree.find('AlertBox')).to.have.lengthOf(1);
     expect(tree.find('AlertBox').text()).to.contain('need some information');
+    const recordedEvent = getLastEvent();
+    expect(recordedEvent.event).to.equal('visible-alert-box');
+    expect(recordedEvent['error-key']).to.include('missing_526');
     tree.unmount();
   });
 
@@ -211,6 +221,11 @@ describe('Form 526EZ Entry Page', () => {
     expect(tree.find('AlertBox')).to.have.lengthOf(1);
     expect(tree.find('AlertBox p').text()).to.contain(
       'We need more information',
+    );
+    const recordedEvent = getLastEvent();
+    expect(recordedEvent.event).to.equal('visible-alert-box');
+    expect(recordedEvent['error-key']).to.include(
+      'missing_526_or_original_claims_service',
     );
     tree.unmount();
   });

--- a/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
@@ -103,7 +103,7 @@ describe('<IntroductionPage/>', () => {
       wrapper.find('withRouter(Connect(SaveInProgressIntro))').length,
     ).to.equal(2);
     expect(wrapper.find('FormTitle').length).to.equal(1);
-    expect(wrapper.find('FileOriginalClaimPage').length).to.equal(0);
+    expect(wrapper.find('Connect(FileOriginalClaimPage)').length).to.equal(0);
     wrapper.unmount();
   });
   it('should block original claim & show alert', () => {
@@ -114,7 +114,7 @@ describe('<IntroductionPage/>', () => {
       wrapper.find('withRouter(Connect(SaveInProgressIntro))').length,
     ).to.equal(0);
     expect(wrapper.find('FormTitle').length).to.equal(1);
-    expect(wrapper.find('FileOriginalClaimPage').length).to.equal(1);
+    expect(wrapper.find('Connect(FileOriginalClaimPage)').length).to.equal(1);
     wrapper.unmount();
   });
   it('should render reset wizard link to info page', () => {

--- a/src/applications/disability-benefits/wizard/pages/appeals.jsx
+++ b/src/applications/disability-benefits/wizard/pages/appeals.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
+
+import recordEvent from 'platform/monitoring/record-event';
+
 import { pageNames } from './pageList';
 
 const label =
@@ -23,7 +26,16 @@ const AppealsPage = ({ setPageState, state = {} }) => (
     label={label}
     id={`${pageNames.appeals}-option`}
     options={options}
-    onValueChange={({ value }) => setPageState({ selected: value }, value)}
+    onValueChange={({ value }) => {
+      recordEvent({
+        event: 'howToWizard-formChange',
+        'form-field-type': 'form-radio-buttons',
+        'form-field-label': label,
+        'form-field-value':
+          value === pageNames.fileClaim ? 'new-worse' : 'disagreeing',
+      });
+      setPageState({ selected: value }, value);
+    }}
     value={{ value: state.selected }}
   />
 );

--- a/src/applications/disability-benefits/wizard/pages/bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/bdd.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import moment from 'moment';
 import Date from '@department-of-veterans-affairs/component-library/Date';
-import { pageNames } from './pageList';
 
+import recordEvent from 'platform/monitoring/record-event';
+
+import { pageNames } from './pageList';
 import unableToFileBDDProduction from './unable-to-file-bdd-production';
 import {
   FORM_STATUS_BDD,
@@ -74,6 +76,8 @@ const isDateInFuture = date =>
 
 const BDDPage = ({ setPageState, state = defaultState, allowBDD }) => {
   if (!allowBDD) {
+    // BDD at 100%, this will need to be removed along with the
+    // form526_benefits_delivery_at_discharge feature flag
     return <unableToFileBDDProduction.component />;
   }
 
@@ -83,6 +87,16 @@ const BDDPage = ({ setPageState, state = defaultState, allowBDD }) => {
       isDateComplete(pageState) && isDateInFuture(pageState)
         ? findNextPage(pageState)
         : null;
+
+    if (value) {
+      recordEvent({
+        event: 'howToWizard-formChange',
+        // Date component wrapper class name
+        'form-field-type': 'usa-date-of-birth',
+        'form-field-label': label,
+        'form-field-value': value,
+      });
+    }
     setPageState(pageState, value);
   };
 

--- a/src/applications/disability-benefits/wizard/pages/bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/bdd.jsx
@@ -67,12 +67,14 @@ const label =
 const isDateComplete = date =>
   date.day.value && date.month.value && date.year.value.length === 4;
 
-const isDateInFuture = date =>
+const getDate = date =>
   moment({
     day: date.day.value,
     month: parseInt(date.month.value, 10) - 1,
     year: date.year.value,
-  }).diff(moment()) > 0;
+  });
+
+const isDateInFuture = date => date && date.diff(moment()) > 0;
 
 const BDDPage = ({ setPageState, state = defaultState, allowBDD }) => {
   if (!allowBDD) {
@@ -83,10 +85,8 @@ const BDDPage = ({ setPageState, state = defaultState, allowBDD }) => {
 
   const onChange = pageState => {
     saveDischargeDate();
-    const value =
-      isDateComplete(pageState) && isDateInFuture(pageState)
-        ? findNextPage(pageState)
-        : null;
+    const date = isDateComplete(pageState) ? getDate(pageState) : null;
+    const value = isDateInFuture(date) ? findNextPage(pageState) : null;
 
     if (value) {
       recordEvent({
@@ -94,7 +94,7 @@ const BDDPage = ({ setPageState, state = defaultState, allowBDD }) => {
         // Date component wrapper class name
         'form-field-type': 'usa-date-of-birth',
         'form-field-label': label,
-        'form-field-value': value,
+        'form-field-value': date.format('YYYY-MM-DD'),
       });
     }
     setPageState(pageState, value);
@@ -108,7 +108,7 @@ const BDDPage = ({ setPageState, state = defaultState, allowBDD }) => {
         name="discharge-date"
         date={state}
         validation={{
-          valid: isDateInFuture(state),
+          valid: isDateInFuture(getDate(state)),
           message: 'Your separation date must be in the future',
         }}
       />

--- a/src/applications/disability-benefits/wizard/pages/disagree-file-claim.jsx
+++ b/src/applications/disability-benefits/wizard/pages/disagree-file-claim.jsx
@@ -1,16 +1,36 @@
 import React from 'react';
 
+import recordEvent from 'platform/monitoring/record-event';
+
 import { pageNames } from './pageList';
 
-const DisagreeFileClaimPage = () => (
-  <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
-    <p className="vads-u-margin-top--0">
-      If you disagree with a VA decision on your claim, you’ll need to request a
-      decision review.
-    </p>
-    <a href="/decision-reviews/">Learn about the decision review process</a>
-  </div>
-);
+const DisagreeFileClaimPage = () => {
+  const linkText = 'Learn about the decision review process';
+
+  recordEvent({
+    event: 'howToWizard-alert-displayed',
+    'reason-for-alert': 'disagree with VA decision, needs a decision review',
+  });
+  return (
+    <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
+      <p className="vads-u-margin-top--0">
+        If you disagree with a VA decision on your claim, you’ll need to request
+        a decision review.
+      </p>
+      <a
+        href="/decision-reviews/"
+        onClick={() => {
+          recordEvent({
+            event: 'howToWizard-alert-link-click',
+            'howToWizard-alert-link-click-label': linkText,
+          });
+        }}
+      >
+        {linkText}
+      </a>
+    </div>
+  );
+};
 
 export default {
   name: pageNames.disagreeFileClaim,

--- a/src/applications/disability-benefits/wizard/pages/file-bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-bdd.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import moment from 'moment';
 
+import recordEvent from 'platform/monitoring/record-event';
+
 import { BDD_INFO_URL } from 'applications/disability-benefits/all-claims/constants';
 
 import { pageNames } from './pageList';
@@ -60,9 +62,20 @@ const FileBDDClaim = ({ getPageStateFromPageName, setWizardStatus }) => {
         setWizardStatus,
         label,
         ariaId: 'learn_about_bdd',
+        eventReason: 'wizard completed, starting BDD flow',
       })}
-      <p id="learn_about_bdd">
-        <a href={BDD_INFO_URL}>{linkText}</a>
+      <p id="learn_about_bdd" className="vads-u-margin-bottom--0">
+        <a
+          href={BDD_INFO_URL}
+          onClick={() => {
+            recordEvent({
+              event: 'howToWizard-alert-link-click',
+              'howToWizard-alert-link-click-label': linkText,
+            });
+          }}
+        >
+          {linkText}
+        </a>
       </p>
     </div>
   );

--- a/src/applications/disability-benefits/wizard/pages/file-claim-early.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-claim-early.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import recordEvent from 'platform/monitoring/record-event';
+
 import { pageNames } from './pageList';
 import { formStartButton } from '../wizard-utils';
 
@@ -17,9 +19,21 @@ const FileClaimPage = ({ setWizardStatus }) => {
         setWizardStatus,
         label,
         ariaId: 'other_ways_to_file_526',
+        eventReason:
+          'wizard completed, starting 526 flow (less than 90 days to discharge)',
       })}
       <p id="other_ways_to_file_526" className="vads-u-margin-bottom--0">
-        <a href="/disability/how-to-file-claim/">{linkText}</a>
+        <a
+          href="/disability/how-to-file-claim/"
+          onClick={() => {
+            recordEvent({
+              event: 'howToWizard-alert-link-click',
+              'howToWizard-alert-link-click-label': linkText,
+            });
+          }}
+        >
+          {linkText}
+        </a>
       </p>
     </div>
   );

--- a/src/applications/disability-benefits/wizard/pages/file-claim.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-claim.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import recordEvent from 'platform/monitoring/record-event';
+
 import { pageNames } from './pageList';
 import { formStartButton } from '../wizard-utils';
 
@@ -17,9 +19,21 @@ const FileClaimPage = ({ setWizardStatus }) => {
         setWizardStatus,
         label,
         ariaId: 'other_ways_to_file_526',
+        eventReason:
+          'wizard completed, starting 526 disability compensation flow',
       })}
       <p id="other_ways_to_file_526" className="vads-u-margin-bottom--0">
-        <a href="/disability/how-to-file-claim/">{linkText}</a>
+        <a
+          href="/disability/how-to-file-claim/"
+          onClick={() => {
+            recordEvent({
+              event: 'howToWizard-alert-link-click',
+              'howToWizard-alert-link-click-label': linkText,
+            });
+          }}
+        >
+          {linkText}
+        </a>
       </p>
     </div>
   );

--- a/src/applications/disability-benefits/wizard/pages/file-original-claim.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-original-claim.jsx
@@ -1,9 +1,21 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
-import { pageNames } from './pageList';
-import EbenefitsLink from 'platform/site-wide/ebenefits/containers/EbenefitsLink';
 
-function FileOriginalClaimPage() {
+import EbenefitsLink from 'platform/site-wide/ebenefits/containers/EbenefitsLink';
+import { isLoggedIn as isLoggedInSelector } from 'platform/user/selectors';
+import recordEvent from 'platform/monitoring/record-event';
+
+import { pageNames } from './pageList';
+
+// Delete file once form526_original_claims feature flag is removed
+function FileOriginalClaimPage({ isLoggedIn }) {
+  const linkText = 'Go to eBenefits';
+
+  recordEvent({
+    event: 'howToWizard-alert-displayed',
+    'reason-for-alert': 'Unable to file for original claims on va.gov',
+  });
   return (
     <AlertBox
       status="warning"
@@ -17,8 +29,17 @@ function FileOriginalClaimPage() {
           <EbenefitsLink
             path="ebenefits/about/feature?feature=disability-compensation"
             className="usa-button-primary va-button-primary"
+            onClick={() => {
+              if (isLoggedIn) {
+                recordEvent({ event: 'nav-ebenefits-click' });
+              }
+              recordEvent({
+                event: 'howToWizard-alert-link-click',
+                'howToWizard-alert-link-click-label': linkText,
+              });
+            }}
           >
-            Go to eBenefits
+            {linkText}
           </EbenefitsLink>
         </>
       }
@@ -26,7 +47,11 @@ function FileOriginalClaimPage() {
   );
 }
 
+const mapStateToProps = state => ({
+  isLoggedIn: isLoggedInSelector(state),
+});
+
 export default {
   name: pageNames.fileOriginalClaim,
-  component: FileOriginalClaimPage,
+  component: connect(mapStateToProps)(FileOriginalClaimPage),
 };

--- a/src/applications/disability-benefits/wizard/pages/start.jsx
+++ b/src/applications/disability-benefits/wizard/pages/start.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
+
+import recordEvent from 'platform/monitoring/record-event';
+
 import { pageNames } from './pageList';
 
 const label = 'Are you on active duty right now?';
@@ -15,7 +18,15 @@ const StartPage = ({ setPageState, state = {} }) => (
     label={label}
     id={`${pageNames.start}-option`}
     options={options}
-    onValueChange={({ value }) => setPageState({ selected: value }, value)}
+    onValueChange={({ value }) => {
+      recordEvent({
+        event: 'howToWizard-formChange',
+        'form-field-type': 'form-radio-buttons',
+        'form-field-label': label,
+        'form-field-value': value === pageNames.bdd ? 'yes-bdd' : 'no-appeals',
+      });
+      setPageState({ selected: value }, value);
+    }}
     value={{ value: state.selected }}
   />
 );

--- a/src/applications/disability-benefits/wizard/pages/unable-to-file-bdd-production.jsx
+++ b/src/applications/disability-benefits/wizard/pages/unable-to-file-bdd-production.jsx
@@ -19,6 +19,12 @@ const oneHundredEightyDays = moment()
   .format(dateFormat);
 
 function alertContent(isLoggedIn) {
+  const linkText = 'Learn more about the BDD program';
+
+  recordEvent({
+    event: 'howToWizard-alert-displayed',
+    'reason-for-alert': 'Unable to file for BDD',
+  });
   return (
     <>
       <p>
@@ -44,7 +50,17 @@ function alertContent(isLoggedIn) {
         Go to eBenefits
       </a>
       <p>
-        <a href={BDD_INFO_URL}>Learn more about the BDD program</a>
+        <a
+          href={BDD_INFO_URL}
+          onClick={() => {
+            recordEvent({
+              event: 'howToWizard-alert-link-click',
+              'howToWizard-alert-link-click-label': linkText,
+            });
+          }}
+        >
+          {linkText}
+        </a>
       </p>
     </>
   );

--- a/src/applications/disability-benefits/wizard/pages/unable-to-file-bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/unable-to-file-bdd.jsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import moment from 'moment';
 
+import recordEvent from 'platform/monitoring/record-event';
+
 import { BDD_INFO_URL } from 'applications/disability-benefits/all-claims/constants';
 
 import { pageNames } from './pageList';
 
 const UnableToFileBDDPage = ({ getPageStateFromPageName }) => {
+  const linkText = 'Learn more about the BDD program';
+
   const stateBDD = getPageStateFromPageName('bdd');
 
   const dateDischarge = moment({
@@ -21,6 +25,10 @@ const UnableToFileBDDPage = ({ getPageStateFromPageName }) => {
     .add(differenceBetweenDatesInDays, 'days')
     .format('MMMM D, YYYY');
 
+  recordEvent({
+    event: 'howToWizard-alert-displayed',
+    'reason-for-alert': 'Unable to file for BDD',
+  });
   return (
     <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
       <p className="vads-u-margin-top--0">
@@ -36,7 +44,17 @@ const UnableToFileBDDPage = ({ getPageStateFromPageName }) => {
         leave the military.
       </p>
       <p>
-        <a href={BDD_INFO_URL}>Learn more about the BDD program</a>
+        <a
+          href={BDD_INFO_URL}
+          onClick={() => {
+            recordEvent({
+              event: 'howToWizard-alert-link-click',
+              'howToWizard-alert-link-click-label': linkText,
+            });
+          }}
+        >
+          {linkText}
+        </a>
       </p>
     </div>
   );

--- a/src/applications/disability-benefits/wizard/wizard-utils.js
+++ b/src/applications/disability-benefits/wizard/wizard-utils.js
@@ -1,22 +1,43 @@
 import React from 'react';
 
+import recordEvent from 'platform/monitoring/record-event';
+
 import { WIZARD_STATUS_COMPLETE } from 'applications/static-pages/wizard';
 import { DISABILITY_526_V2_ROOT_URL } from 'applications/disability-benefits/all-claims/constants';
 
-export const formStartButton = ({ setWizardStatus, label, ariaId }) => (
-  <a
-    href={`${DISABILITY_526_V2_ROOT_URL}/introduction`}
-    className="usa-button-primary va-button-primary"
-    onClick={event => {
-      /* Remove this check, keep the preventDefault once show526Wizard flipper
-          is at 100% */
-      if (window.location.pathname.includes(DISABILITY_526_V2_ROOT_URL)) {
-        event.preventDefault();
-      }
-      setWizardStatus(WIZARD_STATUS_COMPLETE);
-    }}
-    aria-describedby={ariaId}
-  >
-    {label}
-  </a>
-);
+export const formStartButton = ({
+  setWizardStatus,
+  label,
+  ariaId,
+  eventReason,
+}) => {
+  recordEvent({
+    event: 'howToWizard-cta-displayed',
+  });
+  return (
+    <a
+      href={`${DISABILITY_526_V2_ROOT_URL}/introduction`}
+      className="usa-button-primary va-button-primary"
+      onClick={event => {
+        /* Remove this check, keep the preventDefault once show526Wizard flipper
+            is at 100% */
+        if (window.location.pathname.includes(DISABILITY_526_V2_ROOT_URL)) {
+          event.preventDefault();
+        }
+        recordEvent({
+          event: 'howToWizard-hidden',
+          'reason-for-hidden-wizard': eventReason,
+        });
+        recordEvent({
+          event: 'cta-button-click',
+          'button-type': 'primary',
+          'button-click-label': label,
+        });
+        setWizardStatus(WIZARD_STATUS_COMPLETE);
+      }}
+      aria-describedby={ariaId}
+    >
+      {label}
+    </a>
+  );
+};


### PR DESCRIPTION
## Description

Google analytics are added to Form 526's wizard per the spec - https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/analytics/google-analytics/tracking-how-to-wizards.md

Also added analytics to missing services and id shown alerts

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/17080
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/9510
- https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/analytics/google-analytics/tracking-how-to-wizards.md
- https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/analytics/google-analytics/tracking-design-system-components.md#specification

## Testing done

Unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] GA events added to 526 wizard
- [x] GA events added to intro alerts

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
