### PR TITLE
Upgrade web-components dependency to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -365,7 +365,7 @@
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
     "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#4128d1a62e97add367209dbed619f231274bf7eb",
-    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.2.2",
+    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.4.0",
     "whatwg-fetch": "^2.0.3"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19750,9 +19750,9 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   dependencies:
     minimalistic-assert "^1.0.0"
 
-"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.2.2":
-  version "0.2.2"
-  resolved "https://github.com/department-of-veterans-affairs/component-library.git#4417ca82a40d90a583383fb92083c6b47b890487"
+"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.4.0":
+  version "0.4.0"
+  resolved "https://github.com/department-of-veterans-affairs/component-library.git#23d3c19611e4ce4704b213082b2c971c85b430ef"
   dependencies:
     "@stencil/core" "^2.0.1"
     "@stencil/postcss" "^2.0.0"


### PR DESCRIPTION
## Description

### Version 0.3.0

- Added `<va-on-this-page>` Web Component

### Version 0.4.0

- Added optional `subheading` prop to `<va-acordion-item>`


This PR only makes the new Web Component and features available to use.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
