### PR TITLE
Add timeout to location call, handle focus state edge cases in provider selection

### DIFF
--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
@@ -42,10 +42,8 @@ function ProviderSelectionField({
     0,
     providersListLength,
   );
-  const providersListEmpty = currentlyShownProvidersList?.length === 0;
   const loadingProviders =
-    requestStatus === FETCH_STATUS.loading ||
-    requestStatus === FETCH_STATUS.notStarted;
+    !communityCareProviderList && requestStatus !== FETCH_STATUS.failed;
 
   const loadingLocations = requestLocationStatus === FETCH_STATUS.loading;
 
@@ -66,6 +64,10 @@ function ProviderSelectionField({
         requestProvidersList(currentLocation);
       } else {
         requestProvidersList(address);
+      }
+
+      if (communityCareProviderList) {
+        scrollAndFocus('#providerSelectionHeader');
       }
     },
     [sortMethod],
@@ -113,6 +115,12 @@ function ProviderSelectionField({
     () => {
       if (showProvidersList && (loadingProviders || loadingLocations)) {
         scrollAndFocus('.loading-indicator');
+      } else if (
+        showProvidersList &&
+        !loadingProviders &&
+        requestLocationStatus === FETCH_STATUS.failed
+      ) {
+        scrollAndFocus('#providerSelectionBlockedLocation');
       } else if (showProvidersList && !loadingProviders && !loadingLocations) {
         scrollAndFocus('#providerSelectionHeader');
       }
@@ -120,10 +128,10 @@ function ProviderSelectionField({
     [loadingProviders, loadingLocations],
   );
 
-  return (
-    <div className="vads-u-background-color--gray-lightest vads-u-padding--2 medium-screen:vads-u-padding--3">
-      {!showProvidersList &&
-        !providerSelected && (
+  if (!showProvidersList) {
+    return (
+      <div className="vads-u-background-color--gray-lightest vads-u-padding--2 medium-screen:vads-u-padding--3">
+        {!providerSelected && (
           <button
             className="va-button-link"
             type="button"
@@ -137,8 +145,7 @@ function ProviderSelectionField({
             Choose a provider
           </button>
         )}
-      {!showProvidersList &&
-        providerSelected && (
+        {providerSelected && (
           <section id="selectedProvider" aria-label="Selected provider">
             <span className="vads-u-display--block vads-u-font-weight--bold">
               {formData.name}
@@ -177,234 +184,235 @@ function ProviderSelectionField({
             </div>
           </section>
         )}
-      {showProvidersList && (
-        <>
-          <h2
-            id="providerSelectionHeader"
-            className="vads-u-font-size--h3 vads-u-margin-top--0"
-          >
-            Choose a provider
-          </h2>
-          {!loadingProviders &&
-            requestLocationStatus === FETCH_STATUS.succeeded &&
-            sortByDistanceFromCurrentLocation && (
-              <p className="vads-u-margin-top--0">
-                Providers based on your location
+        {showRemoveProviderModal && (
+          <RemoveProviderModal
+            provider={formData}
+            address={address}
+            onClose={response => {
+              setShowRemoveProviderModal(false);
+              if (response === true) {
+                setCheckedProvider(false);
+                onChange({});
+              }
+            }}
+          />
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="vads-u-background-color--gray-lightest vads-u-padding--2 medium-screen:vads-u-padding--3">
+      <h2
+        id="providerSelectionHeader"
+        className="vads-u-font-size--h3 vads-u-margin-top--0"
+      >
+        Choose a provider
+      </h2>
+      {!loadingProviders &&
+        requestLocationStatus === FETCH_STATUS.succeeded &&
+        !!currentlyShownProvidersList &&
+        sortByDistanceFromCurrentLocation && (
+          <p className="vads-u-margin-top--0">
+            Providers based on your location
+          </p>
+        )}
+      {!loadingLocations &&
+        sortByDistanceFromResidential && (
+          <>
+            <p className="vads-u-margin-top--0 vads-u-margin-bottom--1">
+              Your address on file:
+            </p>
+            <ResidentialAddress address={address} />
+            {requestLocationStatus !== FETCH_STATUS.failed && (
+              <p className="vads-u-margin-top--0 vads-u-margin-bottom--3">
+                Or,{' '}
+                <button
+                  type="button"
+                  className="va-button-link"
+                  onClick={() => {
+                    updateCCProviderSortMethod(
+                      FACILITY_SORT_METHODS.distanceFromCurrentLocation,
+                    );
+                  }}
+                >
+                  use your current location
+                </button>
               </p>
             )}
-          {!loadingLocations &&
-            sortByDistanceFromResidential && (
-              <>
-                <p className="vads-u-margin-top--0 vads-u-margin-bottom--1">
-                  Your address on file:
-                </p>
-                <ResidentialAddress address={address} />
-                {(requestLocationStatus === FETCH_STATUS.notStarted ||
-                  requestLocationStatus === FETCH_STATUS.succeeded) && (
-                  <p className="vads-u-margin-top--0 vads-u-margin-bottom--3">
-                    Or,{' '}
-                    <button
-                      type="button"
-                      className="va-button-link"
-                      onClick={() => {
-                        updateCCProviderSortMethod(
-                          FACILITY_SORT_METHODS.distanceFromCurrentLocation,
-                        );
-                      }}
-                    >
-                      use your current location
-                    </button>
-                  </p>
-                )}
-              </>
-            )}
-          {loadingProviders && (
-            <div className="vads-u-padding-bottom--2">
-              <LoadingIndicator message="Loading the list of providers." />
-            </div>
-          )}
-          {loadingLocations && (
-            <div className="vads-u-padding-bottom--2">
-              <LoadingIndicator message="Finding your location. Be sure to allow your browser to find your current location." />
-            </div>
-          )}
-          {requestStatus === FETCH_STATUS.failed && (
-            <div className="vads-u-padding-bottom--2">
-              <LoadProvidersErrorAlert />
-            </div>
-          )}
-          {!loadingLocations &&
-            requestLocationStatus === FETCH_STATUS.failed && (
-              <div className="vads-u-padding--2 vads-u-background-color--primary-alt-lightest">
+            {requestLocationStatus === FETCH_STATUS.failed && (
+              <div
+                id="providerSelectionBlockedLocation"
+                className="vads-u-padding--2 vads-u-background-color--primary-alt-lightest"
+              >
                 <div className="usa-alert-body">
                   Your browser is blocked from finding your current location.
-                  Make sure your browser’s location feature is turned on.
+                  Make sure your browser’s location feature is turned on. <br />
+                  <button
+                    className="va-button-link"
+                    onClick={() =>
+                      updateCCProviderSortMethod(
+                        FACILITY_SORT_METHODS.distanceFromCurrentLocation,
+                      )
+                    }
+                  >
+                    Retry searching based on current location
+                  </button>
                 </div>
               </div>
             )}
-          {!loadingProviders &&
-            !loadingLocations &&
-            (requestStatus === FETCH_STATUS.succeeded ||
-              requestLocationStatus === FETCH_STATUS.succeeded) && (
-              <>
-                {sortByDistanceFromCurrentLocation && (
-                  <p className="vads-u-margin-top--0 vads-u-margin-bottom--3">
-                    Or,{' '}
-                    <button
-                      type="button"
-                      className="va-button-link"
-                      onClick={() => {
-                        updateCCProviderSortMethod(
-                          FACILITY_SORT_METHODS.distanceFromResidential,
-                        );
-                      }}
-                    >
-                      use your home address on file
-                    </button>
-                  </p>
-                )}
-                {providersListEmpty && (
-                  <NoProvidersAlert
-                    sortMethod={sortMethod}
-                    typeOfCareName={typeOfCareName}
-                  />
-                )}
-                {!providersListEmpty && (
-                  <>
-                    <p
-                      id="provider-list-status"
-                      role="status"
-                      aria-live="polite"
-                      aria-atomic="true"
-                    >
-                      Displaying 1 to {currentlyShownProvidersList.length} of{' '}
-                      {communityCareProviderList.length} providers
-                    </p>
-                    {currentlyShownProvidersList.map(
-                      (provider, providerIndex) => {
-                        const { name } = provider;
-                        const checked = provider.id === checkedProvider;
-                        const providerPosition = providerIndex + 1;
-                        return (
-                          <div className="form-radio-buttons" key={provider.id}>
-                            <input
-                              type="radio"
-                              checked={checked}
-                              id={`${idSchema.$id}_${providerPosition}`}
-                              name={`${idSchema.$id}`}
-                              value={provider.id}
-                              onChange={_ => setCheckedProvider(provider.id)}
-                              disabled={loadingProviders}
-                            />
-                            <label
-                              htmlFor={`${idSchema.$id}_${providerPosition}`}
-                            >
-                              <span className="vads-u-display--block vads-u-font-weight--bold">
-                                {name}
-                              </span>
-                              <span className="vads-u-display--block">
-                                {provider.address?.line}
-                              </span>
-                              <span className="vads-u-display--block">
-                                {provider.address.city},{' '}
-                                {provider.address.state}{' '}
-                                {provider.address.postalCode}
-                              </span>
-                              <span className="vads-u-display--block vads-u-font-size--sm vads-u-font-weight--bold">
-                                {provider[sortMethod]} miles
-                                <span className="sr-only">
-                                  {' '}
-                                  {sortByDistanceFromCurrentLocation
-                                    ? 'from your current location'
-                                    : 'from your home address'}
-                                </span>
-                              </span>
-                            </label>
-                            {checked && (
-                              <button
-                                type="button"
-                                onClick={() => {
-                                  onChange(provider);
-                                  setCheckedProvider();
-                                  setShowProvidersList(false);
-                                  recordEvent({
-                                    event: `${GA_PREFIX}-order-position-provider-selection`,
-                                    providerPosition,
-                                  });
-                                }}
-                              >
-                                Choose provider
-                              </button>
-                            )}
-                          </div>
-                        );
-                      },
-                    )}
-                  </>
-                )}
-              </>
-            )}
-        </>
+          </>
+        )}
+      {loadingProviders && (
+        <div className="vads-u-padding-bottom--2">
+          <LoadingIndicator message="Loading the list of providers." />
+        </div>
+      )}
+      {loadingLocations && (
+        <div className="vads-u-padding-bottom--2">
+          <LoadingIndicator message="Finding your location. Be sure to allow your browser to find your current location." />
+        </div>
+      )}
+      {requestStatus === FETCH_STATUS.failed && (
+        <div className="vads-u-padding-bottom--2">
+          <LoadProvidersErrorAlert />
+        </div>
       )}
       {!loadingProviders &&
         !loadingLocations &&
-        requestStatus === FETCH_STATUS.succeeded &&
-        (requestLocationStatus === FETCH_STATUS.notStarted ||
-          requestLocationStatus === FETCH_STATUS.succeeded) &&
-        showProvidersList && (
-          <div className="vads-u-display--flex">
-            {providersListLength < communityCareProviderList.length && (
-              <>
+        !!currentlyShownProvidersList && (
+          <>
+            {sortByDistanceFromCurrentLocation && (
+              <p className="vads-u-margin-top--0 vads-u-margin-bottom--3">
+                Or,{' '}
                 <button
                   type="button"
-                  className="additional-info-button va-button-link vads-u-display--block vads-u-margin-right--2"
+                  className="va-button-link"
                   onClick={() => {
-                    setProvidersListLength(
-                      providersListLength + INITIAL_PROVIDER_DISPLAY_COUNT,
+                    updateCCProviderSortMethod(
+                      FACILITY_SORT_METHODS.distanceFromResidential,
                     );
-                    recordEvent({
-                      event: `${GA_PREFIX}-provider-list-paginate`,
-                    });
                   }}
                 >
-                  <span className="sr-only">show</span>
-                  <span className="va-button-link">
-                    +{' '}
-                    {Math.min(
-                      communityCareProviderList.length - providersListLength,
-                      INITIAL_PROVIDER_DISPLAY_COUNT,
-                    )}{' '}
-                    more providers
-                  </span>
+                  use your home address on file
                 </button>
+              </p>
+            )}
+            {currentlyShownProvidersList.length === 0 && (
+              <NoProvidersAlert
+                sortMethod={sortMethod}
+                typeOfCareName={typeOfCareName}
+              />
+            )}
+            {currentlyShownProvidersList.length > 0 && (
+              <>
+                <p
+                  id="provider-list-status"
+                  role="status"
+                  aria-live="polite"
+                  aria-atomic="true"
+                >
+                  Displaying 1 to {currentlyShownProvidersList.length} of{' '}
+                  {communityCareProviderList.length} providers
+                </p>
+                {currentlyShownProvidersList.map((provider, providerIndex) => {
+                  const { name } = provider;
+                  const checked = provider.id === checkedProvider;
+                  const providerPosition = providerIndex + 1;
+                  return (
+                    <div className="form-radio-buttons" key={provider.id}>
+                      <input
+                        type="radio"
+                        checked={checked}
+                        id={`${idSchema.$id}_${providerPosition}`}
+                        name={`${idSchema.$id}`}
+                        value={provider.id}
+                        onChange={_ => setCheckedProvider(provider.id)}
+                        disabled={loadingProviders}
+                      />
+                      <label htmlFor={`${idSchema.$id}_${providerPosition}`}>
+                        <span className="vads-u-display--block vads-u-font-weight--bold">
+                          {name}
+                        </span>
+                        <span className="vads-u-display--block">
+                          {provider.address?.line}
+                        </span>
+                        <span className="vads-u-display--block">
+                          {provider.address.city}, {provider.address.state}{' '}
+                          {provider.address.postalCode}
+                        </span>
+                        <span className="vads-u-display--block vads-u-font-size--sm vads-u-font-weight--bold">
+                          {provider[sortMethod]} miles
+                          <span className="sr-only">
+                            {' '}
+                            {sortByDistanceFromCurrentLocation
+                              ? 'from your current location'
+                              : 'from your home address'}
+                          </span>
+                        </span>
+                      </label>
+                      {checked && (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            onChange(provider);
+                            setCheckedProvider();
+                            setShowProvidersList(false);
+                            recordEvent({
+                              event: `${GA_PREFIX}-order-position-provider-selection`,
+                              providerPosition,
+                            });
+                          }}
+                        >
+                          Choose provider
+                        </button>
+                      )}
+                    </div>
+                  );
+                })}
               </>
             )}
-            <button
-              type="button"
-              className="vaos-appts__cancel-btn va-button-link vads-u-margin--0 vads-u-flex--0"
-              onClick={() => {
-                setProvidersListLength(INITIAL_PROVIDER_DISPLAY_COUNT);
-                setShowProvidersList(false);
-              }}
-              aria-label="Cancel choosing a provider"
-            >
-              Cancel
-            </button>
-          </div>
+            <div className="vads-u-display--flex">
+              {providersListLength < communityCareProviderList?.length && (
+                <>
+                  <button
+                    type="button"
+                    className="additional-info-button va-button-link vads-u-display--block vads-u-margin-right--2"
+                    onClick={() => {
+                      setProvidersListLength(
+                        providersListLength + INITIAL_PROVIDER_DISPLAY_COUNT,
+                      );
+                      recordEvent({
+                        event: `${GA_PREFIX}-provider-list-paginate`,
+                      });
+                    }}
+                  >
+                    <span className="sr-only">show</span>
+                    <span className="va-button-link">
+                      +{' '}
+                      {Math.min(
+                        communityCareProviderList.length - providersListLength,
+                        INITIAL_PROVIDER_DISPLAY_COUNT,
+                      )}{' '}
+                      more providers
+                    </span>
+                  </button>
+                </>
+              )}
+              <button
+                type="button"
+                className="vaos-appts__cancel-btn va-button-link vads-u-margin--0 vads-u-flex--0"
+                onClick={() => {
+                  setProvidersListLength(INITIAL_PROVIDER_DISPLAY_COUNT);
+                  setShowProvidersList(false);
+                }}
+                aria-label="Cancel choosing a provider"
+              >
+                Cancel
+              </button>
+            </div>
+          </>
         )}
-      {showRemoveProviderModal && (
-        <RemoveProviderModal
-          provider={formData}
-          address={address}
-          onClose={response => {
-            setShowRemoveProviderModal(false);
-            if (response === true) {
-              setCheckedProvider(false);
-              onChange({});
-            }
-          }}
-        />
-      )}
     </div>
   );
 }

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -464,14 +464,18 @@ export function openFacilityPageV2(page, uiSchema, schema) {
 }
 
 export function updateCCProviderSortMethod(sortMethod) {
-  return async (dispatch, _getState) => {
+  return async (dispatch, getState) => {
     let location = null;
+    const { currentLocation } = getNewAppointment(getState());
     const action = {
       type: FORM_PAGE_CC_FACILITY_SORT_METHOD_UPDATED,
       sortMethod,
     };
 
-    if (sortMethod === FACILITY_SORT_METHODS.distanceFromCurrentLocation) {
+    if (
+      sortMethod === FACILITY_SORT_METHODS.distanceFromCurrentLocation &&
+      Object.keys(currentLocation).length === 0
+    ) {
       dispatch({
         type: FORM_REQUEST_CURRENT_LOCATION,
       });

--- a/src/applications/vaos/new-appointment/redux/selectors.js
+++ b/src/applications/vaos/new-appointment/redux/selectors.js
@@ -259,7 +259,7 @@ export function selectProviderSelectionInfo(state) {
     address: selectVAPResidentialAddress(state),
     typeOfCareName: typeOfCare.name,
     communityCareProviderList:
-      communityCareProviders[`${sortMethod}_${typeOfCare.ccId}`] || [],
+      communityCareProviders[`${sortMethod}_${typeOfCare.ccId}`],
     requestStatus,
     requestLocationStatus,
     currentLocation,

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
@@ -259,7 +259,6 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
       },
     );
 
-    screen.debug();
     expect(
       await screen.findByRole('heading', {
         level: 1,

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
@@ -557,4 +557,70 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
     expect(await screen.findByText(/Choose a provider/i)).to.exist;
     expect(screen.queryByText(/OH, JANICE/i)).to.not.exist;
   });
+
+  it('should allow user to retry fetching location when it is blocked', async () => {
+    const store = createTestStore(initialState);
+
+    mockGetCurrentPosition({ fail: true });
+
+    mockCCProviderFetch(
+      initialState.user.profile.vapContactInfo.residentialAddress,
+      ['207QA0505X', '363LP2300X', '363LA2200X', '261QP2300X'],
+      calculateBoundingBox(
+        initialState.user.profile.vapContactInfo.residentialAddress.latitude,
+        initialState.user.profile.vapContactInfo.residentialAddress.longitude,
+        60,
+      ),
+      CC_PROVIDERS_DATA,
+    );
+
+    await setTypeOfCare(store, /primary care/i);
+    await setTypeOfFacility(store, /Community Care/i);
+
+    const screen = renderWithStoreAndRouter(
+      <CommunityCareProviderSelectionPage />,
+      {
+        store,
+      },
+    );
+
+    // Choose Provider
+    userEvent.click(await screen.findByText(/Choose a provider/i));
+    userEvent.click(await screen.findByText(/use your current location/i));
+
+    expect(
+      await screen.findByText(
+        /Your browser is blocked from finding your current location. Make sure your browser’s location feature is turned on./i,
+      ),
+    ).to.be.ok;
+
+    const currentPosition = {
+      latitude: 37.5615,
+      longitude: 121.9988,
+      fail: false,
+    };
+
+    mockGetCurrentPosition(currentPosition);
+    mockCCProviderFetch(
+      currentPosition,
+      ['207QA0505X', '363LP2300X', '363LA2200X', '261QP2300X'],
+      calculateBoundingBox(
+        currentPosition.latitude,
+        currentPosition.longitude,
+        60,
+      ),
+      // Only return one provider to distinguish from initial request
+      // by residential address
+      CC_PROVIDERS_DATA.slice(0, 1),
+    );
+
+    userEvent.click(
+      screen.getByText(/Retry searching based on current location/i),
+    );
+
+    // should eventually be one provder, plus the two site radio buttons
+    await waitFor(() =>
+      expect(screen.getAllByRole('radio').length).to.equal(3),
+    );
+  });
 });

--- a/src/applications/vaos/utils/address.js
+++ b/src/applications/vaos/utils/address.js
@@ -58,6 +58,9 @@ export function getPreciseLocation() {
       position => resolve(position),
       error =>
         reject(new Error(`Geolocation error ${error.code}: ${error.message}`)),
+      {
+        timeout: 10000,
+      },
     );
   });
 }


### PR DESCRIPTION
## Description
This PR
- Adds a 10 second timeout to the get location call, to handle the case when location services is turned off at the system level
- Adds a link to the location blocked state to allow for retrying location request if you can't turn it on in time
- Adds focus to location blocked state after a failure
- Minor refactoring of the provider selection component to remove some strange flashing of the 0 providers alert and make the different states clearer.

## Testing done
Local and unit testing

## Screenshots
![Screen Shot 2021-02-11 at 1 56 54 PM](https://user-images.githubusercontent.com/634932/107697285-08412480-6c81-11eb-91ad-8e238abda0b5.png)


## Acceptance criteria
- [ ] No more indefinite spinner getting location

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
