### PR TITLE
VACMS-4081: Remove deprecated nickname field instances.

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -264,11 +264,6 @@ module.exports = function registerFilters() {
     return output;
   };
 
-  liquid.filters.locationUrlConvention = facility =>
-    facility.fieldNicknameForThisFacility
-      ? facility.fieldNicknameForThisFacility.replace(/\s+/g, '-').toLowerCase()
-      : facility.fieldFacilityLocatorApiId;
-
   liquid.filters.hashReference = str =>
     str
       .toLowerCase()
@@ -290,7 +285,6 @@ module.exports = function registerFilters() {
 
       facilityList[id] = f.fieldMedia ? f.fieldMedia.entity.image : {};
       facilityList[id].entityUrl = f.entityUrl;
-      facilityList[id].nickname = f.fieldNicknameForThisFacility;
     });
     return JSON.stringify(facilityList);
   };

--- a/src/site/stages/build/drupal/graphql/bioPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/bioPage.graphql.js
@@ -20,7 +20,6 @@ module.exports = `
         entityType
         ...on NodeHealthCareRegionPage {
           ${entityElementsFromPages}
-          fieldNicknameForThisFacility
           title
         }
       }

--- a/src/site/stages/build/drupal/graphql/eventListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/eventListingPage.graphql.js
@@ -34,7 +34,7 @@ module.exports = `
                 endValue
                 endTime
                 timezone
-              }              
+              }
               fieldDate {
                 startDate
                 value
@@ -77,7 +77,7 @@ module.exports = `
               endValue
               endTime
               timezone
-            }            
+            }
             fieldDate {
               startDate
               value
@@ -103,7 +103,6 @@ module.exports = `
         ...on NodeHealthCareRegionPage {
           entityLabel
           title
-          fieldNicknameForThisFacility
         }
       }
     }

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareLocalFacility.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareLocalFacility.node.graphql.js
@@ -24,7 +24,6 @@ const FACILITIES_RESULTS = `
       changed
       fieldOperatingStatusFacility
       fieldFacilityLocatorApiId
-      fieldNicknameForThisFacility
       fieldIntroText
       fieldLocationServices {
         entity {
@@ -73,8 +72,7 @@ function queryFilter(isMainLocation) {
   return `
     filter: {conditions: [{field: "status", value: "1", operator: EQUAL, enabled: $onlyPublishedContent}, {field: "field_main_location", value: "${
       isMainLocation ? '1' : '0'
-    }", operator: EQUAL}]}, sort: {field: "field_nickname_for_this_facility", direction: ASC}
-  `;
+    }", operator: EQUAL}]}`;
 }
 
 module.exports = `

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionHealthServices.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionHealthServices.node.graphql.js
@@ -28,7 +28,6 @@ const HEALTH_SERVICES_RESULTS = `
                       path
                     }
                   }
-                  fieldNicknameForThisFacility
                   title
                 }
               }

--- a/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
@@ -8,7 +8,6 @@ module.exports = `
     ${entityElementsFromPages}
     changed
     fieldFacilityLocatorApiId
-    fieldNicknameForThisFacility
     title
     fieldIntroText
     fieldOperatingStatusFacility
@@ -58,7 +57,6 @@ module.exports = `
           entityId
           entityPublished
           title
-          fieldNicknameForThisFacility
           fieldRelatedLinks {
             entity {
               ... listOfLinkTeasers

--- a/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.old.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.old.graphql.js
@@ -5,7 +5,6 @@ module.exports = `
     ${entityElementsFromPages}
     changed
     fieldFacilityLocatorApiId
-    fieldNicknameForThisFacility
     title
     fieldIntroText
     fieldLocationServices {

--- a/src/site/stages/build/drupal/graphql/healthCareRegionDetailPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionDetailPage.graphql.js
@@ -65,7 +65,6 @@ module.exports = `
         ...on NodeHealthCareRegionPage {
           entityLabel
           title
-          fieldNicknameForThisFacility
         }
       }
     }

--- a/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
@@ -13,7 +13,6 @@ module.exports = `
     ${entityElementsFromPages}
     ${healthCareRegionNewsStories}
     ${healthCareRegionEvents}
-    fieldNicknameForThisFacility
     title
     fieldMedia {
       entity {

--- a/src/site/stages/build/drupal/graphql/healthServicesListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthServicesListingPage.graphql.js
@@ -64,7 +64,6 @@ module.exports = `
                               path
                             }
                           }
-                          fieldNicknameForThisFacility
                           title
                         }
                       }
@@ -106,7 +105,6 @@ module.exports = `
         ... on NodeHealthCareRegionPage {
           entityLabel
           title
-          fieldNicknameForThisFacility
         }
       }
     }

--- a/src/site/stages/build/drupal/graphql/leadershipListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/leadershipListingPage.graphql.js
@@ -110,7 +110,6 @@ module.exports = `
         ... on NodeHealthCareRegionPage {
           entityLabel
           title
-          fieldNicknameForThisFacility
         }
       }
     }

--- a/src/site/stages/build/drupal/graphql/locationsListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/locationsListingPage.graphql.js
@@ -21,7 +21,6 @@ module.exports = `
           fieldOtherVaLocations
           entityLabel
           title
-          fieldNicknameForThisFacility
         }
       }
     }

--- a/src/site/stages/build/drupal/graphql/pressReleasesListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/pressReleasesListingPage.graphql.js
@@ -40,7 +40,6 @@ module.exports = `
         ... on NodeHealthCareRegionPage {
           entityLabel
           title
-          fieldNicknameForThisFacility
         }
       }
     }

--- a/src/site/stages/build/drupal/graphql/storyListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/storyListingPage.graphql.js
@@ -66,7 +66,6 @@ module.exports = `
         ... on NodeHealthCareRegionPage {
           entityLabel
           title
-          fieldNicknameForThisFacility
         }
       }
     }

--- a/src/site/stages/build/process-cms-exports/graphql-cms-export-differences/node.md
+++ b/src/site/stages/build/process-cms-exports/graphql-cms-export-differences/node.md
@@ -215,7 +215,6 @@ CMS export returned **774** records.
   - `field_media` | Entity reference
   - `field_meta_tags` | Meta tags
   - `field_meta_title` | Text (plain)
-  - `field_nickname_for_this_facility` | Text (plain)
   - `field_operating_status` | Link
   - `field_other_va_locations` | Text (plain)
   - `field_press_release_blurb` | Text (formatted, long)
@@ -253,7 +252,6 @@ CMS export returned **774** records.
   - `field_mental_health_phone` | Telephone number
   - `field_meta_tags` | Meta tags
   - `field_meta_title` | Text (plain)
-  - `field_nickname_for_this_facility` | Text (plain)
   - `field_operating_status_facility` | List (text)
   - `field_operating_status_more_info` | Text (plain, long)
   - `field_phone_number` | Telephone number
@@ -580,7 +578,6 @@ CMS export returned **774** records.
           "value": "https://dev.cms.va.gov/sites/default/files/2019-04/UD%20front.jpg"
         }
       ],
-      "fieldNicknameForThisFacility": "VA Pittsburgh"
     }
   },
   "fieldIntroText": null,

--- a/src/site/stages/build/process-cms-exports/schemas/input/node-health_care_local_facility.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/node-health_care_local_facility.js
@@ -63,7 +63,6 @@ module.exports = {
       maxItems: 1,
     },
     field_mental_health_phone: { $ref: 'GenericNestedString' },
-    field_nickname_for_this_facility: { $ref: 'GenericNestedString' },
     field_operating_status_facility: { $ref: 'GenericNestedString' },
     // maxItems: 0 until we have an example of what this should be
     field_operating_status_more_info: { $ref: 'GenericNestedString' },
@@ -89,7 +88,6 @@ module.exports = {
     'field_main_location',
     'field_media',
     'field_mental_health_phone',
-    'field_nickname_for_this_facility',
     'field_operating_status_facility',
     'field_operating_status_more_info',
     'field_phone_number',

--- a/src/site/stages/build/process-cms-exports/schemas/input/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/node-health_care_region_page.js
@@ -20,7 +20,6 @@ module.exports = {
     path: { $ref: 'RawPath' },
     metatag: { $ref: 'RawMetaTags' },
     field_intro_text: { $ref: 'GenericNestedString' },
-    field_nickname_for_this_facility: { $ref: 'GenericNestedString' },
     field_link_facility_emerg_list: {
       type: 'array',
       items: {
@@ -53,7 +52,6 @@ module.exports = {
     'field_intro_text',
     // Turns out this sometimes just isn't there
     // 'field_link_facility_emerg_list',
-    'field_nickname_for_this_facility',
     'field_govdelivery_id_emerg',
     'field_govdelivery_id_news',
     'field_operating_status',

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_local_facility.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_local_facility.js
@@ -45,7 +45,6 @@ module.exports = {
     fieldMainLocation: { type: 'boolean' },
     fieldMedia: { $ref: 'Media' },
     fieldMentalHealthPhone: { type: ['string', 'null'] },
-    fieldNicknameForThisFacility: { type: ['string', 'null'] },
     // Could probably be an enum, but it's not clear what all the possible values are
     fieldOperatingStatusFacility: { type: 'string' },
     // Only found null as an example; not sure what else it's supposed to be
@@ -78,7 +77,6 @@ module.exports = {
     'fieldMainLocation',
     'fieldMedia',
     'fieldMentalHealthPhone',
-    'fieldNicknameForThisFacility',
     'fieldOperatingStatusFacility',
     'fieldOperatingStatusMoreInfo',
     'fieldPhoneNumber',

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_local_health_service.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_local_health_service.js
@@ -39,7 +39,6 @@ module.exports = {
           items: {
             entity: partialSchema(healthCareLocalFacilitySchema, [
               'entityUrl',
-              'fieldNicknameForThisFacility',
               'title',
             ]),
           },

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
@@ -32,7 +32,6 @@ const facilitiesSchema = {
           'changed',
           'fieldOperatingStatusFacility',
           'fieldFacilityLocatorApiId',
-          'fieldNicknameForThisFacility',
           'fieldIntroText',
           'fieldLocationServices',
           'fieldAddress',
@@ -100,7 +99,6 @@ module.exports = {
     fieldGovdeliveryIdNews: { type: 'string' },
     fieldOperatingStatus: socialMediaSchema,
     fieldOtherVaLocations: { type: 'array' },
-    fieldNicknameForThisFacility: { type: ['string', 'null'] },
     fieldLinkFacilityEmergList: {
       type: ['object', 'null'],
       properties: {
@@ -164,7 +162,6 @@ module.exports = {
     'fieldGovdeliveryIdNews',
     'fieldOperatingStatus',
     'fieldOtherVaLocations',
-    'fieldNicknameForThisFacility',
     'fieldLinkFacilityEmergList',
     'reverseFieldRegionPageNode',
     'newsStoryTeasers',

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-regional_health_care_service_des.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-regional_health_care_service_des.js
@@ -16,7 +16,6 @@ module.exports = {
           fieldFacilityLocation: {
             entity: {
               title: { type: 'string' },
-              fieldNicknameForThisFacility: { type: 'string' },
             },
           },
         },

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
@@ -65,9 +65,6 @@ const transform = (entity, { ancestors }) => ({
       ? { entity: getImageCrop(entity.fieldMedia[0], '_32MEDIUMTHUMBNAIL') }
       : null,
   fieldMentalHealthPhone: getDrupalValue(entity.fieldMentalHealthPhone),
-  fieldNicknameForThisFacility: getDrupalValue(
-    entity.fieldNicknameForThisFacility,
-  ),
   fieldOperatingStatusFacility: getDrupalValue(
     entity.fieldOperatingStatusFacility,
   ),
@@ -102,7 +99,6 @@ module.exports = {
     'field_main_location',
     'field_media',
     'field_mental_health_phone',
-    'field_nickname_for_this_facility',
     'field_operating_status_facility',
     'field_operating_status_more_info',
     'field_phone_number',

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_health_service.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_health_service.js
@@ -1,27 +1,18 @@
 /* eslint-disable camelcase */
 const { getDrupalValue, getWysiwygString } = require('./helpers');
 
-const getFieldFacilityLocationObject = ({
-  title,
-  entityUrl,
-  fieldNicknameForThisFacility,
-  field_nickname_for_this_facility,
-}) =>
+const getFieldFacilityLocationObject = ({ title, entityUrl }) =>
   typeof title === 'object'
     ? {
         entity: {
           title: getDrupalValue(title),
           entityUrl,
-          fieldNicknameForThisFacility: getDrupalValue(
-            field_nickname_for_this_facility,
-          ),
         },
       }
     : {
         entity: {
           title,
           entityUrl,
-          fieldNicknameForThisFacility,
         },
       };
 

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
@@ -26,7 +26,6 @@ const transform = (
     fieldGovdeliveryIdNews,
     fieldOperatingStatus,
     fieldOtherVaLocations,
-    fieldNicknameForThisFacility,
     fieldRelatedLinks,
     fieldLinkFacilityEmergList,
     reverseFieldRegionPage,
@@ -50,7 +49,6 @@ const transform = (
     fieldMedia && fieldMedia.length
       ? { entity: getImageCrop(fieldMedia[0], '_72MEDIUMTHUMBNAIL') }
       : null,
-  fieldNicknameForThisFacility: getDrupalValue(fieldNicknameForThisFacility),
   fieldLinkFacilityEmergList:
     fieldLinkFacilityEmergList && fieldLinkFacilityEmergList[0]
       ? {
@@ -184,11 +182,6 @@ const transform = (
             reverseField =>
               reverseField.fieldMainLocation && reverseField.entityPublished,
           )
-          .sort((a, b) =>
-            a.fieldNicknameForThisFacility.localeCompare(
-              b.fieldNicknameForThisFacility,
-            ),
-          )
           .map(r => ({
             entityUrl: r.entityUrl,
             entityBundle: r.entityBundle,
@@ -197,7 +190,6 @@ const transform = (
             changed: r.changed,
             fieldOperatingStatusFacility: r.fieldOperatingStatusFacility,
             fieldFacilityLocatorApiId: r.fieldFacilityLocatorApiId,
-            fieldNicknameForThisFacility: r.fieldNicknameForThisFacility,
             fieldIntroText: r.fieldIntroText,
             fieldLocationServices: r.fieldLocationServices,
             fieldAddress: r.fieldAddress,
@@ -217,11 +209,6 @@ const transform = (
             reverseField =>
               !reverseField.fieldMainLocation && reverseField.entityPublished,
           )
-          .sort((a, b) =>
-            a.fieldNicknameForThisFacility.localeCompare(
-              b.fieldNicknameForThisFacility,
-            ),
-          )
           .map(r => ({
             entityUrl: r.entityUrl,
             entityBundle: r.entityBundle,
@@ -230,7 +217,6 @@ const transform = (
             changed: r.changed,
             fieldOperatingStatusFacility: r.fieldOperatingStatusFacility,
             fieldFacilityLocatorApiId: r.fieldFacilityLocatorApiId,
-            fieldNicknameForThisFacility: r.fieldNicknameForThisFacility,
             fieldIntroText: r.fieldIntroText,
             fieldLocationServices: r.fieldLocationServices,
             fieldAddress: r.fieldAddress,
@@ -344,7 +330,6 @@ module.exports = {
     'field_govdelivery_id_news',
     'field_link_facility_emerg_list',
     'field_media',
-    'field_nickname_for_this_facility',
     'field_operating_status',
     'field_other_va_locations',
     'field_press_release_blurb',

--- a/src/site/stages/build/process-cms-exports/transformers/node-regional_health_care_service_des.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-regional_health_care_service_des.js
@@ -15,9 +15,6 @@ const getFieldFacilityLocationObject = ({
             entity: {
               title: getDrupalValue(field_facility_location[0].title),
               entityUrl: field_facility_location[0].entityUrl,
-              fieldNicknameForThisFacility: getDrupalValue(
-                field_facility_location[0].field_nickname_for_this_facility,
-              ),
             },
           },
           entityUrl,


### PR DESCRIPTION
## Description
`field_nickname_for_this_facility` has been deprecated. This pr removes all instances of it from vets-website.

## Testing done
Build

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
