### PR TITLE
Bump web-components version for spacing update

### DIFF
--- a/package.json
+++ b/package.json
@@ -366,7 +366,7 @@
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
     "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#4089b6b4390f05738e0dcef402c56978565a626c",
-    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.4.0",
+    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.4.1",
     "whatwg-fetch": "^2.0.3"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19930,9 +19930,9 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   dependencies:
     minimalistic-assert "^1.0.0"
 
-"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.4.0":
-  version "0.4.0"
-  resolved "https://github.com/department-of-veterans-affairs/component-library.git#23d3c19611e4ce4704b213082b2c971c85b430ef"
+"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.4.1":
+  version "0.4.1"
+  resolved "https://github.com/department-of-veterans-affairs/component-library.git#f05bec344e73e03254f4ee2af1d8e322d4da893c"
   dependencies:
     "@stencil/core" "^2.0.1"
     "@stencil/postcss" "^2.0.0"


### PR DESCRIPTION

## Description

Related to https://github.com/department-of-veterans-affairs/component-library/pull/82

This is to get the styling changes for the accordion with a subheader
prop

## Testing done

Storybook :eyes: 

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
