### PR TITLE
Remove setPublicPath option

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -94,7 +94,6 @@ module.exports = (env = {}) => {
     port: 3001,
     scaffold: false,
     watch: false,
-    setPublicPath: false,
     destination: buildtype,
     ...env,
   };
@@ -120,7 +119,7 @@ module.exports = (env = {}) => {
 
   // Set the publicPath conditional so we can get dynamic modules loading from S3
   const publicAssetPath =
-    buildOptions.setPublicPath && buildtype !== LOCALHOST
+    buildtype !== LOCALHOST
       ? `${BUCKETS[buildtype]}/generated/`
       : '/generated/';
 

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -14,7 +14,7 @@ function generateWebpackDevConfig(buildOptions) {
 
   // This buildType likely always be 'localhost', but adding in to match patterns elsewhere and just incase we ever need it
   const publicAssetPath =
-    buildOptions.setPublicPath && buildOptions.buildtype !== 'localhost'
+    buildOptions.buildtype !== 'localhost'
       ? `${BUCKETS[buildOptions.buildtype]}/generated/`
       : '/generated/';
 


### PR DESCRIPTION
## Description
After the Prearchive step was removed from the Jenkins pipeline, the URL for assets were not using the bucket path. This PR removes the unused `setPublicPath` option in the webpack config so that the bucket URL is used for the asset path.

## Testing done
Downloaded archived assets and verified that assets are using the bucket URL. `fa-solid-900.woff2` can be used as an example.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
