### PR TITLE
Stop disabling the contact info form's SAVE button

### DIFF
--- a/src/applications/personalization/profile/tests/e2e/address-validation/addressValidation.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/addressValidation.js
@@ -137,7 +137,7 @@ export const createAddressValidationResponse = type => {
     };
   }
 
-  if (type === 'valid-address') {
+  if (type === 'valid-address' || type === 'no-change') {
     return {
       addresses: [
         {
@@ -149,7 +149,7 @@ export const createAddressValidationResponse = type => {
             countryCodeIso3: 'USA',
             countyCode: '06001',
             countyName: 'Alameda',
-            stateCode: 'CA',
+            stateCode: 'MD',
             zipCode: '94536',
             zipCodeSuffix: '5537',
           },

--- a/src/applications/personalization/profile/tests/e2e/address-validation/edit-after-validation.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/edit-after-validation.cypress.spec.js
@@ -2,7 +2,7 @@ import { setUp } from '@@profile/tests/e2e/address-validation/setup';
 
 describe('Personal and contact information', () => {
   describe('when returning to the address edit form from the validation screen', () => {
-    it('should prefill the address edit form with the address they have just entered, not the address currently on file', () => {
+    it('should prefill the address edit form with the address they had just entered, _not_ the address currently on file', () => {
       const addressLine1 = '225 irving st';
       const addressLine2 = 'Unit A';
 
@@ -10,7 +10,7 @@ describe('Personal and contact information', () => {
       cy.axeCheck();
 
       cy.findByRole('button', { name: /^Update$/i }).should(
-        'have.attr',
+        'not.have.attr',
         'disabled',
       );
 
@@ -52,27 +52,20 @@ describe('Personal and contact information', () => {
       cy.findByLabelText(/^street address/i).should('have.value', addressLine1);
       cy.findAllByLabelText(/^Line 2/i).should('have.value', addressLine2);
 
-      // The following steps have been commented out due to a bug that
-      // disables the SAVE button if the current form data matches the
-      // prefilled form data. This logic should be updated to disable the SAVE
-      // button if the current form data matches the data that is currently on
-      // file for the user
-      // Bug ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/20494
+      // then click the update button to return to the validation screen
+      cy.findByRole('button', { name: /^Update$/i }).click({ force: true });
 
-      // then click the save button to return to the validation screen
-      // cy.findByRole('button', { name: /^Update$/i }).click({ force: true });
+      cy.findByRole('button', { name: /^use this address$/i }).click({
+        force: true,
+      });
 
-      // cy.findByRole('button', { name: /^use this address$/i }).click({
-      //   force: true,
-      // });
+      cy.findByTestId('mailingAddress')
+        .should('contain', '225 irving st, Unit A')
+        .and('contain', 'San Francisco, CA 94122');
 
-      // cy.findByTestId('mailingAddress')
-      //   .should('contain', '225 irving st, Unit A')
-      //   .and('contain', 'San Francisco, CA 94122');
-
-      // cy.findByRole('button', { name: /edit mailing address/i }).should(
-      //   'be.focused',
-      // );
+      cy.findByRole('button', { name: /edit mailing address/i }).should(
+        'be.focused',
+      );
     });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/no-changes-made.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/no-changes-made.cypress.spec.js
@@ -1,0 +1,31 @@
+import { setUp } from '@@profile/tests/e2e/address-validation/setup';
+
+describe('Personal and contact information', () => {
+  describe('when updating their address without actually making a change', () => {
+    it('should quickly exit edit view', () => {
+      setUp('no-change');
+
+      // hit save without making any changes on the form
+      cy.findByRole('button', { name: /^update$/i }).should(
+        'not.have.attr',
+        'disabled',
+      );
+      cy.findByRole('button', { name: /^update$/i }).click({
+        force: true,
+      });
+
+      // Use a short timeout to make sure that the edit view is exited quickly
+      // and not just because the logic that auto-exits the edit view took
+      // effect
+      cy.findByRole('button', { name: /^update$/i, timeout: 10 }).should(
+        'not.exist',
+      );
+
+      cy.findByTestId('mailingAddress').should('contain', '123 Test Street');
+
+      cy.findByRole('button', { name: /edit mailing address/i }).should(
+        'be.focused',
+      );
+    });
+  });
+});

--- a/src/applications/personalization/profile/tests/e2e/address-validation/setup.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/setup.js
@@ -6,6 +6,7 @@ import { createAddressValidationResponse } from './addressValidation';
 import mockUser from '@@profile/tests/fixtures/users/user-36.json';
 import receivedTransaction from '@@profile/tests/fixtures/transactions/received-transaction.json';
 import finishedTransaction from '@@profile/tests/fixtures/transactions/finished-transaction.json';
+import noChangesTransaction from '@@profile/tests/fixtures/transactions/no-changes-transaction.json';
 
 export const setUp = type => {
   disableFTUXModals();
@@ -29,7 +30,7 @@ export const setUp = type => {
     method: 'PUT',
     url: '/v0/profile/addresses',
     status: 200,
-    response: receivedTransaction,
+    response: type === 'no-change' ? noChangesTransaction : receivedTransaction,
   }).as('saveAddress');
 
   cy.route({

--- a/src/applications/personalization/profile/tests/e2e/address-validation/valid-address.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/valid-address.cypress.spec.js
@@ -15,7 +15,7 @@ describe('Personal and contact information', () => {
         cy.findByLabelText(/City/i)
           .clear()
           .type('Fremont');
-        cy.findByLabelText(/^State/).select('CA');
+        cy.findByLabelText(/^State/).select('MD');
         cy.findByLabelText(/Zip code/i)
           .clear()
           .type('94536');

--- a/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/modals.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/modals.cypress.spec.js
@@ -32,16 +32,10 @@ const checkModals = options => {
     force: true,
   });
 
-  // confirm that the update button is disabled before a change is made
-  cy.findByRole('button', { name: 'Update' }).should('be.disabled');
-
   // Make an edit
   cy.get(`#${editLineId}`)
     .click({ force: true })
     .type('test', { force: true });
-
-  // confirm that the update button is enabled
-  cy.findByRole('button', { name: 'Update' }).should('not.be.disabled');
 
   // Click on a different section to edit
   cy.findByRole('button', {

--- a/src/applications/personalization/profile/tests/fixtures/transactions/no-changes-transaction.json
+++ b/src/applications/personalization/profile/tests/fixtures/transactions/no-changes-transaction.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "id": "",
+    "type": "async_transaction_va_profile_address_transactions",
+    "attributes": {
+      "transactionId": "bfedd909-9dc4-4b27-abc2-a6cccaece35d",
+      "transactionStatus": "COMPLETED_NO_CHANGES_DETECTED",
+      "type": "AsyncTransaction::VAProfile::AddressTransaction",
+      "metadata": []
+    }
+  }
+}


### PR DESCRIPTION
## Description
The easy part was simply removing the logic that disables the SAVE button when the current form data matches the initial form data.
The trickier part was not leaving the edit view showing for five seconds when the create transaction endpoint returns a transaction with `COMPLETED_NO_CHANGES_DETECTED`status.

## Testing done
New cypress tests, updated some existing tests to reflect the fact that the button is no longer disabled, and existing tests hopefully confirm that everything functions as intended. But we should exercise this in staging once we can.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs