### PR TITLE
[Templates] Tweaks to the Campaign Landing Page

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-campaign-landing-page.scss
+++ b/src/platform/site-wide/sass/modules/_m-campaign-landing-page.scss
@@ -12,7 +12,7 @@
   background-size: cover;
 }
 
-.va-u-background--gradiant-blue{
+.va-u-background--gradiant-blue {
   @include linear-gradient-background($color-old-browser-background-start, $color-old-browser-background-end);
 }
 

--- a/src/platform/site-wide/sass/modules/_m-campaign-landing-page.scss
+++ b/src/platform/site-wide/sass/modules/_m-campaign-landing-page.scss
@@ -1,37 +1,21 @@
-.va-c-story-teaser {
-  img {
-    max-height: 150px;
-  }
-}
-
-.va-c-white-box {
-  // width: 220px;
-}
-
 .va-c-blue-line {
   width: 40px;
 }
 
-.va-c-li-box {
-  // min-width: 280px;
-  // width: 280px;
-}
-
-.va-c-benefit-category {
-  min-width: 280px;
-}
-
-.va-c-custom-hero-button {
+.va-u-box-shadow--none {
   box-shadow: none;
 }
 
-.va-c-hero {
+.va-u-background--image {
   background-position: center;
   background-repeat: no-repeat;
   background-size: cover;
 }
 
-.va-c-hero-content {
-  // max-width: 400px;
+.va-u-background--gradiant-blue{
   @include linear-gradient-background($color-old-browser-background-start, $color-old-browser-background-end);
+}
+
+.va-u-text-transform--uppercase {
+  text-transform: uppercase;
 }

--- a/src/platform/site-wide/sass/modules/_m-campaign-landing-page.scss
+++ b/src/platform/site-wide/sass/modules/_m-campaign-landing-page.scss
@@ -5,7 +5,7 @@
 }
 
 .va-c-white-box {
-  width: 220px;
+  // width: 220px;
 }
 
 .va-c-blue-line {
@@ -13,8 +13,8 @@
 }
 
 .va-c-li-box {
-  min-width: 280px;
-  width: 280px;
+  // min-width: 280px;
+  // width: 280px;
 }
 
 .va-c-benefit-category {
@@ -32,5 +32,6 @@
 }
 
 .va-c-hero-content {
-  max-width: 400px;
+  // max-width: 400px;
+  @include linear-gradient-background($color-old-browser-background-start, $color-old-browser-background-end);
 }

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -98,7 +98,7 @@
             <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
               <div class="va-c-li-box vads-u-background-color--gray-light-alt vads-u-display--flex vads-u-flex-direction--column">
                 <img alt="{{ promo.entity.fieldImage.entity.thumbnail.alt }}" src="{{ promo.entity.fieldImage.entity.thumbnail.url }}" />
-                <h3 class="vads-u-padding-x--2">
+                <h3 class="vads-u-padding-x--2 vads-u-margin-top--0">
                   <a href="{{ promo.entity.fieldPromoLink.entity.fieldLink.url }}">
                     {{ promo.entity.fieldPromoLink.entity.fieldLink.title }}
                   </a>
@@ -130,7 +130,7 @@
               class="vads-u-margin-top--4"
               frameBorder="0"
               src="{{ fieldMedia.entity.fieldMediaVideoEmbedField }}"
-              title="{{ fieldMedia.entity.name | default: 'YouTube video' }}"
+              title="{{ fieldMedia.entity.name | default: 'A related YouTube video' }}"
               width="100%"
             ></iframe>
 
@@ -145,7 +145,7 @@
 
             <!-- Call to action -->
             {% if fieldClpVideoPanelMoreVideo %}
-              <a class="vads-u-margin-top--4 usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLink.url }}" rel="noreferrer noopener" target="_blank">
+              <a class="vads-u-margin-top--4 usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLink.url.path }}">
                 {{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel }}
                 <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
               </a>
@@ -163,7 +163,7 @@
           <h2 class="vads-u-margin-top--0">{{ fieldClpSpotlightHeader }}</h2>
           <p class="va-introtext vads-u-margin-top--1 vads-u-margin-bottom--4">
             {{ fieldClpSpotlightIntroText }}
-            <a href="{{ fieldClpSpotlightCta.entity.fieldButtonLink.url }}" rel="noreferrer noopener" target="_ blank">
+            <a href="{{ fieldClpSpotlightCta.entity.fieldButtonLink.url.path }}">
               {{ fieldClpSpotlightCta.entity.fieldButtonLabel }}
             </a>
           </p>
@@ -174,7 +174,7 @@
           <div class="vads-l-col--12 medium-screen:vads-l-col--4">
             <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
               <div class="va-c-li-box vads-u-background-color--gray-light-alt vads-u-display--flex vads-u-flex-direction--column">
-                <h3 class="vads-u-padding-x--2">
+                <h3 class="vads-u-padding-x--2 vads-u-margin-top--0">
                   <a href="{{ linkTeaser.entity.fieldLink.uri }}">
                     {{ linkTeaser.entity.fieldLink.title }}
                   </a>
@@ -196,7 +196,7 @@
           <div class="vads-l-col--12 medium-screen:vads-l-col--9">
             <!-- Title -->
             <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">STORIES</p>
-            <h2 class="vads-u-margin--0">{{ fieldClpStoriesHeader }}</h2>
+            <h2 class="vads-u-margin-top--0">{{ fieldClpStoriesHeader }}</h2>
             <p class="va-introtext vads-u-margin-top--1 vads-u-margin-bottom--4">{{ fieldClpStoriesIntro }}</p>
 
             <!-- List of stories -->
@@ -206,7 +206,7 @@
                   <div class="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-margin-bottom--4">
                     <img alt="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.alt }}" class="vads-l-col--12 medium-screen:vads-l-col--4 medium-screen:vads-u-margin-right--2" src="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.url }}" />
                     <div class="vads-u-margin-top--2 medium-screen:vads-u-margin-top--0">
-                      <h3>
+                      <h3 class="vads-u-margin-top--0">
                         <a href="{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.uri }}">
                           {{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.title }}
                         </a>
@@ -236,7 +236,7 @@
         <div class="vads-l-col--12 medium-screen:vads-l-col--9">
           <!-- Title -->
           <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">DOWNLOADABLE RESOURCES</p>
-          <h2 class="vads-u-margin--0">{{ fieldClpResourcesHeader }}</h2>
+          <h2 class="vads-u-margin-top--0">{{ fieldClpResourcesHeader }}</h2>
           <p class="va-introtext vads-u-margin-top--1 vads-u-margin-bottom--4">{{ fieldClpResourcesIntroText }}</p>
         </div>
       </div>
@@ -249,7 +249,7 @@
                 <div class="vads-u-padding--2">
                   <h3 class="vads-u-margin--0">{{ resource.entity.name }}</h3>
                   <p>{{ resource.entity.fieldDescription }}</p>
-                  <a href="{{ resource.entity.fieldMediaExternalFile.url }}" rel="noreferrer noopener" target="_blank">Download (PDF)</a>
+                  <a href="{{ resource.entity.fieldMediaExternalFile.url }}" download>Download (PDF)</a>
                 </div>
               </div>
             </div>
@@ -260,7 +260,7 @@
       {% if fieldClpResourcesCta %}
         <div class="vads-l-row">
           <div class="vads-u-col--12">
-            <a class="usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldClpResourcesCta.entity.fieldButtonLink.url }}" rel="noreferrer noopener" target="_blank">
+            <a class="usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldClpResourcesCta.entity.fieldButtonLink.url.path }}">
               {{ fieldClpResourcesCta.entity.fieldButtonLabel }}
               <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
             </a>
@@ -270,20 +270,26 @@
     </div><!--/  Downloadable Resources -->
 
     <!-- Events -->
-    <div class="vads-u-background-color--primary-alt-lightest vads-u-padding-bottom--1">
-      <div class="usa-grid usa-grid-full vads-u-padding-y--4 vads-u-padding-x--2 large-screen:vads-u-padding-x--0">
-        <!-- Title -->
-        <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">EVENTS</p>
-        <h2 class="vads-u-margin--0">{{ fieldClpEventsHeader }}</h2>
+    <div class="vads-u-background-color--primary-alt-lightest">
+      <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 medium-screen:vads-u-padding-x--0">
+
+        <!-- CONTENT -->
+        <div class="vads-l-row">
+          <div class="vads-l-col--12 medium-screen:vads-l-col--9">
+            <!-- Title -->
+            <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">EVENTS</p>
+            <h2 class="vads-u-margin-top--0">{{ fieldClpEventsHeader }}</h2>
+          </div>
+        </div>
 
         <!-- List of events -->
-        {% if fieldClpEventsReferences != empty %}
-          <div class="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">
-            {% for eventReference in fieldClpEventsReferences %}
-              <div class="vads-u-display--flex vads-u-flex-direction--column vads-u-margin-right--4">
+        <div class="vads-l-row vads-u-margin-bottom--2 medium-screen:vads-u-margin-x--neg6">
+          {% for eventReference in fieldClpEventsReferences %}
+            <div class="vads-l-col--12 medium-screen:vads-l-col--6">
+              <div class="medium-screen:vads-u-margin-x--6">
                 <!-- Title -->
-                <h3 class="vads-u-margin-top--2">
-                  <a href="{{ eventReference.entity.fieldLink.url }}" rel="noreferrer noopener" target="_blank">
+                <h3 class="vads-u-margin-top--0">
+                  <a href="{{ eventReference.entity.fieldLink.url }}">
                     {{ eventReference.entity.fieldListing.entity.fieldDescription }}
                   </a>
                 </h3>
@@ -311,133 +317,149 @@
                 <div class="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-margin-top--2">
                   <p class="vads-u-font-weight--bold vads-u-margin--0 vads-u-margin-right--2">Where</p>
                   <a href="" rel="noreferrer noopener" target="_blank">
-                    Not sure what to put here
+                    TODO
                   </a>
                 </div>
               </div>
-            {% endfor %}
-          </div>
-        {% endif %}
-
-        <!-- Call to action -->
-        {% if fieldClpResourcesCta %}
-          <a class="usa-button usa-button-secondary vads-u-font-size--sm vads-u-margin-top--4" href="{{ fieldClpResourcesCta.entity.fieldButtonLink.url }}" rel="noreferrer noopener" target="_blank">
-            {{ fieldClpResourcesCta.entity.fieldButtonLabel }}
-            <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
-          </a>
-        {% endif %}
-      </div>
-    </div>
-
-    <!-- FAQ -->
-    <div class="usa-grid usa-grid-full vads-u-padding-y--4 vads-u-padding-x--2 large-screen:vads-u-padding-x--0">
-      <div class="usa-width-three-fourths">
-        <!-- Title -->
-        <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">FAQ</p>
-        <h2 class="vads-u-margin--0">Frequently asked questions</h2>
-
-        <!-- Questions/Answers -->
-        <div class="usa-accordion-bordered vads-u-margin-y--2">
-          <ul class="usa-unstyled-list">
-            {% for faqParagraph in fieldClpFaqParagraphs %}
-              {% if faqParagraph.entity %}
-                <li data-faq-entity-id="{{ faqParagraph.entity.entityId }}">
-                  <button aria-controls="{{ faqParagraph.entity.entityBundle }}-{{ faqParagraph.entity.entityId }}" class="usa-accordion-button usa-button-unstyled" aria-expanded="false" type="button">{{ faqParagraph.entity.fieldQuestion }}</button>
-                  <div id="{{ faqParagraph.entity.entityBundle }}-{{ faqParagraph.entity.entityId }}" class="usa-accordion-content" aria-hidden="true">
-                    {% assign fieldAnswer = faqParagraph.entity.fieldAnswer | first %}
-                    {% assign bundleComponent = "src/site/paragraphs/" | append: fieldAnswer.entity.entityBundle %}
-                    {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
-                    {% include {{ bundleComponentWithExtension }} with entity = fieldAnswer.entity %}
-                  </div>
-                </li>
-              {% endif %}
-            {% endfor %}
-          </ul>
+            </div>
+          {% endfor %}
         </div>
-
-        <!-- Call to action -->
-        {% if fieldClpFaqCta %}
-          <a class="usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldClpFaqCta.entity.fieldButtonLink.url }}" rel="noreferrer noopener" target="_blank">
-            {{ fieldClpFaqCta.entity.fieldButtonLabel }}
-            <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
-          </a>
-        {% endif %}
       </div>
-    </div>
+    </div> <!--/Events -->
+
+    <!-- FAQs -->
+    <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 medium-screen:vads-u-padding-x--0">
+      <div class="vads-l-row">
+        <div class="vads-l-col--12 medium-screen:vads-l-col--9">
+          <!-- Title -->
+          <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">FAQ</p>
+          <h2 class="vads-u-margin-top--0">Frequently asked questions</h2>
+
+          <!-- Questions/Answers -->
+          <div class="usa-accordion-bordered vads-u-margin-y--2">
+            <ul class="usa-unstyled-list">
+              {% for faqParagraph in fieldClpFaqParagraphs %}
+                {% if faqParagraph.entity %}
+                  <li data-faq-entity-id="{{ faqParagraph.entity.entityId }}">
+                    <button aria-controls="{{ faqParagraph.entity.entityBundle }}-{{ faqParagraph.entity.entityId }}" class="usa-accordion-button usa-button-unstyled" aria-expanded="false" type="button">{{ faqParagraph.entity.fieldQuestion }}</button>
+                    <div id="{{ faqParagraph.entity.entityBundle }}-{{ faqParagraph.entity.entityId }}" class="usa-accordion-content" aria-hidden="true">
+                      {% assign fieldAnswer = faqParagraph.entity.fieldAnswer | first %}
+                      {% assign bundleComponent = "src/site/paragraphs/" | append: fieldAnswer.entity.entityBundle %}
+                      {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
+                      {% include {{ bundleComponentWithExtension }} with entity = fieldAnswer.entity %}
+                    </div>
+                  </li>
+                {% endif %}
+              {% endfor %}
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      {% if fieldClpFaqCta %}
+        <div class="vads-l-row">
+          <div class="vads-u-col--12">
+            <a class="usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldClpFaqCta.entity.fieldButtonLink.url.path }}">
+              {{ fieldClpFaqCta.entity.fieldButtonLabel }}
+              <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
+            </a>
+          </div>
+        </div>
+      {% endif %}
+    </div><!--/  FAQs -->
 
     <!-- Connect with us -->
-    {% assign socialLinksObject = fieldClpConnectWithUs.entity.fieldSocialMediaLinks.platformValues | jsonToObj %}
+    <div class="vads-u-background-color--primary-alt-lightest">
+      {% assign socialLinksObject = fieldClpConnectWithUs.entity.fieldSocialMediaLinks.platformValues | jsonToObj %}
+      <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 medium-screen:vads-u-padding-x--0">
+        <div class="vads-l-row">
+          <!-- CONTENT -->
+          <div class="vads-l-col--12 medium-screen:vads-l-col--9">
+            <!-- Title -->
+            <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">CONNECT WITH US</p>
+            <h2 class="vads-u-margin-top--0">Get updates from Veterans Health Administration</h2>
+          </div>
+        </div>
 
-    <div class="vads-u-background-color--primary-alt-lightest vads-u-padding-bottom--1">
-      <div class="usa-grid usa-grid-full vads-u-padding-y--4 vads-u-padding-x--2 large-screen:vads-u-padding-x--0">
-        <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">CONNECT WITH US</p>
-        <h2 class="vads-u-margin--0">Get updates from Veterans Health Administration</h2>
-
-        <ul class="usa-unstyled-list vads-u-padding-top--4 vads-u-display--flex vads-u-flex-wrap--wrap">
-          <li class="vads-l-col--6 medium-screen:vads-l-col--4 vads-u-margin-bottom--2">
-            <a aria-label="{{ fieldClpConnectWithUs.entity.fieldEmailUpdatesLinkText }} (opens in a new window)" href="{{ fieldClpConnectWithUs.entity.fieldEmailUpdatesUrl }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" rel="noreferrer noopener" target="_blank">
-              <i aria-hidden="true" class="fas fa-envelope vads-u-padding-right--1"></i>
-              {{ fieldClpConnectWithUs.entity.fieldEmailUpdatesLinkText }}
-            </a>
-          </li>
-          <li class="vads-l-col--6 medium-screen:vads-l-col--4 vads-u-margin-bottom--2">
-            <a aria-label="{{ fieldClpConnectWithUs.entity.name }} Twitter (opens in a new window)" href="https://twitter.com/{{ socialLinksObject.twitter }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" rel="noreferrer noopener" target="_blank">
-              <i aria-hidden="true" class="fab fa-twitter vads-u-padding-right--1"></i>
-              {{ fieldClpConnectWithUs.entity.name }} Twitter
-            </a>
-          </li>
-          <li class="vads-l-col--6 medium-screen:vads-l-col--4 vads-u-margin-bottom--2">
-            <a aria-label="{{ fieldClpConnectWithUs.entity.name }} Facebook (opens in a new window)" href="https://facebook.com/{{ socialLinksObject.facebook }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" rel="noreferrer noopener" target="_blank">
-              <i aria-hidden="true" class="fab fa-facebook vads-u-padding-right--1"></i>
-              {{ fieldClpConnectWithUs.entity.name }} Facebook
-            </a>
-          </li>
-          <li class="vads-l-col--6 medium-screen:vads-l-col--4 vads-u-margin-bottom--2">
-            <a aria-label="{{ fieldClpConnectWithUs.entity.name }} YouTube (opens in a new window)" href="https://youtube.com/channel/{{ socialLinksObject.youtube }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" rel="noreferrer noopener" target="_blank">
-              <i aria-hidden="true" class="fab fa-youtube vads-u-padding-right--1"></i>
-              {{ fieldClpConnectWithUs.entity.name }} YouTube
-            </a>
-          </li>
-          <li class="vads-l-col--6 medium-screen:vads-l-col--4 vads-u-margin-bottom--2">
-            <a aria-label="{{ fieldClpConnectWithUs.entity.name }} Linkedin (opens in a new window)" href="https://linkedin.com/{{ socialLinksObject.linkedin }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" rel="noreferrer noopener" target="_blank">
-              <i aria-hidden="true" class="fab fa-linkedin vads-u-padding-right--1"></i>
-              {{ fieldClpConnectWithUs.entity.name }} Linkedin
-            </a>
-          </li>
-          <li class="vads-l-col--6 medium-screen:vads-l-col--4 vads-u-margin-bottom--2">
-            <a aria-label="{{ fieldClpConnectWithUs.entity.name }} Instagram (opens in a new window)" href="https://instagram.com/{{ socialLinksObject.instagram }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" rel="noreferrer noopener" target="_blank">
-              <i aria-hidden="true" class="fab fa-instagram vads-u-padding-right--1"></i>
-              {{ fieldClpConnectWithUs.entity.name }} Instagram
-            </a>
-          </li>
-        </ul>
+        <div class="vads-l-row medium-screen:vads-u-margin-x--neg1">
+          <div class="vads-l-col--12 medium-screen:vads-l-col--4">
+            <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
+              <a aria-label="{{ fieldClpConnectWithUs.entity.fieldEmailUpdatesLinkText }} (opens in a new window)" href="{{ fieldClpConnectWithUs.entity.fieldEmailUpdatesUrl }}" rel="noreferrer noopener" target="_blank">
+                <i aria-hidden="true" class="fas fa-envelope vads-u-padding-right--1"></i>
+                {{ fieldClpConnectWithUs.entity.fieldEmailUpdatesLinkText }}
+              </a>
+            </div>
+          </div>
+          <div class="vads-l-col--12 medium-screen:vads-l-col--4">
+            <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
+              <a aria-label="{{ fieldClpConnectWithUs.entity.name }} Twitter (opens in a new window)" href="https://twitter.com/{{ socialLinksObject.twitter.value }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" rel="noreferrer noopener" target="_blank">
+                <i aria-hidden="true" class="fab fa-twitter vads-u-padding-right--1"></i>
+                {{ fieldClpConnectWithUs.entity.name }} Twitter
+              </a>
+            </div>
+          </div>
+          <div class="vads-l-col--12 medium-screen:vads-l-col--4">
+            <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
+              <a aria-label="{{ fieldClpConnectWithUs.entity.name }} Facebook (opens in a new window)" href="https://facebook.com/{{ socialLinksObject.facebook.value }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" rel="noreferrer noopener" target="_blank">
+                <i aria-hidden="true" class="fab fa-facebook vads-u-padding-right--1"></i>
+                {{ fieldClpConnectWithUs.entity.name }} Facebook
+              </a>
+            </div>
+          </div>
+          <div class="vads-l-col--12 medium-screen:vads-l-col--4">
+            <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
+              <a aria-label="{{ fieldClpConnectWithUs.entity.name }} YouTube (opens in a new window)" href="https://youtube.com/channel/{{ socialLinksObject.youtube.value }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" rel="noreferrer noopener" target="_blank">
+                <i aria-hidden="true" class="fab fa-youtube vads-u-padding-right--1"></i>
+                {{ fieldClpConnectWithUs.entity.name }} YouTube
+              </a>
+            </div>
+          </div>
+          <div class="vads-l-col--12 medium-screen:vads-l-col--4">
+            <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
+              <a aria-label="{{ fieldClpConnectWithUs.entity.name }} Linkedin (opens in a new window)" href="https://linkedin.com/{{ socialLinksObject.linkedin.value }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" rel="noreferrer noopener" target="_blank">
+                <i aria-hidden="true" class="fab fa-linkedin vads-u-padding-right--1"></i>
+                {{ fieldClpConnectWithUs.entity.name }} Linkedin
+              </a>
+            </div>
+          </div>
+          <div class="vads-l-col--12 medium-screen:vads-l-col--4">
+            <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
+              <a aria-label="{{ fieldClpConnectWithUs.entity.name }} Instagram (opens in a new window)" href="https://instagram.com/{{ socialLinksObject.instagram.value }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" rel="noreferrer noopener" target="_blank">
+                <i aria-hidden="true" class="fab fa-instagram vads-u-padding-right--1"></i>
+                {{ fieldClpConnectWithUs.entity.name }} Instagram
+              </a>
+            </div>
+          </div>
+        </div>
       </div>
-    </div>
+    </div> <!-- Connect with us -->
 
     <!-- VA Benefits -->
-    <div class="usa-grid usa-grid-full vads-u-padding-y--4 vads-u-padding-x--2 large-screen:vads-u-padding-x--0">
-      <div class="usa-width-three-fourths">
-        <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">VA BENEFITS</p>
-        <h2 class="vads-u-margin--0">Learn more about related VA benefits</h2>
-
-        <!-- Benefit landing pages -->
-        {% if fieldBenefitCategories != empty %}
-          <div class="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-margin-top--4">
-            {% for benefitCategory in fieldBenefitCategories %}
-              <div class="va-c-benefit-category vads-u-display--flex vads-u-flex-direction--column vads-u-margin-bottom--2 medium-screen:vads-u-margin-right--4">
-                <a class="vads-u-display--flex vads-u-align-items--center" href="{{ benefitCategory.entity.entityUrl.path }}" rel="noreferrer noopener" target="_blank">
-                  <div class="inline hub-main-icon vads-u-margin-right--2">
-                    <i class="icon-large white hub-icon-{{ benefitCategory.entity.fieldTitleIcon }} hub-background-{{ benefitCategory.entity.fieldTitleIcon }}" role="presentation" aria-hidden="true"></i>
-                  </div>
-                  {{ benefitCategory.entity.title }}
-                </a>
-                <p>{{ benefitCategory.entity.fieldIntroText }}</p>
-              </div>
-            {% endfor %}
-          </div>
-        {% endif %}
+    <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 medium-screen:vads-u-padding-x--0">
+      <div class="vads-l-row">
+        <div class="vads-l-col--12 medium-screen:vads-l-col--9">
+          <!-- Title -->
+          <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">VA BENEFITS</p>
+          <h2 class="vads-u-margin-top--0">Learn more about related VA benefits</h2>
+        </div>
       </div>
-    </div>
+
+      <div class="vads-l-row medium-screen:vads-u-margin-x--neg6">
+        {% for benefitCategory in fieldBenefitCategories %}
+          <div class="vads-l-col--12 medium-screen:vads-l-col--6">
+            <div class="medium-screen:vads-u-margin-x--6">
+              <div class="vads-u-display--flex vads-u-align-items--center">
+                <div class="inline hub-main-icon vads-u-margin-right--2">
+                  <i class="icon-large white hub-icon-{{ benefitCategory.entity.fieldTitleIcon }} hub-background-{{ benefitCategory.entity.fieldTitleIcon }}" role="presentation" aria-hidden="true"></i>
+                </div>
+                <a href="{{ benefitCategory.entity.entityUrl.path }}">{{ benefitCategory.entity.title }}</a>
+              </div>
+              <p class="vads-u-margin-top--0">{{ benefitCategory.entity.fieldIntroText }}</p>
+            </div>
+          </div>
+        {% endfor %}
+      </div>
+    </div><!--/  VA Benefits -->
 
     <!-- Last Updated -->
     <div class="usa-grid usa-grid-full">

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -94,19 +94,17 @@
       </div>
       <div class="vads-l-row vads-u-margin-bottom--2 medium-screen:vads-u-margin-x--neg1">
         {% for promo in fieldClpWhatYouCanDoPromos %}
-          <div class="vads-l-col--12 medium-screen:vads-l-col--4">
-            <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
-              <div class="va-c-li-box vads-u-background-color--gray-light-alt vads-u-display--flex vads-u-flex-direction--column">
-                <img alt="{{ promo.entity.fieldImage.entity.thumbnail.alt }}" src="{{ promo.entity.fieldImage.entity.thumbnail.url }}" />
-                <h3 class="vads-u-padding-x--2">
-                  <a href="{{ promo.entity.fieldPromoLink.entity.fieldLink.url }}">
-                    {{ promo.entity.fieldPromoLink.entity.fieldLink.title }}
-                  </a>
-                </h3>
-                <p class="vads-u-margin-bottom--2 vads-u-margin-top--1 vads-u-padding-x--2">
-                  {{ promo.entity.fieldPromoLink.entity.fieldLinkSummary }}
-                </p>
-              </div>
+          <div class="vads-l-col--12 medium-screen:vads-l-col--4 vads-u-align-content--stretch vads-u-margin-y--1 ">
+            <div class="vads-u-background-color--gray-light-alt vads-u-height--full medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
+              <img alt="{{ promo.entity.fieldImage.entity.thumbnail.alt }}" src="{{ promo.entity.fieldImage.entity.thumbnail.url }}" />
+              <h3 class="vads-u-padding-x--2">
+                <a href="{{ promo.entity.fieldPromoLink.entity.fieldLink.url }}">
+                  {{ promo.entity.fieldPromoLink.entity.fieldLink.title }}
+                </a>
+              </h3>
+              <p class="vads-u-margin-bottom--2 vads-u-margin-top--1 vads-u-padding-x--2">
+                {{ promo.entity.fieldPromoLink.entity.fieldLinkSummary }}
+              </p>
             </div>
           </div>
         {% endfor %}

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -98,10 +98,14 @@
             <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
               <div class="va-c-li-box vads-u-background-color--gray-light-alt vads-u-display--flex vads-u-flex-direction--column">
                 <img alt="{{ promo.entity.fieldImage.entity.thumbnail.alt }}" src="{{ promo.entity.fieldImage.entity.thumbnail.url }}" />
-                <a class="vads-u-margin-top--2 vads-u-font-weight--bold vads-u-font-size--lg vads-u-padding-x--2" href="{{ promo.entity.fieldPromoLink.entity.fieldLink.url }}" rel="noreferrer noopener" target="_blank">
-                  {{ promo.entity.fieldPromoLink.entity.fieldLink.title }}
-                </a>
-                <p class="vads-u-margin-bottom--2 vads-u-margin-top--1 vads-u-padding-x--2">{{ promo.entity.fieldPromoLink.entity.fieldLinkSummary }}</p>
+                <h3 class="vads-u-padding-x--2">
+                  <a href="{{ promo.entity.fieldPromoLink.entity.fieldLink.url }}">
+                    {{ promo.entity.fieldPromoLink.entity.fieldLink.title }}
+                  </a>
+                </h3>
+                <p class="vads-u-margin-bottom--2 vads-u-margin-top--1 vads-u-padding-x--2">
+                  {{ promo.entity.fieldPromoLink.entity.fieldLinkSummary }}
+                </p>
               </div>
             </div>
           </div>
@@ -149,100 +153,121 @@
           </div>
         </div>
       </div>
-    </div>
+    </div> <!--/Video -->
 
     <!-- Spotlight -->
-    <div class="usa-grid usa-grid-full vads-u-padding-y--4 vads-u-padding-x--2 large-screen:vads-u-padding-x--0">
-      <div class="usa-width-three-fourths">
-        <!-- Title -->
-        <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">SPOTLIGHT</p>
-        <h2 class="vads-u-margin-top--0">{{ fieldClpSpotlightHeader }}</h2>
-        <p class="vads-u-margin-top--1 vads-u-margin-bottom--4">
-          {{ fieldClpSpotlightIntroText }}
-          <a href="{{ fieldClpSpotlightCta.entity.fieldButtonLink.url }}" rel="noreferrer noopener" target="_ blank">
-            {{ fieldClpSpotlightCta.entity.fieldButtonLabel }}
-          </a>
-        </p>
-
-        <!-- List of spotlights -->
-        {% if fieldClpSpotlightLinkTeasers != empty %}
-          <ul class="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-padding--0">
-            {% for linkTeaser in fieldClpSpotlightLinkTeasers %}
-              <li class="va-c-li-box vads-u-background-color--gray-light-alt vads-u-display--flex vads-u-flex-direction--column vads-u-margin-bottom--2 medium-screen:vads-u-margin-right--2">
-                <a class="vads-u-font-weight--bold vads-u-font-size--lg vads-u-margin-top--2 vads-u-padding-x--2" href="{{ linkTeaser.entity.fieldLink.url }}" rel="noreferrer noopener" target="_blank">{{ linkTeaser.entity.fieldLink.title }}</a>
+    <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 medium-screen:vads-u-padding-x--0">
+      <div class="vads-l-row">
+        <div class="vads-l-col--12 medium-screen:vads-l-col--9">
+          <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">SPOTLIGHT</p>
+          <h2 class="vads-u-margin-top--0">{{ fieldClpSpotlightHeader }}</h2>
+          <p class="va-introtext vads-u-margin-top--1 vads-u-margin-bottom--4">
+            {{ fieldClpSpotlightIntroText }}
+            <a href="{{ fieldClpSpotlightCta.entity.fieldButtonLink.url }}" rel="noreferrer noopener" target="_ blank">
+              {{ fieldClpSpotlightCta.entity.fieldButtonLabel }}
+            </a>
+          </p>
+        </div>
+      </div>
+      <div class="vads-l-row vads-u-margin-bottom--2 medium-screen:vads-u-margin-x--neg1">
+        {% for linkTeaser in fieldClpSpotlightLinkTeasers %}
+          <div class="vads-l-col--12 medium-screen:vads-l-col--4">
+            <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
+              <div class="va-c-li-box vads-u-background-color--gray-light-alt vads-u-display--flex vads-u-flex-direction--column">
+                <h3 class="vads-u-padding-x--2">
+                  <a href="{{ linkTeaser.entity.fieldLink.uri }}">
+                    {{ linkTeaser.entity.fieldLink.title }}
+                  </a>
+                </h3>
                 <p class="vads-u-margin-bottom--2 vads-u-margin-top--1 vads-u-padding-x--2">{{ linkTeaser.entity.fieldLinkSummary }}</p>
-              </li>
-            {% endfor %}
-          </ul>
-        {% endif %}
+              </div>
+            </div>
+          </div>
+        {% endfor %}
       </div>
     </div>
+    <!--/ Spotlight -->
 
     <!-- Stories -->
-    <div class="vads-u-background-color--primary-alt-lightest vads-u-padding-bottom--1">
-      <div class="usa-grid usa-grid-full vads-u-padding-y--4 vads-u-padding-x--2 large-screen:vads-u-padding-x--0">
-        <!-- Title -->
-        <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">STORIES</p>
-        <h2 class="vads-u-margin--0">{{ fieldClpStoriesHeader }}</h2>
-        <p class="vads-u-margin-top--1 vads-u-margin-bottom--4">{{ fieldClpStoriesIntro }}</p>
+    <div class="vads-u-background-color--primary-alt-lightest">
+      <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 medium-screen:vads-u-padding-x--0">
+        <div class="vads-l-row">
+          <!-- CONTENT -->
+          <div class="vads-l-col--12 medium-screen:vads-l-col--9">
+            <!-- Title -->
+            <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">STORIES</p>
+            <h2 class="vads-u-margin--0">{{ fieldClpStoriesHeader }}</h2>
+            <p class="va-introtext vads-u-margin-top--1 vads-u-margin-bottom--4">{{ fieldClpStoriesIntro }}</p>
 
-        <!-- List of stories -->
-        {% if fieldClpStoriesTeasers != empty %}
-          <div class="vads-u-display--flex vads-u-flex-direction--column">
-            {% for storyTeaser in fieldClpStoriesTeasers %}
-              <div class="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-margin-bottom--4">
-                <img alt="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.alt }}" class="vads-l-col--4 medium-screen:vads-u-margin-right--2" src="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.url }}" />
-                <div class="vads-u-margin-top--2 medium-screen:vads-u-margin-top--0">
-                  <a aria-label="{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.url }} (opens in new window)" class="vads-u-font-weight--bold" href="{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.url }}" rel="noreferrer noopener" target="_blank">
-                    {{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.title }}
-                  </a>
-                  <p>{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLinkSummary }}</p>
-                </div>
+            <!-- List of stories -->
+            {% if fieldClpStoriesTeasers != empty %}
+              <div class="vads-u-display--flex vads-u-flex-direction--column">
+                {% for storyTeaser in fieldClpStoriesTeasers %}
+                  <div class="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-margin-bottom--4">
+                    <img alt="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.alt }}" class="vads-l-col--12 medium-screen:vads-l-col--4 medium-screen:vads-u-margin-right--2" src="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.url }}" />
+                    <div class="vads-u-margin-top--2 medium-screen:vads-u-margin-top--0">
+                      <h3>
+                        <a href="{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.uri }}">
+                          {{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.title }}
+                        </a>
+                      </h3>
+                      <p>{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLinkSummary }}</p>
+                    </div>
+                  </div>
+                {% endfor %}
               </div>
-            {% endfor %}
-          </div>
-        {% endif %}
+            {% endif %}
 
-        <!-- Call to action -->
-        {% if fieldClpStoriesCta %}
-          <a class="usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldClpStoriesCta.entity.fieldButtonLink.url }}" rel="noreferrer noopener" target="_blank">
-            {{ fieldClpStoriesCta.entity.fieldButtonLabel }}
-            <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
-          </a>
-        {% endif %}
+            <!-- Call to action -->
+            {% if fieldClpStoriesCta %}
+              <a class="usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldClpStoriesCta.entity.fieldButtonLink.url }}" rel="noreferrer noopener" target="_blank">
+                {{ fieldClpStoriesCta.entity.fieldButtonLabel }}
+                <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
+              </a>
+            {% endif %}
+          </div>
+        </div>
       </div>
-    </div>
+    </div> <!--/Stories -->
 
     <!-- Downloadable Resources -->
-    <div class="usa-grid usa-grid-full vads-u-padding-y--4 vads-u-padding-x--2 large-screen:vads-u-padding-x--0">
-      <div class="usa-width-three-fourths">
-        <!-- Title -->
-        <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">DOWNLOADABLE RESOURCES</p>
-        <h2 class="vads-u-margin--0">{{ fieldClpResourcesHeader }}</h2>
-        <p class="vads-u-margin-top--1 vads-u-margin-bottom--4">{{ fieldClpResourcesIntroText }}</p>
-
-        <!-- List of resources -->
-        {% if fieldClpResources != empty %}
-          <ul class="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-padding--0">
-            {% for resource in fieldClpResources %}
-              <li class="va-c-li-box vads-u-padding--2 vads-u-padding-bottom--3 vads-u-background-color--gray-light-alt vads-u-display--flex vads-u-flex-direction--column vads-u-margin-bottom--2 medium-screen:vads-u-margin-right--2">
-                <h3 class="vads-u-margin--0">{{ resource.entity.name }}</h3>
-                <p>{{ resource.entity.fieldDescription }}</p>
-                <a href="{{ resource.entity.fieldMediaExternalFile.url }}" rel="noreferrer noopener" target="_blank">Download (PDF)</a>
-              </li>
-            {% endfor %}
-          </ul>
-        {% endif %}
-
-        <!-- Call to action -->
-        {% if fieldClpResourcesCta %}
-          <a class="usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldClpResourcesCta.entity.fieldButtonLink.url }}" rel="noreferrer noopener" target="_blank">
-            {{ fieldClpResourcesCta.entity.fieldButtonLabel }}
-            <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
-          </a>
-        {% endif %}
+    <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 medium-screen:vads-u-padding-x--0">
+      <div class="vads-l-row">
+        <div class="vads-l-col--12 medium-screen:vads-l-col--9">
+          <!-- Title -->
+          <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">DOWNLOADABLE RESOURCES</p>
+          <h2 class="vads-u-margin--0">{{ fieldClpResourcesHeader }}</h2>
+          <p class="va-introtext vads-u-margin-top--1 vads-u-margin-bottom--4">{{ fieldClpResourcesIntroText }}</p>
+        </div>
       </div>
-    </div>
+
+      <div class="vads-l-row vads-u-margin-bottom--2 medium-screen:vads-u-margin-x--neg1">
+        {% for resource in fieldClpResources %}
+          <div class="vads-l-col--12 medium-screen:vads-l-col--4">
+            <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
+              <div class="va-c-li-box vads-u-background-color--gray-light-alt vads-u-display--flex vads-u-flex-direction--column">
+                <div class="vads-u-padding--2">
+                  <h3 class="vads-u-margin--0">{{ resource.entity.name }}</h3>
+                  <p>{{ resource.entity.fieldDescription }}</p>
+                  <a href="{{ resource.entity.fieldMediaExternalFile.url }}" rel="noreferrer noopener" target="_blank">Download (PDF)</a>
+                </div>
+              </div>
+            </div>
+          </div>
+        {% endfor %}
+      </div>
+
+      {% if fieldClpResourcesCta %}
+        <div class="vads-l-row">
+          <div class="vads-u-col--12">
+            <a class="usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldClpResourcesCta.entity.fieldButtonLink.url }}" rel="noreferrer noopener" target="_blank">
+              {{ fieldClpResourcesCta.entity.fieldButtonLabel }}
+              <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
+            </a>
+          </div>
+        </div>
+      {% endif %}
+    </div><!--/  Downloadable Resources -->
 
     <!-- Events -->
     <div class="vads-u-background-color--primary-alt-lightest vads-u-padding-bottom--1">

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -4,7 +4,9 @@
 <!-- Draft status -->
 {% if !entityPublished %}
 <div class="vads-u-font-size--h4 vads-u-background-color--primary-alt-lightest vads-u-border-color--primary-darker vads-u-border-bottom--2px vads-u-padding--1">
-  You are viewing a draft of "{{ entityUrl.path }}". <a data-same-tab href="{{ drupalSite }}/node/{{ entityId }}/edit">Edit this page in the CMS.</a>
+  <div class="vads-l-grid-container medium-screen:vads-u-padding-x--0">
+    You are viewing a draft of "{{ entityUrl.path }}". <a data-same-tab href="{{ drupalSite }}/node/{{ entityId }}/edit">Edit this page in the CMS.</a>
+  </div>
 </div>
 {% endif %}
 
@@ -16,116 +18,136 @@
   <main class="va-l-detail-page">
 
 
+    <!-- HERO-->
     <div class="va-c-hero" style="background-image: url('{{ fieldHeroImage.entity.image.url }}">
       <!-- Hero Content -->
-      <div class="usa-grid usa-grid-full">
-        <div class="homepage-hub va-c-hero-content vads-u-padding-x--4 vads-u-padding-y--6">
-          <h1 class="vads-u-color--white">{{ title }}</h1>
-          <hr class="va-c-blue-line vads-u-border-color--primary-alt vads-u-margin-y--2" />
-          <p class="vads-u-color--white">{{ fieldHeroBlurb }}</p>
+      <div class="vads-l-grid-container vads-u-padding-x--0">
+        <div class="vads-l-row">
+          <div class="vads-l-col--12 medium-screen:vads-l-col--6">
+            <div class="va-c-hero-content vads-u-padding-x--4 vads-u-padding-y--6  medium-screen:vads-u-margin-right--4">
+              <h1 class="vads-u-color--white">{{ title }}</h1>
+              <hr class="va-c-blue-line vads-u-border-color--primary-alt vads-u-margin-y--2" />
+              <p class="va-introtext vads-u-color--white">{{ fieldHeroBlurb }}</p>
 
-          {% if fieldPrimaryCallToAction %}
-            <a class="va-c-custom-hero-button usa-button usa-button-secondary vads-u-margin-top--2 vads-u-background-color--white vads-u-border-color--white vads-u-font-size--sm" href="{{ fieldPrimaryCallToAction.entity.fieldButtonLink.url.path }}" rel="noreferrer noopener">
-              {{ fieldPrimaryCallToAction.entity.fieldButtonLabel }}
-            </a>
-          {% endif %}
+              {% if fieldPrimaryCallToAction %}
+                <a class="va-c-custom-hero-button usa-button usa-button-secondary vads-u-margin-top--2 vads-u-background-color--white vads-u-border-color--white vads-u-font-size--sm" href="{{ fieldPrimaryCallToAction.entity.fieldButtonLink.url.path }}" rel="noreferrer noopener">
+                  {{ fieldPrimaryCallToAction.entity.fieldButtonLabel }}
+                </a>
+              {% endif %}
+            </div>
+          </div>
         </div>
       </div>
     </div>
+    <!-- /Hero -->
 
     <!-- Why This Matters -->
-    <div class="vads-u-background-color--primary-alt-lightest vads-u-padding-bottom--1">
-      <div class="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row usa-grid usa-grid-full vads-u-padding-y--4 vads-u-padding-x--2 large-screen:vads-u-padding-x--0">
-        <!-- Content -->
-        <div>
-          <h2 class="vads-u-margin--0 vads-u-margin-bottom--2">Why this matters to you</h2>
-          <p class="vads-u-margin-top--0 vads-u-margin-bottom--2">{{ fieldClpWhyThisMatters }}</p>
-          {% if fieldSecondaryCallToAction %}
-            <a class="usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldSecondaryCallToAction.entity.fieldButtonLink.url.path }}">
-              {{ fieldSecondaryCallToAction.entity.fieldButtonLabel }}
-            </a>
-          {% endif %}
-        </div>
+    <div class="vads-u-background-color--primary-alt-lightest">
+      <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 medium-screen:vads-u-padding-x--0">
+          <div class="vads-l-row">
+            <!-- CONTENT -->
+            <div class="vads-l-col--12 medium-screen:vads-l-col--9">
+              <h2 class="vads-u-margin--0 vads-u-margin-bottom--2">Why this matters to you</h2>
+              <p class="va-introtext vads-u-margin-top--0 vads-u-margin-bottom--2">{{ fieldClpWhyThisMatters }}</p>
+              {% if fieldSecondaryCallToAction %}
+                <a class="usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldSecondaryCallToAction.entity.fieldButtonLink.url.path }}">
+                  {{ fieldSecondaryCallToAction.entity.fieldButtonLabel }}
+                </a>
+              {% endif %}
+            </div><!-- /CONTENT -->
 
-        <!-- White box w/ social media links -->
-        <div class="vads-u-margin-top--3 medium-screen:vads-u-margin-top--0 medium-screen:vads-u-margin-left--4">
-          {% if fieldClpAudience != empty %}
-            <div class="va-c-white-box vads-u-background-color--white vads-u-padding--2 vads-u-margin-bottom--3">
-              <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin--0">THIS PAGE IS FOR</p>
-              <hr class="va-c-blue-line vads-u-border-color--primary-alt vads-u-margin-y--2" />
-              <ul class="usa-unstyled-list">
-                {% for clpAudience in fieldClpAudience %}
-                  <li class="vads-u-font-size--sm vads-u-font-weight--bold vads-u-margin-top--1">
-                    {{ clpAudience.entity.name }}
-                  </li>
-                {% endfor %}
-              </ul>
-            </div>
-          {% endif %}
+            <!-- THIS PAGE IS FOR -->
+            <div class="vads-l-col--12 medium-screen:vads-l-col--3">
+              <div class=" vads-u-margin-top--6 medium-screen:vads-u-margin-top--0 medium-screen:vads-u-margin-left--2">
+                {% if fieldClpAudience != empty %}
+                  <div class="va-c-white-box vads-u-background-color--white vads-u-padding--2 vads-u-margin-bottom--2">
+                    <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin--0">THIS PAGE IS FOR</p>
+                    <hr class="va-c-blue-line vads-u-border-color--primary-alt vads-u-margin-y--2" />
+                    <ul class="usa-unstyled-list">
+                      {% for clpAudience in fieldClpAudience %}
+                        <li class="vads-u-font-size--sm vads-u-font-weight--bold vads-u-margin-top--1">
+                          {{ clpAudience.entity.name }}
+                        </li>
+                      {% endfor %}
+                    </ul>
+                  </div>
+                {% endif %}
+                {% include "src/site/includes/social-share.drupal.liquid" %}
+              </div>
+            </div><!-- /THIS PAGE IS FOR-->
 
-          <!-- Links to social media -->
-          {% include "src/site/includes/social-share.drupal.liquid" %}
+          </div>
         </div>
       </div>
     </div>
+    <!-- /Why This Matters -->
 
     <!-- What You Can Do -->
-    <div class="usa-grid usa-grid-full vads-u-padding-y--4 vads-u-padding-x--2 large-screen:vads-u-padding-x--0">
-      <div class="usa-width-three-fourths">
-        <!-- Title -->
-        <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">WHAT YOU CAN DO</p>
-        <h2 class="vads-u-margin--0">{{ fieldClpWhatYouCanDoHeader }}</h2>
-        <p class="vads-u-margin-top--1 vads-u-margin-bottom--4">{{ fieldClpWhatYouCanDoIntro }}</p>
-
-        <!-- List of promos -->
-        {% if fieldClpWhatYouCanDoPromos != empty %}
-          <ul class="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-padding--0">
-            {% for promo in fieldClpWhatYouCanDoPromos %}
-              <li class="va-c-li-box vads-u-background-color--gray-light-alt vads-u-display--flex vads-u-flex-direction--column vads-u-margin-bottom--2 medium-screen:vads-u-margin-right--2">
+    <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 medium-screen:vads-u-padding-x--0">
+      <div class="vads-l-row">
+        <div class="vads-l-col--12 medium-screen:vads-l-col--9">
+          <!-- Title -->
+          <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">WHAT YOU CAN DO</p>
+          <h2 class="vads-u-margin--0">{{ fieldClpWhatYouCanDoHeader }}</h2>
+          <p class="va-introtext vads-u-margin-top--1 vads-u-margin-bottom--4">{{ fieldClpWhatYouCanDoIntro }}</p>
+        </div>
+      </div>
+      <div class="vads-l-row vads-u-margin-bottom--2 medium-screen:vads-u-margin-x--neg1">
+        {% for promo in fieldClpWhatYouCanDoPromos %}
+          <div class="vads-l-col--12 medium-screen:vads-l-col--4">
+            <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
+              <div class="va-c-li-box vads-u-background-color--gray-light-alt vads-u-display--flex vads-u-flex-direction--column">
                 <img alt="{{ promo.entity.fieldImage.entity.thumbnail.alt }}" src="{{ promo.entity.fieldImage.entity.thumbnail.url }}" />
                 <a class="vads-u-margin-top--2 vads-u-font-weight--bold vads-u-font-size--lg vads-u-padding-x--2" href="{{ promo.entity.fieldPromoLink.entity.fieldLink.url }}" rel="noreferrer noopener" target="_blank">
                   {{ promo.entity.fieldPromoLink.entity.fieldLink.title }}
                 </a>
                 <p class="vads-u-margin-bottom--2 vads-u-margin-top--1 vads-u-padding-x--2">{{ promo.entity.fieldPromoLink.entity.fieldLinkSummary }}</p>
-              </li>
-            {% endfor %}
-          </ul>
-        {% endif %}
+              </div>
+            </div>
+          </div>
+        {% endfor %}
       </div>
     </div>
+    <!--/ What You Can Do -->
 
     <!-- Video -->
-    <div class="vads-u-background-color--primary-alt-lightest vads-u-padding-bottom--1">
-      <div class="usa-grid usa-grid-full vads-u-padding-y--4 vads-u-padding-x--2 large-screen:vads-u-padding-x--0">
-        <!-- Title -->
-        <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">VIDEO</p>
-        <h2 class="vads-u-margin--0">{{ fieldClpVideoPanelHeader }}</h2>
+    <div class="vads-u-background-color--primary-alt-lightest">
+      <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 medium-screen:vads-u-padding-x--0">
+        <div class="vads-l-row">
+          <!-- CONTENT -->
+          <div class="vads-l-col--12 medium-screen:vads-l-col--9">
+            <!-- Title -->
+            <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">VIDEO</p>
+            <h2 class="vads-u-margin--0">{{ fieldClpVideoPanelHeader }}</h2>
 
-        <!-- Video -->
-        <iframe
-          allowFullScreen
-          class="vads-u-margin-top--4"
-          frameBorder="0"
-          src="{{ fieldMedia.entity.fieldMediaVideoEmbedField }}"
-          title="{{ fieldMedia.entity.name }}"
-          width="100%"
-        ></iframe>
+            <!-- Video -->
+            <iframe
+              allowFullScreen
+              class="vads-u-margin-top--4"
+              frameBorder="0"
+              src="{{ fieldMedia.entity.fieldMediaVideoEmbedField }}"
+              title="{{ fieldMedia.entity.name | default: 'YouTube video' }}"
+              width="100%"
+            ></iframe>
 
-        <!-- Video description -->
-        {% if fieldMedia.entity.fieldDuration %}
-          <p class="duration vads-u-font-size--sm vads-u-margin--0">{{ fieldMedia.entity.fieldDuration }}</p>
-        {% endif %}
-        {% if fieldMedia.entity.fieldDescription %}
-          <p class="vads-u-margin-top--1 vads-u-margin-bottom--0">{{ fieldMedia.entity.fieldDescription }}</p>
-        {% endif %}
+            <!-- Video description -->
+            {% if fieldMedia.entity.fieldDuration %}
+              <p class="duration vads-u-font-size--sm vads-u-margin--0">{{ fieldMedia.entity.fieldDuration }}</p>
+            {% endif %}
 
-        <!-- Call to action -->
-        {% if fieldClpVideoPanelMoreVideo %}
-          <a class="vads-u-margin-top--4 usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLink.url }}" rel="noreferrer noopener" target="_blank">
-            {{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel }}
-            <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
-          </a>
-        {% endif %}
+            {% if fieldMedia.entity.fieldDescription %}
+              <p class="va-introtext vads-u-margin-top--1 vads-u-margin-bottom--0">{{ fieldMedia.entity.fieldDescription }}</p>
+            {% endif %}
+
+            <!-- Call to action -->
+            {% if fieldClpVideoPanelMoreVideo %}
+              <a class="vads-u-margin-top--4 usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLink.url }}" rel="noreferrer noopener" target="_blank">
+                {{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel }}
+                <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
+              </a>
+            {% endif %}
+          </div>
+        </div>
       </div>
     </div>
 

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -98,7 +98,7 @@
             <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
               <div class="va-c-li-box vads-u-background-color--gray-light-alt vads-u-display--flex vads-u-flex-direction--column">
                 <img alt="{{ promo.entity.fieldImage.entity.thumbnail.alt }}" src="{{ promo.entity.fieldImage.entity.thumbnail.url }}" />
-                <h3 class="vads-u-padding-x--2 vads-u-margin-top--0">
+                <h3 class="vads-u-padding-x--2">
                   <a href="{{ promo.entity.fieldPromoLink.entity.fieldLink.url }}">
                     {{ promo.entity.fieldPromoLink.entity.fieldLink.title }}
                   </a>
@@ -174,7 +174,7 @@
           <div class="vads-l-col--12 medium-screen:vads-l-col--4">
             <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
               <div class="va-c-li-box vads-u-background-color--gray-light-alt vads-u-display--flex vads-u-flex-direction--column">
-                <h3 class="vads-u-padding-x--2 vads-u-margin-top--0">
+                <h3 class="vads-u-padding-x--2">
                   <a href="{{ linkTeaser.entity.fieldLink.uri }}">
                     {{ linkTeaser.entity.fieldLink.title }}
                   </a>

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -169,15 +169,15 @@
       </div>
       <div class="vads-l-row vads-u-margin-bottom--2 medium-screen:vads-u-margin-x--neg1">
         {% for linkTeaser in fieldClpSpotlightLinkTeasers %}
-          <div class="vads-l-col--12 medium-screen:vads-l-col--4">
-            <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
-              <div class="va-c-li-box vads-u-background-color--gray-light-alt vads-u-display--flex vads-u-flex-direction--column">
-                <h3 class="vads-u-padding-x--2">
+          <div class="vads-l-col--12 medium-screen:vads-l-col--4 vads-u-align-content--stretch vads-u-margin-y--1 ">
+            <div class="vads-u-background-color--gray-light-alt vads-u-height--full medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
+              <div class="vads-u-padding--2">
+                <h3 class="vads-u-margin-top--0">
                   <a href="{{ linkTeaser.entity.fieldLink.uri }}">
                     {{ linkTeaser.entity.fieldLink.title }}
                   </a>
                 </h3>
-                <p class="vads-u-margin-bottom--2 vads-u-margin-top--1 vads-u-padding-x--2">{{ linkTeaser.entity.fieldLinkSummary }}</p>
+                <p class="vads-u-margin-top--1">{{ linkTeaser.entity.fieldLinkSummary }}</p>
               </div>
             </div>
           </div>
@@ -241,14 +241,12 @@
 
       <div class="vads-l-row vads-u-margin-bottom--2 medium-screen:vads-u-margin-x--neg1">
         {% for resource in fieldClpResources %}
-          <div class="vads-l-col--12 medium-screen:vads-l-col--4">
-            <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
-              <div class="va-c-li-box vads-u-background-color--gray-light-alt vads-u-display--flex vads-u-flex-direction--column">
-                <div class="vads-u-padding--2">
-                  <h3 class="vads-u-margin--0">{{ resource.entity.name }}</h3>
-                  <p>{{ resource.entity.fieldDescription }}</p>
-                  <a href="{{ resource.entity.fieldMediaExternalFile.url }}" download>Download (PDF)</a>
-                </div>
+          <div class="vads-l-col--12 medium-screen:vads-l-col--4 vads-u-align-content--stretch vads-u-margin-y--1 ">
+            <div class="vads-u-background-color--gray-light-alt vads-u-height--full medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
+              <div class="vads-u-padding--2">
+                <h3 class="vads-u-margin--0">{{ resource.entity.name }}</h3>
+                <p>{{ resource.entity.fieldDescription }}</p>
+                <a href="{{ resource.entity.fieldMediaExternalFile.url }}" download>Download (PDF)</a>
               </div>
             </div>
           </div>

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -205,7 +205,7 @@
                   <div class="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-margin-bottom--4">
                     <img alt="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.alt }}" class="vads-l-col--12 medium-screen:vads-l-col--4 medium-screen:vads-u-margin-right--2" src="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.url }}" />
                     <div class="vads-u-margin-top--2 medium-screen:vads-u-margin-top--0">
-                      <h3 class="vads-u-margin-top--0">
+                      <h3 class="medium-screen:vads-u-margin-top--0">
                         <a href="{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.uri }}">
                           {{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.title }}
                         </a>
@@ -459,10 +459,14 @@
     </div><!--/  VA Benefits -->
 
     <!-- Last Updated -->
-    <div class="usa-grid usa-grid-full">
-      <div class="last-updated usa-content">
-        Last updated: <time
-          datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
+    <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
+      <div class="vads-l-row">
+        <div class="vads-l-col--12 medium-screen:vads-l-col--9">
+          <div class="last-updated">
+            Last updated: <time
+              datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
+          </div>
+        </div>
       </div>
     </div>
   </main>

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -3,7 +3,7 @@
 
 <!-- Draft status -->
 {% if !entityPublished %}
-<div class="vads-u-font-size--h4 vads-u-background-color--primary-alt-lightest vads-u-border-color--primary-darker vads-u-border-bottom--2px vads-u-padding--1">
+<div class="vads-u-background-color--primary-alt-lightest vads-u-padding--1">
   <div class="vads-l-grid-container medium-screen:vads-u-padding-x--0">
     You are viewing a draft of "{{ entityUrl.path }}". <a data-same-tab href="{{ drupalSite }}/node/{{ entityId }}/edit">Edit this page in the CMS.</a>
   </div>
@@ -17,20 +17,21 @@
 <div id="content" class="interior" data-template="node-campaign_landing_page">
   <main class="va-l-detail-page">
 
-
     <!-- HERO-->
-    <div class="va-c-hero" style="background-image: url('{{ fieldHeroImage.entity.image.url }}">
+    <div class="va-u-background--image" style="background-image: url('{{ fieldHeroImage.entity.image.url }}">
       <!-- Hero Content -->
       <div class="vads-l-grid-container vads-u-padding-x--0">
         <div class="vads-l-row">
           <div class="vads-l-col--12 medium-screen:vads-l-col--6">
-            <div class="va-c-hero-content vads-u-padding-x--4 vads-u-padding-y--6  medium-screen:vads-u-margin-right--4">
+            <div class="va-u-background--gradiant-blue vads-u-padding-x--4 vads-u-padding-y--6  medium-screen:vads-u-margin-right--4">
               <h1 class="vads-u-color--white">{{ title }}</h1>
               <hr class="va-c-blue-line vads-u-border-color--primary-alt vads-u-margin-y--2" />
               <p class="va-introtext vads-u-color--white">{{ fieldHeroBlurb }}</p>
 
               {% if fieldPrimaryCallToAction %}
-                <a class="va-c-custom-hero-button usa-button usa-button-secondary vads-u-margin-top--2 vads-u-background-color--white vads-u-border-color--white vads-u-font-size--sm" href="{{ fieldPrimaryCallToAction.entity.fieldButtonLink.url.path }}" rel="noreferrer noopener">
+                <a
+                  class="va-u-box-shadow--none usa-button usa-button-secondary vads-u-margin-top--2 vads-u-background-color--white vads-u-border-color--white vads-u-font-size--sm"
+                  href="{{ fieldPrimaryCallToAction.entity.fieldButtonLink.url.path }}">
                   {{ fieldPrimaryCallToAction.entity.fieldButtonLabel }}
                 </a>
               {% endif %}
@@ -61,7 +62,7 @@
               <div class=" vads-u-margin-top--6 medium-screen:vads-u-margin-top--0 medium-screen:vads-u-margin-left--2">
                 {% if fieldClpAudience != empty %}
                   <div class="va-c-white-box vads-u-background-color--white vads-u-padding--2 vads-u-margin-bottom--2">
-                    <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin--0">THIS PAGE IS FOR</p>
+                    <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin--0">This page is for</p>
                     <hr class="va-c-blue-line vads-u-border-color--primary-alt vads-u-margin-y--2" />
                     <ul class="usa-unstyled-list">
                       {% for clpAudience in fieldClpAudience %}
@@ -87,7 +88,7 @@
       <div class="vads-l-row">
         <div class="vads-l-col--12 medium-screen:vads-l-col--9">
           <!-- Title -->
-          <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">WHAT YOU CAN DO</p>
+          <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">What you can do</p>
           <h2 class="vads-u-margin--0">{{ fieldClpWhatYouCanDoHeader }}</h2>
           <p class="va-introtext vads-u-margin-top--1 vads-u-margin-bottom--4">{{ fieldClpWhatYouCanDoIntro }}</p>
         </div>
@@ -119,7 +120,7 @@
           <!-- CONTENT -->
           <div class="vads-l-col--12 medium-screen:vads-l-col--9">
             <!-- Title -->
-            <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">VIDEO</p>
+            <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">Video</p>
             <h2 class="vads-u-margin--0">{{ fieldClpVideoPanelHeader }}</h2>
 
             <!-- Video -->
@@ -157,7 +158,7 @@
     <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
       <div class="vads-l-row">
         <div class="vads-l-col--12 medium-screen:vads-l-col--9">
-          <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">SPOTLIGHT</p>
+          <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">Spotlight</p>
           <h2 class="vads-u-margin-top--0">{{ fieldClpSpotlightHeader }}</h2>
           <p class="va-introtext vads-u-margin-top--1 vads-u-margin-bottom--4">
             {{ fieldClpSpotlightIntroText }}
@@ -193,7 +194,7 @@
           <!-- CONTENT -->
           <div class="vads-l-col--12 medium-screen:vads-l-col--9">
             <!-- Title -->
-            <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">STORIES</p>
+            <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">Stories</p>
             <h2 class="vads-u-margin-top--0">{{ fieldClpStoriesHeader }}</h2>
             <p class="va-introtext vads-u-margin-top--1 vads-u-margin-bottom--4">{{ fieldClpStoriesIntro }}</p>
 
@@ -233,7 +234,7 @@
       <div class="vads-l-row">
         <div class="vads-l-col--12 medium-screen:vads-l-col--9">
           <!-- Title -->
-          <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">DOWNLOADABLE RESOURCES</p>
+          <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">Downloadable resources</p>
           <h2 class="vads-u-margin-top--0">{{ fieldClpResourcesHeader }}</h2>
           <p class="va-introtext vads-u-margin-top--1 vads-u-margin-bottom--4">{{ fieldClpResourcesIntroText }}</p>
         </div>
@@ -273,7 +274,7 @@
         <div class="vads-l-row">
           <div class="vads-l-col--12 medium-screen:vads-l-col--9">
             <!-- Title -->
-            <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">EVENTS</p>
+            <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">Events</p>
             <h2 class="vads-u-margin-top--0">{{ fieldClpEventsHeader }}</h2>
           </div>
         </div>
@@ -328,7 +329,7 @@
       <div class="vads-l-row">
         <div class="vads-l-col--12 medium-screen:vads-l-col--9">
           <!-- Title -->
-          <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">FAQ</p>
+          <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">FAQ</p>
           <h2 class="vads-u-margin-top--0">Frequently asked questions</h2>
 
           <!-- Questions/Answers -->
@@ -372,7 +373,7 @@
           <!-- CONTENT -->
           <div class="vads-l-col--12 medium-screen:vads-l-col--9">
             <!-- Title -->
-            <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">CONNECT WITH US</p>
+            <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">Connect with us</p>
             <h2 class="vads-u-margin-top--0">Get updates from Veterans Health Administration</h2>
           </div>
         </div>
@@ -435,7 +436,7 @@
       <div class="vads-l-row">
         <div class="vads-l-col--12 medium-screen:vads-l-col--9">
           <!-- Title -->
-          <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">VA BENEFITS</p>
+          <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">VA Benefits</p>
           <h2 class="vads-u-margin-top--0">Learn more about related VA benefits</h2>
         </div>
       </div>

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -1,18 +1,20 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
-{% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" with constructLcBreadcrumbs = true titleInclude = false %}
+
+<!-- Draft status -->
+{% if !entityPublished %}
+<div class="vads-u-font-size--h4 vads-u-background-color--primary-alt-lightest vads-u-border-color--primary-darker vads-u-border-bottom--2px vads-u-padding--1">
+  You are viewing a draft of "{{ entityUrl.path }}". <a data-same-tab href="{{ drupalSite }}/node/{{ entityId }}/edit">Edit this page in the CMS.</a>
+</div>
+{% endif %}
+
+{% comment %}
+  {% include "src/site/includes/breadcrumbs.drupal.liquid" with constructLcBreadcrumbs = true titleInclude = false %}
+{% endcomment %}
 
 <div id="content" class="interior" data-template="node-campaign_landing_page">
   <main class="va-l-detail-page">
-    <!-- Draft status -->
-    {% if !entityPublished %}
-      <div class="usa-alert usa-alert-info">
-        <div class="usa-alert-body">
-          <p class="usa-alert-text">You are viewing a draft.</p>
-        </div>
-      </div>
-    {% endif %}
+
 
     <div class="va-c-hero" style="background-image: url('{{ fieldHeroImage.entity.image.url }}">
       <!-- Hero Content -->

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -98,7 +98,7 @@
             <div class="vads-u-background-color--gray-light-alt vads-u-height--full medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
               <img alt="{{ promo.entity.fieldImage.entity.thumbnail.alt }}" src="{{ promo.entity.fieldImage.entity.thumbnail.url }}" />
               <h3 class="vads-u-padding-x--2">
-                <a href="{{ promo.entity.fieldPromoLink.entity.fieldLink.url }}">
+                <a href="{{ promo.entity.fieldPromoLink.entity.fieldLink.uri }}">
                   {{ promo.entity.fieldPromoLink.entity.fieldLink.title }}
                 </a>
               </h3>

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -43,7 +43,7 @@
 
     <!-- Why This Matters -->
     <div class="vads-u-background-color--primary-alt-lightest">
-      <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 medium-screen:vads-u-padding-x--0">
+      <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
           <div class="vads-l-row">
             <!-- CONTENT -->
             <div class="vads-l-col--12 medium-screen:vads-l-col--9">
@@ -83,7 +83,7 @@
     <!-- /Why This Matters -->
 
     <!-- What You Can Do -->
-    <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 medium-screen:vads-u-padding-x--0">
+    <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
       <div class="vads-l-row">
         <div class="vads-l-col--12 medium-screen:vads-l-col--9">
           <!-- Title -->
@@ -116,7 +116,7 @@
 
     <!-- Video -->
     <div class="vads-u-background-color--primary-alt-lightest">
-      <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 medium-screen:vads-u-padding-x--0">
+      <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
         <div class="vads-l-row">
           <!-- CONTENT -->
           <div class="vads-l-col--12 medium-screen:vads-l-col--9">
@@ -156,7 +156,7 @@
     </div> <!--/Video -->
 
     <!-- Spotlight -->
-    <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 medium-screen:vads-u-padding-x--0">
+    <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
       <div class="vads-l-row">
         <div class="vads-l-col--12 medium-screen:vads-l-col--9">
           <p class="vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">SPOTLIGHT</p>
@@ -190,7 +190,7 @@
 
     <!-- Stories -->
     <div class="vads-u-background-color--primary-alt-lightest">
-      <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 medium-screen:vads-u-padding-x--0">
+      <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
         <div class="vads-l-row">
           <!-- CONTENT -->
           <div class="vads-l-col--12 medium-screen:vads-l-col--9">
@@ -231,7 +231,7 @@
     </div> <!--/Stories -->
 
     <!-- Downloadable Resources -->
-    <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 medium-screen:vads-u-padding-x--0">
+    <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
       <div class="vads-l-row">
         <div class="vads-l-col--12 medium-screen:vads-l-col--9">
           <!-- Title -->
@@ -271,7 +271,7 @@
 
     <!-- Events -->
     <div class="vads-u-background-color--primary-alt-lightest">
-      <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 medium-screen:vads-u-padding-x--0">
+      <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
 
         <!-- CONTENT -->
         <div class="vads-l-row">
@@ -328,7 +328,7 @@
     </div> <!--/Events -->
 
     <!-- FAQs -->
-    <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 medium-screen:vads-u-padding-x--0">
+    <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
       <div class="vads-l-row">
         <div class="vads-l-col--12 medium-screen:vads-l-col--9">
           <!-- Title -->
@@ -371,7 +371,7 @@
     <!-- Connect with us -->
     <div class="vads-u-background-color--primary-alt-lightest">
       {% assign socialLinksObject = fieldClpConnectWithUs.entity.fieldSocialMediaLinks.platformValues | jsonToObj %}
-      <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 medium-screen:vads-u-padding-x--0">
+      <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
         <div class="vads-l-row">
           <!-- CONTENT -->
           <div class="vads-l-col--12 medium-screen:vads-l-col--9">
@@ -435,7 +435,7 @@
     </div> <!-- Connect with us -->
 
     <!-- VA Benefits -->
-    <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 medium-screen:vads-u-padding-x--0">
+    <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
       <div class="vads-l-row">
         <div class="vads-l-col--12 medium-screen:vads-l-col--9">
           <!-- Title -->


### PR DESCRIPTION
## Description

- [x] Gets rid of breadcrumbs (not used in layout)
- [x] Adjusts the "this is a draft" banner so it doesn't break the continuity of the layout during preview
- [x] Various x/y-axis alignment fixes
- [x] Fixes for various links showing `null` or `[object Object]`
- [x] Various font family adjustments

### Next PR(s)
- The fancy bright-blue border-bottom that accents a couple titles appears to have different lengths/widths. I think it has a relationship with the title above it. 
- Make sure the calendar event works when someone clicks the "add to calendar" link. I notice a runtime error about a missing description.
- Figure out the "where" part of each Event
- Change all layouts to consolidate all of the CMS-preview elements to the top of the page 
- Get the YouTube video working (does the content model include the "embed" link? we also need to adjust the width/height of the iframe because it doesn't do that automatically like an image)

## Testing done
- Tested against http://localhost:3001/preview?nodeId=15068 
- Used dev tools to resize the viewport and manipulate the DOM

## Screenshots

<details>
<summary>
Grid alignment of three-cell boxes
</summary>

![image](https://user-images.githubusercontent.com/1915775/106806932-8aed3280-6636-11eb-9b72-ff2bd33cb50c.png)


</details>
<details>
<summary>
Grid alignment of content
</summary>

![image](https://user-images.githubusercontent.com/1915775/106807627-59289b80-6637-11eb-938c-2bddc1cd38de.png)

</details>




## Acceptance criteria
- [ ] Layout is more polished

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
