### PR TITLE
Fix unique id issue on provider selection

### DIFF
--- a/src/applications/vaos/services/location/transformers.js
+++ b/src/applications/vaos/services/location/transformers.js
@@ -331,7 +331,13 @@ export function transformFacilities(facilities) {
 export function transformCommunityProviders(providers) {
   return providers.map(provider => {
     return {
-      id: provider.uniqueId,
+      id: provider.id,
+      identifier: [
+        {
+          system: 'PPMS',
+          value: provider.uniqueId,
+        },
+      ],
       resourceType: 'Location',
       address: {
         line: [provider.address.street],

--- a/src/applications/vaos/services/mocks/var/cc_providers.json
+++ b/src/applications/vaos/services/mocks/var/cc_providers.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "id": "1497723753",
+      "id": "34234234-34234",
       "type": "provider",
       "attributes": {
         "accNewPatients": "true",

--- a/src/applications/vaos/tests/services/location/index.unit.spec.js
+++ b/src/applications/vaos/tests/services/location/index.unit.spec.js
@@ -297,7 +297,7 @@ describe('VAOS Location service', () => {
       const firstProvider = ccProviders.data[0];
       const firstLocation = data[0];
       expect(firstLocation.name).to.equal(firstProvider.attributes.name);
-      expect(firstLocation.id).to.equal(firstProvider.attributes.uniqueId);
+      expect(firstLocation.id).to.equal(firstProvider.id);
       expect(firstLocation.telecom[0].value).to.equal(
         firstProvider.attributes.caresitePhone,
       );


### PR DESCRIPTION
## Description
The `uniqueId` field in the provider data is not actually unique, it turns out, so we need to use something else as the value for the radio buttons, otherwise we can't correctly tell which provider is selected.

## Testing done
Local testing

## Acceptance criteria
- [ ] Provider selection works correctly with duplicate uniqueId values

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
