### PR TITLE
Add a mailto: before email address in service_location.drupal.liquid

### DIFF
--- a/src/site/facilities/service_location.drupal.liquid
+++ b/src/site/facilities/service_location.drupal.liquid
@@ -53,7 +53,7 @@
       {% endif %}
       <a aria-label="{{ email.entity.fieldEmailAddress }}"
          data-template="paragraphs/service_location"
-         href="{{ email.entity.fieldEmailAddress }}">{{ email.entity.fieldEmailAddress }}
+         href="mailto:{{ email.entity.fieldEmailAddress }}">{{ email.entity.fieldEmailAddress }}
       </a>
     {% endfor %}
   {% endif %}


### PR DESCRIPTION
## Description
Service location email address links didn't have a `mailto:` prefix. This was causing broken link errors.

