### PR TITLE
DT-21615 adjusting find forms string replacer

### DIFF
--- a/src/applications/find-forms/helpers/index.js
+++ b/src/applications/find-forms/helpers/index.js
@@ -75,10 +75,8 @@ export const sortTheResults = (sortByPropertyName, indexA, indexB) => {
  * @param {string|number} index index where we need to add the dash
  * @return {string} new substring with dash
  */
-export const regexpDashAdder = (match, index) => {
-  const regex = new RegExp(`(?<=^.{${index}})`);
-  return match.replace(regex, '-');
-};
+export const regexpDashAdder = (match, index) =>
+  `${match.slice(0, index)}-${match.slice(index)}`;
 
 /**
  * This function takes a string and runs through the SEARCH_QUERY_AUTO_CORRECT_MAP to remove/ replace of any of those properties listed.


### PR DESCRIPTION
## Description
The dash adder func used a regexp lookbehind which is no compatible with IE and Safari. 
SEE: https://caniuse.com/?search=lookbehind

## Testing done
Ran find forms unit tests, spun up local and searched on safari the following terms: 200, 210, 220, 260, 290, or 400 which should result in _digitdigitdashdigit_, e.g., 200 => 20-0

## Screenshots
![Screen Shot 2021-03-17 at 10 25 10 AM](https://user-images.githubusercontent.com/26075258/111484251-f7fee800-870b-11eb-93cf-009bfbd07d55.png)


## Acceptance criteria
- [x] Dash is added at index it is needed.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
