### PR TITLE
[23388] Convert RequestedAppointmentDetailsPage from connect to react hooks

### DIFF
--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
@@ -1,11 +1,9 @@
 import React, { useEffect } from 'react';
 import { Link, useParams } from 'react-router-dom';
-import { connect } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import moment from 'moment';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
-
-import * as actions from '../redux/actions';
 import {
   APPOINTMENT_STATUS,
   APPOINTMENT_TYPES,
@@ -21,14 +19,16 @@ import {
   getPatientTelecom,
   getVAAppointmentLocationId,
 } from '../../services/appointment';
-import {
-  selectFirstRequestMessage,
-  getCancelInfo,
-  selectAppointmentById,
-} from '../redux/selectors';
+import { selectRequestedAppointmentDetails } from '../redux/selectors';
 import ErrorMessage from '../../components/ErrorMessage';
 import PageLayout from './AppointmentsPage/PageLayout';
 import FullWidthLayout from '../../components/FullWidthLayout';
+import {
+  cancelAppointment,
+  closeCancelAppointment,
+  confirmCancelAppointment,
+  fetchRequestDetails,
+} from '../redux/actions';
 
 const TIME_TEXT = {
   AM: 'in the morning',
@@ -36,21 +36,22 @@ const TIME_TEXT = {
   'No Time Selected': '',
 };
 
-function RequestedAppointmentDetailsPage({
-  appointment,
-  appointmentDetailsStatus,
-  cancelAppointment,
-  cancelInfo,
-  closeCancelAppointment,
-  confirmCancelAppointment,
-  facilityData,
-  fetchRequestDetails,
-  message,
-}) {
+export default function RequestedAppointmentDetailsPage() {
   const { id } = useParams();
+  const dispatch = useDispatch();
+  const {
+    appointmentDetailsStatus,
+    facilityData,
+    cancelInfo,
+    appointment,
+    message,
+  } = useSelector(
+    state => selectRequestedAppointmentDetails(state, id),
+    shallowEqual,
+  );
 
   useEffect(() => {
-    fetchRequestDetails(id);
+    dispatch(fetchRequestDetails(id));
   }, []);
 
   useEffect(
@@ -157,7 +158,7 @@ function RequestedAppointmentDetailsPage({
               <button
                 aria-label="Cancel request"
                 className="vaos-appts__cancel-btn va-button-link vads-u-flex--0"
-                onClick={() => cancelAppointment(appointment)}
+                onClick={() => dispatch(cancelAppointment(appointment))}
               >
                 Cancel Request
               </button>
@@ -230,33 +231,9 @@ function RequestedAppointmentDetailsPage({
       </Link>
       <CancelAppointmentModal
         {...cancelInfo}
-        onConfirm={confirmCancelAppointment}
-        onClose={closeCancelAppointment}
+        onConfirm={() => dispatch(confirmCancelAppointment())}
+        onClose={() => dispatch(closeCancelAppointment())}
       />
     </PageLayout>
   );
 }
-function mapStateToProps(state, ownProps) {
-  const { appointmentDetailsStatus, facilityData } = state.appointments;
-
-  return {
-    appointment: selectAppointmentById(state, ownProps.match.params.id, [
-      APPOINTMENT_TYPES.request,
-      APPOINTMENT_TYPES.ccRequest,
-    ]),
-    appointmentDetailsStatus,
-    facilityData,
-    message: selectFirstRequestMessage(state, ownProps.match.params.id),
-    cancelInfo: getCancelInfo(state),
-  };
-}
-const mapDispatchToProps = {
-  cancelAppointment: actions.cancelAppointment,
-  closeCancelAppointment: actions.closeCancelAppointment,
-  confirmCancelAppointment: actions.confirmCancelAppointment,
-  fetchRequestDetails: actions.fetchRequestDetails,
-};
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(RequestedAppointmentDetailsPage);

--- a/src/applications/vaos/appointment-list/redux/selectors.js
+++ b/src/applications/vaos/appointment-list/redux/selectors.js
@@ -2,7 +2,11 @@ import moment from 'moment';
 import { createSelector } from 'reselect';
 import { selectCernerAppointmentsFacilities } from 'platform/user/selectors';
 import { titleCase } from '../../utils/formatters';
-import { FETCH_STATUS, APPOINTMENT_STATUS } from '../../utils/constants';
+import {
+  FETCH_STATUS,
+  APPOINTMENT_STATUS,
+  APPOINTMENT_TYPES,
+} from '../../utils/constants';
 import {
   getVAAppointmentLocationId,
   isUpcomingAppointmentOrRequest,
@@ -399,4 +403,19 @@ export function selectCanUseVaccineFlow(state) {
       ),
     )
   );
+}
+
+export function selectRequestedAppointmentDetails(state, id) {
+  const { appointmentDetailsStatus, facilityData } = state.appointments;
+
+  return {
+    appointment: selectAppointmentById(state, id, [
+      APPOINTMENT_TYPES.request,
+      APPOINTMENT_TYPES.ccRequest,
+    ]),
+    appointmentDetailsStatus,
+    facilityData,
+    message: selectFirstRequestMessage(state, id),
+    cancelInfo: getCancelInfo(state),
+  };
 }


### PR DESCRIPTION
## Description
We want to update the way we use react-redux to the current recommended approach, which is to use the useSelector and useDispatch hooks.

Path: src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx

## Testing done
Local

## Screenshots
n/a

## Acceptance criteria
- [ ] connect() is no longer used on page
- [ ] All actions that were in mapDispatchToProps are now wrapped in dispatch() when called
- [ ] All data in mapStateToProps is pulled in through useSelector hooks

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
