### PR TITLE
Cheetah-Update Clinic page copy #21782

### DIFF
--- a/src/applications/vaos/components/FacilityAddress.jsx
+++ b/src/applications/vaos/components/FacilityAddress.jsx
@@ -9,6 +9,7 @@ export default function FacilityAddress({
   facility,
   showDirectionsLink,
   clinicName,
+  showPhone = true,
   level = '4',
 }) {
   const address = facility?.address;
@@ -56,15 +57,16 @@ export default function FacilityAddress({
             {clinicName}
           </>
         )}
-        {!!phone && (
-          <>
-            {!!clinicName && <br />}
-            <Heading className="vads-u-font-family--sans vads-u-display--inline vads-u-font-size--base">
-              Main phone:
-            </Heading>{' '}
-            <FacilityPhone contact={phone} />
-          </>
-        )}
+        {showPhone &&
+          !!phone && (
+            <>
+              {!!clinicName && <br />}
+              <Heading className="vads-u-font-family--sans vads-u-display--inline vads-u-font-size--base">
+                Main phone:
+              </Heading>{' '}
+              <FacilityPhone contact={phone} />
+            </>
+          )}
       </div>
     </>
   );

--- a/src/applications/vaos/project-cheetah/components/ClinicChoicePage.jsx
+++ b/src/applications/vaos/project-cheetah/components/ClinicChoicePage.jsx
@@ -46,13 +46,15 @@ export function ClinicChoicePage({
   return (
     <div>
       <h1 className="vads-u-font-size--h2">{pageTitle}</h1>
-      Choose a clinic located at:
+      <p>Each clinic offers vaccine appointments at different times.</p>
+      <p>Choose a clinic located at:</p>
       {facilityDetails && (
         <div className="vads-u-margin-y--2p5">
           <FacilityAddress
             name={facilityDetails.name}
             facility={facilityDetails}
             level={2}
+            showPhone={false}
           />
         </div>
       )}

--- a/src/applications/vaos/tests/project-cheetah/components/ClinicChoicePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/project-cheetah/components/ClinicChoicePage.unit.spec.jsx
@@ -85,7 +85,6 @@ describe('VAOS vaccine flow <ClinicChoicePage>', () => {
 
     expect(screen.baseElement).to.contain.text('Cheyenne VA Medical Center');
     expect(screen.baseElement).to.contain.text('Cheyenne, WY 82001-5356');
-    expect(screen.baseElement).to.contain.text('307-778-7550');
 
     expect(screen.getAllByRole('radio').length).to.equal(2);
     expect(screen.getByRole('radio', { name: /Green team clinic/ })).to.be.ok;


### PR DESCRIPTION
## Description
This PR changes:

- Adds the text, 'Each clinic offers vaccine appointments at different times.', to the clinic choice page
- Adds a flag to FacilityAddress component to conditionally display the facility phone number (flag defaults to true)
- Does not display the facility phone number on the clinic choice page

## Testing done
Unit testing

## Screenshots
![localhost_3001_health-care_schedule-view-va-appointments_appointments_new-covid-19-vaccine-booking_clinic(iPhone X) (1)](https://user-images.githubusercontent.com/3587066/112019067-16465880-8afd-11eb-8761-66476fc77de3.png)

## Acceptance criteria
- [ ] Changes are behind va_online_scheduling_cheetah feature flag
- [ ] CONTENT - Copy matches the copy doc https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/products/health-care/covid-vaccine-distro/vaos-for-distribution-initiative/copy-docs/clinic-selection.md
- [ ] Facility phone number does not display
- [ ] DESIGN - Spacing and font styling designs match the specs https://www.sketch.com/s/aca1478c-8cfa-433e-8e06-d42b53aaa60d/a/pabMk3k#Inspector

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
