### PR TITLE
show direct deposit connection errors

### DIFF
--- a/src/applications/personalization/profile/components/alerts/DirectDepositConnectionError.jsx
+++ b/src/applications/personalization/profile/components/alerts/DirectDepositConnectionError.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
+
+import { benefitTypes } from '../direct-deposit/DirectDepositV2';
+
+const DirectDepositConnectionError = ({ benefitType }) => {
+  let headline;
+  let content;
+  switch (benefitType) {
+    case benefitTypes.CNP:
+      headline =
+        'We can’t load disability compensation and pension information';
+      content = (
+        <p>
+          We’re sorry. Something went wrong on our end. We are having trouble
+          loading information about disability compensation and pension
+          benefits. Please refresh this page or try again later.
+        </p>
+      );
+      break;
+
+    case benefitTypes.EDU:
+      headline = 'We can’t load education benefits information';
+      content = (
+        <p>
+          We’re sorry. Something went wrong on our end. We are having trouble
+          loading information about education benefits. Please refresh this page
+          or try again later.
+        </p>
+      );
+      break;
+
+    default:
+      break;
+  }
+
+  return (
+    <div className="vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4">
+      <AlertBox headline={headline} content={content} status="warning" />
+    </div>
+  );
+};
+
+export default DirectDepositConnectionError;

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoCNPv2.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoCNPv2.jsx
@@ -21,13 +21,17 @@ import {
   cnpDirectDepositAddressIsSetUp,
   cnpDirectDepositInformation,
   cnpDirectDepositIsSetUp,
+  cnpDirectDepositLoadError,
   cnpDirectDepositUiState as directDepositUiStateSelector,
 } from '@@profile/selectors';
+
+import DirectDepositConnectionError from '../alerts/DirectDepositConnectionError';
 
 import BankInfoForm from './BankInfoForm';
 
 import PaymentInformationEditError from './PaymentInformationEditError';
 import ProfileInfoTable from '../ProfileInfoTable';
+import { benefitTypes } from './DirectDepositV2';
 
 import prefixUtilityClasses from '~/platform/utilities/prefix-utility-classes';
 
@@ -36,6 +40,7 @@ export const BankInfoCNP = ({
   isDirectDepositSetUp,
   isEligibleToSetUpDirectDeposit,
   directDepositAccountInfo,
+  directDepositServerError,
   directDepositUiState,
   saveBankInformation,
   toggleEditState,
@@ -269,6 +274,10 @@ export const BankInfoCNP = ({
     return null;
   }
 
+  if (directDepositServerError) {
+    return <DirectDepositConnectionError benefitType={benefitTypes.CNP} />;
+  }
+
   return (
     <>
       <Modal
@@ -322,6 +331,7 @@ BankInfoCNP.propTypes = {
     financialInstitutionRoutingNumber: PropTypes.string.isRequired,
   }),
   isDirectDepositSetUp: PropTypes.bool.isRequired,
+  directDepositServerError: PropTypes.bool.isRequired,
   isEligibleToSetUpDirectDeposit: PropTypes.bool.isRequired,
   directDepositUiState: PropTypes.shape({
     isEditing: PropTypes.bool.isRequired,
@@ -337,6 +347,7 @@ export const mapStateToProps = state => ({
   directDepositAccountInfo: cnpDirectDepositAccountInformation(state),
   directDepositInfo: cnpDirectDepositInformation(state),
   isDirectDepositSetUp: cnpDirectDepositIsSetUp(state),
+  directDepositServerError: !!cnpDirectDepositLoadError(state),
   isEligibleToSetUpDirectDeposit: cnpDirectDepositAddressIsSetUp(state),
   directDepositUiState: directDepositUiStateSelector(state),
 });

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
@@ -21,13 +21,17 @@ import {
   eduDirectDepositAccountInformation,
   eduDirectDepositInformation,
   eduDirectDepositIsSetUp,
+  eduDirectDepositLoadError,
   eduDirectDepositUiState as directDepositUiStateSelector,
 } from '@@profile/selectors';
+
+import DirectDepositConnectionError from '../alerts/DirectDepositConnectionError';
 
 import BankInfoForm from './BankInfoForm';
 
 import PaymentInformationEditError from './PaymentInformationEditError';
 import ProfileInfoTable from '../ProfileInfoTable';
+import { benefitTypes } from './DirectDepositV2';
 
 import prefixUtilityClasses from '~/platform/utilities/prefix-utility-classes';
 
@@ -35,6 +39,7 @@ export const DirectDepositEDU = ({
   isLOA3,
   isDirectDepositSetUp,
   directDepositAccountInfo,
+  directDepositServerError,
   directDepositUiState,
   saveBankInformation,
   toggleEditState,
@@ -236,6 +241,10 @@ export const DirectDepositEDU = ({
     return null;
   }
 
+  if (directDepositServerError) {
+    return <DirectDepositConnectionError benefitType={benefitTypes.EDU} />;
+  }
+
   return (
     <>
       <Modal
@@ -289,6 +298,7 @@ DirectDepositEDU.propTypes = {
     financialInstitutionRoutingNumber: PropTypes.string.isRequired,
   }),
   isDirectDepositSetUp: PropTypes.bool.isRequired,
+  directDepositServerError: PropTypes.bool.isRequired,
   directDepositUiState: PropTypes.shape({
     isEditing: PropTypes.bool.isRequired,
     isSaving: PropTypes.bool.isRequired,
@@ -303,6 +313,7 @@ export const mapStateToProps = state => ({
   directDepositAccountInfo: eduDirectDepositAccountInformation(state),
   directDepositInfo: eduDirectDepositInformation(state),
   isDirectDepositSetUp: eduDirectDepositIsSetUp(state),
+  directDepositServerError: !!eduDirectDepositLoadError(state),
   directDepositUiState: directDepositUiStateSelector(state),
 });
 

--- a/src/applications/personalization/profile/components/direct-deposit/DirectDepositV2.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/DirectDepositV2.jsx
@@ -29,7 +29,7 @@ import PaymentHistory from './PaymentHistory';
 import BankInfoCNPv2 from './BankInfoCNPv2';
 import BankInfoEDU from './BankInfoEDU';
 
-const benefitTypes = {
+export const benefitTypes = {
   CNP: 'compensation and pension benefits',
   EDU: 'education benefits',
 };

--- a/src/applications/personalization/profile/tests/e2e/direct-deposit/gating.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/direct-deposit/gating.cypress.spec.js
@@ -146,7 +146,6 @@ describe('Direct Deposit', () => {
     confirmDDBlockedAlertIsNotShown();
 
     cy.findByTestId('not-all-data-available-error').should('exist');
-    cy.findByText(/something went wrong/i).should('exist');
   });
   it('should not be blocked if `GET payment_information` fails but they have DD4EDU set up', () => {
     cy.route('GET', 'v0/user', mockUserInEVSS);
@@ -158,10 +157,18 @@ describe('Direct Deposit', () => {
     confirmDDBlockedAlertIsNotShown();
 
     cy.findByTestId('not-all-data-available-error').should('exist');
-    cy.findByText(/something went wrong/i).should('exist');
 
-    // TODO: add check to make sure we show in error alert in place of the CNP bank info
-    // content TBD: https://github.com/department-of-veterans-affairs/va.gov-team/issues/18338
+    cy.findByText(/not receiving disability.*payments/i).should('not.exist');
+    cy.findByRole('link', {
+      name: /find out.*eligible.*VA disability benefits/i,
+    }).should('not.exist');
+    cy.findByRole('link', {
+      name: /find out.*eligible.*VA pension benefits/i,
+    }).should('not.exist');
+    cy.findByText(/can’t load disability.*information/i)
+      .should('exist')
+      .closest('.usa-alert-warning')
+      .should('exist');
   });
   it('should not be blocked if `GET ch33_bank_accounts` fails but they have DD4CNP set up', () => {
     cy.route('GET', 'v0/user', mockUserInEVSS);
@@ -173,10 +180,15 @@ describe('Direct Deposit', () => {
     confirmDDBlockedAlertIsNotShown();
 
     cy.findByTestId('not-all-data-available-error').should('exist');
-    cy.findByText(/something went wrong/i).should('exist');
 
-    // TODO: add check to make sure we show in error alert in place of the EDU bank info
-    // content TBD: https://github.com/department-of-veterans-affairs/va.gov-team/issues/18338
+    cy.findByText(/not receiving education.*payments/i).should('not.exist');
+    cy.findByRole('link', {
+      name: /find out.*eligible.*VA education benefits/i,
+    }).should('not.exist');
+    cy.findByText(/can’t load education.*information/i)
+      .should('exist')
+      .closest('.usa-alert-warning')
+      .should('exist');
   });
   it('should not be blocked if the user is eligible for DD4CNP', () => {
     cy.route('GET', 'v0/user', mockUserInEVSS);


### PR DESCRIPTION
## Description
Shows errors in place of bank info if there is an error connection to the EDU bank info endpoint or the CNP bank info endpoint _but_ the user still sees the Direct Deposit section because they get direct deposit for the _other_ benefit.

## Testing done
Added Cypress tests. That's the easiest way to create the scenarios this PR is meant to handle.

## Screenshots
Error with CNP endpoint:
<img width="1001" alt="cnp error" src="https://user-images.githubusercontent.com/20728956/105526112-d1d24400-5c96-11eb-9d75-e9b46aec09a1.png">

Error with EDU endpoint:
<img width="1000" alt="edu error" src="https://user-images.githubusercontent.com/20728956/105526134-da2a7f00-5c96-11eb-9c4e-f7dd1c47c870.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs