### PR TITLE
Updated URL for un-authed toggle

### DIFF
--- a/src/applications/vre/28-1900/containers/App.jsx
+++ b/src/applications/vre/28-1900/containers/App.jsx
@@ -89,7 +89,7 @@ function App({ location, children, router, chapter31Feature, isLoggedIn }) {
   }
 
   const path =
-    '/careers-employment/vocational-rehabilitation/apply/introduction';
+    '/careers-employment/vocational-rehabilitation/apply-vre-form-28-1900/introduction';
   if (!isLoggedIn && window.location.pathname !== path) {
     window.location.replace(path);
   }

--- a/src/applications/vre/28-1900/tests/e2e/chapter31-maximal.cypress.spec.js
+++ b/src/applications/vre/28-1900/tests/e2e/chapter31-maximal.cypress.spec.js
@@ -15,6 +15,7 @@ const testConfig = createTestConfig(
     fixtures: { data: path.join(__dirname, 'formDataSets') },
     setupPerTest: () => {
       window.sessionStorage.removeItem('wizardStatus31');
+      cy.login();
       cy.intercept('GET', '/v0/feature_toggles*', {
         data: {
           type: 'feature_toggles',
@@ -26,6 +27,18 @@ const testConfig = createTestConfig(
           ],
         },
       });
+      cy.intercept('GET', '/v0/backend_statuses', {
+        data: {
+          type: 'feature_toggles',
+          features: [
+            {
+              name: 'show_chapter_31',
+              value: true,
+            },
+          ],
+        },
+      });
+
       cy.intercept('POST', '/v0/veteran_readiness_employment_claims', {
         formSubmissionId: '123fake-submission-id-567',
         timestamp: '2020-11-12',
@@ -60,7 +73,7 @@ const testConfig = createTestConfig(
           .click();
         cy.injectAxe();
         afterHook(() => {
-          cy.get('.va-button-link.schemaform-start-button:first').click();
+          cy.get('#1-continueButton').click();
         });
       },
       'veteran-contact-information': ({ afterHook }) => {


### PR DESCRIPTION
## Description
[Original Ticlet](https://github.com/department-of-veterans-affairs/va.gov-team/issues/23020)

In order to stop users from directly hitting the URLs on the chapter 31 form in an unauthorized state, we put in a redirect so they will be sent back to the introduction page of the form. Meanwhile, during the sprint, we also made an update to the base URL for the chapter 31 form [in this ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/23014). The timeline of the merges made it so that we now need a separate PR to update the URL in the redirect of the original ticket, this is that PR. 


## Acceptance criteria
- [x] The URL is updated in the unauthorized redirect


