### PR TITLE
Remove conditional for displaying reason text box

### DIFF
--- a/src/applications/vaos/new-appointment/components/ReasonForAppointmentPage.jsx
+++ b/src/applications/vaos/new-appointment/components/ReasonForAppointmentPage.jsx
@@ -50,8 +50,6 @@ const uiSchema = {
       'ui:widget': TextareaWidget,
       'ui:options': {
         rows: 5,
-        expandUnder: 'reasonForAppointment',
-        expandUnderCondition: reasonForAppointment => !!reasonForAppointment,
       },
       'ui:validations': [validateWhiteSpace],
     },

--- a/src/applications/vaos/tests/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
@@ -84,9 +84,9 @@ describe('VAOS integration: reason for appointment page with a single-site user'
 
     await screen.findByLabelText(/Routine or follow-up visit/i);
     fireEvent.click(screen.getByText(/Continue/));
-    expect(await screen.findByRole('alert')).to.contain.text(
-      'Please provide a response',
-    );
+
+    const alerts = await screen.findAllByRole('alert');
+    expect(alerts[0]).to.contain.text('Please provide a response');
   });
 
   it('should show error msg when enter all spaces for VA medical request', async () => {
@@ -103,9 +103,9 @@ describe('VAOS integration: reason for appointment page with a single-site user'
     expect(textBox.value).to.equal('   ');
     fireEvent.click(screen.getByText(/Continue/));
 
-    const alerts = await screen.findAllByRole('alert');
-    expect(alerts[0]).to.contain.text('Please provide a response');
-    expect(alerts[1]).to.contain.text('Please provide a response');
+    expect(await screen.findByRole('alert')).to.contain.text(
+      'Please provide a response',
+    );
   });
 
   it('should show alternate textbox char length if navigated via direct schedule flow', async () => {

--- a/src/applications/vaos/tests/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
@@ -103,9 +103,9 @@ describe('VAOS integration: reason for appointment page with a single-site user'
     expect(textBox.value).to.equal('   ');
     fireEvent.click(screen.getByText(/Continue/));
 
-    expect(await screen.findByRole('alert')).to.contain.text(
-      'Please provide a response',
-    );
+    const alerts = await screen.findAllByRole('alert');
+    expect(alerts[0]).to.contain.text('Please provide a response');
+    expect(alerts[1]).to.contain.text('Please provide a response');
   });
 
   it('should show alternate textbox char length if navigated via direct schedule flow', async () => {

--- a/src/applications/vaos/tests/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
@@ -28,7 +28,7 @@ const initialState = {
   },
 };
 
-describe('VAOS integration: reason for appointment page with a single-site user', () => {
+describe('VAOS <ReasonForAppointmentPage>', () => {
   beforeEach(() => mockFetch());
   afterEach(() => resetFetch());
 


### PR DESCRIPTION
## Description
This PR
- Removes the expand under condition for the reason for appt text box, so it always displays
- Fixes the CommunityCareLanguagePage tests so that they actually test the language page
  - Not sure how this slipped through, but I noticed it because I caused a failing test in them and realized they were a copy of the reason for appointment page tests

## Testing done
Local and unit testing

## Screenshots
![Screen Shot 2021-02-16 at 10 58 03 AM](https://user-images.githubusercontent.com/634932/108092482-c7635a00-704a-11eb-87d3-38097554ce74.png)


## Acceptance criteria
- [ ] Reason text box always displays on page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
