### PR TITLE
Accessibility updates to 526 wizard

### DIFF
--- a/src/applications/disability-benefits/wizard/pages/unable-to-file-bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/unable-to-file-bdd.jsx
@@ -8,7 +8,8 @@ import { BDD_INFO_URL } from 'applications/disability-benefits/all-claims/consta
 import { pageNames } from './pageList';
 
 const UnableToFileBDDPage = ({ getPageStateFromPageName }) => {
-  const linkText = 'Learn more about the BDD program';
+  const linkText =
+    'Learn more about why you’re not eligible for disability benefits right now';
 
   const stateBDD = getPageStateFromPageName('bdd');
 
@@ -33,26 +34,28 @@ const UnableToFileBDDPage = ({ getPageStateFromPageName }) => {
     <div
       id="not-eligible-for-bdd"
       className="usa-alert usa-alert-info background-color-only vads-u-padding--2 vads-u-margin-top--2"
-      aria-live="polite"
     >
-      <span className="sr-only">Info: </span>
-      <p className="vads-u-margin-top--0">
-        Based on your separation date, you’re not eligible to file for
-        disability benefits right now.
-      </p>
-      {differenceBetweenDatesInDays > 0 && (
-        <p>
-          You’ll be eligible to file a disability claim under the Benefits
-          Delivery at Discharge (BDD) program in{' '}
-          <strong>{differenceBetweenDatesInDays}</strong> days (
-          <strong>{dateEligible}</strong>
-          ). This program allows you to apply for disability benefits before you
-          leave the military.
+      <div id="not-eligbile-details" aria-live="polite">
+        <span className="sr-only">Info: </span>
+        <p className="vads-u-margin-top--0">
+          Based on your separation date, you’re not eligible to file for
+          disability benefits right now.
         </p>
-      )}
+        {differenceBetweenDatesInDays > 0 && (
+          <p>
+            You’ll be eligible to file a disability claim under the Benefits
+            Delivery at Discharge (BDD) program in{' '}
+            <strong>{differenceBetweenDatesInDays}</strong> days (
+            <strong>{dateEligible}</strong>
+            ). This program allows you to apply for disability benefits before
+            you leave the military.
+          </p>
+        )}
+      </div>
       <p>
         <a
           href={BDD_INFO_URL}
+          aria-describedby="not-eligbile-details"
           onClick={() => {
             recordEvent({
               event: 'howToWizard-alert-link-click',


### PR DESCRIPTION
## Description

To provide better screenreader context, this PR adds a `aria-describedby` to the info link and updates the link text to be more explicative.

<img width="965" alt="Screen Shot 2021-02-16 at 2 22 51 PM" src="https://user-images.githubusercontent.com/136959/108123949-39986680-706c-11eb-9913-0da9689c0fa1.png">

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/16047

## Testing done

VoiceOver in Safari - works well
VoiceOver in Chrome - not that great

## Screenshots

See above

## Acceptance criteria
- [x] Not eligible for BDD content is read out when the user focuses on the info box link

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
