### PR TITLE
Move h3 into a, add styles for arrows

### DIFF
--- a/src/platform/site-wide/sass/shame.scss
+++ b/src/platform/site-wide/sass/shame.scss
@@ -589,3 +589,10 @@ img[data-srcset] {
     width: 100%;
   }
 }
+
+.all-link-arrow {
+  width: 11px;
+  margin-left: 5px;
+  transition: all 0.15s ease;
+  margin-bottom: 2px;
+}

--- a/src/platform/site-wide/sass/shame.scss
+++ b/src/platform/site-wide/sass/shame.scss
@@ -590,7 +590,7 @@ img[data-srcset] {
   }
 }
 
-.all-link-arrow {
+.field-spokes-link-arrow {
   width: 11px;
   margin-left: 5px;
   transition: all 0.15s ease;

--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -157,7 +157,6 @@
                   <li>
                     <h3 class="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-font-family--sans">
                       <a
-                        class="vads-u-text-decoration--none"
                         href="{{ vaFormLinkTeaser.entity.fieldLink.url.path }}"
                         onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': '{{ vaFormLinkTeaser.entity.fieldLink.title | escape }}', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })">
                         {{ vaFormLinkTeaser.entity.fieldLink.title }}
@@ -171,7 +170,6 @@
                 <li>
                   <h3 class="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-font-family--sans">
                     <a
-                      class="vads-u-text-decoration--none"
                       href="/change-direct-deposit"
                       onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Change your direct deposit information', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })">
                       Change your direct deposit information
@@ -182,7 +180,6 @@
                 <li>
                   <h3 class="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-font-family--sans">
                     <a
-                      class="vads-u-text-decoration--none"
                       href="/change-address"
                       onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Change your address', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })">
                       Change your address
@@ -193,7 +190,6 @@
                 <li>
                   <h3 class="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-font-family--sans">
                     <a
-                      class="vads-u-text-decoration--none"
                       href="/records/get-military-service-records/"
                       onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Request your military records, including DD214', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })">
                       Request your military records, including DD214
@@ -204,7 +200,6 @@
                 <li>
                   <h3 class="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-font-family--sans">
                     <a
-                      class="vads-u-text-decoration--none"
                       href="/records/"
                       onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Get your VA records and documents online', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })">
                       Get your VA records and documents online

--- a/src/site/paragraphs/linkTeaser.drupal.liquid
+++ b/src/site/paragraphs/linkTeaser.drupal.liquid
@@ -33,16 +33,21 @@
   data-links-list-header="{{ link.title | escape }}"
   data-links-list-section-header="{{ section_header | escape }}"
   {% if parentFieldName === 'field_spokes' %}class="hub-page-link-list__item"{% endif %}>
-    <a href="{{link.url.path}}"
-      {% if linkTeaser.options["target"] %}target="{{ linkTeaser.options["target"] }}"{% endif %}
-      >
-        {% if link.title != empty %}
-            <{{ header }} class="{{ headerClass }}">{{ link.title }}</{{ header }}>
-            {% if parentFieldName === "field_spokes" %}
-                <img class="all-link-arrow" src="/img/arrow-right-blue.svg" alt="right-arrow">
-            {% endif %}
-        {% endif %}
-    </a>
+    {% if link.title != empty %}
+      <{{ header }} class="{{ headerClass }}">
+        <a href="{{link.url.path}}" class="vads-u-text-decoration--underline"
+          {% if linkTeaser.options["target"] %}
+            target="{{ linkTeaser.options["target"] }}"
+            rel="noopener noreferrer"
+          {% endif %}
+        >
+          {{ link.title }}
+        </a>
+      </{{ header }}>
+      {% if parentFieldName === "field_spokes" %}
+          <img class="all-link-arrow" src="/img/arrow-right-blue.svg" alt="Blue arrow pointing right">
+      {% endif %}
+    {% endif %}
     {% if linkTeaser.fieldLinkSummary != empty %}
         <p class="va-nav-linkslist-description">{{ linkTeaser.fieldLinkSummary }}</p>
     {% endif %}

--- a/src/site/paragraphs/linkTeaser.drupal.liquid
+++ b/src/site/paragraphs/linkTeaser.drupal.liquid
@@ -45,7 +45,7 @@
         </a>
       </{{ header }}>
       {% if parentFieldName === "field_spokes" %}
-          <img class="all-link-arrow" src="/img/arrow-right-blue.svg" alt="Blue arrow pointing right">
+          <img class="field-spokes-link-arrow" src="/img/arrow-right-blue.svg" alt="Blue arrow pointing right">
       {% endif %}
     {% endif %}
     {% if linkTeaser.fieldLinkSummary != empty %}


### PR DESCRIPTION
This PR is a follow-up on the revert of [this previously merged PR](https://github.com/department-of-veterans-affairs/vets-website/pull/15698) -- the issue was that the arrow styles were no longer being applied. [Post mortem](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/public-websites/post-mortems/arrow-styles-01-22-21.md).


To those reviewing: I would super appreciate a thorough review of this PR since I am unsure how I can check all pages where the `linkTeaser` template is rendered.

## Description
[TICKET](https://github.com/department-of-veterans-affairs/va.gov-team/issues/3556)

This PR:
1) moves the `a` tag within the `h3`, or `b` on pages that use the linkTeaser.
2) ensures that the `a` tag in the linkTeaser is underlined, even when it's not active
3) ensures that the `a` tags on the form detail page are also underlined -- PLEASE CONFIRM DESIRABILITY (@ncksllvn or maybe someone else on the pw team?), I changed it since it seemed to follow the same UI as what's rendered through the linkTeaser  

## Testing done
Looks good locally

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/105864875-9b0a6f80-5faf-11eb-9de2-43243bbda965.png)
![image](https://user-images.githubusercontent.com/14869324/105864922-a6f63180-5faf-11eb-8d84-53c0d5e90b12.png)
![image](https://user-images.githubusercontent.com/14869324/105864966-b5444d80-5faf-11eb-9aee-64d06754f93a.png)


## Acceptance criteria
- [x] Add underline to links
- [x] Move `a` tag within `h3`
- [x] Ensure arrows don't lose their styles

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
