### PR TITLE
[Development] Add HLR wizard Cypress tests

### DIFF
--- a/src/applications/disability-benefits/996/tests/hlr-wizard.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr-wizard.cypress.spec.js
@@ -27,6 +27,10 @@ Cypress.Commands.add('checkFormAlert', value => {
   });
 });
 
+const checkOpt = {
+  waitForAnimations: true,
+};
+
 describe('HLR wizard', () => {
   beforeEach(() => {
     window.dataLayer = [];
@@ -44,7 +48,7 @@ describe('HLR wizard', () => {
   });
   // other claims flow
   it('should show other claims', () => {
-    cy.get('[type="radio"][value="other"]').click();
+    cy.get('[type="radio"][value="other"]').check(checkOpt);
     cy.checkStorage(SAVED_CLAIM_TYPE, undefined);
     // #8622 set by public websites accordion anchor ID
     cy.get('a[href*="/decision-reviews/higher-level-review/#8622"]').should(
@@ -60,14 +64,14 @@ describe('HLR wizard', () => {
 
   // legacy appeals flow
   it('should show legacy appeals question & alert', () => {
-    cy.get('[type="radio"][value="compensation"]').click();
+    cy.get('[type="radio"][value="compensation"]').check(checkOpt);
     cy.get('a[href*="disability/file-an-appeal"]').should('exist');
     cy.checkFormChange({
       label: 'For what type of claim are you requesting a Higher-Level Review?',
       value: 'compensation',
     });
 
-    cy.get('[type="radio"][value="legacy-yes"]').click();
+    cy.get('[type="radio"][value="legacy-yes"]').check(checkOpt);
     // download form link
     cy.get('a[href*="www.vba.va.gov/pubs/forms/VBA-20-0996-ARE.pdf"]').should(
       'exist',
@@ -89,7 +93,7 @@ describe('HLR wizard', () => {
     cy.focused().should('have.attr', 'id', 'va-breadcrumbs-list');
     cy.get('h1').should('have.text', h1Text);
 
-    cy.get('[type="radio"][value="compensation"]').click();
+    cy.get('[type="radio"][value="compensation"]').check(checkOpt);
     cy.checkStorage(SAVED_CLAIM_TYPE, 'compensation');
     cy.checkFormChange({
       label: 'For what type of claim are you requesting a Higher-Level Review?',
@@ -97,7 +101,7 @@ describe('HLR wizard', () => {
     });
 
     cy.get('a[href*="disability/file-an-appeal"]').should('exist');
-    cy.get('[type="radio"][value="legacy-no"]').click();
+    cy.get('[type="radio"][value="legacy-no"]').check(checkOpt);
     // learn more link
     cy.get('a[href*="/decision-reviews/higher-level-review/"]').should('exist');
     cy.checkFormChange({

--- a/src/applications/disability-benefits/996/tests/hlr-wizard.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr-wizard.cypress.spec.js
@@ -1,5 +1,11 @@
 import mockFeatureToggles from './fixtures/mocks/feature-toggles.json';
-import { BASE_URL, WIZARD_STATUS } from '../constants';
+import { BASE_URL, WIZARD_STATUS, SAVED_CLAIM_TYPE } from '../constants';
+
+Cypress.Commands.add('checkStorage', (key, expectedValue) => {
+  cy.window()
+    .its(`sessionStorage.${key}`)
+    .should('eq', expectedValue);
+});
 
 describe('HLR wizard', () => {
   beforeEach(() => {
@@ -18,11 +24,12 @@ describe('HLR wizard', () => {
   // other claims flow
   it('should show other claims', () => {
     cy.get('[type="radio"][value="other"]').click();
-    cy.axeCheck();
+    cy.checkStorage(SAVED_CLAIM_TYPE, undefined);
     // #8622 set by public websites accordion anchor ID
     cy.get('a[href*="/decision-reviews/higher-level-review/#8622"]').should(
       'exist',
     );
+    cy.axeCheck();
   });
 
   // legacy appeals flow
@@ -48,6 +55,7 @@ describe('HLR wizard', () => {
     cy.get('h1').should('have.text', h1Text);
 
     cy.get('[type="radio"][value="compensation"]').click();
+    cy.checkStorage(SAVED_CLAIM_TYPE, 'compensation');
     cy.get('a[href*="disability/file-an-appeal"]').should('exist');
     cy.get('[type="radio"][value="legacy-no"]').click();
     // learn more link
@@ -62,9 +70,7 @@ describe('HLR wizard', () => {
     // title changes & gets focus
     cy.get('h1').should('have.text', h1Text + h1Addition);
     cy.focused().should('have.text', h1Text + h1Addition);
-    cy.window()
-      .its(`sessionStorage.${WIZARD_STATUS}`)
-      .should('eq', 'complete');
+    cy.checkStorage(WIZARD_STATUS, 'complete');
     cy.axeCheck();
   });
 });

--- a/src/applications/disability-benefits/996/tests/hlr-wizard.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr-wizard.cypress.spec.js
@@ -1,0 +1,70 @@
+import mockFeatureToggles from './fixtures/mocks/feature-toggles.json';
+import { BASE_URL, WIZARD_STATUS } from '../constants';
+
+describe('HLR wizard', () => {
+  beforeEach(() => {
+    cy.route('GET', '/v0/feature_toggles?*', mockFeatureToggles);
+    sessionStorage.removeItem(WIZARD_STATUS);
+    cy.visit(BASE_URL);
+    cy.injectAxe();
+  });
+
+  it('should show the form wizard', () => {
+    cy.url().should('include', BASE_URL);
+    cy.axeCheck();
+    cy.get('h1').should('have.text', 'Request a Higher-Level Review');
+    cy.axeCheck();
+  });
+  // other claims flow
+  it('should show other claims', () => {
+    cy.get('[type="radio"][value="other"]').click();
+    cy.axeCheck();
+    // #8622 set by public websites accordion anchor ID
+    cy.get('a[href*="/decision-reviews/higher-level-review/#8622"]').should(
+      'exist',
+    );
+  });
+
+  // legacy appeals flow
+  it('should show legacy appeals question & alert', () => {
+    cy.get('[type="radio"][value="compensation"]').click();
+    cy.get('a[href*="disability/file-an-appeal"]').should('exist');
+
+    cy.get('[type="radio"][value="legacy-yes"]').click();
+    // download form link
+    cy.get('a[href*="www.vba.va.gov/pubs/forms/VBA-20-0996-ARE.pdf"]').should(
+      'exist',
+    );
+    // supplemental claim link
+    cy.get('a[href*="/decision-reviews/supplemental-claim"]').should('exist');
+    cy.axeCheck();
+  });
+
+  // start form flow
+  it('should show legacy appeals question & alert', () => {
+    const h1Text = 'Request a Higher-Level Review';
+    // starts with focus on breadcrumb
+    cy.focused().should('have.attr', 'id', 'va-breadcrumbs-list');
+    cy.get('h1').should('have.text', h1Text);
+
+    cy.get('[type="radio"][value="compensation"]').click();
+    cy.get('a[href*="disability/file-an-appeal"]').should('exist');
+    cy.get('[type="radio"][value="legacy-no"]').click();
+    // learn more link
+    cy.get('a[href*="/decision-reviews/higher-level-review/"]').should('exist');
+    cy.axeCheck();
+
+    // start form
+    const h1Addition = ' with VA Form 20-0996';
+    cy.findAllByText(/higher-level review online/i, { selector: 'button' })
+      .first()
+      .click();
+    // title changes & gets focus
+    cy.get('h1').should('have.text', h1Text + h1Addition);
+    cy.focused().should('have.text', h1Text + h1Addition);
+    cy.window()
+      .its(`sessionStorage.${WIZARD_STATUS}`)
+      .should('eq', 'complete');
+    cy.axeCheck();
+  });
+});


### PR DESCRIPTION
## Description

The Higher-Level Review form needs wizard-specific e2e tests. This new test:

- Check all wizard flows and endpoints
- Runs axe accessibility tests at each endpoint
- Verifies focus start & end management (breadcrumbs at start, `H1` after completing)
- Checks `sessionStorage` values set in the wizard - claim type is eventually added to form data 

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/16517

## Testing done

Cypress e2e test

## Screenshots

N/A

## Acceptance criteria
- [x] HLR wizard includes extensive e2e tests

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
