### PR TITLE
Record accordion-child-label as "undefined" when childlabel is null

### DIFF
--- a/src/applications/static-pages/subscribeAccordionEvents.js
+++ b/src/applications/static-pages/subscribeAccordionEvents.js
@@ -31,6 +31,8 @@ export default function subscribeAccordionEvents() {
 
       if (e.target.dataset?.childlabel) {
         data['accordion-child-label'] = e.target.dataset.childlabel;
+      } else {
+        data['accordion-child-label'] = undefined;
       }
 
       recordEvent(data);


### PR DESCRIPTION
Record accordion-child-label as "undefined" when childlabel is null.