### PR TITLE
Bug - TimeZone filter prevents users from logging in on IE11

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -9,6 +9,10 @@ function getPath(obj) {
   return obj.path;
 }
 
+function isIE11() {
+  return !window.ActiveXObject && 'ActiveXObject' in window;
+}
+
 module.exports = function registerFilters() {
   const { cmsFeatureFlags } = global;
 
@@ -33,7 +37,7 @@ module.exports = function registerFilters() {
   liquid.filters.timeZone = (dt, tz, format) => {
     if (dt && tz) {
       const timeZoneDate = new Date(dt).toLocaleString('en-US', {
-        timeZone: tz,
+        timeZone: isIE11() ? undefined : tz,
       });
       return prettyTimeFormatted(timeZoneDate, format);
     }


### PR DESCRIPTION
## Description
This bug is impacting users from logging in because of a `RangeError` that occurs when trying to set the `timeZone` property with the `.toLocaleString` method.  Setting the `timeZone` property works for modern browsers, however in Internet Explorer 11 this is not the case (see references below).  I believe the updated code will fix the error from preventing users from logging in, however it needs to be thoroughly tested in the Staging environment.

`toLocaleString` method (in IE 11) does not support IANA time zone names [browser reference table](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString#browser_compatibility)
`Intl.DateTimeString().resolvedOptions` method does not support computed `timeZone` property [browser reference table](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/resolvedOptions#browser_compatibility)

## Testing done
Manually tested in Internet Explorer 11 and Chrome.

## Screenshots
GIF of login process on Staging with errors (minimally edited for time)
![TimeZoneError-IE11](https://user-images.githubusercontent.com/67602137/108242415-e4675e00-711a-11eb-9967-6455d74caa76.gif)

From the Developer console in Internet Explorer 11
![Screen Shot 2021-02-16 at 11 29 07 AM](https://user-images.githubusercontent.com/67602137/108239624-175c2280-7118-11eb-9b48-1c1f981ec063.png)


## Acceptance criteria
- [ ] The user is signed in when using Internet Explorer 11 (no errors pop up, no errors in Developer console)
- [ ] The user experience for modern browsers like Chrome, Firefox, and Safari are unchanged.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
