### PR TITLE
DT-14432 adding language field for Va Form Node template.

### DIFF
--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -17,8 +17,8 @@
 
         <dl>
           <div class="vads-u-margin-bottom--4">
-            {%if fieldVaFormLanguage %}
-              <dt class="va-introtext" lang={{ fieldVaFormLanguage }}>
+            {% if fieldVaFormLanguage %}
+              <dt class="va-introtext" lang="{{ fieldVaFormLanguage }}">
             {% else %}
               <dt class="va-introtext" lang="en">
             {% endif %}
@@ -65,7 +65,15 @@
 
         {% if fieldVaFormUsage %}
           <h2 class="vads-u-margin-top--4">When to use this form</h3>
-          {{ fieldVaFormUsage.processed }}
+          {% if fieldVaFormLanguage %}
+            <div lang="{{ fieldVaFormLanguage }}">
+              {{ fieldVaFormUsage.processed }}
+            </div>
+          {% else %}
+            <div lang="en">
+              {{ fieldVaFormUsage.processed }}
+            </div>
+          {% endif %}
 
           <h3>Downloadable PDF</h3>
           <a

--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -20,7 +20,7 @@
             {% if fieldVaFormLanguage %}
               <dt class="va-introtext" lang="{{ fieldVaFormLanguage }}">
             {% else %}
-              <dt class="va-introtext" lang="en">
+              <dt class="va-introtext">
             {% endif %}
               <dfn class="vads-u-visibility--screen-reader">Form name:</dfn>
               {{ fieldVaFormName }}
@@ -70,7 +70,7 @@
               {{ fieldVaFormUsage.processed }}
             </div>
           {% else %}
-            <div lang="en">
+            <div>
               {{ fieldVaFormUsage.processed }}
             </div>
           {% endif %}

--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -17,7 +17,11 @@
 
         <dl>
           <div class="vads-u-margin-bottom--4">
-            <dt class="va-introtext">
+            {%if fieldVaFormLanguage %}
+              <dt class="va-introtext" lang={{ fieldVaFormLanguage }}>
+            {% else %}
+              <dt class="va-introtext" lang="en">
+            {% endif %}
               <dfn class="vads-u-visibility--screen-reader">Form name:</dfn>
               {{ fieldVaFormName }}
             </dt>

--- a/src/site/stages/build/drupal/graphql/vaFormPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vaFormPage.graphql.js
@@ -11,6 +11,7 @@ fragment vaFormPage on NodeVaForm {
   fieldVaFormName
   fieldVaFormTitle
   fieldVaFormType
+  fieldVaFormLanguage
   fieldVaFormUrl {
     uri
     title


### PR DESCRIPTION
## Description
Per this conversation, we are adding the html attribute as the inter solution.
https://github.com/department-of-veterans-affairs/va.gov-team/issues/14432

## Testing done
Ran unit and e2e. Spun up preview server: 

## Screenshots
![Screen Shot 2021-04-01 at 4 44 08 PM](https://user-images.githubusercontent.com/26075258/113353117-33540600-930b-11eb-90ed-d28e3fc4fe3d.png)

## Acceptance criteria
- [x] lang attribute populates

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
