### PR TITLE
[508] Form array buttons need unique aria-labels

### DIFF
--- a/src/applications/disability-benefits/996/pages/contestedIssues.js
+++ b/src/applications/disability-benefits/996/pages/contestedIssues.js
@@ -12,7 +12,7 @@ const contestedIssuesPage = {
   uiSchema: {
     'ui:title': ContestedIssuesTitle,
     'ui:options': {
-      ariaLabelForEditButtonOnReview: 'Edit issues eligible for review',
+      itemName: 'issues eligible for review',
     },
     contestedIssues: {
       'ui:title': ' ',

--- a/src/applications/disability-benefits/996/pages/sameOffice.js
+++ b/src/applications/disability-benefits/996/pages/sameOffice.js
@@ -6,7 +6,7 @@ import {
 const sameOfficePage = {
   uiSchema: {
     'ui:options': {
-      ariaLabelForEditButtonOnReview: 'Edit office of review',
+      itemName: 'office of review',
     },
     'view:sameOfficeInfo': {
       'ui:title': ' ',

--- a/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
@@ -359,8 +359,11 @@ export default class ArrayField extends React.Component {
             );
             const isLast = items.length === index + 1;
             const isEditing = this.state.editing[index];
+            const ariaLabel = uiOptions.itemAriaLabel;
             const itemName =
-              item?.[uiOptions.itemKeyForAriaLabel] || uiOptions.itemName;
+              (typeof ariaLabel === 'function' && ariaLabel(item || {})) ||
+              uiOptions.itemName ||
+              'Item';
             const legendText = `${
               isLast && items.length > 1 ? 'New' : 'Editing'
             } ${itemName || ''} ${

--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -87,7 +87,7 @@ export const uiSchema = {
       'ui:objectViewField': ConditionReviewField,
       'ui:options': {
         itemAriaLabel: data => data.condition,
-        ariaLabelForEditButtonOnReview: 'Edit New condition',
+        itemName: 'New condition',
       },
     },
   },

--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -36,7 +36,7 @@ export const uiSchema = {
       viewField: NewDisability,
       reviewTitle: 'New Conditions',
       itemName: 'Condition',
-      includeIndexInTitle: true,
+      itemAriaLabel: data => data.condition,
       includeRequiredLabelInTitle: true,
     },
     // Ideally, this would show the validation on the array itself (or the name
@@ -86,6 +86,7 @@ export const uiSchema = {
       // disabled until design changes have been approved
       'ui:objectViewField': ConditionReviewField,
       'ui:options': {
+        itemAriaLabel: data => data.condition,
         ariaLabelForEditButtonOnReview: 'Edit New condition',
       },
     },

--- a/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
+++ b/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
@@ -58,10 +58,13 @@ export const uiSchema = {
       'ui:field': ArrayField,
       'ui:options': {
         itemName: 'Service Period',
-        itemAriaLabel: data =>
-          `${data.serviceBranch} ranging from ${formatDate(
-            data.dateRange.from,
-          )} to ${formatDate(data.dateRange.to)}`,
+        itemAriaLabel: data => {
+          const hasDate =
+            data.serviceBranch && data.dateRange?.from
+              ? ` started on ${formatDate(data.dateRange.from)}`
+              : '';
+          return `${data.serviceBranch || ''}${hasDate}`;
+        },
         viewField: ValidatedServicePeriodView,
         reviewMode: true,
         showSave: true,

--- a/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
+++ b/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
@@ -49,6 +49,14 @@ const validateSeparationDate = (
 dateRangeUISchema.from['ui:validations'].push(validateAge);
 dateRangeUISchema.to['ui:validations'].push(validateSeparationDate);
 
+const itemAriaLabel = data => {
+  const hasDate =
+    data.serviceBranch && data.dateRange?.from
+      ? ` started on ${formatDate(data.dateRange.from)}`
+      : '';
+  return `${data.serviceBranch || ''}${hasDate}`;
+};
+
 export const uiSchema = {
   serviceInformation: {
     servicePeriods: {
@@ -58,13 +66,7 @@ export const uiSchema = {
       'ui:field': ArrayField,
       'ui:options': {
         itemName: 'Service Period',
-        itemAriaLabel: data => {
-          const hasDate =
-            data.serviceBranch && data.dateRange?.from
-              ? ` started on ${formatDate(data.dateRange.from)}`
-              : '';
-          return `${data.serviceBranch || ''}${hasDate}`;
-        },
+        itemAriaLabel,
         viewField: ValidatedServicePeriodView,
         reviewMode: true,
         showSave: true,
@@ -77,8 +79,8 @@ export const uiSchema = {
         },
         dateRange: dateRangeUISchema,
         'ui:options': {
-          itemAriaLabel: data => data.serviceBranch,
-          ariaLabelForEditButtonOnReview: 'Edit Military service history',
+          itemAriaLabel,
+          itemName: 'Military service history',
         },
       },
     },

--- a/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
+++ b/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
@@ -58,7 +58,7 @@ export const uiSchema = {
       'ui:field': ArrayField,
       'ui:options': {
         itemName: 'Service Period',
-        itemKeyForAriaLabel: 'serviceBranch',
+        itemAriaLabel: data => data.serviceBranch,
         viewField: ValidatedServicePeriodView,
         reviewMode: true,
         showSave: true,
@@ -71,7 +71,7 @@ export const uiSchema = {
         },
         dateRange: dateRangeUISchema,
         'ui:options': {
-          itemKeyForAriaLabel: 'serviceBranch',
+          itemAriaLabel: data => data.serviceBranch,
           ariaLabelForEditButtonOnReview: 'Edit Military service history',
         },
       },

--- a/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
+++ b/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
@@ -4,7 +4,7 @@ import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 
 import ValidatedServicePeriodView from '../components/ValidatedServicePeriodView';
 import ArrayField from '../components/ArrayField';
-import { isValidServicePeriod } from '../utils';
+import { isValidServicePeriod, formatDate } from '../utils';
 
 const dateRangeUISchema = dateRangeUI(
   'Service start date',
@@ -58,7 +58,10 @@ export const uiSchema = {
       'ui:field': ArrayField,
       'ui:options': {
         itemName: 'Service Period',
-        itemAriaLabel: data => data.serviceBranch,
+        itemAriaLabel: data =>
+          `${data.serviceBranch} ranging from ${formatDate(
+            data.dateRange.from,
+          )} to ${formatDate(data.dateRange.to)}`,
         viewField: ValidatedServicePeriodView,
         reviewMode: true,
         showSave: true,

--- a/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
+++ b/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
@@ -71,6 +71,7 @@ export const uiSchema = {
         },
         dateRange: dateRangeUISchema,
         'ui:options': {
+          itemKeyForAriaLabel: 'serviceBranch',
           ariaLabelForEditButtonOnReview: 'Edit Military service history',
         },
       },

--- a/src/applications/disability-benefits/all-claims/pages/newDisabilityFollowUp.js
+++ b/src/applications/disability-benefits/all-claims/pages/newDisabilityFollowUp.js
@@ -60,6 +60,9 @@ export const uiSchema = {
   newDisabilities: {
     items: {
       'ui:title': disabilityNameTitle,
+      'ui:options': {
+        itemAriaLabel: data => `${data.condition} followup questions`,
+      },
       cause: {
         'ui:title': 'What caused this service-connected disability?',
         'ui:widget': 'radio',

--- a/src/applications/disability-benefits/all-claims/pages/prisonerOfWar.js
+++ b/src/applications/disability-benefits/all-claims/pages/prisonerOfWar.js
@@ -1,8 +1,11 @@
-import moment from 'moment';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
 import PeriodOfConfinement from '../components/PeriodOfConfinement';
-import { makeSchemaForNewDisabilities, claimingNew } from '../utils';
+import {
+  makeSchemaForNewDisabilities,
+  claimingNew,
+  formatDate,
+} from '../utils';
 import { isWithinServicePeriod } from '../validations';
 import { confinementDescription } from '../content/prisonerOfWar';
 
@@ -12,8 +15,6 @@ const confinementUI = dateRangeUI(
   'Confinement start date must be before end date',
 );
 confinementUI['ui:validations'].push(isWithinServicePeriod);
-
-const formatDate = date => moment(date).format('LL');
 
 export const uiSchema = {
   'ui:title': 'Prisoner of War (POW)',

--- a/src/applications/disability-benefits/all-claims/pages/prisonerOfWar.js
+++ b/src/applications/disability-benefits/all-claims/pages/prisonerOfWar.js
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
 import PeriodOfConfinement from '../components/PeriodOfConfinement';
@@ -11,6 +12,8 @@ const confinementUI = dateRangeUI(
   'Confinement start date must be before end date',
 );
 confinementUI['ui:validations'].push(isWithinServicePeriod);
+
+const formatDate = date => moment(date).format('LL');
 
 export const uiSchema = {
   'ui:title': 'Prisoner of War (POW)',
@@ -28,6 +31,8 @@ export const uiSchema = {
       'ui:options': {
         viewField: PeriodOfConfinement,
         reviewTitle: 'Periods of confinement',
+        itemAriaLabel: data =>
+          `period from ${formatDate(data.from)} to ${formatDate(data.to)}`,
         itemName: 'Period',
       },
       items: confinementUI,

--- a/src/applications/disability-benefits/all-claims/pages/prisonerOfWar.js
+++ b/src/applications/disability-benefits/all-claims/pages/prisonerOfWar.js
@@ -16,6 +16,9 @@ const confinementUI = dateRangeUI(
 );
 confinementUI['ui:validations'].push(isWithinServicePeriod);
 
+const itemAriaLabel = data =>
+  data.from ? `period starting on ${formatDate(data.from)}` : 'period';
+
 export const uiSchema = {
   'ui:title': 'Prisoner of War (POW)',
   'view:powStatus': {
@@ -32,11 +35,15 @@ export const uiSchema = {
       'ui:options': {
         viewField: PeriodOfConfinement,
         reviewTitle: 'Periods of confinement',
-        itemAriaLabel: data =>
-          `period from ${formatDate(data.from)} to ${formatDate(data.to)}`,
+        itemAriaLabel,
         itemName: 'Period',
       },
-      items: confinementUI,
+      items: {
+        ...confinementUI,
+        'ui:options': {
+          itemAriaLabel,
+        },
+      },
     },
     powDisabilities: {
       'ui:title': ' ',

--- a/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
@@ -27,7 +27,7 @@ export const uiSchema = {
   vaTreatmentFacilities: {
     'ui:options': {
       itemName: 'Facility',
-      itemKeyForAriaLabel: 'treatmentCenterName',
+      itemAriaLabel: data => data.treatmentCenterName,
       viewField: treatmentView,
     },
     items: {
@@ -53,7 +53,7 @@ export const uiSchema = {
           'Please choose the conditions for which you received treatment at this facility.',
         'ui:options': {
           updateSchema: makeSchemaForAllDisabilities,
-          itemKeyForAriaLabel: 'treatmentCenterName',
+          itemAriaLabel: data => data.treatmentCenterName,
           showFieldLabel: true,
         },
         'ui:validations': [validateBooleanGroup],

--- a/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
@@ -37,6 +37,9 @@ export const uiSchema = {
         'treatmentDateRange',
         'treatmentCenterAddress',
       ],
+      'ui:options': {
+        itemAriaLabel: data => data.treatmentCenterName,
+      },
       treatmentCenterName: autoSuggestUiSchema(
         'Name of VA medical facility',
         queryForFacilities,

--- a/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
@@ -27,6 +27,7 @@ export const uiSchema = {
   vaTreatmentFacilities: {
     'ui:options': {
       itemName: 'Facility',
+      itemKeyForAriaLabel: 'treatmentCenterName',
       viewField: treatmentView,
     },
     items: {
@@ -52,6 +53,7 @@ export const uiSchema = {
           'Please choose the conditions for which you received treatment at this facility.',
         'ui:options': {
           updateSchema: makeSchemaForAllDisabilities,
+          itemKeyForAriaLabel: 'treatmentCenterName',
           showFieldLabel: true,
         },
         'ui:validations': [validateBooleanGroup],

--- a/src/applications/pre-need/utils/helpers.js
+++ b/src/applications/pre-need/utils/helpers.js
@@ -393,7 +393,7 @@ export const serviceRecordsUI = {
   items: {
     'ui:order': ['serviceBranch', '*'],
     'ui:options': {
-      ariaLabelForEditButtonOnReview: 'Service Period',
+      itemName: 'Service Period',
     },
     serviceBranch: autosuggest.uiSchema('Branch of service', null, {
       'ui:options': {

--- a/src/platform/forms-system/src/js/components/ProgressButton.jsx
+++ b/src/platform/forms-system/src/js/components/ProgressButton.jsx
@@ -33,6 +33,7 @@ class ProgressButton extends React.Component {
         }`}
         id={`${this.id}-continueButton`}
         onClick={this.props.onButtonClick}
+        aria-label={this.props['aria-label'] || null}
       >
         {beforeText}
         {this.props.buttonText}

--- a/src/platform/forms-system/src/js/components/ProgressButton.jsx
+++ b/src/platform/forms-system/src/js/components/ProgressButton.jsx
@@ -33,7 +33,7 @@ class ProgressButton extends React.Component {
         }`}
         id={`${this.id}-continueButton`}
         onClick={this.props.onButtonClick}
-        aria-label={this.props['aria-label'] || null}
+        aria-label={this.props.ariaLabel || null}
       >
         {beforeText}
         {this.props.buttonText}
@@ -61,6 +61,10 @@ ProgressButton.propTypes = {
 
   // is the button disabled or not
   disabled: PropTypes.bool,
+
+  // aria-label attribute; needed for the review & submit page "Update page"
+  // button
+  ariaLabel: PropTypes.string,
 
   // is this a submit button or not
   submitButton: PropTypes.bool,

--- a/src/platform/forms-system/src/js/fields/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/fields/ArrayField.jsx
@@ -269,8 +269,9 @@ export default class ArrayField extends React.Component {
             const updateText = showSave && index === 0 ? 'Save' : 'Update';
             const isLast = items.length === index + 1;
             const isEditing = this.state.editing[index];
+            const ariaLabel = uiOptions.itemAriaLabel;
             const itemName =
-              item?.[uiOptions.itemKeyForAriaLabel] ||
+              (typeof ariaLabel === 'function' && ariaLabel(item || {})) ||
               uiOptions.itemName ||
               'Item';
             const notLastOrMultipleRows =

--- a/src/platform/forms-system/src/js/fields/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/fields/ArrayField.jsx
@@ -327,11 +327,7 @@ export default class ArrayField extends React.Component {
                               <button
                                 type="button"
                                 className="usa-button-secondary float-right"
-                                aria-label={`Remove ${
-                                  itemName === uiOptions.itemName
-                                    ? 'incomplete '
-                                    : ''
-                                }${itemName}`}
+                                aria-label={`Remove ${itemName}`}
                                 onClick={() => this.handleRemove(index)}
                               >
                                 Remove

--- a/src/platform/forms-system/src/js/fields/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/fields/ArrayField.jsx
@@ -223,7 +223,7 @@ export default class ArrayField extends React.Component {
       typeof description === 'string' ? description : null;
     const DescriptionField =
       typeof description === 'function' ? uiSchema['ui:description'] : null;
-    const isReviewMode = uiSchema['ui:options'].reviewMode;
+    const isReviewMode = uiOptions.reviewMode;
     const hasTitleOrDescription = (!!title && !hideTitle) || !!description;
 
     // if we have form data, use that, otherwise use an array with a single default object
@@ -250,9 +250,7 @@ export default class ArrayField extends React.Component {
               />
             ) : null}
             {textDescription && <p>{textDescription}</p>}
-            {DescriptionField && (
-              <DescriptionField options={uiSchema['ui:options']} />
-            )}
+            {DescriptionField && <DescriptionField options={uiOptions} />}
             {!textDescription && !DescriptionField && description}
           </div>
         )}
@@ -267,10 +265,14 @@ export default class ArrayField extends React.Component {
               itemIdPrefix,
               definitions,
             );
-            const showSave = uiSchema['ui:options'].showSave;
+            const showSave = uiOptions.showSave;
             const updateText = showSave && index === 0 ? 'Save' : 'Update';
             const isLast = items.length === index + 1;
             const isEditing = this.state.editing[index];
+            const itemName =
+              item?.[uiOptions.itemKeyForAriaLabel] ||
+              uiOptions.itemName ||
+              'Item';
             const notLastOrMultipleRows =
               showSave || !isLast || items.length > 1;
 
@@ -285,12 +287,8 @@ export default class ArrayField extends React.Component {
                   <Element name={`table_${itemIdPrefix}`} />
                   <div className="row small-collapse">
                     <div className="small-12 columns va-growable-expanded">
-                      {isLast &&
-                      items.length > 1 &&
-                      uiSchema['ui:options'].itemName ? (
-                        <h3 className="vads-u-font-size--h5">
-                          New {uiSchema['ui:options'].itemName}
-                        </h3>
+                      {isLast && items.length > 1 ? (
+                        <h3 className="vads-u-font-size--h5">New {itemName}</h3>
                       ) : null}
                       <div className="input-section">
                         <SchemaField
@@ -315,9 +313,10 @@ export default class ArrayField extends React.Component {
                           <div className="small-6 left columns">
                             {(!isLast || showSave) && (
                               <button
+                                type="button"
                                 className="float-left"
+                                aria-label={`${updateText} ${itemName}`}
                                 onClick={() => this.handleUpdate(index)}
-                                aria-label={`${updateText} ${title}`}
                               >
                                 {updateText}
                               </button>
@@ -326,8 +325,13 @@ export default class ArrayField extends React.Component {
                           <div className="small-6 right columns">
                             {index !== 0 && (
                               <button
-                                className="usa-button-secondary float-right"
                                 type="button"
+                                className="usa-button-secondary float-right"
+                                aria-label={`Remove ${
+                                  itemName === uiOptions.itemName
+                                    ? 'incomplete '
+                                    : ''
+                                }${itemName}`}
                                 onClick={() => this.handleRemove(index)}
                               >
                                 Remove
@@ -351,9 +355,10 @@ export default class ArrayField extends React.Component {
                     />
                   </div>
                   <button
+                    type="button"
                     className="usa-button-secondary edit vads-u-flex--auto"
+                    aria-label={`Edit ${itemName}`}
                     onClick={() => this.handleEdit(index)}
-                    aria-label={`Edit ${title}`}
                   >
                     Edit
                   </button>

--- a/src/platform/forms-system/src/js/review/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/review/ArrayField.jsx
@@ -240,6 +240,10 @@ class ArrayField extends React.Component {
               (!schema.minItems || items.length > schema.minItems);
             const itemSchema = this.getItemSchema(index);
             const itemTitle = itemSchema ? itemSchema.title : '';
+            const itemName =
+              item?.[uiOptions.itemKeyForAriaLabel] ||
+              uiOptions.itemName ||
+              'Item';
 
             const idSchema = toIdSchema(
               itemSchema,
@@ -263,7 +267,7 @@ class ArrayField extends React.Component {
                           tabIndex="-1"
                           ref={focusElement}
                         >
-                          New {uiOptions.itemName || 'Item'}
+                          New {itemName}
                         </h4>
                       ) : null}
                       <SchemaForm
@@ -284,13 +288,24 @@ class ArrayField extends React.Component {
                       >
                         <div className="row small-collapse">
                           <div className="small-6 left columns">
-                            <button className="float-left">Update</button>
+                            <button
+                              type="button"
+                              className="float-left"
+                              aria-label={`Update ${itemName}`}
+                            >
+                              Update
+                            </button>
                           </div>
                           <div className="small-6 right columns">
                             {showReviewButton && (
                               <button
                                 type="button"
                                 className="usa-button-secondary float-right"
+                                aria-label={`Remove ${
+                                  itemName === uiOptions.itemName
+                                    ? 'incomplete '
+                                    : ''
+                                }${itemName}`}
                                 onClick={() =>
                                   this.handleRemove(index, fieldName)
                                 }

--- a/src/platform/forms-system/src/js/review/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/review/ArrayField.jsx
@@ -290,7 +290,7 @@ class ArrayField extends React.Component {
                         <div className="row small-collapse">
                           <div className="small-6 left columns">
                             <button
-                              type="button"
+                              type="submit"
                               className="float-left"
                               aria-label={`Update ${itemName}`}
                             >

--- a/src/platform/forms-system/src/js/review/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/review/ArrayField.jsx
@@ -301,11 +301,7 @@ class ArrayField extends React.Component {
                               <button
                                 type="button"
                                 className="usa-button-secondary float-right"
-                                aria-label={`Remove ${
-                                  itemName === uiOptions.itemName
-                                    ? 'incomplete '
-                                    : ''
-                                }${itemName}`}
+                                aria-label={`Remove ${itemName}`}
                                 onClick={() =>
                                   this.handleRemove(index, fieldName)
                                 }

--- a/src/platform/forms-system/src/js/review/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/review/ArrayField.jsx
@@ -240,8 +240,9 @@ class ArrayField extends React.Component {
               (!schema.minItems || items.length > schema.minItems);
             const itemSchema = this.getItemSchema(index);
             const itemTitle = itemSchema ? itemSchema.title : '';
+            const ariaLabel = uiOptions.itemAriaLabel;
             const itemName =
-              item?.[uiOptions.itemKeyForAriaLabel] ||
+              (typeof ariaLabel === 'function' && ariaLabel(item || {})) ||
               uiOptions.itemName ||
               'Item';
 

--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -141,8 +141,11 @@ class ObjectField extends React.Component {
       if (!formContext.hideTitle && typeof title === 'function') {
         title = title(formData, formContext);
       }
+      const uiOptions = uiSchema['ui:options'] || {};
+      const labelKey = uiOptions.itemKeyForAriaLabel;
       const editLabel =
-        _.get('ui:options.ariaLabelForEditButtonOnReview', uiSchema) ||
+        (labelKey && `Edit ${formData[labelKey]}`) ||
+        uiOptions.ariaLabelForEditButtonOnReview ||
         `Edit ${title}`;
 
       const Tag = divWrapper ? 'div' : 'dl';

--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -142,9 +142,12 @@ class ObjectField extends React.Component {
         title = title(formData, formContext);
       }
       const uiOptions = uiSchema['ui:options'] || {};
-      const labelKey = uiOptions.itemKeyForAriaLabel;
+      const ariaLabel = uiOptions.itemAriaLabel;
+      const itemName =
+        (typeof ariaLabel === 'function' && ariaLabel(formData || {})) ||
+        formData[uiOptions.itemName];
       const editLabel =
-        (labelKey && `Edit ${formData[labelKey]}`) ||
+        (itemName && `Edit ${itemName}`) ||
         uiOptions.ariaLabelForEditButtonOnReview ||
         `Edit ${title}`;
 

--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -145,7 +145,8 @@ class ObjectField extends React.Component {
       const ariaLabel = uiOptions.itemAriaLabel;
       const itemName =
         (typeof ariaLabel === 'function' && ariaLabel(formData || {})) ||
-        formData[uiOptions.itemName];
+        formData[uiOptions.itemName] ||
+        'Item';
       const editLabel =
         (itemName && `Edit ${itemName}`) ||
         uiOptions.ariaLabelForEditButtonOnReview ||

--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -145,8 +145,7 @@ class ObjectField extends React.Component {
       const ariaLabel = uiOptions.itemAriaLabel;
       const itemName =
         (typeof ariaLabel === 'function' && ariaLabel(formData || {})) ||
-        formData[uiOptions.itemName] ||
-        'Item';
+        formData[uiOptions.itemName];
       const editLabel =
         (itemName && `Edit ${itemName}`) ||
         uiOptions.ariaLabelForEditButtonOnReview ||

--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -145,11 +145,9 @@ class ObjectField extends React.Component {
       const ariaLabel = uiOptions.itemAriaLabel;
       const itemName =
         (typeof ariaLabel === 'function' && ariaLabel(formData || {})) ||
-        formData[uiOptions.itemName];
-      const editLabel =
-        (itemName && `Edit ${itemName}`) ||
-        uiOptions.ariaLabelForEditButtonOnReview ||
-        `Edit ${title}`;
+        formData[uiOptions.itemName] ||
+        uiOptions.itemName;
+      const editLabel = (itemName && `Edit ${itemName}`) || `Edit ${title}`;
 
       const Tag = divWrapper ? 'div' : 'dl';
       const objectViewField = uiSchema?.['ui:objectViewField'];

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -149,6 +149,9 @@ export default class ReviewCollapsibleChapter extends React.Component {
                 !pageSchema && arrayFields.length === 0,
             });
             const title = page.reviewTitle || page.title || '';
+            const ariaLabel = `Update ${(typeof title === 'function'
+              ? title(pageData)
+              : title) || 'page'}`;
 
             const noVisibleFields =
               pageSchema &&
@@ -225,6 +228,7 @@ export default class ReviewCollapsibleChapter extends React.Component {
                         }}
                         buttonText="Update page"
                         buttonClass="usa-button-primary"
+                        aria-label={ariaLabel}
                       />
                     )}
                   </SchemaForm>

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -228,7 +228,7 @@ export default class ReviewCollapsibleChapter extends React.Component {
                         }}
                         buttonText="Update page"
                         buttonClass="usa-button-primary"
-                        aria-label={ariaLabel}
+                        ariaLabel={ariaLabel}
                       />
                     )}
                   </SchemaForm>

--- a/src/platform/forms-system/test/js/fields/ArrayField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/fields/ArrayField.unit.spec.jsx
@@ -191,6 +191,84 @@ describe('Schemaform <ArrayField>', () => {
     expect(button[3].text()).to.contain('Add another');
   });
 
+  it('should render unique aria-labels on buttons from ui option key in item', () => {
+    const idSchema = {
+      $id: 'field',
+    };
+    const schema = {
+      type: 'array',
+      items: [
+        {
+          type: 'object',
+          properties: {
+            field: {
+              type: 'string',
+            },
+          },
+        },
+        {
+          type: 'object',
+          properties: {
+            field: {
+              type: 'string',
+            },
+          },
+        },
+      ],
+      additionalItems: {
+        type: 'object',
+        properties: {
+          field: {
+            type: 'string',
+          },
+        },
+      },
+    };
+    const uiSchema = {
+      'ui:title': 'List of things',
+      items: {
+        test: {
+          type: 'string',
+        },
+        'ui:options': {
+          itemKeyForAriaLabel: 'field',
+        },
+      },
+      'ui:options': {
+        viewField: f => f,
+        showSave: true,
+        itemKeyForAriaLabel: 'field',
+        itemName: 'Itemz',
+      },
+    };
+    const formData = [{ field: 'foo' }, { field: 'bar' }];
+    const tree = SkinDeep.shallowRender(
+      <ArrayField
+        schema={schema}
+        uiSchema={uiSchema}
+        idSchema={idSchema}
+        registry={registry}
+        formData={formData}
+        formContext={formContext}
+        onChange={f => f}
+        requiredSchema={requiredSchema}
+        errorSchema={[]}
+      />,
+    );
+
+    expect(tree.everySubTree('SchemaField').length).to.equal(1);
+    expect(tree.everySubTree('.va-growable-background').length).to.equal(2);
+    const button = tree.everySubTree('button');
+    expect(button.length).to.equal(4);
+    expect(button[0].text()).to.equal('Edit');
+    expect(button[0].props['aria-label']).to.equal('Edit foo');
+    expect(button[1].text()).to.equal('Update');
+    expect(button[1].props['aria-label']).to.equal('Update bar');
+    expect(button[2].text()).to.equal('Remove');
+    expect(button[2].props['aria-label']).to.equal('Remove bar');
+    expect(button[3].text()).to.contain('Add another');
+  });
+
   it('should render invalid items', () => {
     const idSchema = {
       $id: 'field',
@@ -233,6 +311,7 @@ describe('Schemaform <ArrayField>', () => {
     expect(tree.everySubTree('SchemaField').length).to.equal(2);
     expect(tree.everySubTree('.va-growable-background').length).to.equal(2);
   });
+
   describe('should handle', () => {
     let tree;
     let errorSchema;

--- a/src/platform/forms-system/test/js/fields/ArrayField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/fields/ArrayField.unit.spec.jsx
@@ -231,13 +231,13 @@ describe('Schemaform <ArrayField>', () => {
           type: 'string',
         },
         'ui:options': {
-          itemKeyForAriaLabel: 'field',
+          itemAriaLabel: data => data.field,
         },
       },
       'ui:options': {
         viewField: f => f,
         showSave: true,
-        itemKeyForAriaLabel: 'field',
+        itemAriaLabel: data => data.field,
         itemName: 'Itemz',
       },
     };

--- a/src/platform/forms-system/test/js/review/ArrayField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ArrayField.unit.spec.jsx
@@ -224,6 +224,83 @@ describe('Schemaform review <ArrayField>', () => {
     expect(tree.everySubTree('.schemaform-review-array-warning')).to.not.be
       .empty;
   });
+
+  it('should render unique aria-labels on buttons from ui option key in item', () => {
+    const idSchema = {};
+    const schema = {
+      type: 'array',
+      items: [
+        {
+          type: 'object',
+          properties: {
+            field: {
+              type: 'string',
+            },
+          },
+        },
+        {
+          type: 'object',
+          properties: {
+            field: {
+              type: 'string',
+            },
+          },
+        },
+      ],
+      additionalItems: {
+        type: 'object',
+        properties: {
+          field: {
+            type: 'string',
+          },
+        },
+      },
+    };
+    const uiSchema = {
+      'ui:title': 'List of things',
+      items: {
+        test: {
+          type: 'string',
+        },
+        'ui:options': {
+          itemKeyForAriaLabel: 'field',
+        },
+      },
+      'ui:options': {
+        viewField: f => f,
+        itemKeyForAriaLabel: 'field',
+        itemName: 'Itemz',
+      },
+    };
+    const arrayData = [{ field: 'foo' }, { field: 'bar' }];
+    const tree = SkinDeep.shallowRender(
+      <ArrayField
+        pageKey="page1"
+        arrayData={arrayData}
+        path={['thingList']}
+        schema={schema}
+        uiSchema={uiSchema}
+        idSchema={idSchema}
+        registry={registry}
+        formContext={formContext}
+        pageTitle=""
+        requiredSchema={requiredSchema}
+      />,
+    );
+
+    tree.getMountedInstance().handleEdit(1, true);
+    tree.getMountedInstance().handleAdd();
+    expect(tree.everySubTree('.schemaform-array-row-title')[0].text()).to.equal(
+      'New Itemz',
+    );
+    const buttons = tree.everySubTree('button');
+    expect(buttons[0].props['aria-label']).to.equal('Update bar');
+    expect(buttons[1].props['aria-label']).to.equal('Remove bar');
+    expect(buttons[2].props['aria-label']).to.equal('Update Itemz');
+    expect(buttons[3].props['aria-label']).to.equal('Remove incomplete Itemz');
+    expect(buttons[4].text()).to.equal('Add another Itemz');
+  });
+
   describe('should handle', () => {
     let tree;
     let setData;
@@ -315,6 +392,7 @@ describe('Schemaform review <ArrayField>', () => {
       expect(setData.calledWith({ thingList: [{ test: 1 }] })).to.be.true;
     });
   });
+
   it('should update state when props change', () => {
     const idSchema = {};
     const schema = {

--- a/src/platform/forms-system/test/js/review/ArrayField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ArrayField.unit.spec.jsx
@@ -263,12 +263,12 @@ describe('Schemaform review <ArrayField>', () => {
           type: 'string',
         },
         'ui:options': {
-          itemKeyForAriaLabel: 'field',
+          itemAriaLabel: data => data.field,
         },
       },
       'ui:options': {
         viewField: f => f,
-        itemKeyForAriaLabel: 'field',
+        itemAriaLabel: data => data.field,
         itemName: 'Itemz',
       },
     };

--- a/src/platform/forms-system/test/js/review/ArrayField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ArrayField.unit.spec.jsx
@@ -297,7 +297,7 @@ describe('Schemaform review <ArrayField>', () => {
     expect(buttons[0].props['aria-label']).to.equal('Update bar');
     expect(buttons[1].props['aria-label']).to.equal('Remove bar');
     expect(buttons[2].props['aria-label']).to.equal('Update Itemz');
-    expect(buttons[3].props['aria-label']).to.equal('Remove incomplete Itemz');
+    expect(buttons[3].props['aria-label']).to.equal('Remove Itemz');
     expect(buttons[4].text()).to.equal('Add another Itemz');
   });
 

--- a/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
@@ -524,6 +524,42 @@ describe('Schemaform review: ObjectField', () => {
     expect(tree.getByLabelText('Custom label')).to.exist;
   });
 
+  it('should render aria-label on edit button using value from config', () => {
+    const onChange = sinon.spy();
+    const onBlur = sinon.spy();
+
+    const schema = {
+      type: 'object',
+      properties: {
+        testKey: {
+          type: 'string',
+        },
+      },
+    };
+
+    const tree = render(
+      <ObjectField
+        uiSchema={{
+          'ui:options': {
+            itemKeyForAriaLabel: 'testKey',
+            ariaLabelForEditButtonOnReview: 'Custom label',
+          },
+        }}
+        schema={schema}
+        formContext={{ pageTitle: 'Blah' }}
+        requiredSchema={{}}
+        idSchema={{ $id: 'root' }}
+        formData={{
+          testKey: 'Happy',
+        }}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+
+    expect(tree.getByLabelText('Edit Happy')).to.exist;
+  });
+
   it('should render a div when rendering a ReviewCardField content with volatileData', () => {
     const onChange = sinon.spy();
     const onBlur = sinon.spy();

--- a/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
@@ -508,7 +508,7 @@ describe('Schemaform review: ObjectField', () => {
       <ObjectField
         uiSchema={{
           'ui:options': {
-            ariaLabelForEditButtonOnReview: 'Custom label',
+            itemName: 'Custom label',
           },
         }}
         schema={schema}
@@ -521,7 +521,7 @@ describe('Schemaform review: ObjectField', () => {
       />,
     );
 
-    expect(tree.getByLabelText('Custom label')).to.exist;
+    expect(tree.getByLabelText('Edit Custom label')).to.exist;
   });
 
   it('should render aria-label on edit button using value from config', () => {
@@ -542,7 +542,7 @@ describe('Schemaform review: ObjectField', () => {
         uiSchema={{
           'ui:options': {
             itemAriaLabel: data => data.testKey,
-            ariaLabelForEditButtonOnReview: 'Custom label',
+            itemName: 'Custom label',
           },
         }}
         schema={schema}

--- a/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
@@ -541,7 +541,7 @@ describe('Schemaform review: ObjectField', () => {
       <ObjectField
         uiSchema={{
           'ui:options': {
-            itemKeyForAriaLabel: 'testKey',
+            itemAriaLabel: data => data.testKey,
             ariaLabelForEditButtonOnReview: 'Custom label',
           },
         }}


### PR DESCRIPTION
## Description

Form array cards which don't include an easy method to make unique title and `aria-labels` on buttons. The title has a `includeIndexInTitle` ui option which adds a one-based index after the title, and the edit button has a `ariaLabelForEditButtonOnReview` ui option, but only for the review page. But there isn't any way to uniquely distinguish card buttons while editing.

This PR adds a `itemAriaLabel` ui option which allows you to convert the item data (from the array) and return a unique label to build upon.

```js
'ui:options': {
  itemAriaLabel: data => data[keyInformation],
}
```

Using this text, the `aria-label` for the array card edit, update, save, cancel and remove buttons are created so the screenreader user is able to get the full details on what the button will do (see the screenshot).

Thie PR also updates form 526 add disabilities, military history, POW and VA medical records pages which all use this data pattern.

**Note** If the array data includes an object, then the `ObjectField` will also need a duplicate `ui:options` set within the `items` section of the `uiSchema`.

Related:
- Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/18923
- 526 custom `ArrayField` used `itemKeyForAriaLabel`, but it has since been removed and `itemAriaLabel` from this PR will replace iit - https://github.com/department-of-veterans-affairs/vets-website/pull/16098

## Testing done

Updated unit tests

## Screenshots

<details><summary>Medical records</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-02-19 at 9 26 57 AM](https://user-images.githubusercontent.com/136959/108525533-ca9e5600-7295-11eb-89da-f2bd0fb67b5f.png)</details>

<details><summary>Service history</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-02-18 at 11 23 47 AM](https://user-images.githubusercontent.com/136959/108396606-a2065580-71dc-11eb-9838-388e8b9010ec.png)
![Screen Shot 2021-02-18 at 11 34 18 AM](https://user-images.githubusercontent.com/136959/108397617-c1ea4900-71dd-11eb-94f1-9411e8f8b7f6.png)

Update:
![](https://user-images.githubusercontent.com/136959/108732530-46e1a500-74f3-11eb-9b7b-162afb3cc264.png)</details>

<details>
<summary>POW periods</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-02-19 at 2 05 42 PM](https://user-images.githubusercontent.com/136959/108556508-b7eb4780-72bc-11eb-93fa-15c614f20520.png)</details>

<details><summary>New conditions (review & submit page)</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-02-18 at 12 15 35 PM](https://user-images.githubusercontent.com/136959/108403182-0f69b480-71e4-11eb-8cc4-0d0f0a3615cb.png)</details>



## Acceptance criteria
- [x] Array data cards include unique `aria-labels` on the card buttons on the chapter page
- [x] Array data cards include unique `aria-labels` on the card buttons on the review & submit page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
