### PR TITLE
Add temp check CLP auth solution

### DIFF
--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -4,7 +4,7 @@
 <!-- Derive the total sections the page includes for analytics. -->
 {% assign clpTotalSections = 11 | deriveCLPTotalSections: fieldClpVideoPanel, fieldClpSpotlightPanel, fieldClpStoriesPanel, fieldClpResourcesPanel, fieldClpEventsPanel, fieldClpFaqPanel, fieldBenefitCategories %}
 
-<div id="content" class="interior" data-template="node-campaign_landing_page">
+<div id="content" class="interior vads-u-display--none" data-template="node-campaign_landing_page">
   <main>
     <!-- Hero-->
     <div class="va-u-background--image" style="background-image: url('{{ fieldHeroImage.entity.image.url }}">
@@ -652,6 +652,35 @@
     {% include "src/site/components/up_to_top_button.html" %}
   </main>
 </div>
+
+<!-- TEMPORARY -->
+<!-- =============== -->
+<script>
+  const checkCLPAuth = () => {
+    const password = prompt('This page is in BETA. Please enter the password to access it:');
+
+    // Escape early if the password is incorrect.
+    if (password !== 'clptest123') {
+      checkCLPAuth();
+      return;
+    }
+
+    // Derive the content element.
+    const content = document.getElementById('content');
+
+    // Escape early if we cannot find it.
+    if (!content) {
+      console.error('Unable to find #content to show.');
+      return;
+    }
+
+    // Show the content.
+    content.classList.remove('vads-u-display--none');
+  }
+
+  checkCLPAuth();
+</script>
+<!-- =============== -->
 
 {% include "src/site/includes/footer.html" %}
 {% include "src/site/includes/debug.drupal.liquid" %}

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -675,7 +675,7 @@
     }
 
     // Show the content.
-    content.classList.remove('vads-u-display--none');
+    content.className = content.className.replace(' vads-u-display--none', '');
   }
 
   checkCLPAuth();

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -659,9 +659,9 @@
   function checkCLPAuth() {
     var clpPassphrase = prompt('This page is in BETA. Please enter the passphrase to access it:');
 
-    // Escape early if the passphrase is incorrect.
+    // Redirect to homepage if the passphrase is incorrect.
     if (clpPassphrase !== 'clptest123') {
-      checkCLPAuth();
+      window.location.href = '/';
       return;
     }
 

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -656,17 +656,17 @@
 <!-- TEMPORARY -->
 <!-- =============== -->
 <script>
-  const checkCLPAuth = () => {
-    const password = prompt('This page is in BETA. Please enter the password to access it:');
+  function checkCLPAuth() {
+    var clpPassword = prompt('This page is in BETA. Please enter the password to access it:');
 
     // Escape early if the password is incorrect.
-    if (password !== 'clptest123') {
+    if (clpPassword !== 'clptest123') {
       checkCLPAuth();
       return;
     }
 
     // Derive the content element.
-    const content = document.getElementById('content');
+    var content = document.getElementById('content');
 
     // Escape early if we cannot find it.
     if (!content) {

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -657,10 +657,10 @@
 <!-- =============== -->
 <script>
   function checkCLPAuth() {
-    var clpPassword = prompt('This page is in BETA. Please enter the password to access it:');
+    var clpPassphrase = prompt('This page is in BETA. Please enter the passphrase to access it:');
 
-    // Escape early if the password is incorrect.
-    if (clpPassword !== 'clptest123') {
+    // Escape early if the passphrase is incorrect.
+    if (clpPassphrase !== 'clptest123') {
       checkCLPAuth();
       return;
     }


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/21665

This PR adds a temp auth solution for CLP pages. The password is not meant to be secure but rather a deterrent for the average user until the page is ready for publication. I recommend testing this on **http://localhost:3001/preview?nodeId=16139**.

## Testing done
Locally

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/112513001-86511a80-8d59-11eb-83e7-31d38caf6799.png)

## Acceptance criteria
- [x] Add clp auth check

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
