### PR TITLE
Letters: Remove progressbar role from header wrap

### DIFF
--- a/src/applications/letters/components/StepHeader.jsx
+++ b/src/applications/letters/components/StepHeader.jsx
@@ -2,21 +2,21 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 function StepHeader({ current, steps, name, children }) {
+  const stepText = `Step ${current} of ${steps}: ${name}`;
   return (
     <div className="section-content">
-      <div
-        role="progressbar"
-        aria-valuenow={current}
-        aria-valuemin="1"
-        aria-valuetext={`Step ${current} of ${steps}: ${name}`}
-        aria-valuemax={steps}
-        className="nav-header"
-      >
-        <h4>
-          <span className="form-process-step current">{current}</span>
-          <span className="form-process-total">of {steps}</span>
-          {name}
-        </h4>
+      <div className="schemaform-chapter-progress">
+        <div
+          aria-valuenow={current}
+          aria-valuemin="1"
+          aria-valuetext={stepText}
+          aria-valuemax={steps}
+          className="nav-header nav-header-schemaform"
+        >
+          <h2 id="nav-form-header" className="vads-u-font-size--h4">
+            {stepText}
+          </h2>
+        </div>
       </div>
       {children}
     </div>

--- a/src/applications/letters/tests/components/StepHeader.unit.spec.jsx
+++ b/src/applications/letters/tests/components/StepHeader.unit.spec.jsx
@@ -19,10 +19,8 @@ describe('<StepHeader>', () => {
 
   it('should format step header', () => {
     const tree = SkinDeep.shallowRender(<StepHeader {...defaultProps} />);
-    expect(tree.subTree('.form-process-step').text()).to.equal('3');
-    expect(tree.subTree('.form-process-total').text()).to.equal('of 6');
-    expect(tree.subTree('.section-content').text()).to.contain(
-      'First step of the process',
+    expect(tree.subTree('h2').text()).to.equal(
+      'Step 3 of 6: First step of the process',
     );
   });
 });


### PR DESCRIPTION
## Description

A `<div>` below the progressbar component included a `role="progressbar"` causing automated a11y testing to fail:
- This role was removed
- Class names were updated to bring the design in line with form changes

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/21797

## Testing done

Updated unit tests & ran Nightwatch e2e test

## Screenshots

<details><summary>Current header styling</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-04-08 at 2 38 14 PM](https://user-images.githubusercontent.com/136959/114086328-19b93e00-9878-11eb-810a-f2b7a214349c.png)</details>

<details><summary>Updated header styling</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-04-08 at 2 36 57 PM](https://user-images.githubusercontent.com/136959/114086338-1a51d480-9878-11eb-81f4-fba7fe4e8b0f.png)

Compared to Form 526 progress

![Screen Shot 2021-04-08 at 2 40 48 PM](https://user-images.githubusercontent.com/136959/114086707-8f250e80-9878-11eb-8fbb-f1ac828376a4.png)</details>

## Acceptance criteria
- [x] Failing Nightwatch a11y tests pass
- [x] Progress bar styling matches form system progress

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
