### PR TITLE
Fix flaky personalization profile test and upgrade Cypress to 6 3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "cors": "^2.7.1",
     "css-loader": "^1.0.0",
     "cssnano": "^4.1.10",
-    "cypress": "^6.2.1",
+    "cypress": "^6.3.0",
     "cypress-axe": "^0.8.1",
     "cypress-multi-reporters": "^1.4.0",
     "cypress-plugin-tab": "^1.0.5",
@@ -358,7 +358,7 @@
     "**/http-proxy": "^1.18.1",
     "**/node-forge": "^0.10.0",
     "**/axios": "^0.21.1",
-    "cypress": "^6.2.1",
+    "cypress": "^6.3.0",
     "tar-fs/tar-stream/bl": "^4.0.3",
     "nightwatch/**/lodash.defaultsdeep": "^4.6.1"
   }

--- a/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/modals.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/modals.cypress.spec.js
@@ -75,83 +75,81 @@ const checkModals = options => {
 };
 
 describe('Modals on the personal information and content page', () => {
-  for (let i = 0; i < 60; i += 1) {
-    it('should render as expected on Desktop', () => {
-      setup();
+  it('should render as expected on Desktop', () => {
+    setup();
 
-      // should appear when editing mailing address
-      checkModals({
-        otherSectionName: 'home address',
-        editLineId: 'root_addressLine3',
-        sectionName: 'mailing address',
-      });
-
-      // should appear when editing residential address
-      checkModals({
-        otherSectionName: 'mailing address',
-        editLineId: 'root_addressLine3',
-        sectionName: 'home address',
-      });
-
-      // should appear when editing home phone number
-      checkModals({
-        otherSectionName: 'mailing address',
-        editLineId: 'root_extension',
-        sectionName: 'home phone number',
-      });
-
-      // should appear when editing mobile phone number
-      checkModals({
-        otherSectionName: 'mailing address',
-        editLineId: 'root_extension',
-        sectionName: 'mobile phone number',
-      });
-
-      // should appear when editing email address
-      checkModals({
-        otherSectionName: 'mailing address',
-        editLineId: 'root_emailAddress',
-        sectionName: 'email address',
-      });
+    // should appear when editing mailing address
+    checkModals({
+      otherSectionName: 'home address',
+      editLineId: 'root_addressLine3',
+      sectionName: 'mailing address',
     });
 
-    it('should render as expected on Mobile', () => {
-      setup(true);
-
-      // should appear when editing mailing address
-      checkModals({
-        otherSectionName: 'home address',
-        editLineId: 'root_addressLine3',
-        sectionName: 'mailing address',
-      });
-
-      // should appear when editing residential address
-      checkModals({
-        otherSectionName: 'mailing address',
-        editLineId: 'root_addressLine3',
-        sectionName: 'home address',
-      });
-
-      // should appear when editing home phone number
-      checkModals({
-        otherSectionName: 'mailing address',
-        editLineId: 'root_extension',
-        sectionName: 'home phone number',
-      });
-
-      // should appear when editing mobile phone number
-      checkModals({
-        otherSectionName: 'mailing address',
-        editLineId: 'root_extension',
-        sectionName: 'mobile phone number',
-      });
-
-      // should appear when editing email address
-      checkModals({
-        otherSectionName: 'mailing address',
-        editLineId: 'root_emailAddress',
-        sectionName: 'email address',
-      });
+    // should appear when editing residential address
+    checkModals({
+      otherSectionName: 'mailing address',
+      editLineId: 'root_addressLine3',
+      sectionName: 'home address',
     });
-  }
+
+    // should appear when editing home phone number
+    checkModals({
+      otherSectionName: 'mailing address',
+      editLineId: 'root_extension',
+      sectionName: 'home phone number',
+    });
+
+    // should appear when editing mobile phone number
+    checkModals({
+      otherSectionName: 'mailing address',
+      editLineId: 'root_extension',
+      sectionName: 'mobile phone number',
+    });
+
+    // should appear when editing email address
+    checkModals({
+      otherSectionName: 'mailing address',
+      editLineId: 'root_emailAddress',
+      sectionName: 'email address',
+    });
+  });
+
+  it('should render as expected on Mobile', () => {
+    setup(true);
+
+    // should appear when editing mailing address
+    checkModals({
+      otherSectionName: 'home address',
+      editLineId: 'root_addressLine3',
+      sectionName: 'mailing address',
+    });
+
+    // should appear when editing residential address
+    checkModals({
+      otherSectionName: 'mailing address',
+      editLineId: 'root_addressLine3',
+      sectionName: 'home address',
+    });
+
+    // should appear when editing home phone number
+    checkModals({
+      otherSectionName: 'mailing address',
+      editLineId: 'root_extension',
+      sectionName: 'home phone number',
+    });
+
+    // should appear when editing mobile phone number
+    checkModals({
+      otherSectionName: 'mailing address',
+      editLineId: 'root_extension',
+      sectionName: 'mobile phone number',
+    });
+
+    // should appear when editing email address
+    checkModals({
+      otherSectionName: 'mailing address',
+      editLineId: 'root_emailAddress',
+      sectionName: 'email address',
+    });
+  });
 });

--- a/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/modals.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/modals.cypress.spec.js
@@ -37,8 +37,8 @@ const checkModals = options => {
 
   // Make an edit
   cy.get(`#${editLineId}`)
-    .click()
-    .type('test');
+    .click({ force: true })
+    .type('test', { force: true });
 
   // confirm that the update button is enabled
   cy.findByRole('button', { name: 'Update' }).should('not.be.disabled');
@@ -75,81 +75,83 @@ const checkModals = options => {
 };
 
 describe('Modals on the personal information and content page', () => {
-  it('should render as expected on Desktop', () => {
-    setup();
+  for (let i = 0; i < 60; i += 1) {
+    it('should render as expected on Desktop', () => {
+      setup();
 
-    // should appear when editing mailing address
-    checkModals({
-      otherSectionName: 'home address',
-      editLineId: 'root_addressLine3',
-      sectionName: 'mailing address',
+      // should appear when editing mailing address
+      checkModals({
+        otherSectionName: 'home address',
+        editLineId: 'root_addressLine3',
+        sectionName: 'mailing address',
+      });
+
+      // should appear when editing residential address
+      checkModals({
+        otherSectionName: 'mailing address',
+        editLineId: 'root_addressLine3',
+        sectionName: 'home address',
+      });
+
+      // should appear when editing home phone number
+      checkModals({
+        otherSectionName: 'mailing address',
+        editLineId: 'root_extension',
+        sectionName: 'home phone number',
+      });
+
+      // should appear when editing mobile phone number
+      checkModals({
+        otherSectionName: 'mailing address',
+        editLineId: 'root_extension',
+        sectionName: 'mobile phone number',
+      });
+
+      // should appear when editing email address
+      checkModals({
+        otherSectionName: 'mailing address',
+        editLineId: 'root_emailAddress',
+        sectionName: 'email address',
+      });
     });
 
-    // should appear when editing residential address
-    checkModals({
-      otherSectionName: 'mailing address',
-      editLineId: 'root_addressLine3',
-      sectionName: 'home address',
-    });
+    it('should render as expected on Mobile', () => {
+      setup(true);
 
-    // should appear when editing home phone number
-    checkModals({
-      otherSectionName: 'mailing address',
-      editLineId: 'root_extension',
-      sectionName: 'home phone number',
-    });
+      // should appear when editing mailing address
+      checkModals({
+        otherSectionName: 'home address',
+        editLineId: 'root_addressLine3',
+        sectionName: 'mailing address',
+      });
 
-    // should appear when editing mobile phone number
-    checkModals({
-      otherSectionName: 'mailing address',
-      editLineId: 'root_extension',
-      sectionName: 'mobile phone number',
-    });
+      // should appear when editing residential address
+      checkModals({
+        otherSectionName: 'mailing address',
+        editLineId: 'root_addressLine3',
+        sectionName: 'home address',
+      });
 
-    // should appear when editing email address
-    checkModals({
-      otherSectionName: 'mailing address',
-      editLineId: 'root_emailAddress',
-      sectionName: 'email address',
-    });
-  });
+      // should appear when editing home phone number
+      checkModals({
+        otherSectionName: 'mailing address',
+        editLineId: 'root_extension',
+        sectionName: 'home phone number',
+      });
 
-  it('should render as expected on Mobile', () => {
-    setup(true);
+      // should appear when editing mobile phone number
+      checkModals({
+        otherSectionName: 'mailing address',
+        editLineId: 'root_extension',
+        sectionName: 'mobile phone number',
+      });
 
-    // should appear when editing mailing address
-    checkModals({
-      otherSectionName: 'home address',
-      editLineId: 'root_addressLine3',
-      sectionName: 'mailing address',
+      // should appear when editing email address
+      checkModals({
+        otherSectionName: 'mailing address',
+        editLineId: 'root_emailAddress',
+        sectionName: 'email address',
+      });
     });
-
-    // should appear when editing residential address
-    checkModals({
-      otherSectionName: 'mailing address',
-      editLineId: 'root_addressLine3',
-      sectionName: 'home address',
-    });
-
-    // should appear when editing home phone number
-    checkModals({
-      otherSectionName: 'mailing address',
-      editLineId: 'root_extension',
-      sectionName: 'home phone number',
-    });
-
-    // should appear when editing mobile phone number
-    checkModals({
-      otherSectionName: 'mailing address',
-      editLineId: 'root_extension',
-      sectionName: 'mobile phone number',
-    });
-
-    // should appear when editing email address
-    checkModals({
-      otherSectionName: 'mailing address',
-      editLineId: 'root_emailAddress',
-      sectionName: 'email address',
-    });
-  });
+  }
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5414,10 +5414,10 @@ cypress-testrail-reporter@^1.2.1:
     mocha "^2.2.5"
     moment "^2.22.1"
 
-cypress@^6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.2.1.tgz#27d5fbcf008c698c390fdb0c03441804176d06c4"
-  integrity sha512-OYkSgzA4J4Q7eMjZvNf5qWpBLR4RXrkqjL3UZ1UzGGLAskO0nFTi/RomNTG6TKvL3Zp4tw4zFY1gp5MtmkCZrA==
+cypress@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.3.0.tgz#e27bba01d7e493265700e1e85333dca0b0127ede"
+  integrity sha512-Ec6TAFOxdSB2HPINNJ1f7z75pENXcfCaQkz+A9j0eGSvusFJ2NNErq650DexCbNJAnCQkPqXB4XPH9kXnSQnUA==
   dependencies:
     "@cypress/listr-verbose-renderer" "^0.4.1"
     "@cypress/request" "^2.88.5"


### PR DESCRIPTION
## Description
This PR fixes two minor issues in a Cypress test caused by overlapping elements. Cypress is also being upgraded from `6.2.1` to `6.3.0` in this PR.

## Testing done
- Test was run 60 times locally and on CI without any failures
- No regressions observed locally or on CI from the Cypress upgrade

## Acceptance criteria
- [ ] Tests pass locally and on CI