### PR TITLE
fileNumber value should be type string

### DIFF
--- a/src/applications/debt-letters/components/DebtCardsList.jsx
+++ b/src/applications/debt-letters/components/DebtCardsList.jsx
@@ -92,7 +92,7 @@ const DebtCardsList = ({ debts, errors }) => {
 DebtCardsList.propTypes = {
   debts: PropTypes.arrayOf(
     PropTypes.shape({
-      fileNumber: PropTypes.number,
+      fileNumber: PropTypes.string,
     }),
   ),
   errors: PropTypes.array.isRequired,

--- a/src/applications/debt-letters/components/DebtLettersSummary.jsx
+++ b/src/applications/debt-letters/components/DebtLettersSummary.jsx
@@ -117,7 +117,7 @@ DebtLettersSummary.propTypes = {
   ),
   debts: PropTypes.arrayOf(
     PropTypes.shape({
-      fileNumber: PropTypes.number,
+      fileNumber: PropTypes.string,
     }),
   ),
 };

--- a/src/applications/debt-letters/tests/actions.unit.spec.js
+++ b/src/applications/debt-letters/tests/actions.unit.spec.js
@@ -14,7 +14,7 @@ describe('fetchDebtLetters', () => {
       expect(dispatch.secondCall.args[0].type).to.equal(DEBTS_FETCH_SUCCESS);
       expect(dispatch.secondCall.args[0].debts).to.deep.equal([
         {
-          fileNumber: 796121200,
+          fileNumber: '796121200',
           payeeNumber: '00',
           personEntitled: 'AJHONS',
           deductionCode: '30',
@@ -45,7 +45,7 @@ describe('fetchDebtLetters', () => {
           ],
         },
         {
-          fileNumber: 796121200,
+          fileNumber: '796121200',
           payeeNumber: '00',
           personEntitled: 'STUB_M',
           deductionCode: '44',
@@ -93,7 +93,7 @@ describe('fetchDebtLetters', () => {
           ],
         },
         {
-          fileNumber: 796121200,
+          fileNumber: '796121200',
           payeeNumber: '00',
           personEntitled: 'AJOHNS',
           deductionCode: '71',
@@ -114,7 +114,7 @@ describe('fetchDebtLetters', () => {
           ],
         },
         {
-          fileNumber: 796121200,
+          fileNumber: '796121200',
           payeeNumber: '00',
           personEntitled: 'AJOHNS',
           deductionCode: '74',
@@ -150,7 +150,7 @@ describe('fetchDebtLetters', () => {
           ],
         },
         {
-          fileNumber: 796121200,
+          fileNumber: '796121200',
           payeeNumber: '00',
           personEntitled: 'AJHONS',
           deductionCode: '72',

--- a/src/applications/debt-letters/utils/mockResponses.js
+++ b/src/applications/debt-letters/utils/mockResponses.js
@@ -2,7 +2,7 @@ const data = {
   hasDependentDebts: true,
   debts: [
     {
-      fileNumber: 796121200,
+      fileNumber: '796121200',
       payeeNumber: '00',
       personEntitled: 'AJHONS',
       deductionCode: '30',
@@ -33,7 +33,7 @@ const data = {
       ],
     },
     {
-      fileNumber: 796121200,
+      fileNumber: '796121200',
       payeeNumber: '00',
       personEntitled: 'STUB_M',
       deductionCode: '44',
@@ -80,7 +80,7 @@ const data = {
       ],
     },
     {
-      fileNumber: 796121200,
+      fileNumber: '796121200',
       payeeNumber: '00',
       personEntitled: 'AJOHNS',
       deductionCode: '71',
@@ -100,7 +100,7 @@ const data = {
       ],
     },
     {
-      fileNumber: 796121200,
+      fileNumber: '796121200',
       payeeNumber: '00',
       personEntitled: 'AJOHNS',
       deductionCode: '74',
@@ -135,7 +135,7 @@ const data = {
       ],
     },
     {
-      fileNumber: 796121200,
+      fileNumber: '796121200',
       payeeNumber: '00',
       personEntitled: 'AJHONS',
       deductionCode: '72',

--- a/src/applications/financial-status-report/components/VeteranInfoBox.jsx
+++ b/src/applications/financial-status-report/components/VeteranInfoBox.jsx
@@ -54,7 +54,7 @@ VeteranInfoBox.propTypes = {
   middle: PropTypes.string,
   dateOfBirth: PropTypes.string,
   ssnLastFour: PropTypes.string,
-  fileNumber: PropTypes.number,
+  fileNumber: PropTypes.string,
 };
 
 const mapStateToProps = ({ form }) => ({

--- a/src/applications/financial-status-report/config/form.js
+++ b/src/applications/financial-status-report/config/form.js
@@ -73,7 +73,7 @@ const formConfig = {
             },
             personalIdentification: {
               ssn: '1234',
-              fileNumber: 5678,
+              fileNumber: '5678',
             },
           },
         },

--- a/src/applications/financial-status-report/pages/veteran/debts.js
+++ b/src/applications/financial-status-report/pages/veteran/debts.js
@@ -28,7 +28,7 @@ export const schema = {
         title: 'Debt',
         properties: {
           fileNumber: {
-            type: 'number',
+            type: 'string',
           },
           benefitType: {
             type: 'string',

--- a/src/applications/financial-status-report/pages/veteran/veteranInfo.js
+++ b/src/applications/financial-status-report/pages/veteran/veteranInfo.js
@@ -27,7 +27,7 @@ export const schema = {
               type: 'string',
             },
             fileNumber: {
-              type: 'number',
+              type: 'string',
             },
           },
         },


### PR DESCRIPTION
## Description
There was some confusion around `fileNumber` val type and was originally thought to be type number but was later confirmed to be type string updated all keys to reflect BE changes

## Acceptance criteria

## Screenshots

## Definition of done
- [x] Changes have been tested in vets-website
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs