### PR TITLE
Feature/23389 replace connect with hooks in RequestedAppointmentsList

### DIFF
--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentsList.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentsList.jsx
@@ -1,35 +1,38 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import recordEvent from 'platform/monitoring/record-event';
-import * as actions from '../redux/actions';
 import {
-  selectFeatureRequests,
-  selectIsCernerOnlyPatient,
-} from '../../redux/selectors';
-import { selectPendingAppointments } from '../redux/selectors';
+  fetchPendingAppointments,
+  startNewAppointmentFlow,
+} from '../redux/actions';
+import { getRequestedAppointmentListInfo } from '../redux/selectors';
 import { FETCH_STATUS, GA_PREFIX } from '../../utils/constants';
 import { getVAAppointmentLocationId } from '../../services/appointment';
 import RequestListItem from './AppointmentsPageV2/RequestListItem';
 import NoAppointments from './NoAppointments';
 import { scrollAndFocus } from '../../utils/scrollAndFocus';
 
-function RequestedAppointmentsList({
-  showScheduleButton,
-  isCernerOnlyPatient,
-  pendingAppointments,
-  pendingStatus,
-  facilityData,
-  fetchPendingAppointments,
-  startNewAppointmentFlow,
-  hasTypeChanged,
-}) {
+export default function RequestedAppointmentsList({ hasTypeChanged }) {
+  const {
+    facilityData,
+    isCernerOnlyPatient,
+    pendingAppointments,
+    pendingStatus,
+    showScheduleButton,
+  } = useSelector(
+    state => getRequestedAppointmentListInfo(state),
+    shallowEqual,
+  );
+
+  const dispatch = useDispatch();
+
   useEffect(
     () => {
       if (pendingStatus === FETCH_STATUS.notStarted) {
-        fetchPendingAppointments();
+        dispatch(fetchPendingAppointments());
       } else if (hasTypeChanged && pendingStatus === FETCH_STATUS.succeeded) {
         scrollAndFocus('#type-dropdown');
       } else if (hasTypeChanged && pendingStatus === FETCH_STATUS.failed) {
@@ -107,23 +110,3 @@ RequestedAppointmentsList.propTypes = {
   showScheduleButton: PropTypes.bool,
   startNewAppointmentFlow: PropTypes.func,
 };
-
-function mapStateToProps(state) {
-  return {
-    facilityData: state.appointments.facilityData,
-    pendingStatus: state.appointments.pendingStatus,
-    pendingAppointments: selectPendingAppointments(state),
-    isCernerOnlyPatient: selectIsCernerOnlyPatient(state),
-    showScheduleButton: selectFeatureRequests(state),
-  };
-}
-
-const mapDispatchToProps = {
-  fetchPendingAppointments: actions.fetchPendingAppointments,
-  startNewAppointmentFlow: actions.startNewAppointmentFlow,
-};
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(RequestedAppointmentsList);

--- a/src/applications/vaos/appointment-list/redux/selectors.js
+++ b/src/applications/vaos/appointment-list/redux/selectors.js
@@ -412,3 +412,13 @@ export function getCanceledAppointmentListInfo(state) {
     showScheduleButton: selectFeatureRequests(state),
   };
 }
+
+export function getRequestedAppointmentListInfo(state) {
+  return {
+    facilityData: state.appointments.facilityData,
+    pendingStatus: state.appointments.pendingStatus,
+    pendingAppointments: selectPendingAppointments(state),
+    isCernerOnlyPatient: selectIsCernerOnlyPatient(state),
+    showScheduleButton: selectFeatureRequests(state),
+  };
+}


### PR DESCRIPTION
## Description
replace connect() with react-redux recommended useSelector and useDispatch for `requestedAppointmentsList`

## Testing done
local and unit test

## Screenshots
n/a

## Acceptance criteria
- [ ] connect() is no longer used on page
- [ ] All actions that were in mapDispatchToProps are now wrapped in dispatch() when called
- [ ] All data in mapStateToProps is pulled in through useSelector hooks 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
