### PR TITLE
Add error handling to renderInReduxProvider

### DIFF
--- a/src/platform/testing/unit/react-testing-library-helpers.js
+++ b/src/platform/testing/unit/react-testing-library-helpers.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { combineReducers, applyMiddleware, createStore } from 'redux';
 import thunk from 'redux-thunk';
+import { isPlainObject } from 'lodash';
 import { render as rtlRender } from '@testing-library/react';
 
 import { commonReducer } from 'platform/startup/store';
@@ -20,6 +21,17 @@ export function renderInReduxProvider(
   ui,
   { initialState = {}, reducers = {}, store = null, ...renderOptions } = {},
 ) {
+  if (Object.keys(renderOptions).includes('reducer')) {
+    /* eslint-disable no-console */
+    console.log(
+      'You passed in a `reducer` option to renderInReduxProvider. Did you mean to pass in a `reducers` option instead?',
+    );
+  }
+  if (!isPlainObject(reducers)) {
+    throw new TypeError(
+      "renderInReduxProvider's `reducers` option must be an Object",
+    );
+  }
   const testStore =
     store ||
     createStore(


### PR DESCRIPTION
## Description
I have personally incorrectly used our `renderInReduxProvider` Testing Library helper multiple times. That's especially bad since I think I added that helper to our code. I also know for a fact that others have used it incorrectly as well. This PR addresses two potential issues with incorrectly passing in the `reducers` option:

1. If you fail to pass in an Object for the `reducers` option, it will throw an Error.
2. If you accidentally passed in a `reducer` (note the lack of trailing `s`) option, it `console.log`s a hint. But perhaps this should throw an Error as well.

If you currently make either of these mistakes, you are likely to get test failures without much helpful output indicating what's wrong.

## Testing done
Local.

## Screenshots
This is the output you'll get if you pass in a non-Object for `reducers` and also pass in a `reducer` option:
<img width="1270" alt="Screen Shot 2021-03-18 at 3 23 26 PM" src="https://user-images.githubusercontent.com/20728956/111780570-cce3d800-8874-11eb-8489-42160a42383a.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs