### PR TITLE
Update styling to match style guide

### DIFF
--- a/src/platform/site-wide/user-nav/components/SearchMenu.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchMenu.jsx
@@ -7,7 +7,6 @@ import classNames from 'classnames';
 import recordEvent from 'platform/monitoring/record-event';
 import debounce from 'platform/utilities/data/debounce';
 import Downshift from 'downshift';
-import { escape } from 'lodash';
 import * as Sentry from '@sentry/browser';
 
 import { replaceWithStagingDomain } from '../../../utilities/environment/stagingDomains';
@@ -206,10 +205,10 @@ export class SearchMenu extends React.Component {
     } = this;
 
     const highlightedSuggestion =
-      'suggestion-highlighted vads-u-background-color--primary-alt-light vads-u-margin-x--0 vads-u-margin-top--0p5 vads-u-margin-bottom--0  vads-u-padding--1 vads-u-width--full';
+      'suggestion-highlighted vads-u-background-color--primary-alt-light vads-u-margin-x--0 vads-u-margin-top--0p5 vads-u-margin-bottom--0  vads-u-padding--1 vads-u-width--full vads-u-padding-left--2';
 
     const regularSuggestion =
-      'suggestion vads-u-margin-x--0 vads-u-margin-top--0p5 vads-u-margin-bottom--0 vads-u-padding--1 vads-u-width--full';
+      'suggestion vads-u-margin-x--0 vads-u-margin-top--0p5 vads-u-margin-bottom--0 vads-u-padding--1 vads-u-width--full vads-u-padding-left--2';
 
     // default search experience
     if (!searchTypeaheadEnabled) {
@@ -275,7 +274,7 @@ export class SearchMenu extends React.Component {
               </label>
               <input
                 autoComplete="off"
-                className="usagov-search-autocomplete  vads-u-flex--4 vads-u-margin-left--1 vads-u-margin-right--0p5 vads-u-margin-y--1  vads-u-width--full"
+                className="usagov-search-autocomplete  vads-u-flex--4 vads-u-margin-left--1 vads-u-margin-right--0p5 vads-u-margin-y--1 vads-u-padding-left--1 vads-u-width--full"
                 name="query"
                 aria-controls={isOpen ? 'suggestions-list' : undefined}
                 onFocus={getSuggestions}
@@ -307,10 +306,7 @@ export class SearchMenu extends React.Component {
                 aria-label="suggestions-list"
               >
                 {suggestions?.map((suggestion, index) => {
-                  const formattedSuggestion = suggestion.replace(
-                    userInput,
-                    `<strong>${escape(userInput)}</strong>`,
-                  );
+                  const formattedSuggestion = suggestion.replace(userInput, '');
                   return (
                     <li
                       key={suggestion}
@@ -327,12 +323,10 @@ export class SearchMenu extends React.Component {
                       {...getItemProps({
                         item: suggestion,
                       })}
-                      // this line is used to show the suggestion with the user's input in BOLD
-                      // eslint-disable-next-line react/no-danger
-                      dangerouslySetInnerHTML={{
-                        __html: formattedSuggestion,
-                      }}
-                    />
+                    >
+                      {userInput}
+                      <strong>{formattedSuggestion}</strong>
+                    </li>
                   );
                 })}
               </ul>


### PR DESCRIPTION
## Description
Update the styling of typeahead suggestions to match the style guide!

## Testing done
Manual testing

## Screenshots
![Screen Shot 2021-02-17 at 3 01 55 PM](https://user-images.githubusercontent.com/47081947/108261062-14b9f700-7131-11eb-84a2-da9a65888c92.png)


## Acceptance criteria
- [X] Matches style guide

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
