### PR TITLE
Resolve IE11 query param limit for feature flags request.

### DIFF
--- a/src/platform/utilities/feature-toggles/flipper-client.js
+++ b/src/platform/utilities/feature-toggles/flipper-client.js
@@ -1,13 +1,9 @@
 /* This file is must run in both NodeJS and browser environments */
 
-import FEATURE_FLAG_NAMES from './featureFlagNames';
 import { getFlipperId } from './helpers';
 
 const FLIPPER_ID = getFlipperId();
-const featureToggleQueryList = Object.values(FEATURE_FLAG_NAMES);
-const TOGGLE_VALUES_PATH = `/v0/feature_toggles?features=${featureToggleQueryList.join(
-  ',',
-)}&cookie_id=${FLIPPER_ID}`;
+const TOGGLE_VALUES_PATH = `/v0/feature_toggles?&cookie_id=${FLIPPER_ID}`;
 const TOGGLE_POLLING_INTERVAL = 5000;
 
 let flipperClientInstance;


### PR DESCRIPTION
## Description
[IE11 has a 2083 character limit on URLs.](https://support.microsoft.com/en-us/topic/maximum-url-length-is-2-083-characters-in-internet-explorer-174e7c8a-6666-f4e0-6fd6-908b53c12246)

This has [caused an issue with our request for feature flags](https://dsva.slack.com/archives/CBU0KDSB1/p1618932008202000), which sends a query param that lists all of the flags we track.

This is a part of the interim fix to always send all feature flags in the response.

The corresponding `vets-api` fix (department-of-veterans-affairs/vets-api#6645) will be returning all the flags in both camel and snake case to accommodate the mix of expected casings from `vets-website`.

## Testing done
Tested locally with the `vets-api` changes and confirmed that all of the flags are in the response without the query param in the request.

## Acceptance criteria
- [ ] The `v0/feature_toggles` resopnse should include all feature flags without the query param in the request.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
