### PR TITLE
Add `aria-describedby` to STR radio

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/serviceTreatmentRecords.jsx
+++ b/src/applications/disability-benefits/all-claims/content/serviceTreatmentRecords.jsx
@@ -10,7 +10,7 @@ const alertContent = (
 );
 
 export const serviceTreatmentRecordsSubmitLater = (
-  <div className="service-treatment-records-submit-later">
+  <div id="submit-str-asap" className="service-treatment-records-submit-later">
     <AlertBox
       headline="Please submit your service treatment records as soon as possible"
       content={alertContent}

--- a/src/applications/disability-benefits/all-claims/pages/serviceTreatmentRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/serviceTreatmentRecords.js
@@ -29,6 +29,11 @@ export const uiSchema = {
           Y: 'Yes',
           N: 'No, I will submit them later.',
         },
+        widgetProps: {
+          N: {
+            'aria-describedby': 'submit-str-asap',
+          },
+        },
         // Force ReviewFieldTemplate to wrap this component in a <dl>
         useDlWrap: true,
       },

--- a/src/applications/disability-benefits/all-claims/tests/pages/serviceTreatmentRecords.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/serviceTreatmentRecords.unit.spec.jsx
@@ -96,6 +96,11 @@ describe('serviceTreatmentRecords', () => {
     form.find('form').simulate('submit');
     expect(onSubmit.calledOnce).to.be.true;
     expect(form.find(errorClass).length).to.equal(0);
+    const noRadioId = form.find('input[value="N"]').props()['aria-describedby'];
+    const alertId = form.find('.service-treatment-records-submit-later').props()
+      .id;
+    expect(noRadioId).to.not.be.undefined;
+    expect(noRadioId).to.eq(alertId);
     form.unmount();
   });
 


### PR DESCRIPTION
## Description

Adding an id to the Alert shown after an active service member choses to not upload their service treatment record (STR) and added an `aria-describedby` targeting the alert to fix an accessibility problem where the alert content was not read out by screenreaders

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/19660

## Testing done

Unit test to check `id` & `aria-describedby` have matching id's

## Screenshots

<details><summary>Voiceover window after selecting "No"</summary>

<!-- leave a blank line above -->
![screenreader reading alert](https://user-images.githubusercontent.com/136959/112896066-90e61980-90a3-11eb-8d05-186c19d5165c.gif)</details>

## Acceptance criteria
- [x] STR alert content is included when active member chooses "No"

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
