### PR TITLE
[GraphQL] Reduce number of parallel requests

### DIFF
--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -248,7 +248,7 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
       // Cap the amount of pending requests allowed out at once
       // And also stagger their execution so that at no point
       // are we totally overwhelming the CMS.
-      const maxParallelRequests = 15;
+      const maxParallelRequests = 8;
       const overallStartTime = moment();
       const staggeredRequests = new Array(maxParallelRequests)
         .fill(null)


### PR DESCRIPTION
## Description
This PR reduces the number of parallel CMS GraphQL requests are allowing and will likely remain this way until the monolithic GraphQL query isn't used by any branches.

## Testing done
`yarn build:content --pull-drupal`

## Screenshots
N/A

## Acceptance criteria
- [ ] Reduces CPU strain on the CMS DB

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
