### PR TITLE
Use yarn for the web-components postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "pact:can-i-deploy": "node ./script/can-i-deploy.js",
     "pact:publish": "node ./script/publish-pacts.js",
     "pact:verify": "node ./script/verify-pacts.js",
-    "postinstall": "npm rebuild node-sass && node ./script/check-node-version.js && cd node_modules/web-components && yarn install --production && npm run-script build",
+    "postinstall": "npm rebuild node-sass && node ./script/check-node-version.js && cd node_modules/web-components && yarn install --production && yarn build",
     "proxy-rewrite:verify-targets": "node src/applications/proxy-rewrite/scripts/verify-injection-targets.js",
     "pr-check": "node script/pr-check.js",
     "reset:env": "./script/reset-environment.sh",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "pact:can-i-deploy": "node ./script/can-i-deploy.js",
     "pact:publish": "node ./script/publish-pacts.js",
     "pact:verify": "node ./script/verify-pacts.js",
-    "postinstall": "npm rebuild node-sass && node ./script/check-node-version.js && cd node_modules/web-components && npm install --only=prod && npm run-script build",
+    "postinstall": "npm rebuild node-sass && node ./script/check-node-version.js && cd node_modules/web-components && yarn install --production && npm run-script build",
     "proxy-rewrite:verify-targets": "node src/applications/proxy-rewrite/scripts/verify-injection-targets.js",
     "pr-check": "node script/pr-check.js",
     "reset:env": "./script/reset-environment.sh",


### PR DESCRIPTION
## Description

@cvalarida and I were troubleshooting some local issues related to the `web-components` branch and this seems to be the solution. We think it was due to a difference in lock files and/or the version of npm/yarn. A `yarn.lock` file was present, but no `package-lock.json` for npm to use. 


## Testing done

`yarn watch` locally and made sure that web components still worked in a browser.


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
