### PR TITLE
Fix some a11y problems with location selection

### DIFF
--- a/src/applications/coronavirus-vaccination-expansion/config/va-location/DynamicRadioWidget.jsx
+++ b/src/applications/coronavirus-vaccination-expansion/config/va-location/DynamicRadioWidget.jsx
@@ -13,6 +13,7 @@ export function DynamicRadioWidget(props) {
   // console.log(props);
   const { onChange } = props;
   let locationsList = null;
+  let upperContent = null;
   const [locations, setLocations] = useState([]);
   const [loading, isLoading] = useState(true); // app starts in a loading state
   const [error, setError] = useState(false); // app starts with no error
@@ -55,6 +56,21 @@ export function DynamicRadioWidget(props) {
       <LoadingIndicator message="Loading VA medical centers near you..." />
     );
   } else if (locations.length > 0 && loading === false) {
+    upperContent = (
+      <>
+        <p>
+          These are the VA medical centers closest to where you live. Select one
+          or more medical centers you're willing to go to get a COVID-19
+          vaccine. If you don't select any, we'll match you with the first one
+          on the list
+        </p>
+        <p>
+          <strong>Note</strong>: if you get a vaccine that requires 2 doses to
+          be fully effective, you'll need to return to the same VA medical
+          center to get your second dose.
+        </p>
+      </>
+    );
     const optionsList = locations.map(location => ({
       label: (
         <>
@@ -92,7 +108,12 @@ export function DynamicRadioWidget(props) {
       />
     );
   }
-  return <>{locationsList}</>;
+  return (
+    <>
+      {upperContent}
+      {locationsList}
+    </>
+  );
 }
 
 function mapStateToProps(state) {

--- a/src/applications/coronavirus-vaccination-expansion/config/va-location/DynamicRadioWidget.jsx
+++ b/src/applications/coronavirus-vaccination-expansion/config/va-location/DynamicRadioWidget.jsx
@@ -88,6 +88,7 @@ export function DynamicRadioWidget(props) {
     locationsList = (
       <RadioButtons
         options={optionsList}
+        label="Select your medical center"
         value={selected}
         onValueChange={value => {
           onChange(value.value);

--- a/src/applications/coronavirus-vaccination-expansion/config/va-location/va-location.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/va-location/va-location.js
@@ -15,21 +15,6 @@ export const uiSchema = {
     preferredFacility: {
       'ui:title': 'Selected VA medical center',
       'ui:widget': DynamicRadioWidget,
-      'ui:description': (
-        <>
-          <p>
-            These are the VA medical centers closest to the address you
-            provided. Select the medical center where you’d like to get your
-            COVID-19 vaccine. If you don't select any, we'll match you with the
-            closest one.
-          </p>
-          <p>
-            <strong>Note</strong>: If you get a vaccine that requires 2 doses to
-            be fully effective, you'll need to return to the same VA medical
-            center to get your second dose.
-          </p>
-        </>
-      ),
       'ui:options': {
         hideLabelText: true,
       },

--- a/src/applications/coronavirus-vaccination-expansion/config/va-location/va-location.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/va-location/va-location.js
@@ -13,6 +13,7 @@ export const schema = {
 export const uiSchema = {
   vaLocation: {
     preferredFacility: {
+      'ui:title': 'Selected VA medical center',
       'ui:widget': DynamicRadioWidget,
       'ui:description': (
         <>


### PR DESCRIPTION
## Description

Related to https://github.com/department-of-veterans-affairs/va.gov-team/issues/22249#issuecomment-809684887

This sets the `ui:title` value so that the review page has something nicer to display. It also undoes [some of the changes I made here](https://github.com/department-of-veterans-affairs/vets-website/commit/94d800d16d1cb3f42da8606824bcee1efe6af7c9#diff-538803b91ba157aca8a6a49546e75edbf73966b5ce0635ff7aff34cc26482590) so that the description text doesn't appear on the review page.

Also closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/22333


## Testing done

browser :eyes: 


## Screenshots

### Review page

![image](https://user-images.githubusercontent.com/2008881/112906346-e1a84300-90a0-11eb-9d8e-654390f18197.png)


### Bad zip

![image](https://user-images.githubusercontent.com/2008881/112906190-9beb7a80-90a0-11eb-8e6a-0e88d4f31f98.png)

### Valid zip

![image](https://user-images.githubusercontent.com/2008881/112906232-b4f42b80-90a0-11eb-88cc-0378acb0a9d9.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
