### PR TITLE
[Footer] Fix for footer warning

### DIFF
--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -61,7 +61,7 @@
   {
     "column": 1,
     "href": "https://www.nrd.gov",
-    "order": 8,
+    "order": 9,
     "target": "_blank",
     "title": "National Resource Directory",
     "rel": "noopener noreferrer"


### PR DESCRIPTION
## Description
I noticed a React warning on dev.va.gov about the footer. This PR fixes that by changing a value in the footer links config.

## Testing done
Did a content build, then start the site, and confirmed no warning or visual change.

## Screenshots
Error seen on dev
![image](https://user-images.githubusercontent.com/1915775/117026444-cd6feb00-acc9-11eb-9186-531d91d15531.png)

Fixed
![image](https://user-images.githubusercontent.com/1915775/117026798-13c54a00-acca-11eb-8d8e-11a0aa43263a.png)


## Acceptance criteria
- [ ] No more warning on dev.va.gov

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
