### PR TITLE
Sanlouise inbox error

### DIFF
--- a/src/applications/personalization/dashboard-2/components/health-care/Appointments.jsx
+++ b/src/applications/personalization/dashboard-2/components/health-care/Appointments.jsx
@@ -21,7 +21,7 @@ export const Appointments = ({ appointments }) => {
   }
 
   return (
-    <div className="vads-u-display--flex vads-u-flex-direction--column large-screen:vads-u-flex--1 large-screen:vads-u-margin-right--3 small-screen:vads-u-margin-bottom--2">
+    <div className="vads-u-display--flex vads-u-flex-direction--column large-screen:vads-u-flex--1 large-screen:vads-u-margin-right--3 vads-u-margin-bottom--2p5">
       <div className="vads-u-background-color--gray-lightest vads-u-padding-y--2p5 vads-u-padding-x--2p5">
         <h4 className="vads-u-margin-top--0 vads-u-font-size--h3">
           Next appointment

--- a/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
+++ b/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
@@ -88,11 +88,12 @@ const HealthCare = ({
     );
   }
 
-  const messagesText = !hasInboxError
-    ? `You have ${unreadMessagesCount} new message${
-        unreadMessagesCount === 1 ? '' : 's'
-      }`
-    : 'Send a secure message to your health care team';
+  const messagesText =
+    shouldFetchMessages && !hasInboxError
+      ? `You have ${unreadMessagesCount} new message${
+          unreadMessagesCount === 1 ? '' : 's'
+        }`
+      : 'Send a secure message to your health care team';
 
   return (
     <div className="health-care-wrapper vads-u-margin-y--6">

--- a/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
+++ b/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
@@ -88,12 +88,11 @@ const HealthCare = ({
     );
   }
 
-  const messagesText =
-    typeof unreadMessagesCount === 'number' && !hasInboxError
-      ? `You have ${unreadMessagesCount} new message${
-          unreadMessagesCount === 1 ? '' : 's'
-        }`
-      : 'Send a secure message to your health care team';
+  const messagesText = !hasInboxError
+    ? `You have ${unreadMessagesCount} new message${
+        unreadMessagesCount === 1 ? '' : 's'
+      }`
+    : 'Send a secure message to your health care team';
 
   return (
     <div className="health-care-wrapper vads-u-margin-y--6">

--- a/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
+++ b/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
@@ -88,6 +88,10 @@ const HealthCare = ({
     );
   }
 
+  const wrapperClasses = `vads-u-display--flex large-screen:vads-u-flex-direction--row vads-u-flex-direction--column health-care ${
+    hasUpcomingAppointment ? '' : 'half-width'
+  }`;
+
   const messagesText =
     shouldFetchMessages && !hasInboxError
       ? `You have ${unreadMessagesCount} new message${
@@ -101,7 +105,7 @@ const HealthCare = ({
         Health care
       </h2>
 
-      <div className="vads-u-display--flex large-screen:vads-u-flex-direction--row vads-u-flex-direction--column health-care">
+      <div className={wrapperClasses}>
         {hasUpcomingAppointment && (
           /* Appointments */
           <Appointments appointments={appointments} />

--- a/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
+++ b/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
@@ -5,7 +5,10 @@ import backendServices from '~/platform/user/profile/constants/backendServices';
 import { GeneralCernerWidget } from '~/applications/personalization/dashboard/components/cerner-widgets';
 import { fetchFolder as fetchInboxAction } from '~/applications/personalization/dashboard/actions/messaging';
 import { FOLDER } from '~/applications/personalization/dashboard-2/constants';
-import { selectUnreadMessagesCount } from '~/applications/personalization/dashboard-2/selectors';
+import {
+  selectUnreadMessagesCount,
+  selectFolder,
+} from '~/applications/personalization/dashboard-2/selectors';
 import { fetchConfirmedFutureAppointments as fetchConfirmedFutureAppointmentsAction } from '~/applications/personalization/appointments/actions';
 import { isAuthenticatedWithSSOe } from '~/platform/user/authentication/selectors';
 import { getMedicalCenterNameByID } from '~/platform/utilities/medical-centers/medical-centers';
@@ -192,11 +195,10 @@ const mapStateToProps = state => {
 
   const fetchingAppointments = state.health?.appointments?.fetching;
   const fetchingInbox = shouldFetchMessages
-    ? state.health?.msg?.folders?.data?.currentItem?.fetching
+    ? selectFolder(state)?.fetching
     : false;
 
-  const hasInboxError =
-    state.health?.msg?.folders?.currentItem?.errors?.length > 0;
+  const hasInboxError = selectFolder(state)?.errors?.length > 0;
 
   return {
     appointments: state.health?.appointments?.data,

--- a/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
+++ b/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
@@ -39,6 +39,7 @@ const HealthCare = ({
   // TODO: possibly remove this prop in favor of mocking API calls in our unit tests
   dataLoadingDisabled = false,
   shouldShowLoadingIndicator,
+  hasInboxError,
 }) => {
   const nextAppointment = appointments?.[0];
   const start = new Date(nextAppointment?.startsAt);
@@ -85,7 +86,7 @@ const HealthCare = ({
   }
 
   const messagesText =
-    typeof unreadMessagesCount === 'number'
+    typeof unreadMessagesCount === 'number' && !hasInboxError
       ? `You have ${unreadMessagesCount} new message${
           unreadMessagesCount === 1 ? '' : 's'
         }`
@@ -194,14 +195,18 @@ const mapStateToProps = state => {
     ? state.health?.msg?.folders?.data?.currentItem?.fetching
     : false;
 
+  const hasInboxError =
+    state.health?.msg?.folders?.currentItem?.errors?.length > 0;
+
   return {
     appointments: state.health?.appointments?.data,
-    shouldFetchMessages,
-    isCernerPatient: selectIsCernerPatient(state),
-    facilityNames,
     authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
-    unreadMessagesCount: selectUnreadMessagesCount(state),
+    facilityNames,
+    hasInboxError,
+    isCernerPatient: selectIsCernerPatient(state),
+    shouldFetchMessages,
     shouldShowLoadingIndicator: fetchingAppointments || fetchingInbox,
+    unreadMessagesCount: selectUnreadMessagesCount(state),
   };
 };
 

--- a/src/applications/personalization/dashboard-2/sass/dashboard.scss
+++ b/src/applications/personalization/dashboard-2/sass/dashboard.scss
@@ -17,6 +17,12 @@
       @media (min-width: $large-screen) {
         width: 100%;
       }
+
+      &.half-width {
+        @media (min-width: $large-screen) {
+          width: 520px;
+        }
+      }
     }
 
     .cta-link:nth-of-type(1) {

--- a/src/applications/personalization/dashboard-2/selectors.js
+++ b/src/applications/personalization/dashboard-2/selectors.js
@@ -13,6 +13,6 @@ export const selectShowDashboard2 = state => {
 };
 
 const selectFolders = state => state.health?.msg?.folders;
-const selectFolder = state => selectFolders(state)?.data?.currentItem;
+export const selectFolder = state => selectFolders(state)?.data?.currentItem;
 export const selectUnreadMessagesCount = state =>
   selectFolder(state)?.attributes?.unreadCount;

--- a/src/applications/personalization/dashboard-2/tests/e2e/messaging-error.cypress.spec.js
+++ b/src/applications/personalization/dashboard-2/tests/e2e/messaging-error.cypress.spec.js
@@ -1,0 +1,35 @@
+import { mockFolderErrorResponse } from '~/applications/personalization/dashboard-2/utils/mocks/messaging/folder'
+import { mockFeatureToggles } from './helpers';
+
+import {
+  makeUserObject,
+  mockLocalStorage,
+} from '~/applications/personalization/dashboard/tests/e2e/dashboard-e2e-helpers';
+
+describe('MyVA Dashboard - Messaging', () => {
+  describe('when there is an error fetching the inbox data', () => {
+    beforeEach(() => {
+      mockLocalStorage();
+      const mockUser = makeUserObject({
+        messaging: true,
+        rx: true,
+        isPatient: true,
+      });
+
+      cy.login(mockUser);
+      // login() calls cy.server() so we can now mock routes
+      cy.intercept(
+        'GET',
+        '/v0/messaging/health/folders/0',
+        mockFolderErrorResponse,
+      );
+      mockFeatureToggles();
+    });
+    it('should show the messaging link with the generic copy', () => {
+      cy.visit('my-va/');
+      cy.findByText(/Send a secure message to your health care team/i).should(
+        'exist'
+        );
+    });
+  });
+});

--- a/src/applications/personalization/dashboard-2/tests/e2e/messaging-error.cypress.spec.js
+++ b/src/applications/personalization/dashboard-2/tests/e2e/messaging-error.cypress.spec.js
@@ -1,4 +1,4 @@
-import { mockFolderErrorResponse } from '~/applications/personalization/dashboard-2/utils/mocks/messaging/folder'
+import { mockFolderErrorResponse } from '~/applications/personalization/dashboard-2/utils/mocks/messaging/folder';
 import { mockFeatureToggles } from './helpers';
 
 import {
@@ -28,8 +28,8 @@ describe('MyVA Dashboard - Messaging', () => {
     it('should show the messaging link with the generic copy', () => {
       cy.visit('my-va/');
       cy.findByText(/Send a secure message to your health care team/i).should(
-        'exist'
-        );
+        'exist',
+      );
     });
   });
 });

--- a/src/applications/personalization/dashboard-2/tests/unit/healthcare-messaging.unit.spec.jsx
+++ b/src/applications/personalization/dashboard-2/tests/unit/healthcare-messaging.unit.spec.jsx
@@ -159,20 +159,4 @@ describe('HealthCare component', () => {
       ).to.exist;
     });
   });
-
-  context('when a 400 error occurs', () => {
-    it('should show the correct generic messaging link copy', async () => {
-      initialState.health.msg.folders.data.currentItem = mockFolderErrorResponse;
-
-      view = renderInReduxProvider(<HealthCare dataLoadingDisabled />, {
-        initialState,
-        reducers,
-      });
-      expect(
-        await view.findByText(
-          new RegExp(`Send a secure message to your health care team`, 'i'),
-        ),
-      ).to.exist;
-    });
-  });
 });

--- a/src/applications/personalization/dashboard-2/tests/unit/healthcare-messaging.unit.spec.jsx
+++ b/src/applications/personalization/dashboard-2/tests/unit/healthcare-messaging.unit.spec.jsx
@@ -5,6 +5,7 @@ import { renderInReduxProvider } from '~/platform/testing/unit/react-testing-lib
 import reducers from '~/applications/personalization/dashboard/reducers';
 import { wait } from '@@profile/tests/unit-test-helpers';
 import HealthCare from '~/applications/personalization/dashboard-2/components/health-care/HealthCare';
+import { mockFolderErrorResponse } from '../../utils/mocks/messaging/folder';
 
 describe('HealthCare component', () => {
   let view;
@@ -147,6 +148,22 @@ describe('HealthCare component', () => {
 
     it('should render a generic message when the number of unread messages was not fetched', async () => {
       initialState.health.msg.folders.data.currentItem.attributes.unreadCount = null;
+      view = renderInReduxProvider(<HealthCare dataLoadingDisabled />, {
+        initialState,
+        reducers,
+      });
+      expect(
+        await view.findByText(
+          new RegExp(`Send a secure message to your health care team`, 'i'),
+        ),
+      ).to.exist;
+    });
+  });
+
+  context('when a 400 error occurs', () => {
+    it('should show the correct generic messaging link copy', async () => {
+      initialState.health.msg.folders.data.currentItem = mockFolderErrorResponse;
+
       view = renderInReduxProvider(<HealthCare dataLoadingDisabled />, {
         initialState,
         reducers,

--- a/src/applications/personalization/dashboard-2/tests/unit/healthcare-messaging.unit.spec.jsx
+++ b/src/applications/personalization/dashboard-2/tests/unit/healthcare-messaging.unit.spec.jsx
@@ -5,7 +5,6 @@ import { renderInReduxProvider } from '~/platform/testing/unit/react-testing-lib
 import reducers from '~/applications/personalization/dashboard/reducers';
 import { wait } from '@@profile/tests/unit-test-helpers';
 import HealthCare from '~/applications/personalization/dashboard-2/components/health-care/HealthCare';
-import { mockFolderErrorResponse } from '../../utils/mocks/messaging/folder';
 
 describe('HealthCare component', () => {
   let view;

--- a/src/applications/personalization/dashboard-2/utils/mocks/messaging/folder.js
+++ b/src/applications/personalization/dashboard-2/utils/mocks/messaging/folder.js
@@ -12,3 +12,16 @@ export const mockFolderResponse = {
     links: { self: 'https://staging-api.va.gov/v0/messaging/health/folders/0' },
   },
 };
+
+export const mockFolderErrorResponse = {
+  errors: [
+    {
+      title: 'Bad Request',
+      detail: 'Received a bad request response from the upstream server',
+      code: 'EVSS400',
+      source: 'EVSS::DisabilityCompensationForm::Service',
+      status: '400',
+      meta: {},
+    },
+  ],
+};

--- a/src/applications/personalization/dashboard/actions/messaging.js
+++ b/src/applications/personalization/dashboard/actions/messaging.js
@@ -47,16 +47,7 @@ export const fetchFolder = (id, query = {}) => async dispatch => {
     if (folderResponse?.errors || messagesResponse?.errors) {
       dispatch({
         type: FETCH_FOLDER_FAILURE,
-        errors: [
-          ...folderResponse?.errors?.map(error => ({
-            ...error,
-            errorType: 'folder',
-          })),
-          ...messagesResponse?.errors?.map(error => ({
-            ...error,
-            errorType: 'messages',
-          })),
-        ],
+        errors: [...folderResponse?.errors, ...messagesResponse?.errors],
       });
       return;
     }

--- a/src/applications/personalization/dashboard/actions/messaging.js
+++ b/src/applications/personalization/dashboard/actions/messaging.js
@@ -15,60 +15,61 @@ import {
 
 const baseUrl = `${environment.API_URL}/v0/messaging/health`;
 
-export function fetchFolder(id, query = {}) {
-  return dispatch => {
-    const errorHandler = (folderErrors = [], messagesErrors = []) => {
-      const errors = folderErrors.concat(messagesErrors);
-      dispatch({ type: FETCH_FOLDER_FAILURE, errors });
-    };
+export const fetchFolder = (id, query = {}) => async dispatch => {
+  dispatch({
+    type: LOADING_FOLDER,
+    request: { id, query },
+  });
+
+  // Escape early if do not have a valid ID with which to fetch folders.
+  if (!id && id !== 0) {
+    dispatch({ type: FETCH_FOLDER_FAILURE, errors: [] });
+    return;
+  }
+
+  const folderUrl = `/folders/${id}`;
+  const messagesUrl = createUrlWithQuery(`${folderUrl}/messages`, query);
+
+  if (shouldMockApiRequest()) {
+    dispatch({
+      type: FETCH_FOLDER_SUCCESS,
+      folder: mockFolderResponse,
+      messages: mockMessagesResponse,
+    });
+    return;
+  }
+
+  try {
+    const folderResponse = await apiRequest(`${baseUrl}${folderUrl}`);
+    const messagesResponse = await apiRequest(`${baseUrl}${messagesUrl}`);
+
+    // Escape early if there are errors in either API request.
+    if (folderResponse?.errors || messagesResponse?.errors) {
+      dispatch({
+        type: FETCH_FOLDER_FAILURE,
+        errors: [
+          ...folderResponse?.errors?.map(error => ({
+            ...error,
+            errorType: 'folder',
+          })),
+          ...messagesResponse?.errors?.map(error => ({
+            ...error,
+            errorType: 'messages',
+          })),
+        ],
+      });
+      return;
+    }
 
     dispatch({
-      type: LOADING_FOLDER,
-      request: { id, query },
+      type: FETCH_FOLDER_SUCCESS,
+      folder: folderResponse,
+      messages: messagesResponse,
     });
-
-    if (!id) {
-      const folderUrl = `/folders/${id}`;
-      const messagesUrl = createUrlWithQuery(`${folderUrl}/messages`, query);
-
-      if (shouldMockApiRequest()) {
-        dispatch({
-          type: FETCH_FOLDER_SUCCESS,
-          folder: mockFolderResponse,
-          messages: mockMessagesResponse,
-        });
-        return;
-      }
-
-      Promise.all(
-        [folderUrl, messagesUrl].map(url =>
-          apiRequest(`${baseUrl}${url}`)
-            .then(response => response)
-            .catch(errorHandler),
-        ),
-      )
-        .then(data => {
-          const folder = data?.[0];
-          const messages = data?.[1];
-
-          // Escape early if there are errors in either API request.
-          if (folder?.errors || messages?.errors) {
-            errorHandler(folder?.errors, messages?.errors);
-            return;
-          }
-
-          dispatch({
-            type: FETCH_FOLDER_SUCCESS,
-            folder,
-            messages,
-          });
-        })
-        .catch(errorHandler);
-    } else {
-      errorHandler();
-    }
-  };
-}
+  } catch (error) {
+    dispatch({ type: FETCH_FOLDER_FAILURE, errors: [] });
+  }
+};
 
 export function fetchRecipients() {
   const url = '/recipients';

--- a/src/applications/personalization/dashboard/reducers/folders.js
+++ b/src/applications/personalization/dashboard/reducers/folders.js
@@ -65,6 +65,7 @@ export default function folders(state = initialState, action) {
             value: sortValue,
             order: sortOrder,
           },
+          errors: null,
         },
         newState,
       );

--- a/src/applications/personalization/dashboard/reducers/folders.js
+++ b/src/applications/personalization/dashboard/reducers/folders.js
@@ -74,7 +74,7 @@ export default function folders(state = initialState, action) {
       return set(
         'data.currentItem',
         {
-          errors: action.folder?.data?.errors,
+          errors: action?.errors,
           loading: false,
         },
         state,

--- a/src/applications/personalization/dashboard/reducers/folders.js
+++ b/src/applications/personalization/dashboard/reducers/folders.js
@@ -1,7 +1,11 @@
 import _ from 'lodash';
 import set from 'lodash/fp/set';
 
-import { FETCH_FOLDER_SUCCESS, LOADING_FOLDER } from '../utils/constants';
+import {
+  FETCH_FOLDER_SUCCESS,
+  FETCH_FOLDER_FAILURE,
+  LOADING_FOLDER,
+} from '../utils/constants';
 
 const initialState = {
   data: {
@@ -63,6 +67,17 @@ export default function folders(state = initialState, action) {
           },
         },
         newState,
+      );
+    }
+
+    case FETCH_FOLDER_FAILURE: {
+      return set(
+        'data.currentItem',
+        {
+          errors: action.folder?.data?.errors,
+          loading: false,
+        },
+        state,
       );
     }
 

--- a/src/applications/personalization/dashboard/reducers/folders.js
+++ b/src/applications/personalization/dashboard/reducers/folders.js
@@ -75,7 +75,7 @@ export default function folders(state = initialState, action) {
         'data.currentItem',
         {
           errors: action?.errors,
-          loading: false,
+          fetching: false,
         },
         state,
       );
@@ -97,7 +97,6 @@ export default function folders(state = initialState, action) {
             visible: false,
           },
           lastRequestedFolder: action.request,
-          fetching: true,
         },
         newState,
       );


### PR DESCRIPTION
## Description
This PR ensures we show the correct copy when we get back an error from the messaging/folders endpoints.

## Testing done
Works well locally, added cypress test.

## Acceptance criteria
- [x] Update messaging error logic
- [x] Add appropriate test

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
