### PR TITLE
Change link to point to help desk

### DIFF
--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -5,11 +5,15 @@ import { connect } from 'react-redux';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
 
+import Telephone, {
+  CONTACTS,
+  PATTERNS,
+} from '@department-of-veterans-affairs/component-library/Telephone';
+
 // import { getCurrentGlobalDowntime } from 'platform/monitoring/DowntimeNotification/util/helpers';
 import ExternalServicesError from 'platform/monitoring/external-services/ExternalServicesError';
 import { EXTERNAL_SERVICES } from 'platform/monitoring/external-services/config';
 import recordEvent from 'platform/monitoring/record-event';
-import SubmitSignInForm from 'platform/static-data/SubmitSignInForm';
 import { ssoe } from 'platform/user/authentication/selectors';
 import { login, signup } from 'platform/user/authentication/utilities';
 import { formatDowntime } from 'platform/utilities/date';
@@ -312,7 +316,13 @@ export class SignInModal extends React.Component {
                 .
               </p>
               <p>
-                <SubmitSignInForm startSentence />
+                If you need more help, call our MyVA411 main information line at{' '}
+                <Telephone contact={CONTACTS.HELP_DESK} />, select 0 (TTY:{' '}
+                <Telephone
+                  contact={CONTACTS[711]}
+                  pattern={PATTERNS['3_DIGIT']}
+                />
+                ).
               </p>
             </div>
             <hr />


### PR DESCRIPTION
## Description
This PR changes a link on the SignIn modal to point to the help desk because the webpage isn't working right now.

## Testing done
Confirmed that the HTML is correct in my sign-in modal

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/107587523-ea67b700-6bcf-11eb-9696-3cc751e7ef9e.png)


## Acceptance criteria
- [ ] Broken link is gone

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
