### PR TITLE
Stop showing expired saved-in-progress applications on My VA v1

### DIFF
--- a/src/applications/personalization/dashboard/components/FormItem.jsx
+++ b/src/applications/personalization/dashboard/components/FormItem.jsx
@@ -12,80 +12,43 @@ import DashboardAlert, {
   DASHBOARD_ALERT_TYPES,
 } from 'applications/personalization/dashboard/components/DashboardAlert';
 
-class FormItem extends React.Component {
-  render() {
-    const savedFormData = this.props.savedFormData;
-    const formId = savedFormData.form;
-    const {
-      lastUpdated: lastSaved,
-      expiresAt: expirationTime,
-    } = savedFormData.metadata;
-    const lastSavedDateTime = moment
-      .unix(lastSaved)
-      .format('MMMM D, YYYY [at] h:mm a');
-    const expirationDate = moment.unix(expirationTime).format('MMMM D, YYYY');
-    const isExpired = moment.unix(expirationTime).isBefore();
-    const itemTitle = `Application for ${formTitles[formId]}`;
-    const formIdTitle = presentableFormIDs[formId];
+function FormItem({ savedFormData }) {
+  const formId = savedFormData.form;
+  const {
+    lastUpdated: lastSaved,
+    expiresAt: expirationTime,
+  } = savedFormData.metadata;
+  const lastSavedDateTime = moment
+    .unix(lastSaved)
+    .format('MMMM D, YYYY [at] h:mm a');
+  const expirationDate = moment.unix(expirationTime).format('MMMM D, YYYY');
+  const itemTitle = `Application for ${formTitles[formId]}`;
+  const formIdTitle = presentableFormIDs[formId];
 
-    const activeView = (
-      <DashboardAlert
-        id={formId}
-        status={DASHBOARD_ALERT_TYPES.inProgress}
-        headline={itemTitle}
-        subheadline={formIdTitle}
-        statusHeadline="In progress"
+  return (
+    <DashboardAlert
+      id={formId}
+      status={DASHBOARD_ALERT_TYPES.inProgress}
+      headline={itemTitle}
+      subheadline={formIdTitle}
+      statusHeadline="In progress"
+    >
+      <p>
+        <strong>Application last saved on:</strong> {lastSavedDateTime}
+      </p>
+      <p>
+        <strong>This application expires on:</strong> {expirationDate}
+      </p>
+      <a
+        className="usa-button-primary application-route vads-u-margin--0"
+        aria-label={`Continue your ${itemTitle}`}
+        href={`${formLinks[formId]}resume`}
+        onClick={recordDashboardClick(formId, 'continue-button')}
       >
-        <p>
-          <strong>Application last saved on:</strong> {lastSavedDateTime}
-        </p>
-        <p>
-          <strong>This application expires on:</strong> {expirationDate}
-        </p>
-        <a
-          className="usa-button-primary application-route vads-u-margin--0"
-          aria-label={`Continue your ${itemTitle}`}
-          href={`${formLinks[formId]}resume`}
-          onClick={recordDashboardClick(formId, 'continue-button')}
-        >
-          Continue your application
-        </a>
-      </DashboardAlert>
-    );
-    const expiredView = (
-      <DashboardAlert
-        id={formId}
-        status={DASHBOARD_ALERT_TYPES.closed}
-        headline={itemTitle}
-        subheadline={formId}
-        statusHeadline="Expired"
-        statusInfo={`Your application for ${formTitles[formId]} has expired`}
-      >
-        <a
-          className="usa-button-primary application-route vads-u-margin--0"
-          aria-label={`Start a new ${itemTitle}`}
-          href={formLinks[formId]}
-        >
-          Start a new application
-        </a>
-        <button
-          className="va-button-link remove-notification-link"
-          aria-label={`Remove this notification about my ${itemTitle}`}
-          onClick={() => {
-            this.props.toggleModal(formId);
-            recordDashboardClick(formId, 'delete-link');
-          }}
-        >
-          <i className="fa fa-times" />
-          <span className="remove-notification-label">
-            Remove this notification
-          </span>
-        </button>
-      </DashboardAlert>
-    );
-
-    return isExpired ? expiredView : activeView;
-  }
+        Continue your application
+      </a>
+    </DashboardAlert>
+  );
 }
 
 FormItem.propTypes = {

--- a/src/applications/personalization/dashboard/containers/YourApplications.jsx
+++ b/src/applications/personalization/dashboard/containers/YourApplications.jsx
@@ -18,7 +18,11 @@ import {
 
 import FormItem from '../components/FormItem';
 import HCAStatusAlert from '../components/HCAStatusAlert';
-import { isSIPEnabledForm, sipFormSorter } from '../helpers';
+import {
+  filterOutExpiredForms,
+  isSIPEnabledForm,
+  sipFormSorter,
+} from '../helpers';
 
 class YourApplications extends React.Component {
   componentDidMount() {
@@ -96,6 +100,7 @@ export const mapStateToProps = state => {
   const { savedForms } = profileState;
   const verifiedSavedForms = savedForms
     .filter(isSIPEnabledForm)
+    .filter(filterOutExpiredForms)
     .sort(sipFormSorter);
   const hasVerifiedSavedForms = !!verifiedSavedForms.length;
   const hcaStatusEffectiveDate =

--- a/src/applications/personalization/dashboard/helpers.jsx
+++ b/src/applications/personalization/dashboard/helpers.jsx
@@ -183,6 +183,12 @@ export function isSIPEnabledForm(savedForm) {
   return true;
 }
 
+// This function is intended to be used as an Array.filter callback
+export function filterOutExpiredForms(savedForm) {
+  const { expiresAt } = savedForm.metadata;
+  return new Date(expiresAt).getTime() > Date.now();
+}
+
 // Callback to use with Array.sort that expects two properly formatted form
 // objects (that have `metadata.expiresAt` properties). Used to sort form
 // objects, placing the form that expires sooner before the form that expires

--- a/src/applications/personalization/dashboard/tests/containers/YourApplications.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/containers/YourApplications.unit.spec.jsx
@@ -27,6 +27,15 @@ const sipEnabledForm = {
   form: VA_FORM_IDS.FORM_10_10EZ,
   metadata: {
     lastUpdated: '2019-04-24T00:00:00.000-06:00',
+    // create an expiration date one week in the future
+    expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+};
+
+const expiredSipEnabledForm = {
+  form: VA_FORM_IDS.FORM_10_10EZ,
+  metadata: {
+    lastUpdated: '2019-04-24T00:00:00.000-06:00',
     expiresAt: '2019-07-24T00:00:00.000-06:00',
   },
 };
@@ -35,7 +44,10 @@ const nonSIPEnabledForm = {
   form: 'a-non-sip-enabled-form',
   metadata: {
     lastUpdated: '2019-04-24T00:00:00.000-06:00',
-    expiresAt: '2019-07-24T00:00:00.000-06:00',
+    // create an expiration date one week in the future. We want to test that
+    // this form is filtered out because it's not a SIP-enabled. We do _not want
+    // it filtered out because it expired
+    expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
   },
 };
 
@@ -86,7 +98,7 @@ describe('mapStateToProps', () => {
   });
 
   describe('`savedForms`', () => {
-    it('is the filtered version of `profile.savedForms`', () => {
+    it('is the `profile.savedForms` array with non-verified forms and expired applications removed', () => {
       let mappedProps = mapStateToProps(state);
       expect(mappedProps.savedForms).to.deep.equal([]);
       state.user.profile.savedForms = [nonSIPEnabledForm];
@@ -96,6 +108,13 @@ describe('mapStateToProps', () => {
       mappedProps = mapStateToProps(state);
       expect(mappedProps.savedForms).to.deep.equal([sipEnabledForm]);
       state.user.profile.savedForms = [nonSIPEnabledForm, sipEnabledForm];
+      mappedProps = mapStateToProps(state);
+      expect(mappedProps.savedForms).to.deep.equal([sipEnabledForm]);
+      state.user.profile.savedForms = [
+        expiredSipEnabledForm,
+        nonSIPEnabledForm,
+        sipEnabledForm,
+      ];
       mappedProps = mapStateToProps(state);
       expect(mappedProps.savedForms).to.deep.equal([sipEnabledForm]);
     });

--- a/src/applications/personalization/dashboard/tests/e2e/dashboard.all-widgets.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/dashboard.all-widgets.cypress.spec.js
@@ -22,7 +22,8 @@ describe('MyVA Dashboard', () => {
               version: 0,
               returnUrl: '/preparer',
               savedAt: 1602619612576,
-              expiresAt: 1607803612,
+              // a date 7 days in the future, in seconds
+              expiresAt: Date.now() + 7 * 24 * 60 * 60,
               lastUpdated: 1602619612,
               inProgressFormId: 4950,
             },

--- a/src/applications/personalization/dashboard/tests/e2e/dashboard.minimal-widgets.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/dashboard.minimal-widgets.cypress.spec.js
@@ -15,7 +15,23 @@ describe('MyVA Dashboard', () => {
         messaging: false,
         rx: false,
         facilities: [],
-        inProgressForms: [],
+        inProgressForms: [
+          // a single SIP form that has expired, so this should not be shown in
+          // the UI
+          {
+            form: '40-10007',
+            metadata: {
+              version: 0,
+              returnUrl: '/preparer',
+              savedAt: 1602619612576,
+              // a date one week in the past, in seconds
+              expiresAt: Date.now() - 7 * 24 * 60 * 60,
+              lastUpdated: 1602619612,
+              inProgressFormId: 4950,
+            },
+            lastUpdated: 1602619612,
+          },
+        ],
         isPatient: false,
       });
       cy.login(mockUser);


### PR DESCRIPTION
## Description
We no longer want to show saved applications on the Dashboard if those saved-in-progress applications have expired.

## Testing done
New and updated unit and Cypress tests

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs