### PR TITLE
1990s: add missing entryName to app-entry.jsx

### DIFF
--- a/src/applications/edu-benefits/1990s/app-entry.jsx
+++ b/src/applications/edu-benefits/1990s/app-entry.jsx
@@ -11,4 +11,5 @@ startApp({
   url: manifest.rootUrl,
   reducer,
   routes,
+  entryName: manifest.entryName,
 });


### PR DESCRIPTION
## Description
Currently https://staging.va.gov/vrrap/introduction does not work but https://staging.va.gov/vrrap/ does
And this property is set in other forms

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
