### PR TITLE
[Development] Add headers inside review accordion

### DIFF
--- a/src/applications/disability-benefits/996/components/ReviewDescription.jsx
+++ b/src/applications/disability-benefits/996/components/ReviewDescription.jsx
@@ -41,9 +41,9 @@ const ReviewDescription = ({ profile }) => {
   return (
     <>
       <div className="form-review-panel-page-header-row">
-        <h3 className="vads-u-font-size--h4 vads-u-margin--0">
+        <h4 className="vads-u-font-size--h4 vads-u-margin--0">
           Contact information
-        </h3>
+        </h4>
         <a
           href={PROFILE_URL}
           target="_blank"

--- a/src/applications/disability-benefits/all-claims/components/PaymentViewObjectField.jsx
+++ b/src/applications/disability-benefits/all-claims/components/PaymentViewObjectField.jsx
@@ -29,9 +29,9 @@ const PaymentViewObjectField = (props = {}) => {
   return (
     <>
       <div className="form-review-panel-page-header-row">
-        <h3 className="form-review-panel-page-header vads-u-font-size--h5">
+        <h4 className="form-review-panel-page-header vads-u-font-size--h5">
           {title}
-        </h3>
+        </h4>
         {defaultEditButton()}
       </div>
       <dl className="review">{Object.keys(paymentRows).map(buildRow)}</dl>

--- a/src/applications/vre/28-1900/containers/StaticInformationReviewField.jsx
+++ b/src/applications/vre/28-1900/containers/StaticInformationReviewField.jsx
@@ -24,9 +24,9 @@ const StaticInformationReviewField = props => {
       {!isLoggedIn ? null : (
         <>
           <div className="form-review-panel-page-header-row">
-            <h3 className="vads-u-font-size--h5 vads-u-margin--0">
+            <h4 className="vads-u-font-size--h5 vads-u-margin--0">
               Veteran Information
-            </h3>
+            </h4>
           </div>
           <dl className="review vads-u-border-bottom--0">
             {Object.entries(display).map(([label, value]) => {

--- a/src/applications/vre/28-8832/components/ReadOnlyUserDescription.js
+++ b/src/applications/vre/28-8832/components/ReadOnlyUserDescription.js
@@ -27,9 +27,9 @@ const ReadOnlyUserDescription = props => {
       props.profile.loa.current !== LOA_LEVEL_REQUIRED ? null : (
         <>
           <div className="form-review-panel-page-header-row">
-            <h3 className="vads-u-font-size--h5 vads-u-margin--0">
+            <h4 className="vads-u-font-size--h5 vads-u-margin--0">
               Claimant Information
-            </h3>
+            </h4>
           </div>
           <dl className="review vads-u-border-bottom--0">
             {Object.entries(display).map(([label, value]) => {

--- a/src/platform/forms-system/src/js/review/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/review/ArrayField.jsx
@@ -220,9 +220,9 @@ class ArrayField extends React.Component {
       >
         {title && (
           <div className="form-review-panel-page-header-row">
-            <h3 className="form-review-panel-page-header vads-u-font-size--h4">
+            <h4 className="form-review-panel-page-header vads-u-font-size--h4">
               {title}
-            </h3>
+            </h4>
             {itemsNeeded && (
               <span className="schemaform-review-array-warning-icon" />
             )}

--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -176,9 +176,9 @@ class ObjectField extends React.Component {
             <div className="form-review-panel-page-header-row">
               {title?.trim() &&
                 !formContext.hideTitle && (
-                  <h3 className="form-review-panel-page-header vads-u-font-size--h5">
+                  <h4 className="form-review-panel-page-header vads-u-font-size--h5">
                     {title}
-                  </h3>
+                  </h4>
                 )}
               {defaultEditButton()}
             </div>

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -281,7 +281,9 @@ export default class ReviewCollapsibleChapter extends React.Component {
                 aria-controls={`collapsible-${this.id}`}
                 onClick={this.props.toggleButtonClicked}
               >
-                {chapterTitle || ''}
+                {chapterTitle && (
+                  <h3 className="vads-u-font-size--h4">{chapterTitle}</h3>
+                )}
               </button>
               {showUnviewedPageWarning && (
                 <span className="schemaform-review-chapter-warning-icon" />

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -265,6 +265,14 @@ export default class ReviewCollapsibleChapter extends React.Component {
       'schemaform-review-chapter-warning': showUnviewedPageWarning,
     });
 
+    const headerClasses = classNames(
+      'accordion-header',
+      'clearfix',
+      'schemaform-chapter-accordion-header',
+      'vads-u-font-size--h4',
+      'vads-u-margin-top--0',
+    );
+
     return (
       <div
         id={`${this.id}-collapsiblePanel`}
@@ -274,21 +282,19 @@ export default class ReviewCollapsibleChapter extends React.Component {
         <Element name={`chapter${this.props.chapterKey}ScrollElement`} />
         <ul className="usa-unstyled-list">
           <li>
-            <div className="accordion-header clearfix schemaform-chapter-accordion-header">
+            <h3 className={headerClasses}>
               <button
                 className="usa-button-unstyled"
                 aria-expanded={this.props.open ? 'true' : 'false'}
                 aria-controls={`collapsible-${this.id}`}
                 onClick={this.props.toggleButtonClicked}
               >
-                {chapterTitle && (
-                  <h3 className="vads-u-font-size--h4">{chapterTitle}</h3>
-                )}
+                {chapterTitle || ''}
               </button>
               {showUnviewedPageWarning && (
                 <span className="schemaform-review-chapter-warning-icon" />
               )}
-            </div>
+            </h3>
             <div id={`collapsible-${this.id}`}>{pageContent}</div>
           </li>
         </ul>

--- a/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
@@ -644,7 +644,6 @@ describe('<ReviewCollapsibleChapter>', () => {
       />,
     );
 
-    expect(tree.find('h3').length).to.eq(0);
     expect(tree.find('.form-review-panel-page').length).to.eq(0);
 
     tree.unmount();

--- a/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
@@ -509,8 +509,9 @@ describe('<ReviewCollapsibleChapter>', () => {
       />,
     );
 
-    const titleDiv = wrapper.find('.form-review-panel-page-header');
+    expect(wrapper.find('h3').text()).to.equal(testChapterTitle);
 
+    const titleDiv = wrapper.find('h4.form-review-panel-page-header');
     expect(titleDiv.length).to.equal(1);
     expect(titleDiv.text()).to.equal(testPageTitle);
     expect(titleDiv.text()).to.not.equal(testChapterTitle);
@@ -563,6 +564,8 @@ describe('<ReviewCollapsibleChapter>', () => {
         form={form}
       />,
     );
+
+    expect(wrapper.find('h3').text()).to.equal(testChapterTitle);
 
     const titleDiv = wrapper.find('.form-review-panel-page-header');
     // Title is not rendered if it contains an empty string
@@ -641,6 +644,7 @@ describe('<ReviewCollapsibleChapter>', () => {
       />,
     );
 
+    expect(tree.find('h3').length).to.eq(0);
     expect(tree.find('.form-review-panel-page').length).to.eq(0);
 
     tree.unmount();


### PR DESCRIPTION
## Description

To improve accessibility, the form review & submit accordions should contain a header. This includes the accordions in the list of headers, and also show up on the list of form elements (buttons).

Related:
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/368
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/17846
- Docs: https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/582

## Testing done

- Updated unit tests
- Manual axe, axe coconut & WAVE tests

## Screenshots

<details><summary>Original a11y audit findings</summary>

<!-- leave a blank line above -->
![](https://user-images.githubusercontent.com/14154792/103014613-0d99b280-450d-11eb-97a4-64e7a4c05632.png)</details>

<details><summary>WAVE labels elements after this change</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-01-21 at 11 50 42 AM](https://user-images.githubusercontent.com/136959/105390816-14d0e080-5bdf-11eb-959b-6218ce5a4657.png)</details>

## Acceptance criteria
- [x] Header levels on the review & submit page better align with what is seen visually
- [x] Improved accessibility!

## Definition of done
- [ ] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
