### PR TITLE
DT-18434 Find Forms - Adding lang attributre

### DIFF
--- a/src/applications/find-forms/components/FormTitle.jsx
+++ b/src/applications/find-forms/components/FormTitle.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const FormTitle = ({ id, formUrl, title, recordGAEvent }) => (
+const FormTitle = ({ id, formUrl, title, lang, recordGAEvent }) => (
   <dt
     className="vads-u-padding-top--3 vads-u-margin--0 vads-u-border-top--1px vads-u-border-color--gray-lighter vads-u-font-weight--bold"
     data-e2e-id="result-title"
@@ -18,7 +18,7 @@ const FormTitle = ({ id, formUrl, title, recordGAEvent }) => (
           </span>
           {id}{' '}
         </dfn>
-        {title}
+        <span lang={lang}>{title}</span>
         <i
           aria-hidden="true"
           role="presentation"
@@ -32,7 +32,7 @@ const FormTitle = ({ id, formUrl, title, recordGAEvent }) => (
           <span className="vads-u-visibility--screen-reader">Form number</span>{' '}
           {id}{' '}
         </dfn>
-        {title}
+        <span lang={lang}>{title}</span>
       </>
     )}
   </dt>

--- a/src/applications/find-forms/components/SearchResult.jsx
+++ b/src/applications/find-forms/components/SearchResult.jsx
@@ -116,6 +116,7 @@ const SearchResult = ({ form, formMetaInfo }) => {
       formType,
       formToolUrl,
       formDetailsUrl,
+      language,
       lastRevisionOn,
       benefitCategories,
       vaFormAdministration,
@@ -146,6 +147,7 @@ const SearchResult = ({ form, formMetaInfo }) => {
       <FormTitle
         id={id}
         formUrl={formDetailsUrl}
+        lang={language}
         title={title}
         recordGAEvent={recordGAEvent}
       />

--- a/src/applications/find-forms/tests/components/FormTitle.unit.spec.jsx
+++ b/src/applications/find-forms/tests/components/FormTitle.unit.spec.jsx
@@ -12,6 +12,7 @@ describe('Find VA Forms <FormTitle />', () => {
     formDetailsUrl:
       'https://www.va.gov/health-care/about-information-for-pre-complaint-processing/',
     title: 'Information for Pre-Complaint Processing',
+    language: 'en',
     recordGAEvent: sinon.stub(),
   };
 
@@ -21,6 +22,7 @@ describe('Find VA Forms <FormTitle />', () => {
         id={props.id}
         formUrl={props.formDetailsUrl}
         recordGAEvent={props.recordGAEvent}
+        lang={props.language}
         title={props.title}
       />,
     );
@@ -29,6 +31,7 @@ describe('Find VA Forms <FormTitle />', () => {
     expect(tree.props().id).to.equal(props.id);
     expect(tree.props().formUrl).to.equal(props.formDetailsUrl);
     expect(tree.props().title).to.equal(props.title);
+    expect(tree.props().lang).to.equal(props.language);
     expect(tree.props().recordGAEvent).to.equal(props.recordGAEvent);
 
     tree.unmount();


### PR DESCRIPTION
## Description
Now adding lang attribute now that light house's language property is consuming the property set in drupal.

## Testing done
Added to unit test and ran unit tests.

## Screenshots
<img width="1440" alt="Screen Shot 2021-04-16 at 5 45 44 PM" src="https://user-images.githubusercontent.com/26075258/115087731-badd6f80-9edc-11eb-84b2-7a87b2835b5f.png">


## Acceptance criteria
- [x] Lang attribute is added for the search result title

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
