### PR TITLE
Make flipper data view data type

### DIFF
--- a/src/applications/caregivers/containers/IntroductionPage.jsx
+++ b/src/applications/caregivers/containers/IntroductionPage.jsx
@@ -33,7 +33,10 @@ const IntroductionPage = ({
 
   const getFeatureFlip = useCallback(
     () => {
-      setFormData({ ...formData, canUpload1010cgPOA });
+      setFormData({
+        ...formData,
+        'view:canUpload1010cgPOA': canUpload1010cgPOA,
+      });
     },
     [setFormData, canUpload1010cgPOA],
   );


### PR DESCRIPTION
## Description
We do not need to collect and pass flipper data to the back end to void this make flipper data type of 'view`

## Testing done
- Manual testing

## Screenshots
![Screen Shot 2021-03-25 at 3 16 40 PM](https://user-images.githubusercontent.com/23741323/112530712-27050180-8d7d-11eb-9787-8be0e6e7a53c.png)


## Acceptance criteria
- [ ] Make flipper data on 10-10cg of type `view`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
