### PR TITLE
Fix add to calendar links on VAOS

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage.jsx
@@ -137,7 +137,7 @@ function ConfirmedAppointmentDetailsPage({
                 description={`instructionText`}
                 location={location}
                 duration={appointment.minutesDuration}
-                startDateTime={moment.parseZone(appointment.start)}
+                startDateTime={appointment.start}
               />
             </div>
 

--- a/src/applications/vaos/appointment-list/components/cards/confirmed/ConfirmedAppointmentListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/cards/confirmed/ConfirmedAppointmentListItem.jsx
@@ -220,7 +220,7 @@ export default function ConfirmedAppointmentListItem({
               description={instructionText}
               location={location}
               duration={appointment.minutesDuration}
-              startDateTime={moment.parseZone(appointment.start)}
+              startDateTime={appointment.start}
             />
             {showCancelButton && (
               <button

--- a/src/applications/vaos/appointment-list/components/cards/confirmed/ConfirmedAppointmentListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/cards/confirmed/ConfirmedAppointmentListItem.jsx
@@ -101,11 +101,9 @@ export default function ConfirmedAppointmentListItem({
   if (isAtlas) {
     header = 'VA Video Connect';
     subHeader = ' at an ATLAS location';
-    const { address } = getATLASLocation(appointment);
-    if (address) {
-      location = `${address.streetAddress}, ${address.city}, ${address.state} ${
-        address.zipCode
-      }`;
+    const atlasLocation = getATLASLocation(appointment);
+    if (atlasLocation?.address) {
+      location = formatFacilityAddress(atlasLocation);
     }
   } else if (videoKind === VIDEO_TYPES.clinic) {
     header = 'VA Video Connect';
@@ -134,6 +132,7 @@ export default function ConfirmedAppointmentListItem({
     location = facility ? formatFacilityAddress(facility) : null;
     if (appointment.vaos.isPhoneAppointment) {
       subHeader = ' over the phone';
+      location = 'Phone call';
     }
   }
 

--- a/src/applications/vaos/components/AddToCalendar.jsx
+++ b/src/applications/vaos/components/AddToCalendar.jsx
@@ -38,8 +38,12 @@ function generateICS(
   startDateTime,
   endDateTime,
 ) {
-  const startDate = moment(startDateTime).format('YYYYMMDDTHHmmss');
-  const endDate = moment(endDateTime).format('YYYYMMDDTHHmmss');
+  const startDate = moment(startDateTime)
+    .utc()
+    .format('YYYYMMDDTHHmmss[Z]');
+  const endDate = moment(endDateTime)
+    .utc()
+    .format('YYYYMMDDTHHmmss[Z]');
   return [
     `BEGIN:VCALENDAR`,
     `VERSION:2.0`,
@@ -72,7 +76,7 @@ export default function AddToCalendar({
     startDateTime,
     moment(startDateTime).add(duration, 'minutes'),
   );
-  const formattedDate = moment(startDateTime).format('MMMM D, YYYY');
+  const formattedDate = moment.parseZone(startDateTime).format('MMMM D, YYYY');
 
   // IE11 doesn't support the download attribute, so this creates a button
   // and uses an ms blob save api

--- a/src/applications/vaos/components/AddToCalendar.jsx
+++ b/src/applications/vaos/components/AddToCalendar.jsx
@@ -28,7 +28,7 @@ function formatDescription(description) {
   }
   chunked.push(restOfDescription);
 
-  return chunked.join('\r\n\t');
+  return chunked.join('\r\n\t').replace(/,/g, '\\,');
 }
 
 function generateICS(
@@ -40,19 +40,21 @@ function generateICS(
 ) {
   const startDate = moment(startDateTime).format('YYYYMMDDTHHmmss');
   const endDate = moment(endDateTime).format('YYYYMMDDTHHmmss');
-  return `BEGIN:VCALENDAR
-          VERSION:2.0
-          PRODID:VA
-          BEGIN:VEVENT
-          UID:${guid()}
-          SUMMARY:${summary}
-          ${formatDescription(description)}
-          LOCATION:${location}
-          DTSTAMP:${startDate}
-          DTSTART:${startDate}
-          DTEND:${endDate}
-          END:VEVENT
-          END:VCALENDAR`;
+  return [
+    `BEGIN:VCALENDAR`,
+    `VERSION:2.0`,
+    `PRODID:VA`,
+    `BEGIN:VEVENT`,
+    `UID:${guid()}`,
+    `SUMMARY:${summary}`,
+    `${formatDescription(description)}`,
+    `LOCATION:${location?.replace(/,/g, '\\,')}`,
+    `DTSTAMP:${startDate}`,
+    `DTSTART:${startDate}`,
+    `DTEND:${endDate}`,
+    `END:VEVENT`,
+    `END:VCALENDAR`,
+  ].join('\r\n');
 }
 
 export default function AddToCalendar({
@@ -68,9 +70,7 @@ export default function AddToCalendar({
     description,
     location,
     startDateTime,
-    moment(startDateTime)
-      .add(duration, 'minutes')
-      .toDate(),
+    moment(startDateTime).add(duration, 'minutes'),
   );
   const formattedDate = moment(startDateTime).format('MMMM D, YYYY');
 

--- a/src/applications/vaos/new-appointment/components/ConfirmationPage/ConfirmationDirectScheduleInfo.jsx
+++ b/src/applications/vaos/new-appointment/components/ConfirmationPage/ConfirmationDirectScheduleInfo.jsx
@@ -78,7 +78,7 @@ export default function ConfirmationDirectScheduleInfo({
               summary="VA Appointment"
               description=""
               location={formatFacilityAddress(facilityDetails)}
-              startDateTime={momentDate}
+              startDateTime={momentDate.format()}
               duation={appointmentLength}
             />
           </div>

--- a/src/applications/vaos/tests/components/AddToCalendar.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/AddToCalendar.unit.spec.jsx
@@ -14,7 +14,7 @@ describe('VAOS <AddToCalendar>', () => {
       <AddToCalendar
         summary="VA Appointment"
         description="Follow-up/Routine: some description"
-        location="A location"
+        location="123 main street, bozeman, MT"
         duration={60}
         startDateTime={startDateTime.toDate()}
       />,
@@ -39,7 +39,7 @@ describe('VAOS <AddToCalendar>', () => {
     expect(ics).to.contain('UID:');
     expect(ics).to.contain('SUMMARY:VA Appointment');
     expect(ics).to.contain('DESCRIPTION:Follow-up/Routine: some description');
-    expect(ics).to.contain('LOCATION:A location');
+    expect(ics).to.contain('LOCATION:123 main street\\, bozeman\\, MT');
     expect(ics).to.contain(
       `DTSTAMP:${startDateTime.format('YYYYMMDDTHHmmss')}`,
     );
@@ -73,7 +73,7 @@ describe('VAOS <AddToCalendar>', () => {
         .replace('data:text/calendar;charset=utf-8,', ''),
     );
     expect(ics).to.contain(
-      'DESCRIPTION:Testing long line descriptions Testing long descriptions Testi\r\n\tng long descriptions Testing long descriptions Testing long descriptions T\r\n\testing long descriptions Testing long descriptions Testing long descriptio\r\n\tns\n',
+      'DESCRIPTION:Testing long line descriptions Testing long descriptions Testi\r\n\tng long descriptions Testing long descriptions Testing long descriptions T\r\n\testing long descriptions Testing long descriptions Testing long descriptio\r\n\tns\r\n',
     );
   });
   it('should download ICS file via blob in IE', () => {

--- a/src/applications/vaos/tests/components/AddToCalendar.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/AddToCalendar.unit.spec.jsx
@@ -41,15 +41,20 @@ describe('VAOS <AddToCalendar>', () => {
     expect(ics).to.contain('DESCRIPTION:Follow-up/Routine: some description');
     expect(ics).to.contain('LOCATION:123 main street\\, bozeman\\, MT');
     expect(ics).to.contain(
-      `DTSTAMP:${startDateTime.format('YYYYMMDDTHHmmss')}`,
+      `DTSTAMP:${moment(startDateTime)
+        .utc()
+        .format('YYYYMMDDTHHmmss[Z]')}`,
     );
     expect(ics).to.contain(
-      `DTSTART:${startDateTime.format('YYYYMMDDTHHmmss')}`,
+      `DTSTART:${moment(startDateTime)
+        .utc()
+        .format('YYYYMMDDTHHmmss[Z]')}`,
     );
     expect(ics).to.contain(
       `DTEND:${startDateTime
         .clone()
         .add(60, 'minutes')
+        .utc()
         .format('YYYYMMDDTHHmmss')}`,
     );
   });


### PR DESCRIPTION
## Description
This PR
- Fixes the formatting in the ICS file that was causing calendar apps to throw errors
- Fixes locations getting cutoff at the first comma
- Fixes ics validator error around line breaks needing to be CRLFs
- Fixes phone appointments to remove facility address
- Fixes incorrect duration calculation due to `.toDate()` call

How to test
- Make sure the va_online_scheduling_homepage_refresh flag is turned off
- Click on Add to calendar link on appointment list: http://localhost:3001/health-care/schedule-view-va-appointments/appointments/
- Open ICS file in a calendar app

## Testing done
Unit testing, local testing, used online ics validator tool

## Screenshots
![Screen Shot 2021-02-02 at 4 57 11 PM](https://user-images.githubusercontent.com/634932/106668875-d93bfc00-6578-11eb-80c7-d86fe4df966b.png)

## Acceptance criteria
- [ ] Calendar links generate valid ICS files again

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
