### PR TITLE
Different colors for COVID screener

### DIFF
--- a/src/applications/coronavirus-screener/components/FormResult.jsx
+++ b/src/applications/coronavirus-screener/components/FormResult.jsx
@@ -5,9 +5,17 @@ import classnames from 'classnames';
 import { scrollerTo } from '../lib';
 import { resultText } from '../config/text';
 
-function Complete({ children, selectedLanguage }) {
+function Complete({ children, selectedLanguage, selectedColors }) {
   return (
-    <div>
+    <div
+      style={{
+        backgroundColor: `${selectedColors.background}`,
+        color: `${selectedColors.font}`,
+      }}
+    >
+      <div className="vads-u-font-size--xl vads-u-font-weight--bold">
+        {selectedColors.name}
+      </div>
       {children}
       <div className="covid-screener-date vads-u-font-weight--bold">
         <div className="vads-u-font-size--xl">
@@ -18,11 +26,18 @@ function Complete({ children, selectedLanguage }) {
         <div className="vads-u-font-size--xl">{moment().format('h:mm a')}</div>
       </div>
       {resultText.completeText[selectedLanguage]}
+      <div className="vads-u-font-size--xl vads-u-font-weight--bold">
+        {selectedColors.name}
+      </div>
     </div>
   );
 }
 
-export default function FormResult({ formState, selectedLanguage }) {
+export default function FormResult({
+  formState,
+  selectedLanguage,
+  passFormResultsColors,
+}) {
   const scrollElementName = 'multi-question-form-result-scroll-element';
 
   const Incomplete = () => (
@@ -30,7 +45,10 @@ export default function FormResult({ formState, selectedLanguage }) {
   );
 
   const Pass = () => (
-    <Complete selectedLanguage={selectedLanguage}>
+    <Complete
+      selectedLanguage={selectedLanguage}
+      selectedColors={passFormResultsColors}
+    >
       <i aria-hidden="true" role="presentation" className="fas fa-check" />
       <h2 className="vads-u-font-size--2xl">
         {resultText.passText[selectedLanguage]}
@@ -39,7 +57,10 @@ export default function FormResult({ formState, selectedLanguage }) {
   );
 
   const MoreScreening = () => (
-    <Complete selectedLanguage={selectedLanguage}>
+    <Complete
+      selectedLanguage={selectedLanguage}
+      selectedColors={{ background: '#112e51', font: 'white' }}
+    >
       <h2 className="vads-u-font-size--2xl">
         {resultText.moreScreeningText[selectedLanguage]}
       </h2>

--- a/src/applications/coronavirus-screener/components/FormResult.jsx
+++ b/src/applications/coronavirus-screener/components/FormResult.jsx
@@ -6,6 +6,12 @@ import { scrollerTo } from '../lib';
 import { resultText } from '../config/text';
 
 function Complete({ children, selectedLanguage, selectedColors }) {
+  // If a color other than default is specified, include the name on the results screen.
+  let groupName = '';
+  if (selectedColors.name !== '') {
+    groupName = `Group: ${selectedColors.name}`;
+  }
+
   return (
     <div
       style={{
@@ -13,8 +19,8 @@ function Complete({ children, selectedLanguage, selectedColors }) {
         color: `${selectedColors.font}`,
       }}
     >
-      <div className="vads-u-font-size--xl vads-u-font-weight--bold">
-        {selectedColors.name}
+      <div className="vads-u-font-size--lg vads-u-font-weight--bold">
+        {groupName}
       </div>
       {children}
       <div className="covid-screener-date vads-u-font-weight--bold">
@@ -26,8 +32,8 @@ function Complete({ children, selectedLanguage, selectedColors }) {
         <div className="vads-u-font-size--xl">{moment().format('h:mm a')}</div>
       </div>
       {resultText.completeText[selectedLanguage]}
-      <div className="vads-u-font-size--xl vads-u-font-weight--bold">
-        {selectedColors.name}
+      <div className="vads-u-font-size--lg vads-u-font-weight--bold">
+        {groupName}
       </div>
     </div>
   );

--- a/src/applications/coronavirus-screener/components/MultiQuestionForm.jsx
+++ b/src/applications/coronavirus-screener/components/MultiQuestionForm.jsx
@@ -16,6 +16,7 @@ export default function MultiQuestionForm({
   defaultOptions,
   customId,
   selectedLanguage,
+  passFormResultsColors,
 }) {
   const [formState, setFormState] = useState({
     status: 'incomplete',
@@ -128,7 +129,11 @@ export default function MultiQuestionForm({
     // state and then use it where it is needed.
     <div>
       {formQuestions}
-      <FormResult formState={formState} selectedLanguage={selectedLanguage} />
+      <FormResult
+        formState={formState}
+        selectedLanguage={selectedLanguage}
+        passFormResultsColors={passFormResultsColors}
+      />
     </div>
   );
 }

--- a/src/applications/coronavirus-screener/config/colors.jsx
+++ b/src/applications/coronavirus-screener/config/colors.jsx
@@ -1,0 +1,6 @@
+export const passFormResultsColorOptions = {
+  purple: { background: 'purple', font: 'white', name: 'Purple' },
+  red: { background: 'red', font: 'white', name: 'Red' },
+  yellow: { background: 'yellow', font: '#112e51', name: 'Yellow' },
+  green: { background: 'green', font: 'white', name: 'Green' },
+};

--- a/src/applications/coronavirus-screener/config/colors.jsx
+++ b/src/applications/coronavirus-screener/config/colors.jsx
@@ -1,6 +1,6 @@
 export const passFormResultsColorOptions = {
-  purple: { background: 'purple', font: 'white', name: 'Purple' },
-  red: { background: 'red', font: 'white', name: 'Red' },
-  yellow: { background: 'yellow', font: '#112e51', name: 'Yellow' },
-  green: { background: 'green', font: 'white', name: 'Green' },
+  purple: { background: '#5800AB', font: 'white', name: 'Purple' },
+  red: { background: '#981B1E', font: 'white', name: 'Red' },
+  yellow: { background: '#FAC922', font: '#112e51', name: 'Yellow' },
+  green: { background: '#2E8540', font: 'white', name: 'Green' },
 };

--- a/src/applications/coronavirus-screener/containers/App.jsx
+++ b/src/applications/coronavirus-screener/containers/App.jsx
@@ -3,6 +3,7 @@ import MetaTags from 'react-meta-tags';
 import MultiQuestionForm from '../components/MultiQuestionForm';
 import { questions, defaultOptions } from '../config/questions';
 import { introText } from '../config/text';
+import { passFormResultsColorOptions } from '../config/colors';
 
 export default function App({ params }) {
   let selectedLanguage = 'en';
@@ -31,6 +32,25 @@ export default function App({ params }) {
     alternateLangauge = 'en';
   }
 
+  // If there is a color indicated, store that for the pass results screen. Customization for Bronx VAMC.
+  let passFormResultsColors = {
+    background: '#112e51',
+    font: 'white',
+    name: '',
+  };
+  const colorKeys = Object.keys(passFormResultsColorOptions);
+  let color = null;
+
+  for (let i = 0; i < colorKeys.length; i++) {
+    color = colorKeys[i];
+    if (location.href.toLowerCase().includes(color)) {
+      passFormResultsColors = passFormResultsColorOptions[color];
+      break;
+    } else {
+      color = null;
+    }
+  }
+
   const alternateRef = `${alternateRefBase}${alternateLangauge}`;
 
   return (
@@ -54,6 +74,7 @@ export default function App({ params }) {
           defaultOptions={defaultOptions}
           customId={customId?.toUpperCase()}
           selectedLanguage={selectedLanguage}
+          passFormResultsColors={passFormResultsColors}
         />
       </div>
     </div>

--- a/src/applications/coronavirus-screener/routes.jsx
+++ b/src/applications/coronavirus-screener/routes.jsx
@@ -6,6 +6,11 @@ const routes = [
   <Route path="/" key="/" component={App} />,
   <Route path="/:id" key="/:id" component={App} />,
   <Route path="/:id/:languageId" key="/:id/:languageId" component={App} />,
+  <Route
+    path="/:id/:languageId/:colorOption"
+    key="/:id/:colorOption"
+    component={App}
+  />,
 ];
 
 export default routes;

--- a/src/applications/coronavirus-screener/tests/question-scenario-helper.js
+++ b/src/applications/coronavirus-screener/tests/question-scenario-helper.js
@@ -131,7 +131,7 @@ export const routeOptions = [
   },
   {
     route: '/526/es/purple',
-    expectedText: `${expectTextbyLanguage.en}`,
+    expectedText: `${expectTextbyLanguage.es}`,
     title: 'Route /526/es/purple (expect Spanish)',
   },
 ];

--- a/src/applications/coronavirus-screener/tests/question-scenario-helper.js
+++ b/src/applications/coronavirus-screener/tests/question-scenario-helper.js
@@ -122,11 +122,16 @@ export const routeOptions = [
   {
     route: '/459gh/es',
     expectedText: `${expectTextbyLanguage.es}`,
-    title: 'Route /fr (expect Spanish)',
+    title: 'Route /459gh/es (expect Spanish)',
   },
   {
     route: '/459gh/en',
     expectedText: `${expectTextbyLanguage.en}`,
-    title: 'Route /fr (expect English)',
+    title: 'Route /459gh/en (expect English)',
+  },
+  {
+    route: '/526/es/purple',
+    expectedText: `${expectTextbyLanguage.en}`,
+    title: 'Route /526/es/purple (expect Spanish)',
   },
 ];


### PR DESCRIPTION
## Description
Adds in MVP functionality for different colored pass screen backgrounds for use by the Bronx VAMC in their patient screening process. The four preselected colors for the Bronx VAMC screening process are green, purple, yellow, and red. Patients are categorized into one of these colors based on COVID risk (green needs no additional screening, red requires a nasal swab and test, purple/yellow in between). Patients receive their colorized version of the screener via SMS.

Bronx VAMC is testing out this whole tiered screening flow and has agreed to roll back these changes if the flow does not reduce screening times / burden. Usage will be tracked in GA.

## Testing done
Slightly increased coverage to ensure screener loads when color is specified. Needs E2E tests to validate that color is actually displaying when specified. Manually tested.

## Screenshots

### With no color specified
<img width="519" alt="Screen Shot 2021-02-24 at 11 10 06 AM" src="https://user-images.githubusercontent.com/7645362/109031856-1c2e5280-7693-11eb-83f2-4857e646b7a8.png">

### With color specified
<img width="549" alt="Screen Shot 2021-02-24 at 12 20 30 PM" src="https://user-images.githubusercontent.com/7645362/109040996-91eaec00-769c-11eb-83ee-5303668e7de9.png">

### With color and site specified
<img width="551" alt="Screen Shot 2021-02-24 at 12 37 41 PM" src="https://user-images.githubusercontent.com/7645362/109041531-21909a80-769d-11eb-9812-6ccfc438b566.png">

### With color and site and language specified
<img width="544" alt="Screen Shot 2021-02-24 at 12 38 33 PM" src="https://user-images.githubusercontent.com/7645362/109041612-38cf8800-769d-11eb-9cf4-bd5ea66b48c2.png">

### With unrecognized color specified
<img width="536" alt="Screen Shot 2021-02-24 at 11 28 59 AM" src="https://user-images.githubusercontent.com/7645362/109032453-ad052e00-7693-11eb-8f71-61af5745f7d0.png">

## Acceptance criteria
- [x] Color of pass screen matches color specified in URL if color specified is green, purple, yellow, or red.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
