### PR TITLE
Fixing name of VA Fayetteville Health Care menu to match Drupal.

### DIFF
--- a/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
+++ b/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
@@ -39,7 +39,7 @@ const FACILITY_MENU_NAMES = [
   // VISN 6
   'va-asheville-health-care',
   'va-durham-health-care',
-  'va-fayetteville-coastal-health-care',
+  'va-fayetteville-coastal-health-c',
   'va-hampton-health-care',
   'va-richmond-health-care',
   'va-salem-health-care',

--- a/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
+++ b/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
@@ -15,7 +15,7 @@ const FACILITY_MENU_NAMES = [
   'va-maine-health-care',
   'va-manchester-health-care',
   'va-providence-health-care',
-  'va-white-river-junction-health-care',
+  'va-white-river-junction-health-c',
   // VISN-2
   'va-albany-health-care',
   'va-bronx-health-care',
@@ -50,7 +50,7 @@ const FACILITY_MENU_NAMES = [
   'va-birmingham-health-care',
   'va-central-alabama-health-care',
   'va-charleston-health-care',
-  'va-columbia-south-carolina-health-care',
+  'va-columbia-south-carolina-healt',
   'va-dublin-health-care',
   'va-tuscaloosa-health-care',
   // VISN 8
@@ -64,12 +64,12 @@ const FACILITY_MENU_NAMES = [
   // VISN 16
   'va-alexandria-health-care',
   'va-central-arkansas-health-care',
-  'va-fayetteville-arkansas-health-care',
+  'va-fayetteville-arkansas-health-',
   'va-gulf-coast-health-care',
   'va-houston-health-care',
   'va-jackson-health-care',
   'va-shreveport-health-care',
-  'va-southeast-louisiana-health-care',
+  'va-southeast-louisiana-health-ca',
   // VISN 19
   'va-cheyenne-health-care',
   'va-eastern-colorado-health-care',
@@ -89,8 +89,8 @@ const FACILITY_MENU_NAMES = [
   'va-spokane-health-care',
   'va-wallawalla-health-care',
   // VISN 21
-  'va-central-california-health-care',
-  'va-northern-california-health-care',
+  'va-central-california-health-car',
+  'va-northern-california-health-ca',
   'va-pacific-islands-health-care',
   'va-palo-alto-health-care',
   'va-san-francisco-health-care',
@@ -102,7 +102,7 @@ const FACILITY_MENU_NAMES = [
   'va-fargo-health-care',
   'va-iowa-city-health-care',
   'va-minneapolis-health-care',
-  'va-nebraska-western-iowa-health-care',
+  'va-nebraska-western-iowa-health-',
   'va-sioux-falls-health-care',
   'va-st-cloud-health-care',
 ];


### PR DESCRIPTION
## Description

Machine name spec'd for VA Fayetteville Health Care was `va-fayetteville-coastal-health-care` but should be `va-fayetteville-coastal-health-c` 

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
