### PR TITLE
[PromoBanner] Add banner for the Covid Vaccine Signup

### DIFF
--- a/src/platform/site-wide/announcements/components/CovidVaccineSignUp.jsx
+++ b/src/platform/site-wide/announcements/components/CovidVaccineSignUp.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import PromoBanner from './PromoBanner';
+import { PROMO_BANNER_TYPES } from '@department-of-veterans-affairs/component-library/PromoBanner';
+
+export default function CovidVaccineSignup({ dismiss }) {
+  return (
+    <PromoBanner
+      type={PROMO_BANNER_TYPES.announcement}
+      onClose={dismiss}
+      href="/health-care/covid-19-vaccine/"
+      text="Sign up to get a COVID-19 vaccine at VA"
+    />
+  );
+}

--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -25,7 +25,7 @@ const config = {
     },
     {
       name: 'covid-vaccine-signup',
-      paths: /(.)/,
+      paths: /^(\/)$/,
       component: CovidVaccineSignUp,
     },
     {

--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -5,6 +5,7 @@ import SingleSignOnInfoModal from '../components/SingleSignOnInfoModal';
 import VAMCWelcomeModal, { VAMC_PATHS } from '../components/VAMCWelcomeModal';
 import VAPlusVetsModal from '../components/VAPlusVetsModal';
 import WelcomeVAOSModal from '../components/WelcomeVAOSModal';
+import CovidVaccineSignUp from '../components/CovidVaccineSignUp';
 
 const config = {
   announcements: [
@@ -21,6 +22,11 @@ const config = {
       component: ExploreVAModal,
       disabled: !ExploreVAModal.isEnabled(),
       showEverytime: true,
+    },
+    {
+      name: 'covid-vaccine-signup',
+      paths: /(.)/,
+      component: CovidVaccineSignUp,
     },
     {
       name: 'welcome-to-new-vaos',


### PR DESCRIPTION
## Description
This PR adds a PromoBanner to the homepage to announce the new COVID vaccine sign-up form.

## Testing done
- Confirmed visually 
- Confirmed only appears on homepage
- Confirmed that once clicked, the user is taken to `/health-care/covid-19-vaccine/`
- Confirmed that after click the promobanner does not reappear

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/113452402-e5560580-93d1-11eb-934b-5536beabc705.png)


## Acceptance criteria
- [ ] PromoBanner is visible on homepage

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
