### PR TITLE
Add extra axe info for debugging

### DIFF
--- a/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
@@ -363,14 +363,14 @@ function mockSubmitVAAppointment() {
 }
 
 function setupSchedulingMocks({ cernerUser = false } = {}) {
-  Cypress.Commands.add('axeCheckBestPractice', (context = 'main') =>
+  Cypress.Commands.add('axeCheckBestPractice', (context = 'main') => {
     cy.axeCheck(context, {
       runOnly: {
         type: 'tag',
         values: ['section508', 'wcag2a', 'wcag2aa', 'best-practice'],
       },
-    }),
-  );
+    });
+  });
   cy.server();
   mockFeatureToggles();
 

--- a/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
+++ b/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
@@ -19,9 +19,18 @@ const processAxeCheckResults = violations => {
       nodes: nodes.length,
     }),
   );
-
   cy.task('log', violationMessage);
   cy.task('table', violationData);
+  cy.task(
+    'log',
+    `
+Nodes with violations:
+
+${violations
+      .map(v => `${v.id}:\n${v.nodes?.map(n => n.target[0]).join('\n')}`)
+      .join('\n\n')}
+`,
+  );
 };
 
 /**


### PR DESCRIPTION
## Description
This PR

- Adds some extra info for axe failures, to aid in debugging a flaky test (see https://dsva.slack.com/archives/C5HP4GN3F/p1618520566093000)
- Tweaks the VAOS axeCheck wrapper, just in case something really weird is going on

## Testing done
Local testing

## Screenshots
![Screen Shot 2021-04-16 at 5 42 12 PM](https://user-images.githubusercontent.com/634932/115087085-8a490600-9edb-11eb-8935-fe0543b5ae2b.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
