### PR TITLE
[23101] Remove Reschedule Link

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/index.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/index.jsx
@@ -281,14 +281,6 @@ function ConfirmedAppointmentDetailsPage({
                   </button>
                 </div>
 
-                <div className="vads-u-margin-top--2 vaos-appts__block-label vaos-hide-for-print">
-                  <i
-                    aria-hidden="true"
-                    className="fas fa-clock vads-u-margin-right--1"
-                  />
-                  <a href="#">Reschedule</a>
-                </div>
-
                 {showCancelButton && (
                   <div className="vads-u-margin-top--2 vaos-appts__block-label vaos-hide-for-print">
                     <i

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
@@ -161,7 +161,6 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       }),
     ).to.be.ok;
     expect(screen.getByText(/Print/)).to.be.ok;
-    expect(screen.getByRole('link', { name: /Reschedule/ })).to.be.ok;
 
     const button = screen.getByRole('button', {
       name: /Go back to appointments/,


### PR DESCRIPTION
## Description
The appointment reschedule functionality will be implemented as a separate initiative from the homepage refresh work (though dependent on it). Links and CTAs to reschedule should not appear.

## Testing done
Local and Unit

## Screenshots
![image](https://user-images.githubusercontent.com/8315447/114730824-35589480-9d0f-11eb-95fe-ba7a6061495b.png)


## Acceptance criteria
- [ ] Reschedule link does not display on any appointment details

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
