### PR TITLE
Bump Formation to v6.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -275,7 +275,7 @@
   "private": true,
   "dependencies": {
     "@department-of-veterans-affairs/component-library": "1.0.0",
-    "@department-of-veterans-affairs/formation": "6.11.0",
+    "@department-of-veterans-affairs/formation": "6.12.0",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "@fortawesome/fontawesome-free": "^5.6.3",
     "@mapbox/mapbox-sdk": "^0.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1289,10 +1289,10 @@
     react-transition-group "1"
     recast "^0.14.4"
 
-"@department-of-veterans-affairs/formation@6.11.0":
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-6.11.0.tgz#7a44bea61843d19929d12fc005099e6da44f8f0e"
-  integrity sha512-n/cSKY5SiU5hfeegI2HbUIAcPmS7neMCZk3QT6hmi6pX8SRdelsOTaTz8bsuqSKoww2qbnWenbk7uXj33w6bqA==
+"@department-of-veterans-affairs/formation@6.12.0":
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-6.12.0.tgz#51f188582e9657e67f52be8bbd544b2674d81143"
+  integrity sha512-gi42HSn10qGM60jskUz7ma9rZ1jmRnQxUrQKjmqqiqFzXGMaioCnsa2wt8tkgSMUbZzF79/UREjbZu5bG3ILLQ==
   dependencies:
     "@fortawesome/fontawesome-free" "^5.6.3"
     domready "^1.0.8"


### PR DESCRIPTION
## Description
This PR updates Formation to get the update below

https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/576
## Testing done
confirmed i got the update

![image](https://user-images.githubusercontent.com/1915775/105211919-cce88580-5b1a-11eb-8805-1d7c19909601.png)


## Screenshots
see above

## Acceptance criteria
- [ ] Formation is updated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
