### PR TITLE
Display weekend slots for primary/speciality care direct scheduling flow

### DIFF
--- a/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.jsx
@@ -192,6 +192,7 @@ export function DateTimeSelectPage({
             requiredMessage="Please choose your preferred date and time for your appointment"
             startMonth={startMonth}
             showValidation={submitted && !selectedDates?.length}
+            showWeekends
           />
         </>
       )}


### PR DESCRIPTION
## Description

This PR adds logic to display weekend slots for the primary/specialty care direct scheduling flow.

Ticket: [22711](https://github.com/department-of-veterans-affairs/va.gov-team/issues/22711)

## Testing done

- local/unit tests

## Screenshots

<img width="598" alt="Screen Shot 2021-04-19 at 3 20 47 PM" src="https://user-images.githubusercontent.com/9746156/115310645-fb2e2f00-a122-11eb-8c39-dd6e6cdbd86b.png">

## Acceptance criteria
- [x] In primary/specialty care direct scheduling flow display all days of the week (Sun-Sat) on calendar by default for all months

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
