### PR TITLE
Filter out empty health services in CMS export build

### DIFF
--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -8,22 +8,22 @@
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
       <div class="usa-width-three-fourths">
         {% if !entityPublished %}
-        <div class="usa-alert usa-alert-info">
-          <div class="usa-alert-body">
-            <p class="usa-alert-text">You are viewing a draft.</p>
+          <div class="usa-alert usa-alert-info">
+            <div class="usa-alert-body">
+              <p class="usa-alert-text">You are viewing a draft.</p>
+            </div>
           </div>
-        </div>
         {% endif %}
 
         <article class="usa-content va-l-facility-detail">
           {% if title != empty %}
-          <h1>{{ title }}</h1>
+            <h1>{{ title }}</h1>
           {% endif %}
 
           {% if fieldIntroText != empty %}
-          <div class="va-introtext">
-            <p>{{ fieldIntroText }}</p>
-          </div>
+            <div class="va-introtext">
+              <p>{{ fieldIntroText }}</p>
+            </div>
           {% endif %}
 
           <div
@@ -58,12 +58,12 @@
                       Address
                     </h3>
                     <div class="vads-u-margin-bottom--3">
-                      <div>{{fieldAddress.addressLine1}}</div>
-                      {{fieldAddress.locality}},
-                      {{fieldAddress.administrativeArea}}
-                      {{fieldAddress.postalCode}}
+                      <div>{{ fieldAddress.addressLine1 }}</div>
+                      {{ fieldAddress.locality }},
+                      {{ fieldAddress.administrativeArea }}
+                      {{ fieldAddress.postalCode }}
                       <div><a
-                          href="https://maps.google.com?saddr=Current+Location&daddr={{fieldAddress.addressLine1}}, {{fieldAddress.locality}}, {{fieldAddress.postalCode}}"
+                          href="https://maps.google.com?saddr=Current+Location&daddr={{ fieldAddress.addressLine1 }}, {{ fieldAddress.locality }}, {{ fieldAddress.postalCode }}"
                           target="_blank"
                           rel="noopener noreferrer">Directions</a>
                       </div>
@@ -76,12 +76,12 @@
                       <div class="main-phone vads-u-margin-bottom--1">
                         <strong>Main phone:
                         </strong><a
-                          href="tel:{{fieldPhoneNumber}}">{{fieldPhoneNumber}}</a>
+                          href="tel:{{ fieldPhoneNumber }}">{{ fieldPhoneNumber }}</a>
                       </div>
                       <div class="mental-health-clinic-phone"><strong>Mental
                           health clinic:
                         </strong><a
-                          href="tel:{{fieldMentalHealthPhone}}">{{fieldMentalHealthPhone}}</a>
+                          href="tel:{{ fieldMentalHealthPhone }}">{{ fieldMentalHealthPhone }}</a>
                       </div>
                     </div>
                     <div class="vads-u-margin-bottom--0">
@@ -94,18 +94,18 @@
                           class="vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row vads-u-margin-bottom--0">
                           <ul
                             class="vads-u-flex--1 va-c-facility-hours-list vads-u-margin-top--0 vads-u-margin-bottom--1 small-screen:vads-u-margin-bottom--0 vads-u-margin-right--3">
-                            {% for hours in fieldFacilityHours.value limit:5 %}
-                            <li><b class="abbrv-day">{{hours.0}}:</b>
-                              {{hours.1}}
-                            </li>
+                            {% for hours in fieldFacilityHours.value limit: 5 %}
+                              <li><b class="abbrv-day">{{ hours.0 }}:</b>
+                                {{ hours.1 }}
+                              </li>
                             {% endfor %}
                           </ul>
                           <ul
                             class="vads-u-flex--1 va-c-facility-hours-list vads-u-margin-top--0 'vads-u-margin-bottom--0">
-                            {% for hours in fieldFacilityHours.value offset:5 limit:2 %}
-                            <li><b class="abbrv-day">{{hours.0}}:</b>
-                              {{hours.1}}
-                            </li>
+                            {% for hours in fieldFacilityHours.value offset: 5 limit: 2 %}
+                              <li><b class="abbrv-day">{{ hours.0 }}:</b>
+                                {{ hours.1 }}
+                              </li>
                             {% endfor %} </ul>
                         </div>
                       </div>
@@ -120,95 +120,95 @@
               class="usa-width-one-third inline-table-helper vads-u-order--first small-screen:vads-u-order--initial vads-u-margin-bottom--2 vads-u-margin-left--auto facility">
               <!-- facility image -->
               {% if fieldMedia.entity.image != empty %}
-              {% assign image = fieldMedia.entity.image %}
-              <a href="#" rel="noopener noreferrer" target="_blank"
-                id="google-map-link-image">
-                <img class="facility-img" src="{{ image.derivative.url }}"
-                  alt="{{ image.alt }}" title="{{ image.title }}"
-                  width="{{ image.derivative.width }}"
-                  height="{{ image.derivative.height }}" />
-              </a>
+                {% assign image = fieldMedia.entity.image %}
+                <a href="#" rel="noopener noreferrer" target="_blank"
+                   id="google-map-link-image">
+                  <img class="facility-img" src="{{ image.derivative.url }}"
+                       alt="{{ image.alt }}" title="{{ image.title }}"
+                       width="{{ image.derivative.width }}"
+                       height="{{ image.derivative.height }}" />
+                </a>
               {% endif %}
               <div data-widget-type="facility-map"
-                data-facility="{{ fieldFacilityLocatorApiId | widgetFacilityDetail | escape }}">
+                   data-facility="{{ fieldFacilityLocatorApiId | widgetFacilityDetail | escape }}">
               </div>
             </div>
           </div>
 
           <!-- Location services section -->
           {% capture difference %}
-          {{ fieldLocationServices | size | minus:1 }}
+            {{ fieldLocationServices | size | minus: 1 }}
           {% endcapture %}
           {% unless difference contains '-' %}
-          <div class="vads-u-margin-bottom--4">
-            <h2 id="prepare-for-your-visit"
-              class="vads-u-margin-top--0 vads-u-font-size--lg small-screen:vads-u-font-size--xl vads-u-margin-bottom--2">
-              Prepare for your visit</h2>
+            <div class="vads-u-margin-bottom--4">
+              <h2 id="prepare-for-your-visit"
+                  class="vads-u-margin-top--0 vads-u-font-size--lg small-screen:vads-u-font-size--xl vads-u-margin-bottom--2">
+                Prepare for your visit</h2>
               <p>Click on a topic for more details.</p>
-            <div class="usa-accordion-bordered">
-              <ul class="usa-unstyled-list">
-                {% for accordionItem in fieldLocationServices %}
-                {% assign item = accordionItem.entity %}
-                <li class="vads-u-margin-bottom--1">
-                  <button class="usa-accordion-button usa-button-unstyled vads-u-padding-y--2 vads-u-padding-left--2p5 vads-u-line-height--4
+              <div class="usa-accordion-bordered">
+                <ul class="usa-unstyled-list">
+                  {% for accordionItem in fieldLocationServices %}
+                    {% assign item = accordionItem.entity %}
+                    <li class="vads-u-margin-bottom--1">
+                      <button class="usa-accordion-button usa-button-unstyled vads-u-padding-y--2 vads-u-padding-left--2p5 vads-u-line-height--4
 " aria-expanded="false"
-                    aria-controls="{{ item.entityBundle }}-{{ item.entityId }}">
-                    {{ item.fieldTitle }}
-                  </button>
-                  <div id="{{ item.entityBundle }}-{{ item.entityId }}"
-                    class="usa-accordion-content" aria-hidden="true">
-                    {% include "src/site/paragraphs/wysiwyg.drupal.liquid" entity = item %}
-                  </div>
-                </li>
-                {% endfor %}
-              </ul>
+                              aria-controls="{{ item.entityBundle }}-{{ item.entityId }}">
+                        {{ item.fieldTitle }}
+                      </button>
+                      <div id="{{ item.entityBundle }}-{{ item.entityId }}"
+                           class="usa-accordion-content" aria-hidden="true">
+                        {% include "src/site/paragraphs/wysiwyg.drupal.liquid" entity = item %}
+                      </div>
+                    </li>
+                  {% endfor %}
+                </ul>
+              </div>
             </div>
-          </div>
           {% endunless %}
 
           <!-- List of links section -->
           {% if fieldRegionPage.entity.fieldRelatedLinks != empty %}
-          {% include "src/site/paragraphs/list_of_link_teasers_facility.drupal.liquid" with paragraph = fieldRegionPage.entity.fieldRelatedLinks.entity %}
+            {% include "src/site/paragraphs/list_of_link_teasers_facility.drupal.liquid" with paragraph = fieldRegionPage.entity.fieldRelatedLinks.entity %}
           {% endif %}
 
           <!-- Local Health Services -->
           {% if fieldLocalHealthCareService != empty and fieldLocalHealthCareService.length %}
-          <h2 id="health-care-offered-here"
-            class="vads-u-font-size--xl vads-u-margin-top--5">Health services offered here</h2>
+            <h2 id="health-care-offered-here"
+                class="vads-u-font-size--xl vads-u-margin-top--5">Health services offered here</h2>
             <p>Click on a service for more details like location, contact, and appointment
-            information.</p>
-          <section class="local-health-services" id="local-health-services">
+              information.</p>
+            <section class="local-health-services" id="local-health-services">
 
-            {% assign localHealthServices = fieldLocalHealthCareService | sortObjectsBy: 'entity.fieldRegionalHealthService.entity.fieldServiceNameAndDescripti.entity.name' %}
-            {% for localService in localHealthServices %}
-              {% assign localHealthService = localService.entity | featureFieldRegionalHealthService %}
-              {% if localHealthService != empty %}
+              {% assign localHealthServices = fieldLocalHealthCareService | sortObjectsBy: 'entity.fieldRegionalHealthService.entity.fieldServiceNameAndDescripti.entity.name' %}
+              {% for localService in localHealthServices %}
+                {% assign localHealthService = localService.entity | featureFieldRegionalHealthService %}
+                {% if localHealthService != empty %}
 
-                {% include "src/site/facilities/facility_health_service.drupal.liquid" with
+                  {% include "src/site/facilities/facility_health_service.drupal.liquid" with
                     healthService = localHealthService
                     locationEntity = localService.entity
                     locations = localService.entity.fieldServiceLocation
                     localServiceDescription = localService.entity.fieldBody.processed
                     fieldFacilityLocatorApiId = fieldFacilityLocatorApiId
-                %}
+                  %}
 
-              {% endif %}
-            {% endfor %}
-          </section>
+                {% endif %}
+              {% endfor %}
+            </section>
           {% endif %}
 
           <h2 id="our-patient-satisfaction-scores"
-            class="vads-u-margin-top--4 vads-u-font-size--lg small-screen:vads-u-font-size--xl">
+              class="vads-u-margin-top--4 vads-u-font-size--lg small-screen:vads-u-font-size--xl">
             Veteran satisfaction with appointment wait times at this location
           </h2>
           <div data-widget-type="facility-patient-satisfaction-scores"
-            data-facility="{{ fieldFacilityLocatorApiId | widgetFacilityDetail | escape }}">
+               data-facility="{{ fieldFacilityLocatorApiId | widgetFacilityDetail | escape }}">
           </div>
 
 
           <!-- Social Links -->
           {% include "src/site/facilities/facility_social_links.drupal.liquid"
-          with regionNickname = fieldRegionPage.entity.title
+            with regionNickname = fieldRegionPage.entity.title
           fieldGovdeliveryIdEmerg = fieldRegionPage.entity.fieldGovdeliveryIdEmerg
           fieldGovdeliveryIdNews = fieldRegionPage.entity.fieldGovdeliveryIdNews
           fieldOperatingStatus = fieldRegionPage.entity.fieldOperatingStatus
@@ -218,7 +218,7 @@
         <div class="last-updated usa-content">
           Last updated:
           <time
-            datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
+            datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD' }}">{{ changed | humanizeTimestamp }}</time>
         </div>
       </div>
     </div>

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
@@ -62,14 +62,23 @@ const transform = (entity, { ancestors }) => ({
     ? entity.fieldLocalHealthCareService
         .filter(s => Object.keys(s).length && s.entity)
         .map(s => {
+          // if (!s.entity.fieldRegionalHealthService.entity.fieldBody) {
+          //   console.log("fieldBody is missing from s.entity.fieldRegionalHealthService.entity",
+          //     s.entity.fieldRegionalHealthService.entity)
+          // }
+          // if (!s.entity.fieldRegionalHealthService.entity.fieldServiceNameAndDescripti) {
+          //   console.log("fieldServiceNameAndDescripti is missing from s.entity.fieldRegionalHealthService.entity",
+          //     s.entity.fieldRegionalHealthService.entity)
+          // }
           const newRegionalEntity = {
             ...s.entity.fieldRegionalHealthService.entity,
             entityBundle: 'regional_health_care_service_des',
           };
-          return Object.assign(
+          Object.assign(
             s.entity.fieldRegionalHealthService.entity,
             newRegionalEntity,
           );
+          return s;
         })
     : null,
   fieldLocationServices: entity.fieldLocationServices.length

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
@@ -20,6 +20,7 @@ const getSocialMediaObject = ({ uri, title }) =>
 
 const getFieldRegionObject = ({
   nid,
+  status,
   title,
   field_related_links,
   field_govdelivery_id_emerg,
@@ -30,6 +31,7 @@ const getFieldRegionObject = ({
     ? {
         entityId: getDrupalValue(nid).toString(),
         entityBundle: 'health_care_region_page',
+        entityPublished: getDrupalValue(status),
         title: getDrupalValue(title),
         fieldRelatedLinks: field_related_links[0],
         fieldGovdeliveryIdEmerg: getDrupalValue(field_govdelivery_id_emerg),

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
@@ -19,6 +19,7 @@ const getSocialMediaObject = ({ uri, title }) =>
     : null;
 
 const getFieldRegionObject = ({
+  nid,
   title,
   field_related_links,
   field_govdelivery_id_emerg,
@@ -27,6 +28,7 @@ const getFieldRegionObject = ({
 }) =>
   title
     ? {
+        entityId: getDrupalValue(nid).toString(),
         entityBundle: 'health_care_region_page',
         title: getDrupalValue(title),
         fieldRelatedLinks: field_related_links[0],

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
@@ -59,7 +59,18 @@ const transform = (entity, { ancestors }) => ({
   fieldFacilityLocatorApiId: getDrupalValue(entity.fieldFacilityLocatorApiId),
   fieldIntroText: getDrupalValue(entity.fieldIntroText),
   fieldLocalHealthCareService: entity.fieldLocalHealthCareService.length
-    ? entity.fieldLocalHealthCareService.filter(n => Object.keys(n).length)
+    ? entity.fieldLocalHealthCareService
+        .filter(s => Object.keys(s).length && s.entity)
+        .map(s => {
+          const newRegionalEntity = {
+            ...s.entity.fieldRegionalHealthService.entity,
+            entityBundle: 'regional_health_care_service_des',
+          };
+          return Object.assign(
+            s.entity.fieldRegionalHealthService.entity,
+            newRegionalEntity,
+          );
+        })
     : null,
   fieldLocationServices: entity.fieldLocationServices.length
     ? entity.fieldLocationServices

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
@@ -27,6 +27,7 @@ const getFieldRegionObject = ({
 }) =>
   title
     ? {
+        entityBundle: 'health_care_region_page',
         title: getDrupalValue(title),
         fieldRelatedLinks: field_related_links[0],
         fieldGovdeliveryIdEmerg: getDrupalValue(field_govdelivery_id_emerg),

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
@@ -59,25 +59,11 @@ const transform = (entity, { ancestors }) => ({
   fieldFacilityLocatorApiId: getDrupalValue(entity.fieldFacilityLocatorApiId),
   fieldIntroText: getDrupalValue(entity.fieldIntroText),
   fieldLocalHealthCareService: entity.fieldLocalHealthCareService.length
-    ? entity.fieldLocalHealthCareService
-        .filter(
-          // WIP. This eliminates the "bad" entries but
-          // causes many valid CMS entries to be omitted!
-          s =>
-            Object.keys(s).length &&
-            s.entity?.fieldRegionalHealthService.entity,
-        )
-        .map(s => {
-          const newRegionalEntity = {
-            ...s.entity.fieldRegionalHealthService.entity,
-            entityBundle: 'regional_health_care_service_des',
-          };
-          Object.assign(
-            s.entity.fieldRegionalHealthService.entity,
-            newRegionalEntity,
-          );
-          return s;
-        })
+    ? entity.fieldLocalHealthCareService.filter(
+        s =>
+          s.entity?.fieldRegionalHealthService?.entity
+            ?.fieldServiceNameAndDescripti?.entity?.name,
+      )
     : null,
   fieldLocationServices: entity.fieldLocationServices.length
     ? entity.fieldLocationServices

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
@@ -60,16 +60,14 @@ const transform = (entity, { ancestors }) => ({
   fieldIntroText: getDrupalValue(entity.fieldIntroText),
   fieldLocalHealthCareService: entity.fieldLocalHealthCareService.length
     ? entity.fieldLocalHealthCareService
-        .filter(s => Object.keys(s).length && s.entity)
+        .filter(
+          // WIP. This eliminates the "bad" entries but
+          // causes many valid CMS entries to be omitted!
+          s =>
+            Object.keys(s).length &&
+            s.entity?.fieldRegionalHealthService.entity,
+        )
         .map(s => {
-          // if (!s.entity.fieldRegionalHealthService.entity.fieldBody) {
-          //   console.log("fieldBody is missing from s.entity.fieldRegionalHealthService.entity",
-          //     s.entity.fieldRegionalHealthService.entity)
-          // }
-          // if (!s.entity.fieldRegionalHealthService.entity.fieldServiceNameAndDescripti) {
-          //   console.log("fieldServiceNameAndDescripti is missing from s.entity.fieldRegionalHealthService.entity",
-          //     s.entity.fieldRegionalHealthService.entity)
-          // }
           const newRegionalEntity = {
             ...s.entity.fieldRegionalHealthService.entity,
             entityBundle: 'regional_health_care_service_des',

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
@@ -19,8 +19,6 @@ const getSocialMediaObject = ({ uri, title }) =>
     : null;
 
 const getFieldRegionObject = ({
-  nid,
-  status,
   title,
   field_related_links,
   field_govdelivery_id_emerg,
@@ -29,9 +27,6 @@ const getFieldRegionObject = ({
 }) =>
   title
     ? {
-        entityId: getDrupalValue(nid).toString(),
-        entityBundle: 'health_care_region_page',
-        entityPublished: getDrupalValue(status),
         title: getDrupalValue(title),
         fieldRelatedLinks: field_related_links[0],
         fieldGovdeliveryIdEmerg: getDrupalValue(field_govdelivery_id_emerg),

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_health_service.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_health_service.js
@@ -16,73 +16,53 @@ const getFieldFacilityLocationObject = ({ title, entityUrl }) =>
         },
       };
 
-const transform = entity => {
-  let regionalHealthServiceValid;
-
-  if (
-    !entity.fieldRegionalHealthService[0]?.fieldBody ||
-    !entity.fieldRegionalHealthService[0]?.fieldServiceNameAndDescripti
-  ) {
-    // eslint-disable-next-line no-console
-    console.log(
-      'fieldRegionalHealthService is messed up:',
-      entity.fieldRegionalHealthService,
-    );
-    regionalHealthServiceValid = false;
-  } else {
-    regionalHealthServiceValid = true;
-  }
-
-  return {
-    entity: {
-      entityType: 'node',
-      entityBundle: 'health_care_local_health_service',
-      title: getDrupalValue(entity.title),
-      fieldBody: {
-        processed: getWysiwygString(getDrupalValue(entity.fieldBody)),
-      },
-      fieldRegionalHealthService: regionalHealthServiceValid
+const transform = entity => ({
+  entity: {
+    entityType: 'node',
+    entityBundle: 'health_care_local_health_service',
+    title: getDrupalValue(entity.title),
+    fieldBody: {
+      processed: getWysiwygString(getDrupalValue(entity.fieldBody)),
+    },
+    fieldRegionalHealthService:
+      entity.fieldRegionalHealthService.length > 0
         ? {
             entity: {
-              fieldBody:
-                entity.fieldRegionalHealthService[0].fieldBody?.processed,
-              fieldServiceNameAndDescripti: {
-                entity:
-                  entity.fieldRegionalHealthService[0]
-                    .fieldServiceNameAndDescripti?.entity,
-              },
+              entityUrl: entity.fieldRegionalHealthService[0].entityUrl,
+              fieldBody: entity.fieldRegionalHealthService[0].fieldBody,
+              fieldServiceNameAndDescripti:
+                entity.fieldRegionalHealthService[0]
+                  .fieldServiceNameAndDescripti,
             },
           }
         : {},
-      fieldServiceLocation: entity.fieldServiceLocation.map(locationData => ({
-        entity: locationData,
-      })),
-      fieldHserviceApptLeadin: getDrupalValue(entity.fieldHserviceApptLeadin),
-      fieldHserviceApptIntroSelect: getDrupalValue(
-        entity.fieldHserviceApptIntroSelect,
-      ),
-      fieldOnlineSchedulingAvailabl: getDrupalValue(
-        entity.fieldOnlineSchedulingAvailabl,
-      ),
-      fieldReferralRequired: getDrupalValue(entity.fieldReferralRequired),
-      fieldWalkInsAccepted: getDrupalValue(entity.fieldWalkInsAccepted),
-      fieldPhoneNumbersParagraph: entity.fieldPhoneNumbersParagraph.map(
-        phoneData => ({
-          entity: {
-            fieldPhoneExtension: phoneData.fieldPhoneExtension,
-            fieldPhoneLabel: phoneData.fieldPhoneLabel,
-            fieldPhoneNumber: phoneData.fieldPhoneNumber,
-            fieldPhoneNumberType: phoneData.fieldPhoneNumberType,
-          },
-        }),
-      ),
-      fieldFacilityLocation: entity.fieldFacilityLocation[0]
-        ? getFieldFacilityLocationObject(entity.fieldFacilityLocation[0])
-        : null,
-    },
-  };
-};
-
+    fieldServiceLocation: entity.fieldServiceLocation.map(locationData => ({
+      entity: locationData,
+    })),
+    fieldHserviceApptLeadin: getDrupalValue(entity.fieldHserviceApptLeadin),
+    fieldHserviceApptIntroSelect: getDrupalValue(
+      entity.fieldHserviceApptIntroSelect,
+    ),
+    fieldOnlineSchedulingAvailabl: getDrupalValue(
+      entity.fieldOnlineSchedulingAvailabl,
+    ),
+    fieldReferralRequired: getDrupalValue(entity.fieldReferralRequired),
+    fieldWalkInsAccepted: getDrupalValue(entity.fieldWalkInsAccepted),
+    fieldPhoneNumbersParagraph: entity.fieldPhoneNumbersParagraph.map(
+      phoneData => ({
+        entity: {
+          fieldPhoneExtension: phoneData.fieldPhoneExtension,
+          fieldPhoneLabel: phoneData.fieldPhoneLabel,
+          fieldPhoneNumber: phoneData.fieldPhoneNumber,
+          fieldPhoneNumberType: phoneData.fieldPhoneNumberType,
+        },
+      }),
+    ),
+    fieldFacilityLocation: entity.fieldFacilityLocation[0]
+      ? getFieldFacilityLocationObject(entity.fieldFacilityLocation[0])
+      : null,
+  },
+});
 module.exports = {
   filter: [
     'title',

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_health_service.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_health_service.js
@@ -16,53 +16,73 @@ const getFieldFacilityLocationObject = ({ title, entityUrl }) =>
         },
       };
 
-const transform = entity => ({
-  entity: {
-    entityType: 'node',
-    entityBundle: 'health_care_local_health_service',
-    title: getDrupalValue(entity.title),
-    fieldBody: {
-      processed: getWysiwygString(getDrupalValue(entity.fieldBody)),
-    },
-    fieldRegionalHealthService:
-      entity.fieldRegionalHealthService.length > 0
+const transform = entity => {
+  let regionalHealthServiceValid;
+
+  if (
+    !entity.fieldRegionalHealthService[0]?.fieldBody ||
+    !entity.fieldRegionalHealthService[0]?.fieldServiceNameAndDescripti
+  ) {
+    // eslint-disable-next-line no-console
+    console.log(
+      'fieldRegionalHealthService is messed up:',
+      entity.fieldRegionalHealthService,
+    );
+    regionalHealthServiceValid = false;
+  } else {
+    regionalHealthServiceValid = true;
+  }
+
+  return {
+    entity: {
+      entityType: 'node',
+      entityBundle: 'health_care_local_health_service',
+      title: getDrupalValue(entity.title),
+      fieldBody: {
+        processed: getWysiwygString(getDrupalValue(entity.fieldBody)),
+      },
+      fieldRegionalHealthService: regionalHealthServiceValid
         ? {
             entity: {
-              entityUrl: entity.fieldRegionalHealthService[0].entityUrl,
-              fieldBody: entity.fieldRegionalHealthService[0].fieldBody,
-              fieldServiceNameAndDescripti:
-                entity.fieldRegionalHealthService[0]
-                  .fieldServiceNameAndDescripti,
+              fieldBody:
+                entity.fieldRegionalHealthService[0].fieldBody?.processed,
+              fieldServiceNameAndDescripti: {
+                entity:
+                  entity.fieldRegionalHealthService[0]
+                    .fieldServiceNameAndDescripti?.entity,
+              },
             },
           }
         : {},
-    fieldServiceLocation: entity.fieldServiceLocation.map(locationData => ({
-      entity: locationData,
-    })),
-    fieldHserviceApptLeadin: getDrupalValue(entity.fieldHserviceApptLeadin),
-    fieldHserviceApptIntroSelect: getDrupalValue(
-      entity.fieldHserviceApptIntroSelect,
-    ),
-    fieldOnlineSchedulingAvailabl: getDrupalValue(
-      entity.fieldOnlineSchedulingAvailabl,
-    ),
-    fieldReferralRequired: getDrupalValue(entity.fieldReferralRequired),
-    fieldWalkInsAccepted: getDrupalValue(entity.fieldWalkInsAccepted),
-    fieldPhoneNumbersParagraph: entity.fieldPhoneNumbersParagraph.map(
-      phoneData => ({
-        entity: {
-          fieldPhoneExtension: phoneData.fieldPhoneExtension,
-          fieldPhoneLabel: phoneData.fieldPhoneLabel,
-          fieldPhoneNumber: phoneData.fieldPhoneNumber,
-          fieldPhoneNumberType: phoneData.fieldPhoneNumberType,
-        },
-      }),
-    ),
-    fieldFacilityLocation: entity.fieldFacilityLocation[0]
-      ? getFieldFacilityLocationObject(entity.fieldFacilityLocation[0])
-      : null,
-  },
-});
+      fieldServiceLocation: entity.fieldServiceLocation.map(locationData => ({
+        entity: locationData,
+      })),
+      fieldHserviceApptLeadin: getDrupalValue(entity.fieldHserviceApptLeadin),
+      fieldHserviceApptIntroSelect: getDrupalValue(
+        entity.fieldHserviceApptIntroSelect,
+      ),
+      fieldOnlineSchedulingAvailabl: getDrupalValue(
+        entity.fieldOnlineSchedulingAvailabl,
+      ),
+      fieldReferralRequired: getDrupalValue(entity.fieldReferralRequired),
+      fieldWalkInsAccepted: getDrupalValue(entity.fieldWalkInsAccepted),
+      fieldPhoneNumbersParagraph: entity.fieldPhoneNumbersParagraph.map(
+        phoneData => ({
+          entity: {
+            fieldPhoneExtension: phoneData.fieldPhoneExtension,
+            fieldPhoneLabel: phoneData.fieldPhoneLabel,
+            fieldPhoneNumber: phoneData.fieldPhoneNumber,
+            fieldPhoneNumberType: phoneData.fieldPhoneNumberType,
+          },
+        }),
+      ),
+      fieldFacilityLocation: entity.fieldFacilityLocation[0]
+        ? getFieldFacilityLocationObject(entity.fieldFacilityLocation[0])
+        : null,
+    },
+  };
+};
+
 module.exports = {
   filter: [
     'title',


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/va.gov-team/issues/19083

This PR does not resolve the issue of missing health services. That will be addressed in a separate PR.

This just filters out the ones where the data is missing. Whether this is a bug with the transformers or a CMS export issue is still TBD.
