### PR TITLE
22198: Update spacing for stem denied details claim.

### DIFF
--- a/src/applications/claims-status/components/StemAskVAQuestions.jsx
+++ b/src/applications/claims-status/components/StemAskVAQuestions.jsx
@@ -12,14 +12,14 @@ function StemAskVAQuestions() {
       <h3 className="vads-u-font-size--h4 vads-u-margin-bottom--0p5">
         Ask a question
       </h3>
-      <p>
+      <p className="vads-u-padding-top--1px">
         <a href="https://gibill.custhelp.va.gov/app/">Ask a question online</a>{' '}
         (Include your full name and VA file number)
       </p>
       <h3 className="vads-u-font-size--h4 vads-u-margin-bottom--0p5">
         Call us
       </h3>
-      <p>Veterans Crisis Line: </p>
+      <p className="vads-u-padding-top--1px">Veterans Crisis Line: </p>
       <p>
         <Telephone contact={CONTACTS.CRISIS_LINE} /> and select 1
       </p>
@@ -46,7 +46,7 @@ function StemAskVAQuestions() {
       <h3 className="vads-u-font-size--h4 vads-u-margin-bottom--0p5">
         Send us mail
       </h3>
-      <p>
+      <p className="vads-u-padding-top--1px">
         Include your full name and VA file number on the inside of mailed
         correspondence, not on envelope.
       </p>

--- a/src/applications/claims-status/components/StemAskVAQuestions.jsx
+++ b/src/applications/claims-status/components/StemAskVAQuestions.jsx
@@ -9,12 +9,16 @@ function StemAskVAQuestions() {
   return (
     <div>
       <h2 className="help-heading">Need help?</h2>
-      <h3 className="vads-u-font-size--h4">Ask a question</h3>
+      <h3 className="vads-u-font-size--h4 vads-u-margin-bottom--0p5">
+        Ask a question
+      </h3>
       <p>
         <a href="https://gibill.custhelp.va.gov/app/">Ask a question online</a>{' '}
         (Include your full name and VA file number)
       </p>
-      <h3 className="vads-u-font-size--h4">Call us</h3>
+      <h3 className="vads-u-font-size--h4 vads-u-margin-bottom--0p5">
+        Call us
+      </h3>
       <p>Veterans Crisis Line: </p>
       <p>
         <Telephone contact={CONTACTS.CRISIS_LINE} /> and select 1
@@ -39,7 +43,9 @@ function StemAskVAQuestions() {
         TTY, Federal Relay:{' '}
         <Telephone contact={CONTACTS[711]} pattern={PATTERNS['3_DIGIT']} />
       </p>
-      <h3 className="vads-u-font-size--h4">Send us mail</h3>
+      <h3 className="vads-u-font-size--h4 vads-u-margin-bottom--0p5">
+        Send us mail
+      </h3>
       <p>
         Include your full name and VA file number on the inside of mailed
         correspondence, not on envelope.

--- a/src/applications/claims-status/components/StemDeniedDetails.jsx
+++ b/src/applications/claims-status/components/StemDeniedDetails.jsx
@@ -24,7 +24,7 @@ const StemDeniedDetails = ({
         You must meet all 3 of the eligibility criteria to be considered for the
         Rogers STEM Scholarship.
       </p>
-      <h3 className="vads-u-font-family--sans vads-u-margin-bottom--0">
+      <h3 className="vads-u-font-family--sans vads-u-margin-bottom--neg0p5">
         You didn't meet the following criteria for the Rogers STEM Scholarship:
       </h3>
       <ul className="stem-ad-list">
@@ -45,7 +45,7 @@ const StemDeniedDetails = ({
           </ul>
         </li>
       </ul>
-      <h3 className="vads-u-font-family--sans vads-u-margin-bottom--0">
+      <h3 className="vads-u-font-family--sans vads-u-margin-bottom--neg0p5">
         You met these criteria for the Rogers STEM Scholarship:
       </h3>
       <ul className="stem-ad-list">


### PR DESCRIPTION
## Description
As an EDU developer, I need to update the spacing on the denial reasons detail page so that the page is more readable and it is in line with DEPO patterns and practices.

[Originating Issue](https://github.com/department-of-veterans-affairs/va.gov-team/issues/22198)

## Testing done
Testing passes locally. Changes are stylistic only.

## Screenshots
### Full page screenshot
<img width="1040" alt="Screen Shot 2021-03-29 at 12 07 58 PM" src="https://user-images.githubusercontent.com/48804834/112866137-700fcb00-9087-11eb-9e9f-88d0e0c8bca5.png">


### AC 1:
<img width="359" alt="Screen Shot 2021-03-29 at 12 02 16 PM" src="https://user-images.githubusercontent.com/48804834/112865676-fc6dbe00-9086-11eb-8d3f-9767f7edb9b8.png">
<img width="190" alt="Screen Shot 2021-03-29 at 12 03 35 PM" src="https://user-images.githubusercontent.com/48804834/112865679-fc6dbe00-9086-11eb-92e9-dfe5f1744e91.png">
<img width="206" alt="Screen Shot 2021-03-29 at 12 03 44 PM" src="https://user-images.githubusercontent.com/48804834/112865680-fd065480-9086-11eb-9198-f273fef9f21d.png">

### AC 2:
<img width="289" alt="Screen Shot 2021-03-29 at 12 05 42 PM" src="https://user-images.githubusercontent.com/48804834/112866042-566e8380-9087-11eb-9429-3d104641cecc.png">
<img width="277" alt="Screen Shot 2021-03-29 at 12 05 49 PM" src="https://user-images.githubusercontent.com/48804834/112866043-57071a00-9087-11eb-9e50-2bc3022010be.png">

## Acceptance criteria
- [x] The space between the H3 and the content in the right panel is 16px.
- [x] The space between the header and the bulleted list in the main content panel is 8px.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
