### PR TITLE
[22630] Update axe checks

### DIFF
--- a/src/applications/vaos/tests/e2e/appointment-list.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/appointment-list.cypress.spec.js
@@ -8,10 +8,12 @@ describe('VAOS appointment list', () => {
     initAppointmentListMock();
     cy.visit('health-care/schedule-view-va-appointments/appointments/');
     cy.get('.va-modal-body button').click();
+    cy.injectAxe();
   });
 
   it('should render appointments list', () => {
     cy.get('#appointments-list').should('exist');
+    cy.axeCheckBestPractice();
   });
 
   it('should allow for cancelling of appointments', () => {
@@ -24,6 +26,7 @@ describe('VAOS appointment list', () => {
       .first()
       .click();
     cy.get('#cancelAppt').should('not.exist');
+    cy.axeCheckBestPractice();
   });
 
   it('should show more info for appointments', () => {
@@ -32,6 +35,7 @@ describe('VAOS appointment list', () => {
     ).click();
     cy.get('[id="8a48912a6cab0202016cb4fcaa8b0038-vaos-info-content"]');
     cy.contains('Request 2 Message 1 Text');
+    cy.axeCheckBestPractice();
   });
 
   it('should render past appointments', () => {
@@ -46,5 +50,6 @@ describe('VAOS appointment list', () => {
     cy.findByText('Update').click();
     cy.findByText(/four month clinic name/i).should('exist');
     cy.get('#queryResultLabel').should('have.focus');
+    cy.axeCheckBestPractice();
   });
 });

--- a/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
@@ -23,7 +23,7 @@ describe('VAOS community care flow', () => {
       'contain',
       '/health-care/schedule-view-va-appointments/appointments/new-appointment/choose-facility-type',
     );
-    cy.axeCheck();
+    cy.axeCheckBestPractice();
     // Select community care
     cy.get('#root_facilityType_1').click();
     // Verify community care checked
@@ -36,7 +36,7 @@ describe('VAOS community care flow', () => {
       'contain',
       '/health-care/schedule-view-va-appointments/appointments/new-appointment/request-date',
     );
-    cy.axeCheck();
+    cy.axeCheckBestPractice();
     cy.contains('button', 'Next')
       .focus()
       .click();
@@ -59,7 +59,7 @@ describe('VAOS community care flow', () => {
       'contain',
       '/health-care/schedule-view-va-appointments/appointments/new-appointment/community-care-preferences',
     );
-    cy.axeCheck();
+    cy.axeCheckBestPractice();
     // Select city
     cy.get('#root_communityCareSystemId_0').click();
     cy.get('#root_communityCareSystemId_0').should('be.checked');
@@ -123,7 +123,7 @@ describe('VAOS community care flow', () => {
       'contain',
       '/health-care/schedule-view-va-appointments/appointments/new-appointment/reason-appointment',
     );
-    cy.axeCheck();
+    cy.axeCheckBestPractice();
     // Fill out reason input
     cy.get('#root_reasonAdditionalInfo')
       .type('This is a very good reason.')
@@ -140,7 +140,7 @@ describe('VAOS community care flow', () => {
       'contain',
       '/health-care/schedule-view-va-appointments/appointments/new-appointment/contact-info',
     );
-    cy.axeCheck();
+    cy.axeCheckBestPractice();
     // Verify phone number
     cy.get('#root_phoneNumber').should('have.value', '5035551234');
     // Select best times for us to call morning & evening
@@ -159,7 +159,7 @@ describe('VAOS community care flow', () => {
       'contain',
       '/health-care/schedule-view-va-appointments/appointments/new-appointment/review',
     );
-    cy.axeCheck();
+    cy.axeCheckBestPractice();
     // Click continue button
     cy.get('.usa-button').click();
 
@@ -238,7 +238,7 @@ describe('VAOS community care flow', () => {
       'contain',
       '/health-care/schedule-view-va-appointments/appointments/new-appointment/confirmation',
     );
-    cy.axeCheck();
+    cy.axeCheckBestPractice();
     cy.get('.usa-alert').contains('We’re reviewing your request');
   });
 
@@ -261,7 +261,7 @@ describe('VAOS community care flow', () => {
       'contain',
       '/health-care/schedule-view-va-appointments/appointments/new-appointment/choose-facility-type',
     );
-    cy.axeCheck();
+    cy.axeCheckBestPractice();
     // Select community care
     cy.get('#root_facilityType_1').click();
     // Verify community care checked
@@ -274,7 +274,7 @@ describe('VAOS community care flow', () => {
       'contain',
       '/health-care/schedule-view-va-appointments/appointments/new-appointment/request-date',
     );
-    cy.axeCheck();
+    cy.axeCheckBestPractice();
     cy.contains('button', 'Next')
       .focus()
       .click();
@@ -297,17 +297,17 @@ describe('VAOS community care flow', () => {
       'contain',
       '/health-care/schedule-view-va-appointments/appointments/new-appointment/community-care-preferences',
     );
-    cy.axeCheck();
+    cy.axeCheckBestPractice();
     // Select city
     cy.get('#root_communityCareSystemId_0').click();
     cy.get('#root_communityCareSystemId_0').should('be.checked');
     cy.findByText(/Choose a provider/i).click();
 
     cy.findByLabelText(/doe, jane/i).click();
-    cy.axeCheck();
+    cy.axeCheckBestPractice();
     cy.findByText(/Choose provider/i).click();
     cy.findByText(/remove/i).click();
-    cy.axeCheck();
+    cy.axeCheckBestPractice();
     cy.findByText(/cancel/i).click();
     // Click continue button
     cy.get('.usa-button').click();
@@ -316,7 +316,7 @@ describe('VAOS community care flow', () => {
       'contain',
       '/health-care/schedule-view-va-appointments/appointments/new-appointment/community-care-language',
     );
-    cy.axeCheck();
+    cy.axeCheckBestPractice();
     // Select preferred language
     cy.get('#root_preferredLanguage').select('english');
     cy.get('#root_preferredLanguage').should('have.value', 'english');
@@ -328,7 +328,7 @@ describe('VAOS community care flow', () => {
       'contain',
       '/health-care/schedule-view-va-appointments/appointments/new-appointment/reason-appointment',
     );
-    cy.axeCheck();
+    cy.axeCheckBestPractice();
     // Fill out reason input
     cy.get('#root_reasonAdditionalInfo')
       .type('This is a very good reason.')
@@ -345,7 +345,7 @@ describe('VAOS community care flow', () => {
       'contain',
       '/health-care/schedule-view-va-appointments/appointments/new-appointment/contact-info',
     );
-    cy.axeCheck();
+    cy.axeCheckBestPractice();
     // Verify phone number
     cy.get('#root_phoneNumber').should('have.value', '5035551234');
     // Select best times for us to call morning & evening
@@ -364,7 +364,7 @@ describe('VAOS community care flow', () => {
       'contain',
       '/health-care/schedule-view-va-appointments/appointments/new-appointment/review',
     );
-    cy.axeCheck();
+    cy.axeCheckBestPractice();
     // Click continue button
     cy.get('.usa-button').click();
 
@@ -437,7 +437,7 @@ describe('VAOS community care flow', () => {
       'contain',
       '/health-care/schedule-view-va-appointments/appointments/new-appointment/confirmation',
     );
-    cy.axeCheck();
+    cy.axeCheckBestPractice();
     cy.get('.usa-alert').contains('We’re reviewing your request');
   });
 });

--- a/src/applications/vaos/tests/e2e/express-care.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/express-care.cypress.spec.js
@@ -9,26 +9,26 @@ describe('VAOS Express Care flow', () => {
     cy.injectAxe();
     cy.get('.va-modal-body button').click();
     cy.wait('@getRequestEligibilityCriteria');
-    cy.axeCheck();
+    cy.axeCheckBestPractice();
     cy.findByText('Request Express Care').click();
 
     // Info page
     cy.findByText('How Express Care works');
     cy.url().should('include', '/new-express-care-request');
-    cy.axeCheck();
+    cy.axeCheckBestPractice();
     cy.findByText('Continue with Express Care request').click();
 
     // Select reason page
     cy.findByText('Select a reason for your Express Care request');
     cy.url().should('include', '/new-express-care-request/select-reason');
-    cy.axeCheck();
+    cy.axeCheckBestPractice();
     cy.findByLabelText('Cough').click();
     cy.findByText('Continue').click();
 
     // Additional Appointment detail
     cy.findByText('Express Care request details');
     cy.url().should('include', '/new-express-care-request/additional-details');
-    cy.axeCheck();
+    cy.axeCheckBestPractice();
     cy.get('textarea').type('heavy cough');
     cy.findByText('Submit Express Care request').click();
 

--- a/src/applications/vaos/tests/e2e/va-appointment.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/va-appointment.cypress.spec.js
@@ -98,7 +98,7 @@ describe('VAOS direct schedule flow', () => {
 
     // Type of eye care
     cy.url().should('include', '/choose-eye-care');
-    cy.axeCheck();
+    cy.axeCheckBestPractice();
     cy.findByLabelText(/Optometry/).click();
     cy.findByText(/Continue/).click();
 
@@ -170,7 +170,7 @@ describe('VAOS direct schedule flow', () => {
 
     // Type of sleep care
     cy.url().should('include', '/choose-sleep-care');
-    cy.axeCheck();
+    cy.axeCheckBestPractice();
     cy.findByLabelText(/Sleep medicine/).click();
     cy.findByText(/Continue/).click();
 
@@ -316,7 +316,7 @@ describe('VAOS direct schedule flow with a Cerner site', () => {
 
     // Type of eye care
     cy.url().should('include', '/choose-eye-care');
-    cy.axeCheck();
+    cy.axeCheckBestPractice();
     cy.findByLabelText(/Optometry/).click();
     cy.findByText(/Continue/).click();
 
@@ -388,7 +388,7 @@ describe('VAOS direct schedule flow with a Cerner site', () => {
 
     // Type of sleep care
     cy.url().should('include', '/choose-sleep-care');
-    cy.axeCheck();
+    cy.axeCheckBestPractice();
     cy.findByLabelText(/Sleep medicine/).click();
     cy.findByText(/Continue/).click();
 

--- a/src/applications/vaos/tests/e2e/va-request.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/va-request.cypress.spec.js
@@ -24,7 +24,7 @@ function fillOutForm(facilitySelection) {
 
   // Choose VA Facility
   cy.url().should('include', '/va-facility');
-  cy.axeCheck();
+  cy.axeCheckBestPractice();
   if (facilitySelection) facilitySelection();
   cy.findByText(/Continue/).click();
 
@@ -45,7 +45,7 @@ function fillOutForm(facilitySelection) {
 
   // Review
   cy.url().should('include', '/review');
-  cy.axeCheck();
+  cy.axeCheckBestPractice();
   cy.findByText('Request appointment').click();
 
   // Check form requestBody is as expected

--- a/src/applications/vaos/tests/e2e/vaos-cypress-schedule-appointment-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-cypress-schedule-appointment-helpers.js
@@ -4,21 +4,21 @@ const today = moment();
 
 export function chooseTypeOfCareTest(label) {
   cy.url().should('include', '/new-appointment');
-  cy.axeCheck();
+  cy.axeCheckBestPractice();
   cy.findByLabelText(label).click();
   cy.findByText(/Continue/).click();
 }
 
 export function chooseFacilityTypeTest(label) {
   cy.url().should('include', '/choose-facility-type');
-  cy.axeCheck();
+  cy.axeCheckBestPractice();
   cy.findByLabelText(label).click();
   cy.findByText(/Continue/).click();
 }
 
 export function chooseVAFacilityTest() {
   cy.url().should('include', '/va-facility');
-  cy.axeCheck();
+  cy.axeCheckBestPractice();
   cy.findByLabelText(/CHYSHR/).check();
   cy.findByLabelText(
     'CHYSHR-Cheyenne VA Medical Center (Cheyenne, WY)',
@@ -28,7 +28,7 @@ export function chooseVAFacilityTest() {
 
 export function chooseVAFacilityV2Test() {
   cy.url().should('include', '/va-facility-2');
-  cy.axeCheck();
+  cy.axeCheckBestPractice();
   cy.get('#root_vaFacility_3')
     .focus()
     .click();
@@ -37,7 +37,7 @@ export function chooseVAFacilityV2Test() {
 
 export function chooseClinicTest() {
   cy.url().should('include', '/clinics');
-  cy.axeCheck();
+  cy.axeCheckBestPractice();
   cy.findByText(/You can choose a clinic where you’ve been seen/i);
   cy.get('#root_clinicId_0')
     .focus()
@@ -47,7 +47,7 @@ export function chooseClinicTest() {
 
 export function choosePreferredDateTest() {
   cy.url().should('include', '/preferred-date');
-  cy.axeCheck();
+  cy.axeCheckBestPractice();
 
   const preferredDate = today
     .clone()
@@ -76,7 +76,7 @@ export function selectTimeSlotTest() {
     .focus()
     .click();
 
-  cy.axeCheck();
+  cy.axeCheckBestPractice();
   cy.findByText(/Continue/).click();
 }
 
@@ -91,14 +91,14 @@ export function selectRequestSlotTest() {
   cy.get(
     '.vaos-calendar__day--current .vaos-calendar__options input[id$="_0"]',
   ).click();
-  cy.axeCheck();
+  cy.axeCheckBestPractice();
   cy.findByText(/Continue/).click();
 }
 
 export function howToBeSeenTest() {
   cy.url().should('include', '/choose-visit-type');
   cy.findByLabelText(/Office/i).click();
-  cy.axeCheck();
+  cy.axeCheckBestPractice();
   cy.findByText(/Continue/).click();
 }
 
@@ -107,7 +107,7 @@ export function reasonForAppointmentTest(
   label = /Please provide any additional details/,
 ) {
   cy.url().should('include', '/reason-appointment');
-  cy.axeCheck();
+  cy.axeCheckBestPractice();
   cy.findByLabelText('Routine or follow-up visit').click();
   cy.findByLabelText(label).type(content);
   cy.findByText(/Continue/).click();
@@ -115,14 +115,14 @@ export function reasonForAppointmentTest(
 
 export function contactInfoTest() {
   cy.url().should('include', '/contact-info');
-  cy.axeCheck();
+  cy.axeCheckBestPractice();
   cy.findByLabelText(/Morning/).click();
   cy.findByText(/Continue/).click();
 }
 
 export function reviewTest() {
   cy.url().should('include', '/review');
-  cy.axeCheck();
+  cy.axeCheckBestPractice();
   cy.findByText('Confirm appointment').click();
 }
 

--- a/src/applications/vaos/tests/e2e/vaos-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-helpers.js
@@ -92,7 +92,7 @@ function appointmentDateTimeTest(client, nextElement) {
     .click(
       '.vaos-calendar__day--current .vaos-calendar__options input[id$="_0"]',
     )
-    .axeCheck('.main')
+    .axeCheckBestPractice('.main')
     .click('.form-progress-buttons [type="submit"]')
     .waitForElementPresent(nextElement, Timeouts.slow);
 
@@ -107,7 +107,7 @@ function appointmentReasonTest(client, nextElement) {
       Timeouts.normal,
     )
     .setValue('textarea#root_reasonAdditionalInfo', 'Additonal information')
-    .axeCheck('.main')
+    .axeCheckBestPractice('.main')
     .click('.rjsf [type="submit"]')
     .waitForElementPresent(nextElement, Timeouts.normal);
 
@@ -121,7 +121,7 @@ function appointmentReasonCommunityCareTest(client, nextElement) {
       Timeouts.normal,
     )
     .setValue('textarea#root_reasonAdditionalInfo', 'Additonal information')
-    .axeCheck('.main')
+    .axeCheckBestPractice('.main')
     .click('.rjsf [type="submit"]')
     .waitForElementPresent(nextElement, Timeouts.normal);
 
@@ -131,7 +131,7 @@ function appointmentReasonCommunityCareTest(client, nextElement) {
 function howToBeSeenTest(client, nextElement) {
   client
     .click('input#root_visitType_0')
-    .axeCheck('.main')
+    .axeCheckBestPractice('.main')
     .click('.rjsf [type="submit"]')
     .waitForElementPresent(nextElement, Timeouts.normal);
 }
@@ -139,7 +139,7 @@ function howToBeSeenTest(client, nextElement) {
 function contactInformationTest(client, nextElement) {
   client
     .click('input#root_bestTimeToCall_morning')
-    .axeCheck('.main')
+    .axeCheckBestPractice('.main')
     .click('.rjsf [type="submit"]')
     .waitForElementPresent(nextElement, Timeouts.normal);
 
@@ -148,7 +148,7 @@ function contactInformationTest(client, nextElement) {
 
 function reviewAppointmentTest(client, nextElement = '.usa-alert-success') {
   client
-    .axeCheck('.main')
+    .axeCheckBestPractice('.main')
     .click('button.usa-button.usa-button-primary')
     .waitForElementPresent(nextElement, Timeouts.normal);
 
@@ -157,7 +157,7 @@ function reviewAppointmentTest(client, nextElement = '.usa-alert-success') {
 
 function appointmentSubmittedTest(client) {
   client
-    .axeCheck('.main')
+    .axeCheckBestPractice('.main')
     .click('.usa-button[href$="appointments/"]')
     .assert.containsText('h1', 'VA appointments');
 


### PR DESCRIPTION
## Description
We added a helper for the vaccine flow Cypress tests called axeCheckBestPractice. We should use this across all of our Cypress tests.

## Testing done
E2E

## Screenshots
n/a

## Acceptance criteria
- [x] All VAOS Cypress tests use axeCheckBestPractice instead of axeCheck
- [x] Any revealed accessibility errors are resolved (or spun into separate tickets) - Didn't see any

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
