### PR TITLE
Fix fetching messages loading state

### DIFF
--- a/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
+++ b/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
@@ -91,7 +91,7 @@ const HealthCare = ({
 
   const messagesText =
     shouldFetchMessages && !hasInboxError
-      ? `You have ${unreadMessagesCount} new message${
+      ? `You have ${unreadMessagesCount} unread message${
           unreadMessagesCount === 1 ? '' : 's'
         }`
       : 'Send a secure message to your health care team';

--- a/src/applications/personalization/dashboard-2/tests/unit/healthcare-messaging.unit.spec.jsx
+++ b/src/applications/personalization/dashboard-2/tests/unit/healthcare-messaging.unit.spec.jsx
@@ -92,7 +92,7 @@ describe('HealthCare component', () => {
         reducers,
       });
       expect(
-        await view.findByRole('link', { name: /you have 0 new messages/i }),
+        await view.findByRole('link', { name: /you have 0 unread messages/i }),
       ).to.exist;
     });
   });

--- a/src/applications/personalization/dashboard-2/tests/unit/healthcare-messaging.unit.spec.jsx
+++ b/src/applications/personalization/dashboard-2/tests/unit/healthcare-messaging.unit.spec.jsx
@@ -70,7 +70,7 @@ describe('HealthCare component', () => {
       });
       expect(view.queryByRole('progressbar')).not.to.exist;
       expect(
-        await view.findByRole('link', { name: /you have 3 new messages/i }),
+        await view.findByRole('link', { name: /you have 3 unread messages/i }),
       ).to.exist;
     });
 
@@ -80,8 +80,9 @@ describe('HealthCare component', () => {
         initialState,
         reducers,
       });
-      expect(await view.findByRole('link', { name: /you have 1 new message/i }))
-        .to.exist;
+      expect(
+        await view.findByRole('link', { name: /you have 1 unread message/i }),
+      ).to.exist;
     });
 
     it('should render the unread messages count with 0 messages', async () => {

--- a/src/applications/personalization/dashboard/reducers/folders.js
+++ b/src/applications/personalization/dashboard/reducers/folders.js
@@ -98,6 +98,7 @@ export default function folders(state = initialState, action) {
             visible: false,
           },
           lastRequestedFolder: action.request,
+          fetching: true,
         },
         newState,
       );

--- a/src/applications/personalization/dashboard/reducers/folders.js
+++ b/src/applications/personalization/dashboard/reducers/folders.js
@@ -85,7 +85,10 @@ export default function folders(state = initialState, action) {
     case LOADING_FOLDER: {
       const newState = set(
         'data.currentItem',
-        initialState.data.currentItem,
+        {
+          ...initialState.data.currentItem,
+          fetching: true,
+        },
         state,
       );
 
@@ -98,7 +101,6 @@ export default function folders(state = initialState, action) {
             visible: false,
           },
           lastRequestedFolder: action.request,
-          fetching: true,
         },
         newState,
       );


### PR DESCRIPTION
## Description
We needed to add `fetching: true` to the `currentItem` in the `folder` to make sure we show the loading spinner in the Health Care section when we are still fetching the messages count.

## Testing done
The fetching property is now set correctly locally

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/114593361-417a1e80-9c49-11eb-94aa-4691c7c4897a.png)

![image](https://user-images.githubusercontent.com/14869324/114593388-4939c300-9c49-11eb-90c9-d399b2027e9b.png)


## Acceptance criteria
- [x] Fix fetching state folders

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
