### PR TITLE
Slight ApplicationsInProgress refactor

### DIFF
--- a/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplicationsInProgress.jsx
+++ b/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplicationsInProgress.jsx
@@ -1,0 +1,62 @@
+import React, { useMemo } from 'react';
+import moment from 'moment';
+
+import {
+  formLinks,
+  formTitles,
+  isSIPEnabledForm,
+  presentableFormIDs,
+  sipFormSorter,
+} from '~/applications/personalization/dashboard/helpers';
+
+import ApplicationInProgress from './ApplicationInProgress';
+
+const ApplicationsInProgress = ({ savedForms }) => {
+  const verifiedSavedForms = useMemo(
+    () => savedForms.filter(isSIPEnabledForm).sort(sipFormSorter),
+    [savedForms],
+  );
+
+  return (
+    <>
+      <h3 className="vads-u-font-size--h4 vads-u-font-family--sans vads-u-margin-bottom--2p5">
+        Applications in progress
+      </h3>
+      {verifiedSavedForms.length > 0 && (
+        <div className="vads-l-grid-container vads-u-padding--0">
+          <div className="vads-l-row">
+            {verifiedSavedForms.map(form => {
+              const formId = form.form;
+              const formTitle = `Application for ${formTitles[formId]}`;
+              const presentableFormId = presentableFormIDs[formId];
+              const { lastUpdated, expiresAt } = form.metadata || {};
+              const lastOpenedDate = moment
+                .unix(lastUpdated)
+                .format('MMMM D, YYYY');
+              const expirationDate = moment
+                .unix(expiresAt)
+                .format('MMMM D, YYYY');
+              const continueUrl = `${formLinks[formId]}resume`;
+              return (
+                <ApplicationInProgress
+                  key={formId}
+                  continueUrl={continueUrl}
+                  expirationDate={expirationDate}
+                  formId={formId}
+                  formTitle={formTitle}
+                  lastOpenedDate={lastOpenedDate}
+                  presentableFormId={presentableFormId}
+                />
+              );
+            })}
+          </div>
+        </div>
+      )}
+      {!verifiedSavedForms.length && (
+        <p>You have no applications in progress.</p>
+      )}
+    </>
+  );
+};
+
+export default ApplicationsInProgress;

--- a/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplicationsInProgress.jsx
+++ b/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplicationsInProgress.jsx
@@ -1,5 +1,8 @@
 import React, { useMemo } from 'react';
+import { connect } from 'react-redux';
 import moment from 'moment';
+
+import { selectProfile } from '~/platform/user/selectors';
 
 import {
   formLinks,
@@ -59,4 +62,8 @@ const ApplicationsInProgress = ({ savedForms }) => {
   );
 };
 
-export default ApplicationsInProgress;
+const mapStateToProps = state => ({
+  savedForms: selectProfile(state).savedForms || [],
+});
+
+export default connect(mapStateToProps)(ApplicationsInProgress);

--- a/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.jsx
+++ b/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.jsx
@@ -4,11 +4,7 @@ import { connect } from 'react-redux';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 
-import {
-  isMultifactorEnabled,
-  isVAPatient,
-  selectProfile,
-} from '~/platform/user/selectors';
+import { isMultifactorEnabled, isVAPatient } from '~/platform/user/selectors';
 
 import { getEnrollmentStatus as getEnrollmentStatusAction } from '~/applications/hca/actions';
 import { HCA_ENROLLMENT_STATUSES } from '~/applications/hca/constants';
@@ -101,7 +97,6 @@ const ApplyForBenefits = ({
   hasLoadedAllData,
   isInESR,
   isPatient,
-  savedForms,
   shouldGetDD4EDUStatus,
   shouldGetESRStatus,
 }) => {
@@ -129,7 +124,7 @@ const ApplyForBenefits = ({
   return (
     <>
       <h2>Apply for benefits</h2>
-      <ApplicationsInProgress savedForms={savedForms} />
+      <ApplicationsInProgress />
       <BenefitsOfInterest showChildren={hasLoadedAllData}>
         <>
           {showHealthCare && (
@@ -177,7 +172,6 @@ const ApplyForBenefits = ({
 
 const mapStateToProps = state => {
   const isPatient = isVAPatient(state);
-  const savedForms = selectProfile(state).savedForms || [];
   const esrEnrollmentStatus = selectESRStatus(state).enrollmentStatus;
 
   const shouldGetESRStatus = !isPatient;
@@ -198,7 +192,6 @@ const mapStateToProps = state => {
       !!esrEnrollmentStatus &&
       esrEnrollmentStatus !== HCA_ENROLLMENT_STATUSES.noneOfTheAbove,
     isPatient,
-    savedForms,
     shouldGetDD4EDUStatus,
     shouldGetESRStatus,
   };

--- a/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.jsx
+++ b/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.jsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
-import moment from 'moment';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
@@ -11,13 +10,6 @@ import {
   selectProfile,
 } from '~/platform/user/selectors';
 
-import {
-  formLinks,
-  formTitles,
-  isSIPEnabledForm,
-  presentableFormIDs,
-  sipFormSorter,
-} from '~/applications/personalization/dashboard/helpers';
 import { getEnrollmentStatus as getEnrollmentStatusAction } from '~/applications/hca/actions';
 import { HCA_ENROLLMENT_STATUSES } from '~/applications/hca/constants';
 import {
@@ -31,56 +23,8 @@ import {
   eduDirectDepositIsSetUp,
 } from '@@profile/selectors';
 
-import ApplicationInProgress from './ApplicationInProgress';
+import ApplicationsInProgress from './ApplicationsInProgress';
 import BenefitOfInterest from './BenefitOfInterest';
-
-const ApplicationsInProgress = ({ savedForms }) => {
-  const verifiedSavedForms = useMemo(
-    () => savedForms.filter(isSIPEnabledForm).sort(sipFormSorter),
-    [savedForms],
-  );
-
-  return (
-    <>
-      <h3 className="vads-u-font-size--h4 vads-u-font-family--sans vads-u-margin-bottom--2p5">
-        Applications in progress
-      </h3>
-      {verifiedSavedForms.length > 0 && (
-        <div className="vads-l-grid-container vads-u-padding--0">
-          <div className="vads-l-row">
-            {verifiedSavedForms.map(form => {
-              const formId = form.form;
-              const formTitle = `Application for ${formTitles[formId]}`;
-              const presentableFormId = presentableFormIDs[formId];
-              const { lastUpdated, expiresAt } = form.metadata || {};
-              const lastOpenedDate = moment
-                .unix(lastUpdated)
-                .format('MMMM D, YYYY');
-              const expirationDate = moment
-                .unix(expiresAt)
-                .format('MMMM D, YYYY');
-              const continueUrl = `${formLinks[formId]}resume`;
-              return (
-                <ApplicationInProgress
-                  key={formId}
-                  continueUrl={continueUrl}
-                  expirationDate={expirationDate}
-                  formId={formId}
-                  formTitle={formTitle}
-                  lastOpenedDate={lastOpenedDate}
-                  presentableFormId={presentableFormId}
-                />
-              );
-            })}
-          </div>
-        </div>
-      )}
-      {!verifiedSavedForms.length && (
-        <p>You have no applications in progress.</p>
-      )}
-    </>
-  );
-};
 
 const BenefitsOfInterest = ({ children, showChildren }) => {
   return (

--- a/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.jsx
+++ b/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import moment from 'moment';
 import { connect } from 'react-redux';
 
@@ -34,7 +34,12 @@ import {
 import ApplicationInProgress from './ApplicationInProgress';
 import BenefitOfInterest from './BenefitOfInterest';
 
-const ApplicationsInProgress = ({ verifiedSavedForms }) => {
+const ApplicationsInProgress = ({ savedForms }) => {
+  const verifiedSavedForms = useMemo(
+    () => savedForms.filter(isSIPEnabledForm).sort(sipFormSorter),
+    [savedForms],
+  );
+
   return (
     <>
       <h3 className="vads-u-font-size--h4 vads-u-font-family--sans vads-u-margin-bottom--2p5">
@@ -152,9 +157,9 @@ const ApplyForBenefits = ({
   hasLoadedAllData,
   isInESR,
   isPatient,
+  savedForms,
   shouldGetDD4EDUStatus,
   shouldGetESRStatus,
-  verifiedSavedForms,
 }) => {
   useEffect(
     () => {
@@ -180,7 +185,7 @@ const ApplyForBenefits = ({
   return (
     <>
       <h2>Apply for benefits</h2>
-      <ApplicationsInProgress verifiedSavedForms={verifiedSavedForms} />
+      <ApplicationsInProgress savedForms={savedForms} />
       <BenefitsOfInterest showChildren={hasLoadedAllData}>
         <>
           {showHealthCare && (
@@ -229,9 +234,6 @@ const ApplyForBenefits = ({
 const mapStateToProps = state => {
   const isPatient = isVAPatient(state);
   const savedForms = selectProfile(state).savedForms || [];
-  const verifiedSavedForms = savedForms
-    .filter(isSIPEnabledForm)
-    .sort(sipFormSorter);
   const esrEnrollmentStatus = selectESRStatus(state).enrollmentStatus;
 
   const shouldGetESRStatus = !isPatient;
@@ -252,9 +254,9 @@ const mapStateToProps = state => {
       !!esrEnrollmentStatus &&
       esrEnrollmentStatus !== HCA_ENROLLMENT_STATUSES.noneOfTheAbove,
     isPatient,
+    savedForms,
     shouldGetDD4EDUStatus,
     shouldGetESRStatus,
-    verifiedSavedForms,
   };
 };
 


### PR DESCRIPTION
## Description
1. Move `ApplicationsInProgress` into its own component
2. Make it a connected component so it can pull the forms it needs directly from Redux (and stop making a parent component pull in that data so it can be passed down)
3. Move the form filtering logic from the `mapStateToProps` into the component itself

## Testing done
All the existing RTL and Cypress tests continue to work fine because we weren't testing implementation details :-D

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs