### PR TITLE
Include HTML entities in transformers

### DIFF
--- a/src/site/stages/build/process-cms-exports/transformers/helpers.js
+++ b/src/site/stages/build/process-cms-exports/transformers/helpers.js
@@ -44,6 +44,23 @@ const mediaImageStyles = [
 ];
 
 /**
+ * Takes a string with escaped unicode code points and replaces them
+ * with the unicode characters. E.g. '\u2014' -> '—'
+ *
+ * @param {String} string
+ * @return {String}
+ */
+function unescapeUnicode(string) {
+  assert(
+    typeof string === 'string',
+    `Expected type String in unescapeUnicode, but found ${typeof string}: ${string}`,
+  );
+  return string.replace(/\\u(\d{2,4})/g, (wholeMatch, codePoint) =>
+    String.fromCharCode(`0x${codePoint}`),
+  );
+}
+
+/**
  * Extracts a nested string from specific types of export data.
  *
  * @param {Array} arr - An array with one item, which is an object with
@@ -55,7 +72,14 @@ function getDrupalValue(arr) {
   if (!arr || arr.length === 0) return null;
   if (arr.length === 1 && arr[0].processed === '') return null;
   if (arr.length === 1)
-    return arr[0].processed ? arr[0].processed : arr[0].value;
+    if (arr[0].processed)
+      return typeof arr[0].processed === 'string'
+        ? unescapeUnicode(arr[0].processed)
+        : arr[0].processed;
+    else
+      return typeof arr[0].value === 'string'
+        ? unescapeUnicode(arr[0].value)
+        : arr[0].value;
 
   // eslint-disable-next-line no-console
   console.warn(`Unexpected argument: ${arr.toString()}`);
@@ -111,6 +135,7 @@ function uriToUrl(uri) {
 module.exports = {
   getDrupalValue,
   getImageCrop,
+  unescapeUnicode,
   uriToUrl,
 
   /**

--- a/src/site/stages/build/process-cms-exports/transformers/helpers.js
+++ b/src/site/stages/build/process-cms-exports/transformers/helpers.js
@@ -166,7 +166,7 @@ module.exports = {
    * @return {string}
    */
   getWysiwygString(value) {
-    return !value ? '' : value;
+    return value || '';
   },
 
   /**

--- a/src/site/stages/build/process-cms-exports/transformers/helpers.js
+++ b/src/site/stages/build/process-cms-exports/transformers/helpers.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const assert = require('assert');
-const { sortBy, unescape, pick, omit } = require('lodash');
+const { sortBy, pick, omit } = require('lodash');
 const moment = require('moment-timezone');
 const { readEntity } = require('../helpers');
 
@@ -44,23 +44,6 @@ const mediaImageStyles = [
 ];
 
 /**
- * Takes a string with escaped unicode code points and replaces them
- * with the unicode characters. E.g. '\u2014' -> '—'
- *
- * @param {String} string
- * @return {String}
- */
-function unescapeUnicode(string) {
-  assert(
-    typeof string === 'string',
-    `Expected type String in unescapeUnicode, but found ${typeof string}: ${string}`,
-  );
-  return string.replace(/\\u(\d{2,4})/g, (wholeMatch, codePoint) =>
-    String.fromCharCode(`0x${codePoint}`),
-  );
-}
-
-/**
  * Extracts a nested string from specific types of export data.
  *
  * @param {Array} arr - An array with one item, which is an object with
@@ -72,14 +55,7 @@ function getDrupalValue(arr) {
   if (!arr || arr.length === 0) return null;
   if (arr.length === 1 && arr[0].processed === '') return null;
   if (arr.length === 1)
-    if (arr[0].processed)
-      return typeof arr[0].processed === 'string'
-        ? unescapeUnicode(arr[0].processed)
-        : arr[0].processed;
-    else
-      return typeof arr[0].value === 'string'
-        ? unescapeUnicode(arr[0].value)
-        : arr[0].value;
+    return arr[0].processed ? arr[0].processed : arr[0].value;
 
   // eslint-disable-next-line no-console
   console.warn(`Unexpected argument: ${arr.toString()}`);
@@ -135,7 +111,6 @@ function uriToUrl(uri) {
 module.exports = {
   getDrupalValue,
   getImageCrop,
-  unescapeUnicode,
   uriToUrl,
 
   /**
@@ -159,13 +134,14 @@ module.exports = {
 
   /**
    * Takes a string and applies the following:
-   * - Transforms escaped unicode to characters
+   * Returns a blank string if the value is not defined,
+   * otherwise, returns the value
    *
    * @param {string}
    * @return {string}
    */
   getWysiwygString(value) {
-    return unescape(value);
+    return !value ? '' : value;
   },
 
   /**


### PR DESCRIPTION
## Description
This PR removes the functions that convert HTML entities in transformers. This helps synchronize strings in GraphQL and CMS export objects.

## Testing done
- Tested using `yarn cms:diff:json`, the total number of differences is [reduced](https://github.com/department-of-veterans-affairs/va.gov-team/issues/18955#issuecomment-767206971).
- Confirmed the build completes without errors when using the `--use-cms-export` flag.

## Screenshots
**Number of differences with HTML entities being stripped**
![Screen Shot 2021-01-25 at 4.44.12 PM.png](https://images.zenhubusercontent.com/5e56a58c13bedb092ce69379/622d812f-4d79-4cc5-81e3-cc91cbcb7869)

**Number of differences with HTML entities NOT being stripped**
![Screen Shot 2021-01-25 at 4.46.06 PM.png](https://images.zenhubusercontent.com/5e56a58c13bedb092ce69379/19dc24f4-4e45-4bd0-9341-565ab14ac11d)

## Acceptance criteria
- [ ] HTML entities are no longer removed from transformers.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
