### PR TITLE
Fix shallowEqual typo in TypeOfSleepCarePage component

### DIFF
--- a/src/applications/vaos/new-appointment/components/TypeOfSleepCarePage.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfSleepCarePage.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { shallowEquals, useDispatch, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import FormButtons from '../../components/FormButtons';
@@ -68,7 +68,7 @@ export default function TypeOfSleepCarePage() {
   const dispatch = useDispatch();
   const { schema, data, pageChangeInProgress } = useSelector(
     state => getFormPageInfo(state, pageKey),
-    shallowEquals,
+    shallowEqual,
   );
   useEffect(() => {
     dispatch(openFormPage(pageKey, uiSchema, initialSchema));


### PR DESCRIPTION
## Description

This PR fixes a typo and uses the correct import for `shallowEqual` in the `TypeOfSleepCarePage` component.

Ticket: N/A

## Testing done

- local, unit testing

## Screenshots

N/A

## Acceptance criteria
- [x] Use `shallowEqual` from `react-redux` package

## Definition of done
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
