### PR TITLE
22660 - Chp 31 Orientation update

### DIFF
--- a/src/applications/vre/28-1900/orientation/OrientationApp.jsx
+++ b/src/applications/vre/28-1900/orientation/OrientationApp.jsx
@@ -1,8 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { Link } from 'react-router';
 import Scroll from 'react-scroll';
 import { focusElement } from 'platform/utilities/ui';
-import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
 import StepComponent from './StepComponent';
 import { orientationSteps } from './utils';
 
@@ -17,18 +15,21 @@ const scrollToTop = () => {
 
 const OrientationApp = props => {
   const [step, setStep] = useState(0);
-  const [formStartControl, setFormStartControl] = useState(false);
+  const [isFirstRender, setIsFirstRender] = useState(true);
   const { wizardStateHandler } = props;
 
   // do this to prevent focus skip on prior link tag
-  useEffect(() => {
-    if (formStartControl) {
-      focusElement('#FormStartControl');
-    } else {
-      focusElement('#StepTitle');
-      scrollToTop();
-    }
-  });
+  useEffect(
+    () => {
+      if (isFirstRender && step === 0) {
+        setIsFirstRender(false);
+      } else {
+        focusElement('#StepTitle');
+        scrollToTop();
+      }
+    },
+    [step],
+  );
 
   return (
     <>
@@ -43,7 +44,7 @@ const OrientationApp = props => {
         <p id="orientation-step" className="vads-u-font-weight--bold">
           Slide {step + 1} of {orientationSteps.length}
         </p>
-        <StepComponent step={step} />
+        <StepComponent step={step} clickHandler={wizardStateHandler} />
         <div>
           {step > 0 && (
             <button
@@ -53,45 +54,19 @@ const OrientationApp = props => {
               Previous slide
             </button>
           )}
-          <button
-            onClick={() => {
-              if (step < orientationSteps.length - 1) {
+          {step < orientationSteps.length - 1 && (
+            <button
+              onClick={() => {
                 setStep(step + 1);
-              } else {
-                setFormStartControl(true);
-              }
-            }}
-            type="button"
-            className="usa-button-primary"
-          >
-            {/* eslint-disable-next-line no-nested-ternary */}
-            {step === 0
-              ? 'Start VR&E orientation slideshow'
-              : step < orientationSteps.length - 1
-                ? 'Next slide'
-                : 'Finish VR&E Orientation'}
-          </button>
+              }}
+              type="button"
+              className="usa-button-primary"
+            >
+              {step === 0 ? 'Start VR&E orientation slideshow' : 'Next slide'}
+            </button>
+          )}
         </div>
       </article>
-      {formStartControl && (
-        <div className="vads-u-padding--3 vads-u-background-color--gray-lightest">
-          <p>
-            <strong>Thank you for viewing the VR&E orientation.</strong> To
-            apply for Veteran Readiness & Employment benefits now, click the
-            link below.
-          </p>
-          <Link
-            id="FormStartControl"
-            to="/"
-            className="vads-c-action-link--green vads-u-padding-left--0"
-            onClick={() => {
-              wizardStateHandler(WIZARD_STATUS_COMPLETE);
-            }}
-          >
-            Apply for Veteran Readiness and Employment with VA Form 28-1900
-          </Link>
-        </div>
-      )}
     </>
   );
 };

--- a/src/applications/vre/28-1900/orientation/StepComponent.jsx
+++ b/src/applications/vre/28-1900/orientation/StepComponent.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { Link } from 'react-router';
+import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
 import { orientationSteps } from './utils';
 
 const StepComponent = props => {
-  const { step } = props;
+  const { step, clickHandler } = props;
   const data = orientationSteps[step];
   let content;
 
@@ -43,6 +45,21 @@ const StepComponent = props => {
           </ol>
         </div>
       </>
+    );
+  } else if (step === orientationSteps.length - 1) {
+    content = (
+      <div className=" vads-u-margin-bottom--3">
+        <Link
+          id="FormStartControl"
+          to="/"
+          className="vads-c-action-link--green vads-u-padding-left--0"
+          onClick={() => {
+            clickHandler(WIZARD_STATUS_COMPLETE);
+          }}
+        >
+          Apply for Veteran Readiness and Employment now
+        </Link>
+      </div>
     );
   } else {
     content = (

--- a/src/applications/vre/28-1900/orientation/StepComponent.jsx
+++ b/src/applications/vre/28-1900/orientation/StepComponent.jsx
@@ -48,9 +48,8 @@ const StepComponent = props => {
     );
   } else if (step === orientationSteps.length - 1) {
     content = (
-      <div className=" vads-u-margin-bottom--3">
+      <div className="vads-u-margin-bottom--3">
         <Link
-          id="FormStartControl"
           to="/"
           className="vads-c-action-link--green vads-u-padding-left--0"
           onClick={() => {

--- a/src/applications/vre/28-1900/orientation/utils.js
+++ b/src/applications/vre/28-1900/orientation/utils.js
@@ -268,4 +268,7 @@ export const orientationSteps = [
       'Home adaptations so you can live more independently',
     ],
   },
+  {
+    title: 'Thank you for viewing the VR&E orientation',
+  },
 ];

--- a/src/applications/vre/28-1900/tests/e2e/chapter31-wizard.cypress.spec.js
+++ b/src/applications/vre/28-1900/tests/e2e/chapter31-wizard.cypress.spec.js
@@ -58,10 +58,10 @@ describe('Chapter 31 wizard', () => {
     cy.axeCheck();
     cy.findByRole('button', { name: /Next slide/i }).click();
     cy.axeCheck();
-    cy.findByRole('button', { name: /Finish VR&E Orientation/i }).click();
+    cy.findByRole('button', { name: /Next slide/i }).click();
     cy.axeCheck();
     cy.findAllByRole('link', {
-      name: /Apply for Veteran Readiness and Employment with VA Form 28-1900/i,
+      name: /Apply for Veteran Readiness and Employment now/i,
     })
       .last()
       .click();


### PR DESCRIPTION
## Description
A piece of a11y feedback our team recently received is that it may be confusing for users to finish the chapter 31 orientation, click a button, and then have a link appear below to proceed to the form intro page. A better approach would instead be to include a slide that represents the end of the orientation. This pull request adds a final slide to the slide show which renders the link to the form intro page. 

## Testing done
- local

## Screenshots
<img width="978" alt="Screen Shot 2021-04-30 at 2 32 33 PM" src="https://user-images.githubusercontent.com/15097156/116740204-aca24f80-a9c2-11eb-861d-3cab159d5b20.png">


## Acceptance criteria
- [x] tests pass
- [x] slide added

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
