### PR TITLE
Changing timestamps black for accessible color contrast

### DIFF
--- a/src/applications/virtual-agent/components/webchat/WebChat.jsx
+++ b/src/applications/virtual-agent/components/webchat/WebChat.jsx
@@ -34,6 +34,7 @@ const WebChat = ({ token, WebChatFramework }) => {
     bubbleFromUserBackground: '#f1f1f1',
     bubbleNubSize: 10,
     bubbleFromUserNubSize: 10,
+    timestampColor: '#000000',
   };
 
   return (


### PR DESCRIPTION
The timestamps on the chatbox window were changed from grey to black for 508 compliance.  

## Description


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
