### PR TITLE
Refactor CalendarWidget disabled/loading props

### DIFF
--- a/src/applications/vaos/components/calendar/CalendarRow.jsx
+++ b/src/applications/vaos/components/calendar/CalendarRow.jsx
@@ -42,6 +42,7 @@ export default function CalendarRow({
   availableSlots,
   cells,
   currentlySelectedDate,
+  disabled,
   handleSelectDate,
   handleSelectOption,
   hasError,
@@ -67,12 +68,15 @@ export default function CalendarRow({
             availableSlots={availableSlots}
             currentlySelectedDate={currentlySelectedDate}
             date={date}
-            disabled={isCellDisabled({
-              date,
-              availableSlots,
-              minDate,
-              maxDate,
-            })}
+            disabled={
+              disabled ||
+              isCellDisabled({
+                date,
+                availableSlots,
+                minDate,
+                maxDate,
+              })
+            }
             handleSelectOption={handleSelectOption}
             hasError={hasError}
             index={index}

--- a/src/applications/vaos/components/calendar/CalendarWidget.jsx
+++ b/src/applications/vaos/components/calendar/CalendarWidget.jsx
@@ -2,12 +2,10 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import classNames from 'classnames';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 
 import CalendarRow from './CalendarRow';
 import CalendarNavigation from './CalendarNavigation';
 import CalendarWeekdayHeader from './CalendarWeekdayHeader';
-import { FETCH_STATUS } from '../../utils/constants';
 
 const DEFAULT_MAX_DAYS_AHEAD = 90;
 
@@ -140,8 +138,8 @@ export default function CalendarWidget({
   additionalOptions,
   availableSlots,
   id,
-  loadingErrorMessage,
-  loadingStatus,
+  disabled,
+  disabledMessage,
   maxDate,
   maxSelections = 1,
   minDate,
@@ -169,13 +167,10 @@ export default function CalendarWidget({
   const showError = validationError?.length > 0;
 
   const calendarCss = classNames('vaos-calendar__calendars vads-u-flex--1', {
-    'vaos-calendar__loading': loadingStatus === FETCH_STATUS.loading,
+    'vaos-calendar__disabled': disabled,
     'usa-input-error': showError,
   });
 
-  if (loadingStatus === FETCH_STATUS.failed) {
-    return loadingErrorMessage;
-  }
   // declare const from renderMonth here
   const nextMonthToDisplay = months[months.length - 1]
     ?.clone()
@@ -187,11 +182,8 @@ export default function CalendarWidget({
   const nextDisabled = nextMonthToDisplay > maxMonth;
   return (
     <div className="vaos-calendar vads-u-margin-top--4 vads-u-display--flex">
-      {(loadingStatus === FETCH_STATUS.loading ||
-        loadingStatus === FETCH_STATUS.notStarted) && (
-        <div className="vaos-calendar__loading-overlay">
-          <LoadingIndicator message="Finding appointment availability..." />
-        </div>
+      {disabled && (
+        <div className="vaos-calendar__disabled-overlay">{disabledMessage}</div>
       )}
       <div className={calendarCss}>
         {showError && (
@@ -228,7 +220,6 @@ export default function CalendarWidget({
                   <hr aria-hidden="true" className="vads-u-margin-y--1" />
                   <CalendarWeekdayHeader />
                   <div role="rowgroup">
-                    {/* replace renderWeeks function here */}
                     {getCalendarWeeks(month).map((week, weekIndex) => (
                       <CalendarRow
                         additionalOptions={additionalOptions}
@@ -293,7 +284,8 @@ CalendarWidget.propTypes = {
       end: PropTypes.string,
     }),
   ),
-  loadingStatus: PropTypes.string,
+  disabled: PropTypes.bool,
+  disabledMessage: PropTypes.object,
   minDate: PropTypes.string, // YYYY-MM-DD
   maxDate: PropTypes.string, // YYYY-MM-DD
   maxSelections: PropTypes.number,

--- a/src/applications/vaos/components/calendar/CalendarWidget.jsx
+++ b/src/applications/vaos/components/calendar/CalendarWidget.jsx
@@ -178,8 +178,9 @@ export default function CalendarWidget({
     .format('YYYY-MM');
 
   const prevDisabled =
-    months[0].format('YYYY-MM') <= currentDate.format('YYYY-MM');
-  const nextDisabled = nextMonthToDisplay > maxMonth;
+    disabled || months[0].format('YYYY-MM') <= currentDate.format('YYYY-MM');
+  const nextDisabled = disabled || nextMonthToDisplay > maxMonth;
+
   return (
     <div className="vaos-calendar vads-u-margin-top--4 vads-u-display--flex">
       {disabled && (
@@ -264,6 +265,7 @@ export default function CalendarWidget({
                         selectedDates={value}
                         selectedIndicatorType={selectedIndicatorType}
                         renderOptions={renderOptions}
+                        disabled={disabled}
                       />
                     ))}
                   </div>

--- a/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.jsx
@@ -3,6 +3,7 @@ import { useHistory } from 'react-router-dom';
 import { connect } from 'react-redux';
 import moment from 'moment';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
+import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 
 import * as actions from '../../redux/actions';
 import { scrollAndFocus } from '../../../utils/scrollAndFocus';
@@ -128,6 +129,8 @@ export function DateTimeSelectPage({
     ? moment(preferredDate).format('YYYY-MM')
     : null;
 
+  const fetchFailed = appointmentSlotsStatus === FETCH_STATUS.failed;
+
   return (
     <div>
       <h1 className="vads-u-font-size--h2">{pageTitle}</h1>
@@ -142,12 +145,18 @@ export function DateTimeSelectPage({
           typeOfCareId={typeOfCareId}
         />
       )}
-      {appointmentSlotsStatus !== FETCH_STATUS.failed && (
+      {!fetchFailed && (
         <p>
           Please select a desired date and time for your appointment.
           {timezone &&
             ` Appointment times are displayed in ${timezoneDescription}.`}
         </p>
+      )}
+      {fetchFailed && (
+        <ErrorMessage
+          facilityId={facilityId}
+          requestAppointmentDateChoice={requestAppointmentDateChoice}
+        />
       )}
       <CalendarWidget
         maxSelections={1}
@@ -158,12 +167,9 @@ export function DateTimeSelectPage({
         additionalOptions={{
           required: true,
         }}
-        loadingStatus={appointmentSlotsStatus}
-        loadingErrorMessage={
-          <ErrorMessage
-            facilityId={facilityId}
-            requestAppointmentDateChoice={requestAppointmentDateChoice}
-          />
+        disabled={appointmentSlotsStatus === FETCH_STATUS.loading}
+        disabledMessage={
+          <LoadingIndicator message="Finding appointment availability..." />
         }
         onChange={dates => {
           validate({ dates, setValidationError });

--- a/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.jsx
@@ -130,11 +130,12 @@ export function DateTimeSelectPage({
     : null;
 
   const fetchFailed = appointmentSlotsStatus === FETCH_STATUS.failed;
+  const loadingSlots = appointmentSlotsStatus === FETCH_STATUS.loading;
 
   return (
     <div>
       <h1 className="vads-u-font-size--h2">{pageTitle}</h1>
-      {appointmentSlotsStatus !== FETCH_STATUS.loading && (
+      {!loadingSlots && (
         <WaitTimeAlert
           eligibleForRequests={eligibleForRequests}
           facilityId={facilityId}
@@ -167,7 +168,7 @@ export function DateTimeSelectPage({
         additionalOptions={{
           required: true,
         }}
-        disabled={appointmentSlotsStatus === FETCH_STATUS.loading}
+        disabled={loadingSlots}
         disabledMessage={
           <LoadingIndicator message="Finding appointment availability..." />
         }
@@ -198,7 +199,7 @@ export function DateTimeSelectPage({
             setValidationError,
           })
         }
-        disabled={appointmentSlotsStatus === FETCH_STATUS.failed}
+        disabled={loadingSlots || fetchFailed}
         pageChangeInProgress={pageChangeInProgress}
         loadingText="Page change in progress"
       />

--- a/src/applications/vaos/new-appointment/sass/_calendar.scss
+++ b/src/applications/vaos/new-appointment/sass/_calendar.scss
@@ -1,8 +1,14 @@
-.vaos-calendar__loading {
+.vaos-calendar__disabled {
   opacity: 0.3;
+  pointer-events: none;
+  background: none !important;
+  -webkit-user-select: none;  /* Chrome all / Safari all */
+  -moz-user-select: none;     /* Firefox all */
+  -ms-user-select: none;      /* IE 10+ */
+  user-select: none;          /* Likely future */
 }
 
-.vaos-calendar__loading-overlay {
+.vaos-calendar__disabled-overlay {
   position: absolute;
   width: 100%;
   top: 25%;

--- a/src/applications/vaos/tests/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
@@ -47,25 +47,102 @@ describe('VAOS <DateTimeSelectPage>', () => {
     MockDate.reset();
   });
   it('should not submit form with validation error', async () => {
-    const store = createTestStore({
-      newAppointment: {
-        data: {
-          vaFacility: '983GB',
-          clinicId: '308',
-          selectedDates: [],
+    mockEligibilityFetches({
+      siteId: '983',
+      facilityId: '983',
+      typeOfCareId: '323',
+      limit: true,
+      requestPastVisits: true,
+      directPastVisits: true,
+      clinics: [
+        {
+          id: '308',
+          attributes: {
+            ...getClinicMock(),
+            siteCode: '983',
+            clinicId: '308',
+            institutionCode: '983',
+            clinicFriendlyLocationName: 'Green team clinic',
+          },
         },
-        pages: [],
-        eligibility: [],
-        previousPages: {
-          selectDateTime: 'preferredDate',
+        {
+          id: '309',
+          attributes: {
+            ...getClinicMock(),
+            siteCode: '983',
+            clinicId: '309',
+            institutionCode: '983',
+            clinicFriendlyLocationName: 'Red team clinic',
+          },
         },
+      ],
+      pastClinics: true,
+    });
+
+    const slot308Date = moment()
+      .day(9)
+      .hour(9)
+      .minute(0)
+      .second(0);
+    const slot309Date = moment()
+      .day(11)
+      .hour(13)
+      .minute(0)
+      .second(0);
+    const preferredDate = moment();
+
+    mockAppointmentSlotFetch({
+      siteId: '983',
+      clinicId: '308',
+      typeOfCareId: '323',
+      slots: [
+        {
+          ...getAppointmentSlotMock(),
+          startDateTime: slot308Date.format('YYYY-MM-DDTHH:mm:ss[+00:00]'),
+          endDateTime: slot308Date
+            .clone()
+            .minute(20)
+            .format('YYYY-MM-DDTHH:mm:ss[+00:00]'),
+        },
+      ],
+      preferredDate,
+    });
+    mockAppointmentSlotFetch({
+      siteId: '983',
+      clinicId: '309',
+      typeOfCareId: '323',
+      slots: [
+        {
+          ...getAppointmentSlotMock(),
+          startDateTime: slot309Date.format('YYYY-MM-DDTHH:mm:ss[+00:00]'),
+          endDateTime: slot309Date
+            .clone()
+            .minute(20)
+            .format('YYYY-MM-DDTHH:mm:ss[+00:00]'),
+        },
+      ],
+      preferredDate,
+    });
+
+    const store = createTestStore(initialState);
+
+    await setTypeOfCare(store, /primary care/i);
+    await setVAFacility(store, '983');
+    await setClinic(store, /green team/i);
+    await setPreferredDate(store, preferredDate);
+
+    // First pass check to make sure the slots associated with green team are displayed
+    const screen = renderWithStoreAndRouter(
+      <Route component={DateTimeSelectPage} />,
+      {
+        store,
       },
-    });
+    );
 
-    const screen = renderWithStoreAndRouter(<DateTimeSelectPage />, {
-      store,
-    });
-
+    const overlay = screen.queryByText(/Finding appointment availability.../i);
+    if (overlay) {
+      await waitForElementToBeRemoved(overlay);
+    }
     // it should not allow user to submit the form without selecting a date
     const button = screen.getByText(/^Continue/);
     userEvent.click(button);


### PR DESCRIPTION
## Description
Refactor the way the CalendarWidget handles disabled (loading) state.  The calendar widget does not do any data fetching itself, so we'll replace the loading props with disabled props, and have the parent component determine whether to disable the widget or not and pass an appropriate message.  This PR:

- Removes the loadingStatus and loadingErrorMessage props
- Adds new disabled and disabledMessage props
   - When disabled is true, you should get the UI that shows now for the loading state
   - Instead of a LoadingIndicator, use the value from disabledMessage for the message
- In DateTimeSelectPage, handle loading errors by display an error message instead of the calendar.
- Fix a bug where a user was able to perform click events even when the loading overlay was visible

## Testing done
Local and unit

## Screenshots
![image](https://user-images.githubusercontent.com/786704/109227504-48ba9b00-7775-11eb-9e76-4c0a603afc01.png)