### PR TITLE
20703: Content updates to 0994

### DIFF
--- a/src/applications/edu-benefits/0994/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/0994/containers/IntroductionPage.jsx
@@ -94,7 +94,7 @@ export class IntroductionPage extends React.Component {
                       benefits, <strong>or</strong>
                     </li>
                     <li>
-                      A service member with 180 days of less left on active duty
+                      A service member with 180 days or less left on active duty
                     </li>
                   </ul>
                   <p>

--- a/src/applications/edu-benefits/0994/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/0994/containers/IntroductionPage.jsx
@@ -85,13 +85,23 @@ export class IntroductionPage extends React.Component {
                       want to attend (optional)
                     </li>
                   </ul>
+                  <div>
+                    <h6>To be eligible for VET TEC, you need to be</h6>
+                  </div>
+                  <ul>
+                    <li>
+                      A Veteran with at least one day of unexpired education
+                      benefits, <strong>or</strong>
+                    </li>
+                    <li>
+                      A service member with 180 days of less left on active duty
+                    </li>
+                  </ul>
                   <p>
-                    To be eligible for VET TEC, you need to be a Veteran with at
-                    least one day of unexpired education benefits. You can
-                    complete the VET TEC application to see if you’re eligible
-                    for the program, even if you haven’t yet selected the
-                    training program you’d like to attend.{' '}
-                    <a href="https://www.benefits.va.gov/GIBILL/FGIB/VetTecTrainingProviders.asp">
+                    You can complete the VET TEC application to see if you’re
+                    eligible for the program, even if you haven’t yet selected
+                    the training program you'd like to attend.{' '}
+                    <a href="https://www.benefits.va.gov/gibill/fgib/VetTec_Veteran.asp">
                       Learn more about the programs covered under VET TEC
                     </a>
                     .
@@ -101,9 +111,7 @@ export class IntroductionPage extends React.Component {
                       What if I need help filling out my application?
                     </strong>{' '}
                     An accredited representative, like a Veterans Service
-                    Officer (VSO), can help you with your application.
-                  </p>
-                  <p>
+                    Officer (VSO), can help you fill out your application.{' '}
                     <a href="/disability/get-help-filing-claim/">
                       Get help filing your claim
                     </a>

--- a/src/applications/edu-benefits/0994/content/militaryService.jsx
+++ b/src/applications/edu-benefits/0994/content/militaryService.jsx
@@ -2,22 +2,6 @@ import React from 'react';
 
 // background & foreground class names added to indicate this paragraphs needs
 // an axeCheck color contrast exception
-export const activeDutyNotice = (
-  <p className="vads-u-background-color--white vads-u-color--gray-dark">
-    VET TEC is available only to Veterans. If you’re an active-duty service
-    member, please consider applying for VET TEC when you’re no longer on active
-    duty.
-  </p>
-);
-
-export const benefitNotice = (
-  <p>
-    <strong>Note: </strong>
-    Your eligibility for VET TEC may be affected if you're called to active
-    duty. Please let us know as soon as possible if there's a change in your
-    military status.
-  </p>
-);
 
 export const notActiveBenefitNotice = (
   <p>
@@ -25,13 +9,6 @@ export const notActiveBenefitNotice = (
     Your eligibility for monthly housing allowance may be affected if you're
     called to active duty while receiving VET TEC benefits. Please let us know
     as soon as possible if there's a change in your military status.
-  </p>
-);
-
-export const selectedReserveNationalGuardExpectedDutyTitle = (
-  <p>
-    Are you in the Selected Reserve or National Guard <strong>and</strong> do
-    you expect to be called to duty for 30 days or more?
   </p>
 );
 

--- a/src/applications/edu-benefits/0994/pages/militaryService.js
+++ b/src/applications/edu-benefits/0994/pages/militaryService.js
@@ -1,19 +1,14 @@
 import moment from 'moment';
 import fullSchema from 'vets-json-schema/dist/22-0994-schema.json';
-import environment from 'platform/utilities/environment';
 import { validateCurrentOrFutureDate } from 'platform/forms-system/src/js/validation';
 import {
-  activeDutyNotice,
-  benefitNotice,
   notActiveBenefitNotice,
   remainingDaysGreaterThan180Notice,
   remainingDaysNotGreaterThan180Notice,
-  selectedReserveNationalGuardExpectedDutyTitle,
 } from '../content/militaryService';
 
 const {
   activeDuty,
-  activeDutyDuringVetTec,
   expectedActiveDutyStatusChange,
   expectedReleaseDate,
 } = fullSchema.properties;
@@ -35,21 +30,11 @@ export const uiSchema = {
       "Are you on full-time duty in the Armed Forces? (This doesn't include active-duty training for Reserve and National Guard members.)",
     'ui:widget': 'yesNo',
   },
-  'view:activeDutyNotice': {
-    'ui:description': activeDutyNotice,
-    'ui:options': {
-      hideIf: () => !environment.isProduction(),
-      expandUnder: 'activeDuty',
-      expandUnderCondition: true,
-    },
-  },
   expectedReleaseDate: {
     'ui:title': 'Enter the date you expect to be released from active duty.',
     'ui:widget': 'date',
-    'ui:required': formData =>
-      formData.activeDuty && !environment.isProduction(),
+    'ui:required': formData => formData.activeDuty,
     'ui:options': {
-      hideIf: () => environment.isProduction(),
       expandUnder: 'activeDuty',
       expandUnderCondition: true,
     },
@@ -63,7 +48,6 @@ export const uiSchema = {
     'ui:title': '',
     'ui:description': remainingDaysGreaterThan180Notice,
     'ui:options': {
-      hideIf: () => environment.isProduction(),
       expandUnder: 'activeDuty',
       expandUnderCondition: (value, formData) => {
         return (
@@ -79,7 +63,6 @@ export const uiSchema = {
     'ui:description': remainingDaysNotGreaterThan180Notice,
     expandUnder: 'activeDuty',
     'ui:options': {
-      hideIf: () => environment.isProduction(),
       expandUnder: 'activeDuty',
       expandUnderCondition: (value, formData) => {
         return (
@@ -93,34 +76,14 @@ export const uiSchema = {
   'view:notActiveBenefitNotice': {
     'ui:title': '',
     'ui:description': notActiveBenefitNotice,
-    'ui:options': {
-      hideIf: () => environment.isProduction(),
-      expandUnder: 'activeDuty',
-      expandUnderCondition: false,
-    },
   },
   expectedActiveDutyStatusChange: {
     'ui:title':
       'Do you expect to be called to active duty while enrolled in a VET TEC program?',
     'ui:widget': 'yesNo',
     'ui:options': {
-      hideIf: () => environment.isProduction(),
       expandUnder: 'activeDuty',
       expandUnderCondition: false,
-    },
-  },
-  activeDutyDuringVetTec: {
-    'ui:title': selectedReserveNationalGuardExpectedDutyTitle,
-    'ui:widget': 'yesNo',
-    'ui:options': {
-      hideIf: () => !environment.isProduction(),
-    },
-  },
-  'view:benefitNotice': {
-    'ui:title': '',
-    'ui:description': benefitNotice,
-    'ui:options': {
-      hideIf: () => !environment.isProduction(),
     },
   },
 };
@@ -130,7 +93,6 @@ export const schema = {
   required: ['activeDuty'],
   properties: {
     activeDuty,
-    activeDutyDuringVetTec,
     expectedReleaseDate,
     expectedActiveDutyStatusChange,
     'view:activeDutyNotice': {
@@ -142,10 +104,6 @@ export const schema = {
       properties: {},
     },
     'view:remainingDaysNotGreaterThan180Notice': {
-      type: 'object',
-      properties: {},
-    },
-    'view:benefitNotice': {
       type: 'object',
       properties: {},
     },

--- a/src/applications/edu-benefits/0994/pages/militaryService.js
+++ b/src/applications/edu-benefits/0994/pages/militaryService.js
@@ -76,6 +76,9 @@ export const uiSchema = {
   'view:notActiveBenefitNotice': {
     'ui:title': '',
     'ui:description': notActiveBenefitNotice,
+    'ui:options': {
+      hideIf: formData => formData.activeDuty !== false,
+    },
   },
   expectedActiveDutyStatusChange: {
     'ui:title':

--- a/src/applications/edu-benefits/0994/pages/militaryService.js
+++ b/src/applications/edu-benefits/0994/pages/militaryService.js
@@ -78,6 +78,8 @@ export const uiSchema = {
     'ui:description': notActiveBenefitNotice,
     'ui:options': {
       hideIf: formData => formData.activeDuty !== false,
+      expandUnder: 'activeDuty',
+      expandUnderCondition: false,
     },
   },
   expectedActiveDutyStatusChange: {


### PR DESCRIPTION
## Description
As a developer, I need to remove the prod flag for the service history chapter updates so that they are available in the production environment.

[Originating Issue](https://github.com/department-of-veterans-affairs/va.gov-team/issues/20703)

## Testing done
Testing passes locally

## Screenshots
<img width="735" alt="Screen Shot 2021-03-19 at 3 04 28 PM" src="https://user-images.githubusercontent.com/48804834/111831074-3db2e080-88c5-11eb-87e6-3a759b3672c5.png">


## Acceptance criteria
- [x] The work completed in #20197 is available in the production environment.
 Note: some production flags were removed under https://github.com/department-of-veterans-affairs/vets-website/pull/16384
- [x] The content in the "Prepare" section of the 0994 introduction page is:

```
1. Prepare
To fill out this application, you’ll need your:

Direct deposit information
Highest level of education
Previous high-tech industry experience, if applicable
Information about the training provider or program you want to attend (optional)
To be eligible for VET TEC, you need to be

A Veteran with at least one day of unexpired education benefits, or
A service member with 180 days of less left on active duty
You can complete the VET TEC application to see if you’re eligible for the program, even if you haven’t yet selected the training program you'd like to attend. Learn more about the programs covered under VET TEC.

What if I need help filling out my application? An accredited representative, like a Veterans Service Officer (VSO), can help you fill out your application. Get help filing your claim.
```

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
