### PR TITLE
better GA logging when VAP tx creation fails

### DIFF
--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -304,12 +304,17 @@ const mapStateToProps = state => {
 
   const hasLoadedEDUPaymentInformation = eduDirectDepositInformation(state);
 
+  const hasLoadedTotalDisabilityRating =
+    state.totalRating && !state.totalRating.loading;
+
   const hasLoadedAllData =
     hasLoadedFullName &&
     hasLoadedMHVInformation &&
     hasLoadedPersonalInformation &&
     hasLoadedMilitaryInformation &&
-    (shouldFetchTotalDisabilityRating ? !state.totalRating?.loading : true) &&
+    (shouldFetchTotalDisabilityRating
+      ? hasLoadedTotalDisabilityRating
+      : true) &&
     (shouldFetchCNPDirectDepositInformation
       ? hasLoadedCNPPaymentInformation
       : true) &&

--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -304,17 +304,12 @@ const mapStateToProps = state => {
 
   const hasLoadedEDUPaymentInformation = eduDirectDepositInformation(state);
 
-  const hasLoadedTotalDisabilityRating =
-    state.totalRating?.totalDisabilityRating || state.totalRating?.error;
-
   const hasLoadedAllData =
     hasLoadedFullName &&
     hasLoadedMHVInformation &&
     hasLoadedPersonalInformation &&
     hasLoadedMilitaryInformation &&
-    (shouldFetchTotalDisabilityRating
-      ? hasLoadedTotalDisabilityRating
-      : true) &&
+    (shouldFetchTotalDisabilityRating ? !state.totalRating?.loading : true) &&
     (shouldFetchCNPDirectDepositInformation
       ? hasLoadedCNPPaymentInformation
       : true) &&

--- a/src/platform/user/profile/vap-svc/actions/transactions.js
+++ b/src/platform/user/profile/vap-svc/actions/transactions.js
@@ -203,12 +203,14 @@ export function createTransaction(
         transaction,
       });
     } catch (error) {
+      const [firstError = {}] = error.errors ?? [];
+      const { code = 'code', title = 'title', detail = 'detail' } = firstError;
       const profileSection = analyticsSectionName || 'unknown-profile-section';
       recordEvent({
         event: 'profile-edit-failure',
         'profile-action': 'save-failure',
         'profile-section': profileSection,
-        'error-key': `transaction-creation-error-${profileSection}-save-failure`,
+        'error-key': `tx-creation-error-${profileSection}-${code}-${title}-${detail}`,
       });
       recordEvent({
         'error-key': undefined,


### PR DESCRIPTION
## Description
This should add more info about the errors that happen when we cannot initialize a transaction with VA Profile. It should log error strings that look like: `tx-creation-error-sms-optin-503-Service unavailable-Backend Service Outage`

## Testing done
Local, by mocking an error response.

## Screenshots
This GA dashboard shows the strings that will get updated with more details about the error
<img width="988" alt="Screen Shot 2021-02-10 at 9 32 22 AM" src="https://user-images.githubusercontent.com/20728956/107710430-c06bce80-6c7b-11eb-8e6b-f5068997cbe7.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs