### PR TITLE
Make each bank info form's rendered markup unique

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
@@ -25,7 +25,7 @@ import {
   cnpDirectDepositUiState as directDepositUiStateSelector,
 } from '@@profile/selectors';
 
-import BankInfoForm from './BankInfoForm';
+import BankInfoForm, { makeFormProperties } from './BankInfoForm';
 
 import PaymentInformationEditError from './PaymentInformationEditError';
 import ProfileInfoTable from '../ProfileInfoTable';
@@ -40,6 +40,7 @@ export const BankInfoCNP = ({
   saveBankInformation,
   toggleEditState,
 }) => {
+  const formPrefix = 'CNP';
   const editBankInfoButton = useRef();
   const [formData, setFormData] = useState({});
   const [showSaveSucceededAlert, setShowSaveSucceededAlert] = useState(false);
@@ -51,9 +52,31 @@ export const BankInfoCNP = ({
   const isSavingBankInfo = directDepositUiState.isSaving;
   const saveError = directDepositUiState.responseError;
 
-  const { accountNumber, accountType, routingNumber } = formData;
-  const isEmptyForm = !accountNumber && !accountType && !routingNumber;
+  const bankInfoUpdatedAlertSettings = {
+    FADE_SPEED: window.Cypress ? 1 : 500,
+    TIMEOUT: window.Cypress ? 500 : 6000,
+  };
 
+  const { accountNumber, accountType, routingNumber } = makeFormProperties(
+    formPrefix,
+  );
+
+  const {
+    [accountNumber]: formAccountNumber,
+    [accountType]: formAccountType,
+    [routingNumber]: formRoutingNumber,
+  } = formData;
+  const isEmptyForm =
+    !formAccountNumber && !formAccountType && !formRoutingNumber;
+
+  const removeBankInfoUpdatedAlert = React.useCallback(
+    () => {
+      setTimeout(() => {
+        setShowSaveSucceededAlert(false);
+      }, bankInfoUpdatedAlertSettings.TIMEOUT);
+    },
+    [bankInfoUpdatedAlertSettings],
+  );
   // when we enter and exit edit mode...
   useEffect(
     () => {
@@ -86,21 +109,24 @@ export const BankInfoCNP = ({
     () => {
       if (wasSavingBankInfo && !isSavingBankInfo && !saveError) {
         setShowSaveSucceededAlert(true);
-        setTimeout(() => {
-          setShowSaveSucceededAlert(false);
-        }, 6000);
+        removeBankInfoUpdatedAlert();
       }
     },
-    [wasSavingBankInfo, isSavingBankInfo, saveError],
+    [
+      wasSavingBankInfo,
+      isSavingBankInfo,
+      saveError,
+      removeBankInfoUpdatedAlert,
+    ],
   );
 
   const saveBankInfo = () => {
     // NOTE: You can trigger a save error by sending undefined values in the payload
     const payload = {
       financialInstitutionName: 'Hidden form field',
-      financialInstitutionRoutingNumber: formData.routingNumber,
-      accountNumber: formData.accountNumber,
-      accountType: formData.accountType,
+      financialInstitutionRoutingNumber: formData[routingNumber],
+      accountNumber: formData[accountNumber],
+      accountType: formData[accountType],
     };
     saveBankInformation(payload, isDirectDepositSetUp);
   };
@@ -215,6 +241,7 @@ export const BankInfoCNP = ({
       <BankInfoForm
         formChange={data => setFormData(data)}
         formData={formData}
+        formPrefix={formPrefix}
         formSubmit={saveBankInfo}
         isSaving={directDepositUiState.isSaving}
         onClose={closeDDForm}
@@ -311,20 +338,22 @@ export const BankInfoCNP = ({
         <ReactCSSTransitionGroup
           transitionName="form-expanding-group-inner"
           transitionAppear
-          transitionAppearTimeout={500}
-          transitionEnterTimeout={500}
-          transitionLeaveTimeout={500}
+          transitionAppearTimeout={bankInfoUpdatedAlertSettings.FADE_SPEED}
+          transitionEnterTimeout={bankInfoUpdatedAlertSettings.FADE_SPEED}
+          transitionLeaveTimeout={bankInfoUpdatedAlertSettings.FADE_SPEED}
         >
           {showSaveSucceededAlert && (
-            <AlertBox
-              status="success"
-              backgroundOnly
-              className="vads-u-margin-top--0 vads-u-margin-bottom--2"
-              scrollOnShow
-            >
-              We’ve updated your bank account information for your{' '}
-              <strong>compensation and pension benefits</strong>
-            </AlertBox>
+            <div data-testid="bankInfoUpdateSuccessAlert">
+              <AlertBox
+                status="success"
+                backgroundOnly
+                className="vads-u-margin-top--0 vads-u-margin-bottom--2"
+                scrollOnShow
+              >
+                We’ve updated your bank account information for your{' '}
+                <strong>compensation and pension benefits</strong>
+              </AlertBox>
+            </div>
           )}
         </ReactCSSTransitionGroup>
       </div>

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoCNPv2.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoCNPv2.jsx
@@ -27,7 +27,7 @@ import {
 
 import DirectDepositConnectionError from '../alerts/DirectDepositConnectionError';
 
-import BankInfoForm from './BankInfoForm';
+import BankInfoForm, { makeFormProperties } from './BankInfoForm';
 
 import PaymentInformationEditError from './PaymentInformationEditError';
 import ProfileInfoTable from '../ProfileInfoTable';
@@ -45,6 +45,7 @@ export const BankInfoCNP = ({
   saveBankInformation,
   toggleEditState,
 }) => {
+  const formPrefix = 'CNP';
   const editBankInfoButton = useRef();
   const [formData, setFormData] = useState({});
   const [showConfirmCancelModal, setShowConfirmCancelModal] = useState(false);
@@ -53,8 +54,20 @@ export const BankInfoCNP = ({
   const isEditingBankInfo = directDepositUiState.isEditing;
   const saveError = directDepositUiState.responseError;
 
-  const { accountNumber, accountType, routingNumber } = formData;
-  const isEmptyForm = !accountNumber && !accountType && !routingNumber;
+  const { accountNumber, accountType, routingNumber } = makeFormProperties(
+    formPrefix,
+  );
+
+  // Using computed properties that I got from the `makeFormProperties` call to
+  // destructure the form data object. I learned that this was even possible
+  // here: https://stackoverflow.com/a/37040344/585275
+  const {
+    [accountNumber]: formAccountNumber,
+    [accountType]: formAccountType,
+    [routingNumber]: formRoutingNumber,
+  } = formData;
+  const isEmptyForm =
+    !formAccountNumber && !formAccountType && !formRoutingNumber;
 
   // when we enter and exit edit mode...
   useEffect(
@@ -87,9 +100,9 @@ export const BankInfoCNP = ({
     // NOTE: You can trigger a save error by sending undefined values in the payload
     const payload = {
       financialInstitutionName: 'Hidden form field',
-      financialInstitutionRoutingNumber: formData.routingNumber,
-      accountNumber: formData.accountNumber,
-      accountType: formData.accountType,
+      financialInstitutionRoutingNumber: formData[routingNumber],
+      accountNumber: formData[accountNumber],
+      accountType: formData[accountType],
     };
     saveBankInformation(payload, isDirectDepositSetUp);
   };
@@ -217,7 +230,7 @@ export const BankInfoCNP = ({
   // account information
   const editingBankInfoContent = (
     <>
-      <div id="errors" role="alert" aria-atomic="true">
+      <div id="cnp-bank-save-errors" role="alert" aria-atomic="true">
         {!!saveError && (
           <PaymentInformationEditError
             responseError={saveError}
@@ -237,14 +250,17 @@ export const BankInfoCNP = ({
           />
         </AdditionalInfo>
       </div>
-      <BankInfoForm
-        formChange={data => setFormData(data)}
-        formData={formData}
-        formSubmit={saveBankInfo}
-        isSaving={directDepositUiState.isSaving}
-        onClose={closeDDForm}
-        cancelButtonClasses={['va-button-link', 'vads-u-margin-left--1']}
-      />
+      <div data-testid={`${formPrefix}-bank-info-form`}>
+        <BankInfoForm
+          formChange={data => setFormData(data)}
+          formData={formData}
+          formPrefix={formPrefix}
+          formSubmit={saveBankInfo}
+          isSaving={directDepositUiState.isSaving}
+          onClose={closeDDForm}
+          cancelButtonClasses={['va-button-link', 'vads-u-margin-left--1']}
+        />
+      </div>
     </>
   );
 

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
@@ -27,7 +27,7 @@ import {
 
 import DirectDepositConnectionError from '../alerts/DirectDepositConnectionError';
 
-import BankInfoForm from './BankInfoForm';
+import BankInfoForm, { makeFormProperties } from './BankInfoForm';
 
 import PaymentInformationEditError from './PaymentInformationEditError';
 import ProfileInfoTable from '../ProfileInfoTable';
@@ -44,6 +44,7 @@ export const DirectDepositEDU = ({
   saveBankInformation,
   toggleEditState,
 }) => {
+  const formPrefix = 'EDU';
   const editBankInfoButton = useRef();
   const [formData, setFormData] = useState({});
   const [showConfirmCancelModal, setShowConfirmCancelModal] = useState(false);
@@ -52,8 +53,17 @@ export const DirectDepositEDU = ({
   const isEditingBankInfo = directDepositUiState.isEditing;
   const saveError = directDepositUiState.responseError;
 
-  const { accountNumber, accountType, routingNumber } = formData;
-  const isEmptyForm = !accountNumber && !accountType && !routingNumber;
+  const { accountNumber, accountType, routingNumber } = makeFormProperties(
+    formPrefix,
+  );
+
+  const {
+    [accountNumber]: formAccountNumber,
+    [accountType]: formAccountType,
+    [routingNumber]: formRoutingNumber,
+  } = formData;
+  const isEmptyForm =
+    !formAccountNumber && !formAccountType && !formRoutingNumber;
 
   // when we enter and exit edit mode...
   useEffect(
@@ -84,9 +94,9 @@ export const DirectDepositEDU = ({
 
   const saveBankInfo = () => {
     const payload = {
-      financialInstitutionRoutingNumber: formData.routingNumber,
-      accountNumber: formData.accountNumber,
-      accountType: formData.accountType,
+      financialInstitutionRoutingNumber: formData[routingNumber],
+      accountNumber: formData[accountNumber],
+      accountType: formData[accountType],
     };
     saveBankInformation(payload);
   };
@@ -187,7 +197,7 @@ export const DirectDepositEDU = ({
   // information
   const editingBankInfoContent = (
     <>
-      <div id="errors" role="alert" aria-atomic="true">
+      <div id="edu-bank-save-errors" role="alert" aria-atomic="true">
         {!!saveError && (
           <PaymentInformationEditError
             responseError={saveError}
@@ -207,14 +217,17 @@ export const DirectDepositEDU = ({
           />
         </AdditionalInfo>
       </div>
-      <BankInfoForm
-        formChange={data => setFormData(data)}
-        formData={formData}
-        formSubmit={saveBankInfo}
-        isSaving={directDepositUiState.isSaving}
-        onClose={closeDDForm}
-        cancelButtonClasses={['va-button-link', 'vads-u-margin-left--1']}
-      />
+      <div data-testid={`${formPrefix}-bank-info-form`}>
+        <BankInfoForm
+          formChange={data => setFormData(data)}
+          formData={formData}
+          formPrefix={formPrefix}
+          formSubmit={saveBankInfo}
+          isSaving={directDepositUiState.isSaving}
+          onClose={closeDDForm}
+          cancelButtonClasses={['va-button-link', 'vads-u-margin-left--1']}
+        />
+      </div>
     </>
   );
 

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoForm.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoForm.jsx
@@ -6,93 +6,117 @@ import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
 
 import { ACCOUNT_TYPES_OPTIONS } from '../../constants';
 
-export const schema = {
-  type: 'object',
-  properties: {
-    routingNumber: {
-      type: 'string',
-      pattern: '^\\d{9}$',
-    },
-    accountNumber: {
-      type: 'string',
-      pattern: '^\\d{1,17}$',
-    },
-    accountType: {
-      type: 'string',
-      enum: Object.values(ACCOUNT_TYPES_OPTIONS),
-    },
-  },
-  required: ['accountNumber', 'routingNumber', 'accountType'],
-};
+export function makeFormProperties(prefix) {
+  return {
+    routingNumber: `${prefix}RoutingNumber`,
+    accountNumber: `${prefix}AccountNumber`,
+    accountType: `${prefix}AccountType`,
+  };
+}
 
-export const uiSchema = {
-  routingNumber: {
-    'ui:title':
-      'Routing number (Your bank’s name will appear after you add the 9-digit routing number)',
-    'ui:errorMessages': {
-      pattern: 'Please enter your bank’s 9-digit routing number',
-      required: 'Please enter your bank’s 9-digit routing number',
+function makeSchemas(prefix) {
+  const properties = makeFormProperties(prefix);
+  const schema = {
+    type: 'object',
+    properties: {
+      [properties.routingNumber]: {
+        type: 'string',
+        pattern: '^\\d{9}$',
+      },
+      [properties.accountNumber]: {
+        type: 'string',
+        pattern: '^\\d{1,17}$',
+      },
+      [properties.accountType]: {
+        type: 'string',
+        enum: Object.values(ACCOUNT_TYPES_OPTIONS),
+      },
     },
-  },
-  accountNumber: {
-    'ui:title': 'Account number (This should be no more than 17 digits)',
-    'ui:errorMessages': {
-      pattern: 'Please enter your account number',
-      required: 'Please enter your account number',
+    required: [
+      properties.accountNumber,
+      properties.routingNumber,
+      properties.accountType,
+    ],
+  };
+
+  const uiSchema = {
+    [properties.routingNumber]: {
+      'ui:title':
+        'Routing number (Your bank’s name will appear after you add the 9-digit routing number)',
+      'ui:errorMessages': {
+        pattern: 'Please enter your bank’s 9-digit routing number',
+        required: 'Please enter your bank’s 9-digit routing number',
+      },
     },
-  },
-  accountType: {
-    'ui:title': 'Account type',
-    'ui:errorMessages': {
-      required: 'Please select the type that best describes your account',
+    [properties.accountNumber]: {
+      'ui:title': 'Account number (This should be no more than 17 digits)',
+      'ui:errorMessages': {
+        pattern: 'Please enter your account number',
+        required: 'Please enter your account number',
+      },
     },
-  },
-};
+    [properties.accountType]: {
+      'ui:title': 'Account type',
+      'ui:errorMessages': {
+        required: 'Please select the type that best describes your account',
+      },
+    },
+  };
+
+  return { schema, uiSchema };
+}
 
 const BankInfoForm = ({
   cancelButtonClasses,
   formChange,
   formData,
+  formPrefix,
   formSubmit,
   isSaving,
   onClose,
-}) => (
-  <SchemaForm
-    addNameAttribute
-    name="Direct Deposit Information"
-    // title is required by the SchemaForm and used internally
-    title="Direct Deposit Information"
-    schema={schema}
-    uiSchema={uiSchema}
-    data={formData}
-    onChange={formChange}
-    onSubmit={formSubmit}
-  >
-    <LoadingButton
-      type="submit"
-      className="usa-button-primary vads-u-margin-top--0 vads-u-width--full small-screen:vads-u-width--auto"
-      isLoading={isSaving}
-    >
-      Update
-    </LoadingButton>
+}) => {
+  const { schema, uiSchema } = makeSchemas(formPrefix);
 
-    <button
-      type="button"
-      disabled={isSaving}
-      className={cancelButtonClasses.join(' ')}
-      onClick={onClose}
-      data-qa="cancel-button"
+  return (
+    <SchemaForm
+      addNameAttribute
+      name="Direct Deposit Information"
+      // title is required by the SchemaForm and used internally
+      title="Direct Deposit Information"
+      schema={schema}
+      uiSchema={uiSchema}
+      data={formData}
+      onChange={formChange}
+      onSubmit={formSubmit}
     >
-      Cancel
-    </button>
-  </SchemaForm>
-);
+      <LoadingButton
+        type="submit"
+        loadingText="saving bank information"
+        className="usa-button-primary vads-u-margin-top--0 vads-u-width--full small-screen:vads-u-width--auto"
+        isLoading={isSaving}
+      >
+        Update
+      </LoadingButton>
+      <button
+        type="button"
+        disabled={isSaving}
+        className={cancelButtonClasses.join(' ')}
+        onClick={onClose}
+        data-qa="cancel-button"
+      >
+        Cancel
+      </button>
+    </SchemaForm>
+  );
+};
 
 BankInfoForm.propTypes = {
   // Classes to apply to the form's "cancel" button. Defaults to ['usa-button-secondary']
   cancelButtonClasses: PropTypes.arrayOf(PropTypes.string).isRequired,
   formChange: PropTypes.func.isRequired,
   formData: PropTypes.object.isRequired,
+  // Prefix to apply to all the form's schema fields
+  formPrefix: PropTypes.string.isRequired,
   formSubmit: PropTypes.func.isRequired,
   isSaving: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,

--- a/src/applications/personalization/profile/tests/components/direct-deposit/BankInfoForm.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/direct-deposit/BankInfoForm.unit.spec.jsx
@@ -3,10 +3,7 @@ import sinon from 'sinon';
 import { mount } from 'enzyme';
 import { expect } from 'chai';
 
-import BankInfoForm, {
-  schema,
-  uiSchema,
-} from '@@profile/components/direct-deposit/BankInfoForm';
+import BankInfoForm from '@@profile/components/direct-deposit/BankInfoForm';
 
 describe('<BankInfoForm/>', () => {
   let wrapper;
@@ -35,10 +32,6 @@ describe('<BankInfoForm/>', () => {
 
   it('should render a SchemaForm', () => {
     expect(schemaForm.exists()).to.be.true;
-  });
-  it("should set the SchemaForm's schema  and uiSchema correctly", () => {
-    expect(schemaForm.props().schema).to.deep.equal(schema);
-    expect(schemaForm.props().uiSchema).to.deep.equal(uiSchema);
   });
   it('should pass the formData prop to the SchemaForm', () => {
     expect(schemaForm.props().data).to.equal(defaultProps.formData);

--- a/src/applications/personalization/profile/tests/e2e/direct-deposit/update-flow.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/direct-deposit/update-flow.cypress.spec.js
@@ -19,11 +19,17 @@ const dd4eduEnabled = {
   },
 };
 
-function fillInBankInfoForm() {
+function fillInBankInfoForm(id) {
   cy.axeCheck();
-  cy.findByLabelText(/routing number/i).type('123123123');
-  cy.findByLabelText(/account number/i).type('123123123');
-  cy.findByLabelText(/type/i).select('Checking');
+  cy.findByTestId(`${id}-bank-info-form`)
+    .findByLabelText(/routing number/i)
+    .type('123123123');
+  cy.findByTestId(`${id}-bank-info-form`)
+    .findByLabelText(/account number/i)
+    .type('123123123');
+  cy.findByTestId(`${id}-bank-info-form`)
+    .findByLabelText(/type/i)
+    .select('Checking');
 }
 
 function dismissUnsavedChangesModal() {
@@ -36,8 +42,15 @@ function exitBankInfoForm() {
   cy.findByRole('button', { name: /cancel/i }).click();
 }
 
-function saveNewBankInfo() {
-  cy.findByRole('button', { name: /update/i }).click();
+function saveNewBankInfo(id) {
+  if (!id) {
+    cy.findByRole('button', { name: /update/i }).click({ force: true });
+  } else {
+    cy.findByTestId(`${id}-bank-info-form`)
+      .findByRole('button', { name: /update/i })
+      .click();
+  }
+  cy.axeCheck();
 }
 
 function saveErrorExists() {
@@ -58,11 +71,10 @@ function saveSuccessAlertRemoved() {
 describe('Direct Deposit', () => {
   beforeEach(() => {
     disableFTUXModals();
-    cy.login();
-    cy.route('GET', '/v0/feature_toggles*', dd4eduEnabled);
-    cy.route('GET', 'v0/user', mockUserInEVSS);
-    cy.route('GET', 'v0/ppiu/payment_information', mockDD4CNPNotEnrolled);
-    cy.route('GET', 'v0/profile/ch33_bank_accounts', mockDD4EDUEnrolled);
+    cy.login(mockUserInEVSS);
+    cy.intercept('GET', '/v0/feature_toggles*', dd4eduEnabled);
+    cy.intercept('GET', 'v0/ppiu/payment_information', mockDD4CNPNotEnrolled);
+    cy.intercept('GET', 'v0/profile/ch33_bank_accounts', mockDD4EDUEnrolled);
     cy.visit(PROFILE_PATHS.DIRECT_DEPOSIT);
     cy.injectAxe();
   });
@@ -74,13 +86,17 @@ describe('Direct Deposit', () => {
         // register and the bank info form does not open
         force: true,
       });
-      fillInBankInfoForm();
+      fillInBankInfoForm('CNP');
       exitBankInfoForm();
       dismissUnsavedChangesModal();
       saveNewBankInfo();
       // the save will fail since we didn't mock the update endpoint yet
       saveErrorExists();
-      cy.route('PUT', 'v0/ppiu/payment_information', mockDD4CNPEnrolled);
+      // TODO: can I make this mock smarter so that it inspects the PUT payload
+      // and I can confirm that the correct data is sent to it? We really just
+      // need to make sure that the routingNumber, accountNumber, and
+      // accountType are not null
+      cy.intercept('PUT', 'v0/ppiu/payment_information', mockDD4CNPEnrolled);
       saveNewBankInfo();
       cy.findByRole('button', {
         name: /edit.*disability.*pension.*bank info/i,
@@ -101,19 +117,49 @@ describe('Direct Deposit', () => {
         // register and the bank info form does not open
         force: true,
       });
-      fillInBankInfoForm();
+      fillInBankInfoForm('EDU');
       exitBankInfoForm();
       dismissUnsavedChangesModal();
       saveNewBankInfo();
       // the save will fail since we didn't mock the update endpoint yet
       saveErrorExists();
-      cy.route('PUT', 'v0/profile/ch33_bank_accounts', mockDD4EDUEnrolled);
+      cy.intercept('PUT', 'v0/profile/ch33_bank_accounts', mockDD4EDUEnrolled);
       saveNewBankInfo();
       cy.findByRole('button', {
         name: /edit.*education.*bank info/i,
       }).should('exist');
       saveSuccessAlertShown('education benefits');
       saveSuccessAlertRemoved();
+      cy.axeCheck();
+    });
+  });
+  describe('when editing both at the same time and they both fail to update', () => {
+    it('should not have any aXe violations', () => {
+      cy.findByRole('button', { name: /add.*bank info/i }).click({
+        // using force: true since there are times when the click does not
+        // register and the bank info form does not open
+        force: true,
+      });
+      cy.findByRole('button', {
+        name: /edit.*education.*bank info/i,
+      }).click({
+        // using force: true since there are times when the click does not
+        // register and the bank info form does not open
+        force: true,
+      });
+      fillInBankInfoForm('CNP');
+      fillInBankInfoForm('EDU');
+      saveNewBankInfo('CNP');
+      saveNewBankInfo('EDU');
+      // This scan will be run while the bank info is saving and the
+      // LoadingButton is in its "loading" state. This would throw an aXe error
+      // if LoadingButton.loadingText was not set
+      cy.axeCheck();
+      // Now wait for the update API calls to resolve to failures...
+      cy.findAllByText(/we couldn’t update your bank info/i).should(
+        'have.length',
+        '2',
+      );
       cy.axeCheck();
     });
   });

--- a/src/applications/personalization/profile/tests/e2e/direct-deposit/v1-update-flow.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/direct-deposit/v1-update-flow.cypress.spec.js
@@ -1,0 +1,98 @@
+import disableFTUXModals from '~/platform/user/tests/disableFTUXModals';
+import { PROFILE_PATHS } from '@@profile/constants';
+
+import mockUserInEVSS from '@@profile/tests/fixtures/users/user-36.json';
+import mockDD4CNPNotEnrolled from '@@profile/tests/fixtures/dd4cnp/dd4cnp-is-not-set-up.json';
+import mockDD4CNPEnrolled from '@@profile/tests/fixtures/dd4cnp/dd4cnp-is-set-up.json';
+import mockDD4EDUEnrolled from '@@profile/tests/fixtures/dd4edu/dd4edu-enrolled.json';
+
+// this entire test file can be removed when DD4EDU is on prod to 100% of users
+const dd4eduDisabled = {
+  data: {
+    type: 'feature_toggles',
+    features: [
+      {
+        name: 'ch33_dd_profile',
+        value: false,
+      },
+    ],
+  },
+};
+
+function fillInBankInfoForm() {
+  cy.axeCheck();
+  cy.findByLabelText(/routing number/i).type('123123123');
+  cy.findByLabelText(/account number/i).type('123123123');
+  cy.findByLabelText(/type/i).select('Checking');
+}
+
+function dismissUnsavedChangesModal() {
+  cy.axeCheck();
+  cy.findByText(/are you sure\?/i);
+  cy.findByRole('button', { name: /close this modal/i }).click();
+}
+
+function exitBankInfoForm() {
+  cy.findByRole('button', { name: /cancel/i }).click();
+}
+
+function saveNewBankInfo() {
+  cy.findByRole('button', { name: /update/i }).click();
+}
+
+function saveErrorExists() {
+  cy.findByText(/we couldn’t update your bank info/i).should('exist');
+}
+
+function saveSuccessAlertShown() {
+  cy.axeCheck();
+  cy.findByTestId('bankInfoUpdateSuccessAlert').contains(
+    new RegExp(
+      `we.*updated your.*account info.*compensation and pension benefits`,
+      'i',
+    ),
+  );
+}
+
+function saveSuccessAlertRemoved() {
+  cy.findByTestId('bankInfoUpdateSuccessAlert').should('not.exist');
+}
+
+describe('Direct Deposit', () => {
+  beforeEach(() => {
+    disableFTUXModals();
+    cy.login(mockUserInEVSS);
+    cy.intercept('/v0/feature_toggles*', dd4eduDisabled);
+    cy.intercept('GET', 'v0/ppiu/payment_information', mockDD4CNPNotEnrolled);
+    cy.intercept('GET', 'v0/profile/ch33_bank_accounts', mockDD4EDUEnrolled);
+    cy.visit(PROFILE_PATHS.DIRECT_DEPOSIT);
+    cy.injectAxe();
+  });
+  it('should allow bank info updates, show WIP warning modals, show "update successful" banners, etc.', () => {
+    cy.axeCheck();
+    cy.findByRole('button', { name: /add.*bank info/i }).click({
+      // using force: true since there are times when the click does not
+      // register and the bank info form does not open
+      force: true,
+    });
+    fillInBankInfoForm();
+    exitBankInfoForm();
+    dismissUnsavedChangesModal();
+    saveNewBankInfo();
+    // the save will fail since we didn't mock the update endpoint yet
+    saveErrorExists();
+    // TODO: can I make this mock smarter so that it inspects the PUT payload
+    // and I can confirm that the correct data is sent to it? We really just
+    // need to make sure that the routingNumber, accountNumber, and
+    // accountType are not null
+    cy.intercept('PUT', 'v0/ppiu/payment_information', mockDD4CNPEnrolled);
+    saveNewBankInfo();
+    cy.findByRole('button', {
+      name: /edit.*disability.*pension.*bank info/i,
+    }).should('exist');
+    cy.findByRole('button', { name: /add.*bank info/i }).should('not.exist');
+    saveSuccessAlertShown();
+    saveSuccessAlertRemoved();
+    cy.axeCheck();
+  });
+});


### PR DESCRIPTION
## Description
Fixes https://github.com/department-of-veterans-affairs/va.gov-team/issues/19790 and fixes https://github.com/department-of-veterans-affairs/va.gov-team/issues/19594

Makes is possible to generate unique edit bank info forms, with unique IDs.

## Testing done
Local + Cypress tests

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs