### PR TITLE
Parallelize nightwatch sitemap a11y tests 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ node('vetsgov-general-purpose') {
   dockerContainer = commonStages.setup()
 
   stage('Lint|Security|Unit') {
-    { return } // temporarily skipping; TODO: Delete this line
+    if (true) { return } // temporarily skipping; TODO: Delete this line
     if (params.cmsEnvBuildOverride != 'none') { return }
 
     try {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,6 +84,10 @@ node('vetsgov-general-purpose') {
           parallel (
             'nightwatch-e2e': {
               sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p nightwatch up -d && docker-compose -p nightwatch run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run nightwatch:docker"
+            },
+            // TODO: Remove before merging
+            'nightwatch-accessibility': {
+                sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p accessibility up -d && docker-compose -p accessibility run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run nightwatch:docker -- --env=accessibility"
             },          
             cypress: {
               sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p cypress up -d && docker-compose -p cypress run --rm --entrypoint=npm -e CI=true -e NO_COLOR=1 vets-website --no-color run cy:test:docker"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,7 @@ node('vetsgov-general-purpose') {
   dockerContainer = commonStages.setup()
 
   stage('Lint|Security|Unit') {
+    { return } // temporarily skipping; TODO: Delete this line
     if (params.cmsEnvBuildOverride != 'none') { return }
 
     try {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,6 @@ node('vetsgov-general-purpose') {
   dockerContainer = commonStages.setup()
 
   stage('Lint|Security|Unit') {
-    if (true) { return } // temporarily skipping; TODO: Delete this line
     if (params.cmsEnvBuildOverride != 'none') { return }
 
     try {
@@ -84,11 +83,7 @@ node('vetsgov-general-purpose') {
           parallel (
             'nightwatch-e2e': {
               sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p nightwatch up -d && docker-compose -p nightwatch run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run nightwatch:docker"
-            },
-            // TODO: Remove before merging
-            'nightwatch-accessibility': {
-                sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p accessibility up -d && docker-compose -p accessibility run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run nightwatch:docker -- --env=accessibility"
-            },          
+            },     
             cypress: {
               sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p cypress up -d && docker-compose -p cypress run --rm --entrypoint=npm -e CI=true -e NO_COLOR=1 vets-website --no-color run cy:test:docker"
             }

--- a/config/nightwatch.docker-compose.js
+++ b/config/nightwatch.docker-compose.js
@@ -18,7 +18,13 @@ module.exports = {
   live_output: true,
   parallel_process_delay: 10,
   disable_colors: process.env.BUILDTYPE === 'production',
-  test_workers: false,
+
+  // TODO: Experiment with `test_workers: "auto"` and `test_workers: 4`
+  // If set to true, runs the tests in parallel and determines the number of workers automatically.
+  // If set to an object, can specify specify the number of workers as "auto" or a number.
+  // Source: https://nightwatchjs.org/gettingstarted/configuration/#test-runner-settings
+  test_workers: true,
+
   test_settings: {
     default: {
       launch_url: `vets-website:${process.env.WEB_PORT || 3333}`,

--- a/config/nightwatch.docker-compose.js
+++ b/config/nightwatch.docker-compose.js
@@ -19,11 +19,11 @@ module.exports = {
   parallel_process_delay: 10,
   disable_colors: process.env.BUILDTYPE === 'production',
 
-  // TODO: Experiment with `test_workers: 4`
+  // TODO: Experiment with `test_workers: { enabled: true, workers: 4 }
   // If set to true, runs the tests in parallel and determines the number of workers automatically.
   // If set to an object, can specify specify the number of workers as "auto" or a number.
   // Source: https://nightwatchjs.org/gettingstarted/configuration/#test-runner-settings
-  test_workers: 'auto',
+  test_workers: { enabled: true, workers: 'auto' },
 
   test_settings: {
     default: {

--- a/config/nightwatch.docker-compose.js
+++ b/config/nightwatch.docker-compose.js
@@ -19,11 +19,11 @@ module.exports = {
   parallel_process_delay: 10,
   disable_colors: process.env.BUILDTYPE === 'production',
 
-  // TODO: Experiment with `test_workers: "auto"` and `test_workers: 4`
+  // TODO: Experiment with `test_workers: 4`
   // If set to true, runs the tests in parallel and determines the number of workers automatically.
   // If set to an object, can specify specify the number of workers as "auto" or a number.
   // Source: https://nightwatchjs.org/gettingstarted/configuration/#test-runner-settings
-  test_workers: true,
+  test_workers: 'auto',
 
   test_settings: {
     default: {

--- a/config/nightwatch.docker-compose.js
+++ b/config/nightwatch.docker-compose.js
@@ -19,11 +19,10 @@ module.exports = {
   parallel_process_delay: 10,
   disable_colors: process.env.BUILDTYPE === 'production',
 
-  // TODO: Experiment with `test_workers: { enabled: true, workers: 4 }
   // If set to true, runs the tests in parallel and determines the number of workers automatically.
   // If set to an object, can specify specify the number of workers as "auto" or a number.
   // Source: https://nightwatchjs.org/gettingstarted/configuration/#test-runner-settings
-  test_workers: { enabled: true, workers: 'auto' },
+  test_workers: { enabled: true, workers: 4 },
 
   test_settings: {
     default: {

--- a/src/platform/site-wide/tests/sitemap/sitemap-helpers.js
+++ b/src/platform/site-wide/tests/sitemap/sitemap-helpers.js
@@ -56,8 +56,7 @@ function sitemapURLs() {
 
 function runTests(client, segment, only508List) {
   segment.forEach(url => {
-    // eslint-disable-next-line no-console
-    console.time(url);
+    console.time(url); // eslint-disable-line no-console
     const only508 = only508List.filter(path => url.endsWith(path)).length > 0;
     client
       .perform(() => {})
@@ -67,8 +66,7 @@ function runTests(client, segment, only508List) {
         'document',
         only508 ? { scope: url, rules: ['section508'] } : { scope: url },
       );
-    // eslint-disable-next-line no-console
-    console.timeEnd(url);
+    console.timeEnd(url); // eslint-disable-line no-console
   });
 }
 

--- a/src/platform/site-wide/tests/sitemap/sitemap-helpers.js
+++ b/src/platform/site-wide/tests/sitemap/sitemap-helpers.js
@@ -56,18 +56,19 @@ function sitemapURLs() {
 
 function runTests(client, segment, only508List) {
   segment.forEach(url => {
+    // eslint-disable-next-line no-console
+    console.time(url);
     const only508 = only508List.filter(path => url.endsWith(path)).length > 0;
     client
-      .perform(() => {
-        // eslint-disable-next-line no-console
-        console.log(url);
-      })
+      .perform(() => {})
       .openUrl(url)
       .waitForElementVisible('body', Timeouts.normal)
       .axeCheck(
         'document',
         only508 ? { scope: url, rules: ['section508'] } : { scope: url },
       );
+    // eslint-disable-next-line no-console
+    console.timeEnd(url);
   });
 }
 


### PR DESCRIPTION
## GitHub Issue

https://github.com/department-of-veterans-affairs/va.gov-team/issues/22445

## Description

This PR does the following:

- Updates the parallelization config ([`test_workers`](https://nightwatchjs.org/gettingstarted/configuration/#test-runner-settings)) of the Nightwatch Sitemap a11y tests from `false` to `true`, and specifies `4` workers because the sitemap tests are chunked into four separate files (`src/platform/site-wide/tests/sitemap/sitemap-[1-4].spec.js`). 

Caveat: The `nightwatch-accessibility` step only runs on the `master` branch, so this might speed up CI runs **after** a branch is merged to `master` and deploys, but it won't have any effect on pull requests. 😞  

## Testing done

CI

## Screenshots

### [Before](http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fvets-website/detail/master/10705/pipeline/152/): 1:05:15

![image](https://user-images.githubusercontent.com/6130520/113789807-7fd18400-9705-11eb-8058-5fbedfea45d8.png)

### [After](http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fvets-website/detail/parallelize-nightwatch-sitemap-a11y-tests/9/pipeline/110/): 20:46

![image](https://user-images.githubusercontent.com/6130520/113789700-439e2380-9705-11eb-9a9e-31d3cb026d17.png)

## Methodology

Since the `nightwatch-accessibility` step only runs against the `PROD_BRANCH` (`master`), I temporarily added the `nightwatch-accessibility` step to run against my branch. Once I got a screenshot of the time it took to run against my branch, I deleted that temporary code. 

I got the baseline time AKA the before time from a [recent passing run on `master`](http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fvets-website/detail/master/10705/pipeline/152/). 

## Acceptance criteria
- [ ] The `nightwatch-accessibility` step takes less than an hour to finish

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

## Links

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/22443
- https://nightwatchjs.org/gettingstarted/configuration/#test-runner-settings
- https://markus.oberlehner.net/blog/speeding-up-nightwatch-powered-acceptance-tests/