### PR TITLE
Add build option to force content build to run

### DIFF
--- a/script/build.sh
+++ b/script/build.sh
@@ -43,6 +43,10 @@ for o in "$@"; do
             destination="${o#*=}"
             shift
             ;;
+        --force-content-build)
+            forceContentBuild=true
+            shift
+            ;;
         *)
             ;;
     esac
@@ -71,7 +75,7 @@ else
 fi
 
 # Build the content
-if [ "${buildtype}" != "vagovdev" ]
+if [ -n "${forceContentBuild}" ] || [ "${buildtype}" != "vagovdev" ]
 then
     yarn build:content $args
 fi

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -71,6 +71,7 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   // isn't actually a part of this list of options, but an error would be thrown
   // without it. Remove this when getOptions is decoupled from the cache script.
   { name: 'fetch', type: Boolean, defaultValue: false },
+  { name: 'force-content-build', type: Boolean, defaultValue: false },
 ];
 
 function gatherFromCommandLine() {


### PR DESCRIPTION
## Description

During https://github.com/department-of-veterans-affairs/vets-website/pull/16631 the `vagovdev` `buildtype` skipped the content release.  The CMS uses the`vagovdev` `buildtype` in it's CI pipeline and demo sites.  This PR introduces a new command line argument called `force-content-build` to build content no mater what.

## Testing done

* Ran the build with `bulidtype` of `vagovdev` and `force-content-build` set and the content build ran.
* Ran the build with `bulidtype` of `vagovdev` and `force-content-build` not set  and the content build did not run.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/department-of-veterans-affairs/vets-website/16726)
<!-- Reviewable:end -->
