### PR TITLE
Remove colon in Email label on VAMC

### DIFF
--- a/src/site/facilities/service_location.drupal.liquid
+++ b/src/site/facilities/service_location.drupal.liquid
@@ -46,9 +46,9 @@
       <p class="vads-u-margin-y--1" data-template="paragraphs/service_location">
       {% if email.entity.fieldEmailLabel %}
         {% if haveLocationName %}
-          <h5>{{ email.entity.fieldEmailLabel }}: </h5>
+          <h5>{{ email.entity.fieldEmailLabel }} </h5>
         {% else %}
-          <h4 class="force-small-header">{{ email.entity.fieldEmailLabel }}: </h4>
+          <h4 class="force-small-header">{{ email.entity.fieldEmailLabel }} </h4>
         {% endif %}
       {% endif %}
       <a aria-label="{{ email.entity.fieldEmailAddress }}"


### PR DESCRIPTION
## Description
Issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/18825

## Testing done


## Screenshots
<img width="864" alt="Screen Shot 2021-01-22 at 11 58 44 AM" src="https://user-images.githubusercontent.com/100468/105529469-0dc3d400-5cac-11eb-961b-4a49a6782ed5.png">



## Acceptance criteria
- [x] Phone and Email labels are displayed consistently and without the colon

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
