### PR TITLE
Various VAOS bug fixes

### DIFF
--- a/src/applications/vaos/new-appointment/components/ClinicChoicePage.jsx
+++ b/src/applications/vaos/new-appointment/components/ClinicChoicePage.jsx
@@ -10,6 +10,7 @@ import { FETCH_STATUS } from '../../utils/constants';
 import {
   openClinicPage,
   routeToNextAppointmentPage,
+  routeToPreviousAppointmentPage,
   updateFormData,
 } from '../redux/actions';
 
@@ -150,7 +151,9 @@ export default function ClinicChoicePage() {
           </div>
         )}
         <FormButtons
-          onBack={() => dispatch(routeToNextAppointmentPage(history, pageKey))}
+          onBack={() =>
+            dispatch(routeToPreviousAppointmentPage(history, pageKey))
+          }
           disabled={usingUnsupportedRequestFlow}
           pageChangeInProgress={pageChangeInProgress}
           loadingText="Page change in progress"

--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -359,7 +359,8 @@ function setLocation(appt) {
         vistaId: appt.facilityId,
         clinicId: appt.clinicId,
         stationId: appt.sta6aid,
-        displayName: appt.clinicFriendlyName,
+        displayName:
+          appt.clinicFriendlyName || appt.vdsAppointments?.[0]?.clinic?.name,
       };
     }
     case APPOINTMENT_TYPES.ccAppointment: {

--- a/src/applications/vaos/tests/appointment-list/components/FutureAppointmentsList.va.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/FutureAppointmentsList.va.unit.spec.jsx
@@ -294,12 +294,15 @@ describe('VAOS integration: upcoming VA appointments', () => {
     appointment.attributes = {
       ...appointment.attributes,
       startDate: moment().format(),
-      clinicFriendlyName: 'COVID Vaccine',
       facilityId: '983',
       sta6aid: '983GC',
       char4: 'CDQC',
+      clinicFriendlyName: null,
     };
     appointment.attributes.vdsAppointments[0].currentStatus = 'FUTURE';
+    appointment.attributes.vdsAppointments[0].clinic = {
+      name: 'VACCINE CLINIC 1',
+    };
     mockAppointmentInfo({ va: [appointment] });
 
     const facility = {
@@ -340,7 +343,7 @@ describe('VAOS integration: upcoming VA appointments', () => {
       'href',
       'https://maps.google.com?saddr=Current+Location&daddr=2360 East Pershing Boulevard, Cheyenne, WY 82001-5356',
     );
-    expect(screen.baseElement).to.contain.text('COVID Vaccine');
+    expect(screen.baseElement).to.contain.text('VACCINE CLINIC 1');
     expect(screen.baseElement).to.contain.text('COVID-19 Vaccine');
     expect(screen.baseElement).not.to.contain.text('VA Appointment');
     expect(screen.baseElement).to.contain.text('Cheyenne VA Medical Center');


### PR DESCRIPTION
## Description
This PR fixes three bugs:
1. Not falling back to clinic name if friendly name is missing
2. Back button on the clinic choice page in the primary/speciality appointment flow doesn’t work
3. The facility page shows an error if you choose a sleep or eye care option, have a single facility available for scheduling, and then change your type of sleep/eye care to the other option.

## Testing done
Local testing

## Acceptance criteria
- [ ] Bugs are fixed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
