### PR TITLE
[Jenkinsfile] Unset JSONObject once done

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -222,6 +222,11 @@ def checkForBrokenLinks(String buildLogPath, String envName, Boolean contentOnly
       return;
     }
 
+    // JSONObjects in Groovy are not serializable by default, which is an issue, because
+    // a Jenkinsfile has to be fully serializable for it to be able to pause state.
+    // To get around this,
+    brokenLinks = null
+
     slackSend(
       message: message,
       color: color,

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -224,7 +224,9 @@ def checkForBrokenLinks(String buildLogPath, String envName, Boolean contentOnly
 
     // JSONObjects in Groovy are not serializable by default, which is an issue, because
     // a Jenkinsfile has to be fully serializable for it to be able to pause state.
-    // To get around this,
+    // To get around this, we unset our reference to the brokenLinks JSON file
+    // once we're done with it. It's important that we do this before slackSend, which
+    // is likely causes this pipeline to pause while waiting for the message to complete.
     brokenLinks = null
 
     slackSend(

--- a/src/site/stages/build/plugins/modify-dom/check-broken-links/index.js
+++ b/src/site/stages/build/plugins/modify-dom/check-broken-links/index.js
@@ -83,6 +83,7 @@ module.exports = {
       brokenLinksCount,
     };
 
+    fs.ensureFileSync(this.logFile);
     fs.writeJSONSync(this.logFile, brokenLinksJson);
     console.log(`Broken links found. See results in ${this.logFile}.`);
 


### PR DESCRIPTION
## Description
Follow up to https://github.com/department-of-veterans-affairs/vets-website/pull/16972 after discovering a Groovy exception in the output of a content build. See comments in the Files Changed.

## Testing done
Will observe a Content Release

## Screenshots
See comment in Files Changed

## Acceptance criteria
- [ ] No random Groovy exception

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
