### PR TITLE
[23391] Update UpcomingAppointmentsList to use hooks

### DIFF
--- a/src/applications/vaos/appointment-list/redux/selectors.js
+++ b/src/applications/vaos/appointment-list/redux/selectors.js
@@ -441,3 +441,13 @@ export function getRequestedAppointmentListInfo(state) {
     showScheduleButton: selectFeatureRequests(state),
   };
 }
+
+export function getUpcomingAppointmentListInfo(state) {
+  return {
+    facilityData: state.appointments.facilityData,
+    futureStatus: selectFutureStatus(state),
+    appointmentsByMonth: selectUpcomingAppointments(state),
+    isCernerOnlyPatient: selectIsCernerOnlyPatient(state),
+    showScheduleButton: selectFeatureRequests(state),
+  };
+}


### PR DESCRIPTION
## Description
We want to update the way we use react-redux to the current recommended approach, which is to use the useSelector and useDispatch hooks.

Path: src/applications/vaos/appointment-list/components/UpcomingAppointmentsList.jsx

## Testing done
Local and Unit

## Screenshots
n/a

## Acceptance criteria
- [ ] connect() is no longer used on page
- [ ] All actions that were in mapDispatchToProps are now wrapped in dispatch() when called
- [ ] All data in mapStateToProps is pulled in through useSelector hooks

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
