### PR TITLE
Disallow additional punctuation in KMI name fields

### DIFF
--- a/src/applications/coronavirus-vaccination-expansion/config/personal-information/personal-information.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/personal-information/personal-information.js
@@ -4,7 +4,7 @@ import { personalInformation } from '../schema-imports';
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
 
 function containsDisallowedCharacters(value) {
-  const disAllowedCharacters = ['(', ')'];
+  const disAllowedCharacters = ['(', ')', ',', ':', ';'];
   for (const character of disAllowedCharacters) {
     if (value.indexOf(character) !== -1) {
       return true;
@@ -28,7 +28,9 @@ export const uiSchema = {
         function(errors, fieldData) {
           const setError = containsDisallowedCharacters(fieldData);
           if (setError) {
-            errors.addError('Please only use letters and no parentheses');
+            errors.addError(
+              'Please only use letters and no special punctuation',
+            );
           }
         },
       ],
@@ -46,7 +48,7 @@ export const uiSchema = {
           const setError = containsDisallowedCharacters(fieldData);
           if (setError) {
             errors.addError(
-              'Please only use your current last name and no parentheses',
+              'Please only use your current last name and no special punctuation',
             );
           }
         },

--- a/src/applications/coronavirus-vaccination-expansion/tests/coronavirus-vaccination-expansion-form-validation.cypress.spec.js
+++ b/src/applications/coronavirus-vaccination-expansion/tests/coronavirus-vaccination-expansion-form-validation.cypress.spec.js
@@ -31,7 +31,17 @@ describe('COVID-19 SAVE LIVES Act sign up', () => {
       cy.findByLabelText(/Middle name/i).focus();
 
       cy.get('#root_firstName-error-message').contains(
-        'Please only use letters and no parentheses',
+        'Error Please only use letters and no special punctuation',
+      );
+
+      cy.findByLabelText(/First name/i)
+        .clear()
+        .type('Stephen:');
+
+      cy.findByLabelText(/Middle name/i).focus();
+
+      cy.get('#root_firstName-error-message').contains(
+        'Error Please only use letters and no special punctuation',
       );
 
       cy.findByLabelText(/Last name/i)
@@ -41,7 +51,17 @@ describe('COVID-19 SAVE LIVES Act sign up', () => {
       cy.findByLabelText(/Middle name/i).focus();
 
       cy.get('#root_lastName-error-message').contains(
-        'Error Please only use your current last name and no parentheses',
+        'Error Please only use your current last name and no special punctuation',
+      );
+
+      cy.findByLabelText(/Last name/i)
+        .clear()
+        .type('Beers,');
+
+      cy.findByLabelText(/Middle name/i).focus();
+
+      cy.get('#root_lastName-error-message').contains(
+        'Error Please only use your current last name and no special punctuation',
       );
     });
   });


### PR DESCRIPTION
## Description
- Per request from the MPI team, disallow `:;,` in addition to `()` in name fields.
- Update test cases.

## Testing done
- Browser 👀 
- Updated tests

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
