### PR TITLE
Use live API instead of mock for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ run it locally, you can specify `--env.api`:
 yarn watch --env.api https://dev-api.va.gov
 ```
 
+You will need to disable CORS in your browser when using a non-local API. Here are some helpful links that explain how to do this:
+- https://stackoverflow.com/questions/3102819/disable-same-origin-policy-in-chrome
+- https://stackoverflow.com/questions/4556429/disabling-same-origin-policy-in-safari
+
 **Note:** If you try to log on, ID.me will redirect you to the environment that
 the API is set up for. So in the above example, you'd be **redirected back to
 dev.va.gov.**

--- a/src/applications/facility-locator/api/index.js
+++ b/src/applications/facility-locator/api/index.js
@@ -2,17 +2,14 @@ import MockApi from './MockLocatorApi';
 import LiveApi from './LocatorApi';
 import environment from 'platform/utilities/environment';
 
-// To use vets-api data locally, replace the following with this:
-// export default LiveApi;
-
 const getAPI = () => {
   const isUnitTest = window.Mocha;
   const isReviewEnvironment = environment.API_URL.includes('review.vetsgov');
   const isLocal = environment.isLocalhost();
   const isCypress = window.Cypress;
 
-  if (isUnitTest || isReviewEnvironment) return LiveApi;
-  if (isLocal || isCypress) return MockApi;
+  if (isLocal || isReviewEnvironment) return LiveApi;
+  if (isUnitTest || isCypress) return MockApi;
 
   return LiveApi;
 };

--- a/src/site/constants/environments-configs.js
+++ b/src/site/constants/environments-configs.js
@@ -37,7 +37,7 @@ module.exports = {
           location.port ? location.port : '3001'
         }`,
     API_URL: isNode
-      ? 'http://localhost:3000'
+      ? `http://${process.env.API_HOST}:3000`
       : `http://${location.hostname || 'localhost'}:3000`,
   },
 };


### PR DESCRIPTION
## Description
Enables use of the live data in local environment via the `--env.api` option to point to dev/staging/prod.

Also, use mock API for Facility Locator unit tests.

## Acceptance criteria
- [x] Starting vets-website with `yarn watch --env.api https://staging-api.va.gov` points the API calls to staging.
