### PR TITLE
[20333] Adjust print layout styling

### DIFF
--- a/src/applications/vaos/appointment-list/components/CommunityCareAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/CommunityCareAppointmentDetailsPage.jsx
@@ -106,7 +106,7 @@ function CommunityCareAppointmentDetailsPage({
         />
       </div>
 
-      <div className="vads-u-margin-top--3 vaos-appts__block-label">
+      <div className="vads-u-margin-top--3 vaos-appts__block-label vaos-hide-for-print">
         <i
           aria-hidden="true"
           className="far fa-calendar vads-u-margin-right--1"
@@ -120,7 +120,7 @@ function CommunityCareAppointmentDetailsPage({
         />
       </div>
 
-      <div className="vads-u-margin-top--2 vaos-appts__block-label">
+      <div className="vads-u-margin-top--2 vaos-appts__block-label vaos-hide-for-print">
         <i aria-hidden="true" className="fas fa-print vads-u-margin-right--1" />
         <button className="va-button-link" onClick={() => window.print()}>
           Print

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/ConfirmedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/ConfirmedAppointmentDetailsPage.jsx
@@ -149,7 +149,7 @@ function ConfirmedAppointmentDetailsPage({
                 </div>
               )}
 
-            <div className="vads-u-margin-top--3 vaos-appts__block-label">
+            <div className="vads-u-margin-top--3 vaos-appts__block-label vaos-hide-for-print">
               <i
                 aria-hidden="true"
                 className="far fa-calendar vads-u-margin-right--1"
@@ -163,7 +163,7 @@ function ConfirmedAppointmentDetailsPage({
               />
             </div>
 
-            <div className="vads-u-margin-top--2 vaos-appts__block-label">
+            <div className="vads-u-margin-top--2 vaos-appts__block-label vaos-hide-for-print">
               <i
                 aria-hidden="true"
                 className="fas fa-print vads-u-margin-right--1"
@@ -173,7 +173,7 @@ function ConfirmedAppointmentDetailsPage({
               </button>
             </div>
 
-            <div className="vads-u-margin-top--2 vaos-appts__block-label">
+            <div className="vads-u-margin-top--2 vaos-appts__block-label vaos-hide-for-print">
               <i
                 aria-hidden="true"
                 className="fas fa-clock vads-u-margin-right--1"
@@ -182,7 +182,7 @@ function ConfirmedAppointmentDetailsPage({
             </div>
 
             {showCancelButton && (
-              <div className="vads-u-margin-top--2 vaos-appts__block-label">
+              <div className="vads-u-margin-top--2 vaos-appts__block-label vaos-hide-for-print">
                 <i
                   aria-hidden="true"
                   className="fas fa-times vads-u-margin-right--1 vads-u-font-size--lg"

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoLink.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoLink.jsx
@@ -41,6 +41,7 @@ export default function VideoLink({ appointment }) {
       'vads-u-margin-left--0',
       'vads-u-margin-right--1p5',
       { 'usa-button-disabled': disableVideoLink },
+      'vaos-link-for-print',
     );
 
     return (

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoVisitSection.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoVisitSection.jsx
@@ -126,7 +126,7 @@ export default function VideoVisitLocation({ header, appointment, facility }) {
             </div>
           )}
 
-        <div className="vads-u-margin-top--3 vaos-appts__block-label">
+        <div className="vads-u-margin-top--3 vaos-appts__block-label vaos-hide-for-print">
           <i
             aria-hidden="true"
             className="far fa-calendar vads-u-margin-right--1"
@@ -140,7 +140,7 @@ export default function VideoVisitLocation({ header, appointment, facility }) {
           />
         </div>
 
-        <div className="vads-u-margin-top--2 vaos-appts__block-label">
+        <div className="vads-u-margin-top--2 vaos-appts__block-label vaos-hide-for-print">
           <i
             aria-hidden="true"
             className="fas fa-print vads-u-margin-right--1"

--- a/src/applications/vaos/appointment-list/sass/styles.scss
+++ b/src/applications/vaos/appointment-list/sass/styles.scss
@@ -86,4 +86,10 @@
   .vaos-hide-for-print {
     display: none !important;
   }
+
+  .vaos-link-for-print {
+    color: $color-black;
+    text-align: left;
+    padding-left: 0;
+  }
 }


### PR DESCRIPTION
## Description
Additional enhancements to the printable appointment found from work in #12679.

## Testing done
Local and Unit

## Screenshots
VVC
![image](https://user-images.githubusercontent.com/8315447/109055750-92d84980-76ad-11eb-9fd4-782a27576d8b.png)
CC
![image](https://user-images.githubusercontent.com/8315447/109055785-9b308480-76ad-11eb-819a-49d6b5528645.png)
VA
![Uploading image.png…]()

## Acceptance criteria
- [ ] Changes are behind the va_online_scheduling_homepage_refresh feature flag
- [ ] When user clicks/taps Print link on appointment detail page, open default browser dialog box
- [ ] If appointment has a "Join Appointment" link, Then show link and full URL on the printable page
- [ ] DESIGN - On printable page only, Join Appointment link is:
Black text
Left aligned
- [ ] On printable page only, do not show the following text/links:
Add to calendar
Print
Reschedule
Cancel appointment
- [ ] No changes are made to the actual web page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
