### PR TITLE
20138: Removal of edu_form_omb_and_expiration feature flag

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -86,7 +86,6 @@ export default Object.freeze({
   yellowRibbonEnhancements: 'yellow_ribbon_mvp_enhancement',
   evssUploadLimit150Mb: 'evss_upload_limit_150mb',
   searchRepresentative: 'search_representative',
-  eduFormOmbAndExpiration: 'edu_form_omb_and_expiration',
   manageDependents: 'dependents_management',
   subform89404192: 'subform_8940_4192',
   dependencyVerification: 'dependency_verification',


### PR DESCRIPTION
## Description
As a developer, I need to remove the 'edu_form_omb_and_expiration' feature flag toggle so that it is no longer configurable, and the new functionality is permanent.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/20138

## Testing done
Testing passes locally

## Screenshots
N/A

## Acceptance criteria
- [x] The feature flag 'edu_form_omb_and_expiration' is removed.
- [x] The feature flag is not displayed here: https://[environment]-api.va.gov/flipper/features.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
