### PR TITLE
Add tracking to display of new CC Provider Selection page

### DIFF
--- a/src/applications/vaos/new-appointment/components/CommunityCarePreferencesPage.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCarePreferencesPage.jsx
@@ -163,6 +163,9 @@ export function CommunityCarePreferencesPage({
     document.title = `${pageTitle} | Veterans Affairs`;
     scrollAndFocus();
     openCommunityCarePreferencesPage(pageKey, uiSchema, initialSchema);
+    recordEvent({
+      event: `${GA_PREFIX}-community-care-legacy-provider-page`,
+    });
   }, []);
   const previousData = data;
 

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/index.jsx
@@ -64,6 +64,9 @@ function CommunityCareProviderSelectionPage({
       document.title = `${pageTitle} | Veterans Affairs`;
       scrollAndFocus();
       openCommunityCareProviderSelectionPage(pageKey, uiSchema, initialSchema);
+      recordEvent({
+        event: `${GA_PREFIX}-community-care-provider-selection-page`,
+      });
     }
   }, []);
 

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCarePreferencesPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCarePreferencesPage.unit.spec.jsx
@@ -17,6 +17,7 @@ import {
   mockCommunityCareEligibility,
   mockParentSites,
 } from '../../mocks/helpers';
+import { GA_PREFIX } from '../../../utils/constants';
 
 import CommunityCarePreferencesPage from '../../../new-appointment/components/CommunityCarePreferencesPage';
 
@@ -63,6 +64,12 @@ describe('VAOS <CommunityCarePreferencesPage>', () => {
     await screen.findByText(
       /do you have a preferred VA-approved community care provider for this primary care appointment/i,
     );
+
+    expect(
+      global.window.dataLayer.find(
+        ev => ev.event === `${GA_PREFIX}-community-care-legacy-provider-page`,
+      ),
+    ).to.exist;
 
     expect(screen.getAllByRole('radio').length).to.equal(2);
     expect(screen.getAllByRole('combobox').length).to.equal(1);

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
@@ -113,6 +113,13 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
     );
 
     expect((await screen.findAllByRole('radio')).length).to.equal(2);
+
+    expect(
+      global.window.dataLayer.some(
+        e => e === `${GA_PREFIX}-community-care-provider-selection-page`,
+      ),
+    );
+
     expect(screen.getByLabelText('Bozeman, MT')).to.exist;
     expect(screen.getByLabelText('Belgrade, MT')).to.exist;
     expect(screen.baseElement).to.contain.text(


### PR DESCRIPTION
## Description
Adds events on open to CC provider selection page and legacy page so we can identify in analytics how many users see the new Community Care Provider Selection page.

## Testing done
Local and unit

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
