### PR TITLE
[Templates] Fix two metatags

### DIFF
--- a/src/site/includes/metatags.drupal.liquid
+++ b/src/site/includes/metatags.drupal.liquid
@@ -1,11 +1,11 @@
-<link rel="canonical" href="{{ hostUrl }}{{ entityUrl.path }}" />
+<link rel="canonical" href="{{ hostUrl }}{{ entityUrl.path }}/" />
 
 {% if changed %}
 <meta name="DC.Date" scheme="W3CDTF" content="{{ changed| dateFromUnix: 'YYYY-MM-DD' }}">
 {% endif %}
 
 {% if entityUrl.path %}
-<meta content="{{ hostUrl }}/{{ entityUrl.path }}" property="og:url">
+<meta content="{{ hostUrl }}{{ entityUrl.path }}" property="og:url">
 {% else %}
 <meta content="{{ hostUrl }}" property="og:url">
 {% endif %}

--- a/src/site/includes/metatags.drupal.liquid
+++ b/src/site/includes/metatags.drupal.liquid
@@ -5,9 +5,9 @@
 {% endif %}
 
 {% if entityUrl.path %}
-<meta content="{{ hostUrl }}{{ entityUrl.path }}" property="og:url">
+<meta content="{{ hostUrl }}{{ entityUrl.path }}/" property="og:url">
 {% else %}
-<meta content="{{ hostUrl }}" property="og:url">
+<meta content="{{ hostUrl }}/" property="og:url">
 {% endif %}
 
 <meta content="website" property="og:type">

--- a/src/site/layouts/tests/landing_page/landing_page.unit.spec.js
+++ b/src/site/layouts/tests/landing_page/landing_page.unit.spec.js
@@ -56,4 +56,29 @@ describe('intro', () => {
       ).not.to.equal(null);
     });
   });
+
+  describe('metadata', () => {
+    let container;
+    const data = parseFixture(
+      'src/site/layouts/tests/landing_page/fixtures/landing_page_with_icon.json',
+    );
+
+    before(async () => {
+      container = await renderHTML(layoutPath, data);
+    });
+
+    it('has the correct URLs for the "canonical" field', async () => {
+      const canonical = container
+        .querySelector('link[rel="canonical"]')
+        .getAttribute('href');
+      expect(canonical).to.equal('https://dev.va.gov/records/');
+    });
+
+    it('has the correct URLs for the "og:url" field', async () => {
+      const ogUrl = container
+        .querySelector('meta[property="og:url"]')
+        .getAttribute('content');
+      expect(ogUrl).to.equal('https://dev.va.gov/records/');
+    });
+  });
 });


### PR DESCRIPTION
## Description
We have a couple incorrect metatags that were surfaced on an SEO report.

1. "canonical"  need a trailing slash
2. The `og:url` has two slashes after `va.gov`

https://github.com/department-of-veterans-affairs/va.gov-team/issues/22242

## Testing done
Checked output of files in `build/localhost` and added unit test

## Screenshots
### Wrong URLs
![image](https://user-images.githubusercontent.com/1915775/113235300-c7bd5a80-9270-11eb-8aff-2d9c4cfe8950.png)

### Fixed
![image](https://user-images.githubusercontent.com/1915775/113303235-e05c5d80-92ce-11eb-9d62-a7be1fca1d58.png)

## Acceptance criteria
- [ ] Metatags are correct

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
