### PR TITLE
Fix some medallia mobile styles

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-medallia.scss
+++ b/src/platform/site-wide/sass/modules/_m-medallia.scss
@@ -35,12 +35,6 @@
   width: 50px;
 }
 
-/* Add padding to the bottom of the Medallia form */
-/* `.ng-scope .panel-footer-web` is common to multiple Medallia forms and form pages */
-.ng-scope .panel-footer-web {
-  padding-bottom: 1rem;
-}
-
 /* CSS Overrides for the 3-question survey on /find-locations */
 
 /* An excessively specific selector is needed to override !important and inline styles */

--- a/src/platform/site-wide/sass/modules/_m-medallia.scss
+++ b/src/platform/site-wide/sass/modules/_m-medallia.scss
@@ -57,28 +57,6 @@
   position: relative;
 }
 
-/* The `ng-hide` class only seems to be used in mobile browsers/emulators, but not laptop browsers */
-/* I tried `#liveForm > div > div.neb-show-button-as-link.neb-form-close-btn.pull-right`, but it didn't work */
-/* The intermediary child div selectors seem necessary to reach sufficient specificity */
-#liveForm
-  > div
-  > div.neb-form-close-btn-container.ng-hide
-  > div
-  > button.neb-show-button-as-link {
-  /* Position this button absolutely relative to the `div.row.neb-form-close-btn-container.ng-hide` element */
-  position: absolute;
-
-  /* Give some breathing room above the X-icon */
-  top: 8px;
-
-  /* Give some breathing room to the right of the X-icon */
-  right: calc(0px + 24px);
-
-  /* https://css-tricks.com/rational-z-index-values/ */
-  /* Add `z-index: 100;` to make sure the button is clickable */
-  z-index: 100;
-}
-
 /* https://github.com/department-of-veterans-affairs/va.gov-team/issues/18706#issuecomment-769341669 */
 /* style the focus-circles on radio buttons for the survey page */
 .neb-component


### PR DESCRIPTION
## Description

This PR does the following:

- Removes the style overrides for the x icon in emulated browsers
- Removes the style override for the padding around the Powered by Medallia text

## Screenshots

### Powered by Medallia text

#### Chrome - Large

Before

![image](https://user-images.githubusercontent.com/6130520/115076371-16e6ca80-9ec2-11eb-87f5-cc0237b4653f.png)

After

![image](https://user-images.githubusercontent.com/6130520/115076383-19e1bb00-9ec2-11eb-97b4-aee054ef5d45.png)

#### Chrome - Small

Before

![image](https://user-images.githubusercontent.com/6130520/115076422-282fd700-9ec2-11eb-951d-6e87755bc904.png)

After

![image](https://user-images.githubusercontent.com/6130520/115076430-2bc35e00-9ec2-11eb-88c1-ca897184c66e.png)

#### Chrome - mobile (emulated iPhone 6/7/8 Plus)

Before

![image](https://user-images.githubusercontent.com/6130520/115076472-3a117a00-9ec2-11eb-93ec-2fa33b5b9b6a.png)

After

![image](https://user-images.githubusercontent.com/6130520/115076485-3e3d9780-9ec2-11eb-85f0-1b28c10992ee.png)

### X Icon

#### Chrome - mobile (emulated iPhone 6/7/8 Plus);

Before

![image](https://user-images.githubusercontent.com/6130520/115076190-cec7a800-9ec1-11eb-8022-18a8737d8c34.png)

After

![image](https://user-images.githubusercontent.com/6130520/115076201-d2f3c580-9ec1-11eb-88e1-7f8f9a78a3b0.png)

#### Chrome - small

N/A; The `div.neb-form-close-btn-container.ng-hide` selector is only present on the emulated mobile browser.

![image](https://user-images.githubusercontent.com/6130520/115076422-282fd700-9ec2-11eb-951d-6e87755bc904.png)
