### PR TITLE
[19802] Adjust selected provider styling

### DIFF
--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelectionField.jsx
@@ -80,7 +80,7 @@ function ProviderSelectionField({
       } else if (mounted && !providerSelected) {
         scrollAndFocus('.va-button-link');
       } else if (mounted) {
-        scrollAndFocus('#selectedProvider');
+        scrollAndFocus('#providerPostSelectionHeader');
       }
     },
     [showProvidersList],
@@ -147,9 +147,13 @@ function ProviderSelectionField({
         )}
         {providerSelected && (
           <section id="selectedProvider" aria-label="Selected provider">
-            <span className="vads-u-display--block vads-u-font-weight--bold">
-              {formData.name}
-            </span>
+            <h2
+              id="providerPostSelectionHeader"
+              className="vads-u-font-size--h3 vads-u-margin-top--0"
+            >
+              Selected Provider
+            </h2>
+            <span className="vads-u-display--block">{formData.name}</span>
             <span className="vads-u-display--block">
               {formData.address?.line}
             </span>
@@ -157,7 +161,7 @@ function ProviderSelectionField({
               {formData.address?.city}, {formData.address?.state}{' '}
               {formData.address?.postalCode}
             </span>
-            <span className="vads-u-display--block vads-u-font-size--sm vads-u-font-weight--bold">
+            <span className="vads-u-display--block vads-u-font-size--sm">
               {formData[sortMethod]} miles{' '}
               <span className="sr-only">
                 {sortMethod ===
@@ -166,7 +170,7 @@ function ProviderSelectionField({
                   : 'from your home address'}
               </span>
             </span>
-            <div className="vads-u-display--flex">
+            <div className="vads-u-display--flex vads-u-margin-top--1">
               <button
                 type="button"
                 className="vaos-appts__cancel-btn va-button-link vads-u-margin--0 vads-u-flex--0 vads-u-margin-right--2"

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
@@ -217,6 +217,7 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
     userEvent.click(
       await screen.getByRole('button', { name: /choose provider/i }),
     );
+    expect(screen.baseElement).to.contain.text('Selected Provider');
     expect(screen.baseElement).to.contain.text(
       'AJADI, ADEDIWURA700 CONSTITUTION AVE NEWASHINGTON, DC 20002-6599',
     );


### PR DESCRIPTION
## Description
This should only show if a provider has been selected
Display size is h3 - basically should have the same look/spacing as the "Choose a provider" heading earlier in the workflow
I removed the bolding from provider name and distance. On revisiting this, I can see these are helpful distinguishing multiple providers, not really for a single provider.

## Testing done
Local and Unit

## Screenshots
![image](https://user-images.githubusercontent.com/8315447/109312564-309a5880-7815-11eb-9293-4756920d0599.png)

## Acceptance criteria
- [ ] Heading is added to the markup, nested properly
- [ ] Heading receives focus instead of the container
- [ ] Zero axe-core defects (only ones are on app level navigation hits)


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
