### PR TITLE
Update Profile heading levels and breadcrumbs

### DIFF
--- a/src/applications/personalization/profile/components/ProfileMobileSubNav.jsx
+++ b/src/applications/personalization/profile/components/ProfileMobileSubNav.jsx
@@ -21,7 +21,7 @@ const ProfileMobileSubNav = ({ isLOA3, isInMVI, routes }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [focusTriggerButton, setFocusTriggerButton] = useState(false);
 
-  // on first render, set the focus to the h1
+  // on first render, set the focus to the h4
   useEffect(() => {
     focusElement('#mobile-subnav-header');
   }, []);
@@ -67,9 +67,9 @@ const ProfileMobileSubNav = ({ isLOA3, isInMVI, routes }) => {
             onClick={() => setIsMenuOpen(true)}
           >
             <strong>
-              <h1 id="mobile-subnav-header" className={menuButtonClasses}>
+              <h4 id="mobile-subnav-header" className={menuButtonClasses}>
                 Profile
-              </h1>{' '}
+              </h4>{' '}
               menu
             </strong>
             <i className="fa fa-bars" aria-hidden="true" role="img" />

--- a/src/applications/personalization/profile/components/ProfileSectionHeadline.jsx
+++ b/src/applications/personalization/profile/components/ProfileSectionHeadline.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const ProfileSectionHeadline = ({ children }) => {
+  return (
+    <h1
+      tabIndex="-1"
+      className="vads-u-font-size--h2 vads-u-margin-y--2 medium-screen:vads-u-margin-bottom--4 medium-screen:vads-u-margin-top--3"
+      data-focus-target
+    >
+      {children}
+    </h1>
+  );
+};
+
+export default ProfileSectionHeadline;

--- a/src/applications/personalization/profile/components/ProfileSubNav.jsx
+++ b/src/applications/personalization/profile/components/ProfileSubNav.jsx
@@ -6,7 +6,7 @@ import { focusElement } from 'platform/utilities/ui';
 import ProfileSubNavItems from './ProfileSubNavItems';
 
 const ProfileSubNav = ({ isInMVI, isLOA3, routes }) => {
-  // on first render, set the focus to the h1
+  // on first render, set the focus to the h4
   useEffect(() => {
     focusElement('#subnav-header');
   }, []);
@@ -14,9 +14,7 @@ const ProfileSubNav = ({ isInMVI, isLOA3, routes }) => {
   return (
     <nav className="va-subnav" aria-label="Secondary">
       <div>
-        <h1 id="subnav-header" className="vads-u-font-size--h4">
-          Profile
-        </h1>
+        <h4 id="subnav-header">Profile</h4>
         <ProfileSubNavItems routes={routes} isLOA3={isLOA3} isInMVI={isInMVI} />
       </div>
     </nav>

--- a/src/applications/personalization/profile/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile/components/ProfileWrapper.jsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { Link, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { isEmpty } from 'lodash';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
 
-import { isWideScreen } from '~/platform/utilities/accessibility/index';
 import { selectProfile } from '~/platform/user/selectors';
 
 import {
@@ -22,7 +21,6 @@ import { hasTotalDisabilityServerError } from '~/applications/personalization/ra
 import NameTag from '~/applications/personalization/components/NameTag';
 import ProfileSubNav from './ProfileSubNav';
 import ProfileMobileSubNav from './ProfileMobileSubNav';
-import { PROFILE_PATHS } from '../constants';
 
 const NotAllDataAvailableError = () => (
   <div data-testid="not-all-data-available-error">
@@ -61,14 +59,6 @@ const ProfileWrapper = ({
 
   const { activeLocation, activeRouteName } = createBreadCrumbAttributes();
 
-  // We do not want to display 'Profile' on the mobile personal-information route
-  const onPersonalInformationMobile =
-    activeLocation === PROFILE_PATHS.PERSONAL_INFORMATION && !isWideScreen();
-
-  // Without a verified identity, we want to show 'Home - Account Security'
-  const showLOA1BreadCrumb =
-    (!isLOA3 || !isInMVI) && activeLocation === PROFILE_PATHS.ACCOUNT_SECURITY;
-
   return (
     <>
       {showNameTag &&
@@ -84,15 +74,7 @@ const ProfileWrapper = ({
       <div data-testid="breadcrumbs">
         <Breadcrumbs className="vads-u-padding-x--1 vads-u-padding-y--1p5 medium-screen:vads-u-padding-y--0">
           <a href="/">Home</a>
-
-          {showLOA1BreadCrumb && <Link to="/">Profile - Account security</Link>}
-
-          {!showLOA1BreadCrumb &&
-            !onPersonalInformationMobile && <Link to="/">Profile</Link>}
-
-          {!showLOA1BreadCrumb && (
-            <a href={activeLocation}>{activeRouteName}</a>
-          )}
+          <a href={activeLocation}>{`Profile: ${activeRouteName}`}</a>
         </Breadcrumbs>
       </div>
 

--- a/src/applications/personalization/profile/components/account-security/AccountSecurity.jsx
+++ b/src/applications/personalization/profile/components/account-security/AccountSecurity.jsx
@@ -5,6 +5,7 @@ import DowntimeNotification, {
 import { focusElement } from 'platform/utilities/ui';
 
 import { handleDowntimeForSection } from '../alerts/DowntimeBanner';
+import Headline from '../ProfileSectionHeadline';
 
 import AccountSecurityContent from './AccountSecurityContent';
 
@@ -22,13 +23,7 @@ class AccountSecurity extends Component {
   render() {
     return (
       <>
-        <h2
-          tabIndex="-1"
-          className="vads-u-margin-y--2 medium-screen:vads-u-margin-bottom--4 medium-screen:vads-u-margin-top--3"
-          data-focus-target
-        >
-          Account security
-        </h2>
+        <Headline>Account security</Headline>
         <DowntimeNotification
           render={handleDowntimeForSection('account security')}
           dependencies={[externalServices.emis, externalServices.mvi]}

--- a/src/applications/personalization/profile/components/connected-apps/ConnectedApps.jsx
+++ b/src/applications/personalization/profile/components/connected-apps/ConnectedApps.jsx
@@ -13,6 +13,7 @@ import {
 } from '@@profile/components/connected-apps/actions';
 import recordEvent from 'platform/monitoring/record-event';
 import { focusElement } from 'platform/utilities/ui';
+import Headline from '../ProfileSectionHeadline';
 import { AppDeletedAlert } from './AppDeletedAlert';
 import { ConnectedApp } from './ConnectedApp';
 
@@ -56,13 +57,7 @@ export class ConnectedApps extends Component {
 
     return (
       <div className="va-connected-apps">
-        <h2
-          tabIndex="-1"
-          className="vads-u-margin-y--2 medium-screen:vads-u-margin-bottom--4 medium-screen:vads-u-margin-top--3"
-          data-focus-target
-        >
-          Connected apps
-        </h2>
+        <Headline>Connected apps</Headline>
         {showHasConnectedApps && (
           <p className="va-introtext vads-u-font-size--md">
             Your VA.gov profile is connected to the third-party (non-VA) apps

--- a/src/applications/personalization/profile/components/direct-deposit/DirectDepositV1.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/DirectDepositV1.jsx
@@ -13,6 +13,7 @@ import { isAuthenticatedWithSSOe as isAuthenticatedWithSSOeSelector } from '~/pl
 import { focusElement } from '~/platform/utilities/ui';
 
 import { handleDowntimeForSection } from '../alerts/DowntimeBanner';
+import Headline from '../ProfileSectionHeadline';
 import SetUp2FAAlert from '../alerts/SetUp2FAAlert';
 
 import FraudVictimAlert from './FraudVictimAlert';
@@ -29,13 +30,7 @@ const DirectDeposit = ({ is2faEnabled, isAuthenticatedWithSSOe, isLOA3 }) => {
 
   return (
     <>
-      <h2
-        tabIndex="-1"
-        className="vads-u-margin-y--2 medium-screen:vads-u-margin-bottom--4 medium-screen:vads-u-margin-top--3"
-        data-focus-target
-      >
-        Direct deposit information
-      </h2>
+      <Headline>Direct deposit information</Headline>
       {showSetUp2FactorAuthentication && (
         <SetUp2FAAlert isAuthenticatedWithSSOe={isAuthenticatedWithSSOe} />
       )}

--- a/src/applications/personalization/profile/components/direct-deposit/DirectDepositV2.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/DirectDepositV2.jsx
@@ -24,6 +24,8 @@ import {
 import { handleDowntimeForSection } from '../alerts/DowntimeBanner';
 import SetUp2FAAlert from '../alerts/SetUp2FAAlert';
 
+import Headline from '../ProfileSectionHeadline';
+
 import FraudVictimAlert from './FraudVictimAlert';
 import PaymentHistory from './PaymentHistory';
 import BankInfoCNPv2 from './BankInfoCNPv2';
@@ -136,13 +138,7 @@ const DirectDeposit = ({
 
   return (
     <>
-      <h2
-        tabIndex="-1"
-        className="vads-u-margin-y--2 medium-screen:vads-u-margin-bottom--4 medium-screen:vads-u-margin-top--3"
-        data-focus-target
-      >
-        Direct deposit information
-      </h2>
+      <Headline>Direct deposit information</Headline>
       <div id="success" role="alert" aria-atomic="true">
         <ReactCSSTransitionGroup
           transitionName="form-expanding-group-inner"

--- a/src/applications/personalization/profile/components/military-information/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile/components/military-information/MilitaryInformation.jsx
@@ -20,6 +20,7 @@ import LoadFail from '../alerts/LoadFail';
 import { handleDowntimeForSection } from '../alerts/DowntimeBanner';
 import facilityLocator from 'applications/facility-locator/manifest.json';
 
+import Headline from '../ProfileSectionHeadline';
 import ProfileInfoTable from '../ProfileInfoTable';
 import { transformServiceHistoryEntryIntoTableRow } from '../../helpers';
 
@@ -199,13 +200,7 @@ const MilitaryInformation = ({ militaryInformation, veteranStatus }) => {
 
   return (
     <>
-      <h2
-        tabIndex="-1"
-        className="vads-u-margin-y--2 medium-screen:vads-u-margin-bottom--4 medium-screen:vads-u-margin-top--3"
-        data-focus-target
-      >
-        Military information
-      </h2>
+      <Headline>Military information</Headline>
       <DowntimeNotification
         appTitle="Military Information"
         render={handleDowntimeForSection('military service')}

--- a/src/applications/personalization/profile/components/military-information/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile/components/military-information/MilitaryInformation.jsx
@@ -30,11 +30,11 @@ const NotAVeteranAlert = () => {
     <AlertBox
       isVisible
       status="warning"
-      headline="We don't seem to have your military records"
+      headline="We don’t seem to have your military records"
       content={
         <>
           <p>
-            We're sorry. We can't match your information to our records. If you
+            We’re sorry. We can’t match your information to our records. If you
             think this is an error, please call the VA.gov help desk at{' '}
             <Telephone contact={CONTACTS.HELP_DESK} /> (TTY:{' '}
             <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />

--- a/src/applications/personalization/profile/components/personal-information/PersonalInformation.jsx
+++ b/src/applications/personalization/profile/components/personal-information/PersonalInformation.jsx
@@ -11,8 +11,10 @@ import { hasVAPServiceConnectionError } from '~/platform/user/selectors';
 import { focusElement } from '~/platform/utilities/ui';
 
 import PaymentInformationBlocked from '@@profile/components/direct-deposit/PaymentInformationBlocked';
-import { handleDowntimeForSection } from '../alerts/DowntimeBanner';
 import { cnpDirectDepositIsBlocked } from '@@profile/selectors';
+
+import { handleDowntimeForSection } from '../alerts/DowntimeBanner';
+import Headline from '../ProfileSectionHeadline';
 
 import PersonalInformationContent from './PersonalInformationContent';
 
@@ -62,13 +64,7 @@ const PersonalInformation = ({
         message="Are you sure you want to leave? If you leave, your in-progress work won’t be saved."
         when={hasUnsavedEdits}
       />
-      <h2
-        tabIndex="-1"
-        className="vads-u-margin-y--2 medium-screen:vads-u-margin-bottom--4 medium-screen:vads-u-margin-top--3"
-        data-focus-target
-      >
-        Personal and contact information
-      </h2>
+      <Headline>Personal and contact information</Headline>
       <DowntimeNotification
         render={handleDowntimeForSection('personal and contact')}
         dependencies={[externalServices.mvi, externalServices.vaProfile]}

--- a/src/applications/personalization/profile/sass/profile-subnav.scss
+++ b/src/applications/personalization/profile/sass/profile-subnav.scss
@@ -2,7 +2,7 @@
   border-bottom: 1px solid $color-gray-lighter;
   display: block;
 
-  h1 {
+  h4 {
     border: 1px solid $color-gray-lighter;
     border-left: none;
     border-right: none;

--- a/src/applications/personalization/profile/tests/components/MilitaryInformation.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/MilitaryInformation.unit.spec.jsx
@@ -215,11 +215,11 @@ describe('MilitaryInformation', () => {
         initialState,
       });
 
-      expect(view.getByText(/We don't seem to have your military records/i)).to
+      expect(view.getByText(/We don’t seem to have your military records/i)).to
         .exist;
       expect(
         view.getByText(
-          /We're sorry. We can't match your information to our records./i,
+          /We’re sorry. We can’t match your information to our records./i,
         ),
       ).to.exist;
     });

--- a/src/applications/personalization/profile/tests/components/account-security/AccountSecurity.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/account-security/AccountSecurity.unit.spec.jsx
@@ -6,6 +6,7 @@ import DowntimeNotification, {
   externalServices,
 } from 'platform/monitoring/DowntimeNotification';
 
+import ProfileSectionHeadline from '@@profile/components/ProfileSectionHeadline';
 import AccountSecurity from '@@profile/components/account-security/AccountSecurity';
 import AccountSecurityContent from '@@profile/components/account-security/AccountSecurityContent';
 
@@ -17,9 +18,9 @@ describe('AccountSecurity', () => {
   afterEach(() => {
     wrapper.unmount();
   });
-  it('renders an h2 tag as its first child', () => {
+  it('renders a ProfileSectionHeadline component as its first child', () => {
     const firstChild = wrapper.childAt(0);
-    expect(firstChild.type()).to.equal('h2');
+    expect(firstChild.type()).to.equal(ProfileSectionHeadline);
   });
 
   it('renders a properly configured DowntimeNotification component as its second child', () => {

--- a/src/applications/personalization/profile/tests/components/connected-apps/ConnectedApps.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/connected-apps/ConnectedApps.unit.spec.jsx
@@ -29,8 +29,10 @@ describe('<ConnectedApps>', () => {
 
     const wrapper = shallow(<ConnectedApps {...defaultProps} />);
 
+    const headline = wrapper.find('ProfileSectionHeadline');
+    expect(headline.dive().text()).to.equal(title);
+
     const text = wrapper.text();
-    expect(text).to.include(title);
     expect(text).to.include(
       'Your VA.gov profile is connected to the third-party (non-VA) apps listed below. If you want to stop sharing information with an app, you can disconnect it from your profile at any time.',
     );

--- a/src/applications/personalization/profile/tests/components/direct-deposit/DirectDepositV1.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/direct-deposit/DirectDepositV1.unit.spec.jsx
@@ -8,6 +8,7 @@ import DowntimeNotification, {
   externalServices,
 } from 'platform/monitoring/DowntimeNotification';
 
+import ProfileSectionHeadline from '@@profile/components/ProfileSectionHeadline';
 import DirectDepositV1 from '@@profile/components/direct-deposit/DirectDepositV1';
 import BankInfoCNP from '@@profile/components/direct-deposit/BankInfoCNP';
 
@@ -72,9 +73,9 @@ describe('DirectDeposit version 1', () => {
     wrapper.unmount();
   });
 
-  it('renders an h2 tag as its first child', () => {
+  it('renders a ProfileSectionHeadline component as its first child', () => {
     const firstChild = directDeposit.childAt(0);
-    expect(firstChild.type()).to.equal('h2');
+    expect(firstChild.type()).to.equal(ProfileSectionHeadline);
   });
 
   describe('the DowntimeNotification component', () => {

--- a/src/applications/personalization/profile/tests/e2e/profile-a11y.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile-a11y.cypress.spec.js
@@ -52,11 +52,8 @@ function checkAllPages(mobile = false) {
     'Personal And Contact Information | Veterans Affairs',
   );
 
-  // focus should be on the sub-nav's h1 when redirected from /profile/
-  cy.focused()
-    .contains(/profile/i)
-    .and('have.prop', 'tagName')
-    .should('eq', 'H1');
+  // focus should be on the sub-nav's heading when redirected from /profile/
+  cy.focused().contains(/profile/i);
 
   // make the a11y check on the Personal Info section
   cy.injectAxe();
@@ -70,11 +67,8 @@ function checkAllPages(mobile = false) {
   );
   cy.title().should('eq', 'Military Information | Veterans Affairs');
   cy.axeCheck();
-  // focus should be on the section's h2
-  cy.focused()
-    .contains(PROFILE_PATH_NAMES.MILITARY_INFORMATION)
-    .and('have.prop', 'tagName')
-    .should('eq', 'H2');
+  // focus should be on the section's heading
+  cy.focused().contains(PROFILE_PATH_NAMES.MILITARY_INFORMATION);
 
   // make the a11y and focus management check on the Direct Deposit section
   clickSubNavButton(PROFILE_PATH_NAMES.DIRECT_DEPOSIT, mobile);
@@ -84,11 +78,8 @@ function checkAllPages(mobile = false) {
   );
   cy.title().should('eq', 'Direct Deposit | Veterans Affairs');
   cy.axeCheck();
-  // focus should be on the section's h2
-  cy.focused()
-    .contains(PROFILE_PATH_NAMES.DIRECT_DEPOSIT)
-    .and('have.prop', 'tagName')
-    .should('eq', 'H2');
+  // focus should be on the section's heading
+  cy.focused().contains(PROFILE_PATH_NAMES.DIRECT_DEPOSIT);
 
   // make the a11y and focus management check on the Account Security section
   clickSubNavButton(PROFILE_PATH_NAMES.ACCOUNT_SECURITY, mobile);
@@ -98,11 +89,8 @@ function checkAllPages(mobile = false) {
   );
   cy.title().should('eq', 'Account Security | Veterans Affairs');
   cy.axeCheck();
-  // focus should be on the section's h2
-  cy.focused()
-    .contains(PROFILE_PATH_NAMES.ACCOUNT_SECURITY)
-    .and('have.prop', 'tagName')
-    .should('eq', 'H2');
+  // focus should be on the section's heading
+  cy.focused().contains(PROFILE_PATH_NAMES.ACCOUNT_SECURITY);
 
   // make the a11y and focus management check on the Connected Apps section
   clickSubNavButton(PROFILE_PATH_NAMES.CONNECTED_APPLICATIONS, mobile);
@@ -114,11 +102,8 @@ function checkAllPages(mobile = false) {
   // wait for this section's loading spinner to disappear...
   cy.findByRole('progressbar').should('not.exist');
   cy.axeCheck();
-  // focus should be on the section's h2
-  cy.focused()
-    .contains(PROFILE_PATH_NAMES.CONNECTED_APPLICATIONS)
-    .and('have.prop', 'tagName')
-    .should('eq', 'H2');
+  // focus should be on the section's heading
+  cy.focused().contains(PROFILE_PATH_NAMES.CONNECTED_APPLICATIONS);
 
   // navigate directly to the Personal and Contact Info section via the sub-nav to confirm focus is managed correctly
   clickSubNavButton(PROFILE_PATH_NAMES.PERSONAL_INFORMATION, mobile);
@@ -126,10 +111,7 @@ function checkAllPages(mobile = false) {
     'eq',
     `${Cypress.config().baseUrl}${PROFILE_PATHS.PERSONAL_INFORMATION}`,
   );
-  cy.focused()
-    .contains(PROFILE_PATH_NAMES.PERSONAL_INFORMATION)
-    .and('have.prop', 'tagName')
-    .should('eq', 'H2');
+  cy.focused().contains(PROFILE_PATH_NAMES.PERSONAL_INFORMATION);
 }
 
 describe('Profile', () => {


### PR DESCRIPTION
## Description
This updates the heading levels used on the Profile and also updates the breadcrumbs

## Testing done
Tested locally in Cypress. Updated existing unit and Cypress tests

## Screenshots
Everything still looks good
<img width="1037" alt="Screen Shot 2021-04-20 at 5 19 21 PM" src="https://user-images.githubusercontent.com/20728956/115479229-d908df80-a1fc-11eb-9bf6-a27de6081305.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs