### PR TITLE
Fix failing nightwatch tests in apps only build

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -379,7 +379,7 @@ module.exports = (env = {}) => {
           loadingMessage: 'Please wait while we load the application for you.',
           ...template, // Unpack any template metadata from the registry entry.
         },
-        title: template.title || appName ? `${appName} | VA.gov` : 'VA.gov',
+        title: `${template.title || appName} | Veterans Affairs`,
       });
 
     baseConfig.plugins = baseConfig.plugins.concat(

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -350,6 +350,14 @@ module.exports = (env = {}) => {
         rootUrl: '/find-forms',
         widgetType: 'find-va-forms',
       },
+      {
+        appName: 'Coronavirus Chatbot',
+        rootUrl: '/coronavirus-chatbot',
+        widgetType: 'va-coronavirus-chatbot',
+        template: {
+          title: 'VA coronavirus chatbot',
+        },
+      },
     ];
 
     const generateLandingPage = ({

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -47,6 +47,6 @@ done
 # exit code.  In this case, if the build command fails, the tee
 # command won't trick Jenkins into thinking the step passed.
 set -o pipefail
-npm --no-color run build -- --verbose --buildtype="$envName" --asset-source="$assetSource" --drupal-address="$drupalAddress" --drupal-max-parallel-requests="$drupalMaxParallelRequests" "$omitdebug" "$pullDrupal" 2>&1 | tee "$buildLog"
+npm --no-color run build -- --verbose --scaffold --buildtype="$envName" --asset-source="$assetSource" --drupal-address="$drupalAddress" --drupal-max-parallel-requests="$drupalMaxParallelRequests" "$omitdebug" "$pullDrupal" 2>&1 | tee "$buildLog"
 
 exit $?

--- a/script/build.sh
+++ b/script/build.sh
@@ -71,4 +71,4 @@ else
 fi
 
 # Always build the content
-yarn build:content $args
+# yarn build:content $args


### PR DESCRIPTION
## Description
This PR fixes the failing nightwatch tests in the apps only build.

## Testing done
Tested locally and in the Jenkins pipeline.

## Screenshots


## Acceptance criteria
- [ ] Nightwatch tests ran on the apps only build should pass.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
