### PR TITLE
Bundle Promise polyfill with web-components entry

### DIFF
--- a/src/platform/site-wide/wc-loader.js
+++ b/src/platform/site-wide/wc-loader.js
@@ -1,3 +1,4 @@
+import 'core-js/features/promise';
 import 'web-components/dist/component-library/component-library.css';
 import { applyPolyfills, defineCustomElements } from 'web-components/loader';
 


### PR DESCRIPTION
## Description

I noticed a problem while doing some IE11 testing that our web components weren't loading in IE11 staging environments due to a Promise polyfill not properly loading. I first tried to fix this by adding `defer` to the `web-components` entry script but that didn't fix the issue. There was a [troubleshooting session in slack](https://dsva.slack.com/archives/C5HP4GN3F/p1619046492136800) where we made some progress and identified that a second Promise polyfill that was in the `static-pages` entry, but not the `polyfills.js` script, was necessary.

### Bundle sizes

Before this import, the `web-components` entry was 91K

![image](https://user-images.githubusercontent.com/2008881/115798304-c91f0600-a38a-11eb-8d9c-fc9d98d05e15.png)


With the bundled Promise polyfill, the entry file is 112K:

![image](https://user-images.githubusercontent.com/2008881/115798344-e358e400-a38a-11eb-92ca-d6294ca23c12.png)


This amounts to an increase of 21K for the polyfill.


## Testing done

Local testing. Based on @cvalarida's steps I:

1. Did a `git pull` while on master
1. `yarn`
1. `yarn build`
1. `npx http-serve ./build/localhost`
1. Go to the site on my local network from IE11 and verify that I have a console error about `Promise` being undefined in the `web-components.entry.js` file

After the `core-js/features/promise` import, repeat the previous steps. In IE11, the error no longer appeared


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
