### PR TITLE
15553 redux unit tests

### DIFF
--- a/src/applications/personalization/view-representative/reducers/index.js
+++ b/src/applications/personalization/view-representative/reducers/index.js
@@ -30,4 +30,4 @@ function representative(state = initialState, action) {
   }
 }
 
-export default { representative };
+export default representative;

--- a/src/applications/personalization/view-representative/tests/actions/index.unit.spec.js
+++ b/src/applications/personalization/view-representative/tests/actions/index.unit.spec.js
@@ -7,7 +7,7 @@ import {
   fetchRepresentative,
 } from '../../actions';
 
-import { representative } from '../helpers';
+import { currentRepresentative } from '../helpers';
 
 let fetchMock;
 let oldFetch;
@@ -29,7 +29,7 @@ describe('View Representative', () => {
     fetchMock.returns({
       catch: () => ({
         then: fn =>
-          fn({ ok: true, json: () => Promise.resolve(representative) }),
+          fn({ ok: true, json: () => Promise.resolve(currentRepresentative) }),
       }),
     });
     const thunk = fetchRepresentative();

--- a/src/applications/personalization/view-representative/tests/actions/index.unit.spec.js
+++ b/src/applications/personalization/view-representative/tests/actions/index.unit.spec.js
@@ -1,0 +1,75 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import {
+  FETCH_REPRESENTATIVE_FAILED,
+  FETCH_REPRESENTATIVE_SUCCESS,
+  fetchRepresentative,
+} from '../../actions';
+
+import { representative } from '../helpers';
+
+let fetchMock;
+let oldFetch;
+
+const mockFetch = () => {
+  oldFetch = global.fetch;
+  fetchMock = sinon.stub();
+  global.fetch = fetchMock;
+};
+
+const unMockFetch = () => {
+  global.fetch = oldFetch;
+};
+
+describe('View Representative', () => {
+  beforeEach(mockFetch);
+
+  it('should get current Reppresentative', () => {
+    fetchMock.returns({
+      catch: () => ({
+        then: fn =>
+          fn({ ok: true, json: () => Promise.resolve(representative) }),
+      }),
+    });
+    const thunk = fetchRepresentative();
+    const dispatchSpy = sinon.spy();
+    const dispatch = action => {
+      dispatchSpy(action);
+      if (dispatchSpy.callCount === 2) {
+        expect(dispatchSpy.secondCall.args[0].type).to.equal(
+          FETCH_REPRESENTATIVE_SUCCESS,
+        );
+      }
+    };
+    thunk(dispatch);
+  });
+
+  it('should handle an error', () => {
+    const response = {
+      errors: [
+        {
+          code: '500',
+          status: 'Some status',
+        },
+      ],
+    };
+    fetchMock.returns({
+      catch: () => ({
+        then: fn => fn({ ok: true, json: () => Promise.resolve(response) }),
+      }),
+    });
+    const thunk = fetchRepresentative();
+    const dispatchSpy = sinon.spy();
+    const dispatch = action => {
+      dispatchSpy(action);
+      if (dispatchSpy.callCount === 2) {
+        expect(dispatchSpy.secondCall.args[0].type).to.equal(
+          FETCH_REPRESENTATIVE_FAILED,
+        );
+      }
+    };
+    thunk(dispatch);
+  });
+  afterEach(unMockFetch);
+});

--- a/src/applications/personalization/view-representative/tests/helpers.js
+++ b/src/applications/personalization/view-representative/tests/helpers.js
@@ -1,11 +1,13 @@
-export const representative = {
-  relationshipType: '',
-  dateRequestAccepted: '2014-17-28',
-  status: 'submitted',
-  representative: {
-    poaCode: 'A01',
-    poaFirstName: 'John',
-    paoLastName: 'Doe',
-    participantID: '987654',
+export const currentRepresentative = [
+  {
+    relationshipType: '',
+    dateRequestAccepted: '2014-17-28',
+    status: 'submitted',
+    representative: {
+      poaCode: 'A01',
+      poaFirstName: 'John',
+      paoLastName: 'Doe',
+      participantID: '987654',
+    },
   },
-};
+];

--- a/src/applications/personalization/view-representative/tests/helpers.js
+++ b/src/applications/personalization/view-representative/tests/helpers.js
@@ -1,0 +1,11 @@
+export const representative = {
+  relationshipType: '',
+  dateRequestAccepted: '2014-17-28',
+  status: 'submitted',
+  representative: {
+    poaCode: 'A01',
+    poaFirstName: 'John',
+    paoLastName: 'Doe',
+    participantID: '987654',
+  },
+};

--- a/src/applications/personalization/view-representative/tests/reducers/index.unit.spec.js
+++ b/src/applications/personalization/view-representative/tests/reducers/index.unit.spec.js
@@ -1,0 +1,43 @@
+import { expect } from 'chai';
+
+import representative from '../../reducers';
+import { currentRepresentative } from '../helpers';
+
+const initialState = {
+  loading: true,
+  error: null,
+  representative: null,
+};
+
+describe('View Representative reducer', () => {
+  it('should return initial state', () => {
+    const state = representative(initialState, {});
+    expect(state.loading).to.be.true;
+    expect(state.representative).to.equal(null);
+  });
+
+  it('should handle a successful call for fetching payments', () => {
+    const state = representative(initialState, {
+      type: 'FETCH_REPRESENTATIVE_SUCCESS',
+      response: currentRepresentative,
+    });
+    expect(state.loading).to.be.false;
+    expect(state.representative.length).to.be.greaterThan(0);
+  });
+
+  // TODO: this needs to be updated once the frontend is wired up to the backend.
+  it('should handle an error response from the server', () => {
+    const state = representative(initialState, {
+      type: 'FETCH_REPRESENTATIVE_FAILED',
+      response: [
+        {
+          code: '500',
+          status: 'failed',
+        },
+      ],
+    });
+    expect(state.loading).to.be.false;
+    expect(state.representative).to.equal(null);
+    expect(state.error).to.not.equal(null);
+  });
+});


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/15553)

This PR is to add unit tests for our Redux implementation on the View Representative page. The tests are pretty simple at this point, since the back end API endpoint hasn't been set up and we are using dummy data, so they will probably be elaborated on in the future.

## Testing done
Ran unit test on localhost

## Screenshots

<img width="890" alt="Screen Shot 2021-01-20 at 1 33 22 PM" src="https://user-images.githubusercontent.com/1899695/105243604-22756000-5b24-11eb-815d-a10ec4134f4b.png">

<img width="901" alt="Screen Shot 2021-01-20 at 1 33 13 PM" src="https://user-images.githubusercontent.com/1899695/105243647-2bfec800-5b24-11eb-8846-3cd8a17e5895.png">

## Acceptance criteria
- [x] Redux on View Representative is unit tested it 80% coverage
- [x] A PR has been submitted for review

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
