### PR TITLE
Change profile wording

### DIFF
--- a/src/applications/personalization/profile/components/ProfileMobileSubNav.jsx
+++ b/src/applications/personalization/profile/components/ProfileMobileSubNav.jsx
@@ -191,7 +191,7 @@ const ProfileMobileSubNav = ({ isLOA3, isInMVI, routes }) => {
             >
               <strong>
                 <h1 id="mobile-subnav-header" className={menuButtonClasses}>
-                  Your profile
+                  Profile
                 </h1>{' '}
                 menu
               </strong>
@@ -202,7 +202,7 @@ const ProfileMobileSubNav = ({ isLOA3, isInMVI, routes }) => {
             <>
               <div className="menu-header vads-u-display--flex">
                 <strong className="vads-u-flex--auto">
-                  <h1 className={menuButtonClasses}>Your profile</h1> menu
+                  <h1 className={menuButtonClasses}>Profile</h1> menu
                 </strong>
                 <button
                   ref={closeMenuButton}

--- a/src/applications/personalization/profile/components/ProfileSubNav.jsx
+++ b/src/applications/personalization/profile/components/ProfileSubNav.jsx
@@ -15,7 +15,7 @@ const ProfileSubNav = ({ isInMVI, isLOA3, routes }) => {
     <nav className="va-subnav" aria-label="Secondary">
       <div>
         <h1 id="subnav-header" className="vads-u-font-size--h4">
-          Your profile
+          Profile
         </h1>
         <ProfileSubNavItems routes={routes} isLOA3={isLOA3} isInMVI={isInMVI} />
       </div>

--- a/src/applications/personalization/profile/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile/components/ProfileWrapper.jsx
@@ -81,12 +81,10 @@ const ProfileWrapper = ({
         <Breadcrumbs className="vads-u-padding-x--1 vads-u-padding-y--1p5 medium-screen:vads-u-padding-y--0">
           <a href="/">Home</a>
 
-          {showLOA1BreadCrumb && (
-            <Link to="/">Your profile - Account security</Link>
-          )}
+          {showLOA1BreadCrumb && <Link to="/">Profile - Account security</Link>}
 
           {!showLOA1BreadCrumb &&
-            !onPersonalInformationMobile && <Link to="/">Your profile</Link>}
+            !onPersonalInformationMobile && <Link to="/">Profile</Link>}
 
           {!showLOA1BreadCrumb && (
             <a href={activeLocation}>{activeRouteName}</a>

--- a/src/applications/personalization/profile/components/personal-information/PersonalInformation.jsx
+++ b/src/applications/personalization/profile/components/personal-information/PersonalInformation.jsx
@@ -32,7 +32,7 @@ const PersonalInformation = ({
     () => {
       // Do not manage the focus if the user just came to this route via the
       // root profile route. If a user got to the Profile via a link to /profile
-      // or /profile/ we want to focus on the "Your Profile" sub-nav H1, not the
+      // or /profile/ we want to focus on the "Profile" sub-nav H1, not the
       // H2 on this page
       const pathRegExp = new RegExp(`${PROFILE_PATHS.PROFILE_ROOT}/?$`);
       if (lastLocation?.pathname.match(new RegExp(pathRegExp))) {

--- a/src/applications/personalization/profile/tests/e2e/helpers.js
+++ b/src/applications/personalization/profile/tests/e2e/helpers.js
@@ -2,7 +2,7 @@ import { PROFILE_PATHS, PROFILE_PATH_NAMES } from '../../constants';
 
 export function subNavOnlyContainsAccountSecurity(mobile) {
   if (mobile) {
-    cy.findByRole('button', { name: /your profile menu/i }).click();
+    cy.findByRole('button', { name: /profile menu/i }).click();
   }
   cy.findByRole('navigation', { name: /secondary/i }).within(() => {
     cy.findAllByRole('link').should('have.length', 1);

--- a/src/applications/personalization/profile/tests/e2e/profile-a11y.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile-a11y.cypress.spec.js
@@ -6,7 +6,7 @@ import mockPaymentInfo from '../fixtures/dd4cnp/dd4cnp-is-set-up.json';
 
 function clickSubNavButton(buttonLabel, mobile) {
   if (mobile) {
-    cy.findByRole('button', { name: /your profile menu/i }).click();
+    cy.findByRole('button', { name: /profile menu/i }).click();
   }
   cy.findByRole('link', { name: buttonLabel }).click();
 }
@@ -54,7 +54,7 @@ function checkAllPages(mobile = false) {
 
   // focus should be on the sub-nav's h1 when redirected from /profile/
   cy.focused()
-    .contains(/your profile/i)
+    .contains(/profile/i)
     .and('have.prop', 'tagName')
     .should('eq', 'H1');
 


### PR DESCRIPTION
## Description
We want to change 'Your profile' to profile in the breadcrumbs and the sidenav.

## Testing done
Looks good locally. Tests needed a minor update.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/110386234-47169000-801d-11eb-9edc-06e1b06532a1.png)


## Acceptance criteria
- [x] Change 'Your profile' to 'Profile'
- [x] Tests still pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
