### PR TITLE
Do not fetch HCA enrollment status when user is LOA1

### DIFF
--- a/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.jsx
+++ b/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.jsx
@@ -76,7 +76,7 @@ const ApplyForBenefits = ({
   const showEducation = !hasDD4EDU;
 
   return (
-    <>
+    <div data-testid="dashboard-section-apply-for-benefits">
       <h2>Apply for VA benefits</h2>
       <div className="vads-u-margin-top--2">
         <AdditionalInfo triggerText="What benefits does VA offer?">
@@ -162,7 +162,7 @@ const ApplyForBenefits = ({
           )}
         </>
       </BenefitsOfInterest>
-    </>
+    </div>
   );
 };
 

--- a/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.jsx
+++ b/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.jsx
@@ -7,7 +7,7 @@ import AdditionalInfo from '@department-of-veterans-affairs/component-library/Ad
 import {
   isMultifactorEnabled,
   isVAPatient,
-  isLOA3 as isLOA3Selector,
+  isLOA3,
 } from '~/platform/user/selectors';
 
 import { getEnrollmentStatus as getEnrollmentStatusAction } from '~/applications/hca/actions';
@@ -170,7 +170,7 @@ const mapStateToProps = state => {
   const isPatient = isVAPatient(state);
   const esrEnrollmentStatus = selectESRStatus(state).enrollmentStatus;
 
-  const shouldGetESRStatus = !isPatient && isLOA3Selector(state);
+  const shouldGetESRStatus = !isPatient && isLOA3(state);
   const shouldGetDD4EDUStatus = isMultifactorEnabled(state);
   const hasLoadedESRData =
     !shouldGetESRStatus ||

--- a/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.jsx
+++ b/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.jsx
@@ -4,7 +4,11 @@ import { connect } from 'react-redux';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 
-import { isMultifactorEnabled, isVAPatient } from '~/platform/user/selectors';
+import {
+  isMultifactorEnabled,
+  isVAPatient,
+  isLOA3 as isLOA3Selector,
+} from '~/platform/user/selectors';
 
 import { getEnrollmentStatus as getEnrollmentStatusAction } from '~/applications/hca/actions';
 import { HCA_ENROLLMENT_STATUSES } from '~/applications/hca/constants';
@@ -166,7 +170,7 @@ const mapStateToProps = state => {
   const isPatient = isVAPatient(state);
   const esrEnrollmentStatus = selectESRStatus(state).enrollmentStatus;
 
-  const shouldGetESRStatus = !isPatient;
+  const shouldGetESRStatus = !isPatient && isLOA3Selector(state);
   const shouldGetDD4EDUStatus = isMultifactorEnabled(state);
   const hasLoadedESRData =
     !shouldGetESRStatus ||

--- a/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.unit.spec.jsx
+++ b/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.unit.spec.jsx
@@ -40,6 +40,10 @@ describe('ApplyForBenefits component', () => {
         user: {
           profile: {
             savedForms: [],
+            loa: {
+              current: 1,
+              highest: 3,
+            },
           },
         },
       };
@@ -55,6 +59,10 @@ describe('ApplyForBenefits component', () => {
         hcaEnrollmentStatus: { enrollmentStatus: null, hasServerError: false },
         user: {
           profile: {
+            loa: {
+              current: 1,
+              highest: 3,
+            },
             savedForms: [
               {
                 form: '123-ABC',
@@ -80,6 +88,10 @@ describe('ApplyForBenefits component', () => {
         hcaEnrollmentStatus: { enrollmentStatus: null, hasServerError: false },
         user: {
           profile: {
+            loa: {
+              current: 1,
+              highest: 3,
+            },
             savedForms: [
               {
                 form: '21-526EZ',
@@ -115,6 +127,10 @@ describe('ApplyForBenefits component', () => {
       const initialState = {
         user: {
           profile: {
+            loa: {
+              current: 1,
+              highest: 3,
+            },
             savedForms: [
               {
                 form: '686C-674',
@@ -206,6 +222,10 @@ describe('ApplyForBenefits component', () => {
             profile: {
               vaPatient: false,
               multifactor: true,
+              loa: {
+                current: 3,
+                highest: 3,
+              },
             },
           },
         };
@@ -237,6 +257,69 @@ describe('ApplyForBenefits component', () => {
         });
       });
     });
+
+    context(
+      'when user is not a VA patient, not LOA3, and does not have 2FA set up',
+      () => {
+        beforeEach(() => {
+          mockFetch();
+        });
+        afterEach(() => {
+          resetFetch();
+        });
+        it('should not fetch ESR data or DD4EDU data and show the correct benefits', async () => {
+          const initialState = {
+            user: {
+              profile: {
+                vaPatient: false,
+                multifactor: false,
+                loa: {
+                  current: 1,
+                  highest: 3,
+                },
+              },
+            },
+          };
+          view = renderInReduxProvider(<ApplyForBenefits />, {
+            initialState,
+            reducers,
+          });
+          // Because fetch is called as part of an async Redux thunk, we need to
+          // wait here before confirming that fetch was called
+          await wait(1);
+          const fetchCalls = global.fetch.getCalls();
+          // make sure we are _not_ fetching DD4EDU info
+          expect(
+            fetchCalls.some(call => {
+              return call.args[0].includes('v0/profile/ch33_bank_accounts');
+            }),
+          ).to.be.false;
+          // make sure we are _not_ fetching ESR data
+          expect(
+            fetchCalls.some(call => {
+              return call.args[0].includes(
+                'v0/health_care_applications/enrollment_status',
+              );
+            }),
+          ).to.be.false;
+          // make sure the loading spinner is not shown since we didn't need to load anything
+          expect(
+            view.queryByRole('progressbar', {
+              value: /benefits you might be interested in/i,
+            }),
+          ).to.not.exist;
+          view.getByRole('link', {
+            name: /apply for VA health care/i,
+          });
+          view.getByRole('link', {
+            name: /learn how to file a claim/i,
+          });
+          view.getByRole('link', {
+            name: /learn how to apply for education benefits/i,
+          });
+        });
+      },
+    );
 
     context('when user is a VA patient and does not have 2FA set up', () => {
       beforeEach(() => {
@@ -294,6 +377,10 @@ describe('ApplyForBenefits component', () => {
               profile: {
                 vaPatient: false,
                 multifactor: true,
+                loa: {
+                  current: 1,
+                  highest: 3,
+                },
               },
             },
             hcaEnrollmentStatus: {
@@ -337,6 +424,10 @@ describe('ApplyForBenefits component', () => {
               profile: {
                 vaPatient: false,
                 multifactor: true,
+                loa: {
+                  current: 1,
+                  highest: 3,
+                },
               },
             },
             hcaEnrollmentStatus: {
@@ -410,6 +501,10 @@ describe('ApplyForBenefits component', () => {
               profile: {
                 vaPatient: false,
                 multifactor: true,
+                loa: {
+                  current: 1,
+                  highest: 3,
+                },
               },
             },
             hcaEnrollmentStatus: {

--- a/src/applications/personalization/dashboard-2/components/claims-and-appeals/ClaimsAndAppeals.jsx
+++ b/src/applications/personalization/dashboard-2/components/claims-and-appeals/ClaimsAndAppeals.jsx
@@ -101,7 +101,7 @@ const ClaimsAndAppeals = ({
 
   if (highlightedClaimOrAppeal || openClaimsOrAppealsCount > 0) {
     return (
-      <div>
+      <div data-testid="dashboard-section-claims-and-appeals">
         <h2>Claims & appeals</h2>
         <div className="vads-l-row">
           <DashboardWidgetWrapper>

--- a/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
+++ b/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
@@ -101,7 +101,10 @@ const HealthCare = ({
       : 'Send a secure message to your health care team';
 
   return (
-    <div className="health-care-wrapper vads-u-margin-y--6">
+    <div
+      className="health-care-wrapper vads-u-margin-y--6"
+      data-testid="dashboard-section-health-care"
+    >
       <h2>Health care</h2>
 
       <div className="vads-l-row">

--- a/src/applications/personalization/dashboard-2/tests/e2e/loa1.cypress.spec.js
+++ b/src/applications/personalization/dashboard-2/tests/e2e/loa1.cypress.spec.js
@@ -44,13 +44,20 @@ function loa1DashboardTest(mobile, stubs) {
   cy.findByTestId('name-tag').should('not.exist');
 
   // make sure the claims and appeals section is hidden
-  cy.findByRole('heading', { name: 'Claims & appeals' }).should('not.exist');
+  cy.findByTestId('dashboard-section-claims-and-appeals').should('not.exist');
 
   // make sure that the health care section is hidden
-  cy.findByRole('heading', { name: 'Health care' }).should('not.exist');
+  cy.findByTestId('dashboard-section-health-care').should('not.exist');
 
   // make sure that the apply for benefits section is visible
-  cy.findByRole('heading', { name: /apply for VA benefits/i }).should('exist');
+  cy.findByTestId('dashboard-section-apply-for-benefits').should('exist');
+
+  // make sure all three benefits links are shown in the Apply For Benefits section
+  cy.findByRole('link', { name: /apply for va health care/i }).should('exist');
+  cy.findByRole('link', { name: /file a claim/i }).should('exist');
+  cy.findByRole('link', { name: /apply for education benefits/i }).should(
+    'exist',
+  );
 
   // make the a11y check
   cy.injectAxe();
@@ -58,18 +65,37 @@ function loa1DashboardTest(mobile, stubs) {
 }
 
 describe('The My VA Dashboard', () => {
+  let getAppealsStub;
+  let getClaimsStub;
   let getServiceHistoryStub;
+  let getEnrollmentStatusStub;
   let getFullNameStub;
   let getDisabilityRatingStub;
   let stubs;
   beforeEach(() => {
     disableFTUXModals();
     cy.login(loa1User);
+    getAppealsStub = cy.stub();
+    getClaimsStub = cy.stub();
     getServiceHistoryStub = cy.stub();
+    getEnrollmentStatusStub = cy.stub();
     getFullNameStub = cy.stub();
     getDisabilityRatingStub = cy.stub();
-    stubs = [getServiceHistoryStub, getFullNameStub, getDisabilityRatingStub];
+    stubs = [
+      getAppealsStub,
+      getClaimsStub,
+      getServiceHistoryStub,
+      getFullNameStub,
+      getDisabilityRatingStub,
+      getEnrollmentStatusStub,
+    ];
 
+    cy.intercept('/v0/appeals', () => {
+      getAppealsStub();
+    });
+    cy.intercept('/v0/evss_claims_async', () => {
+      getClaimsStub();
+    });
     cy.intercept('/v0/profile/service_history', () => {
       getServiceHistoryStub();
     });
@@ -78,6 +104,9 @@ describe('The My VA Dashboard', () => {
     });
     cy.intercept('/v0/disability_compensation_form/rating_info', () => {
       getDisabilityRatingStub();
+    });
+    cy.intercept('/v0/health_care_applications/enrollment_status', () => {
+      getEnrollmentStatusStub();
     });
   });
   it('should handle LOA1 users at desktop size', () => {


### PR DESCRIPTION
## Description
LOA1 users are blocked from getting HCA enrollment status, resulting in a poorly-handled error. Best to just not even call ESR if the user is not LOA3

## Testing done
New unit test

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs