### PR TITLE
Kelsonic 19500 clp refinement

### DIFF
--- a/src/applications/coronavirus-screener/tests/00.coronavirus-screener.e2e.spec.js
+++ b/src/applications/coronavirus-screener/tests/00.coronavirus-screener.e2e.spec.js
@@ -25,7 +25,7 @@ export default createE2eTest(client => {
       .pause(1000)
       .waitForElementVisible('body', normal)
       .assert.containsText(
-        'div[class*=vads-l-grid-container]',
+        '.covid-screener div[class*=vads-l-grid-container]',
         `${routeOption.expectedText}`,
         routeOption.title,
       );

--- a/src/platform/site-wide/sass/modules/_m-campaign-landing-page.scss
+++ b/src/platform/site-wide/sass/modules/_m-campaign-landing-page.scss
@@ -27,3 +27,7 @@
 .va-c-video {
   max-width: 560px;
 }
+
+.va-c-main > :nth-child(even) {
+  background: $color-primary-alt-lightest;
+}

--- a/src/platform/site-wide/sass/modules/_m-campaign-landing-page.scss
+++ b/src/platform/site-wide/sass/modules/_m-campaign-landing-page.scss
@@ -7,7 +7,7 @@
 }
 
 .va-u-box-shadow--none {
-  box-shadow: none;
+  box-shadow: none !important;
 }
 
 .va-u-background--image {

--- a/src/platform/site-wide/sass/modules/_m-campaign-landing-page.scss
+++ b/src/platform/site-wide/sass/modules/_m-campaign-landing-page.scss
@@ -2,6 +2,10 @@
   width: 40px;
 }
 
+.va-c-blue-line--large {
+  width: 50px;
+}
+
 .va-u-box-shadow--none {
   box-shadow: none;
 }

--- a/src/platform/site-wide/sass/modules/_m-campaign-landing-page.scss
+++ b/src/platform/site-wide/sass/modules/_m-campaign-landing-page.scss
@@ -28,6 +28,6 @@
   max-width: 560px;
 }
 
-.va-c-main > :nth-child(even) {
+.va-alternating-background-color > :nth-child(even) {
   background: $color-primary-alt-lightest;
 }

--- a/src/platform/site-wide/sass/modules/_m-campaign-landing-page.scss
+++ b/src/platform/site-wide/sass/modules/_m-campaign-landing-page.scss
@@ -23,3 +23,7 @@
 .va-u-text-transform--uppercase {
   text-transform: uppercase;
 }
+
+.va-c-video {
+  max-width: 560px;
+}

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -12,10 +12,6 @@ function getPath(obj) {
 module.exports = function registerFilters() {
   const { cmsFeatureFlags } = global;
 
-  // Set timeout option to something higher (20mins)
-  // eslint-disable-next-line no-new
-  new liquid.Context({ timeout: 1200000 });
-
   // Custom liquid filter(s)
   liquid.filters.humanizeDate = dt =>
     moment(dt, 'YYYY-MM-DD').format('MMMM D, YYYY');
@@ -609,5 +605,32 @@ module.exports = function registerFilters() {
 
     const formattedURL = _.replace(url, 'youtu.be', 'youtube.com/embed');
     return formattedURL;
+  };
+
+  liquid.filters.formatSeconds = rawSeconds => {
+    // Dates need milliseconds, so mulitply by 1000.
+    const date = new Date(rawSeconds * 1000);
+
+    // Derive digits.
+    const hours = date.getUTCHours() || '';
+    const minutes = date.getUTCMinutes() || '';
+    const seconds = date.getUTCSeconds() || '';
+
+    // Derive if we should say 'hours', 'minutes', or 'seconds' at the end.
+    let text = '';
+    if (seconds) {
+      text = ' seconds';
+    }
+    if (minutes) {
+      text = ' minutes';
+    }
+    if (hours) {
+      text = ' hours';
+    }
+
+    const digits = [hours, minutes, seconds].filter(digits => digits).join(':');
+
+    // Return a formatted timestamp string.
+    return `${digits}${text}`;
   };
 };

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -593,4 +593,21 @@ module.exports = function registerFilters() {
 
   liquid.filters.sortEntityMetatags = item =>
     item ? item.sort((a, b) => a.key.localeCompare(b.key)) : undefined;
+
+  liquid.filters.createEmbedYouTubeVideoURL = url => {
+    if (!url) {
+      return url;
+    }
+
+    if (!_.includes(url, 'youtu')) {
+      return url;
+    }
+
+    if (_.includes(url, 'embed')) {
+      return url;
+    }
+
+    const formattedURL = _.replace(url, 'youtu.be', 'youtube.com/embed');
+    return formattedURL;
+  };
 };

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -603,8 +603,7 @@ module.exports = function registerFilters() {
       return url;
     }
 
-    const formattedURL = _.replace(url, 'youtu.be', 'youtube.com/embed');
-    return formattedURL;
+    return _.replace(url, 'youtu.be', 'youtube.com/embed');
   };
 
   liquid.filters.formatSeconds = rawSeconds => {
@@ -628,7 +627,7 @@ module.exports = function registerFilters() {
       text = ' hours';
     }
 
-    const digits = [hours, minutes, seconds].filter(digits => digits).join(':');
+    const digits = [hours, minutes, seconds].filter(item => item).join(':');
 
     // Return a formatted timestamp string.
     return `${digits}${text}`;

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -12,6 +12,10 @@ function getPath(obj) {
 module.exports = function registerFilters() {
   const { cmsFeatureFlags } = global;
 
+  // Set timeout option to something higher (20mins)
+  // eslint-disable-next-line no-new
+  new liquid.Context({ timeout: 1200000 });
+
   // Custom liquid filter(s)
   liquid.filters.humanizeDate = dt =>
     moment(dt, 'YYYY-MM-DD').format('MMMM D, YYYY');

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -169,3 +169,22 @@ describe('formatSeconds', () => {
     expect(liquid.filters.formatSeconds(23)).to.eq('23 seconds');
   });
 });
+
+describe('createEmbedYouTubeVideoURL', () => {
+  it('returns back the raw url if the youtube link should not be changed', () => {
+    expect(liquid.filters.createEmbedYouTubeVideoURL('')).to.eq('');
+    expect(liquid.filters.createEmbedYouTubeVideoURL('asdf')).to.eq('asdf');
+    expect(
+      liquid.filters.createEmbedYouTubeVideoURL('youtube.com/embed/asdf'),
+    ).to.eq('youtube.com/embed/asdf');
+  });
+
+  it('returns the modified URL if it needs it', () => {
+    expect(
+      liquid.filters.createEmbedYouTubeVideoURL('https://youtu.be/asdf'),
+    ).to.eq('https://youtube.com/embed/asdf');
+    expect(
+      liquid.filters.createEmbedYouTubeVideoURL('https://www.youtu.be/asdf'),
+    ).to.eq('https://www.youtube.com/embed/asdf');
+  });
+});

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -155,3 +155,17 @@ describe('deriveLastBreadcrumbFromPath', () => {
     expect(last.text).to.eq(title);
   });
 });
+
+describe('formatSeconds', () => {
+  it('returns hours when needed', () => {
+    expect(liquid.filters.formatSeconds(65245)).to.eq('18:7:25 hours');
+  });
+
+  it('returns minutes when needed', () => {
+    expect(liquid.filters.formatSeconds(160)).to.eq('2:40 minutes');
+  });
+
+  it('returns seconds when needed', () => {
+    expect(liquid.filters.formatSeconds(23)).to.eq('23 seconds');
+  });
+});

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -87,7 +87,7 @@
 
 <body class="{{ body_class }} merger">
   <!-- Draft status -->
-  {% if !entityPublished && entityUrl.path %}
+  {% if entityUrl.path && isPreview && !entityPublished %}
     <div class="vads-u-background-color--primary-alt-lightest vads-u-padding--1">
       <div class="vads-l-grid-container medium-screen:vads-u-padding-x--0">
         You are viewing a draft of "{{ entityUrl.path }}".

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -87,10 +87,15 @@
 
 <body class="{{ body_class }} merger">
   <!-- Draft status -->
-  {% if !entityPublished %}
+  {% if !entityPublished && entityUrl.path %}
     <div class="vads-u-background-color--primary-alt-lightest vads-u-padding--1">
       <div class="vads-l-grid-container medium-screen:vads-u-padding-x--0">
-        You are viewing a draft of "{{ entityUrl.path }}". <a data-same-tab href="{{ drupalSite }}/node/{{ entityId }}/edit">Edit this page in the CMS.</a>
+        You are viewing a draft of "{{ entityUrl.path }}".
+        {% if drupalSite && entityId %}
+          <a data-same-tab href="{{ drupalSite }}/node/{{ entityId }}/edit">
+            Edit this page in the CMS.
+          </a>
+        {% endif %}
       </div>
     </div>
   {% endif %}

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -86,6 +86,15 @@
 </head>
 
 <body class="{{ body_class }} merger">
+  <!-- Draft status -->
+  {% if !entityPublished %}
+    <div class="vads-u-background-color--primary-alt-lightest vads-u-padding--1">
+      <div class="vads-l-grid-container medium-screen:vads-u-padding-x--0">
+        You are viewing a draft of "{{ entityUrl.path }}". <a data-same-tab href="{{ drupalSite }}/node/{{ entityId }}/edit">Edit this page in the CMS.</a>
+      </div>
+    </div>
+  {% endif %}
+
   {{ google_analytics_noscript }}
   <a class="show-on-focus" href="#content">Skip to Content</a>
 

--- a/src/site/layouts/basic_landing_page.drupal.liquid
+++ b/src/site/layouts/basic_landing_page.drupal.liquid
@@ -7,15 +7,6 @@
   <main class="va-l-detail-page">
     <div class="usa-grid usa-grid-full">
       <div class="usa-width-three-fourths">
-        <!-- Draft status -->
-        {% if !entityPublished %}
-          <div class="usa-alert usa-alert-info">
-            <div class="usa-alert-body">
-              <p class="usa-alert-text">You are viewing a draft.</p>
-            </div>
-          </div>
-        {% endif %}
-
         <article class="usa-content vads-u-padding-bottom--0 medium-screen:vads-u-padding-bottom--6">
           <!-- Title -->
           <h1>{{ title }}</h1>

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -6,7 +6,7 @@
 {% endcomment %}
 
 <div id="content" class="interior" data-template="node-campaign_landing_page">
-  <main class="va-l-detail-page va-c-main">
+  <main class="va-l-detail-page va-alternating-background-color">
 
     <!-- HERO-->
     <div class="va-u-background--image" style="background-image: url('{{ fieldHeroImage.entity.image.url }}">
@@ -114,16 +114,18 @@
 
             <!-- Video -->
             {% assign videoURL = fieldMedia.entity.fieldMediaVideoEmbedField | createEmbedYouTubeVideoURL %}
-            <iframe
-              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-              allowFullScreen
-              class="va-c-video vads-u-margin-top--4"
-              frameBorder="0"
-              height="315"
-              src="{{ videoURL }}"
-              title="{{ fieldMedia.entity.name | default: 'A related YouTube video' }}"
-              width="100%"
-            ></iframe>
+            {% if videoURL %}
+              <iframe
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowFullScreen
+                class="va-c-video vads-u-margin-top--4"
+                frameBorder="0"
+                height="315"
+                src="{{ videoURL }}"
+                title="{{ fieldMedia.entity.name | default: 'A related YouTube video' }}"
+                width="100%"
+              ></iframe>
+            {% endif %}
 
             <!-- Video description -->
             {% if fieldMedia.entity.fieldDuration %}
@@ -285,7 +287,7 @@
                 <!-- Title -->
                 <h3 class="vads-u-margin-top--0">
                   <a href="{{ eventReference.entity.fieldLink.url }}">
-                    {{ eventReference.entity.fieldListing.entity.fieldDescription }}
+                    {{ eventReference.entity.title }}
                   </a>
                 </h3>
 
@@ -308,21 +310,29 @@
                 </div>
 
                 <!-- Where -->
-                {% if eventReference.entity.fieldFacilityLocation.entity.entityUrl.path || node.fieldLocationHumanreadable != empty %}
+                {% if eventReference.entity.fieldFacilityLocation.entity.entityUrl.path || eventReference.entity.fieldLocationHumanreadable != empty || eventReference.entity.fieldLink.uri %}
                   <div class="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-margin-top--2">
                     <p class="vads-u-font-weight--bold vads-u-margin--0 vads-u-margin-right--2">Where</p>
 
                     <!-- Event link -->
-                    {% if eventReference.entity.fieldFacilityLocation.entity.entityUrl.path %}
-                      <a href="{{ eventReference.entity.fieldFacilityLocation.entity.entityUrl.path }}" rel="noreferrer noopener" target="_blank">
-                        {{ eventReference.entity.fieldFacilityLocation.entity.title }}
-                      </a>
-                    {% endif %}
+                    <div class="vads-u-display--flex vads-u-flex-direction--column">
+                      {% if eventReference.entity.fieldFacilityLocation.entity.entityUrl.path %}
+                        <a href="{{ eventReference.entity.fieldFacilityLocation.entity.entityUrl.path }}" rel="noreferrer noopener" target="_blank">
+                          {{ eventReference.entity.fieldFacilityLocation.entity.title }}
+                        </a>
+                      {% endif %}
 
-                    <!-- Event address -->
-                    {% if eventReference.entity.fieldLocationHumanreadable != empty %}
-                      <p>{{ eventReference.entity.fieldLocationHumanreadable }}</p>
-                    {% endif %}
+                      {% if eventReference.entity.fieldLink.uri %}
+                        <a href="{{ eventReference.entity.fieldLink.uri }}" rel="noreferrer noopener" target="_blank">
+                          {{ eventReference.entity.fieldEventCta }}
+                        </a>
+                      {% endif %}
+
+                      <!-- Event address -->
+                      {% if eventReference.entity.fieldLocationHumanreadable != empty %}
+                        <p class="vads-u-margin--0">{{ eventReference.entity.fieldLocationHumanreadable }}</p>
+                      {% endif %}
+                    </div>
                   </div>
                 {% endif %}
               </div>

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -1,15 +1,6 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 
-<!-- Draft status -->
-{% if !entityPublished %}
-<div class="vads-u-background-color--primary-alt-lightest vads-u-padding--1">
-  <div class="vads-l-grid-container medium-screen:vads-u-padding-x--0">
-    You are viewing a draft of "{{ entityUrl.path }}". <a data-same-tab href="{{ drupalSite }}/node/{{ entityId }}/edit">Edit this page in the CMS.</a>
-  </div>
-</div>
-{% endif %}
-
 {% comment %}
   {% include "src/site/includes/breadcrumbs.drupal.liquid" with constructLcBreadcrumbs = true titleInclude = false %}
 {% endcomment %}

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -115,11 +115,15 @@
             <h2 class="vads-u-margin--0">{{ fieldClpVideoPanelHeader }}</h2>
 
             <!-- Video -->
+            {% assign videoURL = fieldMedia.entity.fieldMediaVideoEmbedField | createEmbedYouTubeVideoURL %}
             <iframe
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
               allowFullScreen
               class="vads-u-margin-top--4"
               frameBorder="0"
-              src="{{ fieldMedia.entity.fieldMediaVideoEmbedField }}"
+              height="315"
+              src="{{ videoURL }}"
+              style="max-width: 560px;"
               title="{{ fieldMedia.entity.name | default: 'A related YouTube video' }}"
               width="100%"
             ></iframe>

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -103,289 +103,306 @@
     <!--/ What You Can Do -->
 
     <!-- Video -->
-    <div>
-      <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
-        <div class="vads-l-row">
-          <!-- CONTENT -->
-          <div class="vads-l-col--12 medium-screen:vads-l-col--9">
-            <!-- Title -->
-            <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">Video</p>
-            <h2 class="vads-u-margin--0">{{ fieldClpVideoPanelHeader }}</h2>
+    {% if fieldClpVideoPanel %}
+      <div>
+        <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
+          <div class="vads-l-row">
+            <!-- CONTENT -->
+            <div class="vads-l-col--12 medium-screen:vads-l-col--9">
+              <!-- Title -->
+              <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">Video</p>
+              <h2 class="vads-u-margin--0">{{ fieldClpVideoPanelHeader }}</h2>
 
-            <!-- Video -->
-            {% assign videoURL = fieldMedia.entity.fieldMediaVideoEmbedField | createEmbedYouTubeVideoURL %}
-            {% if videoURL %}
-              <iframe
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                allowFullScreen
-                class="va-c-video vads-u-margin-top--4"
-                frameBorder="0"
-                height="315"
-                src="{{ videoURL }}"
-                title="{{ fieldMedia.entity.name | default: 'A related YouTube video' }}"
-                width="100%"
-              ></iframe>
-            {% endif %}
+              <!-- Video -->
+              {% assign videoURL = fieldMedia.entity.fieldMediaVideoEmbedField | createEmbedYouTubeVideoURL %}
+              {% if videoURL %}
+                <iframe
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                  allowFullScreen
+                  class="va-c-video vads-u-margin-top--4"
+                  frameBorder="0"
+                  height="315"
+                  src="{{ videoURL }}"
+                  title="{{ fieldMedia.entity.name | default: 'A related YouTube video' }}"
+                  width="100%"
+                ></iframe>
+              {% endif %}
 
-            <!-- Video description -->
-            {% if fieldMedia.entity.fieldDuration %}
-              <p class="vads-u-font-size--sm vads-u-margin--0">
-                {{ fieldMedia.entity.fieldDuration | formatSeconds }}
-                {% if fieldMedia.entity.fieldDuration != empty && fieldMedia.entity.fieldPublicationDate.date != empty %}
-                  &bull;
-                {% endif %}
-                {{ fieldMedia.entity.fieldPublicationDate.date | humanizeDate }}
-              </p>
-            {% endif %}
+              <!-- Video description -->
+              {% if fieldMedia.entity.fieldDuration %}
+                <p class="vads-u-font-size--sm vads-u-margin--0">
+                  {{ fieldMedia.entity.fieldDuration | formatSeconds }}
+                  {% if fieldMedia.entity.fieldDuration != empty && fieldMedia.entity.fieldPublicationDate.date != empty %}
+                    &bull;
+                  {% endif %}
+                  {{ fieldMedia.entity.fieldPublicationDate.date | humanizeDate }}
+                </p>
+              {% endif %}
 
-            {% if fieldMedia.entity.fieldDescription %}
-              <p class="va-introtext vads-u-margin-top--1 vads-u-margin-bottom--0">{{ fieldMedia.entity.fieldDescription }}</p>
-            {% endif %}
+              {% if fieldMedia.entity.fieldDescription %}
+                <p class="va-introtext vads-u-margin-top--1 vads-u-margin-bottom--0">{{ fieldMedia.entity.fieldDescription }}</p>
+              {% endif %}
 
-            <!-- Call to action -->
-            {% if fieldClpVideoPanelMoreVideo %}
-              <a class="vads-u-margin-top--4 usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLink.url.path }}">
-                {{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel }}
-                <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
-              </a>
-            {% endif %}
+              <!-- Call to action -->
+              {% if fieldClpVideoPanelMoreVideo %}
+                <a class="vads-u-margin-top--4 usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLink.url.path }}">
+                  {{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel }}
+                  <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
+                </a>
+              {% endif %}
+            </div>
           </div>
         </div>
       </div>
-    </div> <!--/Video -->
+    {% endif %}
+    <!--/Video -->
 
     <!-- Spotlight -->
-    <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
-      <div class="vads-l-row">
-        <div class="vads-l-col--12 medium-screen:vads-l-col--9">
-          <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">Spotlight</p>
-          <h2 class="vads-u-margin-top--0">{{ fieldClpSpotlightHeader }}</h2>
-          <p class="va-introtext vads-u-margin-top--1 vads-u-margin-bottom--4">
-            {{ fieldClpSpotlightIntroText }}
-            <a href="{{ fieldClpSpotlightCta.entity.fieldButtonLink.url.path }}">
-              {{ fieldClpSpotlightCta.entity.fieldButtonLabel }}
-            </a>
-          </p>
-        </div>
-      </div>
-      <div class="vads-l-row vads-u-margin-bottom--2 medium-screen:vads-u-margin-x--neg1">
-        {% for linkTeaser in fieldClpSpotlightLinkTeasers %}
-          <div class="vads-l-col--12 medium-screen:vads-l-col--4 vads-u-align-content--stretch vads-u-margin-y--1 ">
-            <div class="vads-u-background-color--gray-light-alt vads-u-height--full medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
-              <div class="vads-u-padding--2">
-                <h3 class="vads-u-margin-top--0">
-                  <a href="{{ linkTeaser.entity.fieldLink.uri }}">
-                    {{ linkTeaser.entity.fieldLink.title }}
-                  </a>
-                </h3>
-                <p class="vads-u-margin-top--1">{{ linkTeaser.entity.fieldLinkSummary }}</p>
-              </div>
-            </div>
-          </div>
-        {% endfor %}
-      </div>
-    </div>
-    <!--/ Spotlight -->
-
-    <!-- Stories -->
-    <div>
+    {% if fieldClpSpotlightPanel %}
       <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
         <div class="vads-l-row">
-          <!-- CONTENT -->
           <div class="vads-l-col--12 medium-screen:vads-l-col--9">
-            <!-- Title -->
-            <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">Stories</p>
-            <h2 class="vads-u-margin-top--0">{{ fieldClpStoriesHeader }}</h2>
-            <p class="va-introtext vads-u-margin-top--1 vads-u-margin-bottom--4">{{ fieldClpStoriesIntro }}</p>
-
-            <!-- List of stories -->
-            {% if fieldClpStoriesTeasers != empty %}
-              <div class="vads-u-display--flex vads-u-flex-direction--column">
-                {% for storyTeaser in fieldClpStoriesTeasers %}
-                  <div class="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-margin-bottom--4">
-                    <img alt="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.alt }}" class="vads-l-col--12 medium-screen:vads-l-col--4 medium-screen:vads-u-margin-right--2" src="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.url }}" />
-                    <div class="vads-u-margin-top--2 medium-screen:vads-u-margin-top--0">
-                      <h3 class="vads-u-margin-top--0">
-                        <a href="{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.uri }}">
-                          {{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.title }}
-                        </a>
-                      </h3>
-                      <p>{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLinkSummary }}</p>
-                    </div>
-                  </div>
-                {% endfor %}
-              </div>
-            {% endif %}
-
-            <!-- Call to action -->
-            {% if fieldClpStoriesCta %}
-              <a class="usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldClpStoriesCta.entity.fieldButtonLink.url }}" rel="noreferrer noopener" target="_blank">
-                {{ fieldClpStoriesCta.entity.fieldButtonLabel }}
-                <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
+            <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">Spotlight</p>
+            <h2 class="vads-u-margin-top--0">{{ fieldClpSpotlightHeader }}</h2>
+            <p class="va-introtext vads-u-margin-top--1 vads-u-margin-bottom--4">
+              {{ fieldClpSpotlightIntroText }}
+              <a href="{{ fieldClpSpotlightCta.entity.fieldButtonLink.url.path }}">
+                {{ fieldClpSpotlightCta.entity.fieldButtonLabel }}
               </a>
-            {% endif %}
+            </p>
           </div>
         </div>
-      </div>
-    </div> <!--/Stories -->
-
-    <!-- Downloadable Resources -->
-    <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
-      <div class="vads-l-row">
-        <div class="vads-l-col--12 medium-screen:vads-l-col--9">
-          <!-- Title -->
-          <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">Downloadable resources</p>
-          <h2 class="vads-u-margin-top--0">{{ fieldClpResourcesHeader }}</h2>
-          <p class="va-introtext vads-u-margin-top--1 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--4">{{ fieldClpResourcesIntroText }}</p>
-        </div>
-      </div>
-
-      <div class="vads-l-row vads-u-margin-bottom--2 medium-screen:vads-u-margin-x--neg1">
-        {% for resource in fieldClpResources %}
-          <div class="vads-l-col--12 medium-screen:vads-l-col--4 vads-u-align-content--stretch vads-u-margin-y--1 ">
-            <div class="vads-u-background-color--gray-light-alt vads-u-height--full medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
-              <div class="vads-u-padding--2">
-                <h3 class="vads-u-margin--0">{{ resource.entity.name }}</h3>
-                <p>{{ resource.entity.fieldDescription }}</p>
-                <a href="{{ resource.entity.fieldMediaExternalFile.url }}" download>Download (PDF)</a>
-              </div>
-            </div>
-          </div>
-        {% endfor %}
-      </div>
-
-      {% if fieldClpResourcesCta %}
-        <div class="vads-l-row">
-          <div class="vads-u-col--12">
-            <a class="usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldClpResourcesCta.entity.fieldButtonLink.url.path }}">
-              {{ fieldClpResourcesCta.entity.fieldButtonLabel }}
-              <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
-            </a>
-          </div>
-        </div>
-      {% endif %}
-    </div><!--/  Downloadable Resources -->
-
-    <!-- Events -->
-    <div>
-      <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
-
-        <!-- CONTENT -->
-        <div class="vads-l-row">
-          <div class="vads-l-col--12 medium-screen:vads-l-col--9">
-            <!-- Title -->
-            <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">Events</p>
-            <h2 class="vads-u-margin-top--0">{{ fieldClpEventsHeader }}</h2>
-          </div>
-        </div>
-
-        <!-- List of events -->
-        <div class="vads-l-row vads-u-margin-bottom--2 medium-screen:vads-u-margin-x--neg6">
-          {% for eventReference in fieldClpEventsReferences %}
-            <div class="vads-l-col--12 medium-screen:vads-l-col--6 {% if !forloop.first %}vads-u-margin-top--4 medium-screen:vads-u-margin-top--0{% endif %}">
-              <div class="medium-screen:vads-u-margin-x--6">
-                <!-- Title -->
-                <h3 class="vads-u-margin-top--0">
-                  <a href="{{ eventReference.entity.fieldLink.url }}">
-                    {{ eventReference.entity.title }}
-                  </a>
-                </h3>
-
-                <!-- Description -->
-                {{ eventReference.entity.fieldBody.processed }}
-
-                <!-- When -->
-                <div class="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">
-                  <p class="vads-u-font-weight--bold vads-u-margin--0 vads-u-margin-right--2">When</p>
-                  <p class="vads-u-margin--0">
-                    {% if eventReference.entity.fieldDatetimeRangeTimezone.value != empty %}
-                      {{eventReference.entity.fieldDatetimeRangeTimezone.value | dateFromUnix: "dddd, MMM D, h:mm A" }} -
-                      <br />
-                      {{eventReference.entity.fieldDatetimeRangeTimezone.endValue | dateFromUnix: "dddd, MMM D, h:mm A" }}
-                    {% endif %}
-                    {% if eventReference.entity.fieldDatetimeRangeTimezone.timezone != empty %}
-                      {{ eventReference.entity.fieldDatetimeRangeTimezone.timezone | timezoneAbbrev: fieldDatetimeRangeTimezone.value }}
-                    {% endif %}
-                  </p>
+        <div class="vads-l-row vads-u-margin-bottom--2 medium-screen:vads-u-margin-x--neg1">
+          {% for linkTeaser in fieldClpSpotlightLinkTeasers %}
+            <div class="vads-l-col--12 medium-screen:vads-l-col--4 vads-u-align-content--stretch vads-u-margin-y--1 ">
+              <div class="vads-u-background-color--gray-light-alt vads-u-height--full medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
+                <div class="vads-u-padding--2">
+                  <h3 class="vads-u-margin-top--0">
+                    <a href="{{ linkTeaser.entity.fieldLink.uri }}">
+                      {{ linkTeaser.entity.fieldLink.title }}
+                    </a>
+                  </h3>
+                  <p class="vads-u-margin-top--1">{{ linkTeaser.entity.fieldLinkSummary }}</p>
                 </div>
-
-                <!-- Where -->
-                {% if eventReference.entity.fieldFacilityLocation.entity.entityUrl.path || eventReference.entity.fieldLocationHumanreadable != empty || eventReference.entity.fieldLink.uri %}
-                  <div class="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-margin-top--2">
-                    <p class="vads-u-font-weight--bold vads-u-margin--0 vads-u-margin-right--2">Where</p>
-
-                    <!-- Event link -->
-                    <div class="vads-u-display--flex vads-u-flex-direction--column">
-                      {% if eventReference.entity.fieldFacilityLocation.entity.entityUrl.path %}
-                        <a href="{{ eventReference.entity.fieldFacilityLocation.entity.entityUrl.path }}" rel="noreferrer noopener" target="_blank">
-                          {{ eventReference.entity.fieldFacilityLocation.entity.title }}
-                        </a>
-                      {% endif %}
-
-                      {% if eventReference.entity.fieldLink.uri %}
-                        <a href="{{ eventReference.entity.fieldLink.uri }}" rel="noreferrer noopener" target="_blank">
-                          {{ eventReference.entity.fieldEventCta }}
-                        </a>
-                      {% endif %}
-
-                      <!-- Event address -->
-                      {% if eventReference.entity.fieldLocationHumanreadable != empty %}
-                        <p class="vads-u-margin--0">{{ eventReference.entity.fieldLocationHumanreadable }}</p>
-                      {% endif %}
-                    </div>
-                  </div>
-                {% endif %}
               </div>
             </div>
           {% endfor %}
         </div>
       </div>
-    </div> <!--/Events -->
+    {% endif %}
+    <!-- / Spotlight -->
 
-    <!-- FAQs -->
-    <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
-      <div class="vads-l-row">
-        <div class="vads-l-col--12 medium-screen:vads-l-col--9">
-          <!-- Title -->
-          <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">FAQ</p>
-          <h2 class="vads-u-margin-top--0">Frequently asked questions</h2>
+    <!-- Stories -->
+    {% if fieldClpStoriesPanel %}
+      <div>
+        <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
+          <div class="vads-l-row">
+            <!-- CONTENT -->
+            <div class="vads-l-col--12 medium-screen:vads-l-col--9">
+              <!-- Title -->
+              <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">Stories</p>
+              <h2 class="vads-u-margin-top--0">{{ fieldClpStoriesHeader }}</h2>
+              <p class="va-introtext vads-u-margin-top--1 vads-u-margin-bottom--4">{{ fieldClpStoriesIntro }}</p>
 
-          <!-- Questions/Answers -->
-          <div class="usa-accordion-bordered vads-u-margin-y--2">
-            <ul class="usa-unstyled-list">
-              {% for faqParagraph in fieldClpFaqParagraphs %}
-                {% if faqParagraph.entity %}
-                  <li data-faq-entity-id="{{ faqParagraph.entity.entityId }}">
-                    <button aria-controls="{{ faqParagraph.entity.entityBundle }}-{{ faqParagraph.entity.entityId }}" class="usa-accordion-button usa-button-unstyled" aria-expanded="false" type="button">{{ faqParagraph.entity.fieldQuestion }}</button>
-                    <div id="{{ faqParagraph.entity.entityBundle }}-{{ faqParagraph.entity.entityId }}" class="usa-accordion-content" aria-hidden="true">
-                      {% assign fieldAnswer = faqParagraph.entity.fieldAnswer | first %}
-                      {% assign bundleComponent = "src/site/paragraphs/" | append: fieldAnswer.entity.entityBundle %}
-                      {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
-                      {% include {{ bundleComponentWithExtension }} with entity = fieldAnswer.entity %}
+              <!-- List of stories -->
+              {% if fieldClpStoriesTeasers != empty %}
+                <div class="vads-u-display--flex vads-u-flex-direction--column">
+                  {% for storyTeaser in fieldClpStoriesTeasers %}
+                    <div class="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-margin-bottom--4">
+                      <img alt="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.alt }}" class="vads-l-col--12 medium-screen:vads-l-col--4 medium-screen:vads-u-margin-right--2" src="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.url }}" />
+                      <div class="vads-u-margin-top--2 medium-screen:vads-u-margin-top--0">
+                        <h3 class="vads-u-margin-top--0">
+                          <a href="{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.uri }}">
+                            {{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.title }}
+                          </a>
+                        </h3>
+                        <p>{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLinkSummary }}</p>
+                      </div>
                     </div>
-                  </li>
-                {% endif %}
-              {% endfor %}
-            </ul>
+                  {% endfor %}
+                </div>
+              {% endif %}
+
+              <!-- Call to action -->
+              {% if fieldClpStoriesCta %}
+                <a class="usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldClpStoriesCta.entity.fieldButtonLink.url }}" rel="noreferrer noopener" target="_blank">
+                  {{ fieldClpStoriesCta.entity.fieldButtonLabel }}
+                  <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
+                </a>
+              {% endif %}
+            </div>
           </div>
         </div>
       </div>
+    {% endif %}
+    <!--/Stories -->
 
-      {% if fieldClpFaqCta %}
+    <!-- Downloadable Resources -->
+    {% if fieldClpResourcesPanel %}
+      <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
         <div class="vads-l-row">
-          <div class="vads-u-col--12">
-            <a class="usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldClpFaqCta.entity.fieldButtonLink.url.path }}">
-              {{ fieldClpFaqCta.entity.fieldButtonLabel }}
-              <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
-            </a>
+          <div class="vads-l-col--12 medium-screen:vads-l-col--9">
+            <!-- Title -->
+            <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">Downloadable resources</p>
+            <h2 class="vads-u-margin-top--0">{{ fieldClpResourcesHeader }}</h2>
+            <p class="va-introtext vads-u-margin-top--1 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--4">{{ fieldClpResourcesIntroText }}</p>
           </div>
         </div>
-      {% endif %}
-    </div><!--/  FAQs -->
+
+        <div class="vads-l-row vads-u-margin-bottom--2 medium-screen:vads-u-margin-x--neg1">
+          {% for resource in fieldClpResources %}
+            <div class="vads-l-col--12 medium-screen:vads-l-col--4 vads-u-align-content--stretch vads-u-margin-y--1 ">
+              <div class="vads-u-background-color--gray-light-alt vads-u-height--full medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
+                <div class="vads-u-padding--2">
+                  <h3 class="vads-u-margin--0">{{ resource.entity.name }}</h3>
+                  <p>{{ resource.entity.fieldDescription }}</p>
+                  <a href="{{ resource.entity.fieldMediaExternalFile.url }}" download>Download (PDF)</a>
+                </div>
+              </div>
+            </div>
+          {% endfor %}
+        </div>
+
+        {% if fieldClpResourcesCta %}
+          <div class="vads-l-row">
+            <div class="vads-u-col--12">
+              <a class="usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldClpResourcesCta.entity.fieldButtonLink.url.path }}">
+                {{ fieldClpResourcesCta.entity.fieldButtonLabel }}
+                <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
+              </a>
+            </div>
+          </div>
+        {% endif %}
+      </div>
+    {% endif %}
+    <!--/  Downloadable Resources -->
+
+    <!-- Events -->
+    {% if fieldClpEventsPanel %}
+      <div>
+        <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
+
+          <!-- CONTENT -->
+          <div class="vads-l-row">
+            <div class="vads-l-col--12 medium-screen:vads-l-col--9">
+              <!-- Title -->
+              <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">Events</p>
+              <h2 class="vads-u-margin-top--0">{{ fieldClpEventsHeader }}</h2>
+            </div>
+          </div>
+
+          <!-- List of events -->
+          <div class="vads-l-row vads-u-margin-bottom--2 medium-screen:vads-u-margin-x--neg6">
+            {% for eventReference in fieldClpEventsReferences %}
+              <div class="vads-l-col--12 medium-screen:vads-l-col--6 {% if !forloop.first %}vads-u-margin-top--4 medium-screen:vads-u-margin-top--0{% endif %}">
+                <div class="medium-screen:vads-u-margin-x--6">
+                  <!-- Title -->
+                  <h3 class="vads-u-margin-top--0">
+                    <a href="{{ eventReference.entity.fieldLink.url }}">
+                      {{ eventReference.entity.title }}
+                    </a>
+                  </h3>
+
+                  <!-- Description -->
+                  {{ eventReference.entity.fieldBody.processed }}
+
+                  <!-- When -->
+                  <div class="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">
+                    <p class="vads-u-font-weight--bold vads-u-margin--0 vads-u-margin-right--2">When</p>
+                    <p class="vads-u-margin--0">
+                      {% if eventReference.entity.fieldDatetimeRangeTimezone.value != empty %}
+                        {{eventReference.entity.fieldDatetimeRangeTimezone.value | dateFromUnix: "dddd, MMM D, h:mm A" }} -
+                        <br />
+                        {{eventReference.entity.fieldDatetimeRangeTimezone.endValue | dateFromUnix: "dddd, MMM D, h:mm A" }}
+                      {% endif %}
+                      {% if eventReference.entity.fieldDatetimeRangeTimezone.timezone != empty %}
+                        {{ eventReference.entity.fieldDatetimeRangeTimezone.timezone | timezoneAbbrev: fieldDatetimeRangeTimezone.value }}
+                      {% endif %}
+                    </p>
+                  </div>
+
+                  <!-- Where -->
+                  {% if eventReference.entity.fieldFacilityLocation.entity.entityUrl.path || eventReference.entity.fieldLocationHumanreadable != empty || eventReference.entity.fieldLink.uri %}
+                    <div class="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-margin-top--2">
+                      <p class="vads-u-font-weight--bold vads-u-margin--0 vads-u-margin-right--2">Where</p>
+
+                      <!-- Event link -->
+                      <div class="vads-u-display--flex vads-u-flex-direction--column">
+                        {% if eventReference.entity.fieldFacilityLocation.entity.entityUrl.path %}
+                          <a href="{{ eventReference.entity.fieldFacilityLocation.entity.entityUrl.path }}" rel="noreferrer noopener" target="_blank">
+                            {{ eventReference.entity.fieldFacilityLocation.entity.title }}
+                          </a>
+                        {% endif %}
+
+                        {% if eventReference.entity.fieldLink.uri %}
+                          <a href="{{ eventReference.entity.fieldLink.uri }}" rel="noreferrer noopener" target="_blank">
+                            {{ eventReference.entity.fieldEventCta }}
+                          </a>
+                        {% endif %}
+
+                        <!-- Event address -->
+                        {% if eventReference.entity.fieldLocationHumanreadable != empty %}
+                          <p class="vads-u-margin--0">{{ eventReference.entity.fieldLocationHumanreadable }}</p>
+                        {% endif %}
+                      </div>
+                    </div>
+                  {% endif %}
+                </div>
+              </div>
+            {% endfor %}
+          </div>
+        </div>
+      </div>
+    {% endif %}
+    <!--/Events -->
+
+    <!-- FAQs -->
+    {% if fieldClpFaqPanel %}
+      <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
+        <div class="vads-l-row">
+          <div class="vads-l-col--12 medium-screen:vads-l-col--9">
+            <!-- Title -->
+            <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">FAQ</p>
+            <h2 class="vads-u-margin-top--0">Frequently asked questions</h2>
+
+            <!-- Questions/Answers -->
+            <div class="usa-accordion-bordered vads-u-margin-y--2">
+              <ul class="usa-unstyled-list">
+                {% for faqParagraph in fieldClpFaqParagraphs %}
+                  {% if faqParagraph.entity %}
+                    <li data-faq-entity-id="{{ faqParagraph.entity.entityId }}">
+                      <button aria-controls="{{ faqParagraph.entity.entityBundle }}-{{ faqParagraph.entity.entityId }}" class="usa-accordion-button usa-button-unstyled" aria-expanded="false" type="button">{{ faqParagraph.entity.fieldQuestion }}</button>
+                      <div id="{{ faqParagraph.entity.entityBundle }}-{{ faqParagraph.entity.entityId }}" class="usa-accordion-content" aria-hidden="true">
+                        {% assign fieldAnswer = faqParagraph.entity.fieldAnswer | first %}
+                        {% assign bundleComponent = "src/site/paragraphs/" | append: fieldAnswer.entity.entityBundle %}
+                        {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
+                        {% include {{ bundleComponentWithExtension }} with entity = fieldAnswer.entity %}
+                      </div>
+                    </li>
+                  {% endif %}
+                {% endfor %}
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        {% if fieldClpFaqCta %}
+          <div class="vads-l-row">
+            <div class="vads-u-col--12">
+              <a class="usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldClpFaqCta.entity.fieldButtonLink.url.path }}">
+                {{ fieldClpFaqCta.entity.fieldButtonLabel }}
+                <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
+              </a>
+            </div>
+          </div>
+        {% endif %}
+      </div>
+    {% endif %}
+    <!--/  FAQs -->
 
     <!-- Connect with us -->
+    {% assign socialLinksObject = fieldClpConnectWithUs.entity.fieldSocialMediaLinks.platformValues | jsonToObj %}
     <div>
-      {% assign socialLinksObject = fieldClpConnectWithUs.entity.fieldSocialMediaLinks.platformValues | jsonToObj %}
       <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
         <div class="vads-l-row">
           <!-- CONTENT -->
@@ -397,84 +414,105 @@
         </div>
 
         <div class="vads-l-row medium-screen:vads-u-margin-x--neg1">
-          <div class="vads-l-col--12 medium-screen:vads-l-col--4">
-            <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
-              <a aria-label="{{ fieldClpConnectWithUs.entity.fieldEmailUpdatesLinkText }} (opens in a new window)" href="{{ fieldClpConnectWithUs.entity.fieldEmailUpdatesUrl }}" rel="noreferrer noopener" target="_blank">
-                <i aria-hidden="true" class="fas fa-envelope vads-u-padding-right--1"></i>
-                {{ fieldClpConnectWithUs.entity.fieldEmailUpdatesLinkText }}
-              </a>
+          {% if fieldClpConnectWithUs.entity.fieldEmailUpdatesUrl %}
+            <div class="vads-l-col--12 medium-screen:vads-l-col--4">
+              <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
+                <a aria-label="{{ fieldClpConnectWithUs.entity.fieldEmailUpdatesLinkText }} (opens in a new window)" href="{{ fieldClpConnectWithUs.entity.fieldEmailUpdatesUrl }}" rel="noreferrer noopener" target="_blank">
+                  <i aria-hidden="true" class="fas fa-envelope vads-u-padding-right--1"></i>
+                  {{ fieldClpConnectWithUs.entity.fieldEmailUpdatesLinkText }}
+                </a>
+              </div>
             </div>
-          </div>
-          <div class="vads-l-col--12 medium-screen:vads-l-col--4">
-            <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
-              <a aria-label="{{ fieldClpConnectWithUs.entity.name }} Twitter (opens in a new window)" href="https://twitter.com/{{ socialLinksObject.twitter.value }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" rel="noreferrer noopener" target="_blank">
-                <i aria-hidden="true" class="fab fa-twitter vads-u-padding-right--1"></i>
-                {{ fieldClpConnectWithUs.entity.name }} Twitter
-              </a>
+          {% endif %}
+
+          {% if socialLinksObject.twitter.value %}
+            <div class="vads-l-col--12 medium-screen:vads-l-col--4">
+              <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
+                <a aria-label="{{ fieldClpConnectWithUs.entity.name }} Twitter (opens in a new window)" href="https://twitter.com/{{ socialLinksObject.twitter.value }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" rel="noreferrer noopener" target="_blank">
+                  <i aria-hidden="true" class="fab fa-twitter vads-u-padding-right--1"></i>
+                  {{ fieldClpConnectWithUs.entity.name }} Twitter
+                </a>
+              </div>
             </div>
-          </div>
-          <div class="vads-l-col--12 medium-screen:vads-l-col--4">
-            <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
-              <a aria-label="{{ fieldClpConnectWithUs.entity.name }} Facebook (opens in a new window)" href="https://facebook.com/{{ socialLinksObject.facebook.value }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" rel="noreferrer noopener" target="_blank">
-                <i aria-hidden="true" class="fab fa-facebook vads-u-padding-right--1"></i>
-                {{ fieldClpConnectWithUs.entity.name }} Facebook
-              </a>
+          {% endif %}
+
+          {% if socialLinksObject.facebook.value %}
+            <div class="vads-l-col--12 medium-screen:vads-l-col--4">
+              <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
+                <a aria-label="{{ fieldClpConnectWithUs.entity.name }} Facebook (opens in a new window)" href="https://facebook.com/{{ socialLinksObject.facebook.value }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" rel="noreferrer noopener" target="_blank">
+                  <i aria-hidden="true" class="fab fa-facebook vads-u-padding-right--1"></i>
+                  {{ fieldClpConnectWithUs.entity.name }} Facebook
+                </a>
+              </div>
             </div>
-          </div>
-          <div class="vads-l-col--12 medium-screen:vads-l-col--4">
-            <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
-              <a aria-label="{{ fieldClpConnectWithUs.entity.name }} YouTube (opens in a new window)" href="https://youtube.com/channel/{{ socialLinksObject.youtube.value }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" rel="noreferrer noopener" target="_blank">
-                <i aria-hidden="true" class="fab fa-youtube vads-u-padding-right--1"></i>
-                {{ fieldClpConnectWithUs.entity.name }} YouTube
-              </a>
+          {% endif %}
+
+          {% if socialLinksObject.youtube.value %}
+            <div class="vads-l-col--12 medium-screen:vads-l-col--4">
+              <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
+                <a aria-label="{{ fieldClpConnectWithUs.entity.name }} YouTube (opens in a new window)" href="https://youtube.com/channel/{{ socialLinksObject.youtube.value }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" rel="noreferrer noopener" target="_blank">
+                  <i aria-hidden="true" class="fab fa-youtube vads-u-padding-right--1"></i>
+                  {{ fieldClpConnectWithUs.entity.name }} YouTube
+                </a>
+              </div>
             </div>
-          </div>
-          <div class="vads-l-col--12 medium-screen:vads-l-col--4">
-            <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
-              <a aria-label="{{ fieldClpConnectWithUs.entity.name }} Linkedin (opens in a new window)" href="https://linkedin.com/{{ socialLinksObject.linkedin.value }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" rel="noreferrer noopener" target="_blank">
-                <i aria-hidden="true" class="fab fa-linkedin vads-u-padding-right--1"></i>
-                {{ fieldClpConnectWithUs.entity.name }} Linkedin
-              </a>
+          {% endif %}
+
+          {% if socialLinksObject.linkedin.value %}
+            <div class="vads-l-col--12 medium-screen:vads-l-col--4">
+              <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
+                <a aria-label="{{ fieldClpConnectWithUs.entity.name }} Linkedin (opens in a new window)" href="https://linkedin.com/{{ socialLinksObject.linkedin.value }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" rel="noreferrer noopener" target="_blank">
+                  <i aria-hidden="true" class="fab fa-linkedin vads-u-padding-right--1"></i>
+                  {{ fieldClpConnectWithUs.entity.name }} Linkedin
+                </a>
+              </div>
             </div>
-          </div>
-          <div class="vads-l-col--12 medium-screen:vads-l-col--4">
-            <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
-              <a aria-label="{{ fieldClpConnectWithUs.entity.name }} Instagram (opens in a new window)" href="https://instagram.com/{{ socialLinksObject.instagram.value }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" rel="noreferrer noopener" target="_blank">
-                <i aria-hidden="true" class="fab fa-instagram vads-u-padding-right--1"></i>
-                {{ fieldClpConnectWithUs.entity.name }} Instagram
-              </a>
+          {% endif %}
+
+          {% if socialLinksObject.instagram.value %}
+            <div class="vads-l-col--12 medium-screen:vads-l-col--4">
+              <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
+                <a aria-label="{{ fieldClpConnectWithUs.entity.name }} Instagram (opens in a new window)" href="https://instagram.com/{{ socialLinksObject.instagram.value }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" rel="noreferrer noopener" target="_blank">
+                  <i aria-hidden="true" class="fab fa-instagram vads-u-padding-right--1"></i>
+                  {{ fieldClpConnectWithUs.entity.name }} Instagram
+                </a>
+              </div>
             </div>
-          </div>
+          {% endif %}
         </div>
       </div>
-    </div> <!-- Connect with us -->
+    </div>
+    <!-- Connect with us -->
 
     <!-- VA Benefits -->
-    <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
-      <div class="vads-l-row">
-        <div class="vads-l-col--12 medium-screen:vads-l-col--9">
-          <!-- Title -->
-          <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">VA Benefits</p>
-          <h2 class="vads-u-margin-top--0 vads-u-margin-bottom--3">Learn more about related VA benefits</h2>
+    {% if fieldBenefitCategories != empty %}
+      <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
+        <div class="vads-l-row">
+          <div class="vads-l-col--12 medium-screen:vads-l-col--9">
+            <!-- Title -->
+            <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">VA Benefits</p>
+            <h2 class="vads-u-margin-top--0 vads-u-margin-bottom--3">Learn more about related VA benefits</h2>
+          </div>
+        </div>
+
+        <div class="vads-l-row medium-screen:vads-u-margin-x--neg6">
+          {% for benefitCategory in fieldBenefitCategories %}
+            <div class="vads-l-col--12 medium-screen:vads-l-col--6 {% if !forloop.first %}vads-u-margin-top--2 medium-screen:vads-u-margin-top--0{% endif %}">
+              <div class="medium-screen:vads-u-margin-x--6">
+                <div class="vads-u-display--flex vads-u-align-items--center">
+                  <div class="inline hub-main-icon vads-u-margin-right--2">
+                    <i class="icon-large white hub-icon-{{ benefitCategory.entity.fieldTitleIcon }} hub-background-{{ benefitCategory.entity.fieldTitleIcon }}" role="presentation" aria-hidden="true"></i>
+                  </div>
+                  <a href="{{ benefitCategory.entity.entityUrl.path }}">{{ benefitCategory.entity.title }}</a>
+                </div>
+                <p class="vads-u-margin-top--0">{{ benefitCategory.entity.fieldIntroText }}</p>
+              </div>
+            </div>
+          {% endfor %}
         </div>
       </div>
-
-      <div class="vads-l-row medium-screen:vads-u-margin-x--neg6">
-        {% for benefitCategory in fieldBenefitCategories %}
-          <div class="vads-l-col--12 medium-screen:vads-l-col--6 {% if !forloop.first %}vads-u-margin-top--2 medium-screen:vads-u-margin-top--0{% endif %}">
-            <div class="medium-screen:vads-u-margin-x--6">
-              <div class="vads-u-display--flex vads-u-align-items--center">
-                <div class="inline hub-main-icon vads-u-margin-right--2">
-                  <i class="icon-large white hub-icon-{{ benefitCategory.entity.fieldTitleIcon }} hub-background-{{ benefitCategory.entity.fieldTitleIcon }}" role="presentation" aria-hidden="true"></i>
-                </div>
-                <a href="{{ benefitCategory.entity.entityUrl.path }}">{{ benefitCategory.entity.title }}</a>
-              </div>
-              <p class="vads-u-margin-top--0">{{ benefitCategory.entity.fieldIntroText }}</p>
-            </div>
-          </div>
-        {% endfor %}
-      </div>
-    </div><!--/  VA Benefits -->
+    {% endif %}
+    <!--/  VA Benefits -->
 
     <!-- Last Updated -->
     <div class="vads-l-grid-container vads-u-background-color--white vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -119,18 +119,23 @@
             <iframe
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
               allowFullScreen
-              class="vads-u-margin-top--4"
+              class="va-c-video vads-u-margin-top--4"
               frameBorder="0"
               height="315"
               src="{{ videoURL }}"
-              style="max-width: 560px;"
               title="{{ fieldMedia.entity.name | default: 'A related YouTube video' }}"
               width="100%"
             ></iframe>
 
             <!-- Video description -->
             {% if fieldMedia.entity.fieldDuration %}
-              <p class="duration vads-u-font-size--sm vads-u-margin--0">{{ fieldMedia.entity.fieldDuration }}</p>
+              <p class="vads-u-font-size--sm vads-u-margin--0">
+                {{ fieldMedia.entity.fieldDuration | formatSeconds }}
+                {% if fieldMedia.entity.fieldDuration != empty && fieldMedia.entity.fieldPublicationDate.date != empty %}
+                  &bull;
+                {% endif %}
+                {{ fieldMedia.entity.fieldPublicationDate.date | humanizeDate }}
+              </p>
             {% endif %}
 
             {% if fieldMedia.entity.fieldDescription %}

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -50,9 +50,9 @@
 
             <!-- THIS PAGE IS FOR -->
             <div class="vads-l-col--12 medium-screen:vads-l-col--3">
-              <div class=" vads-u-margin-top--6 medium-screen:vads-u-margin-top--0 medium-screen:vads-u-margin-left--2">
+              <div class=" vads-u-margin-top--3 medium-screen:vads-u-margin-top--0 medium-screen:vads-u-margin-left--2">
                 {% if fieldClpAudience != empty %}
-                  <div class="va-c-white-box vads-u-background-color--white vads-u-padding--2 vads-u-margin-bottom--2">
+                  <div class="va-c-white-box vads-u-background-color--white vads-u-padding--2 vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--2">
                     <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin--0">This page is for</p>
                     <hr class="va-c-blue-line vads-u-border-color--primary-alt vads-u-margin-y--2" />
                     <ul class="usa-unstyled-list">
@@ -205,7 +205,7 @@
                   <div class="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-margin-bottom--4">
                     <img alt="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.alt }}" class="vads-l-col--12 medium-screen:vads-l-col--4 medium-screen:vads-u-margin-right--2" src="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.url }}" />
                     <div class="vads-u-margin-top--2 medium-screen:vads-u-margin-top--0">
-                      <h3 class="medium-screen:vads-u-margin-top--0">
+                      <h3 class="vads-u-margin-top--0">
                         <a href="{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.uri }}">
                           {{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.title }}
                         </a>
@@ -236,7 +236,7 @@
           <!-- Title -->
           <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">Downloadable resources</p>
           <h2 class="vads-u-margin-top--0">{{ fieldClpResourcesHeader }}</h2>
-          <p class="va-introtext vads-u-margin-top--1 vads-u-margin-bottom--4">{{ fieldClpResourcesIntroText }}</p>
+          <p class="va-introtext vads-u-margin-top--1 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--4">{{ fieldClpResourcesIntroText }}</p>
         </div>
       </div>
 
@@ -282,7 +282,7 @@
         <!-- List of events -->
         <div class="vads-l-row vads-u-margin-bottom--2 medium-screen:vads-u-margin-x--neg6">
           {% for eventReference in fieldClpEventsReferences %}
-            <div class="vads-l-col--12 medium-screen:vads-l-col--6">
+            <div class="vads-l-col--12 medium-screen:vads-l-col--6 {% if !forloop.first %}vads-u-margin-top--4 medium-screen:vads-u-margin-top--0{% endif %}">
               <div class="medium-screen:vads-u-margin-x--6">
                 <!-- Title -->
                 <h3 class="vads-u-margin-top--0">
@@ -437,13 +437,13 @@
         <div class="vads-l-col--12 medium-screen:vads-l-col--9">
           <!-- Title -->
           <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">VA Benefits</p>
-          <h2 class="vads-u-margin-top--0">Learn more about related VA benefits</h2>
+          <h2 class="vads-u-margin-top--0 vads-u-margin-bottom--3">Learn more about related VA benefits</h2>
         </div>
       </div>
 
       <div class="vads-l-row medium-screen:vads-u-margin-x--neg6">
         {% for benefitCategory in fieldBenefitCategories %}
-          <div class="vads-l-col--12 medium-screen:vads-l-col--6">
+          <div class="vads-l-col--12 medium-screen:vads-l-col--6 {% if !forloop.first %}vads-u-margin-top--2 medium-screen:vads-u-margin-top--0{% endif %}">
             <div class="medium-screen:vads-u-margin-x--6">
               <div class="vads-u-display--flex vads-u-align-items--center">
                 <div class="inline hub-main-icon vads-u-margin-right--2">

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -21,7 +21,7 @@
 
               {% if fieldPrimaryCallToAction %}
                 <a
-                  class="va-u-box-shadow--none usa-button usa-button-secondary vads-u-margin-top--2 vads-u-background-color--white vads-u-border-color--white vads-u-font-size--sm"
+                  class="usa-button usa-button-secondary va-u-box-shadow--none vads-u-margin-top--2 vads-u-background-color--white vads-u-border--0 vads-u-font-size--sm"
                   href="{{ fieldPrimaryCallToAction.entity.fieldButtonLink.url.path }}">
                   {{ fieldPrimaryCallToAction.entity.fieldButtonLabel }}
                 </a>

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -308,13 +308,23 @@
                 </div>
 
                 <!-- Where -->
-                <!-- NOT SURE WHAT TO PUT HERE: https://dsva.slack.com/archives/C01DS1XDEQ0/p1611332573004800?thread_ts=1611331917.004100&cid=C01DS1XDEQ0 -->
-                <div class="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-margin-top--2">
-                  <p class="vads-u-font-weight--bold vads-u-margin--0 vads-u-margin-right--2">Where</p>
-                  <a href="" rel="noreferrer noopener" target="_blank">
-                    TODO
-                  </a>
-                </div>
+                {% if eventReference.entity.fieldFacilityLocation.entity.entityUrl.path || node.fieldLocationHumanreadable != empty %}
+                  <div class="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-margin-top--2">
+                    <p class="vads-u-font-weight--bold vads-u-margin--0 vads-u-margin-right--2">Where</p>
+
+                    <!-- Event link -->
+                    {% if eventReference.entity.fieldFacilityLocation.entity.entityUrl.path %}
+                      <a href="{{ eventReference.entity.fieldFacilityLocation.entity.entityUrl.path }}" rel="noreferrer noopener" target="_blank">
+                        {{ eventReference.entity.fieldFacilityLocation.entity.title }}
+                      </a>
+                    {% endif %}
+
+                    <!-- Event address -->
+                    {% if eventReference.entity.fieldLocationHumanreadable != empty %}
+                      <p>{{ eventReference.entity.fieldLocationHumanreadable }}</p>
+                    {% endif %}
+                  </div>
+                {% endif %}
               </div>
             </div>
           {% endfor %}

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -6,7 +6,7 @@
 {% endcomment %}
 
 <div id="content" class="interior" data-template="node-campaign_landing_page">
-  <main class="va-l-detail-page">
+  <main class="va-l-detail-page va-c-main">
 
     <!-- HERO-->
     <div class="va-u-background--image" style="background-image: url('{{ fieldHeroImage.entity.image.url }}">
@@ -34,41 +34,39 @@
     <!-- /Hero -->
 
     <!-- Why This Matters -->
-    <div class="vads-u-background-color--primary-alt-lightest">
+    <div>
       <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
-          <div class="vads-l-row">
-            <!-- CONTENT -->
-            <div class="vads-l-col--12 medium-screen:vads-l-col--9">
-              <h2 class="vads-u-margin--0 vads-u-margin-bottom--2">Why this matters to you</h2>
-              <p class="va-introtext vads-u-margin-top--0 vads-u-margin-bottom--2">{{ fieldClpWhyThisMatters }}</p>
-              {% if fieldSecondaryCallToAction %}
-                <a class="usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldSecondaryCallToAction.entity.fieldButtonLink.url.path }}">
-                  {{ fieldSecondaryCallToAction.entity.fieldButtonLabel }}
-                </a>
+        <div class="vads-l-row">
+          <!-- CONTENT -->
+          <div class="vads-l-col--12 medium-screen:vads-l-col--9">
+            <h2 class="vads-u-margin--0 vads-u-margin-bottom--2">Why this matters to you</h2>
+            <p class="va-introtext vads-u-margin-top--0 vads-u-margin-bottom--2">{{ fieldClpWhyThisMatters }}</p>
+            {% if fieldSecondaryCallToAction %}
+              <a class="usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldSecondaryCallToAction.entity.fieldButtonLink.url.path }}">
+                {{ fieldSecondaryCallToAction.entity.fieldButtonLabel }}
+              </a>
+            {% endif %}
+          </div><!-- /CONTENT -->
+
+          <!-- THIS PAGE IS FOR -->
+          <div class="vads-l-col--12 medium-screen:vads-l-col--3">
+            <div class=" vads-u-margin-top--3 medium-screen:vads-u-margin-top--0 medium-screen:vads-u-margin-left--2">
+              {% if fieldClpAudience != empty %}
+                <div class="va-c-white-box vads-u-background-color--white vads-u-padding--2 vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--2">
+                  <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin--0">This page is for</p>
+                  <hr class="va-c-blue-line vads-u-border-color--primary-alt vads-u-margin-y--2" />
+                  <ul class="usa-unstyled-list">
+                    {% for clpAudience in fieldClpAudience %}
+                      <li class="vads-u-font-size--sm vads-u-font-weight--bold vads-u-margin-top--1">
+                        {{ clpAudience.entity.name }}
+                      </li>
+                    {% endfor %}
+                  </ul>
+                </div>
               {% endif %}
-            </div><!-- /CONTENT -->
-
-            <!-- THIS PAGE IS FOR -->
-            <div class="vads-l-col--12 medium-screen:vads-l-col--3">
-              <div class=" vads-u-margin-top--3 medium-screen:vads-u-margin-top--0 medium-screen:vads-u-margin-left--2">
-                {% if fieldClpAudience != empty %}
-                  <div class="va-c-white-box vads-u-background-color--white vads-u-padding--2 vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--2">
-                    <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin--0">This page is for</p>
-                    <hr class="va-c-blue-line vads-u-border-color--primary-alt vads-u-margin-y--2" />
-                    <ul class="usa-unstyled-list">
-                      {% for clpAudience in fieldClpAudience %}
-                        <li class="vads-u-font-size--sm vads-u-font-weight--bold vads-u-margin-top--1">
-                          {{ clpAudience.entity.name }}
-                        </li>
-                      {% endfor %}
-                    </ul>
-                  </div>
-                {% endif %}
-                {% include "src/site/includes/social-share.drupal.liquid" %}
-              </div>
-            </div><!-- /THIS PAGE IS FOR-->
-
-          </div>
+              {% include "src/site/includes/social-share.drupal.liquid" %}
+            </div>
+          </div><!-- /THIS PAGE IS FOR-->
         </div>
       </div>
     </div>
@@ -105,7 +103,7 @@
     <!--/ What You Can Do -->
 
     <!-- Video -->
-    <div class="vads-u-background-color--primary-alt-lightest">
+    <div>
       <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
         <div class="vads-l-row">
           <!-- CONTENT -->
@@ -188,7 +186,7 @@
     <!--/ Spotlight -->
 
     <!-- Stories -->
-    <div class="vads-u-background-color--primary-alt-lightest">
+    <div>
       <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
         <div class="vads-l-row">
           <!-- CONTENT -->
@@ -267,7 +265,7 @@
     </div><!--/  Downloadable Resources -->
 
     <!-- Events -->
-    <div class="vads-u-background-color--primary-alt-lightest">
+    <div>
       <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
 
         <!-- CONTENT -->
@@ -366,7 +364,7 @@
     </div><!--/  FAQs -->
 
     <!-- Connect with us -->
-    <div class="vads-u-background-color--primary-alt-lightest">
+    <div>
       {% assign socialLinksObject = fieldClpConnectWithUs.entity.fieldSocialMediaLinks.platformValues | jsonToObj %}
       <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
         <div class="vads-l-row">
@@ -459,7 +457,7 @@
     </div><!--/  VA Benefits -->
 
     <!-- Last Updated -->
-    <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
+    <div class="vads-l-grid-container vads-u-background-color--white vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
       <div class="vads-l-row">
         <div class="vads-l-col--12 medium-screen:vads-l-col--9">
           <div class="last-updated">

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -25,7 +25,7 @@
           <div class="vads-l-col--12 medium-screen:vads-l-col--6">
             <div class="va-u-background--gradiant-blue vads-u-padding-x--4 vads-u-padding-y--6  medium-screen:vads-u-margin-right--4">
               <h1 class="vads-u-color--white">{{ title }}</h1>
-              <hr class="va-c-blue-line vads-u-border-color--primary-alt vads-u-margin-y--2" />
+              <hr class="va-c-blue-line--large vads-u-border-color--primary-alt vads-u-border--2px vads-u-margin-y--2" />
               <p class="va-introtext vads-u-color--white">{{ fieldHeroBlurb }}</p>
 
               {% if fieldPrimaryCallToAction %}

--- a/src/site/layouts/checklist.drupal.liquid
+++ b/src/site/layouts/checklist.drupal.liquid
@@ -10,15 +10,6 @@
     <div class="usa-grid usa-grid-full">
       <div class="usa-width-three-fourths">
         <div class="usa-content">
-          <!-- Draft status -->
-          {% if !entityPublished %}
-            <div class="usa-alert usa-alert-info">
-              <div class="usa-alert-body">
-                <p class="usa-alert-text">You are viewing a draft.</p>
-              </div>
-            </div>
-          {% endif %}
-
           <!-- Search bar -->
           <div id="resources-search-bar-wrapper" class="medium-screen:vads-u-border-bottom--2px vads-u-border-color--gray-light medium-screen:vads-u-margin-bottom--3">
             {% include "src/site/includes/support_resources_search_bar.drupal.liquid" %}

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -15,14 +15,6 @@
       {% endif %}
 
       <div class="usa-width-three-fourths">
-        {% if !entityPublished %}
-          <div class="usa-alert usa-alert-info">
-            <div class="usa-alert-body">
-              <p class="usa-alert-text">You are viewing a draft.</p>
-            </div>
-          </div>
-        {% endif %}
-
         <article aria-labelledby="article-heading" class="usa-content" role="region">
           <div class="usa-grid usa-grid-full">
             <h1 id="article-heading" class="{% if fieldMedia %}vads-u-margin-bottom--4{% else %}vads-u-margin-bottom--2{% endif %}">

--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -1,5 +1,4 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
-
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with constructLcBreadcrumbs = true titleInclude = true %}
@@ -9,15 +8,6 @@
     <div class="usa-grid usa-grid-full">
       <div class="usa-width-three-fourths">
         <div class="usa-content">
-          <!-- Draft status -->
-          {% if !entityPublished %}
-            <div class="usa-alert usa-alert-info">
-              <div class="usa-alert-body">
-                <p class="usa-alert-text">You are viewing a draft.</p>
-              </div>
-            </div>
-          {% endif %}
-
           <!-- Search bar -->
           <div class="medium-screen:vads-u-border-bottom--2px vads-u-border-color--gray-light medium-screen:vads-u-margin-bottom--3">
             {% include "src/site/includes/support_resources_search_bar.drupal.liquid" %}
@@ -133,7 +123,7 @@
               datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
           </div>
 
-        
+
         </div>
       </div>
     </div>

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -2,19 +2,12 @@
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true deriveBreadcrumbsFromUrl = true %}
+
 <div class="interior" id="content">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
       <div class="usa-width-three-fourths">
-        {% if !entityPublished %}
-          <div class="usa-alert usa-alert-info">
-            <div class="usa-alert-body">
-              <p class="usa-alert-text">You are viewing a draft.</p>
-            </div>
-          </div>
-        {% endif %}
-
         <article class="usa-content va-l-facility-detail">
           {% if title != empty %}
             <h1>{{ title }}</h1>

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -2,19 +2,12 @@
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
+
 <div id="content" class="interior">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
       <div class="usa-width-three-fourths">
-        {% if !entityPublished %}
-        <div class="usa-alert usa-alert-info">
-          <div class="usa-alert-body">
-            <p class="usa-alert-text">You are viewing a draft.</p>
-          </div>
-        </div>
-        {% endif %}
-
         <article class="usa-content">
           <h1>{{ title }}</h1>
           {% assign image = fieldMedia.entity.image %}

--- a/src/site/layouts/media_list_images.drupal.liquid
+++ b/src/site/layouts/media_list_images.drupal.liquid
@@ -1,5 +1,4 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
-
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with constructLcBreadcrumbs = true titleInclude = true %}
@@ -9,15 +8,6 @@
         <div class="usa-grid usa-grid-full">
             <div class="usa-width-three-fourths">
                 <div class="usa-content">
-                    <!-- Draft status -->
-                    {% if !entityPublished %}
-                        <div class="usa-alert usa-alert-info">
-                            <div class="usa-alert-body">
-                                <p class="usa-alert-text">You are viewing a draft.</p>
-                            </div>
-                        </div>
-                    {% endif %}
-
                     <!-- Search bar -->
                     <div class="medium-screen:vads-u-border-bottom--2px vads-u-border-color--gray-light medium-screen:vads-u-margin-bottom--3">
                         {% include "src/site/includes/support_resources_search_bar.drupal.liquid" %}

--- a/src/site/layouts/media_list_videos.drupal.liquid
+++ b/src/site/layouts/media_list_videos.drupal.liquid
@@ -1,5 +1,4 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
-
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with constructLcBreadcrumbs = true titleInclude = true %}
@@ -9,15 +8,6 @@
     <div class="usa-grid usa-grid-full">
       <div class="usa-width-three-fourths">
         <div class="usa-content">
-          <!-- Draft status -->
-          {% if !entityPublished %}
-            <div class="usa-alert usa-alert-info">
-              <div class="usa-alert-body">
-                <p class="usa-alert-text">You are viewing a draft.</p>
-              </div>
-            </div>
-          {% endif %}
-
           <!-- Search bar -->
           <div class="medium-screen:vads-u-border-bottom--2px vads-u-border-color--gray-light medium-screen:vads-u-margin-bottom--3">
             {% include "src/site/includes/support_resources_search_bar.drupal.liquid" %}

--- a/src/site/layouts/news_story.drupal.liquid
+++ b/src/site/layouts/news_story.drupal.liquid
@@ -10,16 +10,7 @@
     <main class="va-l-detail-page va-facility-page">
         <div class="usa-grid usa-grid-full">
             {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
-
             <div class="usa-width-three-fourths">
-                {% if !entityPublished %}
-                    <div class="usa-alert usa-alert-info" >
-                        <div class="usa-alert-body">
-                            <p class="usa-alert-text">You are viewing a draft.</p>
-                        </div>
-                    </div>
-                {% endif %}
-
                 <article class="usa-content">
                     <h1>{{ title }}</h1>
                     {% assign image = fieldMedia.entity.image %}

--- a/src/site/layouts/office.drupal.liquid
+++ b/src/site/layouts/office.drupal.liquid
@@ -1,5 +1,4 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
-
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}
@@ -9,14 +8,6 @@
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = outreachSidebar %}
       <div class="usa-width-three-fourths">
-        {% if !entityPublished %}
-        <div class="usa-alert usa-alert-info">
-          <div class="usa-alert-body">
-            <p class="usa-alert-text">You are viewing a draft.</p>
-          </div>
-        </div>
-        {% endif %}
-
         <article aria-labelledby="article-heading" class="vads-l-grid-container--full" role="region">
           <div class="vads-l-grid-container--full">
             <h1 id="article-heading">{{ title }}</h1>

--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -1,5 +1,4 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
-
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}
@@ -15,14 +14,6 @@
 
         {% if sidebar.links != empty %}
           {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
-        {% endif %}
-
-        {% if !entityPublished %}
-          <div class="usa-alert usa-alert-info" >
-            <div class="usa-alert-body">
-              <p class="usa-alert-text">You are viewing a draft.</p>
-            </div>
-          </div>
         {% endif %}
 
         <article class="usa-content">

--- a/src/site/layouts/person_profile.drupal.liquid
+++ b/src/site/layouts/person_profile.drupal.liquid
@@ -1,27 +1,18 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true deriveBreadcrumbsFromUrl = true%}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true deriveBreadcrumbsFromUrl = true %}
+
 <div id="content" class="interior">
     <main class="va-l-detail-page va-facility-page">
         <div class="usa-grid usa-grid-full">
             {% if fieldOffice.entity.entityUrl.path %}
                 {% assign sidebarData = '{"depth": 5, "link": {"label":"' | append: title | append: '","url": {"path": "/"}, "links": []}, "parent": {"label": "Leadership", "links": [], "url": {"path": "' | append: fieldOffice.entity.entityUrl.path | append: '/leadership"}}}' %}
-
                 {% include 'src/site/navigation/facility_no_drupal_page_sidebar_nav.drupal.liquid' with entityUrl = entityUrl, sidebarData = sidebarData %}
             {%  endif %}
             <div class="usa-width-three-fourths">
-                {% if !entityPublished %}
-                    <div class="usa-alert usa-alert-info" >
-                        <div class="usa-alert-body">
-                            <p class="usa-alert-text">You are viewing a draft.</p>
-                        </div>
-                    </div>
-                {% endif %}
                 <article class="usa-content">
-
                     <div class="usa-grid usa-grid-full vads-u-margin-bottom--2 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">
-
                         {% if fieldMedia.entity.image != empty %}
                             <div class="vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0 vads-u-margin-right--3">
                                 {% assign image = fieldMedia.entity.image %}

--- a/src/site/layouts/publication_listing.drupal.liquid
+++ b/src/site/layouts/publication_listing.drupal.liquid
@@ -9,13 +9,6 @@
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = outreachSidebar %}
       <div class="usa-width-three-fourths">
-        {% if !entityPublished %}
-        <div class="usa-alert usa-alert-info">
-          <div class="usa-alert-body">
-            <p class="usa-alert-text">You are viewing a draft.</p>
-          </div>
-        </div>
-        {% endif %}
 
         <article aria-labelledby="article-heading" role="region" class="usa-content vads-l-grid-container--full">
           <div class="vads-l-grid-container--full">

--- a/src/site/layouts/q_a.drupal.liquid
+++ b/src/site/layouts/q_a.drupal.liquid
@@ -1,5 +1,4 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
-
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with constructLcBreadcrumbs = true titleInclude = true %}
@@ -9,15 +8,6 @@
     <div class="usa-grid usa-grid-full">
       <div class="usa-width-three-fourths">
         <div class="usa-content">
-          <!-- Draft status -->
-          {% if !entityPublished %}
-            <div class="usa-alert usa-alert-info">
-              <div class="usa-alert-body">
-                <p class="usa-alert-text">You are viewing a draft.</p>
-              </div>
-            </div>
-          {% endif %}
-
           <!-- Search bar -->
           <div class="medium-screen:vads-u-border-bottom--2px vads-u-border-color--gray-light medium-screen:vads-u-margin-bottom--3">
             {% include "src/site/includes/support_resources_search_bar.drupal.liquid" %}

--- a/src/site/layouts/step_by_step.drupal.liquid
+++ b/src/site/layouts/step_by_step.drupal.liquid
@@ -1,5 +1,4 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
-
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with constructLcBreadcrumbs = true titleInclude = true %}
@@ -9,15 +8,6 @@
     <div class="usa-grid usa-grid-full">
       <div class="usa-width-three-fourths">
         <div class="usa-content">
-          <!-- Draft status -->
-          {% if !entityPublished %}
-            <div class="usa-alert usa-alert-info">
-              <div class="usa-alert-body">
-                <p class="usa-alert-text">You are viewing a draft.</p>
-              </div>
-            </div>
-          {% endif %}
-
           <!-- Search bar -->
           <div class="medium-screen:vads-u-border-bottom--2px vads-u-border-color--gray-light medium-screen:vads-u-margin-bottom--3">
             {% include "src/site/includes/support_resources_search_bar.drupal.liquid" %}

--- a/src/site/layouts/support_resources_detail_page.drupal.liquid
+++ b/src/site/layouts/support_resources_detail_page.drupal.liquid
@@ -3,21 +3,11 @@
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with constructLcBreadcrumbs = true titleInclude = true %}
 
-
 <div id="content" class="interior" data-template="node-support_resources_detail_page">
   <main class="va-l-detail-page">
     <div class="usa-grid usa-grid-full">
       <div class="usa-width-three-fourths">
         <div class="usa-content">
-          <!-- Draft status -->
-          {% if !entityPublished %}
-            <div class="usa-alert usa-alert-info">
-              <div class="usa-alert-body">
-                <p class="usa-alert-text">You are viewing a draft.</p>
-              </div>
-            </div>
-          {% endif %}
-
           <!-- Search bar -->
           <div class="medium-screen:vads-u-border-bottom--2px vads-u-border-color--gray-light medium-screen:vads-u-margin-bottom--3">
             {% include "src/site/includes/support_resources_search_bar.drupal.liquid" %}

--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -2,21 +2,13 @@
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with deriveBreadcrumbsFromUrl = true %}
+
 <div id="content" class="interior">
   <main class="va-l-detail-page">
     <div class="usa-grid usa-grid-full">
 
     {% include 'src/site/navigation/sidebar_nav.drupal.liquid' with sidebar %}
-
     <div class="usa-width-three-fourths">
-
-      {% if !entityPublished %}
-        <div class="usa-alert usa-alert-info vads-u-margin-bottom--4">
-          <div class="usa-alert-body">
-            <p class="usa-alert-text">You are viewing a draft.</p>
-          </div>
-        </div>
-      {% endif %}
 
       <article class="usa-content">
         <h1 class="vads-u-margin-bottom--0">

--- a/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
@@ -82,6 +82,10 @@ const nodeCampaignLandingPage = `
         entityBundle
         entityId
         ... on NodeEvent {
+          entityUrl {
+            path
+          }
+          title
           fieldAdditionalInformationAbo {
             value
             format
@@ -147,6 +151,12 @@ const nodeCampaignLandingPage = `
               entityType
               entityBundle
               entityId
+              ... on NodeHealthCareLocalFacility {
+                entityUrl {
+                  path
+                }
+                title
+              }
             }
           }
           fieldFeatured

--- a/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
@@ -505,6 +505,10 @@ const nodeCampaignLandingPage = `
           fieldDescription
           fieldDuration
           fieldMediaVideoEmbedField
+          fieldPublicationDate {
+            date
+            value
+          }
         }
       }
     }


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/19500

This PR does the following:

- [x] The short bright-blue border-bottom that accents a couple titles appears to have different lengths/widths. I think it has a relationship with the title above it.
- [x] Make sure the calendar event works when someone clicks the "add to calendar" link. I notice a runtime error about a missing description.
- [x] Change all layouts to consolidate all of the CMS-preview elements to the top of the page
- [x] Get the YouTube video working (does the content model include the "embed" link? we also need to adjust the width/height of the iframe because it doesn't do that automatically like an image)
- [x] Validate Hero Image Resolution is set appropriately. **FOLLOW HERE: https://dsva.slack.com/archives/C01DS1XDEQ0/p1613075910016200**
- [x] Log into ebenefits needs arrow icon at the end (Validate design specs - ask Ryan) **FOLLOW HERE: https://dsva.slack.com/archives/C01DS1XDEQ0/p1613072241009900**
- [x] Downloadable Resources - calls out for 'other languages' but doesn't have build-in on CMS to add or show on FE element.  _(Action Item - follow up with CMS)_ **FOLLOW HERE: https://dsva.slack.com/archives/C01DS1XDEQ0/p1613072382011100**
- [x] Events - Need to understand if something is virtual (zoom link) or other sources, how is that going to be displayed? (Should get the exact events from the event calendar.  FE needs to see exact data source example (Zoom link for example). **FOLLOW HERE: https://dsva.slack.com/archives/C01DS1XDEQ0/p1613075462013300**
- [x] Check margins on Mobile/Table some areas need adjusted for view.
- [x] Dynamic (blue, white) staggering background needs to be applied.  Do we want this into a separate ticket? 
- [x] Follow up, on https://github.com/department-of-veterans-affairs/va.gov-team/issues/16749

## Testing done
Wrote some unit tests, updated a nightwatch e2e test for coronavirus pages:

![image](https://user-images.githubusercontent.com/12773166/107788873-243ed780-6d0e-11eb-9cec-c8d7226cee06.png)

## Screenshots
![localhost_3001_preview_nodeId=15068](https://user-images.githubusercontent.com/12773166/107703813-71249e80-6c79-11eb-8906-d0e7e8a0f2d1.png)

![localhost_3001_preview_nodeId=15068 (1)](https://user-images.githubusercontent.com/12773166/107703803-6d911780-6c79-11eb-997d-e77336b743bc.png)

## Acceptance criteria
- [x] View above

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
