### PR TITLE
23690 Move mock data into individual tests

### DIFF
--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
@@ -36,69 +36,10 @@ const initialState = {
   },
 };
 
-const appointment = getVAAppointmentMock();
-appointment.attributes = {
-  ...appointment.attributes,
-  clinicId: '308',
-  clinicFriendlyName: "Jennie's Lab",
-  facilityId: '983',
-  sta6aid: '983GC',
-  communityCare: false,
-  vdsAppointments: [
-    {
-      bookingNote: 'New issue: ASAP',
-      appointmentLength: '60',
-      appointmentTime: '2021-12-07T16:00:00Z',
-      clinic: {
-        name: 'CHY OPT VAR1',
-        askForCheckIn: false,
-        facilityCode: '983',
-      },
-      type: 'REGULAR',
-      currentStatus: 'FUTURE',
-    },
-  ],
-  vvsAppointments: [],
-};
-
-const facility = {
-  id: 'vha_442GC',
-  attributes: {
-    ...getVAFacilityMock().attributes,
-    type: 'facility',
-    address: {
-      mailing: {},
-      physical: {
-        zip: '80526-8108',
-        city: 'Fort Collins',
-        state: 'CO',
-        address1: '2509 Research Boulevard',
-        address2: null,
-        address3: null,
-      },
-    },
-    id: 'vha_442GC',
-    name: 'Fort Collins VA Clinic',
-    phone: {
-      main: '970-224-1550',
-    },
-    uniqueId: '442GC',
-  },
-};
-
 describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
   beforeEach(() => {
     mockFetch();
     MockDate.set(getTimezoneTestDate());
-    appointment.attributes.startDate = moment();
-    mockAppointmentInfo({
-      va: [appointment],
-      cc: [],
-      requests: [],
-      isHomepageRefresh: true,
-    });
-
-    mockFacilitiesFetch('vha_442GC', [facility]);
   });
   afterEach(() => {
     resetFetch();
@@ -107,10 +48,41 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
 
   it('should show confirmed appointments detail page', async () => {
     const url = '/va/21cdc6741c00ac67b6cbf6b972d084c1';
+
+    const appointment = getVAAppointmentMock();
+    appointment.attributes = {
+      ...appointment.attributes,
+      clinicId: '308',
+      clinicFriendlyName: "Jennie's Lab",
+      facilityId: '983',
+      sta6aid: '983GC',
+      vdsAppointments: [
+        {
+          bookingNote: 'New issue: ASAP',
+        },
+      ],
+    };
+
+    mockAppointmentInfo({
+      va: [appointment],
+      isHomepageRefresh: true,
+    });
+
     mockSingleAppointmentFetch({
       appointment,
-      type: 'va',
     });
+
+    const facility = {
+      id: 'vha_442GC',
+      attributes: {
+        ...getVAFacilityMock().attributes,
+        uniqueId: '442GC',
+        name: 'Fort Collins VA Clinic',
+        phone: {
+          main: '970-224-1550',
+        },
+      },
+    };
 
     mockFacilityFetch('vha_442GC', facility);
     const screen = renderWithStoreAndRouter(<AppointmentList />, {
@@ -201,6 +173,39 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
 
   it('should allow cancellation', async () => {
     const url = '/va/21cdc6741c00ac67b6cbf6b972d084c1';
+
+    const appointment = getVAAppointmentMock();
+    appointment.attributes = {
+      ...appointment.attributes,
+      clinicId: '308',
+      facilityId: '983',
+      sta6aid: '983GC',
+      startDate: moment(),
+      vdsAppointments: [
+        {
+          clinic: {
+            name: 'CHY OPT VAR1',
+          },
+        },
+      ],
+    };
+
+    mockAppointmentInfo({
+      va: [appointment],
+      isHomepageRefresh: true,
+    });
+
+    const facility = {
+      id: 'vha_442GC',
+      attributes: {
+        ...getVAFacilityMock().attributes,
+        uniqueId: '442GC',
+        name: 'Fort Collins VA Clinic',
+      },
+    };
+
+    mockFacilitiesFetch('vha_442GC', [facility]);
+
     const cancelReason = getCancelReasonMock();
     cancelReason.attributes = {
       ...cancelReason.attributes,
@@ -277,14 +282,32 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
 
   it('should display who canceled the appointment', async () => {
     const url = '/va/21cdc6741c00ac67b6cbf6b972d084c1';
-    const canceledAppointment = JSON.parse(JSON.stringify(appointment));
-    canceledAppointment.attributes.vdsAppointments[0].currentStatus =
-      'CANCELLED BY CLINIC';
+
+    const appointment = getVAAppointmentMock();
+    appointment.attributes = {
+      ...appointment.attributes,
+      clinicId: '308',
+      facilityId: '983',
+      sta6aid: '983GC',
+      vdsAppointments: [
+        {
+          currentStatus: 'CANCELLED BY CLINIC',
+        },
+      ],
+    };
 
     mockSingleAppointmentFetch({
-      appointment: canceledAppointment,
-      type: 'va',
+      appointment,
     });
+
+    const facility = {
+      id: 'vha_442GC',
+      attributes: {
+        ...getVAFacilityMock().attributes,
+        uniqueId: '442GC',
+        name: 'Fort Collins VA Clinic',
+      },
+    };
 
     mockFacilityFetch('vha_442GC', facility);
 
@@ -307,6 +330,34 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
 
   it('should fire a print request when print button clicked', async () => {
     const url = '/va/21cdc6741c00ac67b6cbf6b972d084c1';
+
+    const appointment = getVAAppointmentMock();
+    appointment.attributes = {
+      ...appointment.attributes,
+      clinicId: '308',
+      facilityId: '983',
+      sta6aid: '983GC',
+    };
+
+    mockAppointmentInfo({
+      va: [appointment],
+      isHomepageRefresh: true,
+    });
+
+    mockSingleAppointmentFetch({
+      appointment,
+    });
+
+    const facility = {
+      id: 'vha_442GC',
+      attributes: {
+        ...getVAFacilityMock().attributes,
+        uniqueId: '442GC',
+        name: 'Fort Collins VA Clinic',
+      },
+    };
+
+    mockFacilityFetch('vha_442GC', facility);
 
     const screen = renderWithStoreAndRouter(
       <AppointmentList featureHomepageRefresh />,
@@ -351,9 +402,11 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
 
   it('should show error message when single fetch errors', async () => {
     const url = '/va/21cdc6741c00ac67b6cbf6b972d084c1';
+
+    const appointment = getVAAppointmentMock();
+
     mockSingleAppointmentFetch({
       appointment,
-      type: 'va',
       error: true,
     });
 

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
@@ -27,85 +27,6 @@ import {
 
 const testDate = getTimezoneTestDate();
 
-const appointment = getVARequestMock();
-appointment.attributes = {
-  ...appointment.attributes,
-  typeOfCareId: '323',
-  status: 'Submitted',
-  appointmentType: 'Primary care',
-  optionDate1: moment(testDate)
-    .add(3, 'days')
-    .format('MM/DD/YYYY'),
-  optionTime1: 'AM',
-  optionDate2: moment(testDate)
-    .add(4, 'days')
-    .format('MM/DD/YYYY'),
-  optionTime2: 'AM',
-  optionDate3: moment(testDate)
-    .add(5, 'days')
-    .format('MM/DD/YYYY'),
-  optionTime3: 'PM',
-  facility: {
-    ...getVARequestMock().attributes.facility,
-    facilityCode: '983GC',
-  },
-  bestTimetoCall: ['Morning'],
-  purposeOfVisit: 'New Issue',
-  email: 'patient.test@va.gov',
-  phoneNumber: '(703) 652-0000',
-  friendlyLocationName: 'Some facility name',
-};
-
-appointment.id = '1234';
-
-const ccAppointmentRequest = getCCRequestMock();
-ccAppointmentRequest.attributes = {
-  ...ccAppointmentRequest.attributes,
-  appointmentType: 'Audiology (hearing aid support)',
-  bestTimetoCall: ['Morning'],
-
-  ccAppointmentRequest: {
-    preferredProviders: [
-      {
-        address: {
-          city: 'Orlando',
-          state: 'FL',
-          street: '123 Main Street',
-          zipCode: '32826',
-        },
-        practiceName: 'Atlantic Medical Care',
-      },
-    ],
-  },
-
-  email: 'joe.blow@va.gov',
-  optionDate1: '02/21/2020',
-  optionTime1: 'AM',
-  purposeOfVisit: 'routine-follow-up',
-  typeOfCareId: 'CCAUDHEAR',
-};
-
-ccAppointmentRequest.id = '1234';
-
-const facility = getVAFacilityMock();
-facility.attributes = {
-  ...facility.attributes,
-  id: 'vha_442GC',
-  uniqueId: '442GC',
-  name: 'Cheyenne VA Medical Center',
-  address: {
-    physical: {
-      zip: '82001-5356',
-      city: 'Cheyenne',
-      state: 'WY',
-      address1: '2360 East Pershing Boulevard',
-    },
-  },
-  phone: {
-    main: '307-778-7550',
-  },
-};
-
 const initialState = {
   featureToggles: {
     vaOnlineSchedulingHomepageRefresh: true,
@@ -124,7 +45,56 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
   });
 
   it('should render VA request details', async () => {
+    const appointment = getVARequestMock();
+    appointment.id = '1234';
+    appointment.attributes = {
+      ...appointment.attributes,
+      typeOfCareId: '323',
+      status: 'Submitted',
+      appointmentType: 'Primary care',
+      optionDate1: moment(testDate)
+        .add(3, 'days')
+        .format('MM/DD/YYYY'),
+      optionTime1: 'AM',
+      optionDate2: moment(testDate)
+        .add(4, 'days')
+        .format('MM/DD/YYYY'),
+      optionTime2: 'AM',
+      optionDate3: moment(testDate)
+        .add(5, 'days')
+        .format('MM/DD/YYYY'),
+      optionTime3: 'PM',
+      facility: {
+        ...getVARequestMock().attributes.facility,
+        facilityCode: '983GC',
+      },
+      bestTimetoCall: ['Morning'],
+      purposeOfVisit: 'New Issue',
+      email: 'patient.test@va.gov',
+      phoneNumber: '(703) 652-0000',
+    };
+
     mockSingleRequestFetch({ request: appointment });
+
+    const facility = getVAFacilityMock();
+    facility.attributes = {
+      ...facility.attributes,
+      id: 'vha_442GC',
+      uniqueId: '442GC',
+      name: 'Cheyenne VA Medical Center',
+      address: {
+        physical: {
+          zip: '82001-5356',
+          city: 'Cheyenne',
+          state: 'WY',
+          address1: '2360 East Pershing Boulevard',
+        },
+      },
+      phone: {
+        main: '307-778-7550',
+      },
+    };
+
     mockFacilityFetch('vha_442GC', facility);
     const message = getMessageMock();
     message.attributes = {
@@ -185,6 +155,17 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
   });
 
   it('should go back to requests page when clicking top link', async () => {
+    const appointment = getVARequestMock();
+
+    appointment.attributes = {
+      ...appointment.attributes,
+      appointmentType: 'Primary care',
+      optionDate1: moment(testDate)
+        .add(3, 'days')
+        .format('MM/DD/YYYY'),
+      optionTime1: 'AM',
+    };
+
     mockAppointmentInfo({ requests: [appointment], isHomepageRefresh: true });
     const screen = renderWithStoreAndRouter(<AppointmentList />, {
       initialState,
@@ -205,6 +186,17 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
   });
 
   it('should go back to requests page when clicking go back to appointments button', async () => {
+    const appointment = getVARequestMock();
+
+    appointment.attributes = {
+      ...appointment.attributes,
+      appointmentType: 'Primary care',
+      optionDate1: moment(testDate)
+        .add(3, 'days')
+        .format('MM/DD/YYYY'),
+      optionTime1: 'AM',
+    };
+
     mockAppointmentInfo({ requests: [appointment], isHomepageRefresh: true });
     const screen = renderWithStoreAndRouter(<AppointmentList />, {
       initialState,
@@ -224,6 +216,29 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
   });
 
   it('should render CC request details', async () => {
+    const ccAppointmentRequest = getCCRequestMock();
+    ccAppointmentRequest.attributes = {
+      ...ccAppointmentRequest.attributes,
+      appointmentType: 'Audiology (hearing aid support)',
+      bestTimetoCall: ['Morning'],
+
+      ccAppointmentRequest: {
+        preferredProviders: [
+          {
+            practiceName: 'Atlantic Medical Care',
+          },
+        ],
+      },
+
+      email: 'joe.blow@va.gov',
+      optionDate1: '02/21/2020',
+      optionTime1: 'AM',
+      purposeOfVisit: 'routine-follow-up',
+      typeOfCareId: 'CCAUDHEAR',
+    };
+
+    ccAppointmentRequest.id = '1234';
+
     mockAppointmentInfo({
       requests: [ccAppointmentRequest],
       isHomepageRefresh: true,
@@ -290,6 +305,18 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
   });
 
   it('should allow cancellation', async () => {
+    const appointment = getVARequestMock();
+
+    appointment.id = '1234';
+    appointment.attributes = {
+      ...appointment.attributes,
+      appointmentType: 'Primary care',
+      optionDate1: moment(testDate)
+        .add(3, 'days')
+        .format('MM/DD/YYYY'),
+      optionTime1: 'AM',
+    };
+
     mockAppointmentInfo({ requests: [appointment], isHomepageRefresh: true });
     mockRequestCancelFetch(appointment);
     const screen = renderWithStoreAndRouter(<AppointmentList />, {
@@ -337,6 +364,8 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
   });
 
   it('should show error message when single fetch errors', async () => {
+    const appointment = getVARequestMock();
+
     mockSingleRequestFetch({
       request: appointment,
       type: 'va',
@@ -361,6 +390,27 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
   });
 
   it('should display pending document title', async () => {
+    const appointment = getVARequestMock();
+
+    appointment.id = '1234';
+    appointment.attributes = {
+      ...appointment.attributes,
+      appointmentType: 'Primary care',
+      optionDate1: moment(testDate)
+        .add(3, 'days')
+        .format('MM/DD/YYYY'),
+      optionTime1: 'AM',
+    };
+
+    const ccAppointmentRequest = getCCRequestMock();
+
+    ccAppointmentRequest.id = '1234';
+    ccAppointmentRequest.attributes = {
+      ...ccAppointmentRequest.attributes,
+      appointmentType: 'Audiology (hearing aid support)',
+      typeOfCareId: 'CCAUDHEAR',
+    };
+
     // Verify VA pending
     mockSingleRequestFetch({
       request: appointment,
@@ -397,6 +447,17 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
   });
 
   it('should display cancel document title', async () => {
+    const appointment = getVARequestMock();
+
+    appointment.attributes = {
+      ...appointment.attributes,
+      appointmentType: 'Primary care',
+      optionDate1: moment(testDate)
+        .add(3, 'days')
+        .format('MM/DD/YYYY'),
+      optionTime1: 'AM',
+    };
+
     // Verify cancel VA appt
     const canceledAppointment = { ...appointment };
     canceledAppointment.attributes = {


### PR DESCRIPTION
## Description
The PR moves mock data from global into individual tests. The test mock data was refactored to remove all data not relevant to the test and use defaults.

## Testing done
Unit testing

## Screenshots
N/A

## Acceptance criteria
- [ ] All tests should pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
