### PR TITLE
[20040] Project Cheetah Confirmation Page Updates

### DIFF
--- a/src/applications/vaos/project-cheetah/components/ConfirmationPage.jsx
+++ b/src/applications/vaos/project-cheetah/components/ConfirmationPage.jsx
@@ -9,6 +9,8 @@ import { getTimezoneAbbrBySystemId } from '../../utils/timezone.js';
 import { GA_PREFIX } from '../../utils/constants.js';
 import FacilityAddress from '../../components/FacilityAddress.jsx';
 import { selectConfirmationPage } from '../redux/selectors.js';
+import AddToCalendar from 'applications/vaos/components/AddToCalendar';
+import { formatFacilityAddress } from 'applications/vaos/services/location';
 
 const pageTitle = 'Your appointment has been scheduled';
 
@@ -22,33 +24,53 @@ function ConfirmationPage({ data, systemId, facilityDetails }) {
     return <Redirect to="/" />;
   }
 
-  const { date1 } = data;
+  const appointmentType = 'COVID-19 Vaccination';
+  const appointmentDateString =
+    moment(data.date1, 'YYYY-MM-DDTHH:mm:ssZ').format(
+      'dddd, MMMM D, YYYY [at] h:mm a ',
+    ) + getTimezoneAbbrBySystemId(systemId);
 
   return (
     <div>
       <h1>{pageTitle}</h1>
       <AlertBox status="success">
-        <strong>Your appointment is confirmed</strong>
-        <br />
-        Please see your appointment details below.
+        <strong>
+          Your appointment is confirmed. Please see your appointment details
+          below.
+        </strong>
       </AlertBox>
       <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
-        <h2 className="vads-u-margin-y--0 vads-u-font-size--h3">
-          COVID-19 vaccine
+        <span className="vads-u-margin-y--0 vaos-u-text-transform--uppercase">
+          {appointmentType}
+        </span>
+        <br />
+        <h2 className="vads-u-font-size--h3 vads-u-margin-top--1 vads-u-margin-bottom--2">
+          {appointmentDateString}
         </h2>
-        First dose
-        <br />
-        {moment(date1, 'YYYY-MM-DDTHH:mm:ssZ').format(
-          'dddd, MMMM D, YYYY [at] h:mm a ',
-        ) + getTimezoneAbbrBySystemId(systemId)}
-        <br />
+        <strong>
+          <i className="fa fa-check-circle vads-u-color--green" />
+          <span className="vads-u-font-weight--bold vads-u-margin-left--1 vads-u-display--inline-block">
+            Confirmed
+          </span>
+        </strong>
         <br />
         {facilityDetails && (
-          <FacilityAddress
-            name={facilityDetails.name}
-            facility={facilityDetails}
-          />
+          <div className="vads-u-margin-top--2">
+            <FacilityAddress
+              name={facilityDetails.name}
+              facility={facilityDetails}
+              level={3}
+              showDirectionsLink
+            />
+          </div>
         )}
+        <div className="vads-u-margin-top--3 vaos-appts__block-label">
+          <AddToCalendar
+            summary={appointmentType.concat(' Appointment')}
+            location={formatFacilityAddress(facilityDetails)}
+            startDateTime={data.date1}
+          />
+        </div>
       </div>
       <div className="vads-u-margin-y--2">
         <Link

--- a/src/applications/vaos/project-cheetah/components/ConfirmationPage.jsx
+++ b/src/applications/vaos/project-cheetah/components/ConfirmationPage.jsx
@@ -24,7 +24,7 @@ function ConfirmationPage({ data, systemId, facilityDetails }) {
     return <Redirect to="/" />;
   }
 
-  const appointmentType = 'COVID-19 Vaccination';
+  const appointmentType = 'COVID-19 Vaccine';
   const appointmentDateString =
     moment(data.date1, 'YYYY-MM-DDTHH:mm:ssZ').format(
       'dddd, MMMM D, YYYY [at] h:mm a ',
@@ -68,7 +68,7 @@ function ConfirmationPage({ data, systemId, facilityDetails }) {
           <AddToCalendar
             summary={appointmentType.concat(' Appointment')}
             location={formatFacilityAddress(facilityDetails)}
-            startDateTime={data.date1}
+            startDateTime={data.date1[0]}
           />
         </div>
       </div>

--- a/src/applications/vaos/tests/project-cheetah/components/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/project-cheetah/components/ConfirmationPage.unit.spec.jsx
@@ -44,6 +44,12 @@ describe('VAOS vaccine flow <ConfirmationPage>', () => {
                 state: 'WY',
                 line: ['2360 East Pershing Boulevard'],
               },
+              telecom: [
+                {
+                  system: 'phone',
+                  value: '307-778-7550',
+                },
+              ],
             },
           ],
         },
@@ -60,10 +66,16 @@ describe('VAOS vaccine flow <ConfirmationPage>', () => {
         new RegExp(start.format('MMMM D, YYYY [at] h:mm a'), 'i'),
       ),
     ).to.be.ok;
-
+    expect(screen.baseElement).to.contain.text('Confirmed');
     expect(screen.getByText(/Cheyenne VA Medical Center/i)).to.be.ok;
     expect(screen.getByText(/2360 East Pershing Boulevard/i)).to.be.ok;
     expect(screen.baseElement).to.contain.text('Cheyenne, WY 82001-5356');
+    expect(screen.getByText(/directions/i)).to.have.attribute(
+      'href',
+      'https://maps.google.com?saddr=Current+Location&daddr=2360 East Pershing Boulevard, Cheyenne, WY 82001-5356',
+    );
+    expect(screen.baseElement).to.contain.text('Main phone: 307-778-7550');
+    expect(screen.getByText(/add to calendar/i)).to.have.tagName('a');
 
     userEvent.click(screen.getByText(/View your appointments/i));
     expect(screen.history.push.called).to.be.true;


### PR DESCRIPTION
## Description
Update the appointment scheduling confirmation page for COVID clinics.

- added constant for date string
- added constant for card title and calendar title
- added directions parmeter to facility address
- added the add to calendar link
- updated unit test to reflect changes

## Testing done
Local and Unit

## Screenshots
<img width="719" alt="image" src="https://user-images.githubusercontent.com/8315447/110168287-f573c880-7dc4-11eb-899a-645283dff97e.png">
<img width="321" alt="image" src="https://user-images.githubusercontent.com/8315447/110168336-0a505c00-7dc5-11eb-8ee2-4d96338685e9.png">
<img width="520" alt="image" src="https://user-images.githubusercontent.com/8315447/110168886-d88bc500-7dc5-11eb-80ba-d2ce786605b1.png">

## Acceptance criteria
- [ ] Changes are behind va_online_scheduling_cheetah feature flag
- [ ] Confirmation alert message displays
- [ ] Appointment type label displays
CONTENT - Appointment type label is "COVID-19 VACCINE"
- [ ] Date and time of appointment displays
- [ ] Confirmation icon and label displays
- [ ] Facility name and address displays
- [ ] Directions link displays
If user clicks Directions link, Then open default maps app with facility address pre-populated
- [ ] Facility phone number displays
- [ ] Add to calendar link displays
If user clicks Add to calendar link, Then download/open (respective to device) calendar file with the following pre-populated:
Appointment type
Location
Time
- [ ] View your appointments button displays
 If user clicks View your appointment button, Then display VAOS homepage

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
