### PR TITLE
Run lint/security/unit checks while building

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,6 +29,10 @@ node('vetsgov-general-purpose') {
       parallel (
         failFast: true,
 
+        forceError: {
+          throw new Exception("Testing failFast")
+        },
+
         buildDev: {
           if (commonStages.shouldBail()) { return }
           envName = 'vagovdev'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,6 +32,10 @@ node('vetsgov-general-purpose') {
         buildDev: {
           if (commonStages.shouldBail()) { return }
           envName = 'vagovdev'
+          
+          shouldBuild = !contentOnlyBuild || envName == params.cmsEnvBuildOverride
+          if (!shouldBuild) { return }
+
           try {
             commonStages.build(ref, dockerContainer, assetSource, envName, false, contentOnlyBuild)
             envUsedCache[envName] = false
@@ -52,6 +56,10 @@ node('vetsgov-general-purpose') {
         buildStaging: {
           if (commonStages.shouldBail()) { return }
           envName = 'vagovstaging'
+
+          shouldBuild = !contentOnlyBuild || envName == params.cmsEnvBuildOverride
+          if (!shouldBuild) { return }
+
           try {
             commonStages.build(ref, dockerContainer, assetSource, envName, false, contentOnlyBuild)
             envUsedCache[envName] = false
@@ -72,6 +80,10 @@ node('vetsgov-general-purpose') {
         buildProd: {
           if (commonStages.shouldBail()) { return }
           envName = 'vagovprod'
+
+          shouldBuild = !contentOnlyBuild || envName == params.cmsEnvBuildOverride
+          if (!shouldBuild) { return }
+                    
           try {
             commonStages.build(ref, dockerContainer, assetSource, envName, false, contentOnlyBuild)
             envUsedCache[envName] = false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,6 @@ import org.kohsuke.github.GitHub
 
 env.CONCURRENCY = 10
 
-
 node('vetsgov-general-purpose') {
   properties([[$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', daysToKeepStr: '60']],
               parameters([choice(name: "cmsEnvBuildOverride",
@@ -17,18 +16,81 @@ node('vetsgov-general-purpose') {
   }
 
   def commonStages = load "vets-website/jenkins/common.groovy"
+  def envUsedCache = [:]
 
   // setupStage
   dockerContainer = commonStages.setup()
 
-  stage('Lint|Security|Unit') {
-    if (params.cmsEnvBuildOverride != 'none') { return }
+  stage('Main') {
+    def contentOnlyBuild = params.cmsEnvBuildOverride != 'none'
+    def assetSource = contentOnlyBuild ? ref : 'local'
 
     try {
       parallel (
         failFast: true,
 
+        buildDev: {
+          if (commonStages.shouldBail()) { return }
+          envName = 'vagovdev'
+          try {
+            commonStages.build(ref, dockerContainer, assetSource, envName, false, contentOnlyBuild)
+            envUsedCache[envName] = false
+          } catch (error) {
+            if (!contentOnlyBuild) {
+              dockerContainer.inside(DOCKER_ARGS) {
+                sh "cd /application && node script/drupal-aws-cache.js --fetch --buildtype=${envName}"
+              }
+              commonStages.build(ref, dockerContainer, assetSource, envName, true, contentOnlyBuild)
+              envUsedCache[envName] = true
+            } else {
+              commonStages.build(ref, dockerContainer, assetSource, envName, false, contentOnlyBuild)
+              envUsedCache[envName] = false
+            }
+          }
+        },
+
+        buildStaging: {
+          if (commonStages.shouldBail()) { return }
+          envName = 'vagovstaging'
+          try {
+            commonStages.build(ref, dockerContainer, assetSource, envName, false, contentOnlyBuild)
+            envUsedCache[envName] = false
+          } catch (error) {
+            if (!contentOnlyBuild) {
+              dockerContainer.inside(DOCKER_ARGS) {
+                sh "cd /application && node script/drupal-aws-cache.js --fetch --buildtype=${envName}"
+              }
+              commonStages.build(ref, dockerContainer, assetSource, envName, true, contentOnlyBuild)
+              envUsedCache[envName] = true
+            } else {
+              commonStages.build(ref, dockerContainer, assetSource, envName, false, contentOnlyBuild)
+              envUsedCache[envName] = false
+            }
+          }
+        },
+
+        buildProd: {
+          if (commonStages.shouldBail()) { return }
+          envName = 'vagovprod'
+          try {
+            commonStages.build(ref, dockerContainer, assetSource, envName, false, contentOnlyBuild)
+            envUsedCache[envName] = false
+          } catch (error) {
+            if (!contentOnlyBuild) {
+              dockerContainer.inside(DOCKER_ARGS) {
+                sh "cd /application && node script/drupal-aws-cache.js --fetch --buildtype=${envName}"
+              }
+              commonStages.build(ref, dockerContainer, assetSource, envName, true, contentOnlyBuild)
+              envUsedCache[envName] = true
+            } else {
+              commonStages.build(ref, dockerContainer, assetSource, envName, false, contentOnlyBuild)
+              envUsedCache[envName] = false
+            }
+          }
+        },
+
         lint: {
+          if (params.cmsEnvBuildOverride != 'none') { return }
           dockerContainer.inside(commonStages.DOCKER_ARGS) {
             sh "cd /application && npm --no-color run lint"
           }
@@ -36,6 +98,7 @@ node('vetsgov-general-purpose') {
 
         // Check package.json for known vulnerabilities
         security: {
+          if (params.cmsEnvBuildOverride != 'none') { return }
           retry(3) {
             dockerContainer.inside(commonStages.DOCKER_ARGS) {
               sh "cd /application && npm run security-check"
@@ -44,12 +107,14 @@ node('vetsgov-general-purpose') {
         },
 
         unit: {
+          if (params.cmsEnvBuildOverride != 'none') { return }
           dockerContainer.inside(commonStages.DOCKER_ARGS) {
             sh "/cc-test-reporter before-build"
             sh "cd /application && npm --no-color run test:unit -- --coverage"
             sh "cd /application && /cc-test-reporter after-build -r fe4a84c212da79d7bb849d877649138a9ff0dbbef98e7a84881c97e1659a2e24"
           }
-        }
+        },
+
       )
     } catch (error) {
       commonStages.slackNotify()
@@ -60,9 +125,6 @@ node('vetsgov-general-purpose') {
       }
     }
   }
-
-  // Perform a build for each build type
-  envsUsingDrupalCache = commonStages.buildAll(ref, dockerContainer, params.cmsEnvBuildOverride != 'none')
 
   // Run E2E tests
   stage('Integration') {
@@ -112,6 +174,8 @@ node('vetsgov-general-purpose') {
   commonStages.prearchiveAll(dockerContainer)
 
   commonStages.archiveAll(dockerContainer, ref);
+  
+  envsUsingDrupalCache = envUsedCache
   commonStages.cacheDrupalContent(dockerContainer, envsUsingDrupalCache);
 
   stage('Review') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,10 +29,6 @@ node('vetsgov-general-purpose') {
       parallel (
         failFast: true,
 
-        forceError: {
-          throw new Exception("Testing failFast")
-        },
-
         buildDev: {
           if (commonStages.shouldBail()) { return }
           envName = 'vagovdev'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,14 +24,13 @@ node('vetsgov-general-purpose') {
   stage('Main') {
     def contentOnlyBuild = params.cmsEnvBuildOverride != 'none'
     def assetSource = contentOnlyBuild ? ref : 'local'
-    def shouldNotBuild = contentOnlyBuild && envName == params.cmsEnvBuildOverride
 
     try {
       parallel (
         failFast: true,
 
         buildDev: {
-          if (commonStages.shouldBail() || shouldNotBuild) { return }
+          if (commonStages.shouldBail()) { return }
           envName = 'vagovdev'
           try {
             commonStages.build(ref, dockerContainer, assetSource, envName, false, contentOnlyBuild)
@@ -51,7 +50,7 @@ node('vetsgov-general-purpose') {
         },
 
         buildStaging: {
-          if (commonStages.shouldBail() || shouldNotBuild) { return }
+          if (commonStages.shouldBail()) { return }
           envName = 'vagovstaging'
           try {
             commonStages.build(ref, dockerContainer, assetSource, envName, false, contentOnlyBuild)
@@ -71,7 +70,7 @@ node('vetsgov-general-purpose') {
         },
 
         buildProd: {
-          if (commonStages.shouldBail() || shouldNotBuild) { return }
+          if (commonStages.shouldBail()) { return }
           envName = 'vagovprod'
           try {
             commonStages.build(ref, dockerContainer, assetSource, envName, false, contentOnlyBuild)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,13 +24,14 @@ node('vetsgov-general-purpose') {
   stage('Main') {
     def contentOnlyBuild = params.cmsEnvBuildOverride != 'none'
     def assetSource = contentOnlyBuild ? ref : 'local'
+    def shouldNotBuild = contentOnlyBuild && envName == params.cmsEnvBuildOverride
 
     try {
       parallel (
         failFast: true,
 
         buildDev: {
-          if (commonStages.shouldBail()) { return }
+          if (commonStages.shouldBail() || shouldNotBuild) { return }
           envName = 'vagovdev'
           try {
             commonStages.build(ref, dockerContainer, assetSource, envName, false, contentOnlyBuild)
@@ -50,7 +51,7 @@ node('vetsgov-general-purpose') {
         },
 
         buildStaging: {
-          if (commonStages.shouldBail()) { return }
+          if (commonStages.shouldBail() || shouldNotBuild) { return }
           envName = 'vagovstaging'
           try {
             commonStages.build(ref, dockerContainer, assetSource, envName, false, contentOnlyBuild)
@@ -70,7 +71,7 @@ node('vetsgov-general-purpose') {
         },
 
         buildProd: {
-          if (commonStages.shouldBail()) { return }
+          if (commonStages.shouldBail() || shouldNotBuild) { return }
           envName = 'vagovprod'
           try {
             commonStages.build(ref, dockerContainer, assetSource, envName, false, contentOnlyBuild)


### PR DESCRIPTION
## Description

Run the lint, security, and unit checks while building

## Links

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/22054
- [Thread in #vsp-tools-fe](https://dsva.slack.com/archives/CQH357ZTP/p1619565737196800)

## Testing done

CI

## Screenshots

### `failFast`

As an experiment, I added another parallel step (`forceError`) to test the `failFast` behavior in 38d19d7261f44a0a0b857d679ccc6f2854861823, and it did prevent the other steps from running. 

![image](https://user-images.githubusercontent.com/6130520/116420747-e11bdd00-a803-11eb-8de1-063e60feac49.png)

### [Before](http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fvets-website/detail/master/11000/pipeline) (57:27)

![image](https://user-images.githubusercontent.com/6130520/116323625-07019d00-a784-11eb-8f34-2d7f1a495a66.png)

### [After](http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fvets-website/detail/lint-while-building/14/pipeline/) (46:52)

![image](https://user-images.githubusercontent.com/6130520/116323599-f5b89080-a783-11eb-9524-fc371046ac79.png)


## Acceptance criteria
- [x] The pipeline takes less time than it did when the `Lint|Security|Unit` happened before the `Build` stage

## Definition of done
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
