### PR TITLE
Change all secondary buttons to va action links on CLP

### DIFF
--- a/package.json
+++ b/package.json
@@ -285,7 +285,7 @@
   "private": true,
   "dependencies": {
     "@department-of-veterans-affairs/component-library": "2.3.1",
-    "@department-of-veterans-affairs/formation": "6.14.1",
+    "@department-of-veterans-affairs/formation": "6.15.1",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "@formatjs/intl-datetimeformat": "^3.2.7",
     "@formatjs/intl-getcanonicallocales": "^1.5.3",

--- a/src/applications/static-pages/sass/static-pages.scss
+++ b/src/applications/static-pages/sass/static-pages.scss
@@ -2,6 +2,7 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
+@import "~@department-of-veterans-affairs/formation/sass/modules/m-action-link";
 
 // ----- VA LAYOUTS (GRIDS/HEADER/FOOTER) ---- //
 @import "layouts/l-playbook";

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -167,14 +167,16 @@
 
             <!-- Call to action -->
             {% if fieldClpVideoPanelMoreVideo %}
-              <a
-                class="va-action-link--blue vads-u-margin-top--4"
-                href="{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLink.url.path }}"
-                onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Video', 'clp-section-title': '{{ fieldClpVideoPanelHeader | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel | escape }}' });"
-              >
-                {{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel }}
-                <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
-              </a>
+              <p>
+                <a
+                  class="va-action-link--blue"
+                  href="{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLink.url.path }}"
+                  onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Video', 'clp-section-title': '{{ fieldClpVideoPanelHeader | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel | escape }}' });"
+                >
+                  {{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel }}
+                  <i class="fa fa-chevron-right vads-u-margin-left--0p5" role="presentation" aria-hidden="true"></i>
+                </a>
+              </p>
             {% endif %}
           </div>
         </div>

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -19,7 +19,7 @@
 
               {% if fieldPrimaryCallToAction %}
                 <a
-                  class="usa-button usa-button-secondary va-u-box-shadow--none vads-u-margin-top--2 vads-u-background-color--white vads-u-border--0 vads-u-font-size--sm"
+                  class="va-action-link--white vads-u-margin-top--2"
                   href="{{ fieldPrimaryCallToAction.entity.fieldButtonLink.url.path }}"
                   onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'hero', 'clp-section-title': '{{ title | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldPrimaryCallToAction.entity.fieldButtonLabel | escape }}' });"
                 >
@@ -43,7 +43,7 @@
             <p class="va-introtext vads-u-margin-top--0 vads-u-margin-bottom--2">{{ fieldClpWhyThisMatters }}</p>
             {% if fieldSecondaryCallToAction %}
               <a
-                class="usa-button usa-button-secondary vads-u-font-size--sm"
+                class="va-action-link--blue"
                 href="{{ fieldSecondaryCallToAction.entity.fieldButtonLink.url.path }}"
                 onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Why this matters to you', 'clp-section-title': '{{ fieldClpWhyThisMatters | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldSecondaryCallToAction.entity.fieldButtonLabel | escape }}' });"
               >
@@ -168,7 +168,7 @@
             <!-- Call to action -->
             {% if fieldClpVideoPanelMoreVideo %}
               <a
-                class="vads-u-margin-top--4 usa-button usa-button-secondary vads-u-font-size--sm"
+                class="va-action-link--blue vads-u-margin-top--4"
                 href="{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLink.url.path }}"
                 onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Video', 'clp-section-title': '{{ fieldClpVideoPanelHeader | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel | escape }}' });"
               >
@@ -265,7 +265,7 @@
             <!-- Call to action -->
             {% if fieldClpStoriesCta %}
               <a
-                class="usa-button usa-button-secondary vads-u-font-size--sm"
+                class="va-action-link--blue"
                 href="{{ fieldClpStoriesCta.entity.fieldButtonLink.url }}"
                 onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Stories', 'clp-section-title': '{{ fieldClpStoriesHeader | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpStoriesCta.entity.fieldButtonLabel | escape }}' });"
                 rel="noreferrer noopener"
@@ -316,7 +316,7 @@
           <div class="vads-l-row">
             <div class="vads-u-col--12">
               <a
-                class="usa-button usa-button-secondary vads-u-font-size--sm"
+                class="va-action-link--blue"
                 href="{{ fieldClpResourcesCta.entity.fieldButtonLink.url.path }}"
                 onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Downloadable resources', 'clp-section-title': '{{ fieldClpResourcesHeader | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpResourcesCta.entity.fieldButtonLabel | escape }}' });"
               >
@@ -471,7 +471,7 @@
           <div class="vads-l-row">
             <div class="vads-u-col--12">
               <a
-                class="usa-button usa-button-secondary vads-u-font-size--sm"
+                class="va-action-link--blue"
                 href="{{ fieldClpFaqCta.entity.fieldButtonLink.url.path }}"
                 onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'FAQ', 'clp-section-title': 'Frequently asked questions', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpFaqCta.entity.fieldButtonLabel | escape }}' });"
               >

--- a/yarn.lock
+++ b/yarn.lock
@@ -1298,10 +1298,10 @@
     react-transition-group "1"
     recast "^0.14.4"
 
-"@department-of-veterans-affairs/formation@6.14.1":
-  version "6.14.1"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-6.14.1.tgz#d4b5f4d48c004a07c06764a4db74a10fb679c868"
-  integrity sha512-4ikiMMU8d1tQdz+KVF5w7CqTKZTvmebcBp+w9c4FKan/Ixh/gs1MUeFdLJ2r97br73F/74YPh6zMNd95YrFueQ==
+"@department-of-veterans-affairs/formation@6.15.1":
+  version "6.15.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-6.15.1.tgz#17eef0b979d9ccf18a756141d8d8431e1bfe8268"
+  integrity sha512-hYLaR6IDN4Wk0PW8phD7LnrwYFp0L20ehJCbusEmPa2lJwujQRmQP52SDYlR+VutGswkvDfD5sv5RgJ97VIIMQ==
   dependencies:
     "@fortawesome/fontawesome-free" "^5.6.3"
     domready "^1.0.8"


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/21929

This PR adds `va-action-link--blue` and `va-action-link--white` as a replacement for the current CTA buttons.

You can run this locally and test on http://localhost:3001/campaign-mission-act/

## Testing done
Locally

## Screenshots
![localhost_3001_campaign-mission-act_](https://user-images.githubusercontent.com/12773166/113899273-df717300-9789-11eb-8ea5-106df304ea9c.png)

## Acceptance criteria
- [x] Add action links to CLP

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
