### PR TITLE
Dependency Verification account for no status type

### DIFF
--- a/src/applications/static-pages/dependency-verification/components/dependencyVerificationList.jsx
+++ b/src/applications/static-pages/dependency-verification/components/dependencyVerificationList.jsx
@@ -9,7 +9,10 @@ const DependencyVerificationList = ({ dependents }) => {
     <div className="vads-u-margin-top--4">
       {dependents
         .filter(dependent => {
-          return dependent.dependencyStatusType !== NOTONAWARD;
+          return (
+            dependent.dependencyStatusType &&
+            dependent.dependencyStatusType !== NOTONAWARD
+          );
         })
         .map((dependent, index) => {
           return (


### PR DESCRIPTION
## Description
When previously working with mock data, we weren't aware of the possibility that a veteran's information may be included as one of the records in the diaries entry. This record is indicated by the absence of a status type, along with some additional information pertaining to the veteran. 

This record would throw an invalid time error in `date-fns` because no birthdate was associated with this particular record. This pull request addresses this scenario by adding a check for `dependencyStatusType` before checking for the value of it. 

## Testing done
- local

## Acceptance criteria
- [x] no console error thrown
- [x] modal shows up
- [ ] 
## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
