### PR TITLE
Tweak tags styling

### DIFF
--- a/src/site/includes/tags.drupal.liquid
+++ b/src/site/includes/tags.drupal.liquid
@@ -3,7 +3,7 @@
     class="vads-u-padding-x--1 large-screen:vads-u-padding-x--0"
     data-template="includes/tags">
     <div
-      class="vads-u-padding-top--3 vads-u-padding-bottom--1 vads-u-border-top--1px vads-u-border-bottom--1px vads-u-border-color--gray-light vads-u-display--flex vads-u-align-items--flex-start vads-u-flex-direction--row">
+      class="vads-u-padding-top--3 vads-u-padding-bottom--1p5 vads-u-border-top--1px vads-u-border-bottom--1px vads-u-border-color--gray-light vads-u-display--flex vads-u-align-items--flex-start vads-u-flex-direction--row">
       <!-- Title -->
       <strong class="vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0">Tags</strong>
 

--- a/src/site/includes/tags.drupal.liquid
+++ b/src/site/includes/tags.drupal.liquid
@@ -1,25 +1,25 @@
 {% if fieldTags.entity != empty %}
-<div
-  class="vads-u-border-top--1px vads-u-border-bottom--1px vads-u-border-color--gray-light vads-u-padding-top--3 vads-u-padding-bottom--1 medium-screen:vads-u-padding-bottom--3"
-  data-template="includes/tags">
   <div
-    class="vads-u-display--flex vads-u-align-items--flex-start medium-screen:vads-u-align-items--center vads-u-flex-direction--row vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
-    <!-- Title -->
-    <strong class="vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0">Tags</strong>
+    class="vads-u-padding-x--1 large-screen:vads-u-padding-x--0"
+    data-template="includes/tags">
+    <div
+      class="vads-u-padding-top--3 vads-u-padding-bottom--1 vads-u-border-top--1px vads-u-border-bottom--1px vads-u-border-color--gray-light vads-u-display--flex vads-u-align-items--flex-start vads-u-flex-direction--row">
+      <!-- Title -->
+      <strong class="vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0">Tags</strong>
 
-    <!-- Topic tags -->
-    <div class="vads-u-display--flex vads-u-flex-wrap--wrap">
-      {% assign tags = fieldTags | getTagsList %}
+      <!-- Topic tags -->
+      <div class="vads-u-display--flex vads-u-flex-wrap--wrap">
+        {% assign tags = fieldTags | getTagsList %}
 
-      {% for entity in tags %}
-        <a href="{{ entity.entityUrl.path }}"
-          class="vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0 usa-button-secondary vads-u-font-size--sm vads-u-border--1px vads-u-border-color--primary vads-u-padding--0p25 vads-u-padding-x--0p5 vads-u-margin-left--1 vads-u-text-decoration--none vads-u-color--base"
-          style="border-radius: 3px;"
-          onclick="recordEvent({ 'event': 'nav-page-tag-click', 'page-tag-click-label': '{{ entity.name }}', 'page-tag-category-label': '{{  entity.categoryLabel  }}' });">
-          {{ entity.name }}
-        </a>
-      {% endfor %}
+        {% for entity in tags %}
+          <a href="{{ entity.entityUrl.path }}"
+            class="vads-u-margin-bottom--1p5 usa-button-secondary vads-u-font-size--sm vads-u-border--1px vads-u-border-color--primary vads-u-padding--0p25 vads-u-padding-x--0p5 vads-u-margin-left--1p5 vads-u-text-decoration--none vads-u-color--base"
+            style="border-radius: 3px; line-height: 1.3;"
+            onclick="recordEvent({ 'event': 'nav-page-tag-click', 'page-tag-click-label': '{{ entity.name }}', 'page-tag-category-label': '{{  entity.categoryLabel  }}' });">
+            {{ entity.name }}
+          </a>
+        {% endfor %}
+      </div>
     </div>
   </div>
-</div>
 {% endif %}


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/22226

This PR does the following to the R&S tags component:

 Decrease the line height of the type (not the height of the tag-shape) so if/when type has to run onto two or more lines, it minimized the height.
 Ensure the spacing between the tags is always equal both vertically and horizontally. i've used 12 px (1.5 spacing units) in sketch but we can adjust as needed
 Adjust horizontal rules above and bellow the tags section to follow the margins of the rest of the page

## Testing done
Locally

## Screenshots
### Mobile

![image](https://user-images.githubusercontent.com/12773166/116426625-846af300-a800-11eb-96a5-9d4af9378945.png)

![image](https://user-images.githubusercontent.com/12773166/116426771-a2d0ee80-a800-11eb-9aaf-d43bfd42b5c3.png)

### Desktop

![image](https://user-images.githubusercontent.com/12773166/116426668-8b920100-a800-11eb-8500-555f41790877.png)

![image](https://user-images.githubusercontent.com/12773166/116426846-b3816480-a800-11eb-9fc9-3c89e21b92ad.png)


## Acceptance criteria
- [x] Decrease the line height of the type (not the height of the tag-shape) so if/when type has to run onto two or more lines, it minimized the height.
- [x] Ensure the spacing between the tags is always equal both vertically and horizontally. i've used 12 px (1.5 spacing units) in sketch but we can adjust as needed
- [x] Adjust horizontal rules above and bellow the tags section to follow the margins of the rest of the page

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
