### PR TITLE
Updated labels for parent or guardian

### DIFF
--- a/src/applications/disability-benefits/686c-674/config/chapters/stepchild-no-longer-part-of-household/stepchild-information/stepchild-information.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/stepchild-no-longer-part-of-household/stepchild-information/stepchild-information.js
@@ -47,7 +47,7 @@ export const uiSchema = {
       whoDoesTheStepchildLiveWith: {
         'ui:title': 'Who does this stepchild live with?',
         first: {
-          'ui:title': 'First Name of parent or guardian',
+          'ui:title': 'First name of parent or guardian',
           'ui:required': formData =>
             isChapterFieldRequired(
               formData,
@@ -55,10 +55,10 @@ export const uiSchema = {
             ),
         },
         middle: {
-          'ui:title': 'Middle Name of parent or guardian',
+          'ui:title': 'Middle name of parent or guardian',
         },
         last: {
-          'ui:title': 'Last Name of parent or guardian',
+          'ui:title': 'Last name of parent or guardian',
           'ui:required': formData =>
             isChapterFieldRequired(
               formData,

--- a/src/applications/disability-benefits/686c-674/config/chapters/stepchild-no-longer-part-of-household/stepchild-information/stepchild-information.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/stepchild-no-longer-part-of-household/stepchild-information/stepchild-information.js
@@ -47,7 +47,7 @@ export const uiSchema = {
       whoDoesTheStepchildLiveWith: {
         'ui:title': 'Who does this stepchild live with?',
         first: {
-          'ui:title': 'First Name',
+          'ui:title': 'First Name of parent or guardian',
           'ui:required': formData =>
             isChapterFieldRequired(
               formData,
@@ -55,10 +55,10 @@ export const uiSchema = {
             ),
         },
         middle: {
-          'ui:title': 'Middle Name',
+          'ui:title': 'Middle Name of parent or guardian',
         },
         last: {
-          'ui:title': 'Last Name',
+          'ui:title': 'Last Name of parent or guardian',
           'ui:required': formData =>
             isChapterFieldRequired(
               formData,


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/13016)

This PR is to address some 508 accessibility feedback we got on the 686 form. In the form there is a workflow where the user can choose to remove a stepchild from their benefits and in that there are a set of questions that ask the parent or guardian's first, middle, and last name. The accessibility team felt that it was not clear enough that we were asking for the parent or guardian's name and not the stepchild, particularly in the review screen, so this PR updates the labels for those questions to make the distinction explicit.

## Testing done
All existing unit tests still pass

## Screenshots

Before -

![Screen Shot 2020-08-28 at 10 21 58 AM](https://user-images.githubusercontent.com/934879/91617327-671e1600-e94d-11ea-8d84-5f583418e49e.png)

After -

![Screen Shot 2021-01-21 at 10 29 44 AM](https://user-images.githubusercontent.com/1899695/105397213-9de31a00-5bd5-11eb-9219-6a131bd39db3.png)


## Acceptance criteria
- [x] As a user, I want to be sure the data I am submitting is correct
- [x] As a user, I want to understand what each data point represents, without seeing duplicate labels close to one another

