### PR TITLE
Staging Review Accessibility Fixes for 10-10CG POA work

### DIFF
--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
@@ -38,6 +38,7 @@ const SignatureCheckbox = ({
 
       <section className={classNames({ 'wide-input': isRepresentative })}>
         <SignatureInput
+          aria-describedby={`${label}-signature-label`}
           label={label}
           fullName={fullName}
           required={isRequired}
@@ -49,7 +50,10 @@ const SignatureCheckbox = ({
         />
 
         {isRepresentative && (
-          <p className="on-behalf-representative">
+          <p
+            className="on-behalf-representative"
+            id={`${label}-signature-label`}
+          >
             On behalf of
             <strong className="vads-u-font-size--lg">
               {fullName.first} {fullName.middle} {fullName.last}

--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
@@ -38,7 +38,7 @@ const SignatureCheckbox = ({
 
       <section className={classNames({ 'wide-input': isRepresentative })}>
         <SignatureInput
-          aria-describedby={`${label}-signature-label`}
+          ariaDescribedby={`${label}-signature-label`}
           label={label}
           fullName={fullName}
           required={isRequired}

--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
@@ -11,6 +11,7 @@ const SignatureInput = ({
   isRepresentative,
   setSignatures,
   isChecked,
+  ariaDescribedby,
 }) => {
   const [hasError, setError] = useState(false);
   const firstName = fullName.first || '';
@@ -116,6 +117,7 @@ const SignatureInput = ({
 
   return (
     <TextInput
+      ariaDescribedby={ariaDescribedby}
       additionalClass="signature-input"
       label={createInputLabel(label)}
       required={required}
@@ -134,6 +136,7 @@ SignatureInput.propTypes = {
   hasSubmittedForm: PropTypes.bool.isRequired,
   setSignatures: PropTypes.func.isRequired,
   isRepresentative: PropTypes.bool,
+  ariaDescribedby: PropTypes.string.isRequired,
   required: PropTypes.bool,
 };
 

--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
@@ -16,9 +16,6 @@ const SignatureInput = ({
   const firstName = fullName.first?.toLowerCase() || '';
   const lastName = fullName.last?.toLowerCase() || '';
   const middleName = fullName.middle?.toLowerCase() || '';
-  const errorMessage = isRepresentative
-    ? 'You must sign as representative.'
-    : 'Your signature must match your first and last name as previously entered.';
 
   const [signature, setSignature] = useState({
     value: '',
@@ -41,6 +38,10 @@ const SignatureInput = ({
 
   const getName = (middle = '') =>
     removeSpaces(`${firstName}${middle}${lastName}`);
+
+  const errorMessage = isRepresentative
+    ? 'You must sign as representative.'
+    : `Your signature must match previously entered name: ${getName()}`;
 
   const normalizedSignature = removeSpaces(signature.value);
 

--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
@@ -13,9 +13,9 @@ const SignatureInput = ({
   isChecked,
 }) => {
   const [hasError, setError] = useState(false);
-  const firstName = fullName.first?.toLowerCase() || '';
-  const lastName = fullName.last?.toLowerCase() || '';
-  const middleName = fullName.middle?.toLowerCase() || '';
+  const firstName = fullName.first || '';
+  const lastName = fullName.last || '';
+  const middleName = fullName.middle || '';
 
   const [signature, setSignature] = useState({
     value: '',
@@ -37,11 +37,13 @@ const SignatureInput = ({
       .toLocaleLowerCase();
 
   const getName = (middle = '') =>
-    removeSpaces(`${firstName}${middle}${lastName}`);
+    removeSpaces(
+      `${firstName?.toLowerCase()}${middle?.toLowerCase()}${lastName?.toLowerCase()}`,
+    );
 
   const errorMessage = isRepresentative
     ? 'You must sign as representative.'
-    : `Your signature must match previously entered name: ${getName()}`;
+    : `Your signature must match previously entered name: ${firstName} ${middleName} ${lastName}`;
 
   const normalizedSignature = removeSpaces(signature.value);
 

--- a/src/applications/caregivers/config/chapters/signAsRepresentative/uploadPOADocument.js
+++ b/src/applications/caregivers/config/chapters/signAsRepresentative/uploadPOADocument.js
@@ -64,6 +64,8 @@ export default {
     properties: {
       [representativeFields.documentUpload]: {
         type: 'array',
+        minItems: 1,
+        maxItems: 1,
         items: {
           type: 'object',
           required: ['guid', 'name'],

--- a/src/applications/caregivers/config/chapters/signAsRepresentative/uploadPOADocument.js
+++ b/src/applications/caregivers/config/chapters/signAsRepresentative/uploadPOADocument.js
@@ -64,8 +64,6 @@ export default {
     properties: {
       [representativeFields.documentUpload]: {
         type: 'array',
-        minItems: 1,
-        maxItems: 1,
         items: {
           type: 'object',
           required: ['guid', 'name'],

--- a/src/applications/caregivers/config/chapters/signAsRepresentative/uploadPOADocument.js
+++ b/src/applications/caregivers/config/chapters/signAsRepresentative/uploadPOADocument.js
@@ -36,30 +36,27 @@ export default {
   uiSchema: {
     'ui:description': RepresentativeDocumentUploadDescription(),
     'ui:title': () => (
-      <legend className="vads-u-font-size--h4">
+      <h3 className="vads-u-font-size--h4 vads-u-margin--0">
         Upload your legal representative documentation
-        <span className="vads-u-margin-left--0p5 vads-u-color--secondary-dark vads-u-font-size--sm vads-u-font-weight--normal">
+        <span className="vads-u-margin-left--0p5 vads-u-color--secondary-dark vads-u-font-size--sm vads-u-font-weight--normal vads-u-font-family--sans">
           (*Required)
         </span>
-      </legend>
+      </h3>
     ),
-    [representativeFields.documentUpload]: fileUploadUI(
-      'Upload your legal representative documentation',
-      {
-        buttonText: 'Upload',
-        classNames: 'poa-document-upload',
-        multiple: false,
-        fileUploadUrl: `${environment.API_URL}/v0/form1010cg/attachments`,
-        fileTypes: ['pdf', 'doc', 'docx', 'jpg', 'jpeg', 'rtf', 'png'],
-        maxSize: 1024 * 1024 * 10,
-        hideLabelText: true,
-        createPayload,
-        parseResponse,
-        attachmentName: {
-          'ui:title': 'Document name',
-        },
+    [representativeFields.documentUpload]: fileUploadUI(' ', {
+      buttonText: 'Upload',
+      classNames: 'poa-document-upload',
+      multiple: false,
+      fileUploadUrl: `${environment.API_URL}/v0/form1010cg/attachments`,
+      fileTypes: ['pdf', 'doc', 'docx', 'jpg', 'jpeg', 'rtf', 'png'],
+      maxSize: 1024 * 1024 * 10,
+      hideLabelText: true,
+      createPayload,
+      parseResponse,
+      attachmentName: {
+        'ui:title': 'Document name',
       },
-    ),
+    }),
   },
   schema: {
     type: 'object',

--- a/src/applications/caregivers/config/form.js
+++ b/src/applications/caregivers/config/form.js
@@ -191,7 +191,7 @@ const formConfig = {
       pages: {
         secondaryCaregiverTwo: {
           path: 'secondary-two-1',
-          title: 'Secondary Family Caregiver (2) applicant information',
+          title: secondaryTwoChapterTitle,
           depends: formData => hasSecondaryCaregiverTwo(formData),
           uiSchema: secondaryTwoInfoPage.uiSchema,
           schema: secondaryTwoInfoPage.schema,
@@ -209,17 +209,17 @@ const formConfig = {
       title: 'Representative documentation',
       pages: {
         signAsRepresentative: {
-          depends: formData => formData['view:canUpload1010cgPOA'],
           path: 'representative-documentation',
           title: 'Representative documentation',
+          depends: formData => formData['view:canUpload1010cgPOA'],
           uiSchema: signAsRepresentativeYesNo.uiSchema,
           schema: signAsRepresentativeYesNo.schema,
         },
         documentUpload: {
-          title: 'Supporting documentation',
-          depends: formData => formData.signAsRepresentativeYesNo === 'yes',
-          editModeOnReviewPage: true,
           path: 'representative-document-upload',
+          title: 'Representative documentation',
+          depends: formData => formData.signAsRepresentativeYesNo === 'yes',
+          editModeOnReviewPage: false,
           uiSchema: uploadPOADocument.uiSchema,
           schema: uploadPOADocument.schema,
         },
@@ -227,5 +227,8 @@ const formConfig = {
     },
   },
 };
+
+/* TODO Need to change editModeOnReviewPage for document upload to true 
+when platform bug is fixed and upload button appears with this feature enabled */
 
 export default formConfig;

--- a/src/applications/caregivers/config/form.js
+++ b/src/applications/caregivers/config/form.js
@@ -218,6 +218,7 @@ const formConfig = {
         documentUpload: {
           title: 'Supporting documentation',
           depends: formData => formData.signAsRepresentativeYesNo === 'yes',
+          editModeOnReviewPage: true,
           path: 'representative-document-upload',
           uiSchema: uploadPOADocument.uiSchema,
           schema: uploadPOADocument.schema,

--- a/src/applications/caregivers/sass/signatureBox.scss
+++ b/src/applications/caregivers/sass/signatureBox.scss
@@ -37,7 +37,7 @@
       margin: 10px 0 0 0;
     }
 
-    section {
+    .wide-input {
       flex-direction: column;
 
       label {


### PR DESCRIPTION
## Description
These are fixes that were founding during VSP Collaboration Cycle Review and are documented in this [Ticket](https://app.zenhub.com/workspaces/vsa---caregiver-5fff0cfd1462b6000e320fc7/issues/department-of-veterans-affairs/va.gov-team/23616)

## Testing done
- Manual testing

## Screenshots


## Acceptance criteria
- [x] [Dev intent] Ensure `legend`s are properly used with `fieldset`s
- [x] Style the `legend` to be more recognizable from standard `p` text [Step 4 of 5: Legal Representative](https://preview.uxpin.com/3bf6496017f55041a94c2cfc8009c35dad5a79f2#/pages/137666495/simulate/sitemap?mode=i) (might just be a prototype issue)
- [x] Add labels to signature boxes to satisfy accessibility requirements
- [ ] If we keep "on behalf of" - Either rewrite content so that "on behalf of" is not an isolated `p` tag between two fields (preferred) OR use `aria-describedby` so that it is programatically linked to the first field [Step 5 of 5: Review Application](https://preview.uxpin.com/3bf6496017f55041a94c2cfc8009c35dad5a79f2#/pages/137666520/simulate/sitemap?mode=i)
- [ ] Make document upload edit by default on review page 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
