### PR TITLE
send `error-key` to GA when there is a DD4EDU error

### DIFF
--- a/src/applications/personalization/profile/actions/paymentInformation.js
+++ b/src/applications/personalization/profile/actions/paymentInformation.js
@@ -146,7 +146,7 @@ export function saveCNPPaymentInformation(
     // };
 
     if (response.error || response.errors) {
-      const errors = response?.error?.errors || [];
+      const errors = response.error?.errors || [];
       const analyticsData = createCNPDirectDepositAnalyticsDataObject(
         errors,
         isEnrollingInDirectDeposit,
@@ -240,6 +240,7 @@ export function saveEDUPaymentInformation(
         event: 'profile-edit-failure',
         'profile-action': 'save-failure',
         'profile-section': 'edu-direct-deposit-information',
+        'error-key': 'unknown-save-error',
       });
       dispatch({
         type: EDU_PAYMENT_INFORMATION_SAVE_FAILED,

--- a/src/applications/personalization/profile/tests/actions/paymentInformation.unit.spec.js
+++ b/src/applications/personalization/profile/tests/actions/paymentInformation.unit.spec.js
@@ -598,6 +598,7 @@ describe('actions/paymentInformation', () => {
             event: 'profile-edit-failure',
             'profile-action': 'save-failure',
             'profile-section': 'edu-direct-deposit-information',
+            'error-key': 'unknown-save-error',
           });
         });
       });

--- a/src/applications/personalization/profile/tests/actions/paymentInformation.unit.spec.js
+++ b/src/applications/personalization/profile/tests/actions/paymentInformation.unit.spec.js
@@ -594,12 +594,13 @@ describe('actions/paymentInformation', () => {
         });
 
         it('reports the correct data to Google Analytics', () => {
-          expect(recordEventSpy.firstCall.args[0]).to.deep.equal({
-            event: 'profile-edit-failure',
-            'profile-action': 'save-failure',
-            'profile-section': 'edu-direct-deposit-information',
-            'error-key': 'unknown-save-error',
-          });
+          const gaObject = recordEventSpy.firstCall.args[0];
+          expect(gaObject.event).to.equal('profile-edit-failure');
+          expect(gaObject['profile-action']).to.equal('save-failure');
+          expect(gaObject['profile-section']).to.equal(
+            'edu-direct-deposit-information',
+          );
+          expect(gaObject['error-key']).to.equal('unknown-save-error');
         });
       });
     });


### PR DESCRIPTION
## Description


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs