### PR TITLE
Sets CSRF token in covid KMI API requests

### DIFF
--- a/src/applications/coronavirus-vaccination/api/index.js
+++ b/src/applications/coronavirus-vaccination/api/index.js
@@ -1,4 +1,5 @@
 import environment from 'platform/utilities/environment';
+import localStorage from 'platform/utilities/storage/localStorage';
 import { apiRequest } from 'platform/utilities/api';
 
 const apiUrl = `${environment.API_URL}/covid_vaccine/v0/registration`;
@@ -9,21 +10,25 @@ const unsubscribeUrl = `${
 export const retrievePreviouslySubmittedForm = () => apiRequest(apiUrl);
 
 export const saveForm = formData => {
+  const csrfTokenStored = localStorage.getItem('csrfToken');
   return apiRequest(apiUrl, {
     method: 'POST',
     body: JSON.stringify(formData),
     headers: {
       'Content-Type': 'application/json',
+      'X-CSRF-Token': csrfTokenStored,
     },
   });
 };
 
 export const unsubscribe = sid => {
+  const csrfTokenStored = localStorage.getItem('csrfToken');
   return apiRequest(unsubscribeUrl, {
     method: 'PUT',
     body: JSON.stringify({ sid }),
     headers: {
       'Content-Type': 'application/json',
+      'X-CSRF-Token': csrfTokenStored,
     },
   });
 };


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/23542

We were seeing invalid authenticity token errors on the original KMI tool for both the create and opt_out endpoints:
http://sentry.vfs.va.gov/organizations/vsp/issues/6196/tags/?environment=production&project=3

The original covid_vaccine application was not using VA Form System and hence was not passing the X-CSRF-Token header on PUT/POST requests. This PR fixes that. 

## Testing done
None yet; my local env is a little screwy so hoping to get this into a review instance for further testing. 

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
