### PR TITLE
21203: STEM AD: Update content to be more plain language

### DIFF
--- a/src/applications/claims-status/components/StemAskVAQuestions.jsx
+++ b/src/applications/claims-status/components/StemAskVAQuestions.jsx
@@ -9,7 +9,7 @@ function StemAskVAQuestions() {
   return (
     <div>
       <h2 className="help-heading">Need help?</h2>
-      <h3 className="vads-u-font-size--h4">Ask Questions</h3>
+      <h3 className="vads-u-font-size--h4">Ask a question</h3>
       <p>
         <a href="https://gibill.custhelp.va.gov/app/">Ask a question online</a>{' '}
         (Include your full name and VA file number)
@@ -22,10 +22,7 @@ function StemAskVAQuestions() {
       <br />
       <p>Education Call Center:</p>
       <p>
-        <Telephone contact={CONTACTS.GI_BILL}>
-          1-888-GI-BILL-1 (1-888-442-4551)
-        </Telephone>{' '}
-        (inside the U.S.)
+        <Telephone contact={CONTACTS.GI_BILL} /> (inside the U.S.)
       </p>
       <p>
         <Telephone contact={'19187815678'} pattern={PATTERNS.OUTSIDE_US} />{' '}
@@ -44,8 +41,8 @@ function StemAskVAQuestions() {
       </p>
       <h3 className="vads-u-font-size--h4">Send us mail</h3>
       <p>
-        (Include your full name and VA file number on the inside of mailed
-        correspondence, not on envelope.)
+        Include your full name and VA file number on the inside of mailed
+        correspondence, not on envelope.
       </p>
       <br />
       <p>Mailing Address:</p>

--- a/src/applications/claims-status/components/StemAskVAQuestions.jsx
+++ b/src/applications/claims-status/components/StemAskVAQuestions.jsx
@@ -17,7 +17,7 @@ function StemAskVAQuestions() {
       <h3 className="vads-u-font-size--h4">Call us</h3>
       <p>Veterans Crisis Line: </p>
       <p>
-        <Telephone contact={CONTACTS.CRISIS_LINE} /> and press 1
+        <Telephone contact={CONTACTS.CRISIS_LINE} /> and select 1
       </p>
       <br />
       <p>Education Call Center:</p>

--- a/src/applications/claims-status/components/StemClaimListItem.jsx
+++ b/src/applications/claims-status/components/StemClaimListItem.jsx
@@ -13,7 +13,7 @@ export default function StemClaimListItem({ claim }) {
   return (
     <div className="claim-list-item-container">
       <h2 className="claim-list-item-header-v2 vads-u-font-size--h3">
-        Your Edith Nourse Rogers STEM Scholarship Application
+        Edith Nourse Rogers STEM Scholarship application
         <br />
         updated on {moment(claim.attributes.deniedAt).format('MMMM D, YYYY')}
       </h2>

--- a/src/applications/claims-status/components/StemDeniedDetails.jsx
+++ b/src/applications/claims-status/components/StemDeniedDetails.jsx
@@ -6,7 +6,6 @@ import Telephone, {
 } from '@department-of-veterans-affairs/component-library/Telephone';
 
 const StemDeniedDetails = ({
-  remainingEntitlement,
   deniedAt,
   isEnrolledStem,
   isPursuingTeachingCert,
@@ -29,94 +28,41 @@ const StemDeniedDetails = ({
         You didn't meet the following criteria for the Rogers STEM Scholarship:
       </h3>
       <ul className="stem-ad-list">
-        {remainingEntitlement > 180 && (
-          <li className="stem-ad-list-item">
-            You didn’t meet the benefit requirements for the Rogers STEM
-            Scholarship
-            <ul className="stem-ad-list-secondary">
-              <li className="stem-ad-list-item">
-                According to your service and school data records on file, as of{' '}
-                {date}, you have more than 6 months of Post-9/11 GI Bill
-                (Chapter 33) benefits remaining.
-              </li>
-              <li className="stem-ad-list-item">
-                By law, all Rogers STEM Scholarship recipients must have 6
-                months or less of Post-9/11 GI Bill (Chapter 33) benefits left
-                (38 U.S. Code § 3320).
-              </li>
-            </ul>
-          </li>
-        )}
-        {isEnrolledStem === false &&
-          isPursuingTeachingCert === false && (
+        <li className="stem-ad-list-item">
+          You didn’t meet the benefit requirements for the Rogers STEM
+          Scholarship
+          <ul className="stem-ad-list-secondary">
             <li className="stem-ad-list-item">
-              You didn’t meet the degree requirements for the Rogers STEM
-              Scholarship because you answered “No” to both of the following
-              questions on your application. To be eligible, you must answer
-              “Yes” to one of these questions.
-              <ul className="stem-ad-list-secondary">
-                <li className="stem-ad-list-item">
-                  "Are you enrolled in a science, technology, engineering, or
-                  math (STEM) degree program?"
-                </li>
-                <li className="stem-ad-list-item">
-                  "Do you have a STEM undergraduate degree and are now pursuing
-                  a teaching certification?"
-                </li>
-                <li className="stem-ad-list-item">
-                  By law, all Rogers STEM Scholarship recipients must either:
-                  <ol>
-                    <li>
-                      Be enrolled in an eligible STEM undergraduate degree,{' '}
-                      <strong>or</strong>
-                    </li>
-                    <li>
-                      Have an eligible STEM undergraduate degree and be pursuing
-                      a teaching degree
-                    </li>
-                  </ol>
-                </li>
-              </ul>
+              According to your service and school data records on file, as of{' '}
+              {date}, you have more than 6 months of Post-9/11 GI Bill (Chapter
+              33) benefits remaining.
             </li>
-          )}
+            <li className="stem-ad-list-item">
+              By law, all Rogers STEM Scholarship recipients must have 6 months
+              or less of Post-9/11 GI Bill (Chapter 33) benefits left (38 U.S.
+              Code § 3320).
+            </li>
+          </ul>
+        </li>
       </ul>
       <h3 className="vads-u-font-family--sans vads-u-margin-bottom--0">
         You met these criteria for the Rogers STEM Scholarship:
       </h3>
       <ul className="stem-ad-list">
-        {remainingEntitlement && (
-          <li className="stem-ad-list-item">
-            You're eligible for Post-9/11 GI Bill benefits
-            <ul className="stem-ad-list-secondary">
-              <li className="stem-ad-list-item">
-                According to your service and school data records on file, as of{' '}
-                {date}, you're eligible for Post-9/11 GI Bill benefits.
-              </li>
-              <li className="stem-ad-list-item">
-                By law, all Rogers STEM scholarship recipients must be eligible
-                for Post-9/11 GI Bill (Chapter 33) benefits. (38 U.S. Code §
-                3320).
-              </li>
-            </ul>
-          </li>
-        )}
-        {remainingEntitlement <= 180 && (
-          <li className="stem-ad-list-item">
-            You meet the benefit requirements for the Rogers STEM Scholarship
-            <ul className="stem-ad-list-secondary">
-              <li className="stem-ad-list-item">
-                According to your service and school data records on file, as of{' '}
-                {date}, you have less than 6 months of Post-9/11 GI Bill
-                (Chapter 33) benefits remaining.
-              </li>
-              <li className="stem-ad-list-item">
-                By law, all Rogers STEM Scholarship recipients must have 6
-                months or less of Post-9/11 GI Bill (Chapter 33) benefits left
-                (38 U.S. Code § 3320).
-              </li>
-            </ul>
-          </li>
-        )}
+        <li className="stem-ad-list-item">
+          You're eligible for Post-9/11 GI Bill benefits
+          <ul className="stem-ad-list-secondary">
+            <li className="stem-ad-list-item">
+              According to your service and school data records on file, as of{' '}
+              {date}, you're eligible for Post-9/11 GI Bill benefits.
+            </li>
+            <li className="stem-ad-list-item">
+              By law, all Rogers STEM scholarship recipients must be eligible
+              for Post-9/11 GI Bill (Chapter 33) benefits. (38 U.S. Code §
+              3320).
+            </li>
+          </ul>
+        </li>
         {(isEnrolledStem || isPursuingTeachingCert) && (
           <li>
             You meet the degree requirements for the Rogers STEM Scholarship

--- a/src/applications/claims-status/components/StemDeniedDetails.jsx
+++ b/src/applications/claims-status/components/StemDeniedDetails.jsx
@@ -137,7 +137,7 @@ const StemDeniedDetails = ({
         For more information about these options, please read "Your Rights to
         Seek Further Review of Our Decisions" (VA Form 20-0998).{' '}
         <a href="https://www.va.gov/find-forms/about-form-20-0998/">
-          Download VA Form 20-0998
+          Download VA Form 20-0998.
         </a>
       </p>
       <p>

--- a/src/applications/claims-status/components/StemDeniedDetails.jsx
+++ b/src/applications/claims-status/components/StemDeniedDetails.jsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import moment from 'moment';
 
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/component-library/Telephone';
+
 const StemDeniedDetails = ({
+  remainingEntitlement,
   deniedAt,
   isEnrolledStem,
   isPursuingTeachingCert,
@@ -10,100 +15,151 @@ const StemDeniedDetails = ({
 
   return (
     <>
-      <h1>Your Edith Nourse Rogers STEM Scholarship Application</h1>
+      <h1>Your Edith Nourse Rogers STEM Scholarship application</h1>
       <div className="vads-u-background-color--primary-alt-lightest vads-u-padding--2 vads-u-margin-bottom--3">
         <h2 className="claims-alert-header vads-u-font-size--h4">
           Your application was denied on {date}.
         </h2>
       </div>
-      <h2 className="vads-u-font-family--sans vads-u-margin-y--0">
-        Why we denied your claim
-      </h2>
-      <p className="vads-u-margin--0">
+      <p className="va-introtext">
         You must meet all 3 of the eligibility criteria to be considered for the
         Rogers STEM Scholarship.
       </p>
       <h3 className="vads-u-font-family--sans vads-u-margin-bottom--0">
-        You did not meet these criteria for the Rogers STEM Scholarship:
+        You didn't meet the following criteria for the Rogers STEM Scholarship:
       </h3>
       <ul className="stem-ad-list">
-        <li className="stem-ad-list-item">
-          You don’t meet the benefit requirements for the Rogers STEM
-          Scholarship
-          <ul className="stem-ad-list-secondary">
+        {remainingEntitlement > 180 && (
+          <li className="stem-ad-list-item">
+            You didn’t meet the benefit requirements for the Rogers STEM
+            Scholarship
+            <ul className="stem-ad-list-secondary">
+              <li className="stem-ad-list-item">
+                According to your service and school data records on file, as of{' '}
+                {date}, you have more than 6 months of Post-9/11 GI Bill
+                (Chapter 33) benefits remaining.
+              </li>
+              <li className="stem-ad-list-item">
+                By law, all Rogers STEM Scholarship recipients must have 6
+                months or less of Post-9/11 GI Bill (Chapter 33) benefits left
+                (38 U.S. Code § 3320).
+              </li>
+            </ul>
+          </li>
+        )}
+        {isEnrolledStem === false &&
+          isPursuingTeachingCert === false && (
             <li className="stem-ad-list-item">
-              By law, all Rogers STEM Scholarship recipients must have 6 months
-              or less of Post 9/11 GI Bill (Chapter 33) benefits left (38 U.S.
-              Code § 3320).
+              You didn’t meet the degree requirements for the Rogers STEM
+              Scholarship because you answered “No” to both of the following
+              questions on your application. To be eligible, you must answer
+              “Yes” to one of these questions.
+              <ul className="stem-ad-list-secondary">
+                <li className="stem-ad-list-item">
+                  "Are you enrolled in a science, technology, engineering, or
+                  math (STEM) degree program?"
+                </li>
+                <li className="stem-ad-list-item">
+                  "Do you have a STEM undergraduate degree and are now pursuing
+                  a teaching certification?"
+                </li>
+                <li className="stem-ad-list-item">
+                  By law, all Rogers STEM Scholarship recipients must either:
+                  <ol>
+                    <li>
+                      Be enrolled in an eligible STEM undergraduate degree,{' '}
+                      <strong>or</strong>
+                    </li>
+                    <li>
+                      Have an eligible STEM undergraduate degree and be pursuing
+                      a teaching degree
+                    </li>
+                  </ol>
+                </li>
+              </ul>
             </li>
-            <li className="stem-ad-list-item">
-              We reviewed your service and school data records currently on
-              file. As of [{date}
-              ], you have more than 6 months of Post 9/11 GI Bill (Chapter 33)
-              benefits remaining.
-            </li>
-          </ul>
-        </li>
+          )}
       </ul>
       <h3 className="vads-u-font-family--sans vads-u-margin-bottom--0">
         You met these criteria for the Rogers STEM Scholarship:
       </h3>
       <ul className="stem-ad-list">
-        <li className="stem-ad-list-item">
-          You are eligible for Post 9/11 GI Bill benefits
-          <ul className="stem-ad-list-secondary">
-            <li className="stem-ad-list-item">
-              By law, all Rogers STEM scholarship recipients must be eligible
-              for Post 9/11 GI Bill (Chapter 33) benefits. (38 U.S. Code §
-              3320).
-            </li>
-            <li className="stem-ad-list-item">
-              We reviewed your service and school data records currently on
-              file. As of [{date}
-              ], you are eligible for Post 9/11 GI Bill benefits.
-            </li>
-          </ul>
-        </li>
+        {remainingEntitlement && (
+          <li className="stem-ad-list-item">
+            You're eligible for Post-9/11 GI Bill benefits
+            <ul className="stem-ad-list-secondary">
+              <li className="stem-ad-list-item">
+                According to your service and school data records on file, as of{' '}
+                {date}, you're eligible for Post-9/11 GI Bill benefits.
+              </li>
+              <li className="stem-ad-list-item">
+                By law, all Rogers STEM scholarship recipients must be eligible
+                for Post-9/11 GI Bill (Chapter 33) benefits. (38 U.S. Code §
+                3320).
+              </li>
+            </ul>
+          </li>
+        )}
+        {remainingEntitlement <= 180 && (
+          <li className="stem-ad-list-item">
+            You meet the benefit requirements for the Rogers STEM Scholarship
+            <ul className="stem-ad-list-secondary">
+              <li className="stem-ad-list-item">
+                According to your service and school data records on file, as of{' '}
+                {date}, you have less than 6 months of Post-9/11 GI Bill
+                (Chapter 33) benefits remaining.
+              </li>
+              <li className="stem-ad-list-item">
+                By law, all Rogers STEM Scholarship recipients must have 6
+                months or less of Post-9/11 GI Bill (Chapter 33) benefits left
+                (38 U.S. Code § 3320).
+              </li>
+            </ul>
+          </li>
+        )}
         {(isEnrolledStem || isPursuingTeachingCert) && (
           <li>
             You meet the degree requirements for the Rogers STEM Scholarship
             <ul className="stem-ad-list-secondary">
               <li className="stem-ad-list-item">
-                By law, all Rogers STEM Scholarship recipients must either be:
+                You meet the degree requirements because you answered "Yes" to
+                one of these questions on the Rogers STEM Scholarship
+                application.
+                <ul>
+                  <li>
+                    "Are you enrolled in a science, technology, engineering, or
+                    math (STEM) degree program?" or
+                  </li>
+                  <li>
+                    "Do you have a STEM undergraduate degree and are now
+                    pursuing a teaching certification?"
+                  </li>
+                </ul>
+              </li>
+              <li className="stem-ad-list-item">
+                By law, all Rogers STEM Scholarship recipients must either:
                 <ol>
-                  <li>Enrolled in an eligible STEM undergraduate degree or</li>
+                  <li>
+                    Be enrolled in an eligible STEM undergraduate degree,{' '}
+                    <strong>or</strong>
+                  </li>
                   <li>
                     Have an eligible STEM undergraduate degree and be pursuing a
                     teaching degree
                   </li>
                 </ol>
               </li>
-              <li className="stem-ad-list-item">
-                You meet the degree requirements because you answered "Yes" to
-                one of these questions on the Rogers STEM Scholarship
-                application.
-                <ul className="stem-ad-list-secondary">
-                  <li className="stem-ad-list-item">
-                    "Are you enrolled in a science, technology, engineering, or
-                    math (STEM) degree program?" or
-                  </li>
-                  <li className="stem-ad-list-item">
-                    "Do you have a STEM undergraduate degree and are now
-                    pursuing a teaching certification?"
-                  </li>
-                </ul>
-              </li>
             </ul>
           </li>
         )}
       </ul>
       <h3 className="vads-u-font-family--sans">
-        What you should do if you disagree with our decision
+        What should I do if I disagree with your decision?
       </h3>
       <p>
         If you disagree with our decision, you have 1 year from the date of this
-        letter to request a decision review or appeal. You have 3 options to do
-        this:
+        decision to request a decision review or appeal. You have 3 options to
+        do this:
       </p>
       <ul className="stem-ad-list">
         <li className="stem-ad-list-item">
@@ -123,8 +179,8 @@ const StemDeniedDetails = ({
           </a>
         </li>
         <li className="stem-ad-list-item">
-          If you don't agree with the decision on your Supplemental Claim or
-          Higher-Level Review, you can appeal to a Veterans Law Judge by
+          If you filed a Supplemental Claim or Higher-Level Review and don't
+          agree with the decision, you can appeal to a Veterans Law Judge by
           completing VA Form 10182.{' '}
           <a href="https://www.va.gov/find-forms/about-form-10182/">
             Download VA Form 10182.
@@ -132,13 +188,15 @@ const StemDeniedDetails = ({
         </li>
       </ul>
       <p>
-        You can read more about these options on VA Form 20-0998, "Your Rights
-        to Seek Further Review of Our Decisions".{' '}
+        For more information about these options, please read "Your Rights to
+        Seek Further Review of Our Decisions" (VA Form 20-0998).{' '}
         <a href="https://www.va.gov/find-forms/about-form-20-0998/">
           Download VA Form 20-0998
         </a>
-        . You can also contact us at (888) GI BILL 1 (888-442-4551) to request
-        any of these forms.
+      </p>
+      <p>
+        You can also contact us at <Telephone contact={CONTACTS.GI_BILL} /> to
+        request any of these forms.
       </p>
       <p>
         <a href="https://www.va.gov/decision-reviews">
@@ -146,47 +204,41 @@ const StemDeniedDetails = ({
         </a>{' '}
         If you would like to review the evidence we used in our decision, please
         contact us. You may be able to review some evidence by signing in to
-        your account on <a href="https://www.va.gov/">https://www.va.gov</a>.
+        your <a href="https://www.va.gov/">VA.gov</a> account.
       </p>
-      <h3 className="vads-u-font-family--sans">More resources</h3>
-      <table>
-        <thead>
-          <tr>
-            <th scope="col">Website</th>
-            <th scope="col">Link</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">Rogers STEM Scholarship</th>
-            <td>
-              <a href="https://www.va.gov/education/other-va-education-benefits/stem-scholarship/">
-                https://www.va.gov/education/other-va-education-benefits/stem-scholarship/
-              </a>
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">VA Forms</th>
-            <td>
-              <a href="https://www.va.gov/vaforms">
-                https://www.va.gov/vaforms
-              </a>
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">
-              GI Bill® Comparison Tool: This tool allows you to get information
-              on a school’s value and affordability; and to compare estimated
-              benefits by school.
-            </th>
-            <td>
-              <a href="https://www.va.gov/gi-bill-comparison-tool">
-                https://www.va.gov/gi-bill-comparison-tool
-              </a>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <div className="vads-u-background-color--gray-lightest vads-u-padding-x--2 vads-u-padding-top--1px vads-u-padding-bottom--2p5 vads-u-margin-top--3 vads-u-margin-bottom--5">
+        <h3 className="vads-u-border-bottom--1px vads-u-border-color--gray-light vads-u-padding-top--2 vads-u-padding-bottom--0p5 vads-u-margin--0">
+          More resources about VA benefits
+        </h3>
+        <a
+          href="https://www.va.gov/education/other-va-education-benefits/stem-scholarship/"
+          className="vads-u-margin-top--3 vads-u-margin-bottom--1 vads-u-display--inline-block va-nav-linkslist-title vads-u-font-size--h4 vads-u-font-weight--bold vads-u-font-family--serif vads-u-text-decoration--none"
+        >
+          Edith Nourse Rogers STEM Scholarship
+        </a>
+        <p className="vads-u-margin--0 vads-u-color--base">
+          Learn more about eligibility and how to apply for this scholarship.
+        </p>
+        <a
+          href="https://www.va.gov/vaforms"
+          className="vads-u-margin-top--3 vads-u-margin-bottom--1 vads-u-display--inline-block va-nav-linkslist-title vads-u-font-size--h4 vads-u-font-weight--bold vads-u-font-family--serif vads-u-text-decoration--none"
+        >
+          Find a VA Form
+        </a>
+        <p className="vads-u-margin--0 vads-u-color--base">
+          Search for a VA form.
+        </p>
+        <a
+          href="https://www.va.gov/gi-bill-comparison-tool"
+          className="vads-u-margin-top--3 vads-u-margin-bottom--1 vads-u-display--inline-block va-nav-linkslist-title vads-u-font-size--h4 vads-u-font-weight--bold vads-u-font-family--serif vads-u-text-decoration--none"
+        >
+          GI Bill® Comparison Tool
+        </a>
+        <p className="vads-u-margin--0 vads-u-color--base">
+          Get information on a school’s value and affordability; and compare
+          estimated benefits by school.
+        </p>
+      </div>
     </>
   );
 };

--- a/src/applications/claims-status/containers/StemClaimStatusPage.jsx
+++ b/src/applications/claims-status/containers/StemClaimStatusPage.jsx
@@ -16,8 +16,7 @@ class StemClaimStatusPage extends React.Component {
   }
 
   setTitle() {
-    document.title =
-      'Status - Your Edith Nourse Rogers STEM Scholarship Application Claim';
+    document.title = 'Your Edith Nourse Rogers STEM Scholarship application';
   }
 
   render() {
@@ -32,11 +31,13 @@ class StemClaimStatusPage extends React.Component {
         />
       );
     } else if (claim) {
+      const claimAttributes = claim.attributes;
       content = (
         <StemDeniedDetails
-          deniedAt={claim.attributes.deniedAt}
-          isEnrolledStem={claim.attributes.isEnrolledStem}
-          isPursuingTeachingCert={claim.attributes.isPursuingTeachingCert}
+          remainingEntitlement={claimAttributes.remainingEntitlement}
+          deniedAt={claimAttributes.deniedAt}
+          isEnrolledStem={claimAttributes.isEnrolledStem}
+          isPursuingTeachingCert={claimAttributes.isPursuingTeachingCert}
         />
       );
     } else {
@@ -56,7 +57,7 @@ class StemClaimStatusPage extends React.Component {
             <div className="vads-l-col--12">
               <ClaimsBreadcrumbs>
                 <Link to={claimsPath}>
-                  Your Edith Nourse Rogers STEM Scholarship Application
+                  Your Rogers STEM Scholarship application status details
                 </Link>
               </ClaimsBreadcrumbs>
             </div>

--- a/src/applications/claims-status/containers/StemClaimStatusPage.jsx
+++ b/src/applications/claims-status/containers/StemClaimStatusPage.jsx
@@ -34,7 +34,6 @@ class StemClaimStatusPage extends React.Component {
       const claimAttributes = claim.attributes;
       content = (
         <StemDeniedDetails
-          remainingEntitlement={claimAttributes.remainingEntitlement}
           deniedAt={claimAttributes.deniedAt}
           isEnrolledStem={claimAttributes.isEnrolledStem}
           isPursuingTeachingCert={claimAttributes.isPursuingTeachingCert}


### PR DESCRIPTION
## Description
As a developer, I need to update the content of the STEM automated denial in the claims and appeals tool so that it is more plain language and easier for the user to understand.

[Originating Issue](https://github.com/department-of-veterans-affairs/va.gov-team/issues/21203)

## Testing done
Testing passes locally 

## Screenshots

### Updated Card Content:
<img width="664" alt="Screen Shot 2021-03-11 at 11 00 41 AM" src="https://user-images.githubusercontent.com/48804834/110816558-71549180-8259-11eb-8644-952933780069.png">

### Updated Details (Full page)
![screencapture-localhost-3001-track-claims-your-stem-claims-2-status-2021-03-12-11_00_05](https://user-images.githubusercontent.com/48804834/110965398-25215400-8322-11eb-8ec8-23e6170ab558.png)



## Acceptance criteria
- [x] The contents of the STEM automated denial card page match supporting artifact 1.
- [x] The contents of the STEM automated denial details page match supporting artifact 1.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
