### PR TITLE
[Templates] Change feature flag strategy for "Browse by audience" component

### DIFF
--- a/src/site/components/browse-by-audience.drupal.liquid
+++ b/src/site/components/browse-by-audience.drupal.liquid
@@ -1,0 +1,43 @@
+{% if audienceTags.length > 0 %}
+  <div data-template="components/browse-by-audience">
+    <h2>Browse by audience</h2>
+    <ul class="usa-unstyled-list">
+
+    {% assign pageSize = 5 %}
+
+    {% for audienceTag in audienceTags %}
+      {% if forloop.index <= pageSize %}
+        <li class="vads-u-margin-y--2">
+          <a class="vads-u-font-weight--bold vads-u-text-decoration--none" href="{{ audienceTag.entityUrl.path }}/">
+            {{ audienceTag.name }} <i role="presentation" aria-hidden="true" class="fa fa-chevron-right vads-u-margin-left--1"></i>
+          </a>
+        </li>
+      {% endif %}
+    {% endfor %}
+
+    </ul>
+
+    {% if audienceTags.length > pageSize %}
+      <div class="form-expanding-group additional-info-container vads-u-margin-y--2p5">
+        <div class="additional-info-title">Show more</div>
+
+        {% assign remainingAudienceTags = audienceTags | sliceArrayFromStart: pageSize %}
+
+        <span>
+          <div class="additional-info-content">
+            <ul class="usa-unstyled-list">
+              {% for audienceTag in remainingAudienceTags %}
+                <li class="vads-u-margin-y--2">
+                  <a class="vads-u-font-weight--bold vads-u-text-decoration--none" href="{{ audienceTag.path.alias }}/">
+                    {{ audienceTag.name }}
+                    <i role="presentation" aria-hidden="true" class="fa fa-chevron-right vads-u-margin-left--1"> </i>
+                  </a>
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+        </span>
+      </div>
+    {% endif %}
+  </div>
+{% endif %}

--- a/src/site/layouts/basic_landing_page.drupal.liquid
+++ b/src/site/layouts/basic_landing_page.drupal.liquid
@@ -52,25 +52,25 @@
         </article>
       </div>
 
+      <div class="usa-alert usa-alert-info" role="alert">
+        <div class="usa-alert-body">
+            <h3 class="usa-alert-heading">
+                We're currently in beta testing
+            </h3>
+            <div class="processed-content">
+              <div itemprop="text">
+                <p>Welcome to resources and support, a new part of <a href="/">VA.gov</a>. We'll be adding more articles and topics in the weeks and months ahead, so please check back often.</p>
+              </div>
+            </div>
+        </div>
+      </div>
+
       {% comment %}
         On hold until we have a large set of audience-types
       {% endcomment %}
       {% if buildtype != 'vagovprod' %}
 
         {% if audienceTags.length > 0 %}
-
-          <div class="usa-alert usa-alert-info" role="alert">
-            <div class="usa-alert-body">
-                <h3 class="usa-alert-heading">
-                    We're currently in beta testing
-                </h3>
-                <div class="processed-content">
-                  <div itemprop="text">
-                    <p>Welcome to resources and support, a new part of <a href="/">VA.gov</a>. We'll be adding more articles and topics in the weeks and months ahead, so please check back often.</p>
-                  </div>
-                </div>
-            </div>
-          </div>
 
           <h2>Browse by audience</h2>
           <ul class="usa-unstyled-list">

--- a/src/site/layouts/basic_landing_page.drupal.liquid
+++ b/src/site/layouts/basic_landing_page.drupal.liquid
@@ -52,73 +52,17 @@
         </article>
       </div>
 
-      <div class="usa-alert usa-alert-info" role="alert">
-        <div class="usa-alert-body">
-            <h3 class="usa-alert-heading">
-                We're currently in beta testing
-            </h3>
-            <div class="processed-content">
-              <div itemprop="text">
-                <p>Welcome to resources and support, a new part of <a href="/">VA.gov</a>. We'll be adding more articles and topics in the weeks and months ahead, so please check back often.</p>
-              </div>
-            </div>
-        </div>
-      </div>
-
-      {% comment %}
-        On hold until we have a large set of audience-types
-      {% endcomment %}
-      {% if buildtype != 'vagovprod' %}
-
-        {% if audienceTags.length > 0 %}
-
-          <h2>Browse by audience</h2>
-          <ul class="usa-unstyled-list">
-
-            {% assign pageSize = 5 %}
-
-            {% for audienceTag in audienceTags %}
-              {% if forloop.index <= pageSize %}
-                <li class="vads-u-margin-y--2">
-                  <a class="vads-u-font-weight--bold vads-u-text-decoration--none" href="{{ audienceTag.entityUrl.path }}/">
-                    {{ audienceTag.name }} <i role="presentation" aria-hidden="true" class="fa fa-chevron-right vads-u-margin-left--1"></i>
-                  </a>
-                </li>
-              {% endif %}
-            {% endfor %}
-
-            {% if audienceTags.length > pageSize %}
-              <div class="form-expanding-group additional-info-container vads-u-margin-y--2p5">
-                <div class="additional-info-title">Show more</div>
-
-                {% assign remainingAudienceTags = audienceTags | sliceArrayFromStart: pageSize %}
-
-                <span>
-                  <div class="additional-info-content">
-                    <ul class="usa-unstyled-list">
-                      {% for audienceTag in remainingAudienceTags %}
-                        <li class="vads-u-margin-y--2">
-                          <a class="vads-u-font-weight--bold vads-u-text-decoration--none" href="{{ audienceTag.path.alias }}/">
-                            {{ audienceTag.name }}
-                            <i role="presentation" aria-hidden="true" class="fa fa-chevron-right vads-u-margin-left--1"> </i>
-                          </a>
-                        </li>
-                      {% endfor %}
-                    </ul>
-                  </div>
-                </span>
-              </div>
-            {% endif %}
-          </ul>
-        {% endif %}
-      {% endif %}
-
       <!-- Content blocks -->
       <article class="vads-u-padding-bottom--4">
         {% for block in fieldContentBlock %}
-          {% assign bundleComponent = "src/site/paragraphs/" | append: block.entity.entityBundle %}
-          {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
-          {% include {{ bundleComponentWithExtension }} with entity = block.entity %}
+          {% if block.entity.entityBundle == 'lists_of_links' and block.entity.fieldSectionHeader == 'Browse by audience' %}
+            {% include 'src/site/components/browse-by-audience.drupal.liquid' %}
+          {% else %}
+              {% assign bundleComponent = "src/site/paragraphs/" | append: block.entity.entityBundle %}
+              {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
+              {% include {{ bundleComponentWithExtension }} with entity = block.entity %}
+          {% endif %}
+
         {% endfor %}
       </article>
 


### PR DESCRIPTION
## Description
Currently, the "Browse by audience" section of the page on va.gov/resources/ is hardcoded into the template checking only for the staging environment. This PR changes that behavior by rendering onto the page when it detects a heading that says "Browse by audience". This way a CMS editor has full control over when and where that section displays.

See https://github.com/department-of-veterans-affairs/va.gov-team/issues/17276#issuecomment-764686693

## Testing done
Observed page locally

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/105394660-ddb4fc00-5beb-11eb-9f21-d21596010372.png)


## Acceptance criteria
- [ ] Blue beta banner is in FE code

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
