### PR TITLE
Stop showing rx and messaging CTAs to users who lack those services

### DIFF
--- a/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
+++ b/src/applications/personalization/dashboard-2/components/health-care/HealthCare.jsx
@@ -43,6 +43,7 @@ const HealthCare = ({
   // TODO: possibly remove this prop in favor of mocking API calls in our unit tests
   dataLoadingDisabled = false,
   shouldShowLoadingIndicator,
+  shouldShowPrescriptions,
   hasInboxError,
   hasAppointmentsError,
 }) => {
@@ -137,24 +138,28 @@ const HealthCare = ({
             )}
 
           {/* Messages */}
-          <IconCTALink
-            boldText={unreadMessagesCount > 0}
-            href={mhvUrl(authenticatedWithSSOe, 'secure-messaging')}
-            icon="comments"
-            newTab
-            text={messagesText}
-          />
+          {shouldFetchMessages ? (
+            <IconCTALink
+              boldText={unreadMessagesCount > 0}
+              href={mhvUrl(authenticatedWithSSOe, 'secure-messaging')}
+              icon="comments"
+              newTab
+              text={messagesText}
+            />
+          ) : null}
 
           {/* Prescriptions */}
-          <IconCTALink
-            href={mhvUrl(
-              authenticatedWithSSOe,
-              'web/myhealthevet/refill-prescriptions',
-            )}
-            icon="prescription-bottle"
-            newTab
-            text="Refill and track your prescriptions"
-          />
+          {shouldShowPrescriptions ? (
+            <IconCTALink
+              href={mhvUrl(
+                authenticatedWithSSOe,
+                'web/myhealthevet/refill-prescriptions',
+              )}
+              icon="prescription-bottle"
+              newTab
+              text="Refill and track your prescriptions"
+            />
+          ) : null}
 
           {/* Lab and test results */}
           <IconCTALink
@@ -205,6 +210,9 @@ const mapStateToProps = state => {
   const shouldFetchMessages = selectAvailableServices(state).includes(
     backendServices.MESSAGING,
   );
+  const shouldShowPrescriptions = selectAvailableServices(state).includes(
+    backendServices.RX,
+  );
 
   const fetchingAppointments = state.health?.appointments?.fetching;
   const fetchingInbox = shouldFetchMessages
@@ -223,6 +231,7 @@ const mapStateToProps = state => {
     isCernerPatient: selectIsCernerPatient(state),
     shouldFetchMessages,
     shouldShowLoadingIndicator: fetchingAppointments || fetchingInbox,
+    shouldShowPrescriptions,
     unreadMessagesCount: selectUnreadMessagesCount(state),
   };
 };

--- a/src/applications/personalization/dashboard-2/tests/e2e/health-care-cta-gating.cypress.spec.js
+++ b/src/applications/personalization/dashboard-2/tests/e2e/health-care-cta-gating.cypress.spec.js
@@ -1,0 +1,80 @@
+import enrollmentStatusEnrolled from '@@profile/tests/fixtures/enrollment-system/enrolled.json';
+
+import { mockFeatureToggles } from './helpers';
+
+import { mockFolderResponse } from '../../utils/mocks/messaging/folder';
+import { mockMessagesResponse } from '../../utils/mocks/messaging/messages';
+
+import {
+  makeUserObject,
+  mockLocalStorage,
+} from '~/applications/personalization/dashboard/tests/e2e/dashboard-e2e-helpers';
+
+describe('MyVA Dashboard - CTA Links', () => {
+  beforeEach(() => {
+    mockLocalStorage();
+  });
+  context('when user is has messaging and rx features', () => {
+    beforeEach(() => {
+      const mockUser = makeUserObject({
+        isCerner: false,
+        messaging: true,
+        rx: true,
+        facilities: [{ facilityId: '123', isCerner: false }],
+        isPatient: true,
+      });
+
+      cy.login(mockUser);
+      cy.intercept(
+        'GET',
+        '/v0/health_care_applications/enrollment_status',
+        enrollmentStatusEnrolled,
+      );
+      cy.intercept('/v0/folders/0', mockFolderResponse);
+      cy.intercept('/v0/folders/0/messages', mockMessagesResponse);
+      mockFeatureToggles();
+    });
+    it('should show the rx and messaging CTAs', () => {
+      cy.visit('my-va/');
+      cy.findByRole('link', {
+        name: /schedule and view.*appointments/i,
+      }).should('exist');
+      cy.findByRole('link', { name: /unread message/i }).should('exist');
+      cy.findByRole('link', {
+        name: /refill and track.*prescriptions/i,
+      }).should('exist');
+    });
+  });
+  context('when user lacks messaging and rx features', () => {
+    beforeEach(() => {
+      mockLocalStorage();
+      const mockUser = makeUserObject({
+        isCerner: false,
+        messaging: false,
+        rx: false,
+        facilities: [{ facilityId: '123', isCerner: false }],
+        isPatient: true,
+      });
+
+      cy.login(mockUser);
+      cy.intercept(
+        'GET',
+        '/v0/health_care_applications/enrollment_status',
+        enrollmentStatusEnrolled,
+      );
+      cy.intercept('/v0/folders/0', mockFolderResponse);
+      cy.intercept('/v0/folders/0/messages', mockMessagesResponse);
+      mockFeatureToggles();
+    });
+    it('should not show the rx and messaging CTAs', () => {
+      cy.visit('my-va/');
+      cy.findByRole('link', {
+        name: /schedule and view.*appointments/i,
+      }).should('exist');
+      cy.findByRole('link', { name: /send a.*message/i }).should('not.exist');
+      cy.findByRole('link', {
+        name: /refill and track.*prescriptions/i,
+      }).should('not.exist');
+    });
+  });
+});

--- a/src/applications/personalization/dashboard-2/tests/unit/healthcare-messaging.unit.spec.jsx
+++ b/src/applications/personalization/dashboard-2/tests/unit/healthcare-messaging.unit.spec.jsx
@@ -148,17 +148,17 @@ describe('HealthCare component', () => {
       ).to.be.false;
     });
 
-    it('should render a generic message when the number of unread messages was not fetched', async () => {
+    it('should not render a messaging CTA', () => {
       initialState.health.msg.folders.data.currentItem.attributes.unreadCount = null;
       view = renderInReduxProvider(<HealthCare dataLoadingDisabled />, {
         initialState,
         reducers,
       });
       expect(
-        await view.findByRole('link', {
-          name: /Send a secure message to your health care team/i,
+        view.queryByRole('link', {
+          name: /message/i,
         }),
-      ).to.exist;
+      ).not.to.exist;
     });
   });
 });


### PR DESCRIPTION
## Description
This PR adds some simple gating to the My VA 2.0 Health Care section, hiding Secure Messaging and Prescription CTAs from users who do not have those services.

## Testing done
Added some quick and dirty Cypress tests.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs