### PR TITLE
Conditionally display active duty benefit notice under active duty

### DIFF
--- a/src/applications/edu-benefits/0994/content/militaryService.jsx
+++ b/src/applications/edu-benefits/0994/content/militaryService.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import environment from 'platform/utilities/environment';
 
 // background & foreground class names added to indicate this paragraphs needs
 // an axeCheck color contrast exception
@@ -11,14 +10,16 @@ export const activeDutyNotice = (
   </p>
 );
 
-export const benefitNotice = environment.isProduction() ? (
+export const benefitNotice = (
   <p>
     <strong>Note: </strong>
     Your eligibility for VET TEC may be affected if you're called to active
     duty. Please let us know as soon as possible if there's a change in your
     military status.
   </p>
-) : (
+);
+
+export const notActiveBenefitNotice = (
   <p>
     <strong>Note: </strong>
     Your eligibility for monthly housing allowance may be affected if you're

--- a/src/applications/edu-benefits/0994/pages/militaryService.js
+++ b/src/applications/edu-benefits/0994/pages/militaryService.js
@@ -46,7 +46,8 @@ export const uiSchema = {
   expectedReleaseDate: {
     'ui:title': 'Enter the date you expect to be released from active duty.',
     'ui:widget': 'date',
-    'ui:required': formData => formData.activeDuty,
+    'ui:required': formData =>
+      formData.activeDuty && !environment.isProduction(),
     'ui:options': {
       hideIf: () => environment.isProduction(),
       expandUnder: 'activeDuty',

--- a/src/applications/edu-benefits/0994/pages/militaryService.js
+++ b/src/applications/edu-benefits/0994/pages/militaryService.js
@@ -5,6 +5,7 @@ import { validateCurrentOrFutureDate } from 'platform/forms-system/src/js/valida
 import {
   activeDutyNotice,
   benefitNotice,
+  notActiveBenefitNotice,
   remainingDaysGreaterThan180Notice,
   remainingDaysNotGreaterThan180Notice,
   selectedReserveNationalGuardExpectedDutyTitle,
@@ -88,6 +89,15 @@ export const uiSchema = {
       },
     },
   },
+  'view:notActiveBenefitNotice': {
+    'ui:title': '',
+    'ui:description': notActiveBenefitNotice,
+    'ui:options': {
+      hideIf: () => environment.isProduction(),
+      expandUnder: 'activeDuty',
+      expandUnderCondition: false,
+    },
+  },
   expectedActiveDutyStatusChange: {
     'ui:title':
       'Do you expect to be called to active duty while enrolled in a VET TEC program?',
@@ -108,6 +118,9 @@ export const uiSchema = {
   'view:benefitNotice': {
     'ui:title': '',
     'ui:description': benefitNotice,
+    'ui:options': {
+      hideIf: () => !environment.isProduction(),
+    },
   },
 };
 
@@ -132,6 +145,10 @@ export const schema = {
       properties: {},
     },
     'view:benefitNotice': {
+      type: 'object',
+      properties: {},
+    },
+    'view:notActiveBenefitNotice': {
       type: 'object',
       properties: {},
     },


### PR DESCRIPTION
## Description
Conditionally display active duty benefit note.

[ZenHub Issue 21524](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/21524)

## Testing done
Tested locally and QA reviewed

## Screenshots
![image](https://user-images.githubusercontent.com/41960449/111327664-f5d15680-8643-11eb-8b8b-c19464823a4a.png)
![image](https://user-images.githubusercontent.com/41960449/111327707-ff5abe80-8643-11eb-9db3-a270a7ee9ade.png)

## Acceptance criteria
- [x] Active duty is displayed nested under active duty question and only when active duty is false.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
