### PR TITLE
VACMS-4850: Removing admin taxonomy fields from graphql that will be removed from cms.

### DIFF
--- a/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
@@ -14,16 +14,13 @@ const nodeCampaignLandingPage = `
     fieldAdministration {
       entity {
         ... on TaxonomyTermAdministration {
-          fieldAcronym
           fieldDescription
           fieldEmailUpdatesLinkText
           fieldEmailUpdatesUrl
-          fieldIntroText
           fieldLink {
             uri
             title
           }
-          fieldMetatags
           fieldSocialMediaLinks {
             platform
             value
@@ -57,16 +54,13 @@ const nodeCampaignLandingPage = `
         entityId
         ... on TaxonomyTermAdministration {
           name
-          fieldAcronym
           fieldDescription
           fieldEmailUpdatesLinkText
           fieldEmailUpdatesUrl
-          fieldIntroText
           fieldLink {
             uri
             title
           }
-          fieldMetatags
           fieldSocialMediaLinks {
             platform
             value
@@ -110,16 +104,13 @@ const nodeCampaignLandingPage = `
           fieldAdministration {
             entity {
               ... on TaxonomyTermAdministration {
-                fieldAcronym
                 fieldDescription
                 fieldEmailUpdatesLinkText
                 fieldEmailUpdatesUrl
-                fieldIntroText
                 fieldLink {
                   uri
                   title
                 }
-                fieldMetatags
                 fieldSocialMediaLinks {
                   platform
                   value
@@ -174,16 +165,13 @@ const nodeCampaignLandingPage = `
                 fieldAdministration {
                   entity {
                     ... on TaxonomyTermAdministration {
-                      fieldAcronym
                       fieldDescription
                       fieldEmailUpdatesLinkText
                       fieldEmailUpdatesUrl
-                      fieldIntroText
                       fieldLink {
                         uri
                         title
                       }
-                      fieldMetatags
                       fieldSocialMediaLinks {
                         platform
                         value
@@ -207,16 +195,13 @@ const nodeCampaignLandingPage = `
                           entityBundle
                           entityId
                           ... on TaxonomyTermAdministration {
-                            fieldAcronym
                             fieldDescription
                             fieldEmailUpdatesLinkText
                             fieldEmailUpdatesUrl
-                            fieldIntroText
                             fieldLink {
                               uri
                               title
                             }
-                            fieldMetatags
                             fieldSocialMediaLinks {
                               platform
                               value
@@ -319,11 +304,9 @@ const nodeCampaignLandingPage = `
               entityBundle
               entityId
               ... on TaxonomyTermAdministration {
-                fieldAcronym
                 fieldDescription
                 fieldEmailUpdatesLinkText
                 fieldEmailUpdatesUrl
-                fieldIntroText
                 fieldLink {
                   uri
                   title
@@ -458,11 +441,9 @@ const nodeCampaignLandingPage = `
           fieldOwner {
             entity {
               ... on TaxonomyTermAdministration {
-                fieldAcronym
                 fieldDescription
                 fieldEmailUpdatesLinkText
                 fieldEmailUpdatesUrl
-                fieldIntroText
                 fieldLink {
                   uri
                   title

--- a/src/site/stages/build/drupal/graphql/taxonomy-fragments/administration.taxonomy.graphql.js
+++ b/src/site/stages/build/drupal/graphql/taxonomy-fragments/administration.taxonomy.graphql.js
@@ -15,9 +15,7 @@ module.exports = `
               name
               entityId
               entityBundle
-              fieldIntroText
               fieldDescription
-              fieldAcronym
               fieldLink {
                 url {
                   path


### PR DESCRIPTION
## Description
Three fields are going to be removed from administration taxonomy in cms. To prevent build failures, we need to remove these items from vets-web graphql, first.
This taxonomy is in use on Campaign Landing page, however, it doesn't look like the fields being removed are being used in the page output.
Once this pr is merged, cms team will need to update web version in composer to consume these graphql changes.
See: https://github.com/department-of-veterans-affairs/va.gov-cms/pull/4870

## Testing done
Local build.

## Screenshots
N/A

## Acceptance criteria
- [ ] Successful build

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
