### PR TITLE
updating codeowners for Identity

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,7 @@ src/platform/site-wide/ebenefits/ @department-of-veterans-affairs/vsp-identity
 src/platform/site-wide/user-nav/containers/AutoSSO.jsx @department-of-veterans-affairs/vsp-identity
 src/platform/user/authentication @department-of-veterans-affairs/vsp-identity
 src/platform/utilities/sso @department-of-veterans-affairs/vsp-identity
+src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx @department-of-veterans-affairs/vsp-identity
 
 # VSP Testing Tools
 src/platform/testing/contract/ @department-of-veterans-affairs/vsp-testing


### PR DESCRIPTION
adding in the approval requirement of src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx since this is VSP Identity team owned code.
