### PR TITLE
Express Care details page

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/ExpressCareListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/ExpressCareListItem.jsx
@@ -35,13 +35,13 @@ export default function ExpressCareListItem({ appointment }) {
       <div>
         <Link
           aria-hidden="true"
-          to={`request/${appointment.id}`}
+          to={`express-care/${appointment.id}`}
           className="vads-u-display--none medium-screen:vads-u-display--inline"
         >
           Details
         </Link>
         <Link
-          to={`request/${appointment.id}`}
+          to={`express-care/${appointment.id}`}
           className="vaos-appts__card-link"
           aria-label={`Details for Express Care request on ${appointmentDate.format(
             'dddd, MMMM D YYYY',

--- a/src/applications/vaos/appointment-list/components/ExpressCareDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/ExpressCareDetailsPage.jsx
@@ -10,7 +10,6 @@ import {
 } from '../../utils/constants';
 import { sentenceCase } from '../../utils/formatters';
 import { scrollAndFocus } from '../../utils/scrollAndFocus';
-import ListBestTimeToCall from './cards/pending/ListBestTimeToCall';
 
 import { getPatientTelecom } from '../../services/appointment';
 import { selectExpressCareRequestById } from '../redux/selectors';
@@ -91,7 +90,7 @@ function ExpressCareDetailsPage({ appointment }) {
           {appointment.status === APPOINTMENT_STATUS.pending && (
             <span>A VA health care provider will contact you today.</span>
           )}
-          {appointment.status === APPOINTMENT_STATUS.booked && (
+          {appointment.status === APPOINTMENT_STATUS.fulfilled && (
             <span>
               We’ve completed your screening. Thank you for using Express Care.
             </span>
@@ -116,13 +115,8 @@ function ExpressCareDetailsPage({ appointment }) {
         {getPatientTelecom(appointment, 'email')}
         <br />
         {getPatientTelecom(appointment, 'phone')}
-        <br />
-        <span className="vads-u-font-style--italic">
-          <ListBestTimeToCall
-            timesToCall={appointment.legacyVAR?.bestTimeToCall}
-          />
-        </span>
       </div>
+
       {appointment.status === APPOINTMENT_STATUS.proposed && (
         <p>
           <button className="va-button-link">

--- a/src/applications/vaos/appointment-list/components/ExpressCareDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/ExpressCareDetailsPage.jsx
@@ -1,0 +1,151 @@
+import React, { useEffect } from 'react';
+import { Link, useParams, Redirect } from 'react-router-dom';
+import { connect } from 'react-redux';
+import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
+import moment from 'moment';
+import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
+
+import * as actions from '../redux/actions';
+import { APPOINTMENT_STATUS, FETCH_STATUS } from '../../utils/constants';
+import { sentenceCase } from '../../utils/formatters';
+import { scrollAndFocus } from '../../utils/scrollAndFocus';
+import ListBestTimeToCall from './cards/pending/ListBestTimeToCall';
+
+import { getPatientTelecom } from '../../services/appointment';
+
+function ExpressCareDetailsPage({
+  appointment,
+  appointmentDetailsStatus,
+  fetchExpressCareDetails,
+}) {
+  const { id } = useParams();
+
+  useEffect(() => {
+    if (!appointment || appointment.id !== id) {
+      fetchExpressCareDetails(id);
+    }
+  }, []);
+
+  useEffect(
+    () => {
+      if (appointmentDetailsStatus === FETCH_STATUS.succeeded) {
+        scrollAndFocus();
+      }
+    },
+    [appointmentDetailsStatus],
+  );
+
+  if (
+    appointmentDetailsStatus === FETCH_STATUS.notStarted ||
+    appointmentDetailsStatus === FETCH_STATUS.loading
+  ) {
+    return (
+      <div className="vads-u-margin-y--8">
+        <LoadingIndicator
+          setFocus
+          message="Loading your Express Care request..."
+        />
+      </div>
+    );
+  }
+
+  if (!appointment) {
+    return <Redirect to="/" />;
+  }
+
+  const appointmentDate = moment.parseZone(appointment.start);
+  const canceled = appointment.status === APPOINTMENT_STATUS.cancelled;
+
+  return (
+    <div>
+      <div className="vads-u-display--block vads-u-padding-y--2p5">
+        ‹ <Link to="/">Manage appointments</Link>
+      </div>
+
+      <h1>{appointmentDate.format('dddd, MMMM D, YYYY')}</h1>
+      <h2 className="vads-u-font-size--lg">
+        {sentenceCase(appointment.reason)}
+      </h2>
+
+      {canceled && (
+        <AlertBox
+          status="error"
+          className="vads-u-display--block vads-u-margin-bottom--2"
+          backgroundOnly
+          headline="This screening has been canceled"
+        />
+      )}
+
+      {!canceled && (
+        <>
+          <h3 className="vads-u-margin-top--2 vads-u-margin-bottom--0 vaos-appts__block-label">
+            Express Care request
+          </h3>
+          {appointment.status === APPOINTMENT_STATUS.proposed && (
+            <span>
+              A VA health care provider will contact you today about your
+              request.
+            </span>
+          )}
+          {appointment.status === APPOINTMENT_STATUS.pending && (
+            <span>A VA health care provider will contact you today.</span>
+          )}
+          {appointment.status === APPOINTMENT_STATUS.booked && (
+            <span>
+              We’ve completed your screening. Thank you for using Express Care.
+            </span>
+          )}
+        </>
+      )}
+
+      {!!appointment.comment && (
+        <>
+          <h3 className="vads-u-margin-top--2 vads-u-margin-bottom--0 vaos-appts__block-label">
+            You shared these details about your concern
+          </h3>
+
+          {appointment.comment}
+        </>
+      )}
+
+      <h3 className="vads-u-margin-top--2 vads-u-margin-bottom--0 vaos-appts__block-label">
+        Your contact details
+      </h3>
+      <div>
+        {getPatientTelecom(appointment, 'email')}
+        <br />
+        {getPatientTelecom(appointment, 'phone')}
+        <br />
+        <span className="vads-u-font-style--italic">
+          <ListBestTimeToCall
+            timesToCall={appointment.legacyVAR?.bestTimeToCall}
+          />
+        </span>
+      </div>
+      <Link to="/">
+        <button className="usa-button vads-u-margin-top--2">
+          « Go back to appointments
+        </button>
+      </Link>
+    </div>
+  );
+}
+function mapStateToProps(state) {
+  const {
+    currentAppointment,
+    appointmentDetailsStatus,
+    pendingStatus,
+  } = state.appointments;
+  return {
+    appointment: currentAppointment,
+    appointmentDetailsStatus,
+    pendingStatus,
+  };
+}
+const mapDispatchToProps = {
+  fetchExpressCareDetails: actions.fetchExpressCareDetails,
+};
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ExpressCareDetailsPage);

--- a/src/applications/vaos/appointment-list/components/ExpressCareDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/ExpressCareDetailsPage.jsx
@@ -81,14 +81,12 @@ function ExpressCareDetailsPage({ appointment }) {
           <h3 className="vads-u-margin-top--2 vads-u-margin-bottom--0 vaos-appts__block-label">
             Express Care request
           </h3>
-          {appointment.status === APPOINTMENT_STATUS.proposed && (
+          {(appointment.status === APPOINTMENT_STATUS.proposed ||
+            appointment.status === APPOINTMENT_STATUS.pending) && (
             <span>
               A VA health care provider will contact you today about your
               request.
             </span>
-          )}
-          {appointment.status === APPOINTMENT_STATUS.pending && (
-            <span>A VA health care provider will contact you today.</span>
           )}
           {appointment.status === APPOINTMENT_STATUS.fulfilled && (
             <span>

--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
@@ -67,7 +67,6 @@ function RequestedAppointmentDetailsPage({
 
   const canceled = appointment.status === APPOINTMENT_STATUS.cancelled;
   const isCC = appointment.vaos.isCommunityCare;
-  const isExpressCare = appointment.vaos.isExpressCare;
   const isVideoRequest = isVideoAppointment(appointment);
   const typeOfCareText = lowerCase(appointment?.type?.coding?.[0]?.display);
   const facilityId = getVAAppointmentLocationId(appointment);
@@ -115,13 +114,10 @@ function RequestedAppointmentDetailsPage({
         {isCC && !isCCRequest && 'Community Care'}
         {!isCC && !!isVideoRequest && 'VA Video Connect'}
         {!isCC && !isVideoRequest && 'VA Appointment'}
-        {isExpressCare && 'Express Care'}
-        {isExpressCare && facility?.name}
       </h2>
 
       {!!facility &&
-        !isCC &&
-        !isExpressCare && (
+        !isCC && (
           <VAFacilityLocation
             facility={facility}
             facilityName={facility?.name}
@@ -141,39 +137,23 @@ function RequestedAppointmentDetailsPage({
           </>
         )}
 
-      {!isExpressCare && (
-        <>
-          <h2 className="vaos-appts__block-label vads-u-margin-bottom--0 vads-u-margin-top--2">
-            Preferred date and time
-          </h2>
-          <ul className="usa-unstyled-list">
-            {appointment.requestedPeriod.map((option, optionIndex) => (
-              <li key={`${appointment.id}-option-${optionIndex}`}>
-                {moment(option.start).format('ddd, MMMM D, YYYY')}{' '}
-                {option.start.includes('00:00:00')
-                  ? TIME_TEXT.AM
-                  : TIME_TEXT.PM}
-              </li>
-            ))}
-          </ul>
-        </>
-      )}
-      {isExpressCare && (
-        <>
-          <h2 className="vads-u-margin-top--2 vaos-appts__block-label">
-            Reason for appointment
-          </h2>
-          <div>{appointment.reason}</div>
-        </>
-      )}
-      {!isExpressCare && (
-        <>
-          <h2 className="vads-u-margin-top--2 vaos-appts__block-label">
-            {appointment.reason}
-          </h2>
-          <div>{message}</div>
-        </>
-      )}
+      <h2 className="vaos-appts__block-label vads-u-margin-bottom--0 vads-u-margin-top--2">
+        Preferred date and time
+      </h2>
+      <ul className="usa-unstyled-list">
+        {appointment.requestedPeriod.map((option, optionIndex) => (
+          <li key={`${appointment.id}-option-${optionIndex}`}>
+            {moment(option.start).format('ddd, MMMM D, YYYY')}{' '}
+            {option.start.includes('00:00:00') ? TIME_TEXT.AM : TIME_TEXT.PM}
+          </li>
+        ))}
+      </ul>
+      <>
+        <h2 className="vads-u-margin-top--2 vaos-appts__block-label">
+          {appointment.reason}
+        </h2>
+        <div>{message}</div>
+      </>
       <h2 className="vads-u-margin-top--2 vads-u-margin-bottom--0 vaos-appts__block-label">
         Your contact details
       </h2>

--- a/src/applications/vaos/appointment-list/index.jsx
+++ b/src/applications/vaos/appointment-list/index.jsx
@@ -8,20 +8,19 @@ import AppointmentsPage from './components/AppointmentsPage/index';
 import RequestedAppointmentDetailsPage from './components/RequestedAppointmentDetailsPage';
 import ConfirmedAppointmentDetailsPage from './components/ConfirmedAppointmentDetailsPage';
 import CommunityCareAppointmentDetailsPage from './components/CommunityCareAppointmentDetailsPage';
+import ExpressCareDetailsPage from './components/ExpressCareDetailsPage';
 
 function AppointmentListSection({ featureHomepageRefresh }) {
   return (
     <Switch>
-      {featureHomepageRefresh && (
-        <Route
-          path="/cc/:id"
-          component={() => (
-            <PageLayout>
-              <CommunityCareAppointmentDetailsPage />
-            </PageLayout>
-          )}
-        />
-      )}
+      <Route
+        path="/cc/:id"
+        component={() => (
+          <PageLayout>
+            <CommunityCareAppointmentDetailsPage />
+          </PageLayout>
+        )}
+      />
       <Route
         path="/va/:id"
         component={() => (
@@ -30,17 +29,22 @@ function AppointmentListSection({ featureHomepageRefresh }) {
           </PageLayout>
         )}
       />
-      )}
-      {featureHomepageRefresh && (
-        <Route
-          path="/requests/:id"
-          component={() => (
-            <PageLayout>
-              <RequestedAppointmentDetailsPage />
-            </PageLayout>
-          )}
-        />
-      )}
+      <Route
+        path="/requests/:id"
+        component={() => (
+          <PageLayout>
+            <RequestedAppointmentDetailsPage />
+          </PageLayout>
+        )}
+      />
+      <Route
+        path="/express-care/:id"
+        component={() => (
+          <PageLayout>
+            <ExpressCareDetailsPage />
+          </PageLayout>
+        )}
+      />
       <Route
         path="/"
         render={() => {

--- a/src/applications/vaos/appointment-list/index.jsx
+++ b/src/applications/vaos/appointment-list/index.jsx
@@ -9,8 +9,10 @@ import RequestedAppointmentDetailsPage from './components/RequestedAppointmentDe
 import ConfirmedAppointmentDetailsPage from './components/ConfirmedAppointmentDetailsPage';
 import CommunityCareAppointmentDetailsPage from './components/CommunityCareAppointmentDetailsPage';
 import ExpressCareDetailsPage from './components/ExpressCareDetailsPage';
+import useManualScrollRestoration from '../hooks/useManualScrollRestoration';
 
 function AppointmentListSection({ featureHomepageRefresh }) {
+  useManualScrollRestoration();
   return (
     <Switch>
       <Route
@@ -37,14 +39,7 @@ function AppointmentListSection({ featureHomepageRefresh }) {
           </PageLayout>
         )}
       />
-      <Route
-        path="/express-care/:id"
-        component={() => (
-          <PageLayout>
-            <ExpressCareDetailsPage />
-          </PageLayout>
-        )}
-      />
+      <Route path="/express-care/:id" component={ExpressCareDetailsPage} />
       <Route
         path="/"
         render={() => {

--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -16,7 +16,6 @@ import {
 import {
   selectPendingAppointments,
   selectFutureAppointments,
-  selectUpcomingAppointments,
 } from '../redux/selectors';
 
 import {
@@ -451,39 +450,6 @@ export function fetchRequestDetails(id) {
 
     if (!messages) {
       dispatch(fetchRequestMessages(id));
-    }
-  };
-}
-
-export function fetchExpressCareDetails(id) {
-  return async (dispatch, getState) => {
-    const state = getState();
-    const { appointmentDetails, pending, past, confirmed } = state.appointments;
-
-    const allAppointments = []
-      .concat(pending)
-      .concat(past)
-      .concat(confirmed)
-      .filter(item => !!item);
-    const request =
-      appointmentDetails[id] || allAppointments.find(p => p.id === id);
-
-    dispatch({
-      type: FETCH_REQUEST_DETAILS,
-    });
-
-    if (request) {
-      dispatch({
-        type: FETCH_REQUEST_DETAILS_SUCCEEDED,
-        appointment: request,
-        id,
-      });
-    } else {
-      // TODO: fetch single appointment
-      dispatch({
-        type: FETCH_REQUEST_DETAILS_SUCCEEDED,
-        id,
-      });
     }
   };
 }

--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -16,6 +16,7 @@ import {
 import {
   selectPendingAppointments,
   selectFutureAppointments,
+  selectUpcomingAppointments,
 } from '../redux/selectors';
 
 import {
@@ -450,6 +451,39 @@ export function fetchRequestDetails(id) {
 
     if (!messages) {
       dispatch(fetchRequestMessages(id));
+    }
+  };
+}
+
+export function fetchExpressCareDetails(id) {
+  return async (dispatch, getState) => {
+    const state = getState();
+    const { appointmentDetails, pending, past, confirmed } = state.appointments;
+
+    const allAppointments = []
+      .concat(pending)
+      .concat(past)
+      .concat(confirmed)
+      .filter(item => !!item);
+    const request =
+      appointmentDetails[id] || allAppointments.find(p => p.id === id);
+
+    dispatch({
+      type: FETCH_REQUEST_DETAILS,
+    });
+
+    if (request) {
+      dispatch({
+        type: FETCH_REQUEST_DETAILS_SUCCEEDED,
+        appointment: request,
+        id,
+      });
+    } else {
+      // TODO: fetch single appointment
+      dispatch({
+        type: FETCH_REQUEST_DETAILS_SUCCEEDED,
+        id,
+      });
     }
   };
 }

--- a/src/applications/vaos/appointment-list/redux/selectors.js
+++ b/src/applications/vaos/appointment-list/redux/selectors.js
@@ -376,3 +376,19 @@ export function selectExpressCareAvailability(state) {
     windowsStatus: state.appointments.expressCareWindowsStatus,
   };
 }
+
+export function selectExpressCareRequestById(state, id) {
+  const { appointmentDetails, pending, past, confirmed } = state.appointments;
+
+  if (appointmentDetails[id]) {
+    return appointmentDetails[id];
+  }
+
+  const allAppointments = []
+    .concat(pending)
+    .concat(past)
+    .concat(confirmed)
+    .filter(item => !!item);
+
+  return allAppointments.find(p => p.id === id);
+}

--- a/src/applications/vaos/tests/appointment-list/components/ExpressCareDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ExpressCareDetailsPage.unit.spec.jsx
@@ -103,7 +103,7 @@ describe('VAOS <ExpressCareDetailsPage>', () => {
     );
     expect(screen.baseElement).to.contain.text('Express Care request');
     expect(screen.baseElement).to.contain.text(
-      'A VA health care provider will contact you today.',
+      'A VA health care provider will contact you today about your request.',
     );
     expect(screen.baseElement).to.contain.text('Need help ASAP');
 

--- a/src/applications/vaos/tests/appointment-list/components/ExpressCareDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ExpressCareDetailsPage.unit.spec.jsx
@@ -1,0 +1,250 @@
+import React from 'react';
+import MockDate from 'mockdate';
+import { expect } from 'chai';
+import moment from 'moment';
+import userEvent from '@testing-library/user-event';
+import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+
+import {
+  getTimezoneTestDate,
+  renderWithStoreAndRouter,
+} from '../../mocks/setup';
+import { getVARequestMock } from '../../mocks/v0';
+import { AppointmentList } from '../../../appointment-list';
+import {
+  mockAppointmentInfo,
+  mockPastAppointmentInfo,
+} from '../../mocks/helpers';
+
+const initialState = {
+  featureToggles: {
+    vaOnlineSchedulingHomepageRefresh: true,
+  },
+};
+
+describe('VAOS <ExpressCareDetailsPage>', () => {
+  beforeEach(() => {
+    mockFetch();
+    MockDate.set(getTimezoneTestDate());
+  });
+  afterEach(() => {
+    resetFetch();
+    MockDate.reset();
+  });
+
+  it('should render submitted Express Care request details', async () => {
+    const appointment = getVARequestMock();
+    const startDate = moment();
+    appointment.attributes = {
+      ...appointment.attributes,
+      typeOfCareId: 'CR1',
+      status: 'Submitted',
+      email: 'patient.test@va.gov',
+      phoneNumber: '5555555566',
+      reasonForVisit: 'Back pain',
+      additionalInformation: 'Need help ASAP',
+      date: startDate.format(),
+    };
+    appointment.id = '1234';
+    mockAppointmentInfo({ requests: [appointment], isHomepageRefresh: true });
+    const screen = renderWithStoreAndRouter(<AppointmentList />, {
+      initialState,
+    });
+    const detailLinks = await screen.findAllByRole('link', {
+      name: /Detail/i,
+    });
+
+    userEvent.click(detailLinks[0]);
+
+    expect(await screen.findByText('Back pain')).to.be.ok;
+    expect(screen.baseElement).to.contain.text(
+      startDate.format('dddd, MMMM D, YYYY'),
+    );
+    expect(screen.baseElement).to.contain.text('Express Care request');
+    expect(screen.baseElement).to.contain.text(
+      'A VA health care provider will contact you today about your request.',
+    );
+    expect(screen.baseElement).to.contain.text('Need help ASAP');
+
+    expect(screen.baseElement).to.contain.text('patient.test@va.gov');
+    expect(screen.baseElement).to.contain.text('5555555566');
+
+    expect(screen.getByRole('button', { name: 'Cancel Express Care request' }))
+      .to.be.ok;
+  });
+
+  it('should render escalated Express Care request details', async () => {
+    const appointment = getVARequestMock();
+    const startDate = moment();
+    appointment.attributes = {
+      ...appointment.attributes,
+      typeOfCareId: 'CR1',
+      status: 'Escalated',
+      email: 'patient.test@va.gov',
+      phoneNumber: '5555555566',
+      reasonForVisit: 'Back pain',
+      additionalInformation: 'Need help ASAP',
+      date: startDate.format(),
+    };
+    appointment.id = '1234';
+    mockAppointmentInfo({ requests: [appointment], isHomepageRefresh: true });
+    const screen = renderWithStoreAndRouter(<AppointmentList />, {
+      initialState,
+    });
+    const detailLinks = await screen.findAllByRole('link', {
+      name: /Detail/i,
+    });
+
+    userEvent.click(detailLinks[0]);
+
+    expect(await screen.findByText('Back pain')).to.be.ok;
+    expect(screen.baseElement).to.contain.text(
+      startDate.format('dddd, MMMM D, YYYY'),
+    );
+    expect(screen.baseElement).to.contain.text('Express Care request');
+    expect(screen.baseElement).to.contain.text(
+      'A VA health care provider will contact you today.',
+    );
+    expect(screen.baseElement).to.contain.text('Need help ASAP');
+
+    expect(screen.baseElement).to.contain.text('patient.test@va.gov');
+    expect(screen.baseElement).to.contain.text('5555555566');
+
+    expect(
+      screen.queryByRole('button', { name: 'Cancel Express Care request' }),
+    ).not.to.be.ok;
+  });
+
+  it('should render cancelled by veteran Express Care request details', async () => {
+    const appointment = getVARequestMock();
+    const startDate = moment();
+    appointment.attributes = {
+      ...appointment.attributes,
+      typeOfCareId: 'CR1',
+      status: 'Cancelled',
+      email: 'patient.test@va.gov',
+      phoneNumber: '5555555566',
+      reasonForVisit: 'Back pain',
+      additionalInformation: 'Need help ASAP',
+      date: startDate.format(),
+    };
+    appointment.id = '1234';
+    mockAppointmentInfo({ requests: [appointment], isHomepageRefresh: true });
+    const screen = renderWithStoreAndRouter(<AppointmentList />, {
+      initialState,
+    });
+    const detailLinks = await screen.findAllByRole('link', {
+      name: /Detail/i,
+    });
+
+    userEvent.click(detailLinks[0]);
+
+    expect(await screen.findByText('Back pain')).to.be.ok;
+    expect(screen.baseElement).to.contain.text(
+      startDate.format('dddd, MMMM D, YYYY'),
+    );
+    expect(screen.baseElement).to.contain.text(
+      'This screening has been canceled',
+    );
+    expect(screen.baseElement).to.contain.text(
+      'If you still want to use Express Care, please submit another request tomorrow.',
+    );
+    expect(screen.baseElement).not.to.contain.text(
+      'We tried to call you, but couldn’t reach you by phone',
+    );
+    expect(
+      screen.queryByRole('button', { name: 'Cancel Express Care request' }),
+    ).not.to.be.ok;
+  });
+
+  it('should render unable to reach veteran Express Care request details', async () => {
+    const appointment = getVARequestMock();
+    const startDate = moment();
+    appointment.attributes = {
+      ...appointment.attributes,
+      typeOfCareId: 'CR1',
+      status: 'Cancelled',
+      email: 'patient.test@va.gov',
+      phoneNumber: '5555555566',
+      reasonForVisit: 'Back pain',
+      additionalInformation: 'Need help ASAP',
+      date: startDate.format(),
+      appointmentRequestDetailCode: [
+        {
+          detailCode: {
+            code: 'DETCODE23',
+          },
+        },
+      ],
+    };
+    appointment.id = '1234';
+    mockAppointmentInfo({ requests: [appointment], isHomepageRefresh: true });
+    const screen = renderWithStoreAndRouter(<AppointmentList />, {
+      initialState,
+    });
+    const detailLinks = await screen.findAllByRole('link', {
+      name: /Detail/i,
+    });
+
+    userEvent.click(detailLinks[0]);
+
+    expect(await screen.findByText('Back pain')).to.be.ok;
+    expect(screen.baseElement).to.contain.text(
+      startDate.format('dddd, MMMM D, YYYY'),
+    );
+    expect(screen.baseElement).to.contain.text(
+      'This screening has been canceled',
+    );
+    expect(screen.baseElement).to.contain.text(
+      'If you still want to use Express Care, please submit another request tomorrow.',
+    );
+    expect(screen.baseElement).to.contain.text(
+      'We tried to call you, but couldn’t reach you by phone',
+    );
+    expect(
+      screen.queryByRole('button', { name: 'Cancel Express Care request' }),
+    ).not.to.be.ok;
+  });
+
+  it('should render completed Express Care request details', async () => {
+    const appointment = getVARequestMock();
+    const startDate = moment().subtract(3, 'days');
+    appointment.attributes = {
+      ...appointment.attributes,
+      typeOfCareId: 'CR1',
+      status: 'Resolved',
+      email: 'patient.test@va.gov',
+      phoneNumber: '5555555566',
+      reasonForVisit: 'Back pain',
+      additionalInformation: 'Need help ASAP',
+      date: startDate.format(),
+    };
+    appointment.id = '1234';
+    mockPastAppointmentInfo({
+      requests: [appointment],
+    });
+    const screen = renderWithStoreAndRouter(<AppointmentList />, {
+      initialState,
+      path: '/past',
+    });
+    const detailLinks = await screen.findAllByRole('link', {
+      name: /Detail/i,
+    });
+
+    userEvent.click(detailLinks[0]);
+
+    expect(await screen.findByText('Back pain')).to.be.ok;
+    expect(screen.baseElement).to.contain.text(
+      startDate.format('dddd, MMMM D, YYYY'),
+    );
+
+    expect(screen.baseElement).to.contain.text('Express Care request');
+    expect(screen.baseElement).to.contain.text(
+      'We’ve completed your screening. Thank you for using Express Care.',
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'Cancel Express Care request' }),
+    ).not.to.be.ok;
+  });
+});


### PR DESCRIPTION
## Description
This PR
- Adds the Express Care details page
- Removes EC logic from current request details page
- Updates urls for EC requests to be specific to EC

How to test
1. Make sure va_online_scheduling_homepage_refresh is turned on
2. Go to the past appointments page
3. Click on either of the EC list items

## Testing done
Local and unit testing

## Screenshots
![Screen Shot 2021-02-18 at 2 22 43 PM](https://user-images.githubusercontent.com/634932/108423935-8021c880-7206-11eb-8a3b-a577c3a4c356.png)
![Screen Shot 2021-02-18 at 1 57 44 PM](https://user-images.githubusercontent.com/634932/108423936-80ba5f00-7206-11eb-9b67-34eee9387900.png)
![Screen Shot 2021-02-18 at 1 57 29 PM](https://user-images.githubusercontent.com/634932/108423939-80ba5f00-7206-11eb-9160-e6d9ee56181a.png)

## Acceptance criteria
- [ ] EC details page works correctly, AC is met

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
