### PR TITLE
Disable failing Cypress test

### DIFF
--- a/src/applications/personalization/profile/tests/e2e/profile-a11y.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile-a11y.cypress.spec.js
@@ -132,7 +132,7 @@ function checkAllPages(mobile = false) {
     .should('eq', 'H2');
 }
 
-describe('Profile', () => {
+describe.skip('Profile', () => {
   beforeEach(() => {
     disableFTUXModals();
     cy.login(mockUser);


### PR DESCRIPTION
## Description
`src/applications/personalization/profile/tests/e2e/profile-a11y.cypress.spec.js` has been causing failures on Jenkins recently; the test hangs indefinitely and does not proceed with retries. This test is being disabled until a fix is found.

## Acceptance criteria
- [ ] Test does not run on CI.