### PR TITLE
[508] Add unique aria-labels on array card buttons

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
@@ -359,7 +359,8 @@ export default class ArrayField extends React.Component {
             );
             const isLast = items.length === index + 1;
             const isEditing = this.state.editing[index];
-            const itemName = uiOptions.itemName;
+            const itemName =
+              item?.[uiOptions.itemKeyForAriaLabel] || uiOptions.itemName;
             const legendText = `${
               isLast && items.length > 1 ? 'New' : 'Editing'
             } ${itemName || ''} ${
@@ -402,7 +403,9 @@ export default class ArrayField extends React.Component {
                         <div className="small-6 left columns">
                           {!isLast && (
                             <button
+                              type="button"
                               className="float-left"
+                              aria-label={`Update ${itemName}`}
                               onClick={() => this.handleUpdate(index)}
                             >
                               Update
@@ -412,6 +415,7 @@ export default class ArrayField extends React.Component {
                             <button
                               type="button"
                               className="float-left"
+                              aria-label={`Save ${itemName}`}
                               disabled={!this.props.formData}
                               onClick={this.handleSave}
                             >
@@ -421,8 +425,9 @@ export default class ArrayField extends React.Component {
                           <div className="float-left row columns">
                             {!isLast && (
                               <button
-                                className="usa-button-secondary float-left"
                                 type="button"
+                                className="usa-button-secondary float-left"
+                                aria-label={`Cancel editing ${itemName}`}
                                 onClick={() => this.handleCancelEdit(index)}
                               >
                                 Cancel
@@ -433,8 +438,13 @@ export default class ArrayField extends React.Component {
                         <div className="small-6 right columns">
                           {!isOnlyItem && (
                             <button
-                              className="usa-button-secondary float-right"
                               type="button"
+                              className="usa-button-secondary float-right"
+                              aria-label={`Remove ${
+                                itemName === uiOptions.itemName
+                                  ? 'incomplete '
+                                  : ''
+                              }${itemName}`}
                               onClick={() => this.handleRemove(index)}
                             >
                               Remove
@@ -455,7 +465,9 @@ export default class ArrayField extends React.Component {
                     onEdit={() => this.handleEdit(index)}
                   />
                   <button
+                    type="button"
                     className="edit usa-button-secondary vads-u-flex--auto"
+                    aria-label={`Edit ${itemName}`}
                     onClick={() => this.handleEdit(index)}
                   >
                     Edit

--- a/src/applications/disability-benefits/all-claims/components/ConditionReviewField.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConditionReviewField.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const ConditionReviewField = props => {
-  const { renderedProperties, defaultEditButton } = props;
+  const { renderedProperties, defaultEditButton, formData } = props;
   if (!renderedProperties) {
     return null;
   }
@@ -9,7 +9,7 @@ const ConditionReviewField = props => {
     <dl className="vads-u-width--full">
       <div className="review-row vads-u-display--flex vads-u-justify-content--space-between vads-u-align-items--center">
         <dt className="capitalize-first-letter">{renderedProperties}</dt>
-        <dd>{defaultEditButton()}</dd>
+        <dd>{defaultEditButton({ label: `Edit ${formData.condition}` })}</dd>
       </div>
     </dl>
   );

--- a/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
+++ b/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
@@ -63,7 +63,7 @@ export const uiSchema = {
         reviewMode: true,
         showSave: true,
         setEditState: formData =>
-          formData.map(data => isValidServicePeriod(data)),
+          formData.map(data => !isValidServicePeriod(data)),
       },
       items: {
         serviceBranch: {

--- a/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
+++ b/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
@@ -4,8 +4,7 @@ import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 
 import ValidatedServicePeriodView from '../components/ValidatedServicePeriodView';
 import ArrayField from '../components/ArrayField';
-import { isUndefined } from '../utils';
-import { isValidYear } from 'platform/forms-system/src/js/utilities/validations';
+import { isValidServicePeriod } from '../utils';
 
 const dateRangeUISchema = dateRangeUI(
   'Service start date',
@@ -63,14 +62,7 @@ export const uiSchema = {
         reviewMode: true,
         showSave: true,
         setEditState: formData =>
-          formData.map(
-            data =>
-              isUndefined(data?.serviceBranch) ||
-              isUndefined(data?.dateRange?.from) ||
-              isUndefined(data?.dateRange?.to) ||
-              !isValidYear(data?.dateRange?.from.year) ||
-              !isValidYear(data?.dateRange?.to.year),
-          ),
+          formData.map(data => isValidServicePeriod(data)),
       },
       items: {
         serviceBranch: {

--- a/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
+++ b/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
@@ -58,6 +58,7 @@ export const uiSchema = {
       'ui:field': ArrayField,
       'ui:options': {
         itemName: 'Service Period',
+        itemKeyForAriaLabel: 'serviceBranch',
         viewField: ValidatedServicePeriodView,
         reviewMode: true,
         showSave: true,

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -2,6 +2,7 @@ import sinon from 'sinon';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import moment from 'moment';
+import { minYear, maxYear } from 'platform/forms-system/src/js/helpers';
 
 import {
   SAVED_SEPARATION_DATE,
@@ -36,6 +37,8 @@ import {
   activeServicePeriods,
   formatDate,
   formatDateRange,
+  isValidFullDate,
+  isValidServicePeriod,
   isBDD,
   show526Wizard,
   isUndefined,
@@ -1117,6 +1120,47 @@ describe('526 v2 depends functions', () => {
           },
         }),
       ).to.be.false;
+    });
+  });
+
+  describe('isValidFullDate', () => {
+    it('should return true when a date is valid', () => {
+      expect(isValidFullDate('2021-01-01')).to.be.true;
+      expect(isValidFullDate(`${minYear}-01-01`)).to.be.true;
+      expect(isValidFullDate(`${maxYear}-01-01`)).to.be.true;
+    });
+    it('should return false when a date is invalid', () => {
+      expect(isValidFullDate()).to.be.false;
+      expect(isValidFullDate('')).to.be.false;
+      expect(isValidFullDate('2021')).to.be.false;
+      expect(isValidFullDate('2021-01')).to.be.false;
+      expect(isValidFullDate('01-01')).to.be.false;
+      expect(isValidFullDate('XXXX-01-01')).to.be.false;
+      expect(isValidFullDate('2021-XX-01')).to.be.false;
+      expect(isValidFullDate('2021-01-XX')).to.be.false;
+      expect(isValidFullDate('2021-02-31')).to.be.false;
+      expect(isValidFullDate(`${minYear - 1}-01-01`)).to.be.false;
+      expect(isValidFullDate(`${maxYear + 1}-01-01`)).to.be.false;
+      expect(isValidFullDate(new Date())).to.be.false;
+    });
+  });
+
+  describe('isValidServicePeriod', () => {
+    const check = (serviceBranch, from, to) =>
+      isValidServicePeriod({ serviceBranch, dateRange: { from, to } });
+    it('should return true when a service period data is valid', () => {
+      expect(check('a', '2020-01-31', '2020-02-14')).to.be.true;
+      expect(check('a', `${minYear}-01-31`, `${maxYear}-02-14`)).to.be.true;
+    });
+    it.skip('should return false when a service period data is invalid', () => {
+      expect(check('', '2020-01-31', '2020-02-14')).to.be.false;
+      expect(check('a', 'XXXX-01-31', '2020-02-14')).to.be.false;
+      expect(check('a', '2020-XX-31', '2020-02-14')).to.be.false;
+      expect(check('a', '2020-01-XX', '2020-02-14')).to.be.false;
+      expect(check('a', '2020-01-31', 'XXXX-02-14')).to.be.false;
+      expect(check('a', '2020-01-31', '2020-XX-14')).to.be.false;
+      expect(check('a', '2020-01-31', '2020-02-XX')).to.be.false;
+      expect(check('a', '2020-02-14', '2020-01-31')).to.be.false;
     });
   });
 });

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -21,6 +21,8 @@ import {
 import ReviewCardField from 'platform/forms-system/src/js/components/ReviewCardField';
 import AddressViewField from 'platform/forms-system/src/js/components/AddressViewField';
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import { isValidYear } from 'platform/forms-system/src/js/utilities/validations';
+import { isValidDateRange } from 'platform/forms/validations';
 
 import {
   DATA_PATHS,
@@ -94,9 +96,22 @@ export const formatDateRange = (dateRange = {}, format = DATE_FORMAT) =>
       )}`
     : 'Unknown';
 
+export const isValidDate = dateString => {
+  const date = moment(dateString);
+  return (date && date.isValid() && isValidYear(date.year)) || false;
+};
+
 // moment().isSameOrBefore() => true; so expirationDate can't be undefined
 export const isNotExpired = (expirationDate = '') =>
   moment().isSameOrBefore(expirationDate);
+
+export const isValidServicePeriod = data =>
+  isUndefined(data?.serviceBranch) ||
+  isUndefined(data?.dateRange?.from) ||
+  isUndefined(data?.dateRange?.to) ||
+  !isValidDate(data?.dateRange?.from) ||
+  !isValidDate(data?.dateRange?.to) ||
+  !isValidDateRange(data.dateRange.from, data.dateRange.to);
 
 export const isActiveITF = currentITF => {
   if (currentITF) {


### PR DESCRIPTION
## Description

Military history card buttons do not include unique aria-labels. This change adds a `ui-option` named `itemKeyForAriaLabel` which includes the form data key that points to the branch of service. This branch name will be included in the `aria-label` to make it unique.

Out of scope, but related: A similar change is being made to the new condition edit button aria-label on the review & submit page.

To update the aria-label of the military service history edit button, a change to the platform `ArrayField` component will be made in a separate PR.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/18923

## Testing done

Add unit tests

## Screenshots

<details><summary>Resulting markup</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-02-18 at 11 23 47 AM](https://user-images.githubusercontent.com/136959/108396606-a2065580-71dc-11eb-9838-388e8b9010ec.png)
![Screen Shot 2021-02-18 at 11 34 18 AM](https://user-images.githubusercontent.com/136959/108397617-c1ea4900-71dd-11eb-94f1-9411e8f8b7f6.png)</details>

<details><summary>Review & submit page (new condition)</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-02-18 at 12 15 35 PM](https://user-images.githubusercontent.com/136959/108403182-0f69b480-71e4-11eb-8cc4-0d0f0a3615cb.png)</details>

## Acceptance criteria
- [x] Array card edit, save, remove, update and cancel buttons all have a unique `aria-label`.
- [x] New condition aria-label on the edit button of the review & submit page now includes a unique name.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
