### PR TITLE
Change article description to introText + truncatedIntroText

### DIFF
--- a/src/applications/resources-and-support/components/SearchResult.jsx
+++ b/src/applications/resources-and-support/components/SearchResult.jsx
@@ -57,12 +57,7 @@ export const SearchResult = ({
           {article.title}
         </a>
       </h2>
-      <p
-        className="vads-u-margin-bottom--0"
-        // the article descriptions contain HTML entities
-        // eslint-disable-next-line react/no-danger
-        dangerouslySetInnerHTML={{ __html: article.description }}
-      />
+      <p className="vads-u-margin-bottom--0">{article.truncatedIntroText}</p>
     </div>
   );
 };

--- a/src/applications/resources-and-support/components/SearchResult.jsx
+++ b/src/applications/resources-and-support/components/SearchResult.jsx
@@ -2,6 +2,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
+import { truncate } from 'lodash';
 // Relative imports.
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import recordEvent from 'platform/monitoring/record-event';
@@ -57,7 +58,9 @@ export const SearchResult = ({
           {article.title}
         </a>
       </h2>
-      <p className="vads-u-margin-bottom--0">{article.truncatedIntroText}</p>
+      <p className="vads-u-margin-bottom--0">
+        {truncate(article.introText, { length: 190 })}
+      </p>
     </div>
   );
 };

--- a/src/applications/resources-and-support/hooks/useGetSearchResults.js
+++ b/src/applications/resources-and-support/hooks/useGetSearchResults.js
@@ -64,11 +64,11 @@ export default function useGetSearchResults(articles, query, page) {
           0,
         ),
 
-        // Number of times a keyword is found in the article's description.
+        // Number of times a keyword is found in the article's introText.
         keywordsCountsDescription: keywords?.reduce(
           (keywordInstances, keyword) =>
             keywordInstances +
-            article.description.toLowerCase()?.split(keyword)?.length -
+            article.introText.toLowerCase()?.split(keyword)?.length -
             1,
           0,
         ),
@@ -76,14 +76,13 @@ export default function useGetSearchResults(articles, query, page) {
         wholePhraseMatchCounts:
           article.title.toLowerCase()?.split(query.toLowerCase())?.length -
           1 +
-          (article.description.toLowerCase()?.split(query.toLowerCase())
-            ?.length -
+          (article.introText.toLowerCase()?.split(query.toLowerCase())?.length -
             1),
       }));
 
       if (environment.isProduction()) {
         // Sort first by query word instances found in title descending
-        // Sort ties then by query word instances found in description descending
+        // Sort ties then by query word instances found in introText descending
         // Sort ties then by alphabetical descending
         orderedResults = orderBy(
           filteredArticles,
@@ -91,9 +90,9 @@ export default function useGetSearchResults(articles, query, page) {
           ['desc', 'desc', 'asc'],
         );
       } else {
-        // Sort first by the number of exact query matches (ignoring casing) in the title and description
+        // Sort first by the number of exact query matches (ignoring casing) in the title and introText
         // Sort ties by query word instances found in title descending
-        // Sort ties then by query word instances found in description descending
+        // Sort ties then by query word instances found in introText descending
         // Sort ties then by alphabetical descending
         orderedResults = orderBy(
           filteredArticles,

--- a/src/applications/resources-and-support/prop-types.js
+++ b/src/applications/resources-and-support/prop-types.js
@@ -15,7 +15,8 @@ export const Article = PropTypes.shape({
     path: PropTypes.string.isRequired,
   }).isRequired,
   title: PropTypes.string.isRequired,
-  description: PropTypes.string.isRequired,
+  introText: PropTypes.string.isRequired,
+  truncatedIntroText: PropTypes.string.isRequired,
   fieldPrimaryCategory: PropTypes.shape({
     entity: TaxonomyTerm,
   }),

--- a/src/applications/resources-and-support/prop-types.js
+++ b/src/applications/resources-and-support/prop-types.js
@@ -16,7 +16,6 @@ export const Article = PropTypes.shape({
   }).isRequired,
   title: PropTypes.string.isRequired,
   introText: PropTypes.string.isRequired,
-  truncatedIntroText: PropTypes.string.isRequired,
   fieldPrimaryCategory: PropTypes.shape({
     entity: TaxonomyTerm,
   }),

--- a/src/applications/resources-and-support/tests/components/SearchResult.unit.spec.jsx
+++ b/src/applications/resources-and-support/tests/components/SearchResult.unit.spec.jsx
@@ -13,8 +13,6 @@ const results = [
       'How to change direct deposit information for VA disability or pension ',
     introText:
       'Follow our step-by-step instructions for making&#xA0;changes to your VA direct deposit information for VA disability or pension benefit payments. We&apos;ll show you how to sign in and make changes on this is very long text this is very long text.',
-    truncatedIntroText:
-      'Follow our step-by-step instructions for making&#xA0;changes to your VA direct deposit information for VA disability or pension benefit payments. We&apos;ll show you how to sign in and make changes on...',
     fieldPrimaryCategory: {
       entity: {
         entityUrl: { path: '/taxonomy/term/282' },
@@ -40,8 +38,6 @@ const results = [
     entityUrl: { path: '/node/8520' },
     title: 'How to check your VA claim or appeal status online',
     introText:
-      'Follow our step-by-step instructions for&#xA0;checking the status of your&#xA0;VA claim or appeal online.\n',
-    truncatedIntroText:
       'Follow our step-by-step instructions for&#xA0;checking the status of your&#xA0;VA claim or appeal online.\n',
     fieldPrimaryCategory: {
       entity: {

--- a/src/applications/resources-and-support/tests/components/SearchResult.unit.spec.jsx
+++ b/src/applications/resources-and-support/tests/components/SearchResult.unit.spec.jsx
@@ -11,7 +11,9 @@ const results = [
     entityUrl: { path: '/node/8434' },
     title:
       'How to change direct deposit information for VA disability or pension ',
-    description:
+    introText:
+      'Follow our step-by-step instructions for making&#xA0;changes to your VA direct deposit information for VA disability or pension benefit payments. We&apos;ll show you how to sign in and make changes on this is very long text this is very long text.',
+    truncatedIntroText:
       'Follow our step-by-step instructions for making&#xA0;changes to your VA direct deposit information for VA disability or pension benefit payments. We&apos;ll show you how to sign in and make changes on...',
     fieldPrimaryCategory: {
       entity: {
@@ -37,7 +39,9 @@ const results = [
     entityBundle: 'step_by_step',
     entityUrl: { path: '/node/8520' },
     title: 'How to check your VA claim or appeal status online',
-    description:
+    introText:
+      'Follow our step-by-step instructions for&#xA0;checking the status of your&#xA0;VA claim or appeal online.\n',
+    truncatedIntroText:
       'Follow our step-by-step instructions for&#xA0;checking the status of your&#xA0;VA claim or appeal online.\n',
     fieldPrimaryCategory: {
       entity: {

--- a/src/applications/resources-and-support/tests/components/SearchResultList.unit.spec.jsx
+++ b/src/applications/resources-and-support/tests/components/SearchResultList.unit.spec.jsx
@@ -13,8 +13,6 @@ const results = [
       'How to change direct deposit information for VA disability or pension ',
     introText:
       'Follow our step-by-step instructions for making&#xA0;changes to your VA direct deposit information for VA disability or pension benefit payments. We&apos;ll show you how to sign in and make changes on this is very long text this is very long text.',
-    truncatedIntroText:
-      'Follow our step-by-step instructions for making&#xA0;changes to your VA direct deposit information for VA disability or pension benefit payments. We&apos;ll show you how to sign in and make changes on...',
     fieldPrimaryCategory: {
       entity: {
         entityUrl: { path: '/taxonomy/term/282' },
@@ -40,8 +38,6 @@ const results = [
     entityUrl: { path: '/node/8520' },
     title: 'How to check your VA claim or appeal status online',
     introText:
-      'Follow our step-by-step instructions for&#xA0;checking the status of your&#xA0;VA claim or appeal online.\n',
-    truncatedIntroText:
       'Follow our step-by-step instructions for&#xA0;checking the status of your&#xA0;VA claim or appeal online.\n',
     fieldPrimaryCategory: {
       entity: {

--- a/src/applications/resources-and-support/tests/components/SearchResultList.unit.spec.jsx
+++ b/src/applications/resources-and-support/tests/components/SearchResultList.unit.spec.jsx
@@ -11,7 +11,9 @@ const results = [
     entityUrl: { path: '/node/8434' },
     title:
       'How to change direct deposit information for VA disability or pension ',
-    description:
+    introText:
+      'Follow our step-by-step instructions for making&#xA0;changes to your VA direct deposit information for VA disability or pension benefit payments. We&apos;ll show you how to sign in and make changes on this is very long text this is very long text.',
+    truncatedIntroText:
       'Follow our step-by-step instructions for making&#xA0;changes to your VA direct deposit information for VA disability or pension benefit payments. We&apos;ll show you how to sign in and make changes on...',
     fieldPrimaryCategory: {
       entity: {
@@ -37,7 +39,9 @@ const results = [
     entityBundle: 'step_by_step',
     entityUrl: { path: '/node/8520' },
     title: 'How to check your VA claim or appeal status online',
-    description:
+    introText:
+      'Follow our step-by-step instructions for&#xA0;checking the status of your&#xA0;VA claim or appeal online.\n',
+    truncatedIntroText:
       'Follow our step-by-step instructions for&#xA0;checking the status of your&#xA0;VA claim or appeal online.\n',
     fieldPrimaryCategory: {
       entity: {

--- a/src/applications/resources-and-support/tests/components/articles.json
+++ b/src/applications/resources-and-support/tests/components/articles.json
@@ -5,7 +5,8 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Health 1",
-    "description": "Sample description"
+    "introText": "Sample description",
+    "truncatedIntroText": "Sample description"
   },
   {
     "entityBundle": "support_resources_detail_page",
@@ -13,7 +14,8 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Health 2",
-    "description": "Sample description"
+    "introText": "Sample description",
+    "truncatedIntroText": "Sample description"
   },
   {
     "entityBundle": "support_resources_detail_page",
@@ -21,7 +23,8 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Health 3",
-    "description": "Sample description"
+    "introText": "Sample description",
+    "truncatedIntroText": "Sample description"
   },
   {
     "entityBundle": "support_resources_detail_page",
@@ -29,7 +32,8 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Health 4",
-    "description": "Sample description"
+    "introText": "Sample description",
+    "truncatedIntroText": "Sample description"
   },
   {
     "entityBundle": "support_resources_detail_page",
@@ -37,7 +41,8 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Health 5",
-    "description": "Sample description"
+    "introText": "Sample description",
+    "truncatedIntroText": "Sample description"
   },
   {
     "entityBundle": "support_resources_detail_page",
@@ -45,7 +50,8 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Health 6",
-    "description": "Sample description"
+    "introText": "Sample description",
+    "truncatedIntroText": "Sample description"
   },
   {
     "entityBundle": "support_resources_detail_page",
@@ -53,7 +59,8 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Health 7",
-    "description": "Sample description"
+    "introText": "Sample description",
+    "truncatedIntroText": "Sample description"
   },
   {
     "entityBundle": "support_resources_detail_page",
@@ -61,7 +68,8 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Health 8",
-    "description": "Sample description"
+    "introText": "Sample description",
+    "truncatedIntroText": "Sample description"
   },
   {
     "entityBundle": "support_resources_detail_page",
@@ -69,7 +77,8 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Health 9",
-    "description": "Sample description"
+    "introText": "Sample description",
+    "truncatedIntroText": "Sample description"
   },
   {
     "entityBundle": "support_resources_detail_page",
@@ -77,7 +86,8 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Health 10",
-    "description": "Sample description"
+    "introText": "Sample description",
+    "truncatedIntroText": "Sample description"
   },
   {
     "entityBundle": "support_resources_detail_page",
@@ -85,7 +95,8 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Health 11",
-    "description": "Sample description"
+    "introText": "Sample description",
+    "truncatedIntroText": "Sample description"
   },
   {
     "entityBundle": "support_resources_detail_page",
@@ -93,7 +104,8 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Health 12",
-    "description": "Sample description"
+    "introText": "Sample description",
+    "truncatedIntroText": "Sample description"
   },
   {
     "entityBundle": "support_resources_detail_page",
@@ -101,7 +113,8 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Disabilities",
-    "description": "Sample description"
+    "introText": "Sample description",
+    "truncatedIntroText": "Sample description"
   },
   {
     "entityBundle": "support_resources_detail_page",
@@ -109,6 +122,7 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Disability",
-    "description": "Sample description"
+    "introText": "Sample description",
+    "truncatedIntroText": "Sample description"
   }
 ]

--- a/src/applications/resources-and-support/tests/components/articles.json
+++ b/src/applications/resources-and-support/tests/components/articles.json
@@ -5,8 +5,7 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Health 1",
-    "introText": "Sample description",
-    "truncatedIntroText": "Sample description"
+    "introText": "Sample description"
   },
   {
     "entityBundle": "support_resources_detail_page",
@@ -14,8 +13,7 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Health 2",
-    "introText": "Sample description",
-    "truncatedIntroText": "Sample description"
+    "introText": "Sample description"
   },
   {
     "entityBundle": "support_resources_detail_page",
@@ -23,8 +21,7 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Health 3",
-    "introText": "Sample description",
-    "truncatedIntroText": "Sample description"
+    "introText": "Sample description"
   },
   {
     "entityBundle": "support_resources_detail_page",
@@ -32,8 +29,7 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Health 4",
-    "introText": "Sample description",
-    "truncatedIntroText": "Sample description"
+    "introText": "Sample description"
   },
   {
     "entityBundle": "support_resources_detail_page",
@@ -41,8 +37,7 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Health 5",
-    "introText": "Sample description",
-    "truncatedIntroText": "Sample description"
+    "introText": "Sample description"
   },
   {
     "entityBundle": "support_resources_detail_page",
@@ -50,8 +45,7 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Health 6",
-    "introText": "Sample description",
-    "truncatedIntroText": "Sample description"
+    "introText": "Sample description"
   },
   {
     "entityBundle": "support_resources_detail_page",
@@ -59,8 +53,7 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Health 7",
-    "introText": "Sample description",
-    "truncatedIntroText": "Sample description"
+    "introText": "Sample description"
   },
   {
     "entityBundle": "support_resources_detail_page",
@@ -68,8 +61,7 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Health 8",
-    "introText": "Sample description",
-    "truncatedIntroText": "Sample description"
+    "introText": "Sample description"
   },
   {
     "entityBundle": "support_resources_detail_page",
@@ -77,8 +69,7 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Health 9",
-    "introText": "Sample description",
-    "truncatedIntroText": "Sample description"
+    "introText": "Sample description"
   },
   {
     "entityBundle": "support_resources_detail_page",
@@ -86,8 +77,7 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Health 10",
-    "introText": "Sample description",
-    "truncatedIntroText": "Sample description"
+    "introText": "Sample description"
   },
   {
     "entityBundle": "support_resources_detail_page",
@@ -95,8 +85,7 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Health 11",
-    "introText": "Sample description",
-    "truncatedIntroText": "Sample description"
+    "introText": "Sample description"
   },
   {
     "entityBundle": "support_resources_detail_page",
@@ -104,8 +93,7 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Health 12",
-    "introText": "Sample description",
-    "truncatedIntroText": "Sample description"
+    "introText": "Sample description"
   },
   {
     "entityBundle": "support_resources_detail_page",
@@ -113,8 +101,7 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Disabilities",
-    "introText": "Sample description",
-    "truncatedIntroText": "Sample description"
+    "introText": "Sample description"
   },
   {
     "entityBundle": "support_resources_detail_page",
@@ -122,7 +109,6 @@
       "path": "/resources/test-page"
     },
     "title": "Sample title - Disability",
-    "introText": "Sample description",
-    "truncatedIntroText": "Sample description"
+    "introText": "Sample description"
   }
 ]

--- a/src/site/stages/build/plugins/create-resources-and-support-section.js
+++ b/src/site/stages/build/plugins/create-resources-and-support-section.js
@@ -291,41 +291,23 @@ function createArticleListingsPages(files) {
   );
 }
 
-function deriveIntroText(htmlText, options = {}) {
+function deriveIntroText(htmlText) {
   const sanitizedText = liquid.filters.strip_html(htmlText);
   const strippedNewlines = liquid.filters.strip_newlines(sanitizedText);
   const decodedText = he.decode(strippedNewlines);
-
-  // Truncate the text.
-  const truncated = liquid.filters.truncate(decodedText, 190);
-
-  // Return full html escaped text if we are not truncating text or if text is brief.
-  if (!options?.truncated || decodedText === truncated) {
-    return decodedText;
-  }
-
-  // If the text is long, show an ellipsis at the end of it.
-  return `${truncated}...`;
+  return decodedText;
 }
 
 function createSearchResults(files) {
   const allArticles = getArticlesBelongingToResourcesAndSupportSection(files);
   const articleSearchData = allArticles.map(article => {
-    let truncatedIntroText = '';
     let introText = '';
 
     if (article.entityBundle === 'q_a') {
       const answer = article.fieldAnswer.entity.fieldWysiwyg.processed;
-      truncatedIntroText = deriveIntroText(answer, { truncated: true });
-      introText = deriveIntroText(answer, { truncated: false });
+      introText = deriveIntroText(answer);
     } else {
-      truncatedIntroText = deriveIntroText(
-        article.fieldIntroTextLimitedHtml.processed,
-        { truncated: true },
-      );
-      introText = deriveIntroText(article.fieldIntroTextLimitedHtml.processed, {
-        truncated: false,
-      });
+      introText = deriveIntroText(article.fieldIntroTextLimitedHtml.processed);
     }
 
     return {
@@ -336,7 +318,6 @@ function createSearchResults(files) {
       fieldTags: article.fieldTags,
       introText,
       title: article.title,
-      truncatedIntroText,
     };
   });
 

--- a/src/site/stages/build/plugins/create-resources-and-support-section.js
+++ b/src/site/stages/build/plugins/create-resources-and-support-section.js
@@ -294,8 +294,7 @@ function createArticleListingsPages(files) {
 function deriveIntroText(htmlText) {
   const sanitizedText = liquid.filters.strip_html(htmlText);
   const strippedNewlines = liquid.filters.strip_newlines(sanitizedText);
-  const decodedText = he.decode(strippedNewlines);
-  return decodedText;
+  return he.decode(strippedNewlines);
 }
 
 function createSearchResults(files) {


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/16916

This PR removes `description` from articles and instead breaks it out into `introText` and `truncatedIntroText`. Search filtering + ordering for R&S now relies on the full intro text as opposed to just the truncated version of it.

In a follow-up ticket, we should rely on a composite field called `content` that includes all of the content for a specific R&S page so that our search can parse for query keywords within the article content.

## Testing done
Locally

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/112205468-6ba46780-8bda-11eb-9d20-36fc69abcb22.png)

## Acceptance criteria
- [x] Rename `description` to `truncatedIntroText`.
- [x] Add `introText` field for searching.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
