### PR TITLE
Sanlouise appts error

### DIFF
--- a/src/applications/personalization/appointments/actions/index.js
+++ b/src/applications/personalization/appointments/actions/index.js
@@ -79,6 +79,8 @@ export function fetchConfirmedFutureAppointments() {
     let facilitiesResponse;
     let vaAppointments = [];
     let ccAppointments = [];
+    let vaAppointmentsResponse;
+    let ccAppointmentsResponse;
 
     const startOfToday = moment()
       .startOf('day')
@@ -95,21 +97,36 @@ export function fetchConfirmedFutureAppointments() {
         vaAppointments = MOCK_VA_APPOINTMENTS;
         ccAppointments = MOCK_CC_APPOINTMENTS;
       } else {
-        const vaAppointmentsReponse = await apiRequest(
+        vaAppointmentsResponse = await apiRequest(
           `/appointments?start_date=${startOfToday}&end_date=${endDate}&type=va`,
           { apiVersion: 'vaos/v0' },
         );
-        const ccAppointmentsResponse = await apiRequest(
+        ccAppointmentsResponse = await apiRequest(
           `/appointments?start_date=${startOfToday}&end_date=${endDate}&type=cc`,
           { apiVersion: 'vaos/v0' },
         );
 
-        vaAppointments = vaAppointmentsReponse?.data;
+        // This catches partial errors on the meta object
+        if (
+          vaAppointmentsResponse?.meta?.errors?.length > 0 ||
+          ccAppointmentsResponse?.meta?.errors?.length > 0
+        ) {
+          dispatch({
+            type: FETCH_CONFIRMED_FUTURE_APPOINTMENTS_FAILED,
+            errors: [
+              ...(vaAppointmentsResponse?.meta?.errors || []),
+              ...(ccAppointmentsResponse?.meta?.errors || []),
+            ],
+          });
+          return;
+        }
+
+        vaAppointments = vaAppointmentsResponse?.data;
         ccAppointments = ccAppointmentsResponse?.data;
       }
 
       const facilityIDs = uniq(
-        vaAppointments.map(
+        vaAppointments?.map(
           appointment =>
             getStagingID(appointment?.attributes?.sta6aid)
               ? `vha_${getStagingID(appointment?.attributes?.sta6aid)}`
@@ -138,10 +155,15 @@ export function fetchConfirmedFutureAppointments() {
     } catch (error) {
       dispatch({
         type: FETCH_CONFIRMED_FUTURE_APPOINTMENTS_FAILED,
+        errors: [
+          ...(vaAppointmentsResponse?.errors || []),
+          ...(ccAppointmentsResponse?.errors || []),
+          ...(facilitiesResponse?.data?.errors || []),
+        ],
       });
     }
 
-    const formattedVAAppointments = vaAppointments.reduce(
+    const formattedVAAppointments = vaAppointments?.reduce(
       (accumulator, appointment) => {
         const startDate = moment(appointment?.attributes?.startDate);
         const now = moment();
@@ -180,7 +202,7 @@ export function fetchConfirmedFutureAppointments() {
       [],
     );
 
-    const formattedCCAppointments = ccAppointments.reduce(
+    const formattedCCAppointments = ccAppointments?.reduce(
       (accumulator, appointment) => {
         const startDate = moment(appointment?.attributes?.appointmentTime);
         const now = moment();
@@ -206,8 +228,8 @@ export function fetchConfirmedFutureAppointments() {
     );
 
     const allAppointments = [
-      ...formattedCCAppointments,
-      ...formattedVAAppointments,
+      ...(formattedCCAppointments || []),
+      ...(formattedVAAppointments || []),
     ];
 
     // Sort the appointments by which is soonest.

--- a/src/applications/personalization/appointments/reducers/index.js
+++ b/src/applications/personalization/appointments/reducers/index.js
@@ -18,7 +18,7 @@ export default (state = initialState, action) => {
       return { ...state, fetching: false, data: action.appointments };
     }
     case FETCH_CONFIRMED_FUTURE_APPOINTMENTS_FAILED: {
-      return { ...state, fetching: false };
+      return { ...state, fetching: false, errors: action.errors };
     }
     default: {
       return { ...state };

--- a/src/applications/personalization/dashboard-2/components/health-care/Appointments.jsx
+++ b/src/applications/personalization/dashboard-2/components/health-care/Appointments.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { format } from 'date-fns';
+import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import CTALink from '../CTALink';
 
-export const Appointments = ({ appointments }) => {
+export const Appointments = ({ appointments, hasError }) => {
   const nextAppointment = appointments?.[0];
   const start = new Date(nextAppointment?.startsAt);
   let locationName;
@@ -18,6 +19,33 @@ export const Appointments = ({ appointments }) => {
 
   if (!nextAppointment?.isVideo) {
     locationName = nextAppointment?.providerName;
+  }
+
+  if (hasError) {
+    return (
+      <div className="vads-u-display--flex vads-u-flex-direction--column large-screen:vads-u-flex--1 vads-u-margin-bottom--2p5">
+        <AlertBox
+          status="error"
+          className="vads-u-margin-top--0"
+          headline="We can’t access your appointment information"
+          content={
+            <>
+              <p>
+                We’re sorry. Something went wrong on our end, and we can’t
+                access your appointment information. Please try again later or
+                go to the appointments tool:
+              </p>
+              <p>
+                <CTALink
+                  text="Schedule and view your appointments"
+                  href="/health-care/schedule-view-va-appointments/appointments"
+                />
+              </p>
+            </>
+          }
+        />
+      </div>
+    );
   }
 
   return (
@@ -43,7 +71,7 @@ export const Appointments = ({ appointments }) => {
 };
 
 Appointments.propTypes = {
-  authenticatedWithSSOe: PropTypes.bool,
+  hasError: PropTypes.bool,
   appointments: PropTypes.arrayOf(
     PropTypes.shape({
       additionalInfo: PropTypes.string,

--- a/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
+++ b/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
@@ -109,16 +109,15 @@ const HealthCare = ({
       <h2>Health care</h2>
 
       <div className="vads-l-row">
-        {hasUpcomingAppointment ||
-          (hasAppointmentsError && (
-            /* Appointments */
-            <DashboardWidgetWrapper>
-              <Appointments
-                appointments={appointments}
-                hasError={hasAppointmentsError}
-              />
-            </DashboardWidgetWrapper>
-          ))}
+        {(hasUpcomingAppointment || hasAppointmentsError) && (
+          /* Appointments */
+          <DashboardWidgetWrapper>
+            <Appointments
+              appointments={appointments}
+              hasError={hasAppointmentsError}
+            />
+          </DashboardWidgetWrapper>
+        )}
 
         <DashboardWidgetWrapper>
           {!hasUpcomingAppointment &&

--- a/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
+++ b/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
@@ -44,6 +44,7 @@ const HealthCare = ({
   dataLoadingDisabled = false,
   shouldShowLoadingIndicator,
   hasInboxError,
+  hasAppointmentsError,
 }) => {
   const nextAppointment = appointments?.[0];
   const start = new Date(nextAppointment?.startsAt);
@@ -108,28 +109,33 @@ const HealthCare = ({
       <h2>Health care</h2>
 
       <div className="vads-l-row">
-        {hasUpcomingAppointment && (
-          /* Appointments */
-          <DashboardWidgetWrapper>
-            <Appointments appointments={appointments} />
-          </DashboardWidgetWrapper>
-        )}
+        {hasUpcomingAppointment ||
+          (hasAppointmentsError && (
+            /* Appointments */
+            <DashboardWidgetWrapper>
+              <Appointments
+                appointments={appointments}
+                hasError={hasAppointmentsError}
+              />
+            </DashboardWidgetWrapper>
+          ))}
 
         <DashboardWidgetWrapper>
-          {!hasUpcomingAppointment && (
-            <>
-              {hasFutureAppointments && (
-                <p>You have no appointments scheduled in the next 30 days.</p>
-              )}
+          {!hasUpcomingAppointment &&
+            !hasAppointmentsError && (
+              <>
+                {hasFutureAppointments && (
+                  <p>You have no appointments scheduled in the next 30 days.</p>
+                )}
 
-              <IconCTALink
-                href="/health-care/schedule-view-va-appointments/appointments"
-                icon="calendar-check"
-                newTab
-                text="Schedule and view your appointments"
-              />
-            </>
-          )}
+                <IconCTALink
+                  href="/health-care/schedule-view-va-appointments/appointments"
+                  icon="calendar-check"
+                  newTab
+                  text="Schedule and view your appointments"
+                />
+              </>
+            )}
 
           {/* Messages */}
           <IconCTALink
@@ -207,12 +213,14 @@ const mapStateToProps = state => {
     : false;
 
   const hasInboxError = selectFolder(state)?.errors?.length > 0;
+  const hasAppointmentsError = state.health?.appointments?.errors?.length > 0;
 
   return {
     appointments: state.health?.appointments?.data,
     authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
     facilityNames,
     hasInboxError,
+    hasAppointmentsError,
     isCernerPatient: selectIsCernerPatient(state),
     shouldFetchMessages,
     shouldShowLoadingIndicator: fetchingAppointments || fetchingInbox,

--- a/src/applications/personalization/dashboard-2/tests/e2e/appointments-error.cypress.spec.js
+++ b/src/applications/personalization/dashboard-2/tests/e2e/appointments-error.cypress.spec.js
@@ -1,5 +1,4 @@
 import moment from 'moment';
-import { mockFolderErrorResponse } from '~/applications/personalization/dashboard-2/utils/mocks/messaging/folder';
 import { mockFeatureToggles } from './helpers';
 import { mockUser } from '@@profile/tests/fixtures/users/user.js';
 
@@ -8,78 +7,67 @@ import PARTIAL_ERROR from '~/applications/personalization/dashboard-2/utils/mock
 import MOCK_FACILITIES from '~/applications/personalization/dashboard-2/utils/mocks/appointments/MOCK_FACILITIES.json';
 
 import { mockLocalStorage } from '~/applications/personalization/dashboard/tests/e2e/dashboard-e2e-helpers';
-import { upcomingCCAppointment, upcomingVAAppointment } from '~/applications/personalization/dashboard-2/utils/appointments.js'
+import {
+  upcomingCCAppointment,
+  upcomingVAAppointment,
+} from '~/applications/personalization/dashboard-2/utils/appointments.js';
 
-// 1. One of the appointments endpoints fails
-// 2. Both of the endpoints fail
-// 3. Facilities call fails
-// 4. Partial error in appointment fetch
-
-const alertText = /Something went wrong on our end, and we can’t access your appointment information/i
+const alertText = /Something went wrong on our end, and we can’t access your appointment information/i;
 const startOfToday = moment()
-.startOf('day')
-.toISOString();
+  .startOf('day')
+  .toISOString();
 
 // Maximum number of days you can schedule an appointment in advance in VAOS
 const endDate = moment()
-.add(395, 'days')
-.startOf('day')
-.toISOString();
+  .add(395, 'days')
+  .startOf('day')
+  .toISOString();
 
 describe('MyVA Dashboard - Appointments', () => {
   describe('when there is a 400 error fetching VA appointments', () => {
     it('should show the appointments error alert', () => {
       mockLocalStorage();
-    cy.login(mockUser);
-    cy.intercept(
-      'GET',
-      `vaos/v0/appointments?start_date=${startOfToday}&end_date=${endDate}&type=va`,
-      ERROR_400,
-    );
+      cy.login(mockUser);
+      cy.intercept(
+        'GET',
+        `vaos/v0/appointments?start_date=${startOfToday}&end_date=${endDate}&type=va`,
+        ERROR_400,
+      );
 
-    cy.intercept(
-      'GET',
-      `vaos/v0/appointments?start_date=${startOfToday}&end_date=${endDate}&type=cc`,
-      upcomingCCAppointment,
-    );
+      cy.intercept(
+        'GET',
+        `vaos/v0/appointments?start_date=${startOfToday}&end_date=${endDate}&type=cc`,
+        upcomingCCAppointment,
+      );
 
-    cy.intercept(
-      'GET',
-      `vaos/v1/facilities/va?ids=*`,
-      MOCK_FACILITIES,
-    );
+      cy.intercept('GET', `vaos/v1/facilities/va?ids=*`, MOCK_FACILITIES);
 
-    mockFeatureToggles();
-    cy.visit('my-va/');
+      mockFeatureToggles();
+      cy.visit('my-va/');
       cy.findByText(alertText).should('exist');
     });
   });
 
   describe('when there is a 400 error fetching CC appointments', () => {
-
     it('should show the appointments error alert', () => {
       mockLocalStorage();
-    cy.login(mockUser);
-    cy.intercept(
-      'GET',
-      `vaos/v0/appointments?start_date=${startOfToday}&end_date=${endDate}&type=va`,
-      upcomingVAAppointment,
-    );
+      cy.login(mockUser);
+      cy.intercept(
+        'GET',
+        `vaos/v0/appointments?start_date=${startOfToday}&end_date=${endDate}&type=va`,
+        upcomingVAAppointment,
+      );
 
-    cy.intercept(
-      'GET',
-      `vaos/v0/appointments?start_date=${startOfToday}&end_date=${endDate}&type=cc`,
-      ERROR_400,
-    );
+      cy.intercept(
+        'GET',
+        `vaos/v0/appointments?start_date=${startOfToday}&end_date=${endDate}&type=cc`,
+        ERROR_400,
+      );
 
-    cy.intercept(
-      'GET',
-      `vaos/v1/facilities/va?ids=*`,
-      MOCK_FACILITIES,
-    );
+      cy.intercept('GET', `vaos/v1/facilities/va?ids=*`, MOCK_FACILITIES);
 
-    mockFeatureToggles();
-    cy.visit('my-va/');
+      mockFeatureToggles();
+      cy.visit('my-va/');
       cy.findByText(alertText).should('exist');
     });
   });
@@ -100,11 +88,7 @@ describe('MyVA Dashboard - Appointments', () => {
         upcomingCCAppointment,
       );
 
-      cy.intercept(
-        'GET',
-        `vaos/v1/facilities/va?ids=*`,
-        MOCK_FACILITIES,
-      );
+      cy.intercept('GET', `vaos/v1/facilities/va?ids=*`, MOCK_FACILITIES);
 
       mockFeatureToggles();
       cy.visit('my-va/');
@@ -128,16 +112,13 @@ describe('MyVA Dashboard - Appointments', () => {
         upcomingCCAppointment,
       );
 
-      cy.intercept(
-        'GET',
-        `vaos/v1/facilities/va?ids=*`,
-        ERROR_400,
-      );
+      cy.intercept('GET', `vaos/v1/facilities/va?ids=*`, ERROR_400);
 
       mockFeatureToggles();
       cy.visit('my-va/');
-      cy.findByText('We can’t access any claims or appeals information right now').should('exist');
+      cy.findByText(
+        'We can’t access any claims or appeals information right now',
+      ).should('exist');
     });
-  })
-
+  });
 });

--- a/src/applications/personalization/dashboard-2/tests/e2e/appointments-error.cypress.spec.js
+++ b/src/applications/personalization/dashboard-2/tests/e2e/appointments-error.cypress.spec.js
@@ -1,0 +1,154 @@
+import moment from 'moment';
+import { mockFolderErrorResponse } from '~/applications/personalization/dashboard-2/utils/mocks/messaging/folder';
+import { mockFeatureToggles } from './helpers';
+import { mockUser } from '@@profile/tests/fixtures/users/user.js';
+
+import ERROR_400 from '~/applications/personalization/dashboard-2/utils/mocks/ERROR_400.js';
+import PARTIAL_ERROR from '~/applications/personalization/dashboard-2/utils/mocks/appointments/MOCK_VA_APPOINTMENTS_PARTIAL_ERROR.js';
+import MOCK_FACILITIES from '~/applications/personalization/dashboard-2/utils/mocks/appointments/MOCK_FACILITIES.json';
+
+import { mockLocalStorage } from '~/applications/personalization/dashboard/tests/e2e/dashboard-e2e-helpers';
+import { upcomingCCAppointment, upcomingVAAppointment } from '~/applications/personalization/dashboard-2/utils/appointments.js'
+
+// 1. One of the appointments endpoints fails
+// 2. Both of the endpoints fail
+// 3. Facilities call fails
+// 4. Partial error in appointment fetch
+
+const alertText = /Something went wrong on our end, and we can’t access your appointment information/i
+const startOfToday = moment()
+.startOf('day')
+.toISOString();
+
+// Maximum number of days you can schedule an appointment in advance in VAOS
+const endDate = moment()
+.add(395, 'days')
+.startOf('day')
+.toISOString();
+
+describe('MyVA Dashboard - Appointments', () => {
+  describe('when there is a 400 error fetching VA appointments', () => {
+    beforeEach(() => {
+      mockLocalStorage();
+      cy.login(mockUser);
+      cy.intercept(
+        'GET',
+        `vaos/v0/appointments?start_date=${startOfToday}&end_date=${endDate}&type=va`,
+        ERROR_400,
+      );
+
+      cy.intercept(
+        'GET',
+        `vaos/v0/appointments?start_date=${startOfToday}&end_date=${endDate}&type=cc`,
+        upcomingCCAppointment,
+      );
+
+      cy.intercept(
+        'GET',
+        `vaos/v1/facilities/va?ids=*`,
+        MOCK_FACILITIES,
+      );
+
+      mockFeatureToggles();
+      cy.visit('my-va/');
+    });
+
+    it('should show the appointments error alert', () => {
+      cy.findByText(alertText).should('exist');
+    });
+  });
+
+  describe('when there is a 400 error fetching CC appointments', () => {
+    beforeEach(() => {
+      mockLocalStorage();
+      cy.login(mockUser);
+      cy.intercept(
+        'GET',
+        `vaos/v0/appointments?start_date=${startOfToday}&end_date=${endDate}&type=va`,
+        upcomingVAAppointment,
+      );
+
+      cy.intercept(
+        'GET',
+        `vaos/v0/appointments?start_date=${startOfToday}&end_date=${endDate}&type=cc`,
+        ERROR_400,
+      );
+
+      cy.intercept(
+        'GET',
+        `vaos/v1/facilities/va?ids=*`,
+        MOCK_FACILITIES,
+      );
+
+      mockFeatureToggles();
+      cy.visit('my-va/');
+    });
+
+    it('should show the appointments error alert', () => {
+      cy.findByText(alertText).should('exist');
+    });
+  });
+
+  describe('when there is a partial error fetching VA appointments', () => {
+    beforeEach(() => {
+      mockLocalStorage();
+      cy.login(mockUser);
+      cy.intercept(
+        'GET',
+        `vaos/v0/appointments?start_date=${startOfToday}&end_date=${endDate}&type=va`,
+        PARTIAL_ERROR,
+      );
+
+      cy.intercept(
+        'GET',
+        `vaos/v0/appointments?start_date=${startOfToday}&end_date=${endDate}&type=cc`,
+        upcomingCCAppointment,
+      );
+
+      cy.intercept(
+        'GET',
+        `vaos/v1/facilities/va?ids=*`,
+        MOCK_FACILITIES,
+      );
+
+      mockFeatureToggles();
+      cy.visit('my-va/');
+    });
+
+    it('should show the appointments error alert', () => {
+      cy.findByText(alertText).should('exist');
+    });
+  });
+
+  describe('when there is an error fetching facilities', () => {
+    beforeEach(() => {
+      mockLocalStorage();
+      cy.login(mockUser);
+      cy.intercept(
+        'GET',
+        `vaos/v0/appointments?start_date=${startOfToday}&end_date=${endDate}&type=va`,
+        upcomingVAAppointment,
+      );
+
+      cy.intercept(
+        'GET',
+        `vaos/v0/appointments?start_date=${startOfToday}&end_date=${endDate}&type=cc`,
+        upcomingCCAppointment,
+      );
+
+      cy.intercept(
+        'GET',
+        `vaos/v1/facilities/va?ids=*`,
+        ERROR_400,
+      );
+
+      mockFeatureToggles();
+      cy.visit('my-va/');
+    });
+
+    it('should show the appointments error alert', () => {
+      cy.findByText('We can’t access any claims or appeals information right now').should('exist');
+    });
+  })
+
+});

--- a/src/applications/personalization/dashboard-2/tests/e2e/appointments-error.cypress.spec.js
+++ b/src/applications/personalization/dashboard-2/tests/e2e/appointments-error.cypress.spec.js
@@ -28,69 +28,64 @@ const endDate = moment()
 
 describe('MyVA Dashboard - Appointments', () => {
   describe('when there is a 400 error fetching VA appointments', () => {
-    beforeEach(() => {
-      mockLocalStorage();
-      cy.login(mockUser);
-      cy.intercept(
-        'GET',
-        `vaos/v0/appointments?start_date=${startOfToday}&end_date=${endDate}&type=va`,
-        ERROR_400,
-      );
-
-      cy.intercept(
-        'GET',
-        `vaos/v0/appointments?start_date=${startOfToday}&end_date=${endDate}&type=cc`,
-        upcomingCCAppointment,
-      );
-
-      cy.intercept(
-        'GET',
-        `vaos/v1/facilities/va?ids=*`,
-        MOCK_FACILITIES,
-      );
-
-      mockFeatureToggles();
-      cy.visit('my-va/');
-    });
-
     it('should show the appointments error alert', () => {
+      mockLocalStorage();
+    cy.login(mockUser);
+    cy.intercept(
+      'GET',
+      `vaos/v0/appointments?start_date=${startOfToday}&end_date=${endDate}&type=va`,
+      ERROR_400,
+    );
+
+    cy.intercept(
+      'GET',
+      `vaos/v0/appointments?start_date=${startOfToday}&end_date=${endDate}&type=cc`,
+      upcomingCCAppointment,
+    );
+
+    cy.intercept(
+      'GET',
+      `vaos/v1/facilities/va?ids=*`,
+      MOCK_FACILITIES,
+    );
+
+    mockFeatureToggles();
+    cy.visit('my-va/');
       cy.findByText(alertText).should('exist');
     });
   });
 
   describe('when there is a 400 error fetching CC appointments', () => {
-    beforeEach(() => {
-      mockLocalStorage();
-      cy.login(mockUser);
-      cy.intercept(
-        'GET',
-        `vaos/v0/appointments?start_date=${startOfToday}&end_date=${endDate}&type=va`,
-        upcomingVAAppointment,
-      );
-
-      cy.intercept(
-        'GET',
-        `vaos/v0/appointments?start_date=${startOfToday}&end_date=${endDate}&type=cc`,
-        ERROR_400,
-      );
-
-      cy.intercept(
-        'GET',
-        `vaos/v1/facilities/va?ids=*`,
-        MOCK_FACILITIES,
-      );
-
-      mockFeatureToggles();
-      cy.visit('my-va/');
-    });
 
     it('should show the appointments error alert', () => {
+      mockLocalStorage();
+    cy.login(mockUser);
+    cy.intercept(
+      'GET',
+      `vaos/v0/appointments?start_date=${startOfToday}&end_date=${endDate}&type=va`,
+      upcomingVAAppointment,
+    );
+
+    cy.intercept(
+      'GET',
+      `vaos/v0/appointments?start_date=${startOfToday}&end_date=${endDate}&type=cc`,
+      ERROR_400,
+    );
+
+    cy.intercept(
+      'GET',
+      `vaos/v1/facilities/va?ids=*`,
+      MOCK_FACILITIES,
+    );
+
+    mockFeatureToggles();
+    cy.visit('my-va/');
       cy.findByText(alertText).should('exist');
     });
   });
 
   describe('when there is a partial error fetching VA appointments', () => {
-    beforeEach(() => {
+    it('should show the appointments error alert', () => {
       mockLocalStorage();
       cy.login(mockUser);
       cy.intercept(
@@ -113,15 +108,12 @@ describe('MyVA Dashboard - Appointments', () => {
 
       mockFeatureToggles();
       cy.visit('my-va/');
-    });
-
-    it('should show the appointments error alert', () => {
       cy.findByText(alertText).should('exist');
     });
   });
 
   describe('when there is an error fetching facilities', () => {
-    beforeEach(() => {
+    it('should show the appointments error alert', () => {
       mockLocalStorage();
       cy.login(mockUser);
       cy.intercept(
@@ -144,9 +136,6 @@ describe('MyVA Dashboard - Appointments', () => {
 
       mockFeatureToggles();
       cy.visit('my-va/');
-    });
-
-    it('should show the appointments error alert', () => {
       cy.findByText('We can’t access any claims or appeals information right now').should('exist');
     });
   })

--- a/src/applications/personalization/dashboard-2/tests/e2e/messaging-error.cypress.spec.js
+++ b/src/applications/personalization/dashboard-2/tests/e2e/messaging-error.cypress.spec.js
@@ -1,4 +1,4 @@
-import { mockFolderErrorResponse } from '~/applications/personalization/dashboard-2/utils/mocks/messaging/folder';
+import ERROR_400 from '~/applications/personalization/dashboard-2/utils/mocks/ERROR_400.js';
 import { mockFeatureToggles } from './helpers';
 
 import {
@@ -18,11 +18,7 @@ describe('MyVA Dashboard - Messaging', () => {
 
       cy.login(mockUser);
       // login() calls cy.server() so we can now mock routes
-      cy.intercept(
-        'GET',
-        '/v0/messaging/health/folders/0',
-        mockFolderErrorResponse,
-      );
+      cy.intercept('GET', '/v0/messaging/health/folders/0', ERROR_400);
       mockFeatureToggles();
     });
     it('should show the messaging link with the generic copy', () => {

--- a/src/applications/personalization/dashboard-2/utils/mocks/ERROR_400.js
+++ b/src/applications/personalization/dashboard-2/utils/mocks/ERROR_400.js
@@ -1,0 +1,12 @@
+export default {
+  errors: [
+    {
+      title: 'Bad Request',
+      detail: 'Received a bad request response from the upstream server',
+      code: 'EVSS400',
+      source: 'EVSS::DisabilityCompensationForm::Service',
+      status: '400',
+      meta: {},
+    },
+  ],
+};

--- a/src/applications/personalization/dashboard-2/utils/mocks/appointments/MOCK_VA_APPOINTMENTS_PARTIAL_ERROR.js
+++ b/src/applications/personalization/dashboard-2/utils/mocks/appointments/MOCK_VA_APPOINTMENTS_PARTIAL_ERROR.js
@@ -1,0 +1,11 @@
+export default {
+  meta: {
+    errors: [
+      {
+        code: 112,
+        source: 'test',
+        summary: 'test summary',
+      },
+    ],
+  },
+};

--- a/src/applications/personalization/dashboard-2/utils/mocks/messaging/folder.js
+++ b/src/applications/personalization/dashboard-2/utils/mocks/messaging/folder.js
@@ -12,16 +12,3 @@ export const mockFolderResponse = {
     links: { self: 'https://staging-api.va.gov/v0/messaging/health/folders/0' },
   },
 };
-
-export const mockFolderErrorResponse = {
-  errors: [
-    {
-      title: 'Bad Request',
-      detail: 'Received a bad request response from the upstream server',
-      code: 'EVSS400',
-      source: 'EVSS::DisabilityCompensationForm::Service',
-      status: '400',
-      meta: {},
-    },
-  ],
-};


### PR DESCRIPTION
## Description

We need to show an alert when any of the endpoints responsible for fetching appointment data fail.

1) Fetching va appointments
2) Fetching cc appointments
3) Fetching facilities

It is important to note that after talking with Jeff Balboni, I learned that the appointment call can also fail _partially_. From our conversation:

> The service we use to fetch appointments can return successfully, but have errors listed in the meta object in the return data. This happens when one of the underlying services is having issues. Right now, for example, we have errors from the appointments service because it’s successfully fetching video appointments, but not VA appointments. Without any special handling for this case, you could end up showing an appointment that isn’t actually the user’s next one.

This is the schema for the partial error: https://github.com/department-of-veterans-affairs/vets-api/blob/6193810155b5aaa37989e8ed51261c11fc539800/spec/support/schemas_camelized/vaos/va_appointments.json#L31


## Testing done
Work well tested with Cypress.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/115900376-1fd52000-a41d-11eb-8668-d7ae65a6c7b4.png)


## Acceptance criteria
- [x] Ensure we show an alert when we have issues fetching appointment data
- [x] Add test coverage

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
