### PR TITLE
Covid Vax Expansion - Set prod flag to true

### DIFF
--- a/src/applications/coronavirus-vaccination-expansion/config/attestation/helpers.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/attestation/helpers.js
@@ -7,9 +7,9 @@ export const eligibilityAccordion = (
   <>
     <p>
       We have a limited amount of COVID-19 vaccines. We want to make sure we can
-      offer vaccines to as many Veterans, family members, and caregivers as we
-      can. We can only offer vaccines to people who are eligible under the law.
-      Thank you for helping us to achieve our mission.
+      offer vaccines to as many Veterans, caregivers, spouses, and CHAMPVA
+      recipients as we can. We can only offer vaccines to people who are
+      eligible under the law. Thank you for helping us to achieve our mission.
     </p>
     <h3 className="vads-u-font-size--h4" style={paddingBottom}>
       Learn about who's eligible for a COVID-19 vaccine at VA

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1007,7 +1007,7 @@
     "entryName": "covid-vaccine",
     "rootUrl": "/health-care/covid-19-vaccine/sign-up/",
     "template": {
-      "vagovprod": false,
+      "vagovprod": true,
       "layout": "page-react.html",
       "title": "Sign up to get a vaccine",
       "description": "We’re working to provide COVID-19 vaccines as quickly and safely as we can. We base our vaccine plans on CDC guidelines, federal law, and available supply. Sign up to tell us you’d like to get a COVID-19 vaccine at VA.",


### PR DESCRIPTION
## Description
Set the production flag to true in registry.json

## Testing done
e2e tests pass

## Screenshots


## Acceptance criteria
- [ ] prod flag is set to true

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
