### PR TITLE
Kelsonic clp template

### DIFF
--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -59,8 +59,8 @@
 
       <!-- What You Can Do -->
       <div class="what-you-can-do">
-        <h2>WHAT YOU CAN DO</h2>
-        <h3>{{ fieldClpWhatYouCanDoHeader }}</h3>
+        <p class="grey-header">WHAT YOU CAN DO</p>
+        <h2>{{ fieldClpWhatYouCanDoHeader }}</h2>
         <p>{{ fieldClpWhatYouCanDoIntro }}</p>
 
         {% if fieldClpWhatYouCanDoPromos != empty %}
@@ -80,8 +80,8 @@
 
       <!-- Video -->
       <div class="what-you-can-do">
-        <h2>VIDEO</h2>
-        <h3>{{ fieldClpVideoPanelHeader }}</h3>
+        <p class="grey-header">VIDEO</p>
+        <h2>{{ fieldClpVideoPanelHeader }}</h2>
 
         <iframe
           allowFullScreen
@@ -94,6 +94,48 @@
         <a class="usa-button-secondary" href="{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLink.uri }}" rel="noreferrer noopener" target="_blank">
           {{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel }}
         </a>
+      </div>
+
+      <!-- Spotlight -->
+      <div class="spotlight">
+        <p class="grey-header">SPOTLIGHT</p>
+        <h2>{{ fieldClpSpotlightHeader }}</h2>
+        <p>
+          {{ fieldClpSpotlightIntroText }}
+          <a href="{{ fieldClpSpotlightCta.entity.fieldButtonLink.uri }}" rel="noreferrer noopener" target="_ blank">
+            {{ fieldClpSpotlightCta.entity.fieldButtonLabel }}
+          </a>
+        </p>
+
+        <div class="link-teasers">
+          {% for linkTeaser in fieldClpSpotlightLinkTeasers %}
+            <div class="link-teaser">
+              <a href="{{ linkTeaser.entity.fieldLink.uri }}" rel="noreferrer noopener" target="_blank">{{ linkTeaser.entity.fieldLink.title }}</a>
+              <p>{{ linkTeaser.entity.fieldLinkSummary }}</p>
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+
+      <!-- Stories -->
+      <div class="stories">
+        <p class="grey-header">STORIES</p>
+        <h2>{{ fieldClpStoriesHeader }}</h2>
+        <p>{{ fieldClpStoriesIntro }}</p>
+
+        <div class="stories-list">
+          {% for storyTeaser in fieldClpStoriesTeasers %}
+            <div class="story-teaser">
+              <img alt="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.alt }}" src="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.url }}" />
+              <div class="story-teaser-content">
+                <a href="{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.uri }}" rel="noreferrer noopener" target="_blank">
+                  {{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.title }}
+                </a>
+                <p>{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLinkSummary }}</p>
+              </div>
+            </div>
+          {% endfor %}
+        </div>
       </div>
     </div>
 

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -21,7 +21,7 @@
           <h1>{{ title }}</h1>
           <hr />
           <p>{{ fieldHeroBlurb }}</p>
-          <a class="usa-butto-secondary" href="{{ fieldPrimaryCallToAction.entity.fieldButtonLink.uri }}" rel="noreferrer noopener">
+          <a class="usa-butto-secondary" href="{{ fieldPrimaryCallToAction.entity.fieldButtonLink.url.path }}" rel="noreferrer noopener">
             {{ fieldPrimaryCallToAction.entity.fieldButtonLabel }}
           </a>
         </div>
@@ -33,7 +33,7 @@
         <div class="why-this-matters-content">
           <h2>Why this matters to you</h2>
           <p>{{ fieldClpWhyThisMatters }}</p>
-          <a class="usa-button-secondary" href="{{ fieldSecondaryCallToAction.entity.fieldButtonLink.uri }}">
+          <a class="usa-button-secondary" href="{{ fieldSecondaryCallToAction.entity.fieldButtonLink.url.path }}">
             {{ fieldSecondaryCallToAction.entity.fieldButtonLabel }}
           </a>
         </div>
@@ -46,30 +46,54 @@
               <hr />
               <ul>
                 {% for clpAudience in fieldClpAudience %}
-                  <li>
-                    <a href="{{ clpAudience.entity.fieldLink.uri }}" rel="noreferrer noopener">
-                      {{ clpAudience.entity.fieldLink.label }}
-                    </a>
-                  </li>
+                  <li>{{ clpAudience.entity.name }}</li>
                 {% endfor %}
               </ul>
             </div>
           {% endif %}
 
           <!-- Links to social media -->
-          <a class="va-js-share-link" href="https://www.facebook.com/sharer/sharer.php?href={{ hostUrl }}{{ entityUrl.path }}" rel="noreferrer noopener" target="_blank">
-            <i class="va-c-social-icon fab fa-facebook vads-u-margin-right--0p5"></i>Share on Facebook
-          </a>
-          <a class="va-js-share-link" href="https://twitter.com/intent/tweet?text={{ title }}&url={{ hostUrl }}{{ entityUrl.path }}" rel="noreferrer noopener" target="_blank">
-            <i class="va-c-social-icon fab fa-twitter vads-u-margin-right--0p5"></i>Share on Twitter
-          </a>
+          {% include "src/site/includes/social-share.drupal.liquid" %}
         </div>
       </div>
 
       <!-- What You Can Do -->
       <div class="what-you-can-do">
         <h2>WHAT YOU CAN DO</h2>
-        <h3></h3>
+        <h3>{{ fieldClpWhatYouCanDoHeader }}</h3>
+        <p>{{ fieldClpWhatYouCanDoIntro }}</p>
+
+        {% if fieldClpWhatYouCanDoPromos != empty %}
+          <ul class="promos">
+            {% for promo in fieldClpWhatYouCanDoPromos %}
+              <li class="promo">
+                <img alt="{{ promo.entity.fieldImage.entity.thumbnail.alt }}" src="{{ promo.entity.fieldImage.entity.thumbnail.url }}" />
+                <a href="{{ promo.entity.fieldPromoLink.entity.fieldLink.uri }}" rel="noreferrer noopener" target="_blank">
+                  {{ promo.entity.fieldPromoLink.entity.fieldLink.title }}
+                </a>
+                <p>{{ promo.entity.fieldPromoLink.entity.fieldLinkSummary }}</p>
+              </li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+      </div>
+
+      <!-- Video -->
+      <div class="what-you-can-do">
+        <h2>VIDEO</h2>
+        <h3>{{ fieldClpVideoPanelHeader }}</h3>
+
+        <iframe
+          allowFullScreen
+          frameBorder="0"
+          src="{{ fieldMedia.entity.fieldMediaVideoEmbedField }}"
+          title="{{ fieldMedia.entity.name }}"
+          width="100%"
+        ></iframe>
+
+        <a class="usa-button-secondary" href="{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLink.uri }}" rel="noreferrer noopener" target="_blank">
+          {{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel }}
+        </a>
       </div>
     </div>
 

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -5,28 +5,78 @@
 
 <div id="content" class="interior" data-template="node-campaign_landing_page">
   <main class="va-l-detail-page">
-    <div class="usa-grid usa-grid-full">
-      <div class="usa-width-three-fourths">
-        <!-- Draft status -->
-        {% if !entityPublished %}
-          <div class="usa-alert usa-alert-info">
-            <div class="usa-alert-body">
-              <p class="usa-alert-text">You are viewing a draft.</p>
-            </div>
-          </div>
-        {% endif %}
-
-        <article class="usa-content">
-          <!-- Title -->
-          <h1>{{ title }}</h1>
-        </article>
-
-        <!-- Last Updated -->
-        <div class="last-updated usa-content">
-          Last updated: <time
-            datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
+    <!-- Draft status -->
+    {% if !entityPublished %}
+      <div class="usa-alert usa-alert-info">
+        <div class="usa-alert-body">
+          <p class="usa-alert-text">You are viewing a draft.</p>
         </div>
       </div>
+    {% endif %}
+
+    <div class="campaign-landing-page">
+      <div class="hero" style="background-image: url('{{ fieldHeroImage.entity.image.url }}">
+        <!-- Hero Content -->
+        <div class="hero-content">
+          <h1>{{ title }}</h1>
+          <hr />
+          <p>{{ fieldHeroBlurb }}</p>
+          <a class="usa-butto-secondary" href="{{ fieldPrimaryCallToAction.entity.fieldButtonLink.uri }}" rel="noreferrer noopener">
+            {{ fieldPrimaryCallToAction.entity.fieldButtonLabel }}
+          </a>
+        </div>
+      </div>
+
+      <!-- Why This Matters -->
+      <div class="why-this-matters">
+        <!-- Content -->
+        <div class="why-this-matters-content">
+          <h2>Why this matters to you</h2>
+          <p>{{ fieldClpWhyThisMatters }}</p>
+          <a class="usa-button-secondary" href="{{ fieldSecondaryCallToAction.entity.fieldButtonLink.uri }}">
+            {{ fieldSecondaryCallToAction.entity.fieldButtonLabel }}
+          </a>
+        </div>
+
+        <!-- White box w/ social media links -->
+        <div class="why-this-matters-links">
+          {% if fieldClpAudience != empty %}
+            <div class="white-box">
+              <p>THIS PAGE IS FOR</p>
+              <hr />
+              <ul>
+                {% for clpAudience in fieldClpAudience %}
+                  <li>
+                    <a href="{{ clpAudience.entity.fieldLink.uri }}" rel="noreferrer noopener">
+                      {{ clpAudience.entity.fieldLink.label }}
+                    </a>
+                  </li>
+                {% endfor %}
+              </ul>
+            </div>
+          {% endif %}
+
+          <!-- Links to social media -->
+          <a class="va-js-share-link" href="https://www.facebook.com/sharer/sharer.php?href={{ hostUrl }}{{ entityUrl.path }}" rel="noreferrer noopener" target="_blank">
+            <i class="va-c-social-icon fab fa-facebook vads-u-margin-right--0p5"></i>Share on Facebook
+          </a>
+          <a class="va-js-share-link" href="https://twitter.com/intent/tweet?text={{ title }}&url={{ hostUrl }}{{ entityUrl.path }}" rel="noreferrer noopener" target="_blank">
+            <i class="va-c-social-icon fab fa-twitter vads-u-margin-right--0p5"></i>Share on Twitter
+          </a>
+        </div>
+      </div>
+
+      <!-- What You Can Do -->
+      <div class="what-you-can-do">
+        <h2>WHAT YOU CAN DO</h2>
+        <h3></h3>
+      </div>
+    </div>
+
+    <!-- Last Updated -->
+    <div class="last-updated usa-content">
+      Last updated: <time
+        datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
     </div>
   </main>
 </div>

--- a/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
@@ -550,6 +550,7 @@ module.exports = `
         entityBundle
         entityId
         ... on MediaVideo {
+          fieldMediaVideoEmbedField
           name
           thumbnail {
             height
@@ -567,13 +568,7 @@ module.exports = `
         entityType
         entityBundle
         entityId
-        ... on ParagraphButton {
-          fieldButtonLabel
-          fieldButtonLink {
-            uri
-            title
-          }
-        }
+        ... button
       }
     }
     fieldSecondaryCallToAction {
@@ -581,13 +576,7 @@ module.exports = `
         entityType
         entityBundle
         entityId
-        ... on ParagraphButton {
-          fieldButtonLabel
-          fieldButtonLink {
-            uri
-            title
-          }
-        }
+        ... button
       }
     }
   }


### PR DESCRIPTION
## Description
This PR is in response to a slack thread:

![image](https://user-images.githubusercontent.com/12773166/105371202-987bd480-5bc1-11eb-977b-8abf8e95544b.png)

It makes the `or`s bold as seen above ^.

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Update `or`s

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
