### PR TITLE
Restored accidentally deleted staging app build deploy.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -146,6 +146,7 @@ node('vetsgov-general-purpose') {
       }
 
       if (commonStages.IS_STAGING_BRANCH && commonStages.VAGOV_BUILDTYPES.contains('vagovstaging')) {
+        commonStages.runDeploy('deploys/application-build-vagovstaging', ref, false)
         commonStages.runDeploy('deploys/vets-website-vagovstaging', ref, false)
       }
 


### PR DESCRIPTION
## Description

Added back the deploy for the staging app bucket, which was accidentally removed in #16681.

## Testing done

Will observe that the deploy to the bucket occurs.

## Acceptance criteria
- [ ] App build should continue getting deployed to the staging bucket.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
