### PR TITLE
Add RTL tests for "Benefits of interest" section

### DIFF
--- a/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.unit.spec.jsx
+++ b/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.unit.spec.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import sinon from 'sinon';
 import { expect } from 'chai';
 
 import { renderInReduxProvider } from '~/platform/testing/unit/react-testing-library-helpers';
@@ -26,126 +27,392 @@ function oneYearFromNow() {
   return Date.now() + oneYearInMS;
 }
 
+function wait(timeout) {
+  return new Promise(resolve => {
+    setTimeout(resolve, timeout);
+  });
+}
+
 describe('ApplyForBenefits component', () => {
   let view;
-  it('renders the correct content when there are no applications in progress', () => {
-    const initialState = {
-      user: {
-        profile: {
-          savedForms: [],
+  describe('Applications in progress', () => {
+    it('renders the correct content when there are no applications in progress', () => {
+      const initialState = {
+        user: {
+          profile: {
+            savedForms: [],
+          },
         },
-      },
-    };
-    view = renderInReduxProvider(<ApplyForBenefits />, {
-      initialState,
-      reducers,
+      };
+      view = renderInReduxProvider(<ApplyForBenefits />, {
+        initialState,
+        reducers,
+      });
+      expect(view.findByText(/you have no applications in progress/)).to.exist;
     });
-    expect(view.findByText(/you have no applications in progress/)).to.exist;
-  });
 
-  it('does not render unknown applications that are in progress', () => {
-    const initialState = {
-      hcaEnrollmentStatus: { enrollmentStatus: null, hasServerError: false },
-      user: {
-        profile: {
-          savedForms: [
-            {
-              form: '123-ABC',
-              metadata: {
-                version: 3,
-                returnUrl: '/military/reserve-national-guard',
+    it('does not render unknown applications that are in progress', () => {
+      const initialState = {
+        hcaEnrollmentStatus: { enrollmentStatus: null, hasServerError: false },
+        user: {
+          profile: {
+            savedForms: [
+              {
+                form: '123-ABC',
+                metadata: {
+                  version: 3,
+                  returnUrl: '/military/reserve-national-guard',
+                },
+                lastUpdated: oneDayAgo(),
               },
-              lastUpdated: oneDayAgo(),
-            },
-          ],
+            ],
+          },
         },
-      },
-    };
-    view = renderInReduxProvider(<ApplyForBenefits />, {
-      initialState,
-      reducers,
+      };
+      view = renderInReduxProvider(<ApplyForBenefits />, {
+        initialState,
+        reducers,
+      });
+      expect(view.findByText(/you have no applications in progress/)).to.exist;
     });
-    expect(view.findByText(/you have no applications in progress/)).to.exist;
-  });
 
-  it('sorts the in-progress applications, listing the soonest-to-expire applications first', () => {
-    const initialState = {
-      user: {
-        profile: {
-          savedForms: [
-            {
-              form: '686C-674',
-              metadata: {
-                version: 1,
-                returnUrl: '/net-worth',
-                savedAt: oneDayAgo(),
-                submission: {
-                  status: false,
-                  errorMessage: false,
-                  id: false,
-                  timestamp: false,
-                  hasAttemptedSubmit: false,
+    it('sorts the in-progress applications, listing the soonest-to-expire applications first', () => {
+      const initialState = {
+        user: {
+          profile: {
+            savedForms: [
+              {
+                form: '686C-674',
+                metadata: {
+                  version: 1,
+                  returnUrl: '/net-worth',
+                  savedAt: oneDayAgo(),
+                  submission: {
+                    status: false,
+                    errorMessage: false,
+                    id: false,
+                    timestamp: false,
+                    hasAttemptedSubmit: false,
+                  },
+                  expiresAt: oneWeekFromNow() / 1000,
+                  lastUpdated: oneDayAgo() / 1000,
+                  inProgressFormId: 5179,
                 },
-                expiresAt: oneWeekFromNow() / 1000,
                 lastUpdated: oneDayAgo() / 1000,
-                inProgressFormId: 5179,
               },
-              lastUpdated: oneDayAgo() / 1000,
-            },
-            {
-              form: '21-526EZ',
-              metadata: {
-                version: 1,
-                returnUrl: '/net-worth',
-                savedAt: oneDayAgo(),
-                submission: {
-                  status: false,
-                  errorMessage: false,
-                  id: false,
-                  timestamp: false,
-                  hasAttemptedSubmit: false,
+              {
+                form: '21-526EZ',
+                metadata: {
+                  version: 1,
+                  returnUrl: '/net-worth',
+                  savedAt: oneDayAgo(),
+                  submission: {
+                    status: false,
+                    errorMessage: false,
+                    id: false,
+                    timestamp: false,
+                    hasAttemptedSubmit: false,
+                  },
+                  expiresAt: oneDayFromNow() / 1000,
+                  lastUpdated: oneDayAgo() / 1000,
+                  inProgressFormId: 5179,
                 },
-                expiresAt: oneDayFromNow() / 1000,
                 lastUpdated: oneDayAgo() / 1000,
-                inProgressFormId: 5179,
               },
-              lastUpdated: oneDayAgo() / 1000,
-            },
-            {
-              form: '1010ez',
-              metadata: {
-                version: 1,
-                returnUrl: '/net-worth',
-                savedAt: oneDayAgo(),
-                submission: {
-                  status: false,
-                  errorMessage: false,
-                  id: false,
-                  timestamp: false,
-                  hasAttemptedSubmit: false,
+              {
+                form: '1010ez',
+                metadata: {
+                  version: 1,
+                  returnUrl: '/net-worth',
+                  savedAt: oneDayAgo(),
+                  submission: {
+                    status: false,
+                    errorMessage: false,
+                    id: false,
+                    timestamp: false,
+                    hasAttemptedSubmit: false,
+                  },
+                  expiresAt: oneYearFromNow() / 1000,
+                  lastUpdated: oneDayAgo() / 1000,
+                  inProgressFormId: 5179,
                 },
-                expiresAt: oneYearFromNow() / 1000,
                 lastUpdated: oneDayAgo() / 1000,
-                inProgressFormId: 5179,
               },
-              lastUpdated: oneDayAgo() / 1000,
-            },
-          ],
+            ],
+          },
         },
-      },
-    };
-    view = renderInReduxProvider(<ApplyForBenefits />, {
-      initialState,
-      reducers,
+      };
+      view = renderInReduxProvider(<ApplyForBenefits />, {
+        initialState,
+        reducers,
+      });
+      expect(view.queryByText(/you have no applications in progress/)).not.to
+        .exist;
+      const applicationsInProgress = view.getAllByTestId(
+        'application-in-progress',
+      );
+      expect(applicationsInProgress.length).to.equal(3);
+      expect(applicationsInProgress[0]).to.contain.text('21-526EZ');
+      expect(applicationsInProgress[1]).to.contain.text('686C-674');
+      expect(applicationsInProgress[2]).to.contain.text('1010ez');
     });
-    expect(view.queryByText(/you have no applications in progress/)).not.to
-      .exist;
-    const applicationsInProgress = view.getAllByTestId(
-      'application-in-progress',
+  });
+  describe('Benefits you might be interested in', () => {
+    let fetchSpy;
+    context('when user is not a VA patient and has 2FA set up', () => {
+      beforeEach(() => {
+        fetchSpy = sinon.spy(global, 'fetch');
+      });
+      afterEach(() => {
+        global.fetch.restore();
+      });
+      it('✨ ✨ should fetch ESR and DD4EDU data and show a loading spinner ✨ ✨', async () => {
+        const initialState = {
+          user: {
+            profile: {
+              vaPatient: false,
+              multifactor: true,
+            },
+          },
+        };
+        view = renderInReduxProvider(<ApplyForBenefits />, {
+          initialState,
+          reducers,
+        });
+        // Without this timeout, the test is flaky. For some reason the fetch
+        // spy does not always record calls. This is despite the fact that the
+        // application code does get to the point that it calls fetch (based on
+        // some console logs I inserted). But including the simple 1ms timeout
+        // fixes things. Oddly enough this timeout is not needed when running
+        // the test in isolation
+        await wait(1);
+        const fetchCalls = fetchSpy.getCalls();
+        // make sure we are fetching DD4EDU info
+        expect(
+          fetchCalls.some(call => {
+            return call.args[0].includes('v0/profile/ch33_bank_accounts');
+          }),
+        ).to.be.true;
+        // make sure we are fetching ESR data
+        expect(
+          fetchCalls.some(call => {
+            return call.args[0].includes(
+              'v0/health_care_applications/enrollment_status',
+            );
+          }),
+        ).to.be.true;
+        // make sure the loading spinner is shown
+        view.getByRole('progressbar', {
+          value: /benefits you might be interested in/i,
+        });
+      });
+    });
+
+    context('when user is a VA patient does not have 2FA set up', () => {
+      beforeEach(() => {
+        fetchSpy = sinon.spy(global, 'fetch');
+      });
+      afterEach(() => {
+        global.fetch.restore();
+      });
+      it('should not fetch data from ESR and DD4EDU and not show a loading spinner', async () => {
+        const initialState = {
+          user: {
+            profile: {
+              vaPatient: true,
+              multifactor: false,
+            },
+          },
+        };
+        view = renderInReduxProvider(<ApplyForBenefits />, {
+          initialState,
+          reducers,
+        });
+        // Adding a timeout to ensure the fetch spy records calls correctly. See
+        // the above comment about how sometimes the spy does not report being
+        // called when this timeout is not used.
+        await wait(1);
+        const fetchCalls = fetchSpy.getCalls();
+        // make sure we are not fetching DD4EDU info
+        expect(
+          fetchCalls.some(call => {
+            return call.args[0].includes('v0/profile/ch33_bank_accounts');
+          }),
+        ).to.be.false;
+        // make sure we are not fetching ESR data
+        expect(
+          fetchCalls.some(call => {
+            return call.args[0].includes(
+              'v0/health_care_applications/enrollment_status',
+            );
+          }),
+        ).to.be.false;
+        // make sure the loading spinner is shown
+        expect(
+          view.queryByRole('progressbar', {
+            value: /benefits you might be interested in/i,
+          }),
+        ).to.not.exist;
+      });
+    });
+
+    context(
+      'when user is not a VA patient, is not in ESR, and not enrolled in DD4edu',
+      () => {
+        it('should show the correct benefits', () => {
+          const initialState = {
+            user: {
+              profile: {
+                vaPatient: false,
+                multifactor: true,
+              },
+            },
+            hcaEnrollmentStatus: {
+              noESRRecordFound: true,
+            },
+            vaProfile: {
+              eduPaymentInformation: {
+                error: true,
+              },
+            },
+          };
+          view = renderInReduxProvider(<ApplyForBenefits />, {
+            initialState,
+            reducers,
+          });
+          expect(view.getByRole('link', { name: /apply for health care/i })).to
+            .exist;
+          expect(view.getByRole('link', { name: /file a disability claim/i }))
+            .to.exist;
+          expect(
+            view.getByRole('link', { name: /apply for education benefits/i }),
+          ).to.exist;
+        });
+      },
     );
-    expect(applicationsInProgress.length).to.equal(3);
-    expect(applicationsInProgress[0]).to.contain.text('21-526EZ');
-    expect(applicationsInProgress[1]).to.contain.text('686C-674');
-    expect(applicationsInProgress[2]).to.contain.text('1010ez');
+
+    context(
+      'when user is a VA patient, but is in ESR, and is not enrolled in DD4edu',
+      () => {
+        it('should show the correct benefits', () => {
+          const initialState = {
+            user: {
+              profile: {
+                vaPatient: false,
+                multifactor: true,
+              },
+            },
+            hcaEnrollmentStatus: {
+              enrollmentStatus: 'canceled_declined',
+              noESRRecordFound: false,
+            },
+            vaProfile: {
+              eduPaymentInformation: {
+                error: true,
+              },
+            },
+          };
+          view = renderInReduxProvider(<ApplyForBenefits />, {
+            initialState,
+            reducers,
+          });
+          expect(view.queryByRole('link', { name: /apply for health care/i }))
+            .to.not.exist;
+          view.getByRole('link', { name: /file a disability claim/i });
+          view.getByRole('link', { name: /apply for education benefits/i });
+        });
+      },
+    );
+
+    context('when user is a VA patient and not enrolled in DD4edu', () => {
+      it('should show the correct benefits', () => {
+        const initialState = {
+          user: {
+            profile: {
+              vaPatient: true,
+              multifactor: true,
+            },
+          },
+          vaProfile: {
+            eduPaymentInformation: {
+              error: true,
+            },
+          },
+        };
+        view = renderInReduxProvider(<ApplyForBenefits />, {
+          initialState,
+          reducers,
+        });
+        expect(view.queryByRole('link', { name: /apply for health care/i })).to
+          .not.exist;
+        view.getByRole('link', { name: /file a disability claim/i });
+        view.getByRole('link', { name: /apply for education benefits/i });
+      });
+    });
+
+    context(
+      'when user is not a VA patient, not in ESR, but enrolled in DD4edu',
+      () => {
+        it('should show the correct benefits', () => {
+          const initialState = {
+            user: {
+              profile: {
+                vaPatient: false,
+                multifactor: true,
+              },
+            },
+            hcaEnrollmentStatus: {
+              noESRRecordFound: true,
+            },
+            vaProfile: {
+              eduPaymentInformation: {
+                paymentAccount: {
+                  accountNumber: '123',
+                },
+              },
+            },
+          };
+          view = renderInReduxProvider(<ApplyForBenefits />, {
+            initialState,
+            reducers,
+          });
+          view.getByRole('link', { name: /apply for health care/i });
+          view.getByRole('link', { name: /file a disability claim/i });
+          expect(
+            view.queryByRole('link', { name: /apply for education benefits/i }),
+          ).to.not.exist;
+        });
+      },
+    );
+
+    context('when user is a VA patient and enrolled in DD4edu', () => {
+      it('should show the correct benefits', () => {
+        const initialState = {
+          user: {
+            profile: {
+              vaPatient: true,
+              multifactor: true,
+            },
+          },
+          vaProfile: {
+            eduPaymentInformation: {
+              paymentAccount: {
+                accountNumber: '123',
+              },
+            },
+          },
+        };
+        view = renderInReduxProvider(<ApplyForBenefits />, {
+          initialState,
+          reducers,
+        });
+        expect(view.queryByRole('link', { name: /apply for health care/i })).to
+          .not.exist;
+        view.getByRole('link', { name: /file a disability claim/i });
+        expect(
+          view.queryByRole('link', { name: /apply for education benefits/i }),
+        ).to.not.exist;
+      });
+    });
   });
 });

--- a/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.unit.spec.jsx
+++ b/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.unit.spec.jsx
@@ -166,7 +166,7 @@ describe('ApplyForBenefits component', () => {
       afterEach(() => {
         global.fetch.restore();
       });
-      it('✨ ✨ should fetch ESR and DD4EDU data and show a loading spinner ✨ ✨', async () => {
+      it('should fetch ESR and DD4EDU data and show a loading spinner', async () => {
         const initialState = {
           user: {
             profile: {
@@ -208,7 +208,7 @@ describe('ApplyForBenefits component', () => {
       });
     });
 
-    context('when user is a VA patient does not have 2FA set up', () => {
+    context('when user is a VA patient and does not have 2FA set up', () => {
       beforeEach(() => {
         fetchSpy = sinon.spy(global, 'fetch');
       });


### PR DESCRIPTION
## Description
This adds some tests for the Benefits of Interest section

## Testing done
Added unit tests focused on:
- making sure we don't fetch DD4EDU or ESR info when we don't need to
- displaying the correct benefit widgets depending on user characteristics

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs