### PR TITLE
Fix multiple My VA styling/spacing issues

### DIFF
--- a/src/applications/personalization/components/NameTag.jsx
+++ b/src/applications/personalization/components/NameTag.jsx
@@ -8,6 +8,63 @@ import prefixUtilityClasses from '~/platform/utilities/prefix-utility-classes';
 import { SERVICE_BADGE_IMAGE_PATHS } from '../profile/constants';
 import { getServiceBranchDisplayName } from '../profile/helpers';
 
+const DisabilityRatingContent = ({ rating }) => {
+  const disabilityRatingClasses = prefixUtilityClasses([
+    'margin-top--1p5',
+    'color--white',
+    'text-align--center',
+    'line-height--3',
+  ]);
+
+  const disabilityRatingClassesMedium = prefixUtilityClasses(
+    ['margin-top--1', 'text-align--left'],
+    'medium',
+  );
+
+  const classes = [
+    ...disabilityRatingClasses,
+    ...disabilityRatingClassesMedium,
+  ].join(' ');
+
+  return (
+    <>
+      <dt className="sr-only">your disability rating</dt>
+      <dd className={classes}>
+        {rating ? <>Your disability rating: </> : null}
+        <a
+          href="/disability/view-disability-rating/rating"
+          aria-label="view your disability rating"
+          className="vads-u-color--white"
+          style={{ whiteSpace: 'nowrap' }}
+        >
+          {rating ? (
+            <>{rating}% Service connected </>
+          ) : (
+            <>View disability rating </>
+          )}
+          <i
+            aria-hidden="true"
+            role="img"
+            className="fas fa-angle-double-right vads-u-padding-left--0p5"
+          />
+        </a>
+      </dd>
+    </>
+  );
+};
+
+const DisabilityRating = ({ rating, showFallbackLink }) => {
+  if (showFallbackLink) {
+    return <DisabilityRatingContent />;
+  }
+
+  if (rating) {
+    return <DisabilityRatingContent rating={rating} />;
+  }
+
+  return null;
+};
+
 const NameTag = ({
   userFullName: { first, middle, last, suffix },
   latestBranchOfService,
@@ -45,9 +102,10 @@ const NameTag = ({
     'display--flex',
     'flex-direction--column',
     'width--full',
+    'padding-x--2',
   ]);
   const innerWrapperClassesMedium = prefixUtilityClasses(
-    ['flex-direction--row', 'padding-left--2'],
+    ['flex-direction--row'],
     'medium',
   );
 
@@ -73,11 +131,10 @@ const NameTag = ({
     'font-weight--bold',
     'line-height--3',
     'margin-top--0',
-    'margin-bottom--0p5',
     'text-align--center',
   ]);
   const fullNameClassesMedium = prefixUtilityClasses(
-    ['text-align--left', 'margin-bottom--1p5'],
+    ['text-align--left'],
     'medium',
   );
 
@@ -139,43 +196,13 @@ const NameTag = ({
                 {getServiceBranchDisplayName(latestBranchOfService)}
               </dd>
             )}
-            {showUpdatedNameTag &&
-              totalDisabilityRating && (
-                <>
-                  <dt className="sr-only">your disability rating</dt>
-                  <dd className="vads-u-margin-top--0p5">
-                    Your disability rating:{' '}
-                    <a
-                      href="/disability/view-disability-rating/rating"
-                      aria-label="view your disability rating"
-                      className="vads-u-color--white font-weight--bold"
-                    >
-                      {totalDisabilityRating}% Service connected{' '}
-                      <i
-                        aria-hidden="true"
-                        role="img"
-                        className="fas fa-angle-double-right vads-u-padding-left--0p5"
-                      />
-                    </a>
-                  </dd>
-                </>
-              )}
+            {showUpdatedNameTag ? (
+              <DisabilityRating
+                rating={totalDisabilityRating}
+                showFallbackLink={totalDisabilityRatingServerError}
+              />
+            ) : null}
           </dl>
-          {showUpdatedNameTag &&
-            totalDisabilityRatingServerError && (
-              <a
-                href="/disability/view-disability-rating/rating"
-                aria-label="view your disability rating"
-                className="vads-u-color--white font-weight--bold"
-              >
-                View disability rating{' '}
-                <i
-                  aria-hidden="true"
-                  role="img"
-                  className="fas fa-angle-double-right vads-u-padding-left--0p5"
-                />
-              </a>
-            )}
         </div>
       </div>
     </div>

--- a/src/applications/personalization/dashboard-2/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard-2/components/Dashboard.jsx
@@ -131,7 +131,7 @@ const Dashboard = ({
                 }
               />
             )}
-            <div className="vads-l-grid-container vads-u-padding-bottom--3 medium-screen:vads-u-padding-x--2 medium-screen:vads-u-padding-bottom--4 small-desktop-screen:vads-u-padding-x--0">
+            <div className="vads-l-grid-container vads-u-padding-bottom--3 medium-screen:vads-u-padding-x--2 medium-screen:vads-u-padding-bottom--4">
               <Breadcrumbs className="vads-u-padding-x--0 vads-u-padding-y--1p5 medium-screen:vads-u-padding-y--0">
                 <a href="/" key="home">
                   Home

--- a/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.jsx
+++ b/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.jsx
@@ -33,12 +33,13 @@ const BenefitsOfInterest = ({ children, showChildren }) => {
         VA benefits you might be interested in
       </h3>
       <div data-testid="benefits-of-interest">
-        {!showChildren && (
+        {showChildren ? (
+          <div className="vads-l-row">{children}</div>
+        ) : (
           <div className="vads-u-margin-y--2">
             <LoadingIndicator message="Loading benefits you might be interested in..." />
           </div>
         )}
-        {showChildren && <div className="vads-l-row">{children}</div>}
       </div>
     </>
   );


### PR DESCRIPTION
## Description
This closes four different My VA styling issues. Three related to the NameTag, and one to the overall page padding

- addresses department-of-veterans-affairs/va.gov-team#22896
- addresses department-of-veterans-affairs/va.gov-team#22895
- addresses department-of-veterans-affairs/va.gov-team#22899
- addresses department-of-veterans-affairs/va.gov-team#22898

## Testing done
Local in Cypress

## Screenshots
**Name Tag on desktop:**
<img width="1047" alt="name tag - desktop" src="https://user-images.githubusercontent.com/20728956/115085552-92934800-9ebf-11eb-9816-a1192c4753fe.png">

**Name Tag on mobile:**
<img width="980" alt="name tag - mobile" src="https://user-images.githubusercontent.com/20728956/115085563-97f09280-9ebf-11eb-99b3-4ba9bcd23c22.png">

**Old name tag:**
<img width="989" alt="old name tag" src="https://user-images.githubusercontent.com/20728956/115085581-9c1cb000-9ebf-11eb-873d-8452328eab44.png">

**Profile viewed at 1009px wide (which previously lacked x-padding):**
<img width="805" alt="profile at 1009px wide" src="https://user-images.githubusercontent.com/20728956/115085608-a343be00-9ebf-11eb-881c-7fb18f79e921.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs