### PR TITLE
Add feature flags to form 526 subforms

### DIFF
--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -20,7 +20,12 @@ import { MissingServices, MissingId } from './containers/MissingServices';
 import { MVI_ADD_SUCCEEDED } from './actions';
 import WizardContainer from './containers/WizardContainer';
 import { WIZARD_STATUS, PDF_SIZE_FEATURE } from './constants';
-import { show526Wizard, isBDD, getPageTitle } from './utils';
+import {
+  show526Wizard,
+  isBDD,
+  getPageTitle,
+  showSubform8940And4192,
+} from './utils';
 import { uploadPdfLimitFeature } from './config/selectors';
 
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
@@ -66,6 +71,7 @@ export const Form526Entry = ({
   children,
   mvi,
   showWizard,
+  showSubforms,
   isBDDForm,
   pdfLimit,
   router,
@@ -110,7 +116,10 @@ export const Form526Entry = ({
 
   // wraps the app and redirects user if they are not enrolled
   const content = (
-    <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
+    <RoutedSavableApp
+      formConfig={formConfig({ showSubforms })}
+      currentLocation={location}
+    >
       {children}
     </RoutedSavableApp>
   );
@@ -163,6 +172,7 @@ const mapStateToProps = state => ({
   user: state.user,
   mvi: state.mvi,
   showWizard: show526Wizard(state),
+  showSubforms: showSubform8940And4192(state),
   isBDDForm: isBDD(state?.form?.data),
   pdfLimit: uploadPdfLimitFeature(state),
   isStartingOver: state.form?.isStartingOver,

--- a/src/applications/disability-benefits/all-claims/config/4192/index.js
+++ b/src/applications/disability-benefits/all-claims/config/4192/index.js
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import environment from 'platform/utilities/environment';
 
 import {
   instructionalPart1,
@@ -27,78 +26,72 @@ const isUploading = formData =>
 
 // const isExiting = formData => _.get(formData, 'view:upload4192Choice.view:sendRequests', false);
 
-export default function() {
-  let configObj = {};
-  if (!environment.isProduction()) {
-    configObj = {
-      // Intro
-      pastEmploymentFormIntro: {
-        path: 'past-employment-walkthrough-choice',
-        depends: needsToEnterUnemployability,
-        uiSchema: pastEmploymentFormIntro.uiSchema,
-        schema: pastEmploymentFormIntro.schema,
-        onContinue: captureEvents.pastEmploymentFormIntro,
-      },
-      // Form Tutorial (multiple pages)
-      instructionalPart1: {
-        path: '4192-instructions-part-1',
-        depends: showFormTutorial,
-        uiSchema: instructionalPart1.uiSchema,
-        schema: instructionalPart1.schema,
-      },
-      instructionalPart2: {
-        path: '4192-instructions-part-2',
-        depends: showFormTutorial,
-        uiSchema: instructionalPart2.uiSchema,
-        schema: instructionalPart2.schema,
-      },
-      instructionalPart3: {
-        path: '4192-instructions-part-3',
-        depends: showFormTutorial,
-        uiSchema: instructionalPart3.uiSchema,
-        schema: instructionalPart3.schema,
-      },
-      // Download
-      pastEmploymentFormDownload: {
-        path: 'past-employment-download',
-        depends: isDownloading,
-        uiSchema: pastEmploymentFormDownload.uiSchema,
-        schema: pastEmploymentFormDownload.schema,
-      },
-      // Upload
-      pastEmploymentFormUpload: {
-        path: 'past-employment-form-upload',
-        depends: isUploading,
-        uiSchema: pastEmploymentFormUpload.uiSchema,
-        schema: pastEmploymentFormUpload.schema,
-      },
-      // ***Below page comments for when logic is added in***
-      // Conditional Options (Intro page again if A and not A && B && C)
-      // Form Tutorial (multiple pages)
-      // Download
-      // Upload
-      // Conditional Options (Intro page again if A and not A && B && C)
-      // Form Tutorial (multiple pages)
-      // Download
-      // Upload
-      // Conditional Options (Intro page again if A and not A && B && C)
-      // ***Above page comments for when logic is added in***
-      // Exit
-      conclusion4192: {
-        title: 'Conclusion 4192',
-        path: 'disabilities/conclusion-4192',
-        depends: needsToEnterUnemployability,
-        uiSchema: {
-          'ui:title': ' ',
-          'ui:description':
-            'Thank you for taking the time to answer our questions. The information you provided will help us process your claim.',
-        },
-        schema: {
-          type: 'object',
-          properties: {},
-        },
-      },
-    };
-  }
-  return configObj;
-}
+export default {
+  // Intro
+  pastEmploymentFormIntro: {
+    path: 'past-employment-walkthrough-choice',
+    depends: needsToEnterUnemployability,
+    uiSchema: pastEmploymentFormIntro.uiSchema,
+    schema: pastEmploymentFormIntro.schema,
+    onContinue: captureEvents.pastEmploymentFormIntro,
+  },
+  // Form Tutorial (multiple pages)
+  instructionalPart1: {
+    path: '4192-instructions-part-1',
+    depends: showFormTutorial,
+    uiSchema: instructionalPart1.uiSchema,
+    schema: instructionalPart1.schema,
+  },
+  instructionalPart2: {
+    path: '4192-instructions-part-2',
+    depends: showFormTutorial,
+    uiSchema: instructionalPart2.uiSchema,
+    schema: instructionalPart2.schema,
+  },
+  instructionalPart3: {
+    path: '4192-instructions-part-3',
+    depends: showFormTutorial,
+    uiSchema: instructionalPart3.uiSchema,
+    schema: instructionalPart3.schema,
+  },
+  // Download
+  pastEmploymentFormDownload: {
+    path: 'past-employment-download',
+    depends: isDownloading,
+    uiSchema: pastEmploymentFormDownload.uiSchema,
+    schema: pastEmploymentFormDownload.schema,
+  },
+  // Upload
+  pastEmploymentFormUpload: {
+    path: 'past-employment-form-upload',
+    depends: isUploading,
+    uiSchema: pastEmploymentFormUpload.uiSchema,
+    schema: pastEmploymentFormUpload.schema,
+  },
+  // ***Below page comments for when logic is added in***
+  // Conditional Options (Intro page again if A and not A && B && C)
+  // Form Tutorial (multiple pages)
+  // Download
+  // Upload
+  // Conditional Options (Intro page again if A and not A && B && C)
+  // Form Tutorial (multiple pages)
+  // Download
+  // Upload
+  // Conditional Options (Intro page again if A and not A && B && C)
+  // ***Above page comments for when logic is added in***
+  // Exit
+  conclusion4192: {
+    title: 'Conclusion 4192',
+    path: 'disabilities/conclusion-4192',
+    depends: needsToEnterUnemployability,
+    uiSchema: {
+      'ui:title': ' ',
+      'ui:description':
+        'Thank you for taking the time to answer our questions. The information you provided will help us process your claim.',
+    },
+    schema: {
+      type: 'object',
+      properties: {},
+    },
+  },
+};

--- a/src/applications/disability-benefits/all-claims/config/8940/index.js
+++ b/src/applications/disability-benefits/all-claims/config/8940/index.js
@@ -19,7 +19,6 @@ import {
   medicalCare,
   hospitalizationHistory,
 } from '../../pages';
-import environment from 'platform/utilities/environment';
 
 import {
   needsToEnterUnemployability,
@@ -32,168 +31,167 @@ import {
 
 import captureEvents from '../../analytics-functions';
 
-import createFormConfig4192 from '../4192';
+import formConfig4192 from '../4192';
 
-export default function() {
-  let configObj = {};
-  if (!environment.isProduction()) {
-    configObj = {
-      // 8940 - Introduction
-      unemployabilityFormIntro: {
-        title: 'File a claim for Individual Unemployability',
-        path: 'unemployability-walkthrough-choice',
-        depends: needsToEnterUnemployability,
-        uiSchema: unemployabilityFormIntro.uiSchema,
-        schema: unemployabilityFormIntro.schema,
-        onContinue: captureEvents.unemployabilityFormIntro,
-      },
-      // 8940 - Upload 8940
-      unemployabilityFormUpload: {
-        title: 'Upload unemployability form',
-        path: 'new-disabilities/unemployability-form-upload',
-        depends: isUploading8940Form,
-        uiSchema: unemployabilityFormUpload.uiSchema,
-        schema: unemployabilityFormUpload.schema,
-      },
-      // 8940 - Contentions
-      unemployabilityDisabilities: {
-        title: 'Unemployability disabilities',
-        path: 'unemployability-disabilities',
-        depends: needsToAnswerUnemployability,
-        uiSchema: unemployabilityDisabilities.uiSchema,
-        schema: unemployabilityDisabilities.schema,
-      },
-      // 8940 - Medical Care
-      medicalCare: {
-        title: 'Medical care',
-        path: 'medical-care',
-        depends: needsToAnswerUnemployability,
-        uiSchema: medicalCare.uiSchema,
-        schema: medicalCare.schema,
-      },
-      // 8940 - Hospital Treatment
-      hospitalizationHistory: {
-        title: 'Hospitalization',
-        path: 'hospitalization-history',
-        depends: hasHospitalCare,
-        uiSchema: hospitalizationHistory.uiSchema,
-        schema: hospitalizationHistory.schema,
-      },
-      // 8940 - Doctor Treatment
-      unemployabilityDoctorCare: {
-        title: 'Doctor’s care',
-        path: 'doctor-care',
-        depends: hasDoctorsCare,
-        uiSchema: unemployabilityDoctorCare.uiSchema,
-        schema: unemployabilityDoctorCare.schema,
-      },
-      // 8940 - Disability Dates
-      unemployabilityDates: {
-        title: 'Disability dates',
-        path: 'unemployability-disability-dates',
-        depends: needsToAnswerUnemployability,
-        uiSchema: unemployabilityDates.uiSchema,
-        schema: unemployabilityDates.schema,
-      },
-      // 8940 - Income Details
-      incomeDetails: {
-        title: 'Income details',
-        path: 'unemployability-income-details',
-        depends: needsToAnswerUnemployability,
-        uiSchema: incomeDetails.uiSchema,
-        schema: incomeDetails.schema,
-      },
-      // 8940 - Employment History
-      employmentHistory: {
-        title: 'Employment history',
-        path: 'unemployability-employment-history',
-        depends: needsToAnswerUnemployability,
-        uiSchema: employmentHistory.uiSchema,
-        schema: employmentHistory.schema,
-      },
-      // 8940 - Recent Earnings
-      recentEarnedIncome: {
-        title: 'Recent earnings',
-        path: 'recent-earnings',
-        depends: needsToAnswerUnemployability,
-        uiSchema: recentEarnedIncome.uiSchema,
-        schema: recentEarnedIncome.schema,
-      },
-      // 8940 - Supplementary Benefits
-      supplementalBenefits: {
-        title: 'Supplemental benefits',
-        path: 'supplemental-benefits',
-        depends: needsToAnswerUnemployability,
-        uiSchema: supplementalBenefits.uiSchema,
-        schema: supplementalBenefits.schema,
-      },
-      // 8940 - Military Duty
-      militaryDutyImpact: {
-        title: 'Impact on military duty',
-        path: 'military-duty-impact',
-        depends: needsToAnswerUnemployability,
-        uiSchema: militaryDutyImpact.uiSchema,
-        schema: militaryDutyImpact.schema,
-      },
-      // 8940 - Job Applications
-      recentJobApplications: {
-        title: 'Recent job applications',
-        path: 'recent-job-applications',
-        depends: needsToAnswerUnemployability,
-        uiSchema: recentJobApplications.uiSchema,
-        schema: recentJobApplications.schema,
-      },
-      // 8940 - Education & Training
-      pastEducationTraining: {
-        title: 'Education & training',
-        path: 'past-education-training',
-        depends: needsToAnswerUnemployability,
-        uiSchema: pastEducationTraining.uiSchema,
-        schema: pastEducationTraining.schema,
-      },
-      // 8940 - Recent Education & Training
-      recentEducationTraining: {
-        title: 'Recent education & training',
-        path: 'recent-education-training',
-        depends: needsToAnswerUnemployability,
-        uiSchema: recentEducationTraining.uiSchema,
-        schema: recentEducationTraining.schema,
-      },
-      // 8940 - Additional Remarks
-      unemployabilityAdditionalInformation: {
-        title: '8940 additional information',
-        path: 'unemployability-additional-information',
-        depends: needsToAnswerUnemployability,
-        uiSchema: unemployabilityAdditionalInformation.uiSchema,
-        schema: unemployabilityAdditionalInformation.schema,
-      },
-      // 8940 - Supporting Documents
-      // 8940 - Upload Supporting Docs
-      uploadUnemployabilitySupportingDocumentsChoice: {
-        title: 'Supporting documents',
-        path: 'upload-unemployability-supporting-documents-choice',
-        depends: needsToAnswerUnemployability,
-        uiSchema: uploadUnemployabilitySupportingDocumentsChoice.uiSchema,
-        schema: uploadUnemployabilitySupportingDocumentsChoice.schema,
-      },
-      uploadUnemployabilitySupportingDocuments: {
-        title: 'Upload supporting documents',
-        path: 'upload-unemployability-supporting-documents',
-        depends: formData => isUploadingSupporting8940Documents(formData),
-        uiSchema: uploadUnemployabilitySupportingDocuments.uiSchema,
-        schema: uploadUnemployabilitySupportingDocuments.schema,
-      },
-      // 8940 - Certification
-      unemployabilityCertification: {
-        title: 'Unemployability certification',
-        path: 'unemployability-certification',
-        depends: needsToAnswerUnemployability,
-        uiSchema: unemployabilityCertification.uiSchema,
-        schema: unemployabilityCertification.schema,
-      },
-      // 4192 -
-      ...createFormConfig4192(),
-    };
+export default (showSubforms = false) => {
+  if (!showSubforms) {
+    return {};
   }
-  return configObj;
-}
+  return {
+    // 8940 - Introduction
+    unemployabilityFormIntro: {
+      title: 'File a claim for Individual Unemployability',
+      path: 'unemployability-walkthrough-choice',
+      depends: needsToEnterUnemployability,
+      uiSchema: unemployabilityFormIntro.uiSchema,
+      schema: unemployabilityFormIntro.schema,
+      onContinue: captureEvents.unemployabilityFormIntro,
+    },
+    // 8940 - Upload 8940
+    unemployabilityFormUpload: {
+      title: 'Upload unemployability form',
+      path: 'new-disabilities/unemployability-form-upload',
+      depends: isUploading8940Form,
+      uiSchema: unemployabilityFormUpload.uiSchema,
+      schema: unemployabilityFormUpload.schema,
+    },
+    // 8940 - Contentions
+    unemployabilityDisabilities: {
+      title: 'Unemployability disabilities',
+      path: 'unemployability-disabilities',
+      depends: needsToAnswerUnemployability,
+      uiSchema: unemployabilityDisabilities.uiSchema,
+      schema: unemployabilityDisabilities.schema,
+    },
+    // 8940 - Medical Care
+    medicalCare: {
+      title: 'Medical care',
+      path: 'medical-care',
+      depends: needsToAnswerUnemployability,
+      uiSchema: medicalCare.uiSchema,
+      schema: medicalCare.schema,
+    },
+    // 8940 - Hospital Treatment
+    hospitalizationHistory: {
+      title: 'Hospitalization',
+      path: 'hospitalization-history',
+      depends: hasHospitalCare,
+      uiSchema: hospitalizationHistory.uiSchema,
+      schema: hospitalizationHistory.schema,
+    },
+    // 8940 - Doctor Treatment
+    unemployabilityDoctorCare: {
+      title: 'Doctor’s care',
+      path: 'doctor-care',
+      depends: hasDoctorsCare,
+      uiSchema: unemployabilityDoctorCare.uiSchema,
+      schema: unemployabilityDoctorCare.schema,
+    },
+    // 8940 - Disability Dates
+    unemployabilityDates: {
+      title: 'Disability dates',
+      path: 'unemployability-disability-dates',
+      depends: needsToAnswerUnemployability,
+      uiSchema: unemployabilityDates.uiSchema,
+      schema: unemployabilityDates.schema,
+    },
+    // 8940 - Income Details
+    incomeDetails: {
+      title: 'Income details',
+      path: 'unemployability-income-details',
+      depends: needsToAnswerUnemployability,
+      uiSchema: incomeDetails.uiSchema,
+      schema: incomeDetails.schema,
+    },
+    // 8940 - Employment History
+    employmentHistory: {
+      title: 'Employment history',
+      path: 'unemployability-employment-history',
+      depends: needsToAnswerUnemployability,
+      uiSchema: employmentHistory.uiSchema,
+      schema: employmentHistory.schema,
+    },
+    // 8940 - Recent Earnings
+    recentEarnedIncome: {
+      title: 'Recent earnings',
+      path: 'recent-earnings',
+      depends: needsToAnswerUnemployability,
+      uiSchema: recentEarnedIncome.uiSchema,
+      schema: recentEarnedIncome.schema,
+    },
+    // 8940 - Supplementary Benefits
+    supplementalBenefits: {
+      title: 'Supplemental benefits',
+      path: 'supplemental-benefits',
+      depends: needsToAnswerUnemployability,
+      uiSchema: supplementalBenefits.uiSchema,
+      schema: supplementalBenefits.schema,
+    },
+    // 8940 - Military Duty
+    militaryDutyImpact: {
+      title: 'Impact on military duty',
+      path: 'military-duty-impact',
+      depends: needsToAnswerUnemployability,
+      uiSchema: militaryDutyImpact.uiSchema,
+      schema: militaryDutyImpact.schema,
+    },
+    // 8940 - Job Applications
+    recentJobApplications: {
+      title: 'Recent job applications',
+      path: 'recent-job-applications',
+      depends: needsToAnswerUnemployability,
+      uiSchema: recentJobApplications.uiSchema,
+      schema: recentJobApplications.schema,
+    },
+    // 8940 - Education & Training
+    pastEducationTraining: {
+      title: 'Education & training',
+      path: 'past-education-training',
+      depends: needsToAnswerUnemployability,
+      uiSchema: pastEducationTraining.uiSchema,
+      schema: pastEducationTraining.schema,
+    },
+    // 8940 - Recent Education & Training
+    recentEducationTraining: {
+      title: 'Recent education & training',
+      path: 'recent-education-training',
+      depends: needsToAnswerUnemployability,
+      uiSchema: recentEducationTraining.uiSchema,
+      schema: recentEducationTraining.schema,
+    },
+    // 8940 - Additional Remarks
+    unemployabilityAdditionalInformation: {
+      title: '8940 additional information',
+      path: 'unemployability-additional-information',
+      depends: needsToAnswerUnemployability,
+      uiSchema: unemployabilityAdditionalInformation.uiSchema,
+      schema: unemployabilityAdditionalInformation.schema,
+    },
+    // 8940 - Supporting Documents
+    // 8940 - Upload Supporting Docs
+    uploadUnemployabilitySupportingDocumentsChoice: {
+      title: 'Supporting documents',
+      path: 'upload-unemployability-supporting-documents-choice',
+      depends: needsToAnswerUnemployability,
+      uiSchema: uploadUnemployabilitySupportingDocumentsChoice.uiSchema,
+      schema: uploadUnemployabilitySupportingDocumentsChoice.schema,
+    },
+    uploadUnemployabilitySupportingDocuments: {
+      title: 'Upload supporting documents',
+      path: 'upload-unemployability-supporting-documents',
+      depends: formData => isUploadingSupporting8940Documents(formData),
+      uiSchema: uploadUnemployabilitySupportingDocuments.uiSchema,
+      schema: uploadUnemployabilitySupportingDocuments.schema,
+    },
+    // 8940 - Certification
+    unemployabilityCertification: {
+      title: 'Unemployability certification',
+      path: 'unemployability-certification',
+      depends: needsToAnswerUnemployability,
+      uiSchema: unemployabilityCertification.uiSchema,
+      schema: unemployabilityCertification.schema,
+    },
+    // 4192 -
+    ...formConfig4192,
+  };
+};

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -128,7 +128,7 @@ import manifest from '../manifest.json';
 
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 
-const formConfig = {
+const formConfig = ({ showSubforms = false } = {}) => ({
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
   intentToFileUrl: '/evss_claims/intent_to_file/compensation',
@@ -540,7 +540,7 @@ const formConfig = {
           uiSchema: individualUnemployability.uiSchema,
           schema: individualUnemployability.schema,
         },
-        ...createformConfig8940(),
+        ...createformConfig8940(showSubforms),
         ancillaryFormsWizardSummary: {
           title: 'Summary of additional benefits',
           path: 'additional-disability-benefits-summary',
@@ -701,6 +701,6 @@ const formConfig = {
       },
     },
   },
-};
+});
 
 export default formConfig;

--- a/src/applications/disability-benefits/all-claims/reducers/index.js
+++ b/src/applications/disability-benefits/all-claims/reducers/index.js
@@ -5,7 +5,7 @@ import formConfig from '../config/form';
 import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
 
 export default {
-  form: createSaveInProgressFormReducer(formConfig),
+  form: createSaveInProgressFormReducer(formConfig()),
   itf,
   mvi,
 };

--- a/src/applications/disability-benefits/all-claims/routes.jsx
+++ b/src/applications/disability-benefits/all-claims/routes.jsx
@@ -8,7 +8,7 @@ const routes = [
     path: '/',
     component: Form526EZApp,
     indexRoute: { onEnter: (nextState, replace) => replace('/introduction') },
-    childRoutes: createRoutesWithSaveInProgress(formConfig),
+    childRoutes: createRoutesWithSaveInProgress(formConfig()),
   },
 ];
 

--- a/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
@@ -196,7 +196,7 @@ const testConfig = createTestConfig(
     // skip: [],
   },
   manifest,
-  formConfig,
+  formConfig(),
 );
 
 testForm(testConfig);

--- a/src/applications/disability-benefits/all-claims/tests/config/submitForm.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/config/submitForm.unit.spec.js
@@ -28,7 +28,7 @@ describe('Form 526 submit reject timer', () => {
       },
     };
 
-    return formConfig
+    return formConfig()
       .submit(form, blankFormConfig, { mode: 'testing' })
       .catch(error => {
         expect(error.message).to.eql('client_error: Request taking too long');

--- a/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
@@ -13,7 +13,7 @@ import {
 } from '../../constants';
 
 describe('<IntroductionPage/>', () => {
-  const { formId, prefillEnabled } = formConfig;
+  const { formId, prefillEnabled } = formConfig();
   const defaultProps = {
     formId,
     route: {

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/full-781-781a-8940-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/full-781-781a-8940-test.json
@@ -10,9 +10,6 @@
         "attachmentId": "L115"
       }
     ],
-    "view:claimType": {
-      "view:claimingNew": true
-    },
     "view:upload4192Choice": {
       "view:4192Info": true,
       "view:download4192": true,

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/upload-781-781a-8940-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/upload-781-781a-8940-test.json
@@ -13,9 +13,6 @@
     "view:upload4192Choice": {
       "view:upload4192": true
     },
-    "view:claimType": {
-      "view:claimingNew": true
-    },
     "view:noFdcWarning": {},
     "form8940Upload": [
       {

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/mocks/feature-toggles.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/mocks/feature-toggles.json
@@ -21,6 +21,10 @@
       {
         "name": "form526_confirmation_email_show_copy",
         "value": true
+      },
+      {
+        "name": "subform_8940_4192",
+        "value": true
       }
     ]
   }

--- a/src/applications/disability-benefits/all-claims/tests/migrations/migrations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/migrations/migrations.unit.spec.js
@@ -38,9 +38,9 @@ describe('526 v2 migrations', () => {
     });
     // Sanity check
     it('/claim-type should be a valid url', () => {
-      expect(formConfig.chapters.veteranDetails.pages.claimType.path).to.equal(
-        'claim-type',
-      );
+      expect(
+        formConfig().chapters.veteranDetails.pages.claimType.path,
+      ).to.equal('claim-type');
     });
   });
   describe('02-upgrade-separationPay', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/adaptiveBenefits.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/adaptiveBenefits.unit.spec.jsx
@@ -8,12 +8,13 @@ describe('526 adaptive benefits page', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.disabilities.pages.adaptiveBenefits;
+  } = formConfig().chapters.disabilities.pages.adaptiveBenefits;
+  const defaultDefinitions = formConfig().defaultDefinitions;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}
@@ -27,7 +28,7 @@ describe('526 adaptive benefits page', () => {
   it('should show the double vehicle allowance alert', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{

--- a/src/applications/disability-benefits/all-claims/tests/pages/addDisabilities.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/addDisabilities.unit.spec.jsx
@@ -12,12 +12,13 @@ describe('Add new disabilities', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.disabilities.pages.addDisabilities;
+  } = formConfig().chapters.disabilities.pages.addDisabilities;
+  const defaultDefinitions = formConfig().defaultDefinitions;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}
@@ -33,7 +34,7 @@ describe('Add new disabilities', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -63,7 +64,7 @@ describe('Add new disabilities', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -88,7 +89,7 @@ describe('Add new disabilities', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -115,7 +116,7 @@ describe('Add new disabilities', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{

--- a/src/applications/disability-benefits/all-claims/tests/pages/additionalBehaviorChanges.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/additionalBehaviorChanges.unit.spec.jsx
@@ -9,12 +9,13 @@ describe('Additional Changes 781a', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.disabilities.pages.additionalBehaviorChanges;
+  } = formConfig().chapters.disabilities.pages.additionalBehaviorChanges;
+  const defaultDefinitions = formConfig().defaultDefinitions;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}
@@ -31,7 +32,7 @@ describe('Additional Changes 781a', () => {
 
     const form = mount(
       <DefinitionTester
-        definitions={formConfig}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}

--- a/src/applications/disability-benefits/all-claims/tests/pages/additionalDocuments.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/additionalDocuments.unit.spec.jsx
@@ -30,8 +30,10 @@ const validDocumentData = {
 };
 
 describe('526EZ document upload', () => {
-  const page = formConfig.chapters.supportingEvidence.pages.additionalDocuments;
+  const page = formConfig().chapters.supportingEvidence.pages
+    .additionalDocuments;
   const { schema, uiSchema, arrayPath } = page;
+  const defaultDefinitions = formConfig().defaultDefinitions;
 
   it('should render', () => {
     const form = mount(
@@ -39,7 +41,7 @@ describe('526EZ document upload', () => {
         <DefinitionTester
           arrayPath={arrayPath}
           pagePerItemIndex={0}
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{}}
           uiSchema={uiSchema}
@@ -59,7 +61,7 @@ describe('526EZ document upload', () => {
           arrayPath={arrayPath}
           pagePerItemIndex={0}
           onSubmit={onSubmit}
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{}}
           uiSchema={uiSchema}
@@ -82,7 +84,7 @@ describe('526EZ document upload', () => {
           arrayPath={arrayPath}
           onSubmit={onSubmit}
           pagePerItemIndex={0}
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={invalidDocumentData}
           uiSchema={uiSchema}
@@ -105,7 +107,7 @@ describe('526EZ document upload', () => {
           arrayPath={arrayPath}
           onSubmit={onSubmit}
           pagePerItemIndex={0}
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={validDocumentData}
           uiSchema={uiSchema}

--- a/src/applications/disability-benefits/all-claims/tests/pages/additionalRemarks781.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/additionalRemarks781.unit.spec.jsx
@@ -9,12 +9,13 @@ describe('Additional Remarks 781', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.disabilities.pages.additionalRemarks781;
+  } = formConfig().chapters.disabilities.pages.additionalRemarks781;
+  const defaultDefinitions = formConfig().defaultDefinitions;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}
@@ -31,7 +32,7 @@ describe('Additional Remarks 781', () => {
 
     const form = mount(
       <DefinitionTester
-        definitions={formConfig}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}

--- a/src/applications/disability-benefits/all-claims/tests/pages/aidAndAttendance.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/aidAndAttendance.unit.spec.jsx
@@ -8,12 +8,12 @@ describe('526 aid and attendance page', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.disabilities.pages.aidAndAttendance;
+  } = formConfig().chapters.disabilities.pages.aidAndAttendance;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={formConfig().defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}

--- a/src/applications/disability-benefits/all-claims/tests/pages/choosePtsdType.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/choosePtsdType.unit.spec.jsx
@@ -15,7 +15,8 @@ describe('Disability benefits 718 PTSD type', () => {
     schema,
     uiSchema,
     arrayPath,
-  } = formConfig.chapters.disabilities.pages.choosePtsdType;
+  } = formConfig().chapters.disabilities.pages.choosePtsdType;
+  const defaultDefinitions = formConfig().defaultDefinitions;
 
   it('renders ptsd type form', () => {
     const onSubmit = sinon.spy();
@@ -24,7 +25,7 @@ describe('Disability benefits 718 PTSD type', () => {
         arrayPath={arrayPath}
         pagePerItemIndex={0}
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={{
           newDisabilities: [
@@ -49,7 +50,7 @@ describe('Disability benefits 718 PTSD type', () => {
         arrayPath={arrayPath}
         pagePerItemIndex={0}
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={{
           newDisabilities: [
@@ -97,7 +98,7 @@ describe('Disability benefits 718 PTSD type', () => {
         arrayPath={arrayPath}
         pagePerItemIndex={0}
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={{
           newDisabilities: [

--- a/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
@@ -42,13 +42,14 @@ describe('Disability benefits 526EZ contact information', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.additionalInformation.pages.contactInformation;
+  } = formConfig().chapters.additionalInformation.pages.contactInformation;
+  const defaultDefinitions = formConfig().defaultDefinitions;
 
   it('renders contact information form', () => {
     const form = mount(
       <Provider store={fakeStore}>
         <DefinitionTester
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{
             mailingAddress: {},
@@ -71,7 +72,7 @@ describe('Disability benefits 526EZ contact information', () => {
     const form = mount(
       <Provider store={fakeStore}>
         <DefinitionTester
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{
             mailingAddress: {
@@ -96,7 +97,7 @@ describe('Disability benefits 526EZ contact information', () => {
     const form = mount(
       <Provider store={fakeStore}>
         <DefinitionTester
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{
             mailingAddress: {
@@ -121,7 +122,7 @@ describe('Disability benefits 526EZ contact information', () => {
     const form = mount(
       <Provider store={fakeStore}>
         <DefinitionTester
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{
             mailingAddress: {
@@ -150,7 +151,7 @@ describe('Disability benefits 526EZ contact information', () => {
     const form = mount(
       <Provider store={fakeStore}>
         <DefinitionTester
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{
             mailingAddress: {
@@ -178,7 +179,7 @@ describe('Disability benefits 526EZ contact information', () => {
     const form = mount(
       <Provider store={fakeStore}>
         <DefinitionTester
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{
             phoneAndEmail: {
@@ -211,7 +212,7 @@ describe('Disability benefits 526EZ contact information', () => {
     const form = mount(
       <Provider store={fakeStore}>
         <DefinitionTester
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{
             phoneAndEmail: {
@@ -243,7 +244,7 @@ describe('Disability benefits 526EZ contact information', () => {
     const form = mount(
       <Provider store={fakeStore}>
         <DefinitionTester
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{
             mailingAddress: {
@@ -271,7 +272,7 @@ describe('Disability benefits 526EZ contact information', () => {
   // it('expands forwarding address fields when forwarding address checked', () => {
   //   const form = mount(
   //     <DefinitionTester
-  //       definitions={formConfig.defaultDefinitions}
+  //       definitions={defaultDefinitions}
   //       schema={schema}
   //       data={{
   //         'view:hasForwardingAddress': true,
@@ -301,7 +302,7 @@ describe('Disability benefits 526EZ contact information', () => {
   //   const onSubmit = sinon.spy();
   //   const form = mount(
   //     <DefinitionTester
-  //       definitions={formConfig.defaultDefinitions}
+  //       definitions={defaultDefinitions}
   //       schema={schema}
   //       data={{
   //         phoneAndEmail: {
@@ -343,7 +344,7 @@ describe('Disability benefits 526EZ contact information', () => {
   //   const onSubmit = sinon.spy();
   //   const form = mount(
   //     <DefinitionTester
-  //       definitions={formConfig.defaultDefinitions}
+  //       definitions={defaultDefinitions}
   //       schema={schema}
   //       data={{
   //         phoneAndEmail: {
@@ -385,7 +386,7 @@ describe('Disability benefits 526EZ contact information', () => {
   //   const onSubmit = sinon.spy();
   //   const form = mount(
   //     <DefinitionTester
-  //       definitions={formConfig.defaultDefinitions}
+  //       definitions={defaultDefinitions}
   //       schema={schema}
   //       data={{
   //         phoneAndEmail: {
@@ -427,7 +428,7 @@ describe('Disability benefits 526EZ contact information', () => {
   //   const onSubmit = sinon.spy();
   //   const form = mount(
   //     <DefinitionTester
-  //       definitions={formConfig.defaultDefinitions}
+  //       definitions={defaultDefinitions}
   //       schema={schema}
   //       data={{
   //         phoneAndEmail: {
@@ -471,7 +472,7 @@ describe('Disability benefits 526EZ contact information', () => {
     const form = mount(
       <Provider store={fakeStore}>
         <DefinitionTester
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{
             phoneAndEmail: {
@@ -511,7 +512,7 @@ describe('Disability benefits 526EZ contact information', () => {
     const form = mount(
       <Provider store={fakeStore}>
         <DefinitionTester
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{
             phoneAndEmail: {
@@ -561,7 +562,7 @@ describe('Disability benefits 526EZ contact information', () => {
       mount(
         <Provider store={togglesStore}>
           <DefinitionTester
-            definitions={formConfig.defaultDefinitions}
+            definitions={defaultDefinitions}
             schema={schema}
             data={{
               mailingAddress: {},

--- a/src/applications/disability-benefits/all-claims/tests/pages/evidenceTypes.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/evidenceTypes.unit.spec.jsx
@@ -9,12 +9,13 @@ describe('evidenceTypes', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.supportingEvidence.pages.evidenceTypes;
+  } = formConfig().chapters.supportingEvidence.pages.evidenceTypes;
+  const defaultDefinitions = formConfig().defaultDefinitions;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}
@@ -30,7 +31,7 @@ describe('evidenceTypes', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -51,7 +52,7 @@ describe('evidenceTypes', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -72,7 +73,7 @@ describe('evidenceTypes', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{

--- a/src/applications/disability-benefits/all-claims/tests/pages/evidenceTypesBDD.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/evidenceTypesBDD.unit.spec.jsx
@@ -9,12 +9,13 @@ describe('evidenceTypes', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.supportingEvidence.pages.evidenceTypes;
+  } = formConfig().chapters.supportingEvidence.pages.evidenceTypes;
+  const defaultDefinitions = formConfig().defaultDefinitions;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}
@@ -30,7 +31,7 @@ describe('evidenceTypes', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -51,7 +52,7 @@ describe('evidenceTypes', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -72,7 +73,7 @@ describe('evidenceTypes', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{

--- a/src/applications/disability-benefits/all-claims/tests/pages/federalOrders.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/federalOrders.unit.spec.jsx
@@ -14,12 +14,13 @@ describe('Federal orders info', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.veteranDetails.pages.federalOrders;
+  } = formConfig().chapters.veteranDetails.pages.federalOrders;
+  const defaultDefinitions = formConfig().defaultDefinitions;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}
@@ -34,7 +35,7 @@ describe('Federal orders info', () => {
   it('should render activation fields', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}
@@ -57,7 +58,7 @@ describe('Federal orders info', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}
@@ -76,7 +77,7 @@ describe('Federal orders info', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}

--- a/src/applications/disability-benefits/all-claims/tests/pages/finalIncident.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/finalIncident.unit.spec.jsx
@@ -11,7 +11,8 @@ import {
 import formConfig from '../../config/form';
 
 describe('781 last incident details', () => {
-  const page = formConfig.chapters.disabilities.pages.finalIncident;
+  const page = formConfig().chapters.disabilities.pages.finalIncident;
+  const defaultDefinitions = formConfig().defaultDefinitions;
   const { schema, uiSchema, arrayPath } = page;
 
   it('should render', () => {
@@ -19,7 +20,7 @@ describe('781 last incident details', () => {
       <DefinitionTester
         arrayPath={arrayPath}
         pagePerItemIndex={0}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={{
           'view:selectablePtsdTypes': {
@@ -37,7 +38,7 @@ describe('781 last incident details', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -60,7 +61,7 @@ describe('781 last incident details', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{

--- a/src/applications/disability-benefits/all-claims/tests/pages/fullyDevelopedClaim.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/fullyDevelopedClaim.unit.spec.jsx
@@ -10,11 +10,13 @@ describe('Fully Developed Claim', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.additionalInformation.pages.fullyDevelopedClaim;
+  } = formConfig().chapters.additionalInformation.pages.fullyDevelopedClaim;
+  const defaultDefinitions = formConfig().defaultDefinitions;
+
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         uiSchema={uiSchema}
         schema={schema}
         data={{}}
@@ -31,7 +33,7 @@ describe('Fully Developed Claim', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         uiSchema={uiSchema}
         schema={schema}
         data={{}}

--- a/src/applications/disability-benefits/all-claims/tests/pages/homelessOrAtRisk.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/homelessOrAtRisk.unit.spec.jsx
@@ -16,12 +16,13 @@ describe('Homeless or At Risk Info', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.additionalInformation.pages.homelessOrAtRisk;
+  } = formConfig().chapters.additionalInformation.pages.homelessOrAtRisk;
+  const defaultDefinitions = formConfig().defaultDefinitions;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}
@@ -38,7 +39,7 @@ describe('Homeless or At Risk Info', () => {
 
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -60,7 +61,7 @@ describe('Homeless or At Risk Info', () => {
 
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -82,7 +83,7 @@ describe('Homeless or At Risk Info', () => {
 
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -104,7 +105,7 @@ describe('Homeless or At Risk Info', () => {
 
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -134,7 +135,7 @@ describe('Homeless or At Risk Info', () => {
 
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -164,7 +165,7 @@ describe('Homeless or At Risk Info', () => {
 
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{

--- a/src/applications/disability-benefits/all-claims/tests/pages/hospitalizationHistory.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/hospitalizationHistory.unit.spec.jsx
@@ -11,18 +11,18 @@ import formConfig from '../../config/form.js';
 import initialData from '../initialData.js';
 
 describe('Hospitalization Interview Questions', () => {
-  const {
-    schema,
-    uiSchema,
-    arrayPath,
-  } = formConfig.chapters.disabilities.pages.hospitalizationHistory;
+  const opts = { showSubforms: true };
+  const { schema, uiSchema, arrayPath } = formConfig(
+    opts,
+  ).chapters.disabilities.pages.hospitalizationHistory;
+  const defaultDefinitions = formConfig(opts).defaultDefinitions;
 
   it('should render hospital info form', () => {
     const form = mount(
       <DefinitionTester
         arrayPath={arrayPath}
         pagePerItemIndex={0}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={initialData}
         uiSchema={uiSchema}
@@ -41,7 +41,7 @@ describe('Hospitalization Interview Questions', () => {
         arrayPath={arrayPath}
         pagePerItemIndex={0}
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={initialData}
         formData={initialData}

--- a/src/applications/disability-benefits/all-claims/tests/pages/incidentDate.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/incidentDate.unit.spec.jsx
@@ -10,7 +10,8 @@ import {
 import formConfig from '../../config/form';
 
 describe('781 Incident Date', () => {
-  const page = formConfig.chapters.disabilities.pages.incidentDate0;
+  const page = formConfig().chapters.disabilities.pages.incidentDate0;
+  const defaultDefinitions = formConfig().defaultDefinitions;
   const { schema, uiSchema, arrayPath } = page;
 
   it('should render', () => {
@@ -18,7 +19,7 @@ describe('781 Incident Date', () => {
       <DefinitionTester
         arrayPath={arrayPath}
         pagePerItemIndex={0}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={{}}
         uiSchema={uiSchema}
@@ -36,7 +37,7 @@ describe('781 Incident Date', () => {
         arrayPath={arrayPath}
         pagePerItemIndex={0}
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,
@@ -56,7 +57,7 @@ describe('781 Incident Date', () => {
         arrayPath={arrayPath}
         pagePerItemIndex={0}
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,
@@ -76,7 +77,7 @@ describe('781 Incident Date', () => {
         arrayPath={arrayPath}
         pagePerItemIndex={0}
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         formData={{}}
         uiSchema={uiSchema}

--- a/src/applications/disability-benefits/all-claims/tests/pages/incidentLocation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/incidentLocation.unit.spec.jsx
@@ -12,7 +12,8 @@ import {
 import formConfig from '../../config/form';
 
 describe('PTSD Incident location', () => {
-  const page = formConfig.chapters.disabilities.pages.incidentLocation0;
+  const page = formConfig().chapters.disabilities.pages.incidentLocation0;
+  const defaultDefinitions = formConfig().defaultDefinitions;
   const { schema, uiSchema } = page;
 
   it('should render', () => {
@@ -20,7 +21,7 @@ describe('PTSD Incident location', () => {
       <DefinitionTester
         schema={schema}
         uiSchema={uiSchema}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
       />,
     );
 
@@ -35,7 +36,7 @@ describe('PTSD Incident location', () => {
         onSubmit={onSubmit}
         schema={schema}
         uiSchema={uiSchema}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
       />,
     );
     fillData(form, 'select#root_incident0_incidentLocation_country', 'USA');
@@ -60,7 +61,7 @@ describe('PTSD Incident location', () => {
         schema={schema}
         uiSchema={uiSchema}
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
       />,
     );
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/incidentSupport.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/incidentSupport.unit.spec.jsx
@@ -8,7 +8,7 @@ import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 
 describe('781 / 781a Incident Support page', () => {
-  const page = formConfig.chapters.disabilities.pages.incidentSupport0;
+  const page = formConfig().chapters.disabilities.pages.incidentSupport0;
   const { schema, uiSchema } = page;
 
   it('should submit without validation errors', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/incidentUnitAssignment.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/incidentUnitAssignment.unit.spec.jsx
@@ -13,13 +13,14 @@ import {
 import formConfig from '../../config/form';
 
 describe('781 Unit Assignment Details', () => {
-  const page = formConfig.chapters.disabilities.pages.incidentUnitAssignment0;
+  const page = formConfig().chapters.disabilities.pages.incidentUnitAssignment0;
+  const defaultDefinitions = formConfig().defaultDefinitions;
   const { schema, uiSchema } = page;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,
@@ -33,7 +34,7 @@ describe('781 Unit Assignment Details', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         onSubmit={onSubmit}
         schema={schema}
         uiSchema={uiSchema}
@@ -54,7 +55,7 @@ describe('781 Unit Assignment Details', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         onSubmit={onSubmit}
         schema={schema}
         uiSchema={uiSchema}

--- a/src/applications/disability-benefits/all-claims/tests/pages/incomeDetails.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/incomeDetails.unit.spec.jsx
@@ -11,18 +11,18 @@ import formConfig from '../../config/form.js';
 import initialData from '../initialData.js';
 
 describe('Income Details Questions', () => {
-  const {
-    schema,
-    uiSchema,
-    arrayPath,
-  } = formConfig.chapters.disabilities.pages.incomeDetails;
+  const opts = { showSubforms: true };
+  const { schema, uiSchema, arrayPath } = formConfig(
+    opts,
+  ).chapters.disabilities.pages.incomeDetails;
+  const defaultDefinitions = formConfig(opts).defaultDefinitions;
 
   it('should render income details form', () => {
     const form = mount(
       <DefinitionTester
         arrayPath={arrayPath}
         pagePerItemIndex={0}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={initialData}
         uiSchema={uiSchema}
@@ -41,7 +41,7 @@ describe('Income Details Questions', () => {
       <DefinitionTester
         arrayPath={arrayPath}
         pagePerItemIndex={0}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={initialData}
         uiSchema={uiSchema}
@@ -64,7 +64,7 @@ describe('Income Details Questions', () => {
       <DefinitionTester
         arrayPath={arrayPath}
         pagePerItemIndex={0}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={initialData}
         uiSchema={uiSchema}
@@ -86,7 +86,7 @@ describe('Income Details Questions', () => {
       <DefinitionTester
         arrayPath={arrayPath}
         pagePerItemIndex={0}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={initialData}
         uiSchema={uiSchema}

--- a/src/applications/disability-benefits/all-claims/tests/pages/individualUnemployability.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/individualUnemployability.unit.spec.jsx
@@ -8,12 +8,12 @@ describe('526 individual unemployability page', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.disabilities.pages.individualUnemployability;
+  } = formConfig().chapters.disabilities.pages.individualUnemployability;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={formConfig().defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}

--- a/src/applications/disability-benefits/all-claims/tests/pages/individualsInvolved.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/individualsInvolved.unit.spec.jsx
@@ -11,7 +11,8 @@ import {
 import formConfig from '../../config/form';
 
 describe('781 individuals involved yes/no', () => {
-  const page = formConfig.chapters.disabilities.pages.individualsInvolved0;
+  const page = formConfig().chapters.disabilities.pages.individualsInvolved0;
+  const defaultDefinitions = formConfig().defaultDefinitions;
   const { schema, uiSchema, arrayPath } = page;
 
   it('should render', () => {
@@ -19,7 +20,7 @@ describe('781 individuals involved yes/no', () => {
       <DefinitionTester
         arrayPath={arrayPath}
         pagePerItemIndex={0}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={{
           'view:selectablePtsdTypes': {
@@ -37,7 +38,7 @@ describe('781 individuals involved yes/no', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -60,7 +61,7 @@ describe('781 individuals involved yes/no', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{

--- a/src/applications/disability-benefits/all-claims/tests/pages/individualsInvolvedFollowUp.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/individualsInvolvedFollowUp.unit.spec.jsx
@@ -13,8 +13,9 @@ import {
 import formConfig from '../../config/form';
 
 describe('781 individuals involved', () => {
-  const page =
-    formConfig.chapters.disabilities.pages.individualsInvolvedFollowUp0;
+  const page = formConfig().chapters.disabilities.pages
+    .individualsInvolvedFollowUp0;
+  const defaultDefinitions = formConfig().defaultDefinitions;
   const { schema, uiSchema, arrayPath } = page;
 
   it('should render', () => {
@@ -22,7 +23,7 @@ describe('781 individuals involved', () => {
       <DefinitionTester
         arrayPath={arrayPath}
         pagePerItemIndex={0}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={{
           'view:selectablePtsdTypes': {
@@ -42,7 +43,7 @@ describe('781 individuals involved', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -65,7 +66,7 @@ describe('781 individuals involved', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{

--- a/src/applications/disability-benefits/all-claims/tests/pages/medals.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/medals.unit.spec.jsx
@@ -10,7 +10,8 @@ import {
 import formConfig from '../../config/form';
 
 describe('781 medals', () => {
-  const page = formConfig.chapters.disabilities.pages.medals0;
+  const page = formConfig().chapters.disabilities.pages.medals0;
+  const defaultDefinitions = formConfig().defaultDefinitions;
   const { schema, uiSchema, arrayPath } = page;
 
   it('should render', () => {
@@ -18,7 +19,7 @@ describe('781 medals', () => {
       <DefinitionTester
         arrayPath={arrayPath}
         pagePerItemIndex={0}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={{}}
         uiSchema={uiSchema}
@@ -35,7 +36,7 @@ describe('781 medals', () => {
         arrayPath={arrayPath}
         pagePerItemIndex={0}
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,
@@ -56,7 +57,7 @@ describe('781 medals', () => {
         arrayPath={arrayPath}
         pagePerItemIndex={0}
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         formData={{}}
         uiSchema={uiSchema}

--- a/src/applications/disability-benefits/all-claims/tests/pages/mentalHealthChanges.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/mentalHealthChanges.unit.spec.jsx
@@ -9,12 +9,13 @@ describe('Mental Changes 781a', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.disabilities.pages.mentalHealthChanges;
+  } = formConfig().chapters.disabilities.pages.mentalHealthChanges;
+  const defaultDefinitions = formConfig().defaultDefinitions;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -36,7 +37,7 @@ describe('Mental Changes 781a', () => {
 
     const form = mount(
       <DefinitionTester
-        definitions={formConfig}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{

--- a/src/applications/disability-benefits/all-claims/tests/pages/militaryDutyImpact.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/militaryDutyImpact.unit.spec.jsx
@@ -11,13 +11,15 @@ import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 
 describe('Recent Job Applications', () => {
-  const page = formConfig.chapters.disabilities.pages.militaryDutyImpact;
+  const opts = { showSubforms: true };
+  const page = formConfig(opts).chapters.disabilities.pages.militaryDutyImpact;
+  const defaultDefinitions = formConfig(opts).defaultDefinitions;
   const { schema, uiSchema } = page;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,
@@ -32,7 +34,7 @@ describe('Recent Job Applications', () => {
     const form = mount(
       <DefinitionTester
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,
@@ -56,7 +58,7 @@ describe('Recent Job Applications', () => {
     const form = mount(
       <DefinitionTester
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,

--- a/src/applications/disability-benefits/all-claims/tests/pages/militaryHistory.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/militaryHistory.unit.spec.jsx
@@ -13,7 +13,8 @@ describe('Military history', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.veteranDetails.pages.militaryHistory;
+  } = formConfig().chapters.veteranDetails.pages.militaryHistory;
+  const defaultDefinitions = formConfig().defaultDefinitions;
 
   const appStateData = {
     dob: '1990-01-01',
@@ -23,7 +24,7 @@ describe('Military history', () => {
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}
@@ -41,7 +42,7 @@ describe('Military history', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}
@@ -61,7 +62,7 @@ describe('Military history', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}
@@ -105,7 +106,7 @@ describe('Military history', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}
@@ -146,7 +147,7 @@ describe('Military history', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}

--- a/src/applications/disability-benefits/all-claims/tests/pages/newDisabilitiesFollowUp.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/newDisabilitiesFollowUp.unit.spec.jsx
@@ -18,12 +18,13 @@ describe('New disabilities follow up info', () => {
     schema,
     uiSchema,
     arrayPath,
-  } = formConfig.chapters.disabilities.pages.newDisabilityFollowUp;
+  } = formConfig().chapters.disabilities.pages.newDisabilityFollowUp;
+  const defaultDefinitions = formConfig().defaultDefinitions;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         arrayPath={arrayPath}
         pagePerItemIndex={0}
         schema={schema}
@@ -51,7 +52,7 @@ describe('New disabilities follow up info', () => {
   it('should render NEW disability follow up questions', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         arrayPath={arrayPath}
         pagePerItemIndex={0}
         schema={schema}
@@ -82,7 +83,7 @@ describe('New disabilities follow up info', () => {
   it('should render SECONDARY disability follow up questions', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         arrayPath={arrayPath}
         pagePerItemIndex={0}
         schema={schema}
@@ -114,7 +115,7 @@ describe('New disabilities follow up info', () => {
   it('should render WORSENED disability followup questions', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         arrayPath={arrayPath}
         pagePerItemIndex={0}
         schema={schema}
@@ -145,7 +146,7 @@ describe('New disabilities follow up info', () => {
   it('should render VA mistreatment disability followup questions', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         arrayPath={arrayPath}
         pagePerItemIndex={0}
         schema={schema}
@@ -177,7 +178,7 @@ describe('New disabilities follow up info', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         arrayPath={arrayPath}
         pagePerItemIndex={0}
         schema={schema}
@@ -204,7 +205,7 @@ describe('New disabilities follow up info', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         arrayPath={arrayPath}
         pagePerItemIndex={0}
         schema={schema}
@@ -234,7 +235,7 @@ describe('New disabilities follow up info', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         arrayPath={arrayPath}
         pagePerItemIndex={0}
         schema={schema}
@@ -264,7 +265,7 @@ describe('New disabilities follow up info', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         arrayPath={arrayPath}
         pagePerItemIndex={0}
         schema={schema}
@@ -303,7 +304,7 @@ describe('New disabilities follow up info', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         arrayPath={arrayPath}
         pagePerItemIndex={0}
         schema={schema}
@@ -343,7 +344,7 @@ describe('New disabilities follow up info', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         arrayPath={arrayPath}
         pagePerItemIndex={0}
         schema={schema}

--- a/src/applications/disability-benefits/all-claims/tests/pages/pastEducationTraining.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/pastEducationTraining.unit.spec.jsx
@@ -13,13 +13,16 @@ import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 
 describe('Recent Job Applications', () => {
-  const page = formConfig.chapters.disabilities.pages.pastEducationTraining;
+  const opts = { showSubforms: true };
+  const page = formConfig(opts).chapters.disabilities.pages
+    .pastEducationTraining;
+  const defaultDefinitions = formConfig(opts).defaultDefinitions;
   const { schema, uiSchema } = page;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,
@@ -36,7 +39,7 @@ describe('Recent Job Applications', () => {
     const form = mount(
       <DefinitionTester
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,
@@ -87,7 +90,7 @@ describe('Recent Job Applications', () => {
     const form = mount(
       <DefinitionTester
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,

--- a/src/applications/disability-benefits/all-claims/tests/pages/pastEmploymentFormDownload.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/pastEmploymentFormDownload.unit.spec.jsx
@@ -7,11 +7,10 @@ import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('Disability benefits 4192 Download', () => {
-  const {
-    schema,
-    uiSchema,
-    arrayPath,
-  } = formConfig.chapters.disabilities.pages.pastEmploymentFormDownload;
+  const opts = { showSubforms: true };
+  const { schema, uiSchema, arrayPath } = formConfig(
+    opts,
+  ).chapters.disabilities.pages.pastEmploymentFormDownload;
 
   it('renders 4192 form download', () => {
     const onSubmit = sinon.spy();
@@ -20,7 +19,7 @@ describe('Disability benefits 4192 Download', () => {
         arrayPath={arrayPath}
         pagePerItemIndex={0}
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={formConfig(opts).defaultDefinitions}
         schema={schema}
         data={{}}
         formData={{}}

--- a/src/applications/disability-benefits/all-claims/tests/pages/pastEmploymentFormIntro.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/pastEmploymentFormIntro.unit.spec.jsx
@@ -8,11 +8,11 @@ import formConfig from '../../config/form.js';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 
 describe('Disability benefits 4192', () => {
-  const {
-    schema,
-    uiSchema,
-    arrayPath,
-  } = formConfig.chapters.disabilities.pages.pastEmploymentFormIntro;
+  const opts = { showSubforms: true };
+  const { schema, uiSchema, arrayPath } = formConfig(
+    opts,
+  ).chapters.disabilities.pages.pastEmploymentFormIntro;
+  const defaultDefinitions = formConfig(opts).defaultDefinitions;
 
   it('renders 4192 form intro choices', () => {
     const onSubmit = sinon.spy();
@@ -21,7 +21,7 @@ describe('Disability benefits 4192', () => {
         arrayPath={arrayPath}
         pagePerItemIndex={0}
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={{}}
         formData={{}}
@@ -39,7 +39,7 @@ describe('Disability benefits 4192', () => {
         arrayPath={arrayPath}
         pagePerItemIndex={0}
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={{}}
         formData={{}}

--- a/src/applications/disability-benefits/all-claims/tests/pages/pastEmploymentFormUpload.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/pastEmploymentFormUpload.unit.spec.jsx
@@ -12,7 +12,10 @@ import formConfig from '../../config/form.js';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 
 describe('4192 form upload', () => {
-  const page = formConfig.chapters.disabilities.pages.pastEmploymentFormUpload;
+  const opts = { showSubforms: true };
+  const page = formConfig(opts).chapters.disabilities.pages
+    .pastEmploymentFormUpload;
+  const defaultDefinitions = formConfig(opts).defaultDefinitions;
   const { schema, uiSchema, arrayPath } = page;
 
   it('should render', () => {
@@ -21,7 +24,7 @@ describe('4192 form upload', () => {
         <DefinitionTester
           arrayPath={arrayPath}
           pagePerItemIndex={0}
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{
             'view:unemployabilityUploadChoice': 'answerQuestions',
@@ -44,7 +47,7 @@ describe('4192 form upload', () => {
           arrayPath={arrayPath}
           pagePerItemIndex={0}
           onSubmit={onSubmit}
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{
             'view:uploadUnemployabilitySupportingDocumentsChoice': true,
@@ -68,7 +71,7 @@ describe('4192 form upload', () => {
           arrayPath={arrayPath}
           pagePerItemIndex={0}
           onSubmit={onSubmit}
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{
             form4192Upload: [

--- a/src/applications/disability-benefits/all-claims/tests/pages/paymentInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/paymentInformation.unit.spec.jsx
@@ -11,13 +11,14 @@ import formConfig from '../../config/form.js';
 const {
   schema,
   uiSchema,
-} = formConfig.chapters.additionalInformation.pages.paymentInformation;
+} = formConfig().chapters.additionalInformation.pages.paymentInformation;
+const defaultDefinitions = formConfig().defaultDefinitions;
 
 describe('526 -- paymentInformation', () => {
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         formData={{}}
         uiSchema={uiSchema}
@@ -40,7 +41,7 @@ describe('526 -- paymentInformation', () => {
       // The page's PaymentView is connected to the redux store
       <Provider store={fakeStore}>
         <DefinitionTester
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{
             'view:bankAccount': {
@@ -67,7 +68,7 @@ describe('526 -- paymentInformation', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={{
           'view:bankAccount': {
@@ -90,7 +91,7 @@ describe('526 -- paymentInformation', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={{}}
         formData={{}}

--- a/src/applications/disability-benefits/all-claims/tests/pages/physicalHealthChanges.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/physicalHealthChanges.unit.spec.jsx
@@ -9,12 +9,13 @@ describe('Physical Changes 781a', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.disabilities.pages.physicalHealthChanges;
+  } = formConfig().chapters.disabilities.pages.physicalHealthChanges;
+  const defaultDefinitions = formConfig().defaultDefinitions;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -35,7 +36,7 @@ describe('Physical Changes 781a', () => {
 
     const form = mount(
       <DefinitionTester
-        definitions={formConfig}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{

--- a/src/applications/disability-benefits/all-claims/tests/pages/prisonerOfWar.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/prisonerOfWar.unit.spec.jsx
@@ -14,7 +14,8 @@ describe('Prisoner of war info', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.disabilities.pages.prisonerOfWar;
+  } = formConfig().chapters.disabilities.pages.prisonerOfWar;
+  const defaultDefinitions = formConfig().defaultDefinitions;
 
   const formData = {
     serviceInformation: {
@@ -25,7 +26,7 @@ describe('Prisoner of war info', () => {
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={formData}
@@ -39,7 +40,7 @@ describe('Prisoner of war info', () => {
   it('should render confinement fields', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={formData}
@@ -57,7 +58,7 @@ describe('Prisoner of war info', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={formData}
@@ -74,7 +75,7 @@ describe('Prisoner of war info', () => {
   it('should add another period', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={formData}
@@ -100,7 +101,7 @@ describe('Prisoner of war info', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={formData}
@@ -121,7 +122,7 @@ describe('Prisoner of war info', () => {
   it('should show new disabilities', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={Object.assign({}, formData, {
@@ -141,7 +142,7 @@ describe('Prisoner of war info', () => {
   it('should not show new disabilities section when none entered', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={formData}
@@ -161,7 +162,7 @@ describe('Prisoner of war info', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={formData}

--- a/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecords.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecords.unit.spec.jsx
@@ -10,15 +10,16 @@ import formConfig from '../../config/form.js';
 
 describe('526 All Claims Private medical records', () => {
   const errorClass = '.usa-input-error-message';
-  const page =
-    formConfig.chapters.supportingEvidence.pages.privateMedicalRecords;
+  const page = formConfig().chapters.supportingEvidence.pages
+    .privateMedicalRecords;
+  const defaultDefinitions = formConfig().defaultDefinitions;
   const { schema, uiSchema } = page;
 
   it('should render', () => {
     const form = mount(
       <Provider store={uploadStore}>
         <DefinitionTester
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           uiSchema={uiSchema}
           data={{}}
@@ -35,7 +36,7 @@ describe('526 All Claims Private medical records', () => {
     const form = mount(
       <Provider store={uploadStore}>
         <DefinitionTester
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           uiSchema={uiSchema}
           data={{}}
@@ -54,7 +55,7 @@ describe('526 All Claims Private medical records', () => {
     const form = mount(
       <Provider store={uploadStore}>
         <DefinitionTester
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           uiSchema={uiSchema}
           data={{
@@ -79,7 +80,7 @@ describe('526 All Claims Private medical records', () => {
     const form = mount(
       <Provider store={uploadStore}>
         <DefinitionTester
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           uiSchema={uiSchema}
           data={{
@@ -104,7 +105,7 @@ describe('526 All Claims Private medical records', () => {
     const form = mount(
       <Provider store={uploadStore}>
         <DefinitionTester
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           uiSchema={uiSchema}
           data={{
@@ -129,7 +130,7 @@ describe('526 All Claims Private medical records', () => {
     const form = mount(
       <Provider store={uploadStore}>
         <DefinitionTester
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           uiSchema={uiSchema}
           data={{
@@ -157,7 +158,7 @@ describe('526 All Claims Private medical records', () => {
     const form = mount(
       <Provider store={uploadStore}>
         <DefinitionTester
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           uiSchema={uiSchema}
           data={{

--- a/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecordsRelease.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecordsRelease.unit.spec.jsx
@@ -16,14 +16,15 @@ describe('Disability benefits 4142 provider medical records facility information
     schema,
     uiSchema,
     arrayPath,
-  } = formConfig.chapters.supportingEvidence.pages.privateMedicalRecordsRelease;
+  } = formConfig().chapters.supportingEvidence.pages.privateMedicalRecordsRelease;
+  const defaultDefinitions = formConfig().defaultDefinitions;
 
   it('should render 4142 form', () => {
     const form = mount(
       <DefinitionTester
         arrayPath={arrayPath}
         pagePerItemIndex={0}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={initialData}
         uiSchema={uiSchema}
@@ -43,7 +44,7 @@ describe('Disability benefits 4142 provider medical records facility information
         arrayPath={arrayPath}
         pagePerItemIndex={0}
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={initialData}
         formData={initialData}
@@ -102,7 +103,7 @@ describe('Disability benefits 4142 provider medical records facility information
       <DefinitionTester
         arrayPath={arrayPath}
         pagePerItemIndex={0}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={initialData}
         formData={initialData}
@@ -127,7 +128,7 @@ describe('Disability benefits 4142 provider medical records facility information
       <DefinitionTester
         arrayPath={arrayPath}
         pagePerItemIndex={0}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={{
           'view:limitedConsent': true,

--- a/src/applications/disability-benefits/all-claims/tests/pages/ptsdAdditionalEvents.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/ptsdAdditionalEvents.unit.spec.jsx
@@ -11,7 +11,8 @@ import {
 import formConfig from '../../config/form';
 
 describe('781 additonal events yes/no', () => {
-  const page = formConfig.chapters.disabilities.pages.ptsdAdditionalEvents0;
+  const page = formConfig().chapters.disabilities.pages.ptsdAdditionalEvents0;
+  const defaultDefinitions = formConfig().defaultDefinitions;
   const { schema, uiSchema, arrayPath } = page;
 
   it('should render', () => {
@@ -19,7 +20,7 @@ describe('781 additonal events yes/no', () => {
       <DefinitionTester
         arrayPath={arrayPath}
         pagePerItemIndex={0}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={{
           'view:selectablePtsdTypes': {
@@ -37,7 +38,7 @@ describe('781 additonal events yes/no', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -60,7 +61,7 @@ describe('781 additonal events yes/no', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{

--- a/src/applications/disability-benefits/all-claims/tests/pages/ptsdSecondaryAdditionalEvents.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/ptsdSecondaryAdditionalEvents.unit.spec.jsx
@@ -11,8 +11,9 @@ import {
 import formConfig from '../../config/form';
 
 describe('781a additonal events yes/no', () => {
-  const page =
-    formConfig.chapters.disabilities.pages.ptsdSecondaryAdditionalEvents0;
+  const page = formConfig().chapters.disabilities.pages
+    .ptsdSecondaryAdditionalEvents0;
+  const defaultDefinitions = formConfig().defaultDefinitions;
   const { schema, uiSchema, arrayPath } = page;
 
   it('should render', () => {
@@ -20,7 +21,7 @@ describe('781a additonal events yes/no', () => {
       <DefinitionTester
         arrayPath={arrayPath}
         pagePerItemIndex={0}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={{
           'view:selectablePtsdTypes': {
@@ -38,7 +39,7 @@ describe('781a additonal events yes/no', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -61,7 +62,7 @@ describe('781a additonal events yes/no', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{

--- a/src/applications/disability-benefits/all-claims/tests/pages/ptsdWalkthroughChoice781.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/ptsdWalkthroughChoice781.unit.spec.jsx
@@ -8,14 +8,15 @@ import formConfig from '../../config/form.js';
 import initialData from '../schema/initialData.js';
 
 describe('781 choice screen', () => {
-  const page = formConfig.chapters.disabilities.pages.ptsdWalkthroughChoice781;
+  const page = formConfig().chapters.disabilities.pages
+    .ptsdWalkthroughChoice781;
   const { schema, uiSchema } = page;
 
   it('should submit without validation errors', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={formConfig().defaultDefinitions}
         schema={schema}
         formData={{ initialData }}
         data={{

--- a/src/applications/disability-benefits/all-claims/tests/pages/ptsdWalkthroughChoice781a.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/ptsdWalkthroughChoice781a.unit.spec.jsx
@@ -8,14 +8,15 @@ import formConfig from '../../config/form';
 import initialData from '../schema/initialData';
 
 describe('781a choice screen', () => {
-  const page = formConfig.chapters.disabilities.pages.ptsdWalkthroughChoice781a;
+  const page = formConfig().chapters.disabilities.pages
+    .ptsdWalkthroughChoice781a;
   const { schema, uiSchema } = page;
 
   it('should submit without validation errors', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={formConfig().defaultDefinitions}
         schema={schema}
         formData={{ initialData }}
         data={{

--- a/src/applications/disability-benefits/all-claims/tests/pages/ratedDisabilities.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/ratedDisabilities.unit.spec.jsx
@@ -10,12 +10,13 @@ describe('Disability benefits 526EZ -- Rated disabilities selection', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.disabilities.pages.ratedDisabilities;
+  } = formConfig().chapters.disabilities.pages.ratedDisabilities;
+  const defaultDefinitions = formConfig().defaultDefinitions;
 
   it('renders the rated disabilities selection field', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={initialData}
         uiSchema={uiSchema}
@@ -31,7 +32,7 @@ describe('Disability benefits 526EZ -- Rated disabilities selection', () => {
   it('successfully submits when at least one condition is selected', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={initialData}
         uiSchema={uiSchema}
@@ -51,7 +52,7 @@ describe('Disability benefits 526EZ -- Rated disabilities selection', () => {
   it('successfully submits when no conditions selected', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={initialData}
         uiSchema={uiSchema}
@@ -66,7 +67,7 @@ describe('Disability benefits 526EZ -- Rated disabilities selection', () => {
   it('renders the information about each disability', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={initialData}
         uiSchema={uiSchema}

--- a/src/applications/disability-benefits/all-claims/tests/pages/recentEarnedIncome.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/recentEarnedIncome.unit.spec.jsx
@@ -12,13 +12,15 @@ import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 
 describe('Recent earned income', () => {
-  const page = formConfig.chapters.disabilities.pages.recentEarnedIncome;
+  const opts = { showSubforms: true };
+  const page = formConfig(opts).chapters.disabilities.pages.recentEarnedIncome;
+  const defaultDefinitions = formConfig(opts).defaultDefinitions;
   const { schema, uiSchema } = page;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,
@@ -33,7 +35,7 @@ describe('Recent earned income', () => {
     const form = mount(
       <DefinitionTester
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,
@@ -63,7 +65,7 @@ describe('Recent earned income', () => {
     const form = mount(
       <DefinitionTester
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,
@@ -94,7 +96,7 @@ describe('Recent earned income', () => {
     const form = mount(
       <DefinitionTester
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,

--- a/src/applications/disability-benefits/all-claims/tests/pages/recentEducationTraining.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/recentEducationTraining.unit.spec.jsx
@@ -13,13 +13,16 @@ import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 
 describe('Recent Job Applications', () => {
-  const page = formConfig.chapters.disabilities.pages.recentEducationTraining;
+  const opts = { showSubforms: true };
+  const page = formConfig(opts).chapters.disabilities.pages
+    .recentEducationTraining;
+  const defaultDefinitions = formConfig(opts).defaultDefinitions;
   const { schema, uiSchema } = page;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,
@@ -35,7 +38,7 @@ describe('Recent Job Applications', () => {
     const form = mount(
       <DefinitionTester
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,
@@ -84,7 +87,7 @@ describe('Recent Job Applications', () => {
     const form = mount(
       <DefinitionTester
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,

--- a/src/applications/disability-benefits/all-claims/tests/pages/recentJobApplications.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/recentJobApplications.unit.spec.jsx
@@ -13,13 +13,16 @@ import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 
 describe('Recent Job Applications', () => {
-  const page = formConfig.chapters.disabilities.pages.recentJobApplications;
+  const opts = { showSubforms: true };
+  const page = formConfig(opts).chapters.disabilities.pages
+    .recentJobApplications;
+  const defaultDefinitions = formConfig(opts).defaultDefinitions;
   const { schema, uiSchema } = page;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,
@@ -36,7 +39,7 @@ describe('Recent Job Applications', () => {
     const form = mount(
       <DefinitionTester
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,
@@ -115,7 +118,7 @@ describe('Recent Job Applications', () => {
     const form = mount(
       <DefinitionTester
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,

--- a/src/applications/disability-benefits/all-claims/tests/pages/reservesNationalGuardService.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/reservesNationalGuardService.unit.spec.jsx
@@ -13,12 +13,13 @@ describe('Reserve information', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.veteranDetails.pages.reservesNationalGuardService;
+  } = formConfig().chapters.veteranDetails.pages.reservesNationalGuardService;
+  const defaultDefinitions = formConfig().defaultDefinitions;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}
@@ -35,7 +36,7 @@ describe('Reserve information', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}
@@ -54,7 +55,7 @@ describe('Reserve information', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}

--- a/src/applications/disability-benefits/all-claims/tests/pages/retirementPay.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/retirementPay.unit.spec.jsx
@@ -9,12 +9,13 @@ describe('Retirement Pay', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.veteranDetails.pages.retirementPay;
+  } = formConfig().chapters.veteranDetails.pages.retirementPay;
+  const defaultDefinitions = formConfig().defaultDefinitions;
 
   it('should render two radio options by default', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}
@@ -30,7 +31,7 @@ describe('Retirement Pay', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{ 'view:hasMilitaryRetiredPay': false }}
@@ -49,7 +50,7 @@ describe('Retirement Pay', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{ 'view:hasMilitaryRetiredPay': true }}
@@ -68,7 +69,7 @@ describe('Retirement Pay', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{

--- a/src/applications/disability-benefits/all-claims/tests/pages/retirementPayWaiver.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/retirementPayWaiver.unit.spec.jsx
@@ -9,12 +9,13 @@ describe('Retirement Pay Waiver', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.additionalInformation.pages.retirementPayWaiver;
+  } = formConfig().chapters.additionalInformation.pages.retirementPayWaiver;
+  const defaultDefinitions = formConfig().defaultDefinitions;
 
   it('should render two radio options by default', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}
@@ -30,7 +31,7 @@ describe('Retirement Pay Waiver', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{ waiveRetirementPay: false }}
@@ -49,7 +50,7 @@ describe('Retirement Pay Waiver', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}

--- a/src/applications/disability-benefits/all-claims/tests/pages/secondaryFinalncident.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/secondaryFinalncident.unit.spec.jsx
@@ -11,7 +11,8 @@ import {
 import formConfig from '../../config/form';
 
 describe('781a last incident details', () => {
-  const page = formConfig.chapters.disabilities.pages.secondaryFinalIncident;
+  const page = formConfig().chapters.disabilities.pages.secondaryFinalIncident;
+  const defaultDefinitions = formConfig().defaultDefinitions;
   const { schema, uiSchema, arrayPath } = page;
 
   it('should render', () => {
@@ -19,7 +20,7 @@ describe('781a last incident details', () => {
       <DefinitionTester
         arrayPath={arrayPath}
         pagePerItemIndex={0}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={{
           'view:selectablePtsdTypes': {
@@ -37,7 +38,7 @@ describe('781a last incident details', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -60,7 +61,7 @@ describe('781a last incident details', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{

--- a/src/applications/disability-benefits/all-claims/tests/pages/secondaryIncidentAuthorities.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/secondaryIncidentAuthorities.unit.spec.jsx
@@ -11,14 +11,15 @@ import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 
 describe('PTSD Assault permission notice', () => {
-  const page =
-    formConfig.chapters.disabilities.pages.secondaryIncidentAuthorities0;
+  const page = formConfig().chapters.disabilities.pages
+    .secondaryIncidentAuthorities0;
+  const defaultDefinitions = formConfig().defaultDefinitions;
   const { schema, uiSchema } = page;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,
@@ -36,7 +37,7 @@ describe('PTSD Assault permission notice', () => {
     const form = mount(
       <DefinitionTester
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,
@@ -89,7 +90,7 @@ describe('PTSD Assault permission notice', () => {
     const form = mount(
       <DefinitionTester
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         formData={{}}
         uiSchema={uiSchema}

--- a/src/applications/disability-benefits/all-claims/tests/pages/secondaryIncidentDate.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/secondaryIncidentDate.unit.spec.jsx
@@ -11,7 +11,8 @@ import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 
 describe('781a Incident Date', () => {
-  const page = formConfig.chapters.disabilities.pages.secondaryIncidentDate0;
+  const page = formConfig().chapters.disabilities.pages.secondaryIncidentDate0;
+  const defaultDefinitions = formConfig().defaultDefinitions;
   const { schema, uiSchema, arrayPath } = page;
 
   it('should render', () => {
@@ -19,7 +20,7 @@ describe('781a Incident Date', () => {
       <DefinitionTester
         arrayPath={arrayPath}
         pagePerItemIndex={0}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={{}}
         uiSchema={uiSchema}
@@ -37,7 +38,7 @@ describe('781a Incident Date', () => {
         arrayPath={arrayPath}
         pagePerItemIndex={0}
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,
@@ -57,7 +58,7 @@ describe('781a Incident Date', () => {
         arrayPath={arrayPath}
         pagePerItemIndex={0}
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         formData={{}}
         uiSchema={uiSchema}

--- a/src/applications/disability-benefits/all-claims/tests/pages/secondaryIncidentLocation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/secondaryIncidentLocation.unit.spec.jsx
@@ -12,8 +12,9 @@ import {
 import formConfig from '../../config/form';
 
 describe('PTSD Secondary Incident location', () => {
-  const page =
-    formConfig.chapters.disabilities.pages.secondaryIncidentLocation0;
+  const page = formConfig().chapters.disabilities.pages
+    .secondaryIncidentLocation0;
+  const defaultDefinitions = formConfig().defaultDefinitions;
   const { schema, uiSchema } = page;
 
   it('should render', () => {
@@ -21,7 +22,7 @@ describe('PTSD Secondary Incident location', () => {
       <DefinitionTester
         schema={schema}
         uiSchema={uiSchema}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
       />,
     );
 
@@ -36,7 +37,7 @@ describe('PTSD Secondary Incident location', () => {
         onSubmit={onSubmit}
         schema={schema}
         uiSchema={uiSchema}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
       />,
     );
     fillData(
@@ -73,7 +74,7 @@ describe('PTSD Secondary Incident location', () => {
         schema={schema}
         uiSchema={uiSchema}
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
       />,
     );
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/secondaryIncidentUnitAssignment.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/secondaryIncidentUnitAssignment.unit.spec.jsx
@@ -13,14 +13,15 @@ import {
 import formConfig from '../../config/form';
 
 describe('781 Unit Assignment Details', () => {
-  const page =
-    formConfig.chapters.disabilities.pages.secondaryIncidentUnitAssignment0;
+  const page = formConfig().chapters.disabilities.pages
+    .secondaryIncidentUnitAssignment0;
+  const defaultDefinitions = formConfig().defaultDefinitions;
   const { schema, uiSchema } = page;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,
@@ -34,7 +35,7 @@ describe('781 Unit Assignment Details', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         onSubmit={onSubmit}
         schema={schema}
         uiSchema={uiSchema}
@@ -67,7 +68,7 @@ describe('781 Unit Assignment Details', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         onSubmit={onSubmit}
         schema={schema}
         uiSchema={uiSchema}

--- a/src/applications/disability-benefits/all-claims/tests/pages/secondaryOtherSources.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/pages/secondaryOtherSources.unit.spec.js
@@ -9,7 +9,7 @@ describe('Add secondary other sources of information', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.disabilities.pages.secondaryOtherSources0;
+  } = formConfig().chapters.disabilities.pages.secondaryOtherSources0;
 
   it('should render', () => {
     const form = mount(

--- a/src/applications/disability-benefits/all-claims/tests/pages/secondaryOtherSourcesHelp.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/pages/secondaryOtherSourcesHelp.unit.spec.js
@@ -9,7 +9,7 @@ describe('Add secondary other sources of information help ', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.disabilities.pages.secondaryOtherSourcesHelp0;
+  } = formConfig().chapters.disabilities.pages.secondaryOtherSourcesHelp0;
 
   it('should render', () => {
     const form = mount(

--- a/src/applications/disability-benefits/all-claims/tests/pages/separationLocation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/separationLocation.unit.spec.jsx
@@ -11,12 +11,13 @@ describe.skip('Separation location', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.veteranDetails.pages.separationLocation;
+  } = formConfig().chapters.veteranDetails.pages.separationLocation;
+  const defaultDefinitions = formConfig().defaultDefinitions;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}
@@ -32,7 +33,7 @@ describe.skip('Separation location', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -63,7 +64,7 @@ describe.skip('Separation location', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}

--- a/src/applications/disability-benefits/all-claims/tests/pages/separationPay.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/separationPay.unit.spec.jsx
@@ -9,7 +9,7 @@ describe('Separation Pay', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.veteranDetails.pages.separationPay;
+  } = formConfig().chapters.veteranDetails.pages.separationPay;
   const { defaultDefinitions: definitions } = formConfig;
 
   it('should render', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/servedInCombatZone.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/servedInCombatZone.unit.spec.jsx
@@ -13,12 +13,13 @@ describe('servedInCombatZone', () => {
   const {
     uiSchema,
     schema,
-  } = formConfig.chapters.veteranDetails.pages.servedInCombatZone;
+  } = formConfig().chapters.veteranDetails.pages.servedInCombatZone;
+  const defaultDefinitions = formConfig().defaultDefinitions;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         uiSchema={uiSchema}
         schema={schema}
         data={{}}
@@ -34,7 +35,7 @@ describe('servedInCombatZone', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         uiSchema={uiSchema}
         schema={schema}
         data={{}}
@@ -53,7 +54,7 @@ describe('servedInCombatZone', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         uiSchema={uiSchema}
         schema={schema}
         data={{}}

--- a/src/applications/disability-benefits/all-claims/tests/pages/serviceTreatmentRecords.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/serviceTreatmentRecords.unit.spec.jsx
@@ -13,13 +13,14 @@ describe('serviceTreatmentRecords', () => {
   const {
     uiSchema,
     schema,
-  } = formConfig.chapters.supportingEvidence.pages.serviceTreatmentRecords;
+  } = formConfig().chapters.supportingEvidence.pages.serviceTreatmentRecords;
+  const defaultDefinitions = formConfig().defaultDefinitions;
 
   it('should render', () => {
     const form = mount(
       <Provider store={uploadStore}>
         <DefinitionTester
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           uiSchema={uiSchema}
           schema={schema}
           data={{}}
@@ -36,7 +37,7 @@ describe('serviceTreatmentRecords', () => {
     const form = mount(
       <Provider store={uploadStore}>
         <DefinitionTester
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           uiSchema={uiSchema}
           schema={schema}
           data={{}}
@@ -55,7 +56,7 @@ describe('serviceTreatmentRecords', () => {
     const form = mount(
       <Provider store={uploadStore}>
         <DefinitionTester
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           uiSchema={uiSchema}
           schema={schema}
           data={{
@@ -79,7 +80,7 @@ describe('serviceTreatmentRecords', () => {
     const form = mount(
       <Provider store={uploadStore}>
         <DefinitionTester
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           uiSchema={uiSchema}
           schema={schema}
           data={{
@@ -104,7 +105,7 @@ describe('serviceTreatmentRecords', () => {
     const form = mount(
       <Provider store={uploadStore}>
         <DefinitionTester
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           uiSchema={uiSchema}
           schema={schema}
           data={{
@@ -129,7 +130,7 @@ describe('serviceTreatmentRecords', () => {
     const form = mount(
       <Provider store={uploadStore}>
         <DefinitionTester
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           uiSchema={uiSchema}
           schema={schema}
           data={{
@@ -155,7 +156,7 @@ describe('serviceTreatmentRecords', () => {
     const form = mount(
       <Provider store={uploadStore}>
         <DefinitionTester
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           uiSchema={uiSchema}
           schema={schema}
           data={{

--- a/src/applications/disability-benefits/all-claims/tests/pages/socialBehaviorChanges.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/socialBehaviorChanges.unit.spec.jsx
@@ -9,7 +9,7 @@ describe('Social Behavior Changes 781a', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.disabilities.pages.socialBehaviorChanges;
+  } = formConfig().chapters.disabilities.pages.socialBehaviorChanges;
 
   it('should render', () => {
     const form = mount(

--- a/src/applications/disability-benefits/all-claims/tests/pages/summaryOfEvidence.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/summaryOfEvidence.unit.spec.jsx
@@ -8,7 +8,8 @@ describe('Summary of Evidence', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.supportingEvidence.pages.summaryOfEvidence;
+  } = formConfig().chapters.supportingEvidence.pages.summaryOfEvidence;
+  const defaultDefinitions = formConfig().defaultDefinitions;
 
   const vaTreatmentFacilities = [
     { treatmentCenterName: 'Sommerset' },
@@ -53,7 +54,7 @@ describe('Summary of Evidence', () => {
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}
@@ -68,7 +69,7 @@ describe('Summary of Evidence', () => {
   it("should render 'no evidence' warning when 'no evidence' selected", () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -87,7 +88,7 @@ describe('Summary of Evidence', () => {
   it("should render 'no evidence' warning when 'no evidence' selected even if evidence present", () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -110,7 +111,7 @@ describe('Summary of Evidence', () => {
   it('should not render any evidence whose evidence type was not selected', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -136,7 +137,7 @@ describe('Summary of Evidence', () => {
   it('should render VA evidence list when VA evidence submitted', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -158,7 +159,7 @@ describe('Summary of Evidence', () => {
   it('should render private medical facility list when private facilities selected', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -185,7 +186,7 @@ describe('Summary of Evidence', () => {
   it('should render private evidence list when private evidence submitted', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -223,7 +224,7 @@ describe('Summary of Evidence', () => {
   it('should not render private medical facilities even if entered, when upload selected', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -248,7 +249,7 @@ describe('Summary of Evidence', () => {
   it('should not render private evidence uploads even if uploaded, when upload not selected', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -273,7 +274,7 @@ describe('Summary of Evidence', () => {
   it('should render lay evidence list when lay evidence submitted', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{

--- a/src/applications/disability-benefits/all-claims/tests/pages/supplementalBenefits.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/supplementalBenefits.unit.spec.jsx
@@ -8,15 +8,16 @@ import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 
 describe('Supplmental Benefits 8940', () => {
-  const {
-    schema,
-    uiSchema,
-  } = formConfig.chapters.disabilities.pages.supplementalBenefits;
+  const opts = { showSubforms: true };
+  const { schema, uiSchema } = formConfig(
+    opts,
+  ).chapters.disabilities.pages.supplementalBenefits;
+  const defaultDefinitions = formConfig(opts).defaultDefinitions;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}
@@ -33,7 +34,7 @@ describe('Supplmental Benefits 8940', () => {
 
     const form = mount(
       <DefinitionTester
-        definitions={formConfig}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}

--- a/src/applications/disability-benefits/all-claims/tests/pages/terminallyIll.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/terminallyIll.unit.spec.jsx
@@ -9,7 +9,7 @@ describe('Terminally Ill', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.additionalInformation.pages.terminallyIll;
+  } = formConfig().chapters.additionalInformation.pages.terminallyIll;
   const { defaultDefinitions: definitions } = formConfig;
 
   it('should render', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/trainingPay.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/trainingPay.unit.spec.jsx
@@ -9,7 +9,7 @@ describe('Training Pay', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.veteranDetails.pages.trainingPay;
+  } = formConfig().chapters.veteranDetails.pages.trainingPay;
   const { defaultDefinitions: definitions } = formConfig;
 
   it('should render', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/trainingPayWaiver.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/trainingPayWaiver.unit.spec.jsx
@@ -10,7 +10,7 @@ describe('trainingPayWaiver', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.additionalInformation.pages.trainingPayWaiver;
+  } = formConfig().chapters.additionalInformation.pages.trainingPayWaiver;
   const { defaultDefinitions } = formConfig;
   it('should render', () => {
     const form = mount(

--- a/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityAdditionalInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityAdditionalInformation.unit.spec.jsx
@@ -6,15 +6,16 @@ import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 
 describe('Unemployability Additional Information form', () => {
-  const {
-    schema,
-    uiSchema,
-  } = formConfig.chapters.disabilities.pages.unemployabilityAdditionalInformation;
+  const opts = { showSubforms: true };
+  const { schema, uiSchema } = formConfig(
+    opts,
+  ).chapters.disabilities.pages.unemployabilityAdditionalInformation;
+  const defaultDefinitions = formConfig(opts).defaultDefinitions;
 
   it('should render textarea', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}
@@ -31,7 +32,7 @@ describe('Unemployability Additional Information form', () => {
 
     const form = mount(
       <DefinitionTester
-        definitions={formConfig}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}

--- a/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityCertification.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityCertification.unit.spec.jsx
@@ -11,14 +11,16 @@ import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 
 describe('Recent Job Applications', () => {
-  const page =
-    formConfig.chapters.disabilities.pages.unemployabilityCertification;
+  const opts = { showSubforms: true };
+  const page = formConfig(opts).chapters.disabilities.pages
+    .unemployabilityCertification;
+  const defaultDefinitions = formConfig(opts).defaultDefinitions;
   const { schema, uiSchema } = page;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,
@@ -33,7 +35,7 @@ describe('Recent Job Applications', () => {
     const form = mount(
       <DefinitionTester
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,
@@ -62,7 +64,7 @@ describe('Recent Job Applications', () => {
     const form = mount(
       <DefinitionTester
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,

--- a/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityDates.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityDates.unit.spec.jsx
@@ -11,15 +11,16 @@ import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 
 describe('Unemployability affective Dates', () => {
-  const {
-    schema,
-    uiSchema,
-  } = formConfig.chapters.disabilities.pages.unemployabilityDates;
+  const opts = { showSubforms: true };
+  const { schema, uiSchema } = formConfig(
+    opts,
+  ).chapters.disabilities.pages.unemployabilityDates;
+  const defaultDefinitions = formConfig(opts).defaultDefinitions;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -38,7 +39,7 @@ describe('Unemployability affective Dates', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -59,7 +60,7 @@ describe('Unemployability affective Dates', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{

--- a/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityDisabilities.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityDisabilities.spec.jsx
@@ -13,14 +13,15 @@ describe('Select related disabilities for unemployability', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.disabilities.pages.unemployabilityDisabilities;
+  } = formConfig().chapters.disabilities.pages.unemployabilityDisabilities;
+  const defaultDefinitions = formConfig().defaultDefinitions;
 
   it('renders the rated disabilities selection field', () => {
     const disabilitiesLength =
       initialData.ratedDisabilities.length + initialData.newDisabilities.length;
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={initialData}
         uiSchema={uiSchema}
@@ -38,7 +39,7 @@ describe('Select related disabilities for unemployability', () => {
     const form = mount(
       <DefinitionTester
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={initialData}
         uiSchema={uiSchema}
@@ -60,7 +61,7 @@ describe('Select related disabilities for unemployability', () => {
     const form = mount(
       <DefinitionTester
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={initialData}
         uiSchema={uiSchema}
@@ -76,7 +77,7 @@ describe('Select related disabilities for unemployability', () => {
   it('renders the information about each disability', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={initialData}
         uiSchema={uiSchema}

--- a/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityDoctorCare.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityDoctorCare.unit.spec.jsx
@@ -13,15 +13,16 @@ import initialData from '../initialData.js';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 
 describe("Doctor's care unemployability", () => {
-  const {
-    schema,
-    uiSchema,
-  } = formConfig.chapters.disabilities.pages.unemployabilityDoctorCare;
+  const opts = { showSubforms: true };
+  const { schema, uiSchema } = formConfig(
+    opts,
+  ).chapters.disabilities.pages.unemployabilityDoctorCare;
+  const defaultDefinitions = formConfig(opts).defaultDefinitions;
 
   it("renders the add doctor's care", () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={initialData}
         uiSchema={uiSchema}
@@ -40,7 +41,7 @@ describe("Doctor's care unemployability", () => {
     const form = mount(
       <DefinitionTester
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         data={initialData}
         uiSchema={uiSchema}
@@ -107,7 +108,7 @@ describe("Doctor's care unemployability", () => {
     const form = mount(
       <DefinitionTester
         onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
       />,

--- a/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityFormIntro.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityFormIntro.unit.spec.jsx
@@ -9,15 +9,16 @@ import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 
 describe('Unemployability 8940 Walkthrough', () => {
-  const {
-    schema,
-    uiSchema,
-  } = formConfig.chapters.disabilities.pages.unemployabilityFormIntro;
+  const opts = { showSubforms: true };
+  const { schema, uiSchema } = formConfig(
+    opts,
+  ).chapters.disabilities.pages.unemployabilityFormIntro;
+  const defaultDefinitions = formConfig(opts).defaultDefinitions;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -35,7 +36,7 @@ describe('Unemployability 8940 Walkthrough', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -56,7 +57,7 @@ describe('Unemployability 8940 Walkthrough', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{

--- a/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityFormUpload.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityFormUpload.unit.spec.jsx
@@ -12,7 +12,10 @@ import formConfig from '../../config/form.js';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 
 describe('8940 form upload', () => {
-  const page = formConfig.chapters.disabilities.pages.unemployabilityFormUpload;
+  const opts = { showSubforms: true };
+  const page = formConfig(opts).chapters.disabilities.pages
+    .unemployabilityFormUpload;
+  const defaultDefinitions = formConfig(opts).defaultDefinitions;
   const { schema, uiSchema, arrayPath } = page;
 
   it('should render', () => {
@@ -21,7 +24,7 @@ describe('8940 form upload', () => {
         <DefinitionTester
           arrayPath={arrayPath}
           pagePerItemIndex={0}
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{
             'view:unemployabilityUploadChoice': 'upload',
@@ -43,7 +46,7 @@ describe('8940 form upload', () => {
           arrayPath={arrayPath}
           pagePerItemIndex={0}
           onSubmit={onSubmit}
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{
             'view:unemployabilityUploadChoice': 'upload',
@@ -67,7 +70,7 @@ describe('8940 form upload', () => {
           arrayPath={arrayPath}
           pagePerItemIndex={0}
           onSubmit={onSubmit}
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{
             'view:unemployabilityUploadChoice': 'upload',

--- a/src/applications/disability-benefits/all-claims/tests/pages/uploadPtsdDocuments781.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/uploadPtsdDocuments781.unit.spec.jsx
@@ -12,7 +12,8 @@ import formConfig from '../../config/form.js';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 
 describe('781 record upload', () => {
-  const page = formConfig.chapters.disabilities.pages.uploadPtsdDocuments781;
+  const page = formConfig().chapters.disabilities.pages.uploadPtsdDocuments781;
+  const defaultDefinitions = formConfig().defaultDefinitions;
   const { schema, uiSchema, arrayPath } = page;
 
   it('should render', () => {
@@ -21,7 +22,7 @@ describe('781 record upload', () => {
         <DefinitionTester
           arrayPath={arrayPath}
           pagePerItemIndex={0}
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{
             'view:selectablePtsdTypes': {
@@ -45,7 +46,7 @@ describe('781 record upload', () => {
           arrayPath={arrayPath}
           pagePerItemIndex={0}
           onSubmit={onSubmit}
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{
             'view:selectablePtsdTypes': {
@@ -71,7 +72,7 @@ describe('781 record upload', () => {
           arrayPath={arrayPath}
           pagePerItemIndex={0}
           onSubmit={onSubmit}
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{
             form781Upload: [

--- a/src/applications/disability-benefits/all-claims/tests/pages/uploadPtsdDocuments781a.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/uploadPtsdDocuments781a.unit.spec.jsx
@@ -12,7 +12,8 @@ import formConfig from '../../config/form.js';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 
 describe('781a record upload', () => {
-  const page = formConfig.chapters.disabilities.pages.uploadPtsdDocuments781a;
+  const page = formConfig().chapters.disabilities.pages.uploadPtsdDocuments781a;
+  const defaultDefinitions = formConfig().defaultDefinitions;
   const { schema, uiSchema, arrayPath } = page;
 
   it('should render', () => {
@@ -21,7 +22,7 @@ describe('781a record upload', () => {
         <DefinitionTester
           arrayPath={arrayPath}
           pagePerItemIndex={0}
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{
             'view:selectablePtsdTypes': {
@@ -45,7 +46,7 @@ describe('781a record upload', () => {
           arrayPath={arrayPath}
           pagePerItemIndex={0}
           onSubmit={onSubmit}
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{
             'view:selectablePtsdTypes': {
@@ -71,7 +72,7 @@ describe('781a record upload', () => {
           arrayPath={arrayPath}
           pagePerItemIndex={0}
           onSubmit={onSubmit}
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{
             form781aUpload: [

--- a/src/applications/disability-benefits/all-claims/tests/pages/uploadUnemployabilitySupportingDocuments.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/uploadUnemployabilitySupportingDocuments.unit.spec.jsx
@@ -12,9 +12,10 @@ import formConfig from '../../config/form.js';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 
 describe('8940 supporting documents upload', () => {
-  const page =
-    formConfig.chapters.disabilities.pages
-      .uploadUnemployabilitySupportingDocuments;
+  const opts = { showSubforms: true };
+  const page = formConfig(opts).chapters.disabilities.pages
+    .uploadUnemployabilitySupportingDocuments;
+  const defaultDefinitions = formConfig(opts).defaultDefinitions;
   const { schema, uiSchema, arrayPath } = page;
 
   it('should render', () => {
@@ -23,7 +24,7 @@ describe('8940 supporting documents upload', () => {
         <DefinitionTester
           arrayPath={arrayPath}
           pagePerItemIndex={0}
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{
             'view:unemployabilityUploadChoice': 'answerQuestions',
@@ -46,7 +47,7 @@ describe('8940 supporting documents upload', () => {
           arrayPath={arrayPath}
           pagePerItemIndex={0}
           onSubmit={onSubmit}
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{
             'view:unemployabilityUploadChoice': 'answerQuestions',
@@ -71,7 +72,7 @@ describe('8940 supporting documents upload', () => {
           arrayPath={arrayPath}
           pagePerItemIndex={0}
           onSubmit={onSubmit}
-          definitions={formConfig.defaultDefinitions}
+          definitions={defaultDefinitions}
           schema={schema}
           data={{
             unemployabilitySupportingDocuments: [

--- a/src/applications/disability-benefits/all-claims/tests/pages/vaEmployee.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/vaEmployee.unit.spec.jsx
@@ -8,12 +8,12 @@ describe('526 vaEmployee', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.additionalInformation.pages.vaEmployee;
+  } = formConfig().chapters.additionalInformation.pages.vaEmployee;
 
   it('should render', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={formConfig().defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{}}

--- a/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
@@ -9,7 +9,8 @@ describe('VA Medical Records', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.supportingEvidence.pages.vaMedicalRecords;
+  } = formConfig().chapters.supportingEvidence.pages.vaMedicalRecords;
+  const defaultDefinitions = formConfig().defaultDefinitions;
 
   const ratedDisabilities = [
     {
@@ -29,7 +30,7 @@ describe('VA Medical Records', () => {
   it('should render ', () => {
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -47,7 +48,7 @@ describe('VA Medical Records', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -69,7 +70,7 @@ describe('VA Medical Records', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -112,7 +113,7 @@ describe('VA Medical Records', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -155,7 +156,7 @@ describe('VA Medical Records', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -192,7 +193,7 @@ describe('VA Medical Records', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
@@ -229,7 +230,7 @@ describe('VA Medical Records', () => {
     const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
+        definitions={defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{

--- a/src/applications/disability-benefits/all-claims/tests/pages/workBehaviorChanges.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/workBehaviorChanges.unit.spec.jsx
@@ -9,7 +9,7 @@ describe('Work Behavior Changes 781a', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.disabilities.pages.workBehaviorChanges;
+  } = formConfig().chapters.disabilities.pages.workBehaviorChanges;
 
   it('should render', () => {
     const form = mount(

--- a/src/applications/disability-benefits/all-claims/tests/schema/schema.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/schema/schema.unit.spec.js
@@ -21,7 +21,10 @@ describe('526 all claims schema tests', () => {
           '2020-01-01';
       }
       const submitData = JSON.parse(
-        formConfig.transformForSubmit(formConfig, contents),
+        formConfig().transformForSubmit(
+          formConfig({ showSubforms: true }),
+          contents,
+        ),
       );
       const result = v.validate(submitData.form526, fullSchema);
 

--- a/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
@@ -44,6 +44,7 @@ describe('transform', () => {
   fs.readdirSync(dataDir)
     .filter(fileName => fileName.endsWith('.json'))
     .forEach(fileName => {
+      const opts = { showSubforms: true };
       // Loop through them
       it(`should transform ${fileName} correctly`, () => {
         const rawData = JSON.parse(
@@ -60,7 +61,7 @@ describe('transform', () => {
           // eslint-disable-next-line no-console
           console.error(
             `Transformed ${fileName}:`,
-            transform(formConfig, rawData),
+            transform(formConfig(opts), rawData),
           );
           throw new Error(`Could not find transformed data for ${fileName}`);
         }
@@ -71,7 +72,7 @@ describe('transform', () => {
           transformedData.form526.serviceInformation.servicePeriods = servicePeriodsBDD;
         }
 
-        expect(JSON.parse(transform(formConfig, rawData))).to.deep.equal(
+        expect(JSON.parse(transform(formConfig(opts), rawData))).to.deep.equal(
           transformedData,
         );
       });
@@ -184,7 +185,7 @@ describe('getPtsdChangeText', () => {
   const ignoredFields = ['other', 'otherExplanation', 'noneApply'];
   it('should have mappings for all workBehaviorChanges schema fields', () => {
     Object.keys(
-      formConfig.chapters.disabilities.pages.workBehaviorChanges.schema
+      formConfig().chapters.disabilities.pages.workBehaviorChanges.schema
         .properties.workBehaviorChanges.properties,
     )
       .filter(key => !ignoredFields.includes(key))
@@ -195,7 +196,7 @@ describe('getPtsdChangeText', () => {
 
   it('should have mappings for all mentalHealthChanges schema fields', () => {
     Object.keys(
-      formConfig.chapters.disabilities.pages.mentalHealthChanges.schema
+      formConfig().chapters.disabilities.pages.mentalHealthChanges.schema
         .properties.mentalChanges.properties,
     )
       .filter(key => !ignoredFields.includes(key))
@@ -206,7 +207,7 @@ describe('getPtsdChangeText', () => {
 
   it('should have mappings for all physicalHealthChanges schema fields', () => {
     Object.keys(
-      formConfig.chapters.disabilities.pages.physicalHealthChanges.schema
+      formConfig().chapters.disabilities.pages.physicalHealthChanges.schema
         .properties.physicalChanges.properties,
     )
       .filter(key => !ignoredFields.includes(key))
@@ -217,7 +218,7 @@ describe('getPtsdChangeText', () => {
 
   it('should have mappings for all socialBehaviorChanges schema fields', () => {
     Object.keys(
-      formConfig.chapters.disabilities.pages.socialBehaviorChanges.schema
+      formConfig().chapters.disabilities.pages.socialBehaviorChanges.schema
         .properties.socialBehaviorChanges.properties,
     )
       .filter(key => !ignoredFields.includes(key))

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -849,7 +849,7 @@ export const directToCorrectForm = ({
   router,
 }) => {
   // If we can find the form in the savedForms array, it's not pre-filled
-  const isPrefill = !savedForms.find(form => form.form === formConfig.formId);
+  const isPrefill = !savedForms.find(form => form.form === formConfig().formId);
   const baseUrl = getFormUrl(formData, isPrefill);
   if (!isPrefill && !window.location.pathname.includes(baseUrl)) {
     // Redirect to the other app
@@ -984,6 +984,9 @@ export const showSeparationLocation = formData => {
 };
 
 export const show526Wizard = state => toggleValues(state).show526Wizard;
+
+export const showSubform8940And4192 = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.subform89404192];
 
 export const confirmationEmailFeature = state => {
   const isForm526ConfirmationEmailOn = toggleValues(state)[

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -849,7 +849,7 @@ export const directToCorrectForm = ({
   router,
 }) => {
   // If we can find the form in the savedForms array, it's not pre-filled
-  const isPrefill = !savedForms.find(form => form.form === formConfig().formId);
+  const isPrefill = !savedForms.find(form => form.form === formConfig.formId);
   const baseUrl = getFormUrl(formData, isPrefill);
   if (!isPrefill && !window.location.pathname.includes(baseUrl)) {
     // Redirect to the other app

--- a/src/platform/forms/tests/forms.unit.spec.js
+++ b/src/platform/forms/tests/forms.unit.spec.js
@@ -263,7 +263,9 @@ describe('form:', () => {
       // This return is needed in order for failing expects within the promise to actually trigger a failure of the test
       return expect(
         // Dynamically import the module and perform tests on its default export
-        import(configFilePath).then(({ default: formConfig }) => {
+        import(configFilePath).then(({ default: config }) => {
+          // Account for formConfig functions
+          const formConfig = typeof config === 'function' ? config() : config;
           validFormConfigKeys(formConfig);
           validFormId(formConfig);
           validStringProperty(formConfig, 'rootUrl', true);

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -76,4 +76,5 @@ export default Object.freeze({
   gibctStateSearch: 'gibct_state_search',
   eduFormOmbAndExpiration: 'edu_form_omb_and_expiration',
   manageDependents: 'dependents_management',
+  subform89404192: 'subform_8940_4192',
 });


### PR DESCRIPTION
## Description

Currently unreleased subforms 8940 and 4192 are contained within form 526, but are behind an environment in production flag. This (big) change puts this check behind a feature flag to allow for controlled rollout once work has been evaluated and verified.

To reviewers: Ignore whitespace changes to reduce stress - https://github.com/department-of-veterans-affairs/vets-website/pull/16259/files?diff=unified&w=1

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/13848
- https://github.com/department-of-veterans-affairs/vets-api/pull/6015 

## Testing done

Updated unit tests and Cypress e2e tests

## Screenshots

N/A

## Acceptance criteria
- [x] Forms 8940 & 4192 are controlled by a feature flag

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
