### PR TITLE
Set feature flip POA data to formData on 10-10CG

### DIFF
--- a/src/applications/caregivers/containers/IntroductionPage.jsx
+++ b/src/applications/caregivers/containers/IntroductionPage.jsx
@@ -1,4 +1,6 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 import OMBInfo from '@department-of-veterans-affairs/component-library/OMBInfo';
 import Telephone, {
   CONTACTS,
@@ -14,11 +16,34 @@ import {
   DowntimeNotification,
   externalServices,
 } from 'platform/monitoring/DowntimeNotification';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import { setData } from 'platform/forms-system/src/js/actions';
 
-const IntroductionPage = ({ route, router }) => {
+const IntroductionPage = ({
+  route,
+  router,
+  formData,
+  setFormData,
+  canUpload1010cgPOA,
+}) => {
   useEffect(() => {
     focusElement('.va-nav-breadcrumbs-list');
   }, []);
+
+  const getFeatureFlip = useCallback(
+    () => {
+      setFormData({ ...formData, canUpload1010cgPOA });
+    },
+    [setFormData, canUpload1010cgPOA],
+  );
+
+  useEffect(
+    () => {
+      getFeatureFlip();
+    },
+    [getFeatureFlip],
+  );
 
   const startForm = () => {
     recordEvent({ event: 'caregivers-10-10cg-start-form' });
@@ -243,4 +268,24 @@ const IntroductionPage = ({ route, router }) => {
   );
 };
 
-export default withRouter(IntroductionPage);
+const mapStateToProps = state => ({
+  formData: state.form.data,
+  canUpload1010cgPOA: toggleValues(state)[
+    FEATURE_FLAG_NAMES.canUpload1010cgPOA
+  ],
+});
+
+const mapDispatchToProps = {
+  setFormData: setData,
+};
+
+IntroductionPage.propTypes = {
+  canUpload1010cgPOA: PropTypes.bool,
+  setFormData: PropTypes.func,
+  formData: PropTypes.object,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(withRouter(IntroductionPage));

--- a/src/applications/caregivers/containers/IntroductionPage.jsx
+++ b/src/applications/caregivers/containers/IntroductionPage.jsx
@@ -285,7 +285,9 @@ IntroductionPage.propTypes = {
   formData: PropTypes.object,
 };
 
+const introPageWithRouter = withRouter(IntroductionPage);
+
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-)(withRouter(IntroductionPage));
+)(introPageWithRouter);

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -86,4 +86,5 @@ export default Object.freeze({
   subform89404192: 'subform_8940_4192',
   dependencyVerification: 'dependency_verification',
   form10182Nod: 'form10182_nod',
+  canUpload1010cgPOA: 'can_upload_10_10cg_poa',
 });


### PR DESCRIPTION
## Description
For the Power of Attorney feature for the 10-10CG where we are enabling users to sign as a POA we have a need for a feature flip so we can roll out portion of the features without it effecting users and then needing to test all the features as as hole holistically before releasing to an audience.  

This PR is to add the feature flip to formData so we can toggle fields and pages in the formBuilder using FormData.

[Ticket](https://app.zenhub.com/workspaces/vsa---caregiver-5fff0cfd1462b6000e320fc7/issues/department-of-veterans-affairs/va.gov-team/21856)

## Testing done
- Manual testing

## Screenshots
### Feature flip off
![image](https://user-images.githubusercontent.com/23741323/112489499-ded1e900-8d54-11eb-87ff-0e3ed3c1576a.png)

### Feature flip on
![Screen Shot 2021-03-25 at 10 31 43 AM](https://user-images.githubusercontent.com/23741323/112490001-60c21200-8d55-11eb-8d1e-a9e6aefe7fc1.png)


## Acceptance criteria
- [x] Add feature flip data to formData on intro page mount

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
