### PR TITLE
Wrap My VA v2 in LoginRequired and Downtime components

### DIFF
--- a/src/applications/personalization/dashboard-2/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard-2/components/Dashboard.jsx
@@ -1,11 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import isEmpty from 'lodash/isEmpty';
 
 import '../sass/dashboard.scss';
 
 import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
-import Modal from '@department-of-veterans-affairs/component-library/Modal';
 
 import { focusElement } from '~/platform/utilities/ui';
 import {
@@ -20,7 +19,6 @@ import {
   DowntimeNotification,
   externalServices,
 } from '~/platform/monitoring/DowntimeNotification';
-import externalServiceStatus from '~/platform/monitoring/DowntimeNotification/config/externalServiceStatus';
 
 import NameTag from '~/applications/personalization/components/NameTag';
 import IdentityNotVerified from '~/applications/personalization/components/IdentityNotVerified';
@@ -30,6 +28,8 @@ import {
   fetchMilitaryInformation as fetchMilitaryInformationAction,
   fetchHero as fetchHeroAction,
 } from '@@profile/actions';
+
+import useDowntimeApproachingRenderMethod from '../useDowntimeApproachingRenderMethod';
 
 import ApplyForBenefits from './apply-for-benefits/ApplyForBenefits';
 import ClaimsAndAppeals from './claims-and-appeals/ClaimsAndAppeals';
@@ -43,7 +43,8 @@ const Dashboard = ({
   showLoader,
   ...props
 }) => {
-  const [modalDismissed, setModalDismissed] = useState(false);
+  const downtimeApproachingRenderMethod = useDowntimeApproachingRenderMethod();
+
   // focus on the header when we are done loading
   useEffect(
     () => {
@@ -71,43 +72,6 @@ const Dashboard = ({
     ],
   );
 
-  const renderDowntimeModal = (downtime, children) => {
-    if (downtime.status === externalServiceStatus.downtimeApproaching) {
-      return (
-        <>
-          <Modal
-            id="downtime-approaching-modal"
-            title="Some parts of your dashboard will be down for maintenance soon"
-            status="info"
-            onClose={() => {
-              setModalDismissed(true);
-            }}
-            visible={!modalDismissed}
-          >
-            <p>
-              We’ll be making updates to some tools and features on{' '}
-              {downtime.startTime.format('MMMM Do')} between{' '}
-              {downtime.startTime.format('LT')} and{' '}
-              {downtime.endTime.format('LT')} If you have trouble using parts of
-              the dashboard during that time, please check back soon.
-            </p>
-            <button
-              type="button"
-              className="usa-button-secondary"
-              onClick={() => {
-                setModalDismissed(true);
-              }}
-            >
-              Continue
-            </button>
-          </Modal>
-          {children}
-        </>
-      );
-    }
-    return children;
-  };
-
   return (
     <RequiredLoginView
       serviceRequired={[backendServices.USER_PROFILE]}
@@ -121,7 +85,7 @@ const Dashboard = ({
           externalServices.mhv,
           externalServices.appeals,
         ]}
-        render={renderDowntimeModal}
+        render={downtimeApproachingRenderMethod}
       >
         {showLoader && <RequiredLoginLoader />}
         {!showLoader && (

--- a/src/applications/personalization/dashboard-2/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard-2/components/Dashboard.jsx
@@ -11,7 +11,6 @@ import { focusElement } from '~/platform/utilities/ui';
 import {
   isLOA3 as isLOA3Selector,
   isLOA1 as isLOA1Selector,
-  isLoggedIn as isLoggedInSelector,
 } from '~/platform/user/selectors';
 import RequiredLoginView, {
   RequiredLoginLoader,
@@ -170,7 +169,7 @@ const Dashboard = ({
 };
 
 const mapStateToProps = state => {
-  const isLoggedIn = isLoggedInSelector(state);
+  const { isReady: hasLoadedScheduledDowntime } = state.scheduledDowntime;
   const isLOA3 = isLOA3Selector(state);
   const isLOA1 = isLOA1Selector(state);
   const hero = state.vaProfile?.hero;
@@ -186,7 +185,7 @@ const mapStateToProps = state => {
       hasLoadedFullName &&
       hasLoadedDisabilityRating);
 
-  const showLoader = !isLoggedIn || !hasLoadedAllData;
+  const showLoader = !hasLoadedScheduledDowntime || !hasLoadedAllData;
   const showValidateIdentityAlert = isLOA1;
   const showNameTag = isLOA3 && isEmpty(hero?.errors);
   // TODO: expand on these flags depending on the contents of the user object.

--- a/src/applications/personalization/dashboard-2/tests/e2e/dashboard-loa1.cypress.spec.js
+++ b/src/applications/personalization/dashboard-2/tests/e2e/dashboard-loa1.cypress.spec.js
@@ -22,6 +22,10 @@ function loa1DashboardTest(mobile, stubs) {
     cy.viewport('iphone-4');
   }
 
+  // make sure that the "Verify" alert is shown
+  cy.findByText(/Verify your identity to access/i).should('exist');
+  cy.findByText(/we need to make sure you’re you/i).should('exist');
+
   // focus should be on the h1
   cy.focused()
     .should('have.attr', 'id', 'dashboard-title')
@@ -44,10 +48,6 @@ function loa1DashboardTest(mobile, stubs) {
 
   // make sure that the health care section is hidden
   cy.findByText('Health care').should('not.exist');
-
-  // make sure that the "Verify" alert is shown
-  cy.findByText(/Verify your identity to access/i).should('exist');
-  cy.findByText(/we need to make sure you’re you/i).should('exist');
 
   // make the a11y check
   cy.injectAxe();

--- a/src/applications/personalization/dashboard-2/tests/e2e/upcoming-downtime.cypress.spec.js
+++ b/src/applications/personalization/dashboard-2/tests/e2e/upcoming-downtime.cypress.spec.js
@@ -1,0 +1,84 @@
+import disableFTUXModals from '~/platform/user/tests/disableFTUXModals';
+import { mockUser } from '@@profile/tests/fixtures/users/user.js';
+import serviceHistory from '@@profile/tests/fixtures/service-history-success.json';
+import fullName from '@@profile/tests/fixtures/full-name-success.json';
+import disabilityRating from '@@profile/tests/fixtures/disability-rating-success.json';
+
+import manifest from 'applications/personalization/dashboard/manifest.json';
+
+import { mockFeatureToggles } from './helpers';
+
+/**
+ *
+ * @param {boolean} mobile - test on a mobile viewport or not
+ *
+ * This helper:
+ * - loads the my VA Dashboard,
+ *   checks that focus is managed correctly, and performs an aXe scan
+ */
+describe('The My VA Dashboard', () => {
+  beforeEach(() => {
+    disableFTUXModals();
+    cy.login(mockUser);
+    cy.intercept('/v0/profile/service_history', serviceHistory);
+    cy.intercept('/v0/profile/full_name', fullName);
+    cy.intercept(
+      '/v0/disability_compensation_form/rating_info',
+      disabilityRating,
+    );
+    mockFeatureToggles();
+  });
+  it('should show a dismissible modal if a dependent service has downtime approaching in the next hour', () => {
+    // start time is one minute from now
+    const startTime = new Date(Date.now() + 60 * 1000);
+    // end time is one hour from now
+    const endTime = new Date(Date.now() + 60 * 60 * 1000);
+    cy.route('GET', '/v0/maintenance_windows', {
+      data: [
+        {
+          id: '1',
+          type: 'maintenance_windows',
+          attributes: {
+            externalService: 'mvi',
+            // toISOString() matches the format used by the real API, '2021-02-14T02:00:00.000Z'
+            startTime: startTime.toISOString(),
+            endTime: endTime.toISOString(),
+            description: '',
+          },
+        },
+      ],
+    });
+    cy.visit(manifest.rootUrl);
+    cy.findByRole('button', { name: /continue/i }).click();
+    cy.findByRole('button', { name: /continue/i }).should('not.exist');
+
+    cy.visit(manifest.rootUrl);
+    cy.findByRole('button', { name: /close this modal/i }).click();
+    cy.findByRole('button', { name: /close this modal/i }).should('not.exist');
+  });
+  it('should not show a modal if there is no upcoming downtime', () => {
+    const oneDayInMS = 60 * 60 * 24 * 1000;
+    // start time is one day from now
+    const startTime = new Date(Date.now() + oneDayInMS);
+    // end time is two days from now
+    const endTime = new Date(Date.now() + oneDayInMS * 2);
+    cy.route('GET', '/v0/maintenance_windows', {
+      data: [
+        {
+          id: '1',
+          type: 'maintenance_windows',
+          attributes: {
+            externalService: 'mvi',
+            // toISOString() matches the format used by the real API, '2021-02-14T02:00:00.000Z'
+            startTime: startTime.toISOString(),
+            endTime: endTime.toISOString(),
+            description: '',
+          },
+        },
+      ],
+    });
+    cy.visit(manifest.rootUrl);
+    cy.findByRole('heading', { name: /My VA/i }).should('exist');
+    cy.findByRole('button', { name: /continue/i }).should('not.exist');
+  });
+});

--- a/src/applications/personalization/dashboard-2/useDowntimeApproachingRenderMethod.jsx
+++ b/src/applications/personalization/dashboard-2/useDowntimeApproachingRenderMethod.jsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+import Modal from '@department-of-veterans-affairs/component-library/Modal';
+import externalServiceStatus from '~/platform/monitoring/DowntimeNotification/config/externalServiceStatus';
+
+/**
+ * A simple React hook that returns a render method suitable for use as the
+ * DowntimeNotification's `render` prop. The returned render method simply
+ * displays a Modal if the soonest downtime will start within an hour. The hook
+ * maintains its own  state to track if the Modal should be shown or not (which
+ * is the only reason this needs to be a hook in the first place). This render
+ * prop renders its children like normal if downtime is actually active.
+ */
+export default function useDowntimeApproachingRenderMethod() {
+  const [modalDismissed, setModalDismissed] = useState(false);
+
+  return (downtime, children) => {
+    if (downtime.status === externalServiceStatus.downtimeApproaching) {
+      return (
+        <>
+          <Modal
+            id="downtime-approaching-modal"
+            title="Some parts of your dashboard will be down for maintenance soon"
+            status="info"
+            onClose={() => {
+              setModalDismissed(true);
+            }}
+            visible={!modalDismissed}
+          >
+            <p>
+              We’ll be making updates to some tools and features on{' '}
+              {downtime.startTime.format('MMMM Do')} between{' '}
+              {downtime.startTime.format('LT')} and{' '}
+              {downtime.endTime.format('LT')} If you have trouble using parts of
+              the dashboard during that time, please check back soon.
+            </p>
+            <button
+              type="button"
+              className="usa-button-secondary"
+              onClick={() => {
+                setModalDismissed(true);
+              }}
+            >
+              Continue
+            </button>
+          </Modal>
+          {children}
+        </>
+      );
+    }
+    return children;
+  };
+}

--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -3,20 +3,21 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom';
 import { LastLocationProvider } from 'react-router-last-location';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 
 import DowntimeNotification, {
   externalServices,
   externalServiceStatus,
-} from 'platform/monitoring/DowntimeNotification';
-import DowntimeApproaching from 'platform/monitoring/DowntimeNotification/components/DowntimeApproaching';
+} from '~/platform/monitoring/DowntimeNotification';
+import DowntimeApproaching from '~/platform/monitoring/DowntimeNotification/components/DowntimeApproaching';
 import {
   initializeDowntimeWarnings,
   dismissDowntimeWarning,
-} from 'platform/monitoring/DowntimeNotification/actions';
+} from '~/platform/monitoring/DowntimeNotification/actions';
 
-import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
-import backendServices from 'platform/user/profile/constants/backendServices';
+import RequiredLoginView, {
+  RequiredLoginLoader,
+} from '~/platform/user/authorization/components/RequiredLoginView';
+import backendServices from '~/platform/user/profile/constants/backendServices';
 import {
   createIsServiceAvailableSelector,
   isMultifactorEnabled,
@@ -25,8 +26,8 @@ import {
   isLOA3 as isLOA3Selector,
   isInMPI as isInMVISelector,
   isLoggedIn,
-} from 'platform/user/selectors';
-import { fetchMHVAccount as fetchMHVAccountAction } from 'platform/user/profile/actions';
+} from '~/platform/user/selectors';
+import { fetchMHVAccount as fetchMHVAccountAction } from '~/platform/user/profile/actions';
 import {
   fetchMilitaryInformation as fetchMilitaryInformationAction,
   fetchHero as fetchHeroAction,
@@ -130,16 +131,6 @@ class Profile extends Component {
     return children;
   };
 
-  // content to show if the component is waiting for data to load. This loader
-  // matches the loader shown by the RequiredLoginView component, so when the
-  // RequiredLoginView is done with its loading and this function takes over, it
-  // appears seamless to the user.
-  loadingContent = () => (
-    <div className="vads-u-margin-y--5">
-      <LoadingIndicator setFocus message="Loading your information..." />
-    </div>
-  );
-
   // content to show after data has loaded
   mainContent = () => {
     const routesOptions = {
@@ -209,7 +200,7 @@ class Profile extends Component {
 
   renderContent = () => {
     if (this.props.showLoader) {
-      return this.loadingContent();
+      return <RequiredLoginLoader />;
     }
     return this.mainContent();
   };
@@ -223,7 +214,7 @@ class Profile extends Component {
         <DowntimeNotification
           appTitle="profile"
           render={this.handleDowntimeApproaching}
-          loadingIndicator={this.loadingContent()}
+          loadingIndicator={<RequiredLoginLoader />}
           dependencies={[
             externalServices.emis,
             externalServices.evss,

--- a/src/applications/personalization/profile/tests/components/Profile.unit.spec.js
+++ b/src/applications/personalization/profile/tests/components/Profile.unit.spec.js
@@ -58,7 +58,7 @@ describe('Profile', () => {
     defaultProps.showLoader = true;
     const wrapper = shallow(<Profile {...defaultProps} />);
     wrapper.setProps({ showLoader: true });
-    const loader = wrapper.find('LoadingIndicator');
+    const loader = wrapper.find('RequiredLoginLoader');
     expect(loader.length).to.equal(1);
     wrapper.unmount();
   });

--- a/src/platform/user/authorization/components/RequiredLoginView.jsx
+++ b/src/platform/user/authorization/components/RequiredLoginView.jsx
@@ -14,6 +14,14 @@ const nextQuery = { next: window.location.pathname };
 const signInUrl = appendQuery('/', nextQuery);
 const verifyUrl = appendQuery('/verify', nextQuery);
 
+const RequiredLoginLoader = () => {
+  return (
+    <div className="vads-u-margin-y--5">
+      <LoadingIndicator setFocus message="Loading your information..." />
+    </div>
+  );
+};
+
 class RequiredLoginView extends React.Component {
   componentDidMount() {
     this.redirectIfNeeded();
@@ -122,11 +130,7 @@ class RequiredLoginView extends React.Component {
     const { user, verify } = this.props;
 
     if (user.profile.loading) {
-      return (
-        <div className="vads-u-margin-y--5">
-          <LoadingIndicator setFocus message="Loading your information..." />
-        </div>
-      );
+      return <RequiredLoginLoader />;
     }
 
     if (this.shouldSignIn()) {
@@ -161,3 +165,5 @@ RequiredLoginView.propTypes = {
 };
 
 export default RequiredLoginView;
+
+export { RequiredLoginLoader };

--- a/src/platform/user/authorization/components/RequiredLoginView.jsx
+++ b/src/platform/user/authorization/components/RequiredLoginView.jsx
@@ -149,7 +149,7 @@ class RequiredLoginView extends React.Component {
   };
 
   render() {
-    return <div>{this.renderWrappedContent()}</div>;
+    return <>{this.renderWrappedContent()}</>;
   }
 }
 

--- a/src/platform/user/tests/authorization/components/RequiredLoginView.unit.spec.jsx
+++ b/src/platform/user/tests/authorization/components/RequiredLoginView.unit.spec.jsx
@@ -131,7 +131,8 @@ describe('<RequiredLoginView>', () => {
     const { tree } = setup({
       user: { profile: { loading: true } },
     });
-    const loadingIndicatorElement = tree.dive(['LoadingIndicator']);
+    const loadingIndicator = tree.dive(['RequiredLoginLoader']);
+    const loadingIndicatorElement = loadingIndicator.dive(['LoadingIndicator']);
     expect(loadingIndicatorElement.text()).to.contain(
       'Loading your information',
     );


### PR DESCRIPTION
## Description
The initial goal of this work was to simply export a "content loading" component from the `RequiredLoginView` component so that other components could use it. The idea being so that when the `RequiredLoginView` is done showing its loader, the component that it's _wrapping_ could show an identical loader while it was loading its own content. There are lots of places where one loader is replaced by another that has different text (which is fine) and different margin/padding (this is visually gross).

Then I realized the new My VA Dashboard needs to be wrapped in both `RequiredLoginView` and `DowntimeNotification` components to mirror the current Dashboard.

## Testing done
Local + Cypress test to make sure we show a functional modal when upcoming downtime is detected.

## Screenshots
![image](https://user-images.githubusercontent.com/20728956/107595648-2b5ccd00-6bca-11eb-9229-3b32b4b69963.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs