### PR TITLE
Move debug info stringification into liquid template (#22450)

### DIFF
--- a/src/site/includes/debug.drupal.liquid
+++ b/src/site/includes/debug.drupal.liquid
@@ -6,7 +6,7 @@
 
 {% if showDebug %}
   <script nonce="**CSP_NONCE**" data-template="includes/debug">
-    window.contentData = {{ debug }};
+    window.contentData = {{ debug | json }};
     console.info('Metalsmith template generated from content:', window.contentData);
   </script>
 {% endif %}

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -19,7 +19,7 @@ function createFileObj(page, layout) {
     isDrupalPage: true,
     layout,
     contents: Buffer.from('<!-- Drupal-provided data -->'),
-    debug: JSON.stringify(page, null, 4),
+    debug: page,
     private: privStatus,
   };
 }


### PR DESCRIPTION
## Description
Currently before piping Drupal data into Metalsmith we take each page object, stringify it, and add the string to the corresponding file object. Then in the Apply Layouts step we include the string in a liquid template to help with debugging. However, all those strings use a large amount of extra memory and slow down the build process.

Moving debug stringification to the liquid template itself cuts peak memory use in half and saves about 40 seconds of build time. The benefits will increase as we scale and page count increases.

## Testing done
- Check that debugging information is present in localhost and staging builds (run locally)
- Diff the debugging info on a couple different pages (local vs staging) to ensure no changes
- Ensure builds complete with no errors both locally and on CI

## Acceptance criteria
- [x] Stringification of debugging data is moved from page object to template
- [x] Testing has been completed to ensure this has not introduced any issues
- [x] Compare new debug info to old

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
