### PR TITLE
Disables flaky test

### DIFF
--- a/src/applications/virtual-agent/tests/App.unit.spec.js
+++ b/src/applications/virtual-agent/tests/App.unit.spec.js
@@ -58,7 +58,7 @@ describe('App', () => {
       });
     }
 
-    it('should wait until webchat is loaded', async () => {
+    it.skip('should wait until webchat is loaded', async () => {
       const wrapper = renderInReduxProvider(<App />, {
         initialState: {
           featureToggles: {


### PR DESCRIPTION
## Description
This PR disables a flaky test

A test on virtual agent webchat has been failing in the pipeline ~10% of the time. This is due to the fact that we are trying to test time based functionality and we cannot mock time because of an error in the version of sinon we are using. A fix for this would be to upgrade sinon to at least version 7 so we can use sinon fake timers

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
