### PR TITLE
[23019] CC Facility Type

### DIFF
--- a/src/applications/vaos/new-appointment/components/CommunityCarePreferencesPage.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCarePreferencesPage.jsx
@@ -82,7 +82,7 @@ const uiSchema = {
     'ui:description': (
       <p className="vads-u-font-family--sans vads-u-font-weight--normal vads-u-margin-top--1">
         Use the{' '}
-        <NewTabAnchor href="/find-locations/?facilityType=cc_provider">
+        <NewTabAnchor href="/find-locations/?facilityType=provider">
           facility locator
         </NewTabAnchor>{' '}
         to find your preferred community care provider. Copy and paste their

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCarePreferencesPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCarePreferencesPage.unit.spec.jsx
@@ -83,7 +83,7 @@ describe('VAOS <CommunityCarePreferencesPage>', () => {
     expect(screen.getAllByRole('combobox').length).to.equal(2);
     expect(
       screen.getByRole('link', { name: /facility locator/i }),
-    ).to.have.attribute('href', '/find-locations/?facilityType=cc_provider');
+    ).to.have.attribute('href', '/find-locations/?facilityType=provider');
     expect(screen.baseElement).to.contain.text(
       'We’ll try to schedule your appointment',
     );


### PR DESCRIPTION
## Description
The Facilities team notified us of a change to pre-populate the Facility Type field for community care in FL.

### How to check
- Go to review instance then /health-care/schedule-view-va-appointments/appointments/ on 
- Go through CC flow to provider (old) preference page
- For "Do you have a preferred VA-approved community care provider..?" select Yes
- Click facility locator link

## Testing done
Local

## Screenshots
n/a

## Acceptance criteria
- [ ] Facility Locator Route is `/find-locations/?facilityType=provider`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
