### PR TITLE
Add recordEvent for a tags

### DIFF
--- a/src/applications/static-pages/analytics/addButtonLinkListeners.js
+++ b/src/applications/static-pages/analytics/addButtonLinkListeners.js
@@ -1,6 +1,6 @@
 import recordEvent from 'platform/monitoring/record-event';
 
-function getButtonType(classList) {
+export function getButtonType(classList) {
   if (classList.contains('usa-button-primary')) {
     return 'primary';
   } else if (classList.contains('usa-button-secondary')) {

--- a/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
@@ -10,6 +10,7 @@ import environment from 'platform/utilities/environment';
 import recordEvent from 'platform/monitoring/record-event';
 import { apiRequest } from 'platform/utilities/api';
 import { appointmentsToolLink } from 'platform/utilities/cerner';
+import { getButtonType } from 'applications/static-pages/analytics/addButtonLinkListeners';
 
 export class CernerCallToAction extends Component {
   static defaultProps = {
@@ -85,13 +86,14 @@ export class CernerCallToAction extends Component {
     }
   };
 
-  onCTALinkClick = (buttonLabel, buttonType = 'default') => () => {
+  onCTALinkClick = event => {
+    const style = window.getComputedStyle(event.target);
+
     recordEvent({
       event: 'cta-button-click',
-      'button-type': buttonType,
-      'button-click-label': buttonLabel,
-      'button-background-color':
-        buttonType === 'secondary' ? '#ffffff' : '#0071bb',
+      'button-type': getButtonType(event.target.classList),
+      'button-click-label': event.target.text,
+      'button-background-color': style.getPropertyValue('background-color'),
     });
   };
 
@@ -207,7 +209,7 @@ export class CernerCallToAction extends Component {
                 <a
                   className="usa-button vads-u-color--white vads-u-margin-top--0 vads-u-margin-bottom--4"
                   href={isCerner ? myVAHealthLink : myHealtheVetLink}
-                  onClick={onCTALinkClick(linkText, 'default')}
+                  onClick={onCTALinkClick}
                   rel="noreferrer noopener"
                   target="_blank"
                 >
@@ -224,7 +226,7 @@ export class CernerCallToAction extends Component {
             <a
               className="usa-button usa-button-secondary vads-u-color--primary vads-u-margin-top--0 vads-u-margin-bottom--2"
               href={myHealtheVetLink}
-              onClick={onCTALinkClick(myHealtheVetLinkText, 'secondary')}
+              onClick={onCTALinkClick}
               rel="noreferrer noopener"
               target="_blank"
             >

--- a/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
@@ -7,6 +7,7 @@ import * as Sentry from '@sentry/browser';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import environment from 'platform/utilities/environment';
+import recordEvent from 'platform/monitoring/record-event';
 import { apiRequest } from 'platform/utilities/api';
 import { appointmentsToolLink } from 'platform/utilities/cerner';
 
@@ -84,7 +85,18 @@ export class CernerCallToAction extends Component {
     }
   };
 
+  onCTALinkClick = (buttonLabel, buttonType = 'default') => () => {
+    recordEvent({
+      event: 'cta-button-click',
+      'button-type': buttonType,
+      'button-click-label': buttonLabel,
+      'button-background-color':
+        buttonType === 'secondary' ? '#ffffff' : '#0071bb',
+    });
+  };
+
   render() {
+    const { onCTALinkClick } = this;
     const {
       cernerFacilities,
       linksHeaderText,
@@ -195,6 +207,7 @@ export class CernerCallToAction extends Component {
                 <a
                   className="usa-button vads-u-color--white vads-u-margin-top--0 vads-u-margin-bottom--4"
                   href={isCerner ? myVAHealthLink : myHealtheVetLink}
+                  onClick={onCTALinkClick(linkText, 'default')}
                   rel="noreferrer noopener"
                   target="_blank"
                 >
@@ -211,6 +224,7 @@ export class CernerCallToAction extends Component {
             <a
               className="usa-button usa-button-secondary vads-u-color--primary vads-u-margin-top--0 vads-u-margin-bottom--2"
               href={myHealtheVetLink}
+              onClick={onCTALinkClick(myHealtheVetLinkText, 'secondary')}
               rel="noreferrer noopener"
               target="_blank"
             >


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/21251

This PR adds `recordEvent` to the a tags in the `<CernerCallToAction />` component.

## Testing done
Locally with gtm assistance

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/110652788-ec467b00-8179-11eb-8b94-73cb4d45716d.png)

## Acceptance criteria
- [x] adds `recordEvent` to the a tags in the `<CernerCallToAction />` component

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
