### PR TITLE
make eslint "no-unreachable" a warning

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -48,6 +48,8 @@
       { "args": "after-used", "argsIgnorePattern": "^_", "vars": "local" }
     ],
     "no-restricted-imports": ["error", "raven"],
+    // Override airbnb rule to prevent fix-on-save from deleting unreachable code
+    "no-unreachable": 1,
     "prefer-rest-params": 2,
 
     /* || va custom plugin || */


### PR DESCRIPTION
## Description
I'm proposing switching the ESLint "no-unreachable" rule from an error to a warning.

### Reasoning
If this rule is set to an error and you have your editor set to auto-fix ESLint errors, it's possible to have your editor delete code from underneath you. Especially if you are a compulsive ⌘S smasher. This deletion is usually noticed immediately. But if the deletion happens "below the fold" you might not notice for a while and be forced to restore from git.

## Testing done
N/A

## Screenshots
When the rule is a "warning" the unreachable code is pretty obvious in VSCode (colors are obviously theme-dependent)
<img width="705" alt="Screen Shot 2021-02-21 at 4 14 54 PM" src="https://user-images.githubusercontent.com/20728956/108643571-f1a88380-745f-11eb-9f16-f014e2bba71d.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs