### PR TITLE
Change ProgressBar, SegmentedProgressBar, and LoadingIndicator analytics to opt-in

### DIFF
--- a/package.json
+++ b/package.json
@@ -277,7 +277,7 @@
   },
   "private": true,
   "dependencies": {
-    "@department-of-veterans-affairs/component-library": "2.5.1",
+    "@department-of-veterans-affairs/component-library": "2.5.2",
     "@department-of-veterans-affairs/formation": "6.16.1",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "@formatjs/intl-datetimeformat": "^3.2.7",

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
@@ -305,7 +305,6 @@ function VAFacilityPageV2({
         message="We’re checking if we can create an appointment for you at this
                 facility. This may take up to a minute. Thank you for your
                 patience."
-        disableAnalytics
       />
 
       {showEligibilityModal && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1382,10 +1382,10 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@department-of-veterans-affairs/component-library@2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-2.5.1.tgz#039473f4fbcd2bd640f963761a31b4976bd4fd56"
-  integrity sha512-3QbHZss5ZL8EYdIHZ8q3XA9pJ1CMKk1eYTte2tRKqjahjLbCbd9C5Lk0GQ90nPSkIqZloTu33DGlzu9VfdGuGQ==
+"@department-of-veterans-affairs/component-library@2.5.2":
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-2.5.2.tgz#dabd1f5146c74125f07e211bef656cf611f333be"
+  integrity sha512-3nLgpLlObaW9y8F2ueE8FPEwPXXObjjt7Uy3xDereWo+BX6UgT5A9kiNljU5zhabA1ZzEK4o4LuklEvkMxx+nA==
   dependencies:
     classnames "^2.2.6"
     core-js "^3.9.0"


### PR DESCRIPTION
## Description

For: https://github.com/department-of-veterans-affairs/va.gov-team/issues/24499

Our event counts on ProgressBar, SegmentedProgressBar, and LoadingIndicator are waaaaay higher than expected. We will need to make these opt-in to avoid hitting our monthly GA quota.

I also removed a now unnecessary `disableAnalytics` param from a LoadingIndicator in VAOS. 

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
