### PR TITLE
[20547] VA Phone Details Label

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/ScheduleNewAppointmentRadioButtons.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/ScheduleNewAppointmentRadioButtons.jsx
@@ -9,7 +9,6 @@ import { GA_PREFIX } from 'applications/vaos/utils/constants';
  * @property {boolean} [showCheetahScheduleButton=false] - A boolean value to determine Whether or not to show COVID-19 vaccine option.
  * @property {function} startNewAppointmentFlow - A function that’s called when the user starts the new appointment flow.
  * @property {function} startNewVaccineFlow - A function that’s called when the user starts the vaccine flow.
- * @component
  * @example
  * <ScheduleNewAppointmentRadioButtons
  *  showCheetahScheduleButton={valueFromProp}

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/ConfirmedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/ConfirmedAppointmentDetailsPage.jsx
@@ -53,6 +53,8 @@ function formatHeader(appointment) {
     return 'VA Video Connect at an ATLAS location';
   } else if (isVideoHome(appointment)) {
     return 'VA Video Connect at home';
+  } else if (isVAPhoneAppointment(appointment)) {
+    return 'VA Appointment over the phone';
   } else {
     return 'VA Appointment';
   }


### PR DESCRIPTION
## Description
Include additional detail to appointment type label when a VA appointment is over the phone.

## Testing done
Local and Unit

## Screenshots
![localhost_3001_health-care_schedule-view-va-appointments_appointments_past](https://user-images.githubusercontent.com/8315447/111803118-1fd58380-88a5-11eb-986d-bdcd7ce87463.png)

## Acceptance criteria
- [ ] Changes are behind the va_online_scheduling_homepage_refresh feature flag
- [ ] Given appointment type is phone only, When user clicks VA appointment card on the homepage, Then detail page displays AND label is VA Appointment over the phone
- [ ] All other non-phone-only VA appointments are not impacted

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
