### PR TITLE
Kelsonic 22196 part 1 merge exp sorting to prod

### DIFF
--- a/src/applications/resources-and-support/hooks/useGetSearchResults.js
+++ b/src/applications/resources-and-support/hooks/useGetSearchResults.js
@@ -117,31 +117,20 @@ export default function useGetSearchResults(articles, query, page) {
         };
       });
 
-      if (environment.isProduction()) {
-        // Sort first by query word instances found in title descending
-        // Sort ties then by query word instances found in introText descending
-        // Sort ties then by alphabetical descending
-        orderedResults = orderBy(
-          filteredArticles,
-          ['keywordsCountsTitle', 'keywordsCountsIntroText', 'title'],
-          ['desc', 'desc', 'asc'],
-        );
-      } else {
-        // Sort first by the number of exact query matches (ignoring casing) in the title and introText
-        // Sort ties by query word instances found in title descending
-        // Sort ties then by query word instances found in searchableContent descending
-        // Sort ties then by alphabetical descending
-        orderedResults = orderBy(
-          filteredArticles,
-          [
-            'wholePhraseMatchCountsTotal',
-            'keywordsCountsTitle',
-            'keywordsCountsContent',
-            'title',
-          ],
-          ['desc', 'desc', 'desc', 'asc'],
-        );
-      }
+      // Sort first by the number of exact query matches (ignoring casing) in the title, introText, and searchableContent descending
+      // Sort ties by query word instances found in title descending
+      // Sort ties then by query word instances found in searchableContent descending
+      // Sort ties then by alphabetical descending
+      orderedResults = orderBy(
+        filteredArticles,
+        [
+          'wholePhraseMatchCountsTotal',
+          'keywordsCountsTitle',
+          'keywordsCountsContent',
+          'title',
+        ],
+        ['desc', 'desc', 'desc', 'asc'],
+      );
       // =====
       // End of ordering logic.
 

--- a/src/applications/resources-and-support/hooks/useGetSearchResults.js
+++ b/src/applications/resources-and-support/hooks/useGetSearchResults.js
@@ -40,10 +40,10 @@ export default function useGetSearchResults(articles, query, page) {
         });
 
       let filteredArticles = articles.filter(article => {
-        const articleTitleKeywords = article.title.toLowerCase().split(' ');
+        const articleTitleWords = article.title.toLowerCase().split(' ');
 
         return keywords.some(keyword => {
-          return articleTitleKeywords.some(titleWord =>
+          return articleTitleWords.some(titleWord =>
             titleWord.startsWith(keyword),
           );
         });

--- a/src/applications/resources-and-support/hooks/useGetSearchResults.js
+++ b/src/applications/resources-and-support/hooks/useGetSearchResults.js
@@ -2,7 +2,6 @@
 import { useEffect, useState } from 'react';
 import { orderBy } from 'lodash';
 // Relative imports.
-import environment from 'platform/utilities/environment';
 import recordEvent from 'platform/monitoring/record-event';
 import { SEARCH_IGNORE_LIST } from '../constants';
 


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/22196

This PR moves the [experimental sorting logic](https://github.com/department-of-veterans-affairs/vets-website/blob/e5328976f93cd323a73a19af390e1847e4cd67a2/src/applications/resources-and-support/hooks/useGetSearchResults.js) to production for R&S search.

## Testing done
Locally

## Screenshots
N/A

## Acceptance criteria
- [x] moves the [experimental sorting logic](https://github.com/department-of-veterans-affairs/vets-website/blob/e5328976f93cd323a73a19af390e1847e4cd67a2/src/applications/resources-and-support/hooks/useGetSearchResults.js) to production for R&S search.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
