### PR TITLE
Change link to absolute

### DIFF
--- a/src/platform/site-wide/mega-menu/containers/Main.jsx
+++ b/src/platform/site-wide/mega-menu/containers/Main.jsx
@@ -105,7 +105,7 @@ const mainSelector = createSelector(
       // Add the My VA link to default links.
       {
         className: 'my-va-top-nav',
-        href: 'https://va.gov/my-va/',
+        href: 'https://www.va.gov/my-va/',
         title: 'My VA',
       },
     ];

--- a/src/platform/site-wide/mega-menu/containers/Main.jsx
+++ b/src/platform/site-wide/mega-menu/containers/Main.jsx
@@ -105,7 +105,7 @@ const mainSelector = createSelector(
       // Add the My VA link to default links.
       {
         className: 'my-va-top-nav',
-        href: '/my-va/',
+        href: 'https://va.gov/my-va/',
         title: 'My VA',
       },
     ];


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/21183

This PR makes the `my-va` nav link absolute instead of relative.

## Testing done
Locally

## Screenshots


## Acceptance criteria
- [x] makes the `my-va` nav link absolute instead of relative

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
