### PR TITLE
Added timestamp to asset refs in HTML

### DIFF
--- a/src/site/stages/build/plugins/modify-dom/process-entry-names.js
+++ b/src/site/stages/build/plugins/modify-dom/process-entry-names.js
@@ -83,6 +83,7 @@ module.exports = {
       const $el = dom(el);
       const entryName = $el.data('entryName');
       const attribute = $el.is('script') ? 'src' : 'href';
+      const timestamp = new Date().getTime();
 
       // Derive the hashed entry name.
       const hashedEntryName = this.entryNamesDictionary.get(entryName) || [];
@@ -103,7 +104,7 @@ module.exports = {
       }
 
       // Link the element to the hashed entry name w/o the S3 bucket
-      $el.attr(attribute, `/${fileSearch}`);
+      $el.attr(attribute, `/${fileSearch}?t=${timestamp}`);
       file.modified = true;
     });
   },


### PR DESCRIPTION
## Description
Adding timestamp to HTML as a cache busting measure so we can try and keep files fresh without hashing JS/CSS directly.

Step after this is to try and formally remove the preacrchive build step