### PR TITLE
[Development] BDD: Replace buttons that should be links

### DIFF
--- a/src/applications/disability-benefits/all-claims/containers/WizardContainer.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/WizardContainer.jsx
@@ -10,7 +10,11 @@ import Wizard, {
 import pages from '../../wizard/pages';
 import formConfig from '../config/form';
 import { getPageTitle } from '../utils';
-import { SAVED_SEPARATION_DATE, FORM_STATUS_BDD } from '../constants';
+import {
+  SAVED_SEPARATION_DATE,
+  FORM_STATUS_BDD,
+  DISABILITY_526_V2_ROOT_URL,
+} from '../constants';
 
 const WizardContainer = ({ setWizardStatus }) => {
   sessionStorage.removeItem(SAVED_SEPARATION_DATE);
@@ -51,9 +55,9 @@ const WizardContainer = ({ setWizardStatus }) => {
             complete this application, you can go straight to the application
             without answering the questions above.
           </p>
-          <button
-            type="button"
-            className="va-button-link vads-u-display--inline-block vads-u-margin-bottom--3 skip-wizard-link"
+          <a
+            href={DISABILITY_526_V2_ROOT_URL}
+            className="vads-u-display--inline-block vads-u-margin-bottom--3 skip-wizard-link"
             onClick={e => {
               e.preventDefault();
               recordEvent({ event: 'howToWizard-skip' });
@@ -61,7 +65,7 @@ const WizardContainer = ({ setWizardStatus }) => {
             }}
           >
             If you know VA Form 21-526EZ is right, apply now
-          </button>
+          </a>
         </div>
         <FormFooter formConfig={formConfig} />
       </div>

--- a/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
+++ b/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
@@ -38,9 +38,7 @@ const template = (props, title, content, submissionMessage, messageType) => {
   const backButtonContent = (
     <div className="row form-progress-buttons schemaform-back-buttons">
       <div className="small-6 usa-width-one-half columns">
-        <a href="/">
-          <button className="usa-button-primary">Go back to VA.gov</button>
-        </a>
+        <a href="/">Go back to VA.gov</a>
       </div>
     </div>
   );

--- a/src/applications/disability-benefits/all-claims/tests/containers/WizardContainer.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/WizardContainer.unit.spec.jsx
@@ -23,7 +23,7 @@ describe('Wizard Container', () => {
   it('should update wizard status on bypass click', () => {
     global.status = '';
     const tree = shallow(<WizardContainer {...props} />);
-    tree.find('.va-button-link').simulate('click', {
+    tree.find('.skip-wizard-link').simulate('click', {
       preventDefault: () => {},
     });
     expect(tree.find('.wizard-container')).to.have.lengthOf(1);


### PR DESCRIPTION
## Description

Form 526's skip wizard link is currently a button since it doesn't change the URL and activating it clears a state flag & manages sessionStorage. Given that it appears as a link, Veterans may attempt to use it to open the link in a new tab. 

To remedy this, the `button` is changed to an `a` link, but the link behavior is prevented; this still allows the user to use the link to open the form in a new tab, but doesn't alter the wizard's visible state.

Additionally, removed a button on the confirmation page that was nested inside an `a` - only visible when a submission error occurs.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/18714

## Testing done

Inspection & unit tests

## Screenshots

N/A - no visual change

## Acceptance criteria
- [x] Skip link is an `a` tag by appearance & functionality

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
