### PR TITLE
Allow future separation dates for reserves

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -208,6 +208,8 @@ const formConfig = {
             dob: state.user.profile.dob,
             allowBDD:
               form526BDDFeature(state) && state.form.data?.['view:isBddData'],
+            servicePeriods:
+              state.form.data?.serviceInformation?.servicePeriods || [],
           }),
         },
         separationLocation: {

--- a/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
+++ b/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
@@ -1,50 +1,16 @@
-import moment from 'moment';
 import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 
 import ValidatedServicePeriodView from '../components/ValidatedServicePeriodView';
 import ArrayField from '../components/ArrayField';
 import { isValidServicePeriod, formatDate } from '../utils';
+import { validateAge, validateSeparationDate } from '../validations';
 
 const dateRangeUISchema = dateRangeUI(
   'Service start date',
   'Service end date',
   'End of service must be after start of service',
 );
-
-const validateAge = (
-  errors,
-  dateString,
-  formData,
-  schema,
-  uiSchema,
-  currentIndex,
-  appStateData,
-) => {
-  if (moment(dateString).isBefore(moment(appStateData.dob).add(13, 'years'))) {
-    errors.addError('Your start date must be after your 13th birthday');
-  }
-};
-
-const validateSeparationDate = (
-  errors,
-  dateString,
-  formData,
-  schema,
-  uiSchema,
-  currentIndex,
-  appStateData,
-) => {
-  const allowBDD = appStateData.allowBDD;
-  if (!allowBDD && moment(dateString).isAfter(moment())) {
-    errors.addError('Your separation date must be in the past');
-  } else if (
-    allowBDD &&
-    moment(dateString).isAfter(moment().add(180, 'days'))
-  ) {
-    errors.addError('Your separation date must be before 180 days from today');
-  }
-};
 
 dateRangeUISchema.from['ui:validations'].push(validateAge);
 dateRangeUISchema.to['ui:validations'].push(validateSeparationDate);

--- a/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
@@ -1,3 +1,4 @@
+import { add, format } from 'date-fns';
 import sinon from 'sinon';
 import { expect } from 'chai';
 
@@ -9,11 +10,16 @@ import {
   hasMonthYear,
   validateDisabilityName,
   validateBooleanGroup,
+  validateAge,
+  validateSeparationDate,
 } from '../validations';
 
 import disabilityLabels from '../content/disabilityLabels';
 import { capitalizeEachWord } from '../utils';
 import { minYear, maxYear } from 'platform/forms-system/src/js/helpers';
+
+const formatDate = date => format(date, 'yyyy-MM-dd');
+const daysFromToday = days => formatDate(add(new Date(), { days }));
 
 describe('526 All Claims validations', () => {
   describe('isValidYear', () => {
@@ -375,6 +381,136 @@ describe('526 All Claims validations', () => {
       );
 
       expect(errors.addError.firstCall.args[0]).to.equal('testing');
+    });
+  });
+
+  describe('validateAge', () => {
+    const _ = null;
+    it('should not allow age < 13 years at start of service', () => {
+      const errors = { addError: sinon.spy() };
+      const dob = '2000-01-01';
+      // 13th birthday (needs to be _after_ 13th birthday)
+      const age = formatDate(add(new Date(dob), { years: 13 }));
+      validateAge(errors, age, _, _, _, _, { dob });
+
+      expect(errors.addError.called).to.be.true;
+    });
+    it('should allow age 13 years at start of service', () => {
+      const errors = { addError: sinon.spy() };
+      const dob = '2000-01-01';
+      // Add 1 extra day to ensure we're after 13th birthday
+      const age = formatDate(add(new Date(dob), { years: 13, days: 1 }));
+      validateAge(errors, age, _, _, _, _, { dob });
+
+      expect(errors.addError.called).to.be.false;
+    });
+  });
+
+  describe('validateSeparationDate', () => {
+    const _ = null;
+    // builds the appStateData object
+    const data = ({ bdd = false, branch = 'Army' } = {}) => ({
+      allowBDD: bdd,
+      servicePeriods: [{ serviceBranch: branch }],
+    });
+
+    const pastDate = daysFromToday(-100);
+    const futureDate = daysFromToday(100);
+
+    it('should allow past end service dates for all-claims', () => {
+      const errors = { addError: sinon.spy() };
+      validateSeparationDate(errors, pastDate, _, _, _, 0, data());
+
+      expect(errors.addError.called).to.be.false;
+    });
+    it('should not allow future end service dates for active service all-claims', () => {
+      const errors = { addError: sinon.spy() };
+      const index = 0;
+      validateSeparationDate(errors, futureDate, _, _, _, index, data());
+
+      expect(errors.addError.called).to.be.true;
+      expect(errors.addError.args[0][index]).to.contain('be in the past');
+    });
+    it('should allow future end service dates for all-claims when in the reserves', () => {
+      const errors = { addError: sinon.spy() };
+      validateSeparationDate(
+        errors,
+        futureDate,
+        _,
+        _,
+        _,
+        0,
+        data({ branch: 'Army Reserve' }),
+      );
+
+      expect(errors.addError.called).to.be.false;
+    });
+
+    it('should allow past end service dates for BDD', () => {
+      const errors = { addError: sinon.spy() };
+      validateSeparationDate(errors, pastDate, _, _, _, 0, data({ bdd: true }));
+
+      expect(errors.addError.called).to.be.false;
+    });
+
+    it('should allow future end service dates for BDD', () => {
+      const err = { addError: sinon.spy() };
+      validateSeparationDate(err, futureDate, _, _, _, 0, data({ bdd: true }));
+
+      expect(err.addError.called).to.be.false;
+    });
+
+    // assuming this person has been activated
+    it('should allow future end service dates for BDD when in the reserves', () => {
+      const errors = { addError: sinon.spy() };
+      validateSeparationDate(
+        errors,
+        futureDate,
+        _,
+        _,
+        _,
+        0,
+        data({
+          bdd: true,
+          branch: 'Army Reserve',
+        }),
+      );
+
+      expect(errors.addError.called).to.be.false;
+    });
+    it('should not allow future end service dates > 180 days', () => {
+      const errors = { addError: sinon.spy() };
+      const index = 0;
+      validateSeparationDate(
+        errors,
+        daysFromToday(181),
+        _,
+        _,
+        _,
+        index,
+        data({ bdd: true }),
+      );
+
+      expect(errors.addError.called).to.be.true;
+      expect(errors.addError.args[0][index]).to.contain('before 180 days');
+    });
+    it('should allow future end service dates > 180 days if in the reserves', () => {
+      const errors = { addError: sinon.spy() };
+      const index = 0;
+      validateSeparationDate(
+        errors,
+        daysFromToday(181),
+        _,
+        _,
+        _,
+        index,
+        data({
+          bdd: true,
+          branch: 'Army National Guard',
+        }),
+      );
+
+      expect(errors.addError.called).to.be.false;
     });
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
@@ -390,10 +390,11 @@ describe('526 All Claims validations', () => {
       const errors = { addError: sinon.spy() };
       const dob = '2000-01-01';
       // 13th birthday (needs to be _after_ 13th birthday)
-      const age = formatDate(add(new Date(dob), { years: 13 }));
+      const age = formatDate(add(new Date(dob), { years: 13, days: -1 }));
       validateAge(errors, age, _, _, _, _, { dob });
 
       expect(errors.addError.called).to.be.true;
+      expect(errors.addError.args[0][0]).to.contain('after your 13th birthday');
     });
     it('should allow age 13 years at start of service', () => {
       const errors = { addError: sinon.spy() };

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -374,3 +374,45 @@ export function validateBooleanGroup(
     errors.addError(atLeastOne);
   }
 }
+
+/* Military history validations */
+export const validateAge = (
+  errors,
+  dateString,
+  _formData,
+  _schema,
+  _uiSchema,
+  _currentIndex,
+  appStateData,
+) => {
+  if (moment(dateString).isBefore(moment(appStateData.dob).add(13, 'years'))) {
+    errors.addError('Your start date must be after your 13th birthday');
+  }
+};
+
+// partial matches for reserves
+// NOAA & Public Health Service are considered to be active duty
+const reservesList = ['Reserve', 'National Guard'];
+
+export const validateSeparationDate = (
+  errors,
+  dateString,
+  _formData,
+  _schema,
+  _uiSchema,
+  currentIndex,
+  appStateData,
+) => {
+  const { allowBDD, servicePeriods = [] } = appStateData;
+  const branch = servicePeriods[currentIndex]?.serviceBranch || '';
+  const isReserves = reservesList.some(match => branch.includes(match));
+  if (!allowBDD && !isReserves && moment(dateString).isAfter(moment())) {
+    errors.addError('Your separation date must be in the past');
+  } else if (
+    allowBDD &&
+    !isReserves &&
+    moment(dateString).isAfter(moment().add(180, 'days'))
+  ) {
+    errors.addError('Your separation date must be before 180 days from today');
+  }
+};


### PR DESCRIPTION
## Description

In form 526, future separation dates are only allowed for active service members filing a BDD claim, but if they are in the reserves or national guard, they would not be able to enter a future separation date. This PR allows reservists and members of the guard to enter future separation dates.

Also in this PR, moved the date validation functions into a central file to keep structure consistent.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/21792

## Testing done

Updated unit tests

## Screenshots

<details><summary>Current implementation showing an error</summary>

<!-- leave a blank line above -->
![](https://camo.githubusercontent.com/1c4865c07e970fd7a51d64342ed9a10827b4cf3d2371a9619ffc52cb15daa47d/68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3564363536333865303834356164356632346261646134612f34393438643939352d353534662d343563322d613138642d333363666132323939666165)</details>

<details><summary>No error</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-03-22 at 1 58 12 PM](https://user-images.githubusercontent.com/136959/112043464-b361bb00-8b16-11eb-9f79-349299d6674f.png)</details>

## Acceptance criteria
- [x] Reservist & members of the National Guard can enter future separation dates

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
