### PR TITLE
Add mainEntity to page template

### DIFF
--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -3,7 +3,7 @@
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}
 
-<div  itemscope itemprop="mainEntity" itemtype="https://schema.org/FAQPage">
+<div itemscope itemprop="mainEntity" itemtype="https://schema.org/FAQPage">
   {% assign lang = entityUrl.path | detectLang  %}
 
   <div id="content" class="interior" lang={{lang}}>

--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -3,7 +3,7 @@
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}
 
-<div itemscope itemtype="https://schema.org/FAQPage">
+<div  itemscope itemprop="mainEntity" itemtype="https://schema.org/FAQPage">
   {% assign lang = entityUrl.path | detectLang  %}
 
   <div id="content" class="interior" lang={{lang}}>


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/22442

This PR adds `itemprop="mainEntity"` to the page template.

## Testing done
Still testing locally atm

## Screenshots
Still testing locally atm

## Acceptance criteria
- [x] adds `itemprop="mainEntity"` to the page template.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
