### PR TITLE
Fix Claims/Appeals CTA URL

### DIFF
--- a/src/applications/personalization/dashboard-2/components/claims-and-appeals/ClaimsAndAppeals.jsx
+++ b/src/applications/personalization/dashboard-2/components/claims-and-appeals/ClaimsAndAppeals.jsx
@@ -124,8 +124,9 @@ const ClaimsAndAppeals = ({
           </DashboardWidgetWrapper>
           {highlightedClaimOrAppeal ? (
             <DashboardWidgetWrapper>
-              <div className="vads-u-margin-top--2p5 small-desktop-screen:vads-u-margin-top--0" />
-              <ClaimsAndAppealsCTA />
+              <div className="vads-u-margin-top--2p5 small-desktop-screen:vads-u-margin-top--0">
+                <ClaimsAndAppealsCTA />
+              </div>
             </DashboardWidgetWrapper>
           ) : null}
         </div>

--- a/src/applications/personalization/dashboard-2/components/claims-and-appeals/ClaimsAndAppealsCTA.jsx
+++ b/src/applications/personalization/dashboard-2/components/claims-and-appeals/ClaimsAndAppealsCTA.jsx
@@ -6,7 +6,7 @@ const ClaimsAndAppealsCTA = () => {
   return (
     <IconCTALink
       text="Manage all your claims and appeals"
-      href="claim-or-appeal-status/"
+      href="/claim-or-appeal-status/"
       icon="clipboard"
     />
   );

--- a/src/applications/personalization/dashboard-2/tests/e2e/claims-and-appeals.cypress.spec.js
+++ b/src/applications/personalization/dashboard-2/tests/e2e/claims-and-appeals.cypress.spec.js
@@ -2,6 +2,7 @@ import disableFTUXModals from '~/platform/user/tests/disableFTUXModals';
 import { mockUser } from '@@profile/tests/fixtures/users/user.js';
 import serviceHistory from '@@profile/tests/fixtures/service-history-success.json';
 import fullName from '@@profile/tests/fixtures/full-name-success.json';
+import disabilityRating from '@@profile/tests/fixtures/disability-rating-success.json';
 import claimsSuccess from '@@profile/tests/fixtures/claims-success';
 import appealsSuccess from '@@profile/tests/fixtures/appeals-success';
 import appeals404 from '@@profile/tests/fixtures/appeals-404.json';
@@ -17,6 +18,10 @@ describe('The My VA Dashboard Claims and Appeals section', () => {
     cy.login(mockUser);
     cy.intercept('/v0/profile/service_history', serviceHistory);
     cy.intercept('/v0/profile/full_name', fullName);
+    cy.intercept(
+      '/v0/disability_compensation_form/rating_info',
+      disabilityRating,
+    );
   });
   context(
     'when there is a recent appeals update and recent claims update',
@@ -29,20 +34,52 @@ describe('The My VA Dashboard Claims and Appeals section', () => {
         mockFeatureToggles();
         cy.visit(manifest.rootUrl);
 
-        // should show a loading indicator
-        cy.findByRole('progressbar').should('exist');
-        cy.findByText(/loading your information/i).should('exist');
-
-        // and then the loading indicator should be removed
-        cy.findByRole('progressbar').should('not.exist');
-        cy.findByText(/loading your information/i).should('not.exist');
-
         // make sure that the Claims and Appeals section is shown
         cy.findByTestId('dashboard-section-claims-and-appeals').should('exist');
         cy.findByRole('link', { name: /claims and appeals/ }).should('exist');
         cy.findByRole('heading', { name: /dependency claim received/i }).should(
           'exist',
         );
+        // the claims/appeals error is not shown
+        cy.findByRole('heading', {
+          name: /We can’t access any claims or appeals/i,
+        }).should('not.exist');
+
+        // make the a11y check
+        cy.injectAxe();
+        cy.axeCheck();
+      });
+    },
+  );
+  context(
+    'when there are open claims or appeals but they have not been updated in the past 30 days',
+    () => {
+      beforeEach(() => {
+        cy.intercept('/v0/evss_claims_async', claimsSuccess(31));
+        cy.intercept('/v0/appeals', appealsSuccess(31));
+      });
+      it('should show a CTA but not details about the most recently updated claim or appeal ', () => {
+        mockFeatureToggles();
+        cy.visit(manifest.rootUrl);
+
+        // make sure that the Claims and Appeals section and CTA is shown
+        cy.findByTestId('dashboard-section-claims-and-appeals').should('exist');
+        cy.findByRole('link', { name: /all your claims and appeals/ }).should(
+          'exist',
+        );
+        cy.findByText(
+          /You have no claims or appeals updates in the last 30 days/i,
+        ).should('exist');
+
+        // claim or appeals details are not shown
+        // a highlighted appeal always has "update on" in its title
+        cy.findByRole('heading', { name: /updated on/i }).should('not.exist');
+        // a highlighted claim always has "claim received" in its tile
+        cy.findByRole('heading', { name: /claim received/i }).should(
+          'not.exist',
+        );
+        cy.findByRole('link', { name: /view details/i }).should('not.exist');
+
         // the claims/appeals error is not shown
         cy.findByRole('heading', {
           name: /We can’t access any claims or appeals/i,


### PR DESCRIPTION
## Description
Fixes a broken URL in the claims/appeals CTA

## Testing done
Added an additional test for the "there are open claims/appeals, but they haven't been updated recently" case

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs