### PR TITLE
Possible fix for sentry error "Cannot call method addEventListener of null"

### DIFF
--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -91,7 +91,9 @@ export class Main extends React.Component {
     const triggers = Array.from(
       document.querySelectorAll('.signin-signup-modal-trigger'),
     );
-    triggers.forEach(t => t.addEventListener('click', this.openLoginModal));
+    triggers.forEach(t => {
+      if (t) t.addEventListener('click', this.openLoginModal);
+    });
   };
 
   bindNavbarLinks = () => {


### PR DESCRIPTION
The Facilities team has been tracking this [Sentry error,](http://sentry.vfs.va.gov/organizations/vsp/issues/29941/) which has occurred over 5,000 times in production in the last 90 days.

Our best guess is that this is happening when the `bindModalTriggers` function is called to set up the signin/signup modal button before the button has rendered. We haven't been able to reproduce the error yet, but we are hoping this change will fix it.

See Slack [thread](https://dsva.slack.com/archives/CQH357ZTP/p1619204082170400).