### PR TITLE
Cheetah-Update copy on Screener and Confirmation pages

### DIFF
--- a/src/applications/vaos/project-cheetah/components/ReceivedDoseScreenerPage.jsx
+++ b/src/applications/vaos/project-cheetah/components/ReceivedDoseScreenerPage.jsx
@@ -20,7 +20,16 @@ const initialSchema = {
 const uiSchema = {
   hasReceivedDose: {
     'ui:widget': 'yesNo',
-    'ui:title': 'This includes the first or second shot, at any facility',
+    'ui:options': {
+      labels: {
+        N: "No/I'm not sure",
+      },
+    },
+    'ui:title':
+      "If you've received the first dose of a vaccine that requires 2 doses, answer Yes.",
+    'ui:errorMessages': {
+      required: 'Please select an option',
+    },
   },
 };
 

--- a/src/applications/vaos/tests/project-cheetah/components/ReceivedDoseScreenerPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/project-cheetah/components/ReceivedDoseScreenerPage.unit.spec.jsx
@@ -40,7 +40,7 @@ describe('VAOS <ReceivedDoseScreenerPage> ', () => {
 
     fireEvent.click(screen.getByText(/Continue/));
 
-    expect(await screen.findByText('Please provide a response')).to.exist;
+    expect(await screen.findByText('Please select an option')).to.exist;
     expect(screen.history.push.called).to.not.be.true;
   });
 


### PR DESCRIPTION
## Description
This PR updates page content on the Received Dose (Screener) and Confirmation pages

## Testing done
Unit testing

## Screenshots
![localhost_3001_health-care_schedule-view-va-appointments_appointments_new-covid-19-vaccine-booking_review(iPhone X)](https://user-images.githubusercontent.com/3587066/111509614-e5d87600-871a-11eb-98b5-766803a91bd5.png)
---
![localhost_3001_health-care_schedule-view-va-appointments_appointments_new-covid-19-vaccine-booking_select-date-1(iPhone X) (2)](https://user-images.githubusercontent.com/3587066/111509620-e7a23980-871a-11eb-960d-bc00c4f4a238.png)

## Acceptance criteria
- [ ] Changes are behind va_online_scheduling_cheetah feature flag
- [ ] CONTENT - Screener page copy matches the copy doc
- [ ] CONTENT - Confirmation page copy matches the copy doc

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
