### PR TITLE
replace connect with hooks

### DIFF
--- a/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.jsx
@@ -208,7 +208,6 @@ export default function DateTimeSelectPage() {
             dispatch,
             data,
             history,
-            routeToNextAppointmentPage,
             setSubmitted,
           })
         }

--- a/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeSelectPage/index.jsx
@@ -1,11 +1,18 @@
 import React, { useState, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
-import { connect } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import moment from 'moment';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 
-import * as actions from '../../redux/actions';
+import {
+  getAppointmentSlots,
+  onCalendarChange,
+  routeToNextAppointmentPage,
+  routeToPreviousAppointmentPage,
+  startRequestAppointmentFlow,
+  requestAppointmentDateChoice,
+} from '../../redux/actions';
 import { scrollAndFocus } from '../../../utils/scrollAndFocus';
 import FormButtons from '../../../components/FormButtons';
 import { getDateTimeSelect } from '../../redux/selectors';
@@ -19,7 +26,7 @@ import useIsInitialLoad from '../../../hooks/useIsInitialLoad';
 const pageKey = 'selectDateTime';
 const pageTitle = 'Tell us the date and time you’d like your appointment';
 
-function ErrorMessage({ facilityId, requestAppointmentDateChoice, history }) {
+function ErrorMessage({ facilityId, history }) {
   return (
     <div
       aria-atomic="true"
@@ -50,43 +57,31 @@ function ErrorMessage({ facilityId, requestAppointmentDateChoice, history }) {
   );
 }
 
-function goBack({ routeToPreviousAppointmentPage, history }) {
-  return routeToPreviousAppointmentPage(history, pageKey);
-}
-
-function goForward({
-  data,
-  history,
-  routeToNextAppointmentPage,
-  setSubmitted,
-}) {
+function goForward({ dispatch, data, history, setSubmitted }) {
   setSubmitted(true);
 
   if (data.selectedDates?.length) {
-    routeToNextAppointmentPage(history, pageKey);
+    dispatch(routeToNextAppointmentPage(history, pageKey));
   } else {
     scrollAndFocus('.usa-input-error-message');
   }
 }
 
-export function DateTimeSelectPage({
-  appointmentSlotsStatus,
-  availableSlots,
-  data,
-  eligibleForRequests,
-  facilityId,
-  getAppointmentSlots,
-  pageChangeInProgress,
-  preferredDate,
-  onCalendarChange,
-  routeToPreviousAppointmentPage,
-  requestAppointmentDateChoice,
-  routeToNextAppointmentPage,
-  startRequestAppointmentFlow,
-  timezone,
-  timezoneDescription,
-  typeOfCareId,
-}) {
+export default function DateTimeSelectPage() {
+  const {
+    appointmentSlotsStatus,
+    availableSlots,
+    data,
+    eligibleForRequests,
+    facilityId,
+    pageChangeInProgress,
+    preferredDate,
+    timezone,
+    timezoneDescription,
+    typeOfCareId,
+  } = useSelector(state => getDateTimeSelect(state, pageKey), shallowEqual);
+
+  const dispatch = useDispatch();
   const history = useHistory();
   const [submitted, setSubmitted] = useState(false);
   const fetchFailed = appointmentSlotsStatus === FETCH_STATUS.failed;
@@ -97,15 +92,17 @@ export function DateTimeSelectPage({
   const isInitialLoad = useIsInitialLoad(loadingSlots);
 
   useEffect(() => {
-    getAppointmentSlots(
-      moment(preferredDate)
-        .startOf('month')
-        .format('YYYY-MM-DD'),
-      moment(preferredDate)
-        .add(1, 'months')
-        .endOf('month')
-        .format('YYYY-MM-DD'),
-      true,
+    dispatch(
+      getAppointmentSlots(
+        moment(preferredDate)
+          .startOf('month')
+          .format('YYYY-MM-DD'),
+        moment(preferredDate)
+          .add(1, 'months')
+          .endOf('month')
+          .format('YYYY-MM-DD'),
+        true,
+      ),
     );
     document.title = `${pageTitle} | Veterans Affairs`;
   }, []);
@@ -143,7 +140,9 @@ export function DateTimeSelectPage({
           eligibleForRequests={eligibleForRequests}
           facilityId={facilityId}
           nextAvailableApptDate={availableSlots?.[0]?.start}
-          onClickRequest={startRequestAppointmentFlow}
+          onClickRequest={(...args) =>
+            dispatch(startRequestAppointmentFlow(...args))
+          }
           preferredDate={preferredDate}
           timezone={timezoneDescription}
           typeOfCareId={typeOfCareId}
@@ -153,7 +152,9 @@ export function DateTimeSelectPage({
         <ErrorMessage
           history={history}
           facilityId={facilityId}
-          requestAppointmentDateChoice={requestAppointmentDateChoice}
+          requestAppointmentDateChoice={(...args) =>
+            dispatch(requestAppointmentDateChoice(...args))
+          }
         />
       )}
       {!fetchFailed && (
@@ -179,9 +180,11 @@ export function DateTimeSelectPage({
                 message="Finding appointment availability..."
               />
             }
-            onChange={onCalendarChange}
-            onNextMonth={getAppointmentSlots}
-            onPreviousMonth={getAppointmentSlots}
+            onChange={(...args) => dispatch(onCalendarChange(...args))}
+            onNextMonth={(...args) => dispatch(getAppointmentSlots(...args))}
+            onPreviousMonth={(...args) =>
+              dispatch(getAppointmentSlots(...args))
+            }
             minDate={moment()
               .add(1, 'days')
               .format('YYYY-MM-DD')}
@@ -197,9 +200,12 @@ export function DateTimeSelectPage({
         </>
       )}
       <FormButtons
-        onBack={() => goBack({ routeToPreviousAppointmentPage, history })}
+        onBack={() =>
+          dispatch(routeToPreviousAppointmentPage(history, pageKey))
+        }
         onSubmit={() =>
           goForward({
+            dispatch,
             data,
             history,
             routeToNextAppointmentPage,
@@ -213,21 +219,3 @@ export function DateTimeSelectPage({
     </div>
   );
 }
-
-function mapStateToProps(state) {
-  return getDateTimeSelect(state, pageKey);
-}
-
-const mapDispatchToProps = {
-  getAppointmentSlots: actions.getAppointmentSlots,
-  onCalendarChange: actions.onCalendarChange,
-  routeToNextAppointmentPage: actions.routeToNextAppointmentPage,
-  routeToPreviousAppointmentPage: actions.routeToPreviousAppointmentPage,
-  startRequestAppointmentFlow: actions.startRequestAppointmentFlow,
-  requestAppointmentDateChoice: actions.requestAppointmentDateChoice,
-};
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(DateTimeSelectPage);


### PR DESCRIPTION
## Description
replace connect() with hooks for DateTimeSelectPage

## Testing done
unit and local test

## Screenshots
n/a

## Acceptance criteria
- [ ] connect() is no longer used on page
- [ ]  All actions that were in mapDispatchToProps are now wrapped in dispatch() when called
- [ ]  All data in mapStateToProps is pulled in through useSelector hooks

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
