### PR TITLE
remove covid alert from debt letters

### DIFF
--- a/src/applications/debt-letters/components/DebtLettersDownload.jsx
+++ b/src/applications/debt-letters/components/DebtLettersDownload.jsx
@@ -7,10 +7,7 @@ import { DebtLettersTable } from './DebtLettersTable';
 import { MobileTableView } from './MobileTableView';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { setPageFocus } from '../utils/page';
-import Telephone, {
-  CONTACTS,
-  PATTERNS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
+import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
 
 const DebtLettersDownload = ({ debtLinks, isVBMSError }) => {
   useEffect(() => {
@@ -72,39 +69,6 @@ const DebtLettersDownload = ({ debtLinks, isVBMSError }) => {
               <DebtLettersTable debtLinks={debtLinks} />
               <MobileTableView debtLinks={debtLinks} />
             </>
-          )}
-        {!isVBMSError &&
-          debtLinks.length < 1 && (
-            <div className="vads-u-background-color--gray-lightest vads-u-padding--3 vads-u-margin-top--3">
-              <h2 className="vads-u-font-family--serif vads-u-margin-top--0">
-                We’re collecting again on VA debt
-              </h2>
-              <p className="vads-u-font-family--sans vads-u-margin-bottom--0">
-                On April 3, 2020, we paused collections on new VA debt. On{' '}
-                <strong>January 1, 2021</strong>, we started to send out debt
-                collection letters again. If we granted you an extension due to
-                COVID-19, we’ll start collection again on{' '}
-                <strong>February 1, 2021</strong>.
-              </p>
-              <p className="vads-u-font-family--sans vads-u-margin-bottom--0">
-                If you can’t make your payments, we can help. To avoid late
-                charges, interest, or other collection actions, make a payment
-                or request help now. Call us at{' '}
-                {<Telephone contact={CONTACTS.DMC || '800-827-0648'} />} (or{' '}
-                {
-                  <Telephone
-                    contact={CONTACTS.DMC_OVERSEAS || '1-612-713-6415'}
-                    pattern={PATTERNS.OUTSIDE_US}
-                  />
-                }{' '}
-                from overseas) We’re here Monday through Friday, 7:30 a.m. to
-                7:00 p.m. ET. Or send us a question through our{' '}
-                <a href="https://iris.custhelp.va.gov/app/ask">
-                  {' '}
-                  online question form (called IRIS)
-                </a>
-              </p>
-            </div>
           )}
         <div className="vads-u-margin-bottom--6 vads-u-margin-top--5">
           <h2 className="vads-u-margin-y--0">

--- a/src/applications/debt-letters/components/DebtLettersList.jsx
+++ b/src/applications/debt-letters/components/DebtLettersList.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { CoronaVirusAlert } from '../const/deduction-codes';
 import { DebtLettersTable } from './DebtLettersTable';
 import { connect } from 'react-redux';
 import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
@@ -46,12 +45,6 @@ const DebtLettersList = ({ debtLinks, isVBMSError }) => {
             </p>
             <DebtLettersTable debtLinks={debtLinks} />
           </>
-        )}
-      {!isVBMSError &&
-        debtLinks.length < 1 && (
-          <div className="vads-u-background-color--gray-lightest vads-u-padding--3 vads-u-margin-top--3">
-            <CoronaVirusAlert />
-          </div>
         )}
       <div className="vads-u-margin-bottom--6 vads-u-margin-top--3">
         <h3 className="vads-u-margin-y--0">

--- a/src/applications/debt-letters/components/DebtLettersSummary.jsx
+++ b/src/applications/debt-letters/components/DebtLettersSummary.jsx
@@ -7,10 +7,7 @@ import NeedHelp from './NeedHelp';
 import { OnThisPageLinks } from './OnThisPageLinks';
 import DebtCardsList from './DebtCardsList';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
-import Telephone, {
-  CONTACTS,
-  PATTERNS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
+import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
 
 class DebtLettersSummary extends Component {
   componentDidMount() {
@@ -89,40 +86,6 @@ class DebtLettersSummary extends Component {
               {allDebtsEmpty && renderEmptyAlert()}
               {!allDebtsFetchFailure && (
                 <>
-                  <div className="usa-alert usa-alert-info  vads-u-padding--3 vads-u-margin-top--3">
-                    <div className="usa-alert-body ">
-                      <h2 className="usa-alert-heading vads-u-font-size--h3">
-                        We’re collecting again on VA debt
-                      </h2>
-                      <p className="vads-u-font-family--sans vads-u-margin-bottom--0">
-                        On April 3, 2020, we paused collections on new VA debt.
-                        On <strong>January 1, 2021</strong>, we started to send
-                        out debt collection letters again. If we granted you an
-                        extension due to COVID-19, we’ll start collection again
-                        on <strong>February 1, 2021</strong>.
-                      </p>
-                      <p className="vads-u-font-family--sans vads-u-margin-bottom--0">
-                        If you can’t make your payments, we can help. To avoid
-                        late charges, interest, or other collection actions,
-                        make a payment or request help now. Call us at{' '}
-                        {<Telephone contact={CONTACTS.DMC || '800-827-0648'} />}{' '}
-                        (or{' '}
-                        {
-                          <Telephone
-                            contact={CONTACTS.DMC_OVERSEAS || '1-612-713-6415'}
-                            pattern={PATTERNS.OUTSIDE_US}
-                          />
-                        }{' '}
-                        from overseas) We’re here Monday through Friday, 7:30
-                        a.m. to 7:00 p.m. ET. Or send us a question through our{' '}
-                        <a href="https://iris.custhelp.va.gov/app/ask">
-                          {' '}
-                          online question form (called IRIS)
-                        </a>
-                      </p>
-                    </div>
-                  </div>
-
                   <OnThisPageLinks />
                   <DebtCardsList />
                 </>

--- a/src/applications/debt-letters/tests/DebtLettersList.unit.spec.js
+++ b/src/applications/debt-letters/tests/DebtLettersList.unit.spec.js
@@ -94,7 +94,6 @@ describe('DebtLettersList', () => {
     };
     const wrapper = shallow(<DebtLettersList store={fakeStoreEmptyState} />);
     expect(wrapper.dive().find(`table`).length).to.equal(0);
-    expect(wrapper.dive().find('CoronaVirusAlert').length).to.equal(1);
     wrapper.unmount();
   });
 });


### PR DESCRIPTION
## Description
removes covid alert from debt letters

## Acceptance criteria

## Screenshots
![Your VA Debt  Veterans Affairs 2021-01-25 11-58-43](https://user-images.githubusercontent.com/7518899/105739162-cfc1ec80-5f05-11eb-8461-c69ae9ebfce3.png)


## Definition of done
- [x] Changes have been tested in vets-website
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs