### PR TITLE
Hide/show search this area button correctly

### DIFF
--- a/src/applications/facility-locator/containers/FacilitiesMap.jsx
+++ b/src/applications/facility-locator/containers/FacilitiesMap.jsx
@@ -250,10 +250,10 @@ const FacilitiesMap = props => {
       return;
     }
 
+    // TODO: hide after new search
     if (
       calculateSearchArea() > MAX_SEARCH_AREA ||
-      !props.currentQuery.isValid ||
-      !props.currentQuery.mapMoved
+      !props.currentQuery.isValid
     ) {
       searchAreaControl.style.display = 'none';
       return;
@@ -293,6 +293,7 @@ const FacilitiesMap = props => {
     map.on('dragend', () => {
       props.mapMoved();
       recordPanEvent(map.getCenter(), props.currentQuery);
+      activateSearchAreaControl();
     });
     map.on('zoom', () => {
       const currentZoom = parseInt(map.getZoom(), 10);
@@ -310,6 +311,7 @@ const FacilitiesMap = props => {
       }
 
       lastZoom = currentZoom;
+      activateSearchAreaControl();
     });
   };
 
@@ -548,15 +550,6 @@ const FacilitiesMap = props => {
       })
       .catch(error => error);
   };
-
-  useEffect(
-    () => {
-      if (map) {
-        activateSearchAreaControl();
-      }
-    },
-    [props.currentQuery],
-  );
 
   useEffect(
     () => {


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/va.gov-team/issues/20099

This was broken because we were calling activateSearchAreaControl before the map zoom
was finished, so we were always one zoom event behind.
Calling activateSearchAreaControl on zoomend/dragend fixes this bug, and also
triggers the activateSearchAreaControl logic when zooming using the mouse wheel
or any other method, not just the zoom in/out buttons.


## Acceptance criteria
- [x] STA button appears when zoomed out > 500 miles, and reappears when zoomed < 500 miles

