### PR TITLE
Revert "Update Nightwatch start_process config from false to true"

### DIFF
--- a/config/nightwatch.docker-compose.js
+++ b/config/nightwatch.docker-compose.js
@@ -53,7 +53,7 @@ module.exports = {
         },
       },
       selenium: {
-        start_process: true,
+        start_process: false,
         log_path: selenium_logs,
         host: 'selenium-chrome',
         port: selenium_server_port,


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-website#16945 because the [daily a11y scan failed for the first time in two weeks](https://dsva.slack.com/archives/C01RAS1KAQK/p1619525622074100). 