### PR TITLE
Fix messaging

### DIFF
--- a/src/applications/personalization/dashboard/tests/helpers.js
+++ b/src/applications/personalization/dashboard/tests/helpers.js
@@ -1,4 +1,4 @@
 import environment from '~/platform/utilities/environment';
 
 export const shouldMockApiRequest = () =>
-  environment.isLocalhost && !window.Cypress && !window.VetsGov.pollTimeout;
+  environment.isLocalhost() && !window.Cypress && !window.VetsGov.pollTimeout;


### PR DESCRIPTION
## Description
Fix localhost issue messaging. I forgot to invoke the `environment.isLocalhost()` function which made mock data go to prod.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
