### PR TITLE
VACMS-1421: Replace plain text intro field with rich text field.

### DIFF
--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -27,12 +27,12 @@
 
         <article class="usa-content">
           <div id="i18-link-wrapper" class="vads-u-display--none vads-u-margin-y--3 medium-screen:vads-u-margin-top--0 medium-screen:vads-u-margin-bottom--3">
-            <i aria-hidden="true" class="fas fa-globe vads-u-color--primary"></i> 
+            <i aria-hidden="true" class="fas fa-globe vads-u-color--primary"></i>
             <a class="i18-toggle" data-lang="en"></a>
           </div>
           <h1>{{ title }}</h1>
           <div class="va-introtext">
-            <p>{{ fieldIntroText }}</p>
+            <p>{{ fieldIntroTextLimitedHtml.processed }}</p>
           </div>
           {% if fieldAlert.length %}
             {% for alert in fieldAlert %}

--- a/src/site/stages/build/drupal/graphql/page.graphql.js
+++ b/src/site/stages/build/drupal/graphql/page.graphql.js
@@ -28,7 +28,9 @@ module.exports = `
 
   fragment page on NodePage {
     ${entityElementsFromPages}
-    fieldIntroText
+    fieldIntroTextLimitedHtml {
+      processed
+    }
     fieldDescription
     fieldTableOfContentsBoolean
     fieldFeaturedContent {

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-page.js
@@ -6,9 +6,7 @@ module.exports = {
     title: {
       type: 'string',
     },
-    fieldIntroText: {
-      type: ['string', 'null'],
-    },
+    fieldIntroTextLimitedHtml: { $ref: 'ProcessedString' },
     fieldDescription: {
       type: ['string', 'null'],
     },


### PR DESCRIPTION
## Description
See https://github.com/department-of-veterans-affairs/va.gov-cms/issues/1421

## Testing done
Visual / build

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/106636607-13dd6e80-6550-11eb-9b15-4bb60a6fba27.png)

## Acceptance criteria
- [ ] Benefits pages show intro text. E.g.: `/coronavirus-veteran-frequently-asked-questions/` has this below the H1:
```
Our call centers and some VA health facilities are currently experiencing very high numbers of calls. To help us address the most urgent needs first, we ask that you use our online tools and frequently asked questions (FAQs) for routine or non-urgent questions. We’ll continue to update this page as the situation changes.
```

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
