### PR TITLE
Change confirmation page to match KMI

### DIFF
--- a/src/applications/coronavirus-vaccination-expansion/config/form.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/form.js
@@ -24,7 +24,7 @@ const formConfig = {
   submitUrl: `${environment.API_URL}/covid_vaccine/v0/expanded_registration`,
   trackingPrefix: 'covid-vaccination-expanded-',
   introduction: IntroductionPage,
-  confirmation: ConfirmationPage,
+  // confirmation: ConfirmationPage,
   preSubmitInfo: PreSubmitInfo,
   formId: VA_FORM_IDS.FORM_COVID_VACCINATION_EXPANSION,
   version: 0,
@@ -38,6 +38,13 @@ const formConfig = {
     reviewPageTitle: 'Review your information',
     appType: 'form',
   },
+  additionalRoutes: [
+    {
+      path: 'confirmation',
+      component: ConfirmationPage,
+      pageKey: 'confirmation',
+    },
+  ],
   chapters: {
     attestation: {
       title: 'Make sure you’re eligible',

--- a/src/applications/coronavirus-vaccination-expansion/containers/ConfirmationPage.jsx
+++ b/src/applications/coronavirus-vaccination-expansion/containers/ConfirmationPage.jsx
@@ -1,71 +1,7 @@
 import React from 'react';
-import moment from 'moment';
-import { connect } from 'react-redux';
-import Scroll from 'react-scroll';
+import { Confirmation } from '../../coronavirus-vaccination/components/Confirmation';
 
-import { focusElement } from 'platform/utilities/ui';
-
-const scroller = Scroll.scroller;
-const scrollToTop = () => {
-  scroller.scrollTo('topScrollElement', {
-    duration: 500,
-    delay: 0,
-    smooth: true,
-  });
-};
-
-export class ConfirmationPage extends React.Component {
-  componentDidMount() {
-    focusElement('.schemaform-title > h1');
-    scrollToTop();
-  }
-
-  render() {
-    const { submission, data } = this.props.form;
-    const { response } = submission;
-    const name = data.veteranFullName;
-
-    return (
-      <div>
-        <h3 className="confirmation-page-title">Claim received</h3>
-        <p>
-          We usually process claims within <strong>a week</strong>.
-        </p>
-        <p>
-          We may contact you for more information or documents.
-          <br />
-          <i>Please print this page for your records.</i>
-        </p>
-        <div className="inset">
-          <h4>
-            covid-vaccine-expansion Claim{' '}
-            <span className="additional">(Form )</span>
-          </h4>
-          {name ? (
-            <span>
-              for {name.first} {name.middle} {name.last} {name.suffix}
-            </span>
-          ) : null}
-
-          {response ? (
-            <ul className="claim-list">
-              <li>
-                <strong>Date received</strong>
-                <br />
-                <span>{moment(response.timestamp).format('MMM D, YYYY')}</span>
-              </li>
-            </ul>
-          ) : null}
-        </div>
-      </div>
-    );
-  }
+export default function ConfirmationPage() {
+  // pass a formData prop so we don't automatically get redirected
+  return <Confirmation formData={{}} />;
 }
-
-function mapStateToProps(state) {
-  return {
-    form: state.form,
-  };
-}
-
-export default connect(mapStateToProps)(ConfirmationPage);


### PR DESCRIPTION
## Description

This aims to reuse the confirmation page from KMI.


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
