### PR TITLE
Replace connect with hooks in CanceledAppointmentsList

### DIFF
--- a/src/applications/vaos/appointment-list/redux/selectors.js
+++ b/src/applications/vaos/appointment-list/redux/selectors.js
@@ -20,6 +20,8 @@ import {
 import {
   selectFeatureExpressCareNewRequest,
   selectFeatureCovid19Vaccine,
+  selectFeatureRequests,
+  selectIsCernerOnlyPatient,
 } from '../../redux/selectors';
 import {
   getTimezoneAbbrBySystemId,
@@ -399,4 +401,14 @@ export function selectCanUseVaccineFlow(state) {
       ),
     )
   );
+}
+
+export function getCanceledAppointmentListInfo(state) {
+  return {
+    appointmentsByMonth: selectCanceledAppointments(state),
+    facilityData: state.appointments.facilityData,
+    futureStatus: selectFutureStatus(state),
+    isCernerOnlyPatient: selectIsCernerOnlyPatient(state),
+    showScheduleButton: selectFeatureRequests(state),
+  };
 }


### PR DESCRIPTION
## Description

This PR updates the `CanceledAppointmentList` component to use Redux hooks.

Ticket: [23386](https://github.com/department-of-veterans-affairs/va.gov-team/issues/23386)

## Testing done

- local, unit testing

## Screenshots

N/A

## Acceptance criteria
- [x] `connect()` is no longer used on page
- [x] All actions that were in `mapDispatchToProps` are now wrapped in `dispatch()` when called
- [x] All data in `mapStateToProps` is pulled in through `useSelector` hooks

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
