### PR TITLE
Update user entered phones to display only, add validation to catch 10 digit numbers starting with 1

### DIFF
--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
@@ -238,7 +238,10 @@ export default function RequestedAppointmentDetailsPage() {
       <div>
         {getPatientTelecom(appointment, 'email')}
         <br />
-        <Telephone contact={getPatientTelecom(appointment, 'phone')} />
+        <Telephone
+          notClickable
+          contact={getPatientTelecom(appointment, 'phone')}
+        />
         <br />
         <span className="vads-u-font-style--italic">
           <ListBestTimeToCall

--- a/src/applications/vaos/appointment-list/components/cards/pending/AppointmentRequestListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/cards/pending/AppointmentRequestListItem.jsx
@@ -143,7 +143,10 @@ export default function AppointmentRequestListItem({
               <div>
                 {getPatientTelecom(appointment, 'email')}
                 <br />
-                <Telephone contact={getPatientTelecom(appointment, 'phone')} />
+                <Telephone
+                  notClickable
+                  contact={getPatientTelecom(appointment, 'phone')}
+                />
                 <br />
                 <span className="vads-u-font-style--italic">
                   <ListBestTimeToCall

--- a/src/applications/vaos/covid-19-vaccine/components/ContactInfoPage.jsx
+++ b/src/applications/vaos/covid-19-vaccine/components/ContactInfoPage.jsx
@@ -16,7 +16,7 @@ const initialSchema = {
   properties: {
     phoneNumber: {
       type: 'string',
-      pattern: '^[0-9]{10}$',
+      pattern: '^[2-9][0-9]{9}$',
     },
     email: {
       type: 'string',
@@ -25,6 +25,7 @@ const initialSchema = {
   },
 };
 
+const phoneConfig = phoneUI('Your phone number');
 const uiSchema = {
   'ui:description': (
     <>
@@ -41,7 +42,14 @@ const uiSchema = {
       </p>
     </>
   ),
-  phoneNumber: phoneUI('Your phone number'),
+  phoneNumber: {
+    ...phoneConfig,
+    'ui:errorMessages': {
+      ...phoneConfig['ui:errorMessages'],
+      pattern:
+        'Please enter a valid 10-digit phone number (with or without dashes)',
+    },
+  },
   email: {
     'ui:title': 'Your email address',
   },

--- a/src/applications/vaos/covid-19-vaccine/components/ReviewPage.jsx
+++ b/src/applications/vaos/covid-19-vaccine/components/ReviewPage.jsx
@@ -87,7 +87,7 @@ export default function ReviewPage() {
             <div>
               {data.email}
               <br />
-              <Telephone contact={data.phoneNumber} />
+              <Telephone notClickable contact={data.phoneNumber} />
             </div>
           </div>
           <Link to={flow.contactInfo.url} aria-label="Edit contact information">

--- a/src/applications/vaos/new-appointment/components/ConfirmationPage/ConfirmationRequestInfo.jsx
+++ b/src/applications/vaos/new-appointment/components/ConfirmationPage/ConfirmationRequestInfo.jsx
@@ -209,7 +209,7 @@ export default function ConfirmationRequestInfo({
                 <div>
                   {data.email}
                   <br />
-                  <Telephone contact={data.phoneNumber} />
+                  <Telephone notClickable contact={data.phoneNumber} />
                   <br />
                   {formatBestTime(data.bestTimeToCall)}{' '}
                 </div>

--- a/src/applications/vaos/new-appointment/components/ContactInfoPage.jsx
+++ b/src/applications/vaos/new-appointment/components/ContactInfoPage.jsx
@@ -26,7 +26,7 @@ const initialSchema = {
   properties: {
     phoneNumber: {
       type: 'string',
-      pattern: '^[0-9]{10}$',
+      pattern: '^[2-9][0-9]{9}$',
     },
     bestTimeToCall: {
       type: 'object',
@@ -49,6 +49,7 @@ const initialSchema = {
   },
 };
 
+const phoneConfig = phoneUI('Your phone number');
 const uiSchema = {
   'ui:description': (
     <>
@@ -65,7 +66,14 @@ const uiSchema = {
       </p>
     </>
   ),
-  phoneNumber: phoneUI('Your phone number'),
+  phoneNumber: {
+    ...phoneConfig,
+    'ui:errorMessages': {
+      ...phoneConfig['ui:errorMessages'],
+      pattern:
+        'Please enter a valid 10-digit phone number (with or without dashes)',
+    },
+  },
   bestTimeToCall: {
     'ui:title': 'What are the best times for us to call you?',
     'ui:validations': [validateBooleanGroup],

--- a/src/applications/vaos/new-appointment/components/ReviewPage/ContactDetailSection.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/ContactDetailSection.jsx
@@ -39,7 +39,7 @@ export default function ContactDetailSection({ data }) {
             <span>
               {data.email}
               <br />
-              <Telephone contact={data.phoneNumber} />
+              <Telephone notClickable contact={data.phoneNumber} />
               <br />
               <i>Call {formatBestTimetoCall(data.bestTimeToCall)}</i>
             </span>

--- a/src/applications/vaos/tests/covid-19-vaccine/components/ContactInfoPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/ContactInfoPage.unit.spec.jsx
@@ -53,8 +53,9 @@ describe('VAOS <ContactInfoPage>', () => {
     // it should display page heading
     expect(screen.getByText('Confirm your contact information')).to.be.ok;
 
-    expect(await screen.findByText(/^Please enter a 10-digit phone number/)).to
-      .be.ok;
+    expect(
+      await screen.findByText(/^Please enter a valid 10-digit phone number/),
+    ).to.be.ok;
     expect(screen.getByText(/^Please provide a response/)).to.be.ok;
 
     userEvent.click(button);


### PR DESCRIPTION
## Description
This PR
- Updates user entered phone numbers to be display only, so they have the format, but are not clickable
- Adds validation to our contact info page to prevent phone numbers that start with 1 or 0, which is not valid for NA area codes.

## Testing done
Local and unit testing

## Screenshots
![Screen Shot 2021-05-12 at 10 52 50 AM](https://user-images.githubusercontent.com/634932/117997527-0a169480-b311-11eb-87fa-00e3f65d2ef9.png)
![Screen Shot 2021-05-12 at 10 47 41 AM](https://user-images.githubusercontent.com/634932/117997531-0a169480-b311-11eb-920f-dacf9540117f.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
