### PR TITLE
Stop polling for claims data after 45 seconds

### DIFF
--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -152,16 +152,17 @@ export function fetchClaimsSuccess(response) {
   };
 }
 
-export function pollRequest({
-  onError,
-  onSuccess,
-  pollingExpiration,
-  pollingInterval,
-  request = apiRequest,
-  shouldFail,
-  shouldSucceed,
-  target,
-}) {
+export function pollRequest(options) {
+  const {
+    onError,
+    onSuccess,
+    pollingExpiration,
+    pollingInterval,
+    request = apiRequest,
+    shouldFail,
+    shouldSucceed,
+    target,
+  } = options;
   return request(
     target,
     null,
@@ -181,16 +182,7 @@ export function pollRequest({
         return;
       }
 
-      setTimeout(pollRequest, pollingInterval, {
-        onError,
-        onSuccess,
-        pollingExpiration,
-        pollingInterval,
-        request,
-        shouldFail,
-        shouldSucceed,
-        target,
-      });
+      setTimeout(pollRequest, pollingInterval, options);
     },
     error => onError(error),
   );

--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -201,6 +201,17 @@ export function getSyncStatus(claimsAsyncResponse) {
 }
 
 export function getClaimsV2(options = {}) {
+  // Throw an error if an unsupported value is on the `options` object
+  const recognizedOptions = ['poll', 'pollingExpiration'];
+  Object.keys(options).forEach(option => {
+    if (!recognizedOptions.includes(option)) {
+      throw new TypeError(
+        `Unrecognized option "${option}" passed to "getClaimsV2"\nOnly the following options are supported:\n${recognizedOptions.join(
+          '\n',
+        )}`,
+      );
+    }
+  });
   const { poll = pollRequest, pollingExpiration } = options;
   return dispatch => {
     dispatch({ type: FETCH_CLAIMS_PENDING });

--- a/src/applications/claims-status/tests/actions.unit.spec.js
+++ b/src/applications/claims-status/tests/actions.unit.spec.js
@@ -294,7 +294,7 @@ describe('Actions', () => {
     it('should call dispatch and pollStatus', () => {
       const dispatchSpy = sinon.spy();
       const pollStatusSpy = sinon.spy();
-      getClaimsV2(pollStatusSpy)(dispatchSpy);
+      getClaimsV2({ poll: pollStatusSpy })(dispatchSpy);
 
       expect(dispatchSpy.firstCall.args[0]).to.eql({
         type: 'FETCH_CLAIMS_PENDING',
@@ -306,7 +306,7 @@ describe('Actions', () => {
       it('should dispatch a FETCH_CLAIMS_ERROR action', () => {
         const dispatchSpy = sinon.spy();
         const pollStatusSpy = sinon.spy();
-        getClaimsV2(pollStatusSpy)(dispatchSpy);
+        getClaimsV2({ poll: pollStatusSpy })(dispatchSpy);
 
         pollStatusSpy.firstCall.args[0].onError({ errors: [] });
 
@@ -319,7 +319,7 @@ describe('Actions', () => {
       it('should dispatch a FETCH_CLAIMS_SUCCESS action', () => {
         const dispatchSpy = sinon.spy();
         const pollStatusSpy = sinon.spy();
-        getClaimsV2(pollStatusSpy)(dispatchSpy);
+        getClaimsV2({ poll: pollStatusSpy })(dispatchSpy);
 
         pollStatusSpy.firstCall.args[0].onSuccess({ data: [] });
 
@@ -334,7 +334,7 @@ describe('Actions', () => {
       it('should return true when response.meta.syncStatus is FAILED', () => {
         const dispatchSpy = sinon.spy();
         const pollStatusSpy = sinon.spy();
-        getClaimsV2(pollStatusSpy)(dispatchSpy);
+        getClaimsV2({ poll: pollStatusSpy })(dispatchSpy);
 
         const shouldFail = pollStatusSpy.firstCall.args[0].shouldFail({
           meta: { syncStatus: 'FAILED' },
@@ -345,7 +345,7 @@ describe('Actions', () => {
       it('should return false when response.meta.syncStatus is not FAILED', () => {
         const dispatchSpy = sinon.spy();
         const pollStatusSpy = sinon.spy();
-        getClaimsV2(pollStatusSpy)(dispatchSpy);
+        getClaimsV2({ poll: pollStatusSpy })(dispatchSpy);
 
         const shouldFail = pollStatusSpy.firstCall.args[0].shouldFail({});
 
@@ -356,7 +356,7 @@ describe('Actions', () => {
       it('should return true when response.meta.syncStatus is SUCCESS', () => {
         const dispatchSpy = sinon.spy();
         const pollStatusSpy = sinon.spy();
-        getClaimsV2(pollStatusSpy)(dispatchSpy);
+        getClaimsV2({ poll: pollStatusSpy })(dispatchSpy);
 
         const shouldSucceed = pollStatusSpy.firstCall.args[0].shouldSucceed({
           meta: { syncStatus: 'SUCCESS' },
@@ -367,7 +367,7 @@ describe('Actions', () => {
       it('should return false when response.meta.syncStatus is not SUCCESS', () => {
         const dispatchSpy = sinon.spy();
         const pollStatusSpy = sinon.spy();
-        getClaimsV2(pollStatusSpy)(dispatchSpy);
+        getClaimsV2({ poll: pollStatusSpy })(dispatchSpy);
 
         const shouldSucceed = pollStatusSpy.firstCall.args[0].shouldSucceed({});
 

--- a/src/applications/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/applications/claims-status/utils/appeals-v2-helpers.jsx
@@ -2119,9 +2119,7 @@ export const getErrorStatus = response => {
       Sentry.captureException(response);
     });
   }
-  return response.errors && response.errors.length
-    ? response.errors[0].status
-    : UNKNOWN_STATUS;
+  return response?.errors?.[0]?.status ?? UNKNOWN_STATUS;
 };
 
 // Series of utility functions to sort claims and appeals by last updated date

--- a/src/applications/personalization/dashboard-2/components/claims-and-appeals/ClaimsAndAppeals.jsx
+++ b/src/applications/personalization/dashboard-2/components/claims-and-appeals/ClaimsAndAppeals.jsx
@@ -53,7 +53,8 @@ const ClaimsAndAppeals = ({
   React.useEffect(
     () => {
       if (!dataLoadingDisabled && shouldLoadClaims) {
-        loadClaims();
+        // stop polling the claims API after 45 seconds
+        loadClaims({ pollingExpiration: Date.now() + 45 * 1000 });
       }
     },
     [dataLoadingDisabled, loadClaims, shouldLoadClaims],
@@ -78,7 +79,7 @@ const ClaimsAndAppeals = ({
   }
 
   if (shouldShowLoadingIndicator) {
-    return <LoadingIndicator />;
+    return <LoadingIndicator message="We’re loading your information." />;
   }
 
   if (hasAPIError) {


### PR DESCRIPTION
## Description
The evss claims endpoint can take a long time to resolve. We've decided to just fail and treat it like an error if it still has not resolved after 45 seconds. https://github.com/department-of-veterans-affairs/va.gov-team/issues/22565

## Testing done
Local in Cypress

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs