### PR TITLE
23531: Sandbox card styling

### DIFF
--- a/src/applications/gi-sandbox/components/SearchResultCard.jsx
+++ b/src/applications/gi-sandbox/components/SearchResultCard.jsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import Checkbox from '@department-of-veterans-affairs/component-library/Checkbox';
+import classNames from 'classnames';
+import appendQuery from 'append-query';
+import { Link } from 'react-router-dom';
+import { renderStars } from '../../gi/utils/render';
+
+import { estimatedBenefits } from '../selectors/estimator';
+import { formatCurrency } from '../utils/helpers';
+
+export function SearchResultCard({ institution, estimated }) {
+  const {
+    name,
+    city,
+    state,
+    giBillStudents,
+    ratingAverage,
+    ratingCount,
+    accreditationType,
+    facilityCode,
+  } = institution;
+
+  const estimate = ({ qualifier, value }) => {
+    if (qualifier === '% of instate tuition') {
+      return <span>{value}% in-state</span>;
+    } else if (qualifier === null) {
+      return value;
+    }
+    return <span>{formatCurrency(value)}</span>;
+  };
+
+  const tuition = estimate(estimated.tuition);
+  const housing = estimate(estimated.housing);
+
+  const profileLink = appendQuery(`/profile/${facilityCode}`);
+
+  const accreditationTypeClassNames = classNames(
+    'accreditation-tag vads-u-background-color--white vads-u-margin--0 vads-u-border--2px vads-u-border-color--black vads-u-display--blocks',
+    { 'vads-u-visibility--hidden': accreditationType !== 'regional' },
+  );
+
+  return (
+    <div className="result-card vads-u-background-color--gray-lightest vads-u-margin-bottom--2 vads-u-margin-left--2p5">
+      <div className="vads-u-padding-x--2">
+        <div className="card-title-section">
+          <h3 className="vads-u-margin-top--2">{name}</h3>
+        </div>
+        <p className="vads-u-padding--0">{`${city}, ${state}`}</p>
+
+        <div className={accreditationTypeClassNames}>Regionally accredited</div>
+
+        <p>
+          <strong>GI Bill Students:</strong> {giBillStudents}
+        </p>
+        {ratingCount > 0 ? (
+          <div>
+            <p className="vads-u-margin-bottom--0">
+              <strong>Rated By:</strong> {ratingCount}
+            </p>
+            <div className="vads-u-margin-bottom--2">
+              {renderStars(ratingAverage)} (
+              {Math.round(10 * ratingAverage) / 10} of 5)
+            </div>
+          </div>
+        ) : (
+          <div className="vads-u-padding-bottom--3">
+            <p>
+              <strong>School rating:</strong> Not yet rated
+            </p>
+          </div>
+        )}
+      </div>
+      <div className="vads-u-border-top--3px vads-u-border-color--white vads-u-padding-x--2">
+        <p>
+          <strong>You may be eligible for up to:</strong>
+        </p>
+        <div className="vads-u-display--flex vads-u-text-align--center vads-u-margin-top--0 vads-u-margin-bottom--2">
+          <div className="vads-u-flex--1 ">
+            <p className="secondary-info-label">Tuition benefit:</p>
+            <p className="vads-u-margin-y--0">{tuition}</p>
+          </div>
+          <div className="vads-u-flex--1">
+            <p className="secondary-info-label">Housing Benefit:</p>
+            <p className="vads-u-margin-y--0">{housing} / Month</p>
+          </div>
+        </div>
+      </div>
+      <div className="vads-u-display--flex vads-u-border-top--3px vads-u-border-color--white vads-u-text-align--center">
+        <div className="card-bottom-cell vads-u-flex--1 vads-u-border-right--2px vads-u-border-color--white vads-u-margin--0">
+          <div className="vads-u-padding--0 vads-u-margin-top--neg2 vads-u-margin-bottom--0p5">
+            <Checkbox label="Compare" />
+          </div>
+        </div>
+        <div className="card-bottom-cell vads-u-flex--1 vads-u-border-left--2px vads-u-border-color--white">
+          <Link to={profileLink}>View details ›</Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const mapStateToProps = (state, props) => ({
+  estimated: estimatedBenefits(state, props),
+});
+
+export default connect(mapStateToProps)(SearchResultCard);

--- a/src/applications/gi-sandbox/components/SearchResultCard.jsx
+++ b/src/applications/gi-sandbox/components/SearchResultCard.jsx
@@ -14,7 +14,7 @@ export function SearchResultCard({ institution, estimated }) {
     name,
     city,
     state,
-    giBillStudents,
+    studentCount,
     ratingAverage,
     ratingCount,
     accreditationType,
@@ -51,7 +51,7 @@ export function SearchResultCard({ institution, estimated }) {
         <div className={accreditationTypeClassNames}>Regionally accredited</div>
 
         <p>
-          <strong>GI Bill Students:</strong> {giBillStudents}
+          <strong>GI Bill Students:</strong> {studentCount}
         </p>
         {ratingCount > 0 ? (
           <div>

--- a/src/applications/gi-sandbox/components/SearchResults.jsx
+++ b/src/applications/gi-sandbox/components/SearchResults.jsx
@@ -7,8 +7,8 @@ export default function SearchResults({ search }) {
       {search.count > 0 && (
         <div className="usa-grid vads-u-padding--1">
           <p>
-            Showing <strong>{search.count} search results</strong> for{' '}
-            <strong>'{search.query.name}'</strong>
+            Showing <strong>{search.count} search results</strong> for '
+            <strong>{search.query.name}</strong>'
           </p>
           <div className="usa-width-one-third">
             <h3>Filter Panel</h3>

--- a/src/applications/gi-sandbox/components/SearchResults.jsx
+++ b/src/applications/gi-sandbox/components/SearchResults.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import SearchResultCard from './SearchResultCard';
+
+export default function SearchResults({ search }) {
+  return (
+    <>
+      {search.count > 0 && (
+        <div className="usa-grid vads-u-padding--1">
+          <p>
+            Showing <strong>{search.count} search results</strong> for{' '}
+            <strong>'{search.query.name}'</strong>
+          </p>
+          <div className="usa-width-one-third">
+            <h3>Filter Panel</h3>
+          </div>
+          <div className="usa-width-two-thirds vads-u-margin-right--neg2">
+            <div className="vads-l-row vads-u-flex-wrap--wrap">
+              {search.results.map(institution => (
+                <SearchResultCard
+                  institution={institution}
+                  key={institution.id}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/applications/gi-sandbox/containers/LandingPage.jsx
+++ b/src/applications/gi-sandbox/containers/LandingPage.jsx
@@ -8,6 +8,7 @@ import {
 } from '../actions';
 import { PAGE_TITLE } from '../constants';
 import SearchForm from '../components/SearchForm';
+import SearchResults from '../components/SearchResults';
 
 export function LandingPage({
   search,
@@ -21,7 +22,7 @@ export function LandingPage({
   return (
     <span className="landing-page">
       <div className="vads-u-min-height--viewport row">
-        <div className="column">
+        <div className="column vads-u-padding-bottom--2">
           <div className="vads-u-text-align--center">
             <h1>GI Bill® Comparison Tool</h1>
             <p className="vads-u-font-size--h3 vads-u-color--gray-dark">
@@ -35,7 +36,9 @@ export function LandingPage({
             fetchSearchByName={dispatchFetchSearchByNameResults}
           />
         </div>
-        <div className="small-12 usa-width-one-third medium-4 columns" />
+        <div>
+          <SearchResults search={search} />
+        </div>
       </div>
     </span>
   );

--- a/src/applications/gi-sandbox/sass/partials/_gi-search-page.scss
+++ b/src/applications/gi-sandbox/sass/partials/_gi-search-page.scss
@@ -271,10 +271,36 @@
   .usa-alert-heading {
     font-size: 1em;
   }
-
-
 }
 
 .exclude-warnings-closings-checkbox {
   padding-left: 0.2em;
+}
+
+.result-card {
+  border-radius: 5px;
+  width: 45%;
+}
+
+.card-title-section {
+  height: 100px;
+}
+
+.accreditation-tag {
+  border-radius: 15px;
+  font-size: 14px;
+  height: auto;
+  padding-left: 10px;
+  width: 157px;
+}
+
+.secondary-info-label {
+  font-size: 12px;
+  margin-bottom: 0;
+}
+
+.card-bottom-cell {
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }


### PR DESCRIPTION
## Description
As a developer, I need to update the CT sandbox search results card to match the redesign so that the changes are available for usability testing.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/23531

## Testing done
Testing passes locally

## Screenshots
<img width="1041" alt="Screen Shot 2021-05-07 at 2 15 00 PM" src="https://user-images.githubusercontent.com/48804834/117491788-a706b580-af3e-11eb-9a59-59a910bfc830.png">



## Acceptance criteria
- [x] A card is displayed for each institution that is returned by the search results.
- [x] The following data is displayed in each card:
a. Institution Name
b. Institution City
c. Institution State
d. Accreditation Type
e. # GI Bill Students
f. Institution Rating Score
g. Number of Institution Ratings
h. Tuition Benefit
i. Housing Benefit
- [x] The user has the ability to navigate from the card to the institution profile page.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
