### PR TITLE
[Templates] Add bookmarkable auto-open behavior to accordions

### DIFF
--- a/src/site/facilities/health_service.drupal.liquid
+++ b/src/site/facilities/health_service.drupal.liquid
@@ -1,7 +1,7 @@
-<div data-template="facilities/health_service" class="usa-accordion-bordered service-accordion-output">
+<div data-template="facilities/health_service" class="usa-accordion usa-accordion-bordered service-accordion-output">
     <ul class="usa-unstyled-list">
         {% assign serviceTaxonomy = healthService.fieldServiceNameAndDescripti.entity %}
-        <li>
+        <li id="{{ serviceTaxonomy.entityId }}">
             <button
                     class="usa-accordion-button usa-button-unstyled"
                     aria-expanded="false"

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -145,11 +145,11 @@
               class="vads-u-margin-top--0 vads-u-font-size--lg small-screen:vads-u-font-size--xl vads-u-margin-bottom--2">
               Prepare for your visit</h2>
               <p>Click on a topic for more details.</p>
-            <div class="usa-accordion-bordered">
+            <div class="usa-accordion usa-accordion-bordered">
               <ul class="usa-unstyled-list">
                 {% for accordionItem in fieldLocationServices %}
                 {% assign item = accordionItem.entity %}
-                <li class="vads-u-margin-bottom--1">
+                <li id="{{ item.entityId }}" class="vads-u-margin-bottom--1">
                   <button class="usa-accordion-button usa-button-unstyled vads-u-padding-y--2 vads-u-padding-left--2p5 vads-u-line-height--4
 " aria-expanded="false"
                     aria-controls="{{ item.entityBundle }}-{{ item.entityId }}">


### PR DESCRIPTION
## Description
This PR adds the IDs into the list elements of the accordions across the VAMC pages so that we can link directly to certain accordion items. 

## Testing done

Tested against http://localhost:3001/pittsburgh-health-care/ of the site (see screenshots)

## Screenshots

### http://localhost:3001/pittsburgh-health-care/locations/pittsburgh-va-medical-center-university-drive/#5338
![image](https://user-images.githubusercontent.com/1915775/105890488-6c0af280-5fdd-11eb-91d8-785d9459d57b.png)

### http://localhost:3001/pittsburgh-health-care/locations/pittsburgh-va-medical-center-university-drive/#98
![image](https://user-images.githubusercontent.com/1915775/105890616-99f03700-5fdd-11eb-9300-327ee30e37a9.png)

### http://localhost:3001/pittsburgh-health-care/health-services/#81
![image](https://user-images.githubusercontent.com/1915775/105890881-e9cefe00-5fdd-11eb-80f4-9b2d5747dfdd.png)

## Acceptance criteria
- [ ] On VAMC pages, accordion items can be linked to and will auto-expand

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
