### PR TITLE
Update createEmbedYouTubeVideoURL method to add in missing www

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -612,7 +612,6 @@ module.exports = function registerFilters() {
       const pathname = urlInstance?.pathname?.replace('/embed', '');
       return `https://www.youtube.com/embed${pathname}`;
     } catch (error) {
-      console.warn('Invalid URL for createEmbedYouTubeVideoURL', url, error);
       return url;
     }
   };

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -601,18 +601,37 @@ module.exports = function registerFilters() {
       return url;
     }
 
+    // Ensure URL is https and not http.
+    if (_.includes(url, 'http://')) {
+      url = _.replace(url, 'http://', 'https://');
+    }
+
+    // Ensure URL has `https://`.
+    if (!_.includes(url, 'https://')) {
+      url = `https://${url}`;
+    }
+
+    // Ensure URL has `www`.
+    if (!_.includes(url, 'www')) {
+      url = _.replace(url, 'https://', 'https://www.');
+    }
+
+    // Not a youtube link? Return back the url.
     if (!_.includes(url, 'youtu')) {
       return url;
     }
 
+    // Return back the url if it is already formatted for embedding.
     if (_.includes(url, 'embed')) {
       return url;
     }
 
+    // Modify a normal youtube share link with the embedded version.
     if (_.includes(url, 'youtube.com/watch?v=')) {
       return _.replace(url, '/watch?v=', '/embed/');
     }
 
+    // Modify a shortened youtube share link with the embedded version.
     return _.replace(url, 'youtu.be', 'youtube.com/embed');
   };
 

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -601,38 +601,15 @@ module.exports = function registerFilters() {
       return url;
     }
 
-    // Ensure URL is https and not http.
-    if (_.includes(url, 'http://')) {
-      url = _.replace(url, 'http://', 'https://');
-    }
-
-    // Ensure URL has `https://`.
-    if (!_.includes(url, 'https://')) {
-      url = `https://${url}`;
-    }
-
-    // Ensure URL has `www`.
-    if (!_.includes(url, 'www')) {
-      url = _.replace(url, 'https://', 'https://www.');
-    }
-
-    // Not a youtube link? Return back the url.
+    // Not a youtube link? Return back the modifiedURL.
     if (!_.includes(url, 'youtu')) {
       return url;
     }
 
-    // Return back the url if it is already formatted for embedding.
-    if (_.includes(url, 'embed')) {
-      return url;
-    }
-
-    // Modify a normal youtube share link with the embedded version.
-    if (_.includes(url, 'youtube.com/watch?v=')) {
-      return _.replace(url, '/watch?v=', '/embed/');
-    }
-
-    // Modify a shortened youtube share link with the embedded version.
-    return _.replace(url, 'youtu.be', 'youtube.com/embed');
+    // Recreate the embedded youtube.com URL so we know it's formatted correctly.
+    const urlInstance = new URL(url);
+    const pathname = urlInstance?.pathname?.replace('/embed', '');
+    return `https://www.youtube.com/embed${pathname}`;
   };
 
   liquid.filters.deriveCLPTotalSections = (

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -601,7 +601,7 @@ module.exports = function registerFilters() {
       return url;
     }
 
-    // Not a youtube link? Return back the modifiedURL.
+    // Not a youtube link? Return back the raw url.
     if (!_.includes(url, 'youtu')) {
       return url;
     }

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -606,10 +606,15 @@ module.exports = function registerFilters() {
       return url;
     }
 
-    // Recreate the embedded youtube.com URL so we know it's formatted correctly.
-    const urlInstance = new URL(url);
-    const pathname = urlInstance?.pathname?.replace('/embed', '');
-    return `https://www.youtube.com/embed${pathname}`;
+    try {
+      // Recreate the embedded youtube.com URL so we know it's formatted correctly.
+      const urlInstance = new URL(url);
+      const pathname = urlInstance?.pathname?.replace('/embed', '');
+      return `https://www.youtube.com/embed${pathname}`;
+    } catch (error) {
+      console.warn('Invalid URL for createEmbedYouTubeVideoURL', url, error);
+      return url;
+    }
   };
 
   liquid.filters.deriveCLPTotalSections = (

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -214,7 +214,7 @@ describe('createEmbedYouTubeVideoURL', () => {
   it('returns the modified URL if it needs it', () => {
     expect(
       liquid.filters.createEmbedYouTubeVideoURL('https://youtu.be/asdf'),
-    ).to.eq('https://youtube.com/embed/asdf');
+    ).to.eq('https://www.youtube.com/embed/asdf');
     expect(
       liquid.filters.createEmbedYouTubeVideoURL('https://www.youtu.be/asdf'),
     ).to.eq('https://www.youtube.com/embed/asdf');


### PR DESCRIPTION
## Description
This PR adds support for inserting missing `www`s within the createEmbedYouTubeVideoURL liquid method.

## Testing done
Locally

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/113346735-799c6b80-92f1-11eb-8005-5ae22b0f9822.png)

## Acceptance criteria
- [x] Add `www` if missing in youtube URL

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
