### PR TITLE
Disable loading-indicator analytics to stop duplicates

### DIFF
--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
@@ -328,6 +328,7 @@ function VAFacilityPageV2({
         message="We’re checking if we can create an appointment for you at this
                 facility. This may take up to a minute. Thank you for your
                 patience."
+        disableAnalytics
       />
 
       {showEligibilityModal && (


### PR DESCRIPTION
## Description

Related to:  https://github.com/department-of-veterans-affairs/va.gov-team/issues/

Now that we have component level analytics for the LoadingIndicator, we need to disable them on this VAOS page to stop duplicates.

