### PR TITLE
Remove FDC question from BDD flow

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -695,6 +695,7 @@ const formConfig = {
           path: 'fully-developed-claim',
           uiSchema: fullyDevelopedClaim.uiSchema,
           schema: fullyDevelopedClaim.schema,
+          depends: formData => !isBDD(formData),
         },
       },
     },

--- a/src/applications/disability-benefits/all-claims/submit-transformer.js
+++ b/src/applications/disability-benefits/all-claims/submit-transformer.js
@@ -632,6 +632,17 @@ export function transform(formConfig, form) {
     });
     return { ...clonedData, ...(attachments.length && { attachments }) };
   };
+
+  const fullyDevelopedClaim = formData => {
+    if (isBDD) {
+      const clonedData = _.cloneDeep(formData);
+      // standardClaim = false means it's a fully developed claim (FDC); but
+      // this value is ignored in the BDD flow unless the submission falls out
+      // of BDD status. Then we want it to be a FDC
+      return { ...clonedData, standardClaim: false };
+    }
+    return formData;
+  };
   // End transformation definitions
 
   // Apply the transformations
@@ -656,6 +667,7 @@ export function transform(formConfig, form) {
     addForm0781,
     addForm8940,
     addFileAttachmments,
+    fullyDevelopedClaim,
   ].reduce(
     (formData, transformer) => transformer(formData),
     _.cloneDeep(form.data),


### PR DESCRIPTION
## Description

The fully developed claim (FDC) question is removed from the Benefits Delivery at Discharge (BDD) flow because it doesn't apply to the BDD form. It only applies if the submission is somehow not qualified for BDD, then we automatically set the form as a FDC. If the form isn't qualified for FDC, then the reviewer can make that determination.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/18645

## Testing done

Unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] FDC question is removed from the BDD flow

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
