### PR TITLE
skip test chp31 e2e

### DIFF
--- a/src/applications/vre/28-1900/tests/e2e/chapter31-maximal.cypress.spec.js
+++ b/src/applications/vre/28-1900/tests/e2e/chapter31-maximal.cypress.spec.js
@@ -10,6 +10,7 @@ Cypress.config('waitForAnimations', true);
 
 const testConfig = createTestConfig(
   {
+    skip: ['chapter31-maximal'],
     dataPrefix: 'data',
     dataSets: ['chapter31-maximal'],
     fixtures: { data: path.join(__dirname, 'formDataSets') },


### PR DESCRIPTION
## Description


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
