### PR TITLE
Make healthcare-spinner tests more resiliant

### DIFF
--- a/src/applications/personalization/dashboard-2/components/claims-and-appeals/ClaimsAndAppeals.unit.spec.jsx
+++ b/src/applications/personalization/dashboard-2/components/claims-and-appeals/ClaimsAndAppeals.unit.spec.jsx
@@ -194,8 +194,8 @@ describe('ClaimsAndAppeals component', () => {
             }),
           ).to.be.false;
         });
-        it('should render a loading spinner but no section headline while loading data', () => {
-          expect(view.queryByRole('progressbar', { label: /loading/i })).to
+        it('should render a loading spinner but no section headline while loading data', async () => {
+          expect(await view.findByRole('progressbar', { label: /loading/i })).to
             .exist;
           expect(view.queryByRole('heading', { name: /^claims & appeals$/i }))
             .to.not.exist;
@@ -246,8 +246,8 @@ describe('ClaimsAndAppeals component', () => {
             }),
           ).to.be.true;
         });
-        it('should render a loading spinner but no section headline while loading data', () => {
-          expect(view.queryByRole('progressbar', { label: /loading/i })).to
+        it('should render a loading spinner but no section headline while loading data', async () => {
+          expect(await view.findByRole('progressbar', { label: /loading/i })).to
             .exist;
           expect(view.queryByRole('heading', { name: /^claims & appeals$/i }))
             .to.not.exist;
@@ -290,8 +290,8 @@ describe('ClaimsAndAppeals component', () => {
             }),
           ).to.be.true;
         });
-        it('should render a loading spinner but no section headline while loading data', () => {
-          expect(view.queryByRole('progressbar', { label: /loading/i })).to
+        it('should render a loading spinner but no section headline while loading data', async () => {
+          expect(await view.findByRole('progressbar', { label: /loading/i })).to
             .exist;
           expect(view.queryByRole('heading', { name: /^claims & appeals$/i }))
             .to.not.exist;

--- a/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
+++ b/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
@@ -222,6 +222,14 @@ const mapStateToProps = state => {
     hasAppointmentsError,
     isCernerPatient: selectIsCernerPatient(state),
     shouldFetchMessages,
+    // TODO: We might want to rewrite this component so that we default to
+    // showing the loading indicator until all required API calls have either
+    // resolved or failed. Right now we only set this flag to true _after_ an
+    // API call has started. This means that on first render, before `useEffect`
+    // hooks fire, the component is going to be showing the UI with all of the
+    // IconCTALinks before the supporting data has been loaded. It only switches
+    // to showing the loading indicator _after_ the useEffect hooks have run and
+    // API requests have started.
     shouldShowLoadingIndicator: fetchingAppointments || fetchingInbox,
     unreadMessagesCount: selectUnreadMessagesCount(state),
   };

--- a/src/applications/personalization/dashboard-2/tests/unit/healthcare-spinner.unit.spec.jsx
+++ b/src/applications/personalization/dashboard-2/tests/unit/healthcare-spinner.unit.spec.jsx
@@ -1,12 +1,17 @@
 import React from 'react';
 import { expect } from 'chai';
 import { renderInReduxProvider } from '~/platform/testing/unit/react-testing-library-helpers';
+import { resetFetch } from '~/platform/testing/unit/helpers';
 import reducers from '~/applications/personalization/dashboard/reducers';
 import HealthCare from '~/applications/personalization/dashboard-2/components/health-care/HealthCare';
 
 describe('HealthCare component', () => {
   let view;
   let initialState;
+  // If a test mocks fetch and fails to properly restore fetch, and that
+  // offending test runs shortly before this test, it can result in this test to
+  // fail. So we are calling `resetFetch()` defensively.
+  before(resetFetch);
 
   context('when appointments and messaging data are still loading', () => {
     it('should only show a loading spinner', async () => {
@@ -38,7 +43,8 @@ describe('HealthCare component', () => {
         initialState,
         reducers,
       });
-      expect(view.getByRole('progressbar')).to.exist;
+      expect(await view.findByRole('progressbar', { label: /health care/i })).to
+        .exist;
       expect(
         view.queryByRole('link', {
           name: /Refill and track your prescriptions/i,

--- a/src/applications/personalization/profile/tests/components/direct-deposit/BankInfoCNP.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/direct-deposit/BankInfoCNP.unit.spec.jsx
@@ -179,13 +179,6 @@ describe('DirectDepositCNP', () => {
         view.queryByLabelText(/account number/i),
       );
 
-      // shows a save succeeded alert
-      expect(
-        view.findByRole('alert', {
-          name: /We’ve updated your bank account information/i,
-        }),
-      ).to.exist;
-
       // and the bank info from the mocked call should be shown
       expect(view.getByText(mocks.newPaymentAccount.financialInstitutionName))
         .to.exist;
@@ -222,13 +215,6 @@ describe('DirectDepositCNP', () => {
       await waitForElementToBeRemoved(() =>
         view.queryByLabelText(/account number/i),
       );
-
-      // shows a save succeeded alert
-      expect(
-        view.findByRole('alert', {
-          name: /We’ve updated your bank account information/i,
-        }),
-      ).to.exist;
 
       // and the bank info from the mocked call should be shown
       expect(view.getByText(mocks.newPaymentAccount.financialInstitutionName))


### PR DESCRIPTION
## Description
[On May 11, Katy Bowman let me know that one of my team's tests was failing from time to time in CI](https://dsva.slack.com/archives/C5HP4GN3F/p1620757260254500) I figured that some other test was doing _something_ that made my test fail and I started to dig.

The first thing I discovered was that, for some reason, some unhandled `findBy*` Promises in the `BankInfoCNP.unit.spec.jsx`  were the cause of the failures. If those specs ran <1s before my `healthcare-spinner.unit.spec.jsx`, the assertion that a loading spinner should be in the DOM was made _before_ the `HealthCare` component under test was able to run its `useEffect` hooks and the loading spinner would not appear until one of the `useEffect` hooks fired.

My fix for that was to:
1. Remove those unhandled `findBy` calls in the `BankInfoCNP` tests. Actually awaiting their results wasn't the proper fix in this case because _the stuff is was looking for actually no longer existed in that component_. Those assertions stopped working a long time ago, but never triggered a failure because the we never `await`ed the result from `findBy`.
2. I also adjusted the failing test, changing from `getBy` to `await findBy`. That would give the `HealthCare` component being tested a chance to run its `useEffect` hooks, which would trigger teh API calls, which would the loading spinner appear.

But after running many more rounds of tests I saw the same test still failing. More investigation led me to realize that some test suites were failing to `resetFetch` after mocking/spying on fetch. **This is not the first time I've run into issues with a failure to clean up after mocking fetch resulting in other tests failing.** My first attempt to fix that was the find the offending tests and add `resetFetch` calls in either an `afterEach` or `after` hook. **To be clear, this is something that should be done** because tests that mock fetch with our standard fetch-mocking helpers should also be resetting fetch else, other unrelated tests might randomly break. If there is any way we can check for that with an ESLint rule we really should. The better fix was to just defensively `resetFetch()` in my unit test, before it runs the tests.

Bottom line:
- This particular test _should_ be more resilient to other misbehaving tests..
- I don't really understand why the unhandled `findBy` Promise was making the test run its assertions before the `HealthCare` component's `useEffect` hooks could fire.
- I don't really understand why not reseting fetch would cause the unit tests to be flaky.

So the problem should be solved, but I am unsatisfied with this because I'm not fully getting _why_ the test really failed.

Another thing I might want to do is refactor the `HealthCare` component that was being tested so that is shows a loading spinner until it has loaded all the data is needs (or the API calls have failed) vs. showing a loading spinner if Redux says an API call is still in progress. The latter requires an API call to be fired before a loading spinner appears. The former shows the loading spinner by default and continues to show it until all APIs have resolved or failed, which is the approach I normally take for components that need to load data when they first render.

## Testing done
Running the full unit test suite so. Many. Times. Locally.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs