### PR TITLE
Change view to manage

### DIFF
--- a/src/applications/vaos/components/Breadcrumbs.jsx
+++ b/src/applications/vaos/components/Breadcrumbs.jsx
@@ -15,7 +15,7 @@ export default function VAOSBreadcrumbs({ children }) {
         href="/health-care/schedule-view-va-appointments"
         key="schedule-view-va-appointments"
       >
-        Schedule and view appointments
+        Schedule and manage health appointments
       </a>
       <Link to="/" key="vaos-home">
         VA online scheduling

--- a/src/applications/vaos/tests/components/Breadcrumbs.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/Breadcrumbs.unit.spec.jsx
@@ -15,7 +15,8 @@ describe('VAOS <Breadcrumbs>', () => {
     );
 
     expect(screen.getByText(/Health care/i)).to.be.ok;
-    expect(screen.getByText(/Schedule and view appointments/i)).to.be.ok;
+    expect(screen.getByText(/Schedule and manage health appointments/i)).to.be
+      .ok;
     expect(screen.getByText(/VA online scheduling/i)).to.be.ok;
     expect(screen.getByText(/test/i)).to.be.ok;
   });

--- a/src/platform/landing-pages/header-footer-data.json
+++ b/src/platform/landing-pages/header-footer-data.json
@@ -349,7 +349,7 @@
                   "href": "https://www.va.gov/health-care/secure-messaging"
                 },
                 {
-                  "text": "Schedule and view VA appointments",
+                  "text": "Schedule and manage health appointments",
                   "href": "https://www.va.gov/health-care/schedule-view-va-appointments"
                 },
                 {

--- a/src/site/facilities/service_location.drupal.liquid
+++ b/src/site/facilities/service_location.drupal.liquid
@@ -150,7 +150,7 @@
        data-entity-type="node"
        data-template="paragraphs/service_location"
        href="/health-care/schedule-view-va-appointments"
-       title="Schedule and view VA appointments online">
+       title="Schedule and manage health appointments">
       Schedule an appointment online
     </a>
   {% endif %}

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -81,8 +81,8 @@
                     class="vads-u-height--full vads-u-width--full">
                     <i
                       class="far fa-calendar-check vads-facility-hub-cta-circle">&nbsp;</i>
-                    <span class="vads-facility-hub-cta-label">Schedule and view
-                      your appointments<i
+                    <span class="vads-facility-hub-cta-label">Schedule and manage
+                      health appointments<i
                         class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
                   </a>
                 </div>


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/21569

This PR changes the header "Schedule and **view** appointments" to "Schedule and **manage** appointments" as can now be seen on the schedule appointments page: https://www.va.gov/health-care/schedule-view-va-appointments/

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Update all instances of "Schedule and **view** appointments" to "Schedule and **manage** appointments"

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
