### PR TITLE
[GraphQL] Fix inconsistent operation name

### DIFF
--- a/src/site/stages/build/drupal/graphql/pressReleasePage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/pressReleasePage.graphql.js
@@ -79,7 +79,7 @@ const GetNodePressReleasePages = `
 
   ${pressReleasePage}
 
-  query GetNodeVaForms($onlyPublishedContent: Boolean!) {
+  query GetNodePressRelease($onlyPublishedContent: Boolean!) {
     nodeQuery(limit: 1000, filter: {
       conditions: [
         { field: "status", value: ["1"], enabled: $onlyPublishedContent },


### PR DESCRIPTION
## Description
The name of the operation in the GraphQL query for `pressReleasePage` doesn't match the name of the module. I must have copied over some boilerplate from a different query and missed updating this. 

This PR updates the name. The only time it would've been visible anyway is during a GraphQL error. Otherwise the module's exported query name is always used. It's misleading to leave it here though.

## Testing done
`yarn build:content --pull-drupal` -> confirmed page count is the same

## Screenshots
N/A

## Acceptance criteria
- [ ] String matches the module

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
