### PR TITLE
Provider selection focus handling and explanation updates

### DIFF
--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
@@ -75,9 +75,11 @@ function ProviderSelectionField({
   useEffect(
     () => {
       if (showProvidersList) {
-        scrollAndFocus('h2');
-      } else if (mounted) {
+        scrollAndFocus('#providerSelectionHeader');
+      } else if (mounted && !providerSelected) {
         scrollAndFocus('.va-button-link');
+      } else if (mounted) {
+        scrollAndFocus('#selectedProvider');
       }
     },
     [showProvidersList],
@@ -108,6 +110,17 @@ function ProviderSelectionField({
     [providersListLength],
   );
 
+  useEffect(
+    () => {
+      if (showProvidersList && (loadingProviders || loadingLocations)) {
+        scrollAndFocus('.loading-indicator');
+      } else if (showProvidersList && !loadingProviders && !loadingLocations) {
+        scrollAndFocus('#providerSelectionHeader');
+      }
+    },
+    [loadingProviders, loadingLocations],
+  );
+
   return (
     <div className="vads-u-background-color--gray-lightest vads-u-padding--2 medium-screen:vads-u-padding--3">
       {!showProvidersList &&
@@ -115,6 +128,7 @@ function ProviderSelectionField({
           <button
             className="va-button-link"
             type="button"
+            aria-describedby="providerSelectionDescription"
             onClick={() => {
               setShowProvidersList(true);
               recordEvent({ event: `${GA_PREFIX}-choose-provider-click` });
@@ -126,7 +140,7 @@ function ProviderSelectionField({
         )}
       {!showProvidersList &&
         providerSelected && (
-          <>
+          <section id="selectedProvider" aria-label="Selected provider">
             <span className="vads-u-display--block vads-u-font-weight--bold">
               {formData.name}
             </span>
@@ -168,11 +182,14 @@ function ProviderSelectionField({
                 Remove
               </button>
             </div>
-          </>
+          </section>
         )}
       {showProvidersList && (
         <>
-          <h2 className="vads-u-font-size--h3 vads-u-margin-top--0">
+          <h2
+            id="providerSelectionHeader"
+            className="vads-u-font-size--h3 vads-u-margin-top--0"
+          >
             Choose a provider
           </h2>
           {!loadingProviders &&
@@ -261,7 +278,12 @@ function ProviderSelectionField({
                 )}
                 {!providersListEmpty && (
                   <>
-                    <p role="status" aria-live="polite" aria-atomic="true">
+                    <p
+                      id="provider-list-status"
+                      role="status"
+                      aria-live="polite"
+                      aria-atomic="true"
+                    >
                       Displaying 1 to {currentlyShownProvidersList.length} of{' '}
                       {communityCareProviderList.length} providers
                     </p>
@@ -297,6 +319,12 @@ function ProviderSelectionField({
                               </span>
                               <span className="vads-u-display--block vads-u-font-size--sm vads-u-font-weight--bold">
                                 {provider[sortMethod]} miles
+                                <span className="sr-only">
+                                  {' '}
+                                  {sortByDistanceFromCurrentLocation
+                                    ? 'from your current location'
+                                    : 'from your home address'}
+                                </span>
                               </span>
                             </label>
                             {checked && (

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/index.jsx
@@ -33,8 +33,13 @@ const uiSchema = {
     'ui:options': {
       showFieldLabel: true,
     },
-    'ui:description':
-      'You can request a provider you’d prefer for this appointment. If they aren’t available, we’ll schedule your appointment with a provider close to your home.',
+    'ui:description': (
+      <p id="providerSelectionDescription">
+        You can request a provider you’d prefer for this appointment. If they
+        aren’t available, we’ll schedule your appointment with a provider close
+        to your home.
+      </p>
+    ),
     'ui:field': ProviderSelectionField,
   },
 };


### PR DESCRIPTION
## Description
This PR:

- Adds focus handling for the transition to and from loading states
- Adds a section region for the selected provider and focuses on that after selection
- Adds extra explanatory text after the distance value
- Associates the provider selection field description with the button, so that explanation is read out.

How to test
1. Turn on VO on OSX
2. Navigate through [new appointment flow](http://localhost:3001/health-care/schedule-view-va-appointments/appointments/new-appointment) to provider selection page
3. Using keyboard to tab/navigate through provider selection selection and removal process

## Testing done
VO testing in Chrome

## Acceptance criteria
- [ ] Screen reader interactions meeting standards

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
