### PR TITLE
Update Profile MPI errors

### DIFF
--- a/src/applications/personalization/profile/components/account-security/NotInMPIError.jsx
+++ b/src/applications/personalization/profile/components/account-security/NotInMPIError.jsx
@@ -24,7 +24,7 @@ const NotInMPIError = () => {
   return (
     <div className="vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4">
       <AlertBox
-        headline="We can’t match your information to our Veteran records"
+        headline="We can’t match your information to our records"
         content={content}
         status="warning"
       />

--- a/src/applications/personalization/profile/components/alerts/MPIConnectionError.jsx
+++ b/src/applications/personalization/profile/components/alerts/MPIConnectionError.jsx
@@ -4,7 +4,7 @@ import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox
 const MPIConnectionError = () => {
   const content = (
     <p>
-      We’re sorry. Something went wrong when we tried to connect to your Veteran
+      We’re sorry. Something went wrong when we tried to connect to your
       records. Please refresh this page to try again.
     </p>
   );
@@ -12,7 +12,7 @@ const MPIConnectionError = () => {
   return (
     <div className="vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4">
       <AlertBox
-        headline="We can’t access your Veteran records"
+        headline="We can’t access your records"
         content={content}
         status="warning"
       />

--- a/src/applications/personalization/profile/tests/components/alerts/NotInMPIError.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/alerts/NotInMPIError.unit.spec.jsx
@@ -12,9 +12,7 @@ describe('NotInMPI', () => {
 
   it('should render the correct text', () => {
     expect(
-      wrapper
-        .text()
-        .includes('We can’t match your information to our Veteran records'),
+      wrapper.text().includes('We can’t match your information to our records'),
     ).to.be.true;
     expect(
       wrapper

--- a/src/applications/personalization/profile/tests/e2e/profile.mpi-error.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile.mpi-error.cypress.spec.js
@@ -33,12 +33,12 @@ function test(mobile = false) {
   );
 
   // Should show an error alert about not being able to connect to MPI
-  cy.findByText(/We can’t access your Veteran records/i)
+  cy.findByText(/We can’t access your records/i)
     .should('exist')
     .closest('.usa-alert-warning')
     .should('exist');
   cy.findByText(
-    /something went wrong when we tried to connect to your veteran records/i,
+    /something went wrong when we tried to connect to your records/i,
   )
     .should('exist')
     .closest('.usa-alert-warning')

--- a/src/applications/personalization/profile/tests/e2e/profile.not-in-mpi-error.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile.not-in-mpi-error.cypress.spec.js
@@ -33,7 +33,7 @@ function test(mobile = false) {
   );
 
   // Should show a "not in MPI" error
-  cy.findByText(/We can’t match your information to our Veteran records/i)
+  cy.findByText(/We can’t match your information to our records/i)
     .should('exist')
     .closest('.usa-alert-warning')
     .should('exist');


### PR DESCRIPTION
## Description
Removes the word "Veteran" from the error alerts

## Testing done
Cypress

## Screenshots
MPI error before:
<img width="688" alt="mpi error before" src="https://user-images.githubusercontent.com/20728956/115631669-1b90f180-a2bb-11eb-8302-c7e78ba31c23.png">

MPI error after:
<img width="688" alt="mpi error after" src="https://user-images.githubusercontent.com/20728956/115631683-23e92c80-a2bb-11eb-813b-159c48ffc2f5.png">

Not in MPI before:
<img width="688" alt="not in mpi before" src="https://user-images.githubusercontent.com/20728956/115631689-264b8680-a2bb-11eb-8f5d-478413f3e728.png">

Not in MPI after:
<img width="688" alt="not in mpi after" src="https://user-images.githubusercontent.com/20728956/115631693-28154a00-a2bb-11eb-8b37-89ba0b1d7213.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs