### PR TITLE
[23397] Update NewAppointmentSection to hooks

### DIFF
--- a/src/applications/vaos/new-appointment/index.jsx
+++ b/src/applications/vaos/new-appointment/index.jsx
@@ -37,7 +37,7 @@ import useFormRedirectToStart from '../hooks/useFormRedirectToStart';
 import useFormUnsavedDataWarning from '../hooks/useFormUnsavedDataWarning';
 import useManualScrollRestoration from '../hooks/useManualScrollRestoration';
 
-function NewAppointmentSection() {
+export function NewAppointment() {
   const isCernerOnlyPatient = useSelector(state =>
     selectIsCernerOnlyPatient(state),
   );
@@ -147,7 +147,5 @@ function NewAppointmentSection() {
     </FormLayout>
   );
 }
-
-export const NewAppointment = NewAppointmentSection;
 
 export const reducer = newAppointmentReducer;

--- a/src/applications/vaos/new-appointment/index.jsx
+++ b/src/applications/vaos/new-appointment/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { connect } from 'react-redux';
+import { useSelector } from 'react-redux';
 import {
   Switch,
   Route,
@@ -37,11 +37,16 @@ import useFormRedirectToStart from '../hooks/useFormRedirectToStart';
 import useFormUnsavedDataWarning from '../hooks/useFormUnsavedDataWarning';
 import useManualScrollRestoration from '../hooks/useManualScrollRestoration';
 
-function NewAppointmentSection({
-  flatFacilityPageEnabled,
-  isCernerOnlyPatient,
-  providerSelectionEnabled,
-}) {
+function NewAppointmentSection() {
+  const isCernerOnlyPatient = useSelector(state =>
+    selectIsCernerOnlyPatient(state),
+  );
+  const flatFacilityPageEnabled = useSelector(state =>
+    selectUseFlatFacilityPage(state),
+  );
+  const providerSelectionEnabled = useSelector(state =>
+    selectUseProviderSelection(state),
+  );
   const match = useRouteMatch();
   const location = useLocation();
 
@@ -143,14 +148,6 @@ function NewAppointmentSection({
   );
 }
 
-function mapStateToProps(state) {
-  return {
-    isCernerOnlyPatient: selectIsCernerOnlyPatient(state),
-    flatFacilityPageEnabled: selectUseFlatFacilityPage(state),
-    providerSelectionEnabled: selectUseProviderSelection(state),
-  };
-}
-
-export const NewAppointment = connect(mapStateToProps)(NewAppointmentSection);
+export const NewAppointment = NewAppointmentSection;
 
 export const reducer = newAppointmentReducer;


### PR DESCRIPTION
## Description
We want to update the way we use react-redux to the current recommended approach, which is to use the useSelector and useDispatch hooks.

Path: src/applications/vaos/new-appointment/index.jsx

## Testing done
local and unit

## Screenshots
n/a

## Acceptance criteria
- [ ] connect() is no longer used on page
- [ ] All actions that were in mapDispatchToProps are now wrapped in dispatch() when called
- [ ] All data in mapStateToProps is pulled in through useSelector hooks

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
