### PR TITLE
Add custom margin

### DIFF
--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -107,7 +107,7 @@
           <div class="vads-l-col--12 medium-screen:vads-l-col--4 vads-u-align-content--stretch vads-u-margin-y--1 ">
             <div class="vads-u-background-color--gray-light-alt vads-u-height--full medium-screen:vads-u-margin-x--1 medium-screen:vads-u-margin-y--0">
               <img alt="{{ promo.entity.fieldImage.entity.thumbnail.alt }}" height="{{ promo.entity.fieldImage.entity.thumbnail.derivative.height }}" width="{{ promo.entity.fieldImage.entity.thumbnail.derivative.width }}" src="{{ promo.entity.fieldImage.entity.thumbnail.derivative.url }}" />
-              <h3 class="vads-u-padding-x--2">
+              <h3 class="vads-u-padding-x--2 vads-u-margin-top--1">
                 <a
                   href="{{ promo.entity.fieldPromoLink.entity.fieldLink.uri }}"
                   onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'What you can do', 'clp-section-title': '{{ fieldClpWhatYouCanDoHeader | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ promo.entity.fieldPromoLink.entity.fieldLink.title | escape }}' });"


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/21716

This PR tweaks the CLP styling for the header of the what you can do section boxes.

## Testing done
Locally

## Screenshots

### BEFORE

![image](https://user-images.githubusercontent.com/12773166/111644107-21c81580-87c5-11eb-89d1-1a8ee75b41eb.png)

### AFTER

![image](https://user-images.githubusercontent.com/12773166/111644045-11b03600-87c5-11eb-8037-4c768e8203b4.png)

## Acceptance criteria
- [x] Tweak spacing

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
