### PR TITLE
Add non-US State jurisdictions to KMI/SLA

### DIFF
--- a/src/applications/coronavirus-vaccination-expansion/config/address/addressInformation.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/address/addressInformation.js
@@ -10,13 +10,13 @@ function monkeyPatchStateNames(extraStates, addressInformationObj) {
 }
 
 const extraStates = [
-  // {
-  //   stateCode: 'GU',
-  //   stateName: 'Guam',
-  // },
   {
     stateCode: 'PR',
     stateName: 'Puerto Rico',
+  },
+  {
+    stateCode: 'GU',
+    stateName: 'Guam',
   },
 ];
 

--- a/src/applications/coronavirus-vaccination-expansion/config/address/addressInformation.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/address/addressInformation.js
@@ -11,12 +11,12 @@ function monkeyPatchStateNames(extraStates, addressInformationObj) {
 
 const extraStates = [
   {
-    stateCode: 'PR',
-    stateName: 'Puerto Rico',
-  },
-  {
     stateCode: 'GU',
     stateName: 'Guam',
+  },
+  {
+    stateCode: 'PR',
+    stateName: 'Puerto Rico',
   },
 ];
 

--- a/src/applications/coronavirus-vaccination-expansion/config/address/addressInformation.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/address/addressInformation.js
@@ -47,7 +47,7 @@ export const uiSchema = {
       'ui:title': 'U.S. city',
     },
     stateCode: {
-      'ui:title': 'U.S. state',
+      'ui:title': 'U.S. state or territory',
     },
     zipCode: {
       'ui:title': 'U.S. zip code',

--- a/src/applications/coronavirus-vaccination-expansion/config/address/addressInformation.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/address/addressInformation.js
@@ -2,6 +2,26 @@ import React from 'react';
 import emailUI from 'platform/forms-system/src/js/definitions/email';
 import { addressInformation } from '../schema-imports';
 
+function monkeyPatchStateNames(extraStates, addressInformationObj) {
+  for (const extra of extraStates) {
+    addressInformationObj.properties.stateCode.enum.push(extra.stateCode);
+    addressInformationObj.properties.stateCode.enumNames.push(extra.stateName);
+  }
+}
+
+const extraStates = [
+  // {
+  //   stateCode: 'GU',
+  //   stateName: 'Guam',
+  // },
+  {
+    stateCode: 'PR',
+    stateName: 'Puerto Rico',
+  },
+];
+
+monkeyPatchStateNames(extraStates, addressInformation);
+
 const validateZip = (errors, formData) => {
   if (formData.zipCode > 4) {
     errors.state.addError('Please enter at least 5 digits');

--- a/src/applications/coronavirus-vaccination-expansion/tests/coronavirus-vaccination-expansion.cypress.spec.js
+++ b/src/applications/coronavirus-vaccination-expansion/tests/coronavirus-vaccination-expansion.cypress.spec.js
@@ -16,6 +16,7 @@ const testConfig = createTestConfig(
       'test-data-spouse',
       'test-data-caregiver',
       'test-data-champva',
+      'test-data-veteran-puerto-rico',
     ],
 
     fixtures: {
@@ -38,6 +39,11 @@ const testConfig = createTestConfig(
         cy.get('@testData').then(testData => {
           if (testData.zipCode === '00000') {
             cy.wait('@getFacilitiesError');
+          } else if (testData.zipCode === '00921') {
+            cy.wait('@getFacilitiesPuertoRico');
+            cy.get('.errorable-radio-button > input')
+              .first()
+              .check();
           } else {
             cy.wait('@getFacilities');
             cy.get('.errorable-radio-button > input')
@@ -122,7 +128,23 @@ const testConfig = createTestConfig(
           ],
         },
       }).as('getFacilities');
-
+      cy.intercept('GET', '/covid_vaccine/v0/facilities/00921', {
+        statusCode: 200,
+        body: {
+          data: [
+            {
+              id: 'vha_672',
+              type: 'vaccination_facility',
+              attributes: {
+                name: 'San Juan VA Medical Center',
+                distance: 5.1,
+                city: 'San Juan',
+                state: 'PR',
+              },
+            },
+          ],
+        },
+      }).as('getFacilitiesPuertoRico');
       cy.intercept('POST', '/covid_vaccine/v0/expanded_registration', {
         statusCode: 200,
         body: {},

--- a/src/applications/coronavirus-vaccination-expansion/tests/fixtures/data/test-data-veteran-puerto-rico.json
+++ b/src/applications/coronavirus-vaccination-expansion/tests/fixtures/data/test-data-veteran-puerto-rico.json
@@ -1,0 +1,25 @@
+{
+  "data": {
+    "preferredFacility": "vha_648",
+    "countryName": "USA",
+    "addressLine1": "123 Fake Drive",
+    "addressLine2": "F",
+    "city": "San Juan",
+    "stateCode": "PR",
+    "zipCode": "00921",
+    "emailAddress": "myemail@example.com",
+    "phone": "5035551212",
+    "smsAcknowledgement": true,
+    "firstName": "J",
+    "lastName": "Peterman",
+    "birthDate": "1955-02-02",
+    "birthSex": "Male",
+    "ssn": "666554321",
+    "characterOfService": "Honorable",
+    "applicantType": "caregiverOfVeteran",
+    "complianceAgreement": true,
+    "privacyAgreementAccepted": true,
+    "veteranSsn": "666555444",
+    "veteranBirthDate": "1944-02-03"
+  }
+}


### PR DESCRIPTION
## Description
- Adds PR, GU to state selection list by patching `addressInformation` at runtime
- Updates label to reflect states _and_ territories
- Adds Cypress test coverage for new option

**Note:** Our facility suggestion service can already handle Puerto Rico and Guam zip codes. This change simply gives the user the option to select a non-US state jurisdiction (Puerto Rico and Guam, in this case) in the state drop down.

~**Another note:** Guam is not included in this PR because the Guam CBOC shares the same facility code as the Pacific Islands Healthcare System (459). Need to think a bit further on how to correctly display the Guam CBOC for folks who enter a Guam zip code. Might be another runtime patch on the backend.~

## Testing done
- Browser 👀 
- Cypress


## Screenshots
<img width="495" alt="Screen Shot 2021-04-07 at 10 36 02 AM" src="https://user-images.githubusercontent.com/7645362/113884560-0f6e4580-978d-11eb-91cd-55c428f36441.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
