### PR TITLE
Only scroll confirmation alert into view on first load

### DIFF
--- a/src/applications/personalization/profile/components/personal-information/ContactInformationActionButtons.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationActionButtons.jsx
@@ -7,138 +7,150 @@ import { toLower } from 'lodash';
 
 import recordEvent from '~/platform/monitoring/record-event';
 import LoadingButton from '~/platform/site-wide/loading-button/LoadingButton';
+import { usePrevious } from '~/platform/utilities/react-hooks';
 
-class ContactInformationActionButtons extends React.Component {
-  constructor(props) {
-    super(props);
+function AlertContent({ cancelAction, deleteAction, isLoading, title }) {
+  return (
+    <div>
+      <p>
+        This will delete your {toLower(title)} across many VA records. You can
+        always come back to your profile later if you’d like to add this
+        information back in.
+      </p>
+      <div>
+        <LoadingButton isLoading={isLoading} onClick={deleteAction}>
+          Confirm
+        </LoadingButton>
 
-    this.state = {
-      deleteInitiated: false,
-    };
-  }
+        {!isLoading && (
+          <button
+            type="button"
+            className="usa-button-secondary"
+            onClick={cancelAction}
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
 
-  componentDidUpdate(prevProps, prevState) {
-    // Once the AlertBox is mounted, we want to set the focus to the heading
-    // for screen reader use
-    if (this.state.deleteInitiated && !prevState.deleteInitiated) {
-      const heading = document.getElementById('deleteConfirmationHeading');
-      if (heading) {
-        heading.focus();
+function ContactInformationActionButtons(props) {
+  const [deleteInitiated, setDeleteInitiated] = React.useState(false);
+  const [focusDeleteAlert, setFocusDeleteAlert] = React.useState(false);
+  const wasDeleteInitiated = usePrevious(deleteInitiated);
+
+  React.useEffect(
+    () => {
+      if (deleteInitiated && !wasDeleteInitiated) {
+        const heading = document.getElementById('deleteConfirmationHeading');
+        if (heading) {
+          heading.focus();
+        }
       }
-    }
-    // If delete is cancelled, put focus back on modal close button
-    if (!this.state.deleteInitiated && prevState.deleteInitiated) {
-      const closeButton = document.getElementsByClassName('va-modal-close')[0];
-      if (closeButton) {
-        closeButton.focus();
+      if (!deleteInitiated && wasDeleteInitiated) {
+        const closeButton = document.getElementsByClassName(
+          'va-modal-close',
+        )[0];
+        if (closeButton) {
+          closeButton.focus();
+        }
       }
-    }
-  }
+    },
+    [deleteInitiated, wasDeleteInitiated],
+  );
 
-  cancelDeleteAction = () => {
-    this.setState({ deleteInitiated: false });
+  React.useEffect(
+    () => {
+      if (focusDeleteAlert) {
+        setFocusDeleteAlert(false);
+      }
+    },
+    [focusDeleteAlert, setFocusDeleteAlert],
+  );
+
+  const cancelDeleteAction = () => {
+    setDeleteInitiated(false);
     recordEvent({
       event: 'profile-navigation',
       'profile-action': 'cancel-delete-button',
-      'profile-section': this.props.analyticsSectionName,
+      'profile-section': props.analyticsSectionName,
     });
   };
 
-  confirmDeleteAction = e => {
+  const confirmDeleteAction = e => {
     e.preventDefault();
     recordEvent({
       event: 'profile-navigation',
       'profile-action': 'confirm-delete-button',
-      'profile-section': this.props.analyticsSectionName,
+      'profile-section': props.analyticsSectionName,
     });
-    this.props.onDelete();
+    props.onDelete();
   };
 
-  handleDeleteInitiated = () => {
+  const handleDeleteInitiated = () => {
     recordEvent({
       event: 'profile-navigation',
       'profile-action': 'delete-button',
-      'profile-section': this.props.analyticsSectionName,
+      'profile-section': props.analyticsSectionName,
     });
-    this.setState({ deleteInitiated: true });
+    setDeleteInitiated(true);
+    setFocusDeleteAlert(true);
   };
 
-  renderDeleteAction() {
-    if (this.props.deleteEnabled) {
+  const renderDeleteAction = () => {
+    if (props.deleteEnabled) {
       return (
         <button
           type="button"
           className="va-button-link vads-u-margin-top--1p5"
-          onClick={this.handleDeleteInitiated}
+          onClick={handleDeleteInitiated}
         >
-          Remove {toLower(this.props.title)}
+          Remove {toLower(props.title)}
         </button>
       );
     }
 
     return null;
-  }
+  };
 
-  render() {
-    const alertContent = (
-      <div>
-        <p>
-          This will delete your {toLower(this.props.title)} across many VA
-          records. You can always come back to your profile later if you'd like
-          to add this information back in.
-        </p>
-        <div>
-          <LoadingButton
-            isLoading={this.props.isLoading}
-            onClick={this.confirmDeleteAction}
-          >
-            Confirm
-          </LoadingButton>
-
-          {!this.props.isLoading && (
-            <button
-              type="button"
-              className="usa-button-secondary"
-              onClick={this.cancelDeleteAction}
-            >
-              Cancel
-            </button>
-          )}
-        </div>
-      </div>
-    );
-
-    if (this.state.deleteInitiated) {
-      return (
-        <AlertBox
-          content={alertContent}
-          headline={
-            <span tabIndex="-1" id="deleteConfirmationHeading">
-              Are you sure?
-            </span>
-          }
-          isVisible
-          scrollOnShow
-          scrollPosition="end"
-          status={ALERT_TYPE.WARNING}
-        />
-      );
-    }
-
+  if (deleteInitiated) {
     return (
-      <div className="vads-u-display--flex vads-u-flex-wrap--wrap vads-u-flex-direction--column">
-        {this.props.children}
-        {this.renderDeleteAction()}
-      </div>
+      <AlertBox
+        content={
+          <AlertContent
+            cancelAction={cancelDeleteAction}
+            deleteAction={confirmDeleteAction}
+            isLoading={props.isLoading}
+            title={props.title}
+          />
+        }
+        headline={
+          <span tabIndex="-1" id="deleteConfirmationHeading">
+            Are you sure?
+          </span>
+        }
+        isVisible
+        scrollOnShow={focusDeleteAlert}
+        scrollPosition="end"
+        status={ALERT_TYPE.WARNING}
+      />
     );
   }
+
+  return (
+    <div className="vads-u-display--flex vads-u-flex-wrap--wrap vads-u-flex-direction--column">
+      {props.children}
+      {renderDeleteAction()}
+    </div>
+  );
 }
 
 ContactInformationActionButtons.propTypes = {
   deleteEnabled: PropTypes.bool,
   title: PropTypes.string.isRequired,
   onDelete: PropTypes.func.isRequired,
-  onCancel: PropTypes.func.isRequired,
   isLoading: PropTypes.bool,
 };
 


### PR DESCRIPTION
## Description
This prevents the delete confirmation alert from constantly hijacking scroll whenever the user enters any data in the contact info form while the confirmation alert is visible.

I ended up refactoring the component to a functional one that uses hooks. If I stuck with a class-based component I needed to use a 0ms timeout hack to achieve the same thing. The refactor also lead to redoing the tests with RTL.

## Testing done
Updated tests. Existing tests that make heavy use of deleting contact info data pass.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs