### PR TITLE
Fix for build() call in Jenkinsfile.content

### DIFF
--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -69,7 +69,7 @@ node('vetsgov-general-purpose') {
   dockerContainer = commonStages.setup()
 
   stage("Build") {
-    commonStages.build(ref, dockerContainer, ref, params.env, false, true)
+    commonStages.build(ref, dockerContainer, ref, params.env, false, true, false)
   }
 
   stage("Prearchive") {


### PR DESCRIPTION
## Description
Add missing arg to `build()` call in Jenkinsfile.content

## Testing done


## Screenshots


## Acceptance criteria
- [ ] Successful vets-website deploy

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
