### PR TITLE
Default env to empty object

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -83,7 +83,7 @@ function getEntryPoints(entry) {
   return getWebpackEntryPoints(manifestsToBuild);
 }
 
-module.exports = env => {
+module.exports = (env = {}) => {
   const { buildtype = LOCALHOST } = env;
   const buildOptions = {
     api: '',


### PR DESCRIPTION
## Description

#15815 caused a `TypeError: Cannot read property 'buildtype' of undefined` error. This PR fixes that by defaulting `env` to an empty object (`{}`). 

## Testing done

1. `git checkout master`
1. `yarn build:webpack`
1. Confirm you see a `TypeError: Cannot read property 'buildtype' of undefined` error
1. git checkout fix-undefined-env-error
1. `yarn build:webpack`
1. Confirm webpack starts building

## Screenshots

![image](https://user-images.githubusercontent.com/6130520/106059458-5b7b7a80-60b8-11eb-977a-c4eb3740fa2d.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
