### PR TITLE
Set drupalMaxParallizationRequests to 10 from 15

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -161,7 +161,7 @@ def checkForBrokenLinks(String buildLogPath, String envName, Boolean contentOnly
     // Only break the build if broken links are found in master
     if (IS_PROD_BRANCH || contentOnlyBuild) {
       echo "Notifying Slack channel."
-      
+
       // slackUploadFile(filePath: csvFile, channel: 'dev_null', failOnError: true, initialComment: "Found broken links in the ${envName} build on `${env.BRANCH_NAME}`.")
 
       // Until slackUploadFile works...
@@ -198,16 +198,18 @@ def checkForBrokenLinks(String buildLogPath, String envName, Boolean contentOnly
 }
 
 def build(String ref, dockerContainer, String assetSource, String envName, Boolean useCache, Boolean contentOnlyBuild) {
-  // Use Drupal prod for all environments
+  // Use CMS PROD for all environments
   def drupalAddress = DRUPAL_ADDRESSES.get('vagovprod')
   def drupalCred = DRUPAL_CREDENTIALS.get('vagovprod')
   def drupalMode = useCache ? '' : '--pull-drupal'
+  // 15 puts PROD CMS RDS at 100% load sometimes
+  def drupalMaxParallelRequests = 10
 
   withCredentials([usernamePassword(credentialsId:  "${drupalCred}", usernameVariable: 'DRUPAL_USERNAME', passwordVariable: 'DRUPAL_PASSWORD')]) {
     dockerContainer.inside(DOCKER_ARGS) {
       def buildLogPath = "/application/${envName}-build.log"
 
-      sh "cd /application && jenkins/build.sh --envName ${envName} --assetSource ${assetSource} --drupalAddress ${drupalAddress} ${drupalMode} --buildLog ${buildLogPath} --verbose"
+      sh "cd /application && jenkins/build.sh --drupal-max-parallel-requests ${drupalMaxParallelRequests} --envName ${envName} --assetSource ${assetSource} --drupalAddress ${drupalAddress} ${drupalMode} --buildLog ${buildLogPath} --verbose"
 
       if (envName == 'vagovprod') {
         // Find any broken links in the log


### PR DESCRIPTION
## Description
Follow up from https://github.com/department-of-veterans-affairs/va.gov-cms/issues/4351#issuecomment-790960031. 

This PR is an attempt at getting the new [`drupalMaxParallelizationRequests`](https://github.com/department-of-veterans-affairs/vets-website/pull/16247) down from 15 to 10 on vets-website branch builds. The current changes appear to be global and would even affect PROD builds so is not mergeable as is.

Feel free to push changes up to this branch etc.  

Slack discussion here: https://dsva.slack.com/archives/CBU0KDSB1/p1614893838148200


## Testing done
http://jenkins.vfs.va.gov/job/testing/job/vets-website/job/el-content-build-set-parallelization-10/1/console (running now)

## Screenshots


## Acceptance criteria
- [ ] RDS on CMS PROD doesn't spike to 100%. 


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
