### PR TITLE
Convert DowntimeMessage to react-redux hooks

### DIFF
--- a/src/applications/vaos/components/VAOSApp/DowntimeMessage.jsx
+++ b/src/applications/vaos/components/VAOSApp/DowntimeMessage.jsx
@@ -1,21 +1,23 @@
 import React from 'react';
-import { connect } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
 import externalServiceStatus from 'platform/monitoring/DowntimeNotification/config/externalServiceStatus';
-import * as actions from 'platform/monitoring/DowntimeNotification/actions';
+import { dismissDowntimeWarning } from 'platform/monitoring/DowntimeNotification/actions';
 import FullWidthLayout from '../FullWidthLayout';
 
 const appTitle = 'VA online scheduling tool';
 
-function DowntimeMessage({
+export default function DowntimeMessage({
   startTime,
   endTime,
   status,
   children,
-  isDowntimeWarningDismissed,
-  dismissDowntimeWarning,
 }) {
+  const dispatch = useDispatch();
+  const isDowntimeWarningDismissed = useSelector(state =>
+    state.scheduledDowntime.dismissedDowntimeWarnings.includes(appTitle),
+  );
   if (status === externalServiceStatus.down) {
     return (
       <FullWidthLayout>
@@ -38,7 +40,7 @@ function DowntimeMessage({
     );
   }
 
-  const close = () => dismissDowntimeWarning(appTitle);
+  const close = () => dispatch(dismissDowntimeWarning(appTitle));
   return (
     <>
       {status === externalServiceStatus.downtimeApproaching && (
@@ -69,20 +71,3 @@ function DowntimeMessage({
     </>
   );
 }
-
-function mapStateToProps(state) {
-  return {
-    isDowntimeWarningDismissed: state.scheduledDowntime.dismissedDowntimeWarnings.includes(
-      appTitle,
-    ),
-  };
-}
-
-const mapDispatchToProps = {
-  dismissDowntimeWarning: actions.dismissDowntimeWarning,
-};
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(DowntimeMessage);


### PR DESCRIPTION
## Description
We want to update the way we use react-redux to the current recommended approach, which is to use the useSelector and useDispatch hooks.

Path: src/applications/vaos/components/VAOSApp/DowntimeMessage.jsx

## Testing done
Unit testing

## Acceptance criteria
- [ ] Build passes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
