### PR TITLE
Transformers: skip and log circular reference errors

### DIFF
--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -196,9 +196,18 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
       const assembleEntityTree = entityTreeFactory(contentDir);
 
       const timerStart = process.hrtime.bigint();
-      const transformedEntities = entities.map(entity =>
-        assembleEntityTree(entity),
-      );
+      const transformedEntities = entities.map(entity => {
+        const tree = assembleEntityTree(entity);
+        try {
+          // Check for circular references or other errors:
+          JSON.stringify(tree);
+          return tree;
+        } catch (e) {
+          // eslint-disable-next-line no-console
+          console.error('Error encountered while processing entity', entity, e);
+          return null;
+        }
+      });
       const timeElapsed = (process.hrtime.bigint() - timerStart) / 1000000n;
 
       say(


### PR DESCRIPTION
## Description
Sometimes, the transformers create circular references.

When this happens, the entire build fails.

This PR changes that behavior so that entity trees that contain circular references are skipped and not added to the JSON output. The "problem" entity is logged to the console instead. This allows the build to continue while the problem is sorted out.

