### PR TITLE
Removed prod flag

### DIFF
--- a/src/applications/gi/components/profile/ContactInformation.jsx
+++ b/src/applications/gi/components/profile/ContactInformation.jsx
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 
 import { ScoContact } from './ScoContact';
 import { phoneInfo } from '../../utils/helpers';
-import environment from 'platform/utilities/environment';
 
 export const ContactInformation = ({ institution }) => {
   const firstProgram = _.get(institution, 'programs[0]', {});
@@ -17,10 +16,6 @@ export const ContactInformation = ({ institution }) => {
 
   const primarySCOs = versionedSchoolCertifyingOfficials.filter(
     SCO => SCO.priority.toUpperCase() === 'PRIMARY',
-  );
-
-  const secondarySCOs = versionedSchoolCertifyingOfficials.filter(
-    SCO => SCO.priority.toUpperCase() === 'SECONDARY',
   );
 
   const renderPhysicalAddress = () =>
@@ -147,39 +142,11 @@ export const ContactInformation = ({ institution }) => {
       </div>
     );
 
-  const renderSecondarySCOs = () =>
-    secondarySCOs.length > 0 && (
-      <div className="vads-l-row vads-u-margin-y--2">
-        <div className="vads-l-col--12 medium-screen:vads-l-col--3">
-          <h4
-            id="secondary-contact-header"
-            className="contact-heading vads-u-font-family--sans vads-u-margin--0"
-          >
-            Secondary
-          </h4>
-        </div>
-        <div className="vads-l-col--9">
-          <div className="vads-l-grid-container--full">
-            <ul
-              className="vads-l-row sco-list vads-u-margin--0 secondary-sco-list"
-              aria-labelledby="secondary-contact-header"
-            >
-              {secondarySCOs.map((sco, index) => ScoContact(sco, index))}
-            </ul>
-          </div>
-        </div>
-      </div>
-    );
-
   const renderSCOContactInfoSection = () =>
     versionedSchoolCertifyingOfficials.length > 0 && (
       <div>
         {renderSCOHeader()}
         {renderPrimarySCOs()}
-        {environment.isProduction() &&
-          primarySCOs.length > 0 &&
-          secondarySCOs.length > 0 && <hr />}
-        {environment.isProduction() && renderSecondarySCOs()}
       </div>
     );
 


### PR DESCRIPTION
## Description
Removed prod flag that was displaying secondary SCOs on prod. Secondary SCOs are now not displayed on the CT profile page for any environment.

## Testing done
Tested locally and QA reviewed

## Screenshots
![image](https://user-images.githubusercontent.com/41960449/106474513-fededd80-6472-11eb-94fb-a4e3c77ec31c.png)

## Acceptance criteria
- [x] The prod flag created in #18307 is removed and the functionality implemented in that story is available in production.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
