### PR TITLE
Fix intro PDF download link on 10-10CG

### DIFF
--- a/src/applications/caregivers/containers/IntroductionPage.jsx
+++ b/src/applications/caregivers/containers/IntroductionPage.jsx
@@ -90,7 +90,7 @@ const IntroductionPage = ({
                 download the paper form
                 <p className="vads-u-margin-top--2">
                   <a
-                    href="https://www.va.gov/vaforms/medical/pdf/10-10CG.pdf"
+                    href="https://www.va.gov/vaforms/medical/pdf/VA%20Form%2010-10CG.pdf"
                     download="10-10CG.pdf"
                     type="application/pdf"
                     target="_blank"


### PR DESCRIPTION
## Description
Fix intro page PDF download link on 10-10CG intro page so users can download the new updated form.

[Ticket](https://app.zenhub.com/workspaces/vsa---caregiver-5fff0cfd1462b6000e320fc7/issues/department-of-veterans-affairs/va.gov-team/24338)

## Testing done
- Manual testing

## Screenshots
![pdf-download](https://user-images.githubusercontent.com/23741323/117321948-8f0a3580-ae5b-11eb-82e5-e0bd8b0dc807.gif)


## Acceptance criteria
- [x] New PDF download links works as expected

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
