### PR TITLE
update public facing URL from project-cheetah to covid-19

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/ScheduleNewProjectCheetah.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/ScheduleNewProjectCheetah.jsx
@@ -29,7 +29,7 @@ export default function ScheduleNewProjectCheetah({
       <Link
         id="new-project-cheetah"
         className="usa-button vads-u-font-weight--bold vads-u-font-size--md"
-        to="/new-covid-19-booking"
+        to="/new-covid-19-vaccine-booking"
         onClick={startNewAppointmentFlow}
       >
         Learn more

--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/ScheduleNewProjectCheetah.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/ScheduleNewProjectCheetah.jsx
@@ -29,7 +29,7 @@ export default function ScheduleNewProjectCheetah({
       <Link
         id="new-project-cheetah"
         className="usa-button vads-u-font-weight--bold vads-u-font-size--md"
-        to="/new-project-cheetah-booking"
+        to="/new-covid-19-booking"
         onClick={startNewAppointmentFlow}
       >
         Learn more

--- a/src/applications/vaos/project-cheetah/components/FormLayout.jsx
+++ b/src/applications/vaos/project-cheetah/components/FormLayout.jsx
@@ -12,9 +12,9 @@ export default function FormLayout({ children }) {
   return (
     <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--8">
       <Breadcrumbs>
-        <Link to="new-covid-19-booking">COVID-19 vaccine</Link>
+        <Link to="new-covid-19-vaccine-booking">COVID-19 vaccine</Link>
       </Breadcrumbs>
-      {location.pathname.endsWith('new-covid-19-booking') && (
+      {location.pathname.endsWith('new-covid-19-vaccine-booking') && (
         <DowntimeNotification
           appTitle="VA online scheduling tool"
           isReady

--- a/src/applications/vaos/project-cheetah/components/FormLayout.jsx
+++ b/src/applications/vaos/project-cheetah/components/FormLayout.jsx
@@ -12,9 +12,9 @@ export default function FormLayout({ children }) {
   return (
     <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--8">
       <Breadcrumbs>
-        <Link to="new-project-cheetah-booking">COVID-19 vaccine</Link>
+        <Link to="new-covid-19-booking">COVID-19 vaccine</Link>
       </Breadcrumbs>
-      {location.pathname.endsWith('new-project-cheetah-booking') && (
+      {location.pathname.endsWith('new-covid-19-booking') && (
         <DowntimeNotification
           appTitle="VA online scheduling tool"
           isReady

--- a/src/applications/vaos/project-cheetah/flow.js
+++ b/src/applications/vaos/project-cheetah/flow.js
@@ -11,11 +11,11 @@ export default {
     url: '/',
   },
   planAhead: {
-    url: '/new-covid-19-booking',
+    url: '/new-covid-19-vaccine-booking',
     next: 'receivedDoseScreener',
   },
   receivedDoseScreener: {
-    url: '/new-covid-19-booking/received-dose',
+    url: '/new-covid-19-vaccine-booking/received-dose',
     next(state) {
       const formData = selectProjectCheetahFormData(state);
       if (formData.hasReceivedDose) {
@@ -31,10 +31,10 @@ export default {
     },
   },
   contactFacilities: {
-    url: '/new-covid-19-booking/contact-facilities',
+    url: '/new-covid-19-vaccine-booking/contact-facilities',
   },
   vaFacility: {
-    url: '/new-covid-19-booking/facility',
+    url: '/new-covid-19-vaccine-booking/facility',
     async next(state, dispatch) {
       const formData = selectProjectCheetahFormData(state);
       let clinics = selectProjectCheetahNewBooking(state).clinics?.[
@@ -61,23 +61,23 @@ export default {
     },
   },
   clinicChoice: {
-    url: '/new-covid-19-booking/clinic',
+    url: '/new-covid-19-vaccine-booking/clinic',
     next: 'selectDate1',
   },
   selectDate1: {
-    url: '/new-covid-19-booking/select-date-1',
+    url: '/new-covid-19-vaccine-booking/select-date-1',
     next: 'secondDosePage',
   },
   secondDosePage: {
-    url: '/new-covid-19-booking/plan-second-dose',
+    url: '/new-covid-19-vaccine-booking/plan-second-dose',
     next: 'contactInfo',
   },
   contactInfo: {
-    url: '/new-covid-19-booking/contact-info',
+    url: '/new-covid-19-vaccine-booking/contact-info',
     next: 'review',
   },
   review: {
-    url: '/new-covid-19-booking/review',
+    url: '/new-covid-19-vaccine-booking/review',
     next: '',
   },
 };

--- a/src/applications/vaos/project-cheetah/flow.js
+++ b/src/applications/vaos/project-cheetah/flow.js
@@ -11,11 +11,11 @@ export default {
     url: '/',
   },
   planAhead: {
-    url: '/new-project-cheetah-booking',
+    url: '/new-covid-19-booking',
     next: 'receivedDoseScreener',
   },
   receivedDoseScreener: {
-    url: '/new-project-cheetah-booking/received-dose',
+    url: '/new-covid-19-booking/received-dose',
     next(state) {
       const formData = selectProjectCheetahFormData(state);
       if (formData.hasReceivedDose) {
@@ -31,10 +31,10 @@ export default {
     },
   },
   contactFacilities: {
-    url: '/new-project-cheetah-booking/contact-facilities',
+    url: '/new-covid-19-booking/contact-facilities',
   },
   vaFacility: {
-    url: '/new-project-cheetah-booking/facility',
+    url: '/new-covid-19-booking/facility',
     async next(state, dispatch) {
       const formData = selectProjectCheetahFormData(state);
       let clinics = selectProjectCheetahNewBooking(state).clinics?.[
@@ -61,23 +61,23 @@ export default {
     },
   },
   clinicChoice: {
-    url: '/new-project-cheetah-booking/clinic',
+    url: '/new-covid-19-booking/clinic',
     next: 'selectDate1',
   },
   selectDate1: {
-    url: '/new-project-cheetah-booking/select-date-1',
+    url: '/new-covid-19-booking/select-date-1',
     next: 'secondDosePage',
   },
   secondDosePage: {
-    url: '/new-project-cheetah-booking/plan-second-dose',
+    url: '/new-covid-19-booking/plan-second-dose',
     next: 'contactInfo',
   },
   contactInfo: {
-    url: '/new-project-cheetah-booking/contact-info',
+    url: '/new-covid-19-booking/contact-info',
     next: 'review',
   },
   review: {
-    url: '/new-project-cheetah-booking/review',
+    url: '/new-covid-19-booking/review',
     next: '',
   },
 };

--- a/src/applications/vaos/project-cheetah/index.jsx
+++ b/src/applications/vaos/project-cheetah/index.jsx
@@ -66,11 +66,11 @@ export function NewBookingSection({
 
   const shouldRedirectToStart = useFormRedirectToStart({
     shouldRedirect: () =>
-      !location.pathname.endsWith('new-covid-19-booking') &&
+      !location.pathname.endsWith('new-covid-19-vaccine-booking') &&
       !location.pathname.endsWith('confirmation'),
   });
   if (shouldRedirectToStart) {
-    return <Redirect to="/new-covid-19-booking" />;
+    return <Redirect to="/new-covid-19-vaccine-booking" />;
   }
 
   const title = <h1 className="vads-u-font-size--h2">{'New Booking'}</h1>;
@@ -99,9 +99,11 @@ export function NewBookingSection({
   if (
     !isEligible &&
     newBookingStatus === FETCH_STATUS.succeeded &&
-    !location.pathname.includes('/new-covid-19-booking/contact-facilities')
+    !location.pathname.includes(
+      '/new-covid-19-vaccine-booking/contact-facilities',
+    )
   ) {
-    return <Redirect to="/new-covid-19-booking/contact-facilities" />;
+    return <Redirect to="/new-covid-19-vaccine-booking/contact-facilities" />;
   }
 
   return (

--- a/src/applications/vaos/project-cheetah/index.jsx
+++ b/src/applications/vaos/project-cheetah/index.jsx
@@ -66,11 +66,11 @@ export function NewBookingSection({
 
   const shouldRedirectToStart = useFormRedirectToStart({
     shouldRedirect: () =>
-      !location.pathname.endsWith('new-project-cheetah-booking') &&
+      !location.pathname.endsWith('new-covid-19-booking') &&
       !location.pathname.endsWith('confirmation'),
   });
   if (shouldRedirectToStart) {
-    return <Redirect to="/new-project-cheetah-booking" />;
+    return <Redirect to="/new-covid-19-booking" />;
   }
 
   const title = <h1 className="vads-u-font-size--h2">{'New Booking'}</h1>;
@@ -99,11 +99,9 @@ export function NewBookingSection({
   if (
     !isEligible &&
     newBookingStatus === FETCH_STATUS.succeeded &&
-    !location.pathname.includes(
-      '/new-project-cheetah-booking/contact-facilities',
-    )
+    !location.pathname.includes('/new-covid-19-booking/contact-facilities')
   ) {
-    return <Redirect to="/new-project-cheetah-booking/contact-facilities" />;
+    return <Redirect to="/new-covid-19-booking/contact-facilities" />;
   }
 
   return (

--- a/src/applications/vaos/project-cheetah/redux/actions.js
+++ b/src/applications/vaos/project-cheetah/redux/actions.js
@@ -165,7 +165,7 @@ export function openNewBookingPage(history) {
       // Redirect the user to the 'Contact facility' page if the appointment can't be
       // scheduled at the user's registered facilities.
       if (!isEligible) {
-        history.push('/new-covid-19-booking/contact-facilities');
+        history.push('/new-covid-19-vaccine-booking/contact-facilities');
       }
 
       dispatch({
@@ -414,7 +414,7 @@ export function startAppointmentFlow() {
 export function projectCheetahAppointmentDateChoice(history) {
   return dispatch => {
     dispatch(startAppointmentFlow());
-    history.replace('/new-covid-19-booking');
+    history.replace('/new-covid-19-vaccine-booking');
   };
 }
 
@@ -463,7 +463,7 @@ export function confirmAppointment(history) {
         ...additionalEventData,
       });
       resetDataLayer();
-      history.push('/new-covid-19-booking/confirmation');
+      history.push('/new-covid-19-vaccine-booking/confirmation');
     } catch (error) {
       captureError(error, true);
       dispatch({

--- a/src/applications/vaos/project-cheetah/redux/actions.js
+++ b/src/applications/vaos/project-cheetah/redux/actions.js
@@ -165,7 +165,7 @@ export function openNewBookingPage(history) {
       // Redirect the user to the 'Contact facility' page if the appointment can't be
       // scheduled at the user's registered facilities.
       if (!isEligible) {
-        history.push('/new-project-cheetah-booking/contact-facilities');
+        history.push('/new-covid-19-booking/contact-facilities');
       }
 
       dispatch({
@@ -414,7 +414,7 @@ export function startAppointmentFlow() {
 export function projectCheetahAppointmentDateChoice(history) {
   return dispatch => {
     dispatch(startAppointmentFlow());
-    history.replace('/new-project-cheetah-booking');
+    history.replace('/new-covid-19-booking');
   };
 }
 
@@ -463,7 +463,7 @@ export function confirmAppointment(history) {
         ...additionalEventData,
       });
       resetDataLayer();
-      history.push('/new-project-cheetah-booking/confirmation');
+      history.push('/new-covid-19-booking/confirmation');
     } catch (error) {
       captureError(error, true);
       dispatch({

--- a/src/applications/vaos/routes.jsx
+++ b/src/applications/vaos/routes.jsx
@@ -53,7 +53,7 @@ export default function createRoutesWithStore(store) {
             )}
           />
           <Route
-            path="/new-covid-19-booking"
+            path="/new-covid-19-vaccine-booking"
             component={asyncLoader(() =>
               import(/* webpackChunkName: "project-cheetah" */ './project-cheetah')
                 .then(({ NewBooking, reducer }) => {

--- a/src/applications/vaos/routes.jsx
+++ b/src/applications/vaos/routes.jsx
@@ -53,7 +53,7 @@ export default function createRoutesWithStore(store) {
             )}
           />
           <Route
-            path="/new-project-cheetah-booking"
+            path="/new-covid-19-booking"
             component={asyncLoader(() =>
               import(/* webpackChunkName: "project-cheetah" */ './project-cheetah')
                 .then(({ NewBooking, reducer }) => {

--- a/src/applications/vaos/tests/project-cheetah/components/NewBookingPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/project-cheetah/components/NewBookingPage.unit.spec.jsx
@@ -83,7 +83,7 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
     // Wait for the redirect.
     await waitFor(() =>
       expect(screen.history.push.lastCall.args[0]).to.equal(
-        '/new-covid-19-booking/contact-facilities',
+        '/new-covid-19-vaccine-booking/contact-facilities',
       ),
     );
   });

--- a/src/applications/vaos/tests/project-cheetah/components/NewBookingPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/project-cheetah/components/NewBookingPage.unit.spec.jsx
@@ -83,7 +83,7 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
     // Wait for the redirect.
     await waitFor(() =>
       expect(screen.history.push.lastCall.args[0]).to.equal(
-        '/new-project-cheetah-booking/contact-facilities',
+        '/new-covid-19-booking/contact-facilities',
       ),
     );
   });

--- a/src/applications/vaos/tests/project-cheetah/components/PlanAheadPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/project-cheetah/components/PlanAheadPage.unit.spec.jsx
@@ -31,7 +31,7 @@ describe('VAOS <PlanAheadPage>', () => {
     // Expect router to route to screener page
     await waitFor(() => {
       expect(screen.history.push.firstCall.args[0]).to.equal(
-        '/new-covid-19-booking/received-dose',
+        '/new-covid-19-vaccine-booking/received-dose',
       );
     });
   });

--- a/src/applications/vaos/tests/project-cheetah/components/PlanAheadPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/project-cheetah/components/PlanAheadPage.unit.spec.jsx
@@ -31,7 +31,7 @@ describe('VAOS <PlanAheadPage>', () => {
     // Expect router to route to screener page
     await waitFor(() => {
       expect(screen.history.push.firstCall.args[0]).to.equal(
-        '/new-project-cheetah-booking/received-dose',
+        '/new-covid-19-booking/received-dose',
       );
     });
   });

--- a/src/applications/vaos/tests/project-cheetah/components/ReceivedDoseScreenerPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/project-cheetah/components/ReceivedDoseScreenerPage.unit.spec.jsx
@@ -76,7 +76,7 @@ describe('VAOS <ReceivedDoseScreenerPage> ', () => {
 
     await waitFor(() =>
       expect(screen.history.push.lastCall?.args[0]).to.equal(
-        '/new-covid-19-booking/facility',
+        '/new-covid-19-vaccine-booking/facility',
       ),
     );
 
@@ -85,7 +85,7 @@ describe('VAOS <ReceivedDoseScreenerPage> ', () => {
 
     await waitFor(() =>
       expect(screen.history.push.lastCall?.args[0]).to.equal(
-        '/new-covid-19-booking/contact-facilities',
+        '/new-covid-19-vaccine-booking/contact-facilities',
       ),
     );
   });

--- a/src/applications/vaos/tests/project-cheetah/components/ReceivedDoseScreenerPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/project-cheetah/components/ReceivedDoseScreenerPage.unit.spec.jsx
@@ -76,7 +76,7 @@ describe('VAOS <ReceivedDoseScreenerPage> ', () => {
 
     await waitFor(() =>
       expect(screen.history.push.lastCall?.args[0]).to.equal(
-        '/new-project-cheetah-booking/facility',
+        '/new-covid-19-booking/facility',
       ),
     );
 
@@ -85,7 +85,7 @@ describe('VAOS <ReceivedDoseScreenerPage> ', () => {
 
     await waitFor(() =>
       expect(screen.history.push.lastCall?.args[0]).to.equal(
-        '/new-project-cheetah-booking/contact-facilities',
+        '/new-covid-19-booking/contact-facilities',
       ),
     );
   });

--- a/src/applications/vaos/tests/project-cheetah/components/ReviewPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/project-cheetah/components/ReviewPage.unit.spec.jsx
@@ -145,7 +145,7 @@ describe('VAOS vaccine flow <ReviewPage>', () => {
     userEvent.click(screen.getByText(/Confirm appointment/i));
     await waitFor(() => {
       expect(screen.history.push.lastCall.args[0]).to.equal(
-        '/new-project-cheetah-booking/confirmation',
+        '/new-covid-19-booking/confirmation',
       );
     });
     const submitData = JSON.parse(global.fetch.getCall(0).args[1].body);

--- a/src/applications/vaos/tests/project-cheetah/components/ReviewPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/project-cheetah/components/ReviewPage.unit.spec.jsx
@@ -145,7 +145,7 @@ describe('VAOS vaccine flow <ReviewPage>', () => {
     userEvent.click(screen.getByText(/Confirm appointment/i));
     await waitFor(() => {
       expect(screen.history.push.lastCall.args[0]).to.equal(
-        '/new-covid-19-booking/confirmation',
+        '/new-covid-19-vaccine-booking/confirmation',
       );
     });
     const submitData = JSON.parse(global.fetch.getCall(0).args[1].body);

--- a/src/applications/vaos/tests/project-cheetah/components/SecondDosePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/project-cheetah/components/SecondDosePage.unit.spec.jsx
@@ -111,7 +111,7 @@ describe('VAOS vaccine flow <SecondDosePage>', () => {
 
     await waitFor(() =>
       expect(screen.history.push.firstCall.args[0]).to.equal(
-        '/new-project-cheetah-booking/contact-info',
+        '/new-covid-19-booking/contact-info',
       ),
     );
   });

--- a/src/applications/vaos/tests/project-cheetah/components/SecondDosePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/project-cheetah/components/SecondDosePage.unit.spec.jsx
@@ -111,7 +111,7 @@ describe('VAOS vaccine flow <SecondDosePage>', () => {
 
     await waitFor(() =>
       expect(screen.history.push.firstCall.args[0]).to.equal(
-        '/new-covid-19-booking/contact-info',
+        '/new-covid-19-vaccine-booking/contact-info',
       ),
     );
   });


### PR DESCRIPTION
## Description
Project Cheetah is the internal code name for Covid-19 online appointment scheduling. Update the public facing URLs to show covid-19 instead of project cheetah

**How to test:**

- Click on the `Learn more` button of the Schedule your first COVID-19 vaccine CTA
- As you advance through the flow, part of the URL will now display `new-covid-19-vaccine-booking`

## Testing done
local and unit test

## Screenshots
![image](https://user-images.githubusercontent.com/54327023/110485267-74b11700-80b9-11eb-822c-cccda1927a52.png)



## Acceptance criteria
- [ ] Every page along the Covid-19 new appointment booking flow should have part of the URL display  `/appointments/new-covid-19-vaccine-booking`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
