### PR TITLE
add h3 heading to appt date detail

### DIFF
--- a/src/applications/vaos/covid-19-vaccine/components/ReviewPage.jsx
+++ b/src/applications/vaos/covid-19-vaccine/components/ReviewPage.jsx
@@ -53,11 +53,11 @@ export default function ReviewPage() {
       <div className="vads-l-grid-container vads-u-padding--0">
         <div className="vads-l-row vads-u-justify-content--space-between">
           <div className="vads-u-flex--1 vads-u-padding-right--1">
-            <strong>
+            <h3 className="vaos-appts__block-label">
               {moment(date1, 'YYYY-MM-DDTHH:mm:ssZ').format(
                 'dddd, MMMM DD, YYYY [at] h:mm a ',
               ) + getTimezoneAbbrBySystemId(systemId)}
-            </strong>
+            </h3>
           </div>
         </div>
       </div>

--- a/src/applications/vaos/tests/covid-19-vaccine/components/ReviewPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/ReviewPage.unit.spec.jsx
@@ -105,16 +105,20 @@ describe('VAOS vaccine flow <ReviewPage>', () => {
     });
 
     await screen.findByText(/COVID-19 vaccine/i);
-    const [pageHeading, descHeading, facilityHeading] = screen.getAllByRole(
-      'heading',
-    );
+    const [
+      pageHeading,
+      descHeading,
+      dateHeading,
+      facilityHeading,
+    ] = screen.getAllByRole('heading');
     expect(pageHeading).to.contain.text('Review your appointment details');
     expect(descHeading).to.contain.text('COVID-19 vaccine');
     expect(descHeading).to.have.tagName('h2');
 
-    expect(screen.baseElement).to.contain.text(
+    expect(dateHeading).to.contain.text(
       start.format('dddd, MMMM DD, YYYY [at] h:mm a'),
     );
+    expect(dateHeading).to.have.tagName('h3');
 
     expect(facilityHeading).to.contain.text('Cheyenne VA Medical Center');
     expect(screen.baseElement).to.contain.text('Some VA clinic');


### PR DESCRIPTION
## Description
the appointment date/time detail on the review page should display as heading <h3>

## Testing done
local and unit test

## Screenshots
![image](https://user-images.githubusercontent.com/54327023/117485039-ea105b00-af35-11eb-8431-56efe5b79cba.png)


## Acceptance criteria
- [ ] change the date/time information to be h3 heading

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
