### PR TITLE
Add account_uuid to sentry logs

### DIFF
--- a/src/platform/forms-system/src/js/review/SubmitController.jsx
+++ b/src/platform/forms-system/src/js/review/SubmitController.jsx
@@ -73,6 +73,7 @@ class SubmitController extends Component {
       recordEvent({
         event: `${trackingPrefix}-validation-failed`,
       });
+      Sentry.setUser({ id: user.profile.accountUuid });
       Sentry.withScope(scope => {
         scope.setExtra('errors', errors);
         scope.setExtra('prefix', trackingPrefix);

--- a/src/platform/forms-system/test/js/review/SubmitController.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/SubmitController.unit.spec.jsx
@@ -96,6 +96,9 @@ const createUserLogIn = (status = true) => ({
   login: {
     currentlyLoggedIn: status,
   },
+  profile: {
+    accountUuid: 'user-1234',
+  },
 });
 
 const createStore = (options = {}) => {
@@ -397,6 +400,7 @@ describe('Schemaform review: SubmitController', () => {
 
     const sentryReports = testkit.reports();
     expect(sentryReports.length).to.equal(1);
+    expect(sentryReports[0].user.id).to.equal(user.profile.accountUuid);
     expect(sentryReports[0].extra.inProgressFormId).to.equal('123');
     expect(sentryReports[0].extra.prefix).to.equal('test-');
     expect(sentryReports[0].extra.errors)

--- a/src/platform/user/profile/reducers/index.js
+++ b/src/platform/user/profile/reducers/index.js
@@ -29,6 +29,7 @@ const initialState = {
   dob: null,
   gender: null,
   accountType: null,
+  accountUuid: null,
   isCernerPatient: false,
   loa: {
     current: null,

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -35,6 +35,7 @@ export function mapRawUserDataToState(json) {
   const {
     data: {
       attributes: {
+        account: { accountUuid },
         inProgressForms: savedForms,
         prefillsAvailable,
         profile: {
@@ -61,6 +62,7 @@ export function mapRawUserDataToState(json) {
 
   const userState = {
     accountType: loa.current,
+    accountUuid,
     dob,
     email,
     gender,

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -35,7 +35,7 @@ export function mapRawUserDataToState(json) {
   const {
     data: {
       attributes: {
-        account: { accountUuid },
+        account: { accountUuid } = {},
         inProgressForms: savedForms,
         prefillsAvailable,
         profile: {

--- a/src/platform/user/tests/profile/reducers/index.unit.spec.js
+++ b/src/platform/user/tests/profile/reducers/index.unit.spec.js
@@ -36,7 +36,11 @@ describe('Profile reducer', () => {
   });
 
   it('should be loading when creating MHV account', () => {
-    const state = reducer({ mhvAccount: {} }, { type: CREATING_MHV_ACCOUNT });
+    const userProfile = { data: { attributes: { account: {} } } };
+    const state = reducer(
+      { mhvAccount: {}, userProfile },
+      { type: CREATING_MHV_ACCOUNT },
+    );
     expect(state.mhvAccount.loading).to.be.true;
   });
 
@@ -129,6 +133,7 @@ describe('Profile reducer', () => {
         userProfile: {
           data: {
             attributes: {
+              account: {},
               profile: { loa: { current: 3 } },
               vaProfile: {},
               veteranStatus: {},

--- a/src/platform/user/tests/profile/utilities/index.unit.spec.js
+++ b/src/platform/user/tests/profile/utilities/index.unit.spec.js
@@ -7,6 +7,9 @@ import { VA_FORM_IDS } from '~/platform/forms/constants';
 function createDefaultData() {
   return {
     attributes: {
+      account: {
+        accountUuid: 'user-1234',
+      },
       profile: {
         sign_in: {
           service_name: 'idme',
@@ -85,6 +88,20 @@ describe('Profile utilities', () => {
       });
 
       expect(mappedData.status).to.equal(data.attributes.va_profile.status);
+    });
+
+    it('should map account UUID', () => {
+      const data = createDefaultData();
+      const mappedData = mapRawUserDataToState({
+        data,
+        meta: {
+          errors: null,
+        },
+      });
+
+      expect(mappedData.accountUuid).to.deep.equal(
+        data.attributes.account.accountUuid,
+      );
     });
 
     it('should map veteran status', () => {


### PR DESCRIPTION
## Description

As a dev, we need an easier way to cross-reference a user based on their error logs.

This PR adds the `account_uuid` from the `/v0/user` endpoint to Sentry logs. This is a global form change that will be available to all Sentry error logs upon form submission.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/20534

## Testing done

Updated unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Sentry logs include an `account_uuid` value

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
