### PR TITLE
Add unit tests to ensure each cerner facility ID has a feature toggle

### DIFF
--- a/src/platform/utilities/cerner/index.unit.spec.js
+++ b/src/platform/utilities/cerner/index.unit.spec.js
@@ -1,0 +1,15 @@
+// Node modules.
+import { expect } from 'chai';
+// Relative imports.
+import { CERNER_FACILITY_IDS } from '.';
+import featureFlagNames from '../feature-toggles/featureFlagNames';
+
+describe('CERNER_FACILITY_IDS', () => {
+  it('includes a corresponding feature toggle', () => {
+    CERNER_FACILITY_IDS.forEach(CERNER_FACILITY_ID => {
+      expect(featureFlagNames[`cernerOverride${CERNER_FACILITY_ID}`]).to.eq(
+        `cerner_override_${CERNER_FACILITY_ID}`,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/21235

This PR adds unit tests to ensure that every CERNER_FACILITY_ID has a request for its corresponding feature toggle in `featureFlagNames`.

## Testing done
Unit tests pass and fail when feature toggle is missing.

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/110688752-2a09ca80-819f-11eb-8fd6-9b4539ae863c.png)

## Acceptance criteria
- [x] adds unit tests to ensure that every CERNER_FACILITY_ID has a request for its corresponding feature toggle in `featureFlagNames`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
