### PR TITLE
Failed prop type: ArrayField: prop type `trackingPrefix` is invalid; it must be a function

### DIFF
--- a/src/applications/letters/components/DownloadLetterLink.jsx
+++ b/src/applications/letters/components/DownloadLetterLink.jsx
@@ -115,8 +115,8 @@ function mapStateToProps(state, ownProps) {
 }
 
 DownloadLetterLink.propTypes = {
-  letterType: PropTypes.string.required,
-  letterName: PropTypes.string.required,
+  letterType: PropTypes.string.isRequired,
+  letterName: PropTypes.string.isRequired,
   downloadStatus: PropTypes.string,
 };
 

--- a/src/applications/personalization/dashboard/containers/YourApplications.jsx
+++ b/src/applications/personalization/dashboard/containers/YourApplications.jsx
@@ -77,7 +77,7 @@ YourApplications.propTypes = {
   }),
   savedForms: PropTypes.arrayOf(
     PropTypes.shape({
-      form: PropTypes.string.required,
+      form: PropTypes.string.isRequired,
       metadata: PropTypes.shape({
         lastUpdated: PropTypes.number,
         expiresAt: PropTypes.number,

--- a/src/platform/forms-system/src/js/review/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/review/ArrayField.jsx
@@ -384,7 +384,7 @@ export default ArrayField;
 ArrayField.propTypes = {
   schema: PropTypes.object.isRequired,
   uiSchema: PropTypes.object,
-  trackingPrefix: PropTypes.string.required,
+  trackingPrefix: PropTypes.string.isRequired,
   pageKey: PropTypes.string.isRequired,
   path: PropTypes.array.isRequired,
   formData: PropTypes.object,


### PR DESCRIPTION
## Description
Several instances of PropTypes.string.required are being used which are throwing errors. Code should be updated to use isRequired instead of required.

Warning: Failed prop type: ArrayField: prop type trackingPrefix is invalid; it must be a function, usually from the prop-types package, but received undefined.

## Acceptance criteria

## Screenshots
![Financial Status Report  Veterans Affairs 2021-03-02 15-26-48](https://user-images.githubusercontent.com/7518899/109713612-72a60000-7b6f-11eb-959c-84d57cdd5e28.png)


## Definition of done
- [x] Changes have been tested in vets-website
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs