### PR TITLE
Debug medallia on teamsite pages

### DIFF
--- a/src/site/assets/js/medallia/vagovprod.js
+++ b/src/site/assets/js/medallia/vagovprod.js
@@ -1,7 +1,12 @@
 // Medallia Embed Script
 (function(g) {
+  console.log("src/site/assets/js/medallia/vagovprod.js")
+  console.log("Begin generating Medallia script")
   var isStaging = window.location.host.includes('staging');
-  if (!isStaging) return
+  if (!isStaging) {
+    console.log("Stop generating Medallia script; `window.location.host` doesn't include 'staging'.")
+    return
+  }
 
   var teamSitePathnames = [
     // `/ORMDI` redirects to include a trailing slash (`/ORMDI/`)
@@ -23,7 +28,10 @@
   ];
   var pathname = window.location.pathname;
   var isApprovedPathname = teamSitePathnames.some(x => x.test(pathname))
-  if (!isApprovedPathname) return
+  if (!isApprovedPathname) {
+    console.log("Stop generating Medallia script; page isn't included in the allow list.")
+    return
+  }
 
   var d = document,
     am = d.createElement('script'),
@@ -37,6 +45,7 @@
   for (var attr in aex) {
     am.setAttribute(attr, aex[attr]);
   }
+  console.log("Begin appending Medallia script")
   h.appendChild(am);
   g[fsr] ||
     (g[fsr] = function() {
@@ -44,5 +53,6 @@
       g[aT] = g[aT] || [];
       g[aT].push(arguments);
     });
+  console.log("Finish appending Medallia script")
 })(window);
 

--- a/src/site/assets/js/medallia/vagovstaging.js
+++ b/src/site/assets/js/medallia/vagovstaging.js
@@ -1,0 +1,58 @@
+// Medallia Embed Script
+(function(g) {
+  console.log("src/site/assets/js/medallia/vagovstaging.js")
+  console.log("Begin generating Medallia script")
+  var isStaging = window.location.host.includes('staging');
+  if (!isStaging) {
+    console.log("Stop generating Medallia script; `window.location.host` doesn't include 'staging'.")
+    return
+  }
+
+  var teamSitePathnames = [
+    // `/ORMDI` redirects to include a trailing slash (`/ORMDI/`)
+    // `/\/ormdi\/$/i.test('/ormdi/')` // true
+    // `/\/ormdi\/$/i.test('/ORMDI/')` // true
+    // `/\/ormdi\/$/i.test('/ORMDI/foo')` // false
+    /\/ormdi\/$/i,
+    /\/ormdi\/NoFEAR_Select.asp/i,
+    /\/ormdi\/Contact_Us.asp/i,
+    /\/ormdi\/EEOcomplaint.asp/i,
+    /\/ormdi\/HPP.asp/i,
+    /\/ormdi\/Diversity_Inclusion.asp/i,
+    /\/ormdi\/Reasonable_Accommodations1.asp/i,
+    // `/adr` redirects to include a trailing slash (`/adr/`)
+    // `/\/adr\/$/i.test('/adr/')` // true
+    // `/\/adr\/$/i.test('/ADR/')` // true
+    // `/\/adr\/$/i.test('/ADR/foo')` // false
+    /\/adr\/$/i,
+  ];
+  var pathname = window.location.pathname;
+  var isApprovedPathname = teamSitePathnames.some(x => x.test(pathname))
+  if (!isApprovedPathname) {
+    console.log("Stop generating Medallia script; page isn't included in the allow list.")
+    return
+  }
+
+  var d = document,
+    am = d.createElement('script'),
+    h = d.head || d.getElementsByTagName('head')[0],
+    fsr = 'fsReady',
+    aex = {
+      src: 'https://resource.digital.voice.va.gov/wdcvoice/5/onsite/embed.js',
+      type: 'text/javascript',
+      async: 'true',
+    };
+  for (var attr in aex) {
+    am.setAttribute(attr, aex[attr]);
+  }
+  console.log("Begin appending Medallia script")
+  h.appendChild(am);
+  g[fsr] ||
+    (g[fsr] = function() {
+      var aT = '__' + fsr + '_stk__';
+      g[aT] = g[aT] || [];
+      g[aT].push(arguments);
+    });
+  console.log("Finish appending Medallia script")
+})(window);
+

--- a/src/site/includes/survey-tools.html
+++ b/src/site/includes/survey-tools.html
@@ -1,6 +1,8 @@
 {% if buildtype == 'vagovprod' %}
   <script nonce="**CSP_NONCE**">
     {% include "src/site/assets/js/foresee/vagovprod.js" %}
+  </script>
+  <script nonce="**CSP_NONCE**">
     {% include "src/site/assets/js/medallia/vagovprod.js" %}
   </script>
 {% endif %}
@@ -8,6 +10,9 @@
 {% if buildtype == 'vagovstaging' %}
   <script nonce="**CSP_NONCE**">
     {% include "src/site/assets/js/foresee/vagovstaging.js" %}
+  </script>
+  <script nonce="**CSP_NONCE**">
+    {% include "src/site/assets/js/medallia/vagovstaging.js" %}
   </script>
   <script type="text/javascript" nonce="**CSP_NONCE**" src="https://resource.digital.voice.va.gov/wdcvoice/5/onsite/embed.js" async></script>
 {% endif %}


### PR DESCRIPTION
## GitHub Issue

https://github.com/department-of-veterans-affairs/va.gov-team/issues/18319

## Disclaimer

This PR is not intended to go to prod. It shouldn't hurt anything if it did go to prod, but it's really only meant to add some logs to debug some TeamSite pages in staging. I intend to revert this PR before the next daily deploy. 

## Fun Facts

- Our `.eslintignore` [file](https://github.com/department-of-veterans-affairs/vets-website/blob/master/.eslintignore) currently ignores the `src/site/assets` directory. That's why there are no linting warnings/errors from the `console.log`s. 
- I don't think the `src/site/assets` directory gets transpiled by Babel, which means I think we have to write ES5 JS in that directory to avoid breaking IE11. 

## Description

This PR expands on https://github.com/department-of-veterans-affairs/vets-website/pull/15889, and does the following:

- Adds some console.logs
- Moves the `medallia/vagovprod.js` `include` into a separate `script` element
- Copies `medallia/vagovprod.js` into a `staging` version

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
