### PR TITLE
Add miles helper text on selected state

### DIFF
--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
@@ -158,7 +158,13 @@ function ProviderSelectionField({
               {formData.address?.postalCode}
             </span>
             <span className="vads-u-display--block vads-u-font-size--sm vads-u-font-weight--bold">
-              {formData[sortMethod]} miles
+              {formData[sortMethod]} miles{' '}
+              <span className="sr-only">
+                {sortMethod ===
+                FACILITY_SORT_METHODS.distanceFromCurrentLocation
+                  ? 'from your current location'
+                  : 'from your home address'}
+              </span>
             </span>
             <div className="vads-u-display--flex">
               <button


### PR DESCRIPTION
## Description
This PR
- Adds screen reader only text after the distance value on the selected provider state, similar to the distance on the list

## Testing done
Local testing

## Acceptance criteria
- [ ] Text appears correctly

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
