### PR TITLE
Use top desktop viewport for Cypress default viewport

### DIFF
--- a/config/cypress.json
+++ b/config/cypress.json
@@ -1,7 +1,7 @@
 {
   "baseUrl": "http://localhost:3001",
-  "viewportWidth": 1000,
-  "viewportHeight": 1000,
+  "viewportWidth": 1920,
+  "viewportHeight": 1080,
   "integrationFolder": "./src",
   "modifyObstructiveCode": false,
   "nodeVersion": "system",


### PR DESCRIPTION
## Description
This PR modifies Cypress' default viewport configuration to use the most common desktop viewport.

## Testing done
- Tests pass locally and on CI

## Acceptance criteria
- [ ] Tests pass locally and on CI