### PR TITLE
526: Force text wrap of long disability names

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
@@ -375,7 +375,7 @@ export default class ArrayField extends React.Component {
                 <div key={index} className="va-growable-background">
                   <Element name={`table_${itemIdPrefix}`} />
                   <div className="row small-collapse">
-                    <fieldset className="small-12 columns va-growable-expanded">
+                    <fieldset className="small-12 columns va-growable-expanded word-break">
                       <legend className="vads-u-font-size--base">
                         {legendText}
                         {uiOptions.includeRequiredLabelInTitle && (

--- a/src/applications/disability-benefits/all-claims/components/NewDisability.jsx
+++ b/src/applications/disability-benefits/all-claims/components/NewDisability.jsx
@@ -4,7 +4,7 @@ import { NULL_CONDITION_STRING } from '../constants';
 
 export default function NewDisability({ formData }) {
   return (
-    <div className="vads-u-flex--fill">
+    <div className="vads-u-flex--fill vads-u-padding-right--2 word-break">
       {typeof formData?.condition === 'string'
         ? capitalizeEachWord(formData.condition)
         : NULL_CONDITION_STRING}

--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -17,6 +17,10 @@
   white-space: nowrap;
 }
 
+.word-break {
+  word-break: break-all;
+}
+
 .clearfix:after {
   content: " ";
   visibility: hidden;


### PR DESCRIPTION
## Description

Long disability names that do not include a break (no dashes or spaces) will cause the disability card to expand beyond the page - without a scroll bar.

This PR adds some CSS to force long names to wrap

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/19316

## Testing done

Visual

## Screenshots

<details><summary>Original problem</summary>

<!-- leave a blank line above -->
![](https://user-images.githubusercontent.com/19188/106480850-d5758000-6479-11eb-9175-485b50dcc4d2.png)</details>

<details><summary>Text wrapping</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-02-25 at 1 51 35 PM](https://user-images.githubusercontent.com/136959/109209862-ac42c980-7771-11eb-915a-a97a1eb0ccd8.png)</details>

## Acceptance criteria
- [x] Long new disability names will wrap to maintain the page formatting

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
