### PR TITLE
Fixed appName in manifest for Health care Questionnaire to be consistent with registry

### DIFF
--- a/src/applications/health-care-questionnaire/questionnaire/manifest.json
+++ b/src/applications/health-care-questionnaire/questionnaire/manifest.json
@@ -1,5 +1,5 @@
 {
-  "appName": "Health Care Questionnaire",
+  "appName": "Health care Questionnaire",
   "entryFile": "./app-entry.jsx",
   "entryName": "questionnaire",
   "rootUrl": "/health-care/health-questionnaires/questionnaires/answer-questions"


### PR DESCRIPTION
## Description
Noticed that the casing of the `appName` the manifest for "Health care Questionnare" was inconsistent with the `registry.json` entry. This caused tests to fail in CircleCI since the registry is in `content-build`, which was unavailable to the pipeline, so the scaffolded build used the manifest files as the fallback. Although it's not critical to fix, it seemed worth correcting to avoid confusion later.

## Testing done
Tested with and without `registy.json` available for scaffolded builds.

## Acceptance criteria
- [ ] Manifest attributes should be consistent with `registry.json`.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
