### PR TITLE
Show "not in MPI" error on Dashboard

### DIFF
--- a/src/applications/hca/reducers/hca-enrollment-status-reducer.js
+++ b/src/applications/hca/reducers/hca-enrollment-status-reducer.js
@@ -62,9 +62,10 @@ function hcaEnrollmentStatus(state = initialState, action) {
       const { errors } = action;
       const noESRRecordFound =
         errors && errors.some(error => error.code === '404');
-      const hasServerError = errors && errors.some(error => error.code >= 500);
       const hasRateLimitError =
         errors && errors.some(error => error.code === '429');
+      // if the error is not given special handling, treat it like a server error
+      const hasServerError = !noESRRecordFound && !hasRateLimitError;
       return {
         ...state,
         hasServerError,

--- a/src/applications/hca/tests/reducers.unit.spec.js
+++ b/src/applications/hca/tests/reducers.unit.spec.js
@@ -94,39 +94,31 @@ describe('HCA Enrollment Status Reducer', () => {
   });
 
   describe('FETCH_ENROLLMENT_STATUS_FAILED', () => {
-    describe('regardless of the error codes', () => {
-      it('sets the state correctly', () => {
-        action = {
-          type: actions.FETCH_ENROLLMENT_STATUS_FAILED,
-          errors: [{ code: '400' }],
-        };
-        reducedState = reducer(state, action);
-        expect(reducedState.hasServerError).to.be.false;
-        expect(reducedState.isLoadingApplicationStatus).to.be.false;
-        expect(reducedState.loginRequired).to.be.false;
-        expect(reducedState.noESRRecordFound).to.be.false;
-      });
-    });
-
     describe('if the error code if 404', () => {
-      it('sets `noESRRecordFound` to `true`', () => {
+      it('sets `noESRRecordFound` to `true` and `hasServerError` to `false`', () => {
         action = {
           type: actions.FETCH_ENROLLMENT_STATUS_FAILED,
           errors: [{ code: '404' }],
         };
         reducedState = reducer(state, action);
         expect(reducedState.noESRRecordFound).to.be.true;
+        expect(reducedState.hasServerError).to.be.false;
+        expect(reducedState.loginRequired).to.be.false;
+        expect(reducedState.isLoadingApplicationStatus).to.be.false;
       });
     });
 
     describe('if the error code is 429', () => {
-      it('sets `loginRequired` to `true`', () => {
+      it('sets `loginRequired` to `true` and `hasServerError` to `false`', () => {
         action = {
           type: actions.FETCH_ENROLLMENT_STATUS_FAILED,
           errors: [{ code: '429' }],
         };
         reducedState = reducer(state, action);
         expect(reducedState.loginRequired).to.be.true;
+        expect(reducedState.noESRRecordFound).to.be.false;
+        expect(reducedState.hasServerError).to.be.false;
+        expect(reducedState.isLoadingApplicationStatus).to.be.false;
       });
     });
 
@@ -138,6 +130,21 @@ describe('HCA Enrollment Status Reducer', () => {
         };
         reducedState = reducer(state, action);
         expect(reducedState.hasServerError).to.be.true;
+        expect(reducedState.loginRequired).to.be.false;
+        expect(reducedState.noESRRecordFound).to.be.false;
+        expect(reducedState.isLoadingApplicationStatus).to.be.false;
+      });
+    });
+
+    describe('if the error code cannot be determined', () => {
+      it('sets `hasServerError` to `true`', () => {
+        action = {
+          type: actions.FETCH_ENROLLMENT_STATUS_FAILED,
+          errors: null,
+        };
+        reducedState = reducer(state, action);
+        expect(reducedState.hasServerError).to.be.true;
+        expect(reducedState.isLoadingApplicationStatus).to.be.false;
       });
     });
   });

--- a/src/applications/personalization/dashboard-2/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard-2/components/Dashboard.jsx
@@ -169,7 +169,7 @@ const Dashboard = ({
               {showMPIConnectionError ? (
                 <div className="vads-l-row">
                   <div className="vads-l-col--12 medium-screen:vads-l-col--8 medium-screen:vads-u-padding-right--3">
-                    <MPIConnectionError />
+                    <MPIConnectionError level={2} />
                   </div>
                 </div>
               ) : null}
@@ -177,7 +177,7 @@ const Dashboard = ({
               {showNotInMPIError ? (
                 <div className="vads-l-row">
                   <div className="vads-l-col--12 medium-screen:vads-l-col--8 medium-screen:vads-u-padding-right--3">
-                    <NotInMPIError />
+                    <NotInMPIError level={2} />
                   </div>
                 </div>
               ) : null}

--- a/src/applications/personalization/dashboard-2/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard-2/components/Dashboard.jsx
@@ -16,6 +16,7 @@ import {
   isLOA1 as isLOA1Selector,
   isVAPatient as isVAPatientSelector,
   hasMPIConnectionError,
+  isNotInMPI,
 } from '~/platform/user/selectors';
 import RequiredLoginView, {
   RequiredLoginLoader,
@@ -43,6 +44,7 @@ import ApplyForBenefits from './apply-for-benefits/ApplyForBenefits';
 import ClaimsAndAppeals from './claims-and-appeals/ClaimsAndAppeals';
 import HealthCare from './health-care/HealthCare';
 import MPIConnectionError from './MPIConnectionError';
+import NotInMPIError from './NotInMPIError';
 import CTALink from './CTALink';
 
 const renderWidgetDowntimeNotification = (downtime, children) => {
@@ -93,6 +95,7 @@ const Dashboard = ({
   isLOA3,
   showLoader,
   showMPIConnectionError,
+  showNotInMPIError,
   ...props
 }) => {
   const downtimeApproachingRenderMethod = useDowntimeApproachingRenderMethod();
@@ -171,6 +174,14 @@ const Dashboard = ({
                 </div>
               ) : null}
 
+              {showNotInMPIError ? (
+                <div className="vads-l-row">
+                  <div className="vads-l-col--12 medium-screen:vads-l-col--8 medium-screen:vads-u-padding-right--3">
+                    <NotInMPIError />
+                  </div>
+                </div>
+              ) : null}
+
               {props.showValidateIdentityAlert ? (
                 <div className="vads-l-row">
                   <div className="vads-l-col--12 medium-screen:vads-l-col--8 medium-screen:vads-u-padding-right--3">
@@ -178,6 +189,7 @@ const Dashboard = ({
                   </div>
                 </div>
               ) : null}
+
               {props.showClaimsAndAppeals ? (
                 <DowntimeNotification
                   dependencies={[
@@ -189,7 +201,9 @@ const Dashboard = ({
                   <ClaimsAndAppeals />
                 </DowntimeNotification>
               ) : null}
+
               {props.showHealthCare ? <HealthCare /> : null}
+
               <ApplyForBenefits />
             </div>
           </div>
@@ -230,9 +244,14 @@ const mapStateToProps = state => {
   const showValidateIdentityAlert = isLOA1;
   const showNameTag = isLOA3 && isEmpty(hero?.errors);
   const showMPIConnectionError = hasMPIConnectionError(state);
+  const showNotInMPIError = isNotInMPI(state);
   const showClaimsAndAppeals =
-    !showMPIConnectionError && isLOA3 && hasClaimsOrAppealsService;
-  const showHealthCare = !showMPIConnectionError && isLOA3 && isVAPatient;
+    !showMPIConnectionError &&
+    !showNotInMPIError &&
+    isLOA3 &&
+    hasClaimsOrAppealsService;
+  const showHealthCare =
+    !showMPIConnectionError && !showNotInMPIError && isLOA3 && isVAPatient;
 
   return {
     isLOA3,
@@ -246,6 +265,7 @@ const mapStateToProps = state => {
     totalDisabilityRatingServerError: hasTotalDisabilityServerError(state),
     user: state.user,
     showMPIConnectionError,
+    showNotInMPIError,
   };
 };
 

--- a/src/applications/personalization/dashboard-2/components/MPIConnectionError.jsx
+++ b/src/applications/personalization/dashboard-2/components/MPIConnectionError.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 
-const MPIConnectionError = () => {
+const MPIConnectionError = ({ level }) => {
   const alertMessage = (
     <p>
       We’re sorry. Something went wrong when we tried to connect to your
@@ -14,8 +15,13 @@ const MPIConnectionError = () => {
       headline="We can’t access any health care, claims, or appeals information right now"
       content={alertMessage}
       status="error"
+      level={level}
     />
   );
+};
+
+MPIConnectionError.propTypes = {
+  level: PropTypes.number.isRequired,
 };
 
 export default MPIConnectionError;

--- a/src/applications/personalization/dashboard-2/components/NotInMPIError.jsx
+++ b/src/applications/personalization/dashboard-2/components/NotInMPIError.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
 
-const NotInMPIError = () => {
+const NotInMPIError = ({ level }) => {
   const content = (
     <>
       <p>
@@ -26,8 +27,13 @@ const NotInMPIError = () => {
       headline="We can’t match your information to our records"
       content={content}
       status="warning"
+      level={level}
     />
   );
+};
+
+NotInMPIError.propTypes = {
+  level: PropTypes.number.isRequired,
 };
 
 export default NotInMPIError;

--- a/src/applications/personalization/dashboard-2/components/NotInMPIError.jsx
+++ b/src/applications/personalization/dashboard-2/components/NotInMPIError.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/component-library/Telephone';
+
+const NotInMPIError = () => {
+  const content = (
+    <>
+      <p>
+        We can’t give you access to VA.gov tools to manage your health and
+        benefits right now. We’ll need to match your information and verify your
+        identity first.
+      </p>
+      <p>
+        If you’d like to access these tools on VA.gov, please contact the VA
+        help desk at <Telephone contact={CONTACTS.VA_311} /> (TTY:{' '}
+        <Telephone contact={CONTACTS['711']} />) to verify and update your
+        records.
+      </p>
+    </>
+  );
+
+  return (
+    <AlertBox
+      headline="We can’t match your information to our records"
+      content={content}
+      status="warning"
+    />
+  );
+};
+
+export default NotInMPIError;

--- a/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.unit.spec.jsx
+++ b/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.unit.spec.jsx
@@ -251,10 +251,6 @@ describe('ApplyForBenefits component', () => {
             );
           }),
         ).to.be.true;
-        // make sure the loading spinner is shown
-        view.getByRole('progressbar', {
-          value: /benefits you might be interested in/i,
-        });
       });
     });
 

--- a/src/applications/personalization/dashboard-2/tests/e2e/benefits-of-interest.cypress.spec.js
+++ b/src/applications/personalization/dashboard-2/tests/e2e/benefits-of-interest.cypress.spec.js
@@ -7,37 +7,18 @@ import notInESR from '@@profile/tests/fixtures/enrollment-system/not-in-esr.json
 
 import manifest from '~/applications/personalization/dashboard/manifest.json';
 
-import { mockFeatureToggles } from './helpers';
+import {
+  disabilityCompensationExists,
+  educationBenefitExists,
+  healthCareInfoExists,
+  mockFeatureToggles,
+} from './helpers';
 
 function sectionHeadingsExist() {
   cy.findByRole('heading', { name: /apply for VA benefits/i }).should('exist');
   cy.findByRole('heading', {
     name: /benefits you might be interested in/i,
   }).should('exist');
-}
-
-// Helper to make sure that the "health care" info does or doesn't exist
-function healthCareInfoExists(exists) {
-  const assertion = exists ? 'exist' : 'not.exist';
-  cy.findByTestId('benefits-of-interest')
-    .findByRole('heading', { name: /^health care$/i })
-    .should(assertion);
-}
-
-// Helper to make sure that the "disability compensation" info does or doesn't exist
-function disabilityCompensationExists(exists) {
-  const assertion = exists ? 'exist' : 'not.exist';
-  cy.findByTestId('benefits-of-interest')
-    .findByRole('heading', { name: /^disability compensation$/i })
-    .should(assertion);
-}
-
-// Helper to make sure that the "education and training" info does or doesn't exist
-function educationBenefitExists(exists) {
-  const assertion = exists ? 'exist' : 'not.exist';
-  cy.findByTestId('benefits-of-interest')
-    .findByRole('heading', { name: /^education and training$/i })
-    .should(assertion);
 }
 
 describe('The My VA Dashboard', () => {

--- a/src/applications/personalization/dashboard-2/tests/e2e/helpers.js
+++ b/src/applications/personalization/dashboard-2/tests/e2e/helpers.js
@@ -15,3 +15,27 @@ export const mockFeatureToggles = () => {
     },
   });
 };
+
+// Helper to make sure that the "health care" info does or doesn't exist
+export function healthCareInfoExists(exists) {
+  const assertion = exists ? 'exist' : 'not.exist';
+  cy.findByTestId('benefits-of-interest')
+    .findByRole('heading', { name: /^health care$/i })
+    .should(assertion);
+}
+
+// Helper to make sure that the "disability compensation" info does or doesn't exist
+export function disabilityCompensationExists(exists) {
+  const assertion = exists ? 'exist' : 'not.exist';
+  cy.findByTestId('benefits-of-interest')
+    .findByRole('heading', { name: /^disability compensation$/i })
+    .should(assertion);
+}
+
+// Helper to make sure that the "education and training" info does or doesn't exist
+export function educationBenefitExists(exists) {
+  const assertion = exists ? 'exist' : 'not.exist';
+  cy.findByTestId('benefits-of-interest')
+    .findByRole('heading', { name: /^education and training$/i })
+    .should(assertion);
+}

--- a/src/applications/personalization/dashboard-2/tests/e2e/mpi-connection-error.cypress.spec.js
+++ b/src/applications/personalization/dashboard-2/tests/e2e/mpi-connection-error.cypress.spec.js
@@ -33,6 +33,9 @@ describe('MyVA Dashboard', () => {
       healthCareInfoExists(true);
       disabilityCompensationExists(true);
       educationBenefitExists(true);
+
+      cy.injectAxe();
+      cy.axeCheck();
     });
   });
 });

--- a/src/applications/personalization/dashboard-2/tests/e2e/mpi-connection-error.cypress.spec.js
+++ b/src/applications/personalization/dashboard-2/tests/e2e/mpi-connection-error.cypress.spec.js
@@ -1,8 +1,12 @@
-import { mockFeatureToggles } from './helpers';
-
 import { mockLocalStorage } from '~/applications/personalization/dashboard/tests/e2e/dashboard-e2e-helpers';
-
 import mockMPIErrorUser from '~/applications/personalization/profile/tests/fixtures/users/user-mpi-error.json';
+
+import {
+  disabilityCompensationExists,
+  educationBenefitExists,
+  healthCareInfoExists,
+  mockFeatureToggles,
+} from './helpers';
 
 describe('MyVA Dashboard', () => {
   describe('when there is an error connecting to MPI', () => {
@@ -25,6 +29,10 @@ describe('MyVA Dashboard', () => {
       cy.findByTestId('dashboard-section-claims-and-appeals').should(
         'not.exist',
       );
+
+      healthCareInfoExists(true);
+      disabilityCompensationExists(true);
+      educationBenefitExists(true);
     });
   });
 });

--- a/src/applications/personalization/dashboard-2/tests/e2e/not-in-mpi-error.cypress.spec.js
+++ b/src/applications/personalization/dashboard-2/tests/e2e/not-in-mpi-error.cypress.spec.js
@@ -33,6 +33,9 @@ describe('MyVA Dashboard', () => {
       healthCareInfoExists(true);
       disabilityCompensationExists(true);
       educationBenefitExists(true);
+
+      cy.injectAxe();
+      cy.axeCheck();
     });
   });
 });

--- a/src/applications/personalization/dashboard-2/tests/e2e/not-in-mpi-error.cypress.spec.js
+++ b/src/applications/personalization/dashboard-2/tests/e2e/not-in-mpi-error.cypress.spec.js
@@ -1,0 +1,38 @@
+import { mockLocalStorage } from '~/applications/personalization/dashboard/tests/e2e/dashboard-e2e-helpers';
+import mockNotInMPIUser from '~/applications/personalization/profile/tests/fixtures/users/user-not-in-mpi.json';
+
+import {
+  disabilityCompensationExists,
+  educationBenefitExists,
+  healthCareInfoExists,
+  mockFeatureToggles,
+} from './helpers';
+
+describe('MyVA Dashboard', () => {
+  describe('when the user does not exist in MPI', () => {
+    beforeEach(() => {
+      mockLocalStorage();
+
+      cy.login(mockNotInMPIUser);
+      mockFeatureToggles();
+    });
+    it('should show a "not in MPI" error in place of the claims/appeals and health care sections', () => {
+      cy.visit('my-va/');
+
+      cy.findByRole('heading', {
+        name: /We can’t match your information to our records/i,
+      }).should('exist');
+      cy.findByText(
+        /We can’t give you access to VA.gov tools to manage your health and benefits right now./i,
+      ).should('exist');
+      cy.findByTestId('dashboard-section-health-care').should('not.exist');
+      cy.findByTestId('dashboard-section-claims-and-appeals').should(
+        'not.exist',
+      );
+
+      healthCareInfoExists(true);
+      disabilityCompensationExists(true);
+      educationBenefitExists(true);
+    });
+  });
+});

--- a/src/platform/user/selectors.js
+++ b/src/platform/user/selectors.js
@@ -13,6 +13,7 @@ export const selectProfile = state => selectUser(state)?.profile || {};
 export const isVAPatient = state => selectProfile(state).vaPatient === true;
 export const selectVeteranStatus = state => selectProfile(state).veteranStatus;
 export const isInMPI = state => selectProfile(state)?.status === 'OK';
+export const isNotInMPI = state => selectProfile(state)?.status === 'NOT_FOUND';
 export const hasMPIConnectionError = state =>
   selectProfile(state)?.status === 'SERVER_ERROR';
 export const isProfileLoading = state => selectProfile(state).loading;

--- a/src/platform/user/tests/selectors.unit.spec.js
+++ b/src/platform/user/tests/selectors.unit.spec.js
@@ -516,6 +516,33 @@ describe('user selectors', () => {
     });
   });
 
+  describe('isNotInMPI', () => {
+    it('returns `true` if the profile.status is `NOT_FOUND`', () => {
+      const state = {
+        user: {
+          profile: {
+            status: 'NOT_FOUND',
+          },
+        },
+      };
+      expect(selectors.isNotInMPI(state)).to.be.true;
+    });
+    it('returns `false` if the profile.status is anything other than `NOT_FOUND`', () => {
+      const state = {
+        user: {
+          profile: {
+            status: 'NOT_AUTHORIZED',
+          },
+        },
+      };
+      expect(selectors.isNotInMPI(state)).to.be.false;
+      delete state.user.profile.status;
+      expect(selectors.isNotInMPI(state)).to.be.false;
+      delete state.user.profile;
+      expect(selectors.isNotInMPI(state)).to.be.false;
+    });
+  });
+
   describe('hasMPIConnectionError', () => {
     it('returns `true` if the profile.status is `SERVER_ERROR`', () => {
       const state = {


### PR DESCRIPTION
## Description
This PR adds a new "not in MPI" error in place of the Health Care and Claims/Appeals section of the Dashboard

## Testing done
TDD via Cypress

## Screenshots
<img width="1050" alt="Screen Shot 2021-04-26 at 2 09 30 PM" src="https://user-images.githubusercontent.com/20728956/116151117-10faa180-a699-11eb-8f31-c479fbdcc37f.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs