### PR TITLE
NOD: update path

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1062,8 +1062,8 @@
   },
   {
     "appName": "Request a Board Appeal",
-    "entryName": "10182-notice-of-disagreement",
-    "rootUrl": "/decision-reviews/board-appeal/request-notice-of-disagreement-form-10182",
+    "entryName": "10182-board-appeal",
+    "rootUrl": "/decision-reviews/board-appeal/request-board-review-form-10182",
     "template": {
       "title": "Request a Board Appeal",
       "heading": "Request a Board Appeal",
@@ -1083,8 +1083,8 @@
           "path": "/decision-reviews/board-appeal"
         },
         {
-          "name": "Request a Board Appeal",
-          "path": "/decision-reviews/board-appeal/request-notice-of-disagreement-form-10182"
+          "name": "Request a Board Appeal with VA Form 10182",
+          "path": "/decision-reviews/board-appeal/request-board-review-form-10182"
         }
       ]
     }


### PR DESCRIPTION
## Description

IA has completed their review. A path to the Board Appeals (Form 10182 - Notice of Disagreement) form will be changed to: 

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/21819
- https://github.com/department-of-veterans-affairs/devops/pull/8951
- https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/information-architecture/ia-reviews/bam-board-appeal.md

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] Path to Form 10182 matches IA determination

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
