### PR TITLE
Fix heading level in vaccine flow

### DIFF
--- a/src/applications/vaos/covid-19-vaccine/components/VAFacilityPage/FacilitiesRadioWidget.jsx
+++ b/src/applications/vaos/covid-19-vaccine/components/VAFacilityPage/FacilitiesRadioWidget.jsx
@@ -110,6 +110,7 @@ export default function FacilitiesRadioWidget({
         backgroundOnly
         content="If you get a vaccine that requires 2 doses, you'll need to return to the same facility for your second dose."
         headline="Some COVID-19 vaccines require 2 doses"
+        level={2}
         status="info"
       />
     </div>


### PR DESCRIPTION
## Description
This PR
- Fixes the heading level on an alert, because when the facility page is shown without a home address, there's no other h2 on the page and this causes a skipped heading level axe error.

## Testing done
Local testing

## Acceptance criteria
- [ ] Heading level is correct

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
