### PR TITLE
NameTag handles failure to fetch disability rating

### DIFF
--- a/src/applications/personalization/components/NameTag.jsx
+++ b/src/applications/personalization/components/NameTag.jsx
@@ -12,8 +12,9 @@ const NameTag = ({
   userFullName: { first, middle, last, suffix },
   latestBranchOfService,
   showBadgeImage,
-  totalDisabilityRating,
   showUpdatedNameTag,
+  totalDisabilityRating,
+  totalDisabilityRatingError,
 }) => {
   const fullName = [first, middle, last, suffix]
     .filter(name => !!name)
@@ -153,13 +154,28 @@ const NameTag = ({
                       <i
                         aria-hidden="true"
                         role="img"
-                        className="fas fa-chevron-right vads-u-padding-left--0p5"
+                        className="fas fa-angle-double-right vads-u-padding-left--0p5"
                       />
                     </a>
                   </dd>
                 </>
               )}
           </dl>
+          {showUpdatedNameTag &&
+            totalDisabilityRatingError && (
+              <a
+                href="/disability/view-disability-rating/rating"
+                aria-label="view your disability rating"
+                className="vads-u-color--white font-weight--bold"
+              >
+                View disability rating{' '}
+                <i
+                  aria-hidden="true"
+                  role="img"
+                  className="fas fa-angle-double-right vads-u-padding-left--0p5"
+                />
+              </a>
+            )}
         </div>
       </div>
     </div>
@@ -201,6 +217,7 @@ NameTag.propTypes = {
   latestBranchOfService: PropTypes.string.isRequired,
   showUpdatedNameTag: PropTypes.bool,
   totalDisabilityRating: PropTypes.number,
+  totalDisabilityRatingError: PropTypes.bool,
 };
 
 export default connect(mapStateToProps)(NameTag);

--- a/src/applications/personalization/components/NameTag.jsx
+++ b/src/applications/personalization/components/NameTag.jsx
@@ -141,8 +141,9 @@ const NameTag = ({
             {showUpdatedNameTag &&
               totalDisabilityRating && (
                 <>
-                  <dt className="sr-only">total disability rating</dt>
+                  <dt className="sr-only">your disability rating</dt>
                   <dd className="vads-u-margin-top--0p5">
+                    Your disability rating:{' '}
                     <a
                       href="/disability/view-disability-rating/rating"
                       aria-label="view your disability rating"
@@ -198,6 +199,8 @@ NameTag.propTypes = {
     suffix: PropTypes.string,
   }).isRequired,
   latestBranchOfService: PropTypes.string.isRequired,
+  showUpdatedNameTag: PropTypes.bool,
+  totalDisabilityRating: PropTypes.number,
 };
 
 export default connect(mapStateToProps)(NameTag);

--- a/src/applications/personalization/components/NameTag.unit.spec.jsx
+++ b/src/applications/personalization/components/NameTag.unit.spec.jsx
@@ -93,4 +93,22 @@ describe('<NameTag>', () => {
       });
     },
   );
+  context(
+    'when `showUpdatedNameTag` flag is `true` and `totalDisabilityRatingError` is `true`',
+    () => {
+      it('should render a fallback link', () => {
+        const initialState = getInitialState();
+        const view = render(
+          <NameTag showUpdatedNameTag totalDisabilityRatingError />,
+          { initialState },
+        );
+        expect(view.queryByText(/your disability rating:/i)).to.not.exist;
+        view.getByRole('link', {
+          name: /view your disability rating/i,
+          text: /view disability rating/i,
+          href: /disability\/view-disability-rating\/rating/i,
+        });
+      });
+    },
+  );
 });

--- a/src/applications/personalization/components/NameTag.unit.spec.jsx
+++ b/src/applications/personalization/components/NameTag.unit.spec.jsx
@@ -1,99 +1,96 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { renderWithProfileReducers as render } from '../profile/tests/unit-test-helpers';
 import { expect } from 'chai';
 
 import NameTag from './NameTag';
 
-const fakeStore = {
-  getState: () => ({
-    vaProfile: {
-      hero: {
-        userFullName: {
-          first: 'Johnnie',
-          middle: 'Leonard',
-          last: 'Weaver',
-        },
-      },
-      militaryInformation: {
-        serviceHistory: {
-          serviceHistory: [
-            {
-              branchOfService: 'Army',
-              beginDate: '2004-02-01',
-              endDate: '2007-02-01',
-            },
-            {
-              branchOfService: 'Navy',
-              beginDate: '2007-02-01',
-              endDate: '2009-02-01',
-            },
-            {
-              branchOfService: 'Coast Guard',
-              beginDate: '2009-02-01',
-              endDate: '2019-02-01',
-            },
-          ],
-        },
+const getInitialState = () => ({
+  vaProfile: {
+    hero: {
+      userFullName: {
+        first: 'Johnnie',
+        middle: 'Leonard',
+        last: 'Weaver',
       },
     },
-  }),
-  subscribe: () => {},
-  dispatch: () => {},
-};
+    militaryInformation: {
+      serviceHistory: {
+        serviceHistory: [
+          {
+            branchOfService: 'Army',
+            beginDate: '2004-02-01',
+            endDate: '2007-02-01',
+          },
+          {
+            branchOfService: 'Coast Guard',
+            beginDate: '2009-02-01',
+            endDate: '2019-02-01',
+          },
+          {
+            branchOfService: 'Navy',
+            beginDate: '2007-02-01',
+            endDate: '2009-02-01',
+          },
+        ],
+      },
+    },
+  },
+});
 
 describe('<NameTag>', () => {
-  it('should render', () => {
-    const component = mount(<NameTag store={fakeStore} />);
-    expect(component).to.not.be.undefined;
-    component.unmount();
-  });
-  it('should render name', () => {
-    const component = mount(<NameTag store={fakeStore} />);
-    expect(
-      component
-        .find('dd')
-        .first()
-        .text(),
-    ).to.contain('Johnnie Leonard Weaver');
-    component.unmount();
-  });
-  it('should render most recent military service', () => {
-    // this will render the most recent military service regardless of where it lands in the array
-    const component = mount(<NameTag store={fakeStore} />);
-    expect(
-      component
-        .find('dd')
-        .at(1)
-        .text(),
-    ).to.contain('United States Coast Guard');
-    component.unmount();
-  });
-  it('should render latest service badge', () => {
-    const component = mount(<NameTag store={fakeStore} />);
-    expect(component.find('img').first()).to.not.be.undefined;
-    component.unmount();
-  });
-
-  it('should render disability rating when the dashboardShowDashboard2 feature flag is turned on and the user has a disability rating', () => {
-    const component = mount(
-      <NameTag
-        showUpdatedNameTag
-        totalDisabilityRating="70"
-        store={fakeStore}
-      />,
-    );
-    expect(
-      component
-        .find('dd')
-        .at(2)
-        .text(),
-    ).to.contain('70% Service connected');
-    component.unmount();
-  });
-
-  it('should not render disability rating when the dashboardShowDashboard2 feature flag is turned on and the user has no disability rating', () => {
-    const component = mount(<NameTag showUpdatedNameTag store={fakeStore} />);
-    expect(component.text()).to.not.contain('Service connected');
-    component.unmount();
-  });
+  context(
+    'when name is set and there are multiple service history entries',
+    () => {
+      let view;
+      beforeEach(() => {
+        view = render(<NameTag />, {
+          initialState: getInitialState(),
+        });
+      });
+      it("should render the Veteran's name", () => {
+        view.getByText('Johnnie Leonard Weaver');
+      });
+      it('should render the most recent branch of service', () => {
+        view.getByText('United States Coast Guard');
+        view.getByRole('img', { alt: /coast guard seal/ });
+      });
+    },
+  );
+  context(
+    'when `showUpdatedNameTag` flag is `true` and `totalDisabilityRating` is set',
+    () => {
+      it('should render the disability rating', () => {
+        const initialState = getInitialState();
+        const view = render(
+          <NameTag showUpdatedNameTag totalDisabilityRating={70} />,
+          { initialState },
+        );
+        view.getByText(/your disability rating:/i);
+        view.getByRole('link', {
+          name: /view your disability rating/i,
+          text: /70% service connected/i,
+          href: /disability\/view-disability-rating\/rating/i,
+        });
+      });
+    },
+  );
+  context(
+    'when `showUpdatedNameTag` flag is `true` and `totalDisabilityRating` is not set',
+    () => {
+      it('should not render the disability rating', () => {
+        const initialState = getInitialState();
+        const view = render(
+          <NameTag showUpdatedNameTag totalDisabilityRating={null} />,
+          { initialState },
+        );
+        expect(view.queryByText(/your disability rating:/i)).to.not.exist;
+        expect(
+          view.queryByRole('link', {
+            name: /view your disability rating/i,
+            href: /disability\/view-disability-rating\/rating/i,
+          }),
+        ).to.not.exist;
+      });
+    },
+  );
 });

--- a/src/applications/personalization/dashboard-2/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard-2/components/Dashboard.jsx
@@ -95,6 +95,7 @@ const Dashboard = ({
               <NameTag
                 showUpdatedNameTag
                 totalDisabilityRating={props.totalDisabilityRating}
+                totalDisabilityRatingError={props.totalDisabilityRatingError}
               />
             )}
             <div className="vads-l-grid-container vads-u-padding-bottom--3 medium-screen:vads-u-padding-x--2 medium-screen:vads-u-padding-bottom--4 small-desktop-screen:vads-u-padding-x--0">
@@ -170,6 +171,7 @@ const mapStateToProps = state => {
     showNameTag,
     hero,
     totalDisabilityRating: state.totalRating?.totalDisabilityRating,
+    totalDisabilityRatingError: state.totalRating?.error,
     user: state.user,
   };
 };

--- a/src/applications/personalization/profile/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile/components/ProfileWrapper.jsx
@@ -45,6 +45,7 @@ const ProfileWrapper = ({
   isInMVI,
   showNotAllDataAvailableError,
   totalDisabilityRating,
+  totalDisabilityRatingError,
   showUpdatedNameTag,
   showNameTag,
 }) => {
@@ -73,6 +74,7 @@ const ProfileWrapper = ({
           <NameTag
             showUpdatedNameTag
             totalDisabilityRating={totalDisabilityRating}
+            totalDisabilityRatingError={totalDisabilityRatingError}
           />
         )}
 
@@ -127,6 +129,7 @@ const mapStateToProps = (state, ownProps) => {
   return {
     hero,
     totalDisabilityRating: state.totalRating?.totalDisabilityRating,
+    totalDisabilityRatingError: state.totalRating?.error,
     showNameTag: ownProps.isLOA3 && isEmpty(hero?.errors),
     showNotAllDataAvailableError:
       !!cnpDirectDepositLoadError(state) ||

--- a/src/applications/personalization/profile/tests/e2e/helpers.js
+++ b/src/applications/personalization/profile/tests/e2e/helpers.js
@@ -26,3 +26,21 @@ export function onlyAccountSecuritySectionIsAccessible() {
     );
   });
 }
+
+export const mockFeatureToggles = () => {
+  cy.route({
+    method: 'GET',
+    status: 200,
+    url: '/v0/feature_toggles*',
+    response: {
+      data: {
+        features: [
+          {
+            name: 'dashboard_show_dashboard_2',
+            value: true,
+          },
+        ],
+      },
+    },
+  });
+};

--- a/src/applications/personalization/profile/tests/e2e/helpers.js
+++ b/src/applications/personalization/profile/tests/e2e/helpers.js
@@ -44,3 +44,16 @@ export const mockFeatureToggles = () => {
     },
   });
 };
+
+export function nameTagRenders({ withDisabilityRating = true }) {
+  cy.findByTestId('name-tag').should('exist');
+  cy.findByText('Wesley Watson Ford').should('exist');
+  cy.findByText('United States Air Force').should('exist');
+  if (withDisabilityRating) {
+    cy.findByText('Your disability rating:').should('exist');
+    cy.findByText('90% Service connected').should('exist');
+  } else {
+    cy.findByText(/View disability rating/i).should('exist');
+    cy.findByText(/service connected/i).should('not.exist');
+  }
+}

--- a/src/applications/personalization/profile/tests/e2e/nametag.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/nametag.cypress.spec.js
@@ -16,6 +16,10 @@ describe('Profile NameTag', () => {
     cy.login(mockUser);
     cy.intercept('/v0/profile/service_history', serviceHistory);
     cy.intercept('/v0/profile/full_name', fullName);
+    // Explicitly mocking these APIs as failures, causes the tests to run MUCH
+    // faster. All three tests run in 2-3s instead of 8-9s.
+    cy.intercept('/v0/profile/personal_information', error500);
+    cy.intercept('/v0/mhv_account', error500);
   });
   context('when it can load the disability rating', () => {
     beforeEach(() => {
@@ -46,7 +50,7 @@ describe('Profile NameTag', () => {
   context('when there is a 500 fetching the disability rating', () => {
     beforeEach(() => {
       cy.intercept('/v0/disability_compensation_form/rating_info', {
-        statusCode: 401,
+        statusCode: 500,
         body: error500,
       });
     });

--- a/src/applications/personalization/profile/tests/e2e/nametag.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/nametag.cypress.spec.js
@@ -1,0 +1,72 @@
+import disableFTUXModals from '~/platform/user/tests/disableFTUXModals';
+
+import serviceHistory from '@@profile/tests/fixtures/service-history-success.json';
+import fullName from '@@profile/tests/fixtures/full-name-success.json';
+import disabilityRating from '@@profile/tests/fixtures/disability-rating-success.json';
+import error401 from '@@profile/tests/fixtures/401.json';
+import error500 from '@@profile/tests/fixtures/500.json';
+
+import mockUser from '../fixtures/users/user';
+import { mockFeatureToggles } from './helpers';
+import { PROFILE_PATHS } from '../../constants';
+
+function nameTagRenders(withDisabilityRating = true) {
+  cy.findByTestId('name-tag').should('exist');
+  cy.findByText('Wesley Watson Ford').should('exist');
+  cy.findByText('United States Air Force').should('exist');
+  if (withDisabilityRating) {
+    cy.findByText('Your disability rating:').should('exist');
+    cy.findByText('90% Service connected').should('exist');
+  } else {
+    cy.findByText(/View disability rating/i).should('exist');
+    cy.findByText(/service connected/i).should('not.exist');
+  }
+}
+
+describe('Profile NameTag', () => {
+  beforeEach(() => {
+    disableFTUXModals();
+    cy.login(mockUser);
+    cy.intercept('/v0/profile/service_history', serviceHistory);
+    cy.intercept('/v0/profile/full_name', fullName);
+  });
+  context('when it can load the disability rating', () => {
+    beforeEach(() => {
+      cy.intercept(
+        '/v0/disability_compensation_form/rating_info',
+        disabilityRating,
+      );
+    });
+    it('should render the name, service branch, and disability rating', () => {
+      mockFeatureToggles();
+      cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+      nameTagRenders(true);
+    });
+  });
+  context('when there is a 401 fetching the disability rating', () => {
+    beforeEach(() => {
+      cy.intercept('/v0/disability_compensation_form/rating_info', {
+        statusCode: 401,
+        body: error401,
+      });
+    });
+    it('should render the name, service branch, and show a fallback link for disability rating', () => {
+      mockFeatureToggles();
+      cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+      nameTagRenders(false);
+    });
+  });
+  context('when there is a 500 fetching the disability rating', () => {
+    beforeEach(() => {
+      cy.intercept('/v0/disability_compensation_form/rating_info', {
+        statusCode: 401,
+        body: error500,
+      });
+    });
+    it('should render the name, service branch, and show a fallback link for disability rating', () => {
+      mockFeatureToggles();
+      cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+      nameTagRenders(false);
+    });
+  });
+});

--- a/src/applications/personalization/profile/tests/e2e/nametag.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/nametag.cypress.spec.js
@@ -7,21 +7,8 @@ import error401 from '@@profile/tests/fixtures/401.json';
 import error500 from '@@profile/tests/fixtures/500.json';
 
 import mockUser from '../fixtures/users/user';
-import { mockFeatureToggles } from './helpers';
+import { mockFeatureToggles, nameTagRenders } from './helpers';
 import { PROFILE_PATHS } from '../../constants';
-
-function nameTagRenders(withDisabilityRating = true) {
-  cy.findByTestId('name-tag').should('exist');
-  cy.findByText('Wesley Watson Ford').should('exist');
-  cy.findByText('United States Air Force').should('exist');
-  if (withDisabilityRating) {
-    cy.findByText('Your disability rating:').should('exist');
-    cy.findByText('90% Service connected').should('exist');
-  } else {
-    cy.findByText(/View disability rating/i).should('exist');
-    cy.findByText(/service connected/i).should('not.exist');
-  }
-}
 
 describe('Profile NameTag', () => {
   beforeEach(() => {
@@ -40,7 +27,7 @@ describe('Profile NameTag', () => {
     it('should render the name, service branch, and disability rating', () => {
       mockFeatureToggles();
       cy.visit(PROFILE_PATHS.PROFILE_ROOT);
-      nameTagRenders(true);
+      nameTagRenders({ withDisabilityRating: true });
     });
   });
   context('when there is a 401 fetching the disability rating', () => {
@@ -53,7 +40,7 @@ describe('Profile NameTag', () => {
     it('should render the name, service branch, and show a fallback link for disability rating', () => {
       mockFeatureToggles();
       cy.visit(PROFILE_PATHS.PROFILE_ROOT);
-      nameTagRenders(false);
+      nameTagRenders({ withDisabilityRating: false });
     });
   });
   context('when there is a 500 fetching the disability rating', () => {
@@ -66,7 +53,7 @@ describe('Profile NameTag', () => {
     it('should render the name, service branch, and show a fallback link for disability rating', () => {
       mockFeatureToggles();
       cy.visit(PROFILE_PATHS.PROFILE_ROOT);
-      nameTagRenders(false);
+      nameTagRenders({ withDisabilityRating: false });
     });
   });
 });

--- a/src/applications/personalization/rated-disabilities/actions/index.js
+++ b/src/applications/personalization/rated-disabilities/actions/index.js
@@ -45,6 +45,19 @@ export function fetchRatedDisabilities() {
   };
 }
 
+function getResponseError(response) {
+  if (response.errors?.length) {
+    const { code, detail } = response.errors[0];
+    return { code, detail };
+  } else if (response.error) {
+    return {
+      code: response.status,
+      detail: response.error,
+    };
+  }
+  return null;
+}
+
 export function fetchTotalDisabilityRating() {
   return async dispatch => {
     dispatch({
@@ -52,8 +65,9 @@ export function fetchTotalDisabilityRating() {
     });
     const response = await getData('/disability_compensation_form/rating_info');
 
-    if (response.errors) {
-      const errorCode = response.errors[0].code;
+    const error = getResponseError(response);
+    if (error) {
+      const errorCode = error.code;
       if (isServerError(errorCode)) {
         recordEvent({
           event: `${DISABILITY_PREFIX}-combined-load-failed`,
@@ -67,7 +81,7 @@ export function fetchTotalDisabilityRating() {
       }
       dispatch({
         type: FETCH_TOTAL_RATING_FAILED,
-        response,
+        error,
       });
     } else {
       recordEvent({ event: `${DISABILITY_PREFIX}-combined-load-success` });

--- a/src/applications/personalization/rated-disabilities/reducers/total-disabilities.js
+++ b/src/applications/personalization/rated-disabilities/reducers/total-disabilities.js
@@ -21,10 +21,7 @@ export function totalRating(state = initialState, action) {
       return {
         ...state,
         loading: false,
-        error: {
-          code: action.response.errors[0].code,
-          detail: action.response.errors[0].detail,
-        },
+        error: action.error,
       };
     case FETCH_TOTAL_RATING_SUCCEEDED:
       return {

--- a/src/applications/personalization/rated-disabilities/tests/reducers/total-disabilities.unit.spec.js
+++ b/src/applications/personalization/rated-disabilities/tests/reducers/total-disabilities.unit.spec.js
@@ -23,18 +23,15 @@ describe('totalDisabilities reducer', () => {
   it('should handle an error from the API call', () => {
     const state = totalRating(initialState, {
       type: FETCH_TOTAL_RATING_FAILED,
-      response: {
-        errors: [
-          {
-            code: 500,
-            detail: 'failed to load',
-          },
-        ],
+      error: {
+        code: 500,
+        detail: 'failed to load',
       },
     });
     const err = { code: 500, detail: 'failed to load' };
     expect(state.loading).to.equal(false);
     expect(state.error.code).to.equal(err.code);
+    expect(state.error.detail).to.equal(err.detail);
     expect(state.totalDisabilityRating).to.equal(null);
   });
 


### PR DESCRIPTION
## Description
This PR:
- expands the `NameTag` to handle an error to fetch the total disability rating.
- wires up the `NameTag` properly on both the Profile and My VA Dashboard
- improves the error handling of the total disability rating action/reducer so it doesn't treat some server errors as successful calls

## Testing done
Local. Added Cypress tests to ensure that the `NameTag` is wired up properly on the Dashboard and Profile.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs