### PR TITLE
Fix back button on clinic choice page

### DIFF
--- a/src/applications/vaos/new-appointment/components/ClinicChoicePage.jsx
+++ b/src/applications/vaos/new-appointment/components/ClinicChoicePage.jsx
@@ -10,6 +10,7 @@ import { FETCH_STATUS } from '../../utils/constants';
 import {
   openClinicPage,
   routeToNextAppointmentPage,
+  routeToPreviousAppointmentPage,
   updateFormData,
 } from '../redux/actions';
 
@@ -150,7 +151,9 @@ export default function ClinicChoicePage() {
           </div>
         )}
         <FormButtons
-          onBack={() => dispatch(routeToNextAppointmentPage(history, pageKey))}
+          onBack={() =>
+            dispatch(routeToPreviousAppointmentPage(history, pageKey))
+          }
           disabled={usingUnsupportedRequestFlow}
           pageChangeInProgress={pageChangeInProgress}
           loadingText="Page change in progress"


### PR DESCRIPTION
## Description
This PR
- Fixes a bug introduced on the clinic choice page, which broke the back button.

## Testing done
Local testing

## Acceptance criteria
- [ ] Back button works again

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
