### PR TITLE
Use set instead of array in replacePathInData() (#22448)

### DIFF
--- a/src/site/stages/build/drupal/assets.js
+++ b/src/site/stages/build/drupal/assets.js
@@ -11,14 +11,14 @@ const PUBLIC_URLS_NO_SCHEME = Object.entries(PUBLIC_URLS).reduce(
   {},
 );
 
-function replacePathInData(data, replacer, ancestors = []) {
+function replacePathInData(data, replacer, ancestors = new Set()) {
   // Circular references happen when an entity in the CMS has a child entity
   // which is also in its ancestor tree. When this hapens, this function becomes
   // infinitely recursive. This check looks for circular references and, when
   // found, exits early because it's already checked that data.
-  if (ancestors.includes(data)) return data;
+  if (ancestors.has(data)) return data;
 
-  ancestors.push(data);
+  ancestors.add(data);
 
   let current = data;
   if (Array.isArray(data)) {


### PR DESCRIPTION
## Description
Use a JS set instead of an array in the `replacePathInData()` function. Array lookups change from O(n) to O(1) in circular reference detection. This reduces content build time by about 40 seconds. As node count increases, this change is required for builds to complete in minutes rather than hours.

## Testing done
- Run `yarn build:compare` to ensure no differences between existing build and new build
- Perform spot checks locally and on RI
- All unit and E2E tests pass

## Acceptance criteria
- [x] JS Set is used instead of an array in the replacePathInData() function
- [x] Compare new build output to old with content build comparison script
- [x] Testing has been completed to ensure this has not introduced any issues

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
