### PR TITLE
Fix font size for cc header on details page

### DIFF
--- a/src/applications/vaos/appointment-list/components/CommunityCareAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/CommunityCareAppointmentDetailsPage.jsx
@@ -93,7 +93,7 @@ function CommunityCareAppointmentDetailsPage({
       </h1>
 
       <h2
-        className="vads-u-font-size--sm vads-u-font-family--sans"
+        className="vads-u-font-size--base vads-u-font-family--sans"
         data-cy="community-care-appointment-details-header"
       >
         <span>


### PR DESCRIPTION
## Description
This PR
- Changes font class to match other similar headers on page
- Does not make any semantic heading tag changes, since those have been fixed since the associated ticket was written

## Testing done
Local testing

## Screenshots
![Screen Shot 2021-04-14 at 10 02 01 AM](https://user-images.githubusercontent.com/634932/114723195-79946680-9d08-11eb-80a4-469bdff50a45.png)

## Acceptance criteria
- [ ] Fonts are correct

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
