### PR TITLE
Us phone numbers profile

### DIFF
--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.delete-telephone.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.delete-telephone.unit.spec.jsx
@@ -41,7 +41,10 @@ function getEditButton(numberName) {
 function deletePhoneNumber(numberName) {
   getEditButton(numberName).click();
 
-  const phoneNumberInput = view.getByText(`${numberName} (U.S. numbers only)`);
+  const phoneNumberInput = view.getByLabelText(
+    `${numberName} (U.S. numbers only)`,
+    { exact: false },
+  );
 
   expect(phoneNumberInput).to.exist;
 

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.delete-telephone.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.delete-telephone.unit.spec.jsx
@@ -41,7 +41,8 @@ function getEditButton(numberName) {
 function deletePhoneNumber(numberName) {
   getEditButton(numberName).click();
 
-  const phoneNumberInput = view.getByLabelText(/Number/);
+  const phoneNumberInput = view.getByText(`${numberName} (U.S. numbers only)`);
+
   expect(phoneNumberInput).to.exist;
 
   // delete

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.edit-telephone.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.edit-telephone.unit.spec.jsx
@@ -48,11 +48,14 @@ function editPhoneNumber(numberName) {
   const editButton = getEditButton(numberName);
   editButton.click();
 
-  const phoneNumberInput = view.getByLabelText(/Number/);
+  const phoneNumberInput = view.getByLabelText(
+    `${numberName} (U.S. numbers only)`,
+    { exact: false },
+  );
   const extensionInput = view.getByLabelText(/Extension/);
   expect(phoneNumberInput).to.exist;
 
-  // enter a new email address in the form
+  // enter a new phone number in the form
   user.clear(phoneNumberInput);
   user.type(phoneNumberInput, `${newAreaCode} ${newPhoneNumber}`);
   user.clear(extensionInput);

--- a/src/applications/personalization/profile/util/contact-information/getContactInfoFieldAttributes.js
+++ b/src/applications/personalization/profile/util/contact-information/getContactInfoFieldAttributes.js
@@ -47,7 +47,7 @@ export const getContactInfoFieldAttributes = fieldName => {
   if (phoneNumbers.includes(fieldName)) {
     apiRoute = API_ROUTES.TELEPHONES;
     convertCleanDataToPayload = phoneConvertCleanDataToPayload;
-    uiSchema = phoneUiSchema;
+    uiSchema = phoneUiSchema(FIELD_TITLES[fieldName]);
     formSchema = phoneFormSchema;
 
     if (fieldName === FIELD_NAMES.HOME_PHONE) {

--- a/src/applications/personalization/profile/util/contact-information/phoneUtils.js
+++ b/src/applications/personalization/profile/util/contact-information/phoneUtils.js
@@ -27,25 +27,11 @@ export const phoneFormSchema = {
 };
 
 export const phoneUiSchema = {
-  'view:noInternationalNumbers': {
-    'ui:description': () => (
-      <AlertBox
-        isVisible
-        status="info"
-        className="vads-u-margin-bottom--3 vads-u-margin-top--1 medium-screen:vads-u-margin-top--0"
-      >
-        <p>
-          We can only support U.S. phone numbers right now. If you have an
-          international number, please check back later.
-        </p>
-      </AlertBox>
-    ),
-  },
   inputPhoneNumber: {
     'ui:widget': PhoneNumberWidget,
     'ui:title': 'Number',
     'ui:errorMessages': {
-      pattern: 'Please enter a valid phone number.',
+      pattern: 'Please enter a valid 10-digit U.S. phone number.',
     },
   },
   extension: {

--- a/src/applications/personalization/profile/util/contact-information/phoneUtils.js
+++ b/src/applications/personalization/profile/util/contact-information/phoneUtils.js
@@ -1,6 +1,4 @@
-import React from 'react';
 import { PHONE_TYPE, USA } from '@@vap-svc/constants';
-import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import PhoneNumberWidget from 'platform/forms-system/src/js/widgets/PhoneNumberWidget';
 import pickBy from 'lodash/pickBy';
 
@@ -26,27 +24,29 @@ export const phoneFormSchema = {
   required: ['inputPhoneNumber'],
 };
 
-export const phoneUiSchema = {
-  inputPhoneNumber: {
-    'ui:widget': PhoneNumberWidget,
-    'ui:title': 'Number',
-    'ui:errorMessages': {
-      pattern: 'Please enter a valid 10-digit U.S. phone number.',
+export const phoneUiSchema = fieldName => {
+  return {
+    inputPhoneNumber: {
+      'ui:widget': PhoneNumberWidget,
+      'ui:title': `${fieldName} (U.S. numbers only)`,
+      'ui:errorMessages': {
+        pattern: 'Please enter a valid 10-digit U.S. phone number.',
+      },
     },
-  },
-  extension: {
-    'ui:title': 'Extension',
-    'ui:errorMessages': {
-      pattern: 'Please enter a valid extension.',
+    extension: {
+      'ui:title': 'Extension',
+      'ui:errorMessages': {
+        pattern: 'Please enter a valid extension.',
+      },
     },
-  },
-  isTextPermitted: {
-    'ui:title':
-      'Send me text message (SMS) reminders for my VA health care appointments',
-    'ui:options': {
-      hideIf: formData => !formData['view:showSMSCheckbox'],
+    isTextPermitted: {
+      'ui:title':
+        'Send me text message (SMS) reminders for my VA health care appointments',
+      'ui:options': {
+        hideIf: formData => !formData['view:showSMSCheckbox'],
+      },
     },
-  },
+  };
 };
 
 export const phoneConvertNextValueToCleanData = value => {

--- a/src/platform/user/profile/vap-svc/components/PhoneField/PhoneField.jsx
+++ b/src/platform/user/profile/vap-svc/components/PhoneField/PhoneField.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import pickBy from 'lodash/pickBy';
-import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 
 import { API_ROUTES, FIELD_NAMES, PHONE_TYPE, USA } from '@@vap-svc/constants';
 
@@ -34,27 +33,29 @@ const formSchema = {
   required: ['inputPhoneNumber'],
 };
 
-const uiSchema = {
-  inputPhoneNumber: {
-    'ui:widget': PhoneNumberWidget,
-    'ui:title': 'Number',
-    'ui:errorMessages': {
-      pattern: 'Please enter a valid 10-digit U.S. phone number.',
+const uiSchema = fieldName => {
+  return {
+    inputPhoneNumber: {
+      'ui:widget': PhoneNumberWidget,
+      'ui:title': `${fieldName} (U.S. numbers only)`,
+      'ui:errorMessages': {
+        pattern: 'Please enter a valid 10-digit U.S. phone number.',
+      },
     },
-  },
-  extension: {
-    'ui:title': 'Extension',
-    'ui:errorMessages': {
-      pattern: 'Please enter a valid extension.',
+    extension: {
+      'ui:title': 'Extension',
+      'ui:errorMessages': {
+        pattern: 'Please enter a valid extension.',
+      },
     },
-  },
-  isTextPermitted: {
-    'ui:title':
-      'Send me text message (SMS) reminders for my VA health care appointments',
-    'ui:options': {
-      hideIf: formData => !formData['view:showSMSCheckbox'],
+    isTextPermitted: {
+      'ui:title':
+        'Send me text message (SMS) reminders for my VA health care appointments',
+      'ui:options': {
+        hideIf: formData => !formData['view:showSMSCheckbox'],
+      },
     },
-  },
+  };
 };
 
 export default class PhoneField extends React.Component {
@@ -128,7 +129,7 @@ export default class PhoneField extends React.Component {
         Content={PhoneView}
         EditModal={PhoneEditModal}
         formSchema={formSchema}
-        uiSchema={uiSchema}
+        uiSchema={() => uiSchema(this.props.fieldName)}
       />
     );
   }

--- a/src/platform/user/profile/vap-svc/components/PhoneField/PhoneField.jsx
+++ b/src/platform/user/profile/vap-svc/components/PhoneField/PhoneField.jsx
@@ -129,7 +129,7 @@ export default class PhoneField extends React.Component {
         Content={PhoneView}
         EditModal={PhoneEditModal}
         formSchema={formSchema}
-        uiSchema={() => uiSchema(this.props.fieldName)}
+        uiSchema={uiSchema(this.props.fieldName)}
       />
     );
   }

--- a/src/platform/user/profile/vap-svc/components/PhoneField/PhoneField.jsx
+++ b/src/platform/user/profile/vap-svc/components/PhoneField/PhoneField.jsx
@@ -35,21 +35,11 @@ const formSchema = {
 };
 
 const uiSchema = {
-  'view:noInternationalNumbers': {
-    'ui:description': () => (
-      <AlertBox isVisible status="info" className="vads-u-margin-bottom--3">
-        <p>
-          We can only support U.S. phone numbers right now. If you have an
-          international number, please check back later.
-        </p>
-      </AlertBox>
-    ),
-  },
   inputPhoneNumber: {
     'ui:widget': PhoneNumberWidget,
     'ui:title': 'Number',
     'ui:errorMessages': {
-      pattern: 'Please enter a valid phone number.',
+      pattern: 'Please enter a valid 10-digit U.S. phone number.',
     },
   },
   extension: {

--- a/src/platform/user/profile/vap-svc/constants/index.js
+++ b/src/platform/user/profile/vap-svc/constants/index.js
@@ -68,11 +68,11 @@ export const FIELD_NAMES = {
 };
 
 export const FIELD_TITLES = {
-  [FIELD_NAMES.HOME_PHONE]: 'Home phone number',
-  [FIELD_NAMES.MOBILE_PHONE]: 'Mobile phone number',
-  [FIELD_NAMES.WORK_PHONE]: 'Work phone number',
-  [FIELD_NAMES.TEMP_PHONE]: 'Temporary phone number',
-  [FIELD_NAMES.FAX_NUMBER]: 'Fax number',
+  [FIELD_NAMES.HOME_PHONE]: 'Home phone number (U.S. numbers only)',
+  [FIELD_NAMES.MOBILE_PHONE]: 'Mobile phone number (U.S. numbers only)',
+  [FIELD_NAMES.WORK_PHONE]: 'Work phone number (U.S. numbers only)',
+  [FIELD_NAMES.TEMP_PHONE]: 'Temporary phone number (U.S. numbers only)',
+  [FIELD_NAMES.FAX_NUMBER]: 'Fax number (U.S. numbers only)',
   [FIELD_NAMES.EMAIL]: 'Email address',
   [FIELD_NAMES.MAILING_ADDRESS]: 'Mailing address',
   [FIELD_NAMES.RESIDENTIAL_ADDRESS]: 'Home address',

--- a/src/platform/user/profile/vap-svc/constants/index.js
+++ b/src/platform/user/profile/vap-svc/constants/index.js
@@ -68,11 +68,11 @@ export const FIELD_NAMES = {
 };
 
 export const FIELD_TITLES = {
-  [FIELD_NAMES.HOME_PHONE]: 'Home phone number (U.S. numbers only)',
-  [FIELD_NAMES.MOBILE_PHONE]: 'Mobile phone number (U.S. numbers only)',
-  [FIELD_NAMES.WORK_PHONE]: 'Work phone number (U.S. numbers only)',
-  [FIELD_NAMES.TEMP_PHONE]: 'Temporary phone number (U.S. numbers only)',
-  [FIELD_NAMES.FAX_NUMBER]: 'Fax number (U.S. numbers only)',
+  [FIELD_NAMES.HOME_PHONE]: 'Home phone number',
+  [FIELD_NAMES.MOBILE_PHONE]: 'Mobile phone number',
+  [FIELD_NAMES.WORK_PHONE]: 'Work phone number',
+  [FIELD_NAMES.TEMP_PHONE]: 'Temporary phone number',
+  [FIELD_NAMES.FAX_NUMBER]: 'Fax number',
   [FIELD_NAMES.EMAIL]: 'Email address',
   [FIELD_NAMES.MAILING_ADDRESS]: 'Mailing address',
   [FIELD_NAMES.RESIDENTIAL_ADDRESS]: 'Home address',


### PR DESCRIPTION
## Description
This PR:

- removes existing info box that explains people can only add a US phone number
- uses hint text instead of the alert to clarify we only support U.S. phone numbers
- improves specificity of field label and error to better align w/ other forms on VA.gov and reduce ambiguity
- performs these steps for all number types - home, mobile, work and fax

## Testing done
Works well, checked in Cypress.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/115154777-d3af6780-a039-11eb-9347-814b297e8a9d.png)

![image](https://user-images.githubusercontent.com/14869324/115154782-e033c000-a039-11eb-9d85-5c57fcd8a26b.png)

![image](https://user-images.githubusercontent.com/14869324/115154791-e6c23780-a039-11eb-9238-540f6c35bde5.png)

![image](https://user-images.githubusercontent.com/14869324/115154799-f2adf980-a039-11eb-835e-0c3f3229c1b3.png)


## Acceptance criteria
- [x] Remove AlertBox
- [x] Update error text
- [x] Update phone label text

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
