### PR TITLE
Jc remove unauth link

### DIFF
--- a/src/applications/vre/28-1900/containers/App.jsx
+++ b/src/applications/vre/28-1900/containers/App.jsx
@@ -87,11 +87,13 @@ function App({ location, children, router, chapter31Feature, isLoggedIn }) {
       </RoutedSavableApp>
     );
   }
-  if (!isLoggedIn) {
-    document.location.pathname.replace(
-      '/careers-employment/vocational-rehabilitation/apply',
-    );
+
+  const path =
+    '/careers-employment/vocational-rehabilitation/apply/introduction';
+  if (!isLoggedIn && window.location.pathname !== path) {
+    window.location.replace(path);
   }
+
   return (
     <>
       {content}

--- a/src/applications/vre/28-1900/containers/App.jsx
+++ b/src/applications/vre/28-1900/containers/App.jsx
@@ -21,7 +21,7 @@ import formConfig from '../config/form';
 import OrientationWizardContainer from './OrientationWizardContainer';
 import { WIZARD_STATUS, VRE_ROOT_URL } from '../constants';
 
-function App({ location, children, router, chapter31Feature }) {
+function App({ location, children, router, chapter31Feature, isLoggedIn }) {
   const [wizardState, setWizardState] = useState(WIZARD_STATUS_NOT_STARTED);
   let content;
 
@@ -87,6 +87,11 @@ function App({ location, children, router, chapter31Feature }) {
       </RoutedSavableApp>
     );
   }
+  if (!isLoggedIn) {
+    document.location.pathname.replace(
+      '/careers-employment/vocational-rehabilitation/apply',
+    );
+  }
   return (
     <>
       {content}
@@ -97,6 +102,7 @@ function App({ location, children, router, chapter31Feature }) {
 
 const mapStateToProps = store => ({
   chapter31Feature: toggleValues(store)[FEATURE_FLAG_NAMES.showChapter31],
+  isLoggedIn: store?.user?.login?.currentlyLoggedIn,
 });
 
 export default connect(mapStateToProps)(App);

--- a/src/applications/vre/28-1900/containers/IntroductionPage.jsx
+++ b/src/applications/vre/28-1900/containers/IntroductionPage.jsx
@@ -26,6 +26,7 @@ const IntroductionPage = props => {
         Service-Connected Disabilities)
       </p>
       <SaveInProgressIntro
+        hideUnauthedStartLink
         prefillEnabled={props.route.formConfig.prefillEnabled}
         messages={props.route.formConfig.savedFormMessages}
         pageList={props.route.pageList}
@@ -100,6 +101,7 @@ const IntroductionPage = props => {
         </p>
       </div>
       <SaveInProgressIntro
+        hideUnauthedStartLink
         buttonOnly
         prefillEnabled={props.route.formConfig.prefillEnabled}
         messages={props.route.formConfig.savedFormMessages}


### PR DESCRIPTION
## Description

[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/23020)

When we originally created the Chapter 31 form we thought that the user should be able to fill out the form in an unauthorized state however after reviewing with the stakeholder we found that in fact, the user needs to be authenticated to fill out the form. This PR updates the Chapter 31 form so that a user cannot fill it out without authenticating first.

## Acceptance criteria
- [x] The CH31 feature is only able to be accessed if logged in
- [x] A PR has been requested for merging

