### PR TITLE
18313: Pass gibctStateSearch flag to searches

### DIFF
--- a/src/applications/gi/actions/index.js
+++ b/src/applications/gi/actions/index.js
@@ -202,8 +202,11 @@ export function institutionFilterChange(filter) {
   return { type: INSTITUTION_FILTER_CHANGED, filter };
 }
 
-export function fetchInstitutionSearchResults(query = {}) {
-  const url = appendQuery(`${api.url}/institutions/search`, rubyifyKeys(query));
+export function fetchInstitutionSearchResults(query = {}, stateSearch) {
+  const url = appendQuery(
+    `${api.url}/institutions/search`,
+    stateSearch ? rubyifyKeys({ ...query, stateSearch }) : rubyifyKeys(query),
+  );
 
   return dispatch => {
     dispatch({ type: SEARCH_STARTED, query });
@@ -231,10 +234,10 @@ export function fetchInstitutionSearchResults(query = {}) {
   };
 }
 
-export function fetchProgramSearchResults(query = {}) {
+export function fetchProgramSearchResults(query = {}, stateSearch) {
   const url = appendQuery(
     `${api.url}/institution_programs/search`,
-    rubyifyKeys(query),
+    stateSearch ? rubyifyKeys({ ...query, stateSearch }) : rubyifyKeys(query),
   );
 
   return dispatch => {

--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -49,6 +49,7 @@ export function SearchPage({
   filters,
   gibctBenefitFilterEnhancement,
   gibctSchoolRatings,
+  gibctStateSearch,
   search,
 }) {
   const location = useLocation();
@@ -118,7 +119,7 @@ export function SearchPage({
 
         dispatchInstitutionFilterChange(institutionFilter);
 
-        dispatchFetchInstitutionSearchResults(query);
+        dispatchFetchInstitutionSearchResults(query, gibctStateSearch);
       }
     },
     [location.search],
@@ -300,6 +301,7 @@ const mapStateToProps = state => ({
   gibctBenefitFilterEnhancement: toggleValues(state)[
     FEATURE_FLAG_NAMES.gibctBenefitFilterEnhancement
   ],
+  gibctStateSearch: toggleValues(state)[FEATURE_FLAG_NAMES.gibctStateSearch],
 });
 
 const mapDispatchToProps = {

--- a/src/applications/gi/containers/VetTecSearchPage.jsx
+++ b/src/applications/gi/containers/VetTecSearchPage.jsx
@@ -15,7 +15,8 @@ import {
   eligibilityChange,
   showModal,
 } from '../actions';
-
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import Pagination from '@department-of-veterans-affairs/component-library/Pagination';
 import { getScrollOptions, focusElement } from 'platform/utilities/ui';
@@ -44,6 +45,7 @@ function VetTecSearchPage({
   dispatchUpdateAutocompleteSearchTerm,
   dispatchEligibilityChange,
   dispatchShowModal,
+  gibctStateSearch,
 }) {
   const location = useLocation();
   const history = useHistory();
@@ -147,7 +149,10 @@ function VetTecSearchPage({
     () => {
       if (!search.inProgress) {
         dispatchInstitutionFilterChange(queryFilterFields.institutionFilter);
-        dispatchFetchProgramSearchResults(queryFilterFields.query);
+        dispatchFetchProgramSearchResults(
+          queryFilterFields.query,
+          gibctStateSearch,
+        );
       }
     },
     [!_.isEqual(search.query, queryFilterFields.query)],
@@ -286,6 +291,7 @@ const mapStateToProps = state => ({
   filters: state.filters,
   search: state.search,
   eligibility: state.eligibility,
+  gibctStateSearch: toggleValues(state)[FEATURE_FLAG_NAMES.gibctStateSearch],
 });
 
 const mapDispatchToProps = {

--- a/src/applications/gi/tests/actions/index.unit.spec.js
+++ b/src/applications/gi/tests/actions/index.unit.spec.js
@@ -367,6 +367,20 @@ describe('institution search', () => {
       done();
     }, 0);
   });
+
+  it('should pass state_search when flag value is true', done => {
+    const dispatch = sinon.spy();
+    fetchInstitutionSearchResults({}, true)(dispatch);
+    expect(global.fetch.firstCall.args[0]).to.contain('state_search=true');
+    done();
+  });
+
+  it('should not pass state_search when flag value is false', done => {
+    const dispatch = sinon.spy();
+    fetchInstitutionSearchResults({}, false)(dispatch);
+    expect(global.fetch.firstCall.args[0]).to.not.contain('state_search');
+    done();
+  });
 });
 
 describe('constants', () => {


### PR DESCRIPTION
## Description
As a Comparison Tool user, I need to be able to search by state abbreviation, so I can find schools in my state besides ones that have the state in the name.

[Originating Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/18313)

This is the front end PR to pass the `gibct-state-search` feature flag for usage in GIDS

## Testing done
Testing passes locally, additional unit tests added.

## Screenshots
N/A

## Acceptance criteria
For the non VETTEC search:
- [x] 1. Search by state abbreviation (ex. TX, AL, SC) returns all institutions within that state.
- [x] 2. Search by "city, state abbreviation" returns all institutions within that city and state.

For the VETTEC search:
- [x] 3. Search by state abbreviation (ex. TX, AL, SC) returns all institutions within that state.
- [x] 4. Search by "city, state abbreviation" returns all institutions within that city and state.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
