### PR TITLE
Clean up EC date logic, mock dates for appointment list page based on timezone

### DIFF
--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -593,17 +593,18 @@ export function transformPendingAppointments(requests) {
     const unableToReachVeteran = appt.appointmentRequestDetailCode?.some(
       detail => detail.detailCode?.code === UNABLE_TO_REACH_VETERAN_DETCODE,
     );
+    const created = moment.parseZone(appt.date).format('YYYY-MM-DD');
 
     return {
       resourceType: 'Appointment',
       id: `var${appt.id}`,
       status: getRequestStatus(appt, isExpressCare),
-      created: moment(appt.createdDate, 'MM/DD/YYYY HH:mm:SS').format(),
+      created,
       cancelationReason: unableToReachVeteran
         ? { text: UNABLE_TO_REACH_VETERAN_DETCODE }
         : null,
       requestedPeriod,
-      start: isExpressCare ? appt.date : undefined,
+      start: isExpressCare ? created : undefined,
       minutesDuration: 60,
       type: {
         coding: [

--- a/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/AppointmentsPageV2.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/AppointmentsPageV2.unit.spec.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import MockDate from 'mockdate';
 import { expect } from 'chai';
 import moment from 'moment';
 import { fireEvent, waitFor } from '@testing-library/dom';
@@ -20,6 +21,7 @@ import {
 import {
   createTestStore,
   renderWithStoreAndRouter,
+  getTimezoneTestDate,
 } from '../../../mocks/setup';
 
 import reducers from '../../../../redux/reducer';
@@ -36,8 +38,14 @@ const initialState = {
 };
 
 describe('VAOS <AppointmentsPageV2>', () => {
-  beforeEach(() => mockFetch());
-  afterEach(() => resetFetch());
+  beforeEach(() => {
+    mockFetch();
+    MockDate.set(getTimezoneTestDate());
+  });
+  afterEach(() => {
+    resetFetch();
+    MockDate.reset();
+  });
 
   const userState = {
     profile: {

--- a/src/applications/vaos/tests/appointment-list/components/CanceledAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/CanceledAppointmentsList.unit.spec.jsx
@@ -1,8 +1,13 @@
 import React from 'react';
+import MockDate from 'mockdate';
 import { expect } from 'chai';
 import moment from 'moment';
 import environment from 'platform/utilities/environment';
-import { setFetchJSONFailure } from 'platform/testing/unit/helpers';
+import {
+  mockFetch,
+  resetFetch,
+  setFetchJSONFailure,
+} from 'platform/testing/unit/helpers';
 import reducers from '../../../redux/reducer';
 import {
   getVAAppointmentMock,
@@ -10,7 +15,10 @@ import {
   getVARequestMock,
 } from '../../mocks/v0';
 import { mockAppointmentInfo, mockFacilitiesFetch } from '../../mocks/helpers';
-import { renderWithStoreAndRouter } from '../../mocks/setup';
+import {
+  renderWithStoreAndRouter,
+  getTimezoneTestDate,
+} from '../../mocks/setup';
 import CanceledAppointmentsList from '../../../appointment-list/components/CanceledAppointmentsList';
 
 const initialState = {
@@ -23,6 +31,14 @@ const initialState = {
 };
 
 describe('VAOS <CanceledAppointmentsList>', () => {
+  beforeEach(() => {
+    mockFetch();
+    MockDate.set(getTimezoneTestDate());
+  });
+  afterEach(() => {
+    resetFetch();
+    MockDate.reset();
+  });
   it('should show information without facility name', async () => {
     const startDate = moment.utc();
     const appointment = getVAAppointmentMock();
@@ -436,7 +452,7 @@ describe('VAOS <CanceledAppointmentsList>', () => {
     });
 
     await screen.findByText(
-      new RegExp(startDate.tz('America/New_York').format('dddd, MMMM D'), 'i'),
+      new RegExp(startDate.tz('America/Denver').format('dddd, MMMM D'), 'i'),
     );
 
     expect(screen.queryByText(/You don’t have any appointments/i)).not.to.exist;

--- a/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
@@ -1,9 +1,13 @@
 import React from 'react';
+import MockDate from 'mockdate';
 import { expect } from 'chai';
 import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
 import { getCCAppointmentMock } from '../../mocks/v0';
 import { mockAppointmentInfo } from '../../mocks/helpers';
-import { renderWithStoreAndRouter } from '../../mocks/setup';
+import {
+  renderWithStoreAndRouter,
+  getTimezoneTestDate,
+} from '../../mocks/setup';
 
 import userEvent from '@testing-library/user-event';
 import { AppointmentList } from '../../../appointment-list';
@@ -20,8 +24,14 @@ const initialState = {
 };
 
 describe('VAOS <CommunityCareAppointmentDetailsPage>', () => {
-  beforeEach(() => mockFetch());
-  afterEach(() => resetFetch());
+  beforeEach(() => {
+    mockFetch();
+    MockDate.set(getTimezoneTestDate());
+  });
+  afterEach(() => {
+    resetFetch();
+    MockDate.reset();
+  });
 
   it('should navigate to community care appointments detail page', async () => {
     // CC appointment id from confirmed_cc.json

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage.unit.spec.jsx
@@ -1,10 +1,14 @@
 import React from 'react';
+import MockDate from 'mockdate';
 import { expect } from 'chai';
 import moment from 'moment';
 import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
 import { getVAAppointmentMock, getVAFacilityMock } from '../../mocks/v0';
 import { mockAppointmentInfo, mockFacilitiesFetch } from '../../mocks/helpers';
-import { renderWithStoreAndRouter } from '../../mocks/setup';
+import {
+  renderWithStoreAndRouter,
+  getTimezoneTestDate,
+} from '../../mocks/setup';
 
 import userEvent from '@testing-library/user-event';
 import { AppointmentList } from '../../../appointment-list';
@@ -20,11 +24,17 @@ const initialState = {
   },
 };
 
-describe('VAOS <AppointmentsPageV2>', () => {
-  beforeEach(() => mockFetch());
-  afterEach(() => resetFetch());
+describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
+  beforeEach(() => {
+    mockFetch();
+    MockDate.set(getTimezoneTestDate());
+  });
+  afterEach(() => {
+    resetFetch();
+    MockDate.reset();
+  });
 
-  it.skip('should navigate to confirmed appointments detail page', async () => {
+  it('should navigate to confirmed appointments detail page', async () => {
     // VA appointment id from confirmed_va.json
     const url = '/va/var21cdc6741c00ac67b6cbf6b972d084c1';
 

--- a/src/applications/vaos/tests/appointment-list/components/PastAppointmentsListV2.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/PastAppointmentsListV2.unit.spec.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import MockDate from 'mockdate';
 import { expect } from 'chai';
 import moment from 'moment';
 import { fireEvent } from '@testing-library/react';
 import { within } from '@testing-library/dom';
+import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
 import {
   getVAAppointmentMock,
   getVAFacilityMock,
@@ -14,7 +16,10 @@ import {
   mockPastAppointmentInfo,
   mockPastAppointmentInfoOption1,
 } from '../../mocks/helpers';
-import { renderWithStoreAndRouter } from '../../mocks/setup';
+import {
+  renderWithStoreAndRouter,
+  getTimezoneTestDate,
+} from '../../mocks/setup';
 import PastAppointmentsListV2, {
   getPastAppointmentDateRangeOptions,
 } from '../../../appointment-list/components/PastAppointmentsListV2';
@@ -28,6 +33,14 @@ const initialState = {
 };
 
 describe('VAOS <PastAppointmentsListV2>', () => {
+  beforeEach(() => {
+    mockFetch();
+    MockDate.set(getTimezoneTestDate());
+  });
+  afterEach(() => {
+    resetFetch();
+    MockDate.reset();
+  });
   it('should show select date range dropdown', async () => {
     mockPastAppointmentInfo({ va: [] });
 
@@ -331,7 +344,7 @@ describe('VAOS <PastAppointmentsListV2>', () => {
     });
 
     await screen.findAllByText(
-      new RegExp(startDate.tz('America/Denver').format('dddd, MMMM D'), 'i'),
+      new RegExp(startDate.format('dddd, MMMM D'), 'i'),
     );
 
     const firstCard = screen.getAllByRole('listitem')[0];
@@ -368,7 +381,7 @@ describe('VAOS <PastAppointmentsListV2>', () => {
     });
 
     await screen.findAllByText(
-      new RegExp(startDate.tz('America/Denver').format('dddd, MMMM D'), 'i'),
+      new RegExp(startDate.format('dddd, MMMM D'), 'i'),
     );
 
     const cards = screen.getAllByRole('listitem');

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import MockDate from 'mockdate';
 import { expect } from 'chai';
 import moment from 'moment';
 import { Route } from 'react-router-dom';
@@ -11,7 +12,10 @@ import {
 } from 'platform/testing/unit/helpers';
 
 import RequestedAppointmentDetailsPage from '../../../appointment-list/components/RequestedAppointmentDetailsPage';
-import { renderWithStoreAndRouter } from '../../mocks/setup';
+import {
+  getTimezoneTestDate,
+  renderWithStoreAndRouter,
+} from '../../mocks/setup';
 import {
   getVAFacilityMock,
   getVARequestMock,
@@ -128,8 +132,12 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
       ),
       { data: [message] },
     );
+    MockDate.set(getTimezoneTestDate());
   });
-  afterEach(() => resetFetch());
+  afterEach(() => {
+    resetFetch();
+    MockDate.reset();
+  });
 
   it('should render VA request details', async () => {
     const pending = transformPendingAppointments([appointment]);

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentsList.unit.spec.jsx
@@ -1,12 +1,20 @@
 import React from 'react';
+import MockDate from 'mockdate';
 import { expect } from 'chai';
 import moment from 'moment';
 import environment from 'platform/utilities/environment';
-import { setFetchJSONFailure } from 'platform/testing/unit/helpers';
+import {
+  mockFetch,
+  resetFetch,
+  setFetchJSONFailure,
+} from 'platform/testing/unit/helpers';
 import reducers from '../../../redux/reducer';
 import { getVAFacilityMock, getVARequestMock } from '../../mocks/v0';
 import { mockAppointmentInfo, mockFacilitiesFetch } from '../../mocks/helpers';
-import { renderWithStoreAndRouter } from '../../mocks/setup';
+import {
+  renderWithStoreAndRouter,
+  getTimezoneTestDate,
+} from '../../mocks/setup';
 import RequestedAppointmentsList from '../../../appointment-list/components/RequestedAppointmentsList';
 
 const initialState = {
@@ -19,6 +27,14 @@ const initialState = {
 };
 
 describe('VAOS <RequestedAppointmentsList>', () => {
+  beforeEach(() => {
+    mockFetch();
+    MockDate.set(getTimezoneTestDate());
+  });
+  afterEach(() => {
+    resetFetch();
+    MockDate.reset();
+  });
   it('should show va request', async () => {
     const startDate = moment.utc();
     const appointment = getVARequestMock();

--- a/src/applications/vaos/tests/appointment-list/components/UpcomingAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/UpcomingAppointmentsList.unit.spec.jsx
@@ -1,8 +1,13 @@
 import React from 'react';
+import MockDate from 'mockdate';
 import { expect } from 'chai';
 import moment from 'moment';
 import environment from 'platform/utilities/environment';
-import { setFetchJSONFailure } from 'platform/testing/unit/helpers';
+import {
+  mockFetch,
+  resetFetch,
+  setFetchJSONFailure,
+} from 'platform/testing/unit/helpers';
 import reducers from '../../../redux/reducer';
 import {
   getCCAppointmentMock,
@@ -11,7 +16,10 @@ import {
   getVARequestMock,
 } from '../../mocks/v0';
 import { mockAppointmentInfo, mockFacilitiesFetch } from '../../mocks/helpers';
-import { renderWithStoreAndRouter } from '../../mocks/setup';
+import {
+  getTimezoneTestDate,
+  renderWithStoreAndRouter,
+} from '../../mocks/setup';
 import UpcomingAppointmentsList from '../../../appointment-list/components/UpcomingAppointmentsList';
 
 const initialState = {
@@ -24,6 +32,14 @@ const initialState = {
 };
 
 describe('VAOS <UpcomingAppointmentsList>', () => {
+  beforeEach(() => {
+    mockFetch();
+    MockDate.set(getTimezoneTestDate());
+  });
+  afterEach(() => {
+    resetFetch();
+    MockDate.reset();
+  });
   it('should show information without facility name', async () => {
     const startDate = moment.utc();
     const appointment = getVAAppointmentMock();
@@ -535,9 +551,7 @@ describe('VAOS <UpcomingAppointmentsList>', () => {
       reducers,
     });
 
-    await screen.findByText(
-      new RegExp(startDate.tz('America/New_York').format('dddd, MMMM D'), 'i'),
-    );
+    await screen.findByText(new RegExp(startDate.format('dddd, MMMM D'), 'i'));
 
     expect(screen.queryByText(/You don’t have any appointments/i)).not.to.exist;
     expect(screen.baseElement).to.contain.text(
@@ -597,9 +611,7 @@ describe('VAOS <UpcomingAppointmentsList>', () => {
       reducers,
     });
 
-    await screen.findByText(
-      new RegExp(startDate.tz('America/New_York').format('dddd, MMMM D'), 'i'),
-    );
+    await screen.findByText(new RegExp(startDate.format('dddd, MMMM D'), 'i'));
 
     expect(screen.queryByText(/You don’t have any appointments/i)).not.to.exist;
     expect(screen.baseElement).to.contain.text('Canceled');
@@ -610,7 +622,7 @@ describe('VAOS <UpcomingAppointmentsList>', () => {
   });
 
   it('should show phone call appointment text', async () => {
-    const startDate = moment.utc();
+    const startDate = moment();
     const appointment = getVAAppointmentMock();
     appointment.attributes = {
       ...appointment.attributes,
@@ -628,7 +640,7 @@ describe('VAOS <UpcomingAppointmentsList>', () => {
     });
 
     await screen.findByText(
-      new RegExp(startDate.tz('America/New_York').format('dddd, MMMM D'), 'i'),
+      new RegExp(startDate.tz('America/Denver').format('dddd, MMMM D'), 'i'),
     );
 
     expect(screen.queryByText(/You don’t have any appointments/i)).not.to.exist;

--- a/src/applications/vaos/tests/mocks/setup.js
+++ b/src/applications/vaos/tests/mocks/setup.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import moment from '../../lib/moment-tz';
 import { Route, Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history-v4';
 import { combineReducers, applyMiddleware, createStore } from 'redux';
@@ -107,6 +108,42 @@ export function renderFromRoutes({ initialState, store = null, path = '/' }) {
   );
 
   return { ...screen, history };
+}
+
+/*
+ * This function returns a date for which adjusting the timezone
+ * to the provided zone results in a date on a different day.
+ * 
+ * For example, if you're on ET and you call this function with 
+ * America/Denver, then you'll get a time of 12:30 am, because that will
+ * be a different day of the month than the same time in America/Denver
+ * 
+ * If the local zone and the passed zone are the same, you'll get a 12:30
+ * am date, similar to zones that are ahead of the passed zone.
+ * 
+ * @export
+ * @param {string} zone A timezone description
+ * @returns An ISO date string for a date that will cross over midnight
+ */
+export function getTimezoneTestDate(zone = 'America/Denver') {
+  let mockedDate;
+  const localOffset = moment().utcOffset();
+  const facilityTimezone = moment()
+    .tz(zone)
+    .utcOffset();
+
+  if (localOffset >= facilityTimezone) {
+    mockedDate = moment()
+      .set('hour', 0)
+      .set('minute', 30);
+  } else {
+    mockedDate = moment()
+      .subtract(1, 'day')
+      .set('hour', 23)
+      .set('minute', 30);
+  }
+
+  return mockedDate.format('YYYY-MM-DD[T]HH:mm:ss');
 }
 
 export async function setTypeOfFacility(store, label) {


### PR DESCRIPTION
## Description
This PR
- Fixes a test that's broken in the evenings, due to timezone logic
- Cleans up where Express Care requests have their dates pulled from
- Adds a helper to mock a date that is a different day of the month when adjusting to MT, the timezone most of our test facilities use

## Testing done
Local testing

## Acceptance criteria
- [ ] Build passes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
