### PR TITLE
[23396] Update VAOSApp to use hooks

### DIFF
--- a/src/applications/vaos/components/VAOSApp/index.jsx
+++ b/src/applications/vaos/components/VAOSApp/index.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { connect } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import DowntimeNotification, {
@@ -16,12 +16,14 @@ import AppUnavailable from './AppUnavailable';
 import DowntimeMessage from './DowntimeMessage';
 import FullWidthLayout from '../FullWidthLayout';
 
-function VAOSApp({
-  children,
-  showApplication,
-  loadingFeatureToggles,
-  useFlatFacilityPage,
-}) {
+export default function VAOSApp({ children }) {
+  const showApplication = useSelector(state => selectFeatureApplication(state));
+  const loadingFeatureToggles = useSelector(state =>
+    selectFeatureToggleLoading(state),
+  );
+  const useFlatFacilityPage = useSelector(state =>
+    selectUseFlatFacilityPage(state),
+  );
   useEffect(
     () => {
       if (useFlatFacilityPage) {
@@ -57,13 +59,3 @@ function VAOSApp({
     </>
   );
 }
-
-function mapStateToProps(state) {
-  return {
-    showApplication: selectFeatureApplication(state),
-    loadingFeatureToggles: selectFeatureToggleLoading(state),
-    useFlatFacilityPage: selectUseFlatFacilityPage(state),
-  };
-}
-
-export default connect(mapStateToProps)(VAOSApp);


### PR DESCRIPTION
## Description
We want to update the way we use react-redux to the current recommended approach, which is to use the useSelector and useDispatch hooks.

Path: src/applications/vaos/components/VAOSApp/index.jsx

## Testing done
local and unit

## Screenshots
n/a

## Acceptance criteria
- [ ]  connect() is no longer used on page
- [ ] All actions that were in mapDispatchToProps are now wrapped in dispatch() when called
- [ ] All data in mapStateToProps is pulled in through useSelector hooks

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
