### PR TITLE
Remove unused breadcrumb from facility graphql query

### DIFF
--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareLocalFacility.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareLocalFacility.node.graphql.js
@@ -7,13 +7,6 @@ const FACILITIES_RESULTS = `
     ... on NodeHealthCareLocalFacility {
       entityUrl {
       ... on EntityCanonicalUrl {
-        breadcrumb {
-          url {
-            path
-            routed
-          }
-          text
-        }
         path
       }
     }

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionHealthServices.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionHealthServices.node.graphql.js
@@ -18,13 +18,6 @@ const HEALTH_SERVICES_RESULTS = `
                 ... on NodeHealthCareLocalFacility {
                   entityUrl {
                     ... on EntityCanonicalUrl {
-                      breadcrumb {
-                        url {
-                          path
-                          routed
-                        }
-                        text
-                      }
                       path
                     }
                   }


### PR DESCRIPTION
## Description

This removed breadcrumbs from a facility query `GetNodeHealthCareRegionPage ` where the breadcrumbs are not used.

The main template for the query is `src/site/layouts/health_care_region_page.drupal.liquid`.  This template delegates to `src/site/includes/facilityListing.drupal.liquid` which does not have the breadcrumbs render.



## Testing done

Ran the build locally.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/department-of-veterans-affairs/vets-website/16235)
<!-- Reviewable:end -->
