### PR TITLE
Add frozen-lockfile flag to yarn install in Jenkins

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -117,7 +117,7 @@ def setup() {
       dockerImage = docker.build(DOCKER_TAG)
       retry(5) {
         dockerImage.inside(DOCKER_ARGS) {
-          sh "cd /application && yarn install --production=false"
+          sh "cd /application && yarn install --frozen-lockfile --production=false"
         }
       }
       return dockerImage


### PR DESCRIPTION
## Description
This PR adds the `--frozen-lockfile` flag when installing dependencies in Jenkins. The `yarn.lock` file has been getting out of sync frequently, so this should resolve that.

## Testing done
Confirmed `frozen-lockfile` works as expected in another [branch](https://github.com/department-of-veterans-affairs/vets-website/compare/test-jenkins-frozen-lockfile).

## Screenshots


## Acceptance criteria
- [ ] The `--frozen-lockfile` flag should cause the Jenkins build to fail if `yarn.lock` is not up to date.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
