### PR TITLE
Hide health benefit info if user has HCA in progress

### DIFF
--- a/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.jsx
+++ b/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.jsx
@@ -12,6 +12,8 @@ import {
   selectProfile,
 } from '~/platform/user/selectors';
 
+import { filterOutExpiredForms } from '~/applications/personalization/dashboard/helpers';
+
 import { getEnrollmentStatus as getEnrollmentStatusAction } from '~/applications/hca/actions';
 import { HCA_ENROLLMENT_STATUSES } from '~/applications/hca/constants';
 import {
@@ -172,9 +174,9 @@ const ApplyForBenefits = ({
 
 const mapStateToProps = state => {
   const hasHCAInProgress =
-    selectProfile(state).savedForms?.some(
-      savedForm => savedForm.form === VA_FORM_IDS.FORM_10_10EZ,
-    ) ?? false;
+    selectProfile(state)
+      .savedForms?.filter(filterOutExpiredForms)
+      .some(savedForm => savedForm.form === VA_FORM_IDS.FORM_10_10EZ) ?? false;
 
   const isPatient = isVAPatient(state);
   const esrEnrollmentStatus = selectESRStatus(state).enrollmentStatus;

--- a/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.unit.spec.jsx
+++ b/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.unit.spec.jsx
@@ -420,7 +420,7 @@ describe('ApplyForBenefits component', () => {
     );
 
     context(
-      'when user is not a VA patient, is not in ESR, but has a health care application in progress',
+      'when user is not a VA patient, is not in ESR, but has a non-expired health care application in progress',
       () => {
         it('should not show info about health care benefits', () => {
           const initialState = {
@@ -465,16 +465,68 @@ describe('ApplyForBenefits component', () => {
           });
           // this assertion is to make sure that a loading spinner is not
           // rendered
-          expect(
-            view.getByRole('link', {
-              name: /learn how to apply for education benefits/i,
-            }),
-          ).to.exist;
+          view.getByRole('link', {
+            name: /learn how to apply for education benefits/i,
+          });
           expect(
             view.queryByRole('link', {
               name: /apply for VA health care/i,
             }),
           ).not.to.exist;
+        });
+      },
+    );
+
+    context(
+      'when user is not a VA patient, is not in ESR, and has an expired health care application in progress',
+      () => {
+        it('should show info about health care benefits', () => {
+          const initialState = {
+            user: {
+              profile: {
+                vaPatient: false,
+                multifactor: false,
+                loa: {
+                  current: 1,
+                  highest: 3,
+                },
+                savedForms: [
+                  {
+                    form: '1010ez',
+                    metadata: {
+                      version: 1,
+                      returnUrl: '/net-worth',
+                      savedAt: oneDayAgo(),
+                      submission: {
+                        status: false,
+                        errorMessage: false,
+                        id: false,
+                        timestamp: false,
+                        hasAttemptedSubmit: false,
+                      },
+                      expiresAt: oneDayAgo() / 1000,
+                      lastUpdated: oneDayAgo() / 1000,
+                      inProgressFormId: 5179,
+                    },
+                    lastUpdated: oneDayAgo() / 1000,
+                  },
+                ],
+              },
+            },
+            hcaEnrollmentStatus: {
+              noESRRecordFound: true,
+            },
+          };
+          view = renderInReduxProvider(<ApplyForBenefits />, {
+            initialState,
+            reducers,
+          });
+          view.getByRole('link', {
+            name: /learn how to apply for education benefits/i,
+          });
+          view.getByRole('link', {
+            name: /apply for VA health care/i,
+          });
         });
       },
     );

--- a/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.unit.spec.jsx
+++ b/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.unit.spec.jsx
@@ -332,6 +332,10 @@ describe('ApplyForBenefits component', () => {
         const initialState = {
           user: {
             profile: {
+              loa: {
+                current: 3,
+                highest: 3,
+              },
               vaPatient: true,
               multifactor: false,
             },
@@ -416,6 +420,66 @@ describe('ApplyForBenefits component', () => {
     );
 
     context(
+      'when user is not a VA patient, is not in ESR, but has a health care application in progress',
+      () => {
+        it('should not show info about health care benefits', () => {
+          const initialState = {
+            user: {
+              profile: {
+                vaPatient: false,
+                multifactor: false,
+                loa: {
+                  current: 1,
+                  highest: 3,
+                },
+                savedForms: [
+                  {
+                    form: '1010ez',
+                    metadata: {
+                      version: 1,
+                      returnUrl: '/net-worth',
+                      savedAt: oneDayAgo(),
+                      submission: {
+                        status: false,
+                        errorMessage: false,
+                        id: false,
+                        timestamp: false,
+                        hasAttemptedSubmit: false,
+                      },
+                      expiresAt: oneYearFromNow() / 1000,
+                      lastUpdated: oneDayAgo() / 1000,
+                      inProgressFormId: 5179,
+                    },
+                    lastUpdated: oneDayAgo() / 1000,
+                  },
+                ],
+              },
+            },
+            hcaEnrollmentStatus: {
+              noESRRecordFound: true,
+            },
+          };
+          view = renderInReduxProvider(<ApplyForBenefits />, {
+            initialState,
+            reducers,
+          });
+          // this assertion is to make sure that a loading spinner is not
+          // rendered
+          expect(
+            view.getByRole('link', {
+              name: /learn how to apply for education benefits/i,
+            }),
+          ).to.exist;
+          expect(
+            view.queryByRole('link', {
+              name: /apply for VA health care/i,
+            }),
+          ).not.to.exist;
+        });
+      },
+    );
+
+    context(
       'when user is a VA patient, but is in ESR, and is not enrolled in DD4edu',
       () => {
         it('should show the correct benefits', () => {
@@ -465,6 +529,10 @@ describe('ApplyForBenefits component', () => {
           user: {
             profile: {
               vaPatient: true,
+              loa: {
+                current: 3,
+                highest: 3,
+              },
               multifactor: true,
             },
           },
@@ -542,6 +610,10 @@ describe('ApplyForBenefits component', () => {
         const initialState = {
           user: {
             profile: {
+              loa: {
+                current: 3,
+                highest: 3,
+              },
               vaPatient: true,
               multifactor: true,
             },


### PR DESCRIPTION
## Description
With this change we will no longer show Health Care Benefit info to users if they already have a health care application in progress.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs