### PR TITLE
use consistent terminology for project cheetah

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/ScheduleNewProjectCheetah.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/ScheduleNewProjectCheetah.jsx
@@ -22,7 +22,7 @@ export default function ScheduleNewProjectCheetah({
 
   return (
     <div className={classNames}>
-      <h2 className={headerClass}>Schedule your first COVID-19 vaccination</h2>
+      <h2 className={headerClass}>Schedule your first COVID-19 vaccine</h2>
       <p className="vads-u-margin-top--1">
         You may be eligible to receive the COVID-19 vaccine at a VA Location.
       </p>

--- a/src/applications/vaos/project-cheetah/components/ClinicChoicePage.jsx
+++ b/src/applications/vaos/project-cheetah/components/ClinicChoicePage.jsx
@@ -25,6 +25,7 @@ const uiSchema = {
   },
 };
 const pageKey = 'clinicChoice';
+const pageTitle = 'Choose a clinic';
 export function ClinicChoicePage({
   schema,
   data,
@@ -39,14 +40,12 @@ export function ClinicChoicePage({
   useEffect(() => {
     openClinicPage(pageKey, uiSchema, initialSchema);
     scrollAndFocus();
-    document.title = `Choose a clinic for your Project Cheetah appointment | Veterans Affairs`;
+    document.title = `${pageTitle} | Veterans Affairs`;
   }, []);
 
   return (
     <div>
-      <h1 className="vads-u-font-size--h2">
-        Choose a clinic for your Project Cheetah appointment
-      </h1>
+      <h1 className="vads-u-font-size--h2">{pageTitle}</h1>
       Choose a clinic located at:
       {facilityDetails && (
         <div className="vads-u-margin-y--2p5">

--- a/src/applications/vaos/project-cheetah/components/ConfirmationPage.jsx
+++ b/src/applications/vaos/project-cheetah/components/ConfirmationPage.jsx
@@ -34,7 +34,7 @@ function ConfirmationPage({ data, systemId, facilityDetails }) {
       </AlertBox>
       <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
         <h2 className="vads-u-margin-y--0 vads-u-font-size--h3">
-          COVID-19 vaccination
+          COVID-19 vaccine
         </h2>
         First dose
         <br />

--- a/src/applications/vaos/project-cheetah/components/FormLayout.jsx
+++ b/src/applications/vaos/project-cheetah/components/FormLayout.jsx
@@ -12,7 +12,7 @@ export default function FormLayout({ children }) {
   return (
     <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--8">
       <Breadcrumbs>
-        <Link to="new-project-cheetah-booking">COVID-19 Vaccination</Link>
+        <Link to="new-project-cheetah-booking">COVID-19 vaccine</Link>
       </Breadcrumbs>
       {location.pathname.endsWith('new-project-cheetah-booking') && (
         <DowntimeNotification
@@ -27,7 +27,7 @@ export default function FormLayout({ children }) {
       <div className="vads-l-row">
         <div className="vads-l-col--12 medium-screen:vads-l-col--8">
           <span className="vaos-form__title vaos-u-margin-bottom--1 vads-u-font-size--sm vads-u-font-weight--normal vads-u-font-family--sans">
-            COVID-19 vaccination
+            COVID-19 vaccine
           </span>
           <ErrorBoundary>{children}</ErrorBoundary>
         </div>

--- a/src/applications/vaos/project-cheetah/components/PlanAheadPage.jsx
+++ b/src/applications/vaos/project-cheetah/components/PlanAheadPage.jsx
@@ -22,7 +22,7 @@ function PlanAheadPage({ routeToNextAppointmentPage }) {
     <div>
       <h1>{pageTitle}</h1>
       <p>
-        If you haven’t received a COVID vaccination yet, you can schedule one
+        If you haven’t received a COVID-19 vaccine yet, you can schedule one
         now.
       </p>
 
@@ -55,7 +55,7 @@ function PlanAheadPage({ routeToNextAppointmentPage }) {
         rel="noopener noreferrer"
         className="vads-u-display--block vads-u-margin-top--2"
       >
-        Learn more about COVID-19 vaccinations at the VA.
+        Learn more about COVID-19 vaccines at the VA.
       </a>
     </div>
   );

--- a/src/applications/vaos/project-cheetah/components/ReceivedDoseScreenerPage.jsx
+++ b/src/applications/vaos/project-cheetah/components/ReceivedDoseScreenerPage.jsx
@@ -25,7 +25,7 @@ const uiSchema = {
 };
 
 const pageKey = 'receivedDoseScreener';
-const pageTitle = 'Have you received a COVID vaccination?';
+const pageTitle = 'Have you received a COVID-19 vaccine?';
 
 function ReceivedDoseScreenerPage({
   schema,

--- a/src/applications/vaos/project-cheetah/components/ReviewPage.jsx
+++ b/src/applications/vaos/project-cheetah/components/ReviewPage.jsx
@@ -45,7 +45,7 @@ function ReviewPage({
         Please review the information before confirming your appointments.
       </p>
       <h2 className="vads-u-margin-bottom--0 vads-u-margin-top--3 vads-u-font-size--h3">
-        COVID-19 vaccination
+        COVID-19 vaccine
       </h2>
       First dose
       <hr aria-hidden="true" className="vads-u-margin-y--2" />

--- a/src/applications/vaos/project-cheetah/components/VAFacilityPage/index.jsx
+++ b/src/applications/vaos/project-cheetah/components/VAFacilityPage/index.jsx
@@ -37,7 +37,7 @@ const uiSchema = {
 };
 
 const pageKey = 'vaFacility';
-const pageTitle = 'Choose a VA location for your appointment';
+const pageTitle = 'Choose a location';
 
 function VAFacilityPage({
   address,
@@ -80,11 +80,7 @@ function VAFacilityPage({
 
   const goForward = () => routeToNextAppointmentPage(history, pageKey);
 
-  const title = (
-    <h1 className="vads-u-font-size--h2">
-      Choose a VA location for your project cheetah booking
-    </h1>
-  );
+  const title = <h1 className="vads-u-font-size--h2">{pageTitle}</h1>;
 
   if (hasDataFetchingError) {
     return (
@@ -175,7 +171,7 @@ function VAFacilityPage({
       {title}
       <p>
         Below is a list of VA locations where you’re registered that offer{' '}
-        project cheetah appointments.
+        COVID-19 vaccine appointments.
         {(sortByDistanceFromResidential || sortByDistanceFromCurrentLocation) &&
           ' Locations closest to you are at the top of the list.'}
       </p>

--- a/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/AppointmentsPageV2.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/AppointmentsPageV2.unit.spec.jsx
@@ -445,7 +445,7 @@ describe('VAOS <AppointmentsPageV2>', () => {
     ).to.be.ok;
     expect(screen.getByRole('link', { name: 'Request appointment' }));
   });
-  it('should show COVID-19 vaccination button', async () => {
+  it('should show COVID-19 vaccine button', async () => {
     const defaultState = {
       featureToggles: {
         ...initialState.featureToggles,
@@ -460,7 +460,7 @@ describe('VAOS <AppointmentsPageV2>', () => {
     expect(
       await screen.findAllByRole('heading', {
         level: 2,
-        name: /Schedule your first COVID-19 vaccination/,
+        name: /Schedule your first COVID-19 vaccine/,
       }),
     );
 

--- a/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/index.unit.spec.jsx
@@ -922,7 +922,7 @@ describe('VAOS integration: appointment list', () => {
     expect(screen.getByRole('link', { name: 'Request an appointment' }));
   });
 
-  it('should show COVID-19 vaccination button', async () => {
+  it('should show COVID-19 vaccine button', async () => {
     const defaultState = {
       featureToggles: {
         ...initialState.featureToggles,
@@ -937,7 +937,7 @@ describe('VAOS integration: appointment list', () => {
     expect(
       await screen.findAllByRole('heading', {
         level: 2,
-        name: /Schedule your first COVID-19 vaccination/,
+        name: /Schedule your first COVID-19 vaccine/,
       }),
     );
 

--- a/src/applications/vaos/tests/project-cheetah/components/PlanAheadPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/project-cheetah/components/PlanAheadPage.unit.spec.jsx
@@ -19,7 +19,7 @@ describe('VAOS <PlanAheadPage>', () => {
 
     expect(
       screen.getByRole('link', {
-        name: /learn more about COVID-19 vaccinations at the VA./i,
+        name: /learn more about COVID-19 vaccines at the VA./i,
       }),
     ).to.have.attribute('href', '/health-care/covid-19-vaccine');
 

--- a/src/applications/vaos/tests/project-cheetah/components/ReviewPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/project-cheetah/components/ReviewPage.unit.spec.jsx
@@ -104,12 +104,12 @@ describe('VAOS vaccine flow <ReviewPage>', () => {
       store,
     });
 
-    await screen.findByText(/COVID-19 vaccination/i);
+    await screen.findByText(/COVID-19 vaccine/i);
     const [pageHeading, descHeading, clinicHeading] = screen.getAllByRole(
       'heading',
     );
     expect(pageHeading).to.contain.text('Review your appointment details');
-    expect(descHeading).to.contain.text('COVID-19 vaccination');
+    expect(descHeading).to.contain.text('COVID-19 vaccine');
     expect(descHeading).to.have.tagName('h2');
 
     expect(screen.baseElement).to.contain.text(
@@ -140,7 +140,7 @@ describe('VAOS vaccine flow <ReviewPage>', () => {
       store,
     });
 
-    await screen.findByText(/COVID-19 vaccination/i);
+    await screen.findByText(/COVID-19 vaccine/i);
 
     userEvent.click(screen.getByText(/Confirm appointment/i));
     await waitFor(() => {
@@ -190,7 +190,7 @@ describe('VAOS vaccine flow <ReviewPage>', () => {
       store,
     });
 
-    await screen.findByText(/COVID-19 vaccination/i);
+    await screen.findByText(/COVID-19 vaccine/i);
 
     userEvent.click(screen.getByText(/Confirm appointment/i));
 


### PR DESCRIPTION
## Description
update use of consistent terminology across the project cheetah flow

## Testing done
local 

## Screenshots
screen 1
![image](https://user-images.githubusercontent.com/54327023/108757142-75717700-7517-11eb-9444-279c1d30c6ad.png)

Showing breadcrumb change
![image](https://user-images.githubusercontent.com/54327023/108757266-9cc84400-7517-11eb-9312-a8d76ed1a5b0.png)




## Acceptance criteria
- [ ] All references to covid are COVID-19
- [ ] All references to vaccination (singular) are vaccine
- [ ] All references to vaccinations (plural) are vaccines
- [ ] change title, "Choose a VA location for your project cheetah booking" to "Choose a location"
- [ ] change title, "Choose a clinic for your Project Cheetah appointment" to "Choose a clinic"

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
