### PR TITLE
Add selected props to radio widgets

### DIFF
--- a/src/platform/forms-system/src/js/widgets/RadioWidget.jsx
+++ b/src/platform/forms-system/src/js/widgets/RadioWidget.jsx
@@ -15,7 +15,13 @@ export default function RadioWidget({
     labels = {},
     nestedContent = {},
     widgetProps = {},
+    selectedProps = {},
   } = options;
+
+  const getProps = (key, checked) => ({
+    ...(widgetProps[key] || {}),
+    ...((checked && selectedProps[key]) || {}),
+  });
 
   // nested content could be a component or just jsx/text
   let content = nestedContent[value];
@@ -38,7 +44,7 @@ export default function RadioWidget({
               value={option.value}
               disabled={disabled}
               onChange={_ => onChange(option.value)}
-              {...widgetProps[option.value] || {}}
+              {...getProps(option.value, checked)}
             />
             <label htmlFor={`${id}_${i}`}>
               {labels[option.value] || option.label}

--- a/src/platform/forms-system/src/js/widgets/YesNoWidget.jsx
+++ b/src/platform/forms-system/src/js/widgets/YesNoWidget.jsx
@@ -7,31 +7,45 @@ export default function YesNoWidget({
   onChange,
   options = {},
 }) {
-  const { yesNoReverse = false, labels = {}, widgetProps = {} } = options;
-  const yesValue = !yesNoReverse;
-  const noValue = !yesValue;
+  const {
+    yesNoReverse = false,
+    labels = {},
+    widgetProps = {},
+    selectedProps = {},
+  } = options;
+
+  const values = {
+    Y: !yesNoReverse,
+    N: yesNoReverse,
+  };
+
+  const getProps = key => ({
+    ...(widgetProps[key] || {}),
+    ...((value === values[key] && selectedProps[key]) || {}),
+  });
+
   return (
     <div className="form-radio-buttons">
       <input
         type="radio"
-        checked={value === yesValue}
+        checked={value === values.Y}
         id={`${id}Yes`}
         name={`${id}`}
         value="Y"
         disabled={disabled}
-        onChange={_ => onChange(yesValue)}
-        {...widgetProps.Y || {}}
+        onChange={_ => onChange(values.Y)}
+        {...getProps('Y')}
       />
       <label htmlFor={`${id}Yes`}>{labels.Y || 'Yes'}</label>
       <input
         type="radio"
-        checked={value === noValue}
+        checked={value === values.N}
         id={`${id}No`}
         name={`${id}`}
         value="N"
         disabled={disabled}
-        onChange={_ => onChange(noValue)}
-        {...widgetProps.N || {}}
+        onChange={_ => onChange(values.N)}
+        {...getProps('N')}
       />
       <label htmlFor={`${id}No`}>{labels.N || 'No'}</label>
     </div>

--- a/src/platform/forms-system/test/js/widgets/RadioWidget.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/widgets/RadioWidget.unit.spec.jsx
@@ -134,59 +134,62 @@ describe('Schemaform <RadioWidget>', () => {
     const tree = SkinDeep.shallowRender(
       <RadioWidget value onChange={onChange} options={options} />,
     );
-    expect(tree.everySubTree('input')[0].props['data-test']).to.equal('first');
-    expect(tree.everySubTree('input')[1].props['data-test']).to.equal('second');
-  });
-  it('should add custom and selected props', () => {
-    const onChange = sinon.spy();
-    const options = {
-      enumOptions: [
-        { label: 'Testing', value: '1' },
-        { label: 'Testing2', value: '2' },
-      ],
-      widgetProps: {
-        1: { 'data-test': 'first' },
-        2: { 'data-test': 'second' },
-      },
-      selectedProps: {
-        1: { 'data-selected': 'first' },
-        2: { 'data-selected': 'second' },
-      },
-    };
-    const tree = SkinDeep.shallowRender(
-      <RadioWidget value="1" onChange={onChange} options={options} />,
-    );
-    const inputs = tree.everySubTree('input');
-    expect(inputs[0].props['data-test']).to.equal('first');
-    expect(inputs[0].props['data-selected']).to.equal('first');
-
-    expect(inputs[1].props['data-test']).to.equal('second');
-    expect(inputs[1].props['data-selected']).to.be.undefined;
-  });
-  it('should add custom and selected props', () => {
-    const onChange = sinon.spy();
-    const options = {
-      enumOptions: [
-        { label: 'Testing', value: '1' },
-        { label: 'Testing2', value: '2' },
-      ],
-      widgetProps: {
-        1: { 'data-test': 'first' },
-        2: { 'data-test': 'second' },
-      },
-      selectedProps: {
-        1: { 'data-selected': 'first' },
-        2: { 'data-selected': 'second' },
-      },
-    };
-    const tree = SkinDeep.shallowRender(
-      <RadioWidget value="2" onChange={onChange} options={options} />,
-    );
     const inputs = tree.everySubTree('input');
     expect(inputs[0].props['data-test']).to.equal('first');
     expect(inputs[0].props['data-selected']).to.be.undefined;
 
     expect(inputs[1].props['data-test']).to.equal('second');
-    expect(inputs[1].props['data-selected']).to.equal('second');
+    expect(inputs[1].props['data-selected']).to.be.undefined;
+  });
+  it('should update selected props on radio inputs', () => {
+    const onChange = sinon.spy();
+    const options = {
+      enumOptions: [
+        { label: 'Testing', value: '1' },
+        { label: 'Testing2', value: '2' },
+        { label: 'Testing3', value: '3' },
+      ],
+      widgetProps: {
+        1: { 'data-test': 'first' },
+        2: { 'data-test': 'second' },
+        3: { 'data-test': 'third' },
+      },
+      selectedProps: {
+        1: { 'data-selected': 'first_1' },
+        2: { 'data-selected': 'second_2' },
+        3: { 'data-selected': 'third_3' },
+      },
+    };
+    // first option selected
+    const tree = SkinDeep.shallowRender(
+      <RadioWidget value="1" onChange={onChange} options={options} />,
+    );
+    const inputsFirstSelected = tree.everySubTree('input');
+    expect(inputsFirstSelected[0].props['data-test']).to.equal('first');
+    expect(inputsFirstSelected[0].props['data-selected']).to.equal('first_1');
+    expect(inputsFirstSelected[1].props['data-test']).to.equal('second');
+    expect(inputsFirstSelected[1].props['data-selected']).to.be.undefined;
+    expect(inputsFirstSelected[2].props['data-test']).to.equal('third');
+    expect(inputsFirstSelected[2].props['data-selected']).to.be.undefined;
+
+    // second option selected
+    tree.reRender({ value: '2', onChange, options });
+    const inputsSecondSelected = tree.everySubTree('input');
+    expect(inputsSecondSelected[0].props['data-test']).to.equal('first');
+    expect(inputsSecondSelected[0].props['data-selected']).to.be.undefined;
+    expect(inputsSecondSelected[1].props['data-test']).to.equal('second');
+    expect(inputsSecondSelected[1].props['data-selected']).to.equal('second_2');
+    expect(inputsSecondSelected[2].props['data-test']).to.equal('third');
+    expect(inputsSecondSelected[2].props['data-selected']).to.be.undefined;
+
+    // third option selected
+    tree.reRender({ value: '3', onChange, options });
+    const inputsThirdSelected = tree.everySubTree('input');
+    expect(inputsThirdSelected[0].props['data-test']).to.equal('first');
+    expect(inputsThirdSelected[0].props['data-selected']).to.be.undefined;
+    expect(inputsThirdSelected[1].props['data-test']).to.equal('second');
+    expect(inputsThirdSelected[1].props['data-selected']).to.be.undefined;
+    expect(inputsThirdSelected[2].props['data-test']).to.equal('third');
+    expect(inputsThirdSelected[2].props['data-selected']).to.equal('third_3');
   });
 });

--- a/src/platform/forms-system/test/js/widgets/RadioWidget.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/widgets/RadioWidget.unit.spec.jsx
@@ -118,6 +118,7 @@ describe('Schemaform <RadioWidget>', () => {
 
     expect(tree.text()).not.to.contain('Nested');
   });
+
   it('should add custom props', () => {
     const onChange = sinon.spy();
     const options = {
@@ -135,5 +136,57 @@ describe('Schemaform <RadioWidget>', () => {
     );
     expect(tree.everySubTree('input')[0].props['data-test']).to.equal('first');
     expect(tree.everySubTree('input')[1].props['data-test']).to.equal('second');
+  });
+  it('should add custom and selected props', () => {
+    const onChange = sinon.spy();
+    const options = {
+      enumOptions: [
+        { label: 'Testing', value: '1' },
+        { label: 'Testing2', value: '2' },
+      ],
+      widgetProps: {
+        1: { 'data-test': 'first' },
+        2: { 'data-test': 'second' },
+      },
+      selectedProps: {
+        1: { 'data-selected': 'first' },
+        2: { 'data-selected': 'second' },
+      },
+    };
+    const tree = SkinDeep.shallowRender(
+      <RadioWidget value="1" onChange={onChange} options={options} />,
+    );
+    const inputs = tree.everySubTree('input');
+    expect(inputs[0].props['data-test']).to.equal('first');
+    expect(inputs[0].props['data-selected']).to.equal('first');
+
+    expect(inputs[1].props['data-test']).to.equal('second');
+    expect(inputs[1].props['data-selected']).to.be.undefined;
+  });
+  it('should add custom and selected props', () => {
+    const onChange = sinon.spy();
+    const options = {
+      enumOptions: [
+        { label: 'Testing', value: '1' },
+        { label: 'Testing2', value: '2' },
+      ],
+      widgetProps: {
+        1: { 'data-test': 'first' },
+        2: { 'data-test': 'second' },
+      },
+      selectedProps: {
+        1: { 'data-selected': 'first' },
+        2: { 'data-selected': 'second' },
+      },
+    };
+    const tree = SkinDeep.shallowRender(
+      <RadioWidget value="2" onChange={onChange} options={options} />,
+    );
+    const inputs = tree.everySubTree('input');
+    expect(inputs[0].props['data-test']).to.equal('first');
+    expect(inputs[0].props['data-selected']).to.be.undefined;
+
+    expect(inputs[1].props['data-test']).to.equal('second');
+    expect(inputs[1].props['data-selected']).to.equal('second');
   });
 });

--- a/src/platform/forms-system/test/js/widgets/YesNoWidget.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/widgets/YesNoWidget.unit.spec.jsx
@@ -102,56 +102,35 @@ describe('Schemaform <YesNoWidget>', () => {
       'no-input',
     );
   });
-  it('should add custom and "yes" selected props', () => {
+  it('should update selected props', () => {
+    const options = {
+      widgetProps: {
+        Y: { 'data-test': 'yes-input' },
+        N: { 'data-test': 'no-input' },
+      },
+      selectedProps: {
+        Y: { 'data-selected': 'yes-selected' },
+        N: { 'data-selected': 'no-selected' },
+      },
+    };
     const onChange = sinon.spy();
     const tree = SkinDeep.shallowRender(
-      <YesNoWidget
-        value
-        options={{
-          widgetProps: {
-            Y: { 'data-test': 'yes-input' },
-            N: { 'data-test': 'no-input' },
-          },
-          selectedProps: {
-            Y: { 'data-selected': 'yes-selected' },
-            N: { 'data-selected': 'no-selected' },
-          },
-        }}
-        onChange={onChange}
-      />,
+      <YesNoWidget value options={options} onChange={onChange} />,
     );
 
-    const inputs = tree.everySubTree('input');
-    expect(inputs[0].props['data-test']).to.equal('yes-input');
-    expect(inputs[0].props['data-selected']).to.equal('yes-selected');
+    // "Yes" selected
+    const inputsYes = tree.everySubTree('input');
+    expect(inputsYes[0].props['data-test']).to.equal('yes-input');
+    expect(inputsYes[0].props['data-selected']).to.equal('yes-selected');
+    expect(inputsYes[1].props['data-test']).to.equal('no-input');
+    expect(inputsYes[1].props['data-selected']).to.be.undefined;
 
-    expect(inputs[1].props['data-test']).to.equal('no-input');
-    expect(inputs[1].props['data-selected']).to.be.undefined;
-  });
-  it('should add custom and "no" selected props', () => {
-    const onChange = sinon.spy();
-    const tree = SkinDeep.shallowRender(
-      <YesNoWidget
-        value={false}
-        options={{
-          widgetProps: {
-            Y: { 'data-test': 'yes-input' },
-            N: { 'data-test': 'no-input' },
-          },
-          selectedProps: {
-            Y: { 'data-selected': 'yes-selected' },
-            N: { 'data-selected': 'no-selected' },
-          },
-        }}
-        onChange={onChange}
-      />,
-    );
-
-    const inputs = tree.everySubTree('input');
-    expect(inputs[0].props['data-test']).to.equal('yes-input');
-    expect(inputs[0].props['data-selected']).to.be.undefined;
-
-    expect(inputs[1].props['data-test']).to.equal('no-input');
-    expect(inputs[1].props['data-selected']).to.equal('no-selected');
+    // "No" selected
+    tree.reRender({ value: false, options, onChange });
+    const inputsNo = tree.everySubTree('input');
+    expect(inputsNo[0].props['data-test']).to.equal('yes-input');
+    expect(inputsNo[0].props['data-selected']).to.be.undefined;
+    expect(inputsNo[1].props['data-test']).to.equal('no-input');
+    expect(inputsNo[1].props['data-selected']).to.equal('no-selected');
   });
 });

--- a/src/platform/forms-system/test/js/widgets/YesNoWidget.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/widgets/YesNoWidget.unit.spec.jsx
@@ -102,4 +102,56 @@ describe('Schemaform <YesNoWidget>', () => {
       'no-input',
     );
   });
+  it('should add custom and "yes" selected props', () => {
+    const onChange = sinon.spy();
+    const tree = SkinDeep.shallowRender(
+      <YesNoWidget
+        value
+        options={{
+          widgetProps: {
+            Y: { 'data-test': 'yes-input' },
+            N: { 'data-test': 'no-input' },
+          },
+          selectedProps: {
+            Y: { 'data-selected': 'yes-selected' },
+            N: { 'data-selected': 'no-selected' },
+          },
+        }}
+        onChange={onChange}
+      />,
+    );
+
+    const inputs = tree.everySubTree('input');
+    expect(inputs[0].props['data-test']).to.equal('yes-input');
+    expect(inputs[0].props['data-selected']).to.equal('yes-selected');
+
+    expect(inputs[1].props['data-test']).to.equal('no-input');
+    expect(inputs[1].props['data-selected']).to.be.undefined;
+  });
+  it('should add custom and "no" selected props', () => {
+    const onChange = sinon.spy();
+    const tree = SkinDeep.shallowRender(
+      <YesNoWidget
+        value={false}
+        options={{
+          widgetProps: {
+            Y: { 'data-test': 'yes-input' },
+            N: { 'data-test': 'no-input' },
+          },
+          selectedProps: {
+            Y: { 'data-selected': 'yes-selected' },
+            N: { 'data-selected': 'no-selected' },
+          },
+        }}
+        onChange={onChange}
+      />,
+    );
+
+    const inputs = tree.everySubTree('input');
+    expect(inputs[0].props['data-test']).to.equal('yes-input');
+    expect(inputs[0].props['data-selected']).to.be.undefined;
+
+    expect(inputs[1].props['data-test']).to.equal('no-input');
+    expect(inputs[1].props['data-selected']).to.equal('no-selected');
+  });
 });


### PR DESCRIPTION
## Description

When a radio button is selected, we sometimes show additional information (see screenshot). To get screenreaders to include the extra information, we associate the radio input with the alert ID using `aria-describedby`; but, the `aria-describedby` can not contain an ID that does not yet exist on the page, so we need to dynamically add the attribute when the user selects it.

The existing `ui:options.widgetProps` setting will add the props unconditionally, so a new `selectedProps` was added in this PR which conditionally adds props when a radio is selected.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/19733
- https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/604

## Testing done

Updated unit tests

## Screenshots

<details><summary>Alert displayed after choosing "No"</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-04-02 at 1 23 24 PM](https://user-images.githubusercontent.com/136959/113442966-a8304a00-93b6-11eb-9a6f-dccf7cb5b47c.png)</details>

<details><summary>axe error when <code>aria-describedby</code> is unconditionally added</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-04-02 at 10 36 58 AM](https://user-images.githubusercontent.com/136959/113443638-01e54400-93b8-11eb-9b74-2c202c92e619.png)</details>

## Acceptance criteria
- [x] Conditionally add radio attributes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
