### PR TITLE
Homepage Refresh: Cancellation

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/index.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/index.jsx
@@ -7,9 +7,7 @@ import recordEvent from 'platform/monitoring/record-event';
 
 import ScheduleNewAppointment from './ScheduleNewAppointment';
 import * as actions from '../../redux/actions';
-import CancelAppointmentModal from '../cancel/CancelAppointmentModal';
 import {
-  getCancelInfo,
   selectFutureStatus,
   selectExpressCareAvailability,
 } from '../../redux/selectors';
@@ -37,9 +35,6 @@ import ScheduleNewProjectCheetah from './ScheduleNewProjectCheetah';
 const pageTitle = 'VA appointments';
 
 function AppointmentsPage({
-  cancelInfo,
-  closeCancelAppointment,
-  confirmCancelAppointment,
   expressCare,
   fetchFutureAppointments,
   fetchExpressCareWindows,
@@ -73,18 +68,6 @@ function AppointmentsPage({
       }
     },
     [isWelcomeModalDismissed],
-  );
-
-  useEffect(
-    () => {
-      if (
-        !cancelInfo.showCancelModal &&
-        cancelInfo.cancelAppointmentStatus === FETCH_STATUS.succeeded
-      ) {
-        scrollAndFocus();
-      }
-    },
-    [cancelInfo.showCancelModal, cancelInfo.cancelAppointmentStatus],
   );
 
   const isLoading =
@@ -163,19 +146,11 @@ function AppointmentsPage({
           {routes}
         </>
       )}
-      <CancelAppointmentModal
-        {...cancelInfo}
-        onConfirm={confirmCancelAppointment}
-        onClose={closeCancelAppointment}
-      />
     </>
   );
 }
 
 AppointmentsPage.propTypes = {
-  cancelInfo: PropTypes.object,
-  closeCancelAppointment: PropTypes.func.isRequired,
-  confirmCancelAppointment: PropTypes.func.isRequired,
   isCernerOnlyPatient: PropTypes.bool.isRequired,
   isWelcomeModalDismissed: PropTypes.bool.isRequired,
   showCommunityCare: PropTypes.bool.isRequired,
@@ -188,7 +163,6 @@ function mapStateToProps(state) {
   return {
     pendingStatus: state.appointments.pendingStatus,
     futureStatus: selectFutureStatus(state),
-    cancelInfo: getCancelInfo(state),
     showScheduleButton: selectFeatureRequests(state),
     showCommunityCare: selectFeatureCommunityCare(state),
     showDirectScheduling: selectFeatureDirectScheduling(state),
@@ -201,8 +175,6 @@ function mapStateToProps(state) {
 
 const mapDispatchToProps = {
   fetchExpressCareWindows: actions.fetchExpressCareWindows,
-  closeCancelAppointment: actions.closeCancelAppointment,
-  confirmCancelAppointment: actions.confirmCancelAppointment,
   startNewAppointmentFlow: actions.startNewAppointmentFlow,
   startNewExpressCareFlow: actions.startNewExpressCareFlow,
   fetchFutureAppointments: actions.fetchFutureAppointments,

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/ConfirmedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/ConfirmedAppointmentDetailsPage.jsx
@@ -19,7 +19,6 @@ import {
 import { FETCH_STATUS, PURPOSE_TEXT } from '../../../utils/constants';
 import { scrollAndFocus } from '../../../utils/scrollAndFocus';
 import * as actions from '../../redux/actions';
-import { cancelAppointment } from '../../redux/actions';
 import AppointmentDateTime from './AppointmentDateTime';
 import AppointmentInstructions from './AppointmentInstructions';
 import { selectFeatureCancel } from '../../../redux/selectors';
@@ -51,6 +50,7 @@ function formatHeader(appointment) {
 function ConfirmedAppointmentDetailsPage({
   appointmentDetails,
   appointmentDetailsStatus,
+  cancelAppointment,
   facilityData,
   fetchConfirmedAppointmentDetails,
   confirmedStatus,
@@ -233,6 +233,7 @@ function mapStateToProps(state) {
 }
 
 const mapDispatchToProps = {
+  cancelAppointment: actions.cancelAppointment,
   fetchConfirmedAppointmentDetails: actions.fetchConfirmedAppointmentDetails,
 };
 

--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
@@ -33,6 +33,7 @@ const TIME_TEXT = {
 function RequestedAppointmentDetailsPage({
   appointment,
   appointmentDetailsStatus,
+  cancelAppointment,
   facilityData,
   fetchRequestDetails,
   pendingStatus,
@@ -104,6 +105,7 @@ function RequestedAppointmentDetailsPage({
               <button
                 aria-label="Cancel request"
                 className="vaos-appts__cancel-btn va-button-link vads-u-flex--0"
+                onClick={() => cancelAppointment(appointment)}
               >
                 Cancel Request
               </button>
@@ -212,6 +214,7 @@ function mapStateToProps(state) {
   };
 }
 const mapDispatchToProps = {
+  cancelAppointment: actions.cancelAppointment,
   fetchRequestDetails: actions.fetchRequestDetails,
 };
 export default connect(

--- a/src/applications/vaos/appointment-list/index.jsx
+++ b/src/applications/vaos/appointment-list/index.jsx
@@ -1,6 +1,10 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { Switch, Route } from 'react-router-dom';
+import * as actions from './redux/actions';
+import { FETCH_STATUS } from '../utils/constants';
+import { scrollAndFocus } from '../utils/scrollAndFocus';
+import { getCancelInfo } from './redux/selectors';
 import { selectFeatureHomepageRefresh } from '../redux/selectors';
 import PageLayout from './components/AppointmentsPage/PageLayout';
 import AppointmentsPageV2 from './components/AppointmentsPage/AppointmentsPageV2';
@@ -8,62 +12,97 @@ import AppointmentsPage from './components/AppointmentsPage/index';
 import RequestedAppointmentDetailsPage from './components/RequestedAppointmentDetailsPage';
 import ConfirmedAppointmentDetailsPage from './components/ConfirmedAppointmentDetailsPage/ConfirmedAppointmentDetailsPage';
 import CommunityCareAppointmentDetailsPage from './components/CommunityCareAppointmentDetailsPage';
+import CancelAppointmentModal from './components/cancel/CancelAppointmentModal';
 
-function AppointmentListSection({ featureHomepageRefresh }) {
+function AppointmentListSection({
+  cancelInfo,
+  closeCancelAppointment,
+  confirmCancelAppointment,
+  featureHomepageRefresh,
+}) {
+  useEffect(
+    () => {
+      if (
+        !cancelInfo.showCancelModal &&
+        cancelInfo.cancelAppointmentStatus === FETCH_STATUS.succeeded
+      ) {
+        scrollAndFocus();
+      }
+    },
+    [cancelInfo.showCancelModal, cancelInfo.cancelAppointmentStatus],
+  );
+
   return (
-    <Switch>
-      {featureHomepageRefresh && (
-        <Route
-          path="/cc/:id"
-          component={() => (
-            <PageLayout>
-              <CommunityCareAppointmentDetailsPage />
-            </PageLayout>
-          )}
-        />
-      )}
-      <Route
-        path="/va/:id"
-        component={() => (
-          <PageLayout>
-            <ConfirmedAppointmentDetailsPage />
-          </PageLayout>
+    <>
+      <Switch>
+        {featureHomepageRefresh && (
+          <Route
+            path="/cc/:id"
+            component={() => (
+              <PageLayout>
+                <CommunityCareAppointmentDetailsPage />
+              </PageLayout>
+            )}
+          />
         )}
-      />
-      )}
-      {featureHomepageRefresh && (
+        {featureHomepageRefresh && (
+          <Route
+            path="/va/:id"
+            component={() => (
+              <PageLayout>
+                <ConfirmedAppointmentDetailsPage />
+              </PageLayout>
+            )}
+          />
+        )}
+        {featureHomepageRefresh && (
+          <Route
+            path="/requests/:id"
+            component={() => (
+              <PageLayout>
+                <RequestedAppointmentDetailsPage />
+              </PageLayout>
+            )}
+          />
+        )}
         <Route
-          path="/requests/:id"
-          component={() => (
-            <PageLayout>
-              <RequestedAppointmentDetailsPage />
-            </PageLayout>
-          )}
-        />
-      )}
-      <Route
-        path="/"
-        render={() => {
-          let content = <AppointmentsPage />;
-          if (featureHomepageRefresh) {
-            content = <AppointmentsPageV2 />;
-          }
+          path="/"
+          render={() => {
+            let content = <AppointmentsPage />;
+            if (featureHomepageRefresh) {
+              content = <AppointmentsPageV2 />;
+            }
 
-          return (
-            <PageLayout showBreadcrumbs showNeedHelp>
-              {content}
-            </PageLayout>
-          );
-        }}
+            return (
+              <PageLayout showBreadcrumbs showNeedHelp>
+                {content}
+              </PageLayout>
+            );
+          }}
+        />
+      </Switch>
+      <CancelAppointmentModal
+        {...cancelInfo}
+        onConfirm={confirmCancelAppointment}
+        onClose={closeCancelAppointment}
       />
-    </Switch>
+    </>
   );
 }
 
 function mapStateToProps(state) {
   return {
     featureHomepageRefresh: selectFeatureHomepageRefresh(state),
+    cancelInfo: getCancelInfo(state),
   };
 }
 
-export const AppointmentList = connect(mapStateToProps)(AppointmentListSection);
+const mapDispatchToProps = {
+  closeCancelAppointment: actions.closeCancelAppointment,
+  confirmCancelAppointment: actions.confirmCancelAppointment,
+};
+
+export const AppointmentList = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(AppointmentListSection);


### PR DESCRIPTION
## Description
This PR:
* Adds Cancel Modal to details pages
* Updates `CANCEL_APPOINTMENT_CONFIRMED_SUCCEEDED` reducer case to also update the `currentAppointment` which holds data for the detail page
* Minor bug fixes

## Testing done
Local and unit

## Screenshots
### Cancel Confirmed VA
![image](https://user-images.githubusercontent.com/786704/108807761-08cb9c00-755a-11eb-9c71-81faefc1f858.png)
![image](https://user-images.githubusercontent.com/786704/108807777-0d905000-755a-11eb-9253-18c755637383.png)
![image](https://user-images.githubusercontent.com/786704/108807787-11bc6d80-755a-11eb-94fa-a5f5681e0d42.png)

### Cancel Request
![image](https://user-images.githubusercontent.com/786704/108807428-3bc16000-7559-11eb-80be-80c6063219d2.png)
![image](https://user-images.githubusercontent.com/786704/108807797-15e88b00-755a-11eb-9be7-b107b43f0420.png)
![image](https://user-images.githubusercontent.com/786704/108807803-1a14a880-755a-11eb-833f-f7a4a7b9c51c.png)


## Acceptance criteria
- [ ] Changes are behind the va_online_scheduling_homepage_refresh feature flag
- [ ] When user clicks/taps cancel, request or confirmed appointment is canceled
- [ ] Appointment detail page has a unique URL


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
