### PR TITLE
Perform axe check on disability calculator page

### DIFF
--- a/src/applications/disability-benefits/disability-rating-calculator/tests/00-all-fields.e2e.spec.js
+++ b/src/applications/disability-benefits/disability-rating-calculator/tests/00-all-fields.e2e.spec.js
@@ -25,7 +25,8 @@ module.exports = E2eHelpers.createE2eTest(client => {
   // Navigate to beta-page and wait for component render.
   client
     .openUrl(`${E2eHelpers.baseUrl}${drcPagePath}`)
-    .waitForElementPresent(componentSelector, Timeouts.slow);
+    .waitForElementPresent(componentSelector, Timeouts.slow)
+    .axeCheck();
 
   // Test row deletion.
   DrcE2eHelpers.fillRatings(client, rowDeletionTestInput);


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/7320

This PR adds an axe check to the disability calculator. I ran it locally too and there were no axe errors, woot! 🎉 

## Testing done
Axe checking in e2e test

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/116717083-bcf00580-a995-11eb-98fc-8805020cb8dc.png)

## Acceptance criteria
- [x] Add axe check in disability calculator e2e test

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
