### PR TITLE
Trim leading + trailing whitespace

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -710,4 +710,6 @@ module.exports = function registerFilters() {
   };
 
   liquid.filters.concat = (...args) => _.concat(...args);
+
+  liquid.filters.strip = (string = '') => _.trim(string);
 };

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -358,3 +358,8 @@ describe('concat', () => {
     );
   });
 });
+describe('strip', () => {
+  it('removes leading and trailing whitespace', () => {
+    expect(liquid.filters.strip('   \nhello\n    ')).to.equal('hello');
+  });
+});

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -47,7 +47,7 @@
                 href="{{ fieldSecondaryCallToAction.entity.fieldButtonLink.url.path }}"
                 onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Why this matters to you', 'clp-section-title': '{{ fieldClpWhyThisMatters | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldSecondaryCallToAction.entity.fieldButtonLabel | escape }}' });"
               >
-                {{ fieldSecondaryCallToAction.entity.fieldButtonLabel }}
+                {{ fieldSecondaryCallToAction.entity.fieldButtonLabel | strip }}
               </a>
             {% endif %}
           </div><!-- /Content -->
@@ -173,7 +173,7 @@
                   href="{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLink.url.path }}"
                   onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Video', 'clp-section-title': '{{ fieldClpVideoPanelHeader | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel | escape }}' });"
                 >
-                  {{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel }}
+                  {{ fieldClpVideoPanelMoreVideo.entity.fieldButtonLabel | strip }}
                 </a>
               </p>
             {% endif %}
@@ -320,7 +320,7 @@
                 href="{{ fieldClpResourcesCta.entity.fieldButtonLink.url.path }}"
                 onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'Downloadable resources', 'clp-section-title': '{{ fieldClpResourcesHeader | escape }}', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpResourcesCta.entity.fieldButtonLabel | escape }}' });"
               >
-                {{ fieldClpResourcesCta.entity.fieldButtonLabel }}
+                {{ fieldClpResourcesCta.entity.fieldButtonLabel | strip }}
               </a>
             </div>
           </div>
@@ -474,7 +474,7 @@
                 href="{{ fieldClpFaqCta.entity.fieldButtonLink.url.path }}"
                 onclick="recordEvent({ 'event': 'clp-link-click', 'clp-section-category': 'FAQ', 'clp-section-title': 'Frequently asked questions', 'clp-total-sections': '{{ clpTotalSections }}', 'clp-click-label': '{{ fieldClpFaqCta.entity.fieldButtonLabel | escape }}' });"
               >
-                {{ fieldClpFaqCta.entity.fieldButtonLabel }}
+                {{ fieldClpFaqCta.entity.fieldButtonLabel | strip }}
               </a>
             </div>
           </div>


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/21929

This PR trims the leading + trailing whitespace + newlines for CTA labels.

## Testing done
Locally

## Screenshots
N/A

## Acceptance criteria
- [x] Trim leading + trailing whitespace + newlines for cta labels

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
