### PR TITLE
Custom checkbox values in review

### DIFF
--- a/src/platform/forms-system/src/js/review/widgets.jsx
+++ b/src/platform/forms-system/src/js/review/widgets.jsx
@@ -39,6 +39,10 @@ export const yesNo = ({ value, options = {} }) => {
   return <span>{displayValue}</span>;
 };
 
-export const CheckboxWidget = ({ value }) => (
-  <span>{value === true ? 'Selected' : ''}</span>
+export const CheckboxWidget = ({ value, schema = {} }) => (
+  <span>
+    {value === true
+      ? schema.enumNames?.[0] || 'Selected'
+      : schema.enumNames?.[1] || ''}
+  </span>
 );

--- a/src/platform/forms-system/test/js/review/widgets.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/widgets.unit.spec.jsx
@@ -22,6 +22,20 @@ describe('Schemaform review widgets', () => {
 
       expect(tree.text()).to.equal('');
     });
+    it('should render custom value for true', () => {
+      const tree = SkinDeep.shallowRender(
+        <CheckboxWidget value schema={{ enumNames: ['Yes!'] }} />,
+      );
+
+      expect(tree.text()).to.equal('Yes!');
+    });
+    it('should render custom value for false', () => {
+      const tree = SkinDeep.shallowRender(
+        <CheckboxWidget schema={{ enumNames: ['Yes', 'Nope'] }} />,
+      );
+
+      expect(tree.text()).to.equal('Nope');
+    });
   });
   describe('<TextWidget>', () => {
     it('should render', () => {


### PR DESCRIPTION
## Description

Checkbox values on the review and submit page currently show a checked value of "Selected" and an empty string for unchecked values. This PR adds a method to allow customizing the values using the schema `enumNames` setting.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/23526

## Testing done

Updated unit test

## Screenshots

<details><summary>Before</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-04-28 at 9 21 41 AM](https://user-images.githubusercontent.com/136959/116422399-50460100-a805-11eb-9a3e-8a5efb12e6c1.png)</details>

<details><summary>After</summary>

<!-- leave a blank line above -->

```js
optIn: {
  type: 'boolean',
  enumNames: ['Yes', 'No'],
},
```

![Screen Shot 2021-04-28 at 9 19 55 AM](https://user-images.githubusercontent.com/136959/116422438-5dfb8680-a805-11eb-9097-7aff918b23fe.png)
</details>


## Acceptance criteria
- [x] Checkbox values on the review & submit page are customizable

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
