### PR TITLE
Fix node-publication_listing diffs

### DIFF
--- a/src/site/stages/build/process-cms-exports/schemas/input/node-office.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/node-office.js
@@ -3,6 +3,7 @@
 module.exports = {
   type: 'object',
   properties: {
+    nid: { $ref: 'GenericNestedNumber' },
     title: { $ref: 'GenericNestedString' },
     created: { $ref: 'GenericNestedString' },
     changed: { $ref: 'GenericNestedString' },
@@ -18,6 +19,7 @@ module.exports = {
     field_meta_title: { $ref: 'GenericNestedString' },
   },
   required: [
+    'nid',
     'title',
     'created',
     'changed',

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-office.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-office.js
@@ -1,6 +1,7 @@
 module.exports = {
   type: 'object',
   properties: {
+    targetId: { type: 'number' },
     entityType: { type: 'string', enum: ['node'] },
     entityBundle: { type: 'string', enum: ['office'] },
     title: { type: 'string' },
@@ -13,6 +14,7 @@ module.exports = {
     fieldMetaTitle: { type: 'string' },
   },
   required: [
+    'targetId',
     'title',
     'created',
     'changed',

--- a/src/site/stages/build/process-cms-exports/transformers/node-office.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-office.js
@@ -6,6 +6,7 @@ const {
 } = require('./helpers');
 
 const transform = entity => ({
+  targetId: getDrupalValue(entity.nid),
   entityType: 'node',
   entityBundle: 'office',
   entityLabel: getDrupalValue(entity.title),
@@ -22,6 +23,7 @@ const transform = entity => ({
 });
 module.exports = {
   filter: [
+    'nid',
     'title',
     'created',
     'changed',


### PR DESCRIPTION
## Description
This PR fixes discrepancies found in `publication_listing` nodes when running the JSON diff tool.
- Adds the `targetId` field to the `node-office` transformer.

## Testing done
Local testing with the JSON diff tool.

## Screenshots


## Acceptance criteria
- [ ] `publication_listing` nodes should not be present in the JSON diff tool output.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
