### PR TITLE
Update announcements.json

### DIFF
--- a/src/applications/static-pages/school-resources/constants/announcements.json
+++ b/src/applications/static-pages/school-resources/constants/announcements.json
@@ -1,5 +1,12 @@
 [
     {     
+    "name": "Changes to the “48 Month Rule” for VR&E and EDU Beneficiaries",
+    "url": "https://benefits.va.gov/GIBILL/docs/48_Month_Rule_FAQs.pdf",
+    "date": "2021-04-07",
+    "displayStartDate": "2021-04-07",
+    "displayEndDate": "2021-05-07"
+  },
+    {     
     "name": "VA Office Hours Webinar – April 8 | VRRAP",
     "url": "https://events-na1.adobeconnect.com/content/connect/c1/2372973515/en/events/catalog.html?folder-id=3305575518&from-origin=vbatraining.adobeconnect.com",
     "date": "2021-04-06",

--- a/src/applications/static-pages/school-resources/constants/announcements.json
+++ b/src/applications/static-pages/school-resources/constants/announcements.json
@@ -1,6 +1,6 @@
 [
     {     
-    "name": "Changes to the “48 Month Rule” for VR&E and EDU Beneficiaries",
+    "name": "Changes to the 48-Month Rule for VR&E and EDU Beneficiaries",
     "url": "https://benefits.va.gov/GIBILL/docs/48_Month_Rule_FAQs.pdf",
     "date": "2021-04-07",
     "displayStartDate": "2021-04-07",


### PR DESCRIPTION
Add 48-Month Rule for VR&E and EDU Beneficiaries

## Description


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
