### PR TITLE
Revert KMI route changes

### DIFF
--- a/src/applications/coronavirus-vaccination-expansion/containers/App.jsx
+++ b/src/applications/coronavirus-vaccination-expansion/containers/App.jsx
@@ -11,7 +11,7 @@ export default function App({ location, children }) {
         <a href="/">Home</a>
         <a href="/health-care">Health care</a>
         <a href="/health-care/covid-19-vaccine">COVID-19 vaccines at VA</a>
-        <a href="/health-care/covid-19-vaccine/sign-up/stay-informed">
+        <a href="/health-care/covid-19-vaccine/stay-informed">
           Sign up to get a vaccine
         </a>
       </Breadcrumbs>

--- a/src/applications/coronavirus-vaccination-expansion/containers/IntroductionPage.jsx
+++ b/src/applications/coronavirus-vaccination-expansion/containers/IntroductionPage.jsx
@@ -12,7 +12,7 @@ import { modalContents } from './privacyDataHelper';
 import manifest from '../manifest.json';
 
 const alreadyReceivingCarePath =
-  '/health-care/covid-19-vaccine/sign-up/stay-informed/form';
+  '/health-care/covid-19-vaccine/stay-informed/form';
 const newlyEligiblePath = `${manifest.rootUrl}/eligibility`;
 
 class IntroductionPage extends React.Component {

--- a/src/applications/coronavirus-vaccination/components/Introduction.jsx
+++ b/src/applications/coronavirus-vaccination/components/Introduction.jsx
@@ -64,7 +64,7 @@ function Introduction({
                         environment.BASE_URL
                       }/health-care/covid-19-vaccine/sign-up`,
                     )
-                  : '/health-care/covid-19-vaccine/sign-up/stay-informed/form'
+                  : '/health-care/covid-19-vaccine/stay-informed/form'
               }
             >
               Sign up now

--- a/src/applications/coronavirus-vaccination/manifest.json
+++ b/src/applications/coronavirus-vaccination/manifest.json
@@ -2,5 +2,5 @@
   "appName": "Coronavirus Vaccination",
   "entryFile": "./coronavirus-vaccination-entry.jsx",
   "entryName": "coronavirus-vaccination",
-  "rootUrl": "/health-care/covid-19-vaccine/sign-up/stay-informed"
+  "rootUrl": "/health-care/covid-19-vaccine/stay-informed"
 }

--- a/src/applications/coronavirus-vaccination/tests/e2e/hideauth.cypress.spec.js
+++ b/src/applications/coronavirus-vaccination/tests/e2e/hideauth.cypress.spec.js
@@ -7,7 +7,7 @@ describe('COVID-19 Vaccination Preparation Form', () => {
       cy.route('GET', '/v0/feature_toggles*', featureTogglesEnabled).as(
         'feature',
       );
-      cy.visit('health-care/covid-19-vaccine/sign-up/stay-informed/');
+      cy.visit('health-care/covid-19-vaccine/stay-informed/');
       cy.wait('@feature');
       cy.injectAxe();
     });
@@ -24,7 +24,7 @@ describe('COVID-19 Vaccination Preparation Form', () => {
       // Form page
       cy.url().should(
         'include',
-        '/health-care/covid-19-vaccine/sign-up/stay-informed/form',
+        '/health-care/covid-19-vaccine/stay-informed/form',
       );
       cy.injectAxe();
       cy.axeCheck();
@@ -82,7 +82,7 @@ describe('COVID-19 Vaccination Preparation Form', () => {
       // Confirmation page
       cy.url().should(
         'include',
-        '/health-care/covid-19-vaccine/sign-up/stay-informed/confirmation',
+        '/health-care/covid-19-vaccine/stay-informed/confirmation',
       );
       cy.axeCheck();
       cy.get('#covid-vaccination-heading-confirmation').contains(

--- a/src/applications/coronavirus-vaccination/tests/e2e/signup.cypress.spec.js
+++ b/src/applications/coronavirus-vaccination/tests/e2e/signup.cypress.spec.js
@@ -7,7 +7,7 @@ describe('COVID-19 Vaccination Preparation Form', () => {
       cy.route('GET', '/v0/feature_toggles*', featureTogglesEnabled).as(
         'feature',
       );
-      cy.visit('health-care/covid-19-vaccine/sign-up/stay-informed/');
+      cy.visit('health-care/covid-19-vaccine/stay-informed/');
       cy.wait('@feature');
       cy.injectAxe();
     });
@@ -48,7 +48,7 @@ describe('COVID-19 Vaccination Preparation Form', () => {
       // Form page
       cy.url().should(
         'include',
-        '/health-care/covid-19-vaccine/sign-up/stay-informed/form',
+        '/health-care/covid-19-vaccine/stay-informed/form',
       );
       cy.axeCheck();
       cy.get('#covid-vaccination-heading-form').contains(
@@ -109,7 +109,7 @@ describe('COVID-19 Vaccination Preparation Form', () => {
       // Confirmation page
       cy.url().should(
         'include',
-        '/health-care/covid-19-vaccine/sign-up/stay-informed/confirmation',
+        '/health-care/covid-19-vaccine/stay-informed/confirmation',
       );
       cy.axeCheck();
       cy.get('#covid-vaccination-heading-confirmation').contains(

--- a/src/applications/coronavirus-vaccination/tests/e2e/unsubscribe.cypress.spec.js
+++ b/src/applications/coronavirus-vaccination/tests/e2e/unsubscribe.cypress.spec.js
@@ -10,7 +10,7 @@ describe('COVID-19 Vaccination Preparation Form', () => {
       'feature',
     );
     cy.visit(
-      'health-care/covid-19-vaccine/sign-up/stay-informed/unsubscribe?sid=12345',
+      'health-care/covid-19-vaccine/stay-informed/unsubscribe?sid=12345',
     );
     cy.injectAxe();
 

--- a/src/applications/coronavirus-vaccination/tests/e2e/unsubscribeFail.cypress.spec.js
+++ b/src/applications/coronavirus-vaccination/tests/e2e/unsubscribeFail.cypress.spec.js
@@ -12,7 +12,7 @@ describe('COVID-19 Vaccination Preparation Form', () => {
       'feature',
     );
     cy.visit(
-      'health-care/covid-19-vaccine/sign-up/stay-informed/unsubscribe?sid=00000',
+      'health-care/covid-19-vaccine/stay-informed/unsubscribe?sid=00000',
     );
     cy.injectAxe();
 

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -962,7 +962,7 @@
   {
     "appName": "Coronavirus Vaccination",
     "entryName": "coronavirus-vaccination",
-    "rootUrl": "/health-care/covid-19-vaccine/sign-up/stay-informed",
+    "rootUrl": "/health-care/covid-19-vaccine/stay-informed",
     "template": {
       "title": "Sign up to get a COVID-19 vaccine at VA",
       "layout": "page-react.html",
@@ -978,7 +978,7 @@
           "name": "COVID-19 vaccines"
         },
         {
-          "path": "health-care/covid-19-vaccine/sign-up/stay-informed",
+          "path": "health-care/covid-19-vaccine/stay-informed",
           "name": "Sign up to get a vaccine"
         }
       ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -19525,9 +19525,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#b98e5cdfb0036e2eb49528e373ed8b350e237eb8":
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#c3d46158637446c545e746978f25888c9d147414":
   version "19.0.1"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#b98e5cdfb0036e2eb49528e373ed8b350e237eb8"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#c3d46158637446c545e746978f25888c9d147414"
 
 vinyl-file@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description
- Rolls back some questionable changes to our routing for Keep Me Informed and the expanded eligibility work
- Existing path to KMI is back to its original state
- Will sleep better knowing that if an emergency deploy goes out b/w now and tomorrow, people will still be able to get to KMI :-)
- Also updates yarn.lock with latest vets-json-schema ref

## Testing done
Manual

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
