### PR TITLE
DT-18525 - Adding sort by analytics to the new widget. 

### DIFF
--- a/src/applications/find-forms/containers/SearchResults.jsx
+++ b/src/applications/find-forms/containers/SearchResults.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import Select from '@department-of-veterans-affairs/component-library/Select';
 
 // Relative imports.
+import recordEvent from 'platform/monitoring/record-event';
 import { focusElement } from 'platform/utilities/ui';
 import * as customPropTypes from '../prop-types';
 import {
@@ -61,9 +62,20 @@ export class SearchResults extends Component {
     focusElement('[data-forms-focus]');
   };
 
-  setSortByPropertyNameState = state => {
+  setSortByPropertyNameState = formMetaInfo => state => {
     if (state?.value) {
       this.props.updateSortByPropertyName(state.value, this.props.results);
+
+      recordEvent({
+        event: 'onsite-search-results-change',
+        'search-query': formMetaInfo?.query, // dynamically populate with the search query
+        'search-page-path': '/find-forms', // consistent for all search results from this page
+        'search-results-change-action-type': 'sort', // will consistently classify these actions as 'sort', leaves the door open for other search enhancements to user "filter"
+        'search-results-change-action-label': state.value, // 'oldest' // populate according to user selection
+        'search-results-pagination-current-page': formMetaInfo?.currentPage, // populate with the current pagination number
+        'search-results-total-count': formMetaInfo?.totalResultsCount, // populate with the total number of search results
+        'search-results-total-pages': formMetaInfo?.totalResultsPages, // populate with total number of result pages
+      });
     }
   };
 
@@ -185,7 +197,7 @@ export class SearchResults extends Component {
               label="Sort By"
               includeBlankOption={false}
               name="findFormsSortBySelect"
-              onValueChange={setSortByPropertyNameState}
+              onValueChange={setSortByPropertyNameState(formMetaInfo)}
               options={SORT_OPTIONS}
               value={{ value: sortByPropertyName }}
             />


### PR DESCRIPTION
## Description
Adds analytics to sort by widget per convo: https://github.com/department-of-veterans-affairs/va.gov-team/issues/17273#issuecomment-751840565

## Testing done
Ran unit tests, e2e, and manual functional. 

## Screenshots
![Screen Shot 2021-01-25 at 1 14 27 PM](https://user-images.githubusercontent.com/26075258/105747982-7c549c00-5f0f-11eb-98df-fdee64c75325.png)


## Acceptance criteria
- [x] Correct event and properties is pushed up to GA data layer on browser.

## Definition of done
- [x] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
