### PR TITLE
Filter out files added by the scaffold build from file manifest.

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -280,6 +280,7 @@ module.exports = (env = {}) => {
     baseConfig.plugins.push(
       new ManifestPlugin({
         fileName: 'file-manifest.json',
+        filter: ({ path: filePath }) => !filePath.includes('/generated/..'),
       }),
     );
   }


### PR DESCRIPTION
## Description
The `--scaffold` option for the build generates a file manifest that includes files (e.g., images) that were copied over to generate the app landing pages as well as the generated landing pages themselves. This fix is to ignore anything outside of the `generated` folder when creating the manifest.

## Testing done
Local testing confirmed the lack of extraneous files.

## Acceptance criteria
- [ ] Files copied and generated by the scaffold don't get included in the file manifest.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
