### PR TITLE
Temp Rollback of S3 loading for teamsites

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -243,7 +243,7 @@ def buildAll(String ref, dockerContainer, Boolean contentOnlyBuild) {
 
 def prearchive(dockerContainer, envName) {
   dockerContainer.inside(DOCKER_ARGS) {
-    sh "cd /application && NODE_ENV=production yarn build --buildtype ${envName} --setPublicPath"
+    // sh "cd /application && NODE_ENV=production yarn build --buildtype ${envName} --setPublicPath"
     sh "cd /application && node --max-old-space-size=10240 script/prearchive.js --buildtype=${envName}"
   }
 }


### PR DESCRIPTION
## Description
Teamsite headers are not loading with the new s3 asset loading paths. This PR is to temp roll that back incase a fix isn't in before the next deploy prod.