### PR TITLE
Add help section to COVID-19 Keep Me Informed form

### DIFF
--- a/src/applications/coronavirus-vaccination/components/Form.jsx
+++ b/src/applications/coronavirus-vaccination/components/Form.jsx
@@ -25,6 +25,9 @@ import * as actions from '../actions';
 import useInitializeForm from '../hooks/useInitializeForm';
 import useSubmitForm from '../hooks/useSubmitForm';
 
+import FormFooter from 'platform/forms/components/FormFooter';
+import GetHelp from './GetHelp';
+
 function Form({ formState, updateFormData, router, isLoggedIn, profile }) {
   const [submitStatus, submitToApi] = useSubmitForm();
 
@@ -145,6 +148,9 @@ function Form({ formState, updateFormData, router, isLoggedIn, profile }) {
           <LoadingIndicator message="Loading the form..." />
         )}
       </DowntimeNotification>
+      <div className="vads-u-margin-top--1">
+        <FormFooter formConfig={{ getHelp: GetHelp }} />
+      </div>
     </>
   );
 }

--- a/src/applications/coronavirus-vaccination/components/GetHelp.jsx
+++ b/src/applications/coronavirus-vaccination/components/GetHelp.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import Telephone, {
+  CONTACTS,
+  PATTERNS,
+} from '@department-of-veterans-affairs/component-library/Telephone';
+
+function GetFormHelp() {
+  return (
+    <div>
+      <p className="help-talk">
+        If you have questions or need help filling out this form, call our
+        MyVA411 main information line at{' '}
+        <Telephone contact={CONTACTS.HELP_DESK} /> (TTY:{' '}
+        <Telephone contact={CONTACTS[711]} pattern={PATTERNS['3_DIGIT']} />
+        ).
+      </p>
+    </div>
+  );
+}
+
+export default GetFormHelp;

--- a/src/applications/coronavirus-vaccination/components/Introduction.jsx
+++ b/src/applications/coronavirus-vaccination/components/Introduction.jsx
@@ -24,6 +24,9 @@ import {
   WhyContact,
 } from './VerbiageHelper';
 
+import FormFooter from 'platform/forms/components/FormFooter';
+import GetHelp from './GetHelp';
+
 function Introduction({
   authButtonDisabled = false,
   isLoggedIn,
@@ -171,6 +174,9 @@ function Introduction({
         <CollapsiblePanel panelName="How will VA contact me when I can get a COVID-19 vaccine?">
           <ContactRules />
         </CollapsiblePanel>
+      </div>
+      <div className="vads-u-margin-top--1">
+        <FormFooter formConfig={{ getHelp: GetHelp }} />
       </div>
     </>
   );

--- a/src/applications/coronavirus-vaccination/tests/e2e/signup.cypress.spec.js
+++ b/src/applications/coronavirus-vaccination/tests/e2e/signup.cypress.spec.js
@@ -38,7 +38,9 @@ describe('COVID-19 Vaccination Preparation Form', () => {
       cy.get('div').contains(
         'Your local VA health facility may contact you by phone, email, or text message. If you’re eligible and want to get a vaccine, we encourage you to respond.',
       );
-
+      cy.get('.help-talk').contains(
+        'If you have questions or need help filling out this form, call our MyVA411 main information line at 800-698-2411 (TTY: 711).',
+      );
       cy.axeCheck();
 
       cy.get('.usa-button').contains('Sign in');

--- a/src/applications/coronavirus-vaccination/tests/e2e/signup.cypress.spec.js
+++ b/src/applications/coronavirus-vaccination/tests/e2e/signup.cypress.spec.js
@@ -93,6 +93,10 @@ describe('COVID-19 Vaccination Preparation Form', () => {
       );
       cy.get('#root_vaccineInterest_0').check();
 
+      cy.get('.help-talk').contains(
+        'If you have questions or need help filling out this form, call our MyVA411 main information line at 800-698-2411 (TTY: 711).',
+      );
+
       cy.axeCheck();
       cy.route('POST', '**/covid_vaccine/v0/registration', {
         status: 200,


### PR DESCRIPTION
## Description
This PR adds a footer with a GetHelp component to the Introduction page and the form page

## Testing done
Updated e2e tests to confirm text and phone number exist on the intro and form pages. 

## Screenshots
- Introduction:
![image](https://user-images.githubusercontent.com/2481110/107072079-a92c6d00-67b3-11eb-8fc9-4df9a85a5b3f.png)

- Form:
![image](https://user-images.githubusercontent.com/2481110/107068668-e93d2100-67ae-11eb-828e-2d0476c6073c.png)

Mobile:
- Introduction:
![image](https://user-images.githubusercontent.com/2481110/107072155-be090080-67b3-11eb-97f6-33e24ef8eafe.png)

- Form:
![image](https://user-images.githubusercontent.com/2481110/107068593-d296ca00-67ae-11eb-8715-477687a18234.png)

Phone links:
![image](https://user-images.githubusercontent.com/2481110/107069106-74b6b200-67af-11eb-82aa-316c3e9b4a41.png)


## Acceptance criteria
- [ ] Help section is displayed at the bottom of the form 
- [ ] Help section uses same look and feel as other help sections across va.gov

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
