### PR TITLE
Find Forms 508 screen reader fixes.

### DIFF
--- a/src/applications/find-forms/containers/SearchResults.jsx
+++ b/src/applications/find-forms/containers/SearchResults.jsx
@@ -183,6 +183,8 @@ export class SearchResults extends Component {
           <h2
             className="vads-u-font-size--base vads-u-line-height--3 vads-u-font-family--sans vads-u-font-weight--normal vads-u-margin-y--1p5"
             data-forms-focus
+            role="region"
+            aria-live="polite"
           >
             Showing <strong>{startLabel}</strong> &ndash;{' '}
             <strong>{lastLabel}</strong> of <strong>{results.length}</strong>{' '}


### PR DESCRIPTION
## Description
See comment: https://github.com/department-of-veterans-affairs/va.gov-team/issues/18398#issuecomment-759119105
and user story: https://github.com/department-of-veterans-affairs/va.gov-team/issues/18389

This PR fixes :
1. an issue where the screen reader doesn't read the <h2> search results on the initial search. 
2. an issue where the screen reader counts the number of elements in addition to reading the context; where as, it is only suppose to read the context of the header tag.

## Testing done
Ran e2e, unit, and manual using mac os voice over.

## Acceptance criteria
- [x] Reads h2 as desired. 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
