### PR TITLE
Remove 1 dose only reference

### DIFF
--- a/src/applications/vaos/project-cheetah/components/SecondDosePage.jsx
+++ b/src/applications/vaos/project-cheetah/components/SecondDosePage.jsx
@@ -30,14 +30,8 @@ function SecondDosePage({
       <h1>{pageTitle}</h1>
       <div className="vads-u-margin-bottom--4">
         <p>
-          If you need a second dose, you may need to return to the{' '}
-          {facility.name} after the dates below, depending on which vaccine you
-          receive:
-        </p>
-        <p>
-          If you receive your first dose on{' '}
-          <strong>{moment(date1[0]).format('dddd, MMMM DD, YYYY ')} </strong>
-          and receive:
+          You’ll need to return to the {facility.name} after the dates below,
+          depending on which vaccine you receive:
         </p>
         <h2 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-bottom--0 vads-u-font-weight--normal">
           Moderna
@@ -66,11 +60,6 @@ function SecondDosePage({
               .format('dddd, MMMM DD, YYYY')}
           </strong>
         </div>
-        <hr aria-hidden="true" className="vads-u-margin-y--2" />
-        <h2 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-bottom--0 vaos-appts__block-label  vads-u-font-weight--normal">
-          Johnson & Johnson
-        </h2>
-        <div>1 dose only</div>
       </div>
       <FormButtons
         pageChangeInProgress={pageChangeInProgress}

--- a/src/applications/vaos/tests/project-cheetah/components/SecondDosePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/project-cheetah/components/SecondDosePage.unit.spec.jsx
@@ -56,17 +56,11 @@ describe('VAOS vaccine flow <SecondDosePage>', () => {
     ).to.have.tagName('h1');
     expect(
       screen.getByText(
-        /You may need to return to the Cheyenne VA Medical Center/i,
+        /You’ll need to return to the Cheyenne VA Medical Center/i,
       ),
     ).to.be.ok;
     expect(screen.getByText('Moderna')).to.have.tagName('h2');
     expect(screen.getByText('Pfizer')).to.have.tagName('h2');
-    expect(screen.getByText('Johnson & Johnson')).to.have.tagName('h2');
-    expect(screen.baseElement).to.contain.text(
-      `If you receive your first dose on ${start.format(
-        'dddd, MMMM DD, YYYY',
-      )}`,
-    );
     expect(
       screen.getByText(
         new RegExp(
@@ -89,8 +83,6 @@ describe('VAOS vaccine flow <SecondDosePage>', () => {
         ),
       ),
     ).to.be.ok;
-    // Johnson & Johnson
-    expect(screen.getByText('1 dose only')).to.be.ok;
   });
 
   xit('should show additional message after user clicks the expand link', async () => {


### PR DESCRIPTION
## Description
need to remove explicit references to J&J vaccine in the vaccine flow.

## Testing done
unit and local test

## Screenshots
![image](https://user-images.githubusercontent.com/54327023/114579937-5e642100-9c4c-11eb-842b-a78a8d0469df.png)


## Acceptance criteria
- [ ] Match text copy from https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/products/health-care/covid-vaccine-distro/vaos-for-distribution-initiative/copy-docs/second-dose.md
- [ ] change the text to: `You'll need to return to the {Facility Name} after the dates below, depending on which vaccine you receive: `
- [ ] Remove J&J dose information

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
