### PR TITLE
Gh check for test coverage/circleci to gha

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,6 +1,9 @@
 name: Continuous Integration
 
-on: [push]
+on:
+  push:
+  check_run:
+    types: [created]
 
 jobs:
   unit-tests:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -52,6 +52,15 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: 'test-results/unit-tests.xml'
 
+      - name: GHA Check Unit Test Summary
+        if: ${{ always() }}
+        with: 
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: Test XYZ
+          conclusion: ${{ job.status }}
+          output: |
+            {"summary":${{ steps.test.outputs.summary }}}
+
   linting:
     name: Linting
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -59,8 +59,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: Test XYZ
           conclusion: ${{ job.status }}
-          output: |
-            {"summary":${{ steps.test.outputs.summary }}}
 
   linting:
     name: Linting

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -54,6 +54,7 @@ jobs:
 
       - name: GHA Check Unit Test Summary
         if: ${{ always() }}
+        uses: LouisBrunner/checks-action@v1.1.1
         with: 
           token: ${{ secrets.GITHUB_TOKEN }}
           name: Test XYZ


### PR DESCRIPTION
## Description

In the GitHub Actions pipeline, the unit test job generates a test coverage report in an ASCII table followed by a similar table for a breakdown of that coverage by app.

The pipeline should generate a [GitHub check](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-status-checks#checks) that represents that information as an HTML table, making that information easier to access and read.

Consider combining the existing unit test summary (which reports test failures and related stats) and this coverage report to keep the information all in one place. Doing this will require a custom action to replace the third-party action we're currently using to generate that summary.

## Definition of done
- [ ] Create a GitHub check for the coverage reports generated from the unit test job.
- [ ] Use or create any actions necessary to generate the GitHub check.