### PR TITLE
Bug: Prevent undefined error in 526

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/newDisabilityFollowUp.js
+++ b/src/applications/disability-benefits/all-claims/pages/newDisabilityFollowUp.js
@@ -89,7 +89,7 @@ export const uiSchema = {
           'Please briefly describe the injury or exposure that caused your condition. For example, I operated loud machinery while in the service, and this caused me to lose my hearing. (400 characters maximum)',
         'ui:widget': 'textarea',
         'ui:required': (formData, index) =>
-          !isBDD(formData) && formData.newDisabilities[index].cause === 'NEW',
+          !isBDD(formData) && formData.newDisabilities[index]?.cause === 'NEW',
         'ui:options': {
           expandUnder: 'cause',
           expandUnderCondition: 'NEW',
@@ -106,7 +106,7 @@ export const uiSchema = {
           'ui:title':
             'Please choose the disability that caused the new disability you’re claiming here.',
           'ui:required': (formData, index) =>
-            formData.newDisabilities[index].cause === 'SECONDARY' &&
+            formData.newDisabilities[index]?.cause === 'SECONDARY' &&
             getDisabilitiesList(formData, index).length > 0,
           'ui:options': {
             labels: disabilityLabels,
@@ -129,7 +129,7 @@ export const uiSchema = {
           'ui:widget': 'textarea',
           'ui:required': (formData, index) =>
             !isBDD(formData) &&
-            formData.newDisabilities[index].cause === 'SECONDARY' &&
+            formData.newDisabilities[index]?.cause === 'SECONDARY' &&
             getDisabilitiesList(formData, index).length > 0,
           'ui:options': {
             hideIf: isBDD,
@@ -148,7 +148,7 @@ export const uiSchema = {
             'Please briefly describe the injury or exposure during your military service that caused your existing disability to get worse. (50 characters maximum)',
           'ui:required': (formData, index) =>
             !isBDD(formData) &&
-            formData.newDisabilities[index].cause === 'WORSENED' &&
+            formData.newDisabilities[index]?.cause === 'WORSENED' &&
             getDisabilitiesList(formData, index).length > 0,
           'ui:validations': [validateLength(50)],
         },
@@ -158,7 +158,7 @@ export const uiSchema = {
           'ui:widget': 'textarea',
           'ui:required': (formData, index) =>
             !isBDD(formData) &&
-            formData.newDisabilities[index].cause === 'WORSENED' &&
+            formData.newDisabilities[index]?.cause === 'WORSENED' &&
             getDisabilitiesList(formData, index).length > 0,
           'ui:validations': [validateLength(350)],
         },
@@ -174,7 +174,7 @@ export const uiSchema = {
           'ui:widget': 'textarea',
           'ui:required': (formData, index) =>
             !isBDD(formData) &&
-            formData.newDisabilities[index].cause === 'VA' &&
+            formData.newDisabilities[index]?.cause === 'VA' &&
             getDisabilitiesList(formData, index).length > 0,
           'ui:options': {
             hideIf: isBDD,
@@ -185,7 +185,7 @@ export const uiSchema = {
           'ui:title':
             'Please tell us where this happened. (25 characters maximum)',
           'ui:required': (formData, index) =>
-            formData.newDisabilities[index].cause === 'VA' &&
+            formData.newDisabilities[index]?.cause === 'VA' &&
             getDisabilitiesList(formData, index).length > 0,
           'ui:validations': [validateLength(25)],
         },
@@ -193,7 +193,7 @@ export const uiSchema = {
           'ui:title':
             'Please tell us when this happened. If you’re having trouble remembering the exact date you can provide a year. (25 characters maximum)',
           'ui:required': (formData, index) =>
-            formData.newDisabilities[index].cause === 'VA' &&
+            formData.newDisabilities[index]?.cause === 'VA' &&
             getDisabilitiesList(formData, index).length > 0,
           'ui:validations': [validateLength(25)],
         },


### PR DESCRIPTION
## Description

This fix will prevent the JS error seen in this Sentry report - http://sentry.vfs.va.gov/organizations/vsp/issues/24505/ - showing that the indexed new disability did not include a `cause`. I am not able to reproduce this problem locally, and thus was unable to write a test.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/22366

## Testing done

Unit test still pass

## Screenshots

N/A

## Acceptance criteria
- [x] `cause` of undefined error will no longer occur

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
