### PR TITLE
Update "additional info"s on Profile

### DIFF
--- a/src/applications/personalization/profile/components/personal-information/ContactInformationSection.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationSection.jsx
@@ -8,18 +8,42 @@ import PhoneNumbersTable from './phone-numbers/PhoneNumbersTable';
 
 const ContactInformationSection = ({ className }) => (
   <div className={className}>
+    <div className="vads-u-margin-bottom--2">
+      <AdditionalInfo triggerText="Which benefits and services does VA use this contact information for?">
+        <p className="vads-u-margin-y--1">
+          We use this information to contact you about these VA benefits and
+          services:
+        </p>
+        <ul>
+          <li>Disability compensation</li>
+          <li>Pension benefits</li>
+          <li>Claims and appeals</li>
+          <li>Veteran Readiness and Employment (VR&E)</li>
+        </ul>
+        <p>
+          If you’re enrolled in VA health care, we also use this information to
+          send you these:
+        </p>
+        <ul>
+          <li>Appointment reminders</li>
+          <li>Communications from your VA medical center</li>
+          <li>Lab and test results</li>
+          <li>
+            Prescription medicines (we send your medicines to your mailing
+            address)
+          </li>
+        </ul>
+        <p>
+          <a href="/resources/change-your-address-on-file-with-va/#change-your-address-by-contact">
+            Find out how to change your contact information for other VA
+            benefits{' '}
+          </a>
+        </p>
+      </AdditionalInfo>
+    </div>
     <AddressesTable className="vads-u-margin-bottom--6" />
 
     <PhoneNumbersTable className="vads-u-margin-bottom--3" />
-
-    {/* more info component for contact info */}
-    <AdditionalInfo triggerText="How will you use my contact information?">
-      We’ll use this information to contact you about certain benefits and
-      services, like disability compensation, pension benefits, and claims and
-      appeals. If you’re enrolled in VA health care, we’ll send your
-      prescriptions to your mailing address. Your health care team may also use
-      this information to contact you.
-    </AdditionalInfo>
   </div>
 );
 

--- a/src/applications/personalization/profile/components/personal-information/GenderAndDOBSection.jsx
+++ b/src/applications/personalization/profile/components/personal-information/GenderAndDOBSection.jsx
@@ -20,6 +20,30 @@ const renderDOB = dob => (dob ? moment(dob).format('LL') : notSetText);
 
 const GenderAndDOBSection = ({ gender, dob, className }) => (
   <div className={className}>
+    <div className="vads-u-margin-bottom--2">
+      <AdditionalInfo triggerText="How do I update my personal information?">
+        <h2 className="vads-u-font-size--h5 vads-u-margin-top--3">
+          If you’re enrolled in the VA health care program
+        </h2>
+        <p className="vads-u-margin-y--1">
+          Please contact your nearest VA medical center to update your personal
+          information.
+        </p>
+        <a href="/find-locations/?facilityType=health">
+          Find your nearest VA medical center{' '}
+        </a>
+        <h2 className="vads-u-font-size--h5 vads-u-margin-top--3 vads-u-margin-bottom--1">
+          If you receive VA benefits, but aren’t enrolled in VA health care
+        </h2>
+        <p className="vads-u-margin-y--1">
+          Please contact your nearest VA regional office to update your personal
+          information
+        </p>
+        <a href="/find-locations/?facilityType=benefits">
+          Find your nearest VA regional office
+        </a>
+      </AdditionalInfo>
+    </div>
     <ProfileInfoTable
       title="Personal information"
       data={[
@@ -28,29 +52,6 @@ const GenderAndDOBSection = ({ gender, dob, className }) => (
       ]}
       className="vads-u-margin-bottom--3"
     />
-
-    <AdditionalInfo triggerText="How do I update my personal information?">
-      <h4 className="vads-u-font-size--h5 vads-u-margin-top--3">
-        If you’re enrolled in the VA health care program
-      </h4>
-      <p className="vads-u-margin-y--1">
-        Please contact your nearest VA medical center to update your personal
-        information.
-      </p>
-      <a href="https://va.gov/find-locations/?facilityType=health">
-        Find your nearest VA medical center{' '}
-      </a>
-      <h4 className="vads-u-font-size--h5 vads-u-margin-top--3 vads-u-margin-bottom--1">
-        If you receive VA benefits, but aren’t enrolled in VA health care
-      </h4>
-      <p className="vads-u-margin-y--1">
-        Please contact your nearest VA regional office to update your personal
-        information
-      </p>
-      <a href="https://va.gov/find-locations/?facilityType=benefits">
-        Find your nearest VA regional office
-      </a>
-    </AdditionalInfo>
   </div>
 );
 


### PR DESCRIPTION
## Description
Updates and rearranges the "additional info" components on the Profile

## Testing done
Local

## Screenshots
<details>
  <summary>Closed</summary>
  
<img width="688" alt="Screen Shot 2021-04-27 at 4 51 50 PM" src="https://user-images.githubusercontent.com/20728956/116327398-8c348400-a77b-11eb-929c-cb020a6815fc.png">

</details>

<details>
  <summary>"How do I update..." expanded</summary>
  
<img width="688" alt="Screen Shot 2021-04-27 at 4 52 04 PM" src="https://user-images.githubusercontent.com/20728956/116327438-9d7d9080-a77b-11eb-8855-0d5b64aafadf.png">

</details>

<details>
  <summary>"Which benefits and services..." expanded</summary>
  
<img width="688" alt="Screen Shot 2021-04-27 at 4 52 28 PM" src="https://user-images.githubusercontent.com/20728956/116327461-aa9a7f80-a77b-11eb-87d1-d4e6defbdc59.png">

</details>

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs