### PR TITLE
disable broken link checking on staging due to build differences

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -196,7 +196,7 @@ def build(String ref, dockerContainer, String assetSource, String envName, Boole
 
       sh "cd /application && jenkins/build.sh --envName ${envName} --assetSource ${assetSource} --drupalAddress ${drupalAddress} ${drupalMode} --buildLog ${buildLogPath} --verbose ${cmsExportFlag} --destination ${destination}"
 
-      if (envName == 'vagovprod' || envName == 'vagovstaging') {
+      if (envName == 'vagovprod') {
         // Find any broken links in the log
         checkForBrokenLinks(buildLogPath, envName, contentOnlyBuild)
         // Find any missing query flags in the log

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -165,10 +165,9 @@ def checkForBrokenLinks(String buildLogPath, String envName, Boolean contentOnly
       // slackUploadFile(filePath: csvFile, channel: 'dev_null', failOnError: true, initialComment: "Found broken links in the ${envName} build on `${env.BRANCH_NAME}`.")
 
       // Until slackUploadFile works...
-      def brokenLinks = readFile(file: "/application/${csvFileName}")
       def brokenLinksCount = sh(returnStdout: true, script: "wc -l /application/${csvFileName} | cut -d ' ' -f1") as Integer
 
-      slackSend message: "${brokenLinksCount} broken links found in the `${envName}` build on `${env.BRANCH_NAME}`\n${env.RUN_DISPLAY_URL}\n${brokenLinks}".stripMargin(),
+      slackSend message: "${brokenLinksCount} broken links found in the `${envName}` build on `${env.BRANCH_NAME}`\n${env.RUN_DISPLAY_URL}".stripMargin(),
         color: 'danger',
         failOnError: true,
         channel: 'cms-team'


### PR DESCRIPTION
## Description

tried to enabled broken link checking in staging https://github.com/department-of-veterans-affairs/vets-website/pull/15952

some things are different about staging build which prevents broken link checker from working. this disables that check for now

followup: https://github.com/department-of-veterans-affairs/va.gov-team/issues/19678

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
