### PR TITLE
Add h3 to Prepare for your visit accordion

### DIFF
--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -143,11 +143,13 @@
                   {% for accordionItem in fieldLocationServices %}
                     {% assign item = accordionItem.entity %}
                     <li class="vads-u-margin-bottom--1">
-                      <button class="usa-accordion-button usa-button-unstyled vads-u-padding-y--2 vads-u-padding-left--2p5 vads-u-line-height--4
+                      <h3 class="vads-u-margin--0">
+                        <button class="usa-accordion-button usa-button-unstyled vads-u-padding-y--2 vads-u-padding-left--2p5 vads-u-line-height--4
 " aria-expanded="false"
-                              aria-controls="{{ item.entityBundle }}-{{ item.entityId }}">
-                        {{ item.fieldTitle }}
-                      </button>
+                                aria-controls="{{ item.entityBundle }}-{{ item.entityId }}">
+                          {{ item.fieldTitle }}
+                        </button>
+                      </h3>
                       <div id="{{ item.entityBundle }}-{{ item.entityId }}"
                            class="usa-accordion-content" aria-hidden="true">
                         {% include "src/site/paragraphs/wysiwyg.drupal.liquid" entity = item %}


### PR DESCRIPTION
## Description
issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/18913

## Testing
<img width="996" alt="Screen Shot 2021-02-25 at 1 42 41 PM" src="https://user-images.githubusercontent.com/100468/109208007-6a188880-776f-11eb-89fe-022d735fe787.png">


## Screenshots
<img width="1225" alt="Screen Shot 2021-02-25 at 1 21 08 PM" src="https://user-images.githubusercontent.com/100468/109205547-5f102900-776c-11eb-9131-49246751dbaf.png">


## Acceptance criteria
- [x] Accordion buttons are contained within a `h3`

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
