### PR TITLE
Add instructions for Veterans in the Philippines and other purposes

### DIFF
--- a/src/applications/coronavirus-vaccination/components/Form.jsx
+++ b/src/applications/coronavirus-vaccination/components/Form.jsx
@@ -97,9 +97,9 @@ function Form({ formState, updateFormData, router, isLoggedIn, profile }) {
         ) : (
           <p>
             We’ll share this information with your local VA health facility.
-            They may use this information to determine when to contact you when
-            your risk group becomes eligible for a vaccine. We’ll also send you
-            updates on our vaccine plans.
+            They may use this information to determine when to contact you about
+            getting your COVID-19 vaccine. We’ll also send you updates on our
+            vaccine plans.
           </p>
         )}
 

--- a/src/applications/coronavirus-vaccination/config/uiSchema.js
+++ b/src/applications/coronavirus-vaccination/config/uiSchema.js
@@ -210,10 +210,10 @@ export default {
       'ui:title': 'Zip code',
       'ui:description': () => (
         <span>
-          <b>Note for Veterans residing in the Philippines: </b>
-          Please enter <strong>96517</strong> for your zip code. This will allow
-          us to more easily understand which Veterans in the Philippines are
-          interested in getting a vaccine from VA.
+          <b>If you currently live in the Philippines:</b>
+          Enter <strong>96517</strong> for your zip code. This will help us
+          understand which Veterans in the Philippines want to get a vaccine, so
+          we can serve you better.
         </span>
       ),
       'ui:errorMessages': {

--- a/src/applications/coronavirus-vaccination/config/uiSchema.js
+++ b/src/applications/coronavirus-vaccination/config/uiSchema.js
@@ -210,7 +210,7 @@ export default {
       'ui:title': 'Zip code',
       'ui:description': () => (
         <span>
-          <b>If you currently live in the Philippines:</b>
+          <b>If you currently live in the Philippines: </b>
           Enter <strong>96517</strong> for your zip code. This will help us
           understand which Veterans in the Philippines want to get a vaccine, so
           we can serve you better.

--- a/src/applications/coronavirus-vaccination/config/uiSchema.js
+++ b/src/applications/coronavirus-vaccination/config/uiSchema.js
@@ -38,8 +38,7 @@ export default {
           <b>Note: </b>
           Your date of birth helps us match your information to your Veteran
           records. We can then share your vaccine plans with your local VA
-          health facility so they can contact you when you’re eligible to get a
-          vaccine.
+          health facility so they can contact you.
         </span>
       ),
       'ui:widget': 'date',
@@ -54,7 +53,7 @@ export default {
           Your <abbr title="Social Security Number">SSN</abbr> helps us match
           your information to your Veteran records. We can then share your
           vaccine plans with your local VA health facility so they can contact
-          you when you’re eligible to get a vaccine.
+          you.
         </span>
       ),
       'ui:options': {
@@ -124,7 +123,7 @@ export default {
         <span>
           <b>Note: </b>
           Your facility may use this information to determine when to contact
-          you about getting a vaccine once your risk group becomes eligible.
+          you about getting a vaccine.
         </span>
       ),
     },
@@ -156,8 +155,7 @@ export default {
           <b>Note: </b>
           Your date of birth helps us match your information to your Veteran
           records. We can then share your vaccine plans with your local VA
-          health facility so they can contact you when you’re eligible to get a
-          vaccine.
+          health facility so they can contact you.
         </span>
       ),
       'ui:widget': 'date',
@@ -176,7 +174,7 @@ export default {
           Your <abbr title="Social Security Number">SSN</abbr> helps us match
           your information to your Veteran records. We can then share your
           vaccine plans with your local VA health facility so they can contact
-          you when you’re eligible to get a vaccine.
+          you.
         </span>
       ),
       'ui:options': {
@@ -254,7 +252,7 @@ export default {
         <span>
           <b>Note: </b>
           Your facility may use this information to determine when to contact
-          you about getting a vaccine once your risk group becomes eligible.
+          you about getting a vaccine.
         </span>
       ),
     },

--- a/src/applications/coronavirus-vaccination/config/uiSchema.js
+++ b/src/applications/coronavirus-vaccination/config/uiSchema.js
@@ -208,6 +208,14 @@ export default {
     },
     zipCode: {
       'ui:title': 'Zip code',
+      'ui:description': () => (
+        <span>
+          <b>Note for Veterans residing in the Philippines: </b>
+          Please enter <strong>96517</strong> for your zip code. This will allow
+          us to more easily understand which Veterans in the Philippines are
+          interested in getting a vaccine from VA.
+        </span>
+      ),
       'ui:errorMessages': {
         required: 'Please enter your zip code',
         pattern: 'Please enter a valid zip code',


### PR DESCRIPTION
## Description
- Veterans who live in the Philippines are eligible for a vaccine from the Manila VHA clinic. The clinic team wants to understand the amount of demand in their population for a vaccine. The agreed upon solution is to use the U.S. embassy zip code / FPO zip code for pacific islands to identify KMI subscribers who live in the Philippines. This change provides that direction.
- Also, removes language around risk based eligibility.

## Testing done
Browser 👀 

## Screenshots
![image](https://user-images.githubusercontent.com/7645362/115735987-e89d3b00-a358-11eb-9cc6-c3960e94a17d.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
