### PR TITLE
[21565] Add Project Cheetah Facility 2nd dose Alert and Copy Updates

### DIFF
--- a/src/applications/vaos/project-cheetah/components/VAFacilityPage/FacilitiesRadioWidget.jsx
+++ b/src/applications/vaos/project-cheetah/components/VAFacilityPage/FacilitiesRadioWidget.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import State from '../../../components/State';
 import { FACILITY_SORT_METHODS } from '../../../utils/constants';
 import { scrollAndFocus } from '../../../utils/scrollAndFocus';
+import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 
 const INITIAL_FACILITY_DISPLAY_COUNT = 5;
 
@@ -104,6 +105,13 @@ export default function FacilitiesRadioWidget({
             </span>
           </button>
         )}
+
+      <AlertBox
+        backgroundOnly
+        content="If you get a vaccine that requires 2 doses, you'll need to return to the same facility for your second dose."
+        headline="Some COVID-19 vaccines require 2 doses"
+        status="info"
+      />
     </div>
   );
 }

--- a/src/applications/vaos/tests/e2e/covid19-vaccine.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/covid19-vaccine.cypress.spec.js
@@ -36,6 +36,7 @@ describe('VAOS COVID-19 vaccine appointment flow', () => {
 
     // Choose VA Flat Facility
     cy.url().should('include', '/facility');
+    cy.findByText(/Some COVID-19 vaccines require 2 doses/i).should('exist');
     cy.axeCheckBestPractice();
     cy.findByLabelText(/cheyenne/i).click();
     cy.findByText(/Continue/).click();

--- a/src/applications/vaos/tests/project-cheetah/components/VAFacilityPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/project-cheetah/components/VAFacilityPage/index.unit.spec.jsx
@@ -83,6 +83,38 @@ describe('VAOS vaccine flow: <VAFacilityPage>', () => {
   beforeEach(() => mockFetch());
   afterEach(() => resetFetch());
 
+  it('should display 2 dosages COVID alert', async () => {
+    mockDirectBookingEligibilityCriteria(
+      parentSiteIds,
+      directFacilities.slice(0, 5),
+    );
+    mockRequestEligibilityCriteria(parentSiteIds, []);
+    mockFacilitiesFetch(vhaIds.slice(0, 5).join(','), facilities.slice(0, 5));
+    mockEligibilityFetches({
+      siteId: '983',
+      facilityId: '983',
+      typeOfCareId: TYPE_OF_CARE_ID,
+    });
+    const store = createTestStore(initialState);
+
+    const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
+      store,
+    });
+
+    // Radio buttons only show up after all the data is loaded, which
+    // should mean all page rendering is finished
+    await screen.findAllByRole('radio');
+
+    expect(screen.getByText(/Some COVID-19 vaccines require 2 doses/i)).to
+      .exist;
+
+    expect(
+      screen.getByText(
+        /If you get a vaccine that requires 2 doses, you'll need to return to the same facility for your second dose./i,
+      ),
+    ).to.exist;
+  });
+
   it('should display list of facilities with show more button', async () => {
     mockDirectBookingEligibilityCriteria(parentSiteIds, directFacilities);
     mockRequestEligibilityCriteria(parentSiteIds, []);


### PR DESCRIPTION
## Description
Update the messaging on Facility Selection (Choose a facility) page to reinforce requirements for second dose.
![image](https://user-images.githubusercontent.com/8315447/111524445-ce0cec00-8732-11eb-8cd6-f7436e0e37e1.png)

## Testing done
Local, Unit, E2E

## Screenshots
<img width="331" alt="image" src="https://user-images.githubusercontent.com/8315447/111524347-b03f8700-8732-11eb-8f9f-f57fad408e74.png">

## Acceptance criteria
- [ ] Changes are behind va_online_scheduling_cheetah feature flag
- [ ] CONTENT - Copy matches the copy doc
- [ ] DESIGN - Designs match the specs https://www.sketch.com/s/aca1478c-8cfa-433e-8e06-d42b53aaa60d/a/R1MgY7j#Inspector

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
