### PR TITLE
Add medallia events to Google Tag Manager implementation

### DIFF
--- a/src/site/assets/js/google-analytics/medallia-events.js
+++ b/src/site/assets/js/google-analytics/medallia-events.js
@@ -1,0 +1,73 @@
+(function(window) {
+  function withFormContent(acc, data) {
+    //console.log("acc.content data",data.Content);
+    acc.content = data.Content;
+  }
+
+  function withFeedbackUUID(acc, data) {
+    acc.feedbackUUID = data.Feedback_UUID;
+  }
+
+  function mEvent(name, action, opts) {
+    opts = opts || {};
+    var custom = opts.custom;
+    var label = opts.label;
+
+    function handle(event) {
+      var start = +new Date();
+      var cm = window.cm || function() {};
+      var mData = event.detail;
+      var eData = {
+        category: 'Medallia',
+        action: action,
+        label: label || mData.Form_Type,
+        value: mData.Form_ID,
+        myParams: {},
+      };
+      if (custom) {
+        for (var i = 0; i < custom.length; i++)
+          custom[i](eData.myParams, mData);
+      }
+      var end = +new Date();
+      console.log('send', 'event', eData, end - start);
+      recordEvent({
+        event: eData.action,
+        'survey-tool': eData.category,
+        'survey-form-id': eData.value,
+        'survey-status': eData.label,
+        'survey-details': eData.myParams,
+      });
+    }
+    window.addEventListener('MDigital_' + name, handle);
+  }
+  mEvent('ShowForm_Called', 'survey-show-form-call');
+  mEvent('Form_Displayed', 'survey-start-form');
+  mEvent('Form_Next_Page', 'survey-next-click');
+  mEvent('Form_Back_Page', 'survey-back-click');
+  mEvent('Form_Close_Submitted', 'survey-submit-close');
+  mEvent('Form_Close_No_Submit', 'survey-no-submit-close');
+  mEvent('Feedback_Submit', 'survey-submit', {
+    custom: [withFeedbackUUID, withFormContent],
+  });
+  mEvent('Submit_Feedback', 'survey--submission', {
+    custom: [withFeedbackUUID, withFormContent],
+  });
+  mEvent('Feedback_Button_Clicked', 'survey-button-click', {
+    custom: [withFeedbackUUID],
+  });
+  mEvent('ThankYou_Displayed', 'survey--submission-successful', {
+    custom: [withFeedbackUUID, withFormContent],
+  });
+  mEvent('Invite_Displayed', 'survey-invitation-display', {
+    label: 'Invite',
+  });
+  mEvent('Invite_Accepted', 'survey-invitation-accept', {
+    label: 'Invite',
+  });
+  mEvent('Invite_Declined', 'survey-invitation-decline', {
+    label: 'Invite',
+  });
+  mEvent('Invite_Skipped', 'survey-invitation-skip', {
+    label: 'Invite',
+  });
+})(window);

--- a/src/site/includes/google-analytics.liquid
+++ b/src/site/includes/google-analytics.liquid
@@ -18,6 +18,7 @@
   {% when 'vagovstaging' %}
     {% capture google_analytics_js %}
       {% include "src/site/assets/js/google-analytics/vagovstaging.js" %}
+      {% include "src/site/assets/js/google-analytics/medallia-events.js" %}
     {% endcapture %}
 
     {% capture google_analytics_noscript %}


### PR DESCRIPTION
## GitHub Issue 

https://github.com/department-of-veterans-affairs/va.gov-team/issues/20199

## Description

This PR adds a script that maps Medallia events to our Google Tag Manager events. The [script was provided by @jonwehausen](https://github.com/department-of-veterans-affairs/va.gov-team/issues/20199#issuecomment-785255864). 

## Additional Context

We have different Google Analytics scripts for different environments. This PR only concerns the staging environment. 

1. The `google-analytics/vagovstaging.js` [script](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/site/assets/js/google-analytics/vagovstaging.js) gets loaded by the [`google-analytics.liquid` template](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/site/includes/google-analytics.liquid). 
1. The [`google-analytics.liquid` template](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/site/includes/google-analytics.liquid) gets loaded by the [`header.html` file](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/site/includes/header.html). 
1. The [`header.html` file](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/site/includes/header.html) gets included in many different layout pages. 
   - For example: [`src/site/layouts/home.html`](https://github.com/department-of-veterans-affairs/vets-website/blob/4d910ad9aef5906d494aed7be0c2fc91ed39f1e2/src/site/layouts/home.html#L1)

## Caveats

- There are only two Medallia surveys on modernized VA.gov pages (https://staging.va.gov/find-locations/facility/vha_691 and https://staging.va.gov/find-locations/facility/vha_691), but I believe there are plans to add more in the future. We discussed only adding this script to those two pages specifically, but that would mean each new survey would require a PR, waiting for a successful build, waiting for code review, and waiting for a deployment. By adding it to the global implementation, we should be able to roll out Medallia to additional pages with significantly less overhead. 

## Requested Feedback

- Are `includes` guaranteed to apply in the order of the source code?

```
{% include "src/site/assets/js/google-analytics/vagovstaging.js" %}
{% include "src/site/assets/js/google-analytics/medallia-events.js" %}
```

- Would it be better to add the [analytics code provided by Jon](https://github.com/department-of-veterans-affairs/va.gov-team/issues/20199#issuecomment-785255864) directly to the `src/site/assets/js/google-analytics/vagovstaging.js` [file](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/site/assets/js/google-analytics/vagovstaging.js) instead of putting it in a separate file? 

## Steps to Reproduce

1. Run `git checkout 20199-add-medallia-events-to-gtm` to checkout this branch
1. Run `rm -rf .cache build` to delete the build and cache folders
1. Make sure SOCKS is running
1. Run `NODE_ENV=production ./script/build.sh --buildtype vagovstaging` to produce a staging build
1. Run `BUILDTYPE=vagovstaging yarn watch` to start the application using the staging build
1. Open http://localhost:3001/find-locations/
1. Open the Elements tab of the browser dev tools
1. Confirm the [modernized script that Jon provided](https://github.com/department-of-veterans-affairs/va.gov-team/issues/20199#issuecomment-785255864) is after the `window.dataLayer` script

## Screenshots

![image](https://user-images.githubusercontent.com/6130520/109231287-e4ef9c80-778b-11eb-83e0-384fd47ee5be.png)

## Acceptance criteria
- [ ] The page loads, and nothing is broken

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)

## Next steps

https://github.com/department-of-veterans-affairs/vets-website/pull/16208