### PR TITLE
Remove facilities API query

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -314,24 +314,25 @@ describe('526 helpers', () => {
       global.fetch = originalFetch;
     });
 
-    it('should not call the api if the input length is < 3', () => {
+    /* un-skip these once we get a new enpoint in place; see #14028 */
+    it.skip('should not call the api if the input length is < 3', () => {
       queryForFacilities('12');
       expect(global.fetch.called).to.be.false;
     });
 
-    it('should call the api if the input length is >= 3', () => {
+    it.skip('should call the api if the input length is >= 3', () => {
       queryForFacilities('123');
       expect(global.fetch.called).to.be.true;
     });
 
-    it('should call the api with the input', () => {
+    it.skip('should call the api with the input', () => {
       queryForFacilities('asdf');
       expect(global.fetch.firstCall.args[0]).to.contain(
         '/facilities/suggested?type%5B%5D=health&type%5B%5D=dod_health&name_part=asdf',
       );
     });
 
-    it('should return the mapped data for autosuggest if successful', () => {
+    it.skip('should return the mapped data for autosuggest if successful', () => {
       // Doesn't matter what we call this with since our stub will always return the same thing
       const requestPromise = queryForFacilities('asdf');
       return requestPromise.then(result => {

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import moment from 'moment';
 import * as Sentry from '@sentry/browser';
-import appendQuery from 'append-query';
+// import appendQuery from 'append-query';
 import { createSelector } from 'reselect';
 import { omit } from 'lodash';
 import merge from 'lodash/merge';
@@ -215,6 +215,11 @@ export function queryForFacilities(input = '') {
     return Promise.resolve([]);
   }
 
+  /**
+   * Facilities endpoint removed for now, but we may be able to use EVSS's
+   * endpoint /referencedata/v1/treatmentcenter
+   * See https://github.com/department-of-veterans-affairs/va.gov-team/issues/14028#issuecomment-765717797
+   * /
   const url = appendQuery('/facilities/suggested', {
     type: ['health', 'dod_health'],
     name_part: input, // eslint-disable-line camelcase
@@ -235,6 +240,8 @@ export function queryForFacilities(input = '') {
       });
       return [];
     });
+    /* */
+  return Promise.resolve([]);
 }
 
 export function getSeparationLocations() {


### PR DESCRIPTION
## Description

The `suggestedFacilities` API endpoint has been removed in `v1`, so we need to remove the call from 526's supporting evidence page autocomplete.

I left the code in place as there is a possibility of switching the API to EVSS' endpoint, but it requires a named state before it will return a list of suggestions - see [/referencedata/v1/treatmentcenter](https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/api-reference/index.html?url=https://raw.githubusercontent.com/department-of-veterans-affairs/va.gov-team/master/products/evss-integration/reference-documents/api-docs/wss-referencedata-services-web.yml#/) - we will need to coordinate this change with design before implementing.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/14028

## Testing done

Commented out associated unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] `suggestedFacilities` endpoint is no longer called
- [x] All associated unit tests have been skipped

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
