### PR TITLE
Kelsonic 16916 whole phrase matching rs

### DIFF
--- a/src/applications/resources-and-support/hooks/useGetSearchResults.js
+++ b/src/applications/resources-and-support/hooks/useGetSearchResults.js
@@ -46,43 +46,40 @@ export default function useGetSearchResults(articles, query, page) {
 
       let orderedResults = [];
 
-      // Keep legacy sorting on production.
-      if (environment.isProduction()) {
-        orderedResults = orderBy(filteredArticles, 'title');
+      // Begin ordering logic.
+      // =====
+      filteredArticles = filteredArticles?.map(article => ({
+        ...article,
 
-        // Experiment with new sorting on non-prod envs.
-      } else {
-        filteredArticles = filteredArticles?.map(article => ({
-          ...article,
+        // Number of times a keyword is found in the article's title.
+        keywordsCountsTitle: keywords?.reduce(
+          (keywordInstances, keyword) =>
+            keywordInstances +
+            article.title.toLowerCase()?.split(keyword)?.length -
+            1,
+          0,
+        ),
 
-          // Number of times a keyword is found in the article's title.
-          keywordsCountsTitle: keywords?.reduce(
-            (keywordInstances, keyword) =>
-              keywordInstances +
-              article.title.toLowerCase()?.split(keyword)?.length -
-              1,
-            0,
-          ),
+        // Number of times a keyword is found in the article's description.
+        keywordsCountsDescription: keywords?.reduce(
+          (keywordInstances, keyword) =>
+            keywordInstances +
+            article.description.toLowerCase()?.split(keyword)?.length -
+            1,
+          0,
+        ),
+      }));
 
-          // Number of times a keyword is found in the article's description.
-          keywordsCountsDescription: keywords?.reduce(
-            (keywordInstances, keyword) =>
-              keywordInstances +
-              article.description.toLowerCase()?.split(keyword)?.length -
-              1,
-            0,
-          ),
-        }));
-
-        // Sort first by query word instances found in title descending
-        // Sort ties then by query word instances found in description descending
-        // Sort ties then by alphabetical descending
-        orderedResults = orderBy(
-          filteredArticles,
-          ['keywordsCountsTitle', 'keywordsCountsDescription', 'title'],
-          ['desc', 'desc', 'asc'],
-        );
-      }
+      // Sort first by query word instances found in title descending
+      // Sort ties then by query word instances found in description descending
+      // Sort ties then by alphabetical descending
+      orderedResults = orderBy(
+        filteredArticles,
+        ['keywordsCountsTitle', 'keywordsCountsDescription', 'title'],
+        ['desc', 'desc', 'asc'],
+      );
+      // =====
+      // End of ordering logic.
 
       // Track R&S search results.
       recordEvent({

--- a/src/applications/resources-and-support/hooks/useGetSearchResults.js
+++ b/src/applications/resources-and-support/hooks/useGetSearchResults.js
@@ -16,6 +16,8 @@ export default function useGetSearchResults(articles, query, page) {
         return;
       }
 
+      // Begin filtering logic.
+      // =====
       const keywords = query
         .split(' ')
         .filter(word => !!word)
@@ -43,11 +45,13 @@ export default function useGetSearchResults(articles, query, page) {
           );
         });
       });
-
-      let orderedResults = [];
+      // =====
+      // End of filtering logic.
 
       // Begin ordering logic.
       // =====
+      let orderedResults = [];
+
       filteredArticles = filteredArticles?.map(article => ({
         ...article,
 
@@ -68,16 +72,36 @@ export default function useGetSearchResults(articles, query, page) {
             1,
           0,
         ),
+
+        wholePhraseMatchCounts:
+          article.title.toLowerCase()?.split(query.toLowerCase())?.length -
+          1 +
+          (article.description.toLowerCase()?.split(query.toLowerCase())
+            ?.length -
+            1),
       }));
 
       // Sort first by query word instances found in title descending
       // Sort ties then by query word instances found in description descending
       // Sort ties then by alphabetical descending
-      orderedResults = orderBy(
-        filteredArticles,
-        ['keywordsCountsTitle', 'keywordsCountsDescription', 'title'],
-        ['desc', 'desc', 'asc'],
-      );
+      if (environment.isProduction()) {
+        orderedResults = orderBy(
+          filteredArticles,
+          ['keywordsCountsTitle', 'keywordsCountsDescription', 'title'],
+          ['desc', 'desc', 'asc'],
+        );
+      } else {
+        orderedResults = orderBy(
+          filteredArticles,
+          [
+            'wholePhraseMatchCounts',
+            'keywordsCountsTitle',
+            'keywordsCountsDescription',
+            'title',
+          ],
+          ['desc', 'desc', 'desc', 'asc'],
+        );
+      }
       // =====
       // End of ordering logic.
 

--- a/src/applications/resources-and-support/hooks/useGetSearchResults.js
+++ b/src/applications/resources-and-support/hooks/useGetSearchResults.js
@@ -81,16 +81,20 @@ export default function useGetSearchResults(articles, query, page) {
             1),
       }));
 
-      // Sort first by query word instances found in title descending
-      // Sort ties then by query word instances found in description descending
-      // Sort ties then by alphabetical descending
       if (environment.isProduction()) {
+        // Sort first by query word instances found in title descending
+        // Sort ties then by query word instances found in description descending
+        // Sort ties then by alphabetical descending
         orderedResults = orderBy(
           filteredArticles,
           ['keywordsCountsTitle', 'keywordsCountsDescription', 'title'],
           ['desc', 'desc', 'asc'],
         );
       } else {
+        // Sort first by the number of exact query matches (ignoring casing) in the title and description
+        // Sort ties by query word instances found in title descending
+        // Sort ties then by query word instances found in description descending
+        // Sort ties then by alphabetical descending
         orderedResults = orderBy(
           filteredArticles,
           [


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/16916

This PR adds whole phrase ordering on non-prod envs for R&S search.

## Testing done
N/A

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/111495913-6e4c1c00-8705-11eb-8721-39ad716dfad0.png)

## Acceptance criteria
- [x] Add whole phrase ordering on non-prod envs for R&S search.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
