### PR TITLE
Adding VISN 22 to the sidebar query for Drupal menus.

### DIFF
--- a/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
+++ b/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
@@ -96,6 +96,15 @@ const FACILITY_MENU_NAMES = [
   'va-san-francisco-health-care',
   'va-sierra-nevada-health-care',
   'va-southern-nevada-health-care',
+  // VISN 22
+  'va-greater-los-angeles-health-ca',
+  'va-loma-linda-health-care',
+  'va-long-beach-health-care',
+  'va-new-mexico-health-care',
+  'va-northern-arizona health-care',
+  'va-phoenix-health-care',
+  'va-san-diego-health-care',
+  'va-southern-arizona-health-care',
   // VISN 23
   'va-black-hills-health-care',
   'va-central-iowa-health-care',


### PR DESCRIPTION
## Description

This is a followup to #16444, adding another set of VAMC menu name, including Greater Los Angeles, which does not follow the pattern because machine name is cut off at `va-greater-los-angeles-health-ca` 

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
