### PR TITLE
Revert SiP 526 endpoint change

### DIFF
--- a/src/applications/disability-benefits/all-claims/local-dev-mock-api/index.js
+++ b/src/applications/disability-benefits/all-claims/local-dev-mock-api/index.js
@@ -123,7 +123,7 @@ const responses = {
     },
   },
 
-  'GET /v0/disability_compensation_in_progress_forms/21-526EZ': {
+  'GET /v0/in_progress_forms/21-526EZ': {
     formData: {
       veteran: {
         primaryPhone: '4445551212',

--- a/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
@@ -143,11 +143,7 @@ const testConfig = createTestConfig(
       // because fixtures don't evaluate JS.
       cy.intercept('GET', '/v0/intent_to_file', mockItf);
 
-      cy.intercept(
-        'PUT',
-        '/v0/disability_compensation_in_progress_forms/*',
-        mockInProgress,
-      );
+      cy.intercept('PUT', '/v0/in_progress_forms/*', mockInProgress);
 
       cy.intercept(
         'GET',
@@ -181,24 +177,20 @@ const testConfig = createTestConfig(
           ({ 'view:selected': _, ...obj }) => obj,
         );
 
-        cy.intercept(
-          'GET',
-          'v0/disability_compensation_in_progress_forms/21-526EZ',
-          {
-            formData: {
-              veteran: {
-                primaryPhone: '4445551212',
-                emailAddress: 'test2@test1.net',
-              },
-              disabilities: sanitizedRatedDisabilities,
+        cy.intercept('GET', 'v0/in_progress_forms/21-526EZ', {
+          formData: {
+            veteran: {
+              primaryPhone: '4445551212',
+              emailAddress: 'test2@test1.net',
             },
-            metadata: {
-              version: 0,
-              prefill: true,
-              returnUrl: '/veteran-information',
-            },
+            disabilities: sanitizedRatedDisabilities,
           },
-        );
+          metadata: {
+            version: 0,
+            prefill: true,
+            returnUrl: '/veteran-information',
+          },
+        });
       });
     },
 

--- a/src/applications/disability-benefits/all-claims/tests/disability-benefits-helpers.js
+++ b/src/applications/disability-benefits/all-claims/tests/disability-benefits-helpers.js
@@ -179,7 +179,7 @@ const defaultData = {
 
 function initInProgressMock(token, data = defaultData) {
   mock(token, {
-    path: '/v0/disability_compensation_in_progress_forms/21-526EZ',
+    path: '/v0/in_progress_forms/21-526EZ',
     verb: 'get',
     value: {
       formData: {

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/mocks/in-progress-forms.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/mocks/in-progress-forms.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "id": "1234",
-    "type": "disability_compensation_in_progress_forms",
+    "type": "in_progress_forms",
     "attributes": {
       "formId": "21-526EZ",
       "createdAt": "2020-06-16T00:00:00.000Z",

--- a/src/platform/forms/constants.js
+++ b/src/platform/forms/constants.js
@@ -34,5 +34,6 @@ export const VA_FORM_IDS_SKIP_INFLECTION = Object.freeze([
 export const VA_FORM_IDS_IN_PROGRESS_FORMS_API = Object.freeze({
   // 526 endpoint updates the ratedDisabilities dynamically and includes a
   // `ratedDisabilitiesUpdated` as true in the metadata when the data changes
-  [VA_FORM_IDS.FORM_21_526EZ]: '/v0/disability_compensation_in_progress_forms/',
+  // '/v0/disability_compensation_in_progress_forms/'
+  [VA_FORM_IDS.FORM_21_526EZ]: '/v0/in_progress_forms/',
 });

--- a/src/platform/forms/tests/save-in-progress/actions.unit.spec.js
+++ b/src/platform/forms/tests/save-in-progress/actions.unit.spec.js
@@ -166,7 +166,7 @@ describe('Schemaform save / load actions:', () => {
           done(err);
         });
     });
-    it('calls the Form 526-specific api to save the form', done => {
+    it.skip('calls the Form 526-specific api to save the form', done => {
       const thunk = saveAndRedirectToReturnUrl(VA_FORM_IDS.FORM_21_526EZ, {});
       const dispatch = sinon.spy();
 
@@ -335,7 +335,7 @@ describe('Schemaform save / load actions:', () => {
         );
       });
     });
-    it('dispatches a success from the form 526-specific api on form load', () => {
+    it.skip('dispatches a success from the form 526-specific api on form load', () => {
       const thunk = fetchInProgressForm(VA_FORM_IDS.FORM_21_526EZ, {});
       const dispatch = sinon.spy();
       global.fetch.returns(


### PR DESCRIPTION
## Description

Form 526 has a new save-in-progress API endpoint, but it need more thorough testing. We need to stop using the new endpoint.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/13128

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] Switch 526 SiP API to original endpoint

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
