### PR TITLE
22865 add heading to how to cancel message in appointment details

### DIFF
--- a/src/applications/vaos/appointment-list/components/CommunityCareAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/CommunityCareAppointmentDetailsPage.jsx
@@ -151,11 +151,9 @@ function CommunityCareAppointmentDetailsPage({
       <AlertBox
         status={ALERT_TYPE.INFO}
         className="vads-u-display--block"
+        headline="Need to make changes?"
         backgroundOnly
       >
-        <h2 className="vads-u-font-size--h3 vads-u-font-size--base vads-u-margin-top--0">
-          Need to make changes?
-        </h2>
         Contact this facility if you need to reschedule or cancel your
         appointment.
       </AlertBox>

--- a/src/applications/vaos/appointment-list/components/CommunityCareAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/CommunityCareAppointmentDetailsPage.jsx
@@ -18,6 +18,9 @@ import ErrorMessage from '../../components/ErrorMessage';
 import { selectAppointmentById } from '../redux/selectors';
 import FullWidthLayout from '../../components/FullWidthLayout';
 import Breadcrumbs from '../../components/Breadcrumbs';
+import AlertBox, {
+  ALERT_TYPE,
+} from '@department-of-veterans-affairs/component-library/AlertBox';
 
 function CommunityCareAppointmentDetailsPage({
   appointment,
@@ -145,10 +148,17 @@ function CommunityCareAppointmentDetailsPage({
         </button>
       </div>
 
-      <div className="vads-u-margin-top--2 vaos-appts__block-label vads-u-background-color--primary-alt-lightest vads-u-padding--2p5">
+      <AlertBox
+        status={ALERT_TYPE.INFO}
+        className="vads-u-display--block"
+        backgroundOnly
+      >
+        <h2 className="vads-u-font-size--h3 vads-u-font-size--base vads-u-margin-top--0">
+          Need to make changes?
+        </h2>
         Contact this facility if you need to reschedule or cancel your
         appointment.
-      </div>
+      </AlertBox>
 
       <div className="vads-u-margin-top--3 vaos-appts__block-label vaos-hide-for-print">
         <Link to="/" className="usa-button vads-u-margin-top--2" role="button">

--- a/src/applications/vaos/appointment-list/components/CommunityCareAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/CommunityCareAppointmentDetailsPage.jsx
@@ -146,7 +146,7 @@ function CommunityCareAppointmentDetailsPage({
       </div>
 
       <div className="vads-u-margin-top--2 vaos-appts__block-label vads-u-background-color--primary-alt-lightest vads-u-padding--2p5">
-        Contact this provider if you need to reschedule or cancel your
+        Contact this facility if you need to reschedule or cancel your
         appointment.
       </div>
 

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoVisitSection.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoVisitSection.jsx
@@ -133,11 +133,9 @@ export default function VideoVisitLocation({ header, appointment, facility }) {
         <AlertBox
           status={ALERT_TYPE.INFO}
           className="vads-u-display--block"
+          headline=" Need to make changes?"
           backgroundOnly
         >
-          <h2 className="vads-u-font-size--h3 vads-u-font-size--base vads-u-margin-top--0">
-            Need to make changes?
-          </h2>
           Contact this facility if you need to reschedule or cancel your
           appointment.
           <br />

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoVisitSection.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoVisitSection.jsx
@@ -135,6 +135,9 @@ export default function VideoVisitLocation({ header, appointment, facility }) {
           className="vads-u-display--block"
           backgroundOnly
         >
+          <h2 className="vads-u-font-size--h3 vads-u-font-size--base vads-u-margin-top--0">
+            Need to make changes?
+          </h2>
           Contact this facility if you need to reschedule or cancel your
           appointment.
           <br />


### PR DESCRIPTION
## Description
The PR add/modifies a heading to the how to cancel message box to draw attention to the information

## Testing done
Unit testing

## Screenshots
![localhost_3001_health-care_schedule-view-va-appointments_appointments_va_a784f714fa1606e39dee11e3bdbb7901(iPhone X) (1)](https://user-images.githubusercontent.com/3587066/115061605-feb98000-9eae-11eb-8ebb-4069ffe61ea5.png)
---
![localhost_3001_health-care_schedule-view-va-appointments_appointments_va_a784f714fa1606e39dee11e3bdbb7901(iPhone X) (2)](https://user-images.githubusercontent.com/3587066/115061773-31fc0f00-9eaf-11eb-9980-0b5f9c684920.png)


## Acceptance criteria
- [ ] All test should pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
