### PR TITLE
Support web components in scaffolded build.

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -364,7 +364,7 @@ module.exports = (env = {}) => {
       widgetTemplate,
     }) =>
       new HtmlPlugin({
-        chunks: ['polyfills', 'vendor', 'style', entryName],
+        chunks: ['polyfills', 'web-components', 'vendor', 'style', entryName],
         filename: landingPagePath(rootUrl),
         inject: false,
         scriptLoading: 'defer',


### PR DESCRIPTION
## Description
The templates for the app landing pages were missing `web-components.entry.js` and `web-components.css` in the header.

This resulted in `va-accordion` components not loading when apps were built with the `--scaffold` option.

## Testing done
Verified in http://localhost:3001/health-care/covid-19-vaccine/sign-up/eligibility that accordions did not load before the fix and then did load after the fix.

## Acceptance criteria
- [ ] Web components should render in the scaffolded build.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
