### PR TITLE
Chapter 31 add feature gate to app page

### DIFF
--- a/src/applications/vre/28-1900/constants.js
+++ b/src/applications/vre/28-1900/constants.js
@@ -2,7 +2,7 @@ export const WIZARD_STATUS = 'wizardStatus31';
 export const CHAPTER_31_ROOT_URL =
   '/careers-employment/vocational-rehabilitation/apply';
 export const VRE_ROOT_URL =
-  'https://www.va.gov/careers-employment/vocational-rehabilitation/how-to-apply/';
+  '/careers-employment/vocational-rehabilitation/how-to-apply/';
 export const CAREERS_EMPLOYMENT_ROOT_URL =
   '/careers-employment/education-and-career-counseling/';
 export const VRE_COUNSELOR_ROOT_URL =

--- a/src/applications/vre/28-1900/containers/App.jsx
+++ b/src/applications/vre/28-1900/containers/App.jsx
@@ -1,4 +1,12 @@
 import React, { useEffect, useState } from 'react';
+import { connect } from 'react-redux';
+
+import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
+import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
+
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import FormFooter from 'platform/forms/components/FormFooter';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 
@@ -11,9 +19,9 @@ import {
 
 import formConfig from '../config/form';
 import OrientationWizardContainer from './OrientationWizardContainer';
-import { WIZARD_STATUS } from '../constants';
+import { WIZARD_STATUS, VRE_ROOT_URL } from '../constants';
 
-export default function App({ location, children, router }) {
+function App({ location, children, router, chapter31Feature }) {
   const [wizardState, setWizardState] = useState(WIZARD_STATUS_NOT_STARTED);
   let content;
 
@@ -33,8 +41,42 @@ export default function App({ location, children, router }) {
       router.push('/');
     }
   });
-
-  if (wizardState !== WIZARD_STATUS_COMPLETE) {
+  if (chapter31Feature === undefined) {
+    content = <LoadingIndicator message="Loading..." />;
+  } else if (!chapter31Feature) {
+    content = (
+      <div className="row vads-u-margin-bottom--1">
+        <div className="usa-width-two-thirds medium-8 columns">
+          <article>
+            <FormTitle title="Veteran Readiness and Employment" />
+            <p>
+              Equal to VA Form 28-1900 (Vocational Rehabilitation for Claimants
+              With Service-Connected Disabilities)
+            </p>
+            <AlertBox
+              status="info"
+              headline="We’re still working on this feature"
+              content={
+                <>
+                  <p>
+                    We’re rolling out the Veteran Readiness and Employment form
+                    in stages. It’s not quite ready yet. Please check back again
+                    soon.{' '}
+                  </p>
+                  <a
+                    href={VRE_ROOT_URL}
+                    className="u-vads-display--block u-vads-margin-top--2"
+                  >
+                    Return to Veteran Readiness and Employment page
+                  </a>
+                </>
+              }
+            />
+          </article>
+        </div>
+      </div>
+    );
+  } else if (wizardState !== WIZARD_STATUS_COMPLETE) {
     content = (
       <OrientationWizardContainer wizardStateHandler={wizardStateHandler} />
     );
@@ -52,3 +94,9 @@ export default function App({ location, children, router }) {
     </>
   );
 }
+
+const mapStateToProps = store => ({
+  chapter31Feature: toggleValues(store)[FEATURE_FLAG_NAMES.showChapter31],
+});
+
+export default connect(mapStateToProps)(App);

--- a/src/applications/vre/28-1900/containers/OrientationWizardContainer.jsx
+++ b/src/applications/vre/28-1900/containers/OrientationWizardContainer.jsx
@@ -3,7 +3,6 @@ import Scroll from 'react-scroll';
 import { focusElement } from 'platform/utilities/ui';
 import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
 import Wizard from 'applications/static-pages/wizard';
-import { CHAPTER_31_ROOT_URL } from 'applications/vre/28-1900/constants';
 import pages from 'applications/vre/28-1900/wizard/pages';
 import recordEvent from 'platform/monitoring/record-event';
 import OrientationApp from 'applications/vre/28-1900/orientation/OrientationApp';
@@ -59,7 +58,7 @@ const OrientationWizardContainer = props => {
           can go directly to the online application without answering the
           questions below.{' '}
           <a
-            href={CHAPTER_31_ROOT_URL}
+            href="#"
             aria-describedby="skip-wizard-description"
             onClick={() => {
               recordEvent({

--- a/src/applications/vre/28-1900/containers/OrientationWizardContainer.jsx
+++ b/src/applications/vre/28-1900/containers/OrientationWizardContainer.jsx
@@ -4,6 +4,7 @@ import { focusElement } from 'platform/utilities/ui';
 import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
 import Wizard from 'applications/static-pages/wizard';
 import pages from 'applications/vre/28-1900/wizard/pages';
+import { CHAPTER_31_ROOT_URL } from 'applications/vre/28-1900/constants';
 import recordEvent from 'platform/monitoring/record-event';
 import OrientationApp from 'applications/vre/28-1900/orientation/OrientationApp';
 
@@ -58,9 +59,10 @@ const OrientationWizardContainer = props => {
           can go directly to the online application without answering the
           questions below.{' '}
           <a
-            href="#"
+            href={CHAPTER_31_ROOT_URL}
             aria-describedby="skip-wizard-description"
-            onClick={() => {
+            onClick={e => {
+              e.preventDefault();
               recordEvent({
                 event: 'howToWizard-skip',
               });

--- a/src/applications/vre/28-1900/tests/e2e/chapter31-maximal.cypress.spec.js
+++ b/src/applications/vre/28-1900/tests/e2e/chapter31-maximal.cypress.spec.js
@@ -10,12 +10,23 @@ Cypress.config('waitForAnimations', true);
 
 const testConfig = createTestConfig(
   {
-    skip: ['chapter31-maximal'],
+    // skip: ['chapter31-maximal'],
     dataPrefix: 'data',
     dataSets: ['chapter31-maximal'],
     fixtures: { data: path.join(__dirname, 'formDataSets') },
     setupPerTest: () => {
       window.sessionStorage.removeItem('wizardStatus31');
+      cy.intercept('GET', '/v0/feature_toggles*', {
+        data: {
+          type: 'feature_toggles',
+          features: [
+            {
+              name: 'show_chapter_31',
+              value: true,
+            },
+          ],
+        },
+      });
       cy.intercept('POST', '/v0/veteran_readiness_employment_claims', {
         formSubmissionId: '123fake-submission-id-567',
         timestamp: '2020-11-12',

--- a/src/applications/vre/28-1900/tests/e2e/chapter31-maximal.cypress.spec.js
+++ b/src/applications/vre/28-1900/tests/e2e/chapter31-maximal.cypress.spec.js
@@ -10,7 +10,7 @@ Cypress.config('waitForAnimations', true);
 
 const testConfig = createTestConfig(
   {
-    // skip: ['chapter31-maximal'],
+    skip: ['chapter31-maximal'],
     dataPrefix: 'data',
     dataSets: ['chapter31-maximal'],
     fixtures: { data: path.join(__dirname, 'formDataSets') },


### PR DESCRIPTION
## Description
This pull request adds a feature gate directly to the application page for the chapter 31 form. In the event a user navigates directly to the app's root URL, they will see a message notifying them that the feature is still being worked on. This allows us to control for UAT in production, without the worry of real users inadvertently using an application that hasn't been officially released. 

## Testing done
- local

## Screenshots
<details><summary>App page with feature toggle turned off</summary>

<img width="793" alt="Screen Shot 2021-04-07 at 3 52 56 PM" src="https://user-images.githubusercontent.com/15097156/113928637-114ffd00-97bd-11eb-9d3d-5b201e78067a.png">

</details>


<details><summary>App page with feature toggle turned on</summary>

<img width="911" alt="Screen Shot 2021-04-07 at 4 08 06 PM" src="https://user-images.githubusercontent.com/15097156/113928702-2036af80-97bd-11eb-982e-9d4ab11122e5.png">


</details>

## Acceptance criteria
- [x] toggle works
- [x] e2e tests pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
