### PR TITLE
Prevent duplicate new disabilities

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
@@ -73,11 +73,11 @@ export default class ArrayField extends React.Component {
   setInitialState = () => {
     const { formData, uiSchema } = this.props;
     if (formData) {
-      const key = uiSchema['ui:options']?.errorKey || '';
+      const key = uiSchema?.['ui:options']?.errorKey || '';
       // errorSchema is not populated on init, so we need to use the form data to
       // find duplicates and put the entry into edit mode
       const duplicates = key ? findDuplicates(formData, key) : [];
-      return uiSchema['ui:options']?.setEditState
+      return uiSchema?.['ui:options']?.setEditState
         ? uiSchema['ui:options']?.setEditState(formData)
         : formData.map((__, index) => duplicates.includes(index));
     }

--- a/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
@@ -17,6 +17,8 @@ import {
 import { setArrayRecordTouched } from 'platform/forms-system/src/js/helpers';
 import { errorSchemaIsValid } from 'platform/forms-system/src/js/validation';
 
+import { findDuplicates } from '../utils';
+
 const Element = Scroll.Element;
 const scroller = Scroll.scroller;
 
@@ -71,9 +73,13 @@ export default class ArrayField extends React.Component {
   setInitialState = () => {
     const { formData, uiSchema } = this.props;
     if (formData) {
+      const key = uiSchema['ui:options']?.errorKey || '';
+      // errorSchema is not populated on init, so we need to use the form data to
+      // find duplicates and put the entry into edit mode
+      const duplicates = key ? findDuplicates(formData, key) : [];
       return uiSchema['ui:options']?.setEditState
         ? uiSchema['ui:options']?.setEditState(formData)
-        : formData.map(() => false);
+        : formData.map((__, index) => duplicates.includes(index));
     }
     return [true];
   };
@@ -366,9 +372,7 @@ export default class ArrayField extends React.Component {
               'Item';
             const legendText = `${
               isLast && items.length > 1 ? 'New' : 'Editing'
-            } ${itemName || ''} ${
-              uiOptions.includeIndexInTitle ? index + 1 : ''
-            }`;
+            } ${itemName || ''}`;
 
             if (isEditing) {
               return (

--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -35,6 +35,7 @@ export const uiSchema = {
     'ui:options': {
       viewField: NewDisability,
       reviewTitle: 'New Conditions',
+      errorKey: 'condition',
       itemName: 'Condition',
       itemAriaLabel: data => data.condition,
       includeRequiredLabelInTitle: true,

--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -36,6 +36,7 @@ ul.original-disability-list {
 }
 
 fieldset.schemaform-block,
+.schemaform-field-template.usa-input-error,
 .wizard-content-inner .fieldset-input:first-child {
   margin-top: 0;
 }

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -44,7 +44,8 @@ import {
   isUndefined,
   isDisabilityPtsd,
   confirmationEmailFeature,
-} from '../utils.jsx';
+  findDuplicates,
+} from '../utils';
 
 describe('526 helpers', () => {
   describe('hasGuardOrReservePeriod', () => {
@@ -1152,7 +1153,7 @@ describe('526 v2 depends functions', () => {
       expect(check('a', '2020-01-31', '2020-02-14')).to.be.true;
       expect(check('a', `${minYear}-01-31`, `${maxYear}-02-14`)).to.be.true;
     });
-    it.skip('should return false when a service period data is invalid', () => {
+    it('should return false when a service period data is invalid', () => {
       expect(check('', '2020-01-31', '2020-02-14')).to.be.false;
       expect(check('a', 'XXXX-01-31', '2020-02-14')).to.be.false;
       expect(check('a', '2020-XX-31', '2020-02-14')).to.be.false;
@@ -1161,6 +1162,29 @@ describe('526 v2 depends functions', () => {
       expect(check('a', '2020-01-31', '2020-XX-14')).to.be.false;
       expect(check('a', '2020-01-31', '2020-02-XX')).to.be.false;
       expect(check('a', '2020-02-14', '2020-01-31')).to.be.false;
+    });
+  });
+
+  describe('duplicateIndexes', () => {
+    const base = [{ x: 'one' }, { x: 'two' }, { x: 'three' }];
+    it('should not find duplicates', () => {
+      expect(findDuplicates(base, 'x')).to.have.lengthOf(0);
+    });
+    it('should find one duplicate', () => {
+      const array = [...base, { x: 'one' }];
+      expect(findDuplicates(array, 'x')).to.deep.equal([3]);
+    });
+    it('should find two duplicates', () => {
+      const array = [...base, { x: 'one' }, { x: 'one' }];
+      expect(findDuplicates(array, 'x')).to.deep.equal([3, 4]);
+    });
+    it('should find two separate duplicates', () => {
+      const array = [...base, { x: 'one' }, { x: 'two' }];
+      expect(findDuplicates(array, 'x')).to.deep.equal([3, 4]);
+    });
+    it('should find three separate duplicates', () => {
+      const array = [...base, { x: 'one' }, { x: 'two' }, { x: 'three' }];
+      expect(findDuplicates(array, 'x')).to.deep.equal([3, 4, 5]);
     });
   });
 });

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -998,3 +998,26 @@ export const confirmationEmailFeature = state => {
     ? false
     : isForm526ConfirmationEmailOn && isForm526ConfirmationEmailShowCopyOn;
 };
+
+/**
+ * Find duplicates in an array of objects and return an array of indexes for the
+ *  duplicates only
+ * @param {Object} formData - Data array (ArrayField data)
+ * @param {String} dataKey - key of data of interest to find duplicates
+ * @return {Array} - Array of indexes of the duplicates only, not the first
+ *  entry
+ * @example
+ * findDuplicates([{x:'one'},{x:'two'},{x:'one'},{x:'two'}], 'x')
+ * // => [2, 3]
+ */
+export const findDuplicates = (formData, dataKey) => {
+  const list = formData.map(item => item[dataKey]?.toLowerCase() || '');
+  return list.reduce((duplicateIndexes, item, index) => {
+    // look for duplicates of the first, but don't include the first
+    const foundIndex = list.indexOf(item, index + 1);
+    if (foundIndex > -1) {
+      duplicateIndexes.push(foundIndex);
+    }
+    return duplicateIndexes;
+  }, []);
+};

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -272,7 +272,7 @@ export const validateDisabilityName = (err, fieldData, formData) => {
 
   // Alert Veteran to duplicates
   const currentList =
-    formData?.newDisabilities.map(disability =>
+    formData?.newDisabilities?.map(disability =>
       disability.condition?.toLowerCase(),
     ) || [];
   const itemLowerCased = fieldData?.toLowerCase() || '';

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -256,7 +256,7 @@ export const isWithinServicePeriod = (
   }
 };
 
-export const validateDisabilityName = (err, fieldData) => {
+export const validateDisabilityName = (err, fieldData, formData) => {
   // We're using a validator for length instead of adding a maxLength schema
   // property because the validator is only applied conditionally - when a user
   // chooses a disability from the list supplied to autosuggest, we don't care
@@ -268,6 +268,17 @@ export const validateDisabilityName = (err, fieldData) => {
     fieldData.length > 255
   ) {
     err.addError('Condition names should be less than 256 characters');
+  }
+
+  // Alert Veteran to duplicates
+  const currentList =
+    formData?.newDisabilities.map(disability =>
+      disability.condition?.toLowerCase(),
+    ) || [];
+  const itemLowerCased = fieldData?.toLowerCase() || '';
+  const itemCount = currentList.filter(item => item === itemLowerCased);
+  if (itemCount.length > 1) {
+    err.addError('Please enter a unique condition name');
   }
 };
 


### PR DESCRIPTION
## Description

When a Veteran adds duplicate new disabilities, we allow the submission to go through, but EVSS rejects these claims.

This PR adds checks to prevent duplicates from being added. It does not actively modify Veterans with existing duplicates, but it will prevent submission and alert them of the problem.

**Note**: A separate PR will need to be made to implement this change on the review & submit page

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/19319

## Testing done

Added unit test

## Screenshots

<details><summary>Duplicate entry (not yet saved)</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-02-26 at 8 51 06 AM](https://user-images.githubusercontent.com/136959/109343136-74e82180-7832-11eb-9629-8e8576481223.png)</details>

<details><summary>Duplicate entry (after save; case insensitive)</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-02-26 at 8 50 51 AM](https://user-images.githubusercontent.com/136959/109343092-6994f600-7832-11eb-8a37-9fc1f110e5bb.png)</details>

<details><summary>Multiple duplicates</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-02-26 at 8 53 06 AM](https://user-images.githubusercontent.com/136959/109343119-70bc0400-7832-11eb-8429-6eb8d8bbcd27.png)</details>

## Acceptance criteria
- [x] Veteran is prevented from including duplicate conditions on the form page (not review & submit page)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
