### PR TITLE
[Development] 526: Show compacted new conditions

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -10,7 +10,7 @@ import {
 } from '../content/addDisabilities';
 import NewDisability from '../components/NewDisability';
 import ArrayField from '../components/ArrayField';
-// import ConditionReviewField from '../components/ConditionReviewField';
+import ConditionReviewField from '../components/ConditionReviewField';
 import {
   validateDisabilityName,
   requireDisability,
@@ -53,7 +53,7 @@ export const uiSchema = {
             })),
           ),
         {
-          // 'ui:reviewField': ({ children }) => children,
+          'ui:reviewField': ({ children }) => children,
           'ui:options': {
             debounceRate: 200,
             freeInput: true,
@@ -84,7 +84,7 @@ export const uiSchema = {
       ),
       // custom review & submit layout - see https://github.com/department-of-veterans-affairs/vets-website/pull/14091
       // disabled until design changes have been approved
-      // 'ui:objectViewField': ConditionReviewField,
+      'ui:objectViewField': ConditionReviewField,
       'ui:options': {
         ariaLabelForEditButtonOnReview: 'Edit New condition',
       },


### PR DESCRIPTION
## Description

On Form 526's review & submit page, new condition listings include the descriptive paragraphs making the condition cards excessively large

<details><summary>Current condition card example</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-01-22 at 9 10 52 AM](https://user-images.githubusercontent.com/136959/105509369-09d78800-5c93-11eb-8623-25983657bca7.png)</details>

This PR adds a combination of ui options to only render the condition name on review

<details><summary>Condition name only</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-01-22 at 9 07 01 AM](https://user-images.githubusercontent.com/136959/105509616-4acf9c80-5c93-11eb-8a6e-5ca33675e9f3.png)</details>

But still show the descriptive information while editing

<details><summary>Editing</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-01-22 at 9 21 51 AM](https://user-images.githubusercontent.com/136959/105509737-72bf0000-5c93-11eb-8bf5-4d1ba958935b.png)</details>

Related:
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/309
- Design review: department-of-veterans-affairs/va.gov-team#12678
- Slack: https://dsva.slack.com/archives/C5AGLBNRK/p1598984849010700

## Testing done

Unit tests

## Screenshots

See above

## Acceptance criteria
- [x] New condition cards have a compacted view
- [x] Editing cards retain description

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
