### PR TITLE
Update nav Contact Us min width

### DIFF
--- a/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
@@ -73,7 +73,7 @@ class SearchHelpSignIn extends Component {
           isOpen={this.props.isMenuOpen.search}
         />
         <a
-          className="vads-u-color--white vads-u-text-decoration--none vads-u-padding-top--0p5 vads-u-padding-x--1 vads-u-font-weight--bold"
+          className="contact-us-link vads-u-color--white vads-u-text-decoration--none vads-u-padding-top--0p5 vads-u-padding-x--1 vads-u-font-weight--bold"
           href="https://www.va.gov/contact-us/"
           onClick={() => recordEvent({ event: 'nav-jumplink-click' })}
         >

--- a/src/platform/site-wide/user-nav/sass/user-nav.scss
+++ b/src/platform/site-wide/user-nav/sass/user-nav.scss
@@ -53,7 +53,7 @@ span.sidelines {
   }
 
   .contact-us-link {
-    min-width: fit-content;
+    min-width: 91px;
   }
 
   .login {

--- a/src/platform/site-wide/user-nav/sass/user-nav.scss
+++ b/src/platform/site-wide/user-nav/sass/user-nav.scss
@@ -52,6 +52,10 @@ span.sidelines {
     align-items: center;
   }
 
+  .contact-us-link {
+    min-width: fit-content;
+  }
+
   .login {
     .explanation-content {
       @include media($medium-large-screen) {


### PR DESCRIPTION
[TICKET](https://github.com/department-of-veterans-affairs/va.gov-team/issues/18412)

## Description
We needed to apply a `min-width` to the 'contact us' link to ensure it does not wrap when the username/email address is too long.

## Testing done
Looks good locally.

## Screenshots
BEFORE
![image](https://user-images.githubusercontent.com/14869324/105223735-644cd900-5b19-11eb-8fcf-617734f89365.png)

AFTER
![image](https://user-images.githubusercontent.com/14869324/105223634-47180a80-5b19-11eb-9635-354d620f4a66.png)
![image](https://user-images.githubusercontent.com/14869324/105223672-51d29f80-5b19-11eb-95d4-2cc949e15689.png)

## Acceptance criteria
- [x] Do not wrap `Contact Us`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
