### PR TITLE
[Prearchive] Patch for encoded HTML entities becoming decoded in DOM

### DIFF
--- a/src/site/stages/prearchive/helpers.js
+++ b/src/site/stages/prearchive/helpers.js
@@ -44,6 +44,7 @@ function updateAssetLinkElements(
 ) {
   const doc = cheerio.load(htmlFile, {
     decodeEntities: false,
+    _useHtmlParser2: true,
   });
   const assetLinkElements = doc(assetLinkTags);
   assetLinkElements.each((i, element) => {


### PR DESCRIPTION
## Description
Follow up to https://github.com/department-of-veterans-affairs/vets-website/pull/16276. We discovered that encoded HTML  entities in our HTML files are becoming decoded after being processed through our prearchive stage due to a bug with our virtual DOM parser, Cheerio - https://github.com/cheeriojs/cheerio/issues/1198.

This PR implements a quick patch to fix this, https://github.com/cheeriojs/cheerio/issues/1198#issuecomment-522335541

https://dsva.slack.com/archives/C52CL1PKQ/p1615482535397200

## Testing done

### Without these changes
1. `yarn build:content` -> observe that the HTML of `build/localhost/index.html` contains encoded entities
2. ^ rename `build/localhost` to `build/vagovdev`
3. run `node prearchive --buildtype=vagovdev`. 
4. Observe that the previously encoded HTML entities are now decoded

### With these changes
do steps 1-3 of the above. then on step 4, observe that the encoded HTML entities are still encoded.

## Screenshots

### Problem
See that the `data-homepage-banner-content` attribute contains unescaped HTML
![image](https://user-images.githubusercontent.com/1915775/110840986-60187e80-8273-11eb-90ec-f424a515aabd.png)


## Acceptance criteria
- [ ] Homepage banner works again (which is currently broken due to this HTML encoding issue)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
