### PR TITLE
Override Medallia CSS to show close button (x icon) on mobile browsers

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-medallia.scss
+++ b/src/platform/site-wide/sass/modules/_m-medallia.scss
@@ -65,3 +65,41 @@
 .ng-scope .panel-footer-web {
   padding-bottom: 1rem;
 }
+
+/* CSS Overrides for the 3-question survey on /find-locations */
+
+/* An excessively specific selector is needed to override !important and inline styles */
+/* The `ng-hide` class only seems to be used in mobile browsers/emulators, but not laptop browsers */
+#liveForm > div > div.row.neb-form-close-btn-container.ng-hide {
+  /* `display: block !important;` is necessary because the `ng-hide` class applies `display: block !important` */
+  display: block !important;
+  /* `margin-top: 0px !important;` is necessary because this element has an inline style of `margin-top: -50px;` */
+  margin-top: 0px !important;
+  /* `font-size: 14px !important;` is necessary because this element has an inline style of `font-size: 35px;` */
+  font-size: 14px !important;
+
+  /* Add `position: relative;` so `position: absolute;` can be applied to the child `button` element */
+  position: relative;
+}
+
+/* The `ng-hide` class only seems to be used in mobile browsers/emulators, but not laptop browsers */
+/* I tried `#liveForm > div > div.neb-show-button-as-link.neb-form-close-btn.pull-right`, but it didn't work */
+/* The intermediary child div selectors seem necessary to reach sufficient specificity */
+#liveForm
+  > div
+  > div.neb-form-close-btn-container.ng-hide
+  > div
+  > button.neb-show-button-as-link {
+  /* Position this button absolutely relative to the `div.row.neb-form-close-btn-container.ng-hide` element */
+  position: absolute;
+
+  /* Give some breathing room above the X-icon */
+  top: 8px;
+
+  /* Give some breathing room to the right of the X-icon */
+  right: calc(0px + 24px);
+
+  /* https://css-tricks.com/rational-z-index-values/ */
+  /* Add `z-index: 100;` to make sure the button is clickable */
+  z-index: 100;
+}

--- a/src/platform/site-wide/sass/modules/_m-medallia.scss
+++ b/src/platform/site-wide/sass/modules/_m-medallia.scss
@@ -63,7 +63,7 @@
 /* An excessively specific selector is needed to override !important and inline styles */
 /* The `ng-hide` class only seems to be used in mobile browsers/emulators, but not laptop browsers */
 #liveForm > div > div.row.neb-form-close-btn-container.ng-hide {
-  /* `display: block !important;` is necessary because the `ng-hide` class applies `display: block !important` */
+  /* `display: block !important;` is necessary because the `ng-hide` class applies `display: none !important` */
   display: block !important;
   /* `margin-top: 0px !important;` is necessary because this element has an inline style of `margin-top: -50px;` */
   margin-top: 0px !important;

--- a/src/platform/site-wide/sass/modules/_m-medallia.scss
+++ b/src/platform/site-wide/sass/modules/_m-medallia.scss
@@ -95,3 +95,12 @@
   /* Add `z-index: 100;` to make sure the button is clickable */
   z-index: 100;
 }
+
+/* https://github.com/department-of-veterans-affairs/va.gov-team/issues/18706#issuecomment-769341669 */
+.neb-component
+  .neb-content
+  .neb-native-radio
+  input[type="radio"].wcag-radio-border:focus {
+  border: 2px solid rgb(249, 198, 66) !important;
+  padding: 1px !important;
+}

--- a/src/platform/site-wide/sass/modules/_m-medallia.scss
+++ b/src/platform/site-wide/sass/modules/_m-medallia.scss
@@ -52,14 +52,6 @@
   width: 50px;
 }
 
-/* Hide Powered By Medallia and/or footer containing Powered By Medallia */
-/* Intro page of Medallia survey visible on https://staging.va.gov/find-locations/facility/vha_691 */
-/* `.ng-scope .kpl-form-footer` is common to multiple Medallia forms and form pages */
-.ng-scope .kpl-form-footer,
-.ng-scope .footerCls {
-  display: none;
-}
-
 /* Add padding to the bottom of the Medallia form */
 /* `.ng-scope .panel-footer-web` is common to multiple Medallia forms and form pages */
 .ng-scope .panel-footer-web {


### PR DESCRIPTION
## GitHub Issue

https://github.com/department-of-veterans-affairs/va.gov-team/issues/18706

## Description

This PR does the following:

- Fix 508 blocker (invisible close button) on 3-question Medallia survey on [`/find-locations`](https://staging.va.gov/find-locations)
- Update focus style of radio elements
- Remove `display: none` that was allowing focus to get trapped behind the modal

## Testing done

Local CSS overrides

## Screenshots

### Mobile emulator

#### X-icon is not focused

![image](https://user-images.githubusercontent.com/6130520/108033683-fe5d4f80-6ff9-11eb-83a3-0bb093f61ee4.png)

#### X-icon is focused 

![image](https://user-images.githubusercontent.com/6130520/108033303-695a5680-6ff9-11eb-8b49-0397b7f72c41.png)

### Mobile-sized Chrome window

![image](https://user-images.githubusercontent.com/6130520/108033531-bd653b00-6ff9-11eb-9026-7560d65a492b.png)

### Tablet-sized Chrome window

![image](https://user-images.githubusercontent.com/6130520/108033557-c9e99380-6ff9-11eb-9b43-09319b8833be.png)

### Desktop-sized Chrome window

![image](https://user-images.githubusercontent.com/6130520/108033595-d837af80-6ff9-11eb-96a8-9a99ec60d3ca.png)

## Fixed focus styles & focus trap

![medallia-radio-focus-styles-and-fixed-focus-trap](https://user-images.githubusercontent.com/6130520/108111639-9559f400-705a-11eb-88a0-cd36e05888d0.gif)

## Acceptance criteria
- [ ] Close button (X-icon) is visible on mobile browsers

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)

## Links

- [Notes from before writing the code](https://github.com/department-of-veterans-affairs/va.gov-team/issues/18706#issuecomment-779547388)
- [Notes from after writing the code](https://github.com/department-of-veterans-affairs/va.gov-team/issues/18706#issuecomment-779655765)
- [Chrome Local Overrides](https://www.trysmudford.com/blog/chrome-local-overrides/)
- [Rational `z-index` Values](https://css-tricks.com/rational-z-index-values/)