### PR TITLE
remove duplicate section from review page

### DIFF
--- a/src/applications/vre/28-1900/config/form.js
+++ b/src/applications/vre/28-1900/config/form.js
@@ -6,7 +6,6 @@ import PreSubmitInfo from 'applications/vre/28-1900/components/PreSubmitInfo';
 import { additionalInformation } from './chapters/additional-information';
 import { communicationPreferences } from './chapters/communication-preferences';
 import { veteranInformation, veteranAddress } from './chapters/veteran';
-import StaticInformationReviewField from '../containers/StaticInformationReviewField';
 import GetFormHelp from 'applications/vre/components/GetFormHelp';
 import { transform } from './helpers';
 import { WIZARD_STATUS } from '../constants';
@@ -49,7 +48,8 @@ const formConfig = {
   chapters: {
     veteranInformation: {
       title: 'Veteran Information',
-      reviewDescription: StaticInformationReviewField,
+      // TODO: related to the comment direcly below; add reviewDescription back in once the issues with static veteran information have been resolved.
+      // reviewDescription: StaticInformationReviewField,
       pages: {
         // TODO: possibly add this back in once issue has been investigated.
         // veteranStaticInformation: {


### PR DESCRIPTION
## Description
QA recently discovered duplicate veteran information fields on the review page for the chapter 31 form. This was due to an artifact left in from a prior version of the form which leveraged the `reviewDescription` control available for use in a form config. This pull request comments that line out, as it will be re-introduced at a later date once connected issues that leverage it have been resolved. 

## Testing done
- local

## Screenshots
<details><summary>Original issue with duplicate panels</summary>

![chp-31-dupe-panels](https://user-images.githubusercontent.com/15097156/113931062-0ba7e680-97c0-11eb-8cf2-c5febb830fc8.png)

</details>

<details><summary>Fixed issue with single panel</summary>

<img width="539" alt="Screen Shot 2021-04-07 at 4 36 26 PM" src="https://user-images.githubusercontent.com/15097156/113931146-224e3d80-97c0-11eb-8a24-eb187fb9f7d7.png">


</details>

## Acceptance criteria
- [x] duplicate review panel has been removed.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
