### PR TITLE
Update community care language preference text

### DIFF
--- a/src/applications/vaos/new-appointment/components/CommunityCareLanguagePage.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareLanguagePage.jsx
@@ -23,7 +23,7 @@ const initialSchema = {
 const uiSchema = {
   preferredLanguage: {
     'ui:title':
-      'Do you prefer that your community care provider speak a certain language?',
+      'Select the preferred language for your community care provider.',
   },
 };
 

--- a/src/applications/vaos/new-appointment/components/CommunityCarePreferencesPage.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCarePreferencesPage.jsx
@@ -63,7 +63,7 @@ const uiSchema = {
   },
   preferredLanguage: {
     'ui:title':
-      'Do you prefer that your community care provider speak a certain language?',
+      'Select the preferred language for your community care provider.',
   },
   hasCommunityCareProvider: {
     'ui:widget': 'yesNo',


### PR DESCRIPTION
## Description
This PR
- Updates the language preference question text for both versions of the page

## Testing done
Local and unit testing

## Screenshots
![Screen Shot 2021-02-15 at 11 43 32 AM](https://user-images.githubusercontent.com/634932/107973486-41c8a700-6f83-11eb-95ea-4806707aea61.png)
![Screen Shot 2021-02-15 at 11 42 54 AM](https://user-images.githubusercontent.com/634932/107973488-41c8a700-6f83-11eb-969d-eb12a8df31b8.png)


## Acceptance criteria
- [ ] Text is correct

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
