### PR TITLE
Updated root url and breadcrumbs for 1990s VRRAP

### DIFF
--- a/src/applications/edu-benefits/1990s/manifest.json
+++ b/src/applications/edu-benefits/1990s/manifest.json
@@ -2,5 +2,5 @@
   "appName": "Veteran Rapid Retraining Assistance Program",
   "entryFile": "./app-entry.jsx",
   "entryName": "1990s-edu-benefits",
-  "rootUrl": "/vrrap"
+  "rootUrl": "/education/other-va-education-benefits/veteran-rapid-retraining-assistance/apply-for-vrrap-form-22-1990s"
 }

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1051,7 +1051,7 @@
           "path": "education/other-va-education-benefits/veteran-rapid-retraining-assistance"
         },
         {
-          "name": "Apply for VRRAP VA Form 22-1990s",
+          "name": "Apply for VRRAP VA Form 22&#8208;1990s",
           "path": "education/other-va-education-benefits/veteran-rapid-retraining-assistance/apply-for-vrrap-form-22-1990s"
         }
       ]

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1051,7 +1051,7 @@
           "path": "education/other-va-education-benefits/veteran-rapid-retraining-assistance"
         },
         {
-          "name": "Apply for program VA Form 22-1990s",
+          "name": "Apply for VRRAP VA Form 22-1990s",
           "path": "education/other-va-education-benefits/veteran-rapid-retraining-assistance/apply-for-vrrap-form-22-1990s"
         }
       ]

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1030,7 +1030,7 @@
   {
     "appName": "Veteran Rapid Retraining Assistance Program (VRRAP)",
     "entryName": "1990s-edu-benefits",
-    "rootUrl": "/vrrap",
+    "rootUrl": "/education/other-va-education-benefits/veteran-rapid-retraining-assistance/apply-for-vrrap-form-22-1990s",
     "template": {
       "vagovprod": false,
       "title": "Apply for the Veteran Rapid Retraining Assistance Program (VRRAP)",
@@ -1048,7 +1048,11 @@
         },
         {
           "name": "Veteran Rapid Retraining Assistance Program",
-          "path": "vrrap"
+          "path": "education/other-va-education-benefits/veteran-rapid-retraining-assistance"
+        },
+        {
+          "name": "Apply for program VA Form 22-1990s",
+          "path": "education/other-va-education-benefits/veteran-rapid-retraining-assistance/apply-for-vrrap-form-22-1990s"
         }
       ]
     }


### PR DESCRIPTION
## Description
As a developer, I need to update the form URL and breadcrumbs so that it is consistent with other VA.gov education forms and the users have a consistent experience.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/22528

DEVOPS PR: https://github.com/department-of-veterans-affairs/devops/pull/8861
## Testing done
local Testing

## Screenshots
![image](https://user-images.githubusercontent.com/50601724/113583995-570f9880-95f8-11eb-9c2e-3e24c88edc34.png)




## Acceptance criteria
- [x] The VRRAP form is located at URL: https://[environment].va.gov/education/other-va-education-benefits/veteran-rapid-retraining-assistance/apply-for-vrrap-form-22-1990s
- [x] The breadcrumb for the form is: Home > Education and training > Other VA education benefits > Veteran Rapid Retraining Assistance Program > Apply for program VA Form 22-1990s
a. Home - URL when active: https://[environment].va.gov/
b. Education and training - URL when active: https://[environment].va.gov/education/
c. Other VA education benefits - URL when active: https://[environment].va.gov/education/other-va-education-benefits/
d. Veteran Rapid Retraining Assistance Program - URL when active: https://[environment].va.gov/education/other-va-education-benefits/veteran-rapid-retraining-assistance
e. Apply for program VA Form 22-1990s: static breadcrumb text

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
