### PR TITLE
stop mocking GET feature_toggles in every Cypress test

### DIFF
--- a/src/platform/testing/e2e/cypress/support/index.js
+++ b/src/platform/testing/e2e/cypress/support/index.js
@@ -36,13 +36,6 @@ Cypress.Commands.overwrite('type', (originalFn, element, text, options) => {
 beforeEach(() => {
   cy.server();
 
-  cy.route('GET', '/v0/feature_toggles?*', {
-    data: {
-      type: 'feature_toggles',
-      features: [],
-    },
-  });
-
   cy.route('GET', '/v0/maintenance_windows', {
     data: [],
   });


### PR DESCRIPTION
## Description
@micahchiang and I discovered that if you try to use `cy.intercept()` instead of `cy.route()`, you cannot mock the `GET feature_toggles` endpoint in your tests. This is because you cannot override previously-defined responses (see https://github.com/cypress-io/cypress/issues/9302 and https://glebbahmutov.com/blog/cypress-intercept-problems/#no-overwriting-interceptors)

This change removes the global mock for that endpoint so that you can mock the feature toggles you need in your tests.

## Testing done
Existing tests should still pass. 🤞 

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs