### PR TITLE
Fix date formatting

### DIFF
--- a/src/applications/personalization/dashboard-2/components/health-care/Appointments.jsx
+++ b/src/applications/personalization/dashboard-2/components/health-care/Appointments.jsx
@@ -27,7 +27,7 @@ export const Appointments = ({ appointments }) => {
           Next appointment
         </h4>
         <p className="vads-u-margin-bottom--1">
-          {format(start, 'EEEE, MMMM Mo, yyyy')}
+          {format(start, 'EEEE, MMMM do, yyyy')}
         </p>
         <p className="vads-u-margin-bottom--1 vads-u-margin-top--1">
           {`Time: ${format(start, 'h:mm aaaa')} ${nextAppointment?.timeZone}`}


### PR DESCRIPTION
## Description
I accidentally formatted the appointment date wrong.

Originally I used `Mo` which indicated the nth number of the month. We need the day, represented by `do`.

[Documentation](https://date-fns.org/v2.21.1/docs/format)

## Testing done
Looks good in Cypress! We actually see the day now rather than always April 4th - the 4th representing April.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/115747529-98bb7580-a352-11eb-9073-3d37b0900a0d.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
