### PR TITLE
Removed OMB/Expiration date feature flag

### DIFF
--- a/src/applications/edu-benefits/0994/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/0994/containers/IntroductionPage.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { focusElement } from 'platform/utilities/ui';
-import OMBInfo from '../components/OMBInfo';
 import OMBInfoShared from '@department-of-veterans-affairs/component-library/OMBInfo';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
@@ -13,8 +12,6 @@ import {
   WIZARD_STATUS_NOT_STARTED,
   WIZARD_STATUS_COMPLETE,
 } from 'applications/static-pages/wizard';
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 
 export class IntroductionPage extends React.Component {
   state = {
@@ -32,19 +29,17 @@ export class IntroductionPage extends React.Component {
 
   render() {
     const { status } = this.state;
-    const { showWizard, eduFormOmbAndExpiration } = this.props;
+    const { showWizard } = this.props;
     const show = showWizard && status !== WIZARD_STATUS_COMPLETE;
 
     if (showWizard === undefined) return null;
 
-    const ombInfo = eduFormOmbAndExpiration ? (
+    const ombInfo = (
       <OMBInfoShared
         resBurden={10}
         ombNumber={'2900-0866'}
         expDate={'04/30/2022'}
       />
-    ) : (
-      <OMBInfo resBurden={10} ombNumber={'2900-0866'} expDate={'04/30/2022'} />
     );
 
     return (
@@ -192,9 +187,6 @@ export class IntroductionPage extends React.Component {
 
 const mapStateToProps = state => ({
   showWizard: showEduBenefits0994Wizard(state),
-  eduFormOmbAndExpiration: toggleValues(state)[
-    FEATURE_FLAG_NAMES.eduFormOmbAndExpiration
-  ],
 });
 
 export default connect(mapStateToProps)(IntroductionPage);

--- a/src/applications/edu-benefits/1990/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/1990/containers/IntroductionPage.jsx
@@ -6,8 +6,6 @@ import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressI
 import WizardContainer from '../../wizard/containers/WizardContainer';
 import { connect } from 'react-redux';
 import { showEduBenefits1990Wizard } from 'applications/edu-benefits/selectors/educationWizard';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import {
   WIZARD_STATUS,
   WIZARD_STATUS_NOT_STARTED,
@@ -30,7 +28,7 @@ export class IntroductionPage extends React.Component {
 
   render() {
     const { status } = this.state;
-    const { showWizard, eduFormOmbAndExpiration } = this.props;
+    const { showWizard } = this.props;
     const show = showWizard && status !== WIZARD_STATUS_COMPLETE;
 
     if (showWizard === undefined) return null;
@@ -139,19 +137,11 @@ export class IntroductionPage extends React.Component {
               startText="Start the education application"
             />
             <div className="omb-info--container" style={{ paddingLeft: '0px' }}>
-              {eduFormOmbAndExpiration ? (
-                <OMBInfo
-                  resBurden={15}
-                  ombNumber="2900-0154"
-                  expDate="02/28/2023"
-                />
-              ) : (
-                <OMBInfo
-                  resBurden={15}
-                  ombNumber="2900-0154"
-                  expDate="12/31/2019"
-                />
-              )}
+              <OMBInfo
+                resBurden={15}
+                ombNumber="2900-0154"
+                expDate="02/28/2023"
+              />
             </div>
           </div>
         )}
@@ -162,9 +152,6 @@ export class IntroductionPage extends React.Component {
 
 const mapStateToProps = state => ({
   showWizard: showEduBenefits1990Wizard(state),
-  eduFormOmbAndExpiration: toggleValues(state)[
-    FEATURE_FLAG_NAMES.eduFormOmbAndExpiration
-  ],
 });
 
 export default connect(mapStateToProps)(IntroductionPage);

--- a/src/applications/edu-benefits/1990e/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/1990e/containers/IntroductionPage.jsx
@@ -6,8 +6,6 @@ import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressI
 import WizardContainer from '../../wizard/containers/WizardContainer';
 import { connect } from 'react-redux';
 import { showEduBenefits1990EWizard } from '../../selectors/educationWizard';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import {
   WIZARD_STATUS,
   WIZARD_STATUS_NOT_STARTED,
@@ -30,7 +28,7 @@ export class IntroductionPage extends React.Component {
 
   render() {
     const { status } = this.state;
-    const { showWizard, eduFormOmbAndExpiration } = this.props;
+    const { showWizard } = this.props;
     const show = showWizard && status !== WIZARD_STATUS_COMPLETE;
 
     if (showWizard === undefined) return null;
@@ -141,19 +139,11 @@ export class IntroductionPage extends React.Component {
               startText="Start the education application"
             />
             <div className="omb-info--container" style={{ paddingLeft: '0px' }}>
-              {eduFormOmbAndExpiration ? (
-                <OMBInfo
-                  resBurden={15}
-                  ombNumber="2900-0154"
-                  expDate="02/28/2023"
-                />
-              ) : (
-                <OMBInfo
-                  resBurden={15}
-                  ombNumber="2900-0154"
-                  expDate="12/31/2019"
-                />
-              )}
+              <OMBInfo
+                resBurden={15}
+                ombNumber="2900-0154"
+                expDate="02/28/2023"
+              />
             </div>
           </div>
         )}
@@ -164,9 +154,6 @@ export class IntroductionPage extends React.Component {
 
 const mapStateToProps = state => ({
   showWizard: showEduBenefits1990EWizard(state),
-  eduFormOmbAndExpiration: toggleValues(state)[
-    FEATURE_FLAG_NAMES.eduFormOmbAndExpiration
-  ],
 });
 
 export default connect(mapStateToProps)(IntroductionPage);

--- a/src/applications/edu-benefits/1990n/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/1990n/containers/IntroductionPage.jsx
@@ -6,8 +6,6 @@ import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressI
 import WizardContainer from 'applications/edu-benefits/wizard/containers/WizardContainer';
 import { connect } from 'react-redux';
 import { showEduBenefits1990NWizard } from 'applications/edu-benefits/selectors/educationWizard';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import {
   WIZARD_STATUS,
   WIZARD_STATUS_NOT_STARTED,
@@ -30,7 +28,7 @@ export class IntroductionPage extends React.Component {
 
   render() {
     const { status } = this.state;
-    const { showWizard, eduFormOmbAndExpiration } = this.props;
+    const { showWizard } = this.props;
     const show = showWizard && status !== WIZARD_STATUS_COMPLETE;
 
     if (showWizard === undefined) return null;
@@ -140,19 +138,11 @@ export class IntroductionPage extends React.Component {
               startText="Start the education application"
             />
             <div className="omb-info--container" style={{ paddingLeft: '0px' }}>
-              {eduFormOmbAndExpiration ? (
-                <OMBInfo
-                  resBurden={15}
-                  ombNumber="2900-0154"
-                  expDate="02/28/2023"
-                />
-              ) : (
-                <OMBInfo
-                  resBurden={15}
-                  ombNumber="2900-0154"
-                  expDate="12/31/2019"
-                />
-              )}
+              <OMBInfo
+                resBurden={15}
+                ombNumber="2900-0154"
+                expDate="02/28/2023"
+              />
             </div>
           </div>
         )}
@@ -163,9 +153,6 @@ export class IntroductionPage extends React.Component {
 
 const mapStateToProps = state => ({
   showWizard: showEduBenefits1990NWizard(state),
-  eduFormOmbAndExpiration: toggleValues(state)[
-    FEATURE_FLAG_NAMES.eduFormOmbAndExpiration
-  ],
 });
 
 export default connect(mapStateToProps)(IntroductionPage);

--- a/src/applications/edu-benefits/5495/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/5495/containers/IntroductionPage.jsx
@@ -6,8 +6,6 @@ import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressI
 import WizardContainer from 'applications/edu-benefits/wizard/containers/WizardContainer';
 import { connect } from 'react-redux';
 import { showEduBenefits5495Wizard } from 'applications/edu-benefits/selectors/educationWizard';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import {
   WIZARD_STATUS,
   WIZARD_STATUS_NOT_STARTED,
@@ -30,7 +28,7 @@ export class IntroductionPage extends React.Component {
 
   render() {
     const { status } = this.state;
-    const { showWizard, eduFormOmbAndExpiration } = this.props;
+    const { showWizard } = this.props;
     const show = showWizard && status !== WIZARD_STATUS_COMPLETE;
 
     if (showWizard === undefined) return null;
@@ -142,19 +140,11 @@ export class IntroductionPage extends React.Component {
             />
             {/* TODO: Remove inline style after I figure out why .omb-info--container has a left padding */}
             <div className="omb-info--container" style={{ paddingLeft: '0px' }}>
-              {eduFormOmbAndExpiration ? (
-                <OMBInfo
-                  resBurden={20}
-                  ombNumber="2900-0099"
-                  expDate="02/28/2023"
-                />
-              ) : (
-                <OMBInfo
-                  resBurden={20}
-                  ombNumber="2900-0074"
-                  expDate="05/31/2018"
-                />
-              )}
+              <OMBInfo
+                resBurden={20}
+                ombNumber="2900-0099"
+                expDate="02/28/2023"
+              />
             </div>
           </div>
         )}
@@ -165,9 +155,6 @@ export class IntroductionPage extends React.Component {
 
 const mapStateToProps = state => ({
   showWizard: showEduBenefits5495Wizard(state),
-  eduFormOmbAndExpiration: toggleValues(state)[
-    FEATURE_FLAG_NAMES.eduFormOmbAndExpiration
-  ],
 });
 
 export default connect(mapStateToProps)(IntroductionPage);

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -74,5 +74,6 @@ export default Object.freeze({
   evssUploadLimit150Mb: 'evss_upload_limit_150mb',
   searchRepresentative: 'search_representative',
   gibctStateSearch: 'gibct_state_search',
+  eduFormOmbAndExpiration: 'edu_form_omb_and_expiration',
   manageDependents: 'dependents_management',
 });

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -74,6 +74,5 @@ export default Object.freeze({
   evssUploadLimit150Mb: 'evss_upload_limit_150mb',
   searchRepresentative: 'search_representative',
   gibctStateSearch: 'gibct_state_search',
-  eduFormOmbAndExpiration: 'edu_form_omb_and_expiration',
   manageDependents: 'dependents_management',
 });


### PR DESCRIPTION
## Description
As a developer, I need to remove the 'edu_form_omb_and_expiration' feature flag toggle so that it is no longer configurable, and the new functionality is permanent.
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/18294


## Testing done

Check the OMB / expiration details of each page 
http://localhost:3001/education/apply-for-education-benefits/application/1990/introduction

http://localhost:3001/education/apply-for-education-benefits/application/1990E/introduction

http://localhost:3001/education/apply-for-education-benefits/application/1990N/introduction

http://localhost:3001/education/apply-for-education-benefits/application/5495/introduction

http://localhost:3001/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/apply-for-vettec-form-22-0994/introduction

## Screenshots


## Acceptance criteria
- [x] The usage of feature flag 'edu_form_omb_and_expiration' is removed.
- [x] The feature flag is 'off' when displayed here: https://[environment]-api.va.gov/flipper/features.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
