### PR TITLE
Update CTA with spinner and no radio buttons for single option

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/AppointmentsPageV2.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/AppointmentsPageV2.jsx
@@ -5,19 +5,11 @@ import { Switch, Route, useHistory, useLocation } from 'react-router-dom';
 import recordEvent from 'platform/monitoring/record-event';
 
 import * as actions from '../../redux/actions';
-import {
-  selectCanUseVaccineFlow,
-  selectDirectScheduleSettingsStatus,
-  selectExpressCareAvailability,
-} from '../../redux/selectors';
+import { selectExpressCareAvailability } from '../../redux/selectors';
 import {
   selectFeatureRequests,
-  selectFeatureDirectScheduling,
-  selectFeatureCommunityCare,
   selectIsWelcomeModalDismissed,
   selectIsCernerOnlyPatient,
-  selectFeatureProjectCheetah,
-  selectFeatureHomepageRefresh,
 } from '../../../redux/selectors';
 import { GA_PREFIX, FETCH_STATUS } from '../../../utils/constants';
 import { scrollAndFocus } from '../../../utils/scrollAndFocus';
@@ -67,9 +59,7 @@ function AppointmentsPageV2({
   isCernerOnlyPatient,
   isWelcomeModalDismissed,
   showScheduleButton,
-  startNewAppointmentFlow,
   startNewExpressCareFlow,
-  startNewVaccineFlow,
 }) {
   const location = useLocation();
 
@@ -128,12 +118,7 @@ function AppointmentsPageV2({
         )}
       />
 
-      {showScheduleButton && (
-        <ScheduleNewAppointmentRadioButtons
-          startNewAppointmentFlow={startNewAppointmentFlow}
-          startNewVaccineFlow={startNewVaccineFlow}
-        />
-      )}
+      {showScheduleButton && <ScheduleNewAppointmentRadioButtons />}
 
       {expressCare.useNewFlow &&
         !isCernerOnlyPatient && (
@@ -170,19 +155,11 @@ AppointmentsPageV2.propTypes = {
   isWelcomeModalDismissed: PropTypes.bool.isRequired,
   showCommunityCare: PropTypes.bool.isRequired,
   showDirectScheduling: PropTypes.bool.isRequired,
-  startNewAppointmentFlow: PropTypes.func.isRequired,
-  showCheetahScheduleButton: PropTypes.bool.isRequired,
 };
 
 function mapStateToProps(state) {
   return {
-    canUseVaccineFlow: selectCanUseVaccineFlow(state),
-    directScheduleSettingsStatus: selectDirectScheduleSettingsStatus(state),
     showScheduleButton: selectFeatureRequests(state),
-    showCommunityCare: selectFeatureCommunityCare(state),
-    showDirectScheduling: selectFeatureDirectScheduling(state),
-    showCheetahScheduleButton: selectFeatureProjectCheetah(state),
-    showHomePageRefresh: selectFeatureHomepageRefresh(state),
     isWelcomeModalDismissed: selectIsWelcomeModalDismissed(state),
     isCernerOnlyPatient: selectIsCernerOnlyPatient(state),
     expressCare: selectExpressCareAvailability(state),
@@ -191,10 +168,7 @@ function mapStateToProps(state) {
 
 const mapDispatchToProps = {
   fetchExpressCareWindows: actions.fetchExpressCareWindows,
-  fetchDirectScheduleSettings: actions.fetchDirectScheduleSettings,
-  startNewAppointmentFlow: actions.startNewAppointmentFlow,
   startNewExpressCareFlow: actions.startNewExpressCareFlow,
-  startNewVaccineFlow: actions.startNewVaccineFlow,
 };
 
 export default connect(

--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/AppointmentsPageV2.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/AppointmentsPageV2.jsx
@@ -62,14 +62,10 @@ function getDropdownValueFromLocation(pathname) {
 }
 
 function AppointmentsPageV2({
-  canUseVaccineFlow,
-  directScheduleSettingsStatus,
   expressCare,
-  fetchDirectScheduleSettings,
   fetchExpressCareWindows,
   isCernerOnlyPatient,
   isWelcomeModalDismissed,
-  showCheetahScheduleButton,
   showScheduleButton,
   startNewAppointmentFlow,
   startNewExpressCareFlow,
@@ -85,13 +81,6 @@ function AppointmentsPageV2({
       expressCare.windowsStatus === FETCH_STATUS.notStarted
     ) {
       fetchExpressCareWindows();
-    }
-
-    if (
-      showCheetahScheduleButton &&
-      directScheduleSettingsStatus === FETCH_STATUS.notStarted
-    ) {
-      fetchDirectScheduleSettings();
     }
   }, []);
 
@@ -140,13 +129,10 @@ function AppointmentsPageV2({
       />
 
       {showScheduleButton && (
-        <div className="vads-u-margin-bottom--4">
-          <ScheduleNewAppointmentRadioButtons
-            showCheetahScheduleButton={canUseVaccineFlow}
-            startNewAppointmentFlow={startNewAppointmentFlow}
-            startNewVaccineFlow={startNewVaccineFlow}
-          />
-        </div>
+        <ScheduleNewAppointmentRadioButtons
+          startNewAppointmentFlow={startNewAppointmentFlow}
+          startNewVaccineFlow={startNewVaccineFlow}
+        />
       )}
 
       {expressCare.useNewFlow &&

--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/RequestExpressCare.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/RequestExpressCare.jsx
@@ -18,7 +18,7 @@ export default function RequestExpressCare({
 
   if (allowRequests) {
     return (
-      <div className="vads-u-padding-y--3 vads-u-border-top--1px vads-u-border-bottom--1px vads-u-border-color--gray-lighter">
+      <div className="vads-u-padding-bottom--3 vads-u-border-bottom--1px vads-u-border-color--gray-lighter">
         <h2 className="vads-u-font-size--h3 vads-u-margin-y--0">
           Request a new Express Care appointment
         </h2>
@@ -39,7 +39,7 @@ export default function RequestExpressCare({
   }
 
   return (
-    <div className="vads-u-padding-y--3 vads-u-border-top--1px vads-u-border-bottom--1px vads-u-border-color--gray-lighter">
+    <div className="vads-u-padding-bottom--3 vads-u-border-bottom--1px vads-u-border-color--gray-lighter">
       <h2 className="vads-u-font-size--h3 vads-u-margin-y--0">
         Express Care isn’t available right now
       </h2>

--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/ScheduleNewAppointment.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/ScheduleNewAppointment.jsx
@@ -7,7 +7,7 @@ export default function ScheduleNewAppointment({
   startNewAppointmentFlow,
 }) {
   return (
-    <div className="vads-u-padding-y--3 vads-u-border-top--1px vads-u-border-bottom--1px vads-u-border-color--gray-lighter">
+    <div className="vads-u-padding-y--3 vads-u-margin-bottom--3 vads-u-border-top--1px vads-u-border-bottom--1px vads-u-border-color--gray-lighter">
       <h2 className="vads-u-font-size--h3 vads-u-margin-y--0">
         {showDirectScheduling
           ? 'Create a new appointment'

--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/ScheduleNewAppointmentRadioButtons.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/ScheduleNewAppointmentRadioButtons.jsx
@@ -1,8 +1,15 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { connect } from 'react-redux';
 import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
 import { Link } from 'react-router-dom';
 import recordEvent from 'platform/monitoring/record-event';
-import { GA_PREFIX } from 'applications/vaos/utils/constants';
+import { FETCH_STATUS, GA_PREFIX } from 'applications/vaos/utils/constants';
+import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
+import * as actions from '../../redux/actions';
+import {
+  selectCanUseVaccineFlow,
+  selectDirectScheduleSettingsStatus,
+} from '../../redux/selectors';
 
 /**
  * React component used to conditionally render radio call-to-action buttons and start applicable workflow.
@@ -17,53 +24,83 @@ import { GA_PREFIX } from 'applications/vaos/utils/constants';
  * />
  * @module appointment-list/components
  */
-export default function ScheduleNewAppointmentRadioButtons({
-  showCheetahScheduleButton = false,
+function ScheduleNewAppointmentRadioButtons({
+  canUseVaccineFlow,
+  directScheduleSettingsStatus,
+  fetchDirectScheduleSettings,
   startNewAppointmentFlow,
   startNewVaccineFlow,
 }) {
   const [radioSelection, setRadioSelection] = useState();
-
-  function radioOptions() {
-    const optionsArray = [
-      {
-        value: 'new-appointment',
-        label: 'Primary or specialty care',
-      },
-    ];
-
-    if (showCheetahScheduleButton) {
-      optionsArray.push({
-        value: 'new-covid-19-vaccine-booking',
-        label: 'COVID-19 vaccine',
-      });
+  useEffect(() => {
+    if (directScheduleSettingsStatus === FETCH_STATUS.notStarted) {
+      fetchDirectScheduleSettings();
     }
-    return optionsArray;
+  }, []);
+
+  if (
+    directScheduleSettingsStatus === FETCH_STATUS.loading ||
+    directScheduleSettingsStatus === FETCH_STATUS.notStarted
+  ) {
+    return (
+      <div className="vads-u-padding-y--3 vads-u-margin-bottom--3 vads-u-border-top--1px vads-u-border-bottom--1px vads-u-border-color--gray-lighter">
+        <h2 className="vads-u-font-size--h3 vads-u-padding-bottom--0 vads-u-margin-y--0">
+          Schedule a new appointment
+        </h2>
+        <LoadingIndicator message="Checking for available appointment types..." />
+      </div>
+    );
   }
 
+  const radioOptions = [
+    {
+      value: 'new-appointment',
+      label: 'Primary or specialty care',
+    },
+  ];
+
+  if (canUseVaccineFlow) {
+    radioOptions.push({
+      value: 'new-covid-19-vaccine-booking',
+      label: 'COVID-19 vaccine',
+    });
+  }
+
+  const onlyRegularAppointmentFlow = radioOptions.length === 1;
+  const selectedOption = onlyRegularAppointmentFlow
+    ? radioOptions[0].value
+    : radioSelection;
+
   return (
-    <>
-      <h2 className="vads-u-font-size--h3 vads-u-padding-bottom--0">
+    <div className="vads-u-padding-y--3 vads-u-margin-bottom--3 vads-u-border-top--1px vads-u-border-bottom--1px vads-u-border-color--gray-lighter">
+      <h2 className="vads-u-font-size--h3 vads-u-padding-bottom--0 vads-u-margin-y--0">
         Schedule a new appointment
       </h2>
-      <RadioButtons
-        label={
-          <span className="sr-only">
-            Choose an appointment type to begin scheduling
-          </span>
-        }
-        name={'schedule-new-appointment'}
-        id={'schedule-new-appointment'}
-        options={radioOptions()}
-        additionalFieldsetClass="vads-u-margin-top--0"
-        onValueChange={({ value }) => {
-          setRadioSelection(value);
-        }}
-        value={{ value: radioSelection }}
-        errorMessage=""
-      />
+      {onlyRegularAppointmentFlow && (
+        <div className="vads-u-margin-top--1p5">
+          Schedule primary or specialty care.
+        </div>
+      )}
+      {!onlyRegularAppointmentFlow && (
+        <RadioButtons
+          label={
+            <span className="sr-only">
+              Choose an appointment type to begin scheduling
+            </span>
+          }
+          name={'schedule-new-appointment'}
+          id={'schedule-new-appointment'}
+          options={radioOptions}
+          additionalFieldsetClass="vads-u-margin-top--0"
+          onValueChange={({ value }) => {
+            setRadioSelection(value);
+          }}
+          value={{ value: radioSelection }}
+          errorMessage=""
+        />
+      )}
 
-      {!radioSelection && (
+      {!selectedOption && (
         <span
           aria-disabled="true"
           className="vads-u-padding--0 va-action-link--disabled"
@@ -72,13 +109,13 @@ export default function ScheduleNewAppointmentRadioButtons({
         </span>
       )}
 
-      {radioSelection && (
+      {selectedOption && (
         <Link
           id="new-appointment-radio-link"
           className="vads-u-padding--0 va-action-link--green"
-          to={`/${radioSelection}`}
+          to={`/${selectedOption}`}
           onClick={() => {
-            if (radioSelection === 'new-appointment') {
+            if (selectedOption === 'new-appointment') {
               recordEvent({
                 event: `${GA_PREFIX}-schedule-appointment-button-clicked`,
               });
@@ -94,6 +131,24 @@ export default function ScheduleNewAppointmentRadioButtons({
           Start scheduling
         </Link>
       )}
-    </>
+    </div>
   );
 }
+
+function mapStateToProps(state) {
+  return {
+    canUseVaccineFlow: selectCanUseVaccineFlow(state),
+    directScheduleSettingsStatus: selectDirectScheduleSettingsStatus(state),
+  };
+}
+
+const mapDispatchToProps = {
+  fetchDirectScheduleSettings: actions.fetchDirectScheduleSettings,
+  startNewAppointmentFlow: actions.startNewAppointmentFlow,
+  startNewVaccineFlow: actions.startNewVaccineFlow,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ScheduleNewAppointmentRadioButtons);

--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/index.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/index.jsx
@@ -40,12 +40,10 @@ const pageTitle = 'VA appointments';
 
 function AppointmentsPage({
   cancelInfo,
-  canUseVaccineFlow,
   closeCancelAppointment,
   confirmCancelAppointment,
-  directScheduleSettingsStatus,
   expressCare,
-  fetchDirectScheduleSettings,
+  featureProjectCheetah,
   fetchFutureAppointments,
   fetchExpressCareWindows,
   futureStatus,
@@ -55,10 +53,8 @@ function AppointmentsPage({
   showDirectScheduling,
   pendingStatus,
   showScheduleButton,
-  showCheetahScheduleButton,
   startNewAppointmentFlow,
   startNewExpressCareFlow,
-  startNewVaccineFlow,
 }) {
   useEffect(() => {
     document.title = `${pageTitle} | Veterans Affairs`;
@@ -69,13 +65,6 @@ function AppointmentsPage({
 
     if (expressCare.windowsStatus === FETCH_STATUS.notStarted) {
       fetchExpressCareWindows();
-    }
-
-    if (
-      showCheetahScheduleButton &&
-      directScheduleSettingsStatus === FETCH_STATUS.notStarted
-    ) {
-      fetchDirectScheduleSettings();
     }
   }, []);
 
@@ -128,7 +117,7 @@ function AppointmentsPage({
 
       {showScheduleButton && (
         <>
-          {!showCheetahScheduleButton && (
+          {!featureProjectCheetah && (
             <ScheduleNewAppointment
               isCernerOnlyPatient={isCernerOnlyPatient}
               showCommunityCare={showCommunityCare}
@@ -141,15 +130,7 @@ function AppointmentsPage({
               }}
             />
           )}
-          {showCheetahScheduleButton && (
-            <div className="vads-u-margin-bottom--4">
-              <ScheduleNewAppointmentRadioButtons
-                showCheetahScheduleButton={canUseVaccineFlow}
-                startNewAppointmentFlow={startNewAppointmentFlow}
-                startNewVaccineFlow={startNewVaccineFlow}
-              />
-            </div>
-          )}
+          {featureProjectCheetah && <ScheduleNewAppointmentRadioButtons />}
         </>
       )}
 
@@ -158,17 +139,18 @@ function AppointmentsPage({
       )}
       {!isLoading && (
         <>
-          {!isCernerOnlyPatient && (
-            <RequestExpressCare
-              {...expressCare}
-              startNewExpressCareFlow={() => {
-                recordEvent({
-                  event: `${GA_PREFIX}-express-care-request-button-clicked`,
-                });
-                startNewExpressCareFlow();
-              }}
-            />
-          )}
+          {!isCernerOnlyPatient &&
+            expressCare.useNewFlow && (
+              <RequestExpressCare
+                {...expressCare}
+                startNewExpressCareFlow={() => {
+                  recordEvent({
+                    event: `${GA_PREFIX}-express-care-request-button-clicked`,
+                  });
+                  startNewExpressCareFlow();
+                }}
+              />
+            )}
           {expressCare.hasRequests && (
             <h2 className="vads-u-font-size--h3 vads-u-margin-y--3">
               Your upcoming, past, and Express Care appointments
@@ -196,7 +178,7 @@ AppointmentsPage.propTypes = {
   showCommunityCare: PropTypes.bool.isRequired,
   showDirectScheduling: PropTypes.bool.isRequired,
   startNewAppointmentFlow: PropTypes.func.isRequired,
-  showCheetahScheduleButton: PropTypes.bool.isRequired,
+  featureProjectCheetah: PropTypes.bool.isRequired,
 };
 
 function mapStateToProps(state) {
@@ -209,7 +191,7 @@ function mapStateToProps(state) {
     showScheduleButton: selectFeatureRequests(state),
     showCommunityCare: selectFeatureCommunityCare(state),
     showDirectScheduling: selectFeatureDirectScheduling(state),
-    showCheetahScheduleButton: selectFeatureProjectCheetah(state),
+    featureProjectCheetah: selectFeatureProjectCheetah(state),
     isWelcomeModalDismissed: selectIsWelcomeModalDismissed(state),
     isCernerOnlyPatient: selectIsCernerOnlyPatient(state),
     expressCare: selectExpressCareAvailability(state),

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -119,6 +119,7 @@ export default [
   },
   {
     path: /vaos\/v0\/appointments\?.*type=va.*/,
+    delay: 3000,
     response: confirmedVA,
   },
   {
@@ -292,6 +293,7 @@ export default [
   },
   {
     path: /vaos\/v0\/direct_booking_eligibility_criteria/,
+    delay: 2000,
     response: directBookingEligibilityCriteria,
   },
   {

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -119,7 +119,6 @@ export default [
   },
   {
     path: /vaos\/v0\/appointments\?.*type=va.*/,
-    delay: 3000,
     response: confirmedVA,
   },
   {
@@ -293,7 +292,6 @@ export default [
   },
   {
     path: /vaos\/v0\/direct_booking_eligibility_criteria/,
-    delay: 2000,
     response: directBookingEligibilityCriteria,
   },
   {

--- a/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/AppointmentsPageV2.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/AppointmentsPageV2.unit.spec.jsx
@@ -368,12 +368,12 @@ describe('VAOS <AppointmentsPageV2>', () => {
       }),
     );
 
-    expect(await screen.findAllByRole('radio')).to.have.length(1);
+    expect(await screen.findByText(/start scheduling/i)).be.ok;
 
-    expect(screen.getByText(/Choose an appointment type$/)).to.be.ok;
+    expect(screen.queryByRole('radio')).not.to.exist;
 
     userEvent.click(
-      await screen.findByRole('radio', { name: 'Primary or specialty care' }),
+      await screen.findByRole('link', { name: /Start scheduling/ }),
     );
 
     expect(await screen.findByRole('link', { name: /Start scheduling/ }));
@@ -445,16 +445,10 @@ describe('VAOS <AppointmentsPageV2>', () => {
       }),
     );
 
-    expect(await screen.findAllByRole('radio')).to.have.length(1);
+    expect(await screen.findByText(/start scheduling/i)).be.ok;
 
-    expect(screen.getByText(/Choose an appointment type$/)).to.be.ok;
+    expect(screen.queryByRole('radio')).not.to.exist;
 
-    expect(screen.queryByRole('radio', { name: 'COVID-19 vaccine' })).not.to
-      .exist;
-
-    userEvent.click(
-      await screen.findByRole('radio', { name: /primary or specialty/i }),
-    );
     userEvent.click(
       await screen.findByRole('link', { name: /Start scheduling/ }),
     );

--- a/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/index.unit.spec.jsx
@@ -37,6 +37,7 @@ const initialState = {
     vaOnlineSchedulingCancel: true,
     vaOnlineSchedulingRequests: true,
     vaOnlineSchedulingPast: true,
+    vaOnlineSchedulingExpressCareNew: true,
     // eslint-disable-next-line camelcase
     show_new_schedule_view_appointments_page: true,
   },
@@ -990,16 +991,10 @@ describe('VAOS integration: appointment list', () => {
       }),
     );
 
-    expect(await screen.findAllByRole('radio')).to.have.length(1);
+    expect(await screen.findByText(/start scheduling/i)).be.ok;
 
-    expect(screen.getByText(/Choose an appointment type$/)).to.be.ok;
+    expect(screen.queryByRole('radio')).not.to.exist;
 
-    expect(screen.queryByRole('radio', { name: 'COVID-19 vaccine' })).not.to
-      .exist;
-
-    userEvent.click(
-      await screen.findByRole('radio', { name: /primary or specialty/i }),
-    );
     userEvent.click(
       await screen.findByRole('link', { name: /Start scheduling/ }),
     );


### PR DESCRIPTION
## Description
This PR
- Updates the CTA to have an active action link and no radio button when there's only one option available
- Adds a spinner while we're fetching the appropriate data to determine how many options there are
- Moves fetch action call into schedule component to consolidate related logic into one place

How to test:
- View the main appointments page: http://localhost:3001/health-care/schedule-view-va-appointments/appointments/
- Toggle the cheetah flag on and off, and also modify the direct booking settings mock to enable and disable vaccine scheduling

## Testing done
Local and unit testing

## Screenshots

Single option view:
![localhost_3001_health-care_schedule-view-va-appointments_appointments_(iPad) (3)](https://user-images.githubusercontent.com/634932/112161763-d2695700-8bc1-11eb-8ead-3ce34c8b4536.png)

## Acceptance criteria
- [ ] CTA works as designed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
