### PR TITLE
VACMS-2860: Removing legacy event fields from build.

### DIFF
--- a/src/site/components/situation_updates.drupal.liquid
+++ b/src/site/components/situation_updates.drupal.liquid
@@ -2,7 +2,7 @@
   <h2>Situation updates and information</h2>
   {% for situation in fieldBannerAlert %}
   {% if situation.entity.status == true %}
-    {% assign sortedUpdates = situation.entity.fieldSituationUpdates | sort: update.entity.fieldDateAndTime.date | reverse %}
+    {% assign sortedUpdates = situation.entity.fieldSituationUpdates | sort: update.entity.fieldDatetimeRangeTimezone.value | reverse %}
       {% for update in sortedUpdates %}
         <div data-entity-id="{{ update.entity.entityId }}" class="usa-alert background-color-only vads-u-padding-y--1p5">
           <h3 class="vads-u-margin-top--0">
@@ -12,8 +12,6 @@
             <h4 class="vads-u-margin-top--1 vads-u-margin-bottom--2">
                 {% if update.entity.fieldDatetimeRangeTimezone.value != empty %}
                  {{update.entity.fieldDatetimeRangeTimezone.value | dateFromUnix: "dddd, MMM D, h:mm A"}}
-                {% else %}
-                 {{update.entity.fieldDateAndTime.date | timeZone: "America/New_York", "dddd, MMM D, h:mm A"}}
                 {% endif %}
                 {% if update.entity.fieldDatetimeRangeTimezone.timezone != empty %}
                   {{update.entity.fieldDatetimeRangeTimezone.timezone | timezoneAbbrev: fieldDatetimeRangeTimezone.value }}

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -305,8 +305,8 @@ module.exports = function registerFilters() {
   liquid.filters.eventSorter = item =>
     item &&
     item.sort((a, b) => {
-      const start1 = moment(a.fieldDate.startDate);
-      const start2 = moment(b.fieldDate.startDate);
+      const start1 = moment(a.fieldDatetimeRangeTimezone.startTime);
+      const start2 = moment(b.fieldDatetimeRangeTimezone.startTime);
       return start1.isAfter(start2);
     });
 

--- a/src/site/includes/date.drupal.liquid
+++ b/src/site/includes/date.drupal.liquid
@@ -10,21 +10,12 @@
     {% assign start_time = fieldDatetimeRangeTimezone.value | dateFromUnix: "h:mm A", fieldDatetimeRangeTimezone.timezone %}
     {% assign start_date_full = fieldDatetimeRangeTimezone.value | dateFromUnix: "dddd, MMM D, YYYY h:mm A", fieldDatetimeRangeTimezone.timezone %}
     {% assign start_timestamp = fieldDatetimeRangeTimezone.value %}
-{% else %}
-    {% assign start_date_no_time = fieldDate.startDate | timeZone: defaultTZ, "dddd, MMM YYYY" %}
-    {% assign start_time = fieldDate.startDate | timeZone: defaultTZ, "h:mm A" %}
-    {% assign start_date_full = fieldDate.startDate | timeZone: defaultTZ, "dddd, MMM D, YYYY h:mm A" %}
-    {% assign start_timestamp = fieldDate.value | unixFromDate %}
 {% endif %}
 
 {% if fieldDatetimeRangeTimezone.endValue != empty %}
     {% assign end_date_no_time = fieldDatetimeRangeTimezone.endValue | dateFromUnix: 'dddd, MMM D, YYYY', fieldDatetimeRangeTimezone.timezone %}
     {% assign end_time = fieldDatetimeRangeTimezone.endValue | dateFromUnix: "h:mm A", fieldDatetimeRangeTimezone.timezone %}
     {% assign end_date_full = fieldDatetimeRangeTimezone.endValue | dateFromUnix: "dddd, MMM D, h:mm A", fieldDatetimeRangeTimezone.timezone %}
-{% else %}
-    {% assign end_date_no_time = fieldDate.endValue | timeZone: defaultTZ, "dddd, MMM D, YYYY" %}
-    {% assign end_time = fieldDate.endDate | timeZone: defaultTZ, "h:mm A" %}
-    {% assign end_date_full = fieldDate.endDate | timeZone: defaultTZ, "dddd, MMM D, YYYY h:mm A" %}
 {% endif %}
 
 {% assign current_timestamp = ''| currentTimeInSeconds %}

--- a/src/site/includes/social-share.drupal.liquid
+++ b/src/site/includes/social-share.drupal.liquid
@@ -7,7 +7,7 @@
   <ul class="usa-unstyled-list">
     <li class="vads-u-margin-bottom--2p5">
       <a href="{{ entityUrl.path }}" id="add-to-calendar-link" data-start="{{fieldDatetimeRangeTimezone.value }}" data-end="{{fieldDatetimeRangeTimezone.endTime}}" data-location="{{fieldAddress.addressLine1}} {{fieldAddress.locality}}, {{fieldAddress.administrativeArea}}" data-subject="{{ title }}" data-description="{{fieldDescription}}">
-        <i class="va-c-social-icon fas fa-calendar-check vads-u-margin-right--0p5"></i>Add to Calendar</a>
+        <i class="va-c-social-icon fas fa-calendar-check vads-u-margin-right--0p5" aria-hidden="true"></i>Add to Calendar</a>
     </li>
 
     <li class="vads-u-margin-bottom--2p5">

--- a/src/site/includes/social-share.drupal.liquid
+++ b/src/site/includes/social-share.drupal.liquid
@@ -6,7 +6,7 @@
 <div data-template="includes/social-share" id="va-c-social-share">
   <ul class="usa-unstyled-list">
     <li class="vads-u-margin-bottom--2p5">
-      <a href="{{ entityUrl.path }}" id="add-to-calendar-link" data-start="{{fieldDate.value }}" data-end="{{fieldDate.endValue}}" data-location="{{fieldAddress.addressLine1}} {{fieldAddress.locality}}, {{fieldAddress.administrativeArea}}" data-subject="{{ title }}" data-description="{{fieldDescription}}">
+      <a href="{{ entityUrl.path }}" id="add-to-calendar-link" data-start="{{fieldDatetimeRangeTimezone.value }}" data-end="{{fieldDatetimeRangeTimezone.endTime}}" data-location="{{fieldAddress.addressLine1}} {{fieldAddress.locality}}, {{fieldAddress.administrativeArea}}" data-subject="{{ title }}" data-description="{{fieldDescription}}">
         <i class="va-c-social-icon fas fa-calendar-check vads-u-margin-right--0p5"></i>Add to Calendar</a>
     </li>
 

--- a/src/site/stages/build/drupal/graphql/eventPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/eventPage.graphql.js
@@ -35,12 +35,6 @@ const eventPage = `
         }
       }
     }
-    fieldDate {
-        startDate
-        value
-        endDate
-        endValue
-    }
     fieldDatetimeRangeTimezone {
       value
       endValue

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionEvents.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionEvents.node.graphql.js
@@ -21,12 +21,6 @@ const EVENTS_RESULTS = `
           endValue
           endTime
           timezone
-        }        
-        fieldDate {
-            startDate
-            value
-            endDate
-            endValue
         }
         fieldDescription
         fieldLocationHumanreadable
@@ -56,9 +50,9 @@ function queryFilter(isAll) {
     ${
       isAll
         ? ''
-        : '{ field: "field_featured" value: "1"}, { field: "field_date", value: [$today], operator: GREATER_THAN}'
+        : '{ field: "field_featured" value: "1"}, { field: "field_datetime_range_timezone", value: [$today], operator: GREATER_THAN}'
     }
-  ]} sort: [{field: "field_order", direction: ASC }, {field: "field_date", direction: ASC }] limit: ${
+  ]} sort: [{field: "field_order", direction: ASC }, {field: "field_datetime_range_timezone", direction: ASC }] limit: ${
     isAll ? '500' : '2'
   })
   `;

--- a/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
@@ -79,7 +79,7 @@ const healthCareRegionPageFragment = `
     eventTeasersAll: reverseFieldOfficeNode(limit: 1000, filter: {conditions: [{field: "type", value: "event_listing"}]}) {
       entities {
         ... on NodeEventListing {
-          reverseFieldListingNode(sort: {field: "field_date", direction: ASC }, limit: 1, filter: {conditions: [{field: "type", value: "event"}, {field: "status", value: "1"}, { field: "field_date", value: [$today], operator: GREATER_THAN}]}) {
+          reverseFieldListingNode(sort: {field: "field_datetime_range_timezone", direction: ASC }, limit: 1, filter: {conditions: [{field: "type", value: "event"}, {field: "status", value: "1"}, { field: "field_datetime_range_timezone", value: [$today], operator: GREATER_THAN}]}) {
             entities {
               ... on NodeEvent {
                 title
@@ -92,11 +92,12 @@ const healthCareRegionPageFragment = `
                     }
                   }
                 }
-                fieldDate {
-                  startDate
+                fieldDatetimeRangeTimezone {
                   value
-                  endDate
+                  startTime
                   endValue
+                  endTime
+                  timezone
                 }
                 fieldDescription
                 fieldLocationHumanreadable
@@ -120,7 +121,7 @@ const healthCareRegionPageFragment = `
     eventTeasersFeatured: reverseFieldOfficeNode(limit: 1000, filter: {conditions: [{field: "type", value: "event_listing"}]}) {
       entities {
         ... on NodeEventListing {
-          reverseFieldListingNode(limit: 1000, filter: {conditions: [{field: "type", value: "event"}, {field: "status", value: "1"}, {field: "field_featured", value: "1"}, { field: "field_date", value: [$today], operator: GREATER_THAN}]}) {
+          reverseFieldListingNode(limit: 1000, filter: {conditions: [{field: "type", value: "event"}, {field: "status", value: "1"}, {field: "field_featured", value: "1"}, { field: "field_datetime_range_timezone", value: [$today], operator: GREATER_THAN}]}) {
             entities {
               ... on NodeEvent {
                 title
@@ -133,11 +134,12 @@ const healthCareRegionPageFragment = `
                     }
                   }
                 }
-                fieldDate {
-                  startDate
+                fieldDatetimeRangeTimezone {
                   value
-                  endDate
+                  startTime
                   endValue
+                  endTime
+                  timezone
                 }
                 fieldDescription
                 fieldLocationHumanreadable

--- a/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
@@ -128,12 +128,6 @@ const nodeCampaignLandingPage = `
             format
             processed
           }
-          fieldDate {
-            value
-            startDate
-            endValue
-            endDate
-          }
           fieldDatetimeRangeTimezone {
             value
             startTime

--- a/src/site/stages/build/drupal/graphql/officePage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/officePage.graphql.js
@@ -18,11 +18,12 @@ const officeFragment = `
          entityUrl {
             path
         }
-        fieldDate {
-            startDate
-            value
-            endDate
-            endValue
+        fieldDatetimeRangeTimezone {
+          value
+          startTime
+          endValue
+          endTime
+          timezone
         }
         fieldDescription
         fieldLocationHumanreadable

--- a/src/site/stages/build/drupal/graphql/vamcOperatingStatusAndAlerts.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vamcOperatingStatusAndAlerts.graphql.js
@@ -44,10 +44,6 @@ const vamcOperatingStatusAndAlerts = `
             entity {
               entityId
               ... on ParagraphSituationUpdate {
-                fieldDateAndTime {
-                  date
-                  value
-                }
                 fieldDatetimeRangeTimezone {
                   value
                   startTime

--- a/src/site/stages/build/process-cms-exports/schemas/input/node-event.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/node-event.js
@@ -34,17 +34,6 @@ module.exports = {
     field_additional_information_abo: { $ref: 'GenericNestedString' },
     field_address: { $ref: 'RawAddress' },
     field_body: { $ref: 'GenericNestedString' },
-    field_date: {
-      type: 'array',
-      items: {
-        properties: {
-          // These are actually timestamps like: 2019-05-30T21:00:00-04:00
-          value: { type: 'string' },
-          end_value: { type: 'string' },
-        },
-        required: ['value', 'end_value'],
-      },
-    },
     field_datetime_range_timezone: {
       type: 'array',
       items: {
@@ -89,7 +78,6 @@ module.exports = {
     'field_additional_information_abo',
     'field_address',
     'field_body',
-    'field_date',
     'field_datetime_range_timezone',
     'field_description',
     'field_event_cost',

--- a/src/site/stages/build/process-cms-exports/schemas/input/paragraph-situation_update.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/paragraph-situation_update.js
@@ -3,13 +3,11 @@
 module.exports = {
   type: 'object',
   properties: {
-    field_date_and_time: { $ref: 'GenericNestedString' },
     field_datetime_range_timezone: { $ref: 'GenericNestedString' },
     field_send_email_to_subscribers: { $ref: 'GenericNestedBoolean' },
     field_wysiwyg: { $ref: 'GenericNestedString' },
   },
   required: [
-    'field_date_and_time',
     'field_datetime_range_timezone',
     'field_send_email_to_subscribers',
     'field_wysiwyg',

--- a/src/site/stages/build/process-cms-exports/schemas/output/paragraph-situation_update.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/paragraph-situation_update.js
@@ -7,14 +7,6 @@ module.exports = {
       properties: {
         entityType: { type: 'string' },
         entityBundle: { type: 'string' },
-        fieldDateAndTime: {
-          type: 'object',
-          // These properties are strings resembling dates
-          properties: {
-            date: { type: 'string' },
-            value: { type: 'string' },
-          },
-        },
         fieldDatetimeRangeTimezone: {
           type: 'object',
           properties: {
@@ -34,7 +26,6 @@ module.exports = {
       required: [
         'entityType',
         'entityBundle',
-        'fieldDateAndTime',
         'fieldDatetimeRangeTimezone',
         'fieldSendEmailToSubscribers',
         'fieldWysiwyg',

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
@@ -126,7 +126,6 @@ const transform = (
           .map(r => ({
             title: r.title,
             uid: r.uid,
-            fieldDate: r.fieldDate,
             fieldDatetimeRangeTimezone: r.fieldDatetimeRangeTimezone,
             fieldDescription: r.fieldDescription,
             fieldLocationHumanreadable: r.fieldLocationHumanreadable,
@@ -247,7 +246,6 @@ const transform = (
                     .slice(0, 1000)
                     .map(e => ({
                       title: e.title,
-                      fieldDate: e.fieldDate,
                       fieldDatetimeRangeTimezone: e.fieldDatetimeRangeTimezone,
                       fieldDescription: e.fieldDescription,
                       fieldLocationHumanreadable: e.fieldLocationHumanreadable,
@@ -279,7 +277,6 @@ const transform = (
                     )
                     .map(e => ({
                       title: e.title,
-                      fieldDate: e.fieldDate,
                       fieldDatetimeRangeTimezone: e.fieldDatetimeRangeTimezone,
                       fieldDescription: e.fieldDescription,
                       fieldLocationHumanreadable: e.fieldLocationHumanreadable,

--- a/src/site/stages/build/process-cms-exports/transformers/paragraph-situation_update.js
+++ b/src/site/stages/build/process-cms-exports/transformers/paragraph-situation_update.js
@@ -1,24 +1,12 @@
 const { getDrupalValue } = require('./helpers');
-const moment = require('moment-timezone');
 
 const transform = entity => {
-  const {
-    fieldDateAndTime,
-    fieldSendEmailToSubscribers,
-    fieldWysiwyg,
-  } = entity;
+  const { fieldSendEmailToSubscribers, fieldWysiwyg } = entity;
   return {
     contentModelType: entity.contentModelType,
     entity: {
       entityType: 'paragraph',
       entityBundle: 'situation_update',
-      fieldDateAndTime: {
-        // Assume the raw data is in UTC
-        date: moment
-          .tz(getDrupalValue(fieldDateAndTime), 'UTC')
-          .format('YYYY-MM-DD HH:mm:ss UTC'),
-        value: getDrupalValue(fieldDateAndTime),
-      },
       fieldDatetimeRangeTimezone:
         entity.fieldDatetimeRangeTimezone &&
         entity.fieldDatetimeRangeTimezone.length
@@ -43,7 +31,6 @@ const transform = entity => {
 
 module.exports = {
   filter: [
-    'field_date_and_time',
     'field_datetime_range_timezone',
     'field_send_email_to_subscribers',
     'field_wysiwyg',

--- a/src/site/teasers/event.drupal.liquid
+++ b/src/site/teasers/event.drupal.liquid
@@ -1,5 +1,5 @@
 {% if node != empty %}
-  {% include "src/site/includes/date.drupal.liquid" with fieldDate = node.fieldDate fieldDatetimeRangeTimezone = node.fieldDatetimeRangeTimezone %}
+  {% include "src/site/includes/date.drupal.liquid" with fieldDatetimeRangeTimezone = node.fieldDatetimeRangeTimezone %}
 
   {% if header == empty %}
       {% assign header = "h2" %}

--- a/src/site/teasers/event_featured.drupal.liquid
+++ b/src/site/teasers/event_featured.drupal.liquid
@@ -4,12 +4,6 @@ Optional variable: header - the header level ('h2','h3', etc.) defaults to h4
 Example data:
   {
     "title": "Another Test Event",
-      "fieldDate": {
-      "startDate": "2019-03-16 10:00:01 UTC",
-        "value": "2019-03-16T10:00:01",
-          "endDate": "2019-03-16 11:00:00 UTC",
-            "endValue": "2019-03-16T11:00:00"
-    },
     "fieldDescription": "This gives the user an overview of the event in teaser
     views",
     "fieldLocationHumanreadable": "Here",


### PR DESCRIPTION
## Description
Some legacy fields for event data have been removed from cms. This pr removes their counterparts from vets-website.
See https://github.com/department-of-veterans-affairs/va.gov-cms/issues/2860

## Testing done
Visual, build

## Screenshots
N/A

## Acceptance criteria
- [ ] Successful build

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
