### PR TITLE
[23401] Update TypeOfEyeCarePage to hooks

### DIFF
--- a/src/applications/vaos/new-appointment/components/TypeOfEyeCarePage.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfEyeCarePage.jsx
@@ -1,12 +1,17 @@
 import React, { useEffect } from 'react';
-import { connect } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import FormButtons from '../../components/FormButtons';
-import * as actions from '../redux/actions';
 import { getFormPageInfo } from '../redux/selectors';
 import { TYPES_OF_EYE_CARE } from '../../utils/constants';
 import { scrollAndFocus } from '../../utils/scrollAndFocus';
+import {
+  openFormPage,
+  routeToNextAppointmentPage,
+  routeToPreviousAppointmentPage,
+  updateFormData,
+} from '../redux/actions';
 
 const initialSchema = {
   type: 'object',
@@ -58,18 +63,15 @@ const uiSchema = {
 const pageKey = 'typeOfEyeCare';
 const pageTitle = 'Choose the type of eye care you need';
 
-function TypeOfEyeCarePage({
-  schema,
-  data,
-  pageChangeInProgress,
-  openFormPage,
-  updateFormData,
-  routeToPreviousAppointmentPage,
-  routeToNextAppointmentPage,
-}) {
+export default function TypeOfEyeCarePage() {
+  const dispatch = useDispatch();
+  const { schema, data, pageChangeInProgress } = useSelector(
+    state => getFormPageInfo(state, pageKey),
+    shallowEqual,
+  );
   const history = useHistory();
   useEffect(() => {
-    openFormPage(pageKey, uiSchema, initialSchema);
+    dispatch(openFormPage(pageKey, uiSchema, initialSchema));
     document.title = `${pageTitle} | Veterans Affairs`;
     scrollAndFocus();
   }, []);
@@ -83,12 +85,18 @@ function TypeOfEyeCarePage({
           title="Type of eye care"
           schema={schema}
           uiSchema={uiSchema}
-          onSubmit={() => routeToNextAppointmentPage(history, pageKey)}
-          onChange={newData => updateFormData(pageKey, uiSchema, newData)}
+          onSubmit={() =>
+            dispatch(routeToNextAppointmentPage(history, pageKey))
+          }
+          onChange={newData =>
+            dispatch(updateFormData(pageKey, uiSchema, newData))
+          }
           data={data}
         >
           <FormButtons
-            onBack={() => routeToPreviousAppointmentPage(history, pageKey)}
+            onBack={() =>
+              dispatch(routeToPreviousAppointmentPage(history, pageKey))
+            }
             pageChangeInProgress={pageChangeInProgress}
             loadingText="Page change in progress"
           />
@@ -97,19 +105,3 @@ function TypeOfEyeCarePage({
     </div>
   );
 }
-
-function mapStateToProps(state) {
-  return getFormPageInfo(state, pageKey);
-}
-
-const mapDispatchToProps = {
-  openFormPage: actions.openFormPage,
-  updateFormData: actions.updateFormData,
-  routeToNextAppointmentPage: actions.routeToNextAppointmentPage,
-  routeToPreviousAppointmentPage: actions.routeToPreviousAppointmentPage,
-};
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(TypeOfEyeCarePage);


### PR DESCRIPTION
## Description
We want to update the way we use react-redux to the current recommended approach, which is to use the useSelector and useDispatch hooks.

Path: src/applications/vaos/new-appointment/components/TypeOfEyeCarePage.jsx

## Testing done
local and unit

## Screenshots
n/a

## Acceptance criteria
- [ ] connect() is no longer used on page
- [ ] All actions that were in mapDispatchToProps are now wrapped in dispatch() when called
- [ ] All data in mapStateToProps is pulled in through useSelector hooks

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
