### PR TITLE
Add comment on skipping vagovdev's Drupal cache

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -387,8 +387,9 @@ def cacheDrupalContent(dockerContainer, envUsedCache) {
 
       for (int i=0; i<VAGOV_BUILDTYPES.size(); i++) {
         def envName = VAGOV_BUILDTYPES.get(i)
-        // Skip caching Drupal content for vagovdev since we aren't pulling and building content for that environment 
-        // vagovdev's Drupal cache is created/uploaded in the content-build repo
+        // Skip caching Drupal content for vagovdev since we aren't pulling and building content for that environment.
+        // vagovdev's Drupal cache is created and uploaded in the content-build repo. This prevents overwriting vagovdev's
+        // Drupal cache file with an empty file.
         if(envName != "vagovdev") {
           if (!envUsedCache[envName]) {
             dockerContainer.inside(DOCKER_ARGS) {

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -387,6 +387,8 @@ def cacheDrupalContent(dockerContainer, envUsedCache) {
 
       for (int i=0; i<VAGOV_BUILDTYPES.size(); i++) {
         def envName = VAGOV_BUILDTYPES.get(i)
+        // Skip caching Drupal content for vagovdev since we aren't pulling and building content for that environment 
+        // vagovdev's Drupal cache is created/uploaded in the content-build repo
         if(envName != "vagovdev") {
           if (!envUsedCache[envName]) {
             dockerContainer.inside(DOCKER_ARGS) {


### PR DESCRIPTION
## Description
Provide context as to why we're skipping Drupal cache for `vagovdev`.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
