### PR TITLE
Improve a11y of bank info form buttons

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
@@ -10,6 +10,7 @@ import Modal from '@department-of-veterans-affairs/component-library/Modal';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 
 import recordEvent from '~/platform/monitoring/record-event';
+import LoadingButton from '~/platform/site-wide/loading-button/LoadingButton';
 
 import { isLOA3 as isLOA3Selector } from '~/platform/user/selectors';
 import { usePrevious } from '~/platform/utilities/react-hooks';
@@ -243,10 +244,27 @@ export const BankInfoCNP = ({
         formData={formData}
         formPrefix={formPrefix}
         formSubmit={saveBankInfo}
-        isSaving={directDepositUiState.isSaving}
-        onClose={closeDDForm}
-        cancelButtonClasses={['va-button-link', 'vads-u-margin-left--1']}
-      />
+      >
+        <LoadingButton
+          aria-label="update your bank information for compensation and pension benefits"
+          type="submit"
+          loadingText="saving bank information"
+          className="usa-button-primary vads-u-margin-top--0 vads-u-width--full small-screen:vads-u-width--auto"
+          isLoading={directDepositUiState.isSaving}
+        >
+          Update
+        </LoadingButton>
+        <button
+          aria-label="cancel updating your bank information for compensation and pension benefits"
+          type="button"
+          disabled={directDepositUiState.isSaving}
+          className="va-button-link vads-u-margin-left--1"
+          onClick={closeDDForm}
+          data-qa="cancel-button"
+        >
+          Cancel
+        </button>
+      </BankInfoForm>
     </>
   );
 

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoCNPv2.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoCNPv2.jsx
@@ -10,6 +10,8 @@ import Telephone, {
 } from '@department-of-veterans-affairs/component-library/Telephone';
 
 import recordEvent from '~/platform/monitoring/record-event';
+import LoadingButton from '~/platform/site-wide/loading-button/LoadingButton';
+
 import { isLOA3 as isLOA3Selector } from '~/platform/user/selectors';
 import { usePrevious } from '~/platform/utilities/react-hooks';
 import {
@@ -256,10 +258,27 @@ export const BankInfoCNP = ({
           formData={formData}
           formPrefix={formPrefix}
           formSubmit={saveBankInfo}
-          isSaving={directDepositUiState.isSaving}
-          onClose={closeDDForm}
-          cancelButtonClasses={['va-button-link', 'vads-u-margin-left--1']}
-        />
+        >
+          <LoadingButton
+            aria-label="update your bank information for compensation and pension benefits"
+            type="submit"
+            loadingText="saving bank information"
+            className="usa-button-primary vads-u-margin-top--0 vads-u-width--full small-screen:vads-u-width--auto"
+            isLoading={directDepositUiState.isSaving}
+          >
+            Update
+          </LoadingButton>
+          <button
+            aria-label="cancel updating your bank information for compensation and pension benefits"
+            type="button"
+            disabled={directDepositUiState.isSaving}
+            className="va-button-link vads-u-margin-left--1"
+            onClick={closeDDForm}
+            data-qa="cancel-button"
+          >
+            Cancel
+          </button>
+        </BankInfoForm>
       </div>
     </>
   );

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
@@ -10,6 +10,7 @@ import Telephone, {
 } from '@department-of-veterans-affairs/component-library/Telephone';
 
 import recordEvent from '~/platform/monitoring/record-event';
+import LoadingButton from '~/platform/site-wide/loading-button/LoadingButton';
 
 import { isLOA3 as isLOA3Selector } from '~/platform/user/selectors';
 import { usePrevious } from '~/platform/utilities/react-hooks';
@@ -223,10 +224,27 @@ export const DirectDepositEDU = ({
           formData={formData}
           formPrefix={formPrefix}
           formSubmit={saveBankInfo}
-          isSaving={directDepositUiState.isSaving}
-          onClose={closeDDForm}
-          cancelButtonClasses={['va-button-link', 'vads-u-margin-left--1']}
-        />
+        >
+          <LoadingButton
+            aria-label="update your bank information for education benefits"
+            type="submit"
+            loadingText="saving bank information"
+            className="usa-button-primary vads-u-margin-top--0 vads-u-width--full small-screen:vads-u-width--auto"
+            isLoading={directDepositUiState.isSaving}
+          >
+            Update
+          </LoadingButton>
+          <button
+            aria-label="cancel updating your bank information for education benefits"
+            type="button"
+            disabled={directDepositUiState.isSaving}
+            className="va-button-link vads-u-margin-left--1"
+            onClick={closeDDForm}
+            data-qa="cancel-button"
+          >
+            Cancel
+          </button>
+        </BankInfoForm>
       </div>
     </>
   );

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoForm.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoForm.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import SchemaForm from '~/platform/forms-system/src/js/components/SchemaForm';
-import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
 
 import { ACCOUNT_TYPES_OPTIONS } from '../../constants';
 
@@ -67,13 +66,11 @@ function makeSchemas(prefix) {
 }
 
 const BankInfoForm = ({
-  cancelButtonClasses,
+  children,
   formChange,
   formData,
   formPrefix,
   formSubmit,
-  isSaving,
-  onClose,
 }) => {
   const { schema, uiSchema } = makeSchemas(formPrefix);
 
@@ -89,37 +86,17 @@ const BankInfoForm = ({
       onChange={formChange}
       onSubmit={formSubmit}
     >
-      <LoadingButton
-        type="submit"
-        loadingText="saving bank information"
-        className="usa-button-primary vads-u-margin-top--0 vads-u-width--full small-screen:vads-u-width--auto"
-        isLoading={isSaving}
-      >
-        Update
-      </LoadingButton>
-      <button
-        type="button"
-        disabled={isSaving}
-        className={cancelButtonClasses.join(' ')}
-        onClick={onClose}
-        data-qa="cancel-button"
-      >
-        Cancel
-      </button>
+      {children}
     </SchemaForm>
   );
 };
 
 BankInfoForm.propTypes = {
-  // Classes to apply to the form's "cancel" button. Defaults to ['usa-button-secondary']
-  cancelButtonClasses: PropTypes.arrayOf(PropTypes.string).isRequired,
   formChange: PropTypes.func.isRequired,
   formData: PropTypes.object.isRequired,
   // Prefix to apply to all the form's schema fields
   formPrefix: PropTypes.string.isRequired,
   formSubmit: PropTypes.func.isRequired,
-  isSaving: PropTypes.bool.isRequired,
-  onClose: PropTypes.func.isRequired,
 };
 
 BankInfoForm.defaultProps = {

--- a/src/applications/personalization/profile/tests/components/direct-deposit/BankInfoForm.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/direct-deposit/BankInfoForm.unit.spec.jsx
@@ -11,18 +11,18 @@ describe('<BankInfoForm/>', () => {
 
   const formSubmitSpy = sinon.spy();
   const formChangeSpy = sinon.spy();
-  const onCloseSpy = sinon.spy();
   const defaultProps = {
-    cancelButtonClasses: ['button-class-1', 'button-class-2'],
     formChange: formChangeSpy,
     formData: { name: 'Pat' },
     formSubmit: formSubmitSpy,
-    isSaving: false,
-    onClose: onCloseSpy,
   };
 
   beforeEach(() => {
-    wrapper = mount(<BankInfoForm {...defaultProps} />);
+    wrapper = mount(
+      <BankInfoForm {...defaultProps}>
+        <button>Save</button>
+      </BankInfoForm>,
+    );
     schemaForm = wrapper.find('SchemaForm');
   });
 
@@ -42,18 +42,8 @@ describe('<BankInfoForm/>', () => {
   it('should pass the formChange prop to the SchemaForm', () => {
     expect(schemaForm.props().onChange).to.equal(defaultProps.formChange);
   });
-  it("should pass the onClose prop to the SchemaForm's cancel button", () => {
-    const cancelButton = schemaForm.find('button[data-qa="cancel-button"]');
-    expect(cancelButton.props().onClick).to.equal(defaultProps.onClose);
-  });
-  it("should pass the cancelButtonClasses prop to the SchemaForm's cancel button", () => {
-    const cancelButton = schemaForm.find('button[data-qa="cancel-button"]');
-    expect(cancelButton.props().className).to.equal(
-      defaultProps.cancelButtonClasses.join(' '),
-    );
-  });
-  it("should pass the isSaving prop to the SchemaForm's save button", () => {
-    const saveButton = schemaForm.find('LoadingButton');
-    expect(saveButton.props().isLoading).to.equal(defaultProps.isSaving);
+  it('should render the passed in children', () => {
+    const schemaFormChildren = schemaForm.find('button');
+    expect(schemaFormChildren.exists()).to.be.true;
   });
 });


### PR DESCRIPTION
## Description
Add `aria-labels` to the SAVE and CANCEL buttons

Also refactor the `BankInfoForm` so that the buttons are passed in as children. This allows us to remove some props from the `BankInfoForm`. Without this refactor we would have had to _add_ another prop to make this work.

## Testing done
Cypress tests still pass. Updated the existing unit tests, which could also be simplified since a handful of the old tests just made sure props were getting passed through correctly.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs