### PR TITLE
Refactor/20763 link assets to bucket

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -268,7 +268,7 @@ def buildAll(String ref, dockerContainer, Boolean contentOnlyBuild) {
 def prearchive(dockerContainer, envName) {
   dockerContainer.inside(DOCKER_ARGS) {
     sh "cd /application && NODE_ENV=production yarn build --buildtype ${envName} --setPublicPath"
-    sh "cd /application && node --max-old-space-size=10240 script/prearchive.js --buildtype=${envName}"
+    sh "cd /application && node script/prearchive.js --buildtype=${envName}"
   }
 }
 

--- a/src/site/stages/prearchive/helpers.js
+++ b/src/site/stages/prearchive/helpers.js
@@ -42,7 +42,9 @@ function updateAssetLinkElements(
   teamsiteAssets,
   bucketPath,
 ) {
-  const doc = cheerio.load(htmlFile);
+  const doc = cheerio.load(htmlFile, {
+    decodeEntities: false,
+  });
   const assetLinkElements = doc(assetLinkTags);
   assetLinkElements.each((i, element) => {
     updateSrcPaths(doc, element, bucketPath, teamsiteAssets);

--- a/src/site/stages/prearchive/helpers.js
+++ b/src/site/stages/prearchive/helpers.js
@@ -1,0 +1,51 @@
+const cheerio = require('cheerio');
+
+function updateNotNeededCheck(assetSrc, teamsiteAssets) {
+  return (
+    !assetSrc ||
+    assetSrc.startsWith('http') ||
+    assetSrc.startsWith('data:') ||
+    assetSrc.includes(teamsiteAssets)
+  );
+}
+
+function updateAssetBucketLocation(prop, assetSrc, item, bucketPath) {
+  let assetBucketLocation;
+  if (prop === 'srcset') {
+    const sources = assetSrc.split(',');
+    assetBucketLocation = sources
+      .map(src => `${bucketPath}${src.trim()}`)
+      .join(', ');
+  } else {
+    assetBucketLocation = `${bucketPath}${assetSrc}`;
+  }
+  item.attr(prop, assetBucketLocation);
+}
+
+function updateSrcPaths(doc, element, bucketPath, teamsiteAssets) {
+  const item = doc(element);
+  const possibleSrcProps = ['src', 'href', 'data-src', 'srcset'];
+  possibleSrcProps.forEach(prop => {
+    const assetSrc = item.attr(prop);
+    const updateNotNeeded = updateNotNeededCheck(assetSrc, teamsiteAssets);
+    if (!updateNotNeeded) {
+      updateAssetBucketLocation(prop, assetSrc, item, bucketPath);
+    }
+  });
+}
+
+function updateAssetLinkElements(
+  htmlFile,
+  assetLinkTags,
+  teamsiteAssets,
+  bucketPath,
+) {
+  const doc = cheerio.load(htmlFile);
+  const assetLinkElements = doc(assetLinkTags);
+  assetLinkElements.each((i, element) => {
+    updateSrcPaths(doc, element, bucketPath, teamsiteAssets);
+  });
+  return doc;
+}
+
+module.exports = updateAssetLinkElements;

--- a/src/site/stages/prearchive/helpers.js
+++ b/src/site/stages/prearchive/helpers.js
@@ -1,6 +1,8 @@
 const cheerio = require('cheerio');
 
 function updateNotNeededCheck(assetSrc, teamsiteAssets) {
+  // Making an assumption here that we don't use srcset
+  // to point to both external and internal images
   return (
     !assetSrc ||
     assetSrc.startsWith('http') ||

--- a/src/site/stages/prearchive/link-assets-to-bucket.js
+++ b/src/site/stages/prearchive/link-assets-to-bucket.js
@@ -32,14 +32,7 @@ function linkAssetsToBucketHTML(options, fileNames, bucketPath) {
   });
 }
 
-function linkAssetsToBucket(options, fileNames) {
-  const bucketPath = buckets[options.buildtype];
-
-  // Heroku deployments (review instances) won't have a bucket.
-  if (!bucketPath) return;
-
-  linkAssetsToBucketHTML(options, fileNames, bucketPath);
-
+function linkAssetsToBucketCSS(fileNames, bucketPath) {
   const cssFileNames = fileNames.filter(file => path.extname(file) === '.css');
   const cssUrlRegex = new RegExp(/url\(\/(?!(va_files))/, 'g');
   const cssUrlBucket = `url(${bucketPath}/`;
@@ -52,7 +45,9 @@ function linkAssetsToBucket(options, fileNames) {
 
     fs.writeFileSync(cssFileName, newCss);
   }
+}
 
+function linkAssetsToBucketProxyRewrite(fileNames, bucketPath) {
   // The proxy-rewrite is a special case.
   const proxyRewriteFileName = fileNames.find(file =>
     file.endsWith('proxy-rewrite.entry.js'),
@@ -63,6 +58,17 @@ function linkAssetsToBucket(options, fileNames) {
     .replace(/https:\/\/www\.va\.gov\/img/g, `${bucketPath}/img`);
 
   fs.writeFileSync(proxyRewriteFileName, newProxyRewriteContents);
+}
+
+function linkAssetsToBucket(options, fileNames) {
+  const bucketPath = buckets[options.buildtype];
+
+  // Heroku deployments (review instances) won't have a bucket.
+  if (!bucketPath) return;
+
+  linkAssetsToBucketHTML(options, fileNames, bucketPath);
+  linkAssetsToBucketCSS(fileNames, bucketPath);
+  linkAssetsToBucketProxyRewrite(fileNames, bucketPath);
 }
 
 module.exports = linkAssetsToBucket;

--- a/src/site/stages/prearchive/link-assets-to-bucket.js
+++ b/src/site/stages/prearchive/link-assets-to-bucket.js
@@ -28,7 +28,8 @@ function linkAssetsToBucketHTML(options, fileNames, bucketPath) {
       teamsiteAssets,
       bucketPath,
     );
-    fs.writeFileSync(fileName, updatedFile);
+    const updatedFileBuffer = Buffer.from(updatedFile.html());
+    fs.writeFileSync(fileName, updatedFileBuffer);
   });
 }
 

--- a/src/site/stages/prearchive/tests/helpers.spec.js
+++ b/src/site/stages/prearchive/tests/helpers.spec.js
@@ -1,0 +1,85 @@
+const { expect } = require('chai');
+const updateAssetLinkElements = require('../helpers');
+
+const mockHTML = `
+<img id="img-update" src="/img/updateme.jpg" />
+<script id="script-update" src="/js/updateme.js"></script>
+<link id="link-update" href="/styles/updateme.css">
+<picture><source id="picture-source-srcset-update" srcset="/img/updateme.jpg, /img/updateme2.jpg"></picture>
+<img id="img-data-src-update" data-src="/img/updateme" />
+<div id="div-no-update" src="/img/donotupdate.jpg"></div>
+<img id="img-teamsite-no-update" src="/img/va_files-donotupdate.jpg" />
+<img id="img-http-no-update" src="http://donotupdate.com" />
+<img id="img-https-no-update" src="https://donotupdate.com" />
+<img id="img-data-no-update" src="data:image/gif;base64,donotupdate" />
+`;
+
+describe('prearchive/helpers', () => {
+  let result;
+  before(() => {
+    const assetLinkTags = 'script, img, link, picture > source';
+    const teamsiteAssets = 'va_files';
+    const bucketPath = 'https://updatedPath';
+    result = updateAssetLinkElements(
+      mockHTML,
+      assetLinkTags,
+      teamsiteAssets,
+      bucketPath,
+    );
+  });
+
+  after(() => {
+    result = null;
+  });
+
+  it('updates src link for <img> element', () => {
+    const imgSrc = result('#img-update').attr('src');
+    expect(imgSrc).to.equal('https://updatedPath/img/updateme.jpg');
+  });
+
+  it('updates src link for <script> element', () => {
+    const scriptSrc = result('#script-update').attr('src');
+    expect(scriptSrc).to.equal('https://updatedPath/js/updateme.js');
+  });
+
+  it('updates href link for <link> element', () => {
+    const linkHref = result('#link-update').attr('href');
+    expect(linkHref).to.equal('https://updatedPath/styles/updateme.css');
+  });
+
+  it('updates both links in srcset for <picture><source> element', () => {
+    const pictureSrcset = result('#picture-source-srcset-update').attr(
+      'srcset',
+    );
+    expect(pictureSrcset).to.equal(
+      'https://updatedPath/img/updateme.jpg, https://updatedPath/img/updateme2.jpg',
+    );
+  });
+
+  it('updates data-source link', () => {
+    const dataSrcLink = result('#img-data-src-update').attr('data-src');
+    expect(dataSrcLink).to.equal('https://updatedPath/img/updateme');
+  });
+
+  it('does not update src link in <div> element', () => {
+    const divSrc = result('#div-no-update').attr('src');
+    expect(divSrc).to.equal('/img/donotupdate.jpg');
+  });
+
+  it('does not update src link that contains "va_files"', () => {
+    const teamsiteSrc = result('#img-teamsite-no-update').attr('src');
+    expect(teamsiteSrc).to.equal('/img/va_files-donotupdate.jpg');
+  });
+
+  it('does not update src link that begins with "http" or "https"', () => {
+    const httpSrc = result('#img-http-no-update').attr('src');
+    const httpsSrc = result('#img-https-no-update').attr('src');
+    expect(httpSrc).to.equal('http://donotupdate.com');
+    expect(httpsSrc).to.equal('https://donotupdate.com');
+  });
+
+  it('does not update src link that begins with "data:"', () => {
+    const dataSrc = result('#img-data-no-update').attr('src');
+    expect(dataSrc).to.equal('data:image/gif;base64,donotupdate');
+  });
+});


### PR DESCRIPTION
## Description
**[Replace JSDOM with Cheerio in linkAssetsToBucket function](https://app.zenhub.com/workspaces/vsp-5cedc9cce6e3335dc5a49fc4/issues/department-of-veterans-affairs/va.gov-team/20763)**

This is a refactor of the `linkAssetsToBucket` function in the prearchive stage. There are three things I wanted to accomplish with this refactor:
- [x] Replace JSDOM with Cheerio for traversing and updating asset source links in HTML files
- [x] Break up the `linkAssetsToBucket` function to make it easier to read and easier to test
- [x] Add unit tests that cover the logic in the `linkAssetsToBucket` function

According to some testing I did, this refactor should also allow us to get rid of the memory limit increase we currently have to have in order to run this function.

## Testing done
To spot-check locally:
  1. If you already have a folder in your build directory called “vagovstaging”, delete it.  
  2. Run staging build
    - `NODE_ENV=production yarn build --buildtype vagovstaging --setPublicPath`
    - Need to use staging or prod locally
  3. Check an HTML file for local asset references
    - build/vagovstaging/altoona-health-care/about-us/index.html line 207 should have an image source of “/img/tiny-usa-flag.png”
  4. Run staging prearchive:
    - `node script/prearchive.js --buildtype=vagovstaging`
    - There will be no output to the console.
  5. Check the HTML file for updated asset references
    - build/vagovstaging/altoona-health-care/about-us/index.html line 207 should have an updated image source of “https://staging-va-gov-assets.s3-us-gov-west-1.amazonaws.com/img/tiny-usa-flag.png”

To run just this set of tests locally:
- run `yarn mocha ./src/site/stages/prearchive/tests/helpers.spec.js`

## Acceptance criteria
- [ ] JSDOM is replaced with Cheerio in the `linkAssetsToBucket` function
- [ ] The `linkAssetsToBucket` function accomplishes the same task it did before
- [ ] Unit tests have been written to cover the logic required to update the HTML files

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
