### PR TITLE
Add enddate to appointments query

### DIFF
--- a/src/applications/personalization/appointments/actions/index.js
+++ b/src/applications/personalization/appointments/actions/index.js
@@ -84,17 +84,23 @@ export function fetchConfirmedFutureAppointments() {
       .startOf('day')
       .toISOString();
 
+    // Maximum number of days you can schedule an appointment in advance in VAOS
+    const endDate = moment()
+      .add(395, 'days')
+      .startOf('day')
+      .toISOString();
+
     try {
       if (environment.isLocalhost() && !window.Cypress) {
         vaAppointments = MOCK_VA_APPOINTMENTS;
         ccAppointments = MOCK_CC_APPOINTMENTS;
       } else {
         vaAppointments = await apiRequest(
-          `/appointments?start_date=${startOfToday}&type=va`,
+          `/appointments?start_date=${startOfToday}&end_date=${endDate}&type=va`,
           { apiVersion: 'vaos/v0' },
         );
         ccAppointments = await apiRequest(
-          `/appointments?start_date=${startOfToday}&type=cc`,
+          `/appointments?start_date=${startOfToday}&end_date=${endDate}&type=cc`,
           { apiVersion: 'vaos/v0' },
         );
       }


### PR DESCRIPTION
## Description
While wiring up appointments, I did not know that the `endDate` param was required. Not having this param resulted in the query failing on staging.

## Testing done
Tested that the query format is exactly the same as the VAOS tool.

## Screenshots
Network request at the url `health-care/schedule-view-va-appointments/appointments/`
![image](https://user-images.githubusercontent.com/14869324/114742957-7352ba00-9d09-11eb-915d-50afe81b0775.png)

console.log of my new query string = `/appointments?start_date=2021-04-14T06:00:00.000Z&end_date=2022-05-14T06:00:00.000Z&type=va`

## Acceptance criteria
- [x] Add an end date to the appointments query

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
