### PR TITLE
Switch to 526 Save-in-progress endpoint

### DIFF
--- a/src/applications/disability-benefits/all-claims/local-dev-mock-api/index.js
+++ b/src/applications/disability-benefits/all-claims/local-dev-mock-api/index.js
@@ -123,7 +123,7 @@ const responses = {
     },
   },
 
-  'GET /v0/in_progress_forms/21-526EZ': {
+  'GET /v0/disability_compensation_in_progress_forms/21-526EZ': {
     formData: {
       veteran: {
         primaryPhone: '4445551212',

--- a/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
@@ -143,7 +143,11 @@ const testConfig = createTestConfig(
       // because fixtures don't evaluate JS.
       cy.intercept('GET', '/v0/intent_to_file', mockItf);
 
-      cy.intercept('PUT', '/v0/in_progress_forms/*', mockInProgress);
+      cy.intercept(
+        'PUT',
+        '/v0/disability_compensation_in_progress_forms/*',
+        mockInProgress,
+      );
 
       cy.intercept(
         'GET',
@@ -177,20 +181,24 @@ const testConfig = createTestConfig(
           ({ 'view:selected': _, ...obj }) => obj,
         );
 
-        cy.intercept('GET', 'v0/in_progress_forms/21-526EZ', {
-          formData: {
-            veteran: {
-              primaryPhone: '4445551212',
-              emailAddress: 'test2@test1.net',
+        cy.intercept(
+          'GET',
+          'v0/disability_compensation_in_progress_forms/21-526EZ',
+          {
+            formData: {
+              veteran: {
+                primaryPhone: '4445551212',
+                emailAddress: 'test2@test1.net',
+              },
+              disabilities: sanitizedRatedDisabilities,
             },
-            disabilities: sanitizedRatedDisabilities,
+            metadata: {
+              version: 0,
+              prefill: true,
+              returnUrl: '/veteran-information',
+            },
           },
-          metadata: {
-            version: 0,
-            prefill: true,
-            returnUrl: '/veteran-information',
-          },
-        });
+        );
       });
     },
 

--- a/src/applications/disability-benefits/all-claims/tests/disability-benefits-helpers.js
+++ b/src/applications/disability-benefits/all-claims/tests/disability-benefits-helpers.js
@@ -179,7 +179,7 @@ const defaultData = {
 
 function initInProgressMock(token, data = defaultData) {
   mock(token, {
-    path: '/v0/in_progress_forms/21-526EZ',
+    path: '/v0/disability_compensation_in_progress_forms/21-526EZ',
     verb: 'get',
     value: {
       formData: {

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/mocks/in-progress-forms.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/mocks/in-progress-forms.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "id": "1234",
-    "type": "in_progress_forms",
+    "type": "disability_compensation_in_progress_forms",
     "attributes": {
       "formId": "21-526EZ",
       "createdAt": "2020-06-16T00:00:00.000Z",

--- a/src/platform/forms/constants.js
+++ b/src/platform/forms/constants.js
@@ -30,3 +30,9 @@ export const VA_FORM_IDS = Object.freeze({
 export const VA_FORM_IDS_SKIP_INFLECTION = Object.freeze([
   VA_FORM_IDS.FORM_21_526EZ,
 ]);
+
+export const VA_FORM_IDS_IN_PROGRESS_FORMS_API = Object.freeze({
+  // 526 endpoint updates the ratedDisabilities dynamically and includes a
+  // `ratedDisabilitiesUpdated` as true in the metadata when the data changes
+  [VA_FORM_IDS.FORM_21_526EZ]: '/v0/disability_compensation_in_progress_forms/',
+});

--- a/src/platform/forms/helpers.js
+++ b/src/platform/forms/helpers.js
@@ -1,4 +1,12 @@
 import _ from 'lodash';
+import environment from '../utilities/environment';
+import { VA_FORM_IDS_IN_PROGRESS_FORMS_API } from './constants';
+
+export function inProgressApi(formId) {
+  const apiUrl =
+    VA_FORM_IDS_IN_PROGRESS_FORMS_API[formId] || '/v0/in_progress_forms/';
+  return `${environment.API_URL}${apiUrl}${formId}`;
+}
 
 export function getPageList(routes, prefix = '') {
   return routes

--- a/src/platform/forms/save-in-progress/actions.js
+++ b/src/platform/forms/save-in-progress/actions.js
@@ -7,6 +7,7 @@ import { fetchAndUpdateSessionExpiration as fetch } from '../../utilities/api';
 // import { sanitizeForm } from '../helpers';
 import { removeFormApi, saveFormApi } from './api';
 import { REMOVING_SAVED_FORM_SUCCESS } from '../../user/profile/actions';
+import { VA_FORM_IDS_IN_PROGRESS_FORMS_API } from '../constants';
 
 export const SET_SAVE_FORM_STATUS = 'SET_SAVE_FORM_STATUS';
 export const SET_AUTO_SAVE_FORM_STATUS = 'SET_AUTO_SAVE_FORM_STATUS';
@@ -251,12 +252,14 @@ export function fetchInProgressForm(
   //  redux store, but form.migrations doesn’t exist (nor should it, really)
   return (dispatch, getState) => {
     const trackingPrefix = getState().form.trackingPrefix;
+    const apiUrl =
+      VA_FORM_IDS_IN_PROGRESS_FORMS_API[formId] || '/v0/in_progress_forms/';
 
     // Update UI while we’re waiting for the API
     dispatch(setFetchFormPending(prefill));
 
     // Query the api and return a promise (for navigation / error handling afterward)
-    return fetch(`${environment.API_URL}/v0/in_progress_forms/${formId}`, {
+    return fetch(`${environment.API_URL}${apiUrl}${formId}`, {
       credentials: 'include',
       headers: {
         'Content-Type': 'application/json',

--- a/src/platform/forms/save-in-progress/actions.js
+++ b/src/platform/forms/save-in-progress/actions.js
@@ -2,12 +2,10 @@ import * as Sentry from '@sentry/browser';
 
 import recordEvent from '../../monitoring/record-event';
 import { logOut } from '../../user/authentication/actions';
-import environment from '../../utilities/environment';
 import { fetchAndUpdateSessionExpiration as fetch } from '../../utilities/api';
-// import { sanitizeForm } from '../helpers';
+import { inProgressApi } from '../helpers';
 import { removeFormApi, saveFormApi } from './api';
 import { REMOVING_SAVED_FORM_SUCCESS } from '../../user/profile/actions';
-import { VA_FORM_IDS_IN_PROGRESS_FORMS_API } from '../constants';
 
 export const SET_SAVE_FORM_STATUS = 'SET_SAVE_FORM_STATUS';
 export const SET_AUTO_SAVE_FORM_STATUS = 'SET_AUTO_SAVE_FORM_STATUS';
@@ -252,14 +250,13 @@ export function fetchInProgressForm(
   //  redux store, but form.migrations doesn’t exist (nor should it, really)
   return (dispatch, getState) => {
     const trackingPrefix = getState().form.trackingPrefix;
-    const apiUrl =
-      VA_FORM_IDS_IN_PROGRESS_FORMS_API[formId] || '/v0/in_progress_forms/';
+    const apiUrl = inProgressApi(formId);
 
     // Update UI while we’re waiting for the API
     dispatch(setFetchFormPending(prefill));
 
     // Query the api and return a promise (for navigation / error handling afterward)
-    return fetch(`${environment.API_URL}${apiUrl}${formId}`, {
+    return fetch(apiUrl, {
       credentials: 'include',
       headers: {
         'Content-Type': 'application/json',

--- a/src/platform/forms/save-in-progress/api.js
+++ b/src/platform/forms/save-in-progress/api.js
@@ -1,19 +1,14 @@
 import * as Sentry from '@sentry/browser';
 import recordEvent from '../../monitoring/record-event';
-import environment from '../../utilities/environment';
 import localStorage from '../../utilities/storage/localStorage';
 import { fetchAndUpdateSessionExpiration as fetch } from '../../utilities/api';
-import { sanitizeForm } from '../helpers';
-import {
-  VA_FORM_IDS_SKIP_INFLECTION,
-  VA_FORM_IDS_IN_PROGRESS_FORMS_API,
-} from '../constants';
+import { sanitizeForm, inProgressApi } from '../helpers';
+import { VA_FORM_IDS_SKIP_INFLECTION } from '../constants';
 
 export function removeFormApi(formId) {
   const csrfTokenStored = localStorage.getItem('csrfToken');
-  const apiUrl =
-    VA_FORM_IDS_IN_PROGRESS_FORMS_API[formId] || '/v0/in_progress_forms/';
-  return fetch(`${environment.API_URL}${apiUrl}${formId}`, {
+  const apiUrl = inProgressApi(formId);
+  return fetch(apiUrl, {
     method: 'DELETE',
     credentials: 'include',
     headers: {
@@ -62,8 +57,7 @@ export function saveFormApi(
     formData,
   });
   const csrfTokenStored = localStorage.getItem('csrfToken');
-  const apiUrl =
-    VA_FORM_IDS_IN_PROGRESS_FORMS_API[formId] || '/v0/in_progress_forms/';
+  const apiUrl = inProgressApi(formId);
   const saveFormApiHeaders = {
     'Content-Type': 'application/json',
     'X-Key-Inflection': 'camel',
@@ -74,7 +68,7 @@ export function saveFormApi(
     delete saveFormApiHeaders['X-Key-Inflection'];
   }
 
-  return fetch(`${environment.API_URL}${apiUrl}${formId}`, {
+  return fetch(apiUrl, {
     method: 'PUT',
     credentials: 'include',
     headers: saveFormApiHeaders,

--- a/src/platform/forms/save-in-progress/api.js
+++ b/src/platform/forms/save-in-progress/api.js
@@ -4,11 +4,16 @@ import environment from '../../utilities/environment';
 import localStorage from '../../utilities/storage/localStorage';
 import { fetchAndUpdateSessionExpiration as fetch } from '../../utilities/api';
 import { sanitizeForm } from '../helpers';
-import { VA_FORM_IDS_SKIP_INFLECTION } from '../constants';
+import {
+  VA_FORM_IDS_SKIP_INFLECTION,
+  VA_FORM_IDS_IN_PROGRESS_FORMS_API,
+} from '../constants';
 
 export function removeFormApi(formId) {
   const csrfTokenStored = localStorage.getItem('csrfToken');
-  return fetch(`${environment.API_URL}/v0/in_progress_forms/${formId}`, {
+  const apiUrl =
+    VA_FORM_IDS_IN_PROGRESS_FORMS_API[formId] || '/v0/in_progress_forms/';
+  return fetch(`${environment.API_URL}${apiUrl}${formId}`, {
     method: 'DELETE',
     credentials: 'include',
     headers: {
@@ -57,6 +62,8 @@ export function saveFormApi(
     formData,
   });
   const csrfTokenStored = localStorage.getItem('csrfToken');
+  const apiUrl =
+    VA_FORM_IDS_IN_PROGRESS_FORMS_API[formId] || '/v0/in_progress_forms/';
   const saveFormApiHeaders = {
     'Content-Type': 'application/json',
     'X-Key-Inflection': 'camel',
@@ -67,7 +74,7 @@ export function saveFormApi(
     delete saveFormApiHeaders['X-Key-Inflection'];
   }
 
-  return fetch(`${environment.API_URL}/v0/in_progress_forms/${formId}`, {
+  return fetch(`${environment.API_URL}${apiUrl}${formId}`, {
     method: 'PUT',
     credentials: 'include',
     headers: saveFormApiHeaders,

--- a/src/platform/forms/tests/save-in-progress/actions.unit.spec.js
+++ b/src/platform/forms/tests/save-in-progress/actions.unit.spec.js
@@ -166,6 +166,21 @@ describe('Schemaform save / load actions:', () => {
           done(err);
         });
     });
+    it('calls the disability compensation api to save the form', done => {
+      const thunk = saveAndRedirectToReturnUrl(VA_FORM_IDS.FORM_21_526EZ, {});
+      const dispatch = sinon.spy();
+
+      thunk(dispatch, getState)
+        .then(() => {
+          expect(global.fetch.args[0][0]).to.contain(
+            '/v0/disability_compensation_in_progress_forms/21-526EZ',
+          );
+          done();
+        })
+        .catch(err => {
+          done(err);
+        });
+    });
     it('dispatches a success if the form is saved', done => {
       const thunk = saveAndRedirectToReturnUrl(VA_FORM_IDS.FORM_10_10EZ, {});
       const dispatch = sinon.spy();
@@ -317,6 +332,27 @@ describe('Schemaform save / load actions:', () => {
       return thunk(dispatch, getState).then(() => {
         expect(global.fetch.args[0][0]).to.contain(
           '/v0/in_progress_forms/1010ez',
+        );
+      });
+    });
+    it('dispatches a success if the form is loaded', () => {
+      const thunk = fetchInProgressForm(VA_FORM_IDS.FORM_21_526EZ, {});
+      const dispatch = sinon.spy();
+      global.fetch.returns(
+        Promise.resolve({
+          ok: true,
+          json: () => ({
+            formData: { field: 'foo' }, // eslint-disable-line camelcase
+            metadata: {
+              version: 0,
+            },
+          }),
+        }),
+      );
+
+      return thunk(dispatch, getState).then(() => {
+        expect(global.fetch.args[0][0]).to.contain(
+          '/v0/disability_compensation_in_progress_forms/21-526EZ',
         );
       });
     });

--- a/src/platform/forms/tests/save-in-progress/actions.unit.spec.js
+++ b/src/platform/forms/tests/save-in-progress/actions.unit.spec.js
@@ -166,7 +166,7 @@ describe('Schemaform save / load actions:', () => {
           done(err);
         });
     });
-    it('calls the disability compensation api to save the form', done => {
+    it('calls the Form 526-specific api to save the form', done => {
       const thunk = saveAndRedirectToReturnUrl(VA_FORM_IDS.FORM_21_526EZ, {});
       const dispatch = sinon.spy();
 
@@ -321,7 +321,7 @@ describe('Schemaform save / load actions:', () => {
         Promise.resolve({
           ok: true,
           json: () => ({
-            formData: { field: 'foo' }, // eslint-disable-line camelcase
+            formData: { field: 'foo' },
             metadata: {
               version: 0,
             },
@@ -335,14 +335,14 @@ describe('Schemaform save / load actions:', () => {
         );
       });
     });
-    it('dispatches a success if the form is loaded', () => {
+    it('dispatches a success from the form 526-specific api on form load', () => {
       const thunk = fetchInProgressForm(VA_FORM_IDS.FORM_21_526EZ, {});
       const dispatch = sinon.spy();
       global.fetch.returns(
         Promise.resolve({
           ok: true,
           json: () => ({
-            formData: { field: 'foo' }, // eslint-disable-line camelcase
+            formData: { field: 'foo' },
             metadata: {
               version: 0,
             },


### PR DESCRIPTION
## Description

Form 526 has a new save-in-progress endpoint - [`/v0/disability_compensation_in_progress_forms/`](https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/api-reference/#/in_progress_forms/getInProgressForm1) which behaves almost exactly like the original `/v0/in_progress_forms/` endpoint except that it dynamically updates the `ratedDisabilities` values to provide the most up-to-date values. Additionally, when the `ratedDisabilities` values change, a `ratedDisabilitiesUpdated: true` flag is added to the metadata and the user is returned to the rated disability page of the form (in the metadata `returnUrl`). 

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/13128#issuecomment-763838119
- BE: https://github.com/department-of-veterans-affairs/vets-api/pull/5717
- Swagger: https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/api-reference/#/in_progress_forms/getInProgressForm1

## Testing done

Updated unit tests
Updated 526 Cypress tests

## Screenshots

N/A

## Acceptance criteria
- [x] Switch 526 save-in-progress to new API endpoint
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
