### PR TITLE
Start using `cnp-` GA strings in prod

### DIFF
--- a/src/applications/personalization/profile/actions/paymentInformation.js
+++ b/src/applications/personalization/profile/actions/paymentInformation.js
@@ -4,7 +4,6 @@ import {
   isEligibleForCNPDirectDeposit,
   isSignedUpForCNPDirectDeposit,
   isSignedUpForEDUDirectDeposit,
-  cnpPrefix,
 } from '../util';
 import recordAnalyticsEvent from 'platform/monitoring/record-event';
 
@@ -46,7 +45,7 @@ export function fetchCNPPaymentInformation(recordEvent = recordAnalyticsEvent) {
   return async dispatch => {
     dispatch({ type: CNP_PAYMENT_INFORMATION_FETCH_STARTED });
 
-    recordEvent({ event: `profile-get-${cnpPrefix}direct-deposit-started` });
+    recordEvent({ event: `profile-get-cnp-direct-deposit-started` });
     const response = await getData('/ppiu/payment_information');
 
     // sample error when getting payment information
@@ -63,14 +62,14 @@ export function fetchCNPPaymentInformation(recordEvent = recordAnalyticsEvent) {
     // };
 
     if (response.error) {
-      recordEvent({ event: `profile-get-${cnpPrefix}direct-deposit-failed` });
+      recordEvent({ event: `profile-get-cnp-direct-deposit-failed` });
       dispatch({
         type: CNP_PAYMENT_INFORMATION_FETCH_FAILED,
         response,
       });
     } else {
       recordEvent({
-        event: `profile-get-${cnpPrefix}direct-deposit-retrieved`,
+        event: `profile-get-cnp-direct-deposit-retrieved`,
         // The API might report an empty payment address for some folks who are
         // already enrolled in direct deposit. But we want to make sure we
         // always treat those who are signed up as being eligible. Therefore
@@ -160,7 +159,7 @@ export function saveCNPPaymentInformation(
     } else {
       recordEvent({
         event: 'profile-transaction',
-        'profile-section': `${cnpPrefix}direct-deposit-information`,
+        'profile-section': `cnp-direct-deposit-information`,
       });
       dispatch({
         type: CNP_PAYMENT_INFORMATION_SAVE_SUCCEEDED,

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
@@ -25,8 +25,6 @@ import {
   cnpDirectDepositUiState as directDepositUiStateSelector,
 } from '@@profile/selectors';
 
-import { cnpPrefix } from '@@profile/util';
-
 import BankInfoForm from './BankInfoForm';
 
 import PaymentInformationEditError from './PaymentInformationEditError';
@@ -162,7 +160,7 @@ export const BankInfoCNP = ({
           recordEvent({
             event: 'profile-navigation',
             'profile-action': 'edit-link',
-            'profile-section': `${cnpPrefix}direct-deposit-information`,
+            'profile-section': `cnp-direct-deposit-information`,
           });
           toggleEditState();
         }}
@@ -181,7 +179,7 @@ export const BankInfoCNP = ({
         recordEvent({
           event: 'profile-navigation',
           'profile-action': 'add-link',
-          'profile-section': `${cnpPrefix}direct-deposit-information`,
+          'profile-section': `cnp-direct-deposit-information`,
         });
         toggleEditState();
       }}

--- a/src/applications/personalization/profile/util/index.js
+++ b/src/applications/personalization/profile/util/index.js
@@ -1,5 +1,4 @@
 import { apiRequest } from 'platform/utilities/api';
-import environment from 'platform/utilities/environment';
 
 // possible values for the `key` property on error messages we get from the server
 const ACCOUNT_FLAGGED_FOR_FRAUD_KEY = 'cnp.payment.flashes.on.record.message';
@@ -22,8 +21,6 @@ const GA_ERROR_KEY_INVALID_ROUTING_NUMBER = 'invalid-routing-number-error';
 const GA_ERROR_KEY_PAYMENT_RESTRICTIONS =
   'payment-restriction-indicators-error';
 const GA_ERROR_KEY_DEFAULT = 'other-error';
-
-export const cnpPrefix = !environment.isProduction() ? 'cnp-' : '';
 
 export async function getData(apiRoute, options) {
   try {
@@ -130,7 +127,7 @@ export const createCNPDirectDepositAnalyticsDataObject = (
   return {
     event: 'profile-edit-failure',
     'profile-action': 'save-failure',
-    'profile-section': `${cnpPrefix}direct-deposit-information`,
+    'profile-section': `cnp-direct-deposit-information`,
     [key]: errorCode,
   };
 };


### PR DESCRIPTION
## Description
[Got the okay](https://github.com/department-of-veterans-affairs/va.gov-team/issues/16904#issuecomment-764825267) from @bmcgrady-ep to start using the `cnp-direct-deposit` prefixed strings in place of the old `direct-deposit` strings when reporting data to Google Analytics.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs