### PR TITLE
Sanlouise add profile dashboard header

### DIFF
--- a/src/applications/personalization/dashboard-2/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard-2/components/Dashboard.jsx
@@ -11,6 +11,8 @@ import {
   fetchPersonalInformation as fetchPersonalInformationAction,
 } from '@@profile/actions';
 
+import { fetchTotalDisabilityRating as fetchTotalDisabilityRatingAction } from 'applications/personalization/rated-disabilities/actions';
+
 import ProfileHeader from 'applications/personalization/profile/components/ProfileHeader';
 
 import ApplyForBenefits from './apply-for-benefits/ApplyForBenefits';
@@ -22,14 +24,18 @@ const Dashboard = props => {
     props.fetchFullName();
     props.fetchPersonalInformation();
     props.fetchMilitaryInformation();
+    props.fetchTotalDisabilityRating();
     focusElement('#dashboard-title');
-  });
-
-  console.log('This is props', props);
+  }, []);
 
   return (
     <>
-      {isEmpty(props.hero?.errors) && <ProfileHeader />}
+      {isEmpty(props.hero?.errors) && (
+        <ProfileHeader
+          showUpdatedHeader
+          totalDisabilityRating={props.totalDisabilityRating}
+        />
+      )}
       <div className="vads-l-grid-container vads-u-padding-x--0">
         <Breadcrumbs>
           <a href="/" key="home">
@@ -55,6 +61,7 @@ const Dashboard = props => {
 const mapStateToProps = state => {
   return {
     hero: state.vaProfile?.hero,
+    totalDisabilityRating: state.totalRating?.totalDisabilityRating,
   };
 };
 
@@ -62,6 +69,7 @@ const mapDispatchToProps = {
   fetchFullName: fetchHeroAction,
   fetchMilitaryInformation: fetchMilitaryInformationAction,
   fetchPersonalInformation: fetchPersonalInformationAction,
+  fetchTotalDisabilityRating: fetchTotalDisabilityRatingAction,
 };
 
 export default connect(

--- a/src/applications/personalization/dashboard-2/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard-2/components/Dashboard.jsx
@@ -1,38 +1,70 @@
 import React, { useEffect } from 'react';
+import { connect } from 'react-redux';
+import isEmpty from 'lodash/isEmpty';
 
 import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
-
 import { focusElement } from '~/platform/utilities/ui';
+
+import {
+  fetchMilitaryInformation as fetchMilitaryInformationAction,
+  fetchHero as fetchHeroAction,
+  fetchPersonalInformation as fetchPersonalInformationAction,
+} from '@@profile/actions';
+
+import ProfileHeader from 'applications/personalization/profile/components/ProfileHeader';
 
 import ApplyForBenefits from './apply-for-benefits/ApplyForBenefits';
 import ClaimsAndAppeals from './claims-and-appeals/ClaimsAndAppeals';
 import HealthCare from './health-care/HealthCare';
 
-const Dashboard = () => {
+const Dashboard = props => {
   useEffect(() => {
+    props.fetchFullName();
+    props.fetchPersonalInformation();
+    props.fetchMilitaryInformation();
     focusElement('#dashboard-title');
   });
 
+  console.log('This is props', props);
+
   return (
-    <div className="vads-l-grid-container vads-u-padding-x--0">
-      <Breadcrumbs>
-        <a href="/" key="home">
-          Home
-        </a>
-        <span className="vads-u-color--black" key="dashboard">
-          <strong>My VA</strong>
-        </span>
-      </Breadcrumbs>
+    <>
+      {isEmpty(props.hero?.errors) && <ProfileHeader />}
+      <div className="vads-l-grid-container vads-u-padding-x--0">
+        <Breadcrumbs>
+          <a href="/" key="home">
+            Home
+          </a>
+          <span className="vads-u-color--black" key="dashboard">
+            <strong>My VA</strong>
+          </span>
+        </Breadcrumbs>
 
-      <h1 id="dashboard-title" data-testid="dashboard-title" tabIndex="-1">
-        My VA
-      </h1>
+        <h1 id="dashboard-title" data-testid="dashboard-title" tabIndex="-1">
+          My VA
+        </h1>
 
-      <ClaimsAndAppeals />
-      <HealthCare />
-      <ApplyForBenefits />
-    </div>
+        <ClaimsAndAppeals />
+        <HealthCare />
+        <ApplyForBenefits />
+      </div>
+    </>
   );
 };
 
-export default Dashboard;
+const mapStateToProps = state => {
+  return {
+    hero: state.vaProfile?.hero,
+  };
+};
+
+const mapDispatchToProps = {
+  fetchFullName: fetchHeroAction,
+  fetchMilitaryInformation: fetchMilitaryInformationAction,
+  fetchPersonalInformation: fetchPersonalInformationAction,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(Dashboard);

--- a/src/applications/personalization/dashboard/reducers/index.js
+++ b/src/applications/personalization/dashboard/reducers/index.js
@@ -7,6 +7,8 @@ import preferences from '../../preferences/reducers';
 import appointments from '../../appointments/reducers';
 import profile from '@@profile/reducers';
 
+import ratedDisabilities from '~/applications/personalization/rated-disabilities/reducers';
+
 import { combineReducers } from 'redux';
 
 export default {
@@ -14,6 +16,7 @@ export default {
   preferences,
   appointments,
   ...profile,
+  ...ratedDisabilities,
   hcaEnrollmentStatus,
   health: combineReducers({
     rx: combineReducers({

--- a/src/applications/personalization/dashboard/reducers/index.js
+++ b/src/applications/personalization/dashboard/reducers/index.js
@@ -5,6 +5,7 @@ import recipients from './recipients';
 import folders from './folders';
 import preferences from '../../preferences/reducers';
 import appointments from '../../appointments/reducers';
+import profile from '@@profile/reducers';
 
 import { combineReducers } from 'redux';
 
@@ -12,6 +13,7 @@ export default {
   ...claimsAppeals,
   preferences,
   appointments,
+  ...profile,
   hcaEnrollmentStatus,
   health: combineReducers({
     rx: combineReducers({

--- a/src/applications/personalization/profile/components/ProfileHeader.jsx
+++ b/src/applications/personalization/profile/components/ProfileHeader.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import orderBy from 'lodash/orderBy';
@@ -8,17 +8,12 @@ import prefixUtilityClasses from 'platform/utilities/prefix-utility-classes';
 import { SERVICE_BADGE_IMAGE_PATHS } from '../constants';
 import { getServiceBranchDisplayName } from '../helpers';
 
-import {
-  fetchRatedDisabilities,
-  fetchTotalDisabilityRating,
-} from 'applications/personalization/rated-disabilities/actions';
-
 const ProfileHeader = ({
   userFullName: { first, middle, last, suffix },
   latestBranchOfService,
   showBadgeImage,
   totalDisabilityRating,
-  fetchTotalDisabilityRating,
+  showUpdatedHeader,
 }) => {
   const fullName = [first, middle, last, suffix]
     .filter(name => !!name)
@@ -30,6 +25,13 @@ const ProfileHeader = ({
     'margin-bottom--0',
     'padding-y--2',
   ]);
+
+  const updatedWrapperClasses = prefixUtilityClasses([
+    'background-color--primary',
+    'margin-bottom--0',
+    'padding-y--2',
+  ]);
+
   const wrapperClassesMedium = prefixUtilityClasses(
     ['padding-y--2p5', 'margin-bottom--2'],
     'medium',
@@ -91,8 +93,12 @@ const ProfileHeader = ({
     'medium',
   );
 
+  const wrapperClassDerived = showUpdatedHeader
+    ? updatedWrapperClasses
+    : wrapperClasses;
+
   const classes = {
-    wrapper: [...wrapperClasses, ...wrapperClassesMedium].join(' '),
+    wrapper: [...wrapperClassDerived, ...wrapperClassesMedium].join(' '),
     innerWrapper: [
       ...innerWrapperClasses,
       ...innerWrapperClassesMedium,
@@ -109,12 +115,6 @@ const ProfileHeader = ({
     ),
   };
 
-  useEffect(() => {
-    fetchTotalDisabilityRating();
-  });
-
-  console.log('These are props in header', totalDisabilityRating);
-
   return (
     <div className={classes.wrapper} data-testid="profile-header">
       <div className={classes.innerWrapper}>
@@ -123,11 +123,12 @@ const ProfileHeader = ({
             <img
               src={SERVICE_BADGE_IMAGE_PATHS.get(latestBranchOfService)}
               alt={`${latestBranchOfService} seal`}
-              className="profile-service-badge vads-u-padding-right--3"
+              className="vads-u-padding-right--3"
+              style={{ maxHeight: '75px' }}
             />
           )}
         </div>
-        <div className="name-and-title-wrapper">
+        <div>
           <dl className="vads-u-margin-y--0">
             <dt className="sr-only">Name: </dt>
             <dd className={classes.fullName}>{fullName}</dd>
@@ -137,6 +138,26 @@ const ProfileHeader = ({
                 {getServiceBranchDisplayName(latestBranchOfService)}
               </dd>
             )}
+            {showUpdatedHeader &&
+              totalDisabilityRating && (
+                <>
+                  <dt className="sr-only">total disability rating</dt>
+                  <dd className="vads-u-margin-top--0p5">
+                    <a
+                      href="/disability/view-disability-rating/rating"
+                      aria-label="view your disability rating"
+                      className="vads-u-color--white vads-u-font-size--md font-weight--bold"
+                    >
+                      {totalDisabilityRating}% Service connected{' '}
+                      <i
+                        className={`fa fa-angle-double-right`}
+                        aria-hidden="true"
+                        role="img"
+                      />
+                    </a>
+                  </dd>
+                </>
+              )}
           </dl>
         </div>
       </div>
@@ -153,15 +174,9 @@ const mapStateToProps = state => {
 
   return {
     userFullName: state.vaProfile?.hero?.userFullName,
-    totalDisabilityRating: state.totalRating?.totalDisabilityRating,
     latestBranchOfService,
     showBadgeImage: SERVICE_BADGE_IMAGE_PATHS.has(latestBranchOfService),
   };
-};
-
-const mapDispatchToProps = {
-  fetchRatedDisabilities,
-  fetchTotalDisabilityRating,
 };
 
 ProfileHeader.defaultProps = {
@@ -185,7 +200,4 @@ ProfileHeader.propTypes = {
   latestBranchOfService: PropTypes.string.isRequired,
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(ProfileHeader);
+export default connect(mapStateToProps)(ProfileHeader);

--- a/src/applications/personalization/profile/components/ProfileHeader.jsx
+++ b/src/applications/personalization/profile/components/ProfileHeader.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import orderBy from 'lodash/orderBy';
@@ -8,10 +8,17 @@ import prefixUtilityClasses from 'platform/utilities/prefix-utility-classes';
 import { SERVICE_BADGE_IMAGE_PATHS } from '../constants';
 import { getServiceBranchDisplayName } from '../helpers';
 
+import {
+  fetchRatedDisabilities,
+  fetchTotalDisabilityRating,
+} from 'applications/personalization/rated-disabilities/actions';
+
 const ProfileHeader = ({
   userFullName: { first, middle, last, suffix },
   latestBranchOfService,
   showBadgeImage,
+  totalDisabilityRating,
+  fetchTotalDisabilityRating,
 }) => {
   const fullName = [first, middle, last, suffix]
     .filter(name => !!name)
@@ -102,6 +109,12 @@ const ProfileHeader = ({
     ),
   };
 
+  useEffect(() => {
+    fetchTotalDisabilityRating();
+  });
+
+  console.log('These are props in header', totalDisabilityRating);
+
   return (
     <div className={classes.wrapper} data-testid="profile-header">
       <div className={classes.innerWrapper}>
@@ -140,9 +153,15 @@ const mapStateToProps = state => {
 
   return {
     userFullName: state.vaProfile?.hero?.userFullName,
+    totalDisabilityRating: state.totalRating?.totalDisabilityRating,
     latestBranchOfService,
     showBadgeImage: SERVICE_BADGE_IMAGE_PATHS.has(latestBranchOfService),
   };
+};
+
+const mapDispatchToProps = {
+  fetchRatedDisabilities,
+  fetchTotalDisabilityRating,
 };
 
 ProfileHeader.defaultProps = {
@@ -166,4 +185,7 @@ ProfileHeader.propTypes = {
   latestBranchOfService: PropTypes.string.isRequired,
 };
 
-export default connect(mapStateToProps)(ProfileHeader);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ProfileHeader);

--- a/src/applications/personalization/profile/sass/profile.scss
+++ b/src/applications/personalization/profile/sass/profile.scss
@@ -7,10 +7,6 @@
 @import "./connected-apps";
 @import "./personal-contact-information";
 
-.profile-service-badge {
-  max-height: 75px;
-}
-
 [tabindex="-1"]:focus {
   outline: 0;
 }

--- a/src/applications/personalization/profile/tests/components/ProfileHeader.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/ProfileHeader.unit.spec.jsx
@@ -73,4 +73,29 @@ describe('<ProfileHeader>', () => {
     expect(component.find('img').first()).to.not.be.undefined;
     component.unmount();
   });
+
+  it('should render disability rating when the dashboardShowDashboard2 feature flag is turned on and the user has a disability rating', () => {
+    const component = mount(
+      <ProfileHeader
+        showUpdatedHeader
+        totalDisabilityRating="70"
+        store={fakeStore}
+      />,
+    );
+    expect(
+      component
+        .find('dd')
+        .at(2)
+        .text(),
+    ).to.contain('70% Service connected');
+    component.unmount();
+  });
+
+  it('should not render disability rating when the dashboardShowDashboard2 feature flag is turned on and the user has no disability rating', () => {
+    const component = mount(
+      <ProfileHeader showUpdatedHeader store={fakeStore} />,
+    );
+    expect(component.text()).to.not.contain('Service connected');
+    component.unmount();
+  });
 });


### PR DESCRIPTION
## Description
This PR adds the nametag to the Dashboard. Although we want parity with the nametag in the profile, this PR does not accomplish that - we need a follow up ticket that will ensure they are identical behind the dashboard v2 feature flag.

Designs for the header can be found [here](https://github.com/department-of-veterans-affairs/va.gov-team/issues/18469#issuecomment-764714966).

Wording/aria-label for the` x% service connected` link is TBD.

## Testing done
Works well locally. You can test with user +228.
Added relevant tests.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/106632841-6c564100-653b-11eb-96e4-17875a73b013.png)

** Profile remains identical to current implementation**
![image](https://user-images.githubusercontent.com/14869324/106638799-7d09b580-6541-11eb-8db3-79d1cd97fc8e.png)



## Acceptance criteria
- [x] Ensure we display a name tag header on the dashboard that includes a disability rating.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
