### PR TITLE
Remove 526 axe color contrast exception

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
@@ -27,7 +27,6 @@ const todayPlus120 = moment()
 
 const testConfig = createTestConfig(
   {
-    _13647Exception: true,
     dataPrefix: 'data',
 
     dataSets: [


### PR DESCRIPTION
## Description

With the update of axe-core testing library to v4.1.1, better color contrast testing is in place. We can now remove the color contrast exception in place for form 526.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/14013

## Testing done

Cypress e2e tests of 526 (locally)

## Screenshots

N/A

## Acceptance criteria
- [x] Cypress e2e tests for 526 are passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
