### PR TITLE
NOD: Add hearing type page

### DIFF
--- a/src/applications/appeals/10182/config/form.js
+++ b/src/applications/appeals/10182/config/form.js
@@ -19,6 +19,7 @@ import {
   hasRepresentative,
   canUploadEvidence,
   wantsToUploadEvidence,
+  needsHearingType,
 } from '../utils/helpers';
 
 // Pages
@@ -41,6 +42,7 @@ import {
 // import initialData from '../tests/schema/initialData';
 
 import manifest from '../manifest.json';
+import hearingType from '../pages/hearingType';
 
 const formConfig = {
   rootUrl: manifest.rootUrl,
@@ -160,6 +162,13 @@ const formConfig = {
           depends: wantsToUploadEvidence,
           uiSchema: evidenceUpload.uiSchema,
           schema: evidenceUpload.schema,
+        },
+        hearingType: {
+          title: 'Hearing type',
+          path: 'hearing-type',
+          depends: needsHearingType,
+          uiSchema: hearingType.uiSchema,
+          schema: hearingType.schema,
         },
       },
     },

--- a/src/applications/appeals/10182/content/hearingType.js
+++ b/src/applications/appeals/10182/content/hearingType.js
@@ -1,0 +1,42 @@
+import React from 'react';
+
+/* eslint-disable camelcase */
+export const hearingTypeContent = {
+  virtual_hearing: (
+    <>
+      <strong>I would like a virtual tele-hearing from my home</strong>
+      <p className="hide-on-review">
+        You’ll have the flexibility and convenience of attending your Board
+        hearing with a Veterans Law judge and Veteran representatives from a
+        personal computer or mobile device.
+      </p>
+    </>
+  ),
+
+  video_conference: (
+    <>
+      <strong>I would like a video hearing from a VA location near me</strong>
+      <p className="hide-on-review">
+        You’ll travel to your closest regional office and teleconference with a
+        Judge in Washington, D.C. Video hearings are open depending on the
+        status of the regional office. We are only able to accomodate a limited
+        amount to Veterans to make sure everyone is socially distant and safe.
+      </p>
+    </>
+  ),
+
+  central_office: (
+    <>
+      <strong>
+        I would like an in-person hearing at the Board in Washington, D.C.
+      </strong>
+      <p className="hide-on-review">
+        You'll travel to Washington, D.C., for an in-person hearing with a
+        Judge. Central office hearings are open, but capacity is limited to
+        ensure appropriate social distancing and sanitized hearing rooms.
+      </p>
+    </>
+  ),
+};
+
+export const missingHearingTypeErrorMessage = 'Please choose a conference type';

--- a/src/applications/appeals/10182/pages/hearingType.js
+++ b/src/applications/appeals/10182/pages/hearingType.js
@@ -1,0 +1,34 @@
+import {
+  hearingTypeContent,
+  missingHearingTypeErrorMessage,
+} from '../content/hearingType';
+import { needsHearingType } from '../utils/helpers';
+
+const hearingType = {
+  uiSchema: {
+    hearingTypePreference: {
+      'ui:title': 'What type of hearing would you like to request?',
+      'ui:widget': 'radio',
+      'ui:required': needsHearingType,
+      'ui:options': {
+        labels: hearingTypeContent,
+      },
+      'ui:errorMessages': {
+        required: missingHearingTypeErrorMessage,
+      },
+    },
+  },
+
+  schema: {
+    type: 'object',
+    required: ['hearingTypePreference'],
+    properties: {
+      hearingTypePreference: {
+        type: 'string',
+        enum: ['virtual_hearing', 'video_conference', 'central_office'],
+      },
+    },
+  },
+};
+
+export default hearingType;

--- a/src/applications/appeals/10182/utils/helpers.js
+++ b/src/applications/appeals/10182/utils/helpers.js
@@ -7,6 +7,8 @@ import { SELECTED } from '../constants';
 export const hasRepresentative = formData => formData['view:hasRep'];
 export const canUploadEvidence = formData =>
   formData.boardReviewOption === 'evidence_submission';
+export const needsHearingType = formData =>
+  formData.boardReviewOption === 'hearing';
 export const wantsToUploadEvidence = formData =>
   canUploadEvidence(formData) && formData['view:additionalEvidence'];
 export const someSelected = issues => issues.some(issue => issue[SELECTED]);


### PR DESCRIPTION
## Description

The online Notice of Disagreement form allows Veterans to choose the type of hearing they want: 

- Virtual hearing - meeting call from anywhere
- Video conference - meeting at regional office or satellite location with judge presiding remotely.
- Central office - meet in person

This choice is _not_ on the paper form, but was requested by the Board to include in our virtual form.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/23529
- Design: https://vsateams.invisionapp.com/console/share/8Y10I6K7DU9R/602129894

## Testing done

Manual - will add unit tests in a future PR

## Screenshots

<details><summary>Board hearing type</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-04-22 at 4 11 43 PM](https://user-images.githubusercontent.com/136959/115786627-aee32900-a386-11eb-86e8-3414b88c4bdd.png)
</details>

## Acceptance criteria
- [x] Veteran can choose the hearing conference type

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
