### PR TITLE
Disallow parentheses in first and last names in KMI

### DIFF
--- a/src/applications/coronavirus-vaccination-expansion/config/address/addressInformation.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/address/addressInformation.js
@@ -2,12 +2,6 @@ import React from 'react';
 import emailUI from 'platform/forms-system/src/js/definitions/email';
 import { addressInformation } from '../schema-imports';
 
-const validateZip = (errors, formData) => {
-  if (formData.zipCode > 4) {
-    errors.state.addError('Please enter at least 5 digits');
-  }
-};
-
 export const schema = {
   addressInformation,
 };
@@ -34,7 +28,6 @@ export const uiSchema = {
       'ui:errorMessages': {
         pattern: 'Please enter your five digit zip code',
       },
-      'ui:validations': [validateZip],
     },
     emailAddress: {
       ...emailUI(),

--- a/src/applications/coronavirus-vaccination-expansion/config/personal-information/personal-information.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/personal-information/personal-information.js
@@ -3,6 +3,26 @@ import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
 import { personalInformation } from '../schema-imports';
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
 
+const validateFirstName = (errors, formData) => {
+  const disAllowedCharacters = ['(', ')'];
+  for (const character of disAllowedCharacters) {
+    if (formData.indexOf(character) !== -1) {
+      errors.addError('Please only use letters and no parentheses');
+    }
+  }
+};
+
+const validateLastName = (errors, formData) => {
+  const disAllowedCharacters = ['(', ')'];
+  for (const character of disAllowedCharacters) {
+    if (formData.indexOf(character) !== -1) {
+      errors.addError(
+        'Please only use your current last name and no parentheses',
+      );
+    }
+  }
+};
+
 export const schema = {
   personalInformation,
 };
@@ -14,6 +34,7 @@ export const uiSchema = {
       'ui:errorMessages': {
         required: 'Please enter your first name.',
       },
+      'ui:validations': [validateFirstName],
     },
     middleName: {
       'ui:title': 'Your middle name',
@@ -23,6 +44,7 @@ export const uiSchema = {
       'ui:errorMessages': {
         required: 'Please enter your last name.',
       },
+      'ui:validations': [validateLastName],
     },
     birthDate: {
       ...currentOrPastDateUI('Your date of birth'),

--- a/src/applications/coronavirus-vaccination-expansion/config/personal-information/personal-information.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/personal-information/personal-information.js
@@ -3,25 +3,15 @@ import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
 import { personalInformation } from '../schema-imports';
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
 
-const validateFirstName = (errors, formData) => {
+function containsDisallowedCharacters(value) {
   const disAllowedCharacters = ['(', ')'];
   for (const character of disAllowedCharacters) {
-    if (formData.indexOf(character) !== -1) {
-      errors.addError('Please only use letters and no parentheses');
+    if (value.indexOf(character) !== -1) {
+      return true;
     }
   }
-};
-
-const validateLastName = (errors, formData) => {
-  const disAllowedCharacters = ['(', ')'];
-  for (const character of disAllowedCharacters) {
-    if (formData.indexOf(character) !== -1) {
-      errors.addError(
-        'Please only use your current last name and no parentheses',
-      );
-    }
-  }
-};
+  return false;
+}
 
 export const schema = {
   personalInformation,
@@ -34,7 +24,14 @@ export const uiSchema = {
       'ui:errorMessages': {
         required: 'Please enter your first name.',
       },
-      'ui:validations': [validateFirstName],
+      'ui:validations': [
+        function(errors, fieldData) {
+          const setError = containsDisallowedCharacters(fieldData);
+          if (setError) {
+            errors.addError('Please only use letters and no parentheses');
+          }
+        },
+      ],
     },
     middleName: {
       'ui:title': 'Your middle name',
@@ -44,7 +41,16 @@ export const uiSchema = {
       'ui:errorMessages': {
         required: 'Please enter your last name.',
       },
-      'ui:validations': [validateLastName],
+      'ui:validations': [
+        function(errors, fieldData) {
+          const setError = containsDisallowedCharacters(fieldData);
+          if (setError) {
+            errors.addError(
+              'Please only use your current last name and no parentheses',
+            );
+          }
+        },
+      ],
     },
     birthDate: {
       ...currentOrPastDateUI('Your date of birth'),

--- a/src/applications/coronavirus-vaccination-expansion/tests/coronavirus-vaccination-expansion-form-validation.cypress.spec.js
+++ b/src/applications/coronavirus-vaccination-expansion/tests/coronavirus-vaccination-expansion-form-validation.cypress.spec.js
@@ -1,12 +1,28 @@
 describe('COVID-19 SAVE LIVES Act sign up', () => {
   describe('when entering names with a parentheses', () => {
     before(() => {
-      cy.visit('health-care/covid-19-vaccine/sign-up/personal-information');
+      cy.visit('health-care/covid-19-vaccine/sign-up/');
       cy.injectAxe();
     });
 
     it('should throw a validation error', () => {
       cy.axeCheck();
+
+      cy.get('label')
+        .contains('No')
+        .click({ force: true });
+
+      cy.get('button')
+        .contains('Continue')
+        .click();
+
+      cy.get('label')
+        .contains('CHAMPVA')
+        .click({ force: true });
+
+      cy.get('button')
+        .contains('Continue')
+        .click();
 
       cy.findByLabelText(/First name/i)
         .clear()

--- a/src/applications/coronavirus-vaccination-expansion/tests/coronavirus-vaccination-expansion-form-validation.cypress.spec.js
+++ b/src/applications/coronavirus-vaccination-expansion/tests/coronavirus-vaccination-expansion-form-validation.cypress.spec.js
@@ -1,0 +1,32 @@
+describe('COVID-19 SAVE LIVES Act sign up', () => {
+  describe('when entering names with a parentheses', () => {
+    before(() => {
+      cy.visit('health-care/covid-19-vaccine/sign-up/personal-information');
+      cy.injectAxe();
+    });
+
+    it('should throw a validation error', () => {
+      cy.axeCheck();
+
+      cy.findByLabelText(/First name/i)
+        .clear()
+        .type('Stephen()');
+
+      cy.findByLabelText(/Middle name/i).focus();
+
+      cy.get('#root_firstName-error-message').contains(
+        'Please only use letters and no parentheses',
+      );
+
+      cy.findByLabelText(/Last name/i)
+        .clear()
+        .type('Beers()');
+
+      cy.findByLabelText(/Middle name/i).focus();
+
+      cy.get('#root_lastName-error-message').contains(
+        'Error Please only use your current last name and no parentheses',
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Description
MPI gets upset if you include parentheses in your name. This custom validation and custom error messages makes sure you cannot.

Also removes uncalled custom validation for zip code. Validation is done on using regex pattern in schema instead.

## Testing done
Browser 👀 

## Screenshots
![Screenshot_2021-04-22 Sign up to get a vaccine(1)](https://user-images.githubusercontent.com/7645362/115785025-ece34b80-a38c-11eb-8e1e-6b5848c5beb5.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
