### PR TITLE
Profile: hide NameTag disability rating on 400 errors

### DIFF
--- a/src/applications/personalization/components/NameTag.jsx
+++ b/src/applications/personalization/components/NameTag.jsx
@@ -14,7 +14,7 @@ const NameTag = ({
   showBadgeImage,
   showUpdatedNameTag,
   totalDisabilityRating,
-  totalDisabilityRatingError,
+  totalDisabilityRatingServerError,
 }) => {
   const fullName = [first, middle, last, suffix]
     .filter(name => !!name)
@@ -162,7 +162,7 @@ const NameTag = ({
               )}
           </dl>
           {showUpdatedNameTag &&
-            totalDisabilityRatingError && (
+            totalDisabilityRatingServerError && (
               <a
                 href="/disability/view-disability-rating/rating"
                 aria-label="view your disability rating"
@@ -217,7 +217,7 @@ NameTag.propTypes = {
   latestBranchOfService: PropTypes.string.isRequired,
   showUpdatedNameTag: PropTypes.bool,
   totalDisabilityRating: PropTypes.number,
-  totalDisabilityRatingError: PropTypes.bool,
+  totalDisabilityRatingServerError: PropTypes.bool,
 };
 
 export default connect(mapStateToProps)(NameTag);

--- a/src/applications/personalization/components/NameTag.unit.spec.jsx
+++ b/src/applications/personalization/components/NameTag.unit.spec.jsx
@@ -75,9 +75,9 @@ describe('<NameTag>', () => {
     },
   );
   context(
-    'when `showUpdatedNameTag` flag is `true` and `totalDisabilityRating` is not set',
+    "when `showUpdatedNameTag` flag is `true`, `totalDisabilityRating` is not set and there isn't a server error",
     () => {
-      it('should not render the disability rating', () => {
+      it('should not render the disability rating or a fallback link', () => {
         const initialState = getInitialState();
         const view = render(
           <NameTag showUpdatedNameTag totalDisabilityRating={null} />,
@@ -94,12 +94,16 @@ describe('<NameTag>', () => {
     },
   );
   context(
-    'when `showUpdatedNameTag` flag is `true` and `totalDisabilityRatingError` is `true`',
+    'when `showUpdatedNameTag` flag is `true`, `totalDisabilityRating` is not set and there is a server error',
     () => {
       it('should render a fallback link', () => {
         const initialState = getInitialState();
         const view = render(
-          <NameTag showUpdatedNameTag totalDisabilityRatingError />,
+          <NameTag
+            showUpdatedNameTag
+            totalDisabilityRating={null}
+            totalDisabilityRatingServerError
+          />,
           { initialState },
         );
         expect(view.queryByText(/your disability rating:/i)).to.not.exist;

--- a/src/applications/personalization/dashboard-2/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard-2/components/Dashboard.jsx
@@ -30,6 +30,7 @@ import externalServiceStatus from '~/platform/monitoring/DowntimeNotification/co
 import NameTag from '~/applications/personalization/components/NameTag';
 import IdentityNotVerified from '~/applications/personalization/components/IdentityNotVerified';
 import { fetchTotalDisabilityRating as fetchTotalDisabilityRatingAction } from '~/applications/personalization/rated-disabilities/actions';
+import { hasTotalDisabilityServerError } from '~/applications/personalization/rated-disabilities/selectors';
 
 import {
   fetchMilitaryInformation as fetchMilitaryInformationAction,
@@ -125,7 +126,9 @@ const Dashboard = ({
               <NameTag
                 showUpdatedNameTag
                 totalDisabilityRating={props.totalDisabilityRating}
-                totalDisabilityRatingError={props.totalDisabilityRatingError}
+                totalDisabilityRatingServerError={
+                  props.totalDisabilityRatingServerError
+                }
               />
             )}
             <div className="vads-l-grid-container vads-u-padding-bottom--3 medium-screen:vads-u-padding-x--2 medium-screen:vads-u-padding-bottom--4 small-desktop-screen:vads-u-padding-x--0">
@@ -232,7 +235,7 @@ const mapStateToProps = state => {
     showNameTag,
     hero,
     totalDisabilityRating: state.totalRating?.totalDisabilityRating,
-    totalDisabilityRatingError: state.totalRating?.error,
+    totalDisabilityRatingServerError: hasTotalDisabilityServerError(state),
     user: state.user,
     // TODO: possibly revise this to block both the health care and the claims
     // and appeals content if hasMPIConnectionError() is true. If we do that, we

--- a/src/applications/personalization/dashboard-2/tests/e2e/loa3.cypress.spec.js
+++ b/src/applications/personalization/dashboard-2/tests/e2e/loa3.cypress.spec.js
@@ -7,7 +7,11 @@ import claimsSuccess from '@@profile/tests/fixtures/claims-success';
 import appealsSuccess from '@@profile/tests/fixtures/appeals-success';
 import error401 from '@@profile/tests/fixtures/401.json';
 import error500 from '@@profile/tests/fixtures/500.json';
-import { nameTagRenders } from '@@profile/tests/e2e/helpers';
+import {
+  nameTagRendersWithDisabilityRating,
+  nameTagRendersWithoutDisabilityRating,
+  nameTagRendersWithFallbackLink,
+} from '@@profile/tests/e2e/helpers';
 
 import manifest from '~/applications/personalization/dashboard/manifest.json';
 
@@ -50,7 +54,7 @@ function loa3DashboardTest(mobile) {
     .should('equal', 'H1');
 
   // name tag exists with the right data
-  nameTagRenders({ withDisabilityRating: true });
+  nameTagRendersWithDisabilityRating();
 
   // make the a11y check
   cy.injectAxe();
@@ -97,10 +101,10 @@ describe('The My VA Dashboard', () => {
         body: error401,
       });
     });
-    it('should show the fallback link in the header', () => {
+    it('should totally hide the disability rating in the header', () => {
       mockFeatureToggles();
       cy.visit(manifest.rootUrl);
-      nameTagRenders({ withDisabilityRating: false });
+      nameTagRendersWithoutDisabilityRating();
     });
   });
   context('when there is a 500 fetching the total disability rating', () => {
@@ -113,7 +117,7 @@ describe('The My VA Dashboard', () => {
     it('should show the fallback link in the header', () => {
       mockFeatureToggles();
       cy.visit(manifest.rootUrl);
-      nameTagRenders({ withDisabilityRating: false });
+      nameTagRendersWithFallbackLink();
     });
   });
 });

--- a/src/applications/personalization/profile/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile/components/ProfileWrapper.jsx
@@ -17,6 +17,8 @@ import {
   personalInformationLoadError,
 } from '@@profile/selectors';
 
+import { hasTotalDisabilityServerError } from '~/applications/personalization/rated-disabilities/selectors';
+
 import NameTag from '~/applications/personalization/components/NameTag';
 import ProfileSubNav from './ProfileSubNav';
 import ProfileMobileSubNav from './ProfileMobileSubNav';
@@ -45,7 +47,7 @@ const ProfileWrapper = ({
   isInMVI,
   showNotAllDataAvailableError,
   totalDisabilityRating,
-  totalDisabilityRatingError,
+  totalDisabilityRatingServerError,
   showUpdatedNameTag,
   showNameTag,
 }) => {
@@ -74,7 +76,7 @@ const ProfileWrapper = ({
           <NameTag
             showUpdatedNameTag
             totalDisabilityRating={totalDisabilityRating}
-            totalDisabilityRatingError={totalDisabilityRatingError}
+            totalDisabilityRatingServerError={totalDisabilityRatingServerError}
           />
         )}
 
@@ -129,7 +131,7 @@ const mapStateToProps = (state, ownProps) => {
   return {
     hero,
     totalDisabilityRating: state.totalRating?.totalDisabilityRating,
-    totalDisabilityRatingError: state.totalRating?.error,
+    totalDisabilityRatingServerError: hasTotalDisabilityServerError(state),
     showNameTag: ownProps.isLOA3 && isEmpty(hero?.errors),
     showNotAllDataAvailableError:
       !!cnpDirectDepositLoadError(state) ||

--- a/src/applications/personalization/profile/tests/e2e/helpers.js
+++ b/src/applications/personalization/profile/tests/e2e/helpers.js
@@ -45,15 +45,29 @@ export const mockFeatureToggles = () => {
   });
 };
 
-export function nameTagRenders({ withDisabilityRating = true }) {
+function nameTagRenders() {
   cy.findByTestId('name-tag').should('exist');
   cy.findByText('Wesley Watson Ford').should('exist');
   cy.findByText('United States Air Force').should('exist');
-  if (withDisabilityRating) {
-    cy.findByText('Your disability rating:').should('exist');
-    cy.findByText('90% Service connected').should('exist');
-  } else {
-    cy.findByText(/View disability rating/i).should('exist');
-    cy.findByText(/service connected/i).should('not.exist');
-  }
+}
+
+export function nameTagRendersWithDisabilityRating() {
+  nameTagRenders();
+  cy.findByText('Your disability rating:').should('exist');
+  cy.findByText('90% Service connected').should('exist');
+  cy.findByText(/View disability rating/i).should('not.exist');
+}
+
+export function nameTagRendersWithFallbackLink() {
+  nameTagRenders();
+  cy.findByText('Your disability rating:').should('not.exist');
+  cy.findByText(/View disability rating/i).should('exist');
+  cy.findByText(/service connected/i).should('not.exist');
+}
+
+export function nameTagRendersWithoutDisabilityRating() {
+  nameTagRenders();
+  cy.findByText('Your disability rating:').should('not.exist');
+  cy.findByText(/View disability rating/i).should('not.exist');
+  cy.findByText(/service connected/i).should('not.exist');
 }

--- a/src/applications/personalization/profile/tests/e2e/nametag.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/nametag.cypress.spec.js
@@ -7,7 +7,12 @@ import error401 from '@@profile/tests/fixtures/401.json';
 import error500 from '@@profile/tests/fixtures/500.json';
 
 import mockUser from '../fixtures/users/user';
-import { mockFeatureToggles, nameTagRenders } from './helpers';
+import {
+  mockFeatureToggles,
+  nameTagRendersWithDisabilityRating,
+  nameTagRendersWithFallbackLink,
+  nameTagRendersWithoutDisabilityRating,
+} from './helpers';
 import { PROFILE_PATHS } from '../../constants';
 
 describe('Profile NameTag', () => {
@@ -31,7 +36,7 @@ describe('Profile NameTag', () => {
     it('should render the name, service branch, and disability rating', () => {
       mockFeatureToggles();
       cy.visit(PROFILE_PATHS.PROFILE_ROOT);
-      nameTagRenders({ withDisabilityRating: true });
+      nameTagRendersWithDisabilityRating();
     });
   });
   context('when there is a 401 fetching the disability rating', () => {
@@ -41,10 +46,10 @@ describe('Profile NameTag', () => {
         body: error401,
       });
     });
-    it('should render the name, service branch, and show a fallback link for disability rating', () => {
+    it('should render the name, service branch, and not show disability rating', () => {
       mockFeatureToggles();
       cy.visit(PROFILE_PATHS.PROFILE_ROOT);
-      nameTagRenders({ withDisabilityRating: false });
+      nameTagRendersWithoutDisabilityRating();
     });
   });
   context('when there is a 500 fetching the disability rating', () => {
@@ -57,7 +62,7 @@ describe('Profile NameTag', () => {
     it('should render the name, service branch, and show a fallback link for disability rating', () => {
       mockFeatureToggles();
       cy.visit(PROFILE_PATHS.PROFILE_ROOT);
-      nameTagRenders({ withDisabilityRating: false });
+      nameTagRendersWithFallbackLink();
     });
   });
 });

--- a/src/applications/personalization/profile/tests/fixtures/disability-rating-403.json
+++ b/src/applications/personalization/profile/tests/fixtures/disability-rating-403.json
@@ -1,0 +1,10 @@
+{
+  "errors": [
+    {
+      "title": "Forbidden",
+      "detail": "User does not have access to the requested resource",
+      "code": "403",
+      "status": "403"
+    }
+  ]
+}

--- a/src/applications/personalization/profile/tests/fixtures/disability-rating-success.json
+++ b/src/applications/personalization/profile/tests/fixtures/disability-rating-success.json
@@ -1,9 +1,7 @@
 {
   "data": {
-    "attributes": {
-      "disabilityDecisionTypeName": "Service Connected",
-      "serviceConnectedCombinedDegree": 90,
-      "userPercentOfDisability": 90
-    }
+    "id": "",
+    "type": "evss_disability_compensation_form_rating_info_responses",
+    "attributes": { "userPercentOfDisability": 90 }
   }
 }

--- a/src/applications/personalization/rated-disabilities/selectors.js
+++ b/src/applications/personalization/rated-disabilities/selectors.js
@@ -1,0 +1,21 @@
+import { isClientError, isServerError } from './util';
+
+const totalDisabilityError = state => {
+  return state.totalRating?.error ?? null;
+};
+
+export const hasTotalDisabilityClientError = state => {
+  const error = totalDisabilityError(state);
+  if (!error) {
+    return false;
+  }
+  return isClientError(error.code);
+};
+
+export const hasTotalDisabilityServerError = state => {
+  const error = totalDisabilityError(state);
+  if (!error) {
+    return false;
+  }
+  return isServerError(error.code);
+};

--- a/src/applications/personalization/rated-disabilities/selectors.unit.spec.js
+++ b/src/applications/personalization/rated-disabilities/selectors.unit.spec.js
@@ -1,0 +1,88 @@
+import { expect } from 'chai';
+
+import {
+  hasTotalDisabilityClientError,
+  hasTotalDisabilityServerError,
+} from './selectors';
+
+describe('hasTotalDisabilityServerError', () => {
+  it('returns `true` when there is a 500 error in the Redux state', () => {
+    const state = {
+      totalRating: {
+        loading: false,
+        error: {
+          code: '500',
+          detail: 'server error',
+        },
+        totalDisabilityRating: null,
+        disabilityDecisionTypeName: null,
+      },
+    };
+    expect(hasTotalDisabilityServerError(state)).to.be.true;
+  });
+  it('returns `false` when there is a 400 error in the Redux state', () => {
+    const state = {
+      totalRating: {
+        loading: false,
+        error: {
+          code: '403',
+          detail: 'User does not have access to the requested resource',
+        },
+        totalDisabilityRating: null,
+        disabilityDecisionTypeName: null,
+      },
+    };
+    expect(hasTotalDisabilityServerError(state)).to.be.false;
+  });
+  it('returns `false` when there is no error in the Redux state', () => {
+    const state = {
+      totalRating: {
+        loading: false,
+        error: null,
+        totalDisabilityRating: 100,
+      },
+    };
+    expect(hasTotalDisabilityServerError(state)).to.be.false;
+  });
+});
+
+describe('hasTotalDisabilityClientError', () => {
+  it('returns `false` when there is a 500 error in the Redux state', () => {
+    const state = {
+      totalRating: {
+        loading: false,
+        error: {
+          code: '500',
+          detail: 'server error',
+        },
+        totalDisabilityRating: null,
+        disabilityDecisionTypeName: null,
+      },
+    };
+    expect(hasTotalDisabilityClientError(state)).to.be.false;
+  });
+  it('returns `true` when there is a 400 error in the Redux state', () => {
+    const state = {
+      totalRating: {
+        loading: false,
+        error: {
+          code: '403',
+          detail: 'User does not have access to the requested resource',
+        },
+        totalDisabilityRating: null,
+        disabilityDecisionTypeName: null,
+      },
+    };
+    expect(hasTotalDisabilityClientError(state)).to.be.true;
+  });
+  it('returns `false` when there is no error in the Redux state', () => {
+    const state = {
+      totalRating: {
+        loading: false,
+        error: null,
+        totalDisabilityRating: 100,
+      },
+    };
+    expect(hasTotalDisabilityClientError(state)).to.be.false;
+  });
+});


### PR DESCRIPTION
## Description
Previous to this change, we showed a fallback "View disability rating" link in the NameTag if we encountered any error in fetching the disability rating.

With this change we only show the fallback link if the error was a 500 error. Errors in the 400 range mean the user does not have a disability rating or are blocked from accessing it. This PR totally hides any mention of disability rating from the NameTag in the case of 400 errors.

## Testing done
Updated the existing NameTag component tests as well as the Dashboard and Profile Cypress tests.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs