### PR TITLE
Allow service end dates <90 days in the future

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
@@ -489,7 +489,10 @@ describe('526 All Claims validations', () => {
         _,
         _,
         index,
-        data({ bdd: true }),
+        data({
+          bdd: true,
+          branch: 'Army',
+        }),
       );
 
       expect(errors.addError.called).to.be.true;
@@ -509,6 +512,22 @@ describe('526 All Claims validations', () => {
           bdd: true,
           branch: 'Army National Guard',
         }),
+      );
+
+      expect(errors.addError.called).to.be.false;
+    });
+
+    it('should allow non-BDD future end service dates < 90 days for any type of service', () => {
+      const errors = { addError: sinon.spy() };
+      const index = 0;
+      validateSeparationDate(
+        errors,
+        daysFromToday(89),
+        _,
+        _,
+        _,
+        index,
+        data({ branch: 'Army' }),
       );
 
       expect(errors.addError.called).to.be.false;

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -406,7 +406,8 @@ export const validateSeparationDate = (
   const { allowBDD, servicePeriods = [] } = appStateData;
   const branch = servicePeriods[currentIndex]?.serviceBranch || '';
   const isReserves = reservesList.some(match => branch.includes(match));
-  if (!allowBDD && !isReserves && moment(dateString).isAfter(moment())) {
+  const in90Days = moment().add(90, 'days');
+  if (!allowBDD && !isReserves && moment(dateString).isSameOrAfter(in90Days)) {
     errors.addError('Your separation date must be in the past');
   } else if (
     allowBDD &&


### PR DESCRIPTION
## Description

Active duty service members not eligible for the BDD program have been unable to process an original claim due to a validation bug preventing any non-BDD participant (not in the reseves) from entering a future date.

This PR fixes the separation date validation logic to allow future separation dates:
- from 0 to 90 days - valid non-BDD original claim
- 90-180 days - valid BDD claim
- \> 180 days - only for reserve and national guard services

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/20556

## Testing done

Added unit test

## Screenshots

<details><summary>Bug preventing future separation dates</summary>

<!-- leave a blank line above -->
![](https://user-images.githubusercontent.com/19188/109358278-7ecd4d00-7851-11eb-93b4-746e2eab4dcd.png)</details>

## Acceptance criteria
- [x] Allow original claims with separation dates < 90 days in the future

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
