### PR TITLE
Wrap the alert block template with entityPublished conditional

### DIFF
--- a/src/site/blocks/alert.drupal.liquid
+++ b/src/site/blocks/alert.drupal.liquid
@@ -17,37 +17,44 @@
         }
     }
 {% endcomment %}
+
 {% if alert.fieldAlertContent %}
   {% assign expander = alert.fieldAlertContent.entity %}
 {% endif %}
+
 {% assign alertType = alert.fieldAlertType %}
+
 {% if alertType = "information" %}
   {% assign alertType = "info" %}
 {% endif %}
 
-<div data-template="blocks/alert" data-entity-id="{{ alert.entityId }}" class="usa-alert usa-alert-{{ alertType }}" role="alert">
-  <div class="usa-alert-body">
-    <h2 class="usa-alert-heading vads-u-font-size--h3">
-      {{ alert.fieldAlertTitle }}
-    </h2>
-    {% if expander.fieldTextExpander == empty %}
-        {{ expander.fieldWysiwyg.processed }}
-    {% endif %}
+{% if alert.entityPublished %}
+  <div data-template="blocks/alert" data-entity-id="{{ alert.entityId }}" class="usa-alert usa-alert-{{ alertType }}" role="alert">
+    <div class="usa-alert-body">
+      <h2 class="usa-alert-heading vads-u-font-size--h3">
+        {{ alert.fieldAlertTitle }}
+      </h2>
 
-    {% if expander.fieldTextExpander %}
+      {% if expander.fieldTextExpander == empty %}
+          {{ expander.fieldWysiwyg.processed }}
+      {% endif %}
 
-      {% comment %}
-        NOTE: .additional-info-container is a class utilized by
-        createAdditionalInfoWidget.js to add toggle functionality to info alerts
-      {% endcomment %}
+      {% if expander.fieldTextExpander %}
+        {% comment %}
+          NOTE: .additional-info-container is a class utilized by
+          createAdditionalInfoWidget.js to add toggle functionality to info alerts
+        {% endcomment %}
 
-      <div data-alert-box-title="{{ alert.fieldAlertTitle }}" data-label="{{ expander.fieldTextExpander }}" class="form-expanding-group borderless-alert additional-info-container">
-        <div class="additional-info-title">{{ expander.fieldTextExpander }}</div>
+        <div data-alert-box-title="{{ alert.fieldAlertTitle }}" data-label="{{ expander.fieldTextExpander }}" class="form-expanding-group borderless-alert additional-info-container">
+          <div class="additional-info-title">
+            {{ expander.fieldTextExpander }}
+          </div>
 
-        {% if expander.fieldWysiwyg %}
-          <div class="additional-info-content usa-alert-text" hidden>{{ expander.fieldWysiwyg.processed }}</div>
-        {% endif %}
-      </div>
-    {% endif %}
+          {% if expander.fieldWysiwyg %}
+            <div class="additional-info-content usa-alert-text" hidden>{{ expander.fieldWysiwyg.processed }}</div>
+          {% endif %}
+        </div>
+      {% endif %}
+    </div>
   </div>
-</div>
+{% endif %}

--- a/src/site/stages/build/drupal/graphql/alerts.graphql.js
+++ b/src/site/stages/build/drupal/graphql/alerts.graphql.js
@@ -9,6 +9,7 @@ const partialQuery = `
     entities {
       ... on BlockContentAlert {
         id
+        entityPublished
         fieldAlertDismissable
         fieldAlertFrequency
         fieldNodeReference {

--- a/src/site/stages/build/drupal/graphql/block-fragments/alert.block.graphql.js
+++ b/src/site/stages/build/drupal/graphql/block-fragments/alert.block.graphql.js
@@ -18,6 +18,7 @@ fieldAlert {
 const alert = `
 fragment alert on BlockContentAlert {
   entityId
+  entityPublished
   fieldAlertDismissable
   fieldAlertType
   fieldAlertTitle

--- a/src/site/stages/build/drupal/graphql/paragraph-fragments/alert.paragraph.graphql.js
+++ b/src/site/stages/build/drupal/graphql/paragraph-fragments/alert.paragraph.graphql.js
@@ -31,6 +31,7 @@ module.exports = `
         entity {
           ... on BlockContentAlert {
             entityId
+            entityPublished
             fieldAlertTitle
             fieldAlertType
             fieldReusability

--- a/src/site/stages/build/drupal/graphql/paragraph-fragments/alertSingle.paragraph.graphql.js
+++ b/src/site/stages/build/drupal/graphql/paragraph-fragments/alertSingle.paragraph.graphql.js
@@ -34,6 +34,7 @@ fragment alertSingle on ParagraphAlertSingle {
     entity {
       ... on BlockContentAlert {
         entityId
+        entityPublished
         fieldAlertTitle
         fieldAlertType
         fieldReusability


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/15756

This PR makes it so that we do **not show an alert** if it's not published.

## Testing done
N/A

## Screenshots

**We can see alerts as NOT PUBLISHED in the CMS via GraphQL here:**

![image](https://user-images.githubusercontent.com/12773166/110147774-4a99e500-7d99-11eb-8269-f55a12dd9687.png)

**BEFORE - NOT PUBLISHED, notice how the alert shows (undesirable)**

![before-not_published](https://user-images.githubusercontent.com/12773166/110156151-d749a080-7da3-11eb-814d-0ac07717e6dc.png)

**AFTER - NOT PUBLISHED, notice how the alert does not show (desirable)**

![after-not_published](https://user-images.githubusercontent.com/12773166/110156229-efb9bb00-7da3-11eb-8c9b-13fd35a8935b.png)

**BEFORE - PUBLISHED**:

![published](https://user-images.githubusercontent.com/12773166/110156267-fba57d00-7da3-11eb-8bf0-86dec0cac0cb.png)

**AFTER - PUBLISHED**:

![published](https://user-images.githubusercontent.com/12773166/110156267-fba57d00-7da3-11eb-8bf0-86dec0cac0cb.png)

## Acceptance criteria
- [x] This PR makes it so that we do **not show an alert** if it's not published.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
