### PR TITLE
fix aria label for internal link

### DIFF
--- a/src/applications/coronavirus-vaccination/components/Introduction.jsx
+++ b/src/applications/coronavirus-vaccination/components/Introduction.jsx
@@ -147,7 +147,7 @@ function Introduction({
                 <a
                   href="/health-care/covid-19-vaccine/#who-will-get-a-covid-19-vaccin"
                   aria-label="Learn who will get a COVID-19 vaccine first based on CDC
-                  guidelines (Open in a new window)"
+                  guidelines"
                 >
                   Learn who can get a COVID-19 vaccine now based on CDC
                   guidelines


### PR DESCRIPTION
## Description
Simple fix to remove `Open in new window` from aria-label for an internal link

## Testing done
unit tests and e2e tests all pass

## Screenshots
![image](https://user-images.githubusercontent.com/2481110/106792882-b6ffb800-6624-11eb-9064-c091eea70ea1.png)

## Acceptance criteria
- [ ] text is updated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
