### PR TITLE
Bump web-components dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -359,7 +359,7 @@
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
     "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#4089b6b4390f05738e0dcef402c56978565a626c",
-    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.5.0",
+    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.6.1",
     "whatwg-fetch": "^2.0.3"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19935,9 +19935,9 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   dependencies:
     minimalistic-assert "^1.0.0"
 
-"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.5.0":
-  version "0.5.0"
-  resolved "https://github.com/department-of-veterans-affairs/component-library.git#f2250ee009e8feb811a9cd8b75457f849b6ed8be"
+"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.6.1":
+  version "0.6.1"
+  resolved "https://github.com/department-of-veterans-affairs/component-library.git#b892c5ba2252fbe8800c0e1e7fdc9fdaa90846f5"
   dependencies:
     "@stencil/core" "^2.0.1"
     "@stencil/postcss" "^2.0.0"


### PR DESCRIPTION
## Description

This is to patch a font color with the accordion web component: https://github.com/department-of-veterans-affairs/component-library/pull/94


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
