### PR TITLE
Remove CLP auth on non-staging/prod envs (e.g. preview server)

### DIFF
--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -657,6 +657,12 @@
 <!-- =============== -->
 <script>
   function checkCLPAuth() {
+    // Escape early if we are not on staging or prod.
+    if (window.location.origin !== 'https://staging.va.gov' && window.location.origin !== 'https://www.va.gov') {
+      return;
+    }
+
+    // Prompt the user for the passphrase.
     var clpPassphrase = prompt('This page is in BETA. Please enter the passphrase to access it:');
 
     // Redirect to homepage if the passphrase is incorrect.

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -657,8 +657,11 @@
 <!-- =============== -->
 <script>
   function checkCLPAuth() {
+    // We have a find and replace in the build for `www.va.gov`, so this is us getting creative 😂 😂 😂
+    const prodURL = ['https://', 'www.', 'va', '.gov'].join('')
+
     // Escape early if we are not on staging or prod.
-    if (window.location.origin !== 'https://staging.va.gov' && window.location.origin !== 'https://www.va.gov') {
+    if (window.location.origin !== 'https://staging.va.gov' && window.location.origin !== prodURL) {
       return;
     }
 

--- a/src/site/layouts/campaign_landing_page.drupal.liquid
+++ b/src/site/layouts/campaign_landing_page.drupal.liquid
@@ -660,18 +660,16 @@
     // We have a find and replace in the build for `www.va.gov`, so this is us getting creative 😂 😂 😂
     const prodURL = ['https://', 'www.', 'va', '.gov'].join('')
 
-    // Escape early if we are not on staging or prod.
-    if (window.location.origin !== 'https://staging.va.gov' && window.location.origin !== prodURL) {
-      return;
-    }
+    // Only show CLP auth on staging or prod.
+    if (window.location.origin === 'https://staging.va.gov' || window.location.origin === prodURL) {
+      // Prompt the user for the passphrase.
+      var clpPassphrase = prompt('This page is in BETA. Please enter the passphrase to access it:');
 
-    // Prompt the user for the passphrase.
-    var clpPassphrase = prompt('This page is in BETA. Please enter the passphrase to access it:');
-
-    // Redirect to homepage if the passphrase is incorrect.
-    if (clpPassphrase !== 'clptest123') {
-      window.location.href = '/';
-      return;
+      // Redirect to homepage if the passphrase is incorrect.
+      if (clpPassphrase !== 'clptest123') {
+        window.location.href = '/';
+        return;
+      }
     }
 
     // Derive the content element.


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/23431

This PR removes CLP temp auth on non-staging/prod environments, such as the preview server (we do not want temp auth on the preview server).

## Testing done
Locally

## Screenshots


## Acceptance criteria
- [x] removes CLP temp auth on non-staging/prod environments, such as the preview server (we do not want temp auth on the preview server)

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
