### PR TITLE
Re-try drupal asset downloads 3 times before giving up and exiting

### DIFF
--- a/src/site/stages/build/plugins/download-drupal-assets.js
+++ b/src/site/stages/build/plugins/download-drupal-assets.js
@@ -37,6 +37,9 @@ async function downloadFile(
             asset.src
           }. ${e} Retries remaining: ${retries}`,
         );
+        // Pause to give the proxy connection a break.
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise(resolve => setTimeout(500, resolve));
       } else {
         throw e;
       }


### PR DESCRIPTION
This should hopefully reduce the need to re-start local content builds.