### PR TITLE
[508] BDD: Wrap separation location input in fieldset

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/separationLocation.js
+++ b/src/applications/disability-benefits/all-claims/pages/separationLocation.js
@@ -10,10 +10,8 @@ import { requireSeparationLocation } from '../validations';
 
 export const uiSchema = {
   serviceInformation: {
-    'view:separationLocation': {
-      'ui:title': SeparationLocationTitle,
-      'ui:description': SeparationLocationDescription,
-    },
+    'ui:title': SeparationLocationTitle,
+    'ui:description': SeparationLocationDescription,
     separationLocation: autosuggest.uiSchema(
       'Enter a location',
       getSeparationLocations,

--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -150,6 +150,12 @@ fieldset.schemaform-block,
   white-space: pre-wrap;
 }
 
+article[data-location="review-veteran-details/separation-location"] {
+  fieldset > .schemaform-field-container {
+    margin-top: 0;
+  }
+}
+
 // Style fix for "Private medical records"
 dl.review,
 div.review {


### PR DESCRIPTION
## Description

Form 526 BDD (Benefits Delivery at Discharge) page that asks for the service member's separation location needs to have the location input wrapped inside the `<fieldset>` to group the `legend`, additional info dropdown, label and input together. This improves accessibility for screenreaders.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/19013

## Testing done

N/A

## Screenshots

<details><summary>New Markup</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-02-04 at 11 56 10 AM](https://user-images.githubusercontent.com/136959/106940443-2a69fe00-66e7-11eb-82d5-d982211c39e9.png)</details>

## Acceptance criteria
- [x] Separation location info is grouped with input

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
