### PR TITLE
Liquid Template Testing Tool: Fix bug with html filename. Add optional dataName parameter to filename.

### DIFF
--- a/src/site/layouts/tests/vamc/phone-number.unit.spec.js
+++ b/src/site/layouts/tests/vamc/phone-number.unit.spec.js
@@ -9,7 +9,11 @@ const data = parseFixture(
 describe('phone-number', () => {
   describe('number has label and location', () => {
     it('displays fieldPhoneLabel in h5', async () => {
-      const container = await renderHTML(layoutPath, data.labelAndLocationName);
+      const container = await renderHTML(
+        layoutPath,
+        data.labelAndLocationName,
+        'labelAndLocationName',
+      );
 
       expect(container.querySelector('h5').innerHTML).to.equal(
         data.labelAndLocationName.number.fieldPhoneLabel,
@@ -19,7 +23,11 @@ describe('phone-number', () => {
 
   describe('number has no label, has location', () => {
     it('displays phoneLabel in h5', async () => {
-      const container = await renderHTML(layoutPath, data.noLabelLocationName);
+      const container = await renderHTML(
+        layoutPath,
+        data.noLabelLocationName,
+        'noLabelLocationName',
+      );
 
       expect(container.querySelector('h5').innerHTML).to.equal('Fax');
     });
@@ -30,6 +38,7 @@ describe('phone-number', () => {
       const container = await renderHTML(
         layoutPath,
         data.noLabelNoLocationName,
+        'noLabelNoLocationName',
       );
 
       expect(container.querySelector('h4').innerHTML).to.equal('Phone');
@@ -41,6 +50,7 @@ describe('phone-number', () => {
       const container = await renderHTML(
         layoutPath,
         data.noLabelNoLocationName,
+        'noLabelNoLocationName',
       );
 
       expect(container.querySelector('a').innerHTML.trim()).to.equal(
@@ -52,7 +62,11 @@ describe('phone-number', () => {
     });
 
     it('with extension', async () => {
-      const container = await renderHTML(layoutPath, data.numberWithExtension);
+      const container = await renderHTML(
+        layoutPath,
+        data.numberWithExtension,
+        'numberWithExtension',
+      );
 
       expect(container.querySelector('a').innerHTML.trim()).to.equal(
         `${data.numberWithExtension.number.fieldPhoneNumber}x ${

--- a/src/site/tests/support/index.js
+++ b/src/site/tests/support/index.js
@@ -19,8 +19,7 @@ const getLayout = filePath => getFile(filePath);
 const parseFixture = filePath => JSON.parse(getFile(filePath));
 
 const makeHTMLFileName = (layoutPath, dataName) => {
-  const liquidFileName = layoutPath.match(/(\w|\d|\.|-)+$/g)[0];
-  const fileName = liquidFileName.split('.')[0];
+  const fileName = path.basename(layoutPath).split('.')[0];
   return dataName ? `${fileName}.${dataName}.html` : `${fileName}.html`;
 };
 

--- a/src/site/tests/support/index.js
+++ b/src/site/tests/support/index.js
@@ -18,9 +18,10 @@ const getFile = filePath =>
 const getLayout = filePath => getFile(filePath);
 const parseFixture = filePath => JSON.parse(getFile(filePath));
 
-const makeHTMLFileName = name => {
-  const liquidFileName = name.match(/(\w|\d|\.|-)+$/g)[0];
-  return `${liquidFileName.split('.')[0]}.html`;
+const makeHTMLFileName = (layPath, dataName) => {
+  const liquidFileName = layPath.match(/(\w|\d|\.|-)+$/g)[0];
+  const fileName = liquidFileName.split('.')[0];
+  return dataName ? `${fileName}.${dataName}.html` : `${fileName}.html`;
 };
 
 const createDirectory = async () => {
@@ -68,7 +69,7 @@ const updateHTML = files => {
   modifyDom(options)(files, null, done);
 };
 
-const renderHTML = (layoutPath, data) => {
+const renderHTML = (layoutPath, data, dataName) => {
   const layout = getLayout(layoutPath);
   const context = liquid.newContext({ locals: data });
 
@@ -85,7 +86,7 @@ const renderHTML = (layoutPath, data) => {
         reject(err);
       } else {
         const html = context.getBuffer();
-        const htmlFileName = makeHTMLFileName(layoutPath);
+        const htmlFileName = makeHTMLFileName(layoutPath, dataName);
         const files = {
           [htmlFileName]: { contents: html, isDrupalPage: true },
           'generated/file-manifest.json': { contents: JSON.stringify({}) },

--- a/src/site/tests/support/index.js
+++ b/src/site/tests/support/index.js
@@ -18,8 +18,8 @@ const getFile = filePath =>
 const getLayout = filePath => getFile(filePath);
 const parseFixture = filePath => JSON.parse(getFile(filePath));
 
-const makeHTMLFileName = (layPath, dataName) => {
-  const liquidFileName = layPath.match(/(\w|\d|\.|-)+$/g)[0];
+const makeHTMLFileName = (layoutPath, dataName) => {
+  const liquidFileName = layoutPath.match(/(\w|\d|\.|-)+$/g)[0];
   const fileName = liquidFileName.split('.')[0];
   return dataName ? `${fileName}.${dataName}.html` : `${fileName}.html`;
 };

--- a/src/site/tests/support/index.js
+++ b/src/site/tests/support/index.js
@@ -19,7 +19,7 @@ const getLayout = filePath => getFile(filePath);
 const parseFixture = filePath => JSON.parse(getFile(filePath));
 
 const makeHTMLFileName = name => {
-  const liquidFileName = name.match(/(\w|\d|\.)+$/g)[0];
+  const liquidFileName = name.match(/(\w|\d|\.|-)+$/g)[0];
   return `${liquidFileName.split('.')[0]}.html`;
 };
 


### PR DESCRIPTION
## Description
Resolves ticket #22150 - https://app.zenhub.com/workspaces/vsp-5cedc9cce6e3335dc5a49fc4/issues/department-of-veterans-affairs/va.gov-team/22150

Fixes bug when creating the filename for the `HTML` file. Regex wasn't checking for the `-` character.

Add option to pass in `dataName` parameter to `renderHTML()`. If provided, add it to the `HTML` filename.

Example:
Given the `liquid` file path: `src/site/layouts/health_care_region_page.drupal.liquid`

And a string representing a fixture: `noLabelLocationName`

The resulting `HTML` filename will be:
`health_care_region.noLabelLocationName.html`

Screenshot of `HTML` filenames:
![image](https://user-images.githubusercontent.com/9326247/112540863-1195d480-8d89-11eb-84f7-06fcde38512d.png)

