### PR TITLE
Solve for clp edge case with up_to_top button

### DIFF
--- a/src/site/components/up_to_top_button.html
+++ b/src/site/components/up_to_top_button.html
@@ -13,8 +13,8 @@ Used as quick navigate back to top for long article pages.
 
 <div id="back-to-top-container">
   <div class="usa-grid usa-grid-full">
-    <div class="usa-width-three-fourths">
-      <div class="usa-content">
+    {% if isCampaignLandingPage %}
+      <div class="usa-content" style="max-width: 100rem;">
         <button type="button" className="usa-button">
           <span>
             <i aria-hidden="true" class="fas fa-arrow-up" role="img"></i>
@@ -22,6 +22,17 @@ Used as quick navigate back to top for long article pages.
           <span>Back to top</span>
         </button>
       </div>
-    </div>
+    {% else %}
+      <div class="usa-width-three-fourths">
+        <div class="usa-content">
+          <button type="button" className="usa-button">
+            <span>
+              <i aria-hidden="true" class="fas fa-arrow-up" role="img"></i>
+            </span>
+            <span>Back to top</span>
+          </button>
+        </div>
+      </div>
+    {% endif %}
   </div>
 </div>

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -649,7 +649,9 @@
         </div>
       </div>
     </div>
-    {% include "src/site/components/up_to_top_button.html" %}
+
+    <!-- Back to Top -->
+    {% include "src/site/components/up_to_top_button.html" with isCampaignLandingPage = true %}
   </main>
 </div>
 


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/22087

This PR solves for an edge case for the back to top component on the campaign landing pages on desktop to be aligned correctly to the right of the inner container.

## Testing done
Locally

## Screenshots

### CLP page desktop

![image](https://user-images.githubusercontent.com/12773166/113177897-42538f00-920b-11eb-92aa-193994451dcc.png)

### CLP page tablet

![image](https://user-images.githubusercontent.com/12773166/113177955-513a4180-920b-11eb-8b9a-b5211d70df11.png)

### CLP page mobile

![image](https://user-images.githubusercontent.com/12773166/113177994-5bf4d680-920b-11eb-80c8-081688989c72.png)

### Other R&S page desktop

![image](https://user-images.githubusercontent.com/12773166/113178548-efc6a280-920b-11eb-836a-40a8c747741d.png)

### Other R&S page tablet

![image](https://user-images.githubusercontent.com/12773166/113178636-040a9f80-920c-11eb-8b2f-d29abe524548.png)

### Other R&S page mobile

![image](https://user-images.githubusercontent.com/12773166/113178685-0c62da80-920c-11eb-936d-33d6ee76c047.png)

## Acceptance criteria
- [x] solves for an edge case for the back to top component on the campaign landing pages on desktop to be aligned correctly to the right of the inner container

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
