### PR TITLE
Masking the social security number component

### DIFF
--- a/src/platform/forms-system/src/js/widgets/SSNWidget.jsx
+++ b/src/platform/forms-system/src/js/widgets/SSNWidget.jsx
@@ -37,6 +37,7 @@ export default function SSNWidget(props) {
 
   const handleBlur = () => {
     setDisplayVal(maskSSN(val));
+    props.onBlur(props.id);
   };
 
   const handleFocus = () => {

--- a/src/platform/forms-system/src/js/widgets/SSNWidget.jsx
+++ b/src/platform/forms-system/src/js/widgets/SSNWidget.jsx
@@ -14,11 +14,7 @@ function maskSSN(ssnString = '') {
   let prefix = '';
   let rest = '';
 
-  // If the SSN already has '-' or ' ' in it, assume the user has done the formatting already
-  const formattedSSN =
-    ssnString.includes('-') || ssnString.includes(' ')
-      ? ssnString
-      : formatSSN(ssnString);
+  const formattedSSN = formatSSN(ssnString);
 
   if (formattedSSN.length > MASKED_LENGTH) {
     // The number is long enough for us to have unmasked digits

--- a/src/platform/forms-system/src/js/widgets/SSNWidget.jsx
+++ b/src/platform/forms-system/src/js/widgets/SSNWidget.jsx
@@ -1,33 +1,23 @@
-import React from 'react';
+import React, { useState } from 'react';
 import TextWidget from './TextWidget';
 
 /*
  * Handles removing dashes from SSNs by keeping the user input in local state
  * and saving the transformed version instead
  */
-export default class SSNWidget extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { val: props.value };
-  }
-  handleChange = val => {
+export default function SSNWidget(props) {
+  const [val, setVal] = useState(props.value);
+
+  const handleChange = value => {
     // If val is blank or undefined, pass undefined to onChange
     let strippedSSN;
-    if (val) {
-      strippedSSN = val.replace(/[- ]/g, '');
+    if (value) {
+      strippedSSN = value.replace(/[- ]/g, '');
     }
 
-    this.setState({ val }, () => {
-      this.props.onChange(strippedSSN);
-    });
+    setVal(value);
+    props.onChange(strippedSSN);
   };
-  render() {
-    return (
-      <TextWidget
-        {...this.props}
-        value={this.state.val}
-        onChange={this.handleChange}
-      />
-    );
-  }
+
+  return <TextWidget {...props} value={val} onChange={handleChange} />;
 }

--- a/src/platform/forms-system/src/js/widgets/SSNWidget.jsx
+++ b/src/platform/forms-system/src/js/widgets/SSNWidget.jsx
@@ -3,29 +3,16 @@ import TextWidget from './TextWidget';
 
 import { formatSSN } from 'platform/utilities/ui';
 
-// We only want to mask the first 5 digits of a formatted SSN
-// Anything longer than that should remain unmasked
-const MASKED_LENGTH = 6;
-
 /**
  * Mask a SSN, but leave the final sequence of digits visible (up to 4)
  */
 function maskSSN(ssnString = '') {
-  let prefix = '';
-  let rest = '';
+  const strippedSSN = ssnString.replace(/[- ]/g, '');
+  const maskedSSN = strippedSSN.replace(/^\d{1,5}/, digit =>
+    digit.replace(/\d/g, '●'),
+  );
 
-  const formattedSSN = formatSSN(ssnString);
-
-  if (formattedSSN.length > MASKED_LENGTH) {
-    // The number is long enough for us to have unmasked digits
-    prefix = formattedSSN.slice(0, MASKED_LENGTH);
-    rest = formattedSSN.slice(MASKED_LENGTH);
-  } else {
-    prefix = formattedSSN;
-  }
-
-  const masked = prefix.replace(/[0-9]/g, '●');
-  return `${masked}${rest}`;
+  return formatSSN(maskedSSN);
 }
 
 /*

--- a/src/platform/forms-system/src/js/widgets/SSNWidget.jsx
+++ b/src/platform/forms-system/src/js/widgets/SSNWidget.jsx
@@ -1,12 +1,44 @@
 import React, { useState } from 'react';
 import TextWidget from './TextWidget';
 
+import { formatSSN } from 'platform/utilities/ui';
+
+// We only want to mask the first 5 digits of a formatted SSN
+// Anything longer than that should remain unmasked
+const MASKED_LENGTH = 6;
+
+/**
+ * Mask a SSN, but leave the final sequence of digits visible (up to 4)
+ */
+function maskSSN(ssnString = '') {
+  let prefix = '';
+  let rest = '';
+
+  // If the SSN already has '-' or ' ' in it, assume the user has done the formatting already
+  const formattedSSN =
+    ssnString.includes('-') || ssnString.includes(' ')
+      ? ssnString
+      : formatSSN(ssnString);
+
+  if (formattedSSN.length > MASKED_LENGTH) {
+    // The number is long enough for us to have unmasked digits
+    prefix = formattedSSN.slice(0, MASKED_LENGTH);
+    rest = formattedSSN.slice(MASKED_LENGTH);
+  } else {
+    prefix = formattedSSN;
+  }
+
+  const masked = prefix.replace(/[0-9]/g, '●');
+  return `${masked}${rest}`;
+}
+
 /*
  * Handles removing dashes from SSNs by keeping the user input in local state
  * and saving the transformed version instead
  */
 export default function SSNWidget(props) {
   const [val, setVal] = useState(props.value);
+  const [displayVal, setDisplayVal] = useState(props.value);
 
   const handleChange = value => {
     // If val is blank or undefined, pass undefined to onChange
@@ -16,8 +48,25 @@ export default function SSNWidget(props) {
     }
 
     setVal(value);
+    setDisplayVal(value);
     props.onChange(strippedSSN);
   };
 
-  return <TextWidget {...props} value={val} onChange={handleChange} />;
+  const handleBlur = () => {
+    setDisplayVal(maskSSN(val));
+  };
+
+  const handleFocus = () => {
+    setDisplayVal(val);
+  };
+
+  return (
+    <TextWidget
+      {...props}
+      value={displayVal}
+      onChange={handleChange}
+      onBlur={handleBlur}
+      onFocus={handleFocus}
+    />
+  );
 }

--- a/src/platform/forms-system/test/js/widgets/SSNWidget.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/widgets/SSNWidget.unit.spec.jsx
@@ -26,4 +26,13 @@ describe('Schemaform <SSNWidget>', () => {
     tree.subTree('TextWidget').props.onChange('');
     expect(onChange.calledWith(undefined)).to.be.true;
   });
+
+  it('should call onChange with the value if available', () => {
+    const onChange = sinon.spy();
+    const tree = SkinDeep.shallowRender(
+      <SSNWidget value="456431098" onChange={onChange} />,
+    );
+    tree.subTree('TextWidget').props.onChange('432549877');
+    expect(onChange.calledWith('432549877')).to.be.true;
+  });
 });

--- a/src/platform/forms-system/test/js/widgets/SSNWidget.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/widgets/SSNWidget.unit.spec.jsx
@@ -1,9 +1,16 @@
 import React from 'react';
 import { expect } from 'chai';
 import SkinDeep from 'skin-deep';
+import { render, fireEvent } from '@testing-library/react';
 import sinon from 'sinon';
 
 import SSNWidget from '../../../src/js/widgets/SSNWidget';
+
+const props = {
+  schema: {
+    type: 'text',
+  },
+};
 
 describe('Schemaform <SSNWidget>', () => {
   it('should render', () => {
@@ -34,5 +41,50 @@ describe('Schemaform <SSNWidget>', () => {
     );
     tree.subTree('TextWidget').props.onChange('432549877');
     expect(onChange.calledWith('432549877')).to.be.true;
+  });
+
+  it('should mask all but the last four digits of the SSN onBlur and display with dashes when SSN is entered as all one digit', () => {
+    const { container } = render(<SSNWidget value="456431098" {...props} />);
+    const input = container.querySelector('input');
+    fireEvent.blur(input);
+    expect(input.value).to.equal('●●●-●●-1098');
+  });
+
+  it('should mask all but the last four digits of the SSN onBlur and display with dashes when SSN is entered with dashes', () => {
+    const { container } = render(<SSNWidget value="456-43-1098" {...props} />);
+    const input = container.querySelector('input');
+    fireEvent.blur(input);
+    expect(input.value).to.equal('●●●-●●-1098');
+  });
+
+  it('should mask all but the last four digits of the SSN onBlur and display with dashes when SSN is entered with spaces', () => {
+    const { container } = render(<SSNWidget value="456 43 1098" {...props} />);
+    const input = container.querySelector('input');
+    fireEvent.blur(input);
+    expect(input.value).to.equal('●●●-●●-1098');
+  });
+
+  it('should not mask the SSN onFocus', () => {
+    const { container } = render(<SSNWidget value="456431098" {...props} />);
+    const input = container.querySelector('input');
+    fireEvent.blur(input);
+    fireEvent.focus(input);
+    expect(input.value).to.equal('456431098');
+  });
+
+  it('should display the SSN with dashes when SSN is entered with dashes', () => {
+    const { container } = render(<SSNWidget value="456-43-1098" {...props} />);
+    const input = container.querySelector('input');
+    fireEvent.blur(input);
+    fireEvent.focus(input);
+    expect(input.value).to.equal('456-43-1098');
+  });
+
+  it('should display the SSN with spaces when the SSN is entered with spaces', () => {
+    const { container } = render(<SSNWidget value="456 43 1098" {...props} />);
+    const input = container.querySelector('input');
+    fireEvent.blur(input);
+    fireEvent.focus(input);
+    expect(input.value).to.equal('456 43 1098');
   });
 });

--- a/src/platform/forms-system/test/js/widgets/SSNWidget.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/widgets/SSNWidget.unit.spec.jsx
@@ -87,4 +87,18 @@ describe('Schemaform <SSNWidget>', () => {
     fireEvent.focus(input);
     expect(input.value).to.equal('456 43 1098');
   });
+
+  it('should mask all digits of the SSN onBlur when fewer than 6 digits are entered', () => {
+    const { container } = render(<SSNWidget value="4564" {...props} />);
+    const input = container.querySelector('input');
+    fireEvent.blur(input);
+    expect(input.value).to.equal('●●●-●');
+  });
+
+  it('should mask all but the last two digits of the SSN onBlur when 7 digits are entered', () => {
+    const { container } = render(<SSNWidget value="4564210" {...props} />);
+    const input = container.querySelector('input');
+    fireEvent.blur(input);
+    expect(input.value).to.equal('●●●-●●-10');
+  });
 });

--- a/src/platform/utilities/tests/ui/index.unit.spec.js
+++ b/src/platform/utilities/tests/ui/index.unit.spec.js
@@ -1,0 +1,31 @@
+import { expect } from 'chai';
+import { formatSSN } from '../../ui/index';
+
+describe('ui/index', () => {
+  describe('formatSSN', () => {
+    it('should format SSN properly with dashes when entered as one digit', () => {
+      const result = formatSSN('123456789');
+      expect(result).to.equal('123-45-6789');
+    });
+
+    it('should format SSN properly with dashes when entered with dashes', () => {
+      const result = formatSSN('123-45-6789');
+      expect(result).to.equal('123-45-6789');
+    });
+
+    it('should format SSN properly with dashes when entered with spaces', () => {
+      const result = formatSSN('123 45 6789');
+      expect(result).to.equal('123-45-6789');
+    });
+
+    it('should format SSN properly with dashes when fewer than 6 digits are entered', () => {
+      const result = formatSSN('1234');
+      expect(result).to.equal('123-4');
+    });
+
+    it('should format SSN properly with dashes when between 7 and 9 digits are entered', () => {
+      const result = formatSSN('1234567');
+      expect(result).to.equal('123-45-67');
+    });
+  });
+});

--- a/src/platform/utilities/ui/index.js
+++ b/src/platform/utilities/ui/index.js
@@ -84,3 +84,15 @@ export function scrollAndFocus(errorEl) {
 export function displayPercent(decimalNumber, places = 0) {
   return `${(decimalNumber * 100).toFixed(places)}%`;
 }
+
+/**
+ * Accepts a string of numbers as an argument
+ * and returns a formatted SSN with dashes.
+ */
+export function formatSSN(ssnString = '') {
+  let val = ssnString;
+  val = val.replace(/^(\d{3})(\d{1,2})/, '$1-$2');
+  // The below line only works for a full SSN, not partials
+  val = val.replace(/^(\d{3})-(\d{2})(\d{4})$/, '$1-$2-$3');
+  return val;
+}

--- a/src/platform/utilities/ui/index.js
+++ b/src/platform/utilities/ui/index.js
@@ -91,8 +91,9 @@ export function displayPercent(decimalNumber, places = 0) {
  */
 export function formatSSN(ssnString = '') {
   let val = ssnString;
+  val = val.replace(/[- ]/g, '');
   val = val.replace(/^(\d{3})(\d{1,2})/, '$1-$2');
   // The below line only works for a full SSN, not partials
-  val = val.replace(/^(\d{3})-(\d{2})(\d{4})$/, '$1-$2-$3');
+  val = val.replace(/^(\d{3})-(\d{2})(\d{1,4})$/, '$1-$2-$3');
   return val;
 }

--- a/src/platform/utilities/ui/index.js
+++ b/src/platform/utilities/ui/index.js
@@ -91,9 +91,8 @@ export function displayPercent(decimalNumber, places = 0) {
  */
 export function formatSSN(ssnString = '') {
   let val = ssnString;
-  val = val.replace(/[- ]/g, '');
-  val = val.replace(/^(\d{3})(\d{1,2})/, '$1-$2');
+  val = val.replace(/^(.{3})(.{1,2})/, '$1-$2');
   // The below line only works for a full SSN, not partials
-  val = val.replace(/^(\d{3})-(\d{2})(\d{1,4})$/, '$1-$2-$3');
+  val = val.replace(/^(.{3})-(.{2})(.{1,4})$/, '$1-$2-$3');
   return val;
 }

--- a/src/platform/utilities/ui/index.js
+++ b/src/platform/utilities/ui/index.js
@@ -91,8 +91,12 @@ export function displayPercent(decimalNumber, places = 0) {
  */
 export function formatSSN(ssnString = '') {
   let val = ssnString;
+
+  // Strips any dashes or spaces out of the string if they are included
+  if (val.includes('-') || val.includes(' ')) {
+    val = val.replace(/[- ]/g, '');
+  }
   val = val.replace(/^(.{3})(.{1,2})/, '$1-$2');
-  // The below line only works for a full SSN, not partials
   val = val.replace(/^(.{3})-(.{2})(.{1,4})$/, '$1-$2-$3');
   return val;
 }


### PR DESCRIPTION
## Description
[Feature Request #361](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/361)

Adding masking of the first five digits of Social Security Numbers.

## Testing done
Added unit tests.
Tested locally using this form: http://localhost:3001/ask-a-question/veteran-information

## Screenshots
Masked SSN
<img width="308" alt="image" src="https://user-images.githubusercontent.com/12739849/111169453-5778be80-8579-11eb-8a4c-3569246e9362.png">

Masked partial SSN
<img width="302" alt="image" src="https://user-images.githubusercontent.com/12739849/111169499-665f7100-8579-11eb-85a9-3f1da0ec2da3.png">

Masking and unmasking SSN with focus
https://user-images.githubusercontent.com/12739849/111170781-b25ee580-857a-11eb-8571-51c8bfe79aac.mov

## Acceptance criteria
- [ ] User is able to enter SSN as all one string, with dashes, or with spaces
- [ ] When the user is entering or editing the SSN field, the SSN appears as they entered it (one string, with dashes, with spaces)
- [ ] When the user navigates away from the SSN field (onBlur), the SSN appears with dashes and the first five digits masked
- [ ] If the user has entered fewer than six digits and then navigates away from the SSN field (onBlur), all digits appear masked
- [ ] If the user has entered between 6 and 8 digits and then navigates away from the SSN field (onBlur), the first five digits are masked and any extra digits on the end of the SSN are shown.
- [ ] Unit tests have been added that cover the above scenarios

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
