### PR TITLE
Sanlouise blue box 18935

### DIFF
--- a/src/applications/personalization/dashboard-2/components/BlueAlert.jsx
+++ b/src/applications/personalization/dashboard-2/components/BlueAlert.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const BlueAlert = ({ children }) => (
+  <span className="vads-u-background-color--primary-alt-lightest vads-u-padding-x--1p5 vads-u-padding-y--0p5">
+    {children}
+  </span>
+);
+
+export default BlueAlert;

--- a/src/applications/personalization/dashboard-2/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard-2/components/Dashboard.jsx
@@ -14,7 +14,7 @@ const Dashboard = () => {
   });
 
   return (
-    <div className="vads-l-grid-container vads-u-padding-x--0">
+    <div className="vads-l-grid-container medium-screen:vads-u-padding-x--0">
       <Breadcrumbs>
         <a href="/" key="home">
           Home

--- a/src/applications/personalization/dashboard-2/components/MiniInfoBox.jsx
+++ b/src/applications/personalization/dashboard-2/components/MiniInfoBox.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-const BlueAlert = ({ children }) => (
+const MiniInfoBox = ({ children }) => (
   <span className="vads-u-background-color--primary-alt-lightest vads-u-padding-x--1p5 vads-u-padding-y--0p5">
     {children}
   </span>
 );
 
-export default BlueAlert;
+export default MiniInfoBox;

--- a/src/applications/personalization/dashboard-2/components/claims-and-appeals/ClaimsAndAppeals.jsx
+++ b/src/applications/personalization/dashboard-2/components/claims-and-appeals/ClaimsAndAppeals.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import BlueAlert from '../BlueAlert';
+import MiniInfoBox from '../MiniInfoBox';
 
 const ClaimsAndAppeals = () => {
   return (
     <>
       <h2>Claims & appeals</h2>
-      <BlueAlert>
+      <MiniInfoBox>
         This is an example <strong>blue alert</strong>
-      </BlueAlert>
+      </MiniInfoBox>
     </>
   );
 };

--- a/src/applications/personalization/dashboard-2/components/claims-and-appeals/ClaimsAndAppeals.jsx
+++ b/src/applications/personalization/dashboard-2/components/claims-and-appeals/ClaimsAndAppeals.jsx
@@ -1,7 +1,15 @@
 import React from 'react';
+import BlueAlert from '../BlueAlert';
 
 const ClaimsAndAppeals = () => {
-  return <h2>Claims & appeals</h2>;
+  return (
+    <>
+      <h2>Claims & appeals</h2>
+      <BlueAlert>
+        This is an example <strong>blue alert</strong>
+      </BlueAlert>
+    </>
+  );
 };
 
 export default ClaimsAndAppeals;


### PR DESCRIPTION
## Description
This PR adds a reusable component for the blue alerts on the dashboard. It also updates the padding of the dashboard to only set the x-padding to 0 when the user is on a medium screen on higher.

## Testing done
Looks good locally.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/106173185-e5772200-6150-11eb-8570-f308185f9c81.png)

![image](https://user-images.githubusercontent.com/14869324/106173217-f031b700-6150-11eb-954b-461db35d087a.png)

## Acceptance criteria
- [x] Create wrapper for blue alert

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
