### PR TITLE
Add sitemap a11y tests back to master branch Jenkins workflow

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,9 +76,9 @@ node('vetsgov-general-purpose') {
             'nightwatch-e2e': {
               sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p nightwatch-${env.EXECUTOR_NUMBER} up -d && docker-compose -p nightwatch-${env.EXECUTOR_NUMBER} run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run nightwatch:docker"
             },          
-            // 'nightwatch-accessibility': {
-            //     sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p accessibility up -d && docker-compose -p accessibility run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run nightwatch:docker -- --env=accessibility"
-            // },
+            'nightwatch-accessibility': {
+              sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p accessibility up -d && docker-compose -p accessibility run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run nightwatch:docker -- --env=accessibility"
+            },
             cypress: {
               sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p cypress-${env.EXECUTOR_NUMBER} up -d && docker-compose -p cypress-${env.EXECUTOR_NUMBER} run --rm --entrypoint=npm -e CI=true -e NO_COLOR=1 vets-website --no-color run cy:test:docker"
             }
@@ -100,9 +100,9 @@ node('vetsgov-general-purpose') {
         throw error
       } finally {
         sh "docker-compose -p nightwatch-${env.EXECUTOR_NUMBER} down --remove-orphans"
-        // if (commonStages.IS_PROD_BRANCH && commonStages.VAGOV_BUILDTYPES.contains('vagovprod')) {
-        //   sh "docker-compose -p accessibility down --remove-orphans"
-        // }
+        if (commonStages.IS_PROD_BRANCH && commonStages.VAGOV_BUILDTYPES.contains('vagovprod')) {
+          sh "docker-compose -p accessibility down --remove-orphans"
+        }
         sh "docker-compose -p cypress-${env.EXECUTOR_NUMBER} down --remove-orphans"
         step([$class: 'JUnitResultArchiver', testResults: 'logs/nightwatch/**/*.xml'])
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,45 +21,45 @@ node('vetsgov-general-purpose') {
   // setupStage
   dockerContainer = commonStages.setup()
 
-  stage('Lint|Security|Unit') {
-    if (params.cmsEnvBuildOverride != 'none') { return }
+  // stage('Lint|Security|Unit') {
+  //   if (params.cmsEnvBuildOverride != 'none') { return }
 
-    try {
-      parallel (
-        failFast: true,
+  //   try {
+  //     parallel (
+  //       failFast: true,
 
-        lint: {
-          dockerContainer.inside(commonStages.DOCKER_ARGS) {
-            sh "cd /application && npm --no-color run lint"
-          }
-        },
+  //       lint: {
+  //         dockerContainer.inside(commonStages.DOCKER_ARGS) {
+  //           sh "cd /application && npm --no-color run lint"
+  //         }
+  //       },
 
-        // Check package.json for known vulnerabilities
-        security: {
-          retry(3) {
-            dockerContainer.inside(commonStages.DOCKER_ARGS) {
-              sh "cd /application && npm run security-check"
-            }
-          }
-        },
+  //       // Check package.json for known vulnerabilities
+  //       security: {
+  //         retry(3) {
+  //           dockerContainer.inside(commonStages.DOCKER_ARGS) {
+  //             sh "cd /application && npm run security-check"
+  //           }
+  //         }
+  //       },
 
-        unit: {
-          dockerContainer.inside(commonStages.DOCKER_ARGS) {
-            sh "/cc-test-reporter before-build"
-            sh "cd /application && npm --no-color run test:unit -- --coverage"
-            sh "cd /application && /cc-test-reporter after-build -r fe4a84c212da79d7bb849d877649138a9ff0dbbef98e7a84881c97e1659a2e24"
-          }
-        }
-      )
-    } catch (error) {
-      commonStages.slackNotify()
-      throw error
-    } finally {
-      dir("vets-website") {
-        step([$class: 'JUnitResultArchiver', testResults: 'test-results.xml'])
-      }
-    }
-  }
+  //       unit: {
+  //         dockerContainer.inside(commonStages.DOCKER_ARGS) {
+  //           sh "/cc-test-reporter before-build"
+  //           sh "cd /application && npm --no-color run test:unit -- --coverage"
+  //           sh "cd /application && /cc-test-reporter after-build -r fe4a84c212da79d7bb849d877649138a9ff0dbbef98e7a84881c97e1659a2e24"
+  //         }
+  //       }
+  //     )
+  //   } catch (error) {
+  //     commonStages.slackNotify()
+  //     throw error
+  //   } finally {
+  //     dir("vets-website") {
+  //       step([$class: 'JUnitResultArchiver', testResults: 'test-results.xml'])
+  //     }
+  //   }
+  // }
 
   // Perform a build for each build type
   envsUsingDrupalCache = commonStages.buildAll(ref, dockerContainer, params.cmsEnvBuildOverride != 'none')
@@ -89,7 +89,10 @@ node('vetsgov-general-purpose') {
 
             'nightwatch-e2e': {
               sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p nightwatch-${env.EXECUTOR_NUMBER} up -d && docker-compose -p nightwatch-${env.EXECUTOR_NUMBER} run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run nightwatch:docker"
-            },     
+            },
+            'nightwatch-accessibility': {
+              sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p accessibility up -d && docker-compose -p accessibility run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run nightwatch:docker -- --env=accessibility"
+            },
             cypress: {
               sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p cypress-${env.EXECUTOR_NUMBER} up -d && docker-compose -p cypress-${env.EXECUTOR_NUMBER} run --rm --entrypoint=npm -e CI=true -e NO_COLOR=1 vets-website --no-color run cy:test:docker"
             }


### PR DESCRIPTION
## Description

The nightwatch sitemap a11y tests have been problematic lately. Specifically, we suspect there have been some naming collisions with docker containers and networks. 

For example:

>`2 matches found based on name: network nightwatch_default is ambiguous` - https://dsva.slack.com/archives/CBU0KDSB1/p1618524028051500

On 2021-04-16, Ops merged a [PR](https://github.com/department-of-veterans-affairs/vets-website/pull/16837) to add the executor number to the docker-compose project name, which should hopefully prevent any future collisions.

This PR adds the nightwatch sitemap a11y tests back to the CI workflow that runs after a PR is merged to `master`. 

## Note

This PR should be merged after the daily deploy goes out to minimize the chance of impacting the deploy. 

## Testing done

CI

## Links

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/23331

