### PR TITLE
prevent reading of SVG contents

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoCNPv2.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoCNPv2.jsx
@@ -247,28 +247,36 @@ export const BankInfoCNP = ({
       </p>
       <div className="vads-u-margin-bottom--2">
         <AdditionalInfo triggerText="Where can I find these numbers?">
-          {/* eslint-disable jsx-a11y/no-redundant-roles */}
-          <img
-            src="/img/direct-deposit-check-guide.svg"
-            alt="On a personal check, find your bank’s 9-digit routing number listed along the bottom-left edge, and your account number listed beside that."
-            role="img"
-          />
-          {/* eslint-enable jsx-a11y/no-redundant-roles */}
-          <p>
-            The bank routing number is the first 9 digits on the bottom left
-            corner of a printed check. Your account number is the second set of
-            numbers on the bottom of a check, just to the right of the bank
-            routing number.
-          </p>
-          <p>If you don’t have a printed check, you can:</p>
-          <ul>
-            <li>
-              Sign in to your online bank account and check your account
-              details, or
-            </li>
-            <li>Check your bank statement, or</li>
-            <li>Call your bank</li>
-          </ul>
+          <figure className="vads-u-margin-x--0">
+            {/* eslint-disable jsx-a11y/no-redundant-roles */}
+            <img
+              src="/img/direct-deposit-check-guide.svg"
+              role="img"
+              alt="A personal check"
+              aria-labelledby="check-caption"
+            />
+            {/* eslint-enable jsx-a11y/no-redundant-roles */}
+            <figcaption
+              id="check-caption"
+              className="vads-u-font-size--base vads-u-font-weight--normal vads-u-font-family--sans vads-u-width--auto vads-u-color--gray-dark"
+            >
+              <p>
+                The bank routing number is the first 9 digits on the bottom left
+                corner of a printed check. Your account number is the second set
+                of numbers on the bottom of a check, just to the right of the
+                bank routing number.
+              </p>
+              <p>If you don’t have a printed check, you can:</p>
+              <ul>
+                <li>
+                  Sign in to your online bank account and check your account
+                  details, or
+                </li>
+                <li>Check your bank statement, or</li>
+                <li>Call your bank</li>
+              </ul>
+            </figcaption>
+          </figure>
         </AdditionalInfo>
       </div>
       <div data-testid={`${formPrefix}-bank-info-form`}>

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoCNPv2.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoCNPv2.jsx
@@ -247,19 +247,20 @@ export const BankInfoCNP = ({
       </p>
       <div className="vads-u-margin-bottom--2">
         <AdditionalInfo triggerText="Where can I find these numbers?">
+          {/* eslint-disable jsx-a11y/no-redundant-roles */}
           <img
             src="/img/direct-deposit-check-guide.svg"
             alt="On a personal check, find your bank’s 9-digit routing number listed along the bottom-left edge, and your account number listed beside that."
+            role="img"
           />
+          {/* eslint-enable jsx-a11y/no-redundant-roles */}
           <p>
             The bank routing number is the first 9 digits on the bottom left
             corner of a printed check. Your account number is the second set of
             numbers on the bottom of a check, just to the right of the bank
             routing number.
           </p>
-
           <p>If you don’t have a printed check, you can:</p>
-
           <ul>
             <li>
               Sign in to your online bank account and check your account

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
@@ -213,10 +213,13 @@ export const DirectDepositEDU = ({
       </p>
       <div className="vads-u-margin-bottom--2">
         <AdditionalInfo triggerText="Where can I find these numbers?">
+          {/* eslint-disable jsx-a11y/no-redundant-roles */}
           <img
             src="/img/direct-deposit-check-guide.svg"
             alt="On a personal check, find your bank’s 9-digit routing number listed along the bottom-left edge, and your account number listed beside that."
+            role="img"
           />
+          {/* eslint-enable jsx-a11y/no-redundant-roles */}
           <p>
             The bank routing number is the first 9 digits on the bottom left
             corner of a printed check. Your account number is the second set of

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
@@ -213,30 +213,36 @@ export const DirectDepositEDU = ({
       </p>
       <div className="vads-u-margin-bottom--2">
         <AdditionalInfo triggerText="Where can I find these numbers?">
-          {/* eslint-disable jsx-a11y/no-redundant-roles */}
-          <img
-            src="/img/direct-deposit-check-guide.svg"
-            alt="On a personal check, find your bank’s 9-digit routing number listed along the bottom-left edge, and your account number listed beside that."
-            role="img"
-          />
-          {/* eslint-enable jsx-a11y/no-redundant-roles */}
-          <p>
-            The bank routing number is the first 9 digits on the bottom left
-            corner of a printed check. Your account number is the second set of
-            numbers on the bottom of a check, just to the right of the bank
-            routing number.
-          </p>
-
-          <p>If you don’t have a printed check, you can:</p>
-
-          <ul>
-            <li>
-              Sign in to your online bank account and check your account
-              details, or
-            </li>
-            <li>Check your bank statement, or</li>
-            <li>Call your bank</li>
-          </ul>
+          <figure className="vads-u-margin-x--0">
+            {/* eslint-disable jsx-a11y/no-redundant-roles */}
+            <img
+              src="/img/direct-deposit-check-guide.svg"
+              role="img"
+              alt="A personal check"
+              aria-labelledby="check-caption"
+            />
+            {/* eslint-enable jsx-a11y/no-redundant-roles */}
+            <figcaption
+              id="check-caption"
+              className="vads-u-font-size--base vads-u-font-weight--normal vads-u-font-family--sans vads-u-width--auto vads-u-color--gray-dark"
+            >
+              <p>
+                The bank routing number is the first 9 digits on the bottom left
+                corner of a printed check. Your account number is the second set
+                of numbers on the bottom of a check, just to the right of the
+                bank routing number.
+              </p>
+              <p>If you don’t have a printed check, you can:</p>
+              <ul>
+                <li>
+                  Sign in to your online bank account and check your account
+                  details, or
+                </li>
+                <li>Check your bank statement, or</li>
+                <li>Call your bank</li>
+              </ul>
+            </figcaption>
+          </figure>
         </AdditionalInfo>
       </div>
       <div data-testid={`${formPrefix}-bank-info-form`}>


### PR DESCRIPTION
## Description
Adding `role="img"` to the SVG [to prevent screen readers from reading the SVG contents](https://github.com/department-of-veterans-affairs/va.gov-team/issues/19611#issuecomment-811076998).

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs