### PR TITLE
[23737] Add Johnson & Johnson Copy

### DIFF
--- a/src/applications/vaos/covid-19-vaccine/components/SecondDosePage.jsx
+++ b/src/applications/vaos/covid-19-vaccine/components/SecondDosePage.jsx
@@ -33,8 +33,14 @@ export default function SecondDosePage() {
       <h1>{pageTitle}</h1>
       <div className="vads-u-margin-bottom--4">
         <p>
-          You’ll need to return to the {facility.name} after the dates below,
-          depending on which vaccine you receive:
+          If you need a second dose, you may need to return to the{' '}
+          {facility.name} after the dates below, depending on which vaccine you
+          receive:
+        </p>
+        <p>
+          If you receive your first dose on{' '}
+          <strong>{moment(date1[0]).format('dddd, MMMM DD, YYYY')}</strong> and
+          receive:
         </p>
         <h2 className="vads-u-font-size--h3 vads-u-margin-bottom--0">
           Moderna
@@ -62,6 +68,10 @@ export default function SecondDosePage() {
               .format('dddd, MMMM DD, YYYY')}
           </strong>
         </div>
+        <h2 className="vads-u-font-size--h3 vads-u-margin-bottom--0">
+          Johnson & Johnson
+        </h2>
+        <div>1 dose only</div>
       </div>
       <FormButtons
         pageChangeInProgress={pageChangeInProgress}

--- a/src/applications/vaos/tests/covid-19-vaccine/components/SecondDosePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/SecondDosePage.unit.spec.jsx
@@ -56,11 +56,22 @@ describe('VAOS vaccine flow <SecondDosePage>', () => {
     ).to.have.tagName('h1');
     expect(
       screen.getByText(
-        /You’ll need to return to the Cheyenne VA Medical Center/i,
+        /If you need a second dose, you may need to return to the Cheyenne VA Medical Center/i,
+      ),
+    ).to.be.ok;
+    expect(
+      screen.getByText(
+        new RegExp(
+          `If you receive your first dose on ${start
+            .clone()
+            .format('dddd, MMMM DD, YYYY')} and receive:`,
+          'i',
+        ),
       ),
     ).to.be.ok;
     expect(screen.getByText('Moderna')).to.have.tagName('h2');
     expect(screen.getByText('Pfizer')).to.have.tagName('h2');
+    expect(screen.getByText('Johnson & Johnson')).to.have.tagName('h2');
     expect(
       screen.getByText(
         new RegExp(

--- a/src/applications/vaos/tests/covid-19-vaccine/components/SecondDosePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/SecondDosePage.unit.spec.jsx
@@ -56,17 +56,15 @@ describe('VAOS vaccine flow <SecondDosePage>', () => {
     ).to.have.tagName('h1');
     expect(
       screen.getByText(
-        /If you need a second dose, you may need to return to the Cheyenne VA Medical Center/i,
+        /If you need a second dose, you may need to return to the Cheyenne VA Medical Center after the dates below, depending on which vaccine you receive:/i,
       ),
     ).to.be.ok;
     expect(
+      screen.getByText(new RegExp(`If you receive your first dose on`, 'i')),
+    ).to.be.ok;
+    expect(
       screen.getByText(
-        new RegExp(
-          `If you receive your first dose on ${start
-            .clone()
-            .format('dddd, MMMM DD, YYYY')} and receive:`,
-          'i',
-        ),
+        new RegExp(`${start.clone().format('dddd, MMMM DD, YYYY')}`, 'i'),
       ),
     ).to.be.ok;
     expect(screen.getByText('Moderna')).to.have.tagName('h2');


### PR DESCRIPTION
## Description
Due to latest CDC & FDA guidance, add back references to J&J vaccine on the "Plan second dose" page in the vaccine flow.

## Testing done
Local and Unit

## Screenshots
<img width="676" alt="image" src="https://user-images.githubusercontent.com/8315447/118303247-3a963400-b4b3-11eb-9624-686a53f9bccb.png">

## Acceptance criteria
- [x] Changes are behind the va_online_scheduling_cheetah feature flag
- [x] CONTENT - Content matches the copy doc
- [x] All acceptance criteria are met
- [ ] Documentation/screenshots are updated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
