### PR TITLE
Streaming read/write for GraphQL cache files (#23788)

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "@testing-library/dom": "^7.26.6",
     "@testing-library/react": "^11.1.2",
     "@testing-library/user-event": "^12.2.2",
+    "JSONStream": "^1.3.5",
     "ajv": "^6.12.2",
     "append-query": "2.0.1",
     "ascii-table": "^0.0.9",

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -288,7 +288,9 @@ async function loadDrupal(buildOptions) {
   console.timeEnd(contentTimer);
 
   // Dynamic GraphQL from CMS build
-  fs.outputJsonSync(CMS_EXPORT_CACHE_FILENAME, drupalPages);
+  if (buildOptions[USE_CMS_EXPORT_BUILD_ARG]) {
+    fs.outputJsonSync(CMS_EXPORT_CACHE_FILENAME, drupalPages);
+  }
 
   log('Drupal successfully loaded!');
   return drupalPages;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2472,9 +2472,17 @@
   resolved "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-JSONStream@^1.0.3, JSONStream@^1.2.1, JSONStream@^1.3.5:
+JSONStream@^1.0.3, JSONStream@^1.2.1:
   version "1.3.5"
   resolved "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz"
+  integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
+  dependencies:
+    jsonparse "^1.2.0"
+    through ">=2.2.7 <3"
+
+JSONStream@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
   integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
   dependencies:
     jsonparse "^1.2.0"


### PR DESCRIPTION
## Description
Local GraphQL cache size is currently limited to 500mb due to V8's maximum string length. Implementing a streaming solution to read and write GraphQL query results allows allowing the content build to scale beyond 500mb of GraphQL data. See [#22861](https://github.com/department-of-veterans-affairs/va.gov-team/issues/22861) for related research and benchmarks.

## Testing done
- [x] Local testing with existing content (reading and writing cache files)
- [x] Comparison of existing build with build generated using streaming approach
- [x] Successful Jenkins run

## Acceptance criteria
 - [x] GraphQL query results are stored in pages.json using a streaming approach
 - [x] Content build is unchanged (confirm with comparison script)
 - [x] Content build scales to 48k nodes (note, some experienced some tinyliquid timeouts)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
