### PR TITLE
Fix VAOS tests that are broken on master

### DIFF
--- a/src/applications/vaos/new-appointment/components/DateTimeSelectPage/WaitTimeAlert.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeSelectPage/WaitTimeAlert.jsx
@@ -45,6 +45,7 @@ export const WaitTimeAlert = ({
         <AlertBox
           headline="Your appointment time"
           status={showUrgentCareMessage ? 'warning' : 'info'}
+          level={2}
           content={
             <>
               <p>

--- a/src/applications/vaos/tests/e2e/vaos-cypress-schedule-appointment-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-cypress-schedule-appointment-helpers.js
@@ -5,7 +5,9 @@ const today = moment();
 export function chooseTypeOfCareTest(label) {
   cy.url().should('include', '/new-appointment');
   cy.axeCheckBestPractice();
-  cy.findByLabelText(label).click();
+  cy.findByLabelText(label)
+    .focus()
+    .click();
   cy.findByText(/Continue/).click();
 }
 

--- a/src/applications/vaos/tests/new-appointment/components/ContactInfoPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ContactInfoPage.unit.spec.jsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 
 import ContactInfoPage from '../../../new-appointment/components/ContactInfoPage';
 import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
-import { cleanup } from '@testing-library/react';
+import { cleanup, waitFor } from '@testing-library/react';
 
 describe('VAOS <ContactInfoPage>', () => {
   it('should submit with valid data', async () => {
@@ -34,7 +34,9 @@ describe('VAOS <ContactInfoPage>', () => {
     const button = await screen.findByText(/^Continue/);
 
     userEvent.click(button);
-    expect(screen.history.push.called).to.be.true;
+    await waitFor(() => {
+      expect(screen.history.push.called).to.be.true;
+    });
 
     // Expect the previously entered form data is still there if you unmount and remount the page with the same store,
     await cleanup();


### PR DESCRIPTION
## Description
This PR
- Fixes Cypress test that broke at the beginning of the month (new alert showed up)
- Addresses flaky test

## Testing done
Unit and cypress testing

## Acceptance criteria
- [ ] Build passes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
