### PR TITLE
Uncomment sitemap tests for master branch workflow

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,10 +76,9 @@ node('vetsgov-general-purpose') {
             'nightwatch-e2e': {
               sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p nightwatch up -d && docker-compose -p nightwatch run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run nightwatch:docker"
             },          
-            // TODO: Uncomment once https://github.com/department-of-veterans-affairs/vets-website/pull/16424/ is merged
-            // 'nightwatch-accessibility': {
-            //     sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p accessibility up -d && docker-compose -p accessibility run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run nightwatch:docker -- --env=accessibility"
-            // },
+            'nightwatch-accessibility': {
+                sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p accessibility up -d && docker-compose -p accessibility run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run nightwatch:docker -- --env=accessibility"
+            },
             cypress: {
               sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p cypress up -d && docker-compose -p cypress run --rm --entrypoint=npm -e CI=true -e NO_COLOR=1 vets-website --no-color run cy:test:docker"
             }
@@ -101,10 +100,9 @@ node('vetsgov-general-purpose') {
         throw error
       } finally {
         sh "docker-compose -p nightwatch down --remove-orphans"
-        // TODO: Uncomment once https://github.com/department-of-veterans-affairs/vets-website/pull/16424/ is merged
-        // if (commonStages.IS_PROD_BRANCH && commonStages.VAGOV_BUILDTYPES.contains('vagovprod')) {
-        //   sh "docker-compose -p accessibility down --remove-orphans"
-        // }
+        if (commonStages.IS_PROD_BRANCH && commonStages.VAGOV_BUILDTYPES.contains('vagovprod')) {
+          sh "docker-compose -p accessibility down --remove-orphans"
+        }
         sh "docker-compose -p cypress down --remove-orphans"
         step([$class: 'JUnitResultArchiver', testResults: 'logs/nightwatch/**/*.xml'])
       }

--- a/src/platform/site-wide/tests/sitemap/sitemap-1.spec.js
+++ b/src/platform/site-wide/tests/sitemap/sitemap-1.spec.js
@@ -10,12 +10,11 @@ module.exports = {
     client.timeoutsAsyncScript(1000);
     SitemapHelpers.sitemapURLs().then(function runTestsOnFirstQuarterOfSitemap({
       urls,
-      onlyTest508Rules, // eslint-disable-line no-unused-vars
+      onlyTest508Rules,
     }) {
       const mark = Math.ceil(urls.length / 4);
-      // eslint-disable-next-line no-unused-vars
       const segment = urls.splice(0, mark);
-      // SitemapHelpers.runTests(client, segment, onlyTest508Rules);
+      SitemapHelpers.runTests(client, segment, onlyTest508Rules);
       client.end();
     });
   },


### PR DESCRIPTION
## Description

This PR adds the `nightwatch-accessibility` step back to the CI workflow that runs after a PR is merged to `master`. 

## Additional Context

The sitemap a11y tests previously ran on a daily schedule *and* after PRs were merged to `master`. Those tests started behaving unpredictably earlier this week, and they were blocking the daily deploy. We commented them out as a short-term solution to prevent the daily deploy from being blocked while we investigated the cause. We never found the root cause, but the daily sitemap a11y tests have now passed two days in a row. Therefore we're going to try re-adding them to the `master` branch workflow after the 2021-04-16 deploy goes out. 

## Links

- [Thread](https://dsva.slack.com/archives/C01RAS1KAQK/p1618575641067900) where Tim says, "Might try getting them back in there today after the deploy goes out to see if the Jenkins work Ops did fixed any weirdness"
- [Thread](https://dsva.slack.com/archives/C0MQ281DJ/p1618423474178600) about failures on 2021-04-14
- [Thread](https://dsva.slack.com/archives/C01RAS1KAQK/p1618320302000900) about failures on 2021-04-13

## Testing done

CI
