### PR TITLE
Prevent flash of content before 526 wizard

### DIFF
--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
+import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
@@ -109,6 +110,19 @@ export const Form526Entry = ({
       setPageFocus('.va-nav-breadcrumbs-list');
     }
   });
+
+  // showWizard feature flag loads _after_ page has render causing the full page
+  // content to render, then the wizard to render if this flag is true, so we
+  // show a loading indicator until the feature flags are available. This can be
+  // removed once the feature flag is removed
+  if (typeof showWizard === 'undefined') {
+    return wrapInBreadcrumb(
+      title,
+      <LoadingIndicator message="Please wait while we load the application for you." />,
+    );
+  }
+
+  // showWizard feature flag is initially undefined
   if (showWizard && wizardState !== WIZARD_STATUS_COMPLETE) {
     return wrapInBreadcrumb(
       title,

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -30,6 +30,7 @@ class IntroductionPage extends React.Component {
   }
 
   render() {
+    const { formConfig, pageList } = this.props.route;
     const services = selectAvailableServices(this.props) || [];
     const allowOriginalClaim =
       this.props.allowOriginalClaim || this.props.testOriginalClaim;
@@ -46,7 +47,7 @@ class IntroductionPage extends React.Component {
     if (!allowContinue) {
       return (
         <div className="schemaform-intro">
-          <FormTitle title={pageTitle} />
+          <FormTitle title={pageTitle} subTitle={formConfig.subTitle} />
           <fileOriginalClaimPage.component props={this.props} />
         </div>
       );
@@ -84,12 +85,12 @@ class IntroductionPage extends React.Component {
         )}
         <SaveInProgressIntro
           hideUnauthedStartLink
-          prefillEnabled={this.props.route.formConfig.prefillEnabled}
+          prefillEnabled={formConfig.prefillEnabled}
           formId={this.props.formId}
-          pageList={this.props.route.pageList}
+          pageList={pageList}
           startText={startText}
           retentionPeriod="1 year"
-          downtime={this.props.route.formConfig.downtime}
+          downtime={formConfig.downtime}
         />
         {itfNotice}
         <h2 className="vads-u-font-size--h4">{subwayTitle}</h2>
@@ -252,11 +253,11 @@ class IntroductionPage extends React.Component {
         <SaveInProgressIntro
           hideUnauthedStartLink
           buttonOnly
-          prefillEnabled={this.props.route.formConfig.prefillEnabled}
+          prefillEnabled={formConfig.prefillEnabled}
           formId={this.props.formId}
-          pageList={this.props.route.pageList}
+          pageList={pageList}
           startText={startText}
-          downtime={this.props.route.formConfig.downtime}
+          downtime={formConfig.downtime}
         />
         {itfNotice}
         <div className="omb-info--container">

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -179,7 +179,7 @@ const formConfig = {
     ...fullSchema.definitions,
   },
   title: ({ formData }) => getPageTitle(formData),
-  subTitle: 'Form 21-526EZ',
+  subTitle: 'Equal to VA Form 21-526EZ',
   preSubmitInfo,
   chapters: {
     veteranDetails: {

--- a/src/applications/disability-benefits/all-claims/containers/WizardContainer.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/WizardContainer.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import recordEvent from 'platform/monitoring/record-event';
 import FormFooter from 'platform/forms/components/FormFooter';
 import Wizard from 'applications/static-pages/wizard';
@@ -21,11 +22,7 @@ const WizardContainer = ({ setWizardStatus }) => {
   return (
     <div className="row">
       <div className="usa-width-two-thirds medium-8 columns">
-        <h1>{getPageTitle()}</h1>
-        <p>
-          Equal to VA Form 21-526EZ (Application for Disability Compensation and
-          Related Compensation Benefits).
-        </p>
+        <FormTitle title={getPageTitle()} subTitle={formConfig.subTitle} />
         <div className="wizard-container">
           <h2>Is this the form I need?</h2>
           <p>

--- a/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
@@ -261,4 +261,44 @@ describe('Form 526EZ Entry Page', () => {
     expect(tree.find('WizardContainer')).to.have.lengthOf(0);
     tree.unmount();
   });
+  it('should render loading indicator when feature is undefined', () => {
+    sessionStorage.removeItem(WIZARD_STATUS);
+    const initialState = {
+      form: {
+        loadedStatus: 'success',
+        savedStatus: '',
+        loadedData: { metadata: {} },
+      },
+      user: {
+        login: { currentlyLoggedIn: false },
+        profile: { verified: false, services: [], loading: false, status: '' },
+      },
+      currentLocation: { pathname: '/introduction', search: '' },
+      mvi: { addPersonState: '' },
+    };
+    const fakeStore = createStore(
+      combineReducers({
+        ...commonReducer,
+        ...reducers,
+      }),
+      initialState,
+    );
+    window.dataLayer = [];
+    gaData = global.window.dataLayer;
+    const tree = mount(
+      <Provider store={fakeStore}>
+        <Form526Entry
+          location={initialState.currentLocation}
+          user={initialState.user}
+        >
+          <main>
+            <h1>{fakeSipsIntro(initialState.user)}</h1>
+          </main>
+        </Form526Entry>
+      </Provider>,
+    );
+    expect(tree.find('LoadingIndicator')).to.have.lengthOf(1);
+    expect(tree.find('WizardContainer')).to.have.lengthOf(0);
+    tree.unmount();
+  });
 });

--- a/src/applications/disability-benefits/all-claims/tests/containers/WizardContainer.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/WizardContainer.unit.spec.jsx
@@ -15,7 +15,7 @@ describe('Wizard Container', () => {
 
   it('should render', () => {
     const tree = shallow(<WizardContainer {...props} />);
-    expect(tree.find('h1')).to.have.lengthOf(1);
+    expect(tree.find('FormTitle')).to.have.lengthOf(1);
     expect(tree.find('.wizard-container')).to.have.lengthOf(1);
     expect(tree.find('FormFooter')).to.have.lengthOf(1);
     tree.unmount();


### PR DESCRIPTION
## Description

Due to the delay of feature flag loading, the introduction page content will briefly show before the wizard is displayed, causing an undesirable flash of content. This PR displays a loading indicator in place of rendering content while the feature flags load.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/16517
- Slack discussion about flash of intro content: https://dsva.slack.com/archives/C0113MPTGH5/p1617116963005900?thread_ts=1617112949.005200&cid=C0113MPTGH5

## Testing done

Added unit test

## Screenshots

Previous state: see video in https://dsva.slack.com/archives/C0113MPTGH5/p1617120931007300?thread_ts=1617112949.005200&cid=C0113MPTGH5

<details><summary>Fixed page loading</summary>

<!-- leave a blank line above -->
![loading](https://user-images.githubusercontent.com/136959/113051394-84c58f00-916b-11eb-9e47-a8e0788d7111.gif)</details>

## Acceptance criteria
- [x] Loading indicator shown instead of a flash of content

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
