### PR TITLE
Add instructions for running Contact tests to vets-website readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,20 @@ Just like with unit tests, you can also **specify the path to the test file**
 yarn test:e2e src/applications/path/to/test-file.e2e.spec.js
 ```
 
+### Contract tests
+
+To run all contract tests locally:
+
+```sh
+yarn test:contract
+```
+
+To run a specific contract test:
+
+```sh
+BUILDTYPE=localhost yarn test:unit src/applications/my-app/tests/example.pact.spec.js
+```
+
 ## Running a mock API for local development
 
 In separate terminal from your local dev server, run


### PR DESCRIPTION
Regarding ticket #14020 - https://app.zenhub.com/workspaces/vsp-5cedc9cce6e3335dc5a49fc4/issues/department-of-veterans-affairs/va.gov-team/14020

Add instructions for how to run consumer Contact tests to `vets-website` `README.md`.

Text was copied from here - https://github.com/department-of-veterans-affairs/vets-website/pull/16498