### PR TITLE
Update aria-label for progressbar to have a default value

### DIFF
--- a/src/site/paragraphs/react_widget.drupal.liquid
+++ b/src/site/paragraphs/react_widget.drupal.liquid
@@ -41,7 +41,8 @@
       data-widget-timeout="{{entity.fieldTimeout}}">
       <div class="loading-indicator-container">
         <div
-          aria-label="{% if entity.fieldLoadingMessage %}{{ entity.fieldLoadingMessage }}{% else %}loading indicator{% endif %}"
+          aria-label="{% if entity.fieldLoadingMessage %}{{ entity.fieldLoadingMessage }}{% else %}Loading...{% endif %}"
+          aria-valuetext="Loading your application..."
           class="loading-indicator"
           role="progressbar"
         ></div>

--- a/src/site/paragraphs/react_widget.drupal.liquid
+++ b/src/site/paragraphs/react_widget.drupal.liquid
@@ -40,7 +40,11 @@
       {% if entityUrl.path contains "/eligibility" %}data-widget-show-learn-more{% endif %}
       data-widget-timeout="{{entity.fieldTimeout}}">
       <div class="loading-indicator-container">
-        <div class="loading-indicator" role="progressbar" aria-valuetext="{{ entity.fieldLoadingMessage }}"></div>
+        <div
+          aria-label="{% if entity.fieldLoadingMessage %}{{ entity.fieldLoadingMessage }}{% else %}loading indicator{% endif %}"
+          class="loading-indicator"
+          role="progressbar"
+        ></div>
         <span
           class="loading-indicator-message loading-indicator-message--normal">
           {{ entity.fieldLoadingMessage }}


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/21787

This PR resolves the a11y errors with the loading indicator for react widgets.

## Testing done
Locally

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/116263503-a8620200-a736-11eb-8caa-0f61e997cdb8.png)

## Acceptance criteria
- [x] resolves the a11y errors with the loading indicator for react widgets

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
