### PR TITLE
NOD: Remove `hearingTypePreference` conditionally

### DIFF
--- a/src/applications/appeals/10182/config/submit-transformer.js
+++ b/src/applications/appeals/10182/config/submit-transformer.js
@@ -1,6 +1,7 @@
 import {
   addIncludedIssues,
   addUploads,
+  getRepName,
   getAddress,
   getPhone,
   getTimeZone,
@@ -9,26 +10,32 @@ import {
 export function transform(formConfig, form) {
   // https://dev-developer.va.gov/explore/appeals/docs/decision_reviews?version=current
   // https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/appeals_api/config/schemas/10182.json
-  const mainTransform = formData => ({
-    data: {
-      type: 'noticeOfDisagreement',
-      attributes: {
-        veteran: {
-          homeless: formData.homeless || false,
-          address: getAddress(formData),
-          phone: getPhone(formData),
-          emailAddressText: formData.veteran?.email || '',
-          representativesName: formData.representativesName || '',
+  const mainTransform = formData => {
+    const result = {
+      data: {
+        type: 'noticeOfDisagreement',
+        attributes: {
+          veteran: {
+            homeless: formData.homeless || false,
+            address: getAddress(formData),
+            phone: getPhone(formData),
+            emailAddressText: formData.veteran?.email || '',
+            representativesName: getRepName(formData),
+          },
+          boardReviewOption: formData.boardReviewOption || '',
+          hearingTypePreference: formData.hearingTypePreference || '',
+          timezone: getTimeZone(),
+          socOptIn: true,
         },
-        boardReviewOption: formData.boardReviewOption || '',
-        hearingTypePreference: formData.hearingTypePreference || '',
-        timezone: getTimeZone(),
-        socOptIn: true,
       },
-    },
-    included: addIncludedIssues(formData),
-    nodUploads: addUploads(formData),
-  });
+      included: addIncludedIssues(formData),
+      nodUploads: addUploads(formData),
+    };
+    if (formData.boardReviewOption !== 'hearing') {
+      delete result.data.attributes.hearingTypePreference;
+    }
+    return result;
+  };
 
   // Not using _.cloneDeep on form data - it appears to replace `null` values
   // with an empty object; and causes submission errors due to type mismatch

--- a/src/applications/appeals/10182/tests/fixtures/data/minimal-test.json
+++ b/src/applications/appeals/10182/tests/fixtures/data/minimal-test.json
@@ -1,0 +1,99 @@
+{
+  "data": {
+    "veteran": {
+      "ssnLastFour": "9876",
+      "vaFileLastFour": "8765",
+      "address": {
+        "addressLine1": "123 Main St",
+        "addressLine2": "Suite #1200",
+        "addressLine3": "Box 4",
+        "city": "New York",
+        "countryName": "United States",
+        "stateCode": "NY",
+        "zipCode": "30012",
+        "internationalPostalCode": "1"
+      },
+      "phone": {
+        "countryCode": "6",
+        "areaCode": "555",
+        "phoneNumber": "8001111",
+        "phoneNumberExt": "2"
+      },
+      "email": "user@example.com"
+    },
+    "homeless": false,
+    "view:hasRep": false,
+    "representativesName": "",
+    "boardReviewOption": "hearing",
+    "hearingTypePreference": "central_office",
+    "socOptIn": true,
+    "view:additionalEvidence": false,
+
+    "contestableIssues": [
+      {
+        "type": "contestableIssue",
+        "attributes": {
+          "ratingIssueSubjectText": "tinnitus",
+          "approxDecisionDate": "2020-01-01",
+          "decisionIssueId": 1,
+          "ratingIssueReferenceId": "2",
+          "ratingDecisionReferenceId": "3",
+          "ratingIssuePercentNumber": "10"
+        },
+        "view:selected": false
+      },
+      {
+        "type": "contestableIssue",
+        "attributes": {
+          "ratingIssueSubjectText": "left knee",
+          "approxDecisionDate": "2020-01-02",
+          "decisionIssueId": 4,
+          "ratingIssueReferenceId": "5"
+        },
+        "view:selected": false
+      },
+      {
+        "type": "contestableIssue",
+        "attributes": {
+          "ratingIssueSubjectText": "right knee",
+          "approxDecisionDate": "2020-01-03",
+          "ratingIssueReferenceId": "6",
+          "ratingDecisionReferenceId": "7"
+        },
+        "view:selected": false
+      },
+      {
+        "type": "contestableIssue",
+        "attributes": {
+          "ratingIssueSubjectText": "PTSD",
+          "approxDecisionDate": "2020-01-04",
+          "decisionIssueId": 8,
+          "ratingDecisionReferenceId": "9"
+        },
+        "view:selected": false
+      },
+      {
+        "type": "contestableIssue",
+        "attributes": {
+          "ratingIssueSubjectText": "Traumatic Brain Injury",
+          "approxDecisionDate": "2020-01-05",
+          "decisionIssueId": 10
+        },
+        "view:selected": false
+      }
+    ],
+    "additionalIssues": [
+      {
+        "issue": "right arm",
+        "decisionDate": "2020-01-07",
+        "view:selected": false
+      },
+      {
+        "issue": "right shoulder",
+        "decisionDate": "2020-01-06",
+        "view:selected": true
+      }
+    ],
+    "evidence": []
+  }
+}

--- a/src/applications/appeals/10182/tests/fixtures/data/transformed-minimal-test.json
+++ b/src/applications/appeals/10182/tests/fixtures/data/transformed-minimal-test.json
@@ -21,9 +21,10 @@
           "phoneNumberExt": "2"
         },
         "emailAddressText": "user@example.com",
-        "representativesName": "Tony Danza"
+        "representativesName": ""
       },
-      "boardReviewOption": "evidence_submission",
+      "boardReviewOption": "hearing",
+      "hearingTypePreference": "central_office",
       "timezone": "America/Los_Angeles",
       "socOptIn": true
     }
@@ -32,38 +33,10 @@
     {
       "type": "contestableIssue",
       "attributes": {
-        "issue": "tinnitus - 10%",
-        "decisionDate": "2020-01-01",
-        "decisionIssueId": 1,
-        "ratingIssueReferenceId": "2",
-        "ratingDecisionReferenceId": "3"
-      }
-    },
-    {
-      "type": "contestableIssue",
-      "attributes": {
-        "issue": "left knee - 0%",
-        "decisionDate": "2020-01-02",
-        "decisionIssueId": 4,
-        "ratingIssueReferenceId": "5"
-      }
-    },
-    {
-      "type": "contestableIssue",
-      "attributes": {
         "issue": "right shoulder",
         "decisionDate": "2020-01-06"
       }
     }
   ],
-  "nodUploads": [
-    {
-      "name": "file-1.pdf",
-      "confirmationCode": "some-UUID"
-    },
-    {
-      "name": "file-2.png",
-      "confirmationCode": "another-UUID"
-    }
-  ]
+  "nodUploads": []
 }

--- a/src/applications/appeals/10182/tests/schema/submit-transformer.unit.spec.js
+++ b/src/applications/appeals/10182/tests/schema/submit-transformer.unit.spec.js
@@ -7,12 +7,22 @@ import { transform } from '../../config/submit-transformer';
 import maximalData from '../fixtures/data/maximal-test.json';
 import transformedMaximalData from '../fixtures/data/transformed-maximal-test.json';
 
+import minimalData from '../fixtures/data/minimal-test.json';
+import transformedMinimalData from '../fixtures/data/transformed-minimal-test.json';
+
 describe('transform', () => {
-  it('should transform maximal.json correctly', () => {
+  it('should transform maximal-test.json correctly', () => {
     const transformedResult = JSON.parse(transform(formConfig, maximalData));
     // copy over variables that change based on date & location
     transformedResult.data.attributes.timezone = 'America/Los_Angeles';
 
     expect(transformedResult).to.deep.equal(transformedMaximalData);
+  });
+  it('should transform minimal-test.json correctly', () => {
+    const transformedResult = JSON.parse(transform(formConfig, minimalData));
+    // copy over variables that change based on date & location
+    transformedResult.data.attributes.timezone = 'America/Los_Angeles';
+
+    expect(transformedResult).to.deep.equal(transformedMinimalData);
   });
 });

--- a/src/applications/appeals/10182/utils/submit.js
+++ b/src/applications/appeals/10182/utils/submit.js
@@ -6,10 +6,30 @@ import { isValidDate } from '../validations';
 /**
  * @typedef FormData
  * @type {Object<Object>}
- * @property {ContestableIssues}
- * @property {AdditionaIssues}
- * @property {Evidence}
- * @property {*} Unused properties
+ * @property {Veteran} veteran - data from prefill & profile
+ * @property {ContestableIssues} contestableIssues - issues loaded from API
+ * @property {AdditionaIssues} additionalIssues - issues entered by Veteran
+ * @property {Evidence} evidence - Evidence uploaded by Veteran
+ * @property {Boolean} homeless - homeless choice
+ * @property {Boolean} view:hasRep - Has a VSO choice
+ * @property {String} representativesName - Veteran entered VSO name
+ * @property {String} boardReviewOption - Veteran selected review option - enum
+ *   to "direct_review", "evidence_submission" or "hearing"
+ * @property {String} hearingTypePreference - Vetera selected hearing type -
+ *   enum to "virtual_hearing", "video_conference" or "central_office"
+ * @property {Boolean} socOptIn - check box indicating the Veteran has opted in
+ *   to the new appeal process
+ * @property {Boolean} view:additionalEvidence - Veteran choice to upload more
+ *   evidence
+ */
+/**
+ * @typedef Veteran
+ * @type {Object}
+ * @property {String} ssnLastFour - Last four of SSN from prefill
+ * @property {String} vaFileLastFour - Last four of VA file number from prefill
+ * @property {Object<String>} address - Veteran's home address from profile
+ * @property {Object<String>} phone - Veteran's home phone from profile
+ * @property {Object<String>} email - Veteran's email from profile
  */
 /**
  * @typedef ContestableIssues
@@ -136,7 +156,6 @@ export const getContestableIssues = ({ contestableIssues }) =>
     );
 
     return {
-      // type: "contestableIssues"
       type: issue.type,
       attributes,
     };
@@ -208,10 +227,12 @@ export const addIncludedIssues = formData =>
  * @returns {Evidence~Submittable[]}
  */
 export const addUploads = formData =>
-  formData.evidence.map(({ name, confirmationCode }) => ({
-    name,
-    confirmationCode,
-  }));
+  formData['view:additionalEvidence']
+    ? formData.evidence.map(({ name, confirmationCode }) => ({
+        name,
+        confirmationCode,
+      }))
+    : [];
 
 /**
  * Remove objects with empty string values; Lighthouse doesn't like `null`
@@ -225,12 +246,12 @@ export const removeEmptyEntries = object =>
   );
 
 /**
- * Veteran
- * @property {String} ssnLastFour
- * @property {String} vaFileLastFour
+ * Veteran~submittable
  * @property {Address~submittable} address
  * @property {Phone~submittable} phone
- * @property {String} email
+ * @property {String} emailAddressText
+ * @property {Boolean} homeless
+ * @property {String} representativesName
  */
 /**
  * Address~submittable
@@ -254,7 +275,7 @@ export const removeEmptyEntries = object =>
  */
 /**
  * Strip out extra profile home address data & rename zipCode to zipCode5
- * @param {Object} veteran - Veteran formData object
+ * @param {Veteran} veteran - Veteran formData object
  * @returns {Object} submittable address
  */
 export const getAddress = ({ veteran = {} } = {}) =>
@@ -271,7 +292,7 @@ export const getAddress = ({ veteran = {} } = {}) =>
 
 /**
  * Strip out extra profile phone data
- * @param {Object} veteran - Veteran formData object
+ * @param {Veteran} veteran - Veteran formData object
  * @returns {Object} submittable address
  */
 export const getPhone = ({ veteran = {} } = {}) =>
@@ -281,6 +302,16 @@ export const getPhone = ({ veteran = {} } = {}) =>
     phoneNumber: veteran.phone?.phoneNumber || '',
     phoneNumberExt: veteran.phone?.phoneNumberExt || '',
   });
+
+/**
+ * Get representative name entered by Veteran
+ * @param {FormData}
+ * @returns {String} Rep name with max length of 120 characters
+ */
+export const getRepName = formData =>
+  formData['view:hasRep']
+    ? (formData.representativesName || '').substring(0, 120)
+    : '';
 
 /**
  * Get user's current time zone


### PR DESCRIPTION
## Description

Lighthouse isn't accepting submissions that include a `hearingTypePreference` when the `boardReviewOption` is set to either `direct_review` or `evidence_submission`.

This PR removes the `hearingTypePreference` entry from submissions & adds a `minimal-test` json & transformed submission data for testing.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/23526

cc: @annaswims

## Testing done

Updated submit transformer test

## Screenshots

N/A

## Acceptance criteria
- [x] `hearingTypePreference` is only submitted with a `hearing` type board choice

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
