### PR TITLE
Bold s

### DIFF
--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/UnauthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/UnauthContent/index.js
@@ -86,11 +86,11 @@ const UnauthContent = () => (
         <a href="https://www.myhealth.va.gov/mhv-portal-web/upgrade-account-to-premium#UpgradeToPremiumAccount">
           Premium <strong>My HealtheVet</strong> account
         </a>
-        , or
+        , <strong>or</strong>
       </li>
       <li>
         A Premium <strong>DS Logon</strong> account (used for eBenefits and
-        milConnect), or
+        milConnect), <strong>or</strong>
       </li>
       <li>
         A verified <strong>ID.me</strong> account that you can{' '}


### PR DESCRIPTION
## Description
This PR is in response to a slack thread:

![image](https://user-images.githubusercontent.com/12773166/105371202-987bd480-5bc1-11eb-977b-8abf8e95544b.png)

It makes the `or`s bold as seen above ^.

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Update `or`s

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
