### PR TITLE
Update claim list styling

### DIFF
--- a/src/applications/claims-status/components/StemClaimListItem.jsx
+++ b/src/applications/claims-status/components/StemClaimListItem.jsx
@@ -30,11 +30,10 @@ export default function StemClaimListItem({ claim }) {
       </div>
       <Link
         aria-label={`View details of claim received ${formattedReceiptDate}`}
-        className="usa-button usa-button-primary"
+        className="va-action-link--blue"
         to={`your-stem-claims/${claim.id}/status`}
       >
         View details
-        <i className="fa fa-chevron-right" aria-hidden="true" />
       </Link>
     </div>
   );

--- a/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
+++ b/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
@@ -115,21 +115,19 @@ export default function AppealListItem({ appeal, name, external = false }) {
       )}
       {!external && (
         <Link
-          className="usa-button usa-button-primary"
+          className="va-action-link--blue"
           to={`appeals/${appeal.id}/status`}
         >
           View details
-          <i className="fa fa-chevron-right" />
         </Link>
       )}
       {external && (
         <Link
           aria-label={`View details of ${appealTitle} `}
-          className="usa-button usa-button-primary"
+          className="va-action-link--blue"
           href={`/track-claims/appeals/${appeal.id}/status`}
         >
           View details
-          <i className="fa fa-chevron-right" />
         </Link>
       )}
     </div>

--- a/src/applications/claims-status/components/appeals-v2/ClaimsListItemV2.jsx
+++ b/src/applications/claims-status/components/appeals-v2/ClaimsListItemV2.jsx
@@ -63,11 +63,10 @@ export default function ClaimsListItem({ claim }) {
       </div>
       <Link
         aria-label={`View details of claim received ${formattedReceiptDate}`}
-        className="usa-button usa-button-primary"
+        className="va-action-link--blue"
         to={`your-claims/${claim.id}/status`}
       >
         View details
-        <i className="fa fa-chevron-right" />
       </Link>
     </div>
   );

--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -3,6 +3,8 @@
 @import "~@department-of-veterans-affairs/formation/sass/modules/va-pagination";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
+@import "~@department-of-veterans-affairs/formation/sass/modules/m-action-link";
+@import "~@department-of-veterans-affairs/formation/sass/modules/va-tabs";
 @import "~@department-of-veterans-affairs/formation/sass/modules/va-tabs";
 
 $color-inactive: #9b9b9b;

--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -5,7 +5,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-action-link";
 @import "~@department-of-veterans-affairs/formation/sass/modules/va-tabs";
-@import "~@department-of-veterans-affairs/formation/sass/modules/va-tabs";
 
 $color-inactive: #9b9b9b;
 

--- a/src/applications/claims-status/tests/e2e/00.claims-list.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/00.claims-list.e2e.spec.js
@@ -43,7 +43,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
 
   // Click to detail view
   client
-    .click('.claim-list-item-container:first-child a.usa-button-primary')
+    .click('.claim-list-item-container:first-child a.va-action-link--blue')
     .assert.urlContains('/your-claims/11/status');
 
   client.end();

--- a/src/applications/claims-status/tests/e2e/01.claim-status-decision.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-decision.e2e.spec.js
@@ -15,7 +15,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
   );
 
   client
-    .click('.claim-list-item-container:first-child a.usa-button-primary')
+    .click('.claim-list-item-container:first-child a.va-action-link--blue')
     .waitForElementVisible('body', Timeouts.normal)
     .waitForElementVisible('.claim-title', Timeouts.slow)
     .axeCheck('.main');

--- a/src/applications/claims-status/tests/e2e/01.claim-status-est-current.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-est-current.e2e.spec.js
@@ -26,7 +26,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
   );
 
   client
-    .click('.claim-list-item-container:first-child a.usa-button-primary')
+    .click('.claim-list-item-container:first-child a.va-action-link--blue')
     .waitForElementVisible('body', Timeouts.normal)
     .waitForElementVisible('.claim-title', Timeouts.slow)
     .axeCheck('.main');

--- a/src/applications/claims-status/tests/e2e/01.claim-status-est-past.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-est-past.e2e.spec.js
@@ -26,7 +26,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
   );
 
   client
-    .click('.claim-list-item-container:first-child a.usa-button-primary')
+    .click('.claim-list-item-container:first-child a.va-action-link--blue')
     .waitForElementVisible('body', Timeouts.normal)
     .waitForElementVisible('.claim-title', Timeouts.slow)
     .axeCheck('.main');

--- a/src/applications/claims-status/tests/e2e/01.claim-status-est.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-est.e2e.spec.js
@@ -26,7 +26,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
   );
 
   client
-    .click('.claim-list-item-container:first-child a.usa-button-primary')
+    .click('.claim-list-item-container:first-child a.va-action-link--blue')
     .waitForElementVisible('body', Timeouts.normal)
     .waitForElementVisible('.claim-title', Timeouts.slow)
     .axeCheck('.main');

--- a/src/applications/claims-status/tests/e2e/01.claim-status.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status.e2e.spec.js
@@ -16,7 +16,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
   );
 
   client
-    .click('.claim-list-item-container:first-child a.usa-button-primary')
+    .click('.claim-list-item-container:first-child a.va-action-link--blue')
     .waitForElementVisible('body', Timeouts.slow)
     .waitForElementVisible('.claim-title', Timeouts.slow);
 

--- a/src/applications/claims-status/tests/e2e/02.claim-files.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/02.claim-files.e2e.spec.js
@@ -14,7 +14,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
     Timeouts.slow,
   );
   client
-    .click('.claim-list-item-container:first-child a.usa-button-primary')
+    .click('.claim-list-item-container:first-child a.va-action-link--blue')
     .waitForElementVisible('body', Timeouts.normal)
     .waitForElementVisible('.claim-title', Timeouts.slow);
 

--- a/src/applications/claims-status/tests/e2e/03.claim-details.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/03.claim-details.e2e.spec.js
@@ -14,7 +14,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
     Timeouts.slow,
   );
   client
-    .click('.claim-list-item-container:first-child a.usa-button-primary')
+    .click('.claim-list-item-container:first-child a.va-action-link--blue')
     .waitForElementVisible('body', Timeouts.normal)
     .waitForElementVisible('.claim-title', Timeouts.slow);
 

--- a/src/applications/claims-status/tests/e2e/04.claim-ask-va.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/04.claim-ask-va.e2e.spec.js
@@ -18,7 +18,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
   );
 
   client
-    .click('.claim-list-item-container:first-child a.usa-button-primary')
+    .click('.claim-list-item-container:first-child a.va-action-link--blue')
     .waitForElementVisible('body', Timeouts.normal)
     .waitForElementVisible('.claim-title', Timeouts.slow)
     .axeCheck('.main');

--- a/src/applications/claims-status/tests/e2e/05.claim-additional-evidence.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/05.claim-additional-evidence.e2e.spec.js
@@ -15,7 +15,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
     Timeouts.slow,
   );
   client
-    .click('.claim-list-item-container:first-child a.usa-button-primary')
+    .click('.claim-list-item-container:first-child a.va-action-link--blue')
     .waitForElementVisible('body', Timeouts.normal)
     .waitForElementVisible('.claim-title', Timeouts.normal);
 

--- a/src/applications/claims-status/tests/e2e/05.claim-document-request.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/05.claim-document-request.e2e.spec.js
@@ -16,7 +16,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
   );
 
   client
-    .click('.claim-list-item-container:first-child a.usa-button-primary')
+    .click('.claim-list-item-container:first-child a.va-action-link--blue')
     .waitForElementVisible('body', Timeouts.normal)
     .waitForElementVisible('.claim-title', Timeouts.normal);
 

--- a/src/applications/claims-status/tests/e2e/06-claim-estimation-breadcrumb.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/06-claim-estimation-breadcrumb.e2e.spec.js
@@ -15,7 +15,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
     Timeouts.slow,
   );
   client
-    .click('.claim-list-item-container:first-child a.usa-button-primary')
+    .click('.claim-list-item-container:first-child a.va-action-link--blue')
     .waitForElementVisible('body', Timeouts.normal)
     .waitForElementVisible('.claim-title', Timeouts.normal)
     .axeCheck('.main');

--- a/src/applications/claims-status/tests/e2e/06.claim-estimation.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/06.claim-estimation.e2e.spec.js
@@ -15,7 +15,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
     Timeouts.slow,
   );
   client
-    .click('.claim-list-item-container:first-child a.usa-button-primary')
+    .click('.claim-list-item-container:first-child a.va-action-link--blue')
     .waitForElementVisible('body', Timeouts.normal)
     .waitForElementVisible('.claim-title', Timeouts.normal)
     .axeCheck('.main');


### PR DESCRIPTION
## Description
Updated the view details styling on the claim status cards so that it is consistent with DEPO patterns and practices.

## Testing done
Tested locally and QA reviewed

## Screenshots
![image](https://user-images.githubusercontent.com/41960449/114564144-0faf8a80-9c3e-11eb-9beb-20ce5ebb686b.png)


## Acceptance criteria
- [x] The ‘View details’ button is styled as a Secondary Action Link

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
