### PR TITLE
Add cerner facility IDs

### DIFF
--- a/src/platform/utilities/cerner/index.js
+++ b/src/platform/utilities/cerner/index.js
@@ -2,9 +2,17 @@
 import environment from 'platform/utilities/environment';
 
 // Cerner facilities that do not have the `isCerner` flag set to true
-// 757: Chalmers P. Wylie Veterans Outpatient Clinic
-// 668: Mann Grandstaff
-export const CERNER_FACILITY_IDS = ['757', '668'];
+export const CERNER_FACILITY_IDS = [
+  '463', // Alaska VA
+  '531', // Boise, ID
+  '648', // Portland, OR
+  '653', // Roseburg (Roseburg OR)
+  '663', // Puget Sound (Seattle WA)
+  '668', // Mann Grandstaff
+  '687', // Walla Walla, WA
+  '692', // White City, OR
+  '757', // Chalmers P. Wylie Veterans Outpatient Clinic
+];
 
 // Not all Cerner facilities have the same capabilities. These blocklists are
 // used to determine which facilities lack certain capabilities.


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/20442

**Related `vets-api` feature toggle PR**: https://github.com/department-of-veterans-affairs/vets-api/pull/6045

This PR adds upcoming Cerner facility IDs:

'463', // Alaska VA
'531', // Boise, ID
'648', // Portland, OR
'653', // Roseburg (Roseburg OR)
'663', // Puget Sound (Seattle WA)
'687', // Walla Walla, WA
'692', // White City, OR

As long as the [vets-api feature toggle PR is merged first](https://github.com/department-of-veterans-affairs/vets-api/pull/6045) then, due to [this line of code](https://github.com/department-of-veterans-affairs/vets-website/blob/f2965706ccd1d500c1bc4a25c2a236f9eea6bb3b/src/platform/user/selectors.js#L30), this won't affect anything on the site **until the Cerner feature toggles are enabled**.

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Add Cerner facility IDs

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
