### PR TITLE
[GraphQL] Fix for ParagraphNonReusableAlert not working

### DIFF
--- a/src/site/stages/build/drupal/graphql/faqMultipleQa.graphql.js
+++ b/src/site/stages/build/drupal/graphql/faqMultipleQa.graphql.js
@@ -97,7 +97,6 @@ fragment faqMultipleQA on NodeFaqMultipleQA {
 const GetNodeMultipleQaPages = `
   ${fragments.richTextCharLimit1000}
   ${fragments.reactWidget}
-  ${fragments.alertParagraph}
   ${fragments.alertParagraphSingle}
   ${fragments.button}
   ${fragments.contactInformation}

--- a/src/site/stages/build/drupal/graphql/nodeChecklist.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeChecklist.graphql.js
@@ -84,7 +84,6 @@ fragment nodeChecklist on NodeChecklist {
 `;
 
 const GetNodeChecklist = `
-  ${fragments.alertParagraph}
   ${fragments.alertParagraphSingle}
   ${fragments.button}
   ${fragments.contactInformation}

--- a/src/site/stages/build/drupal/graphql/nodeMediaListImages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeMediaListImages.graphql.js
@@ -90,7 +90,6 @@ fragment nodeMediaListImages on NodeMediaListImages {
 `;
 
 const GetNodeMediaListImages = `
-  ${fragments.alertParagraph}
   ${fragments.alertParagraphSingle}
   ${fragments.button}
   ${fragments.contactInformation}

--- a/src/site/stages/build/drupal/graphql/nodeMediaListVideos.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeMediaListVideos.graphql.js
@@ -85,7 +85,6 @@ fragment nodeMediaListVideos on NodeMediaListVideos {
 `;
 
 const GetNodeMediaListVideos = `
-  ${fragments.alertParagraph}
   ${fragments.alertParagraphSingle}
   ${fragments.button}
   ${fragments.contactInformation}

--- a/src/site/stages/build/drupal/graphql/nodeQa.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeQa.graphql.js
@@ -77,7 +77,6 @@ function getNodeQaSlice(operationName, offset, limit) {
   return `
     ${fragments.richTextCharLimit1000}
     ${fragments.reactWidget}
-    ${fragments.alertParagraph}
     ${fragments.alertParagraphSingle}
     ${fragments.button}
     ${fragments.contactInformation}

--- a/src/site/stages/build/drupal/graphql/nodeStepByStep.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeStepByStep.graphql.js
@@ -99,7 +99,6 @@ fragment nodeStepByStep on NodeStepByStep {
 `;
 
 const GetNodeStepByStep = `
-  ${fragments.alertParagraph}
   ${fragments.alertParagraphSingle}
   ${fragments.button}
   ${fragments.contactInformation}

--- a/src/site/stages/build/drupal/graphql/nodeSupportResourcesDetailPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeSupportResourcesDetailPage.graphql.js
@@ -109,6 +109,7 @@ const GetNodeSupportResourcesDetailPage = `
   ${fragments.listOfLinkTeasers}
   ${fragments.reactWidget}
   ${fragments.spanishSummary}
+  ${fragments.alertParagraph}
   ${fragments.table}
   ${fragments.downloadableFile}
   ${fragments.embeddedImage}

--- a/src/site/stages/build/drupal/graphql/nodeSupportResourcesDetailPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeSupportResourcesDetailPage.graphql.js
@@ -109,7 +109,6 @@ const GetNodeSupportResourcesDetailPage = `
   ${fragments.listOfLinkTeasers}
   ${fragments.reactWidget}
   ${fragments.spanishSummary}
-  ${fragments.alertParagraph}
   ${fragments.table}
   ${fragments.downloadableFile}
   ${fragments.embeddedImage}

--- a/src/site/stages/build/drupal/graphql/paragraph-fragments/alertSingle.paragraph.graphql.js
+++ b/src/site/stages/build/drupal/graphql/paragraph-fragments/alertSingle.paragraph.graphql.js
@@ -1,12 +1,33 @@
-const ALERT_PARAGRAPH = '... alertParagraph';
-
 module.exports = `
 fragment alertSingle on ParagraphAlertSingle {
   entityId
   fieldAlertSelection
   fieldAlertNonReusableRef {
     entity {
-      ${ALERT_PARAGRAPH}
+      ... on ParagraphNonReusableAlert {
+        entityId
+        fieldAlertType
+        fieldAlertHeading
+        fieldVaParagraphs {
+          entity {
+            ... on ParagraphWysiwyg {
+              entityId
+              entityBundle
+              fieldWysiwyg {
+                processed
+              }
+            }
+            ... on ParagraphExpandableText {
+              entityId
+              entityBundle
+              fieldWysiwyg {
+                processed
+              }
+              fieldTextExpander
+            }
+          }
+        }
+      }
     }
   }
   fieldAlertBlockReference {


### PR DESCRIPTION
## Description
I was using the wrong fragment within the `ParagraphAlertSingle` leading to `.fieldAlertNonReusableRef.entity` being an empty object when assigned a value and therefore never showing up in the template. This PR fixes that by using the correct fragment, `ParagraphNonReusableAlert`.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/19653

## Testing done
- Confirmed alert renders in http://localhost:3001/preview?nodeId=15995
- Used GraphQL Explorer to fix the data

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/108383132-7f257280-71d7-11eb-991a-b497843dac98.png)

## Acceptance criteria
- [x] Non-reusable alerts render on R&S pages.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
