### PR TITLE
Covid chatbot styling/autoscroll fix

### DIFF
--- a/src/applications/coronavirus-chatbot/sass/coronavirus-chatbot.scss
+++ b/src/applications/coronavirus-chatbot/sass/coronavirus-chatbot.scss
@@ -111,12 +111,12 @@ div.ac-container.ac-adaptiveCard {
 
 /* additional padding around answer chat bubbles
 (3px + webchat__row 5px + css-1qyo5rb 8px = 16px from design specs) */
-.webchat__stackedLayout--fromUser {
+.webchat__stacked-layout--from-user {
   padding: 3px 0 !important;
 }
 
 /* "just now/5 mins ago" time indicator for each message */
-.css-1kceze8{
+.webchat__stacked-layout__status {
   visibility: hidden;
 }
 

--- a/src/applications/coronavirus-chatbot/utils.js
+++ b/src/applications/coronavirus-chatbot/utils.js
@@ -27,7 +27,7 @@ const disableCheckboxes = () => {
 
 const scrollToNewMessage = () => {
   const messages = [
-    ...document.getElementsByClassName('webchat__stackedLayout--fromUser'),
+    ...document.getElementsByClassName('webchat__stacked-layout--from-user'),
   ];
   const lastMessageFromUser = messages[messages.length - 1];
   lastMessageFromUser.scrollIntoView({ behavior: 'smooth' });


### PR DESCRIPTION
## Description
[department-of-veterans-affairs/orchid#358]
Fixing a recent PR that changed two class names (there was a mismatch in botframework versions)

## Testing done
unit tests, e2e, manual testing locally

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
