### PR TITLE
Add SEO keywords to FSR

### DIFF
--- a/src/applications/financial-status-report/containers/App.jsx
+++ b/src/applications/financial-status-report/containers/App.jsx
@@ -1,18 +1,19 @@
 import React, { useState, useEffect } from 'react';
-import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
-import formConfig from '../config/form';
-import { connect } from 'react-redux';
-import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
-import ErrorMessage from '../components/ErrorMessage';
-import { fetchFormStatus } from '../actions/index';
-import { fsrWizardFeatureToggle, fsrFeatureToggle } from '../utils/helpers';
 import MetaTags from 'react-meta-tags';
-import WizardContainer from '../wizard/WizardContainer';
-import { WIZARD_STATUS } from '../wizard/constants';
+import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
+import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
+import { connect } from 'react-redux';
 import {
   WIZARD_STATUS_NOT_STARTED,
   WIZARD_STATUS_COMPLETE,
 } from 'platform/site-wide/wizard';
+
+import formConfig from '../config/form';
+import ErrorMessage from '../components/ErrorMessage';
+import WizardContainer from '../wizard/WizardContainer';
+import { fetchFormStatus } from '../actions/index';
+import { WIZARD_STATUS } from '../wizard/constants';
+import { fsrWizardFeatureToggle, fsrFeatureToggle } from '../utils/helpers';
 
 const App = ({
   location,
@@ -58,10 +59,15 @@ const App = ({
 
   return showFSR ? (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-      {/* TODO: used to prevent staging form being indexed remove once merged to prod */}
       <MetaTags>
+        {/* TODO: used to prevent staging form being indexed remove once merged to prod */}
         <meta name="robots" content="noindex" />
+        <meta
+          name="keywords"
+          content="repay debt, debt, debt letters, FSR, financial status report, debt forgiveness, compromise, waiver, monthly offsets, education loans repayment"
+        />
       </MetaTags>
+
       {children}
     </RoutedSavableApp>
   ) : null;


### PR DESCRIPTION
## Description
After going through the IA on this [ticket](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/16946) and saw that most of it was implemented besides the SEO keywords. This PR is to add the keywords to the FSR application.

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Add keywords to the FSR application using the `<MetaTags />` component

## Definition of done
- [x] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
