### PR TITLE
Handle "unknown" values for referral and walkin on VAMC services

### DIFF
--- a/src/site/facilities/service_location.drupal.liquid
+++ b/src/site/facilities/service_location.drupal.liquid
@@ -103,20 +103,24 @@
     </div>
   {% endif %}
 
-  {% if locationEntity.fieldReferralRequired and locationEntity.fieldReferralRequired != 'not_applicable' or
-      if locationEntity.fieldReferralRequired and locationEntity.fieldReferralRequired != 'unknown' %}
-    <p class="vads-u-margin-bottom--0" data-template="paragraphs/service_location">
-      <strong>Referral required?</strong>
-      {% if locationEntity.fieldReferralRequired == '1' %}Yes{% else %}No{% endif %}
-    </p>
+  {% assign OMIT_REFERRAL_OR_WALKIN = "not_applicable, unknown" %}
+
+  {% if locationEntity.fieldReferralRequired %}
+    {% unless OMIT_REFERRAL_OR_WALKIN contains locationEntity.fieldReferralRequired %}
+      <p class="vads-u-margin-bottom--0" data-template="paragraphs/service_location">
+        <strong>Referral required?</strong>
+        {% if locationEntity.fieldReferralRequired == '1' %}Yes{% else %}No{% endif %}
+      </p>
+    {% endunless %}
   {% endif %}
 
-  {% if locationEntity.fieldWalkInsAccepted and locationEntity.fieldWalkInsAccepted != 'not_applicable'or
-      if locationEntity.fieldReferralRequired and locationEntity.fieldReferralRequired != 'unknown' %}
-    <p class="vads-u-margin-bottom--0" data-template="paragraphs/service_location">
-      <strong>Walk-ins accepted?</strong>
-      {% if locationEntity.fieldWalkInsAccepted == '1' %}Yes{% else %}No{% endif %}
-    </p>
+  {% if locationEntity.fieldWalkInsAccepted %}
+    {% unless OMIT_REFERRAL_OR_WALKIN contains locationEntity.fieldWalkInsAccepted %}
+      <p class="vads-u-margin-bottom--0" data-template="paragraphs/service_location">
+        <strong>Walk-ins accepted?</strong>
+        {% if locationEntity.fieldWalkInsAccepted == '1' %}Yes{% else %}No{% endif %}
+      </p>
+    {% endunless %}
   {% endif %}
 
   {% if locationEntity.fieldOnlineSchedulingAvailabl == '1' %}

--- a/src/site/facilities/service_location.drupal.liquid
+++ b/src/site/facilities/service_location.drupal.liquid
@@ -103,14 +103,16 @@
     </div>
   {% endif %}
 
-  {% if locationEntity.fieldReferralRequired and locationEntity.fieldReferralRequired != 'not_applicable' %}
+  {% if locationEntity.fieldReferralRequired and locationEntity.fieldReferralRequired != 'not_applicable' or
+      if locationEntity.fieldReferralRequired and locationEntity.fieldReferralRequired != 'unknown' %}
     <p class="vads-u-margin-bottom--0" data-template="paragraphs/service_location">
       <strong>Referral required?</strong>
       {% if locationEntity.fieldReferralRequired == '1' %}Yes{% else %}No{% endif %}
     </p>
   {% endif %}
 
-  {% if locationEntity.fieldWalkInsAccepted and locationEntity.fieldWalkInsAccepted != 'not_applicable' %}
+  {% if locationEntity.fieldWalkInsAccepted and locationEntity.fieldWalkInsAccepted != 'not_applicable'or
+      if locationEntity.fieldReferralRequired and locationEntity.fieldReferralRequired != 'unknown' %}
     <p class="vads-u-margin-bottom--0" data-template="paragraphs/service_location">
       <strong>Walk-ins accepted?</strong>
       {% if locationEntity.fieldWalkInsAccepted == '1' %}Yes{% else %}No{% endif %}


### PR DESCRIPTION
## Description

issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/18816

## Testing done


## Screenshots


## Acceptance criteria
- [x] When the value for "Walk ins" = "Unknown" in CMS, the line "Walk-ins accepted" or "Referrals required" line is not displayed at all.

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
