### PR TITLE
Move staging ordering logic to default ordering logic

### DIFF
--- a/src/applications/resources-and-support/hooks/useGetSearchResults.js
+++ b/src/applications/resources-and-support/hooks/useGetSearchResults.js
@@ -44,45 +44,42 @@ export default function useGetSearchResults(articles, query, page) {
         });
       });
 
+      // Begin ordering logic.
+      // =====
       let orderedResults = [];
 
-      // Keep legacy sorting on production.
-      if (environment.isProduction()) {
-        orderedResults = orderBy(filteredArticles, 'title');
+      filteredArticles = filteredArticles?.map(article => ({
+        ...article,
 
-        // Experiment with new sorting on non-prod envs.
-      } else {
-        filteredArticles = filteredArticles?.map(article => ({
-          ...article,
+        // Number of times a keyword is found in the article's title.
+        keywordsCountsTitle: keywords?.reduce(
+          (keywordInstances, keyword) =>
+            keywordInstances +
+            article.title.toLowerCase()?.split(keyword)?.length -
+            1,
+          0,
+        ),
 
-          // Number of times a keyword is found in the article's title.
-          keywordsCountsTitle: keywords?.reduce(
-            (keywordInstances, keyword) =>
-              keywordInstances +
-              article.title.toLowerCase()?.split(keyword)?.length -
-              1,
-            0,
-          ),
+        // Number of times a keyword is found in the article's description.
+        keywordsCountsDescription: keywords?.reduce(
+          (keywordInstances, keyword) =>
+            keywordInstances +
+            article.description.toLowerCase()?.split(keyword)?.length -
+            1,
+          0,
+        ),
+      }));
 
-          // Number of times a keyword is found in the article's description.
-          keywordsCountsDescription: keywords?.reduce(
-            (keywordInstances, keyword) =>
-              keywordInstances +
-              article.description.toLowerCase()?.split(keyword)?.length -
-              1,
-            0,
-          ),
-        }));
-
-        // Sort first by query word instances found in title descending
-        // Sort ties then by query word instances found in description descending
-        // Sort ties then by alphabetical descending
-        orderedResults = orderBy(
-          filteredArticles,
-          ['keywordsCountsTitle', 'keywordsCountsDescription', 'title'],
-          ['desc', 'desc', 'asc'],
-        );
-      }
+      // Sort first by query word instances found in title descending
+      // Sort ties then by query word instances found in description descending
+      // Sort ties then by alphabetical descending
+      orderedResults = orderBy(
+        filteredArticles,
+        ['keywordsCountsTitle', 'keywordsCountsDescription', 'title'],
+        ['desc', 'desc', 'asc'],
+      );
+      // =====
+      // End of ordering logic.
 
       // Track R&S search results.
       recordEvent({

--- a/src/applications/resources-and-support/hooks/useGetSearchResults.js
+++ b/src/applications/resources-and-support/hooks/useGetSearchResults.js
@@ -2,7 +2,6 @@
 import { useEffect, useState } from 'react';
 import { orderBy } from 'lodash';
 // Relative imports.
-import environment from 'platform/utilities/environment';
 import recordEvent from 'platform/monitoring/record-event';
 import { SEARCH_IGNORE_LIST } from '../constants';
 


### PR DESCRIPTION
## Description
This PR promotes the ordering logic for RS to production.

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Promote ordering logic from staging only to all envs

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
