### PR TITLE
Kelsonic 22181 searchable content field

### DIFF
--- a/src/applications/resources-and-support/hooks/useGetSearchResults.js
+++ b/src/applications/resources-and-support/hooks/useGetSearchResults.js
@@ -65,7 +65,7 @@ export default function useGetSearchResults(articles, query, page) {
         ),
 
         // Number of times a keyword is found in the article's introText.
-        keywordsCountsDescription: keywords?.reduce(
+        keywordsCountsIntroText: keywords?.reduce(
           (keywordInstances, keyword) =>
             keywordInstances +
             article.introText.toLowerCase()?.split(keyword)?.length -
@@ -73,10 +73,37 @@ export default function useGetSearchResults(articles, query, page) {
           0,
         ),
 
-        wholePhraseMatchCounts:
+        // Number of times a keyword is found in the article's searchableContent.
+        keywordsCountsContent: keywords?.reduce(
+          (keywordInstances, keyword) =>
+            keywordInstances +
+            article.searchableContent.toLowerCase()?.split(keyword)?.length -
+            1,
+          0,
+        ),
+
+        // Number of times the full query is found in the article's title.
+        wholePhraseMatchCountsTitle:
+          article.title.toLowerCase()?.split(query.toLowerCase())?.length - 1,
+
+        // Number of times the full query is found in the article's introText.
+        wholePhraseMatchCountsIntroText:
+          article.introText.toLowerCase()?.split(query.toLowerCase())?.length -
+          1,
+
+        // Number of times the full query is found in the article's searchableContent.
+        wholePhraseMatchCountsContent:
+          article.searchableContent.toLowerCase()?.split(query.toLowerCase())
+            ?.length - 1,
+
+        // Number of times the full query is found in the article's title, introText, searchableContent combined.
+        wholePhraseMatchCountsTotal:
           article.title.toLowerCase()?.split(query.toLowerCase())?.length -
           1 +
           (article.introText.toLowerCase()?.split(query.toLowerCase())?.length -
+            1) +
+          (article.searchableContent.toLowerCase()?.split(query.toLowerCase())
+            ?.length -
             1),
       }));
 
@@ -86,20 +113,20 @@ export default function useGetSearchResults(articles, query, page) {
         // Sort ties then by alphabetical descending
         orderedResults = orderBy(
           filteredArticles,
-          ['keywordsCountsTitle', 'keywordsCountsDescription', 'title'],
+          ['keywordsCountsTitle', 'keywordsCountsIntroText', 'title'],
           ['desc', 'desc', 'asc'],
         );
       } else {
         // Sort first by the number of exact query matches (ignoring casing) in the title and introText
         // Sort ties by query word instances found in title descending
-        // Sort ties then by query word instances found in introText descending
+        // Sort ties then by query word instances found in searchableContent descending
         // Sort ties then by alphabetical descending
         orderedResults = orderBy(
           filteredArticles,
           [
-            'wholePhraseMatchCounts',
+            'wholePhraseMatchCountsTotal',
             'keywordsCountsTitle',
-            'keywordsCountsDescription',
+            'keywordsCountsContent',
             'title',
           ],
           ['desc', 'desc', 'desc', 'asc'],

--- a/src/applications/resources-and-support/hooks/useGetSearchResults.js
+++ b/src/applications/resources-and-support/hooks/useGetSearchResults.js
@@ -6,6 +6,9 @@ import environment from 'platform/utilities/environment';
 import recordEvent from 'platform/monitoring/record-event';
 import { SEARCH_IGNORE_LIST } from '../constants';
 
+const countInstancesFound = (searchableString = '', keyword = '') =>
+  searchableString.toLowerCase()?.split(keyword.toLowerCase())?.length - 1;
+
 export default function useGetSearchResults(articles, query, page) {
   const [results, setResults] = useState([]);
 
@@ -58,18 +61,14 @@ export default function useGetSearchResults(articles, query, page) {
         // Number of times a keyword is found in the article's title.
         keywordsCountsTitle: keywords?.reduce(
           (keywordInstances, keyword) =>
-            keywordInstances +
-            article.title.toLowerCase()?.split(keyword)?.length -
-            1,
+            keywordInstances + countInstancesFound(article.title, keyword),
           0,
         ),
 
         // Number of times a keyword is found in the article's introText.
         keywordsCountsIntroText: keywords?.reduce(
           (keywordInstances, keyword) =>
-            keywordInstances +
-            article.introText.toLowerCase()?.split(keyword)?.length -
-            1,
+            keywordInstances + countInstancesFound(article.introText, keyword),
           0,
         ),
 
@@ -77,34 +76,30 @@ export default function useGetSearchResults(articles, query, page) {
         keywordsCountsContent: keywords?.reduce(
           (keywordInstances, keyword) =>
             keywordInstances +
-            article.searchableContent.toLowerCase()?.split(keyword)?.length -
-            1,
+            countInstancesFound(article.searchableContent, keyword),
           0,
         ),
 
         // Number of times the full query is found in the article's title.
-        wholePhraseMatchCountsTitle:
-          article.title.toLowerCase()?.split(query.toLowerCase())?.length - 1,
+        wholePhraseMatchCountsTitle: countInstancesFound(article.title, query),
 
         // Number of times the full query is found in the article's introText.
-        wholePhraseMatchCountsIntroText:
-          article.introText.toLowerCase()?.split(query.toLowerCase())?.length -
-          1,
+        wholePhraseMatchCountsIntroText: countInstancesFound(
+          article.introText,
+          query,
+        ),
 
         // Number of times the full query is found in the article's searchableContent.
-        wholePhraseMatchCountsContent:
-          article.searchableContent.toLowerCase()?.split(query.toLowerCase())
-            ?.length - 1,
+        wholePhraseMatchCountsContent: countInstancesFound(
+          article.searchableContent,
+          query,
+        ),
 
         // Number of times the full query is found in the article's title, introText, searchableContent combined.
         wholePhraseMatchCountsTotal:
-          article.title.toLowerCase()?.split(query.toLowerCase())?.length -
-          1 +
-          (article.introText.toLowerCase()?.split(query.toLowerCase())?.length -
-            1) +
-          (article.searchableContent.toLowerCase()?.split(query.toLowerCase())
-            ?.length -
-            1),
+          countInstancesFound(article.title, query) +
+          countInstancesFound(article.introText, query) +
+          countInstancesFound(article.searchableContent, query),
       }));
 
       if (environment.isProduction()) {

--- a/src/applications/resources-and-support/hooks/useGetSearchResults.js
+++ b/src/applications/resources-and-support/hooks/useGetSearchResults.js
@@ -55,52 +55,67 @@ export default function useGetSearchResults(articles, query, page) {
       // =====
       let orderedResults = [];
 
-      filteredArticles = filteredArticles?.map(article => ({
-        ...article,
-
-        // Number of times a keyword is found in the article's title.
-        keywordsCountsTitle: keywords?.reduce(
+      filteredArticles = filteredArticles?.map(article => {
+        // Derive keywords counts.
+        const keywordsCountsTitle = keywords?.reduce(
           (keywordInstances, keyword) =>
             keywordInstances + countInstancesFound(article.title, keyword),
           0,
-        ),
-
-        // Number of times a keyword is found in the article's introText.
-        keywordsCountsIntroText: keywords?.reduce(
+        );
+        const keywordsCountsIntroText = keywords?.reduce(
           (keywordInstances, keyword) =>
             keywordInstances + countInstancesFound(article.introText, keyword),
           0,
-        ),
-
-        // Number of times a keyword is found in the article's searchableContent.
-        keywordsCountsContent: keywords?.reduce(
+        );
+        const keywordsCountsContent = keywords?.reduce(
           (keywordInstances, keyword) =>
             keywordInstances +
             countInstancesFound(article.searchableContent, keyword),
           0,
-        ),
+        );
 
-        // Number of times the full query is found in the article's title.
-        wholePhraseMatchCountsTitle: countInstancesFound(article.title, query),
-
-        // Number of times the full query is found in the article's introText.
-        wholePhraseMatchCountsIntroText: countInstancesFound(
+        // Derive whole phrase match counts.
+        const wholePhraseMatchCountsTitle = countInstancesFound(
+          article.title,
+          query,
+        );
+        const wholePhraseMatchCountsIntroText = countInstancesFound(
           article.introText,
           query,
-        ),
-
-        // Number of times the full query is found in the article's searchableContent.
-        wholePhraseMatchCountsContent: countInstancesFound(
+        );
+        const wholePhraseMatchCountsContent = countInstancesFound(
           article.searchableContent,
           query,
-        ),
+        );
 
-        // Number of times the full query is found in the article's title, introText, searchableContent combined.
-        wholePhraseMatchCountsTotal:
-          countInstancesFound(article.title, query) +
-          countInstancesFound(article.introText, query) +
-          countInstancesFound(article.searchableContent, query),
-      }));
+        return {
+          ...article,
+
+          // Number of times a keyword is found in the article's title.
+          keywordsCountsTitle,
+
+          // Number of times a keyword is found in the article's introText.
+          keywordsCountsIntroText,
+
+          // Number of times a keyword is found in the article's searchableContent.
+          keywordsCountsContent,
+
+          // Number of times the full query is found in the article's title.
+          wholePhraseMatchCountsTitle,
+
+          // Number of times the full query is found in the article's introText.
+          wholePhraseMatchCountsIntroText,
+
+          // Number of times the full query is found in the article's searchableContent.
+          wholePhraseMatchCountsContent,
+
+          // Number of times the full query is found in the article's title, introText, searchableContent combined.
+          wholePhraseMatchCountsTotal:
+            wholePhraseMatchCountsTitle +
+            wholePhraseMatchCountsIntroText +
+            wholePhraseMatchCountsContent,
+        };
+      });
 
       if (environment.isProduction()) {
         // Sort first by query word instances found in title descending

--- a/src/site/stages/build/plugins/create-resources-and-support-section.js
+++ b/src/site/stages/build/plugins/create-resources-and-support-section.js
@@ -307,16 +307,6 @@ function cleanHTML(text) {
   return he.decode(strippedNewlines);
 }
 
-function deriveFAQMultipleQASearchableContent(entity) {
-  return entity.fieldQAGroups
-    .map(fieldQAGroup =>
-      fieldQAGroup.entity.fieldQAs
-        .map(fieldQA => deriveQASearchableContent(fieldQA.entity))
-        .join(' '),
-    )
-    .join(' ');
-}
-
 function deriveQASearchableContent(entity) {
   // Some QAs have react widgets, so we need to have it default to an empty string in that scenario.
   const wysiwyg = entity.fieldAnswer.entity?.fieldWysiwyg?.processed || '';
@@ -328,13 +318,23 @@ function deriveQASearchableContent(entity) {
   return `${entity.title} ${cleanedWysiwyg}`;
 }
 
+function deriveFAQMultipleQASearchableContent(entity) {
+  return entity.fieldQAGroups
+    .map(fieldQAGroup =>
+      fieldQAGroup.entity.fieldQAs
+        .map(fieldQA => deriveQASearchableContent(fieldQA.entity))
+        .join(' '),
+    )
+    .join(' ');
+}
+
 function deriveStepByStepSearchableContent(entity) {
   return entity.fieldSteps
     .map(
       fieldStep =>
         `${fieldStep.entity.fieldSectionHeader} ${cleanHTML(
           fieldStep.entity.fieldStep
-            .map(fieldStep => fieldStep.entity.fieldWysiwyg.processed)
+            .map(fieldSubStep => fieldSubStep.entity.fieldWysiwyg.processed)
             .join(' '),
         )}`,
     )
@@ -357,8 +357,8 @@ function deriveSupportResourcesDetailPageSearchableContent(entity) {
               return `${
                 vaParagraph.entity.fieldTitle
               } ${vaParagraph.entity.fieldVaParagraphs
-                .map(vaParagraph =>
-                  cleanHTML(vaParagraph.entity.fieldTable.tableValue),
+                .map(subVAParagraph =>
+                  cleanHTML(subVAParagraph.entity.fieldTable.tableValue),
                 )
                 .join(' ')}`;
             })

--- a/src/site/stages/build/plugins/create-resources-and-support-section.js
+++ b/src/site/stages/build/plugins/create-resources-and-support-section.js
@@ -291,7 +291,11 @@ function createArticleListingsPages(files) {
   );
 }
 
-function deriveIntroText(htmlText) {
+function deriveIntroText(article) {
+  const htmlText =
+    article.entityBundle === 'q_a'
+      ? article.fieldAnswer.entity.fieldWysiwyg.processed
+      : article.fieldIntroTextLimitedHtml.processed;
   const sanitizedText = liquid.filters.strip_html(htmlText);
   const strippedNewlines = liquid.filters.strip_newlines(sanitizedText);
   return he.decode(strippedNewlines);
@@ -300,22 +304,13 @@ function deriveIntroText(htmlText) {
 function createSearchResults(files) {
   const allArticles = getArticlesBelongingToResourcesAndSupportSection(files);
   const articleSearchData = allArticles.map(article => {
-    let introText = '';
-
-    if (article.entityBundle === 'q_a') {
-      const answer = article.fieldAnswer.entity.fieldWysiwyg.processed;
-      introText = deriveIntroText(answer);
-    } else {
-      introText = deriveIntroText(article.fieldIntroTextLimitedHtml.processed);
-    }
-
     return {
       entityBundle: article.entityBundle,
       entityUrl: { path: article.entityUrl.path },
       fieldOtherCategories: article.fieldOtherCategories,
       fieldPrimaryCategory: article.fieldPrimaryCategory,
       fieldTags: article.fieldTags,
-      introText,
+      introText: deriveIntroText(article),
       title: article.title,
     };
   });


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/22181

This PR adds a `searchableContent` field for R&S articles to augment our search experience.

## Testing done


## Screenshots
![image](https://user-images.githubusercontent.com/12773166/115062995-37099000-9ea8-11eb-9918-9cd03c3ffe7f.png)

![image](https://user-images.githubusercontent.com/12773166/115062100-34f30180-9ea7-11eb-885b-3b8f9adc886a.png)

![image](https://user-images.githubusercontent.com/12773166/115261816-2f88f780-a0f1-11eb-91b3-706964f91589.png)

## Acceptance criteria
- [x] adds a `searchableContent` field for R&S articles to augment our search experience

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
