### PR TITLE
Non-showstopper design tweaks for facility service locations

### DIFF
--- a/src/applications/facility-locator/utils/facilityHours.js
+++ b/src/applications/facility-locator/utils/facilityHours.js
@@ -5,13 +5,13 @@ import { forIn, upperFirst } from 'lodash';
 export const buildHours = (hours, shortDay = false) => {
   const builtHours = [];
   const shortDays = {
-    Monday: 'Mon',
-    Tuesday: 'Tue',
-    Wednesday: 'Wed',
-    Thursday: 'Thu',
-    Friday: 'Fri',
-    Saturday: 'Sat',
-    Sunday: 'Sun',
+    Monday: 'Mon.',
+    Tuesday: 'Tue.',
+    Wednesday: 'Wed.',
+    Thursday: 'Thu.',
+    Friday: 'Fri.',
+    Saturday: 'Sat.',
+    Sunday: 'Sun.',
   };
 
   forIn(hours, (value, key) => {

--- a/src/site/facilities/service_address.drupal.liquid
+++ b/src/site/facilities/service_address.drupal.liquid
@@ -54,26 +54,4 @@
       {{ single.fieldServiceLocationAddress.entity.fieldWingFloorOrRoomNumber }}
     </span>
   {% endif %}
-
-  {% if address.fieldAddress.locality and useParent == false %}
-    <span class="vads-u-margin-bottom--0">
-      {{ address.fieldAddress.locality }}{% if address.fieldAddress.administrativeArea %},
-        {{ address.fieldAddress.administrativeArea }}
-      {% endif %}
-
-      {% if address.fieldAddress.postalCode %}
-        &nbsp;{{ address.fieldAddress.postalCode }}
-      {% endif %}
-    </span>
-  {% else %}
-    <span class="vads-u-margin-bottom--0">
-      {{ fieldAddress.locality }}{% if fieldAddress.administrativeArea %},
-        {{ fieldAddress.administrativeArea }}
-      {% endif %}
-
-      {% if fieldAddress.postalCode %}
-        &nbsp;{{ fieldAddress.postalCode }}
-      {% endif %}
-    </span>
-  {% endif %}
 </div>

--- a/src/site/facilities/service_location.drupal.liquid
+++ b/src/site/facilities/service_location.drupal.liquid
@@ -88,7 +88,7 @@
     use phone numbers from entities
   {% endcomment %}
   {% if locationEntity.fieldPhoneNumbersParagraph.length > 0 %}
-    <div class="vads-u-display--flex vads-u-flex-direction--column" data-template="paragraphs/service_location">
+    <div class="vads-u-display--flex vads-u-flex-direction--column vads-u-margin-bottom--1" data-template="paragraphs/service_location">
       {% if haveLocationName %}
         <h4 class="force-small-header">Phone</h4>
       {% else %}
@@ -111,7 +111,7 @@
       if fieldPhoneNumbersParagraph is empty and
       fieldUseMainFacilityPhone is true use fieldPhoneNumber
     {% endcomment %}
-      <div class="vads-u-display--flex vads-u-flex-direction--column" data-template="paragraphs/service_location">
+      <div class="vads-u-display--flex vads-u-flex-direction--column vads-u-margin-bottom--1" data-template="paragraphs/service_location">
         {% if haveLocationName %}
           <h4 class="force-small-header">Phone</h4>
         {% else %}
@@ -128,7 +128,7 @@
 
   {% if locationEntity.fieldReferralRequired %}
     {% unless OMIT_REFERRAL_OR_WALKIN contains locationEntity.fieldReferralRequired %}
-      <p class="vads-u-margin-bottom--0" data-template="paragraphs/service_location">
+      <p class="vads-u-margin-bottom--1" data-template="paragraphs/service_location">
         <strong>Referral required?</strong>
         {% if locationEntity.fieldReferralRequired == '1' %}Yes{% else %}No{% endif %}
       </p>
@@ -137,7 +137,7 @@
 
   {% if locationEntity.fieldWalkInsAccepted %}
     {% unless OMIT_REFERRAL_OR_WALKIN contains locationEntity.fieldWalkInsAccepted %}
-      <p class="vads-u-margin-bottom--0" data-template="paragraphs/service_location">
+      <p class="vads-u-margin-bottom--1" data-template="paragraphs/service_location">
         <strong>Walk-ins accepted?</strong>
         {% if locationEntity.fieldWalkInsAccepted == '1' %}Yes{% else %}No{% endif %}
       </p>
@@ -145,7 +145,7 @@
   {% endif %}
 
   {% if locationEntity.fieldOnlineSchedulingAvailabl == '1' %}
-    <a class="usa-button vads-u-margin-bottom--1"
+    <a class="usa-button vads-u-margin-bottom--0"
        data-entity-substitution="canonical"
        data-entity-type="node"
        data-template="paragraphs/service_location"

--- a/src/site/paragraphs/service_hours.drupal.liquid
+++ b/src/site/paragraphs/service_hours.drupal.liquid
@@ -7,7 +7,7 @@
   {% for hours in serviceHours %}
     {% if hours %}
       <tr>
-        <td>{{ hours.0 }}</td>
+        <td>{{ hours.0 }}.</td>
         <td>{{ hours.1 }}</td>
       </tr>
     {% endif %}


### PR DESCRIPTION
 Days of the week in the Hours section should have periods (e.g. Mon., not Mon)
 Spacing above and below the "appointments" button is visually equal
 City, state and zip do not appear in facility health service location information

https://github.com/department-of-veterans-affairs/va.gov-team/issues/18866
