### PR TITLE
Properly handle "edit your address" from validation view

### DIFF
--- a/src/applications/personalization/profile/components/personal-information/ContactInformationEditView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationEditView.jsx
@@ -302,6 +302,7 @@ export class ContactInformationEditView extends Component {
                     data-action="save-edit"
                     data-testid="save-edit-button"
                     isLoading={isLoading}
+                    loadingText="Saving changes"
                     className="vads-u-width--auto vads-u-margin-top--0"
                     disabled={!hasUnsavedEdits}
                   >

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
@@ -285,7 +285,7 @@ class ContactInformationField extends React.Component {
               fieldName,
               data: this.props.data,
               showSMSCheckbox: this.props.showSMSCheckbox,
-              editViewData: this.props.editViewData,
+              modalData: this.props.editViewData,
             })
           }
           hasValidationError={this.props.hasValidationError}

--- a/src/applications/personalization/profile/tests/e2e/address-validation/edit-after-validation.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/edit-after-validation.cypress.spec.js
@@ -1,0 +1,86 @@
+import { setUp } from '@@profile/tests/e2e/address-validation/setup';
+
+describe('Personal and contact information', () => {
+  describe('when returning to the address edit form from the validation screen', () => {
+    it('should prefill the address edit form with the address they have just entered, not the address currently on file', () => {
+      const addressLine1 = '225 irving st';
+      const addressLine2 = 'Unit A';
+
+      setUp('bad-unit');
+      cy.axeCheck();
+
+      cy.findByRole('button', { name: /^Update$/i }).should(
+        'have.attr',
+        'disabled',
+      );
+
+      cy.findAllByLabelText(/street address/i)
+        .first()
+        .clear()
+        .type(addressLine1);
+      cy.findAllByLabelText(/street address/i)
+        .its('1')
+        .clear()
+        .type(addressLine2);
+      cy.findAllByLabelText(/street address/i)
+        .its('2')
+        .clear();
+
+      cy.findByLabelText(/City/i)
+        .clear()
+        .type('San Francisco');
+      cy.findByLabelText(/^State/).select('CA');
+      cy.findByLabelText(/Zip code/i)
+        .clear()
+        .type('94122');
+
+      cy.axeCheck();
+
+      cy.findByRole('button', { name: /^Update$/i }).click({ force: true });
+
+      cy.axeCheck();
+
+      cy.findByText('Please update or confirm your unit number').should(
+        'exist',
+      );
+
+      cy.findByTestId('mailingAddress').should(
+        'contain',
+        `${addressLine1}, ${addressLine2}`,
+      );
+
+      // click the edit address button to return to the edit view
+      cy.findByRole('button', { name: /edit your address/i }).click();
+
+      // confirm the address we just entered is in the form
+      cy.findAllByLabelText(/street address/i)
+        .first()
+        .should('have.value', addressLine1);
+      cy.findAllByLabelText(/street address/i)
+        .its('1')
+        .should('have.value', addressLine2);
+
+      // The following steps have been commented out due to a bug that
+      // disables the SAVE button if the current form data matches the
+      // prefilled form data. This logic should be updated to disable the SAVE
+      // button if the current form data matches the data that is currently on
+      // file for the user
+      // Bug ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/20494
+
+      // then click the save button to return to the validation screen
+      // cy.findByRole('button', { name: /^Update$/i }).click({ force: true });
+
+      // cy.findByRole('button', { name: /^use this address$/i }).click({
+      //   force: true,
+      // });
+
+      // cy.findByTestId('mailingAddress')
+      //   .should('contain', '225 irving st, Unit A')
+      //   .and('contain', 'San Francisco, CA 94122');
+
+      // cy.findByRole('button', { name: /edit mailing address/i }).should(
+      //   'be.focused',
+      // );
+    });
+  });
+});


### PR DESCRIPTION
## Description
Previously if you wanted to go back to editing your new address from the address validation view, the edit form would show the address you have on file instead of showing the address you had just entered.

## Testing done
Added a Cypress test to ensure this works as expected

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs