### PR TITLE
Fix broken links on 10-10CG

### DIFF
--- a/src/applications/caregivers/containers/ConfirmationPage.jsx
+++ b/src/applications/caregivers/containers/ConfirmationPage.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import moment from 'moment';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
-import { links } from 'src/applications/caregivers/definitions/content';
+import { links } from 'applications/caregivers/definitions/content';
 import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
@@ -130,6 +130,8 @@ const ConfirmationPage = props => {
             <a
               className="vads-u-margin-left--0p5"
               href={links.caregiverHelpPage.link}
+              target="_blank"
+              rel="noreferrer noopener"
             >
               {links.caregiverHelpPage.label}
             </a>

--- a/src/applications/caregivers/containers/ConfirmationPage.jsx
+++ b/src/applications/caregivers/containers/ConfirmationPage.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import moment from 'moment';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
+import { links } from 'src/applications/caregivers/definitions/content';
 import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
@@ -126,8 +127,11 @@ const ConfirmationPage = props => {
               className="vads-u-margin-x--0p5"
             />
             or visit
-            <a className="vads-u-margin-left--0p5" href="www.va.caregiver.gov">
-              www.va.caregiver.gov
+            <a
+              className="vads-u-margin-left--0p5"
+              href={links.caregiverHelpPage.link}
+            >
+              {links.caregiverHelpPage.label}
             </a>
             .
           </p>

--- a/src/applications/caregivers/definitions/content.js
+++ b/src/applications/caregivers/definitions/content.js
@@ -15,6 +15,7 @@ export const links = {
   },
   caregiverHelpPage: {
     link: 'https://www.caregiver.va.gov/',
+    label: 'www.va.caregiver.gov',
   },
   applyVAHealthCare: {
     link: 'https://www.va.gov/health-care/how-to-apply/',
@@ -53,7 +54,7 @@ export const PrivacyPolicy = () => (
       target="_blank"
       rel="noopener noreferrer"
       className="vads-u-margin-left--0p5"
-      href={links.privacyPolicy}
+      href={links.privacyPolicy.link}
     >
       privacy policy
     </a>


### PR DESCRIPTION
## Description
Fix broken links by adding `https` protocols 

## Testing done
- Manual testing

## Screenshots
N/A

## Acceptance criteria
- [x] Fix broken link on signature page `Privacy Policy`
- [x] On confirmation page `https://www.caregiver.va.gov/`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
