### PR TITLE
Fix contact box to display choice toggled in cms.

### DIFF
--- a/src/site/paragraphs/contact_information.drupal.liquid
+++ b/src/site/paragraphs/contact_information.drupal.liquid
@@ -4,7 +4,7 @@
 
     <ul class="usa-unstyled-list vads-u-display--flex vads-u-flex-direction--column">
       <!-- Default contact -->
-      {% if entity.fieldBenefitHubContacts == empty and entity.fieldContactDefault != empty %}
+      {% if entity.fieldContactInfoSwitch == 'DC' and entity.fieldContactDefault != empty %}
         <li class="vads-u-margin-top--1">
           <strong>{{ entity.fieldContactDefault.entity.title }} </strong>
           {% if entity.fieldContactDefault.entity.fieldLink %}
@@ -47,7 +47,7 @@
       {% endif %}
 
       <!-- Benefit hub contacts -->
-      {% if entity.fieldBenefitHubContacts != empty %}
+      {% if entity.fieldContactInfoSwitch == 'BHC' and entity.fieldBenefitHubContacts != empty %}
         {% for supportService in entity.fieldBenefitHubContacts.entity.fieldSupportServices %}
           <li class="vads-u-margin-top--1">
             <strong>{{ supportService.entity.title }} </strong>

--- a/src/site/stages/build/drupal/graphql/paragraph-fragments/contactInformation.paragraph.graphql.js
+++ b/src/site/stages/build/drupal/graphql/paragraph-fragments/contactInformation.paragraph.graphql.js
@@ -16,6 +16,7 @@ module.exports = `
         }
       }
     }
+    fieldContactInfoSwitch
     fieldContactDefault {
       entity {
         ... supportService


### PR DESCRIPTION
## Description
Contact info isn't displaying option selected in cms. This pr adds the select field from the cms into the graphql query, and uses the field in the paragraph template to determine which contact group to display on the page.

## Testing done
Visual

## Screenshots
entity.fieldContactInfoSwitch == 'DC'
![image](https://user-images.githubusercontent.com/2404547/109075233-db503100-76c6-11eb-8b86-6d3bbd4bff01.png)
![image](https://user-images.githubusercontent.com/2404547/109075246-dee3b800-76c6-11eb-8e00-f05be0854a6b.png)

## Acceptance criteria
- [ ] Non failing build

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
