### PR TITLE
Kelsonic 21314 clp where event

### DIFF
--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -385,6 +385,7 @@
 
                     <!-- Event link -->
                     <div class="vads-u-display--flex vads-u-flex-direction--column">
+                      <!-- Facility link -->
                       {% if eventReference.entity.fieldFacilityLocation.entity.entityUrl.path %}
                         <a
                           href="{{ eventReference.entity.fieldFacilityLocation.entity.entityUrl.path }}"
@@ -396,6 +397,7 @@
                         </a>
                       {% endif %}
 
+                      <!-- Event link -->
                       {% if eventReference.entity.fieldLink.uri %}
                         <a
                           href="{{ eventReference.entity.fieldLink.uri }}"
@@ -404,6 +406,18 @@
                           target="_blank"
                         >
                           {{ eventReference.entity.fieldEventCta }}
+                        </a>
+                      {% endif %}
+
+                      <!-- Online event link -->
+                      {% if eventReference.entity.fieldUrlOfAnOnlineEvent.uri %}
+                        <a
+                          href="{{ eventReference.entity.fieldUrlOfAnOnlineEvent.uri }}"
+                          onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ eventReference.entity.fieldUrlOfAnOnlineEvent.uri | escape }}' });"
+                          rel="noreferrer noopener"
+                          target="_blank"
+                        >
+                          {{ eventReference.entity.fieldUrlOfAnOnlineEvent.uri }}
                         </a>
                       {% endif %}
 

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -300,6 +300,7 @@
                 <h3 class="vads-u-margin--0">{{ resource.entity.name }}</h3>
                 <p class="vads-u-flex--1">{{ resource.entity.fieldDescription }}</p>
                 <a
+                  alt="Download {{ resource.entity.name }} PDF"
                   download
                   href="{{ resource.entity.fieldMediaExternalFile.uri }}"
                   onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Downloadable resources', 'clp-section-title': '{{ fieldClpResourcesHeader | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': 'Download {{ resource.entity.name | escape }}' });"

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -416,8 +416,6 @@
                         <a
                           href="{{ eventReference.entity.fieldUrlOfAnOnlineEvent.uri }}"
                           onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Events', 'clp-section-title': '{{ fieldClpEventsHeader | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ eventReference.entity.fieldUrlOfAnOnlineEvent.uri | escape }}' });"
-                          rel="noreferrer noopener"
-                          target="_blank"
                         >
                       {% endif %}
                         <!-- Event address -->

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -101,11 +101,12 @@
           <p class="va-introtext vads-u-margin-top--1 vads-u-margin-bottom--4">{{ fieldClpWhatYouCanDoIntro }}</p>
         </div>
       </div>
+
       <div class="vads-l-row vads-u-margin-bottom--2 medium-screen:vads-u-margin-x--neg1">
         {% for promo in fieldClpWhatYouCanDoPromos %}
           <div class="vads-l-col--12 medium-screen:vads-l-col--4 vads-u-align-content--stretch vads-u-margin-y--1 ">
             <div class="vads-u-background-color--gray-light-alt vads-u-height--full medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
-              <img alt="{{ promo.entity.fieldImage.entity.thumbnail.alt }}" src="{{ promo.entity.fieldImage.entity.thumbnail.url }}" />
+              <img alt="{{ promo.entity.fieldImage.entity.thumbnail.alt }}" height="{{ promo.entity.fieldImage.entity.thumbnail.derivative.height }}" width="{{ promo.entity.fieldImage.entity.thumbnail.derivative.width }}" src="{{ promo.entity.fieldImage.entity.thumbnail.derivative.url }}" />
               <h3 class="vads-u-padding-x--2">
                 <a
                   href="{{ promo.entity.fieldPromoLink.entity.fieldLink.uri }}"

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -409,6 +409,7 @@
                         </a>
                       {% endif %}
 
+
                       <!-- Online event link -->
                       {% if eventReference.entity.fieldUrlOfAnOnlineEvent.uri %}
                         <a
@@ -417,13 +418,13 @@
                           rel="noreferrer noopener"
                           target="_blank"
                         >
-                          {{ eventReference.entity.fieldUrlOfAnOnlineEvent.uri }}
-                        </a>
                       {% endif %}
-
-                      <!-- Event address -->
-                      {% if eventReference.entity.fieldLocationHumanreadable != empty %}
-                        <p class="vads-u-margin--0">{{ eventReference.entity.fieldLocationHumanreadable }}</p>
+                        <!-- Event address -->
+                        {% if eventReference.entity.fieldLocationHumanreadable != empty %}
+                          <p class="vads-u-margin--0">{{ eventReference.entity.fieldLocationHumanreadable }}</p>
+                        {% endif %}
+                      {% if eventReference.entity.fieldUrlOfAnOnlineEvent.uri %}
+                        </a>
                       {% endif %}
                     </div>
                   </div>

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -295,18 +295,16 @@
         <div class="vads-l-row vads-u-margin-bottom--2 medium-screen:vads-u-margin-x--neg1">
           {% for resource in fieldClpResources %}
             <div class="vads-l-col--12 medium-screen:vads-l-col--4 vads-u-align-content--stretch vads-u-margin-y--1 ">
-              <div class="vads-u-background-color--gray-light-alt vads-u-height--full medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
-                <div class="vads-u-padding--2">
-                  <h3 class="vads-u-margin--0">{{ resource.entity.name }}</h3>
-                  <p>{{ resource.entity.fieldDescription }}</p>
-                  <a
-                    download
-                    href="{{ resource.entity.fieldMediaExternalFile.uri }}"
-                    onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Downloadable resources', 'clp-section-title': '{{ fieldClpResourcesHeader | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': 'Download {{ resource.entity.name | escape }}' });"
-                  >
-                    Download (PDF)
-                  </a>
-                </div>
+              <div class="vads-u-background-color--gray-light-alt vads-u-height--full vads-u-padding--2 vads-u-display--flex vads-u-flex-direction--column vads-u-justify-content--space-between medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
+                <h3 class="vads-u-margin--0">{{ resource.entity.name }}</h3>
+                <p class="vads-u-flex--1">{{ resource.entity.fieldDescription }}</p>
+                <a
+                  download
+                  href="{{ resource.entity.fieldMediaExternalFile.uri }}"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Downloadable resources', 'clp-section-title': '{{ fieldClpResourcesHeader | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': 'Download {{ resource.entity.name | escape }}' });"
+                >
+                  Download (PDF)
+                </a>
               </div>
             </div>
           {% endfor %}

--- a/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
@@ -440,6 +440,11 @@ const nodeCampaignLandingPage = `
               ... on Media {
                 name
                 thumbnail {
+                  derivative(style: _32MEDIUMTHUMBNAIL) {
+                    url
+                    width
+                    height
+                  }
                   height
                   width
                   url


### PR DESCRIPTION
## Description
**Issues:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/21314

https://github.com/department-of-veterans-affairs/va.gov-team/issues/21321

https://github.com/department-of-veterans-affairs/va.gov-team/issues/21322

https://github.com/department-of-veterans-affairs/va.gov-team/issues/21017

https://github.com/department-of-veterans-affairs/va.gov-team/issues/21312

This PR updates:
1) the styling for downloadable resources 
2) adds online links for events
3) makes image sizes consistent for what you can do section
4) adds `alt` tags for Download (PDF) links

## Testing done
N/A

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/110673494-130eac80-818e-11eb-9272-f4d7eebe7745.png)

![image](https://user-images.githubusercontent.com/12773166/110672793-413fbc80-818d-11eb-825b-ef5f188cd6cd.png)

![image](https://user-images.githubusercontent.com/12773166/110679855-2cffbd80-8195-11eb-9c9d-3ab958fd6aeb.png)

## Acceptance criteria
1) the styling for downloadable resources 
2) adds online links for events
3) makes image sizes consistent for what you can do section
4) adds `alt` tags for Download (PDF) links

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
