### PR TITLE
fix tag variable names

### DIFF
--- a/src/applications/gi/components/profile/HeadingSummary.jsx
+++ b/src/applications/gi/components/profile/HeadingSummary.jsx
@@ -166,10 +166,10 @@ class HeadingSummary extends React.Component {
               <ScorecardTags
                 styling="info-flag"
                 it={this.props.institution}
-                menOnly={this.props.institution.menOnly}
-                womenOnly={this.props.institution.womenOnly}
+                menOnly={this.props.institution.menonly}
+                womenOnly={this.props.institution.womenonly}
                 hbcu={this.props.institution.hbcu}
-                relAffil={this.props.institution.relAffil}
+                relAffil={this.props.institution.relaffil}
               />
             </div>
           </div>


### PR DESCRIPTION
## Description
The 'Women only' tag on the Spelman College card displays in the search results but not on the school profile page.
https://github.com/department-of-veterans-affairs/va.gov-team/issues/19907

## Testing done
- [ ] local testing complete

## Screenshots
![Screen Shot 2021-02-16 at 11 10 09 AM](https://user-images.githubusercontent.com/45575003/108089664-dbf22300-7047-11eb-9f79-59d48d9f4601.png)


## Acceptance criteria
- [ ] 'Women only' tag displays on the school profile page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
