### PR TITLE
Fix years on outreach and events pages

### DIFF
--- a/src/site/includes/date.drupal.liquid
+++ b/src/site/includes/date.drupal.liquid
@@ -6,7 +6,7 @@
 {% endif %}
 
 {% if fieldDatetimeRangeTimezone.value != empty %}
-    {% assign start_date_no_time = fieldDatetimeRangeTimezone.value | dateFromUnix: 'dddd, MMM, YYYY', fieldDatetimeRangeTimezone.timezone %}
+    {% assign start_date_no_time = fieldDatetimeRangeTimezone.value | dateFromUnix: 'dddd, MMM D, YYYY', fieldDatetimeRangeTimezone.timezone %}
     {% assign start_time = fieldDatetimeRangeTimezone.value | dateFromUnix: "h:mm A", fieldDatetimeRangeTimezone.timezone %}
     {% assign start_date_full = fieldDatetimeRangeTimezone.value | dateFromUnix: "dddd, MMM D, YYYY h:mm A", fieldDatetimeRangeTimezone.timezone %}
     {% assign start_timestamp = fieldDatetimeRangeTimezone.value %}

--- a/src/site/includes/date.drupal.liquid
+++ b/src/site/includes/date.drupal.liquid
@@ -6,25 +6,25 @@
 {% endif %}
 
 {% if fieldDatetimeRangeTimezone.value != empty %}
-    {% assign start_date_no_time = fieldDatetimeRangeTimezone.value | dateFromUnix: 'dddd, MMM D', fieldDatetimeRangeTimezone.timezone %}
+    {% assign start_date_no_time = fieldDatetimeRangeTimezone.value | dateFromUnix: 'dddd, MMM, YYYY', fieldDatetimeRangeTimezone.timezone %}
     {% assign start_time = fieldDatetimeRangeTimezone.value | dateFromUnix: "h:mm A", fieldDatetimeRangeTimezone.timezone %}
-    {% assign start_date_full = fieldDatetimeRangeTimezone.value | dateFromUnix: "dddd, MMM D, h:mm A", fieldDatetimeRangeTimezone.timezone %}
+    {% assign start_date_full = fieldDatetimeRangeTimezone.value | dateFromUnix: "dddd, MMM D, YYYY h:mm A", fieldDatetimeRangeTimezone.timezone %}
     {% assign start_timestamp = fieldDatetimeRangeTimezone.value %}
 {% else %}
-    {% assign start_date_no_time = fieldDate.startDate | timeZone: defaultTZ, "dddd, MMM D" %}
+    {% assign start_date_no_time = fieldDate.startDate | timeZone: defaultTZ, "dddd, MMM YYYY" %}
     {% assign start_time = fieldDate.startDate | timeZone: defaultTZ, "h:mm A" %}
-    {% assign start_date_full = fieldDate.startDate | timeZone: defaultTZ, "dddd, MMM D, h:mm A" %}
+    {% assign start_date_full = fieldDate.startDate | timeZone: defaultTZ, "dddd, MMM D, YYYY h:mm A" %}
     {% assign start_timestamp = fieldDate.value | unixFromDate %}
 {% endif %}
 
 {% if fieldDatetimeRangeTimezone.endValue != empty %}
-    {% assign end_date_no_time = fieldDatetimeRangeTimezone.endValue | dateFromUnix: 'dddd, MMM D', fieldDatetimeRangeTimezone.timezone %}
+    {% assign end_date_no_time = fieldDatetimeRangeTimezone.endValue | dateFromUnix: 'dddd, MMM D, YYYY', fieldDatetimeRangeTimezone.timezone %}
     {% assign end_time = fieldDatetimeRangeTimezone.endValue | dateFromUnix: "h:mm A", fieldDatetimeRangeTimezone.timezone %}
     {% assign end_date_full = fieldDatetimeRangeTimezone.endValue | dateFromUnix: "dddd, MMM D, h:mm A", fieldDatetimeRangeTimezone.timezone %}
 {% else %}
-    {% assign end_date_no_time = fieldDate.endValue | timeZone: defaultTZ, "dddd, MMM D" %}
+    {% assign end_date_no_time = fieldDate.endValue | timeZone: defaultTZ, "dddd, MMM D, YYYY" %}
     {% assign end_time = fieldDate.endDate | timeZone: defaultTZ, "h:mm A" %}
-    {% assign end_date_full = fieldDate.endDate | timeZone: defaultTZ, "dddd, MMM D, h:mm A" %}
+    {% assign end_date_full = fieldDate.endDate | timeZone: defaultTZ, "dddd, MMM D, YYYY h:mm A" %}
 {% endif %}
 
 {% assign current_timestamp = ''| currentTimeInSeconds %}


### PR DESCRIPTION

## Description

Issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/15917

## Testing done


## Screenshots

<img width="1025" alt="Screen Shot 2021-02-01 at 3 07 17 PM" src="https://user-images.githubusercontent.com/100468/106518226-2f3c7100-649f-11eb-9609-a97bd223b984.png">

## Acceptance criteria
- [x] Dates appearing on outreach and events page are spelled out, using the full construction: March 31, 1989 (including days of the week, when provided), unless space is limited. Abbreviation (Nov) is acceptable in this case. 

## Definition of done

- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
