### PR TITLE
22203 remove videos

### DIFF
--- a/src/applications/disability-benefits/686c-674/config/chapters/674/student-name-ssn/studentNameSSN.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/674/student-name-ssn/studentNameSSN.js
@@ -58,6 +58,7 @@ export const uiSchema = {
     isParentOrGuardian: {
       'ui:title': 'Are you a parent or guardian of this child?',
       'ui:widget': 'yesNo',
+      'ui:required': formData => isChapterFieldRequired(formData, 'report674'),
     },
     dependentIncome: {
       'ui:title': 'Did this dependent earn an income in the last 365 days?',

--- a/src/applications/disability-benefits/686c-674/tests/config/studentNameSSN674.unit.spec.jsx
+++ b/src/applications/disability-benefits/686c-674/tests/config/studentNameSSN674.unit.spec.jsx
@@ -6,6 +6,7 @@ import { changeDropdown } from '../helpers/index.js';
 import {
   DefinitionTester,
   fillData,
+  selectRadio,
 } from 'platform/testing/unit/schemaform-utils.jsx';
 
 import formConfig from '../../config/form';
@@ -47,7 +48,7 @@ describe('Report 674 student personal information', () => {
       />,
     );
     form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error').length).to.equal(4);
+    expect(form.find('.usa-input-error').length).to.equal(5);
     expect(onSubmit.called).to.be.false;
     form.unmount();
   });
@@ -68,6 +69,7 @@ describe('Report 674 student personal information', () => {
     fillData(form, 'input#root_studentNameAndSsn_ssn', '555-55-5551');
     changeDropdown(form, 'select#root_studentNameAndSsn_birthDateMonth', 1);
     changeDropdown(form, 'select#root_studentNameAndSsn_birthDateDay', 1);
+    selectRadio(form, 'root_studentNameAndSsn_isParentOrGuardian', 'N');
     fillData(form, 'input#root_studentNameAndSsn_birthDateYear', '2002');
 
     form.find('form').simulate('submit');

--- a/src/applications/disability-benefits/686c-674/tests/e2e/fixtures/add-child-add-674.json
+++ b/src/applications/disability-benefits/686c-674/tests/e2e/fixtures/add-child-add-674.json
@@ -58,7 +58,8 @@
       "view:674Information": {},
       "fullName": { "first": "Jonathan", "last": "Yuen" },
       "ssn": "123211234",
-      "birthDate": "1991-03-09"
+      "birthDate": "1991-03-09",
+      "isParentOrGuardian": "N"
     },
     "childrenToAdd": [
       {

--- a/src/applications/vre/28-1900/orientation/StepComponent.jsx
+++ b/src/applications/vre/28-1900/orientation/StepComponent.jsx
@@ -9,17 +9,6 @@ const StepComponent = props => {
   if (data.isVideoStep) {
     content = (
       <>
-        {data.subTitle()}
-
-        <iframe
-          width="325px"
-          height="185px"
-          src={`https://www.youtube.com/embed/${data.path}`}
-          title={data.title}
-          frameBorder="0"
-          allowFullScreen
-          key={data.path}
-        />
         <p>{data.desc}</p>
         <ul>
           {data.list.map((item, index) => {


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/22203)

When we first build the Orientation for the chapter 31 form we put in the Youtube videos that we had at the time. It turns out that those were not the correct videos and the correct ones will not be ready before launch so we are removing the Youtube videos for now. This PR removes them.

[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/22353)

We also did some work earlier this week to add a question that was missing from the 674 workflows on the 686c form. It turns out that the question needs to be set to required so that update is also in this branch as a time saver. Also, the corresponding unit tests and e2e tests have been updated

## Testing done
Unit tests and e2e tests have been updated

## Acceptance criteria
- [x] The video is removed from CH31 orientation content
- [x] The question is in place on the proper page
- [x] A member of the backend team has been made aware for logic and implementation
- [x] A PR has been requested for merging

