### PR TITLE
Ensure runtime error doesn't occur when unable to find meta description

### DIFF
--- a/src/applications/static-pages/social-share-links.js
+++ b/src/applications/static-pages/social-share-links.js
@@ -5,8 +5,12 @@ Open share links in a new modal window
 export function openShareLink(shareLinks) {
   const hasNavigatorShare = navigator.share !== undefined;
   const metaTitle = document.querySelector('title').content;
-  const metaDescription = document.querySelector("meta[name='description']")
-    .content;
+  const metaDescriptionElement = document.querySelector(
+    "meta[name='description']",
+  );
+  const metaDescription = metaDescriptionElement
+    ? metaDescriptionElement.content
+    : '';
   const metaUrl = document.querySelector("meta[property='og:url']").content;
 
   shareLinks.forEach(link => {


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/21517

This PR fixes a runtime error that can occur.

![image](https://user-images.githubusercontent.com/12773166/111817143-44c8f700-88a3-11eb-822c-7df3199ef252.png)

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Fix runtime error

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
