### PR TITLE
Support both `Vet360` and `VAProfile` transaction types

### DIFF
--- a/src/applications/personalization/profile/msw-mocks.js
+++ b/src/applications/personalization/profile/msw-mocks.js
@@ -81,11 +81,11 @@ export const updateDD4CNPFailure = [
 // for _all_ transaction creation requests.
 const createTransactionRequestSuccessBody = {
   id: '',
-  type: 'async_transaction_vet360_email_transactions',
+  type: 'async_transaction_va_profile_email_transactions',
   attributes: {
     transactionId,
     transactionStatus: 'RECEIVED',
-    type: 'AsyncTransaction::Vet360::EmailTransaction',
+    type: 'AsyncTransaction::VAProfile::EmailTransaction',
     metadata: [],
   },
 };
@@ -146,11 +146,11 @@ export const transactionPending = [
       ctx.json({
         data: {
           id: '',
-          type: 'async_transaction_vet360_email_transactions',
+          type: 'async_transaction_va_profile_email_transactions',
           attributes: {
             transactionId,
             transactionStatus: 'RECEIVED',
-            type: 'AsyncTransaction::Vet360::EmailTransaction',
+            type: 'AsyncTransaction::VAProfile::EmailTransaction',
             metadata: [],
           },
         },
@@ -168,11 +168,11 @@ export const transactionFailed = [
       ctx.json({
         data: {
           id: '',
-          type: 'async_transaction_vet360_email_transactions',
+          type: 'async_transaction_va_profile_email_transactions',
           attributes: {
             transactionId,
             transactionStatus: 'COMPLETED_FAILURE',
-            type: 'AsyncTransaction::Vet360::EmailTransaction',
+            type: 'AsyncTransaction::VAProfile::EmailTransaction',
             // this metadata is from a failed address update, _not_ a failed
             // email address update, but the metadata does not matter in the
             // case of a failed email address update
@@ -202,11 +202,11 @@ export const transactionSucceeded = [
       ctx.json({
         data: {
           id: '',
-          type: 'async_transaction_vet360_email_transactions',
+          type: 'async_transaction_va_profile_email_transactions',
           attributes: {
             transactionId,
             transactionStatus: 'COMPLETED_SUCCESS',
-            type: 'AsyncTransaction::Vet360::EmailTransaction',
+            type: 'AsyncTransaction::VAProfile::EmailTransaction',
             metadata: [],
           },
         },

--- a/src/applications/personalization/profile/tests/fixtures/transactions/finished-transaction.json
+++ b/src/applications/personalization/profile/tests/fixtures/transactions/finished-transaction.json
@@ -1,11 +1,11 @@
 {
   "data": {
     "id": "",
-    "type": "async_transaction_vet360_address_transactions",
+    "type": "async_transaction_va_profile_address_transactions",
     "attributes": {
       "transactionId": "bfedd909-9dc4-4b27-abc2-a6cccaece35d",
       "transactionStatus": "COMPLETED_SUCCESS",
-      "type": "AsyncTransaction::Vet360::AddressTransaction",
+      "type": "AsyncTransaction::VAProfile::AddressTransaction",
       "metadata": []
     }
   }

--- a/src/applications/personalization/profile/tests/fixtures/transactions/received-transaction.json
+++ b/src/applications/personalization/profile/tests/fixtures/transactions/received-transaction.json
@@ -1,11 +1,11 @@
 {
   "data": {
     "id": "",
-    "type": "async_transaction_vet360_address_transactions",
+    "type": "async_transaction_va_profile_address_transactions",
     "attributes": {
       "transactionId": "bfedd909-9dc4-4b27-abc2-a6cccaece35d",
       "transactionStatus": "RECEIVED",
-      "type": "AsyncTransaction::Vet360::AddressTransaction",
+      "type": "AsyncTransaction::VAProfile::AddressTransaction",
       "metadata": []
     }
   }

--- a/src/platform/user/profile/vap-svc/constants/index.js
+++ b/src/platform/user/profile/vap-svc/constants/index.js
@@ -27,10 +27,21 @@ export const USA = {
   COUNTRY_ISO3_CODE: 'USA',
 };
 
+// TODO: After https://github.com/department-of-veterans-affairs/va.gov-team/issues/19858
+// is completed and is live on prod, we can update this object to remove the
+// `Vet360` instances:
+//
+// PHONE: 'AsyncTransaction::VAProfile::PhoneTransaction',
+// EMAIL: 'AsyncTransaction::VAProfile::EmailTransaction',
+// ADDRESS: 'AsyncTransaction::VAProfile::AddressTransaction',
+//
 export const TRANSACTION_CATEGORY_TYPES = {
   PHONE: 'AsyncTransaction::Vet360::PhoneTransaction',
   EMAIL: 'AsyncTransaction::Vet360::EmailTransaction',
   ADDRESS: 'AsyncTransaction::Vet360::AddressTransaction',
+  VAP_PHONE: 'AsyncTransaction::VAProfile::PhoneTransaction',
+  VAP_EMAIL: 'AsyncTransaction::VAProfile::EmailTransaction',
+  VAP_ADDRESS: 'AsyncTransaction::VAProfile::AddressTransaction',
 };
 
 export const TRANSACTION_STATUS = {

--- a/src/platform/user/profile/vap-svc/containers/VAPServicePendingTransactionCategory.jsx
+++ b/src/platform/user/profile/vap-svc/containers/VAPServicePendingTransactionCategory.jsx
@@ -19,9 +19,18 @@ function VAPServicePendingTransactionCategory({
   if (!hasPendingCategoryTransaction) return <div>{children}</div>;
 
   let plural = 'email';
-  if (categoryType === TRANSACTION_CATEGORY_TYPES.PHONE) {
+  // TODO: After https://github.com/department-of-veterans-affairs/va.gov-team/issues/19858
+  // is completed and is live on prod, we can remove the `.VAP_` types used
+  // below:
+  if (
+    categoryType === TRANSACTION_CATEGORY_TYPES.PHONE ||
+    categoryType === TRANSACTION_CATEGORY_TYPES.VAP_PHONE
+  ) {
     plural = 'phone numbers';
-  } else if (categoryType === TRANSACTION_CATEGORY_TYPES.ADDRESS) {
+  } else if (
+    categoryType === TRANSACTION_CATEGORY_TYPES.ADDRESS ||
+    categoryType === TRANSACTION_CATEGORY_TYPES.VAP_ADDRESS
+  ) {
     plural = 'addresses';
   }
 


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/19858 will update some strings that are used with VA Profile (formerly Vet360) transaction types. There is one instance where we actually _are_ inspecting that value and looking for `Vet360`. This update makes our logic more flexible to support both the old Vet360 type and the new VAProfile type.

## Testing done
Local

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs