### PR TITLE
update labels of address edit forms

### DIFF
--- a/src/applications/personalization/profile/tests/components/direct-deposit/BankInfoCNP.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/direct-deposit/BankInfoCNP.unit.spec.jsx
@@ -86,7 +86,7 @@ describe('DirectDepositCNP', () => {
   let server;
   before(() => {
     // before we can use msw, we need to make sure that global.fetch has been
-    // restored and is not longer a sinon stub.
+    // restored and is no longer a sinon stub.
     resetFetch();
     server = setupServer(...mocks.updateDD4CNPSuccess);
     server.listen();

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.unit.spec.jsx
@@ -17,7 +17,7 @@ describe('PersonalInformation', () => {
   let server;
   before(() => {
     // before we can use msw, we need to make sure that global.fetch has been
-    // restored and is not longer a sinon stub.
+    // restored and is no longer a sinon stub.
     resetFetch();
     server = setupServer(...mocks.updateDD4CNPSuccess);
     server.listen();

--- a/src/applications/personalization/profile/tests/e2e/address-validation/bad-unit.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/bad-unit.cypress.spec.js
@@ -6,14 +6,14 @@ describe('Personal and contact information', () => {
       setUp('bad-unit');
       cy.axeCheck();
 
-      cy.get('#root_addressLine1')
+      cy.findByLabelText(/^street address/i)
         .clear()
         .type('225 irving st');
-      cy.get('#root_addressLine2')
+      cy.findByLabelText(/^line 2/i)
         .clear()
         .type('Unit A');
 
-      cy.get('#root_addressLine3').clear();
+      cy.findByLabelText(/^line 3/i).clear();
 
       cy.findByLabelText(/City/i)
         .clear()

--- a/src/applications/personalization/profile/tests/e2e/address-validation/confirm-address.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/confirm-address.cypress.spec.js
@@ -5,12 +5,12 @@ describe('Personal and contact information', () => {
     it('should successfully update on Desktop', () => {
       setUp('confirm-address');
 
-      cy.get('#root_addressLine1')
+      cy.findByLabelText(/^street address/i)
         .clear()
         .type('36310 Coronado Dr');
 
-      cy.get('#root_addressLine2').clear();
-      cy.get('#root_addressLine3').clear();
+      cy.findByLabelText(/^line 2/i).clear();
+      cy.findByLabelText(/^line 3/i).clear();
 
       cy.findByLabelText(/City/i)
         .clear()

--- a/src/applications/personalization/profile/tests/e2e/address-validation/edit-after-validation.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/edit-after-validation.cypress.spec.js
@@ -14,17 +14,13 @@ describe('Personal and contact information', () => {
         'disabled',
       );
 
-      cy.findAllByLabelText(/street address/i)
-        .first()
+      cy.findByLabelText(/^Street address/i)
         .clear()
         .type(addressLine1);
-      cy.findAllByLabelText(/street address/i)
-        .its('1')
+      cy.findAllByLabelText(/^Line 2/i)
         .clear()
         .type(addressLine2);
-      cy.findAllByLabelText(/street address/i)
-        .its('2')
-        .clear();
+      cy.findAllByLabelText(/^Line 3/i).clear();
 
       cy.findByLabelText(/City/i)
         .clear()
@@ -53,12 +49,8 @@ describe('Personal and contact information', () => {
       cy.findByRole('button', { name: /edit your address/i }).click();
 
       // confirm the address we just entered is in the form
-      cy.findAllByLabelText(/street address/i)
-        .first()
-        .should('have.value', addressLine1);
-      cy.findAllByLabelText(/street address/i)
-        .its('1')
-        .should('have.value', addressLine2);
+      cy.findByLabelText(/^street address/i).should('have.value', addressLine1);
+      cy.findAllByLabelText(/^Line 2/i).should('have.value', addressLine2);
 
       // The following steps have been commented out due to a bug that
       // disables the SAVE button if the current form data matches the

--- a/src/applications/personalization/profile/tests/e2e/address-validation/international-address.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/international-address.cypress.spec.js
@@ -7,11 +7,11 @@ describe('Personal and contact information', () => {
 
       cy.findByLabelText(/Country/i).select('NLD');
 
-      cy.get('#root_addressLine1')
+      cy.findByLabelText(/^street address/i)
         .clear()
         .type('Dam 1');
-      cy.get('#root_addressLine2').clear();
-      cy.get('#root_addressLine3').clear();
+      cy.findByLabelText(/^line 2/i).clear();
+      cy.findByLabelText(/^line 3/i).clear();
 
       cy.findByLabelText(/City/i)
         .clear()

--- a/src/applications/personalization/profile/tests/e2e/address-validation/low-confidence.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/low-confidence.cypress.spec.js
@@ -5,12 +5,12 @@ describe('Personal and contact information', () => {
     it('should show the validation view and successfully update', () => {
       setUp('low-confidence');
 
-      cy.get('#root_addressLine1')
+      cy.findByLabelText(/^street address/i)
         .clear()
         .type('36320 Coronado Dr');
 
-      cy.get('#root_addressLine2').clear();
-      cy.get('#root_addressLine3').clear();
+      cy.findByLabelText(/^line 2/i).clear();
+      cy.findByLabelText(/^line 3/i).clear();
 
       cy.findByLabelText(/City/i)
         .clear()

--- a/src/applications/personalization/profile/tests/e2e/address-validation/military-address.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/military-address.cypress.spec.js
@@ -9,11 +9,11 @@ describe('Personal and contact information', () => {
         name: /I live on a.*military base/i,
       }).check();
 
-      cy.get('#root_addressLine1')
+      cy.findByLabelText(/^street address/i)
         .clear()
         .type('PSC 808 Box 37');
-      cy.get('#root_addressLine2').clear();
-      cy.get('#root_addressLine3').clear();
+      cy.findByLabelText(/^line 2/i).clear();
+      cy.findByLabelText(/^line 3/i).clear();
 
       cy.get('#root_city').select('FPO');
 

--- a/src/applications/personalization/profile/tests/e2e/address-validation/missing-unit.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/missing-unit.cypress.spec.js
@@ -5,11 +5,11 @@ describe('Personal and contact information', () => {
     it('should successfully update on Desktop', () => {
       setUp('missing-unit');
 
-      cy.get('#root_addressLine1')
+      cy.findByLabelText(/^street address/i)
         .clear()
         .type('225 irving st');
-      cy.get('#root_addressLine2').clear();
-      cy.get('#root_addressLine3').clear();
+      cy.findByLabelText(/^line 2/i).clear();
+      cy.findByLabelText(/^line 3/i).clear();
 
       cy.findByLabelText(/City/i)
         .clear()

--- a/src/applications/personalization/profile/tests/e2e/address-validation/one-suggestion.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/one-suggestion.cypress.spec.js
@@ -5,11 +5,11 @@ describe('Personal and contact information', () => {
     it('should successfully update on Desktop', () => {
       setUp('one-suggestion');
 
-      cy.get('#root_addressLine1')
+      cy.findByLabelText(/^street address/i)
         .clear()
         .type('400 65th st');
-      cy.get('#root_addressLine2').clear();
-      cy.get('#root_addressLine3').clear();
+      cy.findByLabelText(/^line 2/i).clear();
+      cy.findByLabelText(/^line 3/i).clear();
 
       cy.findByLabelText(/City/i)
         .clear()

--- a/src/applications/personalization/profile/tests/e2e/address-validation/two-suggestions.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/two-suggestions.cypress.spec.js
@@ -5,11 +5,11 @@ describe('Personal and contact information', () => {
     it('should successfully update on Desktop', () => {
       setUp('two-suggestions');
 
-      cy.get('#root_addressLine1')
+      cy.findByLabelText(/^street address/i)
         .clear()
         .type('575 20th');
-      cy.get('#root_addressLine2').clear();
-      cy.get('#root_addressLine3').clear();
+      cy.findByLabelText(/^line 2/i).clear();
+      cy.findByLabelText(/^line 3/i).clear();
 
       cy.findByLabelText(/City/i)
         .clear()

--- a/src/applications/personalization/profile/tests/e2e/address-validation/valid-address.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/valid-address.cypress.spec.js
@@ -6,11 +6,11 @@ describe('Personal and contact information', () => {
       it('should update successfully without showing the validation screen', () => {
         setUp('valid-address');
 
-        cy.get('#root_addressLine1')
+        cy.findByLabelText(/^street address/i)
           .clear()
           .type('36320 Coronado Dr');
-        cy.get('#root_addressLine2').clear();
-        cy.get('#root_addressLine3').clear();
+        cy.findByLabelText(/^line 2/i).clear();
+        cy.findByLabelText(/^line 3/i).clear();
 
         cy.findByLabelText(/City/i)
           .clear()

--- a/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/mailing-address.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/mailing-address.cypress.spec.js
@@ -80,26 +80,26 @@ const confirmWebAddressesAreBlocked = () => {
 
   // NOTE: resorting to selecting via a fragile element ID since there are two
   // street lines on this form with identical labels :(
-  cy.get('#root_addressLine2')
+  cy.findByLabelText(/^line 2/i)
     .clear()
     .type('www.propaganda.blah');
   cy.findByRole('button', { name: 'Update' }).focus();
   cy.findByRole('alert')
     .should('exist')
     .contains(/please enter a valid street address/i);
-  cy.get('#root_addressLine2').clear();
+  cy.findByLabelText(/^line 2/i).clear();
   cy.findByRole('alert').should('not.exist');
 
   // NOTE: resorting to selecting via a fragile element ID since there are two
   // street lines on this form with identical labels :(
-  cy.get('#root_addressLine3')
+  cy.findByLabelText(/^line 3/i)
     .clear()
     .type('propaganda.net');
   cy.findByRole('button', { name: 'Update' }).focus();
   cy.findByRole('alert')
     .should('exist')
     .contains(/please enter a valid street address/i);
-  cy.get('#root_addressLine3').clear();
+  cy.findByLabelText(/^line 3/i).clear();
   cy.findByRole('alert').should('not.exist');
 
   cy.findByRole('textbox', { name: /city/i })

--- a/src/platform/user/profile/vap-svc/components/AddressField/address-schemas.js
+++ b/src/platform/user/profile/vap-svc/components/AddressField/address-schemas.js
@@ -137,13 +137,13 @@ const uiSchema = {
     },
   },
   addressLine2: {
-    'ui:title': `Street address (${STREET_LINE_MAX_LENGTH} characters maximum)`,
+    'ui:title': `Line 2 (${STREET_LINE_MAX_LENGTH} characters maximum)`,
     'ui:errorMessages': {
       pattern: `Please enter a valid street address under ${STREET_LINE_MAX_LENGTH} characters`,
     },
   },
   addressLine3: {
-    'ui:title': `Street address (${STREET_LINE_MAX_LENGTH} characters maximum)`,
+    'ui:title': `Line 3 (${STREET_LINE_MAX_LENGTH} characters maximum)`,
     'ui:errorMessages': {
       pattern: `Please enter a valid street address under ${STREET_LINE_MAX_LENGTH} characters`,
     },


### PR DESCRIPTION
## Description
Remove duplicate "Street address" lines on the edit address form

## Testing done
Updated all tests that use the label names.

## Screenshots
![image](https://user-images.githubusercontent.com/20728956/111239335-2ff41700-85b6-11eb-8436-d5d3c94af855.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs