### PR TITLE
Workaround PTSD add person bug

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/IndividualsInvolvedCard.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IndividualsInvolvedCard.jsx
@@ -10,5 +10,9 @@ export default function IndividualsInvolvedCard({ formData }) {
       ? 'Service member'
       : 'Civilian';
   }
-  return <h3 className="vads-u-font-size--h5">{displayTitle}</h3>;
+  return (
+    <h3 className="vads-u-font-size--h5 vads-u-margin-top--1">
+      {displayTitle}
+    </h3>
+  );
 }

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/full-781-781a-8940-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/full-781-781a-8940-test.json
@@ -10,9 +10,6 @@
         "attachmentId": "L115"
       }
     ],
-    "view:claimType": {
-      "view:claimingNew": true
-    },
     "view:upload4192Choice": {
       "view:4192Info": true,
       "view:download4192": true,

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/upload-781-781a-8940-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/upload-781-781a-8940-test.json
@@ -13,9 +13,6 @@
     "view:upload4192Choice": {
       "view:upload4192": true
     },
-    "view:claimType": {
-      "view:claimingNew": true
-    },
     "view:noFdcWarning": {},
     "form8940Upload": [
       {

--- a/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
@@ -16,6 +16,7 @@ import {
   getPtsdChangeText,
   setActionTypes,
   filterServicePeriods,
+  cleanUpPersonsInvolved,
 } from '../submit-transformer';
 
 import maximalData from './fixtures/data/maximal-test.json';
@@ -283,4 +284,64 @@ describe('remove unreferenced reservedNationGuardService', () => {
   const processedServiceInfo = filterServicePeriods(formData);
   expect(processedServiceInfo.serviceInformation.reservesNationalGuardService)
     .to.be.undefined;
+});
+
+describe('cleanUpPersonsInvolved', () => {
+  it('should add injuryDeath and injuryDeathOther to empty entry', () => {
+    const incident = {
+      personsInvolved: [{ name: {}, 'view:individualAddMsg': {} }],
+    };
+    expect(cleanUpPersonsInvolved(incident)).to.deep.equal({
+      personsInvolved: [
+        {
+          name: {},
+          'view:individualAddMsg': {},
+          injuryDeath: 'other',
+          injuryDeathOther: 'Entry left blank',
+        },
+      ],
+    });
+  });
+  it('should only modify empty entries', () => {
+    const person = {
+      name: {
+        first: 'First',
+        middle: 'Person',
+        last: 'Name',
+      },
+      injuryDeath: 'killedInAction',
+      injuryDeathDate: '1900-01-01',
+      description: 'Description.',
+      'view:serviceMember': false,
+      'view:individualAddMsg': {},
+    };
+    const incident = {
+      personsInvolved: [
+        person,
+        {
+          name: {},
+          'view:individualAddMsg': {},
+        },
+        {
+          injuryDeath: 'other',
+          description: 'should not change',
+        },
+      ],
+    };
+    expect(cleanUpPersonsInvolved(incident)).to.deep.equal({
+      personsInvolved: [
+        person,
+        {
+          name: {},
+          'view:individualAddMsg': {},
+          injuryDeath: 'other',
+          injuryDeathOther: 'Entry left blank',
+        },
+        {
+          injuryDeath: 'other',
+          description: 'should not change',
+        },
+      ],
+    });
+  });
 });


### PR DESCRIPTION
## Description

When filling out a subform (781a) within form 526 relating to PTSD, a Veteran can add multiple empty person's involved in the PTSD incident (see screenshot). Per the PTSD research outcomes, none of these entries should be required.

We did find some incidents where submissions were being rejected due to an invalid property ([ref](http://sentry.vfs.va.gov/organizations/vsp/issues/6408/?project=3&query=user.id%3A718c26f51f124bdb9f55cd326af9a9df&statsPeriod=14d)). The  additions of empty "person's involved" appear to have caused this problem. It is possibly related to the `injuryDeath` value being undefined since the error mentions "did not match the following type: array in schema".

The choice to not remove any empty `personsInvolved` from the array stemmed from being unsure how the API would handle an empty array. So I opted to fill in the `injuryDeath` value as `other` which, in turn, uses the `injuryDeathOther` value as an explanation. I filled this entry with "Entry left blank" to explicitly indicate that the Veteran did not make this choice. 

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/21422
- http://sentry.vfs.va.gov/organizations/vsp/issues/6408/?project=3&query=user.id%3A718c26f51f124bdb9f55cd326af9a9df&statsPeriod=14d

## Testing done

Added submit transformer unit test

## Screenshots

<details><summary>Empty new "involved" person</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-03-19 at 2 30 36 PM](https://user-images.githubusercontent.com/136959/111833128-b878fd00-88bf-11eb-9ea2-5bfd8ec03da2.png)</details>

## Acceptance criteria
- [x] Submission does not include a missing `injuryDeath` value
- [x] `injuryDeathOther` is populated if left blank (unlikely)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
