### PR TITLE
Add note about expected axe-core violations from smoke test

### DIFF
--- a/src/site/tests/support/axe.js
+++ b/src/site/tests/support/axe.js
@@ -3,6 +3,10 @@ import { run } from 'axe-core';
 const logViolations = violations => {
   /* eslint-disable no-console */
   console.log(
+    'Please Note: An axe-core smoke test is expected to report 6 violations.',
+  );
+
+  console.log(
     `\n${violations.length} Accessibility Violation${
       violations.length === 1 ? ' Was' : 's Were'
     } Detected`,


### PR DESCRIPTION
## Description
This PR adds the following note to hopefully prevent people from being confused when looking at the Mocha unit test logs:

`Please Note: An axe-core smoke test is expected to report 6 violations.`
