### PR TITLE
Upgrade Cypress to 6.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "cors": "^2.7.1",
     "css-loader": "^1.0.0",
     "cssnano": "^4.1.10",
-    "cypress": "^6.6.0",
+    "cypress": "^6.7.0",
     "cypress-axe": "^0.12.0",
     "cypress-multi-reporters": "^1.4.0",
     "cypress-plugin-tab": "^1.0.5",
@@ -374,7 +374,7 @@
     "**/node-forge": "^0.10.0",
     "**/axios": "^0.21.1",
     "**/elliptic": "^6.5.4",
-    "cypress": "^6.6.0",
+    "cypress": "^6.7.0",
     "tar-fs/tar-stream/bl": "^4.0.3",
     "nightwatch/**/lodash.defaultsdeep": "^4.6.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5505,10 +5505,10 @@ cypress-wait-until@^1.7.1:
   resolved "https://registry.yarnpkg.com/cypress-wait-until/-/cypress-wait-until-1.7.1.tgz#3789cd18affdbb848e3cfc1f918353c7ba1de6f8"
   integrity sha512-8DL5IsBTbAxBjfYgCzdbohPq/bY+IKc63fxtso1C8RWhLnQkZbVESyaclNr76jyxfId6uyzX8+Xnt0ZwaXNtkA==
 
-cypress@^6.6.0:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.6.0.tgz#659c64cdb06e51b6be18fdac39d8f192deb54fa0"
-  integrity sha512-+Xx3Zn653LJHUsCb9h1Keql2jlazbr1ROmbY6DFJMmXKLgXP4ez9cE403W93JNGRbZK0Tng3R/oP8mvd9XAPVg==
+cypress@^6.7.0:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.7.0.tgz#06e5bec43bd1e6f277532f29f8fe9bcccbb372e7"
+  integrity sha512-d1tEF7W4O2Hs68/OxFt5BpnQJVfix8Kjm1kgTIQHxdbtowjiU9ltVRfSPrMfvK/1SGttCUj+3I+o1EuxSo5Asg==
   dependencies:
     "@cypress/listr-verbose-renderer" "^0.4.1"
     "@cypress/request" "^2.88.5"


### PR DESCRIPTION
## Description
This PR upgrades Cypress to the latest version (`6.7.0`). There are no breaking changes according to the [changelog](https://docs.cypress.io/guides/references/changelog.html#6-7-0).

## Testing done
- Tests pass locally and on CI.

## Acceptance criteria
- [ ] Tests pass locally and on CI.