### PR TITLE
Handle SIP applications that have expired

### DIFF
--- a/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplicationInProgress.jsx
+++ b/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplicationInProgress.jsx
@@ -98,7 +98,7 @@ const ApplicationInProgress = ({
               </a>
               <button
                 className="va-button-link"
-                aria-label={`Remove this notification about my `}
+                aria-label={`Remove this notification about my expired ${formTitle}`}
                 onClick={() => {
                   removeForm(formId);
                   recordDashboardClick(formId, 'delete-link');

--- a/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplicationInProgress.jsx
+++ b/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplicationInProgress.jsx
@@ -3,6 +3,17 @@ import PropTypes from 'prop-types';
 
 import { recordDashboardClick } from '~/applications/personalization/dashboard/helpers';
 
+/**
+ * Returns a copy of the passed-in string with the first letter capitalized
+ *
+ * @param {string} input - word to capitalize
+ * @returns {string} - the input string with the first letter capitalized
+ */
+const capitalizeFirstLetter = input => {
+  const capitalizedFirstLetter = input[0].toUpperCase();
+  return `${capitalizedFirstLetter}${input.slice(1)}`;
+};
+
 const ApplicationInProgress = ({
   continueUrl,
   expirationDate,
@@ -10,41 +21,97 @@ const ApplicationInProgress = ({
   formTitle,
   lastOpenedDate,
   presentableFormId,
+  removeForm,
+  startNewApplicationUrl,
 }) => {
+  const isExpired = React.useMemo(
+    () => new Date(expirationDate).getTime() < Date.now(),
+    [expirationDate],
+  );
+
   return (
     <div
       className="vads-u-display--flex vads-l-col--12 medium-screen:vads-l-col--6 small-desktop-screen:vads-l-col--4 medium-screen:vads-u-padding-right--3 vads-u-padding-bottom--3"
       data-testid="application-in-progress"
     >
       <div className="vads-u-display--flex vads-u-width--full vads-u-flex-direction--column vads-u-justify-content--space-between vads-u-align-items--flex-start vads-u-background-color--gray-lightest vads-u-padding--2p5">
-        <div>
-          <div className="vads-u-text-transform--uppercase">
-            {presentableFormId}
-          </div>
-          <h4 className="vads-u-font-size--h3 vads-u-margin-top--0">
-            {formTitle}
-          </h4>
-          <div className="vads-u-display--flex">
-            <i
-              aria-hidden="true"
-              className={`fas fa-fw fa-exclamation-circle vads-u-margin-right--1 vads-u-margin-top--0p5`}
-            />
+        {!isExpired && (
+          <>
             <div>
-              <p className="vads-u-margin-top--0">
-                Application expires on: {expirationDate}
+              <p className="vads-u-text-transform--uppercase vads-u-margin-y--0">
+                {presentableFormId}
               </p>
-              <p>Last opened on: {lastOpenedDate}</p>
+              <h4 className="vads-u-font-size--h3 vads-u-margin-top--0">
+                {capitalizeFirstLetter(formTitle)}
+              </h4>
+              <div className="vads-u-display--flex">
+                <i
+                  aria-hidden="true"
+                  className={`fas fa-fw fa-exclamation-circle vads-u-margin-right--1 vads-u-margin-top--0p5`}
+                />
+                <div>
+                  <p className="vads-u-margin-top--0">
+                    Application expires on: {expirationDate}
+                  </p>
+                  <p>Last opened on: {lastOpenedDate}</p>
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-        <a
-          className="usa-button usa-button-primary"
-          aria-label={`Continue your ${formTitle}`}
-          href={continueUrl}
-          onClick={recordDashboardClick(formId, 'continue-button')}
-        >
-          Continue your application
-        </a>
+            <a
+              className="usa-button usa-button-primary"
+              aria-label={`Continue your ${formTitle}`}
+              href={continueUrl}
+              onClick={recordDashboardClick(formId, 'continue-button')}
+            >
+              Continue your application
+            </a>
+          </>
+        )}
+        {isExpired && (
+          <>
+            <div>
+              <p className="vads-u-text-transform--uppercase vads-u-margin-y--0">
+                {presentableFormId}
+              </p>
+              <h4 className="vads-u-font-size--h3 vads-u-margin-top--0">
+                {capitalizeFirstLetter(formTitle)}
+              </h4>
+              <div className="vads-u-display--flex">
+                <i
+                  aria-hidden="true"
+                  className={`fas fa-fw fa-exclamation-circle vads-u-margin-right--1 vads-u-margin-top--0p5`}
+                />
+                <div>
+                  <p className="vads-u-margin-top--0">
+                    Expired: Your {formTitle} has expired.
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div>
+              <a
+                className="usa-button usa-button-primary"
+                aria-label={`Start a new ${formTitle}`}
+                href={startNewApplicationUrl}
+              >
+                Start a new application
+              </a>
+              <button
+                className="va-button-link"
+                aria-label={`Remove this notification about my `}
+                onClick={() => {
+                  removeForm(formId);
+                  recordDashboardClick(formId, 'delete-link');
+                }}
+              >
+                <i className="fa fa-times vads-u-margin-right--1 vads-u-margin-top--0p5" />
+                <span className="remove-notification-label">
+                  Remove this notification
+                </span>
+              </button>
+            </div>
+          </>
+        )}
       </div>
     </div>
   );
@@ -63,6 +130,10 @@ ApplicationInProgress.propTypes = {
   lastOpenedDate: PropTypes.string.isRequired,
   // String to show at the very top of the component, usually `Form ${formId}`
   presentableFormId: PropTypes.string.isRequired,
+  // Function to call when the user wants to remove an expired form
+  removeForm: PropTypes.func,
+  // The URL that lets the user start a new application
+  startNewApplicationUrl: PropTypes.string.isRequired,
 };
 
 export default ApplicationInProgress;

--- a/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplicationInProgress.jsx
+++ b/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplicationInProgress.jsx
@@ -104,7 +104,10 @@ const ApplicationInProgress = ({
                   recordDashboardClick(formId, 'delete-link');
                 }}
               >
-                <i className="fa fa-times vads-u-margin-right--1 vads-u-margin-top--0p5" />
+                <i
+                  className="fa fa-times vads-u-margin-right--1 vads-u-margin-top--0p5"
+                  aria-hidden="true"
+                />
                 <span className="remove-notification-label">
                   Remove this notification
                 </span>

--- a/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplicationInProgress.unit.spec.jsx
+++ b/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplicationInProgress.unit.spec.jsx
@@ -1,38 +1,81 @@
 import React from 'react';
+import sinon from 'sinon';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
 
 import ApplicationInProgress from './ApplicationInProgress';
 
 describe('ApplicationInProgress component', () => {
-  const props = {
-    continueUrl: 'application-url/',
-    expirationDate: 'Jan 1, 2020',
-    formId: '1234',
-    formTitle: 'Form Title',
-    lastOpenedDate: 'Jan 1, 2019',
-    presentableFormId: 'Form 1234',
+  const defaultProps = () => {
+    return {
+      continueUrl: 'application-url/resume',
+      formId: '1234',
+      formTitle: 'form title',
+      lastOpenedDate: 'Jan 1, 2019',
+      presentableFormId: 'Form 1234',
+      removeForm: () => {},
+      startNewApplicationUrl: 'application-url',
+    };
   };
-  let view;
-  beforeEach(() => {
-    view = render(<ApplicationInProgress {...props} />);
+  const oneWeekInMs = 7 * 24 * 60 * 60 * 1000;
+  // we want to format the expirationDate like: Jan 1, 2021
+  const dateFormatter = Intl.DateTimeFormat('en-US', { dateStyle: 'medium' });
+  describe('when the application has not expired', () => {
+    const expirationEpoch = Date.now() + oneWeekInMs;
+    const expirationDate = dateFormatter.format(expirationEpoch);
+    const props = { ...defaultProps(), expirationDate };
+    let view;
+    beforeEach(() => {
+      view = render(<ApplicationInProgress {...props} />);
+    });
+    it('renders the correct presentable form ID', () => {
+      expect(view.getByText(props.presentableFormId)).to.exist;
+    });
+    it('renders the correct headline', () => {
+      expect(view.getByText('Form title')).to.exist;
+    });
+    it('renders the expiration date', () => {
+      expect(
+        view.getByText(new RegExp(`expires.*${props.expirationDate}`, 'i')),
+      ).to.exist;
+    });
+    it('renders the last opened date', () => {
+      expect(view.getByText(new RegExp(`opened.*${props.lastOpenedDate}`, 'i')))
+        .to.exist;
+    });
+    it('renders the correct "continue" button', () => {
+      const continueButton = view.getByRole('link', { name: /continue/i });
+      expect(continueButton).to.have.attr('href', props.continueUrl);
+    });
   });
-  it('renders the correct presentable form ID', () => {
-    expect(view.getByText(props.presentableFormId)).to.exist;
-  });
-  it('renders the correct headline', () => {
-    expect(view.getByText(props.formTitle)).to.exist;
-  });
-  it('renders the expiration date', () => {
-    expect(view.getByText(new RegExp(`expires.*${props.expirationDate}`, 'i')))
-      .to.exist;
-  });
-  it('renders the last opened date', () => {
-    expect(view.getByText(new RegExp(`opened.*${props.lastOpenedDate}`, 'i')))
-      .to.exist;
-  });
-  it('renders the correct "continue" button', () => {
-    const continueButton = view.getByRole('link', { name: /continue/i });
-    expect(continueButton).to.have.attr('href', props.continueUrl);
+  describe('when the application has expired', () => {
+    const removeFormSpy = sinon.spy();
+    const expirationEpoch = Date.now() - oneWeekInMs;
+    const expirationDate = dateFormatter.format(expirationEpoch);
+    const props = {
+      ...defaultProps(),
+      expirationDate,
+      removeForm: removeFormSpy,
+    };
+    let view;
+    beforeEach(() => {
+      view = render(<ApplicationInProgress {...props} />);
+    });
+    it('renders the "expired" message', () => {
+      expect(view.getByText(/Expired: Your form title has expired/i)).to.exist;
+    });
+    it('renders the "start a new application" button with accessible label', () => {
+      const continueButton = view.getByRole('link', {
+        name: new RegExp(`start a new ${props.formTitle}`, 'i'),
+      });
+      expect(continueButton).to.have.attr('href', props.startNewApplicationUrl);
+    });
+    it('renders a "remove" button that calls the `removeForm` prop when clicked', () => {
+      const removeButton = view.getByRole('button', {
+        name: new RegExp(`remove.*${props.formTitle}`, 'i'),
+      });
+      removeButton.click();
+      expect(removeFormSpy.calledOnce).to.be.true;
+    });
   });
 });


### PR DESCRIPTION
## Description
Render saved-in-progress applications that have expired differently in the `ApplicationsInProgress` component. Also allow them to be removed.

I took an "optimistic update' approach when a user removes an expired application. That is to say I am removing the box from the UI immediately before we get confirmation that the call to `DELETE /v0/in_progress_forms/{form_id}` has succeeded. The drawbacks to this are pretty minimal; they'll just see the expired form on their dashboard the next time they load the page. But the benefits in terms of UX and development time are nice, IMO. I'll loop up with UX on this. **Update**: [They are cool with this](https://dsva.slack.com/archives/C909ZG2BB/p1614711128127700?thread_ts=1614700220.117800&cid=C909ZG2BB)

## Testing done
Local + updated unit tests for the `ApplicationInProgress` component + updated Cypress tests

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs