### PR TITLE
Add proper error class to Date

### DIFF
--- a/src/platform/forms-system/src/js/components/FieldTemplate.jsx
+++ b/src/platform/forms-system/src/js/components/FieldTemplate.jsx
@@ -46,7 +46,7 @@ export default function FieldTemplate(props) {
   let errorSpan;
   let errorClass;
   if (hasErrors) {
-    errorClass = isDateField ? 'input-error-date' : 'usa-input-error';
+    errorClass = `usa-input-error ${isDateField ? 'input-error-date' : ''}`;
     errorSpanId = `${id}-error-message`;
     errorSpan = (
       <span className="usa-input-error-message" role="alert" id={errorSpanId}>

--- a/src/platform/forms-system/src/js/components/FieldTemplate.jsx
+++ b/src/platform/forms-system/src/js/components/FieldTemplate.jsx
@@ -66,7 +66,7 @@ export default function FieldTemplate(props) {
   });
 
   const inputWrapperClassNames = classNames('schemaform-widget-wrapper', {
-    'usa-input-error form-error-date': isDateField && hasErrors,
+    'form-error-date': isDateField && hasErrors,
   });
 
   const noWrapperContent =


### PR DESCRIPTION
## Description

When the date widget has an error, the left-sided red border doesn't extend up into the `legend`

Including the `usa-input-error` class in the wrapper fixes the problem

Design spec: https://design.va.gov/patterns/form-feedback

Related:
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/394
- https://github.com/department-of-veterans-affairs/component-library/pull/34
- https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/588#pullrequestreview-588647907

## Testing done

Visual

## Screenshots

![Screen Shot 2021-02-11 at 4 36 52 PM](https://user-images.githubusercontent.com/136959/107707517-9b7d5880-6c87-11eb-801b-c607649758ab.png)
![Screen Shot 2021-02-11 at 4 31 52 PM](https://user-images.githubusercontent.com/136959/107707515-9b7d5880-6c87-11eb-8ecc-2c152cbe0d4e.png)

## Acceptance criteria
- [x] Red border extends up into the `fieldset`/`legend`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
