### PR TITLE
Make new direct deposit widget for static pages

### DIFF
--- a/src/applications/static-pages/direct-deposit-content/DirectDepositContent.jsx
+++ b/src/applications/static-pages/direct-deposit-content/DirectDepositContent.jsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import AlertBox, {
+  ALERT_TYPE,
+} from '@department-of-veterans-affairs/component-library/AlertBox';
+import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/component-library/Telephone';
+
+import CallToAction from '~/platform/site-wide/cta-widget';
+import { widgetTypes } from '~/platform/site-wide/cta-widget/helpers';
+import { showDirectDepositV2 } from '~/applications/personalization/profile/selectors';
+
+const NewContent = () => {
+  return (
+    <>
+      <p>
+        If you receive disability compensation, pension or education benefits
+        from VA, you can update your direct deposit information in your VA.gov
+        profile. You’ll need your bank’s routing number and account number to
+        make the updates.{' '}
+      </p>
+      <p>
+        <strong>Note:</strong> You’ll need to sign in to VA.gov to update your
+        direct deposit information. Once signed in, you’ll have to verify your
+        identity and set up 2-factor authentication only if you’ve haven’t done
+        this already.
+      </p>
+      <CallToAction appId={widgetTypes.DIRECT_DEPOSIT} />
+      <p>
+        If you have questions, please call us at{' '}
+        <Telephone contact={CONTACTS.VA_BENEFITS} />. We’re here Monday through
+        Friday, 8:00 a.m. to 9:00 p.m. ET. Or go to your{' '}
+        <a href="./find-locations">nearest VA regional office</a>.
+      </p>
+    </>
+  );
+};
+
+const OldContent = () => {
+  return (
+    <>
+      <h3 id="disability-compensation-and-pe">
+        Disability compensation and pension benefit payments
+      </h3>
+      <p>
+        If you receive disability compensation or pension payments from VA, you
+        can update your direct deposit information in your VA.gov profile.
+        You’ll need your bank’s routing number and account number to make the
+        updates.{' '}
+      </p>
+      <p>
+        <strong>Note:</strong> You’ll need to sign in to VA.gov to update your
+        direct deposit information. Once signed in, you’ll have to verify your
+        identity and set up 2-factor authentication only if you’ve haven’t done
+        this already.
+      </p>
+      <CallToAction appId={widgetTypes.DIRECT_DEPOSIT} />
+      <p>
+        If you have questions, please call us at{' '}
+        <Telephone contact={CONTACTS.VA_BENEFITS} />. We’re here Monday through
+        Friday, 8:00 a.m. to 9:00 p.m. ET. Or go to your{' '}
+        <a href="./find-locations">nearest VA regional office</a>.
+      </p>
+      <h3 id="education-benefit-payments">Education benefits</h3>
+      <p>
+        If you receive education benefit payments from VA, you’ll need to sign
+        in to eBenefits to update your direct deposit information. You’ll need
+        your bank’s routing number and account number to make the updates.
+      </p>
+      <AlertBox
+        status={ALERT_TYPE.INFO}
+        headline="Please sign in to eBenefits to change your direct deposit information for education benefits"
+      >
+        <p>
+          To use this feature, you’ll need a Premium <strong>DS Logon</strong>{' '}
+          account. Your My HealtheVet or ID.me credentials won’t work on the
+          eBenefits website. Go to eBenefits to sign in, register, or upgrade
+          your <strong>DS Logon</strong> account to Premium.
+        </p>
+        <a
+          className="usa-button-primary"
+          href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=direct-deposit-and-contact-information"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Go to eBenefits to change your information
+        </a>
+      </AlertBox>
+    </>
+  );
+};
+
+const DirectDepositContent = ({ isDD4EDUAvailable }) => {
+  if (isDD4EDUAvailable) {
+    return <NewContent />;
+  }
+
+  if (isDD4EDUAvailable === false) {
+    return <OldContent />;
+  }
+
+  return <LoadingIndicator message="Loading..." />;
+};
+
+const mapStateToProps = state => ({
+  isDD4EDUAvailable: showDirectDepositV2(state),
+});
+
+export default connect(mapStateToProps)(DirectDepositContent);

--- a/src/applications/static-pages/direct-deposit-content/DirectDepositContent.unit.spec.jsx
+++ b/src/applications/static-pages/direct-deposit-content/DirectDepositContent.unit.spec.jsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { expect } from 'chai';
+
+import { renderInReduxProvider } from '~/platform/testing/unit/react-testing-library-helpers';
+
+import DirectDepositContent from './DirectDepositContent';
+
+describe('DirectDepositContent', () => {
+  let view;
+  context('when the "ch33_dd_profile" feature flag is off', () => {
+    context('and the user is logged out', () => {
+      beforeEach(() => {
+        view = renderInReduxProvider(<DirectDepositContent />, {
+          initialState: {
+            /* eslint-disable-next-line camelcase */
+            featureToggles: { ch33_dd_profile: false },
+            user: {
+              login: {
+                currentlyLoggedIn: false,
+              },
+              profile: {
+                loading: false,
+                mhvAccount: {},
+              },
+            },
+          },
+        });
+      });
+      it('should show the correct content', () => {
+        view.getByRole('heading', {
+          name: /Disability compensation and pension benefit payments/i,
+        });
+        view.getByRole('heading', {
+          name: /Please sign in to change your direct deposit information online/i,
+        });
+        view.getByRole('button', { name: /sign in or create an account/i });
+        view.getByRole('heading', { name: /^Education benefits$/i });
+        view.getByRole('heading', { name: /please sign in to ebenefits/i });
+        view.getByRole('link', { name: /go to ebenefits/i });
+      });
+    });
+
+    context('and the user is logged in, is LOA3, and has 2FA set up', () => {
+      beforeEach(() => {
+        view = renderInReduxProvider(<DirectDepositContent />, {
+          initialState: {
+            /* eslint-disable-next-line camelcase */
+            featureToggles: { ch33_dd_profile: false },
+            user: {
+              login: {
+                currentlyLoggedIn: true,
+              },
+              profile: {
+                loading: false,
+                mhvAccount: {},
+                multifactor: true,
+                verified: true,
+              },
+            },
+          },
+        });
+      });
+      it('should show the correct content', () => {
+        view.getByRole('heading', {
+          name: /Disability compensation and pension benefit payments/i,
+        });
+        view.getByRole('heading', {
+          name: /Go to your VA.gov profile to change your direct deposit information online/i,
+        });
+        view.getByRole('button', { name: /go to your va.gov profile/i });
+        view.getByRole('heading', { name: /^Education benefits$/i });
+        view.getByRole('heading', { name: /please sign in to ebenefits/i });
+        view.getByRole('link', { name: /go to ebenefits/i });
+      });
+      it('should not prompt them to sign in', () => {
+        expect(
+          view.queryByRole('heading', {
+            name: /Please sign in to change your direct deposit information online/i,
+          }),
+        ).to.not.exist;
+        expect(
+          view.queryByRole('button', { name: /sign in or create an account/i }),
+        ).to.not.exist;
+      });
+    });
+  });
+
+  context('when the "ch33_dd_profile" feature flag is on', () => {
+    context('and the user is logged in, is LOA3, and has 2FA set up', () => {
+      beforeEach(() => {
+        view = renderInReduxProvider(<DirectDepositContent />, {
+          initialState: {
+            /* eslint-disable-next-line camelcase */
+            featureToggles: { ch33_dd_profile: true },
+            user: {
+              login: { currentlyLoggedIn: true },
+              profile: {
+                loading: false,
+                mhvAccount: {},
+                multifactor: true,
+                verified: true,
+              },
+            },
+          },
+        });
+      });
+      it('should show the correct content', () => {
+        expect(
+          view.queryByRole('heading', {
+            name: /Disability compensation and pension benefit payments/i,
+          }),
+        ).to.not.exist;
+        view.getByRole('heading', {
+          name: /Go to your VA.gov profile to change your direct deposit information online/i,
+        });
+        view.getByRole('button', { name: /go to your va.gov profile/i });
+        expect(view.queryByRole('heading', { name: /^Education benefits$/i }))
+          .to.not.exist;
+        expect(
+          view.queryByRole('heading', { name: /please sign in to ebenefits/i }),
+        ).to.not.exist;
+        expect(view.queryByRole('link', { name: /go to ebenefits/i })).to.not
+          .exist;
+      });
+    });
+  });
+});

--- a/src/applications/static-pages/direct-deposit-content/createDirectDepositContent.jsx
+++ b/src/applications/static-pages/direct-deposit-content/createDirectDepositContent.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { Provider } from 'react-redux';
+
+export default function createDirectDepositContent(store, widgetType) {
+  const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
+  if (root) {
+    import(/* webpackChunkName: "direct-deposit-content" */
+    './DirectDepositContent').then(module => {
+      const DirectDepositContent = module.default;
+      ReactDOM.render(
+        <Provider store={store}>
+          <DirectDepositContent />
+        </Provider>,
+        root,
+      );
+    });
+  }
+}

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -17,6 +17,7 @@ import subscribeAccordionEvents from './subscribeAccordionEvents';
 import createApplicationStatus from './createApplicationStatus';
 import createCallToActionWidget from './createCallToActionWidget';
 import createMyVALoginWidget from './createMyVALoginWidget';
+import createDirectDepositContent from './direct-deposit-content/createDirectDepositContent';
 import createDisabilityFormWizard from '../disability-benefits/wizard/createWizard';
 import createDisabilityRatingCalculator from '../disability-benefits/disability-rating-calculator/createCalculator';
 import createEducationApplicationStatus from '../edu-benefits/components/createEducationApplicationStatus';
@@ -194,6 +195,8 @@ createViewPaymentHistoryCTA(store, widgetTypes.VIEW_PAYMENT_HISTORY);
 createI18Select(store, widgetTypes.I_18_SELECT);
 
 createDependencyVerification(store, widgetTypes.DEPENDENCY_VERIFICATION);
+
+createDirectDepositContent(store, widgetTypes.DIRECT_DEPOSIT);
 
 // homepage widgets
 if (location.pathname === '/') {

--- a/src/applications/static-pages/widgetTypes.js
+++ b/src/applications/static-pages/widgetTypes.js
@@ -6,6 +6,7 @@ export default {
   CORONAVIRUS_CHATBOT: 'va-coronavirus-chatbot',
   COVID_VACCINE_UPDATES_CTA: 'va-covid-vaccine-updates-cta',
   CTA: 'cta',
+  DIRECT_DEPOSIT: 'direct-deposit',
   DISABILITY_APP_STATUS: 'disability-app-status',
   DISABILITY_RATING_CALCULATOR: 'disability-rating-calculator',
   EDUCATION_APP_STATUS: 'education-app-status',


### PR DESCRIPTION
## Description
This allows the `change-direct-deposit` page to show logged-in users different info if they have access to the DD4EDU feature flag or not.

## Testing done
- Added tests for the widget itself
- Added a `<div data-widget-type="direct-deposit"></div>` on my local `change-direct-deposit` page to confirm things look good for users who are logged in (with or without the feature flag) and logged out users.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs