### PR TITLE
Removed prod flag and updated content

### DIFF
--- a/src/applications/edu-benefits/10203/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/10203/containers/IntroductionPage.jsx
@@ -222,8 +222,8 @@ export class IntroductionPage extends React.Component {
                 usually in the Registrar or Financial Aid office at the school.
               </p>
               <p>
-                If your application isn't approved, you’ll get a denial letter
-                in the mail.
+                If your application isn't approved, you'll get a denial letter
+                in the mail or a claim status notification by email.
               </p>
             </li>
           </ol>

--- a/src/applications/edu-benefits/10203/helpers.jsx
+++ b/src/applications/edu-benefits/10203/helpers.jsx
@@ -3,7 +3,6 @@ import get from 'platform/utilities/data/get';
 import set from 'platform/utilities/data/set';
 import unset from 'platform/utilities/data/unset';
 import { states } from 'platform/forms/address';
-import environment from 'platform/utilities/environment';
 
 export const isChapter33 = form =>
   !!form['view:benefit']?.chapter33 || !!form['view:benefit']?.fryScholarship;
@@ -12,9 +11,7 @@ export const displayConfirmEligibility = form =>
   !isChapter33(form) ||
   (!form.isEnrolledStem && !form.isPursuingTeachingCert) ||
   form.benefitLeft === 'moreThanSixMonths' ||
-  (form['view:remainingEntitlement']?.totalDays > 180 &&
-    // Production flag for 18861
-    !environment.isProduction());
+  form['view:remainingEntitlement']?.totalDays > 180;
 
 export function updateProgramDetailsSchema() {
   const usaStates = states.USA.map(state => state.value);


### PR DESCRIPTION
## Description
As a developer, I need to remove the prod flag for the entitlement warning in the 10203 form so that the updated UI is available in all environments.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/19494

## Testing done
local testing 

## Screenshots


## Acceptance criteria
- [x] The prod flag created in #18861 is removed and the functionality implemented in that story is available in production.

- [x] On the introduction page, the sentence:

If your application isn't approved, you’ll get a denial letter in the mail.

is replaced with

If your application isn't approved, you'll get a denial letter in the mail or a claim status notification by email.

- [ ] The 'stem_automated_decision' feature flag is enabled for the limited rollout starting at 20%.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
