### PR TITLE
Add missing prop to video visit component phone number

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoVisitSection.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoVisitSection.jsx
@@ -146,7 +146,7 @@ export default function VideoVisitLocation({ header, appointment, facility }) {
                 {phone && (
                   <>
                     <br />
-                    <FacilityPhone contact={phone} />
+                    <FacilityPhone contact={phone} level={3} />
                   </>
                 )}
               </span>


### PR DESCRIPTION
## Description

This PR adds a missing prop in the `VideoVisitSection` component.

## Testing done

- local, unit testing

## Screenshots
N/A

## Acceptance criteria
- [x] no missing prop error in console

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
