### PR TITLE
[GraphQL] Use smaller slicing for GetNodeHealthCareLocalFacilityPages

### DIFF
--- a/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
@@ -155,7 +155,7 @@ function getNodeHealthCareLocalFacilityPagesSlice(
 function getNodeHealthCareLocalFacilityPageQueries(entityCounts) {
   return generatePaginatedQueries({
     operationNamePrefix: 'GetNodeHealthCareLocalFacilityPages',
-    entitiesPerSlice: 50,
+    entitiesPerSlice: 25,
     totalEntities: entityCounts.data.healthCareLocalFacility.count,
     getSlice: getNodeHealthCareLocalFacilityPagesSlice,
   });


### PR DESCRIPTION
## Description
This PR uses smaller slicing for the GetNodeHealthCareLocalFacilityPages query because 50 is a lot and these nodes seem kinda heavy. This PR reduces that to only 25 nodes per query.

## Testing done
Locally ran `yarn build:content --pull-drupal`

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/109725673-7a6da080-7b7f-11eb-85d4-1613057d04f7.png)

## Acceptance criteria
- [ ] Better response times

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
