### PR TITLE
18959 add logic

### DIFF
--- a/src/applications/personalization/view-dependents/components/ViewDependentsFormStates/BuildFormlett.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsFormStates/BuildFormlett.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import ViewDependentsChildForm from './ViewDependentsChildForm.jsx';
+import ViewDependentsSpouseForm from './ViewDependentsSpouseForm.jsx';
+import ViewDependentsParentForm from './ViewDependentsParentForm.jsx';
+
+function buildFormlett(relationship) {
+  let formlett = '';
+  switch (relationship) {
+    case 'Child':
+      formlett = <ViewDependentsChildForm />;
+      break;
+    case 'Spouse':
+      formlett = <ViewDependentsSpouseForm />;
+      break;
+    case 'Parent':
+      formlett = <ViewDependentsParentForm />;
+      break;
+    default:
+  }
+
+  return formlett;
+}
+
+export default buildFormlett;

--- a/src/applications/personalization/view-dependents/components/ViewDependentsFormStates/BuildFormlett.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsFormStates/BuildFormlett.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import ViewDependentsChildForm from './ViewDependentsChildForm.jsx';
-import ViewDependentsSpouseForm from './ViewDependentsSpouseForm.jsx';
+import ViewDependentsChildForm from './ViewDependentsChildForm';
+import ViewDependentsSpouseForm from './ViewDependentsSpouseForm';
 
-function buildFormlett(relationship) {
-  let formlett = '';
+function buildFormlett({ relationship }) {
+  let formlett = null;
   switch (relationship) {
     case 'Child':
       formlett = <ViewDependentsChildForm />;
@@ -14,7 +14,7 @@ function buildFormlett(relationship) {
     default:
   }
 
-  return formlett;
+  return <div>{formlett}</div>;
 }
 
 export default buildFormlett;

--- a/src/applications/personalization/view-dependents/components/ViewDependentsFormStates/BuildFormlett.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsFormStates/BuildFormlett.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ViewDependentsChildForm from './ViewDependentsChildForm.jsx';
 import ViewDependentsSpouseForm from './ViewDependentsSpouseForm.jsx';
-import ViewDependentsParentForm from './ViewDependentsParentForm.jsx';
 
 function buildFormlett(relationship) {
   let formlett = '';
@@ -11,9 +10,6 @@ function buildFormlett(relationship) {
       break;
     case 'Spouse':
       formlett = <ViewDependentsSpouseForm />;
-      break;
-    case 'Parent':
-      formlett = <ViewDependentsParentForm />;
       break;
     default:
   }

--- a/src/applications/personalization/view-dependents/components/ViewDependentsFormStates/ViewDependentsChildForm.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsFormStates/ViewDependentsChildForm.jsx
@@ -1,7 +1,29 @@
 import React from 'react';
+import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 
 function ViewDependentsChildForm() {
-  return <div>This is the child form.</div>;
+  const schema = {
+    type: 'object',
+    properties: {
+      firstName: {
+        type: 'string',
+      },
+    },
+  };
+
+  const uiSchema = {};
+
+  function show() {}
+
+  return (
+    <SchemaForm
+      name="View Dependents Child Form"
+      title="Our form"
+      schema={schema}
+      uiSchema={uiSchema}
+      onSubmit={show}
+    />
+  );
 }
 
 export default ViewDependentsChildForm;

--- a/src/applications/personalization/view-dependents/components/ViewDependentsFormStates/ViewDependentsChildForm.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsFormStates/ViewDependentsChildForm.jsx
@@ -18,7 +18,7 @@ function ViewDependentsChildForm() {
   return (
     <SchemaForm
       name="View Dependents Child Form"
-      title="Our form"
+      title=""
       schema={schema}
       uiSchema={uiSchema}
       onSubmit={show}

--- a/src/applications/personalization/view-dependents/components/ViewDependentsFormStates/ViewDependentsChildForm.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsFormStates/ViewDependentsChildForm.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function ViewDependentsChildForm() {
+  return <div>This is the child form.</div>;
+}
+
+export default ViewDependentsChildForm;

--- a/src/applications/personalization/view-dependents/components/ViewDependentsFormStates/ViewDependentsChildForm.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsFormStates/ViewDependentsChildForm.jsx
@@ -11,7 +11,11 @@ function ViewDependentsChildForm() {
     },
   };
 
-  const uiSchema = {};
+  const uiSchema = {
+    firstName: {
+      'ui:title': 'First Name',
+    },
+  };
 
   function show() {}
 

--- a/src/applications/personalization/view-dependents/components/ViewDependentsFormStates/ViewDependentsParentForm.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsFormStates/ViewDependentsParentForm.jsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-function ViewDependentsParentForm() {
-  return <div>This is the Parent form.</div>;
-}
-
-export default ViewDependentsParentForm;

--- a/src/applications/personalization/view-dependents/components/ViewDependentsFormStates/ViewDependentsParentForm.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsFormStates/ViewDependentsParentForm.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function ViewDependentsParentForm() {
+  return <div>This is the Parent form.</div>;
+}
+
+export default ViewDependentsParentForm;

--- a/src/applications/personalization/view-dependents/components/ViewDependentsFormStates/ViewDependentsSpouseForm.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsFormStates/ViewDependentsSpouseForm.jsx
@@ -5,13 +5,17 @@ function ViewDependentsSpouseForm() {
   const schema = {
     type: 'object',
     properties: {
-      firstName: {
+      ssn: {
         type: 'string',
       },
     },
   };
 
-  const uiSchema = {};
+  const uiSchema = {
+    ssn: {
+      'ui:title': 'Social Security Number',
+    },
+  };
 
   function show() {}
 

--- a/src/applications/personalization/view-dependents/components/ViewDependentsFormStates/ViewDependentsSpouseForm.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsFormStates/ViewDependentsSpouseForm.jsx
@@ -1,7 +1,29 @@
 import React from 'react';
+import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 
 function ViewDependentsSpouseForm() {
-  return <div>This is the spouse form.</div>;
+  const schema = {
+    type: 'object',
+    properties: {
+      firstName: {
+        type: 'string',
+      },
+    },
+  };
+
+  const uiSchema = {};
+
+  function show() {}
+
+  return (
+    <SchemaForm
+      name="View Dependents Spouse Form"
+      title="Our form"
+      schema={schema}
+      uiSchema={uiSchema}
+      onSubmit={show}
+    />
+  );
 }
 
 export default ViewDependentsSpouseForm;

--- a/src/applications/personalization/view-dependents/components/ViewDependentsFormStates/ViewDependentsSpouseForm.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsFormStates/ViewDependentsSpouseForm.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function ViewDependentsSpouseForm() {
+  return <div>This is the spouse form.</div>;
+}
+
+export default ViewDependentsSpouseForm;

--- a/src/applications/personalization/view-dependents/components/ViewDependentsFormStates/ViewDependentsSpouseForm.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsFormStates/ViewDependentsSpouseForm.jsx
@@ -18,7 +18,7 @@ function ViewDependentsSpouseForm() {
   return (
     <SchemaForm
       name="View Dependents Spouse Form"
-      title="Our form"
+      title=""
       schema={schema}
       uiSchema={uiSchema}
       onSubmit={show}

--- a/src/applications/personalization/view-dependents/components/ViewDependentsList/ViewDependentsListItem.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsList/ViewDependentsListItem.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import classNames from 'classnames';
+import buildFormlett from '../ViewDependentsFormStates/BuildFormlett.jsx';
 
 function ViewDependentsListItem(props) {
   const [open, setOpen] = useState(false);
@@ -17,6 +18,7 @@ function ViewDependentsListItem(props) {
     ssn,
     dateOfBirth,
   } = props;
+
   return (
     <div className="vads-l-row vads-u-background-color--gray-lightest vads-u-margin-top--0 vads-u-margin-bottom--2">
       <dl
@@ -66,6 +68,7 @@ function ViewDependentsListItem(props) {
                 To remove this dependent from your VA benefits, please enter the
                 information below.
               </p>
+              {buildFormlett(relationship)}
             </div>
           </div>
         </div>

--- a/src/applications/personalization/view-dependents/components/ViewDependentsList/ViewDependentsListItem.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsList/ViewDependentsListItem.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import classNames from 'classnames';
-import buildFormlett from '../ViewDependentsFormStates/BuildFormlett.jsx';
+import buildFormlett from '../ViewDependentsFormStates/BuildFormlett';
 
 function ViewDependentsListItem(props) {
   const [open, setOpen] = useState(false);

--- a/src/applications/personalization/view-dependents/components/ViewDependentsList/ViewDependentsListItem.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsList/ViewDependentsListItem.jsx
@@ -49,25 +49,27 @@ function ViewDependentsListItem(props) {
         ) : null}
       </dl>
       {manageDependentsToggle && (
-        <button
-          onClick={handleClick}
-          className="usa-button-secondary vads-u-margin-x--2 vads-u-background-color--white"
-        >
-          Remove this dependent
-        </button>
-      )}
-      <div
-        className={`vads-l-row vads-l-row vads-u-padding-x--2 vads-u-display--${
-          open ? 'flex' : 'none'
-        }`}
-      >
-        <div className="vads-l-col--8">
-          <p>
-            To remove this dependent from your VA benefits, please enter the
-            information below.
-          </p>
+        <div>
+          <button
+            onClick={handleClick}
+            className="usa-button-secondary vads-u-margin-x--2 vads-u-background-color--white"
+          >
+            Remove this dependent
+          </button>
+          <div
+            className={`vads-l-row vads-l-row vads-u-padding-x--2 vads-u-display--${
+              open ? 'flex' : 'none'
+            }`}
+          >
+            <div className="vads-l-col--8">
+              <p>
+                To remove this dependent from your VA benefits, please enter the
+                information below.
+              </p>
+            </div>
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/18959)

For the next iteration of the View Dependents page we are going to be adding the ability for the cards that show the dependents to open up on the click of a button and the user will put in some information and then be able to remove the dependent right from the page. A previous PR added the ability for the cards to open up, this PR is to add the logic that will render different forms for different types of dependents, as different information is needed to remove different types of dependents.

## Testing done
Unit tests will be included in a subsequent PR

## Screenshots

### Child Dependent Type -

<img width="653" alt="Screen Shot 2021-02-11 at 1 03 29 PM" src="https://user-images.githubusercontent.com/1899695/107698581-9ad5c980-6c69-11eb-9f7a-472c9d20538e.png">


### Spouse Depenedent Type

<img width="648" alt="Screen Shot 2021-02-11 at 1 03 37 PM" src="https://user-images.githubusercontent.com/1899695/107698648-b17c2080-6c69-11eb-85cc-15241362eff7.png">


## Acceptance criteria
- [x] The cards show the correct formlet based on dependent type
- [x] A PR has been submitted for review

