### PR TITLE
Add my VA link for both unauth + auth states to mega meu

### DIFF
--- a/src/platform/site-wide/mega-menu/containers/Main.jsx
+++ b/src/platform/site-wide/mega-menu/containers/Main.jsx
@@ -1,18 +1,18 @@
+// Node modules.
 import React from 'react';
 import { createSelector } from 'reselect';
 import { connect } from 'react-redux';
-
+// Relative imports.
+import MegaMenu from '../components/MegaMenu';
 import authenticatedUserLinkData from '../mega-menu-link-data-for-authenticated-users.json';
-import {
-  togglePanelOpen,
-  toggleMobileDisplayHidden,
-  updateCurrentSection,
-} from '../actions';
 import recordEvent from '../../../monitoring/record-event';
 import { isLoggedIn } from '../../../user/selectors';
 import { replaceDomainsInData } from '../../../utilities/environment/stagingDomains';
-
-import MegaMenu from '../components/MegaMenu';
+import {
+  toggleMobileDisplayHidden,
+  togglePanelOpen,
+  updateCurrentSection,
+} from '../actions';
 
 export function flagCurrentPageInTopLevelLinks(
   links = [],
@@ -99,8 +99,19 @@ const mainSelector = createSelector(
   ({ state }) => state.megaMenu,
   ({ megaMenuData }) => megaMenuData,
   (loggedIn, megaMenu, megaMenuData) => {
+    // Derive the default mega menu links (both auth + unauth).
+    const defaultLinks = [
+      ...megaMenuData,
+      // Add the My VA link to default links.
+      {
+        className: 'my-va-top-nav',
+        href: '/my-va/',
+        title: 'My VA',
+      },
+    ];
+
     const data = flagCurrentPageInTopLevelLinks(
-      getAuthorizedLinkData(loggedIn, megaMenuData),
+      getAuthorizedLinkData(loggedIn, defaultLinks),
     );
 
     return {

--- a/src/platform/site-wide/mega-menu/mega-menu-link-data-for-authenticated-users.json
+++ b/src/platform/site-wide/mega-menu/mega-menu-link-data-for-authenticated-users.json
@@ -1,10 +1,6 @@
-[{
-        "title": "My VA",
-        "href": "/my-va/",
-        "className": "my-va-top-nav"
-    },
-    {
-        "title": "My Health",
-        "href": "/health-care/my-health-account-validation/"
-    }
+[
+  {
+    "href": "/health-care/my-health-account-validation/",
+    "title": "My Health"
+  }
 ]


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/21183

I spent far too long on this PR and removed 90% of my changes 😂 This just makes it so that the `My VA` link shows up also when you're unauthenticated now.

## Testing done
Locally

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/112216955-baa4c980-8be7-11eb-812f-d04788b9a6e5.png)

![image](https://user-images.githubusercontent.com/12773166/112217263-0a839080-8be8-11eb-94b5-cb618f79b067.png)

## Acceptance criteria
- [x] `My VA` nav link appears when unauthenticated

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
