### PR TITLE
Removed compliance agreement schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -363,7 +363,7 @@
     "url-search-params-polyfill": "^8.1.0",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#b98e5cdfb0036e2eb49528e373ed8b350e237eb8",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#c3d46158637446c545e746978f25888c9d147414",
     "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.2.2",
     "whatwg-fetch": "^2.0.3"
   },

--- a/src/applications/coronavirus-vaccination-expansion/config/address/addressInformation.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/address/addressInformation.js
@@ -2,6 +2,12 @@ import React from 'react';
 import emailUI from 'platform/forms-system/src/js/definitions/email';
 import { addressInformation } from '../schema-imports';
 
+const validateZip = (errors, formData) => {
+  if (formData.zipCode > 4) {
+    errors.state.addError('Please enter at least 5 digits');
+  }
+};
+
 export const schema = {
   addressInformation,
 };
@@ -31,6 +37,7 @@ export const uiSchema = {
       'ui:errorMessages': {
         pattern: 'Please enter your five digit zip code',
       },
+      'ui:validations': [validateZip],
     },
     emailAddress: {
       ...emailUI(),


### PR DESCRIPTION
## Description
Now that we no longer need the complianceAgreement schema, this PR bumps the `vets-json-schema` version to remove that schema. This PR also includes a small tweak to the validation of the zip code to make sure it is at least 5 digits since this is used to search for locations on a subsiquent page.

## Acceptance criteria
- [x] `vets-json-schema` version is bumped
- [x] UI validation is added in
- [x] A PR has been submitted for review
