### PR TITLE
Kelsonic 16749 clp analytics

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -620,38 +620,17 @@ module.exports = function registerFilters() {
     fieldClpFaqPanel,
     fieldBenefitCategories,
   ) => {
-    // Start total sections as max number.
-    let clpTotalSections = maxSections;
+    const removedSectionsCount = [
+      fieldClpVideoPanel,
+      fieldClpSpotlightPanel,
+      fieldClpStoriesPanel,
+      fieldClpResourcesPanel,
+      fieldClpEventsPanel,
+      fieldClpFaqPanel,
+      !_.isEmpty(fieldBenefitCategories),
+    ].filter(panel => !panel).length;
 
-    if (!fieldClpVideoPanel) {
-      clpTotalSections -= 1;
-    }
-
-    if (!fieldClpSpotlightPanel) {
-      clpTotalSections -= 1;
-    }
-
-    if (!fieldClpStoriesPanel) {
-      clpTotalSections -= 1;
-    }
-
-    if (!fieldClpResourcesPanel) {
-      clpTotalSections -= 1;
-    }
-
-    if (!fieldClpEventsPanel) {
-      clpTotalSections -= 1;
-    }
-
-    if (!fieldClpFaqPanel) {
-      clpTotalSections -= 1;
-    }
-
-    if (_.isEmpty(fieldBenefitCategories)) {
-      clpTotalSections -= 1;
-    }
-
-    return clpTotalSections;
+    return maxSections - removedSectionsCount;
   };
 
   liquid.filters.formatSeconds = rawSeconds => {

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -610,6 +610,50 @@ module.exports = function registerFilters() {
     return _.replace(url, 'youtu.be', 'youtube.com/embed');
   };
 
+  liquid.filters.deriveCLPTotalSections = (
+    maxSections,
+    fieldClpVideoPanel,
+    fieldClpSpotlightPanel,
+    fieldClpStoriesPanel,
+    fieldClpResourcesPanel,
+    fieldClpEventsPanel,
+    fieldClpFaqPanel,
+    fieldBenefitCategories,
+  ) => {
+    // Start total sections as max number.
+    let clpTotalSections = maxSections;
+
+    if (!fieldClpVideoPanel) {
+      clpTotalSections -= 1;
+    }
+
+    if (!fieldClpSpotlightPanel) {
+      clpTotalSections -= 1;
+    }
+
+    if (!fieldClpStoriesPanel) {
+      clpTotalSections -= 1;
+    }
+
+    if (!fieldClpResourcesPanel) {
+      clpTotalSections -= 1;
+    }
+
+    if (!fieldClpEventsPanel) {
+      clpTotalSections -= 1;
+    }
+
+    if (!fieldClpFaqPanel) {
+      clpTotalSections -= 1;
+    }
+
+    if (_.isEmpty(fieldBenefitCategories)) {
+      clpTotalSections -= 1;
+    }
+
+    return clpTotalSections;
+  };
+
   liquid.filters.formatSeconds = rawSeconds => {
     // Dates need milliseconds, so mulitply by 1000.
     const date = new Date(rawSeconds * 1000);

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -156,6 +156,38 @@ describe('deriveLastBreadcrumbFromPath', () => {
   });
 });
 
+describe('deriveCLPTotalSections', () => {
+  it('returns back max sections when everything is rendered', () => {
+    expect(
+      liquid.filters.deriveCLPTotalSections(
+        11,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        ['category'],
+      ),
+    ).to.eq(11);
+  });
+
+  it('returns back the correct section count when sections are not rendered', () => {
+    expect(
+      liquid.filters.deriveCLPTotalSections(
+        11,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        [],
+      ),
+    ).to.eq(4);
+  });
+});
+
 describe('formatSeconds', () => {
   it('returns hours when needed', () => {
     expect(liquid.filters.formatSeconds(65245)).to.eq('18:7:25 hours');

--- a/src/site/includes/social-share.drupal.liquid
+++ b/src/site/includes/social-share.drupal.liquid
@@ -7,18 +7,18 @@
   <ul class="usa-unstyled-list">
     <li class="vads-u-margin-bottom--2p5">
       <a href="{{ entityUrl.path }}" id="add-to-calendar-link" data-start="{{fieldDatetimeRangeTimezone.value }}" data-end="{{fieldDatetimeRangeTimezone.endTime}}" data-location="{{fieldAddress.addressLine1}} {{fieldAddress.locality}}, {{fieldAddress.administrativeArea}}" data-subject="{{ title }}" data-description="{{fieldDescription}}">
-        <i class="va-c-social-icon fas fa-calendar-check vads-u-margin-right--0p5" aria-hidden="true"></i>Add to Calendar</a>
+        <i class="va-c-social-icon fas fa-calendar-check vads-u-margin-right--0p5" aria-hidden="true" role="presentation" aria-hidden="true"></i>Add to Calendar</a>
     </li>
 
     <li class="vads-u-margin-bottom--2p5">
       <a class="va-js-share-link" href="https://www.facebook.com/sharer/sharer.php?href={{ hostUrl }}{{ entityUrl.path }}">
-        <i class="va-c-social-icon fab fa-facebook vads-u-margin-right--0p5"></i>Share on Facebook
+        <i class="va-c-social-icon fab fa-facebook vads-u-margin-right--0p5" role="presentation" aria-hidden="true"></i>Share on Facebook
       </a>
     </li>
 
     <li>
       <a class="va-js-share-link" href="https://twitter.com/intent/tweet?text={{ title }}&url={{ hostUrl }}{{ entityUrl.path }}">
-        <i class="va-c-social-icon fab fa-twitter vads-u-margin-right--0p5"></i>Share on Twitter
+        <i class="va-c-social-icon fab fa-twitter vads-u-margin-right--0p5" role="presentation" aria-hidden="true"></i>Share on Twitter
       </a>
     </li>
   </ul>

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -74,13 +74,13 @@
                 <ul class="usa-unstyled-list">
                   <li class="vads-u-margin-bottom--2p5">
                     <a class="va-js-share-link" href="https://www.facebook.com/sharer/sharer.php?href={{ hostUrl }}{{ entityUrl.path }}">
-                      <i class="va-c-social-icon fab fa-facebook vads-u-margin-right--0p5"></i>Share on Facebook
+                      <i class="va-c-social-icon fab fa-facebook vads-u-margin-right--0p5" role="presentation" aria-hidden="true"></i>Share on Facebook
                     </a>
                   </li>
 
                   <li>
                     <a class="va-js-share-link" href="https://twitter.com/intent/tweet?text={{ title }}&url={{ hostUrl }}{{ entityUrl.path }}">
-                      <i class="va-c-social-icon fab fa-twitter vads-u-margin-right--0p5"></i>Share on Twitter
+                      <i class="va-c-social-icon fab fa-twitter vads-u-margin-right--0p5" role="presentation" aria-hidden="true"></i>Share on Twitter
                     </a>
                   </li>
                 </ul>

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -1,9 +1,8 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 
-{% comment %}
-  {% include "src/site/includes/breadcrumbs.drupal.liquid" with constructLcBreadcrumbs = true titleInclude = false %}
-{% endcomment %}
+<!-- Derive the total sections the page includes for analytics. -->
+{% assign clpTotalSections = 11 | deriveCLPTotalSections: fieldClpVideoPanel, fieldClpSpotlightPanel, fieldClpStoriesPanel, fieldClpResourcesPanel, fieldClpEventsPanel, fieldClpFaqPanel, fieldBenefitCategories %}
 
 <div id="content" class="interior" data-template="node-campaign_landing_page">
   <main class="va-l-detail-page va-alternating-background-color">
@@ -23,7 +22,7 @@
                 <a
                   class="usa-button usa-button-secondary va-u-box-shadow--none vads-u-margin-top--2 vads-u-background-color--white vads-u-border--0 vads-u-font-size--sm"
                   href="{{ fieldPrimaryCallToAction.entity.fieldButtonLink.url.path }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'hero', 'clp-section-title': '{{ title }}', 'clp-section-index': '0', 'clp-total-sections': '', 'clp-section-background-color': 'image', 'clp-click-label': '{{ fieldPrimaryCallToAction.entity.fieldButtonLabel }}' });"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'hero', 'clp-section-title': '{{ title }}', 'clp-section-index': '0', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': 'image', 'clp-click-label': '{{ fieldPrimaryCallToAction.entity.fieldButtonLabel }}' });"
                 >
                   {{ fieldPrimaryCallToAction.entity.fieldButtonLabel }}
                 </a>
@@ -47,7 +46,7 @@
               <a
                 class="usa-button usa-button-secondary vads-u-font-size--sm"
                 href="{{ fieldSecondaryCallToAction.entity.fieldButtonLink.url.path }}"
-                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Why this matters to you', 'clp-section-title': '{{ fieldClpWhyThisMatters }}', 'clp-section-index': '1', 'clp-total-sections': '', 'clp-section-background-color': 'primary-alt-lightest', 'clp-click-label': '{{ fieldSecondaryCallToAction.entity.fieldButtonLabel }}' });"
+                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Why this matters to you', 'clp-section-title': '{{ fieldClpWhyThisMatters }}', 'clp-section-index': '1', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': 'primary-alt-lightest', 'clp-click-label': '{{ fieldSecondaryCallToAction.entity.fieldButtonLabel }}' });"
               >
                 {{ fieldSecondaryCallToAction.entity.fieldButtonLabel }}
               </a>
@@ -94,7 +93,7 @@
             <div class="vads-u-background-color--gray-light-alt vads-u-height--full medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
               <img alt="{{ promo.entity.fieldImage.entity.thumbnail.alt }}" src="{{ promo.entity.fieldImage.entity.thumbnail.url }}" />
               <h3 class="vads-u-padding-x--2">
-                <a onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'What you can do', 'clp-section-title': '{{ fieldClpWhatYouCanDoHeader }}', 'clp-section-index': '2', 'clp-total-sections': '', 'clp-section-background-color': 'white', 'clp-click-label': '{{ promo.entity.fieldPromoLink.entity.fieldLink.title }}' });" href="{{ promo.entity.fieldPromoLink.entity.fieldLink.uri }}">
+                <a onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'What you can do', 'clp-section-title': '{{ fieldClpWhatYouCanDoHeader }}', 'clp-section-index': '2', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': 'white', 'clp-click-label': '{{ promo.entity.fieldPromoLink.entity.fieldLink.title }}' });" href="{{ promo.entity.fieldPromoLink.entity.fieldLink.uri }}">
                   {{ promo.entity.fieldPromoLink.entity.fieldLink.title }}
                 </a>
               </h3>
@@ -154,7 +153,7 @@
                 <a
                   class="vads-u-margin-top--4 usa-button usa-button-secondary vads-u-font-size--sm"
                   href="{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLink.url.path }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Video', 'clp-section-title': '{{ fieldClpVideoPanelHeader }}', 'clp-section-index': '3', 'clp-total-sections': '', 'clp-section-background-color': 'blue', 'clp-click-label': '{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel }}' });"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Video', 'clp-section-title': '{{ fieldClpVideoPanelHeader }}', 'clp-section-index': '3', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': 'blue', 'clp-click-label': '{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel }}' });"
                 >
                   {{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel }}
                   <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
@@ -178,7 +177,7 @@
               {{ fieldClpSpotlightIntroText }}
               <a
                 href="{{ fieldClpSpotlightCta.entity.fieldButtonLink.url.path }}"
-                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Spotlight', 'clp-section-title': '{{ fieldClpSpotlightHeader }}', 'clp-section-index': {% if fieldClpVideoPanel %}'4'{% else %}'3'{% endif %}, 'clp-total-sections': '', 'clp-section-background-color': {% if fieldClpVideoPanel %}'white'{% else %}'blue'{% endif %}, 'clp-click-label': '{{ fieldClpSpotlightCta.entity.fieldButtonLabel }}'"
+                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Spotlight', 'clp-section-title': '{{ fieldClpSpotlightHeader }}', 'clp-section-index': {% if fieldClpVideoPanel %}'4'{% else %}'3'{% endif %}, 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': {% if fieldClpVideoPanel %}'white'{% else %}'blue'{% endif %}, 'clp-click-label': '{{ fieldClpSpotlightCta.entity.fieldButtonLabel }}'"
               >
                 {{ fieldClpSpotlightCta.entity.fieldButtonLabel }}
               </a>
@@ -193,7 +192,7 @@
                   <h3 class="vads-u-margin-top--0">
                     <a
                       href="{{ linkTeaser.entity.fieldLink.uri }}"
-                      onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Spotlight', 'clp-section-title': '{{ fieldClpSpotlightHeader }}', 'clp-section-index': {% if fieldClpVideoPanel %}'4'{% else %}'3'{% endif %}, 'clp-total-sections': '', 'clp-section-background-color': {% if fieldClpVideoPanel %}'white'{% else %}'blue'{% endif %}, 'clp-click-label': '{{ linkTeaser.entity.fieldLink.title }}'"
+                      onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Spotlight', 'clp-section-title': '{{ fieldClpSpotlightHeader }}', 'clp-section-index': {% if fieldClpVideoPanel %}'4'{% else %}'3'{% endif %}, 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': {% if fieldClpVideoPanel %}'white'{% else %}'blue'{% endif %}, 'clp-click-label': '{{ linkTeaser.entity.fieldLink.title }}'"
                     >
                       {{ linkTeaser.entity.fieldLink.title }}
                     </a>
@@ -230,7 +229,7 @@
                         <h3 class="vads-u-margin-top--0">
                           <a
                             href="{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.uri }}"
-                            onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Stories', 'clp-section-title': '{{ fieldClpStoriesHeader }}', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.title }}' });"
+                            onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Stories', 'clp-section-title': '{{ fieldClpStoriesHeader }}', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.title }}' });"
                           >
                             {{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.title }}
                           </a>
@@ -247,7 +246,7 @@
                 <a
                   class="usa-button usa-button-secondary vads-u-font-size--sm"
                   href="{{ fieldClpStoriesCta.entity.fieldButtonLink.url }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Stories', 'clp-section-title': '{{ fieldClpStoriesHeader }}', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpStoriesCta.entity.fieldButtonLabel }}' });"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Stories', 'clp-section-title': '{{ fieldClpStoriesHeader }}', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpStoriesCta.entity.fieldButtonLabel }}' });"
                   rel="noreferrer noopener"
                   target="_blank"
                 >
@@ -284,7 +283,7 @@
                   <a
                     download
                     href="{{ resource.entity.fieldMediaExternalFile.url }}"
-                    onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Downloadable resources', 'clp-section-title': '{{ fieldClpResourcesHeader }}', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '' });"
+                    onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Downloadable resources', 'clp-section-title': '{{ fieldClpResourcesHeader }}', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '' });"
                   >
                     Download (PDF)
                   </a>
@@ -300,7 +299,7 @@
               <a
                 class="usa-button usa-button-secondary vads-u-font-size--sm"
                 href="{{ fieldClpResourcesCta.entity.fieldButtonLink.url.path }}"
-                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Downloadable resources', 'clp-section-title': '{{ fieldClpResourcesHeader }}', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpResourcesCta.entity.fieldButtonLabel }}' });"
+                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Downloadable resources', 'clp-section-title': '{{ fieldClpResourcesHeader }}', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpResourcesCta.entity.fieldButtonLabel }}' });"
               >
                 {{ fieldClpResourcesCta.entity.fieldButtonLabel }}
                 <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
@@ -335,7 +334,7 @@
                   <h3 class="vads-u-margin-top--0">
                     <a
                       href="{{ eventReference.entity.fieldLink.url }}"
-                      onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader }}', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ eventReference.entity.title }}' });"
+                      onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader }}', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ eventReference.entity.title }}' });"
                     >
                       {{ eventReference.entity.title }}
                     </a>
@@ -369,7 +368,7 @@
                         {% if eventReference.entity.fieldFacilityLocation.entity.entityUrl.path %}
                           <a
                             href="{{ eventReference.entity.fieldFacilityLocation.entity.entityUrl.path }}"
-                            onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader }}', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ eventReference.entity.fieldFacilityLocation.entity.title }}' });"
+                            onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader }}', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ eventReference.entity.fieldFacilityLocation.entity.title }}' });"
                             rel="noreferrer noopener"
                             target="_blank"
                           >
@@ -380,7 +379,7 @@
                         {% if eventReference.entity.fieldLink.uri %}
                           <a
                             href="{{ eventReference.entity.fieldLink.uri }}"
-                            onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader }}', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ eventReference.entity.fieldEventCta }}' });"
+                            onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader }}', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ eventReference.entity.fieldEventCta }}' });"
                             rel="noreferrer noopener"
                             target="_blank"
                           >
@@ -440,7 +439,7 @@
               <a
                 class="usa-button usa-button-secondary vads-u-font-size--sm"
                 href="{{ fieldClpFaqCta.entity.fieldButtonLink.url.path }}"
-                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'FAQ', 'clp-section-title': 'Frequently asked questions', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpFaqCta.entity.fieldButtonLabel }}' });"
+                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'FAQ', 'clp-section-title': 'Frequently asked questions', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpFaqCta.entity.fieldButtonLabel }}' });"
               >
                 {{ fieldClpFaqCta.entity.fieldButtonLabel }}
                 <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
@@ -472,7 +471,7 @@
                 <a
                   aria-label="{{ fieldClpConnectWithUs.entity.fieldEmailUpdatesLinkText }} (opens in a new window)"
                   href="{{ fieldClpConnectWithUs.entity.fieldEmailUpdatesUrl }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.fieldEmailUpdatesLinkText }}' });"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.fieldEmailUpdatesLinkText }}' });"
                   rel="noreferrer noopener"
                   target="_blank"
                 >
@@ -489,7 +488,7 @@
                 <a
                   aria-label="{{ fieldClpConnectWithUs.entity.name }} Twitter (opens in a new window)"
                   href="https://twitter.com/{{ socialLinksObject.twitter.value }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} Twitter' });"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} Twitter' });"
                   rel="noreferrer noopener"
                   target="_blank"
                 >
@@ -506,7 +505,7 @@
                 <a
                   aria-label="{{ fieldClpConnectWithUs.entity.name }} Facebook (opens in a new window)"
                   href="https://facebook.com/{{ socialLinksObject.facebook.value }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} Facebook' });"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} Facebook' });"
                   rel="noreferrer noopener"
                   target="_blank"
                 >
@@ -523,7 +522,7 @@
                 <a
                   aria-label="{{ fieldClpConnectWithUs.entity.name }} YouTube (opens in a new window)"
                   href="https://youtube.com/channel/{{ socialLinksObject.youtube.value }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} YouTube' });"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} YouTube' });"
                   rel="noreferrer noopener"
                   target="_blank"
                 >
@@ -540,7 +539,7 @@
                 <a
                   aria-label="{{ fieldClpConnectWithUs.entity.name }} Linkedin (opens in a new window)"
                   href="https://linkedin.com/{{ socialLinksObject.linkedin.value }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} Linkedin' });"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} Linkedin' });"
                   rel="noreferrer noopener"
                   target="_blank"
                 >
@@ -557,7 +556,7 @@
                 <a
                   aria-label="{{ fieldClpConnectWithUs.entity.name }} Instagram (opens in a new window)"
                   href="https://instagram.com/{{ socialLinksObject.instagram.value }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} Instagram' });"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} Instagram' });"
                   rel="noreferrer noopener"
                   target="_blank"
                 >
@@ -592,7 +591,7 @@
                     <i class="icon-large white hub-icon-{{ benefitCategory.entity.fieldTitleIcon }} hub-background-{{ benefitCategory.entity.fieldTitleIcon }}" role="presentation" aria-hidden="true"></i>
                   </div>
                   <a
-                    onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'VA Benefits', 'clp-section-title': 'Learn more about related VA benefits', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ benefitCategory.entity.title }}' });"
+                    onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'VA Benefits', 'clp-section-title': 'Learn more about related VA benefits', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ benefitCategory.entity.title }}' });"
                     href="{{ benefitCategory.entity.entityUrl.path }}"
                   >
                     {{ benefitCategory.entity.title }}

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -22,7 +22,9 @@
               {% if fieldPrimaryCallToAction %}
                 <a
                   class="usa-button usa-button-secondary va-u-box-shadow--none vads-u-margin-top--2 vads-u-background-color--white vads-u-border--0 vads-u-font-size--sm"
-                  href="{{ fieldPrimaryCallToAction.entity.fieldButtonLink.url.path }}">
+                  href="{{ fieldPrimaryCallToAction.entity.fieldButtonLink.url.path }}"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'hero', 'clp-section-title': '{{ title }}', 'clp-section-index': '0', 'clp-total-sections': '', 'clp-section-background-color': 'image', 'clp-click-label': '{{ fieldPrimaryCallToAction.entity.fieldButtonLabel }}' });"
+                >
                   {{ fieldPrimaryCallToAction.entity.fieldButtonLabel }}
                 </a>
               {% endif %}
@@ -42,7 +44,11 @@
             <h2 class="vads-u-margin--0 vads-u-margin-bottom--2">Why this matters to you</h2>
             <p class="va-introtext vads-u-margin-top--0 vads-u-margin-bottom--2">{{ fieldClpWhyThisMatters }}</p>
             {% if fieldSecondaryCallToAction %}
-              <a class="usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldSecondaryCallToAction.entity.fieldButtonLink.url.path }}">
+              <a
+                class="usa-button usa-button-secondary vads-u-font-size--sm"
+                href="{{ fieldSecondaryCallToAction.entity.fieldButtonLink.url.path }}"
+                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Why this matters to you', 'clp-section-title': '{{ fieldClpWhyThisMatters }}', 'clp-section-index': '1', 'clp-total-sections': '', 'clp-section-background-color': 'primary-alt-lightest', 'clp-click-label': '{{ fieldSecondaryCallToAction.entity.fieldButtonLabel }}' });"
+              >
                 {{ fieldSecondaryCallToAction.entity.fieldButtonLabel }}
               </a>
             {% endif %}
@@ -88,7 +94,7 @@
             <div class="vads-u-background-color--gray-light-alt vads-u-height--full medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
               <img alt="{{ promo.entity.fieldImage.entity.thumbnail.alt }}" src="{{ promo.entity.fieldImage.entity.thumbnail.url }}" />
               <h3 class="vads-u-padding-x--2">
-                <a href="{{ promo.entity.fieldPromoLink.entity.fieldLink.uri }}">
+                <a onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'What you can do', 'clp-section-title': '{{ fieldClpWhatYouCanDoHeader }}', 'clp-section-index': '2', 'clp-total-sections': '', 'clp-section-background-color': 'white', 'clp-click-label': '{{ promo.entity.fieldPromoLink.entity.fieldLink.title }}' });" href="{{ promo.entity.fieldPromoLink.entity.fieldLink.uri }}">
                   {{ promo.entity.fieldPromoLink.entity.fieldLink.title }}
                 </a>
               </h3>
@@ -145,7 +151,11 @@
 
               <!-- Call to action -->
               {% if fieldClpVideoPanelMoreVideo %}
-                <a class="vads-u-margin-top--4 usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLink.url.path }}">
+                <a
+                  class="vads-u-margin-top--4 usa-button usa-button-secondary vads-u-font-size--sm"
+                  href="{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLink.url.path }}"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Video', 'clp-section-title': '{{ fieldClpVideoPanelHeader }}', 'clp-section-index': '3', 'clp-total-sections': '', 'clp-section-background-color': 'blue', 'clp-click-label': '{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel }}' });"
+                >
                   {{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel }}
                   <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
                 </a>
@@ -166,7 +176,10 @@
             <h2 class="vads-u-margin-top--0">{{ fieldClpSpotlightHeader }}</h2>
             <p class="va-introtext vads-u-margin-top--1 vads-u-margin-bottom--4">
               {{ fieldClpSpotlightIntroText }}
-              <a href="{{ fieldClpSpotlightCta.entity.fieldButtonLink.url.path }}">
+              <a
+                href="{{ fieldClpSpotlightCta.entity.fieldButtonLink.url.path }}"
+                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Spotlight', 'clp-section-title': '{{ fieldClpSpotlightHeader }}', 'clp-section-index': {% if fieldClpVideoPanel %}'4'{% else %}'3'{% endif %}, 'clp-total-sections': '', 'clp-section-background-color': {% if fieldClpVideoPanel %}'white'{% else %}'blue'{% endif %}, 'clp-click-label': '{{ fieldClpSpotlightCta.entity.fieldButtonLabel }}'"
+              >
                 {{ fieldClpSpotlightCta.entity.fieldButtonLabel }}
               </a>
             </p>
@@ -178,7 +191,10 @@
               <div class="vads-u-background-color--gray-light-alt vads-u-height--full medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
                 <div class="vads-u-padding--2">
                   <h3 class="vads-u-margin-top--0">
-                    <a href="{{ linkTeaser.entity.fieldLink.uri }}">
+                    <a
+                      href="{{ linkTeaser.entity.fieldLink.uri }}"
+                      onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Spotlight', 'clp-section-title': '{{ fieldClpSpotlightHeader }}', 'clp-section-index': {% if fieldClpVideoPanel %}'4'{% else %}'3'{% endif %}, 'clp-total-sections': '', 'clp-section-background-color': {% if fieldClpVideoPanel %}'white'{% else %}'blue'{% endif %}, 'clp-click-label': '{{ linkTeaser.entity.fieldLink.title }}'"
+                    >
                       {{ linkTeaser.entity.fieldLink.title }}
                     </a>
                   </h3>
@@ -212,7 +228,10 @@
                       <img alt="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.alt }}" class="vads-l-col--12 medium-screen:vads-l-col--4 medium-screen:vads-u-margin-right--2" src="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.url }}" />
                       <div class="vads-u-margin-top--2 medium-screen:vads-u-margin-top--0">
                         <h3 class="vads-u-margin-top--0">
-                          <a href="{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.uri }}">
+                          <a
+                            href="{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.uri }}"
+                            onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Stories', 'clp-section-title': '{{ fieldClpStoriesHeader }}', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.title }}' });"
+                          >
                             {{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.title }}
                           </a>
                         </h3>
@@ -225,7 +244,13 @@
 
               <!-- Call to action -->
               {% if fieldClpStoriesCta %}
-                <a class="usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldClpStoriesCta.entity.fieldButtonLink.url }}" rel="noreferrer noopener" target="_blank">
+                <a
+                  class="usa-button usa-button-secondary vads-u-font-size--sm"
+                  href="{{ fieldClpStoriesCta.entity.fieldButtonLink.url }}"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Stories', 'clp-section-title': '{{ fieldClpStoriesHeader }}', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpStoriesCta.entity.fieldButtonLabel }}' });"
+                  rel="noreferrer noopener"
+                  target="_blank"
+                >
                   {{ fieldClpStoriesCta.entity.fieldButtonLabel }}
                   <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
                 </a>
@@ -256,7 +281,13 @@
                 <div class="vads-u-padding--2">
                   <h3 class="vads-u-margin--0">{{ resource.entity.name }}</h3>
                   <p>{{ resource.entity.fieldDescription }}</p>
-                  <a href="{{ resource.entity.fieldMediaExternalFile.url }}" download>Download (PDF)</a>
+                  <a
+                    download
+                    href="{{ resource.entity.fieldMediaExternalFile.url }}"
+                    onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Downloadable resources', 'clp-section-title': '{{ fieldClpResourcesHeader }}', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '' });"
+                  >
+                    Download (PDF)
+                  </a>
                 </div>
               </div>
             </div>
@@ -266,7 +297,11 @@
         {% if fieldClpResourcesCta %}
           <div class="vads-l-row">
             <div class="vads-u-col--12">
-              <a class="usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldClpResourcesCta.entity.fieldButtonLink.url.path }}">
+              <a
+                class="usa-button usa-button-secondary vads-u-font-size--sm"
+                href="{{ fieldClpResourcesCta.entity.fieldButtonLink.url.path }}"
+                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Downloadable resources', 'clp-section-title': '{{ fieldClpResourcesHeader }}', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpResourcesCta.entity.fieldButtonLabel }}' });"
+              >
                 {{ fieldClpResourcesCta.entity.fieldButtonLabel }}
                 <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
               </a>
@@ -298,7 +333,10 @@
                 <div class="medium-screen:vads-u-margin-x--6">
                   <!-- Title -->
                   <h3 class="vads-u-margin-top--0">
-                    <a href="{{ eventReference.entity.fieldLink.url }}">
+                    <a
+                      href="{{ eventReference.entity.fieldLink.url }}"
+                      onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader }}', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ eventReference.entity.title }}' });"
+                    >
                       {{ eventReference.entity.title }}
                     </a>
                   </h3>
@@ -329,13 +367,23 @@
                       <!-- Event link -->
                       <div class="vads-u-display--flex vads-u-flex-direction--column">
                         {% if eventReference.entity.fieldFacilityLocation.entity.entityUrl.path %}
-                          <a href="{{ eventReference.entity.fieldFacilityLocation.entity.entityUrl.path }}" rel="noreferrer noopener" target="_blank">
+                          <a
+                            href="{{ eventReference.entity.fieldFacilityLocation.entity.entityUrl.path }}"
+                            onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader }}', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ eventReference.entity.fieldFacilityLocation.entity.title }}' });"
+                            rel="noreferrer noopener"
+                            target="_blank"
+                          >
                             {{ eventReference.entity.fieldFacilityLocation.entity.title }}
                           </a>
                         {% endif %}
 
                         {% if eventReference.entity.fieldLink.uri %}
-                          <a href="{{ eventReference.entity.fieldLink.uri }}" rel="noreferrer noopener" target="_blank">
+                          <a
+                            href="{{ eventReference.entity.fieldLink.uri }}"
+                            onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader }}', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ eventReference.entity.fieldEventCta }}' });"
+                            rel="noreferrer noopener"
+                            target="_blank"
+                          >
                             {{ eventReference.entity.fieldEventCta }}
                           </a>
                         {% endif %}
@@ -389,7 +437,11 @@
         {% if fieldClpFaqCta %}
           <div class="vads-l-row">
             <div class="vads-u-col--12">
-              <a class="usa-button usa-button-secondary vads-u-font-size--sm" href="{{ fieldClpFaqCta.entity.fieldButtonLink.url.path }}">
+              <a
+                class="usa-button usa-button-secondary vads-u-font-size--sm"
+                href="{{ fieldClpFaqCta.entity.fieldButtonLink.url.path }}"
+                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'FAQ', 'clp-section-title': 'Frequently asked questions', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpFaqCta.entity.fieldButtonLabel }}' });"
+              >
                 {{ fieldClpFaqCta.entity.fieldButtonLabel }}
                 <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
               </a>
@@ -409,7 +461,7 @@
           <div class="vads-l-col--12 medium-screen:vads-l-col--9">
             <!-- Title -->
             <p class="va-u-text-transform--uppercase vads-u-color--gray-medium vads-u-font-size--sm vads-u-margin-bottom--0">Connect with us</p>
-            <h2 class="vads-u-margin-top--0">Get updates from Veterans Health Administration</h2>
+            <h2 class="vads-u-margin-top--0">Get updates from {{ fieldClpConnectWithUs.entity.name }}</h2>
           </div>
         </div>
 
@@ -417,7 +469,13 @@
           {% if fieldClpConnectWithUs.entity.fieldEmailUpdatesUrl %}
             <div class="vads-l-col--12 medium-screen:vads-l-col--4">
               <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
-                <a aria-label="{{ fieldClpConnectWithUs.entity.fieldEmailUpdatesLinkText }} (opens in a new window)" href="{{ fieldClpConnectWithUs.entity.fieldEmailUpdatesUrl }}" rel="noreferrer noopener" target="_blank">
+                <a
+                  aria-label="{{ fieldClpConnectWithUs.entity.fieldEmailUpdatesLinkText }} (opens in a new window)"
+                  href="{{ fieldClpConnectWithUs.entity.fieldEmailUpdatesUrl }}"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.fieldEmailUpdatesLinkText }}' });"
+                  rel="noreferrer noopener"
+                  target="_blank"
+                >
                   <i aria-hidden="true" class="fas fa-envelope vads-u-padding-right--1"></i>
                   {{ fieldClpConnectWithUs.entity.fieldEmailUpdatesLinkText }}
                 </a>
@@ -428,7 +486,13 @@
           {% if socialLinksObject.twitter.value %}
             <div class="vads-l-col--12 medium-screen:vads-l-col--4">
               <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
-                <a aria-label="{{ fieldClpConnectWithUs.entity.name }} Twitter (opens in a new window)" href="https://twitter.com/{{ socialLinksObject.twitter.value }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" rel="noreferrer noopener" target="_blank">
+                <a
+                  aria-label="{{ fieldClpConnectWithUs.entity.name }} Twitter (opens in a new window)"
+                  href="https://twitter.com/{{ socialLinksObject.twitter.value }}"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} Twitter' });"
+                  rel="noreferrer noopener"
+                  target="_blank"
+                >
                   <i aria-hidden="true" class="fab fa-twitter vads-u-padding-right--1"></i>
                   {{ fieldClpConnectWithUs.entity.name }} Twitter
                 </a>
@@ -439,7 +503,13 @@
           {% if socialLinksObject.facebook.value %}
             <div class="vads-l-col--12 medium-screen:vads-l-col--4">
               <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
-                <a aria-label="{{ fieldClpConnectWithUs.entity.name }} Facebook (opens in a new window)" href="https://facebook.com/{{ socialLinksObject.facebook.value }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" rel="noreferrer noopener" target="_blank">
+                <a
+                  aria-label="{{ fieldClpConnectWithUs.entity.name }} Facebook (opens in a new window)"
+                  href="https://facebook.com/{{ socialLinksObject.facebook.value }}"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} Facebook' });"
+                  rel="noreferrer noopener"
+                  target="_blank"
+                >
                   <i aria-hidden="true" class="fab fa-facebook vads-u-padding-right--1"></i>
                   {{ fieldClpConnectWithUs.entity.name }} Facebook
                 </a>
@@ -450,7 +520,13 @@
           {% if socialLinksObject.youtube.value %}
             <div class="vads-l-col--12 medium-screen:vads-l-col--4">
               <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
-                <a aria-label="{{ fieldClpConnectWithUs.entity.name }} YouTube (opens in a new window)" href="https://youtube.com/channel/{{ socialLinksObject.youtube.value }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" rel="noreferrer noopener" target="_blank">
+                <a
+                  aria-label="{{ fieldClpConnectWithUs.entity.name }} YouTube (opens in a new window)"
+                  href="https://youtube.com/channel/{{ socialLinksObject.youtube.value }}"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} YouTube' });"
+                  rel="noreferrer noopener"
+                  target="_blank"
+                >
                   <i aria-hidden="true" class="fab fa-youtube vads-u-padding-right--1"></i>
                   {{ fieldClpConnectWithUs.entity.name }} YouTube
                 </a>
@@ -461,7 +537,13 @@
           {% if socialLinksObject.linkedin.value %}
             <div class="vads-l-col--12 medium-screen:vads-l-col--4">
               <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
-                <a aria-label="{{ fieldClpConnectWithUs.entity.name }} Linkedin (opens in a new window)" href="https://linkedin.com/{{ socialLinksObject.linkedin.value }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" rel="noreferrer noopener" target="_blank">
+                <a
+                  aria-label="{{ fieldClpConnectWithUs.entity.name }} Linkedin (opens in a new window)"
+                  href="https://linkedin.com/{{ socialLinksObject.linkedin.value }}"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} Linkedin' });"
+                  rel="noreferrer noopener"
+                  target="_blank"
+                >
                   <i aria-hidden="true" class="fab fa-linkedin vads-u-padding-right--1"></i>
                   {{ fieldClpConnectWithUs.entity.name }} Linkedin
                 </a>
@@ -472,7 +554,13 @@
           {% if socialLinksObject.instagram.value %}
             <div class="vads-l-col--12 medium-screen:vads-l-col--4">
               <div class="vads-u-margin-y--1 medium-screen:vads-u-margin-x--1">
-                <a aria-label="{{ fieldClpConnectWithUs.entity.name }} Instagram (opens in a new window)" href="https://instagram.com/{{ socialLinksObject.instagram.value }}" onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });" rel="noreferrer noopener" target="_blank">
+                <a
+                  aria-label="{{ fieldClpConnectWithUs.entity.name }} Instagram (opens in a new window)"
+                  href="https://instagram.com/{{ socialLinksObject.instagram.value }}"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} Instagram' });"
+                  rel="noreferrer noopener"
+                  target="_blank"
+                >
                   <i aria-hidden="true" class="fab fa-instagram vads-u-padding-right--1"></i>
                   {{ fieldClpConnectWithUs.entity.name }} Instagram
                 </a>
@@ -503,7 +591,12 @@
                   <div class="inline hub-main-icon vads-u-margin-right--2">
                     <i class="icon-large white hub-icon-{{ benefitCategory.entity.fieldTitleIcon }} hub-background-{{ benefitCategory.entity.fieldTitleIcon }}" role="presentation" aria-hidden="true"></i>
                   </div>
-                  <a href="{{ benefitCategory.entity.entityUrl.path }}">{{ benefitCategory.entity.title }}</a>
+                  <a
+                    onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'VA Benefits', 'clp-section-title': 'Learn more about related VA benefits', 'clp-section-index': '', 'clp-total-sections': '', 'clp-section-background-color': '', 'clp-click-label': '{{ benefitCategory.entity.title }}' });"
+                    href="{{ benefitCategory.entity.entityUrl.path }}"
+                  >
+                    {{ benefitCategory.entity.title }}
+                  </a>
                 </div>
                 <p class="vads-u-margin-top--0">{{ benefitCategory.entity.fieldIntroText }}</p>
               </div>

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -239,7 +239,13 @@
                 <div class="vads-u-display--flex vads-u-flex-direction--column">
                   {% for storyTeaser in fieldClpStoriesTeasers %}
                     <div class="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-margin-bottom--4">
-                      <img alt="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.alt }}" class="vads-l-col--12 medium-screen:vads-l-col--4 medium-screen:vads-u-margin-right--2" src="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.url }}" />
+                      {% if storyTeaser.entity.fieldMedia.entity.thumbnail.url %}
+                        <img
+                          alt="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.alt }}"
+                          class="vads-l-col--12 medium-screen:vads-l-col--4 medium-screen:vads-u-margin-right--2"
+                          src="{{ storyTeaser.entity.fieldMedia.entity.thumbnail.url }}"
+                        />
+                      {% endif %}
                       <div class="vads-u-margin-top--2 medium-screen:vads-u-margin-top--0">
                         <h3 class="vads-u-margin-top--0">
                           <a

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -7,7 +7,7 @@
 <div id="content" class="interior" data-template="node-campaign_landing_page">
   <main class="va-l-detail-page va-alternating-background-color">
 
-    <!-- HERO-->
+    <!-- Hero-->
     <div class="va-u-background--image" style="background-image: url('{{ fieldHeroImage.entity.image.url }}">
       <!-- Hero Content -->
       <div class="vads-l-grid-container vads-u-padding-x--0">
@@ -38,7 +38,7 @@
     <div>
       <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
         <div class="vads-l-row">
-          <!-- CONTENT -->
+          <!-- Content -->
           <div class="vads-l-col--12 medium-screen:vads-l-col--9">
             <h2 class="vads-u-margin--0 vads-u-margin-bottom--2">Why this matters to you</h2>
             <p class="va-introtext vads-u-margin-top--0 vads-u-margin-bottom--2">{{ fieldClpWhyThisMatters }}</p>
@@ -51,9 +51,9 @@
                 {{ fieldSecondaryCallToAction.entity.fieldButtonLabel }}
               </a>
             {% endif %}
-          </div><!-- /CONTENT -->
+          </div><!-- /Content -->
 
-          <!-- THIS PAGE IS FOR -->
+          <!-- This page is for -->
           <div class="vads-l-col--12 medium-screen:vads-l-col--3">
             <div class=" vads-u-margin-top--3 medium-screen:vads-u-margin-top--0 medium-screen:vads-u-margin-left--2">
               {% if fieldClpAudience != empty %}
@@ -71,7 +71,7 @@
               {% endif %}
               {% include "src/site/includes/social-share.drupal.liquid" %}
             </div>
-          </div><!-- /THIS PAGE IS FOR-->
+          </div><!-- /This page is for -->
         </div>
       </div>
     </div>
@@ -316,7 +316,7 @@
       <div>
         <div class="vads-l-grid-container vads-u-padding-y--6 vads-u-padding-x--4 large-screen:vads-u-padding-x--0">
 
-          <!-- CONTENT -->
+          <!-- Content -->
           <div class="vads-l-row">
             <div class="vads-l-col--12 medium-screen:vads-l-col--9">
               <!-- Title -->

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -22,7 +22,7 @@
                 <a
                   class="usa-button usa-button-secondary va-u-box-shadow--none vads-u-margin-top--2 vads-u-background-color--white vads-u-border--0 vads-u-font-size--sm"
                   href="{{ fieldPrimaryCallToAction.entity.fieldButtonLink.url.path }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'hero', 'clp-section-title': '{{ title }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldPrimaryCallToAction.entity.fieldButtonLabel }}' });"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'hero', 'clp-section-title': '{{ title | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldPrimaryCallToAction.entity.fieldButtonLabel | escape }}' });"
                 >
                   {{ fieldPrimaryCallToAction.entity.fieldButtonLabel }}
                 </a>
@@ -46,7 +46,7 @@
               <a
                 class="usa-button usa-button-secondary vads-u-font-size--sm"
                 href="{{ fieldSecondaryCallToAction.entity.fieldButtonLink.url.path }}"
-                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Why this matters to you', 'clp-section-title': '{{ fieldClpWhyThisMatters }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldSecondaryCallToAction.entity.fieldButtonLabel }}' });"
+                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Why this matters to you', 'clp-section-title': '{{ fieldClpWhyThisMatters | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldSecondaryCallToAction.entity.fieldButtonLabel | escape }}' });"
               >
                 {{ fieldSecondaryCallToAction.entity.fieldButtonLabel }}
               </a>
@@ -108,7 +108,10 @@
             <div class="vads-u-background-color--gray-light-alt vads-u-height--full medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
               <img alt="{{ promo.entity.fieldImage.entity.thumbnail.alt }}" src="{{ promo.entity.fieldImage.entity.thumbnail.url }}" />
               <h3 class="vads-u-padding-x--2">
-                <a onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'What you can do', 'clp-section-title': '{{ fieldClpWhatYouCanDoHeader }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ promo.entity.fieldPromoLink.entity.fieldLink.title }}' });" href="{{ promo.entity.fieldPromoLink.entity.fieldLink.uri }}">
+                <a
+                  href="{{ promo.entity.fieldPromoLink.entity.fieldLink.uri }}"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'What you can do', 'clp-section-title': '{{ fieldClpWhatYouCanDoHeader | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ promo.entity.fieldPromoLink.entity.fieldLink.title | escape }}' });"
+                >
                   {{ promo.entity.fieldPromoLink.entity.fieldLink.title }}
                 </a>
               </h3>
@@ -168,7 +171,7 @@
                 <a
                   class="vads-u-margin-top--4 usa-button usa-button-secondary vads-u-font-size--sm"
                   href="{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLink.url.path }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Video', 'clp-section-title': '{{ fieldClpVideoPanelHeader }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel }}' });"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Video', 'clp-section-title': '{{ fieldClpVideoPanelHeader | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel | escape }}' });"
                 >
                   {{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel }}
                   <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
@@ -192,7 +195,7 @@
               {{ fieldClpSpotlightIntroText }}
               <a
                 href="{{ fieldClpSpotlightCta.entity.fieldButtonLink.url.path }}"
-                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Spotlight', 'clp-section-title': '{{ fieldClpSpotlightHeader }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpSpotlightCta.entity.fieldButtonLabel }}'"
+                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Spotlight', 'clp-section-title': '{{ fieldClpSpotlightHeader | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpSpotlightCta.entity.fieldButtonLabel | escape }}'"
               >
                 {{ fieldClpSpotlightCta.entity.fieldButtonLabel }}
               </a>
@@ -207,7 +210,7 @@
                   <h3 class="vads-u-margin-top--0">
                     <a
                       href="{{ linkTeaser.entity.fieldLink.uri }}"
-                      onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Spotlight', 'clp-section-title': '{{ fieldClpSpotlightHeader }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ linkTeaser.entity.fieldLink.title }}'"
+                      onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Spotlight', 'clp-section-title': '{{ fieldClpSpotlightHeader | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ linkTeaser.entity.fieldLink.title | escape }}'"
                     >
                       {{ linkTeaser.entity.fieldLink.title }}
                     </a>
@@ -250,7 +253,7 @@
                         <h3 class="vads-u-margin-top--0">
                           <a
                             href="{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.uri }}"
-                            onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Stories', 'clp-section-title': '{{ fieldClpStoriesHeader }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.title }}' });"
+                            onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Stories', 'clp-section-title': '{{ fieldClpStoriesHeader | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.title | escape }}' });"
                           >
                             {{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.title }}
                           </a>
@@ -267,7 +270,7 @@
                 <a
                   class="usa-button usa-button-secondary vads-u-font-size--sm"
                   href="{{ fieldClpStoriesCta.entity.fieldButtonLink.url }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Stories', 'clp-section-title': '{{ fieldClpStoriesHeader }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpStoriesCta.entity.fieldButtonLabel }}' });"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Stories', 'clp-section-title': '{{ fieldClpStoriesHeader | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpStoriesCta.entity.fieldButtonLabel | escape }}' });"
                   rel="noreferrer noopener"
                   target="_blank"
                 >
@@ -304,7 +307,7 @@
                   <a
                     download
                     href="{{ resource.entity.fieldMediaExternalFile.url }}"
-                    onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Downloadable resources', 'clp-section-title': '{{ fieldClpResourcesHeader }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '' });"
+                    onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Downloadable resources', 'clp-section-title': '{{ fieldClpResourcesHeader | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': 'Download {{ resource.entity.name | escape }}' });"
                   >
                     Download (PDF)
                   </a>
@@ -320,7 +323,7 @@
               <a
                 class="usa-button usa-button-secondary vads-u-font-size--sm"
                 href="{{ fieldClpResourcesCta.entity.fieldButtonLink.url.path }}"
-                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Downloadable resources', 'clp-section-title': '{{ fieldClpResourcesHeader }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpResourcesCta.entity.fieldButtonLabel }}' });"
+                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Downloadable resources', 'clp-section-title': '{{ fieldClpResourcesHeader | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpResourcesCta.entity.fieldButtonLabel | escape }}' });"
               >
                 {{ fieldClpResourcesCta.entity.fieldButtonLabel }}
                 <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
@@ -355,7 +358,7 @@
                   <h3 class="vads-u-margin-top--0">
                     <a
                       href="{{ eventReference.entity.fieldLink.url }}"
-                      onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ eventReference.entity.title }}' });"
+                      onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ eventReference.entity.title | escape }}' });"
                     >
                       {{ eventReference.entity.title }}
                     </a>
@@ -389,7 +392,7 @@
                         {% if eventReference.entity.fieldFacilityLocation.entity.entityUrl.path %}
                           <a
                             href="{{ eventReference.entity.fieldFacilityLocation.entity.entityUrl.path }}"
-                            onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ eventReference.entity.fieldFacilityLocation.entity.title }}' });"
+                            onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ eventReference.entity.fieldFacilityLocation.entity.title | escape }}' });"
                             rel="noreferrer noopener"
                             target="_blank"
                           >
@@ -400,7 +403,7 @@
                         {% if eventReference.entity.fieldLink.uri %}
                           <a
                             href="{{ eventReference.entity.fieldLink.uri }}"
-                            onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ eventReference.entity.fieldEventCta }}' });"
+                            onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ eventReference.entity.fieldEventCta | escape }}' });"
                             rel="noreferrer noopener"
                             target="_blank"
                           >
@@ -460,7 +463,7 @@
               <a
                 class="usa-button usa-button-secondary vads-u-font-size--sm"
                 href="{{ fieldClpFaqCta.entity.fieldButtonLink.url.path }}"
-                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'FAQ', 'clp-section-title': 'Frequently asked questions', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpFaqCta.entity.fieldButtonLabel }}' });"
+                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'FAQ', 'clp-section-title': 'Frequently asked questions', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpFaqCta.entity.fieldButtonLabel | escape }}' });"
               >
                 {{ fieldClpFaqCta.entity.fieldButtonLabel }}
                 <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
@@ -492,7 +495,7 @@
                 <a
                   aria-label="{{ fieldClpConnectWithUs.entity.fieldEmailUpdatesLinkText }} (opens in a new window)"
                   href="{{ fieldClpConnectWithUs.entity.fieldEmailUpdatesUrl }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.fieldEmailUpdatesLinkText }}' });"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.fieldEmailUpdatesLinkText | escape }}' });"
                   rel="noreferrer noopener"
                   target="_blank"
                 >
@@ -509,7 +512,7 @@
                 <a
                   aria-label="{{ fieldClpConnectWithUs.entity.name }} Twitter (opens in a new window)"
                   href="https://twitter.com/{{ socialLinksObject.twitter.value }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} Twitter' });"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name | escape }} Twitter' });"
                   rel="noreferrer noopener"
                   target="_blank"
                 >
@@ -526,7 +529,7 @@
                 <a
                   aria-label="{{ fieldClpConnectWithUs.entity.name }} Facebook (opens in a new window)"
                   href="https://facebook.com/{{ socialLinksObject.facebook.value }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} Facebook' });"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name | escape }} Facebook' });"
                   rel="noreferrer noopener"
                   target="_blank"
                 >
@@ -543,7 +546,7 @@
                 <a
                   aria-label="{{ fieldClpConnectWithUs.entity.name }} YouTube (opens in a new window)"
                   href="https://youtube.com/channel/{{ socialLinksObject.youtube.value }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} YouTube' });"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name | escape }} YouTube' });"
                   rel="noreferrer noopener"
                   target="_blank"
                 >
@@ -560,7 +563,7 @@
                 <a
                   aria-label="{{ fieldClpConnectWithUs.entity.name }} Linkedin (opens in a new window)"
                   href="https://linkedin.com/{{ socialLinksObject.linkedin.value }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} Linkedin' });"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name | escape }} Linkedin' });"
                   rel="noreferrer noopener"
                   target="_blank"
                 >
@@ -577,7 +580,7 @@
                 <a
                   aria-label="{{ fieldClpConnectWithUs.entity.name }} Instagram (opens in a new window)"
                   href="https://instagram.com/{{ socialLinksObject.instagram.value }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} Instagram' });"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name | escape }} Instagram' });"
                   rel="noreferrer noopener"
                   target="_blank"
                 >
@@ -612,7 +615,7 @@
                     <i class="icon-large white hub-icon-{{ benefitCategory.entity.fieldTitleIcon }} hub-background-{{ benefitCategory.entity.fieldTitleIcon }}" role="presentation" aria-hidden="true"></i>
                   </div>
                   <a
-                    onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'VA Benefits', 'clp-section-title': 'Learn more about related VA benefits', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ benefitCategory.entity.title }}' });"
+                    onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'VA Benefits', 'clp-section-title': 'Learn more about related VA benefits', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ benefitCategory.entity.title | escape }}' });"
                     href="{{ benefitCategory.entity.entityUrl.path }}"
                   >
                     {{ benefitCategory.entity.title }}

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -69,7 +69,22 @@
                   </ul>
                 </div>
               {% endif %}
-              {% include "src/site/includes/social-share.drupal.liquid" %}
+
+              <div data-template="includes/social-share" id="va-c-social-share">
+                <ul class="usa-unstyled-list">
+                  <li class="vads-u-margin-bottom--2p5">
+                    <a class="va-js-share-link" href="https://www.facebook.com/sharer/sharer.php?href={{ hostUrl }}{{ entityUrl.path }}">
+                      <i class="va-c-social-icon fab fa-facebook vads-u-margin-right--0p5"></i>Share on Facebook
+                    </a>
+                  </li>
+
+                  <li>
+                    <a class="va-js-share-link" href="https://twitter.com/intent/tweet?text={{ title }}&url={{ hostUrl }}{{ entityUrl.path }}">
+                      <i class="va-c-social-icon fab fa-twitter vads-u-margin-right--0p5"></i>Share on Twitter
+                    </a>
+                  </li>
+                </ul>
+              </div>
             </div>
           </div><!-- /This page is for -->
         </div>

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -22,7 +22,7 @@
                 <a
                   class="usa-button usa-button-secondary va-u-box-shadow--none vads-u-margin-top--2 vads-u-background-color--white vads-u-border--0 vads-u-font-size--sm"
                   href="{{ fieldPrimaryCallToAction.entity.fieldButtonLink.url.path }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'hero', 'clp-section-title': '{{ title }}', 'clp-section-index': '0', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': 'image', 'clp-click-label': '{{ fieldPrimaryCallToAction.entity.fieldButtonLabel }}' });"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'hero', 'clp-section-title': '{{ title }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldPrimaryCallToAction.entity.fieldButtonLabel }}' });"
                 >
                   {{ fieldPrimaryCallToAction.entity.fieldButtonLabel }}
                 </a>
@@ -46,7 +46,7 @@
               <a
                 class="usa-button usa-button-secondary vads-u-font-size--sm"
                 href="{{ fieldSecondaryCallToAction.entity.fieldButtonLink.url.path }}"
-                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Why this matters to you', 'clp-section-title': '{{ fieldClpWhyThisMatters }}', 'clp-section-index': '1', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': 'primary-alt-lightest', 'clp-click-label': '{{ fieldSecondaryCallToAction.entity.fieldButtonLabel }}' });"
+                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Why this matters to you', 'clp-section-title': '{{ fieldClpWhyThisMatters }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldSecondaryCallToAction.entity.fieldButtonLabel }}' });"
               >
                 {{ fieldSecondaryCallToAction.entity.fieldButtonLabel }}
               </a>
@@ -93,7 +93,7 @@
             <div class="vads-u-background-color--gray-light-alt vads-u-height--full medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
               <img alt="{{ promo.entity.fieldImage.entity.thumbnail.alt }}" src="{{ promo.entity.fieldImage.entity.thumbnail.url }}" />
               <h3 class="vads-u-padding-x--2">
-                <a onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'What you can do', 'clp-section-title': '{{ fieldClpWhatYouCanDoHeader }}', 'clp-section-index': '2', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': 'white', 'clp-click-label': '{{ promo.entity.fieldPromoLink.entity.fieldLink.title }}' });" href="{{ promo.entity.fieldPromoLink.entity.fieldLink.uri }}">
+                <a onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'What you can do', 'clp-section-title': '{{ fieldClpWhatYouCanDoHeader }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ promo.entity.fieldPromoLink.entity.fieldLink.title }}' });" href="{{ promo.entity.fieldPromoLink.entity.fieldLink.uri }}">
                   {{ promo.entity.fieldPromoLink.entity.fieldLink.title }}
                 </a>
               </h3>
@@ -153,7 +153,7 @@
                 <a
                   class="vads-u-margin-top--4 usa-button usa-button-secondary vads-u-font-size--sm"
                   href="{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLink.url.path }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Video', 'clp-section-title': '{{ fieldClpVideoPanelHeader }}', 'clp-section-index': '3', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': 'blue', 'clp-click-label': '{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel }}' });"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Video', 'clp-section-title': '{{ fieldClpVideoPanelHeader }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel }}' });"
                 >
                   {{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel }}
                   <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
@@ -177,7 +177,7 @@
               {{ fieldClpSpotlightIntroText }}
               <a
                 href="{{ fieldClpSpotlightCta.entity.fieldButtonLink.url.path }}"
-                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Spotlight', 'clp-section-title': '{{ fieldClpSpotlightHeader }}', 'clp-section-index': {% if fieldClpVideoPanel %}'4'{% else %}'3'{% endif %}, 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': {% if fieldClpVideoPanel %}'white'{% else %}'blue'{% endif %}, 'clp-click-label': '{{ fieldClpSpotlightCta.entity.fieldButtonLabel }}'"
+                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Spotlight', 'clp-section-title': '{{ fieldClpSpotlightHeader }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpSpotlightCta.entity.fieldButtonLabel }}'"
               >
                 {{ fieldClpSpotlightCta.entity.fieldButtonLabel }}
               </a>
@@ -192,7 +192,7 @@
                   <h3 class="vads-u-margin-top--0">
                     <a
                       href="{{ linkTeaser.entity.fieldLink.uri }}"
-                      onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Spotlight', 'clp-section-title': '{{ fieldClpSpotlightHeader }}', 'clp-section-index': {% if fieldClpVideoPanel %}'4'{% else %}'3'{% endif %}, 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': {% if fieldClpVideoPanel %}'white'{% else %}'blue'{% endif %}, 'clp-click-label': '{{ linkTeaser.entity.fieldLink.title }}'"
+                      onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Spotlight', 'clp-section-title': '{{ fieldClpSpotlightHeader }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ linkTeaser.entity.fieldLink.title }}'"
                     >
                       {{ linkTeaser.entity.fieldLink.title }}
                     </a>
@@ -229,7 +229,7 @@
                         <h3 class="vads-u-margin-top--0">
                           <a
                             href="{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.uri }}"
-                            onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Stories', 'clp-section-title': '{{ fieldClpStoriesHeader }}', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.title }}' });"
+                            onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Stories', 'clp-section-title': '{{ fieldClpStoriesHeader }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.title }}' });"
                           >
                             {{ storyTeaser.entity.fieldLinkTeaser.entity.fieldLink.title }}
                           </a>
@@ -246,7 +246,7 @@
                 <a
                   class="usa-button usa-button-secondary vads-u-font-size--sm"
                   href="{{ fieldClpStoriesCta.entity.fieldButtonLink.url }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Stories', 'clp-section-title': '{{ fieldClpStoriesHeader }}', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpStoriesCta.entity.fieldButtonLabel }}' });"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Stories', 'clp-section-title': '{{ fieldClpStoriesHeader }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpStoriesCta.entity.fieldButtonLabel }}' });"
                   rel="noreferrer noopener"
                   target="_blank"
                 >
@@ -283,7 +283,7 @@
                   <a
                     download
                     href="{{ resource.entity.fieldMediaExternalFile.url }}"
-                    onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Downloadable resources', 'clp-section-title': '{{ fieldClpResourcesHeader }}', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '' });"
+                    onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Downloadable resources', 'clp-section-title': '{{ fieldClpResourcesHeader }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '' });"
                   >
                     Download (PDF)
                   </a>
@@ -299,7 +299,7 @@
               <a
                 class="usa-button usa-button-secondary vads-u-font-size--sm"
                 href="{{ fieldClpResourcesCta.entity.fieldButtonLink.url.path }}"
-                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Downloadable resources', 'clp-section-title': '{{ fieldClpResourcesHeader }}', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpResourcesCta.entity.fieldButtonLabel }}' });"
+                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Downloadable resources', 'clp-section-title': '{{ fieldClpResourcesHeader }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpResourcesCta.entity.fieldButtonLabel }}' });"
               >
                 {{ fieldClpResourcesCta.entity.fieldButtonLabel }}
                 <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
@@ -334,7 +334,7 @@
                   <h3 class="vads-u-margin-top--0">
                     <a
                       href="{{ eventReference.entity.fieldLink.url }}"
-                      onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader }}', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ eventReference.entity.title }}' });"
+                      onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ eventReference.entity.title }}' });"
                     >
                       {{ eventReference.entity.title }}
                     </a>
@@ -368,7 +368,7 @@
                         {% if eventReference.entity.fieldFacilityLocation.entity.entityUrl.path %}
                           <a
                             href="{{ eventReference.entity.fieldFacilityLocation.entity.entityUrl.path }}"
-                            onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader }}', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ eventReference.entity.fieldFacilityLocation.entity.title }}' });"
+                            onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ eventReference.entity.fieldFacilityLocation.entity.title }}' });"
                             rel="noreferrer noopener"
                             target="_blank"
                           >
@@ -379,7 +379,7 @@
                         {% if eventReference.entity.fieldLink.uri %}
                           <a
                             href="{{ eventReference.entity.fieldLink.uri }}"
-                            onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader }}', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ eventReference.entity.fieldEventCta }}' });"
+                            onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ eventReference.entity.fieldEventCta }}' });"
                             rel="noreferrer noopener"
                             target="_blank"
                           >
@@ -439,7 +439,7 @@
               <a
                 class="usa-button usa-button-secondary vads-u-font-size--sm"
                 href="{{ fieldClpFaqCta.entity.fieldButtonLink.url.path }}"
-                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'FAQ', 'clp-section-title': 'Frequently asked questions', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpFaqCta.entity.fieldButtonLabel }}' });"
+                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'FAQ', 'clp-section-title': 'Frequently asked questions', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpFaqCta.entity.fieldButtonLabel }}' });"
               >
                 {{ fieldClpFaqCta.entity.fieldButtonLabel }}
                 <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
@@ -471,7 +471,7 @@
                 <a
                   aria-label="{{ fieldClpConnectWithUs.entity.fieldEmailUpdatesLinkText }} (opens in a new window)"
                   href="{{ fieldClpConnectWithUs.entity.fieldEmailUpdatesUrl }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.fieldEmailUpdatesLinkText }}' });"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.fieldEmailUpdatesLinkText }}' });"
                   rel="noreferrer noopener"
                   target="_blank"
                 >
@@ -488,7 +488,7 @@
                 <a
                   aria-label="{{ fieldClpConnectWithUs.entity.name }} Twitter (opens in a new window)"
                   href="https://twitter.com/{{ socialLinksObject.twitter.value }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} Twitter' });"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} Twitter' });"
                   rel="noreferrer noopener"
                   target="_blank"
                 >
@@ -505,7 +505,7 @@
                 <a
                   aria-label="{{ fieldClpConnectWithUs.entity.name }} Facebook (opens in a new window)"
                   href="https://facebook.com/{{ socialLinksObject.facebook.value }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} Facebook' });"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} Facebook' });"
                   rel="noreferrer noopener"
                   target="_blank"
                 >
@@ -522,7 +522,7 @@
                 <a
                   aria-label="{{ fieldClpConnectWithUs.entity.name }} YouTube (opens in a new window)"
                   href="https://youtube.com/channel/{{ socialLinksObject.youtube.value }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} YouTube' });"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} YouTube' });"
                   rel="noreferrer noopener"
                   target="_blank"
                 >
@@ -539,7 +539,7 @@
                 <a
                   aria-label="{{ fieldClpConnectWithUs.entity.name }} Linkedin (opens in a new window)"
                   href="https://linkedin.com/{{ socialLinksObject.linkedin.value }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} Linkedin' });"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} Linkedin' });"
                   rel="noreferrer noopener"
                   target="_blank"
                 >
@@ -556,7 +556,7 @@
                 <a
                   aria-label="{{ fieldClpConnectWithUs.entity.name }} Instagram (opens in a new window)"
                   href="https://instagram.com/{{ socialLinksObject.instagram.value }}"
-                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} Instagram' });"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Connect with us', 'clp-section-title': 'Get updates from {{ fieldClpConnectWithUs.entity.name }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpConnectWithUs.entity.name }} Instagram' });"
                   rel="noreferrer noopener"
                   target="_blank"
                 >
@@ -591,7 +591,7 @@
                     <i class="icon-large white hub-icon-{{ benefitCategory.entity.fieldTitleIcon }} hub-background-{{ benefitCategory.entity.fieldTitleIcon }}" role="presentation" aria-hidden="true"></i>
                   </div>
                   <a
-                    onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'VA Benefits', 'clp-section-title': 'Learn more about related VA benefits', 'clp-section-index': '', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-section-background-color': '', 'clp-click-label': '{{ benefitCategory.entity.title }}' });"
+                    onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'VA Benefits', 'clp-section-title': 'Learn more about related VA benefits', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ benefitCategory.entity.title }}' });"
                     href="{{ benefitCategory.entity.entityUrl.path }}"
                   >
                     {{ benefitCategory.entity.title }}


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/16749

This PR implements analytics for all a tags on the CLP template pages.

```js
'event': 'clp-link-click', //consistently populate for any link click
'clp-section-category': //dynamically populate according to the `<p>` tag text directly above main title i.e 'WHAT YOU CAN DO', and links in the hero section can populate with `'hero'`
'clp-section-title': //dynamically populate according to the section title, i.e "Where you can get your flu shot" 
'clp-section-index': //beginning with 1, and 1 being the first section with a category, and increment each section below by 1
'clp-total-sections': //populate with the number of total sections 
'clp-section-background-color': //dynamically populate with the background color hex code 
'clp-click-label': //dynamically populate according to the link text
```

## Testing done
Added unit tests for new liquid filter.

## Screenshots
N/A

## Acceptance criteria
- [x] Add analytic events for all a tags on CLP pages.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
