### PR TITLE
Move survey-tools partial from end of body to head element

### DIFF
--- a/src/site/includes/footer.html
+++ b/src/site/includes/footer.html
@@ -15,7 +15,5 @@
 })();
 </script>
 
-{% include "src/site/includes/survey-tools.html" %}
-
 </body>
 </html>

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -87,6 +87,8 @@
     window.VetsGov.headerFooter = JSON.parse({{ headerFooterData }});
   </script>
 
+  {% include "src/site/includes/survey-tools.html" %}
+
 </head>
 
 <body class="{{ body_class }} merger">

--- a/src/site/includes/survey-tools.html
+++ b/src/site/includes/survey-tools.html
@@ -1,13 +1,13 @@
 {% if buildtype == 'vagovprod' %}
-  <script nonce="**CSP_NONCE**">
+  <script defer nonce="**CSP_NONCE**">
     {% include "src/site/assets/js/foresee/vagovprod.js" %}
   </script>
-  <script type="text/javascript" nonce="**CSP_NONCE**" src="https://resource.digital.voice.va.gov/wdcvoice/2/onsite/embed.js" async></script>
+  <script defer type="text/javascript" nonce="**CSP_NONCE**" src="https://resource.digital.voice.va.gov/wdcvoice/2/onsite/embed.js" async></script>
 {% endif %}
 
 {% if buildtype == 'vagovstaging' %}
-  <script nonce="**CSP_NONCE**">
+  <script defer nonce="**CSP_NONCE**">
     {% include "src/site/assets/js/foresee/vagovstaging.js" %}
   </script>
-  <script type="text/javascript" nonce="**CSP_NONCE**" src="https://resource.digital.voice.va.gov/wdcvoice/5/onsite/embed.js" async></script>
+  <script defer type="text/javascript" nonce="**CSP_NONCE**" src="https://resource.digital.voice.va.gov/wdcvoice/5/onsite/embed.js" async></script>
 {% endif %}


### PR DESCRIPTION
## Description

I received an email relaying reports of degraded performance attributed to the Medallia script. I believe this can be attributed to a temporary degradation of Medallia's service hosting and parser/render blocking script elements. 

In the [**See Also** section of MDN's `<script>` element docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#see_also), there's a link to the following page:

https://flaviocopes.com/javascript-async-defer

In that article, the author writes:

>The best thing to do to speed up your page loading when using scripts is to put them in the head, and add a defer attribute to your script tag - https://flaviocopes.com/javascript-async-defer/#just-tell-me-the-best-way

This PR does the following: 
- adds the `defer` attribute to our Medallia and Foresee script elements
- moves the `survey-tools.html` partial that contains the Medallia and ForeSee script elements from the end of the `<body>` element in the `footer.html` partial to the end of the `<head>` element in the `header.html` partial

### Email Excerpts 

>it looks like we’re having issues loading a chunk of JS that i believe supports the medallia customer service tool on va.gov. specifically https://resource.digital.voice.va.gov/wdcvoice/2/onsite/embed.js, which is taking like a couple of minutes to return a response. the impact is that it blocks the loading/painting of FE applications. so when i went to /health-care/covid-19-vaccine/stay-informed (which is getting lots of traffic), i just got a spinner for a looong time. The resource that was causing the issue appeared to be coming from a medallia host. or at least the error message when navigating directly to the URL was branded with Medallia.
>
>**Patrick**: for investigatory purposes, im seeing the degradation of the service hosting  that resource occurring b/w 10:27p ET and 11p ET last night
>
>**Sarkis**: Based on initial review by Medallia ENG contact, it seems that there is a VA Network delay (from akamai) ~0.9s response time. Our instance(s) are all hosted within the VA’s GovCloud Network and any blips within the network will directly impact Medallia. While Medallia ENG continue investigating on this, I will pull in our VA OIT contact to further investigate this on the VA side.

## Links

- https://flaviocopes.com/javascript-async-defer/#just-tell-me-the-best-way
- [Slack thread in #vsp-tools-fe](https://dsva.slack.com/archives/CQH357ZTP/p1616774490065100)

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
