### PR TITLE
Update heading levels in contact and bank info update errors

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
@@ -221,8 +221,9 @@ export const BankInfoCNP = ({
       <div id="errors" role="alert" aria-atomic="true">
         {!!saveError && (
           <PaymentInformationEditError
-            responseError={saveError}
             className="vads-u-margin-top--0 vads-u-margin-bottom--2"
+            level={4}
+            responseError={saveError}
           />
         )}
       </div>

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoCNPv2.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoCNPv2.jsx
@@ -233,8 +233,9 @@ export const BankInfoCNP = ({
       <div id="cnp-bank-save-errors" role="alert" aria-atomic="true">
         {!!saveError && (
           <PaymentInformationEditError
-            responseError={saveError}
             className="vads-u-margin-top--0 vads-u-margin-bottom--2"
+            level={4}
+            responseError={saveError}
           />
         )}
       </div>

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
@@ -200,8 +200,9 @@ export const DirectDepositEDU = ({
       <div id="edu-bank-save-errors" role="alert" aria-atomic="true">
         {!!saveError && (
           <PaymentInformationEditError
-            responseError={saveError}
             className="vads-u-margin-top--0 vads-u-margin-bottom--2"
+            level={4}
+            responseError={saveError}
           />
         )}
       </div>

--- a/src/applications/personalization/profile/components/direct-deposit/PaymentInformationEditError.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/PaymentInformationEditError.jsx
@@ -105,8 +105,9 @@ function UpdatePhoneNumberError({ phoneNumberType = 'home' }) {
 }
 
 export default function PaymentInformationEditError({
-  responseError,
   className,
+  level,
+  responseError,
 }) {
   let content = <GenericError error={responseError} />;
   let headline = 'We couldn’t update your bank information';
@@ -139,6 +140,7 @@ export default function PaymentInformationEditError({
       headline={headline}
       isVisible
       className={className}
+      level={level || 3}
       scrollOnShow
     >
       {content}

--- a/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
+++ b/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
@@ -264,6 +264,7 @@ class AddressValidationView extends React.Component {
         )}
         <AlertBox
           className="vads-u-margin-bottom--1 vads-u-margin-top--0"
+          level={4}
           status="warning"
           headline={addressValidationMessage.headline}
           scrollOnShow

--- a/src/platform/user/profile/vap-svc/tests/containers/AddressValidationView.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/containers/AddressValidationView.unit.spec.jsx
@@ -448,7 +448,7 @@ describe('<AddressValidationView/>', () => {
 
     expect(
       component
-        .find('h3')
+        .find('h4')
         .at(0)
         .text(),
     ).to.equal('Please confirm your address');


### PR DESCRIPTION
## Description
Decreased the heading level of contact info and bank info update alerts from H3 to H4

## Testing done
Testing in Cypress to make sure the headings look correct in the web inspector and still function fine (fall back to H3) if the new `level` prop is not used.

## Screenshots
<img width="580" alt="Screen Shot 2021-02-22 at 5 54 31 PM" src="https://user-images.githubusercontent.com/20728956/108792917-37844b00-7537-11eb-98a1-4d6a0db8ac58.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs