### PR TITLE
Loading state and focus cleanup for calendar and facility pages

### DIFF
--- a/src/applications/vaos/components/LoadingOverlay.jsx
+++ b/src/applications/vaos/components/LoadingOverlay.jsx
@@ -17,7 +17,7 @@ export default function LoadingOverlay({ show, message }) {
     return (
       <div className="vaos__loading-overlay">
         <div className="vaos__loading-overlay-inner">
-          <LoadingIndicator message={message} />
+          <LoadingIndicator setFocus message={message} />
         </div>
       </div>
     );

--- a/src/applications/vaos/hooks/useIsInitialLoad.jsx
+++ b/src/applications/vaos/hooks/useIsInitialLoad.jsx
@@ -1,0 +1,25 @@
+import { useRef, useEffect } from 'react';
+/**
+ * This hook returns true until isLoading is false, then it always
+ * returns false, regardless of any further changes to the value of isLoading
+ *
+ * You can use this if you want to have different behavior the first time something
+ * loads, vs any subsequent requests for the same api call.
+ *
+ * @export
+ * @param {boolean} isLoading Current loading state.
+ * @returns {boolean} Returns if we're still in the initial loading state
+ */
+export default function useIsInitialLoad(isLoading) {
+  const initialLoadRef = useRef(true);
+  useEffect(
+    () => {
+      if (!isLoading) {
+        initialLoadRef.current = false;
+      }
+    },
+    [isLoading],
+  );
+
+  return initialLoadRef.current;
+}

--- a/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
@@ -70,10 +70,6 @@ function TypeOfCarePage({
     }
   }, []);
 
-  if (!schema) {
-    return null;
-  }
-
   return (
     <div>
       <h1 className="vads-u-font-size--h2">{pageTitle}</h1>
@@ -90,32 +86,34 @@ function TypeOfCarePage({
         />
       )}
 
-      <SchemaForm
-        name="Type of care"
-        title="Type of care"
-        schema={schema}
-        uiSchema={uiSchema}
-        onSubmit={() => routeToNextAppointmentPage(history, pageKey)}
-        onChange={newData => {
-          // When someone chooses a type of care that can be direct scheduled,
-          // kick off the past appointments fetch, which takes a while
-          // This could get called multiple times, but the function is memoized
-          // and returns the previous promise if it eixsts
-          if (showDirectScheduling) {
-            getLongTermAppointmentHistory();
-          }
+      {!!schema && (
+        <SchemaForm
+          name="Type of care"
+          title="Type of care"
+          schema={schema}
+          uiSchema={uiSchema}
+          onSubmit={() => routeToNextAppointmentPage(history, pageKey)}
+          onChange={newData => {
+            // When someone chooses a type of care that can be direct scheduled,
+            // kick off the past appointments fetch, which takes a while
+            // This could get called multiple times, but the function is memoized
+            // and returns the previous promise if it eixsts
+            if (showDirectScheduling) {
+              getLongTermAppointmentHistory();
+            }
 
-          updateFormData(pageKey, uiSchema, newData);
-        }}
-        data={data}
-      >
-        <TypeOfCareAlert />
-        <FormButtons
-          onBack={() => routeToPreviousAppointmentPage(history, pageKey)}
-          pageChangeInProgress={pageChangeInProgress}
-          loadingText="Page change in progress"
-        />
-      </SchemaForm>
+            updateFormData(pageKey, uiSchema, newData);
+          }}
+          data={data}
+        >
+          <TypeOfCareAlert />
+          <FormButtons
+            onBack={() => routeToPreviousAppointmentPage(history, pageKey)}
+            pageChangeInProgress={pageChangeInProgress}
+            loadingText="Page change in progress"
+          />
+        </SchemaForm>
+      )}
       <PodiatryAppointmentUnavailableModal
         showModal={showPodiatryApptUnavailableModal}
         onClose={hidePodiatryAppointmentUnavailableModal}

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
@@ -4,6 +4,7 @@ import { useHistory } from 'react-router-dom';
 import { scrollAndFocus } from '../../../utils/scrollAndFocus';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
+import { usePrevious } from 'platform/utilities/react-hooks';
 
 import * as actions from '../../redux/actions';
 import { getFacilityPageV2Info } from '../../redux/selectors';
@@ -97,6 +98,16 @@ function VAFacilityPageV2({
       scrollAndFocus();
     },
     [isLoading],
+  );
+
+  const previouslyShowingModal = usePrevious(showEligibilityModal);
+  useEffect(
+    () => {
+      if (!showEligibilityModal && previouslyShowingModal) {
+        scrollAndFocus('.usa-button-primary');
+      }
+    },
+    [showEligibilityModal, previouslyShowingModal],
   );
 
   const goBack = () => routeToPreviousAppointmentPage(history, pageKey);

--- a/src/applications/vaos/project-cheetah/components/VAFacilityPage/index.jsx
+++ b/src/applications/vaos/project-cheetah/components/VAFacilityPage/index.jsx
@@ -17,6 +17,7 @@ import SingleFacilityEligibilityCheckMessage from './SingleFacilityEligibilityCh
 import VAFacilityInfoMessage from './VAFacilityInfoMessage';
 import ResidentialAddress from './ResidentialAddress';
 import LoadingOverlay from '../../../components/LoadingOverlay';
+import { usePrevious } from 'platform/utilities/react-hooks';
 
 const initialSchema = {
   type: 'object',
@@ -74,6 +75,23 @@ function VAFacilityPage({
       openFacilityPage(uiSchema, initialSchema);
     },
     [openFacilityPage],
+  );
+
+  useEffect(
+    () => {
+      scrollAndFocus();
+    },
+    [loadingFacilities],
+  );
+
+  const previouslyShowingModal = usePrevious(showEligibilityModal);
+  useEffect(
+    () => {
+      if (!showEligibilityModal && previouslyShowingModal) {
+        scrollAndFocus('.usa-button-primary');
+      }
+    },
+    [showEligibilityModal, previouslyShowingModal],
   );
 
   const goBack = () => routeToPreviousAppointmentPage(history, pageKey);

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -253,7 +253,7 @@ export default [
   },
   {
     path: /vaos\/v0\/facilities\/.*\/available_appointments/,
-    delay: 5000,
+    delay: 2000,
     response: () => {
       return set(
         'data[0].attributes.appointmentTimeSlot',

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -253,6 +253,7 @@ export default [
   },
   {
     path: /vaos\/v0\/facilities\/.*\/available_appointments/,
+    delay: 5000,
     response: () => {
       return set(
         'data[0].attributes.appointmentTimeSlot',

--- a/src/applications/vaos/tests/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
@@ -241,7 +241,7 @@ describe('VAOS <DateTimeSelectPage>', () => {
 
     expect(
       screen.getByRole('heading', {
-        level: 3,
+        level: 2,
         name: 'We’ve run into a problem trying to find an appointment time',
       }),
     ).to.be.ok;


### PR DESCRIPTION
## Description
This PR
- Sets focus to loading spinner on calendar pages so that loading states are announced
- Adds additional focus handling around loading states on the calendar so that users aren't lost after loading
- Updated slots error states to hide calendar on error and fix heading level issue
- Fixed bug in request flow link in new appointment flow error message
- Updated cheetah flow loading state to work with refactored calendar
- Added handling for focus when a user clears eligibility modal on facility page

## Testing done
Local and unit testing

## Screenshots
Error states
![Screen Shot 2021-03-03 at 11 02 14 AM](https://user-images.githubusercontent.com/634932/109835897-a20d4900-7c11-11eb-89b6-9b0c1de37c4c.png)
![Screen Shot 2021-03-03 at 11 01 48 AM](https://user-images.githubusercontent.com/634932/109835900-a2a5df80-7c11-11eb-9f55-329510510f11.png)

## Acceptance criteria
- [ ] Loading spinners are announced and focus is handled properly

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
