### PR TITLE
Updated to focus on first title

### DIFF
--- a/src/applications/vre/28-1900/orientation/OrientationApp.jsx
+++ b/src/applications/vre/28-1900/orientation/OrientationApp.jsx
@@ -24,7 +24,7 @@ const OrientationApp = props => {
   useEffect(() => {
     if (formStartControl) {
       focusElement('#FormStartControl');
-    } else if (step > 0) {
+    } else {
       focusElement('#StepTitle');
       scrollToTop();
     }


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/22663)

While testing it was found that on the first step of the orientation we do not bring focus to the title of the orientation step like we do for the other steps. Brining focus to the title is a requirement for 508.

## Testing done

tested in Chrome

## Screenshots

![Screen Shot 2021-04-26 at 10 53 42 AM](https://user-images.githubusercontent.com/1899695/116128366-b3a52700-a67d-11eb-88d4-7fec5a1d7361.png)

## Acceptance criteria
- [ ] Upon pressing the "Previous slide" button on slide 2, the user is returned to slide 1 with focus on the h3 "Veteran Readiness and Employment orientation"

