### PR TITLE
Fix mobile sidenav trigger button overlay bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -276,7 +276,7 @@
   "private": true,
   "dependencies": {
     "@department-of-veterans-affairs/component-library": "1.0.0",
-    "@department-of-veterans-affairs/formation": "6.13.1",
+    "@department-of-veterans-affairs/formation": "6.13.2",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "@fortawesome/fontawesome-free": "^5.6.3",
     "@mapbox/mapbox-sdk": "^0.10.0",

--- a/src/site/components/navigation-sidebar-trigger.html
+++ b/src/site/components/navigation-sidebar-trigger.html
@@ -58,8 +58,8 @@ used in a template with navigation-sidebar.html
     // ensures that the height is not computed until the next run of the event
     // loop
     setTimeout(() => {
-      navTriggerPlaceholder.style.height = `${getButtonHeight(true)}px`
-      buttonBackground.style.height = `${getButtonHeight(false)}px`
+      navTriggerPlaceholder.style.height = getButtonHeight(true) + 'px'
+      buttonBackground.style.height = getButtonHeight(false) + 'px'
     }, 0)
   }
 

--- a/src/site/components/navigation-sidebar-trigger.html
+++ b/src/site/components/navigation-sidebar-trigger.html
@@ -52,8 +52,15 @@ used in a template with navigation-sidebar.html
   }
 
   function setElementHeights() {
-    navTriggerPlaceholder.style.height = `${getButtonHeight(true)}px`
-    buttonBackground.style.height = `${getButtonHeight(false)}px`
+    // In some edge cases when switching from desktop to mobile viewport (such
+    // as when you open the web inspector), getButtonHeight() was returning 0,
+    // likely due to `mobileMediaQuery.matches` failing. This simple hack
+    // ensures that the height is not computed until the next run of the event
+    // loop
+    setTimeout(() => {
+      navTriggerPlaceholder.style.height = `${getButtonHeight(true)}px`
+      buttonBackground.style.height = `${getButtonHeight(false)}px`
+    }, 0)
   }
 
   function setMenuTriggerPosition() {


### PR DESCRIPTION
## Description
This fixes a small but where the trigger button could be layered _over_ the page content.

## Testing done
Local in Safari, Chrome, and Firefox

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs