### PR TITLE
accessibility fix for details link and details page

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItem.jsx
@@ -75,6 +75,7 @@ export default function AppointmentListItem({ appointment, facility }) {
   const isVideo = appointment.vaos.isVideo;
   const isPhone = isVAPhoneAppointment(appointment);
   const isInPersonVAAppointment = !isVideo && !isCommunityCare && !isPhone;
+  const canceled = appointment.status === APPOINTMENT_STATUS.cancelled;
 
   return (
     <li
@@ -82,7 +83,7 @@ export default function AppointmentListItem({ appointment, facility }) {
       className="vaos-appts__card vads-u-display--flex vads-u-align-items--center"
     >
       <div className="vads-u-flex--1">
-        {appointment.status === APPOINTMENT_STATUS.cancelled && (
+        {canceled && (
           <span className="vaos-u-text-transform--uppercase vads-u-font-size--base vads-u-font-weight--bold vads-u-color--secondary-dark vads-u-margin-x--0 vads-u-margin-y--0">
             Canceled
           </span>
@@ -120,24 +121,18 @@ export default function AppointmentListItem({ appointment, facility }) {
       </div>
       <div>
         <Link
-          aria-hidden="true"
+          aria-label={`Details for ${
+            canceled ? 'canceled ' : ''
+          }appointment on ${appointmentDate.format('dddd, MMMM D h:mm a')}`}
           to={isCommunityCare ? `cc/${appointment.id}` : `va/${appointment.id}`}
           className="vads-u-display--none medium-screen:vads-u-display--inline"
         >
           Details
         </Link>
-        <Link
-          to={isCommunityCare ? `cc/${appointment.id}` : `va/${appointment.id}`}
-          className="vaos-appts__card-link"
-          aria-label={`Details for appointment on ${appointmentDate.format(
-            'dddd, MMMM D h:mm a',
-          )}`}
-        >
-          <i
-            aria-hidden="true"
-            className="fas fa-chevron-right vads-u-margin-left--1"
-          />
-        </Link>
+        <i
+          aria-hidden="true"
+          className="fas fa-chevron-right vads-u-margin-left--1"
+        />
       </div>
     </li>
   );

--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItem.jsx
@@ -119,13 +119,13 @@ export default function AppointmentListItem({ appointment, facility }) {
           </>
         )}
       </div>
-      <div>
+      {/* visible to medium screen and larger */}
+      <div className="vads-u-display--none medium-screen:vads-u-display--inline">
         <Link
           aria-label={`Details for ${
             canceled ? 'canceled ' : ''
           }appointment on ${appointmentDate.format('dddd, MMMM D h:mm a')}`}
           to={isCommunityCare ? `cc/${appointment.id}` : `va/${appointment.id}`}
-          className="vads-u-display--none medium-screen:vads-u-display--inline"
         >
           Details
         </Link>
@@ -133,6 +133,21 @@ export default function AppointmentListItem({ appointment, facility }) {
           aria-hidden="true"
           className="fas fa-chevron-right vads-u-margin-left--1"
         />
+      </div>
+      {/* visble to small screen breakpoint */}
+      <div className="medium-screen:vads-u-display--none">
+        <Link
+          to={isCommunityCare ? `cc/${appointment.id}` : `va/${appointment.id}`}
+          className="vaos-appts__card-link"
+          aria-label={`Details for ${
+            canceled ? 'canceled ' : ''
+          }appointment on ${appointmentDate.format('dddd, MMMM D h:mm a')}`}
+        >
+          <i
+            aria-hidden="true"
+            className="fas fa-chevron-right vads-u-margin-left--1"
+          />
+        </Link>
       </div>
     </li>
   );

--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/ExpressCareListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/ExpressCareListItem.jsx
@@ -34,24 +34,20 @@ export default function ExpressCareListItem({ appointment }) {
       </div>
       <div>
         <Link
-          aria-hidden="true"
+          aria-label={`Details for ${
+            canceled ? 'canceled ' : ''
+          }Express Care request on ${appointmentDate.format(
+            'dddd, MMMM D YYYY',
+          )}`}
           to={`express-care/${appointment.id}`}
           className="vads-u-display--none medium-screen:vads-u-display--inline"
         >
           Details
         </Link>
-        <Link
-          to={`express-care/${appointment.id}`}
-          className="vaos-appts__card-link"
-          aria-label={`Details for Express Care request on ${appointmentDate.format(
-            'dddd, MMMM D YYYY',
-          )}`}
-        >
-          <i
-            aria-hidden="true"
-            className="fas fa-chevron-right vads-u-margin-left--1"
-          />
-        </Link>
+        <i
+          aria-hidden="true"
+          className="fas fa-chevron-right vads-u-margin-left--1"
+        />
       </div>
     </li>
   );

--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/ExpressCareListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/ExpressCareListItem.jsx
@@ -32,7 +32,8 @@ export default function ExpressCareListItem({ appointment }) {
         <i aria-hidden="true" className="fas fa-phone vads-u-margin-right--1" />
         Express Care request
       </div>
-      <div>
+      {/* visible to medium screen and larger */}
+      <div className="vads-u-display--none medium-screen:vads-u-display--inline">
         <Link
           aria-label={`Details for ${
             canceled ? 'canceled ' : ''
@@ -40,7 +41,6 @@ export default function ExpressCareListItem({ appointment }) {
             'dddd, MMMM D YYYY',
           )}`}
           to={`express-care/${appointment.id}`}
-          className="vads-u-display--none medium-screen:vads-u-display--inline"
         >
           Details
         </Link>
@@ -48,6 +48,23 @@ export default function ExpressCareListItem({ appointment }) {
           aria-hidden="true"
           className="fas fa-chevron-right vads-u-margin-left--1"
         />
+      </div>
+      {/* visible to small screen breakpoint */}
+      <div className="medium-screen:vads-u-display--none">
+        <Link
+          to={`express-care/${appointment.id}`}
+          className="vaos-appts__card-link"
+          aria-label={`Details for ${
+            canceled ? 'canceled ' : ''
+          }Express Care request on ${appointmentDate.format(
+            'dddd, MMMM D YYYY',
+          )}`}
+        >
+          <i
+            aria-hidden="true"
+            className="fas fa-chevron-right vads-u-margin-left--1"
+          />
+        </Link>
       </div>
     </li>
   );

--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/RequestListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/RequestListItem.jsx
@@ -3,12 +3,16 @@ import { Link } from 'react-router-dom';
 import { sentenceCase } from '../../../utils/formatters';
 import { getPractitionerLocationDisplay } from '../../../services/appointment';
 import { APPOINTMENT_STATUS } from '../../../utils/constants';
+import moment from 'moment';
 
 export default function RequestListItem({ appointment, facility }) {
   const isCC = appointment.vaos.isCommunityCare;
   const typeOfCareText = sentenceCase(appointment.type?.coding?.[0]?.display);
   const ccFacilityName = getPractitionerLocationDisplay(appointment);
   const canceled = appointment.status === APPOINTMENT_STATUS.cancelled;
+  const preferredDate = moment(appointment.requestedPeriod[0].start).format(
+    'MMMM D, YYYY',
+  );
 
   return (
     <li
@@ -21,31 +25,27 @@ export default function RequestListItem({ appointment, facility }) {
             Canceled
           </span>
         )}
-        <h4 className="vads-u-font-size--h4 vads-u-margin-x--0 vads-u-margin-y--0">
+        <h3 className="vads-u-font-size--h4 vads-u-margin-x--0 vads-u-margin-y--0">
           {sentenceCase(typeOfCareText)}
-        </h4>
+        </h3>
         {!!facility && !isCC && facility.name}
         {isCC && !!ccFacilityName && ccFacilityName}
         {isCC && !ccFacilityName && 'Community care'}
       </div>
       <div>
         <Link
-          aria-hidden="true"
+          aria-label={`Details for ${
+            canceled ? 'canceled ' : ''
+          }${typeOfCareText}request for ${preferredDate}`}
           to={`requests/${appointment.id}`}
           className="vads-u-display--none medium-screen:vads-u-display--inline"
         >
           Details
         </Link>
-        <Link
-          to={`requests/${appointment.id}`}
-          className="vaos-appts__card-link"
-          aria-label={`Details for ${typeOfCareText} request`}
-        >
-          <i
-            aria-hidden="true"
-            className="fas fa-chevron-right vads-u-margin-left--1"
-          />
-        </Link>
+        <i
+          aria-hidden="true"
+          className="fas fa-chevron-right vads-u-margin-left--1"
+        />
       </div>
     </li>
   );

--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/RequestListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/RequestListItem.jsx
@@ -32,13 +32,13 @@ export default function RequestListItem({ appointment, facility }) {
         {isCC && !!ccFacilityName && ccFacilityName}
         {isCC && !ccFacilityName && 'Community care'}
       </div>
-      <div>
+      {/* visible to medium screen and larger */}
+      <div className="vads-u-display--none medium-screen:vads-u-display--inline">
         <Link
           aria-label={`Details for ${
             canceled ? 'canceled ' : ''
           }${typeOfCareText}request for ${preferredDate}`}
           to={`requests/${appointment.id}`}
-          className="vads-u-display--none medium-screen:vads-u-display--inline"
         >
           Details
         </Link>
@@ -46,6 +46,21 @@ export default function RequestListItem({ appointment, facility }) {
           aria-hidden="true"
           className="fas fa-chevron-right vads-u-margin-left--1"
         />
+      </div>
+      {/* visible to small screen breakpoint */}
+      <div className="medium-screen:vads-u-display--none">
+        <Link
+          to={`requests/${appointment.id}`}
+          className="vaos-appts__card-link"
+          aria-label={`Details for ${
+            canceled ? 'canceled ' : ''
+          }${typeOfCareText}request for ${preferredDate}`}
+        >
+          <i
+            aria-hidden="true"
+            className="fas fa-chevron-right vads-u-margin-left--1"
+          />
+        </Link>
       </div>
     </li>
   );

--- a/src/applications/vaos/appointment-list/components/PastAppointmentsListV2/PastAppointmentsDateDropdown.jsx
+++ b/src/applications/vaos/appointment-list/components/PastAppointmentsListV2/PastAppointmentsDateDropdown.jsx
@@ -11,7 +11,7 @@ export default function PastAppointmentsDateDropdown({
   return (
     <>
       <label
-        htmlFor="type-dropdown"
+        htmlFor="date-dropdown"
         className="vads-u-display--inline-block vads-u-margin-top--0 vads-u-margin-right--2 vads-u-margin-bottom--0"
       >
         Select a date range{' '}
@@ -20,7 +20,7 @@ export default function PastAppointmentsDateDropdown({
       <Select
         options={options}
         onChange={e => updateDateRangeIndex(Number(e.target.value))}
-        id="type-dropdown"
+        id="date-dropdown"
         value={dateRangeIndex}
       />
       <button


### PR DESCRIPTION
## Description
The "Details" link should be a focusable element and therefore not have aria-hidden. Also, there is a redundant link immediately following the "Details" link, denoted by the right arrow (>) going to the same appointment details page. If the appointment is canceled, the link should have "canceled" as part of the aria description in the link

In the Past Appointment summary page, each dropdown should have its own unique ID. Currently there are two ID label that have the same name

## Testing done
local and axe test

## Screenshots
n/a

## Acceptance criteria
- [ ] Remove aria-hidden from "Details" link
- [ ] Use the right arrow as a hidden icon and remove the `<a>` element
- [ ] Include a check for canceled appointments in the aria label  description
- [ ] change the id in the dropdown element in PastAppointmentsDateDropdown to `date-dropdown`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
