### PR TITLE
Covid Vaccination - remove country select and update vets json schema commit hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -363,7 +363,7 @@
     "url-search-params-polyfill": "^8.1.0",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#3fcf1339d11c400414ad689401abfdb0af57ca55",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#2609a250dbc895824c587a02300df2a5ca8f3415",
     "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.2.2",
     "whatwg-fetch": "^2.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -363,7 +363,7 @@
     "url-search-params-polyfill": "^8.1.0",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#ccf4b138584046eef02577bae8deca17ee1a721c",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#3fcf1339d11c400414ad689401abfdb0af57ca55",
     "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.2.2",
     "whatwg-fetch": "^2.0.3"
   },

--- a/src/applications/coronavirus-vaccination-expansion/config/address/addressInformation.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/address/addressInformation.js
@@ -14,9 +14,6 @@ export const schema = {
 
 export const uiSchema = {
   addressInformation: {
-    countryName: {
-      'ui:title': 'Country where you live now',
-    },
     addressLine1: {
       'ui:title': 'Street address where you live now',
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -19526,9 +19526,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#3fcf1339d11c400414ad689401abfdb0af57ca55":
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#2609a250dbc895824c587a02300df2a5ca8f3415":
   version "20.0.0"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#3fcf1339d11c400414ad689401abfdb0af57ca55"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#2609a250dbc895824c587a02300df2a5ca8f3415"
 
 vinyl-file@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19526,9 +19526,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#83eec41c059780dc915042aecd44e196691fbf60":
-  version "19.1.0"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#83eec41c059780dc915042aecd44e196691fbf60"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#3fcf1339d11c400414ad689401abfdb0af57ca55":
+  version "20.0.0"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#3fcf1339d11c400414ad689401abfdb0af57ca55"
 
 vinyl-file@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description
This PR removes the country code select from UISchema and updates the commit hash to the corresponding `vets-json-schema` commit

vets-json-schema PR: https://github.com/department-of-veterans-affairs/vets-json-schema/pull/578

## Testing done
browser testing

## Screenshots
![image](https://user-images.githubusercontent.com/2481110/113166558-e12eba00-9210-11eb-8904-757b5f096f5a.png)


## Acceptance criteria
- [ ] country select is not displayed
- [ ] form submit is still successful

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
