### PR TITLE
526: Prevent Veterans from adding "Unknown condition"

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
@@ -19,6 +19,8 @@ import { errorSchemaIsValid } from 'platform/forms-system/src/js/validation';
 
 import findDuplicateIndexes from 'platform/forms-system/src/js/utilities/data/findDuplicateIndexes';
 
+import { NULL_CONDITION_STRING } from '../constants';
+
 const Element = Scroll.Element;
 const scroller = Scroll.scroller;
 
@@ -79,7 +81,12 @@ export default class ArrayField extends React.Component {
       const duplicates = key ? findDuplicateIndexes(formData, key) : [];
       return uiSchema?.['ui:options']?.setEditState
         ? uiSchema['ui:options']?.setEditState(formData)
-        : formData.map((__, index) => duplicates.includes(index));
+        : formData.map(
+            (obj, index) =>
+              !obj[key] ||
+              obj[key].toLowerCase() === NULL_CONDITION_STRING.toLowerCase() ||
+              duplicates.includes(index),
+          );
     }
     return [true];
   };

--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -15,6 +15,7 @@ import {
   validateDisabilityName,
   requireDisability,
   limitNewDisabilities,
+  missingConditionMessage,
 } from '../validations';
 import {
   newConditionsOnly,
@@ -78,8 +79,7 @@ export const uiSchema = {
           'ui:validations': [validateDisabilityName, limitNewDisabilities],
           'ui:required': () => true,
           'ui:errorMessages': {
-            required:
-              'Please enter a condition or select one from the suggested list',
+            required: missingConditionMessage,
           },
         },
       ),

--- a/src/applications/disability-benefits/all-claims/tests/pages/addDisabilities.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/addDisabilities.unit.spec.jsx
@@ -139,6 +139,62 @@ describe('Add new disabilities', () => {
     form.unmount();
   });
 
+  it('should not submit when an empty field is submitted', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          newDisabilities: [
+            {
+              condition: '',
+            },
+          ],
+        }}
+        formData={{}}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+    const error = form.find('.usa-input-error-message');
+    expect(error.length).to.equal(1);
+    expect(error.text()).to.include('enter a condition or select one');
+    expect(onSubmit.called).to.be.false;
+    form.unmount();
+  });
+  it('should not submit when "unknown condition" is submitted', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          newDisabilities: [
+            {
+              // case in-sensitive; specifically preventing this because it was
+              // previously the default text used when the user submitted an
+              // empty string
+              condition: 'UNKnowN COnDitioN',
+            },
+          ],
+        }}
+        formData={{}}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+    const error = form.find('.usa-input-error-message');
+    expect(error.length).to.equal(1);
+    expect(error.text()).to.include('enter a condition or select one');
+    expect(onSubmit.called).to.be.false;
+    form.unmount();
+  });
+
   describe('updateFormData', () => {
     // It's a function just to make sure we're not mutating it anywhere along the way
     const oldData = () => ({

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -17,6 +17,7 @@ import {
   MILITARY_CITIES,
   MILITARY_STATE_VALUES,
   LOWERED_DISABILITY_DESCRIPTIONS,
+  NULL_CONDITION_STRING,
 } from './constants';
 
 export const hasMilitaryRetiredPay = data =>
@@ -256,6 +257,9 @@ export const isWithinServicePeriod = (
   }
 };
 
+export const missingConditionMessage =
+  'Please enter a condition or select one from the suggested list';
+
 export const validateDisabilityName = (
   err,
   fieldData,
@@ -276,6 +280,13 @@ export const validateDisabilityName = (
     fieldData.length > 255
   ) {
     err.addError('Condition names should be less than 256 characters');
+  }
+
+  if (
+    !fieldData ||
+    fieldData.toLowerCase() === NULL_CONDITION_STRING.toLowerCase()
+  ) {
+    err.addError(missingConditionMessage);
   }
 
   // Alert Veteran to duplicates

--- a/src/applications/disability-benefits/wizard/pages/disagree-file-claim.jsx
+++ b/src/applications/disability-benefits/wizard/pages/disagree-file-claim.jsx
@@ -13,7 +13,7 @@ const DisagreeFileClaimPage = () => {
   });
   return (
     <div
-      className="usa-alert usa-alert-info background-color-onlys vads-u-padding--2 vads-u-margin-top--2"
+      className="usa-alert usa-alert-info background-color-only vads-u-padding--2 vads-u-margin-top--2"
       aria-live="polite"
     >
       <span className="sr-only">Info: </span>

--- a/src/platform/forms-system/src/js/utilities/data/findDuplicateIndexes.js
+++ b/src/platform/forms-system/src/js/utilities/data/findDuplicateIndexes.js
@@ -13,7 +13,7 @@ export default function(arrayFieldData = [], dataKey) {
   if (!dataKey || arrayFieldData.length === 0) {
     return [];
   }
-  const list = arrayFieldData.map(item => item[dataKey].toLowerCase() || '');
+  const list = arrayFieldData.map(item => (item[dataKey] || '').toLowerCase());
   // This reduce funtion will cycle through the list and look for a _single_
   // duplicate of the currently indexed item, so even if there is more than one
   // duplicate of a single item, or multiple duplicates of multiple items, it

--- a/src/platform/forms-system/test/js/utilities/findDuplicateIndexes.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/findDuplicateIndexes.unit.spec.js
@@ -7,6 +7,10 @@ describe('duplicateIndexes', () => {
   it('should not find duplicates', () => {
     expect(findDuplicateIndexes(base, 'x')).to.have.lengthOf(0);
   });
+  it('should not throw up when a field is empty', () => {
+    const array = [...base, {}];
+    expect(findDuplicateIndexes(array, 'x')).to.have.lengthOf(0);
+  });
   it('should find one duplicate', () => {
     const array = [...base, { x: 'one' }];
     expect(findDuplicateIndexes(array, 'x')).to.deep.equal([3]);


### PR DESCRIPTION
## Description

In form 526, when a Veteran adds an empty new disability, it would previously default to "Unknown condition" and allow them to proceed. This PR prevents the addition of an empty string _and_ "Unknown condition" (case-insensitive) because this is not a valid condition to submit and would get rejected.

Also updated `findDuplicateIndexes` to not throw an error on empty values.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/19315
- https://github.com/department-of-veterans-affairs/vets-website/pull/16216

## Testing done

Updated unit tests

## Screenshots

<details><summary>Unknown condition error</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-03-05 at 4 36 07 PM](https://user-images.githubusercontent.com/136959/110181494-8f417280-7dd1-11eb-99df-8608c98f9807.png)</details>

## Acceptance criteria
- [x] Empty or "Unknown condition" is not a valid disability and shows an error on update

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
