### PR TITLE
Updated Slack channel and message for Broken Links notifications.

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -171,7 +171,7 @@ def checkForBrokenLinks(String buildLogPath, String envName, Boolean contentOnly
       // Until slackUploadFile works...
       def brokenLinks = readFile(csvFile)
       def brokenLinksCount = sh(returnStdout: true, script: "wc -l /application/${csvFileName} | cut -d ' ' -f1") as Integer
-      def brokenLinksMessage = "${brokenLinksCount} broken links found in the `${envName}` build on `${env.BRANCH_NAME}`\n${env.RUN_DISPLAY_URL}\n${brokenLinks}".stripMargin()
+      def brokenLinksMessage = "${brokenLinksCount} broken links found in the `${envName}` build on `${env.BRANCH_NAME}`\n@cmshelpdesk\n${env.RUN_DISPLAY_URL}\n${brokenLinks}".stripMargin()
 
       slackSend(
         message: brokenLinksMessage,

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -171,13 +171,13 @@ def checkForBrokenLinks(String buildLogPath, String envName, Boolean contentOnly
       // Until slackUploadFile works...
       def brokenLinks = readFile(csvFile)
       def brokenLinksCount = sh(returnStdout: true, script: "wc -l /application/${csvFileName} | cut -d ' ' -f1") as Integer
-      def brokenLinksMessage = "${brokenLinksCount} broken links found in the `${envName}` build on `${env.BRANCH_NAME}`\n${env.RUN_DISPLAY_URL}\n${brokenLinks}".stripMargin()
+      def brokenLinksMessage = "${brokenLinksCount} broken links found in the `${envName}` build on `${env.BRANCH_NAME}`\n@cmshelpdesk\n${env.RUN_DISPLAY_URL}\n${brokenLinks}".stripMargin()
 
       slackSend(
         message: brokenLinksMessage,
         color: 'danger',
         failOnError: true,
-        channel: 'cms-team'
+        channel: 'cms-helpdesk-bot'
         // attachments: brokenLinks
         // TODO: errors out with ERROR: Slack notification failed with exception: net.sf.json.JSONException: Invalid JSON String
         // needs to be formatted into JSON

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -171,7 +171,7 @@ def checkForBrokenLinks(String buildLogPath, String envName, Boolean contentOnly
       // Until slackUploadFile works...
       def brokenLinks = readFile(csvFile)
       def brokenLinksCount = sh(returnStdout: true, script: "wc -l /application/${csvFileName} | cut -d ' ' -f1") as Integer
-      def brokenLinksMessage = "${brokenLinksCount} broken links found in the `${envName}` build on `${env.BRANCH_NAME}`\n@cmshelpdesk\n${env.RUN_DISPLAY_URL}\n${brokenLinks}".stripMargin()
+      def brokenLinksMessage = "${brokenLinksCount} broken links found in the `${envName}` build on `${env.BRANCH_NAME}`\n${env.RUN_DISPLAY_URL}\n${brokenLinks}".stripMargin()
 
       slackSend(
         message: brokenLinksMessage,


### PR DESCRIPTION
## Description

Related to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/4448 

Updated Slack channel for Broken Links notifications from #cms-team to #cms-helpdesk-bot.

Added @cmsheldesk to the slack message so that the help desk slack group gets a direct ping.

## Testing done

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
