### PR TITLE
Wrap unit and cypress tests in retry

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,12 +42,10 @@ node('vetsgov-general-purpose') {
         },
 
         unit: {
-          retry(3) {
-            dockerContainer.inside(commonStages.DOCKER_ARGS) {
-              sh "/cc-test-reporter before-build"
-              sh "cd /application && npm --no-color run test:unit -- --coverage"
-              sh "cd /application && /cc-test-reporter after-build -r fe4a84c212da79d7bb849d877649138a9ff0dbbef98e7a84881c97e1659a2e24"
-            }
+          dockerContainer.inside(commonStages.DOCKER_ARGS) {
+            sh "/cc-test-reporter before-build"
+            sh "cd /application && npm --no-color run test:unit -- --coverage"
+            sh "cd /application && /cc-test-reporter after-build -r fe4a84c212da79d7bb849d877649138a9ff0dbbef98e7a84881c97e1659a2e24"
           }
         }
       )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,10 +42,12 @@ node('vetsgov-general-purpose') {
         },
 
         unit: {
-          dockerContainer.inside(commonStages.DOCKER_ARGS) {
-            sh "/cc-test-reporter before-build"
-            sh "cd /application && npm --no-color run test:unit -- --coverage"
-            sh "cd /application && /cc-test-reporter after-build -r fe4a84c212da79d7bb849d877649138a9ff0dbbef98e7a84881c97e1659a2e24"
+          retry(3) {
+            dockerContainer.inside(commonStages.DOCKER_ARGS) {
+              sh "/cc-test-reporter before-build"
+              sh "cd /application && npm --no-color run test:unit -- --coverage"
+              sh "cd /application && /cc-test-reporter after-build -r fe4a84c212da79d7bb849d877649138a9ff0dbbef98e7a84881c97e1659a2e24"
+            }
           }
         }
       )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,7 +79,9 @@ node('vetsgov-general-purpose') {
           },
 
           cypress: {
-            sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p cypress up -d && docker-compose -p cypress run --rm --entrypoint=npm -e CI=true -e NO_COLOR=1 vets-website --no-color run cy:test:docker"
+            retry(3) {
+              sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p cypress up -d && docker-compose -p cypress run --rm --entrypoint=npm -e CI=true -e NO_COLOR=1 vets-website --no-color run cy:test:docker"
+            }
           }
         )
       } catch (error) {


### PR DESCRIPTION
## GitHub Issue

https://github.com/department-of-veterans-affairs/va.gov-team/issues/20755

## Description

We often manually rerun flaky unit/cypress tests. 

This PR wraps the [`cypress` tests](https://github.com/department-of-veterans-affairs/vets-website/blob/88d2f21e2a3f62d3bd388a011bd89965927298a4/Jenkinsfile#L79-L81) in `retry(3)`.

## Relevant Links

- Jenkins docs: [Timeouts, retries and more](https://www.jenkins.io/doc/pipeline/tour/running-multiple-steps/#timeouts-retries-and-more)
- [Search results for `retry` in Groovy files in `vets-website`](https://github.com/department-of-veterans-affairs/vets-website/search?l=Groovy&q=retry)

## Acceptance criteria
- [ ] 

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)

## Requested Feedback

- How many times should we attempt to retry to the `cypress` tests, if any? 
- Are there are any other flaky stages/steps/tasks/jobs/etc that we should consider wrapping with `retry`/`timeout`?
- Should we wrap the `retry` with a `timeout` to ensure that the `retry` doesn't take too long? If so, what's an appropriate timeout value? 