### PR TITLE
stop setting default aria-label in CTA components

### DIFF
--- a/src/applications/personalization/dashboard-2/components/CTALink.jsx
+++ b/src/applications/personalization/dashboard-2/components/CTALink.jsx
@@ -10,7 +10,7 @@ const CTALink = ({ ariaLabel, href, text, onClick, newTab }) => {
 
   return (
     <a
-      aria-label={ariaLabel ? `${ariaLabel}` : text}
+      aria-label={ariaLabel ? `${ariaLabel}` : ''}
       href={href}
       rel={relProp}
       target={targetProp}

--- a/src/applications/personalization/dashboard-2/components/IconCTALink.jsx
+++ b/src/applications/personalization/dashboard-2/components/IconCTALink.jsx
@@ -23,7 +23,7 @@ const IconCTALink = ({
 
   return (
     <a
-      aria-label={ariaLabel ? `${ariaLabel}` : text}
+      aria-label={ariaLabel ? `${ariaLabel}` : ''}
       href={href}
       rel={relProp}
       target={targetProp}


### PR DESCRIPTION
## Description
In my last PR I set up this default aria-label behavior simply so I could use `getByRole('link', {name: /link label/i})`. But it turns out the `*ByRole` selector is smart enough that it doesn't need an aria-label explicitly set.

## Testing done
The tests I wrote in my last PR, that use `getByRole`, all still pass.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs