### PR TITLE
Hide profile error when non-vets cannot load service history

### DIFF
--- a/src/applications/personalization/profile/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile/components/ProfileWrapper.jsx
@@ -107,7 +107,7 @@ const ProfileWrapper = ({
 const mapStateToProps = (state, ownProps) => {
   const veteranStatus = selectProfile(state)?.veteranStatus;
   const invalidVeteranStatus =
-    !veteranStatus || veteranStatus === 'NOT_AUTHORIZED';
+    !veteranStatus || veteranStatus.status === 'NOT_AUTHORIZED';
   const hero = state.vaProfile?.hero;
 
   return {

--- a/src/applications/personalization/profile/tests/components/alerts/Profile.data-unavailable-error.unit.spec.js
+++ b/src/applications/personalization/profile/tests/components/alerts/Profile.data-unavailable-error.unit.spec.js
@@ -94,17 +94,13 @@ async function errorAppearsOnAllPages(
   });
 }
 
-async function errorIsNotShownOnAnyPage(
-  pageNames = [
+async function errorIsNotShownOnAnyPage(initialState) {
+  const pageNames = [
     PROFILE_PATH_NAMES.MILITARY_INFORMATION,
     PROFILE_PATH_NAMES.DIRECT_DEPOSIT,
     PROFILE_PATH_NAMES.ACCOUNT_SECURITY,
     PROFILE_PATH_NAMES.CONNECTED_APPLICATIONS,
-  ],
-) {
-  const initialState = createBasicInitialState();
-  initialState.user.profile.veteranStatus = null;
-
+  ];
   const view = render(<Profile isLOA3 isInMVI />, {
     initialState,
   });
@@ -144,16 +140,40 @@ describe('Profile "Not all data available" error', () => {
     expect(view.queryByTestId(ALERT_ID)).not.to.exist;
   });
 
-  it('should not be shown if there is a 500 error with the `GET service_history` endpoint and the user is not a vet', async () => {
-    server.use(...mocks.getServiceHistory500);
+  context('when veteranStatus is null', () => {
+    it('should not be shown if there is a 500 error with the `GET service_history` endpoint and the user is not a vet', async () => {
+      const initialState = createBasicInitialState();
+      initialState.user.profile.veteranStatus = null;
+      server.use(...mocks.getServiceHistory500);
 
-    await errorIsNotShownOnAnyPage();
+      await errorIsNotShownOnAnyPage(initialState);
+    });
+
+    it('should not be shown if there is a 401 error with the `GET service_history` endpoint and the user is not a vet', async () => {
+      const initialState = createBasicInitialState();
+      initialState.user.profile.veteranStatus = null;
+      server.use(...mocks.getServiceHistory401);
+
+      await errorIsNotShownOnAnyPage(initialState);
+    });
   });
 
-  it('should not be shown if there is a 401 error with the `GET service_history` endpoint and the user is not a vet', async () => {
-    server.use(...mocks.getServiceHistory401);
+  context('when veteranStatus.status is "NOT_AUTHORIZED"', () => {
+    it('should not be shown if there is a 500 error with the `GET service_history` endpoint and the user is not a vet', async () => {
+      const initialState = createBasicInitialState();
+      initialState.user.profile.veteranStatus.status = 'NOT_AUTHORIZED';
+      server.use(...mocks.getServiceHistory500);
 
-    await errorIsNotShownOnAnyPage();
+      await errorIsNotShownOnAnyPage(initialState);
+    });
+
+    it('should not be shown if there is a 401 error with the `GET service_history` endpoint and the user is not a vet', async () => {
+      const initialState = createBasicInitialState();
+      initialState.user.profile.veteranStatus.status = 'NOT_AUTHORIZED';
+      server.use(...mocks.getServiceHistory401);
+
+      await errorIsNotShownOnAnyPage(initialState);
+    });
   });
 
   it('should be shown on all pages if there is an error with the `GET full_name` endpoint', async () => {

--- a/src/applications/personalization/profile/tests/e2e/nametag.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/nametag.cypress.spec.js
@@ -4,6 +4,7 @@ import serviceHistory from '@@profile/tests/fixtures/service-history-success.jso
 import fullName from '@@profile/tests/fixtures/full-name-success.json';
 import disabilityRating from '@@profile/tests/fixtures/disability-rating-success.json';
 import error401 from '@@profile/tests/fixtures/401.json';
+import error403 from '@@profile/tests/fixtures/403.json';
 import error500 from '@@profile/tests/fixtures/500.json';
 
 import { mockUser } from '../fixtures/users/user';
@@ -44,6 +45,19 @@ describe('Profile NameTag', () => {
       cy.intercept('/v0/disability_compensation_form/rating_info', {
         statusCode: 401,
         body: error401,
+      });
+    });
+    it('should render the name, service branch, and not show disability rating', () => {
+      mockFeatureToggles();
+      cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+      nameTagRendersWithoutDisabilityRating();
+    });
+  });
+  context('when there is a 403 fetching the disability rating', () => {
+    beforeEach(() => {
+      cy.intercept('/v0/disability_compensation_form/rating_info', {
+        statusCode: 403,
+        body: error403,
       });
     });
     it('should render the name, service branch, and not show disability rating', () => {

--- a/src/applications/personalization/profile/tests/fixtures/403.json
+++ b/src/applications/personalization/profile/tests/fixtures/403.json
@@ -1,0 +1,10 @@
+{
+  "errors": [
+    {
+      "title": "Forbidden",
+      "detail": "User does not have access to the requested resource",
+      "code": "403",
+      "status": "403"
+    }
+  ]
+}


### PR DESCRIPTION
## Description


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs