### PR TITLE
Point content deployments to CMS Prod

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -245,7 +245,7 @@ def build(String ref, dockerContainer, String assetSource, String envName, Boole
   def drupalMaxParallelRequests = 15
   def noDrupalProxy = '--no-drupal-proxy'
 
-  if (IS_DEV_BRANCH || IS_STAGING_BRANCH || IS_PROD_BRANCH) {
+  if (IS_DEV_BRANCH || IS_STAGING_BRANCH || IS_PROD_BRANCH || contentOnlyBuild) {
     drupalAddress = DRUPAL_ADDRESSES.get('vagovprod')
     noDrupalProxy = ''
   }


### PR DESCRIPTION
## Description
Follow up to 2ed0e89f43690eee11c07d41b8d580e1508578e1. We left out the condition for when we are on the content deployment, in which case the `env.BRANCH_NAME` is null, and we can't rely on `IS_PRODUCTION`. We found this when builds were failing due to a broken link that didn't exist any longer.

## Acceptance criteria
- [ ] Content deployments pull from CMS Prod

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
