### PR TITLE
update cta box

### DIFF
--- a/src/applications/static-pages/covid-vaccine-updates-cta/widget.jsx
+++ b/src/applications/static-pages/covid-vaccine-updates-cta/widget.jsx
@@ -16,7 +16,7 @@ const copy = {
         body: ` we'll ask about your vaccine plans when you sign up. Your local VA health facility may use this information to determine when to contact you once your risk group becomes eligible.`,
       },
       nonVeteran: {
-        boldedNote: `If you're a Veteran who isn't receiving care through VA or a spouse, caregiver, or CHAMPVA recipient,`,
+        boldedNote: `If you're a spouse, caregiver, or CHAMPVA recipient, or a Veteran who isn't receiving care through VA,`,
         body: ` sign up to tell us if you want to get a vaccine. If you're eligible, we'll contact you when we have a vaccine for you. At this time, we don't know when that will be.`,
       },
     },


### PR DESCRIPTION
## Description
- Update call to action box in the vaccine mini-hub to make spouse/caregiver eligibility more obvious.

## Testing done
Browser 👀 

## Screenshots

<img width="679" alt="Screen Shot 2021-04-05 at 1 15 35 PM" src="https://user-images.githubusercontent.com/7645362/113602754-02c4e280-9611-11eb-956e-0cb2afddb59a.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
