### PR TITLE
Use loading state for disability rating

### DIFF
--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -304,12 +304,17 @@ const mapStateToProps = state => {
 
   const hasLoadedEDUPaymentInformation = eduDirectDepositInformation(state);
 
+  const hasLoadedTotalDisabilityRating =
+    state.totalRating && !state.totalRating.loading;
+
   const hasLoadedAllData =
     hasLoadedFullName &&
     hasLoadedMHVInformation &&
     hasLoadedPersonalInformation &&
     hasLoadedMilitaryInformation &&
-    (shouldFetchTotalDisabilityRating ? !state.totalRating?.loading : true) &&
+    (shouldFetchTotalDisabilityRating
+      ? hasLoadedTotalDisabilityRating
+      : true) &&
     (shouldFetchCNPDirectDepositInformation
       ? hasLoadedCNPPaymentInformation
       : true) &&

--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -304,17 +304,12 @@ const mapStateToProps = state => {
 
   const hasLoadedEDUPaymentInformation = eduDirectDepositInformation(state);
 
-  const hasLoadedTotalDisabilityRating =
-    state.totalRating?.totalDisabilityRating || state.totalRating?.error;
-
   const hasLoadedAllData =
     hasLoadedFullName &&
     hasLoadedMHVInformation &&
     hasLoadedPersonalInformation &&
     hasLoadedMilitaryInformation &&
-    (shouldFetchTotalDisabilityRating
-      ? hasLoadedTotalDisabilityRating
-      : true) &&
+    (shouldFetchTotalDisabilityRating ? !state.totalRating?.loading : true) &&
     (shouldFetchCNPDirectDepositInformation
       ? hasLoadedCNPPaymentInformation
       : true) &&


### PR DESCRIPTION
## Description
Behind the new dashboard feature flag, `hasLoadedAllData` would not resolve to truthy if the call to get the disability rating would have a response of `null`.

Now we treat the disability rating call as finished when the `loading` prop turnes to `false`.

## Testing done
Works well locally.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
