### PR TITLE
[GraphQL] Add build arg for max parallelization

### DIFF
--- a/script/content-build-help.js
+++ b/script/content-build-help.js
@@ -82,6 +82,12 @@ const helpSections = [
         description: 'Specify the password for the --drupal-user.',
       },
       {
+        name: 'drupal-max-parallel-requests',
+        type: String,
+        description:
+          'Specify the max number of individual HTTP GraphQL requests allowed sent to Drupal in parallel.',
+      },
+      {
         name: 'no-drupal-proxy',
         type: Boolean,
         description:

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -53,6 +53,11 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
     type: String,
     defaultValue: process.env.DRUPAL_PASSWORD,
   },
+  {
+    name: 'drupal-max-parallel-requests',
+    type: Number,
+    defaultValue: process.env.DRUPAL_MAX_PARALLEL_REQUESTS,
+  },
   { name: 'no-drupal-proxy', type: Boolean, defaultValue: false },
   { name: 'local-proxy-rewrite', type: Boolean, defaultValue: false },
   { name: 'local-css-sourcemaps', type: Boolean, defaultValue: false },


### PR DESCRIPTION
## Description
This PR adds a new build arg `drupal-max-parallel-requests` so that you can specify how many requests are allowed issued to the CMS at once. Previously it was just always 15 but that number is too for the CI env for the CMS.

## Testing done
`yarn build:content --pull-drupal` produces output `Beginning GraphQL queries with parallelization at 15 requests...`

`yarn build:content --pull-drupal --drupal-max-parallel-requests=10` produces output `Beginning GraphQL queries with parallelization at 10 requests...`

^ tells me the config worked correctly

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/109845994-b48c8000-7c1b-11eb-8981-03b4d1a23ff4.png)


## Acceptance criteria
- [ ] Num parallel reqs is configurable via build args/env variable

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
