### PR TITLE
Update list of territories allowed in expanded KMI

### DIFF
--- a/package.json
+++ b/package.json
@@ -364,7 +364,7 @@
     "url-search-params-polyfill": "^8.1.0",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#656403af718a3fbd70326f11ab2b694b707bdd7d",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#d95fd3fdb480cc12aeb8b8b16b8f5b84e054e31c",
     "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.4.0",
     "whatwg-fetch": "^2.0.3"
   },

--- a/src/applications/coronavirus-vaccination-expansion/config/address/addressInformation.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/address/addressInformation.js
@@ -2,26 +2,6 @@ import React from 'react';
 import emailUI from 'platform/forms-system/src/js/definitions/email';
 import { addressInformation } from '../schema-imports';
 
-function monkeyPatchStateNames(extraStates, addressInformationObj) {
-  for (const extra of extraStates) {
-    addressInformationObj.properties.stateCode.enum.push(extra.stateCode);
-    addressInformationObj.properties.stateCode.enumNames.push(extra.stateName);
-  }
-}
-
-const extraStates = [
-  {
-    stateCode: 'GU',
-    stateName: 'Guam',
-  },
-  {
-    stateCode: 'PR',
-    stateName: 'Puerto Rico',
-  },
-];
-
-monkeyPatchStateNames(extraStates, addressInformation);
-
 const validateZip = (errors, formData) => {
   if (formData.zipCode > 4) {
     errors.state.addError('Please enter at least 5 digits');

--- a/yarn.lock
+++ b/yarn.lock
@@ -19597,9 +19597,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#656403af718a3fbd70326f11ab2b694b707bdd7d":
-  version "20.3.1"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#656403af718a3fbd70326f11ab2b694b707bdd7d"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#d95fd3fdb480cc12aeb8b8b16b8f5b84e054e31c":
+  version "20.3.2"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#d95fd3fdb480cc12aeb8b8b16b8f5b84e054e31c"
 
 vinyl-file@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description
- [x] Removes runtime monkey patch for PR and GU
- [x] Updates `vets-json-schema` reference to pull in PR, GU and VI from schema file

Relatedly, added in additional facilities for PR and VI here: https://github.com/department-of-veterans-affairs/devops/commit/dffa802965c7db308f6c722ce9d074765631d1a2 

## Testing done
- Browser 👀 
- Cypress tests cover PR case

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
