### PR TITLE
Remove screen debug from RequestedAppointmentDetailsPage test

### DIFF
--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
@@ -259,7 +259,6 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
       },
     );
 
-    screen.debug();
     expect(
       await screen.findByRole('heading', {
         level: 1,


### PR DESCRIPTION
## Description
Removes a `screen.debug()` from a unit test which might make it appear as though there is an error when running tests even though there isn't.


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
