### PR TITLE
Udpate vets-json-schema reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -347,7 +347,7 @@
     "url-search-params-polyfill": "^8.1.0",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#6fa2f985fdccf884330f61b94619ce13ddaf85a7",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#e16f99ea509943e15887b8f7e8155ff23f584992",
     "whatwg-fetch": "^2.0.3"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18596,9 +18596,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#6fa2f985fdccf884330f61b94619ce13ddaf85a7":
-  version "18.6.0"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#6fa2f985fdccf884330f61b94619ce13ddaf85a7"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#e16f99ea509943e15887b8f7e8155ff23f584992":
+  version "18.6.1"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#e16f99ea509943e15887b8f7e8155ff23f584992"
 
 vinyl-file@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description
This PR simply updates the vets-website refernce to vets-json-schema in support of a patch update to the COVID-VACCINE-TRIAL Schema. 
vets-json-schema PR: https://github.com/department-of-veterans-affairs/vets-json-schema/pull/560

## Testing done
unit tests all pass.  manual testing

## Screenshots
![image](https://user-images.githubusercontent.com/2481110/105367748-c74c7780-5bce-11eb-95f6-abc372503d1c.png)


## Acceptance criteria
- [ ] Gender option for `Prefer to self describe` is last item on Gender list

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
