### PR TITLE
DT-18389 Find Forms adding lint rule override

### DIFF
--- a/src/applications/find-forms/containers/SearchResults.jsx
+++ b/src/applications/find-forms/containers/SearchResults.jsx
@@ -179,21 +179,13 @@ export class SearchResults extends Component {
 
     return (
       <>
-        <div
-          className="find-forms-search-metadata vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row medium-screen:vads-u-justify-content--space-between"
-          aria-atomic="false"
-          aria-live="assertive"
-          aria-relevant="text"
-          role="region"
-        >
+        <div className="find-forms-search-metadata vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row medium-screen:vads-u-justify-content--space-between">
           <h2
             className="vads-u-font-size--md vads-u-line-height--3 vads-u-font-family--sans vads-u-font-weight--normal vads-u-margin-y--1p5"
             data-forms-focus
-            aria-label={`Showing ${startLabel} through ${lastLabel} of ${
-              results.length
-            } results for ${query}, sorted by ${sortByPropertyName}`}
           >
-            <span aria-hidden>
+            {/* eslint-disable-next-line jsx-a11y/aria-role */}
+            <span role="text">
               Showing{' '}
               <span className="vads-u-font-weight--bold">{startLabel}</span>{' '}
               &ndash;{' '}

--- a/src/applications/find-forms/tests/e2e/find-forms-required.cypress.spec.js
+++ b/src/applications/find-forms/tests/e2e/find-forms-required.cypress.spec.js
@@ -16,7 +16,13 @@ const SELECTORS = {
 
 function axeTestPage() {
   cy.injectAxe();
-  cy.axeCheck();
+  cy.axeCheck('main', {
+    rules: {
+      'aria-roles': {
+        enabled: false,
+      },
+    },
+  });
 }
 
 describe('functionality of Find Forms', () => {


### PR DESCRIPTION
## Description
After a few sprints working together with a11y, we finally figured out the best solution for now to help solve the issues we were having with various Screen readers. 
See this thread: https://github.com/department-of-veterans-affairs/va.gov-team/issues/18389

## Testing done
Ran unit, e2e, and spun up repo locally to test screen reader. 

## Screenshots
![Screen Shot 2021-03-22 at 2 05 57 PM](https://user-images.githubusercontent.com/26075258/112037088-c0cb7500-8b17-11eb-966c-9533f134b363.png)

## Acceptance criteria
- [x] Find Forms' e2e passes
- [x] Screen Reader reads header on content change/ focus without counting the number of elements

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
