### PR TITLE
[Development] HLR: Fix alignment in IE11

### DIFF
--- a/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
+++ b/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
@@ -76,6 +76,7 @@ dl.review {
     left: 0;
     width: 100%;
     height: 100%;
+    max-width: auto; /* IE11 */
     max-width: unset;
 
     &.selected {
@@ -92,6 +93,7 @@ dl.review {
   dt.widget-checkbox-wrap {
     margin: 0;
     width: 0;
+    min-width: auto; /* IE11 */
     min-width: unset;
 
     [type="checkbox"] {
@@ -111,8 +113,8 @@ dl.review {
 
   dd.widget-content {
     margin-inline-start: 0; /* override user agent */
-    text-align: unset;
-    margin: 3rem 2rem 0 5rem;
+    text-align: left;
+    margin: 3rem 3.5rem 0 5rem;
   }
 
   .checkbox-hidden {


### PR DESCRIPTION
## Description

Higher-Level Review eligible issue cards in IE11 have improperly aligned content. Found during QA review.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/18919

## Testing done

Visual only

## Screenshots

<details><summary>IE11 current view</summary>

<!-- leave a blank line above -->
![](https://user-images.githubusercontent.com/587583/105564599-2b129580-5ce0-11eb-944d-1efd66919df5.png)</details>

<details><summary>IE11 after fix</summary>

<!-- leave a blank line above -->
![2021-01-25 09_50_51-Request a Higher-Level Review _ Veterans Affairs - Internet Explorer](https://user-images.githubusercontent.com/136959/105739717-07c53180-5efe-11eb-8a8e-e3db063e096a.png)</details>

## Acceptance criteria
- [x] Eligible issue cards have properly aligned content in all browsers

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
