### PR TITLE
Update "Direct deposit" -> "Direct deposit information"

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/DirectDepositV2.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/DirectDepositV2.jsx
@@ -99,7 +99,7 @@ const DirectDeposit = ({
 
   React.useEffect(() => {
     focusElement('[data-focus-target]');
-    document.title = `Direct Deposit | Veterans Affairs`;
+    document.title = `Direct Deposit Information | Veterans Affairs`;
   }, []);
 
   // show the user a success alert after their CNP bank info has saved

--- a/src/applications/personalization/profile/constants.js
+++ b/src/applications/personalization/profile/constants.js
@@ -32,7 +32,7 @@ export const PROFILE_PATHS = Object.freeze({
 });
 
 export const PROFILE_PATH_NAMES = Object.freeze({
-  DIRECT_DEPOSIT: 'Direct deposit',
+  DIRECT_DEPOSIT: 'Direct deposit information',
   PERSONAL_INFORMATION: 'Personal and contact information',
   MILITARY_INFORMATION: 'Military information',
   CONNECTED_APPLICATIONS: 'Connected apps',

--- a/src/applications/personalization/profile/tests/e2e/direct-deposit/gating.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/direct-deposit/gating.cypress.spec.js
@@ -1,5 +1,5 @@
 import disableFTUXModals from '~/platform/user/tests/disableFTUXModals';
-import { PROFILE_PATHS } from '@@profile/constants';
+import { PROFILE_PATHS, PROFILE_PATH_NAMES } from '@@profile/constants';
 
 import mockUserNotInEVSS from '@@profile/tests/fixtures/users/user-non-vet.json';
 import mockUserInEVSS from '@@profile/tests/fixtures/users/user-36.json';
@@ -45,7 +45,9 @@ function confirmDDBlockedAlertIsShown() {
 function confirmDirectDepositIsAvailable() {
   // the DD item should exist in the sub nav
   cy.findByRole('navigation', { name: /secondary/i }).within(() => {
-    cy.findByRole('link', { name: /direct deposit/i }).should('exist');
+    cy.findByRole('link', { name: PROFILE_PATH_NAMES.DIRECT_DEPOSIT }).should(
+      'exist',
+    );
   });
 
   // going directly to DD should work
@@ -62,7 +64,9 @@ function confirmDirectDepositIsBlocked() {
     // Just a test to make sure we can access items in the sub nav to ensure
     // the following test isn't a false negative
     cy.findByRole('link', { name: /personal.*info/i }).should('exist');
-    cy.findByRole('link', { name: /direct deposit/i }).should('not.exist');
+    cy.findByRole('link', { name: PROFILE_PATH_NAMES.DIRECT_DEPOSIT }).should(
+      'not.exist',
+    );
   });
 
   // going directly to DD should redirect to the personal info page

--- a/src/applications/personalization/profile/tests/e2e/profile-a11y.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile-a11y.cypress.spec.js
@@ -1,5 +1,5 @@
 import disableFTUXModals from '~/platform/user/tests/disableFTUXModals';
-import { PROFILE_PATHS } from '../../constants';
+import { PROFILE_PATHS, PROFILE_PATH_NAMES } from '../../constants';
 
 import mockUser from '../fixtures/users/user-36.json';
 import mockPaymentInfo from '../fixtures/dd4cnp/dd4cnp-is-set-up.json';
@@ -63,7 +63,7 @@ function checkAllPages(mobile = false) {
   cy.axeCheck();
 
   // make the a11y and focus management check on the Military Info section
-  clickSubNavButton('Military information', mobile);
+  clickSubNavButton(PROFILE_PATH_NAMES.MILITARY_INFORMATION, mobile);
   cy.url().should(
     'eq',
     `${Cypress.config().baseUrl}${PROFILE_PATHS.MILITARY_INFORMATION}`,
@@ -72,12 +72,12 @@ function checkAllPages(mobile = false) {
   cy.axeCheck();
   // focus should be on the section's h2
   cy.focused()
-    .contains(/military information/i)
+    .contains(PROFILE_PATH_NAMES.MILITARY_INFORMATION)
     .and('have.prop', 'tagName')
     .should('eq', 'H2');
 
   // make the a11y and focus management check on the Direct Deposit section
-  clickSubNavButton('Direct deposit', mobile);
+  clickSubNavButton(PROFILE_PATH_NAMES.DIRECT_DEPOSIT, mobile);
   cy.url().should(
     'eq',
     `${Cypress.config().baseUrl}${PROFILE_PATHS.DIRECT_DEPOSIT}`,
@@ -86,12 +86,12 @@ function checkAllPages(mobile = false) {
   cy.axeCheck();
   // focus should be on the section's h2
   cy.focused()
-    .contains(/direct deposit/i)
+    .contains(PROFILE_PATH_NAMES.DIRECT_DEPOSIT)
     .and('have.prop', 'tagName')
     .should('eq', 'H2');
 
   // make the a11y and focus management check on the Account Security section
-  clickSubNavButton('Account security', mobile);
+  clickSubNavButton(PROFILE_PATH_NAMES.ACCOUNT_SECURITY, mobile);
   cy.url().should(
     'eq',
     `${Cypress.config().baseUrl}${PROFILE_PATHS.ACCOUNT_SECURITY}`,
@@ -100,12 +100,12 @@ function checkAllPages(mobile = false) {
   cy.axeCheck();
   // focus should be on the section's h2
   cy.focused()
-    .contains(/account security/i)
+    .contains(PROFILE_PATH_NAMES.ACCOUNT_SECURITY)
     .and('have.prop', 'tagName')
     .should('eq', 'H2');
 
   // make the a11y and focus management check on the Connected Apps section
-  clickSubNavButton('Connected apps', mobile);
+  clickSubNavButton(PROFILE_PATH_NAMES.CONNECTED_APPLICATIONS, mobile);
   cy.url().should(
     'eq',
     `${Cypress.config().baseUrl}${PROFILE_PATHS.CONNECTED_APPLICATIONS}`,
@@ -116,18 +116,18 @@ function checkAllPages(mobile = false) {
   cy.axeCheck();
   // focus should be on the section's h2
   cy.focused()
-    .contains(/connected apps/i)
+    .contains(PROFILE_PATH_NAMES.CONNECTED_APPLICATIONS)
     .and('have.prop', 'tagName')
     .should('eq', 'H2');
 
   // navigate directly to the Personal and Contact Info section via the sub-nav to confirm focus is managed correctly
-  clickSubNavButton(/Personal and contact info/i, mobile);
+  clickSubNavButton(PROFILE_PATH_NAMES.PERSONAL_INFORMATION, mobile);
   cy.url().should(
     'eq',
     `${Cypress.config().baseUrl}${PROFILE_PATHS.PERSONAL_INFORMATION}`,
   );
   cy.focused()
-    .contains(/personal and contact info/i)
+    .contains(PROFILE_PATH_NAMES.PERSONAL_INFORMATION)
     .and('have.prop', 'tagName')
     .should('eq', 'H2');
 }


### PR DESCRIPTION
## Description
Update the "Direct deposit" section to "Direct deposit information" to match the other Profile sections.

## Testing done
Existing Cypress tests updated to check for the new button labels and section titles. Also updated the Cypress tests to use the constants that are actually used to set these values vs. using static strings/regexes

## Screenshots
<img width="1000" alt="Screen Shot 2021-02-22 at 9 08 48 AM" src="https://user-images.githubusercontent.com/20728956/108743477-a89f1080-74ed-11eb-8ad8-50a7858704a1.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs