### PR TITLE
Kelsonic 17779 r s escape descriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -307,6 +307,7 @@
     "fast-levenshtein": "^2.0.6",
     "fine-uploader": "^5.16.2",
     "foundation-sites": "^5.5.3",
+    "he": "^1.2.0",
     "history": "3",
     "history-v4": "npm:history@4.9.0",
     "ics-js": "^0.10.2",

--- a/src/applications/resources-and-support/hooks/useArticleData.js
+++ b/src/applications/resources-and-support/hooks/useArticleData.js
@@ -15,6 +15,7 @@ export default function useArticleData() {
     () => {
       const getJson = async () => {
         try {
+          // This is injected here: src/site/stages/build/plugins/create-resources-and-support-section.js
           const response = await fetch(
             `${baseUrl}/resources/search/articles.json`,
           );

--- a/src/site/stages/build/plugins/create-resources-and-support-section.js
+++ b/src/site/stages/build/plugins/create-resources-and-support-section.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const liquid = require('tinyliquid');
+const he = require('he');
 
 const { ENTITY_BUNDLES } = require('../../../constants/content-modeling');
 
@@ -291,10 +292,13 @@ function createArticleListingsPages(files) {
 }
 
 function createArticleResultSnippet(text) {
-  const sanitized = liquid.filters.strip_html(text);
-  const truncated = liquid.filters.truncate(sanitized, 200);
+  const sanitizedText = liquid.filters.strip_html(text);
+  const strippedNewlines = liquid.filters.strip_newlines(sanitizedText);
+  const decodedText = he.decode(strippedNewlines);
 
-  if (sanitized !== truncated) {
+  const truncated = liquid.filters.truncate(decodedText, 190);
+
+  if (decodedText !== truncated) {
     return `${truncated}...`;
   }
 


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/17779

This PR strips HTML, strips newlines, and unescapes article descriptions for R&S search.

Introducing a well-known library for decoding called https://github.com/mathiasbynens/he since we don't have access to `document.createElement` or `new DOMParser()` during the build and because neither liquid nor lodash had sufficient unescape methods.

## Testing done
Locally

## Screenshots

### Before

![localhost_3001_resources_search__query=my+healthevet (1)](https://user-images.githubusercontent.com/12773166/111511793-b0308e80-8714-11eb-9a44-9072997061d9.png)

### After

![localhost_3001_resources_search__query=my+healthevet](https://user-images.githubusercontent.com/12773166/111511075-fd603080-8713-11eb-92d0-933111eacf57.png)

## Acceptance criteria
- [x] strips HTML, strips newlines, and unescapes article descriptions for R&S search

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
