### PR TITLE
Adding --omitdebug flag as a build option

### DIFF
--- a/script/build-help.js
+++ b/script/build-help.js
@@ -30,6 +30,12 @@ const helpSections = [
           'Specify a different host. Use with --env.public to serve the website to your local network.\nE.g. {bold 0.0.0.0}',
       },
       {
+        name: 'env.omitdebug',
+        type: Boolean,
+        description:
+          'Prevent debug output from reaching the DOM, this is useful when needing to compare HTML output versions',
+      },
+      {
         name: 'env.port',
         typeLabel: '{underline number}',
         description: 'Run on a specific port. Defaults to {bold 3001}.',

--- a/src/site/includes/debug.drupal.liquid
+++ b/src/site/includes/debug.drupal.liquid
@@ -1,4 +1,4 @@
-{% if buildtype != 'vagovprod' %}
+{% if buildtype != 'vagovprod' and omitdebug == false %}
 <script nonce="**CSP_NONCE**" data-template="includes/debug">
   window.contentData = {{ debug }};
   console.info('Metalsmith template generated from content:', window.contentData);

--- a/src/site/stages/build/index.js
+++ b/src/site/stages/build/index.js
@@ -134,6 +134,7 @@ function build(BUILD_OPTIONS) {
     buildtype: BUILD_OPTIONS.buildtype,
     hostUrl: BUILD_OPTIONS.hostUrl,
     enabledFeatureFlags: BUILD_OPTIONS.cmsFeatureFlags,
+    omitdebug: BUILD_OPTIONS.omitdebug,
   });
 
   smith.use(

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -59,6 +59,7 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'accessibility', type: Boolean, defaultValue: false },
   { name: 'lint-plain-language', type: Boolean, defaultValue: false },
   { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false },
+  { name: 'omitdebug', type: Boolean, defaultValue: false },
 
   // HACK: The drupal-aws-cache script ends up here while trying to cache
   // the query for getting all pages. The 'fetch' option from that cache script

--- a/src/site/stages/build/plugins/create-drupal-debug.js
+++ b/src/site/stages/build/plugins/create-drupal-debug.js
@@ -33,7 +33,8 @@ function createDrupalDebugPage(buildOptions) {
   // a debug page should never be built there.
   if (
     !ENABLED_ENVIRONMENTS.has(buildOptions.buildtype) ||
-    buildOptions.buildtype === ENVIRONMENTS.VAGOVPROD
+    buildOptions.buildtype === ENVIRONMENTS.VAGOVPROD ||
+    buildOptions.omitdebug === true
   ) {
     return () => {};
   }


### PR DESCRIPTION
## Description
The --omitdebug flag let's us prevent the output of debug code into the DOM and the generation of the Drupal debug file. This is need to run comparisons between vets-website and content-build and will probably be removed post-launch.