### PR TITLE
Fix/s3 gen teamsites

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -130,11 +130,9 @@ module.exports = env => {
     output: {
       path: outputPath,
       publicPath: publicAssetPath,
-      filename: pathData => {
-        return !useHashFilenames || pathData.chunk.name === 'proxy-rewrite' // the unhashed proxy-rewrite file is directly accessed in the prearchive job (src/site/stages/prearchive/link-assets-to-bucket.js#93)
-          ? '[name].entry.js'
-          : `[name].entry.[chunkhash]-${timestamp}.js`;
-      },
+      filename: !useHashFilenames
+        ? '[name].entry.js'
+        : `[name].entry.[chunkhash]-${timestamp}.js`,
       chunkFilename: !useHashFilenames
         ? '[name].entry.js'
         : `[name].entry.[chunkhash]-${timestamp}.js`,

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -243,7 +243,7 @@ def buildAll(String ref, dockerContainer, Boolean contentOnlyBuild) {
 
 def prearchive(dockerContainer, envName) {
   dockerContainer.inside(DOCKER_ARGS) {
-    // sh "cd /application && NODE_ENV=production yarn build --buildtype ${envName} --setPublicPath"
+    sh "cd /application && NODE_ENV=production yarn build --buildtype ${envName} --setPublicPath"
     sh "cd /application && node --max-old-space-size=10240 script/prearchive.js --buildtype=${envName}"
   }
 }

--- a/src/site/stages/build/plugins/modify-dom/process-entry-names.js
+++ b/src/site/stages/build/plugins/modify-dom/process-entry-names.js
@@ -32,7 +32,6 @@ function copyAssetsToTeamSitePaths(buildOptions, files, entryNamesDictionary) {
       }
     }
 
-    // const hashedFileNameWithoutLeadingSlash = hashedFileName.slice(1);
     const hashedFileNameWithoutLeadingSlash = `generated/${
       hashedFileName.split('/generated/')[1]
     }`;

--- a/src/site/stages/build/plugins/modify-dom/process-entry-names.js
+++ b/src/site/stages/build/plugins/modify-dom/process-entry-names.js
@@ -38,6 +38,7 @@ function copyAssetsToTeamSitePaths(buildOptions, files, entryNamesDictionary) {
     const file = files[hashedFileNameWithoutLeadingSlash];
 
     if (!file) continue;
+
     files[teamSitePath] = file;
   }
 }

--- a/src/site/stages/build/plugins/modify-dom/process-entry-names.js
+++ b/src/site/stages/build/plugins/modify-dom/process-entry-names.js
@@ -37,6 +37,14 @@ function copyAssetsToTeamSitePaths(buildOptions, files, entryNamesDictionary) {
 
     if (!file) continue;
 
+    console.log('------------------------------');
+    console.log('------------------------------');
+    console.log('------------------------------');
+    console.log(file);
+    console.log('------------------------------');
+    console.log('------------------------------');
+    console.log('------------------------------');
+
     files[teamSitePath] = file;
   }
 }

--- a/src/site/stages/build/plugins/modify-dom/process-entry-names.js
+++ b/src/site/stages/build/plugins/modify-dom/process-entry-names.js
@@ -32,19 +32,13 @@ function copyAssetsToTeamSitePaths(buildOptions, files, entryNamesDictionary) {
       }
     }
 
-    const hashedFileNameWithoutLeadingSlash = hashedFileName.slice(1);
+    // const hashedFileNameWithoutLeadingSlash = hashedFileName.slice(1);
+    const hashedFileNameWithoutLeadingSlash = `generated/${
+      hashedFileName.split('/generated/')[1]
+    }`;
     const file = files[hashedFileNameWithoutLeadingSlash];
 
     if (!file) continue;
-
-    console.log('------------------------------');
-    console.log('------------------------------');
-    console.log('------------------------------');
-    console.log(file);
-    console.log('------------------------------');
-    console.log('------------------------------');
-    console.log('------------------------------');
-
     files[teamSitePath] = file;
   }
 }


### PR DESCRIPTION
## Description
The teamsites need some non-hashed assets in `/generated` with the file-manifests now producing full paths, we just needed to update slice() to split() to get the right paths.

Also turning back on the full build in prearchive.

## Testing done
Running prod build locally and seeing non-hashed files where needed as well as full paths in the manifest.