### PR TITLE
Final content tweaks for SAVE LIVES Act vaccine expansion

### DIFF
--- a/src/applications/coronavirus-vaccination-expansion/config/attestation/attestation.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/attestation/attestation.js
@@ -1,6 +1,7 @@
 import { attestation } from '../schema-imports';
 
 import {
+  title,
   eligibilityAccordion,
   veteranLabel,
   spouseLabel,
@@ -21,7 +22,7 @@ export const uiSchema = {
       },
     },
     applicantType: {
-      'ui:title': 'Which of these best describes you?',
+      'ui:title': title,
       'ui:widget': 'radio',
       'ui:options': {
         labels: {

--- a/src/applications/coronavirus-vaccination-expansion/config/attestation/helpers.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/attestation/helpers.js
@@ -56,12 +56,12 @@ export const eligibilityAccordion = (
         </p>
         <p>
           <strong>Eligible caregiver</strong> enrolled in one of these VA
-          caregiver programs:
+          caregiver support programs:
           <ul>
             <li>
               The Program of Comprehensive Assistance for Family Caregivers
             </li>
-            <li>The General Caregiver Support Services program</li>
+            <li>The Program of General Caregiver Support Services</li>
           </ul>
         </p>
         <p>
@@ -116,15 +116,15 @@ export const spouseLabel = (
 
 export const caregiverEnrolledLabel = (
   <>
-    <strong>Eligible caregiver</strong> enrolled in an official VA caregiver
+    <strong>Eligible caregiver</strong> enrolled in a VA caregiver support
     program
   </>
 );
 
 export const caregiverOfVeteranLabel = (
   <>
-    <strong>Eligible caregiver</strong> of a Veteran who is enrolled in an
-    official VA home-based or long-term care program
+    <strong>Eligible caregiver</strong> of a Veteran who is enrolled in a VA
+    home-based or long-term care program
   </>
 );
 

--- a/src/applications/coronavirus-vaccination-expansion/config/attestation/helpers.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/attestation/helpers.js
@@ -46,20 +46,37 @@ export const eligibilityAccordion = (
         </p>
       </va-accordion-item>
       <va-accordion-item level="4" header="Who else is eligible?">
-        <p>Our caregiver programs include these 2 programs:</p>
-        <ul>
-          <li>The Program of Comprehensive Assistance for Family Caregivers</li>
-          <li>The General Caregiver Support Services program</li>
-        </ul>
         <p>
-          Our home-based and long-term care programs include these 4 programs:
+          To be eligible for a COVID-19 vaccine at VA as a non-Veteran, at least
+          one of these descriptions must fit you:
         </p>
-        <ul>
-          <li>Medical Foster Home program</li>
-          <li>Bowel and Bladder program</li>
-          <li>Home Based Primary</li>
-          <li>Care program Veteran Directed Care program</li>
-        </ul>
+        <p>
+          <strong>Spouse</strong> of an eligible Veteran
+        </p>
+        <p>
+          <strong>Eligible caregiver</strong> enrolled in one of these VA
+          caregiver programs:
+          <ul>
+            <li>
+              The Program of Comprehensive Assistance for Family Caregivers
+            </li>
+            <li>The General Caregiver Support Services program</li>
+          </ul>
+        </p>
+        <p>
+          <strong>Eligible caregiver</strong> of a Veteran who is enrolled in
+          one of these VA home-based or long-term care programs:
+          <ul>
+            <li>Medical Foster Home program</li>
+            <li>Bowel and Bladder program</li>
+            <li>Home Based Primary Care program</li>
+            <li>Veteran Directed Care program</li>
+          </ul>
+        </p>
+        <p>
+          <strong>Recipient of CHAMPVA</strong> (Civilian Health and Medical
+          Program of the Department of Veterans Affairs) benefits
+        </p>
       </va-accordion-item>
       <va-accordion-item level="4" header="What if I'm not eligible?">
         <p>

--- a/src/applications/coronavirus-vaccination-expansion/config/attestation/helpers.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/attestation/helpers.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 const paddingBottom = { paddingBottom: '1em' };
 
+export const title = <strong>Which of these best describes you?</strong>;
 export const eligibilityAccordion = (
   <>
     <p>

--- a/src/applications/coronavirus-vaccination-expansion/containers/IntroductionPage.jsx
+++ b/src/applications/coronavirus-vaccination-expansion/containers/IntroductionPage.jsx
@@ -105,7 +105,7 @@ class IntroductionPage extends React.Component {
           onClose={() => this.togglePrivacyModal()}
           status="info"
           // title="Privacy Act Statement"
-          contents={modalContents(30)}
+          contents={modalContents}
         />
       </div>
     );

--- a/src/applications/coronavirus-vaccination-expansion/containers/IntroductionPage.jsx
+++ b/src/applications/coronavirus-vaccination-expansion/containers/IntroductionPage.jsx
@@ -108,7 +108,7 @@ class IntroductionPage extends React.Component {
           onClose={() => this.togglePrivacyModal()}
           status="info"
           // title="Privacy Act Statement"
-          contents={modalContents(30)}
+          contents={modalContents}
         />
       </div>
     );

--- a/src/applications/coronavirus-vaccination-expansion/containers/IntroductionPage.jsx
+++ b/src/applications/coronavirus-vaccination-expansion/containers/IntroductionPage.jsx
@@ -14,6 +14,11 @@ import manifest from '../manifest.json';
 const alreadyReceivingCarePath =
   '/health-care/covid-19-vaccine/stay-informed/form';
 const newlyEligiblePath = `${manifest.rootUrl}/eligibility`;
+const receivingCareLabelText = (
+  <strong>
+    Are you a Veteran who is enrolled in VA health care or receiving care at VA?
+  </strong>
+);
 
 class IntroductionPage extends React.Component {
   constructor(props) {
@@ -63,30 +68,32 @@ class IntroductionPage extends React.Component {
           To get started, tell us about your experience with VA health care.
           We'll then guide you to the right form.
         </span>
-        <fieldset
-          className="fieldset-input"
-          style={{
-            marginTop: '-2em',
-          }}
-        >
-          <RadioButtons
-            id="introductionRadios"
-            errorMessage={this.state.errorMessage}
-            onKeyDown={function noRefCheck() {}}
-            onMouseDown={function noRefCheck() {}}
-            onValueChange={val => this.setSelected(val)}
-            options={['Yes', 'No', "I'm not sure"]}
-            value={this.state.currentSelection}
-            label="Are you a Veteran who is enrolled in VA health care or receiving care at VA?"
-            required
-          />
-          <ProgressButton
-            id="continueButton"
-            afterText="»"
-            buttonText="Continue"
-            onButtonClick={() => this.loadNextPage()}
-          />
-        </fieldset>
+        <p>
+          <fieldset
+            className="fieldset-input"
+            style={{
+              marginTop: '-2em',
+            }}
+          >
+            <RadioButtons
+              id="introductionRadios"
+              errorMessage={this.state.errorMessage}
+              onKeyDown={function noRefCheck() {}}
+              onMouseDown={function noRefCheck() {}}
+              onValueChange={val => this.setSelected(val)}
+              options={['Yes', 'No', "I'm not sure"]}
+              value={this.state.currentSelection}
+              label={receivingCareLabelText}
+              required
+            />
+            <ProgressButton
+              id="continueButton"
+              afterText="»"
+              buttonText="Continue"
+              onButtonClick={() => this.loadNextPage()}
+            />
+          </fieldset>
+        </p>
         <p>
           <strong>Note:</strong> We take your privacy seriously.{' '}
           <button

--- a/src/applications/coronavirus-vaccination-expansion/containers/privacyDataHelper.js
+++ b/src/applications/coronavirus-vaccination-expansion/containers/privacyDataHelper.js
@@ -6,16 +6,23 @@ export const modalContents = (
     <p>
       <strong>Privacy Act Notice:</strong> Public Law 117-4 authorizes VA to
       provide COVID-19 vaccines to certain eligible Veterans, spouses of
-      eligible Veterans, certain caregivers of Veterans, and certain receipients
+      eligible Veterans, certain caregivers of Veterans, and certain recipients
       of CHAMPVA (Civilian Health and Medical Program of the Department of
-      Veterans Affairs) benefits. This form will be used to collect certain
-      information from interested persons interested in receiving a COVID-19
-      vaccine from VA and determine eligibility for a COVID-19 vaccine
-      administered by VA. If eligibility is determined, a medical may be created
-      if the applicant does not have an existing medical record. The responses
-      you submit are considered confidential (38 U.S.C. 5701). Any information
-      provided by applicants, recipients, and others may be subject to
-      verification through computer matching programs with other agencies.
+      Veterans Affairs) benefits. VA is asking you to provide the information on
+      this form in order for VA to determine your eligibility for vaccination
+      under the law. This form will be used to collect information from certain
+      persons interested in receiving a COVID-19 vaccine from VA and to
+      determine eligibility for a COVID-19 vaccine administered by VA. Providing
+      the requested information is voluntary, but if any or all of the requested
+      information is not provided, it may delay or result in denial of your
+      request for vaccination. If you provide VA your Social Security Number, VA
+      will use it to administer this benefit. Any information provided by
+      applicants, recipients, and others may be subject to verification through
+      computer matching programs with other agencies. VA may disclose the
+      information that you put on the form as permitted by law. VA may make a
+      “routine use” disclosure of the information as outlined in the Privacy Act
+      systems of records notices and in accordance with the VHA Notice of
+      Privacy Practices.
     </p>
   </div>
 );

--- a/src/applications/coronavirus-vaccination-expansion/containers/privacyDataHelper.js
+++ b/src/applications/coronavirus-vaccination-expansion/containers/privacyDataHelper.js
@@ -4,40 +4,18 @@ export const modalContents = minutes => (
   <div>
     <h2>Privacy Act Statement</h2>
     <p>
-      <strong>Respondent Burden:</strong> We need this information to determine
-      your ability to participate in the VET TEC High Technology Pilot Program,
-      38 U.S.C. 3702 (d) and 38 CFR 36.4344. Title 38, United States Code,
-      allows us to ask for this information. We estimate that you will need an
-      average of {minutes} minutes to review the instructions, find the
-      information, and complete this form. The VA cannot conduct or sponsor a
-      collection of information unless a valid OMB control number is displayed.
-      You are not required to respond to a collection of information if this
-      number is not displayed. Valid OMB control numbers can be located on the
-      OMB Internet Page at{' '}
-      <a href="www.reginfo.gov/public/do/PRAMain">
-        www.reginfo.gov/public/do/PRAMain
-      </a>
-      . If desired, you can call <a href="+18008271000">1-800-827-1000</a> to
-      get information on where to send comments or suggestions about this form.
-    </p>
-    <p>
-      <strong>Privacy Act Notice:</strong> § 116 of Public Law 115-48 authorizes
-      VA to implement a 5-year pilot program that proves eligible Veterans the
-      opportunity to enroll in high technology programs of education that
-      provide training and skills sought by employers in relevant high
-      technology fields or industries. Accelerated Learning Programs targeted
-      for VET TEC are generally less than 10 months in duration, offered by
-      organizations which are not institutions of higher learning, and do not
-      lead to a degree. They are designed to provide students the requisite
-      training in demand by employers seeking to source IT talent. Also this
-      form will be used to collect certain information from interested
-      applicants to be used in VA reports to Congress that will help determine
-      if the program should continue. While you do not have to respond, VA
-      cannot process your claim for education assistance unless the information
-      is furnished as required by Public Law 115-48. The responses you submit
-      are considered confidential (38 U.S.C. 5701). Any information provided by
-      applicants, recipients, and others may be subject to verification through
-      computer matching programs with other agencies.
+      <strong>Privacy Act Notice:</strong> Public Law 117-4 authorizes VA to
+      provide COVID-19 vaccines to certain eligible Veterans, spouses of
+      eligible Veterans, certain caregivers of Veterans, and certain receipients
+      of CHAMPVA (Civilian Health and Medical Program of the Department of
+      Veterans Affairs) benefits. This form will be used to collect certain
+      information from interested persons interested in receiving a COVID-19
+      vaccine from VA and determine eligibility for a COVID-19 vaccine
+      administered by VA. If eligibility is determined, a medical may be created
+      if the applicant does not have an existing medical record. The responses
+      you submit are considered confidential (38 U.S.C. 5701). Any information
+      provided by applicants, recipients, and others may be subject to
+      verification through computer matching programs with other agencies.
     </p>
   </div>
 );

--- a/src/applications/coronavirus-vaccination-expansion/containers/privacyDataHelper.js
+++ b/src/applications/coronavirus-vaccination-expansion/containers/privacyDataHelper.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export const modalContents = minutes => (
+export const modalContents = (
   <div>
     <h2>Privacy Act Statement</h2>
     <p>

--- a/src/applications/static-pages/covid-vaccine-updates-cta/widget.jsx
+++ b/src/applications/static-pages/covid-vaccine-updates-cta/widget.jsx
@@ -16,7 +16,7 @@ const copy = {
         body: ` we'll ask about your vaccine plans when you sign up. Your local VA health facility may use this information to determine when to contact you once your risk group becomes eligible.`,
       },
       nonVeteran: {
-        boldedNote: `If you're a Veteran who isn't receiving care through VA or a spouse, caregiver, or CHAMPVA recipient`,
+        boldedNote: `If you're a Veteran who isn't receiving care through VA or a spouse, caregiver, or CHAMPVA recipient,`,
         body: ` sign up to tell us if you want to get a vaccine. If you're eligible, we'll contact you when we have a vaccine for you. At this time, we don't know when that will be.`,
       },
     },

--- a/src/applications/static-pages/covid-vaccine-updates-cta/widget.jsx
+++ b/src/applications/static-pages/covid-vaccine-updates-cta/widget.jsx
@@ -10,19 +10,17 @@ import LoadingIndicator from '@department-of-veterans-affairs/component-library/
 const copy = {
   en: {
     appTitle: 'Covid 19 Vaccination Information',
-    cta: `Sign up for an easy way to stay informed about getting a COVID-19
-      vaccine at VA.`,
     expandedEligibilityContent: {
       veteran: {
         boldedNote: `If you're a Veteran currently receiving care through VA,`,
         body: ` we'll ask about your vaccine plans when you sign up. Your local VA health facility may use this information to determine when to contact you once your risk group becomes eligible.`,
       },
       nonVeteran: {
-        boldedNote: `If you're a Veteran, spouse, or caregiver not receiving care through VA,`,
-        body: ` sign up to tell us if you want to get a vaccine through VA. If you're eligible, we'll contact you when we have a vaccine available for you. At this time, we don't know when that will be.`,
+        boldedNote: `If you're a Veteran who isn’t receiving care through VA or a spouse, caregiver, or CHAMPVA recipient`,
+        body: ` sign up to tell us if you want to get a vaccine. If you're eligible, we'll contact you when we have a vaccine for you. At this time, we don't know when that will be.`,
       },
     },
-    headline: 'Stay informed about getting a COVID-19 vaccine',
+    headline: 'Sign up to get a COVID-19 vaccine at VA',
     buttonText: 'Sign up to get a COVID-19 vaccine',
   },
   es: {

--- a/src/applications/static-pages/covid-vaccine-updates-cta/widget.jsx
+++ b/src/applications/static-pages/covid-vaccine-updates-cta/widget.jsx
@@ -16,7 +16,7 @@ const copy = {
         body: ` we'll ask about your vaccine plans when you sign up. Your local VA health facility may use this information to determine when to contact you once your risk group becomes eligible.`,
       },
       nonVeteran: {
-        boldedNote: `If you're a Veteran who isn’t receiving care through VA or a spouse, caregiver, or CHAMPVA recipient`,
+        boldedNote: `If you're a Veteran who isn't receiving care through VA or a spouse, caregiver, or CHAMPVA recipient`,
         body: ` sign up to tell us if you want to get a vaccine. If you're eligible, we'll contact you when we have a vaccine for you. At this time, we don't know when that will be.`,
       },
     },


### PR DESCRIPTION
## Description
Per stakeholder feedback, fixes:
- [x] "Who else is eligible?" accordion 


## Testing done


## Screenshots
## Eligibility accordion
<img width="730" alt="Screen Shot 2021-03-29 at 10 23 50 AM" src="https://user-images.githubusercontent.com/7645362/112851864-5f585880-9079-11eb-8705-27482f5d3551.png">

## Privacy act statement
<img width="755" alt="Screen Shot 2021-03-29 at 12 37 31 PM" src="https://user-images.githubusercontent.com/7645362/112869784-891a7b00-908b-11eb-979a-c742b2d8a272.png">

## CTA
<img width="691" alt="Screen Shot 2021-03-29 at 12 29 08 PM" src="https://user-images.githubusercontent.com/7645362/112869591-56708280-908b-11eb-9aba-b5da1dc1098d.png">

## Caregiver program naming
<img width="651" alt="Screen Shot 2021-03-29 at 1 06 46 PM" src="https://user-images.githubusercontent.com/7645362/112873843-2aa3cb80-9090-11eb-9a3f-364a45d1254d.png">
<img width="572" alt="Screen Shot 2021-03-29 at 1 06 15 PM" src="https://user-images.githubusercontent.com/7645362/112873847-2c6d8f00-9090-11eb-8c05-f539b2775e49.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
