### PR TITLE
Add analytics events for ProgressBar, LoadingIndicator, Breadcrumbs

### DIFF
--- a/src/platform/site-wide/component-library-analytics-setup.js
+++ b/src/platform/site-wide/component-library-analytics-setup.js
@@ -12,6 +12,14 @@ const analyticsEvents = {
     { action: 'collapse', event: 'int-additional-info-collapse' },
   ],
   AlertBox: [{ action: 'linkClick', event: 'nav-alert-box-link-click' }],
+  Breadcrumbs: [{ action: 'linkClick', event: 'nav-breadcrumb-link-click' }],
+  LoadingIndicator: [
+    { action: 'displayed', event: 'loading-indicator-displayed' },
+  ],
+  ProgressBar: [{ action: 'change', event: 'nav-progress-bar-change' }],
+  SegmentedProgressBar: [
+    { action: 'change', event: 'nav-segmented-progress-bar-change' },
+  ],
 };
 
 export function subscribeComponentAnalyticsEvents(

--- a/src/platform/site-wide/component-library-analytics-setup.js
+++ b/src/platform/site-wide/component-library-analytics-setup.js
@@ -12,14 +12,6 @@ const analyticsEvents = {
     { action: 'collapse', event: 'int-additional-info-collapse' },
   ],
   AlertBox: [{ action: 'linkClick', event: 'nav-alert-box-link-click' }],
-  Breadcrumbs: [{ action: 'linkClick', event: 'nav-breadcrumb-link-click' }],
-  LoadingIndicator: [
-    { action: 'displayed', event: 'loading-indicator-displayed' },
-  ],
-  ProgressBar: [{ action: 'change', event: 'nav-progress-bar-change' }],
-  SegmentedProgressBar: [
-    { action: 'change', event: 'nav-segmented-progress-bar-change' },
-  ],
 };
 
 export function subscribeComponentAnalyticsEvents(

--- a/src/site/includes/breadcrumbs.drupal.liquid
+++ b/src/site/includes/breadcrumbs.drupal.liquid
@@ -14,7 +14,7 @@
       {% if forloop.last == true %}
         <li>
           <a 
-          onclick="recordEvent({ 'event': 'nav-breadcrumb', 'breadcrumb-click-label': '{{ crumb.text }}', 'breadcrumb-click-level': '{{ forloop.index }}', 'breadcrumb-total-levels': '{{ crumbs.length }}' });" 
+          onclick="recordEvent({ 'event': 'nav-breadcrumb-link-click', 'breadcrumbs-clickLabel': '{{ crumb.text }}', 'breadcrumbs-clickLevel': '{{ forloop.index }}', 'breadcrumbs-totalLevels': '{{ crumbs.length }}' });" 
           aria-current="page" 
           href="/{{ path }}"
           lang="{{ path | detectLang }}"
@@ -28,12 +28,12 @@
             <li>
               <a href="{{ crumb.url.path }}"
                 lang="{{ crumb.url.path | detectLang }}"
-                onclick="recordEvent({ event: 'nav-breadcrumb', 'nav-breadcrumb-section': 'home' });">{{ crumb.text }}</a>
+                onclick="recordEvent({ event: 'nav-breadcrumb-link-click', 'breadcrumbs-clickLabel': 'home' });">{{ crumb.text }}</a>
             </li>
           {% endif %}
         {% else %}
           <li><a
-            lang="{{ crumb.url.path | detectLang }}" onclick="recordEvent({ 'event': 'nav-breadcrumb', 'breadcrumb-click-label': '{{ crumb.text }}', 'breadcrumb-click-level': '{{ forloop.index }}', 'breadcrumb-total-levels': '{{ crumbs.length }}' });"
+            lang="{{ crumb.url.path | detectLang }}" onclick="recordEvent({ 'event': 'nav-breadcrumb-link-click', 'breadcrumbs-clickLabel': '{{ crumb.text }}', 'breadcrumbs-clickLevel': '{{ forloop.index }}', 'breadcrumbs-totalLevels: '{{ crumbs.length }}' });"
             href="{{ crumb.url.path }}">{{ crumb.text }}</a></li>
         {% endif %}
       {% endif %}

--- a/src/site/includes/breadcrumbs.html
+++ b/src/site/includes/breadcrumbs.html
@@ -3,7 +3,7 @@
 <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs {{gatePageClassName}} {% if newGrid %}new-grid{% endif %}" id="va-breadcrumbs">
   <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
     <li>
-      <a href="/" onClick="recordEvent({ event: 'nav-breadcrumb', 'nav-breadcrumb-section': 'home' });">Home</a>
+      <a href="/" onClick="recordEvent({ event: 'nav-breadcrumb-link-click', 'breadcrumbs-clickLabel': 'home' });">Home</a>
     </li>
     {% assign crumbs = breadcrumb_path %}
 


### PR DESCRIPTION
## Description

For:
https://github.com/department-of-veterans-affairs/va.gov-team/issues/14493

Components updated:

- ProgressBar
- SegmentedProgressBar
- LoadingIndicator
- Breadcrumbs

## TODO:  find VAOS LoadingIndicator and disable analytics, publish NPM package with new version




## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
