### PR TITLE
DT-14432 - Adding logic for using form name translation in es

### DIFF
--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -19,10 +19,15 @@
           <div class="vads-u-margin-bottom--4">
             {% if fieldVaFormLanguage %}
               <dt class="va-introtext" lang="{{ fieldVaFormLanguage }}">
+              {% if fieldVaFormLanguage === "es" %}
+                <dfn class="vads-u-visibility--screen-reader">Nombre del formulario:</dfn>
+              {% else %}
+                <dfn class="vads-u-visibility--screen-reader">Form name:</dfn>
+              {% endif %}
             {% else %}
-              <dt class="va-introtext">
-            {% endif %}
               <dfn class="vads-u-visibility--screen-reader">Form name:</dfn>
+              <dt class="va-introtext">
+            {% endif %}            
               {{ fieldVaFormName }}
             </dt>
           </div>


### PR DESCRIPTION
## Description
Until we have ES lang template, we are using some "interm" solutions for i18n. For this, we need to make sure the "Form Name: " term is read correctly when reading an form in ES language.  

## Testing done
Ran the preview server using a Spanish node.

## Screenshots
![Screen Shot 2021-04-05 at 11 11 34 AM](https://user-images.githubusercontent.com/26075258/113591760-524fe200-9602-11eb-95c3-2c7ce6779c92.png)


## Acceptance criteria
- [x] "Form name" is translated correctly. 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
