### PR TITLE
18781 update cypress testrail reporter plugin

### DIFF
--- a/config/cypress-testrail.json
+++ b/config/cypress-testrail.json
@@ -9,7 +9,7 @@
   "waitForAnimations": false,
   "reporter": "cypress-testrail-reporter",
   "reporterOptions": {
-    "domain": "dsvavsp.testrail.io",
+    "host": "https://dsvavsp.testrail.io/",
     "username": "TR_USER",
     "password": "TR_API_KEY",
     "projectId": "TR_PROJECTID",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "cy:run": "cypress run --config-file config/cypress.json",
     "cy:test:circle": "./script/run-cypress-tests-circle.sh",
     "cy:test:docker": "./script/run-cypress-tests-docker.sh",
-    "cy:testrail-run": "cypress run --config-file config/cypress-testrail.json --reporter-options domain=dsvavsp.testrail.io,username=$TR_USER,password=$TR_API_KEY,projectId=$TR_PROJECTID,suiteId=$TR_SUITEID,runName=$TR_RUN_NAME,includeAllInTestRun=$TR_INCLUDE_ALL,groupId=$TR_GROUPID,filter=$TR_FILTER",
+    "cy:testrail-run": "cypress run --config-file config/cypress-testrail.json --reporter-options host=https://dsvavsp.testrail.io/,username=$TR_USER,password=$TR_API_KEY,projectId=$TR_PROJECTID,suiteId=$TR_SUITEID,runName=$TR_RUN_NAME,includeAllInTestRun=$TR_INCLUDE_ALL,groupId=$TR_GROUPID,filter=$TR_FILTER",
     "fetch-drupal-cache": "node script/drupal-aws-cache.js --fetch",
     "heroku-serve": "http-server",
     "prebuild": "node script/prebuild.js",

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "cypress-axe": "^0.8.1",
     "cypress-multi-reporters": "^1.4.0",
     "cypress-plugin-tab": "^1.0.5",
-    "cypress-testrail-reporter": "^1.2.1",
+    "cypress-testrail-reporter": "^1.2.3",
     "decompress": "^4.2.1",
     "deep-diff": "^1.0.2",
     "enhanced-resolve": "^0.7.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2981,7 +2981,7 @@ axe-core@^4.0.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.0.tgz#93d395e6262ecdde5cb52a5d06533d0a0c7bb4cd"
   integrity sha512-9atDIOTDLsWL+1GbBec6omflaT5Cxh88J0GtJtGfCVIXpI02rXHkju59W5mMqWa7eiC5OR168v3TK3kUKBW98g==
 
-axios@^0.18.0, axios@^0.18.1, axios@^0.21.0, axios@^0.21.1:
+axios@^0.18.0, axios@^0.20.0, axios@^0.21.0, axios@^0.21.1:
   version "0.21.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
   integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
@@ -5405,12 +5405,12 @@ cypress-plugin-tab@^1.0.5:
   dependencies:
     ally.js "^1.4.1"
 
-cypress-testrail-reporter@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/cypress-testrail-reporter/-/cypress-testrail-reporter-1.2.1.tgz#8c6537a7ae935374fc7f09d4523f996d450e37c7"
-  integrity sha512-SxOKdWfskNlGx2kPleIyAG62iUPUu+0Jd60pIelqG1O23QZV9WKt41iivUZwCDII/tvSLD/5aE54OjBuMd4VMQ==
+cypress-testrail-reporter@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/cypress-testrail-reporter/-/cypress-testrail-reporter-1.2.3.tgz#801a2a994026b258d77d319d5a272404eabeeb1d"
+  integrity sha512-tXVfd5m6dgW7yCYc8Cfv4530QpgM8xFeAyvgxZsJREboSkYUrBWu6B8W9oA/vAY3lJV+IDYScVMPnK5ohRjE/A==
   dependencies:
-    axios "^0.18.1"
+    axios "^0.20.0"
     btoa "^1.1.2"
     chalk "^2.4.1"
     mocha "^2.2.5"


### PR DESCRIPTION
Resolves ticket #18781  - https://app.zenhub.com/workspaces/vsp-5cedc9cce6e3335dc5a49fc4/issues/department-of-veterans-affairs/va.gov-team/18781

This pr bumps the [`cypress-testrail-reporter`](https://www.npmjs.com/package/cypress-testrail-reporter) plugin from`1.2.1` to `1.2.3`. Minor changes were required `cypress-testrail.json`.

The expected integration with Cypress and TestRail was tested and confirmed.

