### PR TITLE
Comprehension refactor of webpack config

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -116,7 +116,7 @@ module.exports = env => {
 
   const outputPath = `${buildOptions.destination}/generated`;
 
-  // Set the pubilcPath conditional so we can get dynamic modules loading from S3
+  // Set the publicPath conditional so we can get dynamic modules loading from S3
   const publicAssetPath =
     buildOptions.setPublicPath && buildtype !== 'localhost'
       ? `${BUCKETS[buildtype]}/generated/`

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -17,6 +17,8 @@ const headerFooterData = require('../src/platform/landing-pages/header-footer-da
 const BUCKETS = require('../src/site/constants/buckets');
 const ENVIRONMENTS = require('../src/site/constants/environments');
 
+const { VAGOVSTAGING, VAGOVPROD, LOCALHOST } = ENVIRONMENTS;
+
 const {
   getAppManifests,
   getWebpackEntryPoints,
@@ -97,20 +99,14 @@ module.exports = env => {
 
   const apps = getEntryPoints(buildOptions.entry);
   const entryFiles = Object.assign({}, apps, globalEntryFiles);
-  const isOptimizedBuild = [
-    ENVIRONMENTS.VAGOVSTAGING,
-    ENVIRONMENTS.VAGOVPROD,
-  ].includes(buildtype);
+  const isOptimizedBuild = [VAGOVSTAGING, VAGOVPROD].includes(buildtype);
 
-  const useHashFilenames = [
-    ENVIRONMENTS.VAGOVSTAGING,
-    ENVIRONMENTS.VAGOVPROD,
-  ].includes(buildtype);
+  const useHashFilenames = [VAGOVSTAGING, VAGOVPROD].includes(buildtype);
 
   // enable css sourcemaps for all non-localhost builds
   // or if build options include local-css-sourcemaps or entry
   const enableCSSSourcemaps =
-    buildtype !== ENVIRONMENTS.LOCALHOST ||
+    buildtype !== LOCALHOST ||
     buildOptions['local-css-sourcemaps'] ||
     !!buildOptions.entry;
 
@@ -264,7 +260,7 @@ module.exports = env => {
           const { name } = chunk;
           const isMedalliaStyleFile = name === vaMedalliaStylesFilename;
 
-          const isStaging = buildtype === ENVIRONMENTS.VAGOVSTAGING;
+          const isStaging = buildtype === VAGOVSTAGING;
 
           if (isMedalliaStyleFile && isStaging) return `[name].css`;
 

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -84,11 +84,11 @@ function getEntryPoints(entry) {
 }
 
 module.exports = env => {
-  const { buildtype = 'localhost' } = env;
+  const { buildtype = LOCALHOST } = env;
   const buildOptions = {
     api: '',
     buildtype,
-    host: 'localhost',
+    host: LOCALHOST,
     port: 3001,
     scaffold: false,
     watch: false,
@@ -114,7 +114,7 @@ module.exports = env => {
 
   // Set the publicPath conditional so we can get dynamic modules loading from S3
   const publicAssetPath =
-    buildOptions.setPublicPath && buildtype !== 'localhost'
+    buildOptions.setPublicPath && buildtype !== LOCALHOST
       ? `${BUCKETS[buildtype]}/generated/`
       : '/generated/';
 


### PR DESCRIPTION
## Description

In [Martin Fowler’s Refactoring](https://martinfowler.com/books/refactoring.html), he uses the term “Comprehension Refactoring.” I was recently looking at the webpack config ([`config/webpack.config.js`](https://github.com/department-of-veterans-affairs/vets-website/blob/master/config/webpack.config.js)), and spent a couple minutes on a “comprehension refactor.” 

This PR does the following:

- Destructure `buildtype` off `env`, and default to `'localhost'` (7077ac5c79fde6f56414216b27b069a119939cae)
- Fixes typo (01c6d7ced8f30bfb02388bdcf6c28e0cf787b9be)
- Use temp variables to prevent some line wrapping AKA code golf (95d3c9e129f8bbc0410c70ab5f02364d80d865ba)
- Replace `'localhost'` strings with `LOCALHOST` constants (ea706d43434396baccd464fe834d0f26d5620988)

### `buildtype`, `env`, and the spread operator

The `buildtype` defaults to `localhost`, and gets overwritten by the spread operator ([relevant Slack thread](https://dsva.slack.com/archives/CQH357ZTP/p1600444692005100?thread_ts=1600443954.004300&cid=CQH357ZTP)). 

```
const env = { ..., buildtype: 'vagovprod' }
const buildOptions = { ..., buildtype: 'localhost', ...env }
console.log(buildOptions) // 'vagovprod'
```

## Testing done

I logged the stringified `env` and `buildoptions` using `console.log(JSON.stringify({ env, buildOptions }, null, 2));` in both the `master` and `comprehension-refactor-of-webpack-config` branches, and they were identical. 

## Screenshots

![image](https://user-images.githubusercontent.com/6130520/106031900-6cff5b00-6095-11eb-9170-abecd9526e0b.png)

### Before

```
{
  "env": {
    "buildtype": "vagovprod"
  },
  "buildOptions": {
    "api": "",
    "buildtype": "vagovprod",
    "host": "localhost",
    "port": 3001,
    "scaffold": false,
    "watch": false,
    "setPublicPath": false,
    "destination": "/Users/bill/work/vets-website/build/vagovprod"
  }
}
```

### After

```
{
  "env": {
    "buildtype": "vagovprod"
  },
  "buildOptions": {
    "api": "",
    "buildtype": "vagovprod",
    "host": "localhost",
    "port": 3001,
    "scaffold": false,
    "watch": false,
    "setPublicPath": false,
    "destination": "/Users/bill/work/vets-website/build/vagovprod"
  }
}
```

