### PR TITLE
Make all r&s templates have full width need more help section + formatting

### DIFF
--- a/src/site/includes/last-updated.drupal.liquid
+++ b/src/site/includes/last-updated.drupal.liquid
@@ -1,0 +1,10 @@
+<div class="usa-grid usa-grid-full">
+  <div class="usa-width-three-fourths">
+    <div class="usa-content">
+      <div class="last-updated usa-content vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
+        Last updated: <time
+          datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/site/layouts/checklist.drupal.liquid
+++ b/src/site/layouts/checklist.drupal.liquid
@@ -92,19 +92,18 @@
 
           <!-- VA benefits -->
           {% include "src/site/includes/benefit-hubs-links.drupal.liquid" with fieldRelatedBenefitHubs = fieldRelatedBenefitHubs %}
-
-          <!-- Need more help -->
-          {% include "src/site/paragraphs/contact_information.drupal.liquid" with entity = fieldContactInformation.entity %}
-
-          <!-- Last Updated -->
-          <div class="last-updated usa-content vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
-            Last updated: <time
-              datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
-          </div>
         </div>
       </div>
     </div>
+
+    <!-- Need more help -->
+    {% include "src/site/paragraphs/contact_information.drupal.liquid" with entity = fieldContactInformation.entity %}
+
+    <!-- Last updated -->
+    {% include "src/site/includes/last-updated.drupal.liquid" %}
   </main>
+
+  <!-- Up To Top Button -->
   {% include "src/site/components/up_to_top_button.html" %}
 </div>
 

--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -113,21 +113,17 @@
 
           <!-- VA benefits -->
           {% include "src/site/includes/benefit-hubs-links.drupal.liquid" with fieldRelatedBenefitHubs = fieldRelatedBenefitHubs %}
-
-          <!-- Need more help -->
-          {% include "src/site/paragraphs/contact_information.drupal.liquid" with entity = fieldContactInformation.entity %}
-
-          <!-- Last Updated -->
-          <div class="last-updated usa-content vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
-            Last updated: <time
-              datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
-          </div>
-
-
         </div>
       </div>
     </div>
+
+    <!-- Need more help -->
+    {% include "src/site/paragraphs/contact_information.drupal.liquid" with entity = fieldContactInformation.entity %}
+
+    <!-- Last updated -->
+    {% include "src/site/includes/last-updated.drupal.liquid" %}
   </main>
+
   <!-- Up To Top Button -->
   {% include "src/site/components/up_to_top_button.html" %}
 </div>

--- a/src/site/layouts/media_list_images.drupal.liquid
+++ b/src/site/layouts/media_list_images.drupal.liquid
@@ -4,82 +4,83 @@
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with constructLcBreadcrumbs = true titleInclude = true %}
 
 <div class="interior" id="content" data-template="node-media_list_images">
-    <main class="va-l-detail-page">
-        <div class="usa-grid usa-grid-full">
-            <div class="usa-width-three-fourths">
-                <div class="usa-content">
-                    <!-- Search bar -->
-                    <div class="medium-screen:vads-u-border-bottom--2px vads-u-border-color--gray-light medium-screen:vads-u-margin-bottom--3">
-                      {% include "src/site/includes/support_resources_search_bar.drupal.liquid" %}
-                    </div>
+  <main class="va-l-detail-page">
+    <div class="usa-grid usa-grid-full">
+      <div class="usa-width-three-fourths">
+        <div class="usa-content">
+          <!-- Search bar -->
+          <div class="medium-screen:vads-u-border-bottom--2px vads-u-border-color--gray-light medium-screen:vads-u-margin-bottom--3">
+            {% include "src/site/includes/support_resources_search_bar.drupal.liquid" %}
+          </div>
 
-                    <article class="vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
-                        <!-- Title -->
-                        <h1>{{ title }}</h1>
+          <article class="vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
+            <!-- Title -->
+            <h1>{{ title }}</h1>
 
-                        <!-- Intro -->
-                        <div class="va-introtext">{{ fieldIntroTextLimitedHtml.processed }}</div>
+            <!-- Intro -->
+            <div class="va-introtext">{{ fieldIntroTextLimitedHtml.processed }}</div>
 
-                        <!-- Alert -->
-                        {% if fieldAlertSingle %}
-                            {% include "src/site/paragraphs/alert_single.drupal.liquid" with entity = fieldAlertSingle.entity %}
-                        {% endif %}
+            <!-- Alert -->
+            {% if fieldAlertSingle %}
+              {% include "src/site/paragraphs/alert_single.drupal.liquid" with entity = fieldAlertSingle.entity %}
+            {% endif %}
 
-                        <!-- Buttons -->
-                        <div class="vads-u-margin-y--3">
-                            {% for fieldButton in fieldButtons %}
-                                {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
-                            {% endfor %}
-                        </div>
-                        <!-- Section Header -->
-                        {% if fieldMediaListImages.entity.fieldSectionHeader %}
-                            {% assign image_title_tag = "h3" %}
-                            {% assign image_title_classes = "vads-u-margin-y--0 medium-screen:vads-u-margin-y--1p5" %}
-                            <h2 class="vads-u-margin-bottom--2">{{fieldMediaListImages.entity.fieldSectionHeader }}</h2>
-                        {% else %}
-                            {% assign image_title_tag = "h2" %}
-                            {% assign image_title_classes = "vads-u-font-size--h3" %}
-                        {% endif %}
-                        <!-- Images List -->
-                        <dl class="usa-unstyled-list">
-                            {% include "src/site/includes/images_list_with_additional_info_component.drupal.liquid"
-                            with images = fieldMediaListImages.entity.fieldImages %}
-                        </dl>
-                        <!-- Repeated buttons -->
-                        {% if fieldButtonsRepeat %}
-                            <div class="vads-u-margin-top--3">
-                                {% for fieldButton in fieldButtons %}
-                                    {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
-                                {% endfor %}
-                            </div>
-                        {% endif %}
-                    </article>
-
-                    <!-- Tags -->
-                    {% include "src/site/includes/tags.drupal.liquid" with fieldTags = fieldTags %}
-
-                    <!-- How do you rate -->
-                    {% include "src/site/includes/how-do-you-rate.drupal.liquid" %}
-
-                    <!-- Related information -->
-                    {% include "src/site/includes/related-information.drupal.liquid" with fieldRelatedInformation = fieldRelatedInformation %}
-
-                    <!-- VA benefits -->
-                    {% include "src/site/includes/benefit-hubs-links.drupal.liquid" with fieldRelatedBenefitHubs = fieldRelatedBenefitHubs %}
-
-                    <!-- Need more help -->
-                    {% include "src/site/paragraphs/contact_information.drupal.liquid" with entity = fieldContactInformation.entity %}
-
-                    <!-- Last updated -->
-                    <div class="last-updated usa-content vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
-                        Last updated:
-                        <time datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
-                    </div>
-                </div>
+            <!-- Buttons -->
+            <div class="vads-u-margin-y--3">
+              {% for fieldButton in fieldButtons %}
+                {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+              {% endfor %}
             </div>
+
+            <!-- Section Header -->
+            {% if fieldMediaListImages.entity.fieldSectionHeader %}
+              {% assign image_title_tag = "h3" %}
+              {% assign image_title_classes = "vads-u-margin-y--0 medium-screen:vads-u-margin-y--1p5" %}
+              <h2 class="vads-u-margin-bottom--2">{{fieldMediaListImages.entity.fieldSectionHeader }}</h2>
+            {% else %}
+              {% assign image_title_tag = "h2" %}
+              {% assign image_title_classes = "vads-u-font-size--h3" %}
+            {% endif %}
+
+            <!-- Images List -->
+            <dl class="usa-unstyled-list">
+              {% include "src/site/includes/images_list_with_additional_info_component.drupal.liquid" with images = fieldMediaListImages.entity.fieldImages %}
+            </dl>
+
+            <!-- Repeated buttons -->
+            {% if fieldButtonsRepeat %}
+              <div class="vads-u-margin-top--3">
+                {% for fieldButton in fieldButtons %}
+                  {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+                {% endfor %}
+              </div>
+            {% endif %}
+          </article>
+
+          <!-- Tags -->
+          {% include "src/site/includes/tags.drupal.liquid" with fieldTags = fieldTags %}
+
+          <!-- How do you rate -->
+          {% include "src/site/includes/how-do-you-rate.drupal.liquid" %}
+
+          <!-- Related information -->
+          {% include "src/site/includes/related-information.drupal.liquid" with fieldRelatedInformation = fieldRelatedInformation %}
+
+          <!-- VA benefits -->
+          {% include "src/site/includes/benefit-hubs-links.drupal.liquid" with fieldRelatedBenefitHubs = fieldRelatedBenefitHubs %}
         </div>
-    </main>
-    {% include "src/site/components/up_to_top_button.html" %}
+      </div>
+    </div>
+
+    <!-- Need more help -->
+    {% include "src/site/paragraphs/contact_information.drupal.liquid" with entity = fieldContactInformation.entity %}
+
+    <!-- Last updated -->
+    {% include "src/site/includes/last-updated.drupal.liquid" %}
+  </main>
+
+  <!-- Up To Top Button -->
+  {% include "src/site/components/up_to_top_button.html" %}
 </div>
 
 {% include "src/site/includes/footer.html" %}

--- a/src/site/layouts/media_list_videos.drupal.liquid
+++ b/src/site/layouts/media_list_videos.drupal.liquid
@@ -72,19 +72,18 @@
 
           <!-- VA benefits -->
           {% include "src/site/includes/benefit-hubs-links.drupal.liquid" with fieldRelatedBenefitHubs = fieldRelatedBenefitHubs %}
-
-          <!-- Need more help -->
-          {% include "src/site/paragraphs/contact_information.drupal.liquid" with entity = fieldContactInformation.entity %}
-
-          <!-- Last updated -->
-          <div class="last-updated usa-content vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
-            Last updated: <time
-              datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
-          </div>
         </div>
       </div>
     </div>
+
+    <!-- Need more help -->
+    {% include "src/site/paragraphs/contact_information.drupal.liquid" with entity = fieldContactInformation.entity %}
+
+    <!-- Last updated -->
+    {% include "src/site/includes/last-updated.drupal.liquid" %}
   </main>
+
+  <!-- Up To Top Button -->
   {% include "src/site/components/up_to_top_button.html" %}
 </div>
 

--- a/src/site/layouts/q_a.drupal.liquid
+++ b/src/site/layouts/q_a.drupal.liquid
@@ -47,19 +47,18 @@
 
           <!-- VA benefits -->
           {% include "src/site/includes/benefit-hubs-links.drupal.liquid" with fieldRelatedBenefitHubs = fieldRelatedBenefitHubs %}
-
-          <!-- Need more help -->
-          {% include "src/site/paragraphs/contact_information.drupal.liquid" with entity = fieldContactInformation.entity %}
-
-          <!-- Last updated -->
-          <div class="last-updated usa-content vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
-            Last updated: <time
-              datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
-          </div>
         </div>
       </div>
     </div>
+
+    <!-- Need more help -->
+    {% include "src/site/paragraphs/contact_information.drupal.liquid" with entity = fieldContactInformation.entity %}
+
+    <!-- Last updated -->
+    {% include "src/site/includes/last-updated.drupal.liquid" %}
   </main>
+
+  <!-- Up To Top Button -->
   {% include "src/site/components/up_to_top_button.html" %}
 </div>
 

--- a/src/site/layouts/step_by_step.drupal.liquid
+++ b/src/site/layouts/step_by_step.drupal.liquid
@@ -106,19 +106,18 @@
 
           <!-- VA benefits -->
           {% include "src/site/includes/benefit-hubs-links.drupal.liquid" with fieldRelatedBenefitHubs = fieldRelatedBenefitHubs %}
-
-          <!-- Need more help -->
-          {% include "src/site/paragraphs/contact_information.drupal.liquid" with entity = fieldContactInformation.entity %}
-
-          <!-- Last updated -->
-          <div class="last-updated usa-content vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
-            Last updated: <time
-              datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
-          </div>
         </div>
       </div>
     </div>
+
+    <!-- Need more help -->
+    {% include "src/site/paragraphs/contact_information.drupal.liquid" with entity = fieldContactInformation.entity %}
+
+    <!-- Last updated -->
+    {% include "src/site/includes/last-updated.drupal.liquid" %}
   </main>
+
+  <!-- Up To Top Button -->
   {% include "src/site/components/up_to_top_button.html" %}
 </div>
 

--- a/src/site/layouts/support_resources_detail_page.drupal.liquid
+++ b/src/site/layouts/support_resources_detail_page.drupal.liquid
@@ -68,19 +68,18 @@
 
           <!-- VA benefits -->
           {% include "src/site/includes/benefit-hubs-links.drupal.liquid" with fieldRelatedBenefitHubs = fieldRelatedBenefitHubs %}
-
-          <!-- Need more help -->
-          {% include "src/site/paragraphs/contact_information.drupal.liquid" with entity = fieldContactInformation.entity %}
-
-          <!-- Last Updated -->
-          <div class="last-updated usa-content vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
-            Last updated: <time
-              datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
-          </div>
         </div>
       </div>
     </div>
+
+    <!-- Need more help -->
+    {% include "src/site/paragraphs/contact_information.drupal.liquid" with entity = fieldContactInformation.entity %}
+
+    <!-- Last updated -->
+    {% include "src/site/includes/last-updated.drupal.liquid" %}
   </main>
+
+  <!-- Up To Top Button -->
   {% include "src/site/components/up_to_top_button.html" %}
 </div>
 

--- a/src/site/paragraphs/contact_information.drupal.liquid
+++ b/src/site/paragraphs/contact_information.drupal.liquid
@@ -1,68 +1,74 @@
 {% if entity.fieldAdditionalContact != empty or entity.fieldBenefitHubContacts != empty or entity.fieldContactDefault != empty %}
-  <div class="vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
-    <section class="vads-u-display--flex vads-u-flex-direction--column vads-u-background-color--gray-light-alt vads-u-padding--2" data-template="paragraphs/contact_information">
-      <h2 class="vads-u-font-size--h3 vads-u-border-bottom--4px vads-u-border-color--primary vads-u-margin--0 vads-u-margin-y--1 vads-u-padding-bottom--1">Need more help?</h2>
+  <div class="vads-u-background-color--gray-light-alt">
+    <div class="usa-grid usa-grid-full">
+      <div class="usa-width-three-fourths">
+        <div class="usa-content vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
+          <section class="vads-u-display--flex vads-u-flex-direction--column vads-u-padding-y--2" data-template="paragraphs/contact_information">
+            <h2 class="vads-u-font-size--h3 vads-u-border-bottom--4px vads-u-border-color--primary vads-u-margin--0 vads-u-margin-y--1 vads-u-padding-bottom--1">Need more help?</h2>
 
-      <ul class="usa-unstyled-list vads-u-display--flex vads-u-flex-direction--column">
-        <!-- Default contact -->
-        {% if entity.fieldContactInfoSwitch == 'DC' and entity.fieldContactDefault != empty %}
-          <li class="vads-u-margin-top--1">
-            <strong>{{ entity.fieldContactDefault.entity.title }} </strong>
-            {% if entity.fieldContactDefault.entity.fieldLink %}
-              <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ entity.fieldContactDefault.entity.fieldPhoneNumber }}', 'links-list-section-header': 'Need more help?' })"
-                  href="{{ entity.fieldContactDefault.entity.fieldLink.url.path }}"
-                  rel="noreferrer noopener">
-                {{ entity.fieldContactDefault.entity.fieldPhoneNumber }}
-              </a>
-            {% endif %}
-          </li>
-        {% endif %}
-
-        <!-- Additional contact -->
-        {% if entity.fieldAdditionalContact != empty %}
-          <li class="vads-u-margin-top--1">
-            <!-- Email -->
-            {% if entity.fieldAdditionalContact.entity.fieldEmailLabel and entity.fieldAdditionalContact.entity.fieldEmailAddress %}
-              <strong>{{ entity.fieldAdditionalContact.entity.fieldEmailLabel }}: </strong>
-              {% if entity.fieldAdditionalContact.entity.fieldEmailAddress %}
-                <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ entity.fieldAdditionalContact.entity.fieldEmailAddress | escape }}', 'links-list-section-header': 'Need more help?' })"
-                    href="mailto:{{ entity.fieldAdditionalContact.entity.fieldEmailAddress }}"
-                    rel="noreferrer noopener">
-                  {{ entity.fieldAdditionalContact.entity.fieldEmailAddress }}
-                </a>
+            <ul class="usa-unstyled-list vads-u-display--flex vads-u-flex-direction--column">
+              <!-- Default contact -->
+              {% if entity.fieldContactInfoSwitch == 'DC' and entity.fieldContactDefault != empty %}
+                <li class="vads-u-margin-top--1">
+                  <strong>{{ entity.fieldContactDefault.entity.title }} </strong>
+                  {% if entity.fieldContactDefault.entity.fieldLink %}
+                    <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ entity.fieldContactDefault.entity.fieldPhoneNumber }}', 'links-list-section-header': 'Need more help?' })"
+                        href="{{ entity.fieldContactDefault.entity.fieldLink.url.path }}"
+                        rel="noreferrer noopener">
+                      {{ entity.fieldContactDefault.entity.fieldPhoneNumber }}
+                    </a>
+                  {% endif %}
+                </li>
               {% endif %}
-            {% endif %}
 
-            <!-- Phone number -->
-            {% if entity.fieldAdditionalContact.entity.fieldPhoneLabel and entity.fieldAdditionalContact.entity.fieldPhoneNumber %}
-              <strong>{{ entity.fieldAdditionalContact.entity.fieldPhoneLabel }}: </strong>
-              {% if entity.fieldAdditionalContact.entity.fieldPhoneNumber %}
-                <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ entity.fieldAdditionalContact.entity.fieldPhoneNumber | escape }}{% if fieldPhoneExtension %}p{{ fieldPhoneExtension }}{% endif %}', 'links-list-section-header': 'Need more help?' })"
-                    href="tel:{{ entity.fieldAdditionalContact.entity.fieldPhoneNumber }}{% if fieldPhoneExtension %}p{{ fieldPhoneExtension }}{% endif %}"
-                    rel="noreferrer noopener">
-                  {{ entity.fieldAdditionalContact.entity.fieldPhoneNumber }}{% if fieldPhoneExtension %}p{{ fieldPhoneExtension }}{% endif %}
-                </a>
-              {% endif %}
-            {% endif %}
-          </li>
-        {% endif %}
+              <!-- Additional contact -->
+              {% if entity.fieldAdditionalContact != empty %}
+                <li class="vads-u-margin-top--1">
+                  <!-- Email -->
+                  {% if entity.fieldAdditionalContact.entity.fieldEmailLabel and entity.fieldAdditionalContact.entity.fieldEmailAddress %}
+                    <strong>{{ entity.fieldAdditionalContact.entity.fieldEmailLabel }}: </strong>
+                    {% if entity.fieldAdditionalContact.entity.fieldEmailAddress %}
+                      <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ entity.fieldAdditionalContact.entity.fieldEmailAddress | escape }}', 'links-list-section-header': 'Need more help?' })"
+                          href="mailto:{{ entity.fieldAdditionalContact.entity.fieldEmailAddress }}"
+                          rel="noreferrer noopener">
+                        {{ entity.fieldAdditionalContact.entity.fieldEmailAddress }}
+                      </a>
+                    {% endif %}
+                  {% endif %}
 
-        <!-- Benefit hub contacts -->
-        {% if entity.fieldContactInfoSwitch == 'BHC' and entity.fieldBenefitHubContacts != empty %}
-          {% for supportService in entity.fieldBenefitHubContacts.entity.fieldSupportServices %}
-            <li class="vads-u-margin-top--1">
-              <strong>{{ supportService.entity.title }} </strong>
-              {% if supportService.entity.fieldLink %}
-                <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ supportService.entity.fieldPhoneNumber | escape }}', 'links-list-section-header': 'Need more help?' })"
-                    href="{{ supportService.entity.fieldLink.url.path }}"
-                    rel="noreferrer noopener">
-                  {{ supportService.entity.fieldPhoneNumber }}
-                </a>
+                  <!-- Phone number -->
+                  {% if entity.fieldAdditionalContact.entity.fieldPhoneLabel and entity.fieldAdditionalContact.entity.fieldPhoneNumber %}
+                    <strong>{{ entity.fieldAdditionalContact.entity.fieldPhoneLabel }}: </strong>
+                    {% if entity.fieldAdditionalContact.entity.fieldPhoneNumber %}
+                      <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ entity.fieldAdditionalContact.entity.fieldPhoneNumber | escape }}{% if fieldPhoneExtension %}p{{ fieldPhoneExtension }}{% endif %}', 'links-list-section-header': 'Need more help?' })"
+                          href="tel:{{ entity.fieldAdditionalContact.entity.fieldPhoneNumber }}{% if fieldPhoneExtension %}p{{ fieldPhoneExtension }}{% endif %}"
+                          rel="noreferrer noopener">
+                        {{ entity.fieldAdditionalContact.entity.fieldPhoneNumber }}{% if fieldPhoneExtension %}p{{ fieldPhoneExtension }}{% endif %}
+                      </a>
+                    {% endif %}
+                  {% endif %}
+                </li>
               {% endif %}
-            </li>
-          {% endfor %}
-        {% endif %}
-      </ul>
-    </section>
+
+              <!-- Benefit hub contacts -->
+              {% if entity.fieldContactInfoSwitch == 'BHC' and entity.fieldBenefitHubContacts != empty %}
+                {% for supportService in entity.fieldBenefitHubContacts.entity.fieldSupportServices %}
+                  <li class="vads-u-margin-top--1">
+                    <strong>{{ supportService.entity.title }} </strong>
+                    {% if supportService.entity.fieldLink %}
+                      <a onclick="recordEvent({ 'event': 'nav-linkslist', 'links-list-header': '{{ supportService.entity.fieldPhoneNumber | escape }}', 'links-list-section-header': 'Need more help?' })"
+                          href="{{ supportService.entity.fieldLink.url.path }}"
+                          rel="noreferrer noopener">
+                        {{ supportService.entity.fieldPhoneNumber }}
+                      </a>
+                    {% endif %}
+                  </li>
+                {% endfor %}
+              {% endif %}
+            </ul>
+          </section>
+        </div>
+      </div>
+    </div>
   </div>
 {% endif %}


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/15272

This PR makes it so that all `Need more help` sections on R&S pages are full-width. It also standardizes a lot of the formatting across R&S templates.

## Testing done
N/A

## Screenshots
Will upload 1 screenshot per template

### checklist (http://localhost:3001/preview?nodeId=9544)
![localhost_3001_preview_nodeId=9544](https://user-images.githubusercontent.com/12773166/110966186-3f533600-8312-11eb-83d2-47c55bc34419.png)

### faq_multiple_q_a (http://localhost:3001/preview?nodeId=8487)
![localhost_3001_preview_nodeId=8487](https://user-images.githubusercontent.com/12773166/110966565-9c4eec00-8312-11eb-89c6-78a934bec5f3.png)

### media_list_images (http://localhost:3001/preview?nodeId=6954)
![localhost_3001_preview_nodeId=6954](https://user-images.githubusercontent.com/12773166/110966581-a07b0980-8312-11eb-8db9-4d402d2ca158.png)

### media_list_videos (http://localhost:3001/preview?nodeId=6950)
![localhost_3001_preview_nodeId=6950 (1)](https://user-images.githubusercontent.com/12773166/110957186-9ce28500-8308-11eb-8ccf-e7be1e4dc485.png)

### q_a (http://localhost:3001/preview?nodeId=8504)
![localhost_3001_preview_nodeId=8504](https://user-images.githubusercontent.com/12773166/110966595-a5d85400-8312-11eb-9437-5c2cde00a824.png)

### step_by_step (http://localhost:3001/preview?nodeId=8434)
![localhost_3001_preview_nodeId=8434](https://user-images.githubusercontent.com/12773166/110966812-eafc8600-8312-11eb-9635-6ae9139a13a7.png)

### support_resources_detail_page (http://localhost:3001/preview?nodeId=8541)
![localhost_3001_preview_nodeId=8541](https://user-images.githubusercontent.com/12773166/110966829-ef28a380-8312-11eb-83a0-f775c848df41.png)

## Acceptance criteria
- [x] makes it so that all `Need more help` sections on R&S pages are full-width
- [x] standardizes a lot of the formatting across R&S templates

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
