### PR TITLE
Make envName local to avoid changes by other builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ node('vetsgov-general-purpose') {
 
         buildDev: {
           if (commonStages.shouldBail()) { return }
-          envName = 'vagovdev'
+          def envName = 'vagovdev'
           
           shouldBuild = !contentOnlyBuild || envName == params.cmsEnvBuildOverride
           if (!shouldBuild) { return }
@@ -55,7 +55,7 @@ node('vetsgov-general-purpose') {
 
         buildStaging: {
           if (commonStages.shouldBail()) { return }
-          envName = 'vagovstaging'
+          def envName = 'vagovstaging'
 
           shouldBuild = !contentOnlyBuild || envName == params.cmsEnvBuildOverride
           if (!shouldBuild) { return }
@@ -79,7 +79,7 @@ node('vetsgov-general-purpose') {
 
         buildProd: {
           if (commonStages.shouldBail()) { return }
-          envName = 'vagovprod'
+          def envName = 'vagovprod'
 
           shouldBuild = !contentOnlyBuild || envName == params.cmsEnvBuildOverride
           if (!shouldBuild) { return }


### PR DESCRIPTION
## Description
The `envName` var in Jenkinsfile was global, leading to a race condition between builds. For example, if the staging build ran and failed, but the prod build ran and succeeded, when the staging build retried, envName could be set to `vagovprod` instead of `vagovstaging`. See [this build](http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fvets-website/detail/master/11056/pipeline/55/) for example. Making `envName` local using the `def` keyword should resolve the issue.

Discussion: https://dsva.slack.com/archives/CBU0KDSB1/p1619819047204000

## Testing done
- Successful build

## Previous example of failure due to race condition
![Screen Shot 2021-04-30 at 4 37 33 PM](https://user-images.githubusercontent.com/5805150/116762711-7f609c00-a9d8-11eb-8911-a40731d3c531.png)
