### PR TITLE
Stop fetching personal data when user is LOA1

### DIFF
--- a/src/applications/personalization/components/IdentityNotVerified.jsx
+++ b/src/applications/personalization/components/IdentityNotVerified.jsx
@@ -15,6 +15,7 @@ const IdentityNotVerified = ({
     </p>
   ),
   additionalInfoClickHandler = null,
+  level = 3,
 }) => {
   const content = (
     <>
@@ -36,7 +37,12 @@ const IdentityNotVerified = ({
 
   return (
     <>
-      <AlertBox headline={alertHeadline} content={content} status="warning" />
+      <AlertBox
+        headline={alertHeadline}
+        content={content}
+        status="warning"
+        level={level}
+      />
       <div
         className="account-security-content vads-u-margin--2p5"
         onClick={additionalInfoClickHandler}

--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -65,14 +65,17 @@ class Profile extends Component {
       fetchMilitaryInformation,
       fetchPersonalInformation,
       fetchTotalDisabilityRating,
+      isLOA3,
       shouldFetchCNPDirectDepositInformation,
       shouldFetchTotalDisabilityRating,
       shouldFetchEDUDirectDepositInformation,
     } = this.props;
     fetchMHVAccount();
-    fetchFullName();
-    fetchPersonalInformation();
-    fetchMilitaryInformation();
+    if (isLOA3) {
+      fetchFullName();
+      fetchPersonalInformation();
+      fetchMilitaryInformation();
+    }
     if (shouldFetchCNPDirectDepositInformation) {
       fetchCNPPaymentInformation();
     }
@@ -85,23 +88,40 @@ class Profile extends Component {
   }
 
   componentDidUpdate(prevProps) {
+    const {
+      fetchCNPPaymentInformation,
+      fetchEDUPaymentInformation,
+      fetchFullName,
+      fetchMilitaryInformation,
+      fetchPersonalInformation,
+      fetchTotalDisabilityRating,
+      isLOA3,
+      shouldFetchCNPDirectDepositInformation,
+      shouldFetchEDUDirectDepositInformation,
+      shouldFetchTotalDisabilityRating,
+    } = this.props;
+    if (isLOA3 && !prevProps.isLOA3) {
+      fetchFullName();
+      fetchPersonalInformation();
+      fetchMilitaryInformation();
+    }
     if (
-      this.props.shouldFetchTotalDisabilityRating &&
+      shouldFetchTotalDisabilityRating &&
       !prevProps.shouldFetchTotalDisabilityRating
     ) {
-      this.props.fetchTotalDisabilityRating();
+      fetchTotalDisabilityRating();
     }
     if (
-      this.props.shouldFetchCNPDirectDepositInformation &&
+      shouldFetchCNPDirectDepositInformation &&
       !prevProps.shouldFetchCNPDirectDepositInformation
     ) {
-      this.props.fetchCNPPaymentInformation();
+      fetchCNPPaymentInformation();
     }
     if (
-      this.props.shouldFetchEDUDirectDepositInformation &&
+      shouldFetchEDUDirectDepositInformation &&
       !prevProps.shouldFetchEDUDirectDepositInformation
     ) {
-      this.props.fetchEDUPaymentInformation();
+      fetchEDUPaymentInformation();
     }
   }
 
@@ -273,7 +293,8 @@ const mapStateToProps = state => {
 
   // this piece of state will be set if the call to load military info succeeds
   // or fails:
-  const hasLoadedMilitaryInformation = state.vaProfile?.militaryInformation;
+  const hasLoadedMilitaryInformation =
+    isLOA1 || state.vaProfile?.militaryInformation;
 
   // when the call to load MHV fails, `errors` will be set to a non-null value
   // when the call succeeds, the `accountState` will be set to a non-null value
@@ -283,11 +304,12 @@ const mapStateToProps = state => {
 
   // this piece of state will be set if the call to load personal info succeeds
   // or fails:
-  const hasLoadedPersonalInformation = state.vaProfile?.personalInformation;
+  const hasLoadedPersonalInformation =
+    isLOA1 || state.vaProfile?.personalInformation;
 
   // this piece of state will be set if the call to load name info succeeds or
   // fails:
-  const hasLoadedFullName = state.vaProfile?.hero;
+  const hasLoadedFullName = isLOA1 || state.vaProfile?.hero;
 
   // this piece of state will be set if the call to load name info succeeds or
   // fails:

--- a/src/applications/personalization/profile/components/account-security/AccountSecurityContent.jsx
+++ b/src/applications/personalization/profile/components/account-security/AccountSecurityContent.jsx
@@ -82,6 +82,7 @@ export const AccountSecurityContent = ({
               'additional-info': 'learn-more-identity',
             })
           }
+          level={2}
         />
       )}
       {showMPIConnectionError && <MPIConnectionError />}

--- a/src/applications/personalization/profile/tests/components/Profile.unit.spec.js
+++ b/src/applications/personalization/profile/tests/components/Profile.unit.spec.js
@@ -38,6 +38,7 @@ describe('Profile', () => {
       shouldFetchCNPDirectDepositInformation: true,
       shouldFetchTotalDisabilityRating: true,
       showLoader: false,
+      isLOA3: true,
       user: {},
       location: {
         pathname: '/profile/personal-information',
@@ -64,22 +65,47 @@ describe('Profile', () => {
   });
 
   describe('when the component mounts', () => {
-    it('should fetch the military information data', () => {
-      const wrapper = shallow(<Profile {...defaultProps} />);
-      expect(fetchMilitaryInfoSpy.called).to.be.true;
-      wrapper.unmount();
+    context('when user is LOA3', () => {
+      it('should fetch the military information data', () => {
+        const wrapper = shallow(<Profile {...defaultProps} />);
+        expect(fetchMilitaryInfoSpy.called).to.be.true;
+        wrapper.unmount();
+      });
+
+      it('should fetch the full name data', () => {
+        const wrapper = shallow(<Profile {...defaultProps} />);
+        expect(fetchFullNameSpy.called).to.be.true;
+        wrapper.unmount();
+      });
+
+      it('should fetch the personal information data', () => {
+        const wrapper = shallow(<Profile {...defaultProps} />);
+        expect(fetchPersonalInfoSpy.called).to.be.true;
+        wrapper.unmount();
+      });
     });
 
-    it('should fetch the full name data', () => {
-      const wrapper = shallow(<Profile {...defaultProps} />);
-      expect(fetchFullNameSpy.called).to.be.true;
-      wrapper.unmount();
-    });
+    context('when user is not LOA1', () => {
+      beforeEach(() => {
+        defaultProps.isLOA3 = false;
+      });
+      it('should not fetch the military information data', () => {
+        const wrapper = shallow(<Profile {...defaultProps} />);
+        expect(fetchMilitaryInfoSpy.called).to.be.false;
+        wrapper.unmount();
+      });
 
-    it('should fetch the personal information data', () => {
-      const wrapper = shallow(<Profile {...defaultProps} />);
-      expect(fetchPersonalInfoSpy.called).to.be.true;
-      wrapper.unmount();
+      it('should not fetch the full name data', () => {
+        const wrapper = shallow(<Profile {...defaultProps} />);
+        expect(fetchFullNameSpy.called).to.be.false;
+        wrapper.unmount();
+      });
+
+      it('should not fetch the personal information data', () => {
+        const wrapper = shallow(<Profile {...defaultProps} />);
+        expect(fetchPersonalInfoSpy.called).to.be.false;
+        wrapper.unmount();
+      });
     });
 
     it('should fetch the My HealtheVet data', () => {


### PR DESCRIPTION
## Description
Three Profile APIs return 401 or 403 when the user is LOA1. So stop trying to fetch that data in the first place if the user is LOA1. This also prevents an error from showing up on the Account Security page when the user is LOA1.

## Testing done
TDD via Cypress. And existing tests to confirm that no regressions were introduced.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs