### PR TITLE
Prevent duplicate new disabilities on review & submit

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
@@ -17,7 +17,7 @@ import {
 import { setArrayRecordTouched } from 'platform/forms-system/src/js/helpers';
 import { errorSchemaIsValid } from 'platform/forms-system/src/js/validation';
 
-import { findDuplicates } from '../utils';
+import { findDuplicateIndexes } from 'platform/forms-system/src/js/utilities/data/findDuplicateIndexes';
 
 const Element = Scroll.Element;
 const scroller = Scroll.scroller;
@@ -73,10 +73,10 @@ export default class ArrayField extends React.Component {
   setInitialState = () => {
     const { formData, uiSchema } = this.props;
     if (formData) {
-      const key = uiSchema?.['ui:options']?.errorKey || '';
+      const key = uiSchema?.['ui:options']?.duplicateKey || '';
       // errorSchema is not populated on init, so we need to use the form data to
       // find duplicates and put the entry into edit mode
-      const duplicates = key ? findDuplicates(formData, key) : [];
+      const duplicates = key ? findDuplicateIndexes(formData, key) : [];
       return uiSchema?.['ui:options']?.setEditState
         ? uiSchema['ui:options']?.setEditState(formData)
         : formData.map((__, index) => duplicates.includes(index));

--- a/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
@@ -17,7 +17,7 @@ import {
 import { setArrayRecordTouched } from 'platform/forms-system/src/js/helpers';
 import { errorSchemaIsValid } from 'platform/forms-system/src/js/validation';
 
-import { findDuplicateIndexes } from 'platform/forms-system/src/js/utilities/data/findDuplicateIndexes';
+import findDuplicateIndexes from 'platform/forms-system/src/js/utilities/data/findDuplicateIndexes';
 
 const Element = Scroll.Element;
 const scroller = Scroll.scroller;

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -300,6 +300,11 @@ const formConfig = {
           uiSchema: addDisabilities.uiSchema,
           schema: addDisabilities.schema,
           updateFormData: addDisabilities.updateFormData,
+          appStateSelector: state => ({
+            // needed for validateDisabilityName to work properly on the review
+            // & submit page
+            newDisabilities: state.form?.data?.newDisabilities || [],
+          }),
         },
         followUpDesc: {
           title: 'Follow-up questions',

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -302,7 +302,9 @@ const formConfig = {
           updateFormData: addDisabilities.updateFormData,
           appStateSelector: state => ({
             // needed for validateDisabilityName to work properly on the review
-            // & submit page
+            // & submit page. Validation functions are provided the pageData and
+            // not the formData on the review & submit page. For more details
+            // see https://dsva.slack.com/archives/CBU0KDSB1/p1614182869206900
             newDisabilities: state.form?.data?.newDisabilities || [],
           }),
         },

--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -35,7 +35,7 @@ export const uiSchema = {
     'ui:options': {
       viewField: NewDisability,
       reviewTitle: 'New Conditions',
-      errorKey: 'condition',
+      duplicateKey: 'condition',
       itemName: 'Condition',
       itemAriaLabel: data => data.condition,
       includeRequiredLabelInTitle: true,

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -44,7 +44,6 @@ import {
   isUndefined,
   isDisabilityPtsd,
   confirmationEmailFeature,
-  findDuplicates,
 } from '../utils';
 
 describe('526 helpers', () => {
@@ -1162,29 +1161,6 @@ describe('526 v2 depends functions', () => {
       expect(check('a', '2020-01-31', '2020-XX-14')).to.be.false;
       expect(check('a', '2020-01-31', '2020-02-XX')).to.be.false;
       expect(check('a', '2020-02-14', '2020-01-31')).to.be.false;
-    });
-  });
-
-  describe('duplicateIndexes', () => {
-    const base = [{ x: 'one' }, { x: 'two' }, { x: 'three' }];
-    it('should not find duplicates', () => {
-      expect(findDuplicates(base, 'x')).to.have.lengthOf(0);
-    });
-    it('should find one duplicate', () => {
-      const array = [...base, { x: 'one' }];
-      expect(findDuplicates(array, 'x')).to.deep.equal([3]);
-    });
-    it('should find two duplicates', () => {
-      const array = [...base, { x: 'one' }, { x: 'one' }];
-      expect(findDuplicates(array, 'x')).to.deep.equal([3, 4]);
-    });
-    it('should find two separate duplicates', () => {
-      const array = [...base, { x: 'one' }, { x: 'two' }];
-      expect(findDuplicates(array, 'x')).to.deep.equal([3, 4]);
-    });
-    it('should find three separate duplicates', () => {
-      const array = [...base, { x: 'one' }, { x: 'two' }, { x: 'three' }];
-      expect(findDuplicates(array, 'x')).to.deep.equal([3, 4, 5]);
     });
   });
 });

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -998,26 +998,3 @@ export const confirmationEmailFeature = state => {
     ? false
     : isForm526ConfirmationEmailOn && isForm526ConfirmationEmailShowCopyOn;
 };
-
-/**
- * Find duplicates in an array of objects and return an array of indexes for the
- *  duplicates only
- * @param {Object} formData - Data array (ArrayField data)
- * @param {String} dataKey - key of data of interest to find duplicates
- * @return {Array} - Array of indexes of the duplicates only, not the first
- *  entry
- * @example
- * findDuplicates([{x:'one'},{x:'two'},{x:'one'},{x:'two'}], 'x')
- * // => [2, 3]
- */
-export const findDuplicates = (formData, dataKey) => {
-  const list = formData.map(item => item[dataKey]?.toLowerCase() || '');
-  return list.reduce((duplicateIndexes, item, index) => {
-    // look for duplicates of the first, but don't include the first
-    const foundIndex = list.indexOf(item, index + 1);
-    if (foundIndex > -1) {
-      duplicateIndexes.push(foundIndex);
-    }
-    return duplicateIndexes;
-  }, []);
-};

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -256,7 +256,15 @@ export const isWithinServicePeriod = (
   }
 };
 
-export const validateDisabilityName = (err, fieldData, formData) => {
+export const validateDisabilityName = (
+  err,
+  fieldData,
+  formData,
+  _schema,
+  _uiSchema,
+  _index,
+  appStateData,
+) => {
   // We're using a validator for length instead of adding a maxLength schema
   // property because the validator is only applied conditionally - when a user
   // chooses a disability from the list supplied to autosuggest, we don't care
@@ -272,7 +280,7 @@ export const validateDisabilityName = (err, fieldData, formData) => {
 
   // Alert Veteran to duplicates
   const currentList =
-    formData?.newDisabilities?.map(disability =>
+    appStateData?.newDisabilities?.map(disability =>
       disability.condition?.toLowerCase(),
     ) || [];
   const itemLowerCased = fieldData?.toLowerCase() || '';

--- a/src/platform/forms-system/src/js/review/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/review/ArrayField.jsx
@@ -30,7 +30,7 @@ class ArrayField extends React.Component {
     // and always show at least one item on the review page
     const arrayData = (Array.isArray(props.arrayData) && props.arrayData) || [];
 
-    // Including an `duplicateKey` is what causes this unique entry validation to
+    // Including a `duplicateKey` is what causes this unique entry validation to
     // open the array card in edit mode
     const key = props.uiSchema?.['ui:options']?.duplicateKey || '';
     const duplicates = key
@@ -191,7 +191,8 @@ class ArrayField extends React.Component {
    */
   handleSave(index, fieldName) {
     const { uiSchema, arrayData } = this.props;
-    // Prevent save if the `duplicateKey` option is set and there are duplicates
+    // Prevent card from closing (stay in edit mode) if the `duplicateKey`
+    // option is set and the field is a duplicate
     const key = uiSchema?.['ui:options']?.duplicateKey;
     const duplicates = key ? findDuplicateIndexes(arrayData, key) : [];
     const editing = arrayData.map((__, indx) => duplicates.includes(indx));

--- a/src/platform/forms-system/src/js/review/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/review/ArrayField.jsx
@@ -11,6 +11,8 @@ import {
 import SchemaForm from '../components/SchemaForm';
 import { focusElement } from '../utilities/ui';
 
+import findDuplicateIndexes from '../utilities/data/findDuplicateIndexes';
+
 const Element = Scroll.Element;
 const scroller = Scroll.scroller;
 
@@ -26,10 +28,17 @@ class ArrayField extends React.Component {
     super(props);
     // In contrast to the normal array field, we don’t want to add an empty item
     // and always show at least one item on the review page
-    const arrayData = Array.isArray(props.arrayData) ? props.arrayData : null;
+    const arrayData = (Array.isArray(props.arrayData) && props.arrayData) || [];
+
+    // Including an `duplicateKey` is what causes this unique entry validation to
+    // open the array card in edit mode
+    const key = props.uiSchema?.['ui:options']?.duplicateKey || '';
+    const duplicates = key
+      ? findDuplicateIndexes(props?.arrayData || [], key)
+      : [];
     this.state = {
-      items: arrayData || [],
-      editing: (this.props.arrayData || []).map(() => false),
+      items: arrayData,
+      editing: arrayData.map((__, index) => duplicates.includes(index)),
     };
     this.handleAdd = this.handleAdd.bind(this);
     this.handleSave = this.handleSave.bind(this);
@@ -181,8 +190,13 @@ class ArrayField extends React.Component {
    *   determined from path
    */
   handleSave(index, fieldName) {
-    const newEditingArray = _.set(index, false, this.state.editing);
-    this.setState({ editing: newEditingArray }, () => {
+    const { uiSchema, arrayData } = this.props;
+    // Prevent save if the `duplicateKey` option is set and there are duplicates
+    const key = uiSchema?.['ui:options']?.duplicateKey;
+    const duplicates = key ? findDuplicateIndexes(arrayData, key) : [];
+    const editing = arrayData.map((__, indx) => duplicates.includes(indx));
+
+    this.setState({ editing }, () => {
       // Return focus to button that toggled edit mode
       this.scrollToAndFocus(`${fieldName}-${index}`, '.edit-btn');
     });

--- a/src/platform/forms-system/src/js/utilities/data/findDuplicateIndexes.js
+++ b/src/platform/forms-system/src/js/utilities/data/findDuplicateIndexes.js
@@ -1,0 +1,25 @@
+/**
+ * Find duplicates in an array of objects and return an array of indexes for the
+ *  duplicates only
+ * @param {Object} formData - Data array (ArrayField data)
+ * @param {String} dataKey - key of data of interest to find duplicates
+ * @return {Array} - Array of indexes of the duplicates only, not the first
+ *  entry
+ * @example
+ * findDuplicateIndexes([{x:'one'},{x:'two'},{x:'one'},{x:'two'}], 'x')
+ * // => [2, 3]
+ */
+export default function(formData = [], dataKey = '') {
+  if (!dataKey || formData?.length === 0) {
+    return [];
+  }
+  const list = formData.map(item => item[dataKey]?.toLowerCase() || '');
+  return list.reduce((duplicateIndexes, item, index) => {
+    // look for duplicates of the first, but don't include the first
+    const foundIndex = list.indexOf(item, index + 1);
+    if (foundIndex > -1) {
+      duplicateIndexes.push(foundIndex);
+    }
+    return duplicateIndexes;
+  }, []);
+}

--- a/src/platform/forms-system/src/js/utilities/data/findDuplicateIndexes.js
+++ b/src/platform/forms-system/src/js/utilities/data/findDuplicateIndexes.js
@@ -1,7 +1,7 @@
 /**
  * Find duplicates in an array of objects and return an array of indexes for the
  *  duplicates only
- * @param {Object} formData - Data array (ArrayField data)
+ * @param {Object[]} arrayFieldData - Data array (ArrayField data)
  * @param {String} dataKey - key of data of interest to find duplicates
  * @return {Array} - Array of indexes of the duplicates only, not the first
  *  entry
@@ -9,11 +9,11 @@
  * findDuplicateIndexes([{x:'one'},{x:'two'},{x:'one'},{x:'two'}], 'x')
  * // => [2, 3]
  */
-export default function(formData = [], dataKey = '') {
-  if (!dataKey || formData?.length === 0) {
+export default function(arrayFieldData = [], dataKey = '') {
+  if (!dataKey || arrayFieldData?.length === 0) {
     return [];
   }
-  const list = formData.map(item => item[dataKey]?.toLowerCase() || '');
+  const list = arrayFieldData.map(item => item[dataKey]?.toLowerCase() || '');
   return list.reduce((duplicateIndexes, item, index) => {
     // look for duplicates of the first, but don't include the first
     const foundIndex = list.indexOf(item, index + 1);

--- a/src/platform/forms-system/src/js/utilities/data/findDuplicateIndexes.js
+++ b/src/platform/forms-system/src/js/utilities/data/findDuplicateIndexes.js
@@ -3,17 +3,21 @@
  *  duplicates only
  * @param {Object[]} arrayFieldData - Data array (ArrayField data)
  * @param {String} dataKey - key of data of interest to find duplicates
- * @return {Array} - Array of indexes of the duplicates only, not the first
+ * @return {Number[]} - Array of indexes of the duplicates only, not the first
  *  entry
  * @example
  * findDuplicateIndexes([{x:'one'},{x:'two'},{x:'one'},{x:'two'}], 'x')
  * // => [2, 3]
  */
-export default function(arrayFieldData = [], dataKey = '') {
-  if (!dataKey || arrayFieldData?.length === 0) {
+export default function(arrayFieldData = [], dataKey) {
+  if (!dataKey || arrayFieldData.length === 0) {
     return [];
   }
-  const list = arrayFieldData.map(item => item[dataKey]?.toLowerCase() || '');
+  const list = arrayFieldData.map(item => item[dataKey].toLowerCase() || '');
+  // This reduce funtion will cycle through the list and look for a _single_
+  // duplicate of the currently indexed item, so even if there is more than one
+  // duplicate of a single item, or multiple duplicates of multiple items, it
+  // will include them in the returned array
   return list.reduce((duplicateIndexes, item, index) => {
     // look for duplicates of the first, but don't include the first
     const foundIndex = list.indexOf(item, index + 1);

--- a/src/platform/forms-system/test/js/review/ArrayField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ArrayField.unit.spec.jsx
@@ -257,14 +257,25 @@ describe('Schemaform review <ArrayField>', () => {
     };
     const uiSchema = {
       'ui:title': 'List of things',
-      items: {},
+      items: {
+        test: {
+          type: 'string',
+        },
+      },
       'ui:options': {
         viewField: f => f,
         itemName: 'Item name',
         duplicateKey: 'field',
       },
     };
-    const arrayData = [{ field: 'a' }, { field: 'b' }, { field: 'a' }];
+    // Duplicates are case insensitive
+    const arrayData = [
+      { field: 'a' },
+      { field: 'b' },
+      { field: 'A' },
+      { field: 'a' },
+      { field: 'B' },
+    ];
     const tree = SkinDeep.shallowRender(
       <ArrayField
         pageKey="page1"
@@ -283,6 +294,8 @@ describe('Schemaform review <ArrayField>', () => {
     expect(tree.getMountedInstance().state.editing).to.deep.equal([
       false,
       false,
+      true,
+      true,
       true,
     ]);
   });

--- a/src/platform/forms-system/test/js/review/ArrayField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ArrayField.unit.spec.jsx
@@ -224,6 +224,68 @@ describe('Schemaform review <ArrayField>', () => {
     expect(tree.everySubTree('.schemaform-review-array-warning')).to.not.be
       .empty;
   });
+  it('should render start in edit mode for duplicate items', () => {
+    const idSchema = {};
+    const schema = {
+      type: 'array',
+      items: [
+        {
+          type: 'object',
+          properties: {
+            field: {
+              type: 'string',
+            },
+          },
+        },
+        {
+          type: 'object',
+          properties: {
+            field: {
+              type: 'string',
+            },
+          },
+        },
+      ],
+      additionalItems: {
+        type: 'object',
+        properties: {
+          field: {
+            type: 'string',
+          },
+        },
+      },
+    };
+    const uiSchema = {
+      'ui:title': 'List of things',
+      items: {},
+      'ui:options': {
+        viewField: f => f,
+        itemName: 'Item name',
+        duplicateKey: 'field',
+      },
+    };
+    const arrayData = [{ field: 'a' }, { field: 'b' }, { field: 'a' }];
+    const tree = SkinDeep.shallowRender(
+      <ArrayField
+        pageKey="page1"
+        arrayData={arrayData}
+        path={['thingList']}
+        schema={schema}
+        uiSchema={uiSchema}
+        idSchema={idSchema}
+        registry={registry}
+        formContext={formContext}
+        pageTitle=""
+        requiredSchema={requiredSchema}
+      />,
+    );
+
+    expect(tree.getMountedInstance().state.editing).to.deep.equal([
+      false,
+      false,
+      true,
+    ]);
+  });
 
   it('should render unique aria-labels on buttons from ui option key in item', () => {
     const idSchema = {};
@@ -259,9 +321,7 @@ describe('Schemaform review <ArrayField>', () => {
     const uiSchema = {
       'ui:title': 'List of things',
       items: {
-        test: {
-          type: 'string',
-        },
+        test: {},
         'ui:options': {
           itemAriaLabel: data => data.field,
         },

--- a/src/platform/forms-system/test/js/utilities/findDuplicateIndexes.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/findDuplicateIndexes.unit.spec.js
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+
+import findDuplicateIndexes from 'platform/forms-system/src/js/utilities/data/findDuplicateIndexes';
+
+describe('duplicateIndexes', () => {
+  const base = [{ x: 'one' }, { x: 'two' }, { x: 'three' }];
+  it('should not find duplicates', () => {
+    expect(findDuplicateIndexes(base, 'x')).to.have.lengthOf(0);
+  });
+  it('should find one duplicate', () => {
+    const array = [...base, { x: 'one' }];
+    expect(findDuplicateIndexes(array, 'x')).to.deep.equal([3]);
+  });
+  it('should find two duplicates', () => {
+    const array = [...base, { x: 'one' }, { x: 'one' }];
+    expect(findDuplicateIndexes(array, 'x')).to.deep.equal([3, 4]);
+  });
+  it('should find two separate duplicates', () => {
+    const array = [...base, { x: 'one' }, { x: 'two' }];
+    expect(findDuplicateIndexes(array, 'x')).to.deep.equal([3, 4]);
+  });
+  it('should find three separate duplicates', () => {
+    const array = [...base, { x: 'one' }, { x: 'two' }, { x: 'three' }];
+    expect(findDuplicateIndexes(array, 'x')).to.deep.equal([3, 4, 5]);
+  });
+});

--- a/src/platform/forms-system/test/js/utilities/findDuplicateIndexes.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/findDuplicateIndexes.unit.spec.js
@@ -23,4 +23,8 @@ describe('duplicateIndexes', () => {
     const array = [...base, { x: 'one' }, { x: 'two' }, { x: 'three' }];
     expect(findDuplicateIndexes(array, 'x')).to.deep.equal([3, 4, 5]);
   });
+  it('should find three separate case-insensitive duplicates', () => {
+    const array = [...base, { x: 'One' }, { x: 'tWo' }, { x: 'thREe' }];
+    expect(findDuplicateIndexes(array, 'x')).to.deep.equal([3, 4, 5]);
+  });
 });


### PR DESCRIPTION
## Description

EVSS does not allow duplicate new disabilities to be submitted for form 526.

Prevention of duplicate new disabilities has already been added in https://github.com/department-of-veterans-affairs/vets-website/pull/16205, but the review & submit page uses `review/ArrayField` to render array items. This PR moves the find duplicate items code from the `all-claims` folder into the platform code to reduce duplication.

A `ui:option` named `duplicateKey` is added to target the array field that should not include duplicate strings. When a duplicate is found, it will initialize the `ArrayField` duplicates in edit mode to draw attention to the entry. It will not show an error message initially (handled by `react-json-schemaform`), but it will prevent page & form submission

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/19319
- https://github.com/department-of-veterans-affairs/vets-website/pull/16205

## Testing done

Updated unit tests

## Screenshots

<details><summary>Error shown on the review & submit page</summary>

<!-- leave a blank line above -->

Logged into user 228 using maximal data; then added a new "asthma" disability

![Screen Shot 2021-03-01 at 3 46 04 PM](https://user-images.githubusercontent.com/136959/109564305-80438300-7aa6-11eb-8910-21ea2c249e53.png)</details>

## Acceptance criteria
- [x] Duplicate new disabilities are not allowed to be submitted in form 526

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
