### PR TITLE
Change broken link notifications channel

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -233,7 +233,7 @@ def checkForBrokenLinks(String buildLogPath, String envName, Boolean contentOnly
       message: message,
       color: color,
       failOnError: true,
-      channel: 'cms-helpdesk-bot'
+      channel: 'vfs-platform-builds'
     )
 
     if (color == 'danger') {


### PR DESCRIPTION
## Description

This PR changes the broken link notification Slack channel from #cms-helpdesk-bot to #vfs-platform-builds. This is being done to help all platform engineers have awareness of broken link issues.

Parent issue: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/5050

## Testing done

Pending automated tests.

## Acceptance criteria
- [ ] Broken link warning/error messages are delivered to #vfs-platform-builds

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
