### PR TITLE
Create custom hooks and use Redirect component to make redirects more reliable

### DIFF
--- a/src/applications/vaos/express-care/components/ExpressCareConfirmationPage.jsx
+++ b/src/applications/vaos/express-care/components/ExpressCareConfirmationPage.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { Link, Redirect } from 'react-router-dom';
 import { connect } from 'react-redux';
 import recordEvent from 'platform/monitoring/record-event';
 import { scrollAndFocus } from '../../utils/scrollAndFocus';
@@ -10,22 +10,14 @@ import ExpressCareCard from '../../appointment-list/components/cards/express-car
 const pageTitle = 'You’ve successfully submitted your Express Care request';
 
 function ExpressCareConfirmationPage({ successfulRequest }) {
-  const history = useHistory();
-  useEffect(
-    () => {
-      document.title = `${pageTitle} | Veterans Affairs`;
+  useEffect(() => {
+    document.title = `${pageTitle} | Veterans Affairs`;
 
-      if (!successfulRequest) {
-        history.replace('/new-express-care-request');
-      }
-
-      scrollAndFocus();
-    },
-    [successfulRequest, history],
-  );
+    scrollAndFocus();
+  }, []);
 
   if (!successfulRequest) {
-    return null;
+    return <Redirect to="/new-express-care-request" />;
   }
 
   const transformedRequest = transformPendingAppointments([

--- a/src/applications/vaos/express-care/components/ExpressCareDetailsPage.jsx
+++ b/src/applications/vaos/express-care/components/ExpressCareDetailsPage.jsx
@@ -109,11 +109,7 @@ function ExpressCareDetailsPage({
     document.title = `${pageTitle} | Veterans Affairs`;
     scrollAndFocus();
 
-    if (!data.reason) {
-      history.replace('/new-express-care-request');
-    } else {
-      openAdditionalDetailsPage(pageKey, uiSchema, initialSchema, history);
-    }
+    openAdditionalDetailsPage(pageKey, uiSchema, initialSchema, history);
   }, []);
 
   return (

--- a/src/applications/vaos/express-care/index.jsx
+++ b/src/applications/vaos/express-care/index.jsx
@@ -6,6 +6,7 @@ import {
   useRouteMatch,
   useHistory,
   useLocation,
+  Redirect,
 } from 'react-router-dom';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import * as actions from '../appointment-list/redux/actions';
@@ -19,6 +20,8 @@ import ExpressCareConfirmationPage from './components/ExpressCareConfirmationPag
 import ExpressCareInfoPage from './components/ExpressCareInfoPage';
 import ExpressCareRequestLimitPage from './components/ExpressCareRequestLimitPage';
 import ErrorMessage from '../components/ErrorMessage';
+import useFormRedirectToStart from '../hooks/useFormRedirectToStart';
+import useManualScrollRestoration from '../hooks/useManualScrollRestoration';
 
 function NewExpressCareRequestSection({
   windowsStatus,
@@ -30,22 +33,11 @@ function NewExpressCareRequestSection({
   const history = useHistory();
   const location = useLocation();
 
+  useManualScrollRestoration();
+
   useEffect(() => {
     if (windowsStatus === FETCH_STATUS.notStarted) {
       fetchExpressCareWindows();
-    }
-
-    if (window.History) {
-      window.History.scrollRestoration = 'manual';
-    }
-
-    const { pathname } = location;
-
-    if (
-      !pathname.endsWith('new-express-care-request') &&
-      !pathname.endsWith('confirmation')
-    ) {
-      history.replace('/new-express-care-request');
     }
   }, []);
 
@@ -60,6 +52,18 @@ function NewExpressCareRequestSection({
     },
     [history, windowsStatus, allowRequests, useNewFlow],
   );
+
+  const shouldRedirectToStart = useFormRedirectToStart({
+    shouldRedirect: () =>
+      !location.pathname.endsWith('new-express-care-request') &&
+      !location.pathname.endsWith('confirmation'),
+    enabled:
+      useNewFlow && windowsStatus === FETCH_STATUS.succeeded && allowRequests,
+  });
+
+  if (shouldRedirectToStart) {
+    return <Redirect to="/new-express-care-request" />;
+  }
 
   return (
     <FormLayout>

--- a/src/applications/vaos/express-care/index.jsx
+++ b/src/applications/vaos/express-care/index.jsx
@@ -22,6 +22,7 @@ import ExpressCareRequestLimitPage from './components/ExpressCareRequestLimitPag
 import ErrorMessage from '../components/ErrorMessage';
 import useFormRedirectToStart from '../hooks/useFormRedirectToStart';
 import useManualScrollRestoration from '../hooks/useManualScrollRestoration';
+import useFormUnsavedDataWarning from '../hooks/useFormUnsavedDataWarning';
 
 function NewExpressCareRequestSection({
   windowsStatus,
@@ -52,6 +53,7 @@ function NewExpressCareRequestSection({
     },
     [history, windowsStatus, allowRequests, useNewFlow],
   );
+  useFormUnsavedDataWarning();
 
   const shouldRedirectToStart = useFormRedirectToStart({
     shouldRedirect: () =>

--- a/src/applications/vaos/hooks/useFormRedirectToStart.js
+++ b/src/applications/vaos/hooks/useFormRedirectToStart.js
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Returns a boolean indicating if we should redirect a user
+ * to the start of the form, because they tried to open it in the middle.
+ *
+ * The returned value is intended to trigger a rendering of the Redirect component,
+ * which immediately redirects the user to the specified page
+ *
+ * After the value of shouldRedirect is returned, any subsequent calls to this hook
+ * will get a false return value.
+ *
+ *
+ * @export
+ * @param {Object} hookParams The parameters for the hook
+ * @param {Function} hookParams.shouldRedirect A function indicating if the app should
+ *   redirect to the start of the flow. Only run once.
+ * @param {boolean} [hookParams.enabled=true] A boolean indicating if we should run the redirect logic. The
+ *   shouldRedirect function is not run until enabled becomes true
+ * @returns {boolean} A boolean indicating if we should redirect to the start of the form
+ */
+export default function useFormRedirectToStart({
+  shouldRedirect,
+  enabled = true,
+}) {
+  // using a ref here to hold state that we don't need to trigger a re-render
+  const hadEnabledRender = useRef(false);
+  useEffect(
+    () => {
+      if (enabled) {
+        hadEnabledRender.current = true;
+      }
+    },
+    [enabled],
+  );
+
+  if (!enabled || hadEnabledRender.current) {
+    return false;
+  } else {
+    return shouldRedirect();
+  }
+}

--- a/src/applications/vaos/hooks/useFormUnsavedDataWarning.js
+++ b/src/applications/vaos/hooks/useFormUnsavedDataWarning.js
@@ -1,0 +1,50 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+function onBeforeUnload(e) {
+  const expirationDate = localStorage.getItem('sessionExpiration');
+  const expirationDateSSO = localStorage.getItem('sessionExpirationSSO');
+
+  // If there's no expiration date, then the session has already expired
+  // and keeping a person on the form won't save their data
+  if (expirationDate || expirationDateSSO) {
+    e.preventDefault();
+    e.returnValue =
+      'Are you sure you wish to leave this application? All progress will be lost.';
+  }
+}
+/**
+ * Hook for managing the warning message about unsaved data on forms.
+ *
+ * @export
+ * @param {Object} [hookParams={}]
+ * @param {boolean} [hookParams.disabled=false] A boolean indicating if we should currently show the unsaved
+ *   data warning. Can be used to disable the warning on certain pages
+ */
+export default function useFormUnsavedDataWarning({ disabled = false } = {}) {
+  const location = useLocation();
+
+  useEffect(
+    () => {
+      if (location.pathname.endsWith('confirmation')) {
+        window.removeEventListener('beforeunload', onBeforeUnload);
+      }
+    },
+    [location],
+  );
+
+  useEffect(
+    () => {
+      if (disabled) {
+        window.removeEventListener('beforeunload', onBeforeUnload);
+      } else {
+        window.addEventListener('beforeunload', onBeforeUnload);
+      }
+
+      return () => {
+        window.removeEventListener('beforeunload', onBeforeUnload);
+      };
+    },
+    [location.pathname, disabled],
+  );
+}

--- a/src/applications/vaos/hooks/useManualScrollRestoration.js
+++ b/src/applications/vaos/hooks/useManualScrollRestoration.js
@@ -1,0 +1,9 @@
+import { useEffect } from 'react';
+
+export default function useManualScrollRestoration() {
+  useEffect(() => {
+    if (window.History) {
+      window.History.scrollRestoration = 'manual';
+    }
+  }, []);
+}

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/index.jsx
@@ -58,16 +58,12 @@ function CommunityCareProviderSelectionPage({
 }) {
   const history = useHistory();
   useEffect(() => {
-    if (history && !data?.typeOfCareId) {
-      history.replace('/new-appointment');
-    } else {
-      document.title = `${pageTitle} | Veterans Affairs`;
-      scrollAndFocus();
-      openCommunityCareProviderSelectionPage(pageKey, uiSchema, initialSchema);
-      recordEvent({
-        event: `${GA_PREFIX}-community-care-provider-selection-page`,
-      });
-    }
+    document.title = `${pageTitle} | Veterans Affairs`;
+    scrollAndFocus();
+    openCommunityCareProviderSelectionPage(pageKey, uiSchema, initialSchema);
+    recordEvent({
+      event: `${GA_PREFIX}-community-care-provider-selection-page`,
+    });
   }, []);
 
   return (

--- a/src/applications/vaos/new-appointment/components/ConfirmationPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/ConfirmationPage/index.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import { Link, Redirect } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import recordEvent from 'platform/monitoring/record-event';
@@ -34,16 +34,11 @@ export function ConfirmationPage({
   fetchFacilityDetails,
   useProviderSelection,
 }) {
-  const history = useHistory();
   const isDirectSchedule = flowType === FLOW_TYPES.DIRECT;
   const pageTitle = isDirectSchedule
     ? 'Your appointment has been scheduled'
     : 'Your appointment request has been submitted';
   useEffect(() => {
-    if (history && !data?.typeOfCareId) {
-      history.replace('/new-appointment');
-    }
-
     if (
       !facilityDetails &&
       data?.vaFacility &&
@@ -56,6 +51,10 @@ export function ConfirmationPage({
     document.title = `${pageTitle} | Veterans Affairs`;
     scrollAndFocus();
   }, []);
+
+  if (!data?.typeOfCareId) {
+    return <Redirect to="/new-appointment" />;
+  }
 
   return (
     <div>

--- a/src/applications/vaos/new-appointment/components/ReviewPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/index.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { Redirect, useHistory } from 'react-router-dom';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import { selectUseProviderSelection } from '../../../redux/selectors';
 import {
@@ -30,20 +31,21 @@ export function ReviewPage({
   clinic,
   vaCityState,
   flowType,
-  history,
   submitStatus,
   submitStatusVaos400,
   systemId,
   submitAppointmentOrRequest,
   useProviderSelection,
 }) {
+  const history = useHistory();
   useEffect(() => {
-    if (history && !data?.typeOfCareId) {
-      history.replace('/new-appointment');
-    }
     document.title = `${pageTitle} | Veterans Affairs`;
     scrollAndFocus();
   }, []);
+
+  if (!data?.typeOfCareId) {
+    return <Redirect to="/new-appointment" />;
+  }
 
   const isDirectSchedule = flowType === FLOW_TYPES.DIRECT;
 

--- a/src/applications/vaos/project-cheetah/components/ConfirmationPage.jsx
+++ b/src/applications/vaos/project-cheetah/components/ConfirmationPage.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import moment from '../../lib/moment-tz.js';
-import { Link, useHistory } from 'react-router-dom';
+import { Link, Redirect } from 'react-router-dom';
 import { connect } from 'react-redux';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import recordEvent from 'platform/monitoring/record-event.js';
@@ -13,14 +13,14 @@ import { selectConfirmationPage } from '../redux/selectors.js';
 const pageTitle = 'Your appointment has been scheduled';
 
 function ConfirmationPage({ data, systemId, facilityDetails }) {
-  const history = useHistory();
   useEffect(() => {
-    if (history && !data?.date1) {
-      history.replace('/');
-    }
     document.title = `${pageTitle} | Veterans Affairs`;
     scrollAndFocus();
   }, []);
+
+  if (!data?.date1) {
+    return <Redirect to="/" />;
+  }
 
   const { date1 } = data;
 

--- a/src/applications/vaos/project-cheetah/components/ReviewPage.jsx
+++ b/src/applications/vaos/project-cheetah/components/ReviewPage.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import moment from 'moment';
-import { Link, useHistory } from 'react-router-dom';
+import { Link, useHistory, Redirect } from 'react-router-dom';
 import * as actions from '../redux/actions';
 import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
@@ -30,12 +30,13 @@ function ReviewPage({
   const { date1, vaFacility } = data;
 
   useEffect(() => {
-    if (history && !vaFacility) {
-      history.replace('/new-project-cheetah-booking');
-    }
     document.title = `${pageTitle} | Veterans Affairs`;
     scrollAndFocus();
   }, []);
+
+  if (!vaFacility) {
+    return <Redirect to="/" />;
+  }
 
   return (
     <div>

--- a/src/applications/vaos/project-cheetah/index.jsx
+++ b/src/applications/vaos/project-cheetah/index.jsx
@@ -1,6 +1,12 @@
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
-import { Switch, Route, useRouteMatch, useHistory } from 'react-router-dom';
+import {
+  Switch,
+  Route,
+  useRouteMatch,
+  useHistory,
+  Redirect,
+} from 'react-router-dom';
 import projectCheetahReducer from './redux/reducer';
 import FormLayout from './components/FormLayout';
 import PlanAheadPage from './components/PlanAheadPage';
@@ -14,6 +20,9 @@ import ConfirmationPage from './components/ConfirmationPage';
 import { selectFeatureProjectCheetah } from '../redux/selectors';
 import ReceivedDoseScreenerPage from './components/ReceivedDoseScreenerPage';
 import ContactFacilitiesPage from './components/ContactFacilitiesPage';
+import useManualScrollRestoration from '../hooks/useManualScrollRestoration';
+import useFormRedirectToStart from '../hooks/useFormRedirectToStart';
+import useFormUnsavedDataWarning from '../hooks/useFormUnsavedDataWarning';
 
 export function NewBookingSection({ featureProjectCheetah }) {
   const match = useRouteMatch();
@@ -28,21 +37,22 @@ export function NewBookingSection({ featureProjectCheetah }) {
     [featureProjectCheetah, history],
   );
 
-  useEffect(() => {
-    if (window.History) {
-      window.History.scrollRestoration = 'manual';
-    }
+  useManualScrollRestoration();
 
-    // We don't want people to start in the middle of the form, so redirect them when they jump
-    // in the middle. We make an exception for the confirmation page in case someone is going back
-    // after submitting.
-    if (
+  useFormUnsavedDataWarning({
+    // We don't want to warn a user about leaving the flow when they're shown the page
+    // that says they can't make an appointment online
+    disabled: location.pathname.includes('contact-facilities'),
+  });
+
+  const shouldRedirectToStart = useFormRedirectToStart({
+    shouldRedirect: () =>
       !location.pathname.endsWith('new-project-cheetah-booking') &&
-      !location.pathname.endsWith('confirmation')
-    ) {
-      history.replace('/new-project-cheetah-booking');
-    }
-  }, []);
+      !location.pathname.endsWith('confirmation'),
+  });
+  if (shouldRedirectToStart) {
+    return <Redirect to="/new-project-cheetah-booking" />;
+  }
 
   return (
     <FormLayout>

--- a/src/applications/vaos/tests/express-care/components/ExpressCareConfirmationPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/express-care/components/ExpressCareConfirmationPage.unit.spec.jsx
@@ -189,10 +189,10 @@ describe('VAOS integration: Express Care form submission', () => {
       store,
     });
 
-    await waitFor(() => expect(screen.history.replace.called).to.be.true);
-    expect(screen.baseElement.textContent).to.not.be.ok;
-    expect(screen.history.replace.firstCall.args[0]).to.equal(
-      '/new-express-care-request',
+    await waitFor(() =>
+      expect(screen.history.location.pathname).to.equal(
+        '/new-express-care-request',
+      ),
     );
   });
 

--- a/src/applications/vaos/tests/express-care/components/ExpressCareDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/express-care/components/ExpressCareDetailsPage.unit.spec.jsx
@@ -14,6 +14,9 @@ import ExpressCareDetailsPage from '../../../express-care/components/ExpressCare
 import { fetchExpressCareWindows } from '../../../appointment-list/redux/actions';
 
 const initialState = {
+  featureToggles: {
+    vaOnlineSchedulingExpressCareNew: true,
+  },
   user: {
     profile: {
       facilities: [{ facilityId: '983', isCerner: false }],
@@ -85,7 +88,7 @@ describe('VAOS integration: Express Care form - Additional Details Page', () => 
     screen.getByText(/submit express care request/i);
   });
 
-  it('should redirect to info page when there is no reason in data', async () => {
+  it('should redirect to info page when starting on details page', async () => {
     const store = createTestStore({
       ...initialState,
       expressCare: {
@@ -95,16 +98,40 @@ describe('VAOS integration: Express Care form - Additional Details Page', () => 
         },
       },
     });
-    store.dispatch(fetchExpressCareWindows());
+    const today = moment();
+    mockRequestEligibilityCriteria(
+      ['983'],
+      [
+        getExpressCareRequestCriteriaMock('983', [
+          {
+            day: today
+              .clone()
+              .tz('America/Denver')
+              .format('dddd')
+              .toUpperCase(),
+            canSchedule: true,
+            startTime: today
+              .clone()
+              .subtract('2', 'minutes')
+              .tz('America/Denver')
+              .format('HH:mm'),
+            endTime: today
+              .clone()
+              .add('1', 'minutes')
+              .tz('America/Denver')
+              .format('HH:mm'),
+          },
+        ]),
+      ],
+    );
 
     const { history } = renderWithStoreAndRouter(<NewExpressCareRequest />, {
       store,
       path: '/additional-details',
     });
 
-    await waitFor(() => expect(history.replace.called).to.be.true);
-    expect(history.replace.firstCall.args[0]).to.equal(
-      '/new-express-care-request',
+    await waitFor(() =>
+      expect(history.location.pathname).to.equal('/new-express-care-request'),
     );
   });
 });

--- a/src/applications/vaos/tests/express-care/components/ExpressCareInfoPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/express-care/components/ExpressCareInfoPage.unit.spec.jsx
@@ -157,6 +157,22 @@ describe('VAOS integration: Express Care info page', () => {
   });
 
   it('should render warning message', async () => {
+    const today = moment();
+    const startTime = today
+      .clone()
+      .subtract(5, 'minutes')
+      .tz('America/Denver');
+    const endTime = today
+      .clone()
+      .add(3, 'minutes')
+      .tz('America/Denver');
+
+    setupExpressCareMocks({
+      startTime,
+      endTime,
+      isUnderRequestLimit: true,
+      isWindowOpen: true,
+    });
     setFetchJSONResponse(
       global.fetch.withArgs(`${environment.API_URL}/v0/maintenance_windows/`),
       {

--- a/src/applications/vaos/tests/new-appointment/components/ConfirmationPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ConfirmationPage/index.unit.spec.jsx
@@ -315,6 +315,7 @@ describe('VAOS <ConfirmationPage>', () => {
   it('should format the best time to call correctly when 2 times are selected', async () => {
     const flowType = FLOW_TYPES.REQUEST;
     const data = {
+      typeOfCareId: '323',
       bestTimeToCall: {
         evening: true,
         morning: true,
@@ -348,6 +349,7 @@ describe('VAOS <ConfirmationPage>', () => {
   it('should format the best time to call correctly when 3 times are selected', async () => {
     const flowType = FLOW_TYPES.REQUEST;
     const data = {
+      typeOfCareId: '323',
       bestTimeToCall: {
         evening: true,
         morning: true,
@@ -446,9 +448,7 @@ describe('VAOS <ConfirmationPage>', () => {
 
     // Expect router to route to new appointment page
     await waitFor(() => {
-      expect(screen.history.replace.firstCall.args[0]).to.equal(
-        '/new-appointment',
-      );
+      expect(screen.history.location.pathname).to.equal('/new-appointment');
     });
   });
 });

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.unit.spec.jsx
@@ -37,9 +37,7 @@ describe('VAOS <ReviewPage>', () => {
     });
 
     await waitFor(() => {
-      expect(screen.history.replace.firstCall.args[0]).to.equal(
-        '/new-appointment',
-      );
+      expect(screen.history.location.pathname).to.equal('/new-appointment');
     });
   });
 });

--- a/src/applications/vaos/tests/project-cheetah/components/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/project-cheetah/components/ConfirmationPage.unit.spec.jsx
@@ -78,7 +78,7 @@ describe('VAOS vaccine flow <ConfirmationPage>', () => {
 
     // Expect router to route to home page
     await waitFor(() => {
-      expect(screen.history.replace.firstCall.args[0]).to.equal('/');
+      expect(screen.history.location.pathname).to.equal('/');
     });
   });
 });


### PR DESCRIPTION
## Description
Currently we redirect away from pages in `useEffect` hooks, but this creates some weird edge cases where we might render a page briefly and then immediately redirect away from it. This creates some strange behavior, including flashing of content and Redux state data being in an unexpected state.

This PR
- Creates a set of custom hooks that deal with redirect and application section gating logic
- Updates any redirects in our form flow to use the `<Redirect/>` component from react-router, instead of using `history.replace` in a `useEffect` hook.

## Testing done
Local and unit testing

## Acceptance criteria
- [ ] App still works and redirects appropriately

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
