### PR TITLE
Kelsonic fix omitdebug

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -55,6 +55,7 @@ src/applications/find-forms @department-of-veterans-affairs/vsa-public-websites-
 src/applications/yellow-ribbon @department-of-veterans-affairs/vsa-public-websites-frontend
 src/applications/search @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend @department-of-veterans-affairs/vsa-caregiver-frontend
 src/applications/resources-and-support @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend @department-of-veterans-affairs/vsa-caregiver-frontend
+src/site/includes/debug.drupal.liquid @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend
 src/site/layouts/campaign_landing_page.drupal.liquid @department-of-veterans-affairs/vsa-public-websites-frontend
 src/site/stages/build/process-cms-exports/schemas/input/block_content-promo.js @department-of-veterans-affairs/vsa-public-websites-frontend
 src/site/stages/build/process-cms-exports/schemas/input/node-basic_landing_page.js @department-of-veterans-affairs/vsa-public-websites-frontend

--- a/script/preview.js
+++ b/script/preview.js
@@ -37,6 +37,7 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'content-directory', type: String, defaultValue: defaultContentDir },
   { name: 'accessibility', type: Boolean, defaultValue: true },
   { name: 'lint-plain-language', type: Boolean, defaultValue: false },
+  { name: 'omitdebug', type: Boolean, defaultValue: false },
   {
     name: 'drupal-address',
     type: String,

--- a/src/site/includes/debug.drupal.liquid
+++ b/src/site/includes/debug.drupal.liquid
@@ -1,12 +1,12 @@
 {% if isPreview or buildtype != 'vagovprod' %}
-  {% if omitdebug == false %}
+  {% if !omitdebug %}
     {% assign showDebug = true %}
   {% endif %}
 {% endif %}
 
 {% if showDebug %}
-<script nonce="**CSP_NONCE**" data-template="includes/debug">
-  window.contentData = {{ debug }};
-  console.info('Metalsmith template generated from content:', window.contentData);
-</script>
+  <script nonce="**CSP_NONCE**" data-template="includes/debug">
+    window.contentData = {{ debug }};
+    console.info('Metalsmith template generated from content:', window.contentData);
+  </script>
 {% endif %}


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/vets-website/pull/16240#issuecomment-790966430 This blocks Public Websites and Facilities from seeing the data the CMS gives our liquid templates on the preview servers like [I mentioned](https://github.com/department-of-veterans-affairs/vets-website/pull/16240#issuecomment-790892403), so This PR fixes it with [my proposed suggestion](https://github.com/department-of-veterans-affairs/vets-website/pull/16240#discussion_r586825839).

## Testing done
Tested locally, we now have the debug log locally that was omitted: http://localhost:3001/preview?nodeId=16108

## Screenshots
N/A

## Acceptance criteria
- [x] Fix omitdebug implementation

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
