### PR TITLE
Adjust icon for COVID-19 vaccines

### DIFF
--- a/src/applications/facility-locator/components/search-results-items/common/Covid19Alert.jsx
+++ b/src/applications/facility-locator/components/search-results-items/common/Covid19Alert.jsx
@@ -9,7 +9,7 @@ const Covid19Alert = () => {
       <i
         aria-hidden="true"
         role="img"
-        className={`fa fa-exclamation-circle vads-u-margin-top--1 icon-base`}
+        className={`fa fa-info-circle vads-u-margin-top--1 icon-base`}
       />
       <span className="sr-only">Alert: </span>
       <div className="usa-alert-body">


### PR DESCRIPTION
## Description
issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/19063

## Testing done


## Screenshots
<img width="851" alt="Screen Shot 2021-01-28 at 2 15 41 PM" src="https://user-images.githubusercontent.com/100468/106193590-52031880-6173-11eb-8a19-ddd7d4864d82.png">


## Acceptance criteria
- [x] Replace alert icon (!) with info icon (i) for COVID-19 vaccines 

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
