### PR TITLE
Add zoom levels to voiceover when facility locator map is zoomed in/out

### DIFF
--- a/src/applications/facility-locator/containers/FacilitiesMap.jsx
+++ b/src/applications/facility-locator/containers/FacilitiesMap.jsx
@@ -276,11 +276,11 @@ const FacilitiesMap = props => {
         screenreaderZoomElement.innerText.length === 0
       ) {
         if (lastZoom < currentZoom) {
-          screenreaderZoomElement.innerText = 'zooming in';
+          screenreaderZoomElement.innerText = `zooming in, level ${currentZoom}`;
         }
 
         if (lastZoom > currentZoom) {
-          screenreaderZoomElement.innerText = 'zooming out';
+          screenreaderZoomElement.innerText = `zooming out, level ${currentZoom}`;
         }
       }
     }


### PR DESCRIPTION
## Description
Fix for zoom out not being read consistently.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/17963

## Acceptance criteria
- [x] Zoom announcement is read every time the zoom level changes

