### PR TITLE
FSR Wizard Screen Reader Enchantment 

### DIFF
--- a/src/applications/financial-status-report/wizard/DelayedLiveRegion.jsx
+++ b/src/applications/financial-status-report/wizard/DelayedLiveRegion.jsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+
+/* aria-live region must be on the screen FIRST when rendering conditional content
+   artificial delay on the content so it will always render second and the region will announce the updated conditional content
+   not wrapping the wizard as a whole to avoid a overly verbose experience on screen readers */
+const DelayedLiveRegion = ({ children, delay = 100 }) => {
+  const [timer, setTimer] = useState(0);
+  const [showContent, setShowContent] = useState(false);
+  const shouldRenderContent = showContent;
+
+  useEffect(
+    () => {
+      let interval = null;
+
+      if (interval === null) {
+        interval = setInterval(() => {
+          setTimer(milliseconds => milliseconds + 1);
+        }, 1);
+      }
+
+      if (delay + 1 === timer) {
+        setShowContent(true);
+        clearInterval(interval);
+      }
+
+      return () => {
+        clearInterval(interval);
+        setShowContent(false);
+      };
+    },
+    [timer, delay],
+  );
+
+  return (
+    <section
+      aria-live="polite"
+      aria-atomic="true"
+      aria-labelledby="wizard-results"
+    >
+      {shouldRenderContent && children}
+    </section>
+  );
+};
+
+DelayedLiveRegion.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]).isRequired,
+  delay: PropTypes.number,
+};
+
+export default DelayedLiveRegion;

--- a/src/applications/financial-status-report/wizard/WizardContainer.jsx
+++ b/src/applications/financial-status-report/wizard/WizardContainer.jsx
@@ -47,11 +47,14 @@ const WizardContainer = ({ setWizardStatus }) => {
               learn how to request financial hardship assistance.
             </a>
           </p>
-          <Wizard
-            pages={pages}
-            expander={false}
-            setWizardStatus={setWizardStatus}
-          />
+
+          <section aria-live="polite">
+            <Wizard
+              pages={pages}
+              expander={false}
+              setWizardStatus={setWizardStatus}
+            />
+          </section>
         </div>
         <div className="help-container">
           <h2 className="help-heading">Need help?</h2>

--- a/src/applications/financial-status-report/wizard/pages/Appeals.jsx
+++ b/src/applications/financial-status-report/wizard/pages/Appeals.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import recordEvent from 'platform/monitoring/record-event';
 import { PAGE_NAMES } from '../constants';
+import DelayedLiveRegion from '../DelayedLiveRegion';
 
 const Appeals = () => {
   useEffect(() => {
@@ -12,62 +13,67 @@ const Appeals = () => {
   }, []);
 
   return (
-    <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
-      <p className="vads-u-margin-top--0">
-        Based on the information you provided, this isn’t the form you need.
-      </p>
-      <p className="vads-u-margin-bottom--0">
-        <strong>
-          If you disagree with our decision on your waiver request,
-        </strong>{' '}
-        you can{' '}
-        <a
-          href="/decision-reviews/board-appeal/"
-          onClick={() => {
-            recordEvent({
-              event: 'howToWizard-alert-link-click',
-              'howToWizard-alert-link-click-label': 'request a Board Appeal',
-            });
-          }}
+    <DelayedLiveRegion>
+      <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
+        <h2
+          className="vads-u-margin-top--0 vads-u-font-size--h6 vads-u-font-weight--normal vads-u-font-family--sans"
+          id="wizard-results"
         >
-          request a Board Appeal
-        </a>
-        . When you choose this option, you appeal to a Veterans Law Judge at the
-        Board of Veterans' Appeals in Washington, D.C. A judge who’s an expert
-        in Veterans law will review your case.
-      </p>
-      <p className="vads-u-margin-top--1">
-        <a
-          href="/decision-reviews/board-appeal/"
-          onClick={() => {
-            recordEvent({
-              event: 'howToWizard-alert-link-click',
-              'howToWizard-alert-link-click-label':
-                'Find out how to request a Board Appeal',
-            });
-          }}
-        >
-          Find out how to request a Board Appeal
-        </a>
-      </p>
-      <p>
-        <strong>Note: </strong>
-        You have one year from the date on your decision letter to request a
-        Board Appeal, unless you have a{' '}
-        <a
-          href="/decision-reviews/contested-claims"
-          onClick={() => {
-            recordEvent({
-              event: 'howToWizard-alert-link-click',
-              'howToWizard-alert-link-click-label': 'contested claim',
-            });
-          }}
-        >
-          contested claim
-        </a>
-        .
-      </p>
-    </div>
+          Based on the information you provided, this isn’t the form you need.
+        </h2>
+        <p className="vads-u-margin-bottom--0">
+          <strong>
+            If you disagree with our decision on your waiver request,
+          </strong>{' '}
+          you can{' '}
+          <a
+            href="/decision-reviews/board-appeal/"
+            onClick={() => {
+              recordEvent({
+                event: 'howToWizard-alert-link-click',
+                'howToWizard-alert-link-click-label': 'request a Board Appeal',
+              });
+            }}
+          >
+            request a Board Appeal
+          </a>
+          . When you choose this option, you appeal to a Veterans Law Judge at
+          the Board of Veterans' Appeals in Washington, D.C. A judge who’s an
+          expert in Veterans law will review your case.
+        </p>
+        <p className="vads-u-margin-top--1">
+          <a
+            href="/decision-reviews/board-appeal/"
+            onClick={() => {
+              recordEvent({
+                event: 'howToWizard-alert-link-click',
+                'howToWizard-alert-link-click-label':
+                  'Find out how to request a Board Appeal',
+              });
+            }}
+          >
+            Find out how to request a Board Appeal
+          </a>
+        </p>
+        <p>
+          <strong>Note: </strong>
+          You have one year from the date on your decision letter to request a
+          Board Appeal, unless you have a{' '}
+          <a
+            href="/decision-reviews/contested-claims"
+            onClick={() => {
+              recordEvent({
+                event: 'howToWizard-alert-link-click',
+                'howToWizard-alert-link-click-label': 'contested claim',
+              });
+            }}
+          >
+            contested claim
+          </a>
+          .
+        </p>
+      </div>
+    </DelayedLiveRegion>
   );
 };
 

--- a/src/applications/financial-status-report/wizard/pages/Benefits.jsx
+++ b/src/applications/financial-status-report/wizard/pages/Benefits.jsx
@@ -5,6 +5,7 @@ import Telephone, {
   CONTACTS,
   PATTERNS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
+import DelayedLiveRegion from '../DelayedLiveRegion';
 
 const ContactBenefits = () => {
   useEffect(() => {
@@ -15,20 +16,25 @@ const ContactBenefits = () => {
   }, []);
 
   return (
-    <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
-      <p className="vads-u-margin-top--0">
-        Based on the information you provided, this isn’t the form you need.
-      </p>
-      <p>
-        <strong>
-          For help with debt related to separation pay/attorney fees
-        </strong>
-        , call us at <Telephone contact={'800-827-1000'} />. We're here Monday
-        through Friday, 8:00 a.m. to 8:00 p.m. ET. If you have hearing loss,
-        call TTY:{' '}
-        <Telephone contact={CONTACTS[711]} pattern={PATTERNS['3_DIGIT']} />.
-      </p>
-    </div>
+    <DelayedLiveRegion>
+      <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
+        <h2
+          className="vads-u-margin-top--0 vads-u-font-size--h6 vads-u-font-weight--normal vads-u-font-family--sans"
+          id="wizard-results"
+        >
+          Based on the information you provided, this isn’t the form you need.
+        </h2>
+        <p>
+          <strong>
+            For help with debt related to separation pay/attorney fees
+          </strong>
+          , call us at <Telephone contact={'800-827-1000'} />. We're here Monday
+          through Friday, 8:00 a.m. to 8:00 p.m. ET. If you have hearing loss,
+          call TTY:{' '}
+          <Telephone contact={CONTACTS[711]} pattern={PATTERNS['3_DIGIT']} />.
+        </p>
+      </div>
+    </DelayedLiveRegion>
   );
 };
 

--- a/src/applications/financial-status-report/wizard/pages/Copays.jsx
+++ b/src/applications/financial-status-report/wizard/pages/Copays.jsx
@@ -5,6 +5,7 @@ import Telephone, {
   CONTACTS,
   PATTERNS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
+import DelayedLiveRegion from '../DelayedLiveRegion';
 
 const Copays = () => {
   useEffect(() => {
@@ -15,48 +16,55 @@ const Copays = () => {
   }, []);
 
   return (
-    <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
-      <p className="vads-u-margin-top--0">
-        Based on the information you provided, this isn’t the form you need.
-      </p>
-      <p>
-        <strong>Here’s how to pay or get help with your VA copay bill:</strong>
-      </p>
-      <p>
-        <a
-          href="/health-care/pay-copay-bill/"
-          onClick={() => {
-            recordEvent({
-              event: 'howToWizard-alert-link-click',
-              'howToWizard-alert-link-click-label':
-                'Find out how to pay your VA copay bill',
-            });
-          }}
+    <DelayedLiveRegion>
+      <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
+        <h2
+          className="vads-u-margin-top--0 vads-u-font-size--h6 vads-u-font-weight--normal vads-u-font-family--sans"
+          id="wizard-results"
         >
-          Find out how to pay your VA copay bill
-        </a>
-      </p>
-      <p>
-        <a
-          href="/health-care/pay-copay-bill/financial-hardship/"
-          onClick={() => {
-            recordEvent({
-              event: 'howToWizard-alert-link-click',
-              'howToWizard-alert-link-click-label':
-                'Learn how to request financial hardship assistance',
-            });
-          }}
-        >
-          Learn how to request financial hardship assistance
-        </a>
-      </p>
-      <p>
-        Or call us at <Telephone contact={'866-400-1238'} />. We're here Monday
-        through Friday, 8:00 a.m. to 8:00 p.m. ET. If you have hearing loss,
-        call TTY:{' '}
-        <Telephone contact={CONTACTS[711]} pattern={PATTERNS['3_DIGIT']} />.
-      </p>
-    </div>
+          Based on the information you provided, this isn’t the form you need.
+        </h2>
+        <p>
+          <strong>
+            Here’s how to pay or get help with your VA copay bill:
+          </strong>
+        </p>
+        <p>
+          <a
+            href="/health-care/pay-copay-bill/"
+            onClick={() => {
+              recordEvent({
+                event: 'howToWizard-alert-link-click',
+                'howToWizard-alert-link-click-label':
+                  'Find out how to pay your VA copay bill',
+              });
+            }}
+          >
+            Find out how to pay your VA copay bill
+          </a>
+        </p>
+        <p>
+          <a
+            href="/health-care/pay-copay-bill/financial-hardship/"
+            onClick={() => {
+              recordEvent({
+                event: 'howToWizard-alert-link-click',
+                'howToWizard-alert-link-click-label':
+                  'Learn how to request financial hardship assistance',
+              });
+            }}
+          >
+            Learn how to request financial hardship assistance
+          </a>
+        </p>
+        <p>
+          Or call us at <Telephone contact={'866-400-1238'} />. We're here
+          Monday through Friday, 8:00 a.m. to 8:00 p.m. ET. If you have hearing
+          loss, call TTY:{' '}
+          <Telephone contact={CONTACTS[711]} pattern={PATTERNS['3_DIGIT']} />.
+        </p>
+      </div>
+    </DelayedLiveRegion>
   );
 };
 

--- a/src/applications/financial-status-report/wizard/pages/Dependents.jsx
+++ b/src/applications/financial-status-report/wizard/pages/Dependents.jsx
@@ -3,6 +3,7 @@ import recordEvent from 'platform/monitoring/record-event';
 import { PAGE_NAMES } from '../constants';
 import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
 import ContactDMC from '../components/Contacts';
+import DelayedLiveRegion from '../DelayedLiveRegion';
 
 const Dependents = () => {
   useEffect(() => {
@@ -13,57 +14,62 @@ const Dependents = () => {
   }, []);
 
   return (
-    <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
-      <p className="vads-u-margin-top--0">
-        Based on the information you provided, this isn’t the form you need.
-      </p>
-      <p>
-        <strong>
-          Here’s how to request help with debt for spouses or dependents:
-        </strong>
-      </p>
-      <p>
-        To request help with VA education, disability compensation, or pension
-        benefit debt, fill out the PDF version of our{' '}
-        <a
-          href="https://www.va.gov/debtman/Financial_Status_Report.asp"
-          onClick={() => {
-            recordEvent({
-              event: 'howToWizard-alert-link-click',
-              'howToWizard-alert-link-click-label':
-                'Financial Status Report (VA Form 5655).',
-            });
-          }}
+    <DelayedLiveRegion>
+      <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
+        <h2
+          className="vads-u-margin-top--0 vads-u-font-size--h6 vads-u-font-weight--normal vads-u-font-family--sans"
+          id="wizard-results"
         >
-          Financial Status Report (VA Form 5655).
-        </a>
-      </p>
-      <p>
-        You can use this form to request a debt waiver, compromise offer, or
-        extended monthly payment plan. You’ll also need to include a personal
-        statement to tell us why it’s hard for you to repay the debt.
-      </p>
-      <p>Submit your completed, signed form and statement by mail or fax.</p>
-      <ul>
-        <li>
-          <strong>Mail: </strong>
-          <div>Debt Management Center</div>
-          <div>P.O. Box 11930</div>
-          <div>St. Paul, MN 55111-0930</div>
-        </li>
-        <li>
-          <strong>Fax: </strong>
-          <Telephone contact={'1-612-970-5688'} />
-        </li>
-      </ul>
-      <p>
-        <strong>If you submitted VA Form 5655 in the past 6 months</strong>
-      </p>
-      <p>
-        You don’t need to submit a new request unless you have changes to
-        report. <ContactDMC />
-      </p>
-    </div>
+          Based on the information you provided, this isn’t the form you need.
+        </h2>
+        <p>
+          <strong>
+            Here’s how to request help with debt for spouses or dependents:
+          </strong>
+        </p>
+        <p>
+          To request help with VA education, disability compensation, or pension
+          benefit debt, fill out the PDF version of our{' '}
+          <a
+            href="https://www.va.gov/debtman/Financial_Status_Report.asp"
+            onClick={() => {
+              recordEvent({
+                event: 'howToWizard-alert-link-click',
+                'howToWizard-alert-link-click-label':
+                  'Financial Status Report (VA Form 5655).',
+              });
+            }}
+          >
+            Financial Status Report (VA Form 5655).
+          </a>
+        </p>
+        <p>
+          You can use this form to request a debt waiver, compromise offer, or
+          extended monthly payment plan. You’ll also need to include a personal
+          statement to tell us why it’s hard for you to repay the debt.
+        </p>
+        <p>Submit your completed, signed form and statement by mail or fax.</p>
+        <ul>
+          <li>
+            <strong>Mail: </strong>
+            <div>Debt Management Center</div>
+            <div>P.O. Box 11930</div>
+            <div>St. Paul, MN 55111-0930</div>
+          </li>
+          <li>
+            <strong>Fax: </strong>
+            <Telephone contact={'1-612-970-5688'} />
+          </li>
+        </ul>
+        <p>
+          <strong>If you submitted VA Form 5655 in the past 6 months</strong>
+        </p>
+        <p>
+          You don’t need to submit a new request unless you have changes to
+          report. <ContactDMC />
+        </p>
+      </div>
+    </DelayedLiveRegion>
   );
 };
 

--- a/src/applications/financial-status-report/wizard/pages/Disagree.jsx
+++ b/src/applications/financial-status-report/wizard/pages/Disagree.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import recordEvent from 'platform/monitoring/record-event';
 import { PAGE_NAMES } from '../constants';
+import DelayedLiveRegion from '../DelayedLiveRegion';
 
 const Disagree = () => {
   useEffect(() => {
@@ -12,80 +13,85 @@ const Disagree = () => {
   }, []);
 
   return (
-    <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
-      <p className="vads-u-margin-top--0">
-        Based on the information you provided, this isn’t the form you need.
-      </p>
-      <p className="vads-u-margin-bottom--0">
-        <strong>
-          If you disagree with the VA decision that resulted in this debt,
-        </strong>{' '}
-        you can submit a supplemental claim or request a higher level review or
-        board appeal.
-      </p>
-      <p className="vads-u-margin-top--1">
-        <a
-          href="/decision-reviews/"
-          onClick={() => {
-            recordEvent({
-              event: 'howToWizard-alert-link-click',
-              'howToWizard-alert-link-click-label':
-                'Learn more about the VA appeals process',
-            });
-          }}
+    <DelayedLiveRegion>
+      <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
+        <h2
+          className="vads-u-margin-top--0 vads-u-font-size--h6 vads-u-font-weight--normal vads-u-font-family--sans"
+          id="wizard-results"
         >
-          Learn more about the VA appeals process
-        </a>
-      </p>
-      <p className="vads-u-margin-bottom--0">
-        <strong>If you need more help, </strong>
-        call your VA benefit office.
-      </p>
-      <p className="vads-u-margin-top--1">
-        <a
-          href="/resources/helpful-va-phone-numbers/"
-          onClick={() => {
-            recordEvent({
-              event: 'howToWizard-alert-link-click',
-              'howToWizard-alert-link-click-label':
-                'Find helpful VA phone numbers',
-            });
-          }}
-        >
-          Find helpful VA phone numbers
-        </a>
-      </p>
-      <h3>What to know about debt waivers</h3>
-      <p>
-        You have <strong>180 days</strong> from the date you received your first
-        debt letter to request a debt waiver. A waiver is a request to ask us to
-        stop collection on your debt.
-      </p>
-      <p className="vads-u-margin-bottom--0">
-        If you’re worried that we won’t complete your appeal before the 180-day
-        limit, you can request a waiver with our online Financial Status Report
-        (VA Form 5655).
-      </p>
-      <p className="vads-u-margin-top--1">
-        <a
-          href="https://www.va.gov/debtman/Financial_Status_Report.asp"
-          onClick={() => {
-            recordEvent({
-              event: 'howToWizard-alert-link-click',
-              'howToWizard-alert-link-click-label':
-                'Request help with VA Form 5655',
-            });
-          }}
-        >
-          Request help with VA Form 5655
-        </a>
-      </p>
-      <p>
-        <strong>Note: </strong>
-        We’ll continue to add late fees and interest, and take other collection
-        action as needed, while we consider your appeal.
-      </p>
-    </div>
+          Based on the information you provided, this isn’t the form you need.
+        </h2>
+        <p className="vads-u-margin-bottom--0">
+          <strong>
+            If you disagree with the VA decision that resulted in this debt,
+          </strong>{' '}
+          you can submit a supplemental claim or request a higher level review
+          or board appeal.
+        </p>
+        <p className="vads-u-margin-top--1">
+          <a
+            href="/decision-reviews/"
+            onClick={() => {
+              recordEvent({
+                event: 'howToWizard-alert-link-click',
+                'howToWizard-alert-link-click-label':
+                  'Learn more about the VA appeals process',
+              });
+            }}
+          >
+            Learn more about the VA appeals process
+          </a>
+        </p>
+        <p className="vads-u-margin-bottom--0">
+          <strong>If you need more help, </strong>
+          call your VA benefit office.
+        </p>
+        <p className="vads-u-margin-top--1">
+          <a
+            href="/resources/helpful-va-phone-numbers/"
+            onClick={() => {
+              recordEvent({
+                event: 'howToWizard-alert-link-click',
+                'howToWizard-alert-link-click-label':
+                  'Find helpful VA phone numbers',
+              });
+            }}
+          >
+            Find helpful VA phone numbers
+          </a>
+        </p>
+        <h3>What to know about debt waivers</h3>
+        <p>
+          You have <strong>180 days</strong> from the date you received your
+          first debt letter to request a debt waiver. A waiver is a request to
+          ask us to stop collection on your debt.
+        </p>
+        <p className="vads-u-margin-bottom--0">
+          If you’re worried that we won’t complete your appeal before the
+          180-day limit, you can request a waiver with our online Financial
+          Status Report (VA Form 5655).
+        </p>
+        <p className="vads-u-margin-top--1">
+          <a
+            href="https://www.va.gov/debtman/Financial_Status_Report.asp"
+            onClick={() => {
+              recordEvent({
+                event: 'howToWizard-alert-link-click',
+                'howToWizard-alert-link-click-label':
+                  'Request help with VA Form 5655',
+              });
+            }}
+          >
+            Request help with VA Form 5655
+          </a>
+        </p>
+        <p>
+          <strong>Note: </strong>
+          We’ll continue to add late fees and interest, and take other
+          collection action as needed, while we consider your appeal.
+        </p>
+      </div>
+    </DelayedLiveRegion>
   );
 };
 

--- a/src/applications/financial-status-report/wizard/pages/Error.jsx
+++ b/src/applications/financial-status-report/wizard/pages/Error.jsx
@@ -11,10 +11,13 @@ const DebtError = () => {
   }, []);
 
   return (
-    <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
-      <p className="vads-u-margin-top--0">
+    <div className=" vads-u-padding--2 vads-u-margin-top--2">
+      <h2
+        className="vads-u-margin-top--0 vads-u-font-size--h6 vads-u-font-weight--normal vads-u-font-family--sans"
+        id="wizard-results"
+      >
         Based on the information you provided, this isn’t the form you need.
-      </p>
+      </h2>
       <p>
         <strong>
           If you think your debt or the amount of your debt is due to an error,

--- a/src/applications/financial-status-report/wizard/pages/LessThanFive.jsx
+++ b/src/applications/financial-status-report/wizard/pages/LessThanFive.jsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import recordEvent from 'platform/monitoring/record-event';
 import { PAGE_NAMES } from '../constants';
 import ContactDMC from '../components/Contacts';
+import DelayedLiveRegion from '../DelayedLiveRegion';
 
 const LessThanFive = () => {
   useEffect(() => {
@@ -13,53 +14,58 @@ const LessThanFive = () => {
   }, []);
 
   return (
-    <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
-      <p className="vads-u-margin-top--0">
-        Based on the information you provided, this isn’t the form you need.
-      </p>
-      <p>
-        <strong>
-          We’ve changed our process for extended monthly payment plans as part
-          of COVID-19 debt relief.
-        </strong>
-      </p>
-      <p>
-        You don't need to submit a Financial Status Report (VA Form 5655) to
-        request an extended monthly payment plan of up to 5 years. During this
-        time, you can request a plan online, by phone, or by mail.
-      </p>
-      <ul>
-        <li>
-          <strong>Online: </strong>
-          <a
-            href="https://iris.custhelp.va.gov/app/ask"
-            onClick={() => {
-              recordEvent({
-                event: 'howToWizard-alert-link-click',
-                'howToWizard-alert-link-click-label':
-                  'Go to our online question form (called IRIS)',
-              });
-            }}
-          >
-            Go to our online question form (called IRIS)
-          </a>
-          . On the IRIS page, select <strong>Debt Management Center</strong>,
-          your debt type, and <strong>Payment Plan</strong> within the Topic
-          dropdown. For Inquiry Type, select <strong>Question</strong>. Write
-          your request within the <strong>Question</strong> section.
-        </li>
-        <li>
-          <strong>Phone: </strong>
-          <ContactDMC />
-        </li>
-        <li>
-          <strong>Mail: </strong>
-          <div>Debt Management Center</div>
-          <div>P.O. Box 11930</div>
-          <div>St. Paul, MN 55111-0930</div>
-        </li>
-      </ul>
-    </div>
+    <DelayedLiveRegion>
+      <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
+        <h2
+          className="vads-u-margin-top--0 vads-u-font-size--h6 vads-u-font-weight--normal vads-u-font-family--sans"
+          id="wizard-results"
+        >
+          Based on the information you provided, this isn’t the form you need.
+        </h2>
+        <p>
+          <strong>
+            We’ve changed our process for extended monthly payment plans as part
+            of COVID-19 debt relief.
+          </strong>
+        </p>
+        <p>
+          You don't need to submit a Financial Status Report (VA Form 5655) to
+          request an extended monthly payment plan of up to 5 years. During this
+          time, you can request a plan online, by phone, or by mail.
+        </p>
+        <ul>
+          <li>
+            <strong>Online: </strong>
+            <a
+              href="https://iris.custhelp.va.gov/app/ask"
+              onClick={() => {
+                recordEvent({
+                  event: 'howToWizard-alert-link-click',
+                  'howToWizard-alert-link-click-label':
+                    'Go to our online question form (called IRIS)',
+                });
+              }}
+            >
+              Go to our online question form (called IRIS)
+            </a>
+            . On the IRIS page, select <strong>Debt Management Center</strong>,
+            your debt type, and <strong>Payment Plan</strong> within the Topic
+            dropdown. For Inquiry Type, select <strong>Question</strong>. Write
+            your request within the <strong>Question</strong> section.
+          </li>
+          <li>
+            <strong>Phone: </strong>
+            <ContactDMC />
+          </li>
+          <li>
+            <strong>Mail: </strong>
+            <div>Debt Management Center</div>
+            <div>P.O. Box 11930</div>
+            <div>St. Paul, MN 55111-0930</div>
+          </li>
+        </ul>
+      </div>
+    </DelayedLiveRegion>
   );
 };
 

--- a/src/applications/financial-status-report/wizard/pages/MakePayment.jsx
+++ b/src/applications/financial-status-report/wizard/pages/MakePayment.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import recordEvent from 'platform/monitoring/record-event';
 import { PAGE_NAMES } from '../constants';
+import DelayedLiveRegion from '../DelayedLiveRegion';
 
 const MakePayment = () => {
   useEffect(() => {
@@ -11,37 +12,42 @@ const MakePayment = () => {
   }, []);
 
   return (
-    <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
-      <p className="vads-u-margin-top--0">
-        Based on the information you provided, this isn’t the form you need.
-      </p>
-      <p className="vads-u-margin-bottom--0">
-        <strong>
-          You can make payments on VA disability compensation, pension, or
-          education debts online, by phone, or by mail.
-        </strong>
-      </p>
-      <p className="vads-u-margin-top--1">
-        <a
-          href="/manage-va-debt"
-          onClick={() => {
-            recordEvent({
-              event: 'howToWizard-alert-link-click',
-              'howToWizard-alert-link-click-label':
-                'Find out how to manage your debt',
-            });
-          }}
+    <DelayedLiveRegion>
+      <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
+        <h2
+          className="vads-u-margin-top--0 vads-u-font-size--h6 vads-u-font-weight--normal vads-u-font-family--sans"
+          id="wizard-results"
         >
-          Find out how to manage your debt
-        </a>
-      </p>
-      <p>
-        Be sure to make a payment or request help within{' '}
-        <strong>30 days</strong> of when you receive your first debt letter from
-        us. This will help you avoid late fees, interest, or other collection
-        action.
-      </p>
-    </div>
+          Based on the information you provided, this isn’t the form you need.
+        </h2>
+        <p className="vads-u-margin-bottom--0">
+          <strong>
+            You can make payments on VA disability compensation, pension, or
+            education debts online, by phone, or by mail.
+          </strong>
+        </p>
+        <p className="vads-u-margin-top--1">
+          <a
+            href="/manage-va-debt"
+            onClick={() => {
+              recordEvent({
+                event: 'howToWizard-alert-link-click',
+                'howToWizard-alert-link-click-label':
+                  'Find out how to manage your debt',
+              });
+            }}
+          >
+            Find out how to manage your debt
+          </a>
+        </p>
+        <p>
+          Be sure to make a payment or request help within{' '}
+          <strong>30 days</strong> of when you receive your first debt letter
+          from us. This will help you avoid late fees, interest, or other
+          collection action.
+        </p>
+      </div>
+    </DelayedLiveRegion>
   );
 };
 

--- a/src/applications/financial-status-report/wizard/pages/RogersStem.jsx
+++ b/src/applications/financial-status-report/wizard/pages/RogersStem.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import recordEvent from 'platform/monitoring/record-event';
 import { PAGE_NAMES } from '../constants';
+import DelayedLiveRegion from '../DelayedLiveRegion';
 
 const RogersStem = () => {
   useEffect(() => {
@@ -11,27 +12,32 @@ const RogersStem = () => {
   }, []);
 
   return (
-    <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
-      <p className="vads-u-margin-top--0">
-        Based on the information you provided, this isn’t the form you need.
-      </p>
-      <p>
-        <strong>For help with STEM program debt,</strong> contact us by email or
-        regular mail.
-      </p>
-      <ul>
-        <li>
-          <strong>Email: </strong>
-          <a href="mailto:stem.vbauf@va.gov">STEM.VBAUF@va.gov</a>.
-        </li>
-        <li>
-          <strong>Mail: </strong>
-          <div>VA Regional Processing Office 307</div>
-          <div>P.O. Box 4616</div>
-          <div>Buffalo, NY 14240-4616</div>
-        </li>
-      </ul>
-    </div>
+    <DelayedLiveRegion>
+      <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
+        <h2
+          className="vads-u-margin-top--0 vads-u-font-size--h6 vads-u-font-weight--normal vads-u-font-family--sans"
+          id="wizard-results"
+        >
+          Based on the information you provided, this isn’t the form you need.
+        </h2>
+        <p>
+          <strong>For help with STEM program debt,</strong> contact us by email
+          or regular mail.
+        </p>
+        <ul>
+          <li>
+            <strong>Email: </strong>
+            <a href="mailto:stem.vbauf@va.gov">STEM.VBAUF@va.gov</a>.
+          </li>
+          <li>
+            <strong>Mail: </strong>
+            <div>VA Regional Processing Office 307</div>
+            <div>P.O. Box 4616</div>
+            <div>Buffalo, NY 14240-4616</div>
+          </li>
+        </ul>
+      </div>
+    </DelayedLiveRegion>
   );
 };
 

--- a/src/applications/financial-status-report/wizard/pages/Submit.jsx
+++ b/src/applications/financial-status-report/wizard/pages/Submit.jsx
@@ -2,29 +2,35 @@ import React from 'react';
 import { PAGE_NAMES } from '../constants';
 import StartFormButton from '../components/StartFormButton';
 import ContactDMC from '../components/Contacts';
+import DelayedLiveRegion from '../DelayedLiveRegion';
 
 const Submit = ({ setWizardStatus }) => {
   const label = 'Submit a Financial Status Report';
 
   return (
-    <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
-      <p className="vads-u-margin-top--0">
-        Based on the information you provided, you can use our online Financial
-        Status Report (VA Form 5655) to request help with your debt.
-      </p>
-      <StartFormButton
-        setWizardStatus={setWizardStatus}
-        label={label}
-        ariaId={'other_ways_to_file_526'}
-      />
-      <p className="vads-u-margin-bottom--1">
-        <strong>If you submitted VA Form 5655 in the past 6 months</strong>
-      </p>
-      <p className="vads-u-margin-top--0">
-        You don’t need to submit a new request unless you have changes to
-        report. <ContactDMC />
-      </p>
-    </div>
+    <DelayedLiveRegion>
+      <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
+        <h2
+          className="vads-u-margin-top--0 vads-u-font-size--h6 vads-u-font-weight--normal vads-u-font-family--sans"
+          id="wizard-results"
+        >
+          Based on the information you provided, you can use our online
+          Financial Status Report (VA Form 5655) to request help with your debt.
+        </h2>
+        <StartFormButton
+          setWizardStatus={setWizardStatus}
+          label={label}
+          ariaId={'other_ways_to_file_526'}
+        />
+        <p className="vads-u-margin-bottom--1">
+          <strong>If you submitted VA Form 5655 in the past 6 months</strong>
+        </p>
+        <p className="vads-u-margin-top--0">
+          You don’t need to submit a new request unless you have changes to
+          report. <ContactDMC />
+        </p>
+      </div>
+    </DelayedLiveRegion>
   );
 };
 

--- a/src/applications/financial-status-report/wizard/pages/VetTec.jsx
+++ b/src/applications/financial-status-report/wizard/pages/VetTec.jsx
@@ -5,6 +5,7 @@ import Telephone, {
   CONTACTS,
   PATTERNS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
+import DelayedLiveRegion from '../DelayedLiveRegion';
 
 const VetTec = () => {
   useEffect(() => {
@@ -15,33 +16,39 @@ const VetTec = () => {
   }, []);
 
   return (
-    <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
-      <p className="vads-u-margin-top--0">
-        Based on the information you provided, this isn’t the form you need.
-      </p>
-      <p>
-        <strong>For help with VET TEC program debt,</strong> contact us by
-        email, phone, or mail.
-      </p>
-      <ul>
-        <li>
-          <strong>Email: </strong>
-          <a href="mailto:vettec.vbauf@va.gov">VETTEC.VBAUF@va.gov</a>.
-        </li>
-        <li>
-          <strong>Phone: </strong>
-          Call us at <Telephone contact={'716-857-5061'} /> (TTY:{' '}
-          <Telephone contact={CONTACTS[711]} pattern={PATTERNS['3_DIGIT']} />)
-          and leave a detailed message. We'll call you back as soon as possible.
-        </li>
-        <li>
-          <strong>Mail: </strong>
-          <div>VA Regional Processing Office 307</div>
-          <div>P.O. Box 4616</div>
-          <div>Buffalo, NY 14240-4616</div>
-        </li>
-      </ul>
-    </div>
+    <DelayedLiveRegion>
+      <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
+        <h2
+          className="vads-u-margin-top--0 vads-u-font-size--h6 vads-u-font-weight--normal vads-u-font-family--sans"
+          id="wizard-results"
+        >
+          Based on the information you provided, this isn’t the form you need.
+        </h2>
+        <p>
+          <strong>For help with VET TEC program debt,</strong> contact us by
+          email, phone, or mail.
+        </p>
+        <ul>
+          <li>
+            <strong>Email: </strong>
+            <a href="mailto:vettec.vbauf@va.gov">VETTEC.VBAUF@va.gov</a>.
+          </li>
+          <li>
+            <strong>Phone: </strong>
+            Call us at <Telephone contact={'716-857-5061'} /> (TTY:{' '}
+            <Telephone contact={CONTACTS[711]} pattern={PATTERNS['3_DIGIT']} />)
+            and leave a detailed message. We'll call you back as soon as
+            possible.
+          </li>
+          <li>
+            <strong>Mail: </strong>
+            <div>VA Regional Processing Office 307</div>
+            <div>P.O. Box 4616</div>
+            <div>Buffalo, NY 14240-4616</div>
+          </li>
+        </ul>
+      </div>
+    </DelayedLiveRegion>
   );
 };
 

--- a/src/applications/financial-status-report/wizard/pages/Waivers.jsx
+++ b/src/applications/financial-status-report/wizard/pages/Waivers.jsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import recordEvent from 'platform/monitoring/record-event';
 import { PAGE_NAMES } from '../constants';
 import ContactDMC from '../components/Contacts';
+import DelayedLiveRegion from '../DelayedLiveRegion';
 
 const Waivers = () => {
   useEffect(() => {
@@ -13,50 +14,55 @@ const Waivers = () => {
   }, []);
 
   return (
-    <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
-      <p className="vads-u-margin-top--0">
-        Based on the information you provided, this isn’t the form you need.
-      </p>
-      <p>
-        <strong>
-          To ask our Committee of Waivers and Compromises to reconsider your
-          waiver,{' '}
-        </strong>
-        you’ll need to tell us why you think we should reconsider.
-      </p>
-      <p>You can submit your request online, by phone, or by mail.</p>
-      <ul>
-        <li>
-          <strong>Online: </strong>
-          <a
-            href="https://iris.custhelp.va.gov/app/ask"
-            onClick={() => {
-              recordEvent({
-                event: 'howToWizard-alert-link-click',
-                'howToWizard-alert-link-click-label':
-                  'Go to our online question form (called IRIS)',
-              });
-            }}
-          >
-            Go to our online question form (called IRIS)
-          </a>
-          . On the IRIS page, select <strong>Debt Management Center</strong>,
-          your debt type, and <strong>Waiver</strong> within the Topic dropdown.
-          For Inquiry Type, select <strong>Question</strong>. Write your request
-          in the <strong>Question</strong> section.
-        </li>
-        <li>
-          <strong>Phone: </strong>
-          <ContactDMC />
-        </li>
-        <li>
-          <strong>Mail: </strong>
-          <div>Debt Management Center</div>
-          <div>P.O. Box 11930</div>
-          <div>St. Paul, MN 55111-0930</div>
-        </li>
-      </ul>
-    </div>
+    <DelayedLiveRegion>
+      <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
+        <h2
+          className="vads-u-margin-top--0 vads-u-font-size--h6 vads-u-font-weight--normal vads-u-font-family--sans"
+          id="wizard-results"
+        >
+          Based on the information you provided, this isn’t the form you need.
+        </h2>
+        <p>
+          <strong>
+            To ask our Committee of Waivers and Compromises to reconsider your
+            waiver,{' '}
+          </strong>
+          you’ll need to tell us why you think we should reconsider.
+        </p>
+        <p>You can submit your request online, by phone, or by mail.</p>
+        <ul>
+          <li>
+            <strong>Online: </strong>
+            <a
+              href="https://iris.custhelp.va.gov/app/ask"
+              onClick={() => {
+                recordEvent({
+                  event: 'howToWizard-alert-link-click',
+                  'howToWizard-alert-link-click-label':
+                    'Go to our online question form (called IRIS)',
+                });
+              }}
+            >
+              Go to our online question form (called IRIS)
+            </a>
+            . On the IRIS page, select <strong>Debt Management Center</strong>,
+            your debt type, and <strong>Waiver</strong> within the Topic
+            dropdown. For Inquiry Type, select <strong>Question</strong>. Write
+            your request in the <strong>Question</strong> section.
+          </li>
+          <li>
+            <strong>Phone: </strong>
+            <ContactDMC />
+          </li>
+          <li>
+            <strong>Mail: </strong>
+            <div>Debt Management Center</div>
+            <div>P.O. Box 11930</div>
+            <div>St. Paul, MN 55111-0930</div>
+          </li>
+        </ul>
+      </div>
+    </DelayedLiveRegion>
   );
 };
 


### PR DESCRIPTION
## Description
Make static content in wizard screen reader announce-able via aria live region 

[Ticket](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/22725)

## Testing done
- Manual testing

## Screenshots
![Apr-16-2021 11-42-10](https://user-images.githubusercontent.com/23741323/115049521-d0d13d00-9ea8-11eb-9d1b-0d815c5d76a4.gif)




## Acceptance criteria
- [x] Screen reader announces static content in gray boxes on FSR wizard  

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
