### PR TITLE
[12679] Print Appointment Details

### DIFF
--- a/src/applications/vaos/appointment-list/components/CommunityCareAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/CommunityCareAppointmentDetailsPage.jsx
@@ -69,7 +69,7 @@ function CommunityCareAppointmentDetailsPage({
 
   return (
     <div>
-      <div className="vads-u-display--block vads-u-padding-y--2p5">
+      <div className="vads-u-display--block vads-u-padding-y--2p5 vaos-hide-for-print">
         ‹ <Link to="/">Manage appointments</Link>
       </div>
 
@@ -122,7 +122,7 @@ function CommunityCareAppointmentDetailsPage({
 
       <div className="vads-u-margin-top--2 vaos-appts__block-label">
         <i aria-hidden="true" className="fas fa-print vads-u-margin-right--1" />
-        <a href="#">Print</a>
+        <span onClick={() => window.print()}>Print</span>
       </div>
 
       <div className="vads-u-margin-top--2 vaos-appts__block-label vads-u-background-color--primary-alt-lightest vads-u-padding--2p5">
@@ -130,7 +130,7 @@ function CommunityCareAppointmentDetailsPage({
         appointment.
       </div>
 
-      <div className="vads-u-margin-top--3 vaos-appts__block-label">
+      <div className="vads-u-margin-top--3 vaos-appts__block-label vaos-hide-for-print">
         <Link to="/" className="usa-button vads-u-margin-top--2" role="button">
           « Go back to appointments
         </Link>

--- a/src/applications/vaos/appointment-list/components/CommunityCareAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/CommunityCareAppointmentDetailsPage.jsx
@@ -122,7 +122,9 @@ function CommunityCareAppointmentDetailsPage({
 
       <div className="vads-u-margin-top--2 vaos-appts__block-label">
         <i aria-hidden="true" className="fas fa-print vads-u-margin-right--1" />
-        <span onClick={() => window.print()}>Print</span>
+        <button className="va-button-link" onClick={() => window.print()}>
+          Print
+        </button>
       </div>
 
       <div className="vads-u-margin-top--2 vaos-appts__block-label vads-u-background-color--primary-alt-lightest vads-u-padding--2p5">

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/ConfirmedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/ConfirmedAppointmentDetailsPage.jsx
@@ -168,7 +168,9 @@ function ConfirmedAppointmentDetailsPage({
                 aria-hidden="true"
                 className="fas fa-print vads-u-margin-right--1"
               />
-              <span onClick={() => window.print()}>Print</span>
+              <button className="va-button-link" onClick={() => window.print()}>
+                Print
+              </button>
             </div>
 
             <div className="vads-u-margin-top--2 vaos-appts__block-label">

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/ConfirmedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/ConfirmedAppointmentDetailsPage.jsx
@@ -104,7 +104,7 @@ function ConfirmedAppointmentDetailsPage({
 
   return (
     <div>
-      <div className="vads-u-display--block vads-u-padding-y--2p5">
+      <div className="vads-u-display--block vads-u-padding-y--2p5 vaos-hide-for-print">
         ‹ <Link to="/">Manage appointments</Link>
       </div>
 
@@ -168,7 +168,7 @@ function ConfirmedAppointmentDetailsPage({
                 aria-hidden="true"
                 className="fas fa-print vads-u-margin-right--1"
               />
-              <a href="#">Print</a>
+              <span onClick={() => window.print()}>Print</span>
             </div>
 
             <div className="vads-u-margin-top--2 vaos-appts__block-label">
@@ -204,7 +204,7 @@ function ConfirmedAppointmentDetailsPage({
           </>
         )}
 
-      <div className="vads-u-margin-top--3 vaos-appts__block-label">
+      <div className="vads-u-margin-top--3 vaos-appts__block-label vaos-hide-for-print">
         <Link to="/" className="usa-button vads-u-margin-top--2" role="button">
           « Go back to appointments
         </Link>

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoVisitSection.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoVisitSection.jsx
@@ -145,7 +145,9 @@ export default function VideoVisitLocation({ header, appointment, facility }) {
             aria-hidden="true"
             className="fas fa-print vads-u-margin-right--1"
           />
-          <span onClick={() => window.print()}>Print</span>
+          <button className="va-button-link" onClick={() => window.print()}>
+            Print
+          </button>
         </div>
         <AlertBox
           status={ALERT_TYPE.INFO}

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoVisitSection.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoVisitSection.jsx
@@ -145,7 +145,7 @@ export default function VideoVisitLocation({ header, appointment, facility }) {
             aria-hidden="true"
             className="fas fa-print vads-u-margin-right--1"
           />
-          <a href="#">Print</a>
+          <span onClick={() => window.print()}>Print</span>
         </div>
         <AlertBox
           status={ALERT_TYPE.INFO}

--- a/src/applications/vaos/appointment-list/sass/styles.scss
+++ b/src/applications/vaos/appointment-list/sass/styles.scss
@@ -81,3 +81,9 @@
     position: static;
   }
 }
+
+@media print {
+  .vaos-hide-for-print {
+    display: none !important;
+  }
+}

--- a/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
@@ -11,6 +11,8 @@ import {
 
 import userEvent from '@testing-library/user-event';
 import { AppointmentList } from '../../../appointment-list';
+import sinon from 'sinon';
+import { fireEvent } from '@testing-library/react';
 
 const initialState = {
   featureToggles: {
@@ -101,7 +103,7 @@ describe('VAOS <CommunityCareAppointmentDetailsPage>', () => {
         name: /^Add May 20, 2021 appointment to your calendar/,
       }),
     ).to.be.ok;
-    expect(screen.getByRole('link', { name: /Print/ })).to.be.ok;
+    expect(screen.getByText(/Print/)).to.be.ok;
 
     const button = screen.getByRole('button', {
       name: /Go back to appointments/,
@@ -132,5 +134,71 @@ describe('VAOS <CommunityCareAppointmentDetailsPage>', () => {
     });
     userEvent.click(manageAppointmentLink);
     expect(await screen.findAllByText(/Detail/)).to.be.ok;
+  });
+
+  it('should fire a print request when print button clicked', async () => {
+    // CC appointment id from confirmed_cc.json
+    const url = '/cc/8a4885896a22f88f016a2cb7f5de0062';
+
+    const appointment = getCCAppointmentMock();
+    appointment.id = '8a4885896a22f88f016a2cb7f5de0062';
+    appointment.attributes = {
+      ...appointment.attributes,
+      appointmentRequestId: '8a4885896a22f88f016a2cb7f5de0062',
+      distanceEligibleConfirmed: true,
+      name: { firstName: 'Rick', lastName: 'Katz' },
+      providerPractice: 'My Eye Dr',
+      providerPhone: '(703) 555-1264',
+      address: {
+        street: '123',
+        city: 'Burke',
+        state: 'VA',
+        zipCode: '20151',
+      },
+      instructionsToVeteran: 'Bring your glasses',
+      appointmentTime: '05/20/2021 14:15:00',
+      timeZone: 'UTC',
+    };
+
+    mockAppointmentInfo({
+      va: [],
+      cc: [appointment],
+      requests: [],
+      isHomepageRefresh: true,
+    });
+
+    const screen = renderWithStoreAndRouter(
+      <AppointmentList featureHomepageRefresh />,
+      {
+        initialState,
+      },
+    );
+
+    const oldPrint = global.window.print;
+    const printSpy = sinon.spy();
+    global.window.print = printSpy;
+
+    const detailLinks = await screen.findAllByRole('link', {
+      name: /Detail/i,
+    });
+
+    // Select an appointment details link...
+    const detailLink = detailLinks.find(l => l.getAttribute('href') === url);
+    userEvent.click(detailLink);
+
+    // Verify page content...
+    expect(
+      await screen.findByRole('heading', {
+        level: 1,
+        name: /^Thursday, May 20, 2021/,
+      }),
+    ).to.be.ok;
+
+    expect(screen.getByText(/Community care/)).to.be.ok;
+
+    expect(printSpy.notCalled).to.be.true;
+    fireEvent.click(await screen.findByText(/Print/i));
+    expect(printSpy.calledOnce).to.be.true;
+    global.window.print = oldPrint;
   });
 });

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage.unit.spec.jsx
@@ -12,6 +12,8 @@ import {
 
 import userEvent from '@testing-library/user-event';
 import { AppointmentList } from '../../../appointment-list';
+import sinon from 'sinon';
+import { fireEvent } from '@testing-library/react';
 
 const initialState = {
   featureToggles: {
@@ -142,7 +144,7 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
         ),
       }),
     ).to.be.ok;
-    expect(screen.getByRole('link', { name: /Print/ })).to.be.ok;
+    expect(screen.getByText(/Print/)).to.be.ok;
     expect(screen.getByRole('link', { name: /Reschedule/ })).to.be.ok;
 
     const button = screen.getByRole('button', {
@@ -180,5 +182,108 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
     });
     userEvent.click(manageAppointmentLink);
     expect(await screen.findAllByText(/Detail/)).to.be.ok;
+  });
+
+  it('should fire a print request when print button clicked', async () => {
+    const url = '/va/21cdc6741c00ac67b6cbf6b972d084c1';
+
+    const appointment = getVAAppointmentMock();
+    appointment.attributes = {
+      ...appointment.attributes,
+      startDate: moment().format(),
+      clinicId: '308',
+      clinicFriendlyName: "Jennie's Lab",
+      facilityId: '983',
+      sta6aid: '983GC',
+      communityCare: false,
+      vdsAppointments: [
+        {
+          bookingNote: 'New issue: ASAP',
+          appointmentLength: '60',
+          appointmentTime: '2021-12-07T16:00:00Z',
+          clinic: {
+            name: 'CHY OPT VAR1',
+            askForCheckIn: false,
+            facilityCode: '983',
+          },
+          type: 'REGULAR',
+          currentStatus: 'NO ACTION TAKEN/TODAY',
+        },
+      ],
+      vvsAppointments: [],
+    };
+
+    mockAppointmentInfo({
+      va: [appointment],
+      cc: [],
+      requests: [],
+      isHomepageRefresh: true,
+    });
+
+    const facility = {
+      id: 'vha_442GC',
+      attributes: {
+        ...getVAFacilityMock().attributes,
+        type: 'facility',
+        address: {
+          mailing: {},
+          physical: {
+            zip: '80526-8108',
+            city: 'Fort Collins',
+            state: 'CO',
+            address1: '2509 Research Boulevard',
+            address2: null,
+            address3: null,
+          },
+        },
+        id: 'vha_442GC',
+        name: 'Fort Collins VA Clinic',
+        phone: {
+          main: '970-224-1550',
+        },
+        uniqueId: '442GC',
+      },
+    };
+    mockFacilitiesFetch('vha_442GC', [facility]);
+
+    const screen = renderWithStoreAndRouter(
+      <AppointmentList featureHomepageRefresh />,
+      {
+        initialState,
+      },
+    );
+
+    const oldPrint = global.window.print;
+    const printSpy = sinon.spy();
+    global.window.print = printSpy;
+
+    const detailLinks = await screen.findAllByRole('link', {
+      name: /Detail/i,
+    });
+
+    // Select an appointment details link...
+    const detailLink = detailLinks.find(l => l.getAttribute('href') === url);
+    userEvent.click(detailLink);
+
+    // Verify page content...
+    expect(
+      await screen.findByRole('heading', {
+        level: 1,
+        name: new RegExp(
+          moment()
+            .tz('America/Denver')
+            .format('dddd, MMMM D, YYYY'),
+          'i',
+        ),
+      }),
+    ).to.be.ok;
+
+    // NOTE: This 2nd 'await' is needed due to async facilities fetch call!!!
+    expect(await screen.findByText(/Fort Collins VA Clinic/)).to.be.ok;
+
+    expect(printSpy.notCalled).to.be.true;
+    fireEvent.click(await screen.findByText(/Print/i));
+    expect(printSpy.calledOnce).to.be.true;
+    global.window.print = oldPrint;
   });
 });


### PR DESCRIPTION
## Description
Currently to print in VAOS means printing the full homepage of all the upcoming appointments. This isn't practical, especially for some Veterans who have a long list of appointments.

Instead, as part of us improving details about appointments, we should enable the ability to print individual appointments.

## Testing done
Local and Unit

## Screenshots
VVC
![image](https://user-images.githubusercontent.com/8315447/108769192-aa38fa80-7526-11eb-9112-ab74586bfec1.png)
![image](https://user-images.githubusercontent.com/8315447/108769454-01d76600-7527-11eb-82de-b99c57c73319.png)
CC
![image](https://user-images.githubusercontent.com/8315447/108769254-bfae2480-7526-11eb-9c33-38e3b4ac6ad3.png)
![image](https://user-images.githubusercontent.com/8315447/108769423-f6843a80-7526-11eb-8b59-af90a92eb942.png)
VA
![image](https://user-images.githubusercontent.com/8315447/108769286-ca68b980-7526-11eb-949a-9155b0690058.png)
![image](https://user-images.githubusercontent.com/8315447/108769375-e9674b80-7526-11eb-9335-b585766163b6.png)

## Acceptance criteria
- [ ] Changes are behind the `va_online_scheduling_homepage_refresh` feature flag
- [ ] Print link appears on confirmed appointment detail pages
- [ ] When user clicks/taps Print link, open default browser dialog box [VA, CC, VVC]
- [ ] Printable page does not include navigation links (breadcrumb, go back)
![image](https://user-images.githubusercontent.com/8315447/108768426-a22c8b00-7525-11eb-97bc-5f879ea546ae.png)
- [ ] DESIGN - All desktop, tablet, and mobile designs match the specs:
VA - https://www.sketch.com/s/4198dca5-69c7-4769-9686-d213c900876d/a/WKROK1n#Inspector
CC - https://www.sketch.com/s/4198dca5-69c7-4769-9686-d213c900876d/a/QbaZbAx#Inspector
VVC - https://www.sketch.com/s/4198dca5-69c7-4769-9686-d213c900876d/a/Kv9bDLV#Inspector

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
