### PR TITLE
Add breadcrumbs to app

### DIFF
--- a/src/applications/coronavirus-vaccination-expansion/config/form.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/form.js
@@ -36,6 +36,7 @@ const formConfig = {
   },
   customText: {
     reviewPageTitle: 'Review your information',
+    appType: 'form',
   },
   chapters: {
     attestation: {

--- a/src/applications/coronavirus-vaccination-expansion/config/form.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/form.js
@@ -35,7 +35,7 @@ const formConfig = {
     ...fullSchema.definitions,
   },
   customText: {
-    reviewPageTitle: 'Review your submission',
+    reviewPageTitle: 'Review your information',
   },
   chapters: {
     attestation: {

--- a/src/applications/coronavirus-vaccination-expansion/config/form.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/form.js
@@ -34,6 +34,9 @@ const formConfig = {
   defaultDefinitions: {
     ...fullSchema.definitions,
   },
+  customText: {
+    reviewPageTitle: 'Review your submission',
+  },
   chapters: {
     attestation: {
       title: 'Make sure you’re eligible',

--- a/src/applications/coronavirus-vaccination-expansion/containers/App.jsx
+++ b/src/applications/coronavirus-vaccination-expansion/containers/App.jsx
@@ -10,7 +10,7 @@ export default function App({ location, children }) {
       <Breadcrumbs>
         <a href="/">Home</a>
         <a href="/health-care">Health care</a>
-        <a href="/health-care/covid-19-vaccine">COVID 19 vaccines</a>
+        <a href="/health-care/covid-19-vaccine">COVID-19 vaccines at VA</a>
         <a href="/health-care/covid-19-vaccine/sign-up/stay-informed">
           Sign up to get a vaccine
         </a>

--- a/src/applications/coronavirus-vaccination-expansion/containers/App.jsx
+++ b/src/applications/coronavirus-vaccination-expansion/containers/App.jsx
@@ -1,12 +1,23 @@
 import React from 'react';
+import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
 
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from '../config/form';
 
 export default function App({ location, children }) {
   return (
-    <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-      {children}
-    </RoutedSavableApp>
+    <>
+      <Breadcrumbs>
+        <a href="/">Home</a>
+        <a href="/health-care">Health care</a>
+        <a href="/health-care/covid-19-vaccine">COVID 19 vaccines</a>
+        <a href="/health-care/covid-19-vaccine/sign-up/stay-informed">
+          Sign up to get a vaccine
+        </a>
+      </Breadcrumbs>
+      <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
+        {children}
+      </RoutedSavableApp>
+    </>
   );
 }


### PR DESCRIPTION
## Description

This PR:

- Adds breadcrumbs to the COVID 19 vaccine app
- Changes the review page title from `Review Application` to `Review your information`.
- Changes the submit button from `Submit application` to `Submit form`


## Testing done

Browser :eyes:


## Screenshots

### Introduction

![image](https://user-images.githubusercontent.com/2008881/112762455-9b75b580-8fb4-11eb-804c-4fbe34fe0cff.png)

### Eligibility

![image](https://user-images.githubusercontent.com/2008881/112762472-acbec200-8fb4-11eb-8f85-c1dfd7a26f4a.png)

### Review page with title & submit text changed

![image](https://user-images.githubusercontent.com/2008881/112763143-0d033300-8fb8-11eb-9c45-4812aa6c8615.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
