### PR TITLE
[Broken link checker] Allow JSON file to fail to write

### DIFF
--- a/src/site/stages/build/plugins/modify-dom/check-broken-links/index.js
+++ b/src/site/stages/build/plugins/modify-dom/check-broken-links/index.js
@@ -61,7 +61,7 @@ module.exports = {
   getMarkdownSummary(brokenPages) {
     const markdownMessage = brokenPages.map(page => {
       const brokenLinksForPage = page.linkErrors.map(linkError => {
-        return `\`\`\`${linkError.html}\`\`\``;
+        return `\`\`\`\n${linkError.html}\n\`\`\``;
       });
 
       return `*\`${page.path}\`* : \n${brokenLinksForPage.join('\n')}`;

--- a/src/site/stages/build/plugins/modify-dom/check-broken-links/index.js
+++ b/src/site/stages/build/plugins/modify-dom/check-broken-links/index.js
@@ -92,9 +92,18 @@ module.exports = {
       brokenLinksCount,
     };
 
-    fs.ensureFileSync(this.logFile);
-    fs.writeJSONSync(this.logFile, brokenLinksJson);
-    console.log(`Broken links found. See results in ${this.logFile}.`);
+    console.log(`${brokenLinksCount} broken links were found.`);
+
+    try {
+      fs.ensureFileSync(this.logFile);
+      fs.writeJSONSync(this.logFile, brokenLinksJson);
+      console.log(`See report in ${this.logFile}.`);
+    } catch (err) {
+      console.log(
+        `Failed to report into ${this.logFile}. Outputting here instead...`,
+      );
+      console.log(markdownSummary);
+    }
 
     if (buildOptions['drupal-fail-fast']) {
       throw new Error(brokenLinksJson);


### PR DESCRIPTION
## Description
This PR wraps the file-write in the broken link checker with a try-catch. If the file-write fails, it just outputs the summary into the terminal.

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/5204

## Testing done
- [ ] Confirmed successful file write
- [ ] Confirmed handler when unsuccessful

## Screenshots


## Acceptance criteria
- [ ] Tugboat no longer failing at file write

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
