### PR TITLE
Removed file hashes from staging

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -101,7 +101,7 @@ module.exports = (env = {}) => {
   const entryFiles = Object.assign({}, apps, globalEntryFiles);
   const isOptimizedBuild = [VAGOVSTAGING, VAGOVPROD].includes(buildtype);
 
-  const useHashFilenames = [VAGOVSTAGING, VAGOVPROD].includes(buildtype);
+  const useHashFilenames = [VAGOVPROD].includes(buildtype);
 
   // enable css sourcemaps for all non-localhost builds
   // or if build options include local-css-sourcemaps or entry


### PR DESCRIPTION
## Description
Removing file hashes from staging builds to break a dependancy between the new content build and vets-website repos.

## Testing done
Manual testing on staging will be done, if all is well we'll move to prod and monitor Sentry alerts.