### PR TITLE
Set wizard start button type

### DIFF
--- a/src/applications/static-pages/wizard/index.js
+++ b/src/applications/static-pages/wizard/index.js
@@ -133,6 +133,7 @@ export class Wizard extends React.Component {
       <form onSubmit={e => e.preventDefault()}>
         {expander && (
           <button
+            type="button"
             aria-expanded={this.state.expanded ? 'true' : 'false'}
             aria-controls="wizardOptions"
             className={buttonClasses}


### PR DESCRIPTION
## Description

When the wizard is expanded (on the info page), pressing <kbd>Enter</kbd> when any wizard form element is focused causes the wizard to collapse and focus to be lost. This happens because the wizard toggle button does not include a `type="button"` and thus when the <kbd>Enter</kbd> key is pressed, the "submit" get activated and causes it to collapse the wizard.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/19845

## Testing done

Manual

## Screenshots

In production - https://www.va.gov/disability/how-to-file-claim/

https://user-images.githubusercontent.com/136959/107684824-dd4ad680-6c68-11eb-88fc-8652f44faed6.mov

## Acceptance criteria
- [x] No unexpected collapsing wizard
- [x] Maintain focus within wizard form element

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
