### PR TITLE
Store `disability_decision_type_name` alongside `totalDisabilityRating`

### DIFF
--- a/src/applications/personalization/rated-disabilities/actions/index.js
+++ b/src/applications/personalization/rated-disabilities/actions/index.js
@@ -6,6 +6,7 @@ export const FETCH_RATED_DISABILITIES_SUCCESS =
 export const FETCH_RATED_DISABILITIES_FAILED =
   'FETCH_RATED_DISABILITIES_FAILED';
 
+export const FETCH_TOTAL_RATING_STARTED = 'FETCH_TOTAL_RATING_STARTED';
 export const FETCH_TOTAL_RATING_SUCCEEDED = 'FETCH_TOTAL_RATING_SUCCEEDED';
 export const FETCH_TOTAL_RATING_FAILED = 'FETCH_TOTAL_RATING_FAILED';
 
@@ -46,6 +47,9 @@ export function fetchRatedDisabilities() {
 
 export function fetchTotalDisabilityRating() {
   return async dispatch => {
+    dispatch({
+      type: FETCH_TOTAL_RATING_STARTED,
+    });
     const response = await getData('/disability_compensation_form/rating_info');
 
     if (response.errors) {

--- a/src/applications/personalization/rated-disabilities/reducers/total-disabilities.js
+++ b/src/applications/personalization/rated-disabilities/reducers/total-disabilities.js
@@ -1,4 +1,5 @@
 import {
+  FETCH_TOTAL_RATING_STARTED,
   FETCH_TOTAL_RATING_SUCCEEDED,
   FETCH_TOTAL_RATING_FAILED,
 } from '../actions/index';
@@ -7,10 +8,15 @@ const initialState = {
   loading: true, // app starts in loading state
   error: null,
   totalDisabilityRating: null,
+  disabilityDecisionTypeName: null,
 };
 
 export function totalRating(state = initialState, action) {
   switch (action.type) {
+    case FETCH_TOTAL_RATING_STARTED:
+      return {
+        ...initialState,
+      };
     case FETCH_TOTAL_RATING_FAILED:
       return {
         ...state,
@@ -25,6 +31,7 @@ export function totalRating(state = initialState, action) {
         ...state,
         loading: false,
         totalDisabilityRating: action.response.userPercentOfDisability,
+        disabilityDecisionTypeName: action.response.disabilityDecisionTypeName,
       };
     default:
       return state;

--- a/src/applications/personalization/rated-disabilities/tests/reducers/total-disabilities.unit.spec.js
+++ b/src/applications/personalization/rated-disabilities/tests/reducers/total-disabilities.unit.spec.js
@@ -9,6 +9,7 @@ const initialState = {
   loading: true, // app starts in loading state
   error: null,
   totalDisabilityRating: null,
+  disabilityDecisionTypeName: null,
 };
 
 describe('totalDisabilities reducer', () => {
@@ -41,12 +42,14 @@ describe('totalDisabilities reducer', () => {
     const state = totalRating(initialState, {
       type: FETCH_TOTAL_RATING_SUCCEEDED,
       response: {
+        disabilityDecisionTypeName: 'Service Connected',
         userPercentOfDisability: 80,
       },
     });
     expect(state.loading).to.equal(false);
     expect(state.error).to.equal(null);
     expect(state.totalDisabilityRating).to.equal(80);
+    expect(state.disabilityDecisionTypeName).to.equal('Service Connected');
   });
 
   it('should return the state if a type is not matched', () => {
@@ -57,5 +60,6 @@ describe('totalDisabilities reducer', () => {
     expect(state.loading).to.equal(true);
     expect(state.error).to.equal(null);
     expect(state.totalDisabilityRating).to.equal(null);
+    expect(state.disabilityDecisionTypeName).to.equal(null);
   });
 });


### PR DESCRIPTION
## Description
The `disability_decision_type_name` we get from the `GET /v0/disability_compensation_form/rating_info` might prove useful, so let's store it in Redux.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs