### PR TITLE
fix alert message heading level

### DIFF
--- a/src/applications/vaos/project-cheetah/components/VAFacilityPage/SingleFacilityEligibilityCheckMessage.jsx
+++ b/src/applications/vaos/project-cheetah/components/VAFacilityPage/SingleFacilityEligibilityCheckMessage.jsx
@@ -6,7 +6,11 @@ import NewTabAnchor from '../../../components/NewTabAnchor';
 export default function SingleFacilityEligibilityCheckMessage({ facility }) {
   return (
     <div aria-atomic="true" aria-live="assertive">
-      <AlertBox status="warning" headline="We found one VA location for you">
+      <AlertBox
+        status="warning"
+        headline="We found one VA location for you"
+        level="2"
+      >
         <p>
           <strong>{facility.name}</strong>
           <br />

--- a/src/applications/vaos/project-cheetah/components/VAFacilityPage/VAFacilityInfoMessage.jsx
+++ b/src/applications/vaos/project-cheetah/components/VAFacilityPage/VAFacilityInfoMessage.jsx
@@ -5,7 +5,11 @@ import NewTabAnchor from '../../../components/NewTabAnchor';
 
 export default function VAFacilityInfoMessage({ facility }) {
   return (
-    <AlertBox status="info" headline="We found one VA location for you">
+    <AlertBox
+      status="info"
+      headline="We found one VA location for you"
+      level="2"
+    >
       <p>
         <strong>{facility.name}</strong>
         <br />

--- a/src/applications/vaos/tests/project-cheetah/components/VAFacilityPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/project-cheetah/components/VAFacilityPage/index.unit.spec.jsx
@@ -594,7 +594,7 @@ describe('VAOS vaccine flow: <VAFacilityPage>', () => {
         level: 2,
         name: 'We found one VA location for you',
       }),
-    );
+    ).to.exist;
 
     expect(screen.baseElement).to.contain.text('Fake facility name 1');
     expect(screen.baseElement).to.contain.text('Fake city 1');
@@ -635,7 +635,7 @@ describe('VAOS vaccine flow: <VAFacilityPage>', () => {
         level: 2,
         name: 'We found one VA location for you',
       }),
-    );
+    ).to.exist;
 
     expect(screen.baseElement).to.contain.text('Fake facility name 1');
     expect(screen.baseElement).to.contain.text('Fake city 1');
@@ -674,7 +674,7 @@ describe('VAOS vaccine flow: <VAFacilityPage>', () => {
         level: 2,
         name: 'We found one VA location for you',
       }),
-    );
+    ).to.exist;
 
     expect(screen.baseElement).to.contain.text(
       'However, we couldn’t find any available slots right now',

--- a/src/applications/vaos/tests/project-cheetah/components/VAFacilityPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/project-cheetah/components/VAFacilityPage/index.unit.spec.jsx
@@ -588,7 +588,13 @@ describe('VAOS vaccine flow: <VAFacilityPage>', () => {
       store,
     });
 
-    await screen.findByText(/We found one VA location for you/i);
+    // it should verify alert heading
+    expect(
+      await screen.findByRole('heading', {
+        level: 2,
+        name: 'We found one VA location for you',
+      }),
+    );
 
     expect(screen.baseElement).to.contain.text('Fake facility name 1');
     expect(screen.baseElement).to.contain.text('Fake city 1');
@@ -623,7 +629,13 @@ describe('VAOS vaccine flow: <VAFacilityPage>', () => {
       store,
     });
 
-    await screen.findByText(/We found one VA location for you/i);
+    // it should verify alert heading
+    expect(
+      await screen.findByRole('heading', {
+        level: 2,
+        name: 'We found one VA location for you',
+      }),
+    );
 
     expect(screen.baseElement).to.contain.text('Fake facility name 1');
     expect(screen.baseElement).to.contain.text('Fake city 1');
@@ -656,7 +668,13 @@ describe('VAOS vaccine flow: <VAFacilityPage>', () => {
       store,
     });
 
-    await screen.findByText(/We found one VA location for you/i);
+    // it should verify alert heading
+    expect(
+      await screen.findByRole('heading', {
+        level: 2,
+        name: 'We found one VA location for you',
+      }),
+    );
 
     expect(screen.baseElement).to.contain.text(
       'However, we couldn’t find any available slots right now',


### PR DESCRIPTION
## Description
The accessibility scan finds invalid heading order where the heading leap frog from h1 to h3. Update the alert message heading to be h2.

## Testing done
local and unit test

## Screenshots
**Single supporting facility but no available slot message**
![image](https://user-images.githubusercontent.com/54327023/112635013-aba15f80-8e11-11eb-834a-441347760454.png)

**Single supporting facility message**
![image](https://user-images.githubusercontent.com/54327023/112635198-e4413900-8e11-11eb-9113-0e63911adb71.png)

## Acceptance criteria
- [ ] Change the alert message heading to h3 for Single supporting facility but no slot scheduling message
- [ ] Change the alert message heading to h3 for Single supporting facility message

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
