### PR TITLE
Update focus style of Medallia feedback button

### DIFF
--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -11,12 +11,11 @@ $facility-locator-color-gray: #ccc;
 $facility-locator-shadow: rgba(0, 0, 0, 0.5);
 
 .facility-locator {
-
-  @media(max-width: $large-screen) {
+  @media (max-width: $large-screen) {
     margin: 0 12px;
   }
 
-  @media(max-width: $small-screen) {
+  @media (max-width: $small-screen) {
     margin: 0;
   }
 
@@ -74,7 +73,7 @@ $facility-locator-shadow: rgba(0, 0, 0, 0.5);
 
   .facility-result {
     padding: 22px 4px 34px;
-    background: $color-white ;
+    background: $color-white;
     border-top: solid 2px $color-gray-lighter;
     border-bottom: none;
 
@@ -115,7 +114,7 @@ $facility-locator-shadow: rgba(0, 0, 0, 0.5);
   }
 
   @media screen and (max-width: $small-screen) {
-    .facility-result+.facility-result {
+    .facility-result + .facility-result {
       border-top: solid 1px $color-gray-light;
     }
   }
@@ -162,7 +161,7 @@ $facility-locator-shadow: rgba(0, 0, 0, 0.5);
     }
   }
 
-  .react-tabs [role=tab][aria-selected=true] {
+  .react-tabs [role="tab"][aria-selected="true"] {
     border-left-color: $color-black;
     border-right-color: $color-black;
   }
@@ -171,7 +170,7 @@ $facility-locator-shadow: rgba(0, 0, 0, 0.5);
     padding: 0;
   }
 
-  .react-tabs__tab+.react-tabs__tab {
+  .react-tabs__tab + .react-tabs__tab {
     border-left: none;
   }
 
@@ -256,23 +255,25 @@ $facility-locator-shadow: rgba(0, 0, 0, 0.5);
       display: flex;
       flex-direction: column;
 
-      input, textarea, select {
+      input,
+      textarea,
+      select {
         max-width: none;
         margin-bottom: 24px;
 
-        @media(min-width: $small-desktop-screen) {
+        @media (min-width: $small-desktop-screen) {
           max-width: 418px;
           width: 418px;
           margin-right: 18px;
         }
       }
 
-      input[type=submit] {
+      input[type="submit"] {
         width: 100%;
         padding: 0 1rem;
         margin-top: 0;
 
-        @media(min-width: $small-desktop-screen) {
+        @media (min-width: $small-desktop-screen) {
           margin-top: 27px;
           min-width: 67px;
           width: auto;
@@ -283,7 +284,7 @@ $facility-locator-shadow: rgba(0, 0, 0, 0.5);
         display: flex;
         flex-direction: column;
 
-        @media(min-width: $small-desktop-screen) {
+        @media (min-width: $small-desktop-screen) {
           flex-direction: row;
         }
       }
@@ -292,7 +293,7 @@ $facility-locator-shadow: rgba(0, 0, 0, 0.5);
         text-decoration: none;
         margin: 0 0 0 20px;
 
-        @media(max-width: $small-desktop-screen) {
+        @media (max-width: $small-desktop-screen) {
           margin: 1em 0 1em 0;
         }
       }
@@ -307,13 +308,12 @@ $facility-locator-shadow: rgba(0, 0, 0, 0.5);
       }
 
       #search-controls-bottom-row {
-        @media(min-width: $small-desktop-screen) {
+        @media (min-width: $small-desktop-screen) {
           display: flex;
           flex-direction: row;
         }
       }
     }
-
   }
 
   .facility-detail {
@@ -411,7 +411,7 @@ $facility-locator-shadow: rgba(0, 0, 0, 0.5);
     width: 100%;
     z-index: 1010;
 
-    @media(min-width: $small-desktop-screen) {
+    @media (min-width: $small-desktop-screen) {
       width: 418px;
     }
 
@@ -481,7 +481,6 @@ $facility-locator-shadow: rgba(0, 0, 0, 0.5);
     color: $facility-locator-color-info-bubble-text;
   }
 
-
   h6 {
     font-size: 1.6rem !important;
     line-height: 1.9rem;
@@ -523,7 +522,7 @@ $facility-locator-shadow: rgba(0, 0, 0, 0.5);
   padding-top: 1px;
   width: 24px;
   height: 24px;
- }
+}
 
 .notice-marg-pad {
   padding: 0.5rem !important;
@@ -548,7 +547,7 @@ $facility-locator-shadow: rgba(0, 0, 0, 0.5);
   margin: 22px auto;
   clear: both;
 
-  @media(max-width: $small-screen) {
+  @media (max-width: $small-screen) {
     width: 260px;
     white-space: pre-line;
   }
@@ -569,7 +568,7 @@ $facility-locator-shadow: rgba(0, 0, 0, 0.5);
   color: $color-white;
   font-family: $font-sans;
 
-  @media(max-width: $small-screen) {
+  @media (max-width: $small-screen) {
     width: 235px;
     height: 43px;
   }
@@ -590,13 +589,13 @@ $facility-locator-shadow: rgba(0, 0, 0, 0.5);
   margin: 15px 0 0 15px;
 }
 
-button.mapboxgl-ctrl-zoom-in  {
+button.mapboxgl-ctrl-zoom-in {
   margin-top: 0;
   margin-bottom: 0;
   margin-right: 0;
 }
 
-button.mapboxgl-ctrl-zoom-out  {
+button.mapboxgl-ctrl-zoom-out {
   margin-top: 0;
   margin-bottom: 0;
   margin-right: 0;
@@ -625,7 +624,6 @@ canvas.mapboxgl-canvas:focus {
       top: 16px;
     }
   }
-
 }
 
 #street-city-state-zip {

--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -630,3 +630,10 @@ canvas.mapboxgl-canvas:focus {
   font-weight: bold;
   padding-right: 28px;
 }
+
+// Make focus styles on the Medallia 'Feedback' button consistent with focus styles in the survey
+.nebula_image_button.wcagOutline:focus {
+  outline: 2px solid rgb(249, 198, 66) !important;
+  outline-offset: 2px !important;
+  transition: none !important;
+}


### PR DESCRIPTION
## GitHub Issue

https://github.com/department-of-veterans-affairs/va.gov-team/issues/17460

## Description

This PR does the following:

- Applies formatting from prettier
   - 4d0ce8fbdc1315f1100e104e98dabc5eeb28165a
- Updates the focus style for the Feedback button that is used to open the Medallia survey on https://staging.va.gov/find-locations
   - 0580d7f9d9704a2607038335aa868c15307ecb56

## Screenshots

![medallia-feedback-button-needs-important](https://user-images.githubusercontent.com/6130520/109038683-9bbb2200-7691-11eb-8047-dcd9ad41da48.gif)

## Acceptance criteria
- [ ] Feedback button has the following styles when focused

```
outline: 2px solid rgb(249, 198, 66) !important;
outline-offset: 2px !important;
transition: none !important;
```

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
