### PR TITLE
NOD: Update path

### DIFF
--- a/src/applications/appeals/10182/constants.js
+++ b/src/applications/appeals/10182/constants.js
@@ -1,7 +1,7 @@
 export const NOD_INFO_URL = '/decision-reviews/board-appeal/';
 
 // Same as "rootUrl" in manifest.json
-export const BASE_URL = `${NOD_INFO_URL}request-board-review-form-10182`;
+export const BASE_URL = `${NOD_INFO_URL}request-board-appeal-form-10182`;
 
 export const FORM_URL = 'https://www.va.gov/vaforms/va/pdf/VA10182.pdf';
 

--- a/src/applications/appeals/10182/manifest.json
+++ b/src/applications/appeals/10182/manifest.json
@@ -2,5 +2,5 @@
   "appName": "Request a Board Appeal",
   "entryFile": "./form-entry.jsx",
   "entryName": "10182-board-appeal",
-  "rootUrl": "/decision-reviews/board-appeal/request-board-review-form-10182"
+  "rootUrl": "/decision-reviews/board-appeal/request-board-appeal-form-10182"
 }

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -1062,7 +1062,7 @@
   {
     "appName": "Request a Board Appeal",
     "entryName": "10182-board-appeal",
-    "rootUrl": "/decision-reviews/board-appeal/request-board-review-form-10182",
+    "rootUrl": "/decision-reviews/board-appeal/request-board-appeal-form-10182",
     "template": {
       "title": "Request a Board Appeal",
       "heading": "Request a Board Appeal",
@@ -1083,7 +1083,7 @@
         },
         {
           "name": "Request a Board Appeal",
-          "path": "/decision-reviews/board-appeal/request-board-review-form-10182"
+          "path": "/decision-reviews/board-appeal/request-board-appeal-form-10182"
         }
       ]
     }


### PR DESCRIPTION
## Description

Changing the path to form 10182 (Board Appeals: Notice of Disagreement). Specifically changing "review" to "appeal" in the path per recommendations. This form is not in production.

Resulting path: http://staging.va.gov/decision-reviews/board-appeal/request-board-appeal-form-10182/

I don't plan to merge this change until after May 4, 2021 (after our sprint review & demo).

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/24138
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/21819#issuecomment-831469494
- https://github.com/department-of-veterans-affairs/devops/pull/9095 (route update)

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] NOD path updatedd

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
