### PR TITLE
Update TypeOfCarePage to use redux hooks

### DIFF
--- a/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
@@ -128,7 +128,7 @@ export default function TypeOfCarePage() {
       )}
       <PodiatryAppointmentUnavailableModal
         showModal={showPodiatryApptUnavailableModal}
-        onClose={dispatch(hidePodiatryAppointmentUnavailableModal)}
+        onClose={() => dispatch(hidePodiatryAppointmentUnavailableModal())}
       />
     </div>
   );

--- a/src/applications/vaos/new-appointment/redux/selectors.js
+++ b/src/applications/vaos/new-appointment/redux/selectors.js
@@ -21,6 +21,8 @@ import {
   getSiteIdFromFacilityId,
 } from '../../services/location';
 import {
+  selectFeatureCommunityCare,
+  selectFeatureDirectScheduling,
   selectUseFlatFacilityPage,
   selectIsCernerOnlyPatient,
   selectUseProviderSelection,
@@ -420,5 +422,20 @@ export function selectReviewPage(state) {
     systemId: getSiteIdForChosenFacility(state),
     useProviderSelection: selectUseProviderSelection(state),
     vaCityState: getChosenVACityState(state),
+  };
+}
+
+export function selectTypeOfCarePage(state) {
+  const newAppointment = getNewAppointment(state);
+  const address = selectVAPResidentialAddress(state);
+  return {
+    ...address,
+    hideUpdateAddressAlert: newAppointment.hideUpdateAddressAlert,
+    initialData: getFormData(state),
+    pageChangeInProgress: selectPageChangeInProgress(state),
+    showCommunityCare: selectFeatureCommunityCare(state),
+    showDirectScheduling: selectFeatureDirectScheduling(state),
+    showPodiatryApptUnavailableModal:
+      newAppointment.showPodiatryAppointmentUnavailableModal,
   };
 }


### PR DESCRIPTION
## Description

This PR updates the TypeOfCarePage to use redux hooks.

Ticket: [23409](https://github.com/department-of-veterans-affairs/va.gov-team/issues/23409)

## Testing done

- local, unit testing

## Screenshots
N/A

## Acceptance criteria
- [x] connect() is no longer used on page
- [x] All actions that were in mapDispatchToProps are now wrapped in dispatch() when called
- [x] All data in mapStateToProps is pulled in through useSelector hooks

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
