### PR TITLE
Discharge Wizard - Reverted URL

### DIFF
--- a/src/applications/discharge-wizard/helpers/index.jsx
+++ b/src/applications/discharge-wizard/helpers/index.jsx
@@ -196,9 +196,7 @@ export const formData = formValues => {
   }
   return {
     num: 149,
-    link:
-      'https://www.dfas.mil/Portals/98/Documents/CorrectMilitaryRecords/dd0149.pdf?ver=2020-01-08-143351-750',
-    // link: 'http://www.esd.whs.mil/Portals/54/Documents/DD/forms/dd/dd0149.pdf',
+    link: 'http://www.esd.whs.mil/Portals/54/Documents/DD/forms/dd/dd0149.pdf',
   };
 };
 


### PR DESCRIPTION
## Issue
https://github.com/department-of-veterans-affairs/va.gov-team/issues/21944

## Description
We are not reverting to the DD149 original URL because our VA stakeholders where able to fix the publishing of the PDF. 

## Testing done
Tested locally

## Screenshots
![Screen Shot 2021-05-07 at 4 07 30 PM](https://user-images.githubusercontent.com/26075258/117503328-cb6a8e00-af4e-11eb-8e2d-107f8163a347.png)
![Screen Shot 2021-05-07 at 4 07 36 PM](https://user-images.githubusercontent.com/26075258/117503353-d4f3f600-af4e-11eb-98ca-44fb48c4c665.png)


## Acceptance criteria
- [x] Form is reverted

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
