### PR TITLE
Update Nightwatch start_process config from false to true

### DIFF
--- a/config/nightwatch.docker-compose.js
+++ b/config/nightwatch.docker-compose.js
@@ -53,7 +53,7 @@ module.exports = {
         },
       },
       selenium: {
-        start_process: false,
+        start_process: true,
         log_path: selenium_logs,
         host: 'selenium-chrome',
         port: selenium_server_port,


### PR DESCRIPTION
## Description

We have two different nightwatch config files ([`config/nightwatch.js`](https://github.com/department-of-veterans-affairs/vets-website/blob/master/config/nightwatch.js) and [`config/nightwatch.docker-compose.js`](https://github.com/department-of-veterans-affairs/vets-website/blob/master/config/nightwatch.docker-compose.js)). But they have different `start_process` config values. One has been `true` since the file was [created](https://github.com/department-of-veterans-affairs/vets-website/commit/469cda1e1366407f2ce6e449387c3213620c2b85#diff-617b2e47160d9798eeb4d23c3b13e8a4ed592653beddf335e682bab7e6a370d6). The other has been `false` since the file was [created](https://github.com/department-of-veterans-affairs/vets-website/commit/d74a3182dbf22b4c2ec2fb1e0947498a0e097f98#diff-d571abdc3a4b71ff902c7f7a440ba984e0ab8c1ecfa26c47adb794d8d130b0b8). This PR reconciles that difference. 

I chose to change the `false` config to `true` because the [Selenium Example Configuration](https://nightwatchjs.org/gettingstarted/configuration/#selenium-example-configuration) uses `start_process: true`. 

>`start_process`: When this is enabled, the Webdriver server is run in background in a child process and started/stopped automatically. Nightwatch includes support for managing Chromedriver, Geckodriver (Firefox), Safaridriver, and Selenium Server. Please refer to the [Install Webdriver section](https://nightwatchjs.org/gettingstarted/installation/#webdriver-service) for details. - https://nightwatchjs.org/gettingstarted/configuration/#output-settings

## Links

- https://nightwatchjs.org/gettingstarted/configuration/#selenium-example-configuration
- https://nightwatchjs.org/gettingstarted/configuration/#output-settings
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/23331

## Testing done

CI

