### PR TITLE
18809 - view payments - update cy.route to cy.intercept

### DIFF
--- a/src/applications/disability-benefits/view-payments/tests/e2e/view-payments.cypress.spec.js
+++ b/src/applications/disability-benefits/view-payments/tests/e2e/view-payments.cypress.spec.js
@@ -21,7 +21,7 @@ const testAxe = () => {
 };
 
 const testPagination = () => {
-  cy.route('GET', PAYMENTS_API_ENDPOINT, mockPayments).as('mockPayments');
+  cy.intercept('GET', PAYMENTS_API_ENDPOINT, mockPayments).as('mockPayments');
   testLoadingState();
   cy.wait('@mockPayments');
   cy.findByText(/Payments you received/i).should('exist');
@@ -33,7 +33,7 @@ const testPagination = () => {
 };
 
 const testNoPayments = () => {
-  cy.route('GET', PAYMENTS_API_ENDPOINT, mockEmptyPayments).as(
+  cy.intercept('GET', PAYMENTS_API_ENDPOINT, mockEmptyPayments).as(
     'mockEmptyPayments',
   );
   cy.visit(PAYMENTS_PATH);
@@ -46,7 +46,7 @@ const testNoPayments = () => {
 
 const testEmptyPaymentsArray = (category = 'payments') => {
   if (category === 'returnPayments') {
-    cy.route('GET', PAYMENTS_API_ENDPOINT, mockEmptyPaymentsReturned).as(
+    cy.intercept('GET', PAYMENTS_API_ENDPOINT, mockEmptyPaymentsReturned).as(
       'mockEmptyReturnedPayments',
     );
     testLoadingState();
@@ -57,7 +57,7 @@ const testEmptyPaymentsArray = (category = 'payments') => {
       'exist',
     );
   } else {
-    cy.route('GET', PAYMENTS_API_ENDPOINT, mockEmptyPaymentsReceived).as(
+    cy.intercept('GET', PAYMENTS_API_ENDPOINT, mockEmptyPaymentsReceived).as(
       'mockEmptyReceivedPayments',
     );
     testLoadingState();
@@ -72,11 +72,9 @@ const testEmptyPaymentsArray = (category = 'payments') => {
 
 const testApiError = (errCode = '500') => {
   if (errCode === '400') {
-    cy.route({
-      method: 'GET',
-      url: PAYMENTS_API_ENDPOINT,
-      status: 404,
-      response: mockClientError,
+    cy.intercept(PAYMENTS_API_ENDPOINT, {
+      body: mockClientError,
+      statusCode: 404,
     }).as('clientError');
     testLoadingState();
     cy.wait('@clientError');
@@ -84,11 +82,9 @@ const testApiError = (errCode = '500') => {
       selector: 'h2',
     });
   } else {
-    cy.route({
-      method: 'GET',
-      url: PAYMENTS_API_ENDPOINT,
-      status: 500,
-      response: mockServerError,
+    cy.intercept(PAYMENTS_API_ENDPOINT, {
+      body: mockServerError,
+      statusCode: 500,
     }).as('serverError');
     testLoadingState();
     cy.wait('@serverError');
@@ -104,6 +100,17 @@ describe('View payment history', () => {
   beforeEach(() => {
     disableFTUXModals();
     cy.login(mockUser);
+    cy.intercept('GET', '/v0/feature_toggles*', {
+      data: {
+        type: 'feature_toggles',
+        features: [
+          {
+            name: 'view_payment_history',
+            value: true,
+          },
+        ],
+      },
+    });
   });
   it('should pass an aXe scan and paginate through payment data', () => {
     testPagination();


### PR DESCRIPTION
## Description
This pull request updates the view payments e2e cypress tests per the recommendations of [this migration guide](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/testing/end-to-end/cypress-upgrade-guide.md).

## Testing done
- local all tests pass

## Screenshots
<img width="752" alt="Screen Shot 2021-02-04 at 3 55 14 PM" src="https://user-images.githubusercontent.com/15097156/106954874-665e8c80-6702-11eb-8681-c9819a33ee65.png">


## Acceptance criteria
- [ ] all tests pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
