### PR TITLE
Removed gibctBenefitFilterEnhancement Feature Flag

### DIFF
--- a/src/applications/gi/components/profile/BenefitsForm.jsx
+++ b/src/applications/gi/components/profile/BenefitsForm.jsx
@@ -7,7 +7,6 @@ import { renderLearnMoreLabel } from '../../utils/render';
 import { ariaLabels } from '../../constants';
 import Dropdown from '../Dropdown';
 import ExpandingGroup from '@department-of-veterans-affairs/component-library/ExpandingGroup';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 
 export class BenefitsForm extends React.Component {
   state = { showYourMilitaryDetails: false };
@@ -20,7 +19,6 @@ export class BenefitsForm extends React.Component {
     handleInputFocus: PropTypes.func,
     giBillChapterOpen: PropTypes.arrayOf(PropTypes.bool),
     yourMilitaryDetails: PropTypes.bool,
-    gibctBenefitFilterEnhancement: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -231,16 +229,6 @@ export class BenefitsForm extends React.Component {
   }
 
   render() {
-    if (this.props.gibctBenefitFilterEnhancement) {
-      return (
-        <div className="filter-additional-info">
-          <AdditionalInfo triggerText="Your military details">
-            {this.renderYourMilitaryDetails()}
-          </AdditionalInfo>
-        </div>
-      );
-    }
-
     return (
       <div className="eligibility-form">
         {this.props.showHeader && <h2>Your benefits</h2>}

--- a/src/applications/gi/components/search/InstitutionSearchForm.jsx
+++ b/src/applications/gi/components/search/InstitutionSearchForm.jsx
@@ -17,7 +17,6 @@ function InstitutionSearchForm({
   eligibilityChange,
   fetchAutocompleteSuggestions,
   filters,
-  gibctBenefitFilterEnhancement,
   filtersClass,
   handleFilterChange,
   hideModal,
@@ -123,14 +122,12 @@ function InstitutionSearchForm({
                 showModal={showModal}
                 showHeader
                 handleInputFocus={handleInstitutionSearchInputFocus}
-                gibctBenefitFilterEnhancement={gibctBenefitFilterEnhancement}
               />
               <OnlineClassesFilter
                 onlineClasses={eligibility.onlineClasses}
                 onChange={eligibilityChange}
                 showModal={showModal}
                 handleInputFocus={handleInstitutionSearchInputFocus}
-                gibctBenefitFilterEnhancement={gibctBenefitFilterEnhancement}
               />
             </form>
           </div>

--- a/src/applications/gi/components/search/OnlineClassesFilter.jsx
+++ b/src/applications/gi/components/search/OnlineClassesFilter.jsx
@@ -3,42 +3,19 @@ import RadioButtons from '../RadioButtons';
 import PropTypes from 'prop-types';
 import { renderLearnMoreLabel } from '../../utils/render';
 import { ariaLabels } from '../../constants';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 
 function OnlineClassesFilter({
   showModal,
   onlineClasses,
   onChange,
   handleInputFocus,
-  gibctBenefitFilterEnhancement,
 }) {
   const radioButtonsLabelText = 'Will you be taking any classes in person?';
   const options = [
     { value: 'no', label: 'Yes' },
     { value: 'yes', label: 'No' },
   ];
-  if (gibctBenefitFilterEnhancement) {
-    return (
-      <div className="filter-additional-info vads-u-margin-bottom--4">
-        <AdditionalInfo triggerText="Your housing allowance">
-          <RadioButtons
-            label={renderLearnMoreLabel({
-              text: radioButtonsLabelText,
-              modal: 'onlineOnlyDistanceLearning',
-              showModal,
-              ariaLabel: ariaLabels.learnMore.onlineOnlyDistanceLearning,
-              component: OnlineClassesFilter,
-            })}
-            name="onlineClasses"
-            options={options}
-            value={onlineClasses}
-            onChange={onChange}
-            onFocus={handleInputFocus}
-          />
-        </AdditionalInfo>
-      </div>
-    );
-  }
+
   return (
     <RadioButtons
       label={renderLearnMoreLabel({

--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -47,7 +47,6 @@ export function SearchPage({
   dispatchUpdateAutocompleteSearchTerm,
   eligibility,
   filters,
-  gibctBenefitFilterEnhancement,
   gibctSchoolRatings,
   gibctStateSearch,
   search,
@@ -273,7 +272,6 @@ export function SearchPage({
           eligibilityChange={dispatchEligibilityChange}
           hideModal={dispatchHideModal}
           searchOnAutcompleteSelection
-          gibctBenefitFilterEnhancement={gibctBenefitFilterEnhancement}
         />
       </div>
     );
@@ -297,9 +295,6 @@ const mapStateToProps = state => ({
   eligibility: state.eligibility,
   gibctSchoolRatings: toggleValues(state)[
     FEATURE_FLAG_NAMES.gibctSchoolRatings
-  ],
-  gibctBenefitFilterEnhancement: toggleValues(state)[
-    FEATURE_FLAG_NAMES.gibctBenefitFilterEnhancement
   ],
   gibctStateSearch: toggleValues(state)[FEATURE_FLAG_NAMES.gibctStateSearch],
 });

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -34,7 +34,6 @@ export default Object.freeze({
   form526OriginalClaims: 'form526OriginalClaims',
   vaViewDependentsAccess: 'vaViewDependentsAccess',
   gibctEybBottomSheet: 'gibctEybBottomSheet',
-  gibctBenefitFilterEnhancement: 'gibctBenefitFilterEnhancement',
   gibctSchoolRatings: 'gibctSchoolRatings',
   form996HigherLevelReview: 'form996HigherLevelReview',
   debtLettersShowLetters: 'debtLettersShowLetters',


### PR DESCRIPTION
## Description
As a developer, I need to remove the 'gibctBenefitFilterEnhancement' feature flag toggle and related functionality so that dead code is no longer in the codebase.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/13364

backend PR: https://github.com/department-of-veterans-affairs/vets-api/pull/5975
## Testing done
local testing

## Screenshots
![Screen Shot 2021-02-19 at 1 25 31 PM](https://user-images.githubusercontent.com/50601724/108545651-0d702600-72b6-11eb-97b4-a71acfb368da.png)
![Screen Shot 2021-02-19 at 1 25 17 PM](https://user-images.githubusercontent.com/50601724/108545656-0ea15300-72b6-11eb-928d-78f229bbd462.png)
![Screen Shot 2021-02-19 at 1 17 37 PM](https://user-images.githubusercontent.com/50601724/108545664-1103ad00-72b6-11eb-8aba-939218aa94fe.png)


## Acceptance criteria
- [x] The feature flag 'gibctBenefitFilterEnhancement' is removed.
- [x] The feature flag is not displayed here: https://[environment]-api.va.gov/flipper/features.
- [x] The functionality shown in SA1 is removed from staging and matches current production functionality.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
