### PR TITLE
Record error when we cannot create a VA Profile transaction

### DIFF
--- a/src/platform/user/profile/vap-svc/actions/transactions.js
+++ b/src/platform/user/profile/vap-svc/actions/transactions.js
@@ -203,6 +203,16 @@ export function createTransaction(
         transaction,
       });
     } catch (error) {
+      const profileSection = analyticsSectionName || 'unknown-profile-section';
+      recordEvent({
+        event: 'profile-edit-failure',
+        'profile-action': 'save-failure',
+        'profile-section': profileSection,
+        'error-key': `transaction-creation-error-${profileSection}-save-failure`,
+      });
+      recordEvent({
+        'error-key': undefined,
+      });
       dispatch({
         type: VAP_SERVICE_TRANSACTION_REQUEST_FAILED,
         error,


### PR DESCRIPTION
## Description
We want to record errors to GA when we cannot create a VA Profile transaction. The errors should be similar to [the errors we record when a pending transaction has failed](https://github.com/department-of-veterans-affairs/vets-website/blob/982dee29c4b2023efcf9f179812f286e01196162/src/platform/user/profile/vap-svc/actions/transactions.js#L136-L144). 

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs