### PR TITLE
Tweak error messaging for graphql errors

### DIFF
--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -224,7 +224,7 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
           const pluralizedErrors =
             json.errors.length > 1 ? 'errors' : 'an error';
           throw new Error(
-            `${queryName} has ${pluralizedErrors} in its query.\nThis is likely happening in the file ${queryName}.graphql.js.\nThis is the query that has ${pluralizedErrors}:${query}`,
+            `${queryName} has ${pluralizedErrors} in its query.\nThis is likely happening in the file ${queryName}.graphql.js.\nThis is the query that has ${pluralizedErrors}:\n${query}`,
           );
         }
 

--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -224,7 +224,9 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
           const pluralizedErrors =
             json.errors.length > 1 ? 'errors' : 'an error';
           throw new Error(
-            `Error with ${queryName}:\n\n${formattedErrors}\n\nGraphQL query that has ${pluralizedErrors}:\n${query}`,
+            `GraphQL query ${queryName} had ${pluralizedErrors}:\n${query}\n\n${chalk.red(
+              `Error with ${queryName}. Scroll up for the GraphQL query that has ${pluralizedErrors}:\n\n${formattedErrors}`,
+            )}`,
           );
         }
 

--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -221,7 +221,11 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
 
         if (json.errors) {
           console.log(json.errors);
-          throw new Error(`${queryName} resulted in errors`);
+          const pluralizedErrors =
+            json.errors.length > 1 ? 'errors' : 'an error';
+          throw new Error(
+            `${queryName} has ${pluralizedErrors} in its query.\nThis is likely happening in the file ${queryName}.graphql.js.\nThis is the query that has ${pluralizedErrors}:${query}`,
+          );
         }
 
         if (json.data?.nodeQuery) {

--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -220,11 +220,11 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
         const json = await request;
 
         if (json.errors) {
-          console.log(json.errors);
+          const formattedErrors = JSON.stringify(json.errors, null, 2);
           const pluralizedErrors =
             json.errors.length > 1 ? 'errors' : 'an error';
           throw new Error(
-            `${queryName} has ${pluralizedErrors} in its query.\nThis is likely happening in the file ${queryName}.graphql.js.\nThis is the query that has ${pluralizedErrors}:\n${query}`,
+            `Error with ${queryName}:\n\n${formattedErrors}\n\nGraphQL query that has ${pluralizedErrors}:\n${query}`,
           );
         }
 

--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -224,7 +224,7 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
           const pluralizedErrors =
             json.errors.length > 1 ? 'errors' : 'an error';
           throw new Error(
-            `GraphQL query ${queryName} had ${pluralizedErrors}:\n${query}\n\n${chalk.red(
+            `GraphQL query ${queryName} has ${pluralizedErrors}:\n${query}\n\n${chalk.red(
               `Error with ${queryName}. Scroll up for the GraphQL query that has ${pluralizedErrors}:\n\n${formattedErrors}`,
             )}`,
           );


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/20101

This PR attempts to improve the GraphQL error logging.

## Testing done
N/A

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/109179495-2f9af580-7747-11eb-8d43-d2546b8b6205.png)
![image](https://user-images.githubusercontent.com/12773166/109178991-ac799f80-7746-11eb-9a0c-5eb9110d3357.png)

## Acceptance criteria
- [x] Improve graphql error logging

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
