### PR TITLE
[GraphQL] Speed up the Health Care Service Listings queries

### DIFF
--- a/src/site/stages/build/drupal/graphql/healthServicesListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthServicesListingPage.graphql.js
@@ -56,13 +56,6 @@ const healthServicesListingPage = `
                         ... on NodeHealthCareLocalFacility {
                           entityUrl {
                             ... on EntityCanonicalUrl {
-                              breadcrumb {
-                                url {
-                                  path
-                                  routed
-                                }
-                                text
-                              }
                               path
                             }
                           }


### PR DESCRIPTION
## Description
Output indicated `GetNodeHealthServicesListingPage` was a costly query. We were able to determine that this was due to the breadcrumbs part of the query.

https://dsva.slack.com/archives/C52CL1PKQ/p1614641260111700

## Testing done
Locally ran `yarn build:content --pull-drupal` against CMS prod and staging

`GetNodeHealthServicesListingPage` were taking upwards of two mins this morning and on a hit against staging we saw these results

![image](https://user-images.githubusercontent.com/1915775/109677966-2dbaa300-7b48-11eb-80b1-47a8ec9747a8.png)

This means we may have just completely eliminated it as a bottleneck
## Screenshots
Appears to have no impact on `/pittsburgh-health-care/health-services/`

![image](https://user-images.githubusercontent.com/1915775/109688437-40d27080-7b52-11eb-9f24-012b214b864a.png)


## Acceptance criteria
- [ ] Query is faster w/o affecting visual

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
