### PR TITLE
Force VAOS 401 errors into own group

### DIFF
--- a/src/applications/vaos/services/utils.js
+++ b/src/applications/vaos/services/utils.js
@@ -38,6 +38,7 @@ export function mapToFHIRErrors(errors) {
       severity: 'error',
       code: error.code,
       diagnostics: error.title,
+      source: error.source,
       details: {
         code: error.status,
         text: error.detail,

--- a/src/applications/vaos/tests/services/utils.unit.spec.js
+++ b/src/applications/vaos/tests/services/utils.unit.spec.js
@@ -31,6 +31,9 @@ describe('VAOS FHIR utils', () => {
             severity: 'error',
             code: 'VAOS_400',
             diagnostics: 'Bad Request',
+            source: {
+              loadError: null,
+            },
             details: {
               code: '400',
               text: 'Error detail',

--- a/src/applications/vaos/utils/error.js
+++ b/src/applications/vaos/utils/error.js
@@ -19,13 +19,25 @@ export function captureError(
       if (extraData) {
         scope.setExtra('extraData', extraData);
       }
-      const errorTitle =
-        customTitle ||
-        err?.errors?.[0]?.title ||
-        err?.issue?.[0]?.diagnostics ||
-        err?.errors?.[0]?.code ||
-        err?.issue?.[0]?.code ||
-        err;
+
+      let errorTitle;
+
+      // If error is a 401, force that into its own bucket
+      if (err?.errors?.[0]?.code === '401' || err?.issue?.[0]?.code === '401') {
+        errorTitle =
+          err?.errors?.[0]?.title ||
+          err?.issue?.[0]?.diagnostics ||
+          'Not authorized';
+      } else {
+        errorTitle =
+          customTitle ||
+          err?.errors?.[0]?.title ||
+          err?.issue?.[0]?.diagnostics ||
+          err?.errors?.[0]?.code ||
+          err?.issue?.[0]?.code ||
+          err;
+      }
+
       const message = `vaos_server_error${errorTitle ? `: ${errorTitle}` : ''}`;
       eventErrorKey = message;
       // the apiRequest helper returns the errors array, instead of an exception


### PR DESCRIPTION
## Description
This PR
- Moves all 401 errors into the vaos_server_error: Not authorized group, so that we can evaluate them separately from other errors.
- Passes through `source` error data in FHIR transformed errors.

## Testing done
Not much, besides making sure the unit tests pass. Mostly we'll have to evaluate this in staging/prod

## Acceptance criteria
- [ ] Buckets are now appropriate

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
