### PR TITLE
Sanlouise 19436 nametag profile

### DIFF
--- a/src/applications/personalization/components/NameTag.jsx
+++ b/src/applications/personalization/components/NameTag.jsx
@@ -146,13 +146,13 @@ const NameTag = ({
                     <a
                       href="/disability/view-disability-rating/rating"
                       aria-label="view your disability rating"
-                      className="vads-u-color--white vads-u-font-size--md font-weight--bold"
+                      className="vads-u-color--white font-weight--bold"
                     >
                       {totalDisabilityRating}% Service connected{' '}
                       <i
-                        className={`fa fa-angle-double-right`}
                         aria-hidden="true"
                         role="img"
+                        className="fas fa-chevron-right vads-u-padding-left--0p5"
                       />
                     </a>
                   </dd>

--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -137,11 +137,7 @@ class Profile extends Component {
     return (
       <BrowserRouter>
         <LastLocationProvider>
-          <ProfileWrapper
-            routes={routes}
-            isLOA3={this.props.isLOA3}
-            isInMVI={this.props.isInMVI}
-          >
+          <ProfileWrapper routes={routes} isInMVI={this.props.isInMVI}>
             <Switch>
               {/* Redirect users to Account Security to upgrade their account if they need to */}
               {routes.map(route => {

--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -137,7 +137,11 @@ class Profile extends Component {
     return (
       <BrowserRouter>
         <LastLocationProvider>
-          <ProfileWrapper routes={routes} isInMVI={this.props.isInMVI}>
+          <ProfileWrapper
+            routes={routes}
+            isInMVI={this.props.isInMVI}
+            isLOA3={this.props.isLOA3}
+          >
             <Switch>
               {/* Redirect users to Account Security to upgrade their account if they need to */}
               {routes.map(route => {

--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -304,12 +304,17 @@ const mapStateToProps = state => {
 
   const hasLoadedEDUPaymentInformation = eduDirectDepositInformation(state);
 
+  const hasLoadedTotalDisabilityRating =
+    state.totalRating?.totalDisabilityRating;
+
   const hasLoadedAllData =
     hasLoadedFullName &&
     hasLoadedMHVInformation &&
     hasLoadedPersonalInformation &&
     hasLoadedMilitaryInformation &&
-    shouldFetchTotalDisabilityRating &&
+    (shouldFetchTotalDisabilityRating
+      ? hasLoadedTotalDisabilityRating
+      : true) &&
     (shouldFetchCNPDirectDepositInformation
       ? hasLoadedCNPPaymentInformation
       : true) &&

--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -45,6 +45,10 @@ import {
   fetchCNPPaymentInformation as fetchCNPPaymentInformationAction,
   fetchEDUPaymentInformation as fetchEDUPaymentInformationAction,
 } from '@@profile/actions/paymentInformation';
+
+import { selectShowDashboard2 } from '~/applications/personalization/dashboard-2/selectors';
+import { fetchTotalDisabilityRating as fetchTotalDisabilityRatingAction } from '~/applications/personalization/rated-disabilities/actions';
+
 import getRoutes from '../routes';
 import { PROFILE_PATHS } from '../constants';
 
@@ -53,13 +57,15 @@ import ProfileWrapper from './ProfileWrapper';
 class Profile extends Component {
   componentDidMount() {
     const {
+      fetchCNPPaymentInformation,
+      fetchEDUPaymentInformation,
       fetchFullName,
       fetchMHVAccount,
       fetchMilitaryInformation,
       fetchPersonalInformation,
-      fetchCNPPaymentInformation,
-      fetchEDUPaymentInformation,
+      fetchTotalDisabilityRating,
       shouldFetchCNPDirectDepositInformation,
+      shouldFetchTotalDisabilityRating,
       shouldFetchEDUDirectDepositInformation,
     } = this.props;
     fetchMHVAccount();
@@ -69,12 +75,21 @@ class Profile extends Component {
     if (shouldFetchCNPDirectDepositInformation) {
       fetchCNPPaymentInformation();
     }
+    if (shouldFetchTotalDisabilityRating) {
+      fetchTotalDisabilityRating();
+    }
     if (shouldFetchEDUDirectDepositInformation) {
       fetchEDUPaymentInformation();
     }
   }
 
   componentDidUpdate(prevProps) {
+    if (
+      this.props.shouldFetchTotalDisabilityRating &&
+      !prevProps.shouldFetchTotalDisabilityRating
+    ) {
+      this.props.fetchTotalDisabilityRating();
+    }
     if (
       this.props.shouldFetchCNPDirectDepositInformation &&
       !prevProps.shouldFetchCNPDirectDepositInformation
@@ -141,6 +156,7 @@ class Profile extends Component {
             routes={routes}
             isInMVI={this.props.isInMVI}
             isLOA3={this.props.isLOA3}
+            showUpdatedNameTag={this.props.shouldFetchTotalDisabilityRating}
           >
             <Switch>
               {/* Redirect users to Account Security to upgrade their account if they need to */}
@@ -247,6 +263,12 @@ const mapStateToProps = state => {
   const isCNPDirectDepositBlocked = cnpDirectDepositIsBlocked(state);
   const isEligibleToSetUpCNP = cnpDirectDepositAddressIsSetUp(state);
   const is2faEnabled = isMultifactorEnabled(state);
+
+  const LSDashboardVersion = localStorage.getItem('DASHBOARD_VERSION');
+  const LSDashboard1 = LSDashboardVersion === '1';
+  const LSDashboard2 = LSDashboardVersion === '2';
+  const FFDashboard2 = selectShowDashboard2(state);
+
   const shouldFetchCNPDirectDepositInformation =
     isEvssAvailable && is2faEnabled;
   const shouldFetchEDUDirectDepositInformation =
@@ -254,6 +276,9 @@ const mapStateToProps = state => {
   const currentlyLoggedIn = isLoggedIn(state);
   const isLOA1 = isLOA1Selector(state);
   const isLOA3 = isLOA3Selector(state);
+
+  const shouldFetchTotalDisabilityRating =
+    isLOA3 && (LSDashboard2 || (FFDashboard2 && !LSDashboard1));
 
   // this piece of state will be set if the call to load military info succeeds
   // or fails:
@@ -284,6 +309,7 @@ const mapStateToProps = state => {
     hasLoadedMHVInformation &&
     hasLoadedPersonalInformation &&
     hasLoadedMilitaryInformation &&
+    shouldFetchTotalDisabilityRating &&
     (shouldFetchCNPDirectDepositInformation
       ? hasLoadedCNPPaymentInformation
       : true) &&
@@ -312,6 +338,7 @@ const mapStateToProps = state => {
     isLOA3,
     shouldFetchCNPDirectDepositInformation,
     shouldFetchEDUDirectDepositInformation,
+    shouldFetchTotalDisabilityRating,
     shouldShowDirectDeposit: shouldShowDirectDeposit(),
     isDowntimeWarningDismissed: state.scheduledDowntime?.dismissedDowntimeWarnings?.includes(
       'profile',
@@ -326,6 +353,7 @@ const mapDispatchToProps = {
   fetchPersonalInformation: fetchPersonalInformationAction,
   fetchCNPPaymentInformation: fetchCNPPaymentInformationAction,
   fetchEDUPaymentInformation: fetchEDUPaymentInformationAction,
+  fetchTotalDisabilityRating: fetchTotalDisabilityRatingAction,
   initializeDowntimeWarnings,
   dismissDowntimeWarning,
 };

--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -305,7 +305,7 @@ const mapStateToProps = state => {
   const hasLoadedEDUPaymentInformation = eduDirectDepositInformation(state);
 
   const hasLoadedTotalDisabilityRating =
-    state.totalRating?.totalDisabilityRating;
+    state.totalRating?.totalDisabilityRating || state.totalRating?.error;
 
   const hasLoadedAllData =
     hasLoadedFullName &&

--- a/src/applications/personalization/profile/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile/components/ProfileWrapper.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Link, useLocation } from 'react-router-dom';
@@ -7,10 +7,7 @@ import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox
 import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
 
 import { isWideScreen } from '~/platform/utilities/accessibility/index';
-import {
-  selectProfile,
-  isLOA3 as isLOA3Selector,
-} from '~/platform/user/selectors';
+import { selectProfile } from '~/platform/user/selectors';
 
 import {
   cnpDirectDepositLoadError,
@@ -50,10 +47,21 @@ const ProfileWrapper = ({
   isLOA3,
   isInMVI,
   showNotAllDataAvailableError,
+  fetchTotalDisabilityRating,
   totalDisabilityRating,
   showUpdatedNameTag,
   showNameTag,
 }) => {
+  // fetch data when we determine they are LOA3
+  useEffect(
+    () => {
+      if (isLOA3 && showUpdatedNameTag) {
+        fetchTotalDisabilityRating();
+      }
+    },
+    [showUpdatedNameTag, isLOA3, fetchTotalDisabilityRating],
+  );
+
   const location = useLocation();
   const createBreadCrumbAttributes = () => {
     const activeLocation = location?.pathname;
@@ -126,7 +134,7 @@ const ProfileWrapper = ({
   );
 };
 
-const mapStateToProps = state => {
+const mapStateToProps = (state, ownProps) => {
   const veteranStatus = selectProfile(state)?.veteranStatus;
   const invalidVeteranStatus =
     !veteranStatus || veteranStatus === 'NOT_AUTHORIZED';
@@ -134,14 +142,13 @@ const mapStateToProps = state => {
   const LSDashboard1 = LSDashboardVersion === '1';
   const LSDashboard2 = LSDashboardVersion === '2';
   const FFDashboard2 = selectShowDashboard2(state);
-  const isLOA3 = isLOA3Selector(state);
   const hero = state.vaProfile?.hero;
 
   return {
     hero,
     totalDisabilityRating: state.totalRating?.totalDisabilityRating,
     showUpdatedNameTag: LSDashboard2 || (FFDashboard2 && !LSDashboard1),
-    showNameTag: isLOA3 && isEmpty(hero?.errors),
+    showNameTag: ownProps.isLOA3 && isEmpty(hero?.errors),
     showNotAllDataAvailableError:
       !!cnpDirectDepositLoadError(state) ||
       !!eduDirectDepositLoadError(state) ||

--- a/src/applications/personalization/profile/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile/components/ProfileWrapper.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Link, useLocation } from 'react-router-dom';
@@ -18,9 +18,6 @@ import {
 } from '@@profile/selectors';
 
 import NameTag from '~/applications/personalization/components/NameTag';
-import { fetchTotalDisabilityRating as fetchTotalDisabilityRatingAction } from '~/applications/personalization/rated-disabilities/actions';
-import { selectShowDashboard2 } from '~/applications/personalization/dashboard-2/selectors';
-
 import ProfileSubNav from './ProfileSubNav';
 import ProfileMobileSubNav from './ProfileMobileSubNav';
 import { PROFILE_PATHS } from '../constants';
@@ -47,21 +44,10 @@ const ProfileWrapper = ({
   isLOA3,
   isInMVI,
   showNotAllDataAvailableError,
-  fetchTotalDisabilityRating,
   totalDisabilityRating,
   showUpdatedNameTag,
   showNameTag,
 }) => {
-  // fetch data when we determine they are LOA3
-  useEffect(
-    () => {
-      if (isLOA3 && showUpdatedNameTag) {
-        fetchTotalDisabilityRating();
-      }
-    },
-    [showUpdatedNameTag, isLOA3, fetchTotalDisabilityRating],
-  );
-
   const location = useLocation();
   const createBreadCrumbAttributes = () => {
     const activeLocation = location?.pathname;
@@ -138,16 +124,11 @@ const mapStateToProps = (state, ownProps) => {
   const veteranStatus = selectProfile(state)?.veteranStatus;
   const invalidVeteranStatus =
     !veteranStatus || veteranStatus === 'NOT_AUTHORIZED';
-  const LSDashboardVersion = localStorage.getItem('DASHBOARD_VERSION');
-  const LSDashboard1 = LSDashboardVersion === '1';
-  const LSDashboard2 = LSDashboardVersion === '2';
-  const FFDashboard2 = selectShowDashboard2(state);
   const hero = state.vaProfile?.hero;
 
   return {
     hero,
     totalDisabilityRating: state.totalRating?.totalDisabilityRating,
-    showUpdatedNameTag: LSDashboard2 || (FFDashboard2 && !LSDashboard1),
     showNameTag: ownProps.isLOA3 && isEmpty(hero?.errors),
     showNotAllDataAvailableError:
       !!cnpDirectDepositLoadError(state) ||
@@ -156,10 +137,6 @@ const mapStateToProps = (state, ownProps) => {
       !!personalInformationLoadError(state) ||
       (!!militaryInformationLoadError(state) && !invalidVeteranStatus),
   };
-};
-
-const mapDispatchToProps = {
-  fetchTotalDisabilityRating: fetchTotalDisabilityRatingAction,
 };
 
 ProfileWrapper.propTypes = {
@@ -178,7 +155,4 @@ ProfileWrapper.propTypes = {
   showNotAllDataAvailableError: PropTypes.bool.isRequired,
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(ProfileWrapper);
+export default connect(mapStateToProps)(ProfileWrapper);

--- a/src/applications/personalization/profile/reducers/index.js
+++ b/src/applications/personalization/profile/reducers/index.js
@@ -1,9 +1,11 @@
 import vapService from '@@vap-svc/reducers';
 import hcaEnrollmentStatus from '~/applications/hca/reducers/hca-enrollment-status-reducer';
+import ratedDisabilities from '~/applications/personalization/rated-disabilities/reducers';
 import vaProfile from './vaProfile';
 
 export default {
   vaProfile,
   vapService,
   hcaEnrollmentStatus,
+  ...ratedDisabilities,
 };

--- a/src/applications/personalization/profile/tests/components/Profile.unit.spec.js
+++ b/src/applications/personalization/profile/tests/components/Profile.unit.spec.js
@@ -18,6 +18,7 @@ describe('Profile', () => {
   let fetchMHVAccountSpy;
   let fetchCNPPaymentInfoSpy;
   let fetchPersonalInfoSpy;
+  let fetchTotalDisabilityRatingSpy;
 
   beforeEach(() => {
     fetchFullNameSpy = sinon.spy();
@@ -25,6 +26,7 @@ describe('Profile', () => {
     fetchMHVAccountSpy = sinon.spy();
     fetchCNPPaymentInfoSpy = sinon.spy();
     fetchPersonalInfoSpy = sinon.spy();
+    fetchTotalDisabilityRatingSpy = sinon.spy();
 
     defaultProps = {
       fetchFullName: fetchFullNameSpy,
@@ -32,7 +34,9 @@ describe('Profile', () => {
       fetchMilitaryInformation: fetchMilitaryInfoSpy,
       fetchCNPPaymentInformation: fetchCNPPaymentInfoSpy,
       fetchPersonalInformation: fetchPersonalInfoSpy,
+      fetchTotalDisabilityRating: fetchTotalDisabilityRatingSpy,
       shouldFetchCNPDirectDepositInformation: true,
+      shouldFetchTotalDisabilityRating: true,
       showLoader: false,
       user: {},
       location: {
@@ -97,6 +101,24 @@ describe('Profile', () => {
         defaultProps.shouldFetchCNPDirectDepositInformation = false;
         const wrapper = shallow(<Profile {...defaultProps} />);
         expect(fetchCNPPaymentInfoSpy.called).to.be.false;
+        wrapper.unmount();
+      });
+    });
+
+    describe('when `shouldFetchTotalDisabilityRating` is `true`', () => {
+      it('should fetch the total disability rating', () => {
+        defaultProps.shouldFetchTotalDisabilityRating = true;
+        const wrapper = shallow(<Profile {...defaultProps} />);
+        expect(fetchTotalDisabilityRatingSpy.called).to.be.true;
+        wrapper.unmount();
+      });
+    });
+
+    describe('when `shouldFetchTotalDisabilityRating` is `false`', () => {
+      it('should not fetch the total disability rating', () => {
+        defaultProps.shouldFetchTotalDisabilityRating = false;
+        const wrapper = shallow(<Profile {...defaultProps} />);
+        expect(fetchTotalDisabilityRatingSpy.called).to.be.false;
         wrapper.unmount();
       });
     });
@@ -204,6 +226,9 @@ describe('mapStateToProps', () => {
       },
     },
     vaProfile: makeDefaultVaProfileState(),
+    totalRating: {
+      totalDisabilityRating: null,
+    },
   });
 
   it('returns an object with the correct keys', () => {
@@ -216,6 +241,7 @@ describe('mapStateToProps', () => {
       'isLOA3',
       'shouldFetchCNPDirectDepositInformation',
       'shouldFetchEDUDirectDepositInformation',
+      'shouldFetchTotalDisabilityRating',
       'shouldShowDirectDeposit',
       'isDowntimeWarningDismissed',
     ];
@@ -345,6 +371,7 @@ describe('mapStateToProps', () => {
         state.vaProfile.userFullName = { error: {} };
         state.vaProfile.personalInformation = { error: {} };
         state.vaProfile.militaryInformation = { error: {} };
+        state.totalRating.totalDisabilityRating = { error: {} };
         state.user.profile.mhvAccount = { errors: [] };
         const props = mapStateToProps(state);
         expect(props.showLoader).to.be.false;


### PR DESCRIPTION
## Description
[TICKET](https://github.com/department-of-veterans-affairs/va.gov-team/issues/19436)
We added the updated name tag to myVA2, and we now need to also show this updated name tag on the Profile when the feature flag for myVA2 is turned on.

## Testing done
Works well locally, updated relevant unit tests.

## Screenshots

**With the new feature turned on**
![image](https://user-images.githubusercontent.com/14869324/107267834-a5dbf000-6a04-11eb-8436-482aebc473e5.png)

**With the new feature turned off, no changes to current design**
![image](https://user-images.githubusercontent.com/14869324/107268200-0d923b00-6a05-11eb-9a7f-c4e5c69b946c.png)

## Acceptance criteria
- [x] Mirror the new name tag of My VA2 on the profile when the feature flag is turned on.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
