### PR TITLE
bradl3yC - Add formData to expandUnderCondition callback

### DIFF
--- a/src/platform/forms-system/src/js/state/helpers.js
+++ b/src/platform/forms-system/src/js/state/helpers.js
@@ -92,11 +92,11 @@ export function updateRequiredFields(schema, uiSchema, formData, index = null) {
   return schema;
 }
 
-export function isContentExpanded(data, matcher) {
+export function isContentExpanded(data, matcher, formData) {
   if (typeof matcher === 'undefined') {
     return !!data;
   } else if (typeof matcher === 'function') {
-    return matcher(data);
+    return matcher(data, formData);
   }
 
   return data === matcher;
@@ -141,7 +141,11 @@ export function setHiddenFields(schema, uiSchema, formData, path = []) {
   );
   if (
     expandUnder &&
-    !isContentExpanded(containingObject[expandUnder], expandUnderCondition)
+    !isContentExpanded(
+      containingObject[expandUnder],
+      expandUnderCondition,
+      formData,
+    )
   ) {
     if (!updatedSchema['ui:collapsed']) {
       updatedSchema = _.set('ui:collapsed', true, updatedSchema);

--- a/src/platform/forms-system/test/js/state/helpers.unit.spec.js
+++ b/src/platform/forms-system/test/js/state/helpers.unit.spec.js
@@ -255,6 +255,50 @@ describe('Schemaform formState:', () => {
       expect(newSchema.properties.field['ui:collapsed']).to.be.true;
       expect(newSchema).not.to.equal(schema);
     });
+    it('should not set collapsed on expandUnder field with function condition based on formData', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          field: {},
+          field2: {},
+        },
+      };
+      const uiSchema = {
+        field: {
+          'ui:options': {
+            expandUnder: 'field2',
+            expandUnderCondition: (condition, formData) =>
+              formData.field2 === 'bleh',
+          },
+        },
+      };
+      const data = { field: '', field2: 'bleh' };
+
+      const newSchema = setHiddenFields(schema, uiSchema, data);
+      expect(newSchema.properties.field['ui:collapsed']).to.be.undefined;
+    });
+    it('should set collapsed on expandUnder field with function condition based on formData', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          field: {},
+          field2: {},
+        },
+      };
+      const uiSchema = {
+        field: {
+          'ui:options': {
+            expandUnder: 'field2',
+            expandUnderCondition: (condition, formData) =>
+              formData.field2 !== 'bleh',
+          },
+        },
+      };
+      const data = { field: '', field2: 'bleh' };
+
+      const newSchema = setHiddenFields(schema, uiSchema, data);
+      expect(newSchema.properties.field['ui:collapsed']).not.to.be.undefined;
+    });
     it('should set collapsed on nested expandUnder field', () => {
       const schema = {
         type: 'object',

--- a/src/platform/forms-system/test/js/state/helpers.unit.spec.js
+++ b/src/platform/forms-system/test/js/state/helpers.unit.spec.js
@@ -273,7 +273,7 @@ describe('Schemaform formState:', () => {
         },
       };
       const data = { field: '', field2: 'bleh' };
-
+      // condition is met so we expect this field to not be collapsed
       const newSchema = setHiddenFields(schema, uiSchema, data);
       expect(newSchema.properties.field['ui:collapsed']).to.be.undefined;
     });
@@ -290,12 +290,12 @@ describe('Schemaform formState:', () => {
           'ui:options': {
             expandUnder: 'field2',
             expandUnderCondition: (condition, formData) =>
-              formData.field2 !== 'bleh',
+              formData.field2 === 'foo',
           },
         },
       };
       const data = { field: '', field2: 'bleh' };
-
+      // condition is not met so we expect this field to be collapsed
       const newSchema = setHiddenFields(schema, uiSchema, data);
       expect(newSchema.properties.field['ui:collapsed']).not.to.be.undefined;
     });


### PR DESCRIPTION
## Description
While working on the Financial Status Report form - we need a way to conditionally render different content in the expand under section.  Currently, there is limited data being passed back to the uiSchema in the callback.  We only have access to the value that is selected.  This PR will give access to the full formData and give more information in that callback.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
