### PR TITLE
Update vets-json-schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -360,7 +360,7 @@
     "url-search-params-polyfill": "^8.1.0",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#fe46f30b91ad4cbf6fe73833a16d4ec990f48eb6",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#54f01e83285646adc77ae9a656c3ac1d67713c26",
     "whatwg-fetch": "^2.0.3"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -360,7 +360,7 @@
     "url-search-params-polyfill": "^8.1.0",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#54f01e83285646adc77ae9a656c3ac1d67713c26",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#456ba74f7ab19c105e69abf795943afb1007f127",
     "whatwg-fetch": "^2.0.3"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18848,9 +18848,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#54f01e83285646adc77ae9a656c3ac1d67713c26":
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#456ba74f7ab19c105e69abf795943afb1007f127":
   version "18.6.8"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#54f01e83285646adc77ae9a656c3ac1d67713c26"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#456ba74f7ab19c105e69abf795943afb1007f127"
 
 vinyl-file@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18848,9 +18848,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#fe46f30b91ad4cbf6fe73833a16d4ec990f48eb6":
-  version "18.6.7"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#fe46f30b91ad4cbf6fe73833a16d4ec990f48eb6"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#54f01e83285646adc77ae9a656c3ac1d67713c26":
+  version "18.6.8"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#54f01e83285646adc77ae9a656c3ac1d67713c26"
 
 vinyl-file@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description
Update vets-json-schema version to `18.6.8`

vets-json-schema PR with `18.6.8` changes: https://github.com/department-of-veterans-affairs/vets-json-schema/pull/567

## Original issue(s)
department-of-veterans-affairs/va.gov-team#20197

## Testing done
Tested locally

## Screenshots
N/A

## Acceptance criteria
- [x] Schema updated

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
