### PR TITLE
add souce app name for HLR

### DIFF
--- a/src/applications/disability-benefits/996/form-entry.jsx
+++ b/src/applications/disability-benefits/996/form-entry.jsx
@@ -11,5 +11,6 @@ startApp({
   url: manifest.rootUrl,
   reducer,
   routes,
+  entryName: manifest.entryName,
   analyticsEvents: [],
 });


### PR DESCRIPTION
## Description
the Source-App-Name header, when properly configured, powers [this graph](http://grafana.vfs.va.gov/d/zGS4XzkMk/backend-to-frontend-app-mapping?orgId=1) and sentry tags. 

the value was `unknown` and is now `0996-higher-level-review`
## Testing done
looked at header in browser. 

## Screenshots

![Screen Shot 2021-02-25 at 1 33 32 PM](https://user-images.githubusercontent.com/19188/109202597-27f04680-7771-11eb-9112-a2a8c5aee732.png)
## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
https://github.com/department-of-veterans-affairs/va.gov-team/issues/20521
