### PR TITLE
Update 686 e2e cy.route to cy.intercept

### DIFF
--- a/src/applications/disability-benefits/686c-674/tests/e2e/686C-674-ancilliary.cypress.spec.js
+++ b/src/applications/disability-benefits/686c-674/tests/e2e/686C-674-ancilliary.cypress.spec.js
@@ -19,7 +19,7 @@ const testConfig = createTestConfig(
     fixtures: { data: path.join(__dirname, 'fixtures') },
     setupPerTest: () => {
       cy.login();
-      cy.route('GET', '/v0/feature_toggles*', {
+      cy.intercept('GET', '/v0/feature_toggles*', {
         data: {
           type: 'feature_toggles',
           features: [
@@ -30,14 +30,16 @@ const testConfig = createTestConfig(
           ],
         },
       });
-      cy.route('GET', '/v0/profile/valid_va_file_number', mockVaFileNumber).as(
-        'mockVaFileNumber',
-      );
+      cy.intercept(
+        'GET',
+        '/v0/profile/valid_va_file_number',
+        mockVaFileNumber,
+      ).as('mockVaFileNumber');
       cy.get('@testData').then(testData => {
-        cy.route('GET', '/v0/in_progress_forms/686C-674', testData);
-        cy.route('PUT', 'v0/in_progress_forms/686C-674', testData);
+        cy.intercept('GET', '/v0/in_progress_forms/686C-674', testData);
+        cy.intercept('PUT', 'v0/in_progress_forms/686C-674', testData);
       });
-      cy.route('POST', '/v0/dependents_applications', {
+      cy.intercept('POST', '/v0/dependents_applications', {
         formSubmissionId: '123fake-submission-id-567',
         timestamp: '2020-11-12',
         attributes: {

--- a/src/applications/disability-benefits/686c-674/tests/e2e/686C-674.cypress.spec.js
+++ b/src/applications/disability-benefits/686c-674/tests/e2e/686C-674.cypress.spec.js
@@ -15,7 +15,7 @@ const testConfig = createTestConfig(
     fixtures: { data: path.join(__dirname, 'fixtures') },
     setupPerTest: () => {
       cy.login();
-      cy.route('GET', '/v0/feature_toggles*', {
+      cy.intercept('GET', '/v0/feature_toggles*', {
         data: {
           type: 'feature_toggles',
           features: [
@@ -26,14 +26,16 @@ const testConfig = createTestConfig(
           ],
         },
       });
-      cy.route('GET', '/v0/profile/valid_va_file_number', mockVaFileNumber).as(
-        'mockVaFileNumber',
-      );
+      cy.intercept(
+        'GET',
+        '/v0/profile/valid_va_file_number',
+        mockVaFileNumber,
+      ).as('mockVaFileNumber');
       cy.get('@testData').then(testData => {
-        cy.route('GET', '/v0/in_progress_forms/686C-674', testData);
-        cy.route('PUT', 'v0/in_progress_forms/686C-674', testData);
+        cy.intercept('GET', '/v0/in_progress_forms/686C-674', testData);
+        cy.intercept('PUT', 'v0/in_progress_forms/686C-674', testData);
       });
-      cy.route('POST', '/v0/dependents_applications', {
+      cy.intercept('POST', '/v0/dependents_applications', {
         formSubmissionId: '123fake-submission-id-567',
         timestamp: '2020-11-12',
         attributes: {


### PR DESCRIPTION
## Description
This pull request updates the 686c-674 e2e tests to use `cy.intercept` instead of `cy.route`

## Testing done
- local, all tests pass

## Screenshots
<details><summary>All tests passing</summary>

<img width="742" alt="Screen Shot 2021-02-05 at 2 46 20 PM" src="https://user-images.githubusercontent.com/15097156/107086488-134f0d00-67c8-11eb-8d3f-650a82862906.png">
<img width="762" alt="Screen Shot 2021-02-05 at 2 48 02 PM" src="https://user-images.githubusercontent.com/15097156/107086490-13e7a380-67c8-11eb-9a6b-7a091e248823.png">

</details>

## Acceptance criteria
- [x] tests pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
