### PR TITLE
VAOS minor accessibility fixes for provider selection

### DIFF
--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
@@ -109,7 +109,7 @@ function ProviderSelectionField({
   );
 
   return (
-    <div className="vads-u-background-color--gray-lightest small-screen:vads-u-padding--2 medium-screen:vads-u-padding--3">
+    <div className="vads-u-background-color--gray-lightest vads-u-padding--2 medium-screen:vads-u-padding--3">
       {!showProvidersList &&
         !providerSelected && (
           <button

--- a/src/applications/vaos/new-appointment/components/TypeOfCarePage/TypeOfCareAlert.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfCarePage/TypeOfCareAlert.jsx
@@ -8,6 +8,7 @@ export default function TypeOfCareAlert() {
     <AlertBox
       status="info"
       headline={headline}
+      level="2"
       className="vads-u-margin-top--3 vads-u-margin-bottom--7"
       content={
         <p>


### PR DESCRIPTION
## Description
Two fixes here
- We found that padding was getting removed from boxes on provider selection page at high zoom levels, because the breakpoint being used was smaller than the small-screen one
- We also noticed that the heading level of the alert on the type of care page skipped a level, so updating it to fix the level

How to test
- Open new appointment flow: http://localhost:3001/health-care/schedule-view-va-appointments/appointments/new-appointment
- See type of care info alert at the bottom
- Continue through CC flow to preferences page
- Zoom in 400% and view the padding on the grey box around the add to provider link and info

## Testing done
Local testing

## Screenshots
Zoomed in screenshot:
![Screen Shot 2021-01-26 at 5 00 18 PM](https://user-images.githubusercontent.com/634932/105912329-4db2f000-5ff9-11eb-9311-82cbc4f71790.png)

Type of care heading level:
![Screen Shot 2021-01-26 at 4 59 53 PM](https://user-images.githubusercontent.com/634932/105912331-4e4b8680-5ff9-11eb-86cd-d63df833475b.png)

## Acceptance criteria
- [ ] Accessibility checklist items are met

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
