### PR TITLE
[Preview server] Disable broken link checker

### DIFF
--- a/src/site/stages/build/plugins/modify-dom/check-broken-links/index.js
+++ b/src/site/stages/build/plugins/modify-dom/check-broken-links/index.js
@@ -12,10 +12,17 @@ const applyIgnoredRoutes = require('./helpers/applyIgnoredRoutes');
 
 module.exports = {
   initialize(buildOptions, files) {
+    this.isDisabled = (
+      buildOptions.watch || buildOptions.isPreviewServer
+    );
+
+    if (this.isDisabled) {
+      return;
+    }
+
     const fileNames = Object.keys(files);
     this.allPaths = new Set(fileNames);
     this.brokenPages = [];
-
     this.logFile = path.join(
       __dirname,
       '../../../../../../../logs',
@@ -28,7 +35,7 @@ module.exports = {
   },
 
   modifyFile(fileName, file, files, buildOptions) {
-    if (buildOptions.watch) {
+    if (this.isDisabled) {
       return;
     }
 
@@ -66,6 +73,10 @@ module.exports = {
   },
 
   conclude(buildOptions, files) {
+    if (this.isDisabled) {
+      return;
+    }
+
     const brokenPages = applyIgnoredRoutes(this.brokenPages, files);
 
     if (brokenPages.length === 0) {

--- a/src/site/stages/build/plugins/modify-dom/check-broken-links/index.js
+++ b/src/site/stages/build/plugins/modify-dom/check-broken-links/index.js
@@ -12,9 +12,7 @@ const applyIgnoredRoutes = require('./helpers/applyIgnoredRoutes');
 
 module.exports = {
   initialize(buildOptions, files) {
-    this.isDisabled = (
-      buildOptions.watch || buildOptions.isPreviewServer
-    );
+    this.isDisabled = buildOptions.watch || buildOptions.isPreviewServer;
 
     if (this.isDisabled) {
       return;
@@ -34,7 +32,7 @@ module.exports = {
     }
   },
 
-  modifyFile(fileName, file, files, buildOptions) {
+  modifyFile(fileName, file) {
     if (this.isDisabled) {
       return;
     }


### PR DESCRIPTION
## Description
This is a follow to https://github.com/department-of-veterans-affairs/vets-website/commit/4b71aa5584d20464f14bb1cf01993aa3efb20d49#.

I didn't realize the broken link checker runs even on preview server, which is obviously pointless because all links will be detected as broken. My changes in the commit above have broken preview server so this PR just disabled it on the preview server.

https://dsva.slack.com/archives/C52CL1PKQ/p1619786042416800
## Testing done
Ran preview server locally and confirmed it renders pages

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/116701545-07718200-a996-11eb-8c2b-61d4da9e949a.png)


## Acceptance criteria
- [ ] Preview server is fixed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
