### PR TITLE
added logic to pop modal after call

### DIFF
--- a/src/applications/static-pages/dependency-verification/actions/index.js
+++ b/src/applications/static-pages/dependency-verification/actions/index.js
@@ -1,1 +1,33 @@
-// Nothing in this file yet but there will be...
+export const DEPENDENCY_VERIFICATION_CALL_SUCCESS =
+  'DEPENDENCY_VERIFICATION_CALL_SUCCESS';
+export const DEPENDENCY_VERIFICATION_CALL_FAILED =
+  'DEPENDENCY_VERIFICATION_CALL_FAILED';
+
+const fakeAPICAller = () => {
+  return {
+    dependents: [
+      {
+        id: 1,
+        name: 'Bill Bradsky',
+        relationship: 'Spouse',
+      },
+    ],
+  };
+};
+
+export function dependencyVerificationCall() {
+  return async dispatch => {
+    const response = await fakeAPICAller();
+    if (response.errors) {
+      dispatch({
+        type: DEPENDENCY_VERIFICATION_CALL_FAILED,
+        response,
+      });
+    } else {
+      dispatch({
+        type: DEPENDENCY_VERIFICATION_CALL_SUCCESS,
+        response,
+      });
+    }
+  };
+}

--- a/src/applications/static-pages/dependency-verification/components/dependencyVerificationModal.jsx
+++ b/src/applications/static-pages/dependency-verification/components/dependencyVerificationModal.jsx
@@ -1,20 +1,30 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { connect } from 'react-redux';
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
+import { dependencyVerificationCall } from '../actions/index';
 import DependencyVerificationHeader from './dependencyVerificationHeader';
 import DependencyVerificationList from './dependencyVerificationList';
 import DependencyVerificationFooter from './dependencyVerificationFooter';
 
-const DependencyVerificationModal = () => {
+const DependencyVerificationModal = props => {
   const [isModalShowing, setIsModalShowing] = useState(false);
   const handleClick = e => {
     setIsModalShowing(prevState => !prevState);
     return e;
   };
+  useEffect(() => {
+    props.dependencyVerificationCall();
+  }, []);
+  useEffect(
+    () => {
+      if (props?.data?.verifiableDependents?.length > 0) {
+        setIsModalShowing(true);
+      }
+    },
+    [props.data],
+  );
   return (
     <>
-      <button className="va-button-link" onClick={e => handleClick(e)}>
-        Privacy Act Statement
-      </button>
       <Modal
         onClose={e => handleClick(e)}
         visible={isModalShowing}
@@ -32,4 +42,16 @@ const DependencyVerificationModal = () => {
   );
 };
 
-export default DependencyVerificationModal;
+const mapStateToProps = state => ({
+  data: state.verifyDependents,
+});
+
+const mapDispatchToProps = {
+  dependencyVerificationCall,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(DependencyVerificationModal);
+export { DependencyVerificationModal };

--- a/src/applications/static-pages/dependency-verification/reducers/index.js
+++ b/src/applications/static-pages/dependency-verification/reducers/index.js
@@ -1,1 +1,33 @@
-// nothing in this file either, but soon...
+import {
+  DEPENDENCY_VERIFICATION_CALL_SUCCESS,
+  DEPENDENCY_VERIFICATION_CALL_FAILED,
+} from '../actions';
+
+const initialState = {
+  loading: true, // app starts in loading state
+  error: null,
+  verifiableDependents: null,
+};
+
+function verifyDependents(state = initialState, action) {
+  switch (action.type) {
+    case DEPENDENCY_VERIFICATION_CALL_SUCCESS:
+      return {
+        ...state,
+        loading: false,
+        verifiableDependents: action.response.dependents,
+      };
+    case DEPENDENCY_VERIFICATION_CALL_FAILED:
+      return {
+        ...state,
+        loading: false,
+        error: {
+          code: action.response.errors[0].status,
+        },
+      };
+    default:
+      return state;
+  }
+}
+
+export default { verifyDependents };

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -73,6 +73,7 @@ import createThirdPartyApps, {
 import initTranslation from './translation';
 
 import createDependencyVerification from './dependency-verification/createDependencyVerification';
+import dependencyVerificationReducer from './dependency-verification/reducers/index';
 
 // Set the app name header when using the apiRequest helper
 window.appName = 'static-pages';
@@ -85,6 +86,7 @@ const store = createCommonStore({
   ...findVaFormsWidgetReducer,
   ...post911GIBillStatusReducer,
   ...thirdPartyAppsReducer,
+  ...dependencyVerificationReducer,
 });
 
 Sentry.withScope(scope => {


### PR DESCRIPTION
## Description
[Original Ticlet](https://github.com/department-of-veterans-affairs/va.gov-team/issues/20284)

Now that we have the dependency verification modal scaffolded we need to add logic to pop the modal based on an API call. This API call will most likely need to be changed once the BE is in place but this PR is just to get the basics down.

## Testing done
Unit tests will be included in a subsiquent ticket

## Acceptance criteria
- [x] The modal now shows based on a mock API call
- [x] A PR has been submitted

