### PR TITLE
Chapter 31 fix additional info bug

### DIFF
--- a/src/applications/vre/28-1900/config/chapters/additional-information/additionalInformation.js
+++ b/src/applications/vre/28-1900/config/chapters/additional-information/additionalInformation.js
@@ -55,6 +55,13 @@ export const uiSchema = {
     'ui:options': {
       expandUnder: 'isMoving',
       expandUnderCondition: true,
+      updateSchema: (formData, formSchema) => {
+        // Clear out required fields here to avoid silent validation errors for hidden fields.
+        if (!formData.isMoving && formData.newAddress) {
+          return { ...formSchema, required: [] };
+        }
+        return formSchema;
+      },
     },
   },
 };


### PR DESCRIPTION
## Description
QA recently discovered that on the review page of the chapter 31 form, attempting to update information [would fail on clicking the update button](https://github.com/department-of-veterans-affairs/va.gov-team/issues/22724). This was due to fields relying on `ui:required` not being properly updated once an `expandUnder` condition was triggered. This pull request fixes this issue by using `updateSchema` at the root of the offending schema and returning an empty `required` array.

## Testing done
- local

## Screenshots
<details><summary>Demo of fix</summary>


https://user-images.githubusercontent.com/15097156/114067856-47e45100-986b-11eb-8580-36ae7fff5191.mov


</details>

## Acceptance criteria
- [x] issue has been resolved

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
