### PR TITLE
[Templates] Add non-beneficiary audience tags

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -683,12 +683,10 @@ module.exports = function registerFilters() {
       fieldNonBeneficiares?.entity,
     ]
       .filter(tag => !!tag)
-      .map(audience => {
-        return {
-          ...audience,
-          categoryLabel: 'Audience',
-        };
-      });
+      .map(audience => ({
+        ...audience,
+        categoryLabel: 'Audience',
+      }));
 
     const tagList = [...topics, ...audiences];
 

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -673,12 +673,10 @@ module.exports = function registerFilters() {
       },
     } = fieldTags;
 
-    const topics = fieldTopics.map(topic => {
-      return {
-        ...topic.entity,
-        categoryLabel: 'Topics',
-      };
-    });
+    const topics = fieldTopics.map(topic => ({
+      ...topic.entity,
+      categoryLabel: 'Topics',
+    }));
 
     const audiences = [
       fieldAudienceBeneficiares?.entity,

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -673,16 +673,26 @@ module.exports = function registerFilters() {
       },
     } = fieldTags;
 
-    const tagList = [
-      fieldTopics.map(topic => {
-        return {
-          ...topic.entity,
-          categoryLabel: 'Topics',
-        };
-      }),
+    const topics = fieldTopics.map(topic => {
+      return {
+        ...topic.entity,
+        categoryLabel: 'Topics',
+      };
+    });
+
+    const audiences = [
       fieldAudienceBeneficiares?.entity,
       fieldNonBeneficiares?.entity,
-    ];
+    ]
+      .filter(tag => !!tag)
+      .map(audience => {
+        return {
+          ...audience,
+          categoryLabel: 'Audience',
+        };
+      });
+
+    const tagList = [...topics, ...audiences];
 
     return _.sortBy(tagList, 'name');
   };

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -663,4 +663,27 @@ module.exports = function registerFilters() {
     // Return a formatted timestamp string.
     return `${digits}${text}`;
   };
+
+  liquid.filters.getTagsList = fieldTags => {
+    const {
+      entity: {
+        fieldTopics = [],
+        fieldAudienceBeneficiares,
+        fieldNonBeneficiares,
+      },
+    } = fieldTags;
+
+    const tagList = [
+      fieldTopics.map(topic => {
+        return {
+          ...topic.entity,
+          categoryLabel: 'Topics',
+        };
+      }),
+      fieldAudienceBeneficiares?.entity,
+      fieldNonBeneficiares?.entity,
+    ];
+
+    return _.sortBy(tagList, 'name');
+  };
 };

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -220,3 +220,90 @@ describe('createEmbedYouTubeVideoURL', () => {
     ).to.eq('https://www.youtube.com/embed/asdf');
   });
 });
+
+describe('getTagsList', () => {
+  const fieldTags = {
+    entity: {
+      fieldTopics: [
+        {
+          entity: {
+            name: 'A. Example',
+          },
+        },
+        {
+          entity: {
+            name: 'B. Example',
+          },
+        },
+        {
+          entity: {
+            name: 'E. Example',
+          },
+        },
+      ],
+      fieldAudienceBeneficiares: {
+        entity: {
+          name: 'C. Example',
+        },
+      },
+      fieldNonBeneficiares: {
+        entity: {
+          name: 'D. Example',
+        },
+      },
+    },
+  };
+
+  it('forms a sorted list from properties "fieldTopics", "fieldAudienceBeneficiares", and "fieldNonBeneficiares"', () => {
+    const result = liquid.filters.getTagsList(fieldTags);
+
+    expect(result).to.be.deep.equal([
+      {
+        name: 'A. Example',
+        categoryLabel: 'Topics',
+      },
+      {
+        name: 'B. Example',
+        categoryLabel: 'Topics',
+      },
+      {
+        name: 'C. Example',
+        categoryLabel: 'Audience',
+      },
+      {
+        name: 'D. Example',
+        categoryLabel: 'Audience',
+      },
+      {
+        name: 'E. Example',
+        categoryLabel: 'Topics',
+      },
+    ]);
+  });
+
+  it('omits null poperties', () => {
+    const fieldTags2 = { entity: { ...fieldTags.entity } };
+    fieldTags2.entity.fieldAudienceBeneficiares = null;
+
+    const result = liquid.filters.getTagsList(fieldTags2);
+
+    expect(result).to.be.deep.equal([
+      {
+        name: 'A. Example',
+        categoryLabel: 'Topics',
+      },
+      {
+        name: 'B. Example',
+        categoryLabel: 'Topics',
+      },
+      {
+        name: 'D. Example',
+        categoryLabel: 'Audience',
+      },
+      {
+        name: 'E. Example',
+        categoryLabel: 'Topics',
+      },
+    ]);
+  });
+});

--- a/src/site/includes/benefit-hubs-links.drupal.liquid
+++ b/src/site/includes/benefit-hubs-links.drupal.liquid
@@ -4,7 +4,7 @@
 
     <ul class="usa-unstyled-list">
       {% for relatedBenefitHub in fieldRelatedBenefitHubs %}
-        <li class="vads-u-margin--y-1">
+        <li class="vads-u-margin-y--2">
           <p class="vads-u-margin--0">
             <strong>
               <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ relatedBenefitHub.entity.fieldHomePageHubLabel | escape }}', 'links-list-section-header': 'VA benefits' })" href="{{ relatedBenefitHub.entity.path.alias }}">

--- a/src/site/includes/benefit-hubs-links.drupal.liquid
+++ b/src/site/includes/benefit-hubs-links.drupal.liquid
@@ -1,10 +1,10 @@
 {% if fieldRelatedBenefitHubs != empty %}
   <section class="vads-u-padding-y--3 vads-u-display--flex vads-u-flex-direction--column vads-u-padding-x--1 large-screen:vads-u-padding-x--0" data-template="includes/benefit-hubs-links">
-    <h2 class="vads-u-margin-top--0 vads-u-font-size--h3">VA benefits</h2>
+    <h2 class="vads-u-margin-y--0 vads-u-font-size--h3">VA benefits</h2>
 
     <ul class="usa-unstyled-list">
       {% for relatedBenefitHub in fieldRelatedBenefitHubs %}
-        <li>
+        <li class="vads-u-margin--y-1">
           <p class="vads-u-margin--0">
             <strong>
               <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ relatedBenefitHub.entity.fieldHomePageHubLabel | escape }}', 'links-list-section-header': 'VA benefits' })" href="{{ relatedBenefitHub.entity.path.alias }}">
@@ -12,7 +12,7 @@
               </a>
             </strong>
           </p>
-          <p>{{ relatedBenefitHub.entity.fieldTeaserText }}</p>
+          <p class="vads-u-margin--0">{{ relatedBenefitHub.entity.fieldTeaserText }}</p>
         </li>
       {% endfor %}
     </ul>

--- a/src/site/includes/related-information.drupal.liquid
+++ b/src/site/includes/related-information.drupal.liquid
@@ -2,12 +2,12 @@
   <section class="vads-u-padding-top--3 vads-u-display--flex vads-u-flex-direction--column vads-u-padding-x--1 large-screen:vads-u-padding-x--0"
     data-template="includes/related-information">
     <!-- Section title -->
-    <h2 class="vads-u-margin-top--0 vads-u-font-size--h3">Related information</h2>
+    <h2 class="vads-u-margin-y--0 vads-u-font-size--h3">Related information</h2>
 
     <!-- Links -->
     <ul class="usa-unstyled-list">
       {% for fieldRelatedInformationLink in fieldRelatedInformation %}
-      <li>
+      <li class="vads-u-margin-y--1">
         <p class="vads-u-margin--0">
           <strong>
             <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ fieldRelatedInformationLink.entity.fieldLink.title | escape }}', 'links-list-section-header': 'Related information' })" href="{{ fieldRelatedInformationLink.entity.fieldLink.url.path }}">
@@ -15,7 +15,7 @@
             </a>
           </strong>
         </p>
-        <p>{{ fieldRelatedInformationLink.entity.fieldLinkSummary }}</p>
+        <p class="vads-u-margin--0">{{ fieldRelatedInformationLink.entity.fieldLinkSummary }}</p>
       </li>
       {% endfor %}
     </ul>

--- a/src/site/includes/related-information.drupal.liquid
+++ b/src/site/includes/related-information.drupal.liquid
@@ -7,7 +7,7 @@
     <!-- Links -->
     <ul class="usa-unstyled-list">
       {% for fieldRelatedInformationLink in fieldRelatedInformation %}
-      <li class="vads-u-margin-y--1">
+      <li class="vads-u-margin-y--2">
         <p class="vads-u-margin--0">
           <strong>
             <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ fieldRelatedInformationLink.entity.fieldLink.title | escape }}', 'links-list-section-header': 'Related information' })" href="{{ fieldRelatedInformationLink.entity.fieldLink.url.path }}">

--- a/src/site/includes/tags.drupal.liquid
+++ b/src/site/includes/tags.drupal.liquid
@@ -11,17 +11,12 @@
     <div class="vads-u-display--flex vads-u-flex-wrap--wrap">
       {% assign tags = fieldTags | getTagsList %}
 
-      {% for tag in tags %}
-        {% assign categoryLabel = 'Topics' | default: 'Audience' %}
-
-        <a href="{{ tag.entity.entityUrl.path }}"
+      {% for entity in tags %}
+        <a href="{{ entity.entityUrl.path }}"
           class="vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0 usa-button-secondary vads-u-font-size--sm vads-u-border--1px vads-u-border-color--primary vads-u-padding--0p25 vads-u-padding-x--0p5 vads-u-margin-left--1 vads-u-text-decoration--none vads-u-color--base"
           style="border-radius: 3px;"
-          onclick="recordEvent({
-            'event': 'nav-page-tag-click',
-            'page-tag-click-label': '{{ tag.entity.name }}',
-            'page-tag-category-label': '{{ categoryLabel }}' });">
-          {{ tag.entity.name }}
+          onclick="recordEvent({ 'event': 'nav-page-tag-click', 'page-tag-click-label': '{{ entity.name }}', 'page-tag-category-label': '{{  entity.categoryLabel  }}' });">
+          {{ entity.name }}
         </a>
       {% endfor %}
     </div>

--- a/src/site/includes/tags.drupal.liquid
+++ b/src/site/includes/tags.drupal.liquid
@@ -9,16 +9,21 @@
 
     <!-- Topic tags -->
     <div class="vads-u-display--flex vads-u-flex-wrap--wrap">
-      {% for topic in fieldTags.entity.fieldTopics %}
-      <a onclick="recordEvent({ 'event': 'nav-page-tag-click', 'page-tag-click-label': '{{ topic.entity.name }}', 'page-tag-category-label': 'Topics' });"
-        href="{{ topic.entity.entityUrl.path }}" style="border-radius: 3px;"
-        class="vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0 usa-button-secondary vads-u-font-size--sm vads-u-border--1px vads-u-border-color--primary vads-u-padding--0p25 vads-u-padding-x--0p5 vads-u-margin-left--1 vads-u-text-decoration--none vads-u-color--base">{{ topic.entity.name }}</a>
-      {% endfor %}
+      {% assign tags = fieldTags | getTagsList %}
 
-      <!-- Audience beneficiary tag -->
-      <a onclick="recordEvent({ 'event': 'nav-page-tag-click', 'page-tag-click-label': '{{ fieldTags.entity.fieldAudienceBeneficiares.entity.name }}', 'page-tag-category-label': 'Audience' });"
-        href="{{ fieldTags.entity.fieldAudienceBeneficiares.entity.entityUrl.path }}" style="border-radius: 3px;"
-        class="usa-button-secondary vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0 vads-u-font-size--sm vads-u-border--1px vads-u-border-color--primary vads-u-padding--0p25 vads-u-padding-x--0p5 vads-u-margin-left--1 vads-u-text-decoration--none vads-u-color--base">{{ fieldTags.entity.fieldAudienceBeneficiares.entity.name }}</a>
+      {% for tag in tags %}
+        {% assign categoryLabel = 'Topics' | default: 'Audience' %}
+
+        <a href="{{ tag.entity.entityUrl.path }}"
+          class="vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0 usa-button-secondary vads-u-font-size--sm vads-u-border--1px vads-u-border-color--primary vads-u-padding--0p25 vads-u-padding-x--0p5 vads-u-margin-left--1 vads-u-text-decoration--none vads-u-color--base"
+          style="border-radius: 3px;"
+          onclick="recordEvent({
+            'event': 'nav-page-tag-click',
+            'page-tag-click-label': '{{ tag.entity.name }}',
+            'page-tag-category-label': '{{ categoryLabel }}' });">
+          {{ tag.entity.name }}
+        </a>
+      {% endfor %}
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Description
This PR adds the field `fieldTags.entity.fieldNonBeneficiares` into the tag template, uses across Resources articles. That field was already added into the GraphQL queries in an old PR.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/16623

## Testing done
- Tested against http://localhost:3001/preview?nodeId=7910 to confirm visually looks good and GA event is correct
- Added unit test

## Screenshots
In the screenshot below, the `Schools, administrators, and other education professionals` tag reflects the `fieldTags.entity.fieldNonBeneficiares` .

![image](https://user-images.githubusercontent.com/1915775/110493709-e04ab280-80c0-11eb-9f91-1ff72deae740.png)

### Unrelated change, but while I was in the area..
I fixed a margin issue.

#### Before
![image](https://user-images.githubusercontent.com/1915775/110493951-1ab44f80-80c1-11eb-9c0b-452ceb303979.png)

#### After
![image](https://user-images.githubusercontent.com/1915775/110499960-bac0a780-80c6-11eb-82f4-2f2822d04057.png)



## Acceptance criteria
- [ ] `fieldTags.entity.fieldNonBeneficiares` is included in tags

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
