### PR TITLE
STEM Claim Status Check - Move feature flag check out of componentDidMount

### DIFF
--- a/src/applications/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/applications/claims-status/containers/YourClaimsPageV2.jsx
@@ -54,9 +54,7 @@ class YourClaimsPageV2 extends React.Component {
       this.props.getAppealsV2();
     }
 
-    if (this.props.stemAutomatedDecision) {
-      this.props.getStemClaims();
-    }
+    this.props.getStemClaims();
 
     if (
       this.props.claimsLoading &&
@@ -268,17 +266,19 @@ function mapStateToProps(state) {
   const canAccessClaims = profileState.services.includes(
     backendServices.EVSS_CLAIMS,
   );
+  const stemAutomatedDecision = toggleValues(state)[
+    FEATURE_FLAG_NAMES.stemAutomatedDecision
+  ];
+
+  const stemClaims = stemAutomatedDecision ? claimsV2Root.stemClaims : [];
+
   // TO-DO: Implement with reselect to save cycles
   const sortedList = [
     ...claimsV2Root.appeals,
     ...claimsV2Root.claims,
-    ...claimsV2Root.stemClaims,
+    ...stemClaims,
   ].sort(sortByLastUpdated);
   const list = getVisibleRows(sortedList, claimsV2Root.page);
-
-  const stemAutomatedDecision = toggleValues(state)[
-    FEATURE_FLAG_NAMES.stemAutomatedDecision
-  ];
 
   return {
     appealsAvailable: claimsV2Root.v2Availability,
@@ -297,7 +297,6 @@ function mapStateToProps(state) {
     canAccessAppeals,
     canAccessClaims,
     fullName: state.user.profile.userFullName,
-    stemAutomatedDecision,
   };
 }
 


### PR DESCRIPTION
## Description
The `stemAutomatedDecision` feature flag was being checked in `componentDidMount`, which was causing the stem claim statuses to not load. Removed condition from `componentDidMount` so that the call always happens.

## Testing done
Tested locally and QA reviewed

## Screenshots
N/A

## Acceptance criteria
- [x] STEM claims load correctly

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
