### PR TITLE
Sanlouise add loading indicator

### DIFF
--- a/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
+++ b/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
@@ -159,11 +159,14 @@ const mapStateToProps = state => {
     ]),
   ];
 
-  const fetchingAppointments = state.health?.appointments?.fetching;
-  const fetchingInbox = state.health.msg.folders.data.currentItem.fetching;
   const shouldFetchMessages = selectAvailableServices(state).includes(
     backendServices.MESSAGING,
   );
+
+  const fetchingAppointments = state.health?.appointments?.fetching;
+  const fetchingInbox = shouldFetchMessages
+    ? state.health?.msg?.folders?.data?.currentItem?.fetching
+    : false;
 
   return {
     appointments: state.health?.appointments?.data,
@@ -172,8 +175,7 @@ const mapStateToProps = state => {
     facilityNames,
     authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
     unreadMessagesCount: selectUnreadMessagesCount(state),
-    shouldShowLoadingIndicator:
-      fetchingAppointments || (shouldFetchMessages && fetchingInbox),
+    shouldShowLoadingIndicator: fetchingAppointments || fetchingInbox,
   };
 };
 

--- a/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
+++ b/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
@@ -55,6 +55,17 @@ const HealthCare = ({
     [shouldFetchMessages, fetchInbox, dataLoadingDisabled],
   );
 
+  if (shouldShowLoadingIndicator) {
+    return (
+      <div className="health-care vads-u-margin-y--6">
+        <h2 className="vads-u-margin-top--0 vads-u-margin-bottom--2">
+          Health care
+        </h2>
+        <LoadingIndicator message="Loading health care..." />
+      </div>
+    );
+  }
+
   if (isCernerPatient && facilityNames?.length) {
     return (
       <GeneralCernerWidget
@@ -62,10 +73,6 @@ const HealthCare = ({
         authenticatedWithSSOe={authenticatedWithSSOe}
       />
     );
-  }
-
-  if (shouldShowLoadingIndicator) {
-    return <LoadingIndicator />;
   }
 
   const messagesText =
@@ -81,7 +88,7 @@ const HealthCare = ({
         Health care
       </h2>
 
-      <div className="vads-u-display--flex vads-u-flex-wrap--wrap">
+      <div className="vads-u-display--flex medium-screen:vads-u-flex-direction--row vads-u-flex-direction--column">
         {/* Appointments */}
         <Appointments appointments={appointments} />
 
@@ -153,12 +160,10 @@ const mapStateToProps = state => {
   ];
 
   const fetchingAppointments = state.health?.appointments?.fetching;
-  const fetchingInbox = state.health.msg.folders.data.currentItem.loading;
-  // const shouldFetchMessages = selectAvailableServices(state).includes(
-  //   backendServices.MESSAGING,
-  // ),
-
-  const shouldFetchMessages = true;
+  const fetchingInbox = state.health.msg.folders.data.currentItem.fetching;
+  const shouldFetchMessages = selectAvailableServices(state).includes(
+    backendServices.MESSAGING,
+  );
 
   return {
     appointments: state.health?.appointments?.data,
@@ -167,8 +172,6 @@ const mapStateToProps = state => {
     facilityNames,
     authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
     unreadMessagesCount: selectUnreadMessagesCount(state),
-    // loading messages
-    // laoding appointments
     shouldShowLoadingIndicator:
       fetchingAppointments || (shouldFetchMessages && fetchingInbox),
   };

--- a/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
+++ b/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
@@ -17,6 +17,8 @@ import {
   selectAvailableServices,
 } from '~/platform/user/selectors';
 
+import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
+
 import { mhvUrl } from '~/platform/site-wide/mhv/utilities';
 
 import Appointments from './Appointments';
@@ -33,6 +35,7 @@ const HealthCare = ({
   unreadMessagesCount,
   // TODO: possibly remove this prop in favor of mocking API calls in our unit tests
   dataLoadingDisabled = false,
+  shouldShowLoadingIndicator,
 }) => {
   useEffect(
     () => {
@@ -59,6 +62,10 @@ const HealthCare = ({
         authenticatedWithSSOe={authenticatedWithSSOe}
       />
     );
+  }
+
+  if (shouldShowLoadingIndicator) {
+    return <LoadingIndicator />;
   }
 
   const messagesText =
@@ -145,15 +152,25 @@ const mapStateToProps = state => {
     ]),
   ];
 
+  const fetchingAppointments = state.health?.appointments?.fetching;
+  const fetchingInbox = state.health.msg.folders.data.currentItem.loading;
+  // const shouldFetchMessages = selectAvailableServices(state).includes(
+  //   backendServices.MESSAGING,
+  // ),
+
+  const shouldFetchMessages = true;
+
   return {
     appointments: state.health?.appointments?.data,
-    shouldFetchMessages: selectAvailableServices(state).includes(
-      backendServices.MESSAGING,
-    ),
+    shouldFetchMessages,
     isCernerPatient: selectIsCernerPatient(state),
     facilityNames,
     authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
     unreadMessagesCount: selectUnreadMessagesCount(state),
+    // loading messages
+    // laoding appointments
+    shouldShowLoadingIndicator:
+      fetchingAppointments || (shouldFetchMessages && fetchingInbox),
   };
 };
 

--- a/src/applications/personalization/dashboard-2/sass/dashboard.scss
+++ b/src/applications/personalization/dashboard-2/sass/dashboard.scss
@@ -8,6 +8,10 @@
   .health-care {
     .cta-link:nth-of-type(1) {
       border-top: 1px solid $color-primary-alt-light;
+
+      @media (max-width: $small-screen) {
+        margin-top: 20px;
+      }
     }
 
     .cta-link {

--- a/src/applications/personalization/dashboard-2/sass/dashboard.scss
+++ b/src/applications/personalization/dashboard-2/sass/dashboard.scss
@@ -10,7 +10,7 @@
       border-top: 1px solid $color-primary-alt-light;
 
       @media (max-width: $small-screen) {
-        margin-top: 20px;
+        margin-top: units(2.5);
       }
     }
 

--- a/src/applications/personalization/dashboard-2/tests/unit/healthcare.unit.spec.jsx
+++ b/src/applications/personalization/dashboard-2/tests/unit/healthcare.unit.spec.jsx
@@ -9,6 +9,52 @@ import HealthCare from '~/applications/personalization/dashboard-2/components/he
 describe('HealthCare component', () => {
   let view;
   let initialState;
+
+  context('when appointments and messaging data are still loading', () => {
+    it('should only show a loading spinner', async () => {
+      window.VetsGov = { pollTimeout: 1 };
+      mockFetch();
+      initialState = {
+        user: {
+          profile: {
+            services: ['messaging'],
+          },
+        },
+        health: {
+          appointments: {
+            fetching: true,
+          },
+          msg: {
+            folders: {
+              data: {
+                currentItem: {
+                  loading: true,
+                },
+              },
+              ui: {
+                nav: {
+                  foldersExpanded: false,
+                  visible: false,
+                },
+              },
+            },
+          },
+        },
+      };
+
+      view = renderInReduxProvider(<HealthCare dataLoadingDisabled />, {
+        initialState,
+        reducers,
+      });
+      expect(view.queryByRole('progressbar')).to.exist;
+      expect(view.queryByText('Refill and track your prescriptions')).not.to
+        .exist;
+      expect(view.queryByText('Get your lab and test results')).not.to.exist;
+      expect(view.queryByText('Get your VA medical records')).not.to.exist;
+      resetFetch();
+    });
+  });
+
   context('when user has the `messaging` service', () => {
     beforeEach(() => {
       window.VetsGov = { pollTimeout: 1 };
@@ -67,6 +113,7 @@ describe('HealthCare component', () => {
         initialState,
         reducers,
       });
+      expect(view.queryByRole('progressbar')).not.to.exist;
       expect(await view.findByText(new RegExp(`you have 3 new messages`, 'i')))
         .to.exist;
     });

--- a/src/applications/personalization/dashboard-2/tests/unit/healthcare.unit.spec.jsx
+++ b/src/applications/personalization/dashboard-2/tests/unit/healthcare.unit.spec.jsx
@@ -12,7 +12,6 @@ describe('HealthCare component', () => {
 
   context('when appointments and messaging data are still loading', () => {
     it('should only show a loading spinner', async () => {
-      window.VetsGov = { pollTimeout: 1 };
       initialState = {
         user: {
           profile: {

--- a/src/applications/personalization/dashboard-2/tests/unit/healthcare.unit.spec.jsx
+++ b/src/applications/personalization/dashboard-2/tests/unit/healthcare.unit.spec.jsx
@@ -13,7 +13,6 @@ describe('HealthCare component', () => {
   context('when appointments and messaging data are still loading', () => {
     it('should only show a loading spinner', async () => {
       window.VetsGov = { pollTimeout: 1 };
-      mockFetch();
       initialState = {
         user: {
           profile: {
@@ -46,12 +45,11 @@ describe('HealthCare component', () => {
         initialState,
         reducers,
       });
-      expect(view.queryByRole('progressbar')).to.exist;
-      expect(view.queryByText('Refill and track your prescriptions')).not.to
+      expect(view.getByRole('progressbar')).to.exist;
+      expect(view.queryByText(/Refill and track your prescriptions/i)).not.to
         .exist;
-      expect(view.queryByText('Get your lab and test results')).not.to.exist;
-      expect(view.queryByText('Get your VA medical records')).not.to.exist;
-      resetFetch();
+      expect(view.queryByText(/Get your lab and test results/i)).not.to.exist;
+      expect(view.queryByText(/Get your VA medical records/i)).not.to.exist;
     });
   });
 

--- a/src/applications/personalization/dashboard/reducers/folders.js
+++ b/src/applications/personalization/dashboard/reducers/folders.js
@@ -7,6 +7,7 @@ const initialState = {
   data: {
     currentItem: {
       attributes: {},
+      fetching: false,
       filter: {},
       messages: [],
       pagination: {},
@@ -52,7 +53,7 @@ export default function folders(state = initialState, action) {
         'data.currentItem',
         {
           attributes,
-          loading: false,
+          fetching: false,
           filter,
           messages,
           pagination,
@@ -81,7 +82,7 @@ export default function folders(state = initialState, action) {
             visible: false,
           },
           lastRequestedFolder: action.request,
-          loading: true,
+          fetching: true,
         },
         newState,
       );

--- a/src/applications/personalization/dashboard/reducers/folders.js
+++ b/src/applications/personalization/dashboard/reducers/folders.js
@@ -52,6 +52,7 @@ export default function folders(state = initialState, action) {
         'data.currentItem',
         {
           attributes,
+          loading: false,
           filter,
           messages,
           pagination,
@@ -80,6 +81,7 @@ export default function folders(state = initialState, action) {
             visible: false,
           },
           lastRequestedFolder: action.request,
+          loading: true,
         },
         newState,
       );


### PR DESCRIPTION
## Description
This PR adds a spinner to the health care section for when the messaging and appointments data are being fetched.

## Testing done
Works well locally, updated unit tests.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/112211176-32232a80-8be1-11eb-8bc6-675499a9de17.png)


## Acceptance criteria
- [x] Add spinner
- [x] Update layout of health care section so the design is mobile responsive

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
