### PR TITLE
Restore 526 form-specific SiP endpoint

### DIFF
--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -1,4 +1,8 @@
 import { pciuStates as PCIU_STATES } from 'vets-json-schema/dist/constants.json';
+import {
+  VA_FORM_IDS,
+  VA_FORM_IDS_IN_PROGRESS_FORMS_API,
+} from 'platform/forms/constants';
 
 import disabilityLabels from './content/disabilityLabels';
 
@@ -269,6 +273,12 @@ export const ANALYTICS_EVENTS = {
       'Disability - Form 21-0781a - PTSD Secondary Sources - Which should I choose',
   },
 };
+
+// new /v0/disability_compensation_in_progress_forms/21-526EZ. Not using the
+// platform/forms/helpers/inProgressApi because the mock doesn't include the
+// environment.API_URL
+export const MOCK_SIPS_API =
+  VA_FORM_IDS_IN_PROGRESS_FORMS_API[VA_FORM_IDS.FORM_21_526EZ];
 
 export const NULL_CONDITION_STRING = 'Unknown Condition';
 

--- a/src/applications/disability-benefits/all-claims/local-dev-mock-api/index.js
+++ b/src/applications/disability-benefits/all-claims/local-dev-mock-api/index.js
@@ -1,5 +1,6 @@
 const moment = require('moment');
 const commonResponses = require('../../../../platform/testing/local-dev-mock-api/common');
+const { MOCK_SIPS_API } = require('../constants');
 
 const responses = {
   ...commonResponses,
@@ -123,7 +124,7 @@ const responses = {
     },
   },
 
-  'GET /v0/in_progress_forms/21-526EZ': {
+  [`GET ${MOCK_SIPS_API}`]: {
     formData: {
       veteran: {
         primaryPhone: '4445551212',

--- a/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
@@ -15,6 +15,7 @@ import formConfig from '../config/form';
 import manifest from '../manifest.json';
 import { mockItf } from './all-claims.cypress.helpers';
 import {
+  MOCK_SIPS_API,
   WIZARD_STATUS,
   FORM_STATUS_BDD,
   SAVED_SEPARATION_DATE,
@@ -142,7 +143,7 @@ const testConfig = createTestConfig(
       // because fixtures don't evaluate JS.
       cy.intercept('GET', '/v0/intent_to_file', mockItf);
 
-      cy.intercept('PUT', '/v0/in_progress_forms/*', mockInProgress);
+      cy.intercept('PUT', `${MOCK_SIPS_API}*`, mockInProgress);
 
       cy.intercept(
         'GET',
@@ -176,7 +177,7 @@ const testConfig = createTestConfig(
           ({ 'view:selected': _, ...obj }) => obj,
         );
 
-        cy.intercept('GET', 'v0/in_progress_forms/21-526EZ', {
+        cy.intercept('GET', MOCK_SIPS_API, {
           formData: {
             veteran: {
               primaryPhone: '4445551212',

--- a/src/applications/disability-benefits/all-claims/tests/disability-benefits-helpers.js
+++ b/src/applications/disability-benefits/all-claims/tests/disability-benefits-helpers.js
@@ -1,6 +1,7 @@
 import moment from 'moment';
 
 const mock = require('platform/testing/e2e/mock-helpers');
+const { MOCK_SIPS_API } = require('../constants');
 
 function initDocumentUploadMock(token) {
   mock(token, {
@@ -179,7 +180,7 @@ const defaultData = {
 
 function initInProgressMock(token, data = defaultData) {
   mock(token, {
-    path: '/v0/in_progress_forms/21-526EZ',
+    path: MOCK_SIPS_API,
     verb: 'get',
     value: {
       formData: {

--- a/src/applications/personalization/dashboard-2/tests/e2e/in-progress-forms.cypress.spec.js
+++ b/src/applications/personalization/dashboard-2/tests/e2e/in-progress-forms.cypress.spec.js
@@ -5,6 +5,10 @@ import fullName from '@@profile/tests/fixtures/full-name-success.json';
 import disabilityRating from '@@profile/tests/fixtures/disability-rating-success.json';
 
 import manifest from 'applications/personalization/dashboard/manifest.json';
+import {
+  VA_FORM_IDS,
+  VA_FORM_IDS_IN_PROGRESS_FORMS_API,
+} from '~/platform/forms/constants';
 
 import { mockFeatureToggles } from './helpers';
 
@@ -106,7 +110,9 @@ describe('The My VA Dashboard', () => {
       cy.login(mockUser);
       mockFeatureToggles();
       deleteApplicationStub = cy.stub();
-      cy.intercept('DELETE', '/v0/in_progress_forms/21-526EZ', () => {
+      const form526InProgressApi =
+        VA_FORM_IDS_IN_PROGRESS_FORMS_API[VA_FORM_IDS.FORM_21_526EZ];
+      cy.intercept('DELETE', form526InProgressApi, () => {
         deleteApplicationStub();
       });
       cy.visit(manifest.rootUrl);

--- a/src/platform/forms/constants.js
+++ b/src/platform/forms/constants.js
@@ -32,8 +32,7 @@ export const VA_FORM_IDS_SKIP_INFLECTION = Object.freeze([
 ]);
 
 export const VA_FORM_IDS_IN_PROGRESS_FORMS_API = Object.freeze({
-  // 526 endpoint updates the ratedDisabilities dynamically and includes a
-  // `ratedDisabilitiesUpdated` as true in the metadata when the data changes
-  // '/v0/disability_compensation_in_progress_forms/'
-  [VA_FORM_IDS.FORM_21_526EZ]: '/v0/in_progress_forms/',
+  // 526 save-in-progress endpoint that adds an `updatedRatedDisabilities` array
+  // to the saved form data from /v0/disability_compensation_in_progress_forms/
+  [VA_FORM_IDS.FORM_21_526EZ]: '/v0/disability_compensation_in_progress_forms/',
 });

--- a/src/platform/forms/tests/save-in-progress/actions.unit.spec.js
+++ b/src/platform/forms/tests/save-in-progress/actions.unit.spec.js
@@ -22,6 +22,7 @@ import {
 } from '../../save-in-progress/actions';
 
 import { logOut } from '../../../user/authentication/actions';
+import { inProgressApi } from '../../helpers';
 
 let oldFetch;
 const setup = () => {
@@ -166,14 +167,14 @@ describe('Schemaform save / load actions:', () => {
           done(err);
         });
     });
-    it.skip('calls the Form 526-specific api to save the form', done => {
+    it('calls the Form 526-specific api to save the form', done => {
       const thunk = saveAndRedirectToReturnUrl(VA_FORM_IDS.FORM_21_526EZ, {});
       const dispatch = sinon.spy();
 
       thunk(dispatch, getState)
         .then(() => {
           expect(global.fetch.args[0][0]).to.contain(
-            '/v0/disability_compensation_in_progress_forms/21-526EZ',
+            inProgressApi(VA_FORM_IDS.FORM_21_526EZ),
           );
           done();
         })
@@ -335,7 +336,7 @@ describe('Schemaform save / load actions:', () => {
         );
       });
     });
-    it.skip('dispatches a success from the form 526-specific api on form load', () => {
+    it('dispatches a success from the form 526-specific api on form load', () => {
       const thunk = fetchInProgressForm(VA_FORM_IDS.FORM_21_526EZ, {});
       const dispatch = sinon.spy();
       global.fetch.returns(
@@ -352,7 +353,7 @@ describe('Schemaform save / load actions:', () => {
 
       return thunk(dispatch, getState).then(() => {
         expect(global.fetch.args[0][0]).to.contain(
-          '/v0/disability_compensation_in_progress_forms/21-526EZ',
+          inProgressApi(VA_FORM_IDS.FORM_21_526EZ),
         );
       });
     });


### PR DESCRIPTION
## Description

Form 526 has a new save-in-progress endpoint - [`/v0/disability_compensation_in_progress_forms/`](https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/api-reference/#/in_progress_forms/getInProgressForm1) which behaves almost exactly like the original `/v0/in_progress_forms/` endpoint except that it dynamically adds an `updatedRatedDisabilities` array into the form data to indicated that there are newer values. Additionally, when the `updatedRatedDisabilities` values is added, the metadata `returnUrl` is modified to return the user to the rated disability page.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/13128#issuecomment-763838119
- BE: https://github.com/department-of-veterans-affairs/vets-api/pull/5717
- Swagger: https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/api-reference/#/in_progress_forms/getInProgressForm1
- Original switch - https://github.com/department-of-veterans-affairs/vets-website/pull/16051 & reversion due to endpoint issues- https://github.com/department-of-veterans-affairs/vets-website/pull/16082

## Testing done

Updated unit tests
Updated 526 Cypress tests

## Screenshots

N/A

## Acceptance criteria
- [x] Switch 526 save-in-progress to new API endpoint
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
