### PR TITLE
[Templates] Fix for CPL FAQ accordion

### DIFF
--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -295,7 +295,7 @@
                 <li data-faq-entity-id="{{ faqParagraph.entity.entityId }}">
                   <button aria-controls="{{ faqParagraph.entity.entityBundle }}-{{ faqParagraph.entity.entityId }}" class="usa-accordion-button usa-button-unstyled" aria-expanded="false" type="button">{{ faqParagraph.entity.fieldQuestion }}</button>
                   <div id="{{ faqParagraph.entity.entityBundle }}-{{ faqParagraph.entity.entityId }}" class="usa-accordion-content" aria-hidden="true">
-                    {% assign fieldAnswer = faqParagraph.entity.fieldAnswer[0] %}
+                    {% assign fieldAnswer = faqParagraph.entity.fieldAnswer.0 %}
                     {% assign bundleComponent = "src/site/paragraphs/" | append: fieldAnswer.entity.entityBundle %}
                     {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
                     {% include {{ bundleComponentWithExtension }} with entity = fieldAnswer.entity %}

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -295,7 +295,7 @@
                 <li data-faq-entity-id="{{ faqParagraph.entity.entityId }}">
                   <button aria-controls="{{ faqParagraph.entity.entityBundle }}-{{ faqParagraph.entity.entityId }}" class="usa-accordion-button usa-button-unstyled" aria-expanded="false" type="button">{{ faqParagraph.entity.fieldQuestion }}</button>
                   <div id="{{ faqParagraph.entity.entityBundle }}-{{ faqParagraph.entity.entityId }}" class="usa-accordion-content" aria-hidden="true">
-                    {% assign fieldAnswer = faqParagraph.entity.fieldAnswer.0 %}
+                    {% assign fieldAnswer = faqParagraph.entity.fieldAnswer | first %}
                     {% assign bundleComponent = "src/site/paragraphs/" | append: fieldAnswer.entity.entityBundle %}
                     {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
                     {% include {{ bundleComponentWithExtension }} with entity = fieldAnswer.entity %}


### PR DESCRIPTION
## Description
This PR contains a fix for the Campaign Landing Page template's FAQ section

## Testing done
Tested against http://localhost:3001/preview?nodeId=15068

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/106516137-a0caee00-64a4-11eb-9500-72093a1e73a7.png)

## Acceptance criteria
- [ ] FAQs all render w/answer blocks

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
