### PR TITLE
Connect() replaced with useSelector and useDispatch in AppointmentLis…

### DIFF
--- a/src/applications/vaos/appointment-list/index.jsx
+++ b/src/applications/vaos/appointment-list/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { connect } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { Switch, Route } from 'react-router-dom';
 import { selectFeatureHomepageRefresh } from '../redux/selectors';
 import PageLayout from './components/AppointmentsPage/PageLayout';
@@ -11,7 +11,10 @@ import CommunityCareAppointmentDetailsPage from './components/CommunityCareAppoi
 import ExpressCareDetailsPage from './components/ExpressCareDetailsPage';
 import useManualScrollRestoration from '../hooks/useManualScrollRestoration';
 
-function AppointmentListSection({ featureHomepageRefresh }) {
+function AppointmentListSection() {
+  const featureHomepageRefresh = useSelector(state =>
+    selectFeatureHomepageRefresh(state),
+  );
   useManualScrollRestoration();
   return (
     <Switch>
@@ -38,10 +41,4 @@ function AppointmentListSection({ featureHomepageRefresh }) {
   );
 }
 
-function mapStateToProps(state) {
-  return {
-    featureHomepageRefresh: selectFeatureHomepageRefresh(state),
-  };
-}
-
-export const AppointmentList = connect(mapStateToProps)(AppointmentListSection);
+export const AppointmentList = AppointmentListSection;


### PR DESCRIPTION
## Description
This is part of an ongoing effort to upgrade redux to use hooks instead of `connect`

## Testing done
Unit tests did not need to be altered

## Acceptance criteria
- [x] connect() is no longer used on page
- [x] All actions that were in mapDispatchToProps are now wrapped in dispatch() when called
- [x] All data in mapStateToProps is pulled in through useSelector hooks

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
