### PR TITLE
Revert "Add underline and move a into h3 (#15698)"

### DIFF
--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -157,6 +157,7 @@
                   <li>
                     <h3 class="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-font-family--sans">
                       <a
+                        class="vads-u-text-decoration--none"
                         href="{{ vaFormLinkTeaser.entity.fieldLink.url.path }}"
                         onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': '{{ vaFormLinkTeaser.entity.fieldLink.title | escape }}', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })">
                         {{ vaFormLinkTeaser.entity.fieldLink.title }}
@@ -170,6 +171,7 @@
                 <li>
                   <h3 class="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-font-family--sans">
                     <a
+                      class="vads-u-text-decoration--none"
                       href="/change-direct-deposit"
                       onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Change your direct deposit information', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })">
                       Change your direct deposit information
@@ -180,6 +182,7 @@
                 <li>
                   <h3 class="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-font-family--sans">
                     <a
+                      class="vads-u-text-decoration--none"
                       href="/change-address"
                       onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Change your address', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })">
                       Change your address
@@ -190,6 +193,7 @@
                 <li>
                   <h3 class="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-font-family--sans">
                     <a
+                      class="vads-u-text-decoration--none"
                       href="/records/get-military-service-records/"
                       onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Request your military records, including DD214', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })">
                       Request your military records, including DD214
@@ -200,6 +204,7 @@
                 <li>
                   <h3 class="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-font-family--sans">
                     <a
+                      class="vads-u-text-decoration--none"
                       href="/records/"
                       onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Get your VA records and documents online', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })">
                       Get your VA records and documents online

--- a/src/site/paragraphs/linkTeaser.drupal.liquid
+++ b/src/site/paragraphs/linkTeaser.drupal.liquid
@@ -33,21 +33,16 @@
   data-links-list-header="{{ link.title | escape }}"
   data-links-list-section-header="{{ section_header | escape }}"
   {% if parentFieldName === 'field_spokes' %}class="hub-page-link-list__item"{% endif %}>
-    {% if link.title != empty %}
-      <{{ header }} class="{{ headerClass }}">
-        <a href="{{link.url.path}}" class="vads-u-text-decoration--underline"
-          {% if linkTeaser.options["target"] %}
-            target="{{ linkTeaser.options["target"] }}"
-            rel="noopener noreferrer"
-          {% endif %}
-        >
-          {{ link.title }}
-        </a>
-      </{{ header }}>
-      {% if parentFieldName === "field_spokes" %}
-          <img class="all-link-arrow" src="/img/arrow-right-blue.svg" alt="Blue arrow pointing right">
-      {% endif %}
-    {% endif %}
+    <a href="{{link.url.path}}"
+      {% if linkTeaser.options["target"] %}target="{{ linkTeaser.options["target"] }}"{% endif %}
+      >
+        {% if link.title != empty %}
+            <{{ header }} class="{{ headerClass }}">{{ link.title }}</{{ header }}>
+            {% if parentFieldName === "field_spokes" %}
+                <img class="all-link-arrow" src="/img/arrow-right-blue.svg" alt="right-arrow">
+            {% endif %}
+        {% endif %}
+    </a>
     {% if linkTeaser.fieldLinkSummary != empty %}
         <p class="va-nav-linkslist-description">{{ linkTeaser.fieldLinkSummary }}</p>
     {% endif %}


### PR DESCRIPTION
This reverts commit 321752fa0b723199393938893f7f06d580cb3e36.

## Description
There is an issue on hub pages where the arrows show up gigantic. These PR restores the previous style to fix that.

## Testing done
recreated locally and then confirmed the fix

## Screenshots

### issue
![image](https://user-images.githubusercontent.com/1915775/105445976-2c3fb600-5c3f-11eb-8546-223a29ea1555.png)

### fixed
![image](https://user-images.githubusercontent.com/1915775/105445987-32ce2d80-5c3f-11eb-990c-0553fbe3144e.png)



## Acceptance criteria
- [ ] arrows are right size

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
