### PR TITLE
Filter out unpublished services from VAMC location pages

### DIFF
--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -174,7 +174,7 @@
               {% assign localHealthServices = fieldLocalHealthCareService | sortObjectsBy: 'entity.fieldRegionalHealthService.entity.fieldServiceNameAndDescripti.entity.name' %}
               {% for localService in localHealthServices %}
                 {% assign localHealthService = localService.entity | featureFieldRegionalHealthService %}
-                {% if localHealthService != empty %}
+                {% if localHealthService != empty and localService.entity.status == true %}
 
                   {% include "src/site/facilities/facility_health_service.drupal.liquid" with
                     healthService = localHealthService

--- a/src/site/layouts/tests/vamc/fixtures/health_care_local_facility_no_phone_mental.json
+++ b/src/site/layouts/tests/vamc/fixtures/health_care_local_facility_no_phone_mental.json
@@ -311,6 +311,7 @@
   "fieldLocalHealthCareService": [
     {
       "entity": {
+        "status": true,
         "fieldBody": {
           "processed": "<html><head></head><body><h3>Location and contact information</h3>\n\n<p class=\"va-address-block\"><br>\n901 South East Washington Street<br><strong>Phone:</strong> <a aria-label=\"5 8 0. 9 2 0. 7 2 0 0.\" href=\"tel:+15809207200\">580-920-7200</a><br><strong>Hours:</strong><br>\nMonday - 8:00 a.m. to 4:30 p.m. CT<br>\nTuesday - 8:00 a.m. to 4:30 p.m. CT<br>\nWednesday - 8:00 a.m. to 4:30 p.m. CT<br>\nThursday - 8:00 a.m. to 4:30 p.m. CT<br>\nFriday - 8:00 a.m. to 4:30 p.m. CT<br>\nSaturday - Closed<br>\nSunday - Closed</p>\n\n<h3>Appointments</h3>\n\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you will need to contact your primary care provider first.</p>\n\n<p><strong>Referral needed? </strong> Y<br><strong>Walk-ins accepted?</strong> N<br><strong>Phone: </strong><a aria-label=\"5 8 0. 9 2 0. 7 2 0 0.\" href=\"tel:+15809207200\">580-920-7200</a></p></body></html>"
         },
@@ -426,6 +427,7 @@
     },
     {
       "entity": {
+        "status": true,
         "fieldBody": {
           "processed": "<html><head></head><body><h3>Location and contact information</h3>\n\n<p class=\"va-address-block\"><br>\n901 South East Washington Street<br><strong>Phone:</strong> <a aria-label=\"5 8 0. 9 2 0. 7 2 0 0.\" href=\"tel:+15809207200\">580-920-7200</a><br><strong>Hours:</strong><br>\nMonday - 8:00 a.m. to 4:30 p.m. CT<br>\nTuesday - 8:00 a.m. to 4:30 p.m. CT<br>\nWednesday - 8:00 a.m. to 4:30 p.m. CT<br>\nThursday - 8:00 a.m. to 4:30 p.m. CT<br>\nFriday - 8:00 a.m. to 4:30 p.m. CT<br>\nSaturday - Closed<br>\nSunday - Closed</p>\n\n<h3>Appointments</h3>\n\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you will need to contact your primary care provider first.</p>\n\n<p><strong>Referral needed? </strong> N<br><strong>Walk-ins accepted?</strong> Y<br><strong>Phone: </strong><a aria-label=\"5 8 0. 9 2 0. 7 2 0 0.\" href=\"tel:+15809207200\">580-920-7200</a></p></body></html>"
         },
@@ -541,6 +543,7 @@
     },
     {
       "entity": {
+        "status": true,
         "fieldBody": {
           "processed": "<html><head></head><body><h3>Location and contact information</h3>\n\n<p class=\"va-address-block\"><br>\n901 South East Washington Street<br><strong>Phone:</strong> <a aria-label=\"5 8 0. 9 2 0. 7 2 0 0.\" href=\"tel:+15809207200\">580-920-7200</a><br><strong>Hours:</strong><br>\nMonday - 8:00 a.m. to 4:30 p.m. CT<br>\nTuesday - 8:00 a.m. to 4:30 p.m. CT<br>\nWednesday - 8:00 a.m. to 4:30 p.m. CT<br>\nThursday - 8:00 a.m. to 4:30 p.m. CT<br>\nFriday - 8:00 a.m. to 4:30 p.m. CT<br>\nSaturday - Closed<br>\nSunday - Closed</p>\n\n<h3>Appointments</h3>\n\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you will need to contact your primary care provider first.</p>\n\n<p><strong>Referral needed? </strong> N<br><strong>Walk-ins accepted?</strong> Y<br><strong>Phone: </strong><a aria-label=\"5 8 0. 9 2 0. 7 2 0 0.\" href=\"tel:+15809207200\">580-920-7200</a></p></body></html>"
         },
@@ -664,6 +667,131 @@
     },
     {
       "entity": {
+        "status": false,
+        "fieldBody": {
+          "processed": "<html><head></head><body><h3>Location and contact information</h3>\n\n<p class=\"va-address-block\"><br>\n901 South East Washington Street<br><strong>Phone:</strong> <a aria-label=\"5 8 0. 9 2 0. 7 2 0 0.\" href=\"tel:+15809207200\">580-920-7200</a><br><strong>Hours:</strong><br>\nMonday - 8:00 a.m. to 4:30 p.m. CT<br>\nTuesday - 8:00 a.m. to 4:30 p.m. CT<br>\nWednesday - 8:00 a.m. to 4:30 p.m. CT<br>\nThursday - 8:00 a.m. to 4:30 p.m. CT<br>\nFriday - 8:00 a.m. to 4:30 p.m. CT<br>\nSaturday - Closed<br>\nSunday - Closed</p>\n\n<h3>Appointments</h3>\n\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you will need to contact your primary care provider first.</p>\n\n<p><strong>Referral needed? </strong> N<br><strong>Walk-ins accepted?</strong> Y<br><strong>Phone: </strong><a aria-label=\"5 8 0. 9 2 0. 7 2 0 0.\" href=\"tel:+15809207200\">580-920-7200</a></p></body></html>"
+        },
+        "fieldServiceLocation": [
+          {
+            "entity": {
+              "fieldServiceLocationAddress": {
+                "entity": {
+                  "fieldUseFacilityAddress": true,
+                  "fieldClinicName": null,
+                  "fieldBuildingNameNumber": null,
+                  "fieldWingFloorOrRoomNumber": null,
+                  "fieldAddress": {
+                    "addressLine1": "",
+                    "addressLine2": null,
+                    "additionalName": null,
+                    "administrativeArea": "",
+                    "postalCode": "",
+                    "locality": "",
+                    "organization": null,
+                    "dependentLocality": null,
+                    "countryCode": "US",
+                    "sortingCode": null
+                  }
+                }
+              },
+              "fieldEmailContacts": [],
+              "fieldFacilityServiceHours": {
+                "value": [
+                  [
+                    "Mon",
+                    ""
+                  ],
+                  [
+                    "Tue",
+                    ""
+                  ],
+                  [
+                    "Wed",
+                    ""
+                  ],
+                  [
+                    "Thu",
+                    ""
+                  ],
+                  [
+                    "Fri",
+                    ""
+                  ],
+                  [
+                    "Sat",
+                    ""
+                  ],
+                  [
+                    "Sun",
+                    ""
+                  ]
+                ],
+                "caption": null,
+                "format": "plain_text"
+              },
+              "fieldHours": "0",
+              "fieldAdditionalHoursInfo": null,
+              "fieldPhone": [],
+              "fieldUseMainFacilityPhone": true
+            }
+          }
+        ],
+        "fieldHserviceApptLeadin": null,
+        "fieldHserviceApptIntroSelect": null,
+        "fieldOnlineSchedulingAvailabl": "0",
+        "fieldReferralRequired": "0",
+        "fieldWalkInsAccepted": "1",
+        "fieldPhoneNumbersParagraph": [
+          {
+            "entity": {
+              "fieldPhoneExtension": null,
+              "fieldPhoneLabel": "Appointments",
+              "fieldPhoneNumber": "888-397-8387",
+              "fieldPhoneNumberType": "tel"
+            }
+          },
+          {
+            "entity": {
+              "fieldPhoneExtension": null,
+              "fieldPhoneLabel": "Appointments",
+              "fieldPhoneNumber": "580-920-7200",
+              "fieldPhoneNumberType": "tel"
+            }
+          }
+        ],
+        "fieldRegionalHealthService": {
+          "entity": {
+            "entityBundle": "regional_health_care_service_des",
+            "fieldBody": {
+              "processed": "<html><head></head><body><h3>Care we provide at VA Eastern Oklahoma health care</h3> <p>A strong network of family and internal medicine specialists and services can offer you the best possible care. Internal medicine doctors (internists) prevent, diagnose, and treat adult diseases. Doctors who specialize in family medicine provide primary health care to the entire family. Your primary care team can coordinate the many services you receive such as:</p> <ul><li>Labs and blood work</li><li>Mental health care</li><li>Womens health care</li><li>Radiology</li><li>Social services</li><li>Telehealth </li></ul>&apos;</body></html>"
+            },
+            "fieldServiceNameAndDescripti": {
+              "entity": {
+                "entityId": "37",
+                "entityBundle": "health_care_service_taxonomy",
+                "fieldAlsoKnownAs": "Family and internal medicine",
+                "fieldCommonlyTreatedCondition": null,
+                "name": "Primary care",
+                "description": {
+                  "processed": "<html><head></head><body><p>Your VA primary care provider will work closely with you to plan for all the care you need to stay healthy and well throughout your life. They will also work with&#xA0;family members or caregivers who support you.</p></body></html>"
+                },
+                "parent": [
+                  {
+                    "entity": {
+                      "name": "Primary care"
+                    }
+                  }
+                ],
+                "fieldHealthServiceApiId": "primaryCare"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "entity": {
+        "status": true,
         "fieldBody": {
           "processed": "<html><head></head><body><h3>Location and contact information</h3>\n\n<p class=\"va-address-block\"><br>\n901 South East Washington Street<br><strong>Phone:</strong> <a aria-label=\"5 8 0. 9 2 0. 7 2 0 0.\" href=\"tel:+15809207200\">580-920-7200</a><br><strong>Hours:</strong><br>\nMonday - 8:00 a.m. to 4:30 p.m. CT<br>\nTuesday - 8:00 a.m. to 4:30 p.m. CT<br>\nWednesday - 8:00 a.m. to 4:30 p.m. CT<br>\nThursday - 8:00 a.m. to 4:30 p.m. CT<br>\nFriday - 8:00 a.m. to 4:30 p.m. CT<br>\nSaturday - Closed<br>\nSunday - Closed</p>\n\n<h3>Appointments</h3>\n\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you will need to contact your primary care provider first.</p>\n\n<p><strong>Referral needed? </strong> N<br><strong>Walk-ins accepted?</strong> Y<br><strong>Phone: </strong><a aria-label=\"5 8 0. 9 2 0. 7 2 0 0.\" href=\"tel:+15809207200\">580-920-7200</a></p></body></html>"
         },

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionHealthServices.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionHealthServices.node.graphql.js
@@ -13,6 +13,7 @@ const HEALTH_SERVICES_RESULTS = `
       fieldLocalHealthCareService {
         entity {
           ...on NodeHealthCareLocalHealthService {
+            status
             fieldFacilityLocation {
               entity {
                 ... on NodeHealthCareLocalFacility {

--- a/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
@@ -79,6 +79,7 @@ const healthCareLocalFacilityPageFragment = `
     fieldLocalHealthCareService {
       entity {
         ... on NodeHealthCareLocalHealthService {
+          status        
           fieldBody {
             processed
           }
@@ -88,6 +89,7 @@ const healthCareLocalFacilityPageFragment = `
           {
             entity {
               ... on NodeRegionalHealthCareServiceDes {
+                status              
                 entityBundle
                 fieldBody {
                   processed

--- a/src/site/stages/build/drupal/graphql/healthServicesListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthServicesListingPage.graphql.js
@@ -48,6 +48,7 @@ const healthServicesListingPage = `
               fieldLocalHealthCareService {
                 entity {
                   ... on NodeHealthCareLocalHealthService {
+                    status                  
                     entityUrl {
                       path
                     }

--- a/src/site/stages/build/drupal/graphql/paragraph-fragments/serviceLocation.paragraph.graphql.js
+++ b/src/site/stages/build/drupal/graphql/paragraph-fragments/serviceLocation.paragraph.graphql.js
@@ -7,6 +7,7 @@ module.exports = `
   fieldServiceLocation {
     entity {
       ... on ParagraphServiceLocation {
+        status
         fieldServiceLocationAddress {
           entity {
             ... on ParagraphServiceLocationAddress {


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/va.gov-team/issues/23470

To test: 

1. Run a full build (`yarn build:content --pull-drupal`), and view http://localhost:3001/wilmington-health-care/locations/wilmington-va-medical-center/.
2. Confirm there's only one entry on the page for "Homeless Veteran Care". 
3. Also run an AXE check on the page and confirm no violations for duplicate accordion ID's.
