### PR TITLE
updated vbbp link

### DIFF
--- a/src/applications/edu-benefits/1990s/content/directDeposit.jsx
+++ b/src/applications/edu-benefits/1990s/content/directDeposit.jsx
@@ -17,13 +17,13 @@ export const directDepositAlert = () => (
 export const bankInfoHelpText = (
   <AdditionalInfo triggerText="What if I don’t have a bank account?">
     <p>
-      The Veterans{' '}
+      The{' '}
       <a
         href="https://veteransbenefitsbanking.org/"
         target="_blank"
         rel="noreferrer"
       >
-        Benefits Banking Program (VBBP)
+        Veterans Benefits Banking Program (VBBP)
       </a>{' '}
       provides a list of Veteran-friendly banks and credit unions. They’ll work
       with you to set up an account, or help you qualify for an account, so you


### PR DESCRIPTION
## Description
While filling out the VRRAP (1990s) form, the user is asked for bank account information. Under these fields is a helper text section that can be expanded by clicking "What if I don’t have a bank account?". Contained within that helper text is a link to https://veteransbenefitsbanking.org/. The link functions correctly, however, not all of the words that should be part of the link currently are.
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/23875
## Testing done
local

## Screenshots
![image](https://user-images.githubusercontent.com/50601724/116296628-6f428580-a768-11eb-9ccd-34d921f95463.png)


## Acceptance criteria
- [x]  `Veterans Benefits Banking Program` fully included in link 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
