### PR TITLE
Fix NOD uploads

### DIFF
--- a/src/applications/appeals/10182/utils/upload.js
+++ b/src/applications/appeals/10182/utils/upload.js
@@ -27,9 +27,9 @@ export const evidenceUploadUI = {
     fileTypes: SUPPORTED_UPLOAD_TYPES,
     maxSize: MAX_FILE_SIZE_BYTES,
     minSize: 1024,
-    createPayload: ({ name }) => {
+    createPayload: file => {
       const payload = new FormData();
-      payload.append('decision_review_evidence_attachment[file_data]', name);
+      payload.append('decision_review_evidence_attachment[file_data]', file);
       return payload;
     },
     parseResponse: (response, { name }) => {


### PR DESCRIPTION
## Description

File names were only being uploaded. This PR uploads the binary.

## Testing done

Manual

## Screenshots

N/A

## Acceptance criteria
- [x] Uploaded files include the binary data

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
