### PR TITLE
20144 update form numbers

### DIFF
--- a/src/applications/disability-benefits/686c-674/config/form.js
+++ b/src/applications/disability-benefits/686c-674/config/form.js
@@ -95,7 +95,7 @@ const formConfig = {
       'Please sign in again to continue your application for declare or remove a dependent.',
   },
   title: 'Add or remove a dependent on your VA disability benefits',
-  subTitle: 'VA Form 21-686c (and 21-674)',
+  subTitle: 'VA Form 21-686c (with 21P-527EZ and 21-674)',
   defaultDefinitions: { ...fullSchema.definitions },
   chapters: {
     optionSelection: {
@@ -379,7 +379,7 @@ const formConfig = {
       },
     },
     reportChildMarriage: {
-      title: 'nformation to remove a child under 18 who has married',
+      title: 'Information to remove a child under 18 who has married',
       pages: {
         childInformation: {
           depends: formData =>

--- a/src/applications/disability-benefits/686c-674/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/686c-674/containers/ConfirmationPage.jsx
@@ -40,9 +40,14 @@ export class ConfirmationPage extends React.Component {
             <p className="vads-u-font-size--lg vads-u-font-family--serif vads-u-font-weight--bold">
               Thank you for submitting your application
             </p>
-            <p className="vads-u-font-size--base vads-u-font-family--serif vads-u-font-weight--bold">
+            <p className="vads-u-font-size--base vads-u-font-family--serif vads-u-font-weight--bold vads-u-margin--0">
               Application for Declaration of Status of Dependents (Form 21-686c)
+            </p>
+            <p className="vads-u-font-size--base vads-u-font-family--serif vads-u-font-weight--bold vads-u-margin--0">
               and/or Request for Approval of School Attendance (Form 21-674)
+            </p>
+            <p className="vads-u-font-size--base vads-u-font-family--serif vads-u-font-weight--bold vads-u-margin--0">
+              and/or Application for Veterans Pension (Form 21P-527EZ)
             </p>
             {response && (
               <div>


### PR DESCRIPTION
## Description
This pull request adds the 527 form number to the 686 form header subtext, since pensions line of business will now be able to derive pension updates from a submitted 686 application.

## Testing done
- local

## Screenshots
<details><summary>Updated form numbers</summary>

<img width="747" alt="Screen Shot 2021-03-11 at 9 39 24 AM" src="https://user-images.githubusercontent.com/15097156/110806485-1b2f2080-8250-11eb-85dd-f806a0460714.png">
<img width="769" alt="Screen Shot 2021-03-11 at 9 56 06 AM" src="https://user-images.githubusercontent.com/15097156/110806488-1c604d80-8250-11eb-9c8d-4087adfda333.png">

</details>

## Acceptance criteria
- [x] tests pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
