### PR TITLE
Remove custom classes + tweak dropdown css

### DIFF
--- a/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
@@ -67,13 +67,13 @@ class SearchHelpSignIn extends Component {
 
   render() {
     return (
-      <div className="profile-nav">
+      <div className="vads-u-display--flex vads-u-align-items--center vads-u-padding-top--1">
         <SearchMenu
           clickHandler={this.handleSearchMenuClick}
           isOpen={this.props.isMenuOpen.search}
         />
         <a
-          className="contact-us-link vads-u-color--white vads-u-text-decoration--none vads-u-padding-top--0p5 vads-u-padding-x--1 vads-u-font-weight--bold"
+          className="vads-u-color--white vads-u-text-decoration--none vads-u-padding-x--1 vads-u-font-weight--bold"
           href="https://www.va.gov/contact-us/"
           onClick={() => recordEvent({ event: 'nav-jumplink-click' })}
         >

--- a/src/platform/site-wide/user-nav/components/SearchMenu.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchMenu.jsx
@@ -386,14 +386,14 @@ export class SearchMenu extends React.Component {
 
     return (
       <DropDownPanel
-        onClick={() => recordEvent({ event: 'nav-jumplink-click' })}
         buttonText="Search"
         clickHandler={clickHandler}
-        dropdownPanelClassNames="vads-u-padding--0 vads-u-margin--0"
         cssClass={buttonClasses}
-        id="search"
+        dropdownPanelClassNames="vads-u-padding--0 vads-u-margin--0"
         icon={icon}
+        id="search"
         isOpen={isOpen}
+        onClick={() => recordEvent({ event: 'nav-jumplink-click' })}
       >
         {makeForm()}
       </DropDownPanel>

--- a/src/platform/site-wide/user-nav/components/SignInProfileMenu.jsx
+++ b/src/platform/site-wide/user-nav/components/SignInProfileMenu.jsx
@@ -13,10 +13,11 @@ function SignInProfileMenu({ greeting, clickHandler, isOpen, disabled }) {
       <DropDownPanel
         buttonText={greeting}
         clickHandler={clickHandler}
-        id="account-menu"
-        icon={icon}
-        isOpen={isOpen}
+        cssClass="sign-in-drop-down-panel-button"
         disabled={disabled}
+        icon={icon}
+        id="account-menu"
+        isOpen={isOpen}
       >
         <PersonalizationDropdown />
       </DropDownPanel>

--- a/src/platform/site-wide/user-nav/sass/user-nav.scss
+++ b/src/platform/site-wide/user-nav/sass/user-nav.scss
@@ -47,10 +47,11 @@ span.sidelines {
 }
 
 #login-root {
-  .sitewide-search-drop-down-panel-button {
+  .sitewide-search-drop-down-panel-button, .sign-in-drop-down-panel-button {
     border-top: none;
-    padding-bottom: 0;
-    padding-top: 0;
+    margin-right: 0;
+    padding: 0 30px 0 0;
+    width: auto;
   }
 
   .login {

--- a/src/platform/site-wide/user-nav/sass/user-nav.scss
+++ b/src/platform/site-wide/user-nav/sass/user-nav.scss
@@ -47,13 +47,10 @@ span.sidelines {
 }
 
 #login-root {
-  .profile-nav {
-    display: flex;
-    align-items: center;
-  }
-
-  .contact-us-link {
-    min-width: 91px;
+  .sitewide-search-drop-down-panel-button {
+    border-top: none;
+    padding-bottom: 0;
+    padding-top: 0;
   }
 
   .login {


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/21317

I realized that a lot of the issues we were having with alignment in the top nav items was due to the dropdown adding transparent top border, among other custom CSS issues (instead of using design utilities). This PR removes a couple of those custom CSS classes and tweaks the dropdown css in the top nav.

## Testing done
Locally

## Screenshots

### Unauth
![image](https://user-images.githubusercontent.com/12773166/112508961-a67eda80-8d55-11eb-8902-9be25b5c818a.png)


### Auth
![image](https://user-images.githubusercontent.com/12773166/112508900-9666fb00-8d55-11eb-8773-fd753647d9fc.png)

## Acceptance criteria
- [x] Fix top nav item alignment

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
