### PR TITLE
[Tech debt] Update Cypress tests

### DIFF
--- a/src/applications/disability-benefits/996/tests/hlr-wizard.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr-wizard.cypress.spec.js
@@ -1,5 +1,10 @@
 import mockFeatureToggles from './fixtures/mocks/feature-toggles.json';
-import { BASE_URL, WIZARD_STATUS, SAVED_CLAIM_TYPE } from '../constants';
+import {
+  BASE_URL,
+  WIZARD_STATUS,
+  SAVED_CLAIM_TYPE,
+  CONTESTABLE_ISSUES_API,
+} from '../constants';
 
 Cypress.Commands.add('checkStorage', (key, expectedValue) => {
   cy.window()
@@ -34,7 +39,8 @@ const checkOpt = {
 describe('HLR wizard', () => {
   beforeEach(() => {
     window.dataLayer = [];
-    cy.route('GET', '/v0/feature_toggles?*', mockFeatureToggles);
+    cy.intercept('GET', '/v0/feature_toggles?*', mockFeatureToggles);
+    cy.intercept('GET', `/v0${CONTESTABLE_ISSUES_API}*`, []);
     sessionStorage.removeItem(WIZARD_STATUS);
     cy.visit(BASE_URL);
     cy.injectAxe();

--- a/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
@@ -6,6 +6,9 @@ import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-test
 import formConfig from '../config/form';
 import manifest from '../manifest.json';
 import { mockContestableIssues } from './hlr.cypress.helpers';
+import mockFeatureToggles from './fixtures/mocks/feature-toggles.json';
+import mockInProgress from './fixtures/mocks/in-progress-forms.json';
+import mockSubmit from './fixtures/mocks/application-submit.json';
 import mockUser from './fixtures/mocks/user.json';
 import { CONTESTABLE_ISSUES_API, WIZARD_STATUS } from '../constants';
 
@@ -40,24 +43,21 @@ const testConfig = createTestConfig(
 
       cy.login(mockUser);
 
-      cy.route('GET', '/v0/feature_toggles*', 'fx:mocks/feature-toggles');
+      cy.intercept('GET', '/v0/feature_toggles?*', mockFeatureToggles);
 
-      cy.route(
+      cy.intercept(
         'GET',
         `/v0${CONTESTABLE_ISSUES_API}compensation`,
         mockContestableIssues,
       );
 
-      cy.route('PUT', '/v0/in_progress_forms/*', 'fx:mocks/in-progress-forms');
+      cy.intercept('PUT', 'v0/in_progress_forms/20-0996', mockInProgress);
 
-      cy.route(
-        'POST',
-        '/v0/higher_level_reviews',
-        'fx:mocks/application-submit',
-      );
+      cy.intercept('POST', '/v0/higher_level_reviews', mockSubmit);
 
       cy.get('@testData').then(testData => {
-        cy.route('GET', '/v0/in_progress_forms/20-0996', testData);
+        cy.intercept('GET', '/v0/in_progress_forms/20-0996', testData);
+        cy.intercept('PUT', 'v0/in_progress_forms/20-0996', testData);
       });
     },
   },

--- a/src/applications/disability-benefits/all-claims/tests/all-claims-wizard.cypress.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/all-claims-wizard.cypress.spec.js
@@ -66,7 +66,7 @@ Cypress.Commands.add('checkCallToAction', () => {
 describe('526 wizard', () => {
   beforeEach(() => {
     window.dataLayer = [];
-    cy.route('GET', '/v0/feature_toggles?*', mockFeatureToggles);
+    cy.intercept('GET', '/v0/feature_toggles?*', mockFeatureToggles);
     sessionStorage.removeItem(WIZARD_STATUS);
     sessionStorage.removeItem(FORM_STATUS_BDD);
     sessionStorage.removeItem(SAVED_SEPARATION_DATE);

--- a/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
@@ -4,6 +4,13 @@ import moment from 'moment';
 import testForm from 'platform/testing/e2e/cypress/support/form-tester';
 import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
 
+import mockFeatureToggles from './fixtures/mocks/feature-toggles.json';
+import mockInProgress from './fixtures/mocks/in-progress-forms.json';
+import mockLocations from './fixtures/mocks/separation-locations.json';
+import mockPayment from './fixtures/mocks/payment-information.json';
+import mockSubmit from './fixtures/mocks/application-submit.json';
+import mockUpload from './fixtures/mocks/document-upload.json';
+
 import formConfig from '../config/form';
 import manifest from '../manifest.json';
 import { mockItf } from './all-claims.cypress.helpers';
@@ -130,40 +137,32 @@ const testConfig = createTestConfig(
     setupPerTest: () => {
       cy.login();
 
-      cy.route('GET', '/v0/feature_toggles*', 'fx:mocks/feature-toggles');
+      cy.intercept('GET', '/v0/feature_toggles*', mockFeatureToggles);
 
       // `mockItf` is not a fixture; it can't be loaded as a fixture
       // because fixtures don't evaluate JS.
-      cy.route('GET', '/v0/intent_to_file', mockItf);
+      cy.intercept('GET', '/v0/intent_to_file', mockItf);
 
-      cy.route('PUT', '/v0/in_progress_forms/*', 'fx:mocks/in-progress-forms');
+      cy.intercept('PUT', '/v0/in_progress_forms/*', mockInProgress);
 
-      cy.route(
+      cy.intercept(
         'GET',
         '/v0/disability_compensation_form/separation_locations',
-        'fx:mocks/separation-locations',
+        mockLocations,
       );
 
-      cy.route(
-        'GET',
-        '/v0/ppiu/payment_information',
-        'fx:mocks/payment-information',
-      );
+      cy.intercept('GET', '/v0/ppiu/payment_information', mockPayment);
 
-      cy.route(
-        'POST',
-        '/v0/upload_supporting_evidence',
-        'fx:mocks/document-upload',
-      );
+      cy.intercept('POST', '/v0/upload_supporting_evidence', mockUpload);
 
-      cy.route(
+      cy.intercept(
         'POST',
         '/v0/disability_compensation_form/submit_all_claim',
-        'fx:mocks/application-submit',
+        mockSubmit,
       );
 
       // Stub submission status for immediate transition to confirmation page.
-      cy.route(
+      cy.intercept(
         'GET',
         '/v0/disability_compensation_form/submission_status/*',
         '',
@@ -178,7 +177,7 @@ const testConfig = createTestConfig(
           ({ 'view:selected': _, ...obj }) => obj,
         );
 
-        cy.route('GET', 'v0/in_progress_forms/21-526EZ', {
+        cy.intercept('GET', 'v0/in_progress_forms/21-526EZ', {
           formData: {
             veteran: {
               primaryPhone: '4445551212',


### PR DESCRIPTION
## Description

Cypress was upgraded to v6.2.1+, which deprecated specific Cypress functions. This PR updates the Cypress tests for HLR & 526.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/19591
- https://dsva.slack.com/archives/CE4304QPK/p1610486583177300

## Testing done

Cypress

## Screenshots

N/A

## Acceptance criteria
- [x] HLR Cypress tests passing
- [x] 526 Cypress tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
