### PR TITLE
Make location selection use radio buttons

### DIFF
--- a/src/applications/coronavirus-vaccination-expansion/config/va-location/DynamicCheckboxWidget.jsx
+++ b/src/applications/coronavirus-vaccination-expansion/config/va-location/DynamicCheckboxWidget.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import environment from 'platform/utilities/environment';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
+import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
 
 import { apiRequest } from 'platform/utilities/api';
 
@@ -15,6 +16,7 @@ export function DynamicCheckboxWidget(props) {
   const [locations, setLocations] = useState([]);
   const [loading, isLoading] = useState(true); // app starts in a loading state
   const [error, setError] = useState(false); // app starts with no error
+  const [selected, setSelected] = useState(null); // app starts with no error
 
   useEffect(
     () => {
@@ -39,27 +41,29 @@ export function DynamicCheckboxWidget(props) {
       <LoadingIndicator message="Loading VA medical centers near you..." />
     );
   } else if (locations.length > 0 && loading === false) {
+    const optionsList = locations.map(location => ({
+      label: (
+        <>
+          <p className="vads-u-padding-left--4 vads-u-margin-top--neg3">
+            {location.attributes.name}
+          </p>
+          <p className="vads-u-padding-left--4 vads-u-margin-top--neg2">{`${
+            location.attributes.city
+          } ${location.attributes.state}`}</p>
+        </>
+      ),
+      value: location.attributes.name,
+    }));
+
     locationsList = (
-      <fieldset className="fieldset-input vads-u-margin-top--0">
-        {locations.map((location, index) => (
-          <div key={index}>
-            <input
-              type="checkbox"
-              id={`location-${index}`}
-              value={location.attributes.name}
-              onChange={_ => onChange(location.id)}
-            />
-            <label name="undefined-0-label" htmlFor="default-0">
-              <p className="vads-u-padding-left--4 vads-u-margin-top--neg3">
-                {location.attributes.name}
-              </p>
-              <p className="vads-u-padding-left--4 vads-u-margin-top--neg2">{`${
-                location.attributes.city
-              } ${location.attributes.state}`}</p>
-            </label>
-          </div>
-        ))}
-      </fieldset>
+      <RadioButtons
+        options={optionsList.enumOptions}
+        value={selected}
+        onValueChange={value => {
+          onChange(value.value);
+          setSelected(value);
+        }}
+      />
     );
   } else if (locations.length === 0 && error === false && loading === false) {
     // there are no locations returned

--- a/src/applications/coronavirus-vaccination-expansion/config/va-location/DynamicRadioWidget.jsx
+++ b/src/applications/coronavirus-vaccination-expansion/config/va-location/DynamicRadioWidget.jsx
@@ -9,7 +9,7 @@ import { apiRequest } from 'platform/utilities/api';
 
 const apiUrl = `${environment.API_URL}/covid_vaccine/v0/facilities/`;
 
-export function DynamicCheckboxWidget(props) {
+export function DynamicRadioWidget(props) {
   // console.log(props);
   const { onChange } = props;
   let locationsList = null;
@@ -96,4 +96,4 @@ function mapStateToProps(state) {
 export default connect(
   mapStateToProps,
   null,
-)(DynamicCheckboxWidget);
+)(DynamicRadioWidget);

--- a/src/applications/coronavirus-vaccination-expansion/config/va-location/DynamicRadioWidget.jsx
+++ b/src/applications/coronavirus-vaccination-expansion/config/va-location/DynamicRadioWidget.jsx
@@ -57,7 +57,7 @@ export function DynamicRadioWidget(props) {
 
     locationsList = (
       <RadioButtons
-        options={optionsList.enumOptions}
+        options={optionsList}
         value={selected}
         onValueChange={value => {
           onChange(value.value);

--- a/src/applications/coronavirus-vaccination-expansion/config/va-location/va-location.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/va-location/va-location.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import DynamicCheckboxWidget from './DynamicCheckboxWidget.jsx';
+import DynamicRadioWidget from './DynamicRadioWidget.jsx';
 import { vaLocation } from '../schema-imports';
 
 function ReviewWidget({ value }) {
@@ -13,7 +13,7 @@ export const schema = {
 export const uiSchema = {
   vaLocation: {
     preferredFacility: {
-      'ui:widget': DynamicCheckboxWidget,
+      'ui:widget': DynamicRadioWidget,
       'ui:description': (
         <>
           <p>


### PR DESCRIPTION
## Description

This updates the location selection page to use radio buttons instead of checkboxes so that only one location can be selected.

## Testing done

Local browser testing, :eyes: on review page.


## Screenshots

![image](https://user-images.githubusercontent.com/2008881/112766809-50659d80-8fc8-11eb-9e37-d407ea1a9d15.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
