### PR TITLE
[Jenkinsfile] Decrement Drupal parallelization to 10 if not a content deployment

### DIFF
--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -17,6 +17,10 @@ do
       assetSource="${2}"
       shift 2
       ;;
+    --drupalMaxParallelRequests)
+      drupalMaxParallelRequests="${2}"
+      shift 2
+      ;;
     --drupalAddress)
       drupalAddress="${2}"
       shift 2
@@ -43,6 +47,6 @@ done
 # exit code.  In this case, if the build command fails, the tee
 # command won't trick Jenkins into thinking the step passed.
 set -o pipefail
-npm --no-color run build -- --buildtype="$envName" --asset-source="$assetSource" --drupal-address="$drupalAddress" "$omitdebug" "$pullDrupal" 2>&1 | tee "$buildLog"
+npm --no-color run build -- --buildtype="$envName" --asset-source="$assetSource" --drupal-address="$drupalAddress" --drupal-max-parallel-requests="$drupalMaxParallelRequests" "$omitdebug" "$pullDrupal" 2>&1 | tee "$buildLog"
 
 exit $?

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -17,12 +17,12 @@ do
       assetSource="${2}"
       shift 2
       ;;
-    --drupalMaxParallelRequests)
-      drupalMaxParallelRequests="${2}"
-      shift 2
-      ;;
     --drupalAddress)
       drupalAddress="${2}"
+      shift 2
+      ;;
+    --drupalMaxParallelRequests)
+      drupalMaxParallelRequests="${2}"
       shift 2
       ;;
     --pull-drupal)
@@ -47,6 +47,6 @@ done
 # exit code.  In this case, if the build command fails, the tee
 # command won't trick Jenkins into thinking the step passed.
 set -o pipefail
-npm --no-color run build -- --buildtype="$envName" --asset-source="$assetSource" --drupal-address="$drupalAddress" --drupal-max-parallel-requests="$drupalMaxParallelRequests" "$omitdebug" "$pullDrupal" 2>&1 | tee "$buildLog"
+npm --no-color run build -- --verbose --buildtype="$envName" --asset-source="$assetSource" --drupal-address="$drupalAddress" --drupal-max-parallel-requests="$drupalMaxParallelRequests" "$omitdebug" "$pullDrupal" 2>&1 | tee "$buildLog"
 
 exit $?

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -212,7 +212,7 @@ def build(String ref, dockerContainer, String assetSource, String envName, Boole
     dockerContainer.inside(DOCKER_ARGS) {
       def buildLogPath = "/application/${envName}-build.log"
 
-      sh "cd /application && jenkins/build.sh --envName ${envName} --assetSource ${assetSource} --drupalAddress ${drupalAddress} --drupal-max-parallel-requests=${drupalMaxParallelRequests} ${drupalMode} --buildLog ${buildLogPath} --verbose"
+      sh "cd /application && jenkins/build.sh --envName ${envName} --assetSource ${assetSource} --drupalAddress ${drupalAddress} --drupalMaxParallelRequests=${drupalMaxParallelRequests} ${drupalMode} --buildLog ${buildLogPath} --verbose"
 
       if (envName == 'vagovprod') {
         // Find any broken links in the log

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -161,7 +161,7 @@ def checkForBrokenLinks(String buildLogPath, String envName, Boolean contentOnly
     // Only break the build if broken links are found in master
     if (IS_PROD_BRANCH || contentOnlyBuild) {
       echo "Notifying Slack channel."
-      
+
       // slackUploadFile(filePath: csvFile, channel: 'dev_null', failOnError: true, initialComment: "Found broken links in the ${envName} build on `${env.BRANCH_NAME}`.")
 
       // Until slackUploadFile works...
@@ -202,12 +202,17 @@ def build(String ref, dockerContainer, String assetSource, String envName, Boole
   def drupalAddress = DRUPAL_ADDRESSES.get('vagovprod')
   def drupalCred = DRUPAL_CREDENTIALS.get('vagovprod')
   def drupalMode = useCache ? '' : '--pull-drupal'
+  def drupalMaxParallelRequests = 10;
+
+  if (contentOnlyBuild) {
+    drupalMaxParallelRequests = 15
+  }
 
   withCredentials([usernamePassword(credentialsId:  "${drupalCred}", usernameVariable: 'DRUPAL_USERNAME', passwordVariable: 'DRUPAL_PASSWORD')]) {
     dockerContainer.inside(DOCKER_ARGS) {
       def buildLogPath = "/application/${envName}-build.log"
 
-      sh "cd /application && jenkins/build.sh --envName ${envName} --assetSource ${assetSource} --drupalAddress ${drupalAddress} ${drupalMode} --buildLog ${buildLogPath} --verbose"
+      sh "cd /application && jenkins/build.sh --envName ${envName} --assetSource ${assetSource} --drupalAddress ${drupalAddress} --drupal-max-parallel-requests=${drupalMaxParallelRequests} ${drupalMode} --buildLog ${buildLogPath} --verbose"
 
       if (envName == 'vagovprod') {
         // Find any broken links in the log

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -212,7 +212,7 @@ def build(String ref, dockerContainer, String assetSource, String envName, Boole
     dockerContainer.inside(DOCKER_ARGS) {
       def buildLogPath = "/application/${envName}-build.log"
 
-      sh "cd /application && jenkins/build.sh --envName ${envName} --assetSource ${assetSource} --drupalAddress ${drupalAddress} --drupalMaxParallelRequests=${drupalMaxParallelRequests} ${drupalMode} --buildLog ${buildLogPath} --verbose"
+      sh "cd /application && jenkins/build.sh --envName ${envName} --assetSource ${assetSource} --drupalAddress ${drupalAddress} --drupalMaxParallelRequests ${drupalMaxParallelRequests} ${drupalMode} --buildLog ${buildLogPath} --verbose"
 
       if (envName == 'vagovprod') {
         // Find any broken links in the log

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -202,7 +202,7 @@ def build(String ref, dockerContainer, String assetSource, String envName, Boole
   def drupalAddress = DRUPAL_ADDRESSES.get('vagovprod')
   def drupalCred = DRUPAL_CREDENTIALS.get('vagovprod')
   def drupalMode = useCache ? '' : '--pull-drupal'
-  def drupalMaxParallelRequests = 10;
+  def drupalMaxParallelRequests = 5;
 
   if (contentOnlyBuild) {
     drupalMaxParallelRequests = 15


### PR DESCRIPTION

## Description
Per CMS team, we should use only 10 HTTP requests on vets-website branch builds.

https://dsva.slack.com/archives/CBU0KDSB1/p1614893838148200
https://github.com/department-of-veterans-affairs/vets-website/pull/16269
## Testing done
CI is the test!

## Screenshots
N/A

## Acceptance criteria
- [ ] Less requests to CMS during regular CI

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
