### PR TITLE
[Development] Set disability wizard status using unique IDs

### DIFF
--- a/src/applications/disability-benefits/996/constants.js
+++ b/src/applications/disability-benefits/996/constants.js
@@ -52,7 +52,9 @@ export const errorMessages = {
 
 export const NULL_CONDITION_STRING = 'Unknown Condition';
 
+// session storage keys
 export const SAVED_CLAIM_TYPE = 'hlrClaimType';
+export const WIZARD_STATUS = 'wizardStatus996';
 
 // Values from benefitTypes in vets-json-schema constants
 const supportedBenefitTypes = [

--- a/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
@@ -9,8 +9,7 @@ import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
 
-import { WIZARD_STATUS } from 'applications/static-pages/wizard';
-import { SELECTED, SAVED_CLAIM_TYPE } from '../constants';
+import { SELECTED, SAVED_CLAIM_TYPE, WIZARD_STATUS } from '../constants';
 
 const scroller = Scroll.scroller;
 const scrollToTop = () => {

--- a/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
@@ -29,6 +29,7 @@ import {
   SUPPLEMENTAL_CLAIM_URL,
   FACILITY_LOCATOR_URL,
   GET_HELP_REVIEW_REQUEST_URL,
+  WIZARD_STATUS,
 } from '../constants';
 import {
   noContestableIssuesFound,
@@ -38,7 +39,6 @@ import {
 } from '../content/contestableIssueAlerts';
 import WizardContainer from '../wizard/WizardContainer';
 import {
-  WIZARD_STATUS,
   WIZARD_STATUS_NOT_STARTED,
   WIZARD_STATUS_COMPLETE,
 } from 'applications/static-pages/wizard';

--- a/src/applications/disability-benefits/996/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -7,8 +7,7 @@ import formConfig from '../../config/form';
 import initialData from '../schema/initialData';
 
 import ConfirmationPage from '../../containers/ConfirmationPage';
-import { SELECTED, SAVED_CLAIM_TYPE } from '../../constants';
-import { WIZARD_STATUS } from 'applications/static-pages/wizard';
+import { WIZARD_STATUS, SELECTED, SAVED_CLAIM_TYPE } from '../../constants';
 
 const data = {
   user: {

--- a/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
@@ -8,10 +8,8 @@ import { IntroductionPage } from '../../containers/IntroductionPage';
 import formConfig from '../../config/form';
 
 import { FETCH_CONTESTABLE_ISSUES_INIT } from '../../actions';
-import {
-  WIZARD_STATUS,
-  WIZARD_STATUS_COMPLETE,
-} from 'applications/static-pages/wizard';
+import { WIZARD_STATUS } from '../../constants';
+import { WIZARD_STATUS_COMPLETE } from 'applications/static-pages/wizard';
 
 const defaultProps = {
   getContestableIssues: () => {},

--- a/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
@@ -3,12 +3,11 @@ import path from 'path';
 import testForm from 'platform/testing/e2e/cypress/support/form-tester';
 import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
 
-import { WIZARD_STATUS } from 'applications/static-pages/wizard';
 import formConfig from '../config/form';
 import manifest from '../manifest.json';
 import { mockContestableIssues } from './hlr.cypress.helpers';
 import mockUser from './fixtures/mocks/user.json';
-import { CONTESTABLE_ISSUES_API } from '../constants';
+import { CONTESTABLE_ISSUES_API, WIZARD_STATUS } from '../constants';
 
 const testConfig = createTestConfig(
   {

--- a/src/applications/disability-benefits/996/tests/wizard/WizardContainer.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/wizard/WizardContainer.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 
-import { WIZARD_STATUS } from 'applications/static-pages/wizard';
+import { WIZARD_STATUS } from '../../constants';
 import WizardContainer from '../../wizard/WizardContainer';
 
 describe('<WizardContainer>', () => {

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -276,7 +276,7 @@ export const NULL_CONDITION_STRING = 'Unknown Condition';
 export const DATE_FORMAT = 'LL';
 
 // sessionStorage key used to show the wizard has or hasn't been completed
-export const WIZARD_STATUS = 'wizardStatus';
+export const WIZARD_STATUS = 'wizardStatus526';
 // sessionStorage key used to determine if the form title should be set to BDD
 export const FORM_STATUS_BDD = 'formStatusBdd';
 


### PR DESCRIPTION
## Description

Wizard status (complete) is shared across the platform. This PR changes the storage key to make the wizard status for form 526 & 996 (Higher-Level Review) unique.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/18820

## Testing done

Unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] 526 wizard has a unique status ID
- [x] HLR wizard has a unique status ID

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
