### PR TITLE
Remove HCA _13647Exception

### DIFF
--- a/src/applications/hca/tests/hca.cypress.spec.js
+++ b/src/applications/hca/tests/hca.cypress.spec.js
@@ -11,7 +11,6 @@ import toggleOff from './fixtures/mocks/toggle-off-multiple-address-1010ez.json'
 
 const testConfig = createTestConfig(
   {
-    _13647Exception: true,
     dataPrefix: 'data',
     dataSets: ['maximal-test', 'minimal-test', 'foreign-address-test'],
     fixtures: { data: path.join(__dirname, 'schema') },


### PR DESCRIPTION
## Description
To help catch asesibility issues before they get shipped with a feature we are removing the `_13647Exception` now that the contrast false positives  are fixed.

[Ticket](https://app.zenhub.com/workspaces/vsa---caregiver-5fff0cfd1462b6000e320fc7/issues/department-of-veterans-affairs/va.gov-team/19221)

## Testing done
- Ran CY e2e test

## Screenshots
N/A

## Acceptance criteria
- [x] CY e2e test pass with _13647Exception removed

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
