### PR TITLE
fix incorrect more screening needed colors

### DIFF
--- a/src/applications/coronavirus-screener/components/FormResult.jsx
+++ b/src/applications/coronavirus-screener/components/FormResult.jsx
@@ -65,7 +65,7 @@ export default function FormResult({
   const MoreScreening = () => (
     <Complete
       selectedLanguage={selectedLanguage}
-      selectedColors={{ background: '#112e51', font: 'white' }}
+      selectedColors={{ background: 'white', font: '#112e51', name: '' }}
     >
       <h2 className="vads-u-font-size--2xl">
         {resultText.moreScreeningText[selectedLanguage]}


### PR DESCRIPTION
## Description

Fixes bug that resulted in the "pass" and "more screening needed" results to be the same color. Yes, better testing would have caught this :-).

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
