### PR TITLE
Fix VAOS Cypress tests again

### DIFF
--- a/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/index.cancel.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/index.cancel.unit.spec.jsx
@@ -270,7 +270,9 @@ describe('VAOS integration appointment cancellation:', () => {
 
     expect(queryByRole('alertdialog')).to.not.be.ok;
     expect(baseElement).to.contain.text('Canceled');
-    expect(document.activeElement).to.have.tagName('h1');
+    await waitFor(() => {
+      expect(document.activeElement).to.have.tagName('h1');
+    });
   });
 
   it('should display error when cancel fails', async () => {

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentsList.unit.spec.jsx
@@ -71,7 +71,7 @@ describe('VAOS <RequestedAppointmentsList>', () => {
     });
 
     expect(await screen.findByText('Primary care')).to.be.ok;
-    expect(screen.baseElement).to.contain.text(facility.attributes.name);
+    expect(await screen.findByText(facility.attributes.name)).to.be.ok;
     expect(screen.queryByText(/You don’t have any appointments/i)).not.to.exist;
   });
 

--- a/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
@@ -1,7 +1,7 @@
 import { initCommunityCareMock } from './vaos-cypress-helpers';
 import moment from 'moment';
 
-describe.skip('VAOS community care flow', () => {
+describe('VAOS community care flow', () => {
   beforeEach(() => {
     initCommunityCareMock();
     cy.visit(
@@ -165,7 +165,10 @@ describe.skip('VAOS community care flow', () => {
 
     // Check form requestBody is as expected
     cy.wait('@appointmentRequests').should(xhr => {
-      let date = moment().add(5, 'days');
+      let date = moment()
+        .add(5, 'days')
+        .add(1, 'months')
+        .startOf('month');
 
       // Check for weekend and select following Monday if true
       if (date.weekday() === 0) {

--- a/src/applications/vaos/tests/e2e/va-request.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/va-request.cypress.spec.js
@@ -47,7 +47,10 @@ function fillOutForm(facilitySelection) {
 
   // Check form requestBody is as expected
   cy.wait('@appointmentRequests').should(xhr => {
-    let date = moment().add(5, 'days');
+    let date = moment()
+      .add(5, 'days')
+      .add(1, 'months')
+      .startOf('month');
 
     // Check for weekend and select following Monday if true
     if (date.weekday() === 0) {
@@ -100,7 +103,7 @@ function fillOutForm(facilitySelection) {
   cy.findByText('cough');
 }
 
-describe.skip('VAOS request flow', () => {
+describe('VAOS request flow', () => {
   beforeEach(() => {});
 
   it('should submit form successfully for a multi system user', () => {


### PR DESCRIPTION
## Description
This PR
- Updates the date used to check submitted form data, since it no longer matches the month logic
- Fixes a flaky VAOS test noticed during CI

This PR would like to
- Abolish the concept of time

## Testing done
Ran these tests with the date set to each day in the last week of January and the first week of February

## Acceptance criteria
- [ ] Tests pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
