### PR TITLE
Remove extraneous ui:order properties

### DIFF
--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -32,18 +32,17 @@ class ObjectField extends React.Component {
     super();
     this.isRequired = this.isRequired.bind(this);
     this.orderAndFilterProperties = _.flow(
-      properties => {
-        const order = _.get('ui:order', this.props.uiSchema);
-        const filtered = order
-          ? // If there is no ui:order, don't bother filtering it; leave it as
-            // undefined so orderProperties doesn't get angry about missing
-            // properties
-            order.filter(prop =>
-              Object.keys(this.props.schema.properties).includes(prop),
-            )
-          : order;
-        return orderProperties(properties, filtered);
-      },
+      properties =>
+        orderProperties(
+          properties,
+          this.props.uiSchema['ui:order']?.filter(prop =>
+            // `view:*` properties will have been removed from the schema and
+            // values by the time they reach this component. This removes them
+            // from the ui:order so we don't trigger an error in the
+            // react-json-schema library for having "extraneous properties."
+            Object.keys(this.props.schema.properties).includes(prop),
+          ),
+        ),
       _.groupBy(item => {
         const expandUnderField = _.get(
           [item, 'ui:options', 'expandUnder'],

--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -32,8 +32,18 @@ class ObjectField extends React.Component {
     super();
     this.isRequired = this.isRequired.bind(this);
     this.orderAndFilterProperties = _.flow(
-      properties =>
-        orderProperties(properties, _.get('ui:order', this.props.uiSchema)),
+      properties => {
+        const order = _.get('ui:order', this.props.uiSchema);
+        const filtered = order
+          ? // If there is no ui:order, don't bother filtering it; leave it as
+            // undefined so orderProperties doesn't get angry about missing
+            // properties
+            order.filter(prop =>
+              Object.keys(this.props.schema.properties).includes(prop),
+            )
+          : order;
+        return orderProperties(properties, filtered);
+      },
       _.groupBy(item => {
         const expandUnderField = _.get(
           [item, 'ui:options', 'expandUnder'],

--- a/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
@@ -31,6 +31,41 @@ describe('Schemaform review: ObjectField', () => {
     expect(tree.getByRole('textbox')).to.exist;
   });
 
+  it('should render with "extra" view:* fields in the ui:order', () => {
+    // When the review ObjectField is rendered, the `view:*` properties are
+    // removed. This test ensures that the `view:*` properties are also removed
+    // from the `ui:order` before running orderProperties(), which will throw an
+    // error if extraneous `ui:order` properties are present (properties which
+    // aren't in the schema).
+    const onChange = sinon.spy();
+    const onBlur = sinon.spy();
+
+    const schema = {
+      properties: {
+        test: {
+          type: 'string',
+        },
+      },
+    };
+
+    const uiSchema = {
+      'ui:order': ['test', 'view:testProp'],
+    };
+
+    const tree = render(
+      <ObjectField
+        schema={schema}
+        uiSchema={uiSchema}
+        idSchema={{}}
+        requiredSchema={{}}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+
+    expect(tree.getByRole('textbox')).to.exist;
+  });
+
   it('should not render hidden field', () => {
     const onChange = sinon.spy();
     const onBlur = sinon.spy();


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/22921

## Testing done
Manual testing: I followed the instructions @zurbergram provided in https://github.com/department-of-veterans-affairs/vets-website/pull/16658 to recreate the issue and confirm the fix.

I also wrote a new unit test. I ensured that it broke without the fix and worked with the fix in place.

## Screenshots
N/A

## Acceptance criteria
- [ ] The object field renders successfully when `view:*` properties are specified in an object's `ui:order`