### PR TITLE
[Development] Fix BDD focus management

### DIFF
--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -85,7 +85,10 @@ export const Form526Entry = ({
   };
 
   useEffect(() => {
-    if (defaultWizardState === WIZARD_STATUS_COMPLETE) {
+    if (
+      window.location.pathname.endsWith('/introduction') &&
+      defaultWizardState === WIZARD_STATUS_COMPLETE
+    ) {
       setPageFocus('h1');
       setWizardStatus(WIZARD_STATUS_COMPLETE);
     } else if (defaultWizardState === WIZARD_STATUS_NOT_STARTED) {

--- a/src/applications/disability-benefits/all-claims/components/ConfirmationPoll.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationPoll.jsx
@@ -4,6 +4,7 @@ import { createSelector } from 'reselect';
 
 import get from 'platform/utilities/data/get';
 import { apiRequest } from 'platform/utilities/api';
+import { focusElement } from 'platform/utilities/ui';
 
 import ConfirmationPage from '../containers/ConfirmationPage';
 import { pendingMessage } from '../content/confirmation-poll';
@@ -99,6 +100,7 @@ export class ConfirmationPoll extends React.Component {
   render() {
     const { submissionStatus, claimId } = this.state;
     if (submissionStatus === submissionStatuses.pending) {
+      setTimeout(() => focusElement('.loading-indicator-container'));
       return pendingMessage(this.state.longWait);
     }
 
@@ -110,6 +112,7 @@ export class ConfirmationPoll extends React.Component {
       areConfirmationEmailTogglesOn,
     } = this.props;
 
+    setTimeout(() => focusElement('h2'));
     return (
       <ConfirmationPage
         submissionStatus={submissionStatus}

--- a/src/applications/disability-benefits/all-claims/components/ITFBanner.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ITFBanner.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { focusElement } from 'platform/utilities/ui';
+
 import {
   itfMessage,
   itfError,
@@ -53,6 +55,10 @@ export default class ITFBanner extends React.Component {
           `Unexpected status prop in ITFBanner: ${this.props.status}`,
         );
     }
+
+    setTimeout(() => {
+      focusElement('.itf-wrapper');
+    });
 
     return (
       <div className="vads-l-grid-container vads-u-padding-left--0 vads-u-padding-bottom--5">

--- a/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
@@ -32,7 +32,7 @@ export default class ConfirmationPage extends React.Component {
   }
 
   componentDidMount() {
-    focusElement('.usa-alert-body > h3');
+    focusElement('.usa-alert-body > h2');
     scrollToTop();
   }
 

--- a/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
+++ b/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
@@ -31,6 +31,7 @@ const template = (props, title, content, submissionMessage, messageType) => {
       headline={title}
       content={renderableContent}
       status={messageType}
+      level="2"
     />
   );
 
@@ -69,6 +70,7 @@ const template = (props, title, content, submissionMessage, messageType) => {
         headline={title}
         content={renderableContent}
         status={messageType}
+        level="2"
       />
 
       {props.areConfirmationEmailTogglesOn ? (
@@ -85,9 +87,9 @@ const template = (props, title, content, submissionMessage, messageType) => {
       )}
 
       <div className="inset">
-        <h3 className="vads-u-font-size--h4">
+        <h2 className="vads-u-font-size--h4">
           {pageTitle} <span className="additional">(Form 21-526EZ)</span>
-        </h3>
+        </h2>
         <span>
           For {first} {middle} {last} {suffix}
         </span>
@@ -121,9 +123,9 @@ const template = (props, title, content, submissionMessage, messageType) => {
       </div>
 
       <div className="confirmation-guidance-container">
-        <h3 className="confirmation-guidance-heading vads-u-font-size--h4">
+        <h2 className="confirmation-guidance-heading vads-u-font-size--h4">
           How long will it take VA to make a decision on my claim?
-        </h3>
+        </h2>
         <p className="confirmation-guidance-message">
           We process applications in the order we receive them. The amount of
           time it takes us to review you claim depends on:
@@ -141,9 +143,9 @@ const template = (props, title, content, submissionMessage, messageType) => {
           </li>
         </ul>
 
-        <h3 className="confirmation-guidance-heading vads-u-font-size--h4">
+        <h2 className="confirmation-guidance-heading vads-u-font-size--h4">
           How can I check the status of my claim?
-        </h3>
+        </h2>
         <p className="confirmation-guidance-message">
           You can check the status of your claim online. Please allow 24 hours
           for your disability claim to show up there. If you don’t see your
@@ -155,9 +157,9 @@ const template = (props, title, content, submissionMessage, messageType) => {
           <a href="/track-claims">Check the status of your claim</a>
         </p>
 
-        <h3 className="confirmation-guidance-heading vads-u-font-size--h4">
+        <h2 className="confirmation-guidance-heading vads-u-font-size--h4">
           What happens after I file a claim for disability compensation?
-        </h3>
+        </h2>
         <p className="confirmation-guidance-message">
           <a href="/disability/after-you-file-claim/">
             Learn more about what happens after you file a disability claim

--- a/src/applications/disability-benefits/all-claims/content/itfWrapper.jsx
+++ b/src/applications/disability-benefits/all-claims/content/itfWrapper.jsx
@@ -18,7 +18,13 @@ export const itfMessage = (headline, content, status) => (
   // Inline style to match .full-page-alert bottom margin because usa-grid > :last-child has a
   //  bottom margin of 0 and overrides it
   <div className="full-page-alert itf-wrapper">
-    <AlertBox isVisible headline={headline} content={content} status={status} />
+    <AlertBox
+      isVisible
+      headline={headline}
+      content={content}
+      status={status}
+      level="2"
+    />
   </div>
 );
 


### PR DESCRIPTION
## Description

This PR fixes focus management issues found during a Benefits Delivery at Discharge (BDD) audit: Within the form, the progress indicator ("Step 1 of 5") should receive initial focus when changing pages

This PR also moves focus to the Intent to File (ITF) alert card when it becomes visible. Also, the header inside the ITF was changed to an `H2`.

So the current behavior is:
- Intro page, wizard visible - focus on the breadcrumbs
- Intro page, wizard complete - focus on `H1`
- Intent to file page - focus on alert box
- All internal pages will focus on the `h2` step indicator (e.g. "Step 1 of 5")
- Confirmation page will focus on loading indicator when visible, then the first `h2`

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/18965

## Testing done

Visual

## Screenshots

N/A

## Acceptance criteria
- [x] Focus on the intro page is as expected
- [x] Focus on form intermediate pages is on the step text
- [x] Focus on the confirmation page is as expected for both error and non-error conditions

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
