### PR TITLE
Enable geolocation Cypress test

### DIFF
--- a/src/applications/facility-locator/components/SearchControls.jsx
+++ b/src/applications/facility-locator/components/SearchControls.jsx
@@ -72,7 +72,7 @@ class SearchControls extends Component {
           City, state or postal code{' '}
           <span className="vads-u-color--secondary-dark">(*Required)</span>
         </label>
-        {!environment.isProduction() &&
+        {(window.Cypress || !environment.isProduction()) &&
           (currentQuery.geocodeInProgress ? (
             <div className="use-my-location-link">
               <i

--- a/src/applications/facility-locator/tests/e2e/geolocation.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/geolocation.cypress.spec.js
@@ -20,8 +20,7 @@ describe('Facility geolocation', () => {
     });
   });
 
-  // TODO - re-enable once we remove the environment check
-  it.skip('geolocates the user(', () => {
+  it('geolocates the user(', () => {
     // Mock the call to Mapbox
     cy.route('GET', '/geocoding/**/*', 'fx:constants/mock-la-location').as(
       'caLocation',


### PR DESCRIPTION
## Description

Cypress tests are run against production builds in CI.

Add `window.Cypress` to the conditions for displaying the Use my location link so it can be tested in CI.
