### PR TITLE
Sanlouise hide nametag loa1

### DIFF
--- a/src/applications/personalization/dashboard-2/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard-2/components/Dashboard.jsx
@@ -32,7 +32,7 @@ const Dashboard = props => {
     <>
       {isEmpty(props.hero?.errors) && (
         <NameTag
-          showUpdatedHeader
+          showUpdatedNameTag
           totalDisabilityRating={props.totalDisabilityRating}
         />
       )}

--- a/src/applications/personalization/dashboard-2/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard-2/components/Dashboard.jsx
@@ -11,9 +11,9 @@ import {
   fetchPersonalInformation as fetchPersonalInformationAction,
 } from '@@profile/actions';
 
-import { fetchTotalDisabilityRating as fetchTotalDisabilityRatingAction } from 'applications/personalization/rated-disabilities/actions';
+import { fetchTotalDisabilityRating as fetchTotalDisabilityRatingAction } from '~/applications/personalization/rated-disabilities/actions';
 
-import ProfileHeader from 'applications/personalization/profile/components/ProfileHeader';
+import NameTag from '~/applications/personalization/profile/components/NameTag';
 
 import ApplyForBenefits from './apply-for-benefits/ApplyForBenefits';
 import ClaimsAndAppeals from './claims-and-appeals/ClaimsAndAppeals';
@@ -31,7 +31,7 @@ const Dashboard = props => {
   return (
     <>
       {isEmpty(props.hero?.errors) && (
-        <ProfileHeader
+        <NameTag
           showUpdatedHeader
           totalDisabilityRating={props.totalDisabilityRating}
         />

--- a/src/applications/personalization/profile/components/NameTag.jsx
+++ b/src/applications/personalization/profile/components/NameTag.jsx
@@ -13,7 +13,7 @@ const NameTag = ({
   latestBranchOfService,
   showBadgeImage,
   totalDisabilityRating,
-  showUpdatedHeader,
+  showUpdatedNameTag,
 }) => {
   const fullName = [first, middle, last, suffix]
     .filter(name => !!name)
@@ -93,7 +93,7 @@ const NameTag = ({
     'medium',
   );
 
-  const wrapperClassDerived = showUpdatedHeader
+  const wrapperClassDerived = showUpdatedNameTag
     ? updatedWrapperClasses
     : wrapperClasses;
 
@@ -116,7 +116,7 @@ const NameTag = ({
   };
 
   return (
-    <div className={classes.wrapper} data-testid="profile-header">
+    <div className={classes.wrapper} data-testid="name-tag">
       <div className={classes.innerWrapper}>
         <div className={classes.serviceBadge}>
           {showBadgeImage && (
@@ -138,7 +138,7 @@ const NameTag = ({
                 {getServiceBranchDisplayName(latestBranchOfService)}
               </dd>
             )}
-            {showUpdatedHeader &&
+            {showUpdatedNameTag &&
               totalDisabilityRating && (
                 <>
                   <dt className="sr-only">total disability rating</dt>

--- a/src/applications/personalization/profile/components/NameTag.jsx
+++ b/src/applications/personalization/profile/components/NameTag.jsx
@@ -8,7 +8,7 @@ import prefixUtilityClasses from 'platform/utilities/prefix-utility-classes';
 import { SERVICE_BADGE_IMAGE_PATHS } from '../constants';
 import { getServiceBranchDisplayName } from '../helpers';
 
-const ProfileHeader = ({
+const NameTag = ({
   userFullName: { first, middle, last, suffix },
   latestBranchOfService,
   showBadgeImage,
@@ -179,7 +179,7 @@ const mapStateToProps = state => {
   };
 };
 
-ProfileHeader.defaultProps = {
+NameTag.defaultProps = {
   userFullName: {
     first: '',
     middle: '',
@@ -189,7 +189,7 @@ ProfileHeader.defaultProps = {
   latestBranchOfService: '',
 };
 
-ProfileHeader.propTypes = {
+NameTag.propTypes = {
   showBadgeImage: PropTypes.bool,
   userFullName: PropTypes.shape({
     first: PropTypes.string,
@@ -200,4 +200,4 @@ ProfileHeader.propTypes = {
   latestBranchOfService: PropTypes.string.isRequired,
 };
 
-export default connect(mapStateToProps)(ProfileHeader);
+export default connect(mapStateToProps)(NameTag);

--- a/src/applications/personalization/profile/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile/components/ProfileWrapper.jsx
@@ -84,7 +84,7 @@ const ProfileWrapper = ({
         </Breadcrumbs>
       </div>
 
-      {isEmpty(hero.errors) && <ProfileHeader />}
+      {isEmpty(hero.errors) && isLOA3 && <ProfileHeader />}
 
       <div className="medium-screen:vads-u-display--none">
         <ProfileMobileSubNav

--- a/src/applications/personalization/profile/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile/components/ProfileWrapper.jsx
@@ -16,7 +16,7 @@ import {
   personalInformationLoadError,
 } from '@@profile/selectors';
 
-import ProfileHeader from './ProfileHeader';
+import NameTag from './NameTag';
 import ProfileSubNav from './ProfileSubNav';
 import ProfileMobileSubNav from './ProfileMobileSubNav';
 import { PROFILE_PATHS } from '../constants';
@@ -84,7 +84,7 @@ const ProfileWrapper = ({
         </Breadcrumbs>
       </div>
 
-      {isEmpty(hero.errors) && isLOA3 && <ProfileHeader />}
+      {isEmpty(hero.errors) && isLOA3 && <NameTag />}
 
       <div className="medium-screen:vads-u-display--none">
         <ProfileMobileSubNav

--- a/src/applications/personalization/profile/tests/components/NameTag.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/NameTag.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { expect } from 'chai';
 
-import ProfileHeader from '../../components/ProfileHeader';
+import NameTag from '../../components/NameTag';
 
 const fakeStore = {
   getState: () => ({
@@ -41,14 +41,14 @@ const fakeStore = {
   dispatch: () => {},
 };
 
-describe('<ProfileHeader>', () => {
+describe('<NameTag>', () => {
   it('should render', () => {
-    const component = mount(<ProfileHeader store={fakeStore} />);
+    const component = mount(<NameTag store={fakeStore} />);
     expect(component).to.not.be.undefined;
     component.unmount();
   });
   it('should render name', () => {
-    const component = mount(<ProfileHeader store={fakeStore} />);
+    const component = mount(<NameTag store={fakeStore} />);
     expect(
       component
         .find('dd')
@@ -59,7 +59,7 @@ describe('<ProfileHeader>', () => {
   });
   it('should render most recent military service', () => {
     // this will render the most recent military service regardless of where it lands in the array
-    const component = mount(<ProfileHeader store={fakeStore} />);
+    const component = mount(<NameTag store={fakeStore} />);
     expect(
       component
         .find('dd')
@@ -69,14 +69,14 @@ describe('<ProfileHeader>', () => {
     component.unmount();
   });
   it('should render latest service badge', () => {
-    const component = mount(<ProfileHeader store={fakeStore} />);
+    const component = mount(<NameTag store={fakeStore} />);
     expect(component.find('img').first()).to.not.be.undefined;
     component.unmount();
   });
 
   it('should render disability rating when the dashboardShowDashboard2 feature flag is turned on and the user has a disability rating', () => {
     const component = mount(
-      <ProfileHeader
+      <NameTag
         showUpdatedHeader
         totalDisabilityRating="70"
         store={fakeStore}
@@ -92,9 +92,7 @@ describe('<ProfileHeader>', () => {
   });
 
   it('should not render disability rating when the dashboardShowDashboard2 feature flag is turned on and the user has no disability rating', () => {
-    const component = mount(
-      <ProfileHeader showUpdatedHeader store={fakeStore} />,
-    );
+    const component = mount(<NameTag showUpdatedHeader store={fakeStore} />);
     expect(component.text()).to.not.contain('Service connected');
     component.unmount();
   });

--- a/src/applications/personalization/profile/tests/components/NameTag.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/NameTag.unit.spec.jsx
@@ -77,7 +77,7 @@ describe('<NameTag>', () => {
   it('should render disability rating when the dashboardShowDashboard2 feature flag is turned on and the user has a disability rating', () => {
     const component = mount(
       <NameTag
-        showUpdatedHeader
+        showUpdatedNameTag
         totalDisabilityRating="70"
         store={fakeStore}
       />,
@@ -92,7 +92,7 @@ describe('<NameTag>', () => {
   });
 
   it('should not render disability rating when the dashboardShowDashboard2 feature flag is turned on and the user has no disability rating', () => {
-    const component = mount(<NameTag showUpdatedHeader store={fakeStore} />);
+    const component = mount(<NameTag showUpdatedNameTag store={fakeStore} />);
     expect(component.text()).to.not.contain('Service connected');
     component.unmount();
   });

--- a/src/applications/personalization/profile/tests/components/ProfileWrapper.unit.spec.js
+++ b/src/applications/personalization/profile/tests/components/ProfileWrapper.unit.spec.js
@@ -34,7 +34,7 @@ describe('ProfileWrapper', () => {
       .not.to.be.null;
   });
 
-  it('should render ProfileHeader when the full name of the user was fetched)', () => {
+  it('should render NameTag when the full name of the user was fetched)', () => {
     const initialState = {
       vaProfile: {
         hero: {
@@ -46,11 +46,11 @@ describe('ProfileWrapper', () => {
       },
     };
     const { getByTestId } = render(ui, { initialState });
-    const profileHeader = getByTestId('profile-header');
-    expect(profileHeader.textContent.match(/Test Test/i)).not.to.be.null;
+    const NameTag = getByTestId('profile-header');
+    expect(NameTag.textContent.match(/Test Test/i)).not.to.be.null;
   });
 
-  it('should not render ProfileHeader when the full name of the user could not be fetched)', () => {
+  it('should not render NameTag when the full name of the user could not be fetched)', () => {
     const initialState = {
       vaProfile: {
         hero: {
@@ -59,11 +59,11 @@ describe('ProfileWrapper', () => {
       },
     };
     const { queryByTestId } = render(ui, { initialState });
-    const profileHeader = queryByTestId('profile-header');
-    expect(profileHeader).to.be.null;
+    const NameTag = queryByTestId('profile-header');
+    expect(NameTag).to.be.null;
   });
 
-  it('should not render ProfileHeader when the user is LOA1)', () => {
+  it('should not render NameTag when the user is LOA1)', () => {
     ui = (
       <MemoryRouter initialEntries={[PROFILE_PATHS.PERSONAL_INFORMATION]}>
         <ProfileWrapper routes={getRoutes(config)} />
@@ -78,7 +78,7 @@ describe('ProfileWrapper', () => {
       },
     };
     const { queryByTestId } = render(ui, { initialState });
-    const profileHeader = queryByTestId('profile-header');
-    expect(profileHeader).to.not.exist;
+    const NameTag = queryByTestId('profile-header');
+    expect(NameTag).to.not.exist;
   });
 });

--- a/src/applications/personalization/profile/tests/components/ProfileWrapper.unit.spec.js
+++ b/src/applications/personalization/profile/tests/components/ProfileWrapper.unit.spec.js
@@ -46,7 +46,7 @@ describe('ProfileWrapper', () => {
       },
     };
     const { getByTestId } = render(ui, { initialState });
-    const NameTag = getByTestId('profile-header');
+    const NameTag = getByTestId('name-tag');
     expect(NameTag.textContent.match(/Test Test/i)).not.to.be.null;
   });
 
@@ -59,7 +59,7 @@ describe('ProfileWrapper', () => {
       },
     };
     const { queryByTestId } = render(ui, { initialState });
-    const NameTag = queryByTestId('profile-header');
+    const NameTag = queryByTestId('name-tag');
     expect(NameTag).to.be.null;
   });
 
@@ -78,7 +78,7 @@ describe('ProfileWrapper', () => {
       },
     };
     const { queryByTestId } = render(ui, { initialState });
-    const NameTag = queryByTestId('profile-header');
+    const NameTag = queryByTestId('name-tag');
     expect(NameTag).to.not.exist;
   });
 });

--- a/src/applications/personalization/profile/tests/components/ProfileWrapper.unit.spec.js
+++ b/src/applications/personalization/profile/tests/components/ProfileWrapper.unit.spec.js
@@ -9,10 +9,11 @@ import { PROFILE_PATHS } from '../../constants';
 import { renderWithProfileReducers as render } from '../unit-test-helpers';
 
 describe('ProfileWrapper', () => {
+  let ui;
   const config = {};
-  const ui = (
+  ui = (
     <MemoryRouter initialEntries={[PROFILE_PATHS.PERSONAL_INFORMATION]}>
-      <ProfileWrapper routes={getRoutes(config)} />
+      <ProfileWrapper routes={getRoutes(config)} isLOA3 />
     </MemoryRouter>
   );
 
@@ -60,5 +61,24 @@ describe('ProfileWrapper', () => {
     const { queryByTestId } = render(ui, { initialState });
     const profileHeader = queryByTestId('profile-header');
     expect(profileHeader).to.be.null;
+  });
+
+  it('should not render ProfileHeader when the user is LOA1)', () => {
+    ui = (
+      <MemoryRouter initialEntries={[PROFILE_PATHS.PERSONAL_INFORMATION]}>
+        <ProfileWrapper routes={getRoutes(config)} />
+      </MemoryRouter>
+    );
+
+    const initialState = {
+      vaProfile: {
+        hero: {
+          errors: ['This is an error'],
+        },
+      },
+    };
+    const { queryByTestId } = render(ui, { initialState });
+    const profileHeader = queryByTestId('profile-header');
+    expect(profileHeader).to.not.exist;
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/profile-a11y.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile-a11y.cypress.spec.js
@@ -40,7 +40,7 @@ function checkAllPages(mobile = false) {
 
   // since we did not mock the `GET profile/full_name` endpoint, the
   // NameTag should not be rendered on the page
-  cy.findByTestId('profile-header').should('not.exist');
+  cy.findByTestId('name-tag').should('not.exist');
 
   // visiting /profile should redirect to profile/personal-information
   cy.url().should(

--- a/src/applications/personalization/profile/tests/e2e/profile-a11y.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile-a11y.cypress.spec.js
@@ -39,7 +39,7 @@ function checkAllPages(mobile = false) {
   cy.findByText(/loading your information/i).should('not.exist');
 
   // since we did not mock the `GET profile/full_name` endpoint, the
-  // ProfileHeader should not be rendered on the page
+  // NameTag should not be rendered on the page
   cy.findByTestId('profile-header').should('not.exist');
 
   // visiting /profile should redirect to profile/personal-information


### PR DESCRIPTION
## Description
We want to hide the `NameTag` for LOA1 users because we don't have access to their full name. Also, renaming the `ProfileHeader` to `NameTag` makes sense since it's now a shared component with the Dashboard.

## Testing done
Updated unit tests, checked locally.

## Acceptance criteria
- [x] Renames `ProfileHeader` to `NameTag`
- [x] Hides the `NameTag` for LOA1 users 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
