### PR TITLE
Add feature flags to form 526 subforms

### DIFF
--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -19,8 +19,13 @@ import { MissingServices, MissingId } from './containers/MissingServices';
 
 import { MVI_ADD_SUCCEEDED } from './actions';
 import WizardContainer from './containers/WizardContainer';
-import { WIZARD_STATUS, PDF_SIZE_FEATURE } from './constants';
-import { show526Wizard, isBDD, getPageTitle } from './utils';
+import { WIZARD_STATUS, PDF_SIZE_FEATURE, SHOW_8940_4192 } from './constants';
+import {
+  show526Wizard,
+  isBDD,
+  getPageTitle,
+  showSubform8940And4192,
+} from './utils';
 import { uploadPdfLimitFeature } from './config/selectors';
 
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
@@ -69,6 +74,7 @@ export const Form526Entry = ({
   isBDDForm,
   pdfLimit,
   router,
+  showSubforms,
 }) => {
   const defaultWizardState = getWizardStatus();
   const [wizardState, setWizardState] = useState(defaultWizardState);
@@ -97,6 +103,8 @@ export const Form526Entry = ({
     ) {
       setPageFocus('h1');
       setWizardStatus(WIZARD_STATUS_COMPLETE);
+      // save feature flag for 8940/4192
+      sessionStorage.setItem(SHOW_8940_4192, showSubforms);
     } else if (defaultWizardState === WIZARD_STATUS_NOT_STARTED) {
       setPageFocus('.va-nav-breadcrumbs-list');
     }
@@ -163,6 +171,7 @@ const mapStateToProps = state => ({
   user: state.user,
   mvi: state.mvi,
   showWizard: show526Wizard(state),
+  showSubforms: showSubform8940And4192(state),
   isBDDForm: isBDD(state?.form?.data),
   pdfLimit: uploadPdfLimitFeature(state),
   isStartingOver: state.form?.isStartingOver,

--- a/src/applications/disability-benefits/all-claims/config/4192/index.js
+++ b/src/applications/disability-benefits/all-claims/config/4192/index.js
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import environment from 'platform/utilities/environment';
 
 import {
   instructionalPart1,
@@ -27,78 +26,72 @@ const isUploading = formData =>
 
 // const isExiting = formData => _.get(formData, 'view:upload4192Choice.view:sendRequests', false);
 
-export default function() {
-  let configObj = {};
-  if (!environment.isProduction()) {
-    configObj = {
-      // Intro
-      pastEmploymentFormIntro: {
-        path: 'past-employment-walkthrough-choice',
-        depends: needsToEnterUnemployability,
-        uiSchema: pastEmploymentFormIntro.uiSchema,
-        schema: pastEmploymentFormIntro.schema,
-        onContinue: captureEvents.pastEmploymentFormIntro,
-      },
-      // Form Tutorial (multiple pages)
-      instructionalPart1: {
-        path: '4192-instructions-part-1',
-        depends: showFormTutorial,
-        uiSchema: instructionalPart1.uiSchema,
-        schema: instructionalPart1.schema,
-      },
-      instructionalPart2: {
-        path: '4192-instructions-part-2',
-        depends: showFormTutorial,
-        uiSchema: instructionalPart2.uiSchema,
-        schema: instructionalPart2.schema,
-      },
-      instructionalPart3: {
-        path: '4192-instructions-part-3',
-        depends: showFormTutorial,
-        uiSchema: instructionalPart3.uiSchema,
-        schema: instructionalPart3.schema,
-      },
-      // Download
-      pastEmploymentFormDownload: {
-        path: 'past-employment-download',
-        depends: isDownloading,
-        uiSchema: pastEmploymentFormDownload.uiSchema,
-        schema: pastEmploymentFormDownload.schema,
-      },
-      // Upload
-      pastEmploymentFormUpload: {
-        path: 'past-employment-form-upload',
-        depends: isUploading,
-        uiSchema: pastEmploymentFormUpload.uiSchema,
-        schema: pastEmploymentFormUpload.schema,
-      },
-      // ***Below page comments for when logic is added in***
-      // Conditional Options (Intro page again if A and not A && B && C)
-      // Form Tutorial (multiple pages)
-      // Download
-      // Upload
-      // Conditional Options (Intro page again if A and not A && B && C)
-      // Form Tutorial (multiple pages)
-      // Download
-      // Upload
-      // Conditional Options (Intro page again if A and not A && B && C)
-      // ***Above page comments for when logic is added in***
-      // Exit
-      conclusion4192: {
-        title: 'Conclusion 4192',
-        path: 'disabilities/conclusion-4192',
-        depends: needsToEnterUnemployability,
-        uiSchema: {
-          'ui:title': ' ',
-          'ui:description':
-            'Thank you for taking the time to answer our questions. The information you provided will help us process your claim.',
-        },
-        schema: {
-          type: 'object',
-          properties: {},
-        },
-      },
-    };
-  }
-  return configObj;
-}
+export default {
+  // Intro
+  pastEmploymentFormIntro: {
+    path: 'past-employment-walkthrough-choice',
+    depends: needsToEnterUnemployability,
+    uiSchema: pastEmploymentFormIntro.uiSchema,
+    schema: pastEmploymentFormIntro.schema,
+    onContinue: captureEvents.pastEmploymentFormIntro,
+  },
+  // Form Tutorial (multiple pages)
+  instructionalPart1: {
+    path: '4192-instructions-part-1',
+    depends: showFormTutorial,
+    uiSchema: instructionalPart1.uiSchema,
+    schema: instructionalPart1.schema,
+  },
+  instructionalPart2: {
+    path: '4192-instructions-part-2',
+    depends: showFormTutorial,
+    uiSchema: instructionalPart2.uiSchema,
+    schema: instructionalPart2.schema,
+  },
+  instructionalPart3: {
+    path: '4192-instructions-part-3',
+    depends: showFormTutorial,
+    uiSchema: instructionalPart3.uiSchema,
+    schema: instructionalPart3.schema,
+  },
+  // Download
+  pastEmploymentFormDownload: {
+    path: 'past-employment-download',
+    depends: isDownloading,
+    uiSchema: pastEmploymentFormDownload.uiSchema,
+    schema: pastEmploymentFormDownload.schema,
+  },
+  // Upload
+  pastEmploymentFormUpload: {
+    path: 'past-employment-form-upload',
+    depends: isUploading,
+    uiSchema: pastEmploymentFormUpload.uiSchema,
+    schema: pastEmploymentFormUpload.schema,
+  },
+  // ***Below page comments for when logic is added in***
+  // Conditional Options (Intro page again if A and not A && B && C)
+  // Form Tutorial (multiple pages)
+  // Download
+  // Upload
+  // Conditional Options (Intro page again if A and not A && B && C)
+  // Form Tutorial (multiple pages)
+  // Download
+  // Upload
+  // Conditional Options (Intro page again if A and not A && B && C)
+  // ***Above page comments for when logic is added in***
+  // Exit
+  conclusion4192: {
+    title: 'Conclusion 4192',
+    path: 'disabilities/conclusion-4192',
+    depends: needsToEnterUnemployability,
+    uiSchema: {
+      'ui:title': ' ',
+      'ui:description':
+        'Thank you for taking the time to answer our questions. The information you provided will help us process your claim.',
+    },
+    schema: {
+      type: 'object',
+      properties: {},
+    },
+  },
+};

--- a/src/applications/disability-benefits/all-claims/config/8940/index.js
+++ b/src/applications/disability-benefits/all-claims/config/8940/index.js
@@ -1,3 +1,4 @@
+import { SHOW_8940_4192 } from '../../constants';
 import {
   unemployabilityAdditionalInformation,
   unemployabilityFormIntro,
@@ -32,168 +33,172 @@ import {
 
 import captureEvents from '../../analytics-functions';
 
-import createFormConfig4192 from '../4192';
+import formConfig4192 from '../4192';
 
 export default function() {
-  let configObj = {};
-  if (!environment.isProduction()) {
-    configObj = {
-      // 8940 - Introduction
-      unemployabilityFormIntro: {
-        title: 'File a claim for Individual Unemployability',
-        path: 'unemployability-walkthrough-choice',
-        depends: needsToEnterUnemployability,
-        uiSchema: unemployabilityFormIntro.uiSchema,
-        schema: unemployabilityFormIntro.schema,
-        onContinue: captureEvents.unemployabilityFormIntro,
-      },
-      // 8940 - Upload 8940
-      unemployabilityFormUpload: {
-        title: 'Upload unemployability form',
-        path: 'new-disabilities/unemployability-form-upload',
-        depends: isUploading8940Form,
-        uiSchema: unemployabilityFormUpload.uiSchema,
-        schema: unemployabilityFormUpload.schema,
-      },
-      // 8940 - Contentions
-      unemployabilityDisabilities: {
-        title: 'Unemployability disabilities',
-        path: 'unemployability-disabilities',
-        depends: needsToAnswerUnemployability,
-        uiSchema: unemployabilityDisabilities.uiSchema,
-        schema: unemployabilityDisabilities.schema,
-      },
-      // 8940 - Medical Care
-      medicalCare: {
-        title: 'Medical care',
-        path: 'medical-care',
-        depends: needsToAnswerUnemployability,
-        uiSchema: medicalCare.uiSchema,
-        schema: medicalCare.schema,
-      },
-      // 8940 - Hospital Treatment
-      hospitalizationHistory: {
-        title: 'Hospitalization',
-        path: 'hospitalization-history',
-        depends: hasHospitalCare,
-        uiSchema: hospitalizationHistory.uiSchema,
-        schema: hospitalizationHistory.schema,
-      },
-      // 8940 - Doctor Treatment
-      unemployabilityDoctorCare: {
-        title: 'Doctor’s care',
-        path: 'doctor-care',
-        depends: hasDoctorsCare,
-        uiSchema: unemployabilityDoctorCare.uiSchema,
-        schema: unemployabilityDoctorCare.schema,
-      },
-      // 8940 - Disability Dates
-      unemployabilityDates: {
-        title: 'Disability dates',
-        path: 'unemployability-disability-dates',
-        depends: needsToAnswerUnemployability,
-        uiSchema: unemployabilityDates.uiSchema,
-        schema: unemployabilityDates.schema,
-      },
-      // 8940 - Income Details
-      incomeDetails: {
-        title: 'Income details',
-        path: 'unemployability-income-details',
-        depends: needsToAnswerUnemployability,
-        uiSchema: incomeDetails.uiSchema,
-        schema: incomeDetails.schema,
-      },
-      // 8940 - Employment History
-      employmentHistory: {
-        title: 'Employment history',
-        path: 'unemployability-employment-history',
-        depends: needsToAnswerUnemployability,
-        uiSchema: employmentHistory.uiSchema,
-        schema: employmentHistory.schema,
-      },
-      // 8940 - Recent Earnings
-      recentEarnedIncome: {
-        title: 'Recent earnings',
-        path: 'recent-earnings',
-        depends: needsToAnswerUnemployability,
-        uiSchema: recentEarnedIncome.uiSchema,
-        schema: recentEarnedIncome.schema,
-      },
-      // 8940 - Supplementary Benefits
-      supplementalBenefits: {
-        title: 'Supplemental benefits',
-        path: 'supplemental-benefits',
-        depends: needsToAnswerUnemployability,
-        uiSchema: supplementalBenefits.uiSchema,
-        schema: supplementalBenefits.schema,
-      },
-      // 8940 - Military Duty
-      militaryDutyImpact: {
-        title: 'Impact on military duty',
-        path: 'military-duty-impact',
-        depends: needsToAnswerUnemployability,
-        uiSchema: militaryDutyImpact.uiSchema,
-        schema: militaryDutyImpact.schema,
-      },
-      // 8940 - Job Applications
-      recentJobApplications: {
-        title: 'Recent job applications',
-        path: 'recent-job-applications',
-        depends: needsToAnswerUnemployability,
-        uiSchema: recentJobApplications.uiSchema,
-        schema: recentJobApplications.schema,
-      },
-      // 8940 - Education & Training
-      pastEducationTraining: {
-        title: 'Education & training',
-        path: 'past-education-training',
-        depends: needsToAnswerUnemployability,
-        uiSchema: pastEducationTraining.uiSchema,
-        schema: pastEducationTraining.schema,
-      },
-      // 8940 - Recent Education & Training
-      recentEducationTraining: {
-        title: 'Recent education & training',
-        path: 'recent-education-training',
-        depends: needsToAnswerUnemployability,
-        uiSchema: recentEducationTraining.uiSchema,
-        schema: recentEducationTraining.schema,
-      },
-      // 8940 - Additional Remarks
-      unemployabilityAdditionalInformation: {
-        title: '8940 additional information',
-        path: 'unemployability-additional-information',
-        depends: needsToAnswerUnemployability,
-        uiSchema: unemployabilityAdditionalInformation.uiSchema,
-        schema: unemployabilityAdditionalInformation.schema,
-      },
-      // 8940 - Supporting Documents
-      // 8940 - Upload Supporting Docs
-      uploadUnemployabilitySupportingDocumentsChoice: {
-        title: 'Supporting documents',
-        path: 'upload-unemployability-supporting-documents-choice',
-        depends: needsToAnswerUnemployability,
-        uiSchema: uploadUnemployabilitySupportingDocumentsChoice.uiSchema,
-        schema: uploadUnemployabilitySupportingDocumentsChoice.schema,
-      },
-      uploadUnemployabilitySupportingDocuments: {
-        title: 'Upload supporting documents',
-        path: 'upload-unemployability-supporting-documents',
-        depends: formData => isUploadingSupporting8940Documents(formData),
-        uiSchema: uploadUnemployabilitySupportingDocuments.uiSchema,
-        schema: uploadUnemployabilitySupportingDocuments.schema,
-      },
-      // 8940 - Certification
-      unemployabilityCertification: {
-        title: 'Unemployability certification',
-        path: 'unemployability-certification',
-        depends: needsToAnswerUnemployability,
-        uiSchema: unemployabilityCertification.uiSchema,
-        schema: unemployabilityCertification.schema,
-      },
-      // 4192 -
-      ...createFormConfig4192(),
-    };
+  if (
+    // need this environment check for unit tests to work
+    environment.isProduction() &&
+    // this will filter production users using the feature flag
+    sessionStorage.getItem(SHOW_8940_4192) !== 'true'
+  ) {
+    return {};
   }
-  return configObj;
+  return {
+    // 8940 - Introduction
+    unemployabilityFormIntro: {
+      title: 'File a claim for Individual Unemployability (8940)',
+      path: 'unemployability-walkthrough-choice',
+      depends: needsToEnterUnemployability,
+      uiSchema: unemployabilityFormIntro.uiSchema,
+      schema: unemployabilityFormIntro.schema,
+      onContinue: captureEvents.unemployabilityFormIntro,
+    },
+    // 8940 - Upload 8940
+    unemployabilityFormUpload: {
+      title: 'Upload unemployability form',
+      path: 'new-disabilities/unemployability-form-upload',
+      depends: isUploading8940Form,
+      uiSchema: unemployabilityFormUpload.uiSchema,
+      schema: unemployabilityFormUpload.schema,
+    },
+    // 8940 - Contentions
+    unemployabilityDisabilities: {
+      title: 'Unemployability disabilities',
+      path: 'unemployability-disabilities',
+      depends: needsToAnswerUnemployability,
+      uiSchema: unemployabilityDisabilities.uiSchema,
+      schema: unemployabilityDisabilities.schema,
+    },
+    // 8940 - Medical Care
+    medicalCare: {
+      title: 'Medical care',
+      path: 'medical-care',
+      depends: needsToAnswerUnemployability,
+      uiSchema: medicalCare.uiSchema,
+      schema: medicalCare.schema,
+    },
+    // 8940 - Hospital Treatment
+    hospitalizationHistory: {
+      title: 'Hospitalization',
+      path: 'hospitalization-history',
+      depends: hasHospitalCare,
+      uiSchema: hospitalizationHistory.uiSchema,
+      schema: hospitalizationHistory.schema,
+    },
+    // 8940 - Doctor Treatment
+    unemployabilityDoctorCare: {
+      title: 'Doctor’s care',
+      path: 'doctor-care',
+      depends: hasDoctorsCare,
+      uiSchema: unemployabilityDoctorCare.uiSchema,
+      schema: unemployabilityDoctorCare.schema,
+    },
+    // 8940 - Disability Dates
+    unemployabilityDates: {
+      title: 'Disability dates',
+      path: 'unemployability-disability-dates',
+      depends: needsToAnswerUnemployability,
+      uiSchema: unemployabilityDates.uiSchema,
+      schema: unemployabilityDates.schema,
+    },
+    // 8940 - Income Details
+    incomeDetails: {
+      title: 'Income details',
+      path: 'unemployability-income-details',
+      depends: needsToAnswerUnemployability,
+      uiSchema: incomeDetails.uiSchema,
+      schema: incomeDetails.schema,
+    },
+    // 8940 - Employment History
+    employmentHistory: {
+      title: 'Employment history',
+      path: 'unemployability-employment-history',
+      depends: needsToAnswerUnemployability,
+      uiSchema: employmentHistory.uiSchema,
+      schema: employmentHistory.schema,
+    },
+    // 8940 - Recent Earnings
+    recentEarnedIncome: {
+      title: 'Recent earnings',
+      path: 'recent-earnings',
+      depends: needsToAnswerUnemployability,
+      uiSchema: recentEarnedIncome.uiSchema,
+      schema: recentEarnedIncome.schema,
+    },
+    // 8940 - Supplementary Benefits
+    supplementalBenefits: {
+      title: 'Supplemental benefits',
+      path: 'supplemental-benefits',
+      depends: needsToAnswerUnemployability,
+      uiSchema: supplementalBenefits.uiSchema,
+      schema: supplementalBenefits.schema,
+    },
+    // 8940 - Military Duty
+    militaryDutyImpact: {
+      title: 'Impact on military duty',
+      path: 'military-duty-impact',
+      depends: needsToAnswerUnemployability,
+      uiSchema: militaryDutyImpact.uiSchema,
+      schema: militaryDutyImpact.schema,
+    },
+    // 8940 - Job Applications
+    recentJobApplications: {
+      title: 'Recent job applications',
+      path: 'recent-job-applications',
+      depends: needsToAnswerUnemployability,
+      uiSchema: recentJobApplications.uiSchema,
+      schema: recentJobApplications.schema,
+    },
+    // 8940 - Education & Training
+    pastEducationTraining: {
+      title: 'Education & training',
+      path: 'past-education-training',
+      depends: needsToAnswerUnemployability,
+      uiSchema: pastEducationTraining.uiSchema,
+      schema: pastEducationTraining.schema,
+    },
+    // 8940 - Recent Education & Training
+    recentEducationTraining: {
+      title: 'Recent education & training',
+      path: 'recent-education-training',
+      depends: needsToAnswerUnemployability,
+      uiSchema: recentEducationTraining.uiSchema,
+      schema: recentEducationTraining.schema,
+    },
+    // 8940 - Additional Remarks
+    unemployabilityAdditionalInformation: {
+      title: '8940 additional information',
+      path: 'unemployability-additional-information',
+      depends: needsToAnswerUnemployability,
+      uiSchema: unemployabilityAdditionalInformation.uiSchema,
+      schema: unemployabilityAdditionalInformation.schema,
+    },
+    // 8940 - Supporting Documents
+    // 8940 - Upload Supporting Docs
+    uploadUnemployabilitySupportingDocumentsChoice: {
+      title: 'Supporting documents',
+      path: 'upload-unemployability-supporting-documents-choice',
+      depends: needsToAnswerUnemployability,
+      uiSchema: uploadUnemployabilitySupportingDocumentsChoice.uiSchema,
+      schema: uploadUnemployabilitySupportingDocumentsChoice.schema,
+    },
+    uploadUnemployabilitySupportingDocuments: {
+      title: 'Upload supporting documents',
+      path: 'upload-unemployability-supporting-documents',
+      depends: formData => isUploadingSupporting8940Documents(formData),
+      uiSchema: uploadUnemployabilitySupportingDocuments.uiSchema,
+      schema: uploadUnemployabilitySupportingDocuments.schema,
+    },
+    // 8940 - Certification
+    unemployabilityCertification: {
+      title: 'Unemployability certification',
+      path: 'unemployability-certification',
+      depends: needsToAnswerUnemployability,
+      uiSchema: unemployabilityCertification.uiSchema,
+      schema: unemployabilityCertification.schema,
+    },
+    // 4192 -
+    ...formConfig4192,
+  };
 }

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -280,6 +280,8 @@ export const WIZARD_STATUS = 'wizardStatus526';
 // sessionStorage key used to determine if the form title should be set to BDD
 export const FORM_STATUS_BDD = 'formStatusBdd';
 
+export const SHOW_8940_4192 = 'showSubforms';
+
 // sessionStorage key used for the user entered separation date in the wizard
 // used by the first page of the form to populate the form data
 export const SAVED_SEPARATION_DATE = 'savedSeparationDate';

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/mocks/feature-toggles.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/mocks/feature-toggles.json
@@ -21,6 +21,10 @@
       {
         "name": "form526_confirmation_email_show_copy",
         "value": true
+      },
+      {
+        "name": "subform_8940_4192",
+        "value": true
       }
     ]
   }

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -985,6 +985,9 @@ export const showSeparationLocation = formData => {
 
 export const show526Wizard = state => toggleValues(state).show526Wizard;
 
+export const showSubform8940And4192 = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.subform89404192];
+
 export const confirmationEmailFeature = state => {
   const isForm526ConfirmationEmailOn = toggleValues(state)[
     FEATURE_FLAG_NAMES.form526ConfirmationEmail

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -76,4 +76,5 @@ export default Object.freeze({
   gibctStateSearch: 'gibct_state_search',
   eduFormOmbAndExpiration: 'edu_form_omb_and_expiration',
   manageDependents: 'dependents_management',
+  subform89404192: 'subform_8940_4192',
 });


### PR DESCRIPTION
## Description

Currently unreleased subforms 8940 and 4192 are contained within form 526, but are behind a combined production environment flag and a feature flag.

The reason for the combination is because the feature flag isn't readily available to the `formConfig` so the `FormApp` checks the feature flag and sets a session storage value. The session storage flag isn't available to unit tests, because it appears the form config loads before the session storage is set - even when it is places at the top of the unit test.

Related:

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/13848
- https://github.com/department-of-veterans-affairs/vets-api/pull/6015

## Testing done

Unit tests & Cypress e2e tests

## Screenshots

N/A

## Acceptance criteria
- [x] Forms 8940 & 4192 are controlled by a combo environment production flag and a feature flag

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
