### PR TITLE
Add repeat search tracking

### DIFF
--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -94,6 +94,17 @@ class SearchApp extends React.Component {
     if (e) e.preventDefault();
     const { userInput, currentResultsQuery, page } = this.state;
 
+    let userInputFromAddress = '';
+    let pageFromAddress;
+
+    if (this.props.router.location.query) {
+      userInputFromAddress = this.props.router.location.query.query;
+      pageFromAddress = this.props.router.location.query.page;
+    }
+
+    const repeatSearch =
+      userInputFromAddress === userInput && pageFromAddress === page;
+
     const queryChanged = userInput !== currentResultsQuery;
     const nextPage = queryChanged ? 1 : page;
 
@@ -108,7 +119,7 @@ class SearchApp extends React.Component {
 
     // Fetch new results
     this.props.fetchSearchResults(userInput, nextPage, {
-      trackEvent: queryChanged,
+      trackEvent: queryChanged || repeatSearch,
       eventName: 'view_search_results',
       path: document.location.pathname,
       userInput,

--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -95,13 +95,15 @@ class SearchApp extends React.Component {
     const { userInput, currentResultsQuery, page } = this.state;
 
     const userInputFromURL = this.props.router?.location?.query?.query;
-    const pageFromURL = this.props.router?.location?.query?.page;
+    const rawPageFromURL = this.props.router?.location?.query?.page;
+    const pageFromURL = rawPageFromURL
+      ? parseInt(rawPageFromURL, 10)
+      : undefined;
 
     const repeatSearch = userInputFromURL === userInput && pageFromURL === page;
 
     const queryChanged = userInput !== currentResultsQuery;
     const nextPage = queryChanged ? 1 : page;
-
     // Update URL
     this.props.router.push({
       pathname: '',

--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -36,13 +36,8 @@ class SearchApp extends React.Component {
   constructor(props) {
     super(props);
 
-    let userInputFromURL = '';
-    let pageFromURL;
-
-    if (this.props.router.location.query) {
-      userInputFromURL = this.props.router?.location?.query?.query;
-      pageFromURL = this.props.router?.location?.query?.page;
-    }
+    const userInputFromURL = this.props.router?.location?.query?.query || '';
+    const pageFromURL = this.props.router?.location?.query?.page || undefined;
 
     this.state = {
       userInput: userInputFromURL,

--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -36,21 +36,21 @@ class SearchApp extends React.Component {
   constructor(props) {
     super(props);
 
-    let userInputFromAddress = '';
-    let page;
+    let userInputFromURL = '';
+    let pageFromURL;
 
     if (this.props.router.location.query) {
-      userInputFromAddress = this.props.router.location.query.query;
-      page = this.props.router.location.query.page;
+      userInputFromURL = this.props.router?.location?.query?.query;
+      pageFromURL = this.props.router?.location?.query?.page;
     }
 
     this.state = {
-      userInput: userInputFromAddress,
-      currentResultsQuery: userInputFromAddress,
-      page,
+      userInput: userInputFromURL,
+      currentResultsQuery: userInputFromURL,
+      page: pageFromURL,
     };
 
-    if (!userInputFromAddress) {
+    if (!userInputFromURL) {
       window.location.href = '/';
     }
   }
@@ -94,16 +94,10 @@ class SearchApp extends React.Component {
     if (e) e.preventDefault();
     const { userInput, currentResultsQuery, page } = this.state;
 
-    let userInputFromAddress = '';
-    let pageFromAddress;
+    const userInputFromURL = this.props.router?.location?.query?.query;
+    const pageFromURL = this.props.router?.location?.query?.page;
 
-    if (this.props.router.location.query) {
-      userInputFromAddress = this.props.router.location.query.query;
-      pageFromAddress = this.props.router.location.query.page;
-    }
-
-    const repeatSearch =
-      userInputFromAddress === userInput && pageFromAddress === page;
+    const repeatSearch = userInputFromURL === userInput && pageFromURL === page;
 
     const queryChanged = userInput !== currentResultsQuery;
     const nextPage = queryChanged ? 1 : page;


### PR DESCRIPTION
## Description
This PR adds event tracking to the search results page for when a user repeats their search term for the same query

## Testing done
Manual testing

## Acceptance criteria
- [X] repeat searches are tracked

## Related
https://github.com/department-of-veterans-affairs/va.gov-team/issues/20889
