### PR TITLE
18808 chp31 cypress migration

### DIFF
--- a/src/applications/vre/28-1900/tests/e2e/chapter31-maximal.cypress.spec.js
+++ b/src/applications/vre/28-1900/tests/e2e/chapter31-maximal.cypress.spec.js
@@ -15,7 +15,7 @@ const testConfig = createTestConfig(
     dataSets: ['chapter31-maximal'],
     fixtures: { data: path.join(__dirname, 'formDataSets') },
     setupPerTest: () => {
-      cy.route('POST', '/v0/veteran_readiness_employment_claims', {
+      cy.intercept('POST', '/v0/veteran_readiness_employment_claims', {
         formSubmissionId: '123fake-submission-id-567',
         timestamp: '2020-11-12',
         attributes: {


### PR DESCRIPTION
## Description
This pull request updates the chapter 31 e2e test to use `cy.intercept` instead of `cy.route` in preparation for the impending support drop in Cypress 7

## Testing done
- local

## Acceptance criteria
- [x] tests pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
