### PR TITLE
covid vaccine - send facility code to backend instead of name

### DIFF
--- a/src/applications/coronavirus-vaccination-expansion/config/form.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/form.js
@@ -5,6 +5,7 @@ import { VA_FORM_IDS } from 'platform/forms/constants';
 import environment from 'platform/utilities/environment';
 import FormFooter from 'platform/forms/components/FormFooter';
 import GetFormHelp from './getFormHelp.jsx';
+import { transformForSubmit } from 'platform/forms-system/src/js/helpers';
 
 import {
   attestation,
@@ -34,6 +35,13 @@ const formConfig = {
   footerContent: FormFooter,
   getHelp: GetFormHelp,
   saveInProgress: {},
+  transformForSubmit: (config, form) => {
+    const transformedForm = form;
+    transformedForm.data.preferredFacility = form?.data?.preferredFacility
+      ? form.data.preferredFacility.split('|')[1]
+      : '';
+    return transformForSubmit(formConfig, transformedForm);
+  },
   title: 'Sign up to get a COVID-19 vaccine at VA',
   defaultDefinitions: {
     ...fullSchema.definitions,

--- a/src/applications/coronavirus-vaccination-expansion/config/va-location/DynamicRadioWidget.jsx
+++ b/src/applications/coronavirus-vaccination-expansion/config/va-location/DynamicRadioWidget.jsx
@@ -81,7 +81,7 @@ export function DynamicRadioWidget(props) {
           } ${location.attributes.state}`}</p>
         </>
       ),
-      value: location.attributes.name,
+      value: `${location.attributes.name}|${location.id}`,
     }));
 
     locationsList = (

--- a/src/applications/coronavirus-vaccination-expansion/config/va-location/va-location.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/va-location/va-location.js
@@ -3,7 +3,7 @@ import DynamicRadioWidget from './DynamicRadioWidget.jsx';
 import { vaLocation } from '../schema-imports';
 
 function ReviewWidget({ value }) {
-  return <span>{value}</span>;
+  return <span>{value ? value?.split('|')[0] : `None`}</span>;
 }
 
 export const schema = {


### PR DESCRIPTION
## Description
Transform form data to send only facility code to back end instead of facility name
This was done by updating the value for each radio button to be `facilityName|facilityId` and then splitting the value when displaying the facility name on the review page and in `transformForSubmit` to send only the facilityID. 

## Testing done
Cy tests and manual testing

## Screenshots
Display and payload with facilities:
![image](https://user-images.githubusercontent.com/2481110/113340882-73f75380-92fa-11eb-9653-c92e9f35205f.png)
![image](https://user-images.githubusercontent.com/2481110/113340935-87a2ba00-92fa-11eb-9ec8-5f078f806eb0.png)


Display and payload with no facilities:
![image](https://user-images.githubusercontent.com/2481110/113340591-16630700-92fa-11eb-8a60-f6a04039db99.png)
![image](https://user-images.githubusercontent.com/2481110/113340479-f29fc100-92f9-11eb-9ece-a614006893c6.png)


## Acceptance criteria
- [ ] Facility name displays correctly on review screen
- [ ] facility ID or '' is sent in payload

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
