### PR TITLE
Comment out fieldContentBlock to avoid transformer validation errors

### DIFF
--- a/src/site/stages/build/process-cms-exports/schemas/output/node-support_resources_detail_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-support_resources_detail_page.js
@@ -15,22 +15,22 @@ module.exports = {
     },
     fieldButtonsRepeat: { type: 'boolean' },
     fieldContactInformation: { $ref: 'output/paragraph-contact_information' },
-    fieldContentBlock: {
-      oneOf: [
-        { $ref: 'output/paragraph-alert' },
-        { $ref: 'output/paragraph-collapsible_panel' },
-        { $ref: 'output/paragraph-downloadable_file' },
-        { $ref: 'output/paragraph-list_of_link_teasers' },
-        { $ref: 'output/paragraph-media' },
-        { $ref: 'output/paragraph-number_callout' },
-        { $ref: 'output/paragraph-process' },
-        { $ref: 'output/paragraph-q_a' },
-        { $ref: 'output/paragraph-q_a_section' },
-        { $ref: 'output/paragraph-react_widget' },
-        { $ref: 'output/paragraph-table' },
-        { $ref: 'output/paragraph-wysiwyg' },
-      ],
-    },
+    // fieldContentBlock: {
+    //   oneOf: [
+    //     { $ref: 'output/paragraph-alert' },
+    //     { $ref: 'output/paragraph-collapsible_panel' },
+    //     { $ref: 'output/paragraph-downloadable_file' },
+    //     { $ref: 'output/paragraph-list_of_link_teasers' },
+    //     { $ref: 'output/paragraph-media' },
+    //     { $ref: 'output/paragraph-number_callout' },
+    //     { $ref: 'output/paragraph-process' },
+    //     { $ref: 'output/paragraph-q_a' },
+    //     { $ref: 'output/paragraph-q_a_section' },
+    //     { $ref: 'output/paragraph-react_widget' },
+    //     { $ref: 'output/paragraph-table' },
+    //     { $ref: 'output/paragraph-wysiwyg' },
+    //   ],
+    // },
     fieldIntroTextLimitedHtml: {
       type: ['object', 'null'],
       properties: {
@@ -67,7 +67,7 @@ module.exports = {
     'entityMetatags',
     'entityPublished',
     'entityType',
-    'fieldContentBlock',
+    // 'fieldContentBlock',
     'fieldIntroTextLimitedHtml',
   ],
 };


### PR DESCRIPTION
The cms-export builds were failing due to validation errors in fieldContentBlock in support_resources_detail_page.

Commenting out the field in the output schema to unblock the team.