### PR TITLE
Update HLR breadcrumb labels

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -284,7 +284,7 @@
       "vagovprod": true,
       "breadcrumbs_override": [
         {
-          "name": "VA decision review and appeals",
+          "name": "Decision reviews and appeals",
           "path": "decision-reviews"
         },
         {
@@ -292,7 +292,7 @@
           "path": "decision-reviews/higher-level-review/"
         },
         {
-          "name": "Request a Higher-Level Review",
+          "name": "Request a Higher-Level Review with VA Form 20-0996",
           "path": "decision-reviews/higher-level-review/request-higher-level-review-form-20-0996"
         }
       ]

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -288,11 +288,11 @@
           "path": "decision-reviews"
         },
         {
-          "name": "Higher-Level Reviews",
+          "name": "Higher‑Level Reviews",
           "path": "decision-reviews/higher-level-review/"
         },
         {
-          "name": "Request a Higher-Level Review with VA Form 20-0996",
+          "name": "Request a Higher‑Level Review with VA Form 20‑0996",
           "path": "decision-reviews/higher-level-review/request-higher-level-review-form-20-0996"
         }
       ]


### PR DESCRIPTION
## Description

The Higher-Level Review form breadcrumbs do not currently match the page titles. This PR updates them to match.

Note: The label includes a dash in the form number `20-0996`, but this is not showing up within the breadcrumb (see screenshot)

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/16195
- https://dsva.slack.com/archives/CBU0KDSB1/p1620146856312700

## Testing done

N/A

## Screenshots

**Solved!** Switched to using an en-dash. Thanks Micah!

![Screen Shot 2021-05-04 at 11 34 38 AM](https://user-images.githubusercontent.com/136959/117039067-f4c8b700-accd-11eb-837a-bd1053264c88.png)

## Acceptance criteria
- [x] HLR breadcrumbs match page titles

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
