### PR TITLE
NOD: Add upload pages

### DIFF
--- a/src/applications/appeals/10182/config/form.js
+++ b/src/applications/appeals/10182/config/form.js
@@ -23,6 +23,8 @@ import hasRep from '../pages/hasRep';
 import repInfo from '../pages/repInfo';
 import contestableIssues from '../pages/contestableIssues';
 import boardReview from '../pages/boardReview';
+import evidenceIntro from '../pages/evidenceIntro';
+import evidenceUpload from '../pages/evidenceUpload';
 
 import initialData from '../tests/schema/initialData';
 
@@ -140,6 +142,19 @@ const formConfig = {
           path: 'board-review-option',
           uiSchema: boardReview.uiSchema,
           schema: boardReview.schema,
+        },
+        evidenceIntro: {
+          title: 'Additional evidence',
+          path: 'additional-evidence',
+          uiSchema: evidenceIntro.uiSchema,
+          schema: evidenceIntro.schema,
+        },
+        evidenceUpload: {
+          title: 'Additional evidence',
+          path: 'additional-evidence/upload',
+          depends: formData => formData?.['view:additionalEvidence'],
+          uiSchema: evidenceUpload.uiSchema,
+          schema: evidenceUpload.schema,
         },
       },
     },

--- a/src/applications/appeals/10182/config/form.js
+++ b/src/applications/appeals/10182/config/form.js
@@ -15,6 +15,12 @@ import ConfirmationPage from '../containers/ConfirmationPage';
 import GetFormHelp from '../content/GetFormHelp';
 import ReviewDescription from '../components/ReviewDescription';
 
+import {
+  hasRepresentative,
+  canUploadEvidence,
+  wantsToUploadEvidence,
+} from '../utils/helpers';
+
 // Pages
 import veteranInfo from '../pages/veteranInfo';
 import contactInfo from '../pages/contactInfo';
@@ -26,7 +32,7 @@ import boardReview from '../pages/boardReview';
 import evidenceIntro from '../pages/evidenceIntro';
 import evidenceUpload from '../pages/evidenceUpload';
 
-import initialData from '../tests/schema/initialData';
+// import initialData from '../tests/schema/initialData';
 
 // const { } = fullSchema.properties;
 // const { } = fullSchema.definitions;
@@ -89,7 +95,7 @@ const formConfig = {
           path: 'veteran-information',
           uiSchema: veteranInfo.uiSchema,
           schema: veteranInfo.schema,
-          initialData,
+          // initialData,
         },
         confirmContactInformation: {
           title: 'Contact information',
@@ -117,7 +123,7 @@ const formConfig = {
         repInfo: {
           title: 'Representative Information',
           path: 'representative-information',
-          depends: formData => formData?.['view:hasRep'],
+          depends: hasRepresentative,
           uiSchema: repInfo.uiSchema,
           schema: repInfo.schema,
         },
@@ -146,13 +152,14 @@ const formConfig = {
         evidenceIntro: {
           title: 'Additional evidence',
           path: 'additional-evidence',
+          depends: canUploadEvidence,
           uiSchema: evidenceIntro.uiSchema,
           schema: evidenceIntro.schema,
         },
         evidenceUpload: {
           title: 'Additional evidence',
           path: 'additional-evidence/upload',
-          depends: formData => formData?.['view:additionalEvidence'],
+          depends: wantsToUploadEvidence,
           uiSchema: evidenceUpload.uiSchema,
           schema: evidenceUpload.schema,
         },

--- a/src/applications/appeals/10182/constants.js
+++ b/src/applications/appeals/10182/constants.js
@@ -22,3 +22,16 @@ export const FORMAT_READABLE = 'MMMM d, yyyy';
 
 // contested issue dates
 export const FORMAT_YMD = 'yyyy-MM-dd';
+
+export const SUPPORTED_UPLOAD_TYPES = [
+  'pdf',
+  'jpg',
+  'jpeg',
+  'png',
+  'gif',
+  'bmp',
+  'txt',
+];
+
+export const MAX_FILE_SIZE_MB = 100;
+export const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 ** 2; // binary based

--- a/src/applications/appeals/10182/content/EvidenceUpload.jsx
+++ b/src/applications/appeals/10182/content/EvidenceUpload.jsx
@@ -8,9 +8,14 @@ const fileTypes = `.${SUPPORTED_UPLOAD_TYPES.slice(0, -1).join(
   ', .',
 )} or .${SUPPORTED_UPLOAD_TYPES.slice(-1)}`;
 
+export const EvidenceUploadLabel = (
+  <h3 className="vads-u-font-size--h4 vads-u-display--inline">
+    Upload your additional evidence
+  </h3>
+);
+
 export const EvidenceUploadDescription = (
   <div>
-    <h3 className="vads-u-font-size--h4">Additional evidence</h3>
     <p>
       You can upload your document in a {fileTypes} file format. You’ll first
       need to scan a copy of your document onto your computer or mobile phone.

--- a/src/applications/appeals/10182/content/EvidenceUpload.jsx
+++ b/src/applications/appeals/10182/content/EvidenceUpload.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import { SUPPORTED_UPLOAD_TYPES, MAX_FILE_SIZE_MB } from '../constants';
+
+export const evidenceUploadTitle = 'Additional evidence';
+
+const fileTypes = `.${SUPPORTED_UPLOAD_TYPES.slice(0, -1).join(
+  ', .',
+)} or .${SUPPORTED_UPLOAD_TYPES.slice(-1)}`;
+
+export const EvidenceUploadDescription = (
+  <div>
+    <h3 className="vads-u-font-size--h4">Additional evidence</h3>
+    <p>
+      You can upload your document in a {fileTypes} file format. You’ll first
+      need to scan a copy of your document onto your computer or mobile phone.
+      You can then upload the document from there.
+    </p>
+    <p>Guidelines for uploading a file:</p>
+    <ul>
+      <li>File types you can upload: {fileTypes}</li>
+      <li>{`Maximum file size: ${MAX_FILE_SIZE_MB}MB`}</li>
+    </ul>
+    <p>
+      <em>
+        A 1MB file equals about 500 pages of text. A photo is usually about 6MB.
+        Large files can take longer to upload with a slow Internet connection.
+      </em>
+    </p>
+  </div>
+);

--- a/src/applications/appeals/10182/content/evidenceIntro.jsx
+++ b/src/applications/appeals/10182/content/evidenceIntro.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
+import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
+
+export const evidenceUploadIntroTitle = 'Additional evidence';
+
+export const evidenceUploadIntroDescription = (
+  <>
+    <p>
+      You can choose to submit more evidence with this request, or within 90
+      days after we receive this request.
+    </p>
+    <div className="vads-u-margin-y--2">
+      <AdditionalInfo triggerText="How do I submit evidence later?">
+        You can submit more evidence by mailing it to this address:
+        <p className="va-address-block vads-u-margin-left--0p5">
+          Board of Veterans’ Appeals
+          <br />
+          PO Box 27063
+          <br />
+          Washington, D.C. 20038
+        </p>
+        You can also send it by fax to{' '}
+        <Telephone notClickable contact="844-678-8979" />
+      </AdditionalInfo>
+    </div>
+  </>
+);
+
+export const evidenceUploadIntroLabel =
+  'Would you like to submit more evidence right now?';

--- a/src/applications/appeals/10182/pages/evidenceIntro.js
+++ b/src/applications/appeals/10182/pages/evidenceIntro.js
@@ -1,0 +1,32 @@
+import {
+  evidenceUploadIntroTitle,
+  evidenceUploadIntroDescription,
+  evidenceUploadIntroLabel,
+} from '../content/evidenceIntro';
+
+const contactInfo = {
+  uiSchema: {
+    'ui:title': evidenceUploadIntroTitle,
+    'ui:description': evidenceUploadIntroDescription,
+    'view:additionalEvidence': {
+      'ui:title': evidenceUploadIntroLabel,
+      'ui:widget': 'yesNo',
+      'ui:options': {
+        labels: {
+          N: 'No, I’ll submit it later.',
+        },
+      },
+    },
+  },
+
+  schema: {
+    type: 'object',
+    properties: {
+      'view:additionalEvidence': {
+        type: 'boolean',
+      },
+    },
+  },
+};
+
+export default contactInfo;

--- a/src/applications/appeals/10182/pages/evidenceUpload.jsx
+++ b/src/applications/appeals/10182/pages/evidenceUpload.jsx
@@ -1,0 +1,32 @@
+import { EvidenceUploadDescription } from '../content/EvidenceUpload';
+import { evidenceUploadUI } from '../utils/upload';
+
+export const evidenceUpload = {
+  uiSchema: {
+    'ui:description': EvidenceUploadDescription,
+    evidence: evidenceUploadUI,
+  },
+
+  schema: {
+    type: 'object',
+    properties: {
+      evidence: {
+        type: 'array',
+        minItems: 1,
+        items: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+            },
+            confirmationCode: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+export default evidenceUpload;

--- a/src/applications/appeals/10182/pages/evidenceUpload.jsx
+++ b/src/applications/appeals/10182/pages/evidenceUpload.jsx
@@ -1,14 +1,13 @@
-import { EvidenceUploadDescription } from '../content/EvidenceUpload';
 import { evidenceUploadUI } from '../utils/upload';
 
 export const evidenceUpload = {
   uiSchema: {
-    'ui:description': EvidenceUploadDescription,
     evidence: evidenceUploadUI,
   },
 
   schema: {
     type: 'object',
+    required: ['evidence'],
     properties: {
       evidence: {
         type: 'array',

--- a/src/applications/appeals/10182/sass/10182-nod.scss
+++ b/src/applications/appeals/10182/sass/10182-nod.scss
@@ -99,6 +99,23 @@ dl.review {
   }
 }
 
+
 .form-checkbox.usa-input-error {
   margin-top: 0;
+}
+
+/* additional evidence */
+article[data-location$="/upload"] {
+  #root_evidence_add_label {
+    margin-top: 0;
+  }
+  .schemaform-file-list {
+    p {
+      margin: 0;
+    }
+    strong {
+      display: block;
+      margin-bottom: 0.5em;
+    }
+  }
 }

--- a/src/applications/appeals/10182/tests/pages/evidenceIntro.unit.spec.js
+++ b/src/applications/appeals/10182/tests/pages/evidenceIntro.unit.spec.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import {
+  DefinitionTester,
+  selectRadio,
+} from 'platform/testing/unit/schemaform-utils.jsx';
+import { mount } from 'enzyme';
+import formConfig from '../../config/form';
+
+describe('evidence intro page', () => {
+  const {
+    schema,
+    uiSchema,
+  } = formConfig.chapters.boardReview.pages.evidenceIntro;
+
+  it('should render', () => {
+    const form = mount(
+      <DefinitionTester
+        definitions={{}}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+      />,
+    );
+
+    expect(form.find('input').length).to.equal(2);
+    form.unmount();
+  });
+
+  it('should allow submit', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={{}}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    selectRadio(form, 'root_view:additionalEvidence', 'N');
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error-message').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+    form.unmount();
+  });
+});

--- a/src/applications/appeals/10182/tests/pages/evidenceUpload.unit.spec.js
+++ b/src/applications/appeals/10182/tests/pages/evidenceUpload.unit.spec.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+
+import { uploadStore } from 'platform/forms-system/test/config/helpers';
+import {
+  DefinitionTester, // selectCheckbox
+} from 'platform/testing/unit/schemaform-utils.jsx';
+import formConfig from '../../config/form.js';
+
+describe('Additional evidence upload', () => {
+  const page = formConfig.chapters.boardReview.pages.evidenceUpload;
+  const { schema, uiSchema, arrayPath } = page;
+
+  it('should render', () => {
+    const form = mount(
+      <Provider store={uploadStore}>
+        <DefinitionTester
+          arrayPath={arrayPath}
+          pagePerItemIndex={0}
+          definitions={{}}
+          schema={schema}
+          data={{}}
+          uiSchema={uiSchema}
+        />
+      </Provider>,
+    );
+
+    expect(form.find('input[type="file"]').length).to.equal(1);
+    form.unmount();
+  });
+
+  it('should not submit without required upload', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <Provider store={uploadStore}>
+        <DefinitionTester
+          arrayPath={arrayPath}
+          pagePerItemIndex={0}
+          onSubmit={onSubmit}
+          definitions={{}}
+          schema={schema}
+          data={{}}
+          uiSchema={uiSchema}
+        />
+      </Provider>,
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error-message').length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
+    form.unmount();
+  });
+
+  it('should submit with uploaded form', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <Provider store={uploadStore}>
+        <DefinitionTester
+          arrayPath={arrayPath}
+          pagePerItemIndex={0}
+          onSubmit={onSubmit}
+          definitions={{}}
+          schema={schema}
+          data={{
+            evidence: [
+              {
+                confirmationCode: 'testing',
+                name: 'test.pdf',
+              },
+            ],
+          }}
+          uiSchema={uiSchema}
+        />
+      </Provider>,
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error-message').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+    form.unmount();
+  });
+});

--- a/src/applications/appeals/10182/utils/helpers.js
+++ b/src/applications/appeals/10182/utils/helpers.js
@@ -6,6 +6,13 @@ import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNa
 import { SELECTED } from '../constants';
 import { isValidDate } from '../validations';
 
+// checks
+export const hasRepresentative = formData => formData['view:hasRep'];
+export const canUploadEvidence = formData =>
+  formData.boardReviewOption !== 'direct_review';
+export const wantsToUploadEvidence = formData =>
+  canUploadEvidence(formData) && formData['view:additionalEvidence'];
+
 export const noticeOfDisagreementFeature = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.form10182Nod];
 

--- a/src/applications/appeals/10182/utils/upload.js
+++ b/src/applications/appeals/10182/utils/upload.js
@@ -4,6 +4,11 @@ import { focusElement } from 'platform/utilities/ui';
 
 import { SUPPORTED_UPLOAD_TYPES, MAX_FILE_SIZE_BYTES } from '../constants';
 
+import {
+  EvidenceUploadLabel,
+  EvidenceUploadDescription,
+} from '../content/EvidenceUpload';
+
 const focusFileCard = name => {
   const target = [
     ...document.querySelectorAll('.schemaform-file-list li'),
@@ -13,26 +18,29 @@ const focusFileCard = name => {
   }
 };
 
-export const evidenceUploadUI = fileUiSchema(' ', {
-  fileUploadUrl: `${environment.API_URL}/v0/decision_review_evidence`,
-  addAnotherLabel: 'Add another document',
-  fileTypes: SUPPORTED_UPLOAD_TYPES,
-  maxSize: MAX_FILE_SIZE_BYTES,
-  minSize: 1,
-  createPayload: ({ name }) => {
-    const payload = new FormData();
-    payload.append('decision_review_evidence_attachment[file_data]', name);
-    return payload;
-  },
-  parseResponse: (response, { name }) => {
-    setTimeout(() => {
-      focusFileCard(name);
-    });
-    return {
-      name,
-      confirmationCode: response.data.attributes.guid,
-    };
-  },
-  classNames: '',
-  attachmentName: false,
-});
+export const evidenceUploadUI = {
+  ...fileUiSchema(EvidenceUploadLabel, {
+    fileUploadUrl: `${environment.API_URL}/v0/decision_review_evidence`,
+    addAnotherLabel: 'Add another document',
+    fileTypes: SUPPORTED_UPLOAD_TYPES,
+    maxSize: MAX_FILE_SIZE_BYTES,
+    minSize: 1024,
+    createPayload: ({ name }) => {
+      const payload = new FormData();
+      payload.append('decision_review_evidence_attachment[file_data]', name);
+      return payload;
+    },
+    parseResponse: (response, { name }) => {
+      setTimeout(() => {
+        focusFileCard(name);
+      });
+      return {
+        name,
+        confirmationCode: response.data.attributes.guid,
+      };
+    },
+    classNames: '',
+    attachmentName: false,
+  }),
+  'ui:description': EvidenceUploadDescription,
+};

--- a/src/applications/appeals/10182/utils/upload.js
+++ b/src/applications/appeals/10182/utils/upload.js
@@ -1,0 +1,38 @@
+import environment from 'platform/utilities/environment';
+import fileUiSchema from 'platform/forms-system/src/js/definitions/file';
+import { focusElement } from 'platform/utilities/ui';
+
+import { SUPPORTED_UPLOAD_TYPES, MAX_FILE_SIZE_BYTES } from '../constants';
+
+const focusFileCard = name => {
+  const target = [
+    ...document.querySelectorAll('.schemaform-file-list li'),
+  ].find(entry => entry.textContent?.trim().includes(name));
+  if (target) {
+    focusElement(target);
+  }
+};
+
+export const evidenceUploadUI = fileUiSchema(' ', {
+  fileUploadUrl: `${environment.API_URL}/v0/decision_review_evidence`,
+  addAnotherLabel: 'Add another document',
+  fileTypes: SUPPORTED_UPLOAD_TYPES,
+  maxSize: MAX_FILE_SIZE_BYTES,
+  minSize: 1,
+  createPayload: ({ name }) => {
+    const payload = new FormData();
+    payload.append('decision_review_evidence_attachment[file_data]', name);
+    return payload;
+  },
+  parseResponse: (response, { name }) => {
+    setTimeout(() => {
+      focusFileCard(name);
+    });
+    return {
+      name,
+      confirmationCode: response.data.attributes.guid,
+    };
+  },
+  classNames: '',
+  attachmentName: false,
+});


### PR DESCRIPTION
## Description

Add Board Appeals Form 10182 (Notice of Disagreement) upload pages, and fixed the rendering of the intro page - the "Direct review" choice will skip the upload intro and file upload pages.

This is preliminary work. We still need to determine what file types are allowed to be uploaded and if we will support password-protected PDFs.

`100MB` is a determined max file size.

Related:
- Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/23195
- Design: https://vsateams.invisionapp.com/share/8Y10I6K7DU9R#/screens/447560989
- API: https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/api-reference/index.html?url=https://staging-api.va.gov/v0/apidocs#/nod/decisionReviewEvidence

## Testing done

Added unit tests

## Screenshots

<details><summary>Upload intro page</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-04-15 at 4 17 08 PM](https://user-images.githubusercontent.com/136959/114939446-0ffa8200-9e06-11eb-87a8-b7cfe04a8740.png)</details>

<details><summary>Upload files page</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-04-15 at 3 59 50 PM](https://user-images.githubusercontent.com/136959/114939449-10931880-9e06-11eb-804f-ffa2f05018af.png)</details>

## Acceptance criteria
- [x] Add upload intro page
- [x] Add upload file page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
