### PR TITLE
DT-8279 FAF a11y removed outline

### DIFF
--- a/src/applications/find-forms/containers/SearchResults.jsx
+++ b/src/applications/find-forms/containers/SearchResults.jsx
@@ -118,7 +118,7 @@ export class SearchResults extends Component {
       return (
         <p
           className="vads-u-font-size--base vads-u-line-height--3 vads-u-font-family--sans
-    vads-u-margin-top--1p5 vads-u-font-weight--normal"
+    vads-u-margin-top--1p5 vads-u-font-weight--normal removed-outline"
           data-forms-focus
         >
           The form you're looking for has been retired or is no longer valid,
@@ -131,7 +131,7 @@ export class SearchResults extends Component {
       return (
         <p
           className="vads-u-font-size--base vads-u-line-height--3 vads-u-font-family--sans
-        vads-u-margin-top--1p5 vads-u-font-weight--normal"
+        vads-u-margin-top--1p5 vads-u-font-weight--normal removed-outline"
           data-forms-focus
         >
           No results were found for "<strong>{query}</strong>
@@ -181,7 +181,7 @@ export class SearchResults extends Component {
       <>
         <div className="find-forms-search-metadata vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row medium-screen:vads-u-justify-content--space-between">
           <h2
-            className="vads-u-font-size--md vads-u-line-height--3 vads-u-font-family--sans vads-u-font-weight--normal vads-u-margin-y--1p5"
+            className="vads-u-font-size--md vads-u-line-height--3 vads-u-font-family--sans vads-u-font-weight--normal vads-u-margin-y--1p5 removed-outline"
             data-forms-focus
           >
             {/* eslint-disable-next-line jsx-a11y/aria-role */}

--- a/src/applications/find-forms/containers/SearchResults.jsx
+++ b/src/applications/find-forms/containers/SearchResults.jsx
@@ -118,7 +118,7 @@ export class SearchResults extends Component {
       return (
         <p
           className="vads-u-font-size--base vads-u-line-height--3 vads-u-font-family--sans
-    vads-u-margin-top--1p5 vads-u-font-weight--normal removed-outline"
+    vads-u-margin-top--1p5 vads-u-font-weight--normal va-u-outline--none"
           data-forms-focus
         >
           The form you're looking for has been retired or is no longer valid,
@@ -131,7 +131,7 @@ export class SearchResults extends Component {
       return (
         <p
           className="vads-u-font-size--base vads-u-line-height--3 vads-u-font-family--sans
-        vads-u-margin-top--1p5 vads-u-font-weight--normal removed-outline"
+        vads-u-margin-top--1p5 vads-u-font-weight--normal va-u-outline--none"
           data-forms-focus
         >
           No results were found for "<strong>{query}</strong>
@@ -181,7 +181,7 @@ export class SearchResults extends Component {
       <>
         <div className="find-forms-search-metadata vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row medium-screen:vads-u-justify-content--space-between">
           <h2
-            className="vads-u-font-size--md vads-u-line-height--3 vads-u-font-family--sans vads-u-font-weight--normal vads-u-margin-y--1p5 removed-outline"
+            className="vads-u-font-size--md vads-u-line-height--3 vads-u-font-family--sans vads-u-font-weight--normal vads-u-margin-y--1p5 va-u-outline--none"
             data-forms-focus
           >
             {/* eslint-disable-next-line jsx-a11y/aria-role */}

--- a/src/applications/find-forms/sass/find-va-forms.scss
+++ b/src/applications/find-forms/sass/find-va-forms.scss
@@ -21,3 +21,9 @@
     }
   }
 }
+
+.find-forms-search-metadata {
+  .removed-outline:focus {
+    outline: 0;
+  }
+}

--- a/src/applications/find-forms/sass/find-va-forms.scss
+++ b/src/applications/find-forms/sass/find-va-forms.scss
@@ -20,9 +20,7 @@
       width: 75px;
     }
   }
-}
 
-.find-forms-search-metadata {
   .removed-outline:focus {
     outline: 0;
   }

--- a/src/applications/find-forms/sass/find-va-forms.scss
+++ b/src/applications/find-forms/sass/find-va-forms.scss
@@ -20,8 +20,4 @@
       width: 75px;
     }
   }
-
-  .removed-outline:focus {
-    outline: 0;
-  }
 }


### PR DESCRIPTION
## Description
Removed outline per a11y request.

## Testing done
Ran e2e, unit, and spin up local.

## Screenshots
![Screen Shot 2021-03-29 at 12 15 54 PM](https://user-images.githubusercontent.com/26075258/112867307-c29db700-9088-11eb-83a1-ddda9c0f59d3.png)


## Acceptance criteria
- [x] header 2 focused shouldn't have outline.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
