### PR TITLE
[17103] Update Specialty Codes

### DIFF
--- a/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
@@ -91,7 +91,7 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
     });
     mockCCProviderFetch(
       initialState.user.profile.vapContactInfo.residentialAddress,
-      ['208D00000X', '207R00000X', '261QP2300X', '207Q00000X'],
+      ['207QA0505X', '363LP2300X', '363LA2200X', '261QP2300X'],
       calculateBoundingBox(
         initialState.user.profile.vapContactInfo.residentialAddress.latitude,
         initialState.user.profile.vapContactInfo.residentialAddress.longitude,
@@ -293,7 +293,7 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
     await setTypeOfFacility(store, /Community Care/i);
     mockCCProviderFetch(
       initialState.user.profile.vapContactInfo.residentialAddress,
-      ['208D00000X', '207R00000X', '261QP2300X', '207Q00000X'],
+      ['207QA0505X', '363LP2300X', '363LA2200X', '261QP2300X'],
       calculateBoundingBox(
         initialState.user.profile.vapContactInfo.residentialAddress.latitude,
         initialState.user.profile.vapContactInfo.residentialAddress.longitude,
@@ -329,7 +329,7 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
     await setTypeOfFacility(store, /Community Care/i);
     mockCCProviderFetch(
       initialState.user.profile.vapContactInfo.residentialAddress,
-      ['208D00000X', '207R00000X', '261QP2300X', '207Q00000X'],
+      ['207QA0505X', '363LP2300X', '363LA2200X', '261QP2300X'],
       calculateBoundingBox(
         initialState.user.profile.vapContactInfo.residentialAddress.latitude,
         initialState.user.profile.vapContactInfo.residentialAddress.longitude,
@@ -366,7 +366,7 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
 
     mockCCProviderFetch(
       initialState.user.profile.vapContactInfo.residentialAddress,
-      ['208D00000X', '207R00000X', '261QP2300X', '207Q00000X'],
+      ['207QA0505X', '363LP2300X', '363LA2200X', '261QP2300X'],
       calculateBoundingBox(
         initialState.user.profile.vapContactInfo.residentialAddress.latitude,
         initialState.user.profile.vapContactInfo.residentialAddress.longitude,
@@ -401,7 +401,7 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
 
     mockCCProviderFetch(
       initialState.user.profile.vapContactInfo.residentialAddress,
-      ['208D00000X', '207R00000X', '261QP2300X', '207Q00000X'],
+      ['207QA0505X', '363LP2300X', '363LA2200X', '261QP2300X'],
       calculateBoundingBox(
         initialState.user.profile.vapContactInfo.residentialAddress.latitude,
         initialState.user.profile.vapContactInfo.residentialAddress.longitude,
@@ -452,7 +452,7 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
 
     mockCCProviderFetch(
       currentPosition,
-      ['208D00000X', '207R00000X', '261QP2300X', '207Q00000X'],
+      ['207QA0505X', '363LP2300X', '363LA2200X', '261QP2300X'],
       calculateBoundingBox(
         currentPosition.latitude,
         currentPosition.longitude,
@@ -499,7 +499,7 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
 
     mockCCProviderFetch(
       initialState.user.profile.vapContactInfo.residentialAddress,
-      ['208D00000X', '207R00000X', '261QP2300X', '207Q00000X'],
+      ['207QA0505X', '363LP2300X', '363LA2200X', '261QP2300X'],
       calculateBoundingBox(
         initialState.user.profile.vapContactInfo.residentialAddress.latitude,
         initialState.user.profile.vapContactInfo.residentialAddress.longitude,

--- a/src/applications/vaos/tests/services/location/index.unit.spec.js
+++ b/src/applications/vaos/tests/services/location/index.unit.spec.js
@@ -286,12 +286,12 @@ describe('VAOS Location service', () => {
           longitude: 42.12,
         },
         typeOfCare: {
-          specialties: ['133N00000X'],
+          specialties: ['133NN1002X'],
         },
       });
 
       expect(global.fetch.firstCall.args[0]).to.contain(
-        '/v1/facilities/ccp?latitude=-72.73&longitude=42.12&radius=60&per_page=15&page=1&bbox[]=-73.598&bbox[]=39.194&bbox[]=-71.862&bbox[]=45.046&specialties[]=133N00000X&type=provider&trim=true',
+        '/v1/facilities/ccp?latitude=-72.73&longitude=42.12&radius=60&per_page=15&page=1&bbox[]=-73.598&bbox[]=39.194&bbox[]=-71.862&bbox[]=45.046&specialties[]=133NN1002X&type=provider&trim=true',
       );
       expect(data.length).to.equal(ccProviders.data.length);
       const firstProvider = ccProviders.data[0];

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -65,7 +65,7 @@ export const TYPES_OF_CARE = [
     group: 'primary',
     ccId: 'CCPRMYRTNE',
     cceType: 'PrimaryCare',
-    specialties: ['208D00000X', '207R00000X', '261QP2300X', '207Q00000X'],
+    specialties: ['207QA0505X', '363LP2300X', '363LA2200X', '261QP2300X'],
   },
   {
     id: '160',
@@ -106,7 +106,7 @@ export const TYPES_OF_CARE = [
     group: 'specialty',
     ccId: 'CCNUTRN',
     cceType: 'Nutrition',
-    specialties: ['133N00000X', '136A00000X', '132700000X', '133V00000X'],
+    specialties: ['133V00000X', '133VN1201X', '133N00000X', '133NN1002X'],
   },
   {
     id: PODIATRY_ID,
@@ -115,7 +115,7 @@ export const TYPES_OF_CARE = [
     ccId: 'CCPOD',
     group: 'specialty',
     cceType: 'Podiatry',
-    specialties: ['211D00000X', '213E00000X', '261QP1100X', '207XX0004X'],
+    specialties: ['213E00000X', '213EG0000X', '213EP1101X', '213ES0131X'],
   },
   {
     id: 'SLEEP',
@@ -146,7 +146,7 @@ export const TYPES_OF_EYE_CARE = [
     name: 'Optometry',
     ccId: 'CCOPT',
     cceType: 'Optometry',
-    specialties: ['152W00000X', '156F00000X'],
+    specialties: ['152W00000X', '152WC0802X'],
   },
   {
     id: '407',
@@ -158,12 +158,12 @@ export const AUDIOLOGY_TYPES_OF_CARE = [
   {
     ccId: 'CCAUDRTNE',
     name: 'Routine hearing exam',
-    specialties: ['231H00000X', '261QH0700X'],
+    specialties: ['231H00000X', '237600000X', '261QH0700X'],
   },
   {
     ccId: 'CCAUDHEAR',
     name: 'Hearing aid support',
-    specialties: ['332S00000X', '237600000X', '237700000X', '231H00000X'],
+    specialties: ['231H00000X', '237600000X'],
   },
 ];
 


### PR DESCRIPTION
## Description
For the community care provider selection list, define the 4 speciality codes in the query for each type of care.

## Testing done
Local

## Screenshots


## Acceptance criteria
- [ ] Update is behind VA Online Scheduling Provider Selection feature flag
- [ ] If user selects Primary Care type of care , provider list results match at least one of the defined speciality codes
- [ ] If user selects Audiology - Routine hearing exam type of care, provider list results match at least one of the defined speciality codes
- [ ] If user selects Audiology - Hearing aid support type of care, provider list results match at least one of the defined speciality codes
- [ ] If user selects Nutrition type of care, provider list results match at least one of the defined speciality codes
- [ ] If user selects Podiatry type of care, provider list results match at least one of the defined speciality codes
- [ ] If user selects Eye Care - Optometry type of care, provider list results match at least one of the defined speciality codes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
