### PR TITLE
Allow future separation date for BDD only

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -206,7 +206,8 @@ const formConfig = {
           onContinue: captureEvents.militaryHistory,
           appStateSelector: state => ({
             dob: state.user.profile.dob,
-            allowBDD: form526BDDFeature(state),
+            allowBDD:
+              form526BDDFeature(state) && state.form.data?.['view:isBddData'],
           }),
         },
         separationLocation: {

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -911,9 +911,10 @@ export const isBDD = formData => {
     : servicePeriods
         .filter(({ dateRange }) => dateRange?.to)
         .map(({ dateRange }) => moment(dateRange?.to))
-        .sort((dateA, dateB) => dateB - dateA)[0];
+        .sort((dateA, dateB) => (dateB.isBefore(dateA) ? -1 : 1))[0];
 
   if (!mostRecentDate) {
+    window.sessionStorage.setItem(FORM_STATUS_BDD, 'false');
     return false;
   }
 
@@ -921,6 +922,7 @@ export const isBDD = formData => {
     isActiveDuty &&
     mostRecentDate.isAfter(moment().add(89, 'days')) &&
     !mostRecentDate.isAfter(moment().add(180, 'days'));
+
   // this flag helps maintain the correct form title within a session
   window.sessionStorage.setItem(FORM_STATUS_BDD, result ? 'true' : 'false');
   return Boolean(result);


### PR DESCRIPTION
## Description

The `view:isBddDate` should be used to allow entering a future separation date. Previously, only the BDD feature flag was used during validation.

Also, we need to ensure the page title is updated properly when form 526 is in, or not within, the BDD flow. A session storage value is updated to properly manage the page title.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/20556

## Testing done

Unit tests

## Screenshots

![](https://user-images.githubusercontent.com/136959/109697270-99563d80-7b53-11eb-9edc-d24dbf7e71d3.gif)

## Acceptance criteria
- [x] Page & document title update based on the entered separation date

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
