### PR TITLE
Updated direct deposit payment label for 1990s

### DIFF
--- a/src/applications/edu-benefits/1990s/components/PaymentView.jsx
+++ b/src/applications/edu-benefits/1990s/components/PaymentView.jsx
@@ -44,7 +44,7 @@ export const PaymentView = ({ formData = {}, originalData = {} }) => {
           </strong>
         </p>
         <p data-testid="account-number">
-          Account number: {mask(accountNumber, 4)}
+          Bank account number: {mask(accountNumber, 4)}
         </p>
         <p data-testid="routing-number">
           Bank routing number: {mask(routingNumber, 4)}


### PR DESCRIPTION
## Description
Updated direct deposit label for 1990S

https://github.com/department-of-veterans-affairs/va.gov-team/issues/23138

## Testing done
local 

## Screenshots
<img width="655" alt="Screen Shot 2021-04-16 at 2 57 49 PM" src="https://user-images.githubusercontent.com/50601724/115071493-51e9fd80-9ec4-11eb-913d-b1022d267e23.png">


## Acceptance criteria
- [x] Change direct deposit label from Account Number to Bank account number

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
