### PR TITLE
Updated modal component event name

### DIFF
--- a/src/platform/site-wide/component-library-analytics-setup.js
+++ b/src/platform/site-wide/component-library-analytics-setup.js
@@ -6,7 +6,7 @@ import _recordEvent from 'platform/monitoring/record-event';
 import { kebabCase } from 'lodash';
 
 const analyticsEvents = {
-  Modal: [{ action: 'show', event: 'int-modal-click' }],
+  Modal: [{ action: 'show', event: 'int-modal-show' }],
   AlertBox: [{ action: 'linkClick', event: 'nav-alert-box-link-click' }],
 };
 

--- a/src/platform/site-wide/tests/component-library-analytics-setup.unit.spec.js
+++ b/src/platform/site-wide/tests/component-library-analytics-setup.unit.spec.js
@@ -19,7 +19,7 @@ describe('Site-wide component library analytics', () => {
     };
 
     const dataLayerEvent = {
-      event: 'int-modal-click',
+      event: 'int-modal-show',
       'event-source': 'component-library',
       'modal-title': 'Modal title',
       'modal-status': 'info',


### PR DESCRIPTION
## Description

At Jon's request (https://github.com/department-of-veterans-affairs/va.gov-team/issues/22184), we are updating the event name for modals from `int-modal-click` to `int-modal-show`

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
