### PR TITLE
Reverted changes made to getImageCrop

### DIFF
--- a/src/site/stages/build/process-cms-exports/transformers/helpers.js
+++ b/src/site/stages/build/process-cms-exports/transformers/helpers.js
@@ -3,7 +3,6 @@ const assert = require('assert');
 const { sortBy, unescape, pick, omit } = require('lodash');
 const moment = require('moment-timezone');
 const { readEntity } = require('../helpers');
-const buckets = require('../../../../constants/buckets');
 
 const mediaImageStyles = [
   {
@@ -109,11 +108,7 @@ function getImageCrop(obj, imageStyle = null) {
       image.machine
     }/public${imageObj.image.derivative.url.replace('/img', '')}`;
     imageObj.image.url = url;
-    // Derivative urls have a full path starting with
-    // 'https://{buildtype}.cms.va.gov/sites/default/files/', so add that here.
-    // It doesn't matter what the build type is since it gets stripped out in convertDrupalFilesToLocal
-    // so just use prod here
-    imageObj.image.derivative.url = `${buckets.vagovprod}${url}`;
+    imageObj.image.derivative.url = url;
     imageObj.image.derivative.width = image.width;
     imageObj.image.derivative.height = image.height;
     return imageObj;


### PR DESCRIPTION
## Description
Reverted changes made on this [PR](https://github.com/department-of-veterans-affairs/vets-website/commit/cc1124be9742bb6ae138ad820f4baddfc5d84224)

Changes broke the ability to download the images in the `styles` folder. This should be fixed on a later PR

<img width="324" alt="Screen Shot 2021-01-25 at 2 57 59 PM" src="https://user-images.githubusercontent.com/55560129/105887159-5bf11400-5fd9-11eb-8f89-01307c4bab88.png">

