### PR TITLE
[508 Focus management ]526: Focus document type select after upload

### DIFF
--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -10,6 +10,7 @@ import fastLevenshtein from 'fast-levenshtein';
 import { apiRequest } from 'platform/utilities/api';
 import environment from 'platform/utilities/environment';
 import _ from 'platform/utilities/data';
+import { focusElement } from 'platform/utilities/ui';
 
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import fileUploadUI from 'platform/forms-system/src/js/definitions/file';
@@ -684,6 +685,15 @@ export const ancillaryFormUploadUi = (
   } = {},
 ) => {
   const pdfSizeFeature = getPdfSizeFeature();
+  // a11y focus management. Move focus to select after upload
+  // see va.gov-team/issues/19688
+  const findAndFocusLastSelect = () => {
+    // focus on last document type select since all new uploads are appended
+    const lastSelect = [...document.querySelectorAll('select')].slice(-1);
+    if (lastSelect.length) {
+      focusElement(lastSelect[0]);
+    }
+  };
   return fileUploadUI(label, {
     itemDescription,
     hideLabelText: !label,
@@ -703,11 +713,16 @@ export const ancillaryFormUploadUi = (
       }
       return payload;
     },
-    parseResponse: (response, file) => ({
-      name: file.name,
-      confirmationCode: response.data.attributes.guid,
-      attachmentId,
-    }),
+    parseResponse: (response, file) => {
+      setTimeout(() => {
+        findAndFocusLastSelect();
+      });
+      return {
+        name: file.name,
+        confirmationCode: response.data.attributes.guid,
+        attachmentId,
+      };
+    },
     attachmentSchema: {
       'ui:title': 'Document type',
       'ui:disabled': isDisabled,


### PR DESCRIPTION
## Description

Fix focus management on 526 file uploads. After uploading a file, focus is shifted to the "Document type" select within the uploaded file card.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/19688

## Testing done

Manually tested

## Screenshots

![](https://user-images.githubusercontent.com/14154792/107421417-efe9d200-6ae7-11eb-85aa-2039348f901f.png)

## Acceptance criteria
- [x] Focus on "Document type" select after upload

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
