### PR TITLE
Retrieve registry.json from content-build before building in CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,6 +218,11 @@ jobs:
             - ~/.cache/yarn
             - ~/.cache/Cypress
       - run:
+          name: Download registry from content-build repo
+          command: |
+            mkdir -p ../content-build/src/applications
+            curl -L https://raw.githubusercontent.com/department-of-veterans-affairs/content-build/master/src/applications/registry.json -o ../content-build/src/applications/registry.json
+      - run:
           name: Build apps
           command: yarn build:webpack --env.buildtype vagovprod --env.scaffold
           no_output_timeout: 15m


### PR DESCRIPTION
## Description
Some Cypress tests were failing in CircleCI because they expected some behavior that the scaffolded build couldn't replicate without the registry.

The registry is in `content-build`, but the pipeline wasn't checking it out, so the build used manifest files as a fallback. Manifest files are inadequate for recreating the expected behavior due to missing template metadata (e.g., overrides for things like title, breadcrumbs, etc.) that are available in the registry.

This fix resolves those test failures by retrieving the registry specifically before running the scaffolded build.

## Testing done
Cypress tests pass in CircleCI.

## Acceptance criteria
- [ ] The scaffolded build should use the registry when run in CI.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
