### PR TITLE
Get letters after address verification

### DIFF
--- a/src/applications/letters/routes.jsx
+++ b/src/applications/letters/routes.jsx
@@ -9,20 +9,20 @@ import LettersApp from './containers/LettersApp.jsx';
 
 const routes = (
   <Route path="/" component={LettersApp}>
-    <Route component={Main} key="main">
+    <Route
+      component={DownloadLetters}
+      name="Download Letters"
+      key="download-letters"
+    >
+      <IndexRedirect to="confirm-address" />,
       <Route
-        component={DownloadLetters}
-        name="Download Letters"
-        key="download-letters"
-      >
-        <IndexRedirect to="confirm-address" />,
-        <Route
-          component={AddressSection}
-          name="Review your address"
-          key="confirm-address"
-          path="confirm-address"
-        />
-        ,
+        component={AddressSection}
+        name="Review your address"
+        key="confirm-address"
+        path="confirm-address"
+      />
+      ,
+      <Route component={Main} key="main">
         <Route
           component={LetterList}
           name="Select and download"


### PR DESCRIPTION
## Description

The API call to get a Veteran's letters is currently performed _before_ the Veteran can verify their address. Without a valid address on file the CORPDB and VA Profile databases may not be properly synced, and the app gets stuck.

Quote from @annaswims:
> It looks like we've got years worth of logged people affected in the database in InvalidLetterAddressEdipi. > 50k people affected.

This PR set up the API to be made _after_ the address is displayed to the user. Once they click on the "View Letters" button (/records/download-va-letters/letters/confirm-address), the letters API call is made. This doesn't fix the syncing problem, but it should fix the problem where the app is stuck.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/7816

## Testing done

Unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] The letters API calls occurs _after_ the Veteran verifies their address

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
