### PR TITLE
[Templates] Always hide the Resources search bar during print view

### DIFF
--- a/src/applications/resources-and-support/style.scss
+++ b/src/applications/resources-and-support/style.scss
@@ -24,7 +24,7 @@
 }
 
 @media print {
-  #resources-search-bar-wrapper {
+  .va-hide-on-print-view {
     display: none;
   }
 }

--- a/src/applications/resources-and-support/style.scss
+++ b/src/applications/resources-and-support/style.scss
@@ -22,3 +22,9 @@
   border-bottom-left-radius: 5px;
   border-bottom-right-radius: 5px;
 }
+
+@media print {
+  #resources-search-bar-wrapper {
+    display: none;
+  }
+}

--- a/src/applications/static-pages/sass/modules/_m-checklist-layout.scss
+++ b/src/applications/static-pages/sass/modules/_m-checklist-layout.scss
@@ -1,7 +1,0 @@
-.va-l-detail-page--checklist {
-  @media print {
-    #resources-search-bar-wrapper {
-      display: none;
-    }
-  }
-}

--- a/src/applications/static-pages/sass/static-pages.scss
+++ b/src/applications/static-pages/sass/static-pages.scss
@@ -22,8 +22,6 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
 @import "modules/m-facilities";
 @import "modules/m-facility-events";
 
-@import "modules/m-checklist-layout";
-
 //=============================
 // Home page only styles.
 //=============================

--- a/src/site/includes/support_resources_search_bar.drupal.liquid
+++ b/src/site/includes/support_resources_search_bar.drupal.liquid
@@ -1,1 +1,1 @@
-<div id="resources-search-bar-wrapper" data-widget-type="resources-and-support-search"></div>
+<div class="va-hide-on-print-view" data-widget-type="resources-and-support-search"></div>

--- a/src/site/includes/support_resources_search_bar.drupal.liquid
+++ b/src/site/includes/support_resources_search_bar.drupal.liquid
@@ -1,1 +1,1 @@
-<div data-widget-type="resources-and-support-search"></div>
+<div id="resources-search-bar-wrapper" data-widget-type="resources-and-support-search"></div>


### PR DESCRIPTION
## Description
Follow up to https://github.com/department-of-veterans-affairs/vets-website/pull/15687

I realized that we can probably hide this search bar from any printed page, so it makes more sense to have the style here instead

## Testing done
Observed the print preview of `/resources/change-your-address-on-file-with-va/`

## Screenshots
No search bar 
![image](https://user-images.githubusercontent.com/1915775/106026113-696cd380-6097-11eb-9945-f538177ad0f4.png)


## Acceptance criteria
- [ ] Cleaned up SCSS without breaking anything

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
