### PR TITLE
Remove support for audience tags in clp

### DIFF
--- a/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeCampaignLandingPage.graphql.js
@@ -42,9 +42,6 @@ const nodeCampaignLandingPage = `
         entityType
         entityBundle
         entityId
-        ... on TaxonomyTermAudienceTags {
-          name
-        }
         ... on TaxonomyTermAudienceBeneficiaries {
           name
         }


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/23990

This PR removes support for `audience_tags` in CLPs.

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Remove support for `audience_tags` in CLPs.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
