### PR TITLE
Standardize 1990s route structure

### DIFF
--- a/src/applications/edu-benefits/1990s/routes.jsx
+++ b/src/applications/edu-benefits/1990s/routes.jsx
@@ -2,12 +2,13 @@ import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/
 import formConfig from './config/form';
 import App from './containers/App.jsx';
 
-const route = {
-  path: '/',
-  component: App,
-  indexRoute: { onEnter: (nextState, replace) => replace('/introduction') },
-
-  childRoutes: createRoutesWithSaveInProgress(formConfig),
-};
+const route = [
+  {
+    path: '/',
+    component: App,
+    indexRoute: { onEnter: (nextState, replace) => replace('/introduction') },
+    childRoutes: createRoutesWithSaveInProgress(formConfig),
+  },
+];
 
 export default route;

--- a/src/applications/edu-benefits/1990s/routes.jsx
+++ b/src/applications/edu-benefits/1990s/routes.jsx
@@ -2,7 +2,7 @@ import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/
 import formConfig from './config/form';
 import App from './containers/App.jsx';
 
-const route = [
+const routes = [
   {
     path: '/',
     component: App,
@@ -11,4 +11,4 @@ const route = [
   },
 ];
 
-export default route;
+export default routes;


### PR DESCRIPTION
## Description
Standardize format of 1990s form routes to match existing edu forms.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/22925

## Testing done
Tested locally.

## Screenshots
N/A

## Acceptance criteria
- [x] 1990s works

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
