### PR TITLE
DT-18434 refactored form title with a11y 

### DIFF
--- a/src/applications/find-forms/components/FormTitle.jsx
+++ b/src/applications/find-forms/components/FormTitle.jsx
@@ -11,14 +11,9 @@ const FormTitle = ({ id, formUrl, title, lang, recordGAEvent }) => (
         href={formUrl}
         className="vads-u-text-decoration--none"
         onClick={() => recordGAEvent(title, formUrl, 'title')}
+        lang={lang}
       >
-        <dfn>
-          <span className="vads-u-visibility--screen-reader">
-            Visit the landing page for Form number
-          </span>
-          {id}{' '}
-        </dfn>
-        <span lang={lang}>{title}</span>
+        {id} {title}{' '}
         <i
           aria-hidden="true"
           role="presentation"
@@ -28,11 +23,7 @@ const FormTitle = ({ id, formUrl, title, lang, recordGAEvent }) => (
       </a>
     ) : (
       <>
-        <dfn>
-          <span className="vads-u-visibility--screen-reader">Form number</span>{' '}
-          {id}{' '}
-        </dfn>
-        <span lang={lang}>{title}</span>
+        {id} {title}
       </>
     )}
   </dt>


### PR DESCRIPTION
## Description
The span with language attribute was causing some issues. To remedy this, I partnered with @joshkimux to refactor and find a simple solution.

## Testing done
Ran e2e, and unit locally. 

## Screenshots
![Screen Shot 2021-04-21 at 10 19 16 AM](https://user-images.githubusercontent.com/26075258/115569515-4cf1c900-a28b-11eb-8d32-12473a222718.png)


## Acceptance criteria
- [x] Delete the span wrapping the form name.
- [x] Move the lang attribute up to the anchor tag

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
