### PR TITLE
[Templates] Fix table rendering

### DIFF
--- a/src/site/paragraphs/table.drupal.liquid
+++ b/src/site/paragraphs/table.drupal.liquid
@@ -42,7 +42,6 @@
                     </tr>
                 </thead>
                 <tbody>
-            <!-- this elsif is here to prevent the caption from showing up as a row -->
             {% else %}
                     <tr class="vads-u-padding-top--5" role="row">
                         {% for column in value %}

--- a/src/site/paragraphs/table.drupal.liquid
+++ b/src/site/paragraphs/table.drupal.liquid
@@ -33,30 +33,30 @@
         {% endif %}
         {% assign colLabels = entity.fieldTable.value.0  %}
         {% for value in entity.fieldTable.value %}
-          {% if forloop.first == true %}
-            <thead>
-              <tr role="row">
-                {% for column in value %}
-                  <th role="columnheader" scope="col">{{ column }}</th>
-                {% endfor %}
-              </tr>
-            </thead>
-            <tbody>
-          {% else %}
-            <tr class="vads-u-padding-top--5" role="row">
-              {% for column in value %}
-                  <td class="vads-u-padding-bottom--0 column-label vads-u-font-weight--bold medium-screen:vads-u-display--none" role="cell">
-                      <dfn> {{colLabels | getValueFromObjPath: forloop.index0}}      </dfn>
-                  </td>
-                  <td class="column-value"  role="cell">
-                      <dfn class="vads-u-display--block"> {{ column }}  </dfn>
-                  </td>
-              {% endfor %}
-            </tr>
-          {% endif %}
-
-          {% if forloop.last %}
-              </tbody>
-          {% endif %}
+            {% if forloop.first == true %}
+                <thead>
+                    <tr role="row">
+                        {% for column in value %}
+                            <th role="columnheader" scope="col">{{ column }}</th>
+                        {% endfor %}
+                    </tr>
+                </thead>
+                <tbody>
+            <!-- this elsif is here to prevent the caption from showing up as a row -->
+            {% else %}
+                    <tr class="vads-u-padding-top--5" role="row">
+                        {% for column in value %}
+                                <td class="vads-u-padding-bottom--0 column-label vads-u-font-weight--bold medium-screen:vads-u-display--none" role="cell">
+                                    <dfn> {{colLabels | getValueFromObjPath: forloop.index0}}      </dfn>
+                                </td>
+                                <td class="column-value"  role="cell">
+                                    <dfn class="vads-u-display--block"> {{ column }}  </dfn>
+                                </td>
+                        {% endfor %}
+                    </tr>
+            {% endif %}
+            {% if forloop.last %}
+                </tbody>
+            {% endif %}
         {% endfor %}
 </table>

--- a/src/site/paragraphs/table.drupal.liquid
+++ b/src/site/paragraphs/table.drupal.liquid
@@ -35,23 +35,23 @@
         {% for value in entity.fieldTable.value %}
           {% if forloop.first == true %}
             <thead>
-                <tr role="row">
-                    {% for column in value %}
-                        <th role="columnheader" scope="col">{{ column }}</th>
-                    {% endfor %}
-                </tr>
+              <tr role="row">
+                {% for column in value %}
+                  <th role="columnheader" scope="col">{{ column }}</th>
+                {% endfor %}
+              </tr>
             </thead>
             <tbody>
           {% else %}
             <tr class="vads-u-padding-top--5" role="row">
-                {% for column in value %}
-                        <td class="vads-u-padding-bottom--0 column-label vads-u-font-weight--bold medium-screen:vads-u-display--none" role="cell">
-                            <dfn> {{colLabels | getValueFromObjPath: forloop.index0}}      </dfn>
-                        </td>
-                        <td class="column-value"  role="cell">
-                            <dfn class="vads-u-display--block"> {{ column }}  </dfn>
-                        </td>
-                {% endfor %}
+              {% for column in value %}
+                  <td class="vads-u-padding-bottom--0 column-label vads-u-font-weight--bold medium-screen:vads-u-display--none" role="cell">
+                      <dfn> {{colLabels | getValueFromObjPath: forloop.index0}}      </dfn>
+                  </td>
+                  <td class="column-value"  role="cell">
+                      <dfn class="vads-u-display--block"> {{ column }}  </dfn>
+                  </td>
+              {% endfor %}
             </tr>
           {% endif %}
 

--- a/src/site/paragraphs/table.drupal.liquid
+++ b/src/site/paragraphs/table.drupal.liquid
@@ -33,28 +33,30 @@
         {% endif %}
         {% assign colLabels = entity.fieldTable.value.0  %}
         {% for value in entity.fieldTable.value %}
-            {% if forloop.first == true %}
-                <thead>
-                    <tr role="row">
-                        {% for column in value %}
-                            <th role="columnheader" scope="col">{{ column }}</th>
-                        {% endfor %}
-                    </tr>
-                </thead>
-                <tbody>
-            <!-- this elsif is here to prevent the caption from showing up as a row -->
-            {% elsif forloop.last == false %}
-                    <tr class="vads-u-padding-top--5" role="row">
-                        {% for column in value %}
-                                <td class="vads-u-padding-bottom--0 column-label vads-u-font-weight--bold medium-screen:vads-u-display--none" role="cell">
-                                    <dfn> {{colLabels | getValueFromObjPath: forloop.index0}}      </dfn>
-                                </td>
-                                <td class="column-value"  role="cell">
-                                    <dfn class="vads-u-display--block"> {{ column }}  </dfn>
-                                </td>
-                        {% endfor %}
-                    </tr>
-            {% endif %}
-                </tbody>
+          {% if forloop.first == true %}
+            <thead>
+                <tr role="row">
+                    {% for column in value %}
+                        <th role="columnheader" scope="col">{{ column }}</th>
+                    {% endfor %}
+                </tr>
+            </thead>
+            <tbody>
+          {% else %}
+            <tr class="vads-u-padding-top--5" role="row">
+                {% for column in value %}
+                        <td class="vads-u-padding-bottom--0 column-label vads-u-font-weight--bold medium-screen:vads-u-display--none" role="cell">
+                            <dfn> {{colLabels | getValueFromObjPath: forloop.index0}}      </dfn>
+                        </td>
+                        <td class="column-value"  role="cell">
+                            <dfn class="vads-u-display--block"> {{ column }}  </dfn>
+                        </td>
+                {% endfor %}
+            </tr>
+          {% endif %}
+
+          {% if forloop.last %}
+              </tbody>
+          {% endif %}
         {% endfor %}
 </table>


### PR DESCRIPTION
## Description
This PR fixes an issue where the last table row isn't being rendered.

https://github.com/department-of-veterans-affairs/vets-website/issues/15910
## Testing done
Tested against http://localhost:3001/preview?nodeId=993 (https://www.va.gov/disability/compensation-rates/birth-defect-rates/) and http://localhost:3001/preview?nodeId=1001

## Screenshots

![image](https://user-images.githubusercontent.com/1915775/106656729-14ceca00-6569-11eb-851d-78a0095a4ca1.png)


## Acceptance criteria
- [ ] Last table row is rendered

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
