### PR TITLE
Fix calendar links

### DIFF
--- a/src/applications/static-pages/ics-generator.js
+++ b/src/applications/static-pages/ics-generator.js
@@ -3,10 +3,12 @@ export function icsCreate(calendarLink) {
     const cal = new ICS.VCALENDAR();
     const event = new ICS.VEVENT();
     const addToCalendarLink = document.getElementById('add-to-calendar-link');
-    const start = addToCalendarLink.getAttribute('data-start');
-    const startDateObj = new Date(start);
-    const end = addToCalendarLink.getAttribute('data-end');
-    const endDateObj = new Date(end);
+    const startSecondsString = addToCalendarLink.getAttribute('data-start');
+    const startMS = parseInt(startSecondsString, 10) * 1000;
+    const startDateObj = new Date(startMS);
+    const endSecondsString = addToCalendarLink.getAttribute('data-end');
+    const endMS = parseInt(endSecondsString, 10) * 1000;
+    const endDateObj = new Date(endMS);
     const location = addToCalendarLink.getAttribute('data-location');
     const description = addToCalendarLink.getAttribute('data-description');
     const title = addToCalendarLink.getAttribute('data-subject');

--- a/src/site/includes/social-share.drupal.liquid
+++ b/src/site/includes/social-share.drupal.liquid
@@ -6,8 +6,17 @@
 <div data-template="includes/social-share" id="va-c-social-share">
   <ul class="usa-unstyled-list">
     <li class="vads-u-margin-bottom--2p5">
-      <a href="{{ entityUrl.path }}" id="add-to-calendar-link" data-start="{{fieldDatetimeRangeTimezone.value }}" data-end="{{fieldDatetimeRangeTimezone.endTime}}" data-location="{{fieldAddress.addressLine1}} {{fieldAddress.locality}}, {{fieldAddress.administrativeArea}}" data-subject="{{ title }}" data-description="{{fieldDescription}}">
-        <i class="va-c-social-icon fas fa-calendar-check vads-u-margin-right--0p5" aria-hidden="true" role="presentation" aria-hidden="true"></i>Add to Calendar</a>
+      <a
+        data-description="{{ fieldDescription }}"
+        data-end="{{ fieldDatetimeRangeTimezone.endValue }}"
+        data-location="{{ fieldAddress.addressLine1 }} {{ fieldAddress.locality }}, {{ fieldAddress.administrativeArea }}"
+        data-subject="{{ title }}"
+        href="{{ entityUrl.path }}"
+        id="add-to-calendar-link" data-start="{{fieldDatetimeRangeTimezone.value }}"
+      >
+        <i class="va-c-social-icon fas fa-calendar-check vads-u-margin-right--0p5" aria-hidden="true" role="presentation" aria-hidden="true"></i>
+        Add to Calendar
+      </a>
     </li>
 
     <li class="vads-u-margin-bottom--2p5">


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/23991

This PR fixes the calendar links from showing:

```ics
BEGIN:VCALENDAR
VERSION:2.0
PRODID:VA
BEGIN:VEVENT
UID:13523709-410D-46FF-8C99-C07DEF6D1483
SUMMARY:Sexual Harassment & Violence Prevention
DESCRIPTION:Virtual Training presented by The Steven A. Cohen Military Fami
 ly Clinic at Endeavors
LOCATION: , 
DTSTAMP:NaNNaNNaNTNaNNaNNaN
DTSTART:NaNNaNNaNTNaNNaNNaN
DTEND:NaNNaNNaNTNaNNaNNaN
END:VEVENT
END:VCALENDAR
```

to:

```ics
BEGIN:VCALENDAR
VERSION:2.0
PRODID:VA
BEGIN:VEVENT
UID:2B684CA1-0359-48E9-B446-2E35F1A0C56F
SUMMARY:Sexual Harassment & Violence Prevention
DESCRIPTION:Virtual Training presented by The Steven A. Cohen Military Fami
 ly Clinic at Endeavors
LOCATION: , 
DTSTAMP:20210429T120000
DTSTART:20210429T120000
DTEND:20210429T140000
END:VEVENT
END:VCALENDAR
```

## Testing done
Locally

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/117167632-a9251480-ad84-11eb-93e8-ad5532e913ec.png)

## Acceptance criteria
- [x] Fix DTSTAMP, DTSTART, and DTEND for cal links

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
