### PR TITLE
Fix 526 validation issue

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -488,6 +488,9 @@ const formConfig = {
           depends: formData => !increaseOnly(formData) && !isBDD(formData),
           uiSchema: prisonerOfWar.uiSchema,
           schema: prisonerOfWar.schema,
+          appStateSelector: state => ({
+            serviceInformation: state.form?.data?.serviceInformation,
+          }),
         },
         // Ancillary forms wizard
         ancillaryFormsWizardIntro: {

--- a/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 
 import {
   isValidYear,
+  isWithinServicePeriod,
   startedAfterServicePeriod,
   oneDisabilityRequired,
   hasMonthYear,
@@ -214,6 +215,86 @@ describe('526 All Claims validations', () => {
       };
       hasMonthYear(err, '1980-12-XX');
       expect(err.addError.called).to.be.false;
+    });
+  });
+
+  describe('isWithinServicePeriod', () => {
+    const appStateData = {
+      serviceInformation: {
+        servicePeriods: [
+          { dateRange: { from: '2001-03-21', to: '2014-07-21' } },
+          { dateRange: { from: '2015-01-01', to: '2017-05-13' } },
+        ],
+      },
+    };
+
+    it('should not add an error when date range is within a service period', () => {
+      const err = {
+        from: { addError: sinon.spy() },
+        to: { addError: sinon.spy() },
+      };
+      isWithinServicePeriod(
+        err,
+        { from: '2014-07-01', to: '2014-07-20' },
+        null,
+        null,
+        null,
+        null,
+        appStateData,
+      );
+      expect(err.from.addError.called).to.be.false;
+      expect(err.to.addError.called).to.be.false;
+    });
+    it('should not add an error when with incomplete date ranges', () => {
+      const err = {
+        from: { addError: sinon.spy() },
+        to: { addError: sinon.spy() },
+      };
+      isWithinServicePeriod(
+        err,
+        { from: '2014-07-01', to: '2014-07-XX' },
+        null,
+        null,
+        null,
+        null,
+        appStateData,
+      );
+      expect(err.from.addError.called).to.be.false;
+      expect(err.to.addError.called).to.be.false;
+    });
+    it('should add an error when date range is within a service period', () => {
+      const err = {
+        from: { addError: sinon.spy() },
+        to: { addError: sinon.spy() },
+      };
+      isWithinServicePeriod(
+        err,
+        { from: '2014-07-01', to: '2014-07-30' },
+        null,
+        null,
+        null,
+        null,
+        appStateData,
+      );
+      expect(err.from.addError.called).to.be.true;
+      expect(err.to.addError.called).to.be.true;
+    });
+    it('should add an error when date range is within a service period', () => {
+      const err = {
+        from: { addError: sinon.spy() },
+        to: { addError: sinon.spy() },
+      };
+      isWithinServicePeriod(
+        err,
+        { from: '2014-08-01', to: '2014-08-10' },
+        null,
+        null,
+        null,
+        null,
+        appStateData,
+      );
+      expect(err.from.addError.called).to.be.true;
+      expect(err.to.addError.called).to.be.true;
     });
   });
 

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -229,7 +229,7 @@ export const hasMonthYear = (err, fieldData) => {
 export const isWithinServicePeriod = (
   errors,
   fieldData,
-  formData,
+  _formData,
   _schema,
   _uiSchema,
   _index,

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -229,15 +229,17 @@ export const hasMonthYear = (err, fieldData) => {
 export const isWithinServicePeriod = (
   errors,
   fieldData,
-  _formData,
+  formData,
   _schema,
   _uiSchema,
   _index,
   appStateData,
 ) => {
-  // formData === fieldData on review & submit, so we're only using appStateData
-  // here - see #20301
-  const servicePeriods = appStateData?.serviceInformation?.servicePeriods || [];
+  // formData === fieldData on review & submit - see #20301
+  const servicePeriods =
+    formData?.serviceInformation?.servicePeriods ||
+    appStateData?.serviceInformation?.servicePeriods ||
+    [];
   const inServicePeriod = servicePeriods.some(pos =>
     isWithinRange(fieldData, pos.dateRange),
   );

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -226,12 +226,18 @@ export const hasMonthYear = (err, fieldData) => {
   }
 };
 
-export const isWithinServicePeriod = (errors, fieldData, formData) => {
-  const servicePeriods = _.get(
-    'serviceInformation.servicePeriods',
-    formData,
-    [],
-  );
+export const isWithinServicePeriod = (
+  errors,
+  fieldData,
+  formData,
+  _schema,
+  _uiSchema,
+  _index,
+  appStateData,
+) => {
+  // formData === fieldData on review & submit, so we're only using appStateData
+  // here - see #20301
+  const servicePeriods = appStateData?.serviceInformation?.servicePeriods || [];
   const inServicePeriod = servicePeriods.some(pos =>
     isWithinRange(fieldData, pos.dateRange),
   );


### PR DESCRIPTION
## Description

Veteran's editing the POW periods of confinement on the review & submit page would always see a validation error message. The underlying problem is that the validation function would receive the page data and not the overall form data. 

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/20301
- https://github.com/department-of-veterans-affairs/vsp-support/issues/162

## Testing done

Add unit tests for `isWithinServicePeriod`

## Screenshots

<details><summary>Invalid errors showing when editing confinement period</summary>

<!-- leave a blank line above -->
![](https://user-images.githubusercontent.com/136959/108773196-9c35aa80-7523-11eb-8358-05b856d29fa9.gif)</details>

## Acceptance criteria
- [x] confinement dates can be edited on the 526 review & submit page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
