### PR TITLE
Do not treat 404 from appeals API as an error

### DIFF
--- a/src/applications/personalization/dashboard-2/components/claims-and-appeals/ClaimsAndAppeals.jsx
+++ b/src/applications/personalization/dashboard-2/components/claims-and-appeals/ClaimsAndAppeals.jsx
@@ -84,7 +84,10 @@ const ClaimsAndAppeals = ({
 
   if (hasAPIError) {
     return (
-      <div className="vads-l-row">
+      <div
+        className="vads-l-row"
+        data-testid="dashboard-section-claims-and-appeals"
+      >
         <div className="vads-l-col--12 medium-screen:vads-l-col--8 medium-screen:vads-u-padding-right--3">
           <AlertBox
             status={ALERT_TYPE.ERROR}

--- a/src/applications/personalization/dashboard-2/components/claims-and-appeals/ClaimsAndAppeals.jsx
+++ b/src/applications/personalization/dashboard-2/components/claims-and-appeals/ClaimsAndAppeals.jsx
@@ -139,14 +139,23 @@ const isAppealsAvailableSelector = createIsServiceAvailableSelector(
   backendServices.APPEALS_STATUS,
 );
 
+// returns true if claimsV2.v2Availability is set to a value other than
+// appealsAvailability.AVAILABLE or appealsAvailability.RECORD_NOT_FOUND_ERROR
+const hasAppealsErrorSelector = state => {
+  const claimsV2Root = state.disability.status.claimsV2;
+  return (
+    claimsV2Root.v2Availability &&
+    claimsV2Root.v2Availability !== appealsAvailability.AVAILABLE &&
+    claimsV2Root.v2Availability !== appealsAvailability.RECORD_NOT_FOUND_ERROR
+  );
+};
+
 const mapStateToProps = state => {
   const claimsState = state.disability.status;
   const claimsV2Root = claimsState.claimsV2;
   const appealsLoading = claimsV2Root.appealsLoading;
   const claimsLoading = claimsV2Root.claimsLoading;
-  const hasAppealsError =
-    claimsV2Root.v2Availability &&
-    claimsV2Root.v2Availability !== appealsAvailability.AVAILABLE;
+  const hasAppealsError = hasAppealsErrorSelector(state);
   const hasClaimsError =
     claimsV2Root.claimsAvailability === claimsAvailability.UNAVAILABLE;
   const hasAPIError = !!hasAppealsError || !!hasClaimsError;

--- a/src/applications/personalization/dashboard-2/components/claims-and-appeals/ClaimsAndAppeals.unit.spec.jsx
+++ b/src/applications/personalization/dashboard-2/components/claims-and-appeals/ClaimsAndAppeals.unit.spec.jsx
@@ -687,5 +687,42 @@ describe('ClaimsAndAppeals component', () => {
         });
       },
     );
+    context(
+      'the user has claims that closed over thirty days ago and got a 404 from the appeals endpoint because they have no appeals on file',
+      () => {
+        beforeEach(() => {
+          initialState = {
+            user: claimsAppealsUser(),
+            disability: {
+              status: {
+                claimsV2: {
+                  appealsLoading: false,
+                  claimsLoading: false,
+                  appeals: [],
+                  v2Availability: 'RECORD_NOT_FOUND_ERROR',
+                  claims: [
+                    makeClaimObject({ updateDate: daysAgo(100), phase: 8 }),
+                    makeClaimObject({ updateDate: daysAgo(35), phase: 8 }),
+                    makeClaimObject({ updateDate: daysAgo(60), phase: 8 }),
+                  ],
+                },
+              },
+            },
+          };
+          view = renderInReduxProvider(
+            <ClaimsAndAppeals dataLoadingDisabled />,
+            {
+              initialState,
+              reducers,
+            },
+          );
+        });
+        it('does not render anything', () => {
+          expect(view.queryByRole('progressbar')).to.not.exist;
+          expect(view.queryByTestId('dashboard-section-claims-and-appeals')).to
+            .not.exist;
+        });
+      },
+    );
   });
 });

--- a/src/applications/personalization/dashboard-2/tests/e2e/claims-and-appeals.cypress.spec.js
+++ b/src/applications/personalization/dashboard-2/tests/e2e/claims-and-appeals.cypress.spec.js
@@ -1,0 +1,128 @@
+import disableFTUXModals from '~/platform/user/tests/disableFTUXModals';
+import { mockUser } from '@@profile/tests/fixtures/users/user.js';
+import serviceHistory from '@@profile/tests/fixtures/service-history-success.json';
+import fullName from '@@profile/tests/fixtures/full-name-success.json';
+import claimsSuccess from '@@profile/tests/fixtures/claims-success';
+import appealsSuccess from '@@profile/tests/fixtures/appeals-success';
+import appeals404 from '@@profile/tests/fixtures/appeals-404.json';
+import error500 from '@@profile/tests/fixtures/500.json';
+
+import manifest from '~/applications/personalization/dashboard/manifest.json';
+
+import { mockFeatureToggles } from './helpers';
+
+describe('The My VA Dashboard Claims and Appeals section', () => {
+  beforeEach(() => {
+    disableFTUXModals();
+    cy.login(mockUser);
+    cy.intercept('/v0/profile/service_history', serviceHistory);
+    cy.intercept('/v0/profile/full_name', fullName);
+  });
+  context(
+    'when there is a recent appeals update and recent claims update',
+    () => {
+      beforeEach(() => {
+        cy.intercept('/v0/evss_claims_async', claimsSuccess(1));
+        cy.intercept('/v0/appeals', appealsSuccess(10));
+      });
+      it('should show details about the updated claim because it was updated more recently than the appeal', () => {
+        mockFeatureToggles();
+        cy.visit(manifest.rootUrl);
+
+        // should show a loading indicator
+        cy.findByRole('progressbar').should('exist');
+        cy.findByText(/loading your information/i).should('exist');
+
+        // and then the loading indicator should be removed
+        cy.findByRole('progressbar').should('not.exist');
+        cy.findByText(/loading your information/i).should('not.exist');
+
+        // make sure that the Claims and Appeals section is shown
+        cy.findByTestId('dashboard-section-claims-and-appeals').should('exist');
+        cy.findByRole('link', { name: /claims and appeals/ }).should('exist');
+        cy.findByRole('heading', { name: /dependency claim received/i }).should(
+          'exist',
+        );
+        // the claims/appeals error is not shown
+        cy.findByRole('heading', {
+          name: /We can’t access any claims or appeals/i,
+        }).should('not.exist');
+
+        // make the a11y check
+        cy.injectAxe();
+        cy.axeCheck();
+      });
+    },
+  );
+  context(
+    'when there is a recent claim update but there is a 500 from the appeals API',
+    () => {
+      beforeEach(() => {
+        cy.intercept('/v0/evss_claims_async', claimsSuccess());
+        cy.intercept('/v0/appeals', {
+          statusCode: 500,
+          body: error500,
+        });
+      });
+      it('should show an error in the Claims and Appeals section', () => {
+        mockFeatureToggles();
+        cy.visit(manifest.rootUrl);
+
+        // should show a loading indicator
+        cy.findByRole('progressbar').should('exist');
+        cy.findByText(/loading your information/i).should('exist');
+
+        // and then the loading indicator should be removed
+        cy.findByRole('progressbar').should('not.exist');
+        cy.findByText(/loading your information/i).should('not.exist');
+
+        // make sure that the Claims and Appeals section is shown
+        cy.findByTestId('dashboard-section-claims-and-appeals').should('exist');
+        cy.findByRole('heading', {
+          name: /We can’t access any claims or appeals/i,
+        }).should('exist');
+
+        // make the a11y check
+        cy.injectAxe();
+        cy.axeCheck();
+      });
+    },
+  );
+  context(
+    'when there is a 404 from the appeals API and all claims closed over 30 days ago',
+    () => {
+      beforeEach(() => {
+        cy.intercept('/v0/evss_claims_async', claimsSuccess(100, false));
+        cy.intercept('/v0/appeals', {
+          statusCode: 404,
+          body: appeals404,
+        });
+      });
+      it('should hide the entire Claims and Appeals section', () => {
+        mockFeatureToggles();
+        cy.visit(manifest.rootUrl);
+
+        // should show a loading indicator
+        cy.findByRole('progressbar').should('exist');
+        cy.findByText(/loading your information/i).should('exist');
+
+        // and then the loading indicator should be removed
+        cy.findByRole('progressbar').should('not.exist');
+        cy.findByText(/loading your information/i).should('not.exist');
+
+        // make sure that the Claims and Appeals section is hidden
+        cy.findByTestId('dashboard-section-claims-and-appeals').should(
+          'not.exist',
+        );
+        // and it doesn't show an error related to getting claims or appeals data
+        cy.findByRole('heading', {
+          name: /We can’t access any claims or appeals/i,
+        }).should('not.exist');
+
+        // make the a11y check
+        cy.injectAxe();
+        cy.axeCheck();
+      });
+    },
+  );
+});

--- a/src/applications/personalization/profile/tests/fixtures/appeals-404.json
+++ b/src/applications/personalization/profile/tests/fixtures/appeals-404.json
@@ -1,0 +1,11 @@
+{
+  "errors": [
+    {
+      "title": "Not found",
+      "detail": "Appeals data for a veteran with that SSN was not found",
+      "code": "CASEFLOWSTATUS404",
+      "source": "Appeals Caseflow",
+      "status": "404"
+    }
+  ]
+}

--- a/src/applications/personalization/profile/tests/fixtures/claims-success.js
+++ b/src/applications/personalization/profile/tests/fixtures/claims-success.js
@@ -1,6 +1,6 @@
 import { daysAgo } from '../helpers';
 
-const claimsSuccess = (updatedDaysAgo = 1) => {
+const claimsSuccess = (updatedDaysAgo = 1, open = true) => {
   return {
     data: [
       {
@@ -12,12 +12,12 @@ const claimsSuccess = (updatedDaysAgo = 1) => {
           minEstDate: '2014-06-03',
           maxEstDate: '2014-06-08',
           phaseChangeDate: daysAgo(updatedDaysAgo),
-          open: true,
+          open,
           waiverSubmitted: false,
           documentsNeeded: false,
           developmentLetterSent: true,
           decisionLetterSent: false,
-          phase: 2,
+          phase: open ? 2 : 8,
           everPhaseBack: false,
           currentPhaseBack: false,
           requestedDecision: false,


### PR DESCRIPTION
## Description
With this change we no longer show an error alert if we get a 404 from the appeals API. Instead we treat 404s as though the user has no appeals on file (because that's what it really means!)

## Testing done
Built this via Cypress TDD.

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs