### PR TITLE
Covid Vaccine - make facility selection required

### DIFF
--- a/src/applications/coronavirus-vaccination-expansion/config/va-location/DynamicRadioWidget.jsx
+++ b/src/applications/coronavirus-vaccination-expansion/config/va-location/DynamicRadioWidget.jsx
@@ -45,8 +45,8 @@ export function DynamicRadioWidget(props) {
           })
           .catch(err => {
             isLoading(false);
-            setSelected('None');
-            onChange('None');
+            setSelected('');
+            onChange('');
             setError(true);
             return err;
           });

--- a/src/applications/coronavirus-vaccination-expansion/config/va-location/DynamicRadioWidget.jsx
+++ b/src/applications/coronavirus-vaccination-expansion/config/va-location/DynamicRadioWidget.jsx
@@ -36,6 +36,8 @@ export function DynamicRadioWidget(props) {
     () => {
       // how sure are we that people will always enter 5 digits for their zipcode?
       if (props.zipcode && props.zipcode.length === 5) {
+        setSelected(null);
+        onChange();
         apiRequest(`${apiUrl}${props.zipcode}`, {})
           .then(resp => {
             setLocations(resp.data);
@@ -43,6 +45,8 @@ export function DynamicRadioWidget(props) {
           })
           .catch(err => {
             isLoading(false);
+            setSelected('None');
+            onChange('None');
             setError(true);
             return err;
           });
@@ -60,8 +64,7 @@ export function DynamicRadioWidget(props) {
       <>
         <p>
           These are the VA medical centers closest to where you live. Select the
-          medical center you'd like to go to get a COVID-19 vaccine. If you
-          don't select one, we'll match you with the first one on the list.
+          medical center you'd like to go to get a COVID-19 vaccine.
         </p>
         <p>
           <strong>Note</strong>: If you get a vaccine that requires 2 doses to
@@ -88,6 +91,7 @@ export function DynamicRadioWidget(props) {
       <RadioButtons
         options={optionsList}
         label="Select your medical center"
+        required
         value={selected}
         onValueChange={value => {
           onChange(value.value);

--- a/src/applications/coronavirus-vaccination-expansion/config/va-location/va-location.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/va-location/va-location.js
@@ -19,6 +19,7 @@ export const uiSchema = {
         hideLabelText: true,
       },
       'ui:reviewWidget': ReviewWidget,
+      'ui:required': () => true,
     },
   },
 };

--- a/src/applications/coronavirus-vaccination-expansion/tests/fixtures/data/test-data-veteran-no-facilities.json
+++ b/src/applications/coronavirus-vaccination-expansion/tests/fixtures/data/test-data-veteran-no-facilities.json
@@ -1,0 +1,28 @@
+{
+  "data": {
+    "preferredFacility": "vha_648",
+    "countryName": "USA",
+    "addressLine1": "123 Fake Drive",
+    "addressLine2": "F",
+    "city": "Portland",
+    "stateCode": "OR",
+    "zipCode": "00000",
+    "emailAddress": "myemail@example.com",
+    "phone": "5035551212",
+    "smsAcknowledgement": true,
+    "firstName": "J",
+    "lastName": "Peterman",
+    "birthDate": "1955-02-02",
+    "birthSex": "Male",
+    "ssn": "666554321",
+    "lastBranchOfService": "Army",
+    "dateRange": {
+      "from": "1981-03-XX",
+      "to": "1985-06-XX"
+    },
+    "characterOfService": "Honorable",
+    "applicantType": "veteran",
+    "complianceAgreement": true,
+    "privacyAgreementAccepted": true
+  }
+}


### PR DESCRIPTION
## Description
Require selection of a facility of facilities are returned and the list is populted

## Testing done
browser

## Screenshots
![image](https://user-images.githubusercontent.com/2481110/113327035-72249480-92e8-11eb-82df-941987c6fdba.png)


## Acceptance criteria
- [ ] when facilities are returned the selection is required
- [ ] when no facilities are returned the selection is not required and an empty string is added to formData
- [ ] verbiage is updated to remove reference to not having to select a facility if any are present

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
