### PR TITLE
Speed up some Profile Cypress tests

### DIFF
--- a/src/applications/personalization/profile/tests/e2e/helpers.js
+++ b/src/applications/personalization/profile/tests/e2e/helpers.js
@@ -1,4 +1,5 @@
 import { PROFILE_PATHS, PROFILE_PATH_NAMES } from '../../constants';
+import error500 from '@@profile/tests/fixtures/500.json';
 
 export function subNavOnlyContainsAccountSecurity(mobile) {
   if (mobile) {
@@ -26,6 +27,22 @@ export function onlyAccountSecuritySectionIsAccessible() {
     );
   });
 }
+
+// Pass in an array of GET endpoints you want to mock. All endpoints will be
+// mocked with the same statusCode and response body, both of which can be
+// specified as optional arguments
+export const mockGETEndpoints = (
+  endpoints,
+  statusCode = 500,
+  body = error500,
+) => {
+  endpoints.forEach(endpoint => {
+    cy.intercept(endpoint, {
+      statusCode,
+      body,
+    });
+  });
+};
 
 export const mockFeatureToggles = () => {
   cy.server();

--- a/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/fields-check.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/fields-check.cypress.spec.js
@@ -4,13 +4,18 @@ import { mockUser } from '@@profile/tests/fixtures/users/user.js';
 import mockPersonalInformation from '@@profile/tests/fixtures/personal-information-success.json';
 import mockServiceHistory from '@@profile/tests/fixtures/service-history-success.json';
 import mockFullName from '@@profile/tests/fixtures/full-name-success.json';
+import { mockGETEndpoints } from '@@profile/tests/e2e/helpers';
 
 const setup = () => {
   cy.login(mockUser);
-  cy.server();
-  cy.route('GET', 'v0/profile/personal_information', mockPersonalInformation);
-  cy.route('GET', 'v0/profile/service_history', mockServiceHistory);
-  cy.route('GET', 'v0/profile/full_name', mockFullName);
+  cy.intercept('v0/profile/personal_information', mockPersonalInformation);
+  cy.intercept('v0/profile/service_history', mockServiceHistory);
+  cy.intercept('v0/profile/full_name', mockFullName);
+  mockGETEndpoints([
+    'v0/mhv_account',
+    'v0/feature_toggles*',
+    'v0/ppiu/payment_information',
+  ]);
   cy.visit(PROFILE_PATHS.PROFILE_ROOT);
 
   // should show a loading indicator

--- a/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/mailing-address.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/mailing-address.cypress.spec.js
@@ -1,5 +1,6 @@
 import { PROFILE_PATHS } from '@@profile/constants';
 import mockUser from '@@profile/tests/fixtures/users/user-36.json';
+import { mockGETEndpoints } from '@@profile/tests/e2e/helpers';
 
 const setup = (mobile = false) => {
   if (mobile) {
@@ -7,6 +8,15 @@ const setup = (mobile = false) => {
   }
 
   cy.login(mockUser);
+  mockGETEndpoints([
+    'v0/mhv_account',
+    'v0/profile/full_name',
+    'v0/profile/status',
+    'v0/profile/personal_information',
+    'v0/profile/service_history',
+    'v0/feature_toggles*',
+    'v0/ppiu/payment_information',
+  ]);
   cy.visit(PROFILE_PATHS.PROFILE_ROOT);
 
   // should show a loading indicator
@@ -65,21 +75,19 @@ const confirmWebAddressesAreBlocked = () => {
 
   cy.findByRole('textbox', { name: /street address.*required/i })
     .clear()
-    .type('propaganda.com');
+    .type('x.com', { delay: 1 });
   cy.findByRole('button', { name: 'Update' }).focus();
   cy.findByRole('alert')
     .should('exist')
     .contains(/please enter a valid street address/i);
   cy.findByRole('textbox', { name: /street address.*required/i })
     .clear()
-    .type('123 main');
+    .type('123 main', { delay: 1 });
   cy.findByRole('alert').should('not.exist');
 
-  // NOTE: resorting to selecting via a fragile element ID since there are two
-  // street lines on this form with identical labels :(
   cy.findByLabelText(/^Street address line 2/i)
     .clear()
-    .type('www.propaganda.blah');
+    .type('www.x.blah', { delay: 1 });
   cy.findByRole('button', { name: 'Update' }).focus();
   cy.findByRole('alert')
     .should('exist')
@@ -91,7 +99,7 @@ const confirmWebAddressesAreBlocked = () => {
   // street lines on this form with identical labels :(
   cy.findByLabelText(/^Street address line 3/i)
     .clear()
-    .type('propaganda.net');
+    .type('x.net', { delay: 1 });
   cy.findByRole('button', { name: 'Update' }).focus();
   cy.findByRole('alert')
     .should('exist')
@@ -101,38 +109,38 @@ const confirmWebAddressesAreBlocked = () => {
 
   cy.findByRole('textbox', { name: /city/i })
     .clear()
-    .type('http://');
+    .type('http://', { delay: 1 });
   cy.findByRole('button', { name: 'Update' }).focus();
   cy.findByRole('alert')
     .should('exist')
     .contains(/please enter a valid city/i);
   cy.findByRole('textbox', { name: /city/i })
     .clear()
-    .type('Paris');
+    .type('Paris', { delay: 1 });
   cy.findByRole('alert').should('not.exist');
 
   cy.findByRole('textbox', { name: /state/i })
     .clear()
-    .type('propaganda.gov');
+    .type('x.gov', { delay: 1 });
   cy.findByRole('button', { name: 'Update' }).focus();
   cy.findByRole('alert')
     .should('exist')
     .contains(/please enter a valid state/i);
   cy.findByRole('textbox', { name: /state/i })
     .clear()
-    .type('Paris');
+    .type('Paris', { delay: 1 });
   cy.findByRole('alert').should('not.exist');
 
   cy.findByRole('textbox', { name: /postal code/i })
     .clear()
-    .type('propaganda.edu');
+    .type('x.edu', { delay: 1 });
   cy.findByRole('button', { name: 'Update' }).focus();
   cy.findByRole('alert')
     .should('exist')
     .contains(/please enter a valid postal code/i);
   cy.findByRole('textbox', { name: /postal code/i })
     .clear()
-    .type('12345-1234');
+    .type('12345-1234', { delay: 1 });
   cy.findByRole('alert').should('not.exist');
 
   // cancel out of edit mode and discard unsaved changes

--- a/src/applications/personalization/profile/tests/e2e/profile.mpi-error.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile.mpi-error.cypress.spec.js
@@ -3,6 +3,7 @@ import { PROFILE_PATHS } from '../../constants';
 import mockMPIErrorUser from '../fixtures/users/user-mpi-error.json';
 
 import {
+  mockGETEndpoints,
   onlyAccountSecuritySectionIsAccessible,
   subNavOnlyContainsAccountSecurity,
 } from './helpers';
@@ -51,6 +52,13 @@ function test(mobile = false) {
 describe('When user is LOA3 with 2FA turned on but we cannot connect to MPI', () => {
   beforeEach(() => {
     cy.login(mockMPIErrorUser);
+    mockGETEndpoints([
+      'v0/mhv_account',
+      'v0/profile/full_name',
+      'v0/profile/personal_information',
+      'v0/profile/service_history',
+      'v0/feature_toggles*',
+    ]);
   });
   it('should only have access to the Account Security section at desktop size', () => {
     test();

--- a/src/applications/personalization/profile/tests/e2e/profile.not-in-mpi-error.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile.not-in-mpi-error.cypress.spec.js
@@ -3,6 +3,7 @@ import { PROFILE_PATHS } from '../../constants';
 import mockUserNotInMPI from '../fixtures/users/user-not-in-mpi.json';
 
 import {
+  mockGETEndpoints,
   onlyAccountSecuritySectionIsAccessible,
   subNavOnlyContainsAccountSecurity,
 } from './helpers';
@@ -49,6 +50,13 @@ function test(mobile = false) {
 describe('When user is LOA3 with 2FA turned on but we cannot connect to MPI', () => {
   beforeEach(() => {
     cy.login(mockUserNotInMPI);
+    mockGETEndpoints([
+      'v0/mhv_account',
+      'v0/profile/full_name',
+      'v0/profile/personal_information',
+      'v0/profile/service_history',
+      'v0/feature_toggles*',
+    ]);
   });
   it('should only have access to the Account Security section at desktop size', () => {
     test();


### PR DESCRIPTION
## Description
This makes a few Profile e2e tests run significantly faster, over 50% faster (~5s -> ~2s, in general) by explicitly mocking some APIs to be 500s. They fail much faster this way, compared to leaving them un-mocked.

Also sped up some "typing" that happens in form fields.

## Testing done
Tests still pass.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs