### PR TITLE
Add redirects [merge 02/03]

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -1042,31 +1042,31 @@
   {
     "domain": "www.benefits.va.gov",
     "src": "/PENSION/rates_survivor_pen18.asp",
-    "dest": "https://www.va.gov/pension/survivors-pension-rates/past-rates-2019/"
+    "dest": "/pension/survivors-pension-rates/past-rates-2019/"
   },
   {
     "domain": "www.benefits.va.gov",
     "src": "/PENSION/rates_survivor_pen17.asp",
-    "dest": "https://www.va.gov/pension/survivors-pension-rates/past-rates-2018/"
+    "dest": "/pension/survivors-pension-rates/past-rates-2018/"
   },
   {
     "domain": "www.benefits.va.gov",
     "src": "/PENSION/protected_pension_rate_tables_pen18.asp",
-    "dest": "https://www.va.gov/pension/protected-pension-rates/past-rates-2019/"
+    "dest": "/pension/protected-pension-rates/past-rates-2019/"
   },
   {
     "domain": "www.benefits.va.gov",
     "src": "/PENSION/protected_pension_rate_tables_pen17.asp",
-    "dest": "https://www.va.gov/pension/protected-pension-rates/past-rates-2018/"
+    "dest": "/pension/protected-pension-rates/past-rates-2018/"
   },
   {
     "domain": "www.benefits.va.gov",
     "src": "/PENSION/rates_veteran_pen18.asp",
-    "dest": "https://www.va.gov/pension/veterans-pension-rates/past-rates-2019/"
+    "dest": "/pension/veterans-pension-rates/past-rates-2019/"
   },
   {
     "domain": "www.benefits.va.gov",
     "src": "/PENSION/rates_veteran_pen17.asp",
-    "dest": "https://www.va.gov/pension/veterans-pension-rates/past-rates-2018/"
+    "dest": "/pension/veterans-pension-rates/past-rates-2018/"
   }
 ]

--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -1038,5 +1038,35 @@
     "domain": "www.benefits.va.gov",
     "src": "/compensation/agentorange-c123.asp",
     "dest": "/disability/eligibility/hazardous-materials-exposure/agent-orange/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/PENSION/rates_survivor_pen18.asp",
+    "dest": "https://www.va.gov/pension/survivors-pension-rates/past-rates-2019/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/PENSION/rates_survivor_pen17.asp",
+    "dest": "https://www.va.gov/pension/survivors-pension-rates/past-rates-2018/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/PENSION/protected_pension_rate_tables_pen18.asp",
+    "dest": "https://www.va.gov/pension/protected-pension-rates/past-rates-2019/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/PENSION/protected_pension_rate_tables_pen17.asp",
+    "dest": "https://www.va.gov/pension/protected-pension-rates/past-rates-2018/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/PENSION/rates_veteran_pen18.asp",
+    "dest": "https://www.va.gov/pension/veterans-pension-rates/past-rates-2019/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/PENSION/rates_veteran_pen17.asp",
+    "dest": "https://www.va.gov/pension/veterans-pension-rates/past-rates-2018/"
   }
 ]


### PR DESCRIPTION
# Don't merge until 02/03
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/18837

This PR implements the following redirects:

Current URL  |  Redirect Destination or New URL
---  |  ---
https://www.benefits.va.gov/PENSION/rates_survivor_pen18.asp | https://www.va.gov/pension/survivors-pension-rates/past-rates-2019/
https://www.benefits.va.gov/PENSION/rates_survivor_pen17.asp | https://www.va.gov/pension/survivors-pension-rates/past-rates-2018/
https://benefits.va.gov/PENSION/protected_pension_rate_tables_pen18.asp | https://www.va.gov/pension/protected-pension-rates/past-rates-2019/
https://benefits.va.gov/PENSION/protected_pension_rate_tables_pen17.asp | https://www.va.gov/pension/protected-pension-rates/past-rates-2018/
https://www.benefits.va.gov/PENSION/rates_veteran_pen18.asp | https://www.va.gov/pension/veterans-pension-rates/past-rates-2019/
https://www.benefits.va.gov/PENSION/rates_veteran_pen17.asp | https://www.va.gov/pension/veterans-pension-rates/past-rates-2018/

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Implement redirects

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
