### PR TITLE
Add build txt to apps bucket

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -349,8 +349,10 @@ def archive(dockerContainer, String ref, String envName) {
                      usernameVariable: 'AWS_ACCESS_KEY', passwordVariable: 'AWS_SECRET_KEY']]) {
       sh "echo \"${buildDetails}\" > /application/build/${envName}/BUILD.txt"
       if(envName == 'vagovdev') {
+        sh "echo \"${buildDetails}\" > /application/build/${envName}/generated/BUILD.txt"
         sh "tar -C /application/build/${envName} -cf /application/build/apps.${envName}.tar.bz2 ."
         sh "aws s3 cp /application/build/apps.${envName}.tar.bz2 s3://vetsgov-website-builds-s3-upload/application-build/${ref}/${envName}.tar.bz2 --acl public-read --region us-gov-west-1 --quiet"
+        sh "rm /application/build/${envName}/generated/BUILD.txt"
       }
       sh "tar -C /application/build/${envName} -cf /application/build/${envName}.tar.bz2 ."
       sh "aws s3 cp /application/build/${envName}.tar.bz2 s3://vetsgov-website-builds-s3-upload/${ref}/${envName}.tar.bz2 --acl public-read --region us-gov-west-1 --quiet"

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -349,7 +349,7 @@ def archive(dockerContainer, String ref, String envName) {
                      usernameVariable: 'AWS_ACCESS_KEY', passwordVariable: 'AWS_SECRET_KEY']]) {
       sh "echo \"${buildDetails}\" > /application/build/${envName}/BUILD.txt"
       if(envName == 'vagovdev') {
-        sh "echo \"${buildDetails}\" > /application/build/${envName}/generated/BUILD.txt"
+        sh "cp /application/build/${envName}/BUILD.txt /application/build/${envName}/generated/BUILD.txt"
         sh "tar -C /application/build/${envName} -cf /application/build/apps.${envName}.tar.bz2 ."
         sh "aws s3 cp /application/build/apps.${envName}.tar.bz2 s3://vetsgov-website-builds-s3-upload/application-build/${ref}/${envName}.tar.bz2 --acl public-read --region us-gov-west-1 --quiet"
         sh "rm /application/build/${envName}/generated/BUILD.txt"


### PR DESCRIPTION
## Description
Add `BUILD.txt` file to `generated` directory in apps bucket, so we can distinguish assets in the application deploy.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
