### PR TITLE
Tweak content on scheduling appts page

### DIFF
--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/AuthContent/index.js
@@ -15,7 +15,7 @@ export const AuthContent = ({ cernerFacilities, otherFacilities }) => (
       myHealtheVetLink={appointmentsToolLink}
       myVAHealthLink={getCernerURL('/pages/scheduling/upcoming')}
     />
-    <p>
+    <p data-testid="cerner-content">
       <strong>Please note:</strong> The fastest way to make all your VA
       appointments is usually to call the VA or community care health facility
       where you want to receive care. If you can’t keep an existing appointment,

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/AuthContent/index.js
@@ -8,41 +8,6 @@ import { appointmentsToolLink, getCernerURL } from 'platform/utilities/cerner';
 
 export const AuthContent = ({ cernerFacilities, otherFacilities }) => (
   <>
-    <div
-      className="usa-alert usa-alert-info"
-      data-testid="cerner-content"
-      role="alert"
-    >
-      <div className="usa-alert-body">
-        <h2
-          className="usa-alert-heading vads-u-font-size--h3"
-          id="due-to-covid-19-you-can-only-r"
-        >
-          Due to COVID-19, we&apos;ll need to contact you to confirm your
-          appointment
-        </h2>
-        <p className="vads-u-margin--0">
-          You can still use our online appointments tool to request an
-          appointment. We'll then contact you to confirm the date, time, and
-          location.
-        </p>
-      </div>
-    </div>
-    <br />
-    <div className="processed-content">
-      <p>
-        <strong>Please note:</strong> The fastest way to make all your VA
-        appointments is usually to call the VA or community care health facility
-        where you want to receive care. If you can’t keep an existing
-        appointment, please contact the facility as soon as possible to
-        reschedule or cancel.
-        <br />
-        <a href="/find-locations/">Find your health facility’s phone number</a>
-      </p>
-      <h2 id="view-schedule-or-cancel-a-va-a">
-        View, schedule, or cancel a VA appointment online
-      </h2>
-    </div>
     <CernerCallToAction
       cernerFacilities={cernerFacilities}
       otherFacilities={otherFacilities}
@@ -50,6 +15,14 @@ export const AuthContent = ({ cernerFacilities, otherFacilities }) => (
       myHealtheVetLink={appointmentsToolLink}
       myVAHealthLink={getCernerURL('/pages/scheduling/upcoming')}
     />
+    <p>
+      <strong>Please note:</strong> The fastest way to make all your VA
+      appointments is usually to call the VA or community care health facility
+      where you want to receive care. If you can’t keep an existing appointment,
+      please contact the facility as soon as possible to reschedule or cancel.
+      <br />
+      <a href="/find-locations/">Find your health facility’s phone number</a>
+    </p>
     <h2>How can these appointment tools help me manage my care?</h2>
     <p>
       These tools offer a secure, online way to schedule, view, and organize

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/AuthContent/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/AuthContent/index.unit.spec.js
@@ -11,8 +11,6 @@ describe('Scheduling Page <AuthContent>', () => {
 
     const text = wrapper.text();
     expect(text).to.include('CernerCallToAction');
-    expect(text).to.include('Due to COVID-19,');
-    expect(text).to.include('View, schedule, or cancel a VA appointment');
     expect(text).to.include(
       'How can these appointment tools help me manage my care?',
     );

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/UnauthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/UnauthContent/index.js
@@ -6,42 +6,15 @@ import MoreInfoAboutBenefits from '../../../components/MoreInfoAboutBenefits';
 
 export const UnauthContent = () => (
   <>
-    <div
-      className="usa-alert usa-alert-info"
-      data-testid="non-cerner-content"
-      role="alert"
-    >
-      <div className="usa-alert-body">
-        <h2
-          className="usa-alert-heading vads-u-font-size--h3"
-          id="due-to-covid-19-you-can-only-r"
-        >
-          Due to COVID-19, we&apos;ll need to contact you to confirm your
-          appointment
-        </h2>
-        <p className="vads-u-margin--0">
-          You can still use our online appointments tool to request an
-          appointment. We'll then contact you to confirm the date, time, and
-          location.
-        </p>
-      </div>
-    </div>
-    <div className="processed-content">
-      <p>&nbsp;</p>
-      <p>
-        <strong>Please note:</strong> The fastest way to make all your VA
-        appointments is usually to call the VA or community care health facility
-        where you want to receive care. If you can’t keep an existing
-        appointment, please contact the facility as soon as possible to
-        reschedule or cancel.
-        <br />
-        <a href="/find-locations/">Find your health facility’s phone number</a>
-      </p>
-      <h2 id="view-schedule-or-cancel-a-va-a">
-        View, schedule, or cancel a VA appointment online
-      </h2>
-    </div>
     <CallToActionWidget appId="view-appointments" setFocus={false} />
+    <p>
+      <strong>Please note:</strong> The fastest way to make all your VA
+      appointments is usually to call the VA or community care health facility
+      where you want to receive care. If you can’t keep an existing appointment,
+      please contact the facility as soon as possible to reschedule or cancel.
+      <br />
+      <a href="/find-locations/">Find your health facility’s phone number</a>
+    </p>
     <h2>How can the VA appointments tool help me manage my care?</h2>
     <p>
       This tool offers a secure, online way to schedule, view, and organize your

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/UnauthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/UnauthContent/index.js
@@ -7,7 +7,7 @@ import MoreInfoAboutBenefits from '../../../components/MoreInfoAboutBenefits';
 export const UnauthContent = () => (
   <>
     <CallToActionWidget appId="view-appointments" setFocus={false} />
-    <p>
+    <p data-testid="non-cerner-content">
       <strong>Please note:</strong> The fastest way to make all your VA
       appointments is usually to call the VA or community care health facility
       where you want to receive care. If you can’t keep an existing appointment,

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/UnauthContent/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/UnauthContent/index.unit.spec.js
@@ -10,10 +10,6 @@ describe('Scheduling Page <UnauthContent>', () => {
     const wrapper = shallow(<UnauthContent />);
 
     const text = wrapper.text();
-    expect(text).to.include('Due to COVID-19,');
-    expect(text).to.include(
-      'View, schedule, or cancel a VA appointment online',
-    );
     expect(text).to.include(
       'How can the VA appointments tool help me manage my care?',
     );


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/20746

This PR makes some content tweaks for the `/health-care/schedule-view-va-appointments/` page (both auth + Cerner user and unauth).

## Testing done
N/A

## Screenshots
![localhost_3001_health-care_schedule-view-va-appointments_](https://user-images.githubusercontent.com/12773166/111482985-004e2780-86fa-11eb-956d-0facc8415d6f.png)

## Acceptance criteria
- [x] Tweak content

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
