### PR TITLE
Polyfill Intl.DateTimeFormat

### DIFF
--- a/package.json
+++ b/package.json
@@ -292,6 +292,7 @@
     "core-js": "^3.8.1",
     "cy-mobile-commands": "^0.2.1",
     "date-fns": "^2.17.0",
+    "date-time-format-timezone": "^1.0.22",
     "downloadjs": "^1.4.7",
     "downshift": "^1.22.5",
     "express": "^4.17.1",

--- a/src/platform/polyfills/index.js
+++ b/src/platform/polyfills/index.js
@@ -5,6 +5,7 @@
 
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
+import 'date-time-format-timezone';
 
 import './download-attribute';
 import './canvas-toBlob';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5546,6 +5546,11 @@ date-fns@^2.17.0:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.17.0.tgz#afa55daea539239db0a64e236ce716ef3d681ba1"
   integrity sha512-ZEhqxUtEZeGgg9eHNSOAJ8O9xqSgiJdrL0lzSSfMF54x6KXWJiOH/xntSJ9YomJPrYH/p08t6gWjGWq1SDJlSA==
 
+date-time-format-timezone@^1.0.22:
+  version "1.0.22"
+  resolved "https://registry.yarnpkg.com/date-time-format-timezone/-/date-time-format-timezone-1.0.22.tgz#6bb4713aac3bf36338738b59c374583cfcbe6246"
+  integrity sha512-4hEeKPpNlbFO05ldht9FwJEy2g1xL7kU3dTPY5hNSd1AyMjrrIeUS54kSWgt/KdttYshhjDMIonU+vCmL4NjVw==
+
 dateformat@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"


### PR DESCRIPTION
## Description
Without this, using `date-fns-tz` caused a bug in IE11 which prevented loading at least the facility locator, but probably more.

**Note:** Adding this polyfill fixes the bug, but inflates the `vendor` bundle enormously. One problem at a time, though. First fix the site. Then make it better.

![image](https://user-images.githubusercontent.com/12970166/108397517-e853b880-71cc-11eb-8d72-963acec88953.png)

See https://github.com/department-of-veterans-affairs/vsp-support/issues/159 for the related support request ticket created from the Slack thread.

## Testing done
Tested on my local network using a Windows machine running IE 11.

1. Reproduce the error
    a. Run a production build with `NODE_ENV=production yarn build --buildtype vagovprod`
    b. Navigate to the build directory and serve it with `cd build/vagovprod/ && npx http-server`
    c. In IE 11, go to `http://<ip-address>:8080/find-locations`
    d. In the browser console, verify that the expected error exists and the application doesn't load
2. Add the polyfill
3. Re-build the site and verify the fix using steps 1.a through 1.c