### PR TITLE
Fix tests that are failing at end of the month

### DIFF
--- a/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
@@ -1,7 +1,7 @@
 import { initCommunityCareMock } from './vaos-cypress-helpers';
 import moment from 'moment';
 
-describe.skip('VAOS community care flow', () => {
+describe('VAOS community care flow', () => {
   beforeEach(() => {
     initCommunityCareMock();
     cy.visit(
@@ -37,6 +37,9 @@ describe.skip('VAOS community care flow', () => {
       '/health-care/schedule-view-va-appointments/appointments/new-appointment/request-date',
     );
     cy.axeCheck();
+    cy.contains('button', 'Next')
+      .focus()
+      .click();
     // Select first available appointment
     cy.get('.vaos-calendar__calendars button[id^="date-cell"]:not([disabled])')
       .first()

--- a/src/applications/vaos/tests/e2e/va-request.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/va-request.cypress.spec.js
@@ -100,7 +100,7 @@ function fillOutForm(facilitySelection) {
   cy.findByText('cough');
 }
 
-describe.skip('VAOS request flow', () => {
+describe('VAOS request flow', () => {
   beforeEach(() => {});
 
   it('should submit form successfully for a multi system user', () => {

--- a/src/applications/vaos/tests/e2e/vaos-cypress-schedule-appointment-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-cypress-schedule-appointment-helpers.js
@@ -75,6 +75,9 @@ export function selectTimeSlotTest() {
 
 export function selectRequestSlotTest() {
   cy.url().should('include', '/request-date');
+  cy.contains('button', 'Next')
+    .focus()
+    .click();
   cy.get('.vaos-calendar__calendars button[id^="date-cell"]:not([disabled])')
     .first()
     .click();

--- a/src/applications/vaos/tests/new-appointment/components/DateTimeRequestPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/DateTimeRequestPage.unit.spec.jsx
@@ -10,7 +10,7 @@ import { waitFor } from '@testing-library/dom';
 import { Route } from 'react-router-dom';
 
 describe('VAOS <DateTimeRequestPage>', () => {
-  it.skip('should allow user to request date and time for a community care appointment', async () => {
+  it('should allow user to request date and time for a community care appointment', async () => {
     const store = createTestStore({
       newAppointment: {
         data: {},
@@ -36,7 +36,6 @@ describe('VAOS <DateTimeRequestPage>', () => {
       }),
     ).to.be.ok;
 
-    // it should display 2 calendar months for community care appointments
     expect(
       screen.getByRole('heading', {
         level: 2,
@@ -58,12 +57,31 @@ describe('VAOS <DateTimeRequestPage>', () => {
     ]);
 
     // Find all available appointments for the current month
-    const currentMonth = moment()
+    let currentMonth = moment()
       .add(5, 'days')
       .format('MMMM');
-    const buttons = screen
+
+    let buttons = screen
       .getAllByLabelText(new RegExp(currentMonth))
       .filter(button => button.disabled === false);
+
+    // Towards the end of the month our 4 days out min date will be in the next
+    // month, and we need to move the calendar to the next month before selecting a date
+    if (!buttons.length) {
+      userEvent.click(screen.getByText('Next'));
+      await screen.findByRole('heading', {
+        name: moment()
+          .add(1, 'month')
+          .format('MMMM YYYY'),
+      });
+      currentMonth = moment()
+        .add(1, 'month')
+        .format('MMMM');
+
+      buttons = screen
+        .getAllByLabelText(new RegExp(currentMonth))
+        .filter(button => button.disabled === false);
+    }
 
     // it should allow the user to select morning for currently selected date
     userEvent.click(buttons[0]);


### PR DESCRIPTION
## Description
Some of the VAOS tests started failing now that we're at the end of the month and there aren't any available dates in January.

How to test:
- Run the unit tests

## Testing done
Unit testing

## Acceptance criteria
- [ ] Build passes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
