### PR TITLE
Use SVG for check and add supporting text

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoCNPv2.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoCNPv2.jsx
@@ -248,9 +248,26 @@ export const BankInfoCNP = ({
       <div className="vads-u-margin-bottom--2">
         <AdditionalInfo triggerText="Where can I find these numbers?">
           <img
-            src="/img/direct-deposit-check-guide.png"
+            src="/img/direct-deposit-check-guide.svg"
             alt="On a personal check, find your bank’s 9-digit routing number listed along the bottom-left edge, and your account number listed beside that."
           />
+          <p>
+            The bank routing number is the first 9 digits on the bottom left
+            corner of a printed check. Your account number is the second set of
+            numbers on the bottom of a check, just to the right of the bank
+            routing number.
+          </p>
+
+          <p>If you don’t have a printed check, you can:</p>
+
+          <ul>
+            <li>
+              Sign in to your online bank account and check your account
+              details, or
+            </li>
+            <li>Check your bank statement, or</li>
+            <li>Call your bank</li>
+          </ul>
         </AdditionalInfo>
       </div>
       <div data-testid={`${formPrefix}-bank-info-form`}>

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
@@ -214,9 +214,26 @@ export const DirectDepositEDU = ({
       <div className="vads-u-margin-bottom--2">
         <AdditionalInfo triggerText="Where can I find these numbers?">
           <img
-            src="/img/direct-deposit-check-guide.png"
+            src="/img/direct-deposit-check-guide.svg"
             alt="On a personal check, find your bank’s 9-digit routing number listed along the bottom-left edge, and your account number listed beside that."
           />
+          <p>
+            The bank routing number is the first 9 digits on the bottom left
+            corner of a printed check. Your account number is the second set of
+            numbers on the bottom of a check, just to the right of the bank
+            routing number.
+          </p>
+
+          <p>If you don’t have a printed check, you can:</p>
+
+          <ul>
+            <li>
+              Sign in to your online bank account and check your account
+              details, or
+            </li>
+            <li>Check your bank statement, or</li>
+            <li>Call your bank</li>
+          </ul>
         </AdditionalInfo>
       </div>
       <div data-testid={`${formPrefix}-bank-info-form`}>

--- a/src/site/assets/img/direct-deposit-check-guide.svg
+++ b/src/site/assets/img/direct-deposit-check-guide.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1000px" height="503px" viewBox="0 0 1000 503" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <style>
+    text {
+        font-family:sans-serif;
+    }
+    </style>
+    <title>Check</title>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="direct-deposit-check-guide">
+            <rect id="Rectangle" fill="#FFFFFF" fill-rule="nonzero" x="0" y="0" width="1000" height="500"></rect>
+            <rect id="Rectangle" stroke="#C9C9C9" fill="#F7F7F7" fill-rule="nonzero" x="0.5" y="0.5" width="999" height="399"></rect>
+            <g id="YOUR-NAME" transform="translate(30.000000, 58.000000)" fill="#3F3F3F" fill-rule="nonzero" font-size="30" font-weight="normal">
+                <text>
+                    <tspan x="0" y="29">YOUR NAME</tspan>
+                </text>
+            </g>
+            <g id="YOUR-ADDRESS" transform="translate(30.000000, 96.000000)" fill="#3F3F3F" fill-rule="nonzero" font-size="30" font-weight="normal">
+                <text>
+                    <tspan x="0" y="29">YOUR ADDRESS</tspan>
+                </text>
+            </g>
+            <g id="DATE" transform="translate(602.000000, 96.000000)" fill="#3F3F3F" fill-rule="nonzero" font-size="30" font-weight="normal">
+                <text>
+                    <tspan x="0" y="29">DATE</tspan>
+                </text>
+            </g>
+            <g id="DOLLARS" transform="translate(849.060000, 248.000000)" fill="#3F3F3F" fill-rule="nonzero" font-size="30" font-weight="normal">
+                <text>
+                    <tspan x="0" y="29">DOLLARS</tspan>
+                </text>
+            </g>
+            <g id="|:04407234" transform="translate(27.000000, 321.000000)" fill="#3F3F3F" fill-rule="nonzero" font-size="30" font-weight="bold">
+                <text>
+                    <tspan x="0" y="29">|:04407234</tspan>
+                </text>
+            </g>
+            <g id="|:000123456789" transform="translate(224.000000, 321.000000)" fill="#3F3F3F" fill-rule="nonzero" font-size="30" font-weight="bold">
+                <text>
+                    <tspan x="0" y="29">|:000123456789</tspan>
+                </text>
+            </g>
+            <g id="|:" transform="translate(491.000000, 321.000000)" fill="#3F3F3F" fill-rule="nonzero" font-size="30" font-weight="normal">
+                <text>
+                    <tspan x="0" y="29">|:</tspan>
+                </text>
+            </g>
+            <g id="$" transform="translate(793.000000, 163.000000)" fill="#3F3F3F" fill-rule="nonzero" font-size="40" font-weight="normal">
+                <text>
+                    <tspan x="0" y="39">$</tspan>
+                </text>
+            </g>
+            <g id="1001" transform="translate(909.360000, 47.000000)" fill="#3F3F3F" fill-rule="nonzero" font-size="30" font-weight="normal">
+                <text>
+                    <tspan x="0" y="29">1001</tspan>
+                </text>
+            </g>
+            <g id="PAY-TO-THE-ORDER-OF" transform="translate(30.000000, 159.000000)" fill="#3F3F3F" fill-rule="nonzero" font-size="30" font-weight="normal">
+                <text id="PAY-TO-THE">
+                    <tspan x="0" y="29">PAY TO THE</tspan>
+                </text>
+                <text id="ORDER-OF">
+                    <tspan x="0" y="58">ORDER OF</tspan>
+                </text>
+            </g>
+            <rect id="Rectangle" fill="#C9C9C9" fill-rule="nonzero" x="188" y="218" width="597" height="3"></rect>
+            <rect id="Rectangle-Copy-2" fill="#C9C9C9" fill-rule="nonzero" x="685" y="123" width="285" height="3"></rect>
+            <rect id="Rectangle-Copy" fill="#C9C9C9" fill-rule="nonzero" x="30" y="275" width="810" height="3"></rect>
+            <rect id="Rectangle" fill="#FFFFFF" fill-rule="nonzero" x="822" y="165" width="147" height="48"></rect>
+            <g id="Label" transform="translate(17.000000, 337.000000)">
+                <path d="M0,0 L0,33 L82,33 L166,33 L166,0 M83,33 L83,85" id="Combined-Shape" stroke="#0087FF" stroke-width="3"></path>
+                <g id="routing-number" transform="translate(39.000000, 96.000000)" fill="#3F3F3F" fill-rule="nonzero" font-size="30" font-weight="normal">
+                    <text id="routing">
+                        <tspan x="0" y="29">routing</tspan>
+                    </text>
+                    <text id="number">
+                        <tspan x="0" y="63">number</tspan>
+                    </text>
+                </g>
+            </g>
+            <g id="Label-Copy-2" transform="translate(478.000000, 337.000000)">
+                <path d="M0,0 L0,33 L82,33 L166,33 L166,0 M83,33 L83,85" id="Combined-Shape" stroke="#0087FF" stroke-width="3"></path>
+                <g id="check-number" transform="translate(39.000000, 96.000000)" fill="#3F3F3F" fill-rule="nonzero" font-size="30" font-weight="normal">
+                    <text id="check">
+                        <tspan x="0" y="29">check</tspan>
+                    </text>
+                    <text id="number">
+                        <tspan x="0" y="63">number</tspan>
+                    </text>
+                </g>
+            </g>
+            <g id="Label-Copy" transform="translate(217.000000, 337.000000)">
+                <path d="M0,2.27373675e-13 L0,33 L114.5,33 L229,33 L229,2.27373675e-13 M115.5,33 L115.5,85" id="Combined-Shape" stroke="#0087FF" stroke-width="3"></path>
+                <g id="account-number" transform="translate(64.000000, 96.000000)" fill="#3F3F3F" fill-rule="nonzero" font-size="30" font-weight="normal">
+                    <text id="account">
+                        <tspan x="0" y="29">account</tspan>
+                    </text>
+                    <text id="number">
+                        <tspan x="0" y="63">number</tspan>
+                    </text>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
## Description
I couldn't get Source Sans Pro to work with the check (it was falling back to a serif font) so I just forced it to use the basic sans-serif and I think that actually looks better than Source Sans.

## Testing done
Local

## Screenshots
<img width="506" alt="Screen Shot 2021-03-26 at 12 37 44 PM" src="https://user-images.githubusercontent.com/20728956/112684717-a8699c00-8e30-11eb-93c2-48c222f127b8.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs