### PR TITLE
Remove content hash from Medallia custom CSS filename

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -264,11 +264,9 @@ module.exports = (env = {}) => {
       new MiniCssExtractPlugin({
         moduleFilename: chunk => {
           const { name } = chunk;
+
           const isMedalliaStyleFile = name === vaMedalliaStylesFilename;
-
-          const isStaging = buildtype === VAGOVSTAGING;
-
-          if (isMedalliaStyleFile && isStaging) return `[name].css`;
+          if (isMedalliaStyleFile) return `[name].css`;
 
           return useHashFilenames
             ? `[name].[contenthash]-${timestamp}.css`


### PR DESCRIPTION
## Description

This PR removes the content hash from the [`va-medallia-styles`](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/site-wide/sass/va-medallia-style.scss) filename. 

The content hash was already excluded from the filename on staging. This PR expands that logic to include the other environments.

## Acceptance criteria
- [ ] The Medallia custom css url should not have a content hash in the URL
