### PR TITLE
Remove @department-of-veterans-affairs/vsa-ebenefits-frontend from CodeOwners per Request

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,7 +29,7 @@ src/platform/utilities/medical-centers @department-of-veterans-affairs/vsa-authd
 # Benefits and Memorials
 src/applications/letters @department-of-veterans-affairs/vsa-bam-1-frontend @department-of-veterans-affairs/vsa-authd-exp-frontend
 src/applications/disability-benefits @department-of-veterans-affairs/vsa-bam-1-frontend @department-of-veterans-affairs/vsa-ebenefits-frontend
-src/applications/claims-status @department-of-veterans-affairs/vsa-bam-1-frontend @department-of-veterans-affairs/vsa-bam-2-frontend @department-of-veterans-affairs/vsa-ebenefits-frontend
+src/applications/claims-status @department-of-veterans-affairs/vsa-bam-1-frontend @department-of-veterans-affairs/vsa-bam-2-frontend
 
 # Benefits and Memorials 2
 src/applications/disability-benefits/2346 @department-of-veterans-affairs/vsa-bam-2-frontend @department-of-veterans-affairs/vsa-bam-1-frontend @department-of-veterans-affairs/vsa-caregiver-frontend @department-of-veterans-affairs/vsa-ebenefits-frontend


### PR DESCRIPTION
## Description
Remove @department-of-veterans-affairs/vsa-ebenefits-frontend from `src/applications/claims-status` https://dsva.slack.com/archives/CBU0KDSB1/p1615822906129100?thread_ts=1615822645.128300&cid=CBU0KDSB1

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] @department-of-veterans-affairs/vsa-ebenefits-frontend is removed from `src/applications/claims-status`
