### PR TITLE
Update "verify your ID" button text

### DIFF
--- a/src/applications/personalization/components/IdentityNotVerified.jsx
+++ b/src/applications/personalization/components/IdentityNotVerified.jsx
@@ -29,7 +29,7 @@ const IdentityNotVerified = ({
         onClick={() => recordEvent({ event: 'verify-link-clicked' })}
       >
         <img alt="ID.me" src="/img/signin/idme-icon-white.svg" />
-        <strong>Verify my identity</strong>
+        <strong>Verify your identity</strong>
       </a>
     </>
   );

--- a/src/applications/personalization/components/IdentityNotVerified.unit.spec.jsx
+++ b/src/applications/personalization/components/IdentityNotVerified.unit.spec.jsx
@@ -26,7 +26,7 @@ describe('IdentityNotVerified component', () => {
     });
     it('renders the correct CTA', () => {
       expect(
-        view.getByRole('link', { name: /Verify my identity/i }),
+        view.getByRole('link', { name: /Verify your identity/i }),
       ).to.have.attr('href', '/verify');
     });
     it('renders the correct additional info component', () => {
@@ -57,7 +57,7 @@ describe('IdentityNotVerified component', () => {
     });
     it('renders the correct CTA', () => {
       expect(
-        view.getByRole('link', { name: /Verify my identity/i }),
+        view.getByRole('link', { name: /Verify your identity/i }),
       ).to.have.attr('href', '/verify');
     });
     it('renders the correct additional info component', () => {


### PR DESCRIPTION
## Description
This PR simply updates the label of the "verify" button

But https://github.com/department-of-veterans-affairs/vets-website/pull/16703 should fix the ID.me SVG that is way too large.

## Testing done


## Screenshots

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs