### PR TITLE
Homepage Refresh: Request Details

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/PageLayout.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/PageLayout.jsx
@@ -2,14 +2,18 @@ import React from 'react';
 import Breadcrumbs from '../../../components/Breadcrumbs';
 import NeedHelp from '../../../components/NeedHelp';
 
-export default function PageLayout({ children }) {
+export default function PageLayout({
+  children,
+  showBreadcrumbs,
+  showNeedHelp,
+}) {
   return (
     <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2p5">
-      <Breadcrumbs />
+      {showBreadcrumbs && <Breadcrumbs />}
       <div className="vads-l-row">
         <div className="vads-l-col--12 medium-screen:vads-l-col--8 vads-u-margin-bottom--2">
           {children}
-          <NeedHelp />
+          {showNeedHelp && <NeedHelp />}
         </div>
       </div>
     </div>

--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/RequestListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/RequestListItem.jsx
@@ -30,7 +30,7 @@ export default function RequestListItem({ appointment, facility }) {
           Details
         </Link>
         <Link
-          to={`request/${appointment.id}`}
+          to={`requests/${appointment.id}`}
           className="vaos-appts__card-link"
           aria-label={`Details for ${typeOfCareText} request`}
         >

--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/RequestListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/RequestListItem.jsx
@@ -24,7 +24,7 @@ export default function RequestListItem({ appointment, facility }) {
       <div>
         <Link
           aria-hidden="true"
-          to={`request/${appointment.id}`}
+          to={`requests/${appointment.id}`}
           className="vads-u-display--none medium-screen:vads-u-display--inline"
         >
           Details

--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
@@ -84,13 +84,14 @@ function RequestedAppointmentDetailsPage({
       </div>
 
       <h1>Pending {typeOfCareText} appointment</h1>
-      <h4 className="vaos-appts__block-label vads-u-margin-bottom--0">
+      <span className="vads-u-display--block vads-u-font-weight--bold">
         {isCC && 'Community Care'}
         {!isCC && !!isVideoRequest && 'VA Video Connect'}
         {!isCC && !isVideoRequest && 'VA Appointment'}
-      </h4>
+        {isExpressCare && 'Express Care'}
+        {isExpressCare && facility?.name}
+      </span>
 
-      {isExpressCare && facility?.name}
       {!!facility &&
         !isCC &&
         !isExpressCare && (
@@ -98,15 +99,15 @@ function RequestedAppointmentDetailsPage({
             facility={facility}
             facilityName={facility?.name}
             facilityId={parseFakeFHIRId(facilityId)}
-            isV2
+            isHomepageRefresh
           />
         )}
 
       {!isExpressCare && (
         <>
-          <h4 className="vaos-appts__block-label vads-u-margin-bottom--0 vads-u-margin-top--2">
+          <h2 className="vaos-appts__block-label vads-u-margin-bottom--0 vads-u-margin-top--2">
             Preferred date and time
-          </h4>
+          </h2>
           <ul className="usa-unstyled-list">
             {appointment.requestedPeriod.map((option, optionIndex) => (
               <li key={`${appointment.id}-option-${optionIndex}`}>
@@ -121,25 +122,25 @@ function RequestedAppointmentDetailsPage({
       )}
       {isExpressCare && (
         <>
-          <h4 className="vads-u-margin-top--2 vaos-appts__block-label">
+          <h2 className="vads-u-margin-top--2 vaos-appts__block-label">
             Reason for appointment
-          </h4>
+          </h2>
           <div>{appointment.reason}</div>
         </>
       )}
 
       {!isExpressCare && (
         <>
-          <h4 className="vads-u-margin-top--2 vaos-appts__block-label">
+          <h2 className="vads-u-margin-top--2 vaos-appts__block-label">
             {appointment.reason}
-          </h4>
+          </h2>
           <div>{firstMessage}</div>
         </>
       )}
 
-      <h4 className="vads-u-margin-top--2 vads-u-margin-bottom--0 vaos-appts__block-label">
+      <h2 className="vads-u-margin-top--2 vads-u-margin-bottom--0 vaos-appts__block-label">
         Your contact details
-      </h4>
+      </h2>
       <div>
         {getPatientTelecom(appointment, 'email')}
         <br />

--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
@@ -2,16 +2,40 @@ import React, { useEffect } from 'react';
 import { Link, useParams, useHistory } from 'react-router-dom';
 import { connect } from 'react-redux';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
+import moment from 'moment';
+
 import * as actions from '../redux/actions';
 import { FETCH_STATUS } from '../../utils/constants';
 import { lowerCase } from '../../utils/formatters';
 import { scrollAndFocus } from '../../utils/scrollAndFocus';
+import ListBestTimeToCall from './cards/pending/ListBestTimeToCall';
+import VAFacilityLocation from '../../components/VAFacilityLocation';
+
+import {
+  getPatientTelecom,
+  isVideoAppointment,
+  getVAAppointmentLocationId,
+} from '../../services/appointment';
+
+const TIME_TEXT = {
+  AM: 'in the morning',
+  PM: 'in the afternoon',
+  'No Time Selected': '',
+};
+
+// Only use this when we need to pass data that comes back from one of our
+// services files to one of the older api functions
+function parseFakeFHIRId(id) {
+  return id ? id.replace('var', '') : id;
+}
 
 function RequestedAppointmentDetailsPage({
   appointmentDetails,
   appointmentDetailsStatus,
+  facilityData,
   fetchRequestDetails,
   pendingStatus,
+  requestMessages,
 }) {
   const { id } = useParams();
   const history = useHistory();
@@ -42,7 +66,19 @@ function RequestedAppointmentDetailsPage({
     );
   }
 
+  if (!appointment) {
+    return null;
+  }
+
+  const isCC = appointment.vaos.isCommunityCare;
+  const isExpressCare = appointment.vaos.isExpressCare;
+  const isVideoRequest = isVideoAppointment(appointment);
   const typeOfCareText = lowerCase(appointment?.type?.coding?.[0]?.display);
+  const facilityId = getVAAppointmentLocationId(appointment);
+  const facility = facilityData?.[facilityId];
+  const firstMessage =
+    requestMessages?.[parseFakeFHIRId(appointment.id)]?.[0]?.attributes
+      ?.messageText;
 
   return (
     <div>
@@ -51,8 +87,77 @@ function RequestedAppointmentDetailsPage({
       </div>
 
       <h1>Pending {typeOfCareText} appointment</h1>
+      <div className="vvads-u-font-size--sm vads-u-font-weight--bold vads-u-font-family--sans">
+        {isCC && 'Community Care'}
+        {!isCC && !!isVideoRequest && 'VA Video Connect'}
+        {!isCC && !isVideoRequest && 'VA Appointment'}
+      </div>
+
+      {isExpressCare && facility?.name}
+      {!!facility &&
+        !isCC &&
+        !isExpressCare && (
+          <VAFacilityLocation
+            facility={facility}
+            facilityName={facility?.name}
+            facilityId={parseFakeFHIRId(facilityId)}
+            isV2
+          />
+        )}
+
+      {!isExpressCare && (
+        <>
+          <h4 className="vaos-appts__block-label vads-u-margin-bottom--0 vads-u-margin-top--2">
+            Preferred date and time
+          </h4>
+          <ul className="usa-unstyled-list">
+            {appointment.requestedPeriod.map((option, optionIndex) => (
+              <li key={`${appointment.id}-option-${optionIndex}`}>
+                {moment(option.start).format('ddd, MMMM D, YYYY')}{' '}
+                {option.start.includes('00:00:00')
+                  ? TIME_TEXT.AM
+                  : TIME_TEXT.PM}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+      {isExpressCare && (
+        <>
+          <h4 className="vads-u-margin-top--2 vaos-appts__block-label">
+            Reason for appointment
+          </h4>
+          <div>{appointment.reason}</div>
+        </>
+      )}
+
+      {!isExpressCare && (
+        <>
+          <h4 className="vads-u-margin-top--2 vaos-appts__block-label">
+            {appointment.reason}
+          </h4>
+          <div>{firstMessage}</div>
+        </>
+      )}
+
+      <h4 className="vads-u-margin-top--2 vads-u-margin-bottom--0 vaos-appts__block-label">
+        Your contact details
+      </h4>
+      <div>
+        {getPatientTelecom(appointment, 'email')}
+        <br />
+        {getPatientTelecom(appointment, 'phone')}
+        <br />
+        <span className="vads-u-font-style--italic">
+          <ListBestTimeToCall
+            timesToCall={appointment.legacyVAR?.bestTimeToCall}
+          />
+        </span>
+      </div>
       <Link to="/requested">
-        <button className="usa-button">« Go back to appointments</button>
+        <button className="usa-button vads-u-margin-top--2">
+          « Go back to appointments
+        </button>
       </Link>
     </div>
   );
@@ -62,12 +167,16 @@ function mapStateToProps(state) {
   const {
     appointmentDetails,
     appointmentDetailsStatus,
+    facilityData,
     pendingStatus,
+    requestMessages,
   } = state.appointments;
 
   return {
     appointmentDetails,
     appointmentDetailsStatus,
+    facilityData,
+    requestMessages,
     pendingStatus,
   };
 }

--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
@@ -1,31 +1,74 @@
 import React, { useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { Link, useParams, useHistory } from 'react-router-dom';
 import { connect } from 'react-redux';
-import { selectPendingAppointments } from '../redux/selectors';
+import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import * as actions from '../redux/actions';
+import { FETCH_STATUS } from '../../utils/constants';
+import { lowerCase } from '../../utils/formatters';
+import { scrollAndFocus } from '../../utils/scrollAndFocus';
 
 function RequestedAppointmentDetailsPage({
   appointmentDetails,
+  appointmentDetailsStatus,
   fetchRequestDetails,
+  pendingStatus,
 }) {
   const { id } = useParams();
+  const history = useHistory();
+  const appointment = appointmentDetails?.[id];
+
   useEffect(() => {
-    if (!appointmentDetails[id]) {
+    const fetchedPending = pendingStatus === FETCH_STATUS.succeeded;
+
+    if (!fetchedPending) {
+      history.push('/requested');
+    }
+
+    if (!appointment) {
       fetchRequestDetails(id);
     }
+
+    scrollAndFocus();
   }, []);
+
+  if (
+    appointmentDetailsStatus === FETCH_STATUS.notStarted ||
+    appointmentDetailsStatus === FETCH_STATUS.loading
+  ) {
+    return (
+      <div className="vads-u-margin-y--8">
+        <LoadingIndicator message="Loading your appointment request..." />
+      </div>
+    );
+  }
+
+  const typeOfCareText = lowerCase(appointment?.type?.coding?.[0]?.display);
 
   return (
     <div>
-      <h1>Pending details</h1>
+      <div className="vads-u-display--block vads-u-padding-y--2p5">
+        ‹ <Link to="/requested">Manage appointments</Link>
+      </div>
+
+      <h1>Pending {typeOfCareText} appointment</h1>
+      <Link to="/requested">
+        <button className="usa-button">« Go back to appointments</button>
+      </Link>
     </div>
   );
 }
 
 function mapStateToProps(state) {
+  const {
+    appointmentDetails,
+    appointmentDetailsStatus,
+    pendingStatus,
+  } = state.appointments;
+
   return {
-    pendingStatus: state.appointments.pendingStatus,
-    pendingAppointments: selectPendingAppointments(state),
+    appointmentDetails,
+    appointmentDetailsStatus,
+    pendingStatus,
   };
 }
 

--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
@@ -55,10 +55,7 @@ function RequestedAppointmentDetailsPage({
     scrollAndFocus();
   }, []);
 
-  if (
-    appointmentDetailsStatus === FETCH_STATUS.notStarted ||
-    appointmentDetailsStatus === FETCH_STATUS.loading
-  ) {
+  if (appointmentDetailsStatus === FETCH_STATUS.loading) {
     return (
       <div className="vads-u-margin-y--8">
         <LoadingIndicator message="Loading your appointment request..." />

--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
@@ -16,6 +16,7 @@ import {
   isVideoAppointment,
   getVAAppointmentLocationId,
 } from '../../services/appointment';
+import { selectFirstRequestMessage } from '../redux/selectors';
 
 const TIME_TEXT = {
   AM: 'in the morning',
@@ -30,25 +31,22 @@ function parseFakeFHIRId(id) {
 }
 
 function RequestedAppointmentDetailsPage({
-  appointmentDetails,
+  appointment,
   appointmentDetailsStatus,
   facilityData,
   fetchRequestDetails,
   pendingStatus,
-  requestMessages,
+  message,
 }) {
   const { id } = useParams();
   const history = useHistory();
-  const appointment = appointmentDetails?.[id];
 
   useEffect(() => {
-    const fetchedPending = pendingStatus === FETCH_STATUS.succeeded;
-
-    if (!fetchedPending) {
+    if (pendingStatus !== FETCH_STATUS.succeeded) {
       history.push('/requested');
     }
 
-    if (!appointment) {
+    if (!appointment || appointment.id !== id) {
       fetchRequestDetails(id);
     }
 
@@ -73,9 +71,6 @@ function RequestedAppointmentDetailsPage({
   const typeOfCareText = lowerCase(appointment?.type?.coding?.[0]?.display);
   const facilityId = getVAAppointmentLocationId(appointment);
   const facility = facilityData?.[facilityId];
-  const firstMessage =
-    requestMessages?.[parseFakeFHIRId(appointment.id)]?.[0]?.attributes
-      ?.messageText;
 
   return (
     <div>
@@ -134,7 +129,7 @@ function RequestedAppointmentDetailsPage({
           <h2 className="vads-u-margin-top--2 vaos-appts__block-label">
             {appointment.reason}
           </h2>
-          <div>{firstMessage}</div>
+          <div>{message}</div>
         </>
       )}
 
@@ -163,18 +158,17 @@ function RequestedAppointmentDetailsPage({
 
 function mapStateToProps(state) {
   const {
-    appointmentDetails,
+    currentAppointment,
     appointmentDetailsStatus,
     facilityData,
     pendingStatus,
-    requestMessages,
   } = state.appointments;
 
   return {
-    appointmentDetails,
+    appointment: currentAppointment,
     appointmentDetailsStatus,
     facilityData,
-    requestMessages,
+    message: selectFirstRequestMessage(state),
     pendingStatus,
   };
 }

--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
@@ -84,11 +84,11 @@ function RequestedAppointmentDetailsPage({
       </div>
 
       <h1>Pending {typeOfCareText} appointment</h1>
-      <div className="vvads-u-font-size--sm vads-u-font-weight--bold vads-u-font-family--sans">
+      <h4 className="vaos-appts__block-label vads-u-margin-bottom--0">
         {isCC && 'Community Care'}
         {!isCC && !!isVideoRequest && 'VA Video Connect'}
         {!isCC && !isVideoRequest && 'VA Appointment'}
-      </div>
+      </h4>
 
       {isExpressCare && facility?.name}
       {!!facility &&

--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
@@ -1,0 +1,39 @@
+import React, { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { connect } from 'react-redux';
+import { selectPendingAppointments } from '../redux/selectors';
+import * as actions from '../redux/actions';
+
+function RequestedAppointmentDetailsPage({
+  appointmentDetails,
+  fetchRequestDetails,
+}) {
+  const { id } = useParams();
+  useEffect(() => {
+    if (!appointmentDetails[id]) {
+      fetchRequestDetails(id);
+    }
+  }, []);
+
+  return (
+    <div>
+      <h1>Pending details</h1>
+    </div>
+  );
+}
+
+function mapStateToProps(state) {
+  return {
+    pendingStatus: state.appointments.pendingStatus,
+    pendingAppointments: selectPendingAppointments(state),
+  };
+}
+
+const mapDispatchToProps = {
+  fetchRequestDetails: actions.fetchRequestDetails,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(RequestedAppointmentDetailsPage);

--- a/src/applications/vaos/appointment-list/index.jsx
+++ b/src/applications/vaos/appointment-list/index.jsx
@@ -9,26 +9,33 @@ import RequestedAppointmentDetailsPage from './components/RequestedAppointmentDe
 
 function AppointmentListSection({ featureHomepageRefresh }) {
   return (
-    <PageLayout>
-      <Switch>
-        {featureHomepageRefresh && (
-          <Route
-            path="/request/:id"
-            component={RequestedAppointmentDetailsPage}
-          />
-        )}
+    <Switch>
+      {featureHomepageRefresh && (
         <Route
-          path="/"
-          render={() => {
-            if (featureHomepageRefresh) {
-              return <AppointmentsPageV2 />;
-            }
-
-            return <AppointmentsPage />;
-          }}
+          path="/request/:id"
+          component={() => (
+            <PageLayout>
+              <RequestedAppointmentDetailsPage />
+            </PageLayout>
+          )}
         />
-      </Switch>
-    </PageLayout>
+      )}
+      <Route
+        path="/"
+        render={() => {
+          let content = <AppointmentsPage />;
+          if (featureHomepageRefresh) {
+            content = <AppointmentsPageV2 />;
+          }
+
+          return (
+            <PageLayout showBreadcrumbs showNeedHelp>
+              {content}
+            </PageLayout>
+          );
+        }}
+      />
+    </Switch>
   );
 }
 

--- a/src/applications/vaos/appointment-list/index.jsx
+++ b/src/applications/vaos/appointment-list/index.jsx
@@ -5,11 +5,18 @@ import { selectFeatureHomepageRefresh } from '../redux/selectors';
 import PageLayout from './components/AppointmentsPage/PageLayout';
 import AppointmentsPageV2 from './components/AppointmentsPage/AppointmentsPageV2';
 import AppointmentsPage from './components/AppointmentsPage/index';
+import RequestedAppointmentDetailsPage from './components/RequestedAppointmentDetailsPage';
 
 function AppointmentListSection({ featureHomepageRefresh }) {
   return (
     <PageLayout>
       <Switch>
+        {featureHomepageRefresh && (
+          <Route
+            path="/request/:id"
+            component={RequestedAppointmentDetailsPage}
+          />
+        )}
         <Route
           path="/"
           render={() => {

--- a/src/applications/vaos/appointment-list/index.jsx
+++ b/src/applications/vaos/appointment-list/index.jsx
@@ -12,7 +12,7 @@ function AppointmentListSection({ featureHomepageRefresh }) {
     <Switch>
       {featureHomepageRefresh && (
         <Route
-          path="/request/:id"
+          path="/requests/:id"
           component={() => (
             <PageLayout>
               <RequestedAppointmentDetailsPage />

--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -64,6 +64,11 @@ export const FETCH_PAST_APPOINTMENTS_FAILED =
 export const FETCH_PAST_APPOINTMENTS_SUCCEEDED =
   'vaos/FETCH_PAST_APPOINTMENTS_SUCCEEDED';
 
+export const FETCH_REQUEST_DETAILS = 'vaos/FETCH_REQUEST_DETAILS';
+export const FETCH_REQUEST_DETAILS_FAILED = 'vaos/FETCH_REQUEST_DETAILS_FAILED';
+export const FETCH_REQUEST_DETAILS_SUCCEEDED =
+  'vaos/FETCH_REQUEST_DETAILS_SUCCEEDED';
+
 export const FETCH_REQUEST_MESSAGES = 'vaos/FETCH_REQUEST_MESSAGES';
 export const FETCH_REQUEST_MESSAGES_FAILED =
   'vaos/FETCH_REQUEST_MESSAGES_FAILED';
@@ -394,12 +399,18 @@ export function fetchPastAppointments(startDate, endDate, selectedIndex) {
 export function fetchRequestDetails(id) {
   return async (dispatch, getState) => {
     const state = getState();
-    const { appointmentDetails } = state;
+    const { appointmentDetails } = state.appointments;
     const pendingAppointments = selectPendingAppointments(state);
-    const appointment =
-      appointmentDetails[id] || pendingAppointments.find(p => p.id === id);
+    const request =
+      appointmentDetails[id] || pendingAppointments?.find(p => p.id === id);
 
-    if (!appointment) {
+    dispatch({
+      type: FETCH_REQUEST_DETAILS,
+    });
+
+    if (request) {
+      dispatch({ type: FETCH_REQUEST_DETAILS_SUCCEEDED, request, id });
+    } else {
       // TODO: fetch single appointment
     }
   };

--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -14,6 +14,8 @@ import {
   selectFeatureHomepageRefresh,
 } from '../../redux/selectors';
 
+import { selectPendingAppointments } from '../redux/selectors';
+
 import {
   getCancelReasons,
   getRequestEligibilityCriteria,
@@ -385,6 +387,20 @@ export function fetchPastAppointments(startDate, endDate, selectedIndex) {
       recordEvent({
         event: `${GA_PREFIX}-get-past-appointments-failed`,
       });
+    }
+  };
+}
+
+export function fetchRequestDetails(id) {
+  return async (dispatch, getState) => {
+    const state = getState();
+    const { appointmentDetails } = state;
+    const pendingAppointments = selectPendingAppointments(state);
+    const appointment =
+      appointmentDetails[id] || pendingAppointments.find(p => p.id === id);
+
+    if (!appointment) {
+      // TODO: fetch single appointment
     }
   };
 }

--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -91,6 +91,10 @@ export const FETCH_EXPRESS_CARE_WINDOWS_FAILED =
 export const FETCH_EXPRESS_CARE_WINDOWS_SUCCEEDED =
   'vaos/FETCH_EXPRESS_CARE_WINDOWS_SUCCEEDED';
 
+function parseFakeFHIRId(id) {
+  return id ? id.replace('var', '') : id;
+}
+
 export function fetchRequestMessages(requestId) {
   return async dispatch => {
     try {
@@ -399,7 +403,7 @@ export function fetchPastAppointments(startDate, endDate, selectedIndex) {
 export function fetchRequestDetails(id) {
   return async (dispatch, getState) => {
     const state = getState();
-    const { appointmentDetails } = state.appointments;
+    const { appointmentDetails, requestMessages } = state.appointments;
     const pendingAppointments = selectPendingAppointments(state);
     const request =
       appointmentDetails[id] || pendingAppointments?.find(p => p.id === id);
@@ -412,6 +416,13 @@ export function fetchRequestDetails(id) {
       dispatch({ type: FETCH_REQUEST_DETAILS_SUCCEEDED, request, id });
     } else {
       // TODO: fetch single appointment
+    }
+
+    const parsedId = parseFakeFHIRId(id);
+    const messages = requestMessages?.[parsedId];
+
+    if (!messages) {
+      dispatch(fetchRequestMessages(parsedId));
     }
   };
 }

--- a/src/applications/vaos/appointment-list/redux/reducer.js
+++ b/src/applications/vaos/appointment-list/redux/reducer.js
@@ -156,7 +156,7 @@ export default function appointmentsReducer(state = initialState, action) {
       };
     }
     case FETCH_REQUEST_DETAILS_SUCCEEDED: {
-      const appointmentDetails = state.appointmentDetails;
+      const appointmentDetails = { ...state.appointmentDetails };
 
       appointmentDetails[action.id] = action.request;
 

--- a/src/applications/vaos/appointment-list/redux/reducer.js
+++ b/src/applications/vaos/appointment-list/redux/reducer.js
@@ -11,6 +11,8 @@ import {
   FETCH_PAST_APPOINTMENTS,
   FETCH_PAST_APPOINTMENTS_SUCCEEDED,
   FETCH_PAST_APPOINTMENTS_FAILED,
+  FETCH_REQUEST_DETAILS,
+  FETCH_REQUEST_DETAILS_SUCCEEDED,
   FETCH_REQUEST_MESSAGES_SUCCEEDED,
   FETCH_EXPRESS_CARE_WINDOWS_FAILED,
   FETCH_EXPRESS_CARE_WINDOWS_SUCCEEDED,
@@ -57,6 +59,8 @@ const initialState = {
   pastSelectedIndex: 0,
   showCancelModal: false,
   cancelAppointmentStatus: FETCH_STATUS.notStarted,
+  appointmentDetails: {},
+  appointmentDetailsStatus: FETCH_STATUS.notStarted,
   appointmentToCancel: null,
   facilityData: {},
   requestMessages: {},
@@ -143,6 +147,23 @@ export default function appointmentsReducer(state = initialState, action) {
       return {
         ...state,
         facilityData,
+      };
+    }
+    case FETCH_REQUEST_DETAILS: {
+      return {
+        ...state,
+        appointmentDetailsStatus: FETCH_STATUS.loading,
+      };
+    }
+    case FETCH_REQUEST_DETAILS_SUCCEEDED: {
+      const appointmentDetails = state.appointmentDetails;
+
+      appointmentDetails[action.id] = action.request;
+
+      return {
+        ...state,
+        appointmentDetails,
+        appointmentDetailsStatus: FETCH_STATUS.succeeded,
       };
     }
     case FETCH_REQUEST_MESSAGES_SUCCEEDED: {

--- a/src/applications/vaos/appointment-list/redux/reducer.js
+++ b/src/applications/vaos/appointment-list/redux/reducer.js
@@ -59,6 +59,7 @@ const initialState = {
   pastSelectedIndex: 0,
   showCancelModal: false,
   cancelAppointmentStatus: FETCH_STATUS.notStarted,
+  currentAppointment: null,
   appointmentDetails: {},
   appointmentDetailsStatus: FETCH_STATUS.notStarted,
   appointmentToCancel: null,
@@ -153,6 +154,7 @@ export default function appointmentsReducer(state = initialState, action) {
       return {
         ...state,
         appointmentDetailsStatus: FETCH_STATUS.loading,
+        currentAppointment: null,
       };
     }
     case FETCH_REQUEST_DETAILS_SUCCEEDED: {
@@ -162,6 +164,7 @@ export default function appointmentsReducer(state = initialState, action) {
 
       return {
         ...state,
+        currentAppointment: action.request,
         appointmentDetails,
         appointmentDetailsStatus: FETCH_STATUS.succeeded,
       };

--- a/src/applications/vaos/appointment-list/redux/selectors.js
+++ b/src/applications/vaos/appointment-list/redux/selectors.js
@@ -26,6 +26,12 @@ import {
   getTimezoneBySystemId,
 } from '../../utils/timezone';
 
+// Only use this when we need to pass data that comes back from one of our
+// services files to one of the older api functions
+function parseFakeFHIRId(id) {
+  return id ? id.replace('var', '') : id;
+}
+
 export function getCancelInfo(state) {
   const {
     appointmentToCancel,
@@ -151,6 +157,18 @@ export const selectPastAppointments = createSelector(
     return past?.filter(isValidPastAppointment).sort(sortByDateDescending);
   },
 );
+
+export function selectFirstRequestMessage(state) {
+  const { currentAppointment, requestMessages } = state.appointments;
+
+  if (!currentAppointment) {
+    return null;
+  }
+
+  const parsedId = parseFakeFHIRId(currentAppointment.id);
+
+  return requestMessages?.[parsedId]?.[0]?.attributes?.messageText || null;
+}
 
 /*
  * Express Care related appointments state selectors

--- a/src/applications/vaos/components/VAFacilityLocation.jsx
+++ b/src/applications/vaos/components/VAFacilityLocation.jsx
@@ -7,6 +7,7 @@ export default function VAFacilityLocation({
   facility,
   facilityName,
   facilityId,
+  isV2,
 }) {
   let content = null;
 
@@ -40,11 +41,12 @@ export default function VAFacilityLocation({
     );
   }
 
+  const name = clinicName || facilityName || facility?.name;
+
   return (
     <>
-      <h4 className="vaos-appts__block-label">
-        {clinicName || facilityName || facility?.name}
-      </h4>
+      {!isV2 && <h4 className="vaos-appts__block-label">{name}</h4>}
+      {isV2 && name}
       <div>{content}</div>
     </>
   );

--- a/src/applications/vaos/components/VAFacilityLocation.jsx
+++ b/src/applications/vaos/components/VAFacilityLocation.jsx
@@ -7,7 +7,7 @@ export default function VAFacilityLocation({
   facility,
   facilityName,
   facilityId,
-  isV2,
+  isHomepageRefresh,
 }) {
   let content = null;
 
@@ -45,8 +45,10 @@ export default function VAFacilityLocation({
 
   return (
     <>
-      {!isV2 && <h4 className="vaos-appts__block-label">{name}</h4>}
-      {isV2 && name}
+      {!isHomepageRefresh && (
+        <h4 className="vaos-appts__block-label">{name}</h4>
+      )}
+      {isHomepageRefresh && name}
       <div>{content}</div>
     </>
   );

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
@@ -4,7 +4,11 @@ import moment from 'moment';
 import { Route } from 'react-router-dom';
 import { fireEvent } from '@testing-library/react';
 import environment from 'platform/utilities/environment';
-import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
+import {
+  mockFetch,
+  resetFetch,
+  setFetchJSONResponse,
+} from 'platform/testing/unit/helpers';
 
 import RequestedAppointmentDetailsPage from '../../../appointment-list/components/RequestedAppointmentDetailsPage';
 import { renderWithStoreAndRouter } from '../../mocks/setup';
@@ -81,7 +85,7 @@ const initialState = {
 };
 
 describe('VAOS <RequestedAppointmentDetailsPage>', () => {
-  it('should render VA request details', async () => {
+  beforeEach(() => {
     mockFetch();
     const message = getMessageMock();
     message.attributes = {
@@ -95,7 +99,10 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
       ),
       { data: [message] },
     );
+  });
+  afterEach(() => resetFetch());
 
+  it('should render VA request details', async () => {
     const { findByText, baseElement } = renderWithStoreAndRouter(
       <Route path="/request/:id">
         <RequestedAppointmentDetailsPage />
@@ -131,7 +138,11 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
       )} in the afternoon`,
     );
     expect(baseElement).to.contain.text('New issue');
-    await findByText(/a message from the patient/i);
+
+    expect(await findByText(/A message from the patient/i)).to.be.ok;
+    // await waitFor(() =>
+    //   expect(baseElement).to.contain.text('A message from the patient'),
+    // );
     expect(baseElement).to.contain.text('patient.test@va.gov');
     expect(baseElement).to.contain.text('(703) 652-0000');
     expect(baseElement).to.contain.text('Call morning');

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
@@ -106,13 +106,13 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
 
   it('should render VA request details', async () => {
     const screen = renderWithStoreAndRouter(
-      <Route path="/request/:id">
+      <Route path="/requests/:id">
         <RequestedAppointmentDetailsPage />
       </Route>,
       {
         initialState,
         reducers,
-        path: '/request/var1234',
+        path: '/requests/var1234',
       },
     );
 
@@ -151,13 +151,13 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
 
   it('should go back to requests page when clicking top link', async () => {
     const screen = renderWithStoreAndRouter(
-      <Route path="/request/:id">
+      <Route path="/requests/:id">
         <RequestedAppointmentDetailsPage />
       </Route>,
       {
         initialState,
         reducers,
-        path: '/request/var1234',
+        path: '/requests/var1234',
       },
     );
 
@@ -169,13 +169,13 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
 
   it('should go back to requests page when clicking go back to appointments button', async () => {
     const screen = renderWithStoreAndRouter(
-      <Route path="/request/:id">
+      <Route path="/requests/:id">
         <RequestedAppointmentDetailsPage />
       </Route>,
       {
         initialState,
         reducers,
-        path: '/request/var1234',
+        path: '/requests/var1234',
       },
     );
 

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
@@ -76,6 +76,8 @@ const initialState = {
   appointments: {
     appointmentDetails: {},
     appointmentDetailsStatus: FETCH_STATUS.notStarted,
+    requestMessages: {},
+    requestMessagesStatus: FETCH_STATUS.notStarted,
     pendingStatus: FETCH_STATUS.succeeded,
     pending,
     facilityData: {
@@ -103,7 +105,7 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
   afterEach(() => resetFetch());
 
   it('should render VA request details', async () => {
-    const { findByText, baseElement } = renderWithStoreAndRouter(
+    const screen = renderWithStoreAndRouter(
       <Route path="/request/:id">
         <RequestedAppointmentDetailsPage />
       </Route>,
@@ -114,42 +116,42 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
       },
     );
 
-    expect(await findByText('Pending primary care appointment')).to.be.ok;
-    expect(baseElement).to.contain.text('VA Appointment');
-    expect(baseElement).to.contain.text('Cheyenne VA Medical Center');
-    expect(baseElement).to.contain.text('2360 East Pershing Boulevard');
-    expect(baseElement).to.contain.text('Cheyenne, WY 82001-5356');
-    expect(baseElement).to.contain.text('Main phone:');
-    expect(baseElement).to.contain.text('307-778-7550');
-    expect(baseElement).to.contain.text('Preferred date and time');
-    expect(baseElement).to.contain.text(
+    expect(await screen.findByText('Pending primary care appointment')).to.be
+      .ok;
+    expect(screen.baseElement).to.contain.text('VA Appointment');
+    expect(screen.baseElement).to.contain.text('Cheyenne VA Medical Center');
+    expect(screen.baseElement).to.contain.text('2360 East Pershing Boulevard');
+    expect(screen.baseElement).to.contain.text('Cheyenne, WY 82001-5356');
+    expect(screen.baseElement).to.contain.text('Main phone:');
+    expect(screen.baseElement).to.contain.text('307-778-7550');
+    expect(screen.baseElement).to.contain.text('Preferred date and time');
+    expect(screen.baseElement).to.contain.text(
       `${moment(appointment.optionDate1).format(
         'ddd, MMMM D, YYYY',
       )} in the morning`,
     );
-    expect(baseElement).to.contain.text(
+    expect(screen.baseElement).to.contain.text(
       `${moment(appointment.optionDate2).format(
         'ddd, MMMM D, YYYY',
       )} in the morning`,
     );
-    expect(baseElement).to.contain.text(
+    expect(screen.baseElement).to.contain.text(
       `${moment(appointment.optionDate3).format(
         'ddd, MMMM D, YYYY',
       )} in the afternoon`,
     );
-    expect(baseElement).to.contain.text('New issue');
+    expect(screen.baseElement).to.contain.text('New issue');
 
-    expect(await findByText(/A message from the patient/i)).to.be.ok;
-    // await waitFor(() =>
-    //   expect(baseElement).to.contain.text('A message from the patient'),
-    // );
-    expect(baseElement).to.contain.text('patient.test@va.gov');
-    expect(baseElement).to.contain.text('(703) 652-0000');
-    expect(baseElement).to.contain.text('Call morning');
+    // TODO: fix flaky message test
+    // expect(await screen.findByText(/A message from the patient/i)).to.be.ok;
+    expect(screen.baseElement).to.contain.text('patient.test@va.gov');
+    expect(screen.baseElement).to.contain.text('(703) 652-0000');
+    expect(screen.baseElement).to.contain.text('Call morning');
+    screen.debug();
   });
 
   it('should go back to requests page when clicking top link', async () => {
-    const { findByText, getByText, history } = renderWithStoreAndRouter(
+    const screen = renderWithStoreAndRouter(
       <Route path="/request/:id">
         <RequestedAppointmentDetailsPage />
       </Route>,
@@ -160,13 +162,14 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
       },
     );
 
-    expect(await findByText('Pending primary care appointment')).to.be.ok;
-    fireEvent.click(getByText('Manage appointments'));
-    expect(history.push.lastCall.args[0]).to.equal('/requested');
+    expect(await screen.findByText('Pending primary care appointment')).to.be
+      .ok;
+    fireEvent.click(screen.getByText('Manage appointments'));
+    expect(screen.history.push.lastCall.args[0]).to.equal('/requested');
   });
 
   it('should go back to requests page when clicking go back to appointments button', async () => {
-    const { findByText, history } = renderWithStoreAndRouter(
+    const screen = renderWithStoreAndRouter(
       <Route path="/request/:id">
         <RequestedAppointmentDetailsPage />
       </Route>,
@@ -177,8 +180,9 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
       },
     );
 
-    expect(await findByText('Pending primary care appointment')).to.be.ok;
-    fireEvent.click(await findByText(/Go back to appointments/));
-    expect(history.push.lastCall.args[0]).to.equal('/requested');
+    expect(await screen.findByText('Pending primary care appointment')).to.be
+      .ok;
+    fireEvent.click(await screen.findByText(/Go back to appointments/));
+    expect(screen.history.push.lastCall.args[0]).to.equal('/requested');
   });
 });

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
@@ -147,7 +147,6 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
     expect(screen.baseElement).to.contain.text('patient.test@va.gov');
     expect(screen.baseElement).to.contain.text('(703) 652-0000');
     expect(screen.baseElement).to.contain.text('Call morning');
-    screen.debug();
   });
 
   it('should go back to requests page when clicking top link', async () => {

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
@@ -142,8 +142,7 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
     );
     expect(screen.baseElement).to.contain.text('New issue');
 
-    // TODO: fix flaky message test
-    // expect(await screen.findByText(/A message from the patient/i)).to.be.ok;
+    expect(await screen.findByText(/A message from the patient/i)).to.be.ok;
     expect(screen.baseElement).to.contain.text('patient.test@va.gov');
     expect(screen.baseElement).to.contain.text('(703) 652-0000');
     expect(screen.baseElement).to.contain.text('Call morning');

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { expect } from 'chai';
+import moment from 'moment';
+import { Route } from 'react-router-dom';
+import { fireEvent } from '@testing-library/react';
+
+import RequestedAppointmentDetailsPage from '../../../appointment-list/components/RequestedAppointmentDetailsPage';
+import { renderWithStoreAndRouter } from '../../mocks/setup';
+import { getVAFacilityMock, getVARequestMock } from '../../mocks/v0';
+import { FETCH_STATUS } from '../../../utils/constants';
+import reducers from '../../../redux/reducer';
+import { transformPendingAppointments } from '../../../services/appointment/transformers';
+import { transformFacility } from '../../../services/location/transformers';
+
+const appointment = {
+  id: '1234',
+  ...getVARequestMock().attributes,
+  typeOfCareId: '323',
+  status: 'Submitted',
+  appointmentType: 'Primary care',
+  optionDate1: moment()
+    .add(3, 'days')
+    .format('MM/DD/YYYY'),
+  optionTime1: 'AM',
+  optionDate2: moment()
+    .add(4, 'days')
+    .format('MM/DD/YYYY'),
+  optionTime2: 'AM',
+  optionDate3: moment()
+    .add(5, 'days')
+    .format('MM/DD/YYYY'),
+  optionTime3: 'PM',
+  facility: {
+    ...getVARequestMock().attributes.facility,
+    facilityCode: '983GC',
+  },
+  bestTimetoCall: ['Morning'],
+  purposeOfVisit: 'New Issue',
+  email: 'patient.test@va.gov',
+  phoneNumber: '(703) 652-0000',
+  friendlyLocationName: 'Some facility name',
+};
+
+const pending = transformPendingAppointments([appointment]);
+
+const facility = {
+  ...getVAFacilityMock().attributes,
+  id: 'vha_442GC',
+  uniqueId: '442GC',
+  name: 'Cheyenne VA Medical Center',
+  address: {
+    physical: {
+      zip: '82001-5356',
+      city: 'Cheyenne',
+      state: 'WY',
+      address1: '2360 East Pershing Boulevard',
+    },
+  },
+  phone: {
+    main: '307-778-7550',
+  },
+};
+const var983GC = transformFacility(facility);
+
+const initialState = {
+  appointments: {
+    appointmentDetails: {},
+    appointmentDetailsStatus: FETCH_STATUS.notStarted,
+    pendingStatus: FETCH_STATUS.succeeded,
+    pending,
+    facilityData: {
+      var983GC,
+    },
+  },
+};
+
+describe('VAOS <RequestedAppointmentDetailsPage>', () => {
+  it('should render VA request details', async () => {
+    const { findByText, baseElement } = renderWithStoreAndRouter(
+      <Route path="/request/:id">
+        <RequestedAppointmentDetailsPage />
+      </Route>,
+      {
+        initialState,
+        reducers,
+        path: '/request/var1234',
+      },
+    );
+
+    expect(await findByText('Pending primary care appointment')).to.be.ok;
+    expect(baseElement).to.contain.text('VA Appointment');
+    expect(baseElement).to.contain.text('Cheyenne VA Medical Center');
+    expect(baseElement).to.contain.text('2360 East Pershing Boulevard');
+    expect(baseElement).to.contain.text('Cheyenne, WY 82001-5356');
+    expect(baseElement).to.contain.text('Main phone:');
+    expect(baseElement).to.contain.text('307-778-7550');
+    expect(baseElement).to.contain.text('Preferred date and time');
+    expect(baseElement).to.contain.text(
+      `${moment(appointment.optionDate1).format(
+        'ddd, MMMM D, YYYY',
+      )} in the morning`,
+    );
+    expect(baseElement).to.contain.text(
+      `${moment(appointment.optionDate2).format(
+        'ddd, MMMM D, YYYY',
+      )} in the morning`,
+    );
+    expect(baseElement).to.contain.text(
+      `${moment(appointment.optionDate3).format(
+        'ddd, MMMM D, YYYY',
+      )} in the afternoon`,
+    );
+    expect(baseElement).to.contain.text('New issue');
+    expect(baseElement).to.contain.text('patient.test@va.gov');
+    expect(baseElement).to.contain.text('(703) 652-0000');
+    expect(baseElement).to.contain.text('Call morning');
+  });
+
+  it('should go back to requests page when clicking top link', async () => {
+    const { findByText, getByText, history } = renderWithStoreAndRouter(
+      <Route path="/request/:id">
+        <RequestedAppointmentDetailsPage />
+      </Route>,
+      {
+        initialState,
+        reducers,
+        path: '/request/var1234',
+      },
+    );
+
+    expect(await findByText('Pending primary care appointment')).to.be.ok;
+    fireEvent.click(getByText('Manage appointments'));
+    expect(history.push.lastCall.args[0]).to.equal('/requested');
+  });
+
+  it('should go back to requests page when clicking go back to appointments button', async () => {
+    const { findByText, history } = renderWithStoreAndRouter(
+      <Route path="/request/:id">
+        <RequestedAppointmentDetailsPage />
+      </Route>,
+      {
+        initialState,
+        reducers,
+        path: '/request/var1234',
+      },
+    );
+
+    expect(await findByText('Pending primary care appointment')).to.be.ok;
+    fireEvent.click(await findByText(/Go back to appointments/));
+    expect(history.push.lastCall.args[0]).to.equal('/requested');
+  });
+});

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentsList.unit.spec.jsx
@@ -80,13 +80,6 @@ describe('VAOS <RequestedAppointmentsList>', () => {
     await waitFor(() =>
       expect(screen.history.push.lastCall.args[0]).to.equal('request/var1234'),
     );
-
-    expect(await screen.findByText('Pending primary care appointment')).to.be
-      .ok;
-
-    // expect(screen.baseElement).to.contain.text(
-    //   'Pending primary care appointment',
-    // );
   });
 
   it('should show cc request', async () => {

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentsList.unit.spec.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
 import moment from 'moment';
-
 import environment from 'platform/utilities/environment';
 import { setFetchJSONFailure } from 'platform/testing/unit/helpers';
 import reducers from '../../../redux/reducer';

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentsList.unit.spec.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { expect } from 'chai';
 import moment from 'moment';
+import { fireEvent, waitFor } from '@testing-library/dom';
+
 import environment from 'platform/utilities/environment';
 import { setFetchJSONFailure } from 'platform/testing/unit/helpers';
 import reducers from '../../../redux/reducer';
@@ -19,7 +21,7 @@ const initialState = {
 };
 
 describe('VAOS <RequestedAppointmentsList>', () => {
-  it('should show va request', async () => {
+  it('should show va request and details onclick', async () => {
     const startDate = moment.utc();
     const appointment = getVARequestMock();
     appointment.attributes = {
@@ -73,6 +75,18 @@ describe('VAOS <RequestedAppointmentsList>', () => {
     expect(await screen.findByText('Primary care')).to.be.ok;
     expect(screen.baseElement).to.contain.text(facility.attributes.name);
     expect(screen.queryByText(/You don’t have any appointments/i)).not.to.exist;
+    fireEvent.click(screen.getByText(/details/i));
+
+    await waitFor(() =>
+      expect(screen.history.push.lastCall.args[0]).to.equal('request/var1234'),
+    );
+
+    expect(await screen.findByText('Pending primary care appointment')).to.be
+      .ok;
+
+    // expect(screen.baseElement).to.contain.text(
+    //   'Pending primary care appointment',
+    // );
   });
 
   it('should show cc request', async () => {

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentsList.unit.spec.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
 import moment from 'moment';
-import { fireEvent, waitFor } from '@testing-library/dom';
 
 import environment from 'platform/utilities/environment';
 import { setFetchJSONFailure } from 'platform/testing/unit/helpers';
@@ -21,7 +20,7 @@ const initialState = {
 };
 
 describe('VAOS <RequestedAppointmentsList>', () => {
-  it('should show va request and details onclick', async () => {
+  it('should show va request', async () => {
     const startDate = moment.utc();
     const appointment = getVARequestMock();
     appointment.attributes = {
@@ -75,11 +74,6 @@ describe('VAOS <RequestedAppointmentsList>', () => {
     expect(await screen.findByText('Primary care')).to.be.ok;
     expect(screen.baseElement).to.contain.text(facility.attributes.name);
     expect(screen.queryByText(/You don’t have any appointments/i)).not.to.exist;
-    fireEvent.click(screen.getByText(/details/i));
-
-    await waitFor(() =>
-      expect(screen.history.push.lastCall.args[0]).to.equal('request/var1234'),
-    );
   });
 
   it('should show cc request', async () => {


### PR DESCRIPTION
## Description
This PR covers the display of a VA Request's details.  CC requests will be covered in a different ticket.  A couple notes:

* This page assumes it is being directed to from the requested list page, so it does not fetch request data on its own
* It will redirect to the requests list if navigated to directly
* Fetching of a single request will be covered in a future ticket
* Modified PageLayout to have `showBreadcrumbs` and` showNeedHelp` flags since the details pages do not have them

## Testing done
Local and unit

## Screenshots
![image](https://user-images.githubusercontent.com/786704/105754806-5921f080-5eff-11eb-8d9b-d7e6d9f43576.png)
![image](https://user-images.githubusercontent.com/786704/105754818-5cb57780-5eff-11eb-8111-bfb7a14b18a0.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
