### PR TITLE
Updated commit hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -365,7 +365,7 @@
     "url-search-params-polyfill": "^8.1.0",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#d95fd3fdb480cc12aeb8b8b16b8f5b84e054e31c",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#4089b6b4390f05738e0dcef402c56978565a626c",
     "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.4.0",
     "whatwg-fetch": "^2.0.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -19777,9 +19777,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#d95fd3fdb480cc12aeb8b8b16b8f5b84e054e31c":
-  version "20.3.2"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#d95fd3fdb480cc12aeb8b8b16b8f5b84e054e31c"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#4089b6b4390f05738e0dcef402c56978565a626c":
+  version "20.3.3"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#4089b6b4390f05738e0dcef402c56978565a626c"
 
 vinyl-file@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/22512)

When we initially set up the document type select box for some 686c workflows we set them up with placeholder values because we had not gotten the actual values from the stakeholders. Now that we have those values this PR updates the commit hash on vet-json-schema to the real values. There is a corresponding PR that has already been merged into vets-json-schema.

## Screenshots

<img width="647" alt="Screen Shot 2021-04-27 at 1 42 16 PM" src="https://user-images.githubusercontent.com/1899695/116310218-91370a80-a75e-11eb-8164-40b7e6b369a3.png">

<img width="585" alt="Screen Shot 2021-04-27 at 1 43 23 PM" src="https://user-images.githubusercontent.com/1899695/116310250-98f6af00-a75e-11eb-88cb-6d74a0320338.png">

## Acceptance criteria
- [x] Values are in place on the frontend
- [x] Numeric values are passed to BE
- [x] A PR has been requested for merging

