### PR TITLE
fix bug in event logging

### DIFF
--- a/src/applications/search/actions/index.js
+++ b/src/applications/search/actions/index.js
@@ -34,7 +34,7 @@ export function fetchSearchResults(query, page, analyticsMetaInfo) {
             'type-ahead-option-position': analyticsMetaInfo?.keywordPosition,
             'type-ahead-options-list': analyticsMetaInfo?.suggestionsList,
             'type-ahead-options-count':
-              analyticsMetaInfo?.suggestionsList.length,
+              analyticsMetaInfo?.suggestionsList?.length,
           });
         }
         dispatch({
@@ -43,11 +43,11 @@ export function fetchSearchResults(query, page, analyticsMetaInfo) {
           meta: response.meta,
         });
       })
-      .catch(error =>
+      .catch(error => {
         dispatch({
           type: FETCH_SEARCH_RESULTS_FAILURE,
           errors: error.errors,
-        }),
-      );
+        });
+      });
   };
 }

--- a/src/applications/search/actions/index.js
+++ b/src/applications/search/actions/index.js
@@ -43,11 +43,11 @@ export function fetchSearchResults(query, page, analyticsMetaInfo) {
           meta: response.meta,
         });
       })
-      .catch(error => {
+      .catch(error =>
         dispatch({
           type: FETCH_SEARCH_RESULTS_FAILURE,
           errors: error.errors,
-        });
-      });
+        }),
+      );
   };
 }


### PR DESCRIPTION
This PR fixes an analytics bug that prevents search results from being displayed when there are no typeahead suggestions.