### PR TITLE
Upgrade Cypress to 6.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "cors": "^2.7.1",
     "css-loader": "^1.0.0",
     "cssnano": "^4.1.10",
-    "cypress": "^6.7.1",
+    "cypress": "^6.8.0",
     "cypress-axe": "^0.12.0",
     "cypress-multi-reporters": "^1.4.0",
     "cypress-plugin-tab": "^1.0.5",
@@ -376,7 +376,7 @@
     "**/node-forge": "^0.10.0",
     "**/axios": "^0.21.1",
     "**/elliptic": "^6.5.4",
-    "cypress": "^6.7.1",
+    "cypress": "^6.8.0",
     "tar-fs/tar-stream/bl": "^4.0.3",
     "nightwatch/**/lodash.defaultsdeep": "^4.6.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5593,10 +5593,10 @@ cypress-wait-until@^1.7.1:
   resolved "https://registry.npmjs.org/cypress-wait-until/-/cypress-wait-until-1.7.1.tgz"
   integrity sha512-8DL5IsBTbAxBjfYgCzdbohPq/bY+IKc63fxtso1C8RWhLnQkZbVESyaclNr76jyxfId6uyzX8+Xnt0ZwaXNtkA==
 
-cypress@^6.7.1:
-  version "6.7.1"
-  resolved "https://registry.npmjs.org/cypress/-/cypress-6.7.1.tgz"
-  integrity sha512-MC9yt1GqpL4WVDQ0STI89K+PdLeC3T3NuAb2N61d6vYGR9pJy8w3Fqe0OWZwaRTJtg9eAyHXPGmFsyKeNQ3tmg==
+cypress@^6.8.0:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.8.0.tgz#8338f39212a8f71e91ff8c017a1b6e22d823d8c1"
+  integrity sha512-W2e9Oqi7DmF48QtOD0LfsOLVq6ef2hcXZvJXI/E3PgFNmZXEVwBefhAxVCW9yTPortjYA2XkM20KyC4HRkOm9w==
   dependencies:
     "@cypress/listr-verbose-renderer" "^0.4.1"
     "@cypress/request" "^2.88.5"


### PR DESCRIPTION
## Description
This PR upgrades Cypress to the latest version (`6.8.0`). The [changelog](https://docs.cypress.io/guides/references/changelog.html#6-8-0) has a bug fix that affects testing the Cypress Dashboard and parallelization.

## Testing done
- Tests pass locally and on CI.

## Acceptance criteria
- [ ] Tests pass locally and on CI.