### PR TITLE
Fix for runtime error with .remove during widget-startup

### DIFF
--- a/src/site/assets/js/static-page-widgets.js
+++ b/src/site/assets/js/static-page-widgets.js
@@ -33,7 +33,7 @@ function mountWidgets(widgets, slowLoadingThreshold) {
           var loadingMessage = widget.querySelector('.loading-indicator-container');
 
           if (!replacedWithWidget && loadingMessage) {
-            loadingMessage.remove();
+            loadingMessage.parentNode.removeChild(loadingMessage);
           }
 
           if (!replacedWithWidget && errorMessage) {


### PR DESCRIPTION
## Description
I noticed in Sentry that we have a call to `.remove` from this file. `.remove` doesn't work in IE. This PR fixes that.

http://sentry.vfs.va.gov/organizations/vsp/issues/218/?query=is%3Aunresolved&statsPeriod=14d. This should also fix many of the other widget errors, http://sentry.vfs.va.gov/organizations/vsp/issues/?query=is%3Aunresolved+method+%27remove%27&statsPeriod=14d.

My initial inclination was to polyfill `.remove` but then I realized that this script tag has to run in the body of the HTML page anyway so polyfills are no good there.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/18982

## Testing done
Confirmed that the replacement code for `.remove` works on `/find-forms/`

## Screenshots
Working error state
![image](https://user-images.githubusercontent.com/1915775/105775203-6efdd880-5f34-11eb-9515-f4238d4c4b51.png)


## Acceptance criteria
- [ ] Error is resolved

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
