### PR TITLE
feat(1010cg): add e2e coverage for poa, upload and sign as rep

### DIFF
--- a/src/applications/caregivers/config/chapters/signAsRepresentative/uploadPOADocument.js
+++ b/src/applications/caregivers/config/chapters/signAsRepresentative/uploadPOADocument.js
@@ -55,6 +55,9 @@ export default {
       parseResponse,
       attachmentName: {
         'ui:title': 'Document name',
+        'ui:options': {
+          useDlWrap: true,
+        },
       },
     }),
   },

--- a/src/applications/caregivers/tests/e2e/1010cg.cypress.spec.js
+++ b/src/applications/caregivers/tests/e2e/1010cg.cypress.spec.js
@@ -69,7 +69,7 @@ const testSecondaryTwo = createTestConfig(
       'secondaryOneOnly',
       'oneSecondaryCaregivers',
       'twoSecondaryCaregivers',
-      // 'signAsRepresentativeYes',
+      'signAsRepresentativeYes',
       'signAsRepresentativeNoRep',
       'signAsRepresentativeNo',
     ],

--- a/src/applications/caregivers/tests/e2e/1010cg.cypress.spec.js
+++ b/src/applications/caregivers/tests/e2e/1010cg.cypress.spec.js
@@ -69,7 +69,6 @@ const testSecondaryTwo = createTestConfig(
       'secondaryOneOnly',
       'oneSecondaryCaregivers',
       'twoSecondaryCaregivers',
-      'signAsRepresentativeYes',
       'signAsRepresentativeNoRep',
       'signAsRepresentativeNo',
     ],

--- a/src/applications/caregivers/tests/e2e/1010cg.cypress.spec.js
+++ b/src/applications/caregivers/tests/e2e/1010cg.cypress.spec.js
@@ -69,7 +69,7 @@ const testSecondaryTwo = createTestConfig(
       'secondaryOneOnly',
       'oneSecondaryCaregivers',
       'twoSecondaryCaregivers',
-      'signAsRepresentativeYes',
+      // 'signAsRepresentativeYes',
       'signAsRepresentativeNoRep',
       'signAsRepresentativeNo',
     ],

--- a/src/applications/caregivers/tests/e2e/1010cg.cypress.spec.js
+++ b/src/applications/caregivers/tests/e2e/1010cg.cypress.spec.js
@@ -4,6 +4,7 @@ import formConfig from 'applications/caregivers/config/form';
 import manifest from 'applications/caregivers/manifest.json';
 import testForm from 'platform/testing/e2e/cypress/support/form-tester';
 import featureToggles from './fixtures/mocks/feature-toggles.json';
+import mockUpload from './fixtures/mocks/mock-upload.json';
 import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
 import {
   veteranSignatureContent,
@@ -13,10 +14,16 @@ import {
   primaryLabel,
   secondaryOneLabel,
   secondaryTwoLabel,
+  representativeLabel,
+  representativeSignatureContent,
 } from 'applications/caregivers/definitions/content';
 
 export const mockVeteranSignatureContent = [
   'I certify that I give consent to the individual(s) named in this application to perform personal care services for me upon being approved as Primary and/or Secondary Family Caregivers in the Program of Comprehensive Assistance for Family Caregivers.',
+];
+export const mockRepresentativeSignatureContent = [
+  'Signed by the Veteran’s legal representative on behalf of the Veteran.',
+  'I certify that I give consent to the individual(s) named in this application to perform personal care services for me (or if the Veteran’s Representative, the Veteran) upon being approved as a Primary and/or Secondary Family Caregiver(s) in the Program of Comprehensive Assistance for Family Caregivers.',
 ];
 export const mockPrimaryCaregiverContent = [
   'I certify that I am at least 18 years of age.',
@@ -62,6 +69,9 @@ const testSecondaryTwo = createTestConfig(
       'secondaryOneOnly',
       'oneSecondaryCaregivers',
       'twoSecondaryCaregivers',
+      'signAsRepresentativeYes',
+      'signAsRepresentativeNoRep',
+      'signAsRepresentativeNo',
     ],
     fixtures: {
       data: path.join(__dirname, 'fixtures', 'data'),
@@ -71,6 +81,7 @@ const testSecondaryTwo = createTestConfig(
     setupPerTest: () => {
       cy.server();
       cy.intercept('GET', '/v0/feature_toggles?*', featureToggles);
+      cy.intercept('POST', 'v0/form1010cg/attachments', mockUpload);
     },
     pageHooks: {
       introduction: () => {
@@ -158,6 +169,24 @@ const testSecondaryTwo = createTestConfig(
                 mockSecondaryCaregiverContent,
               );
               signAsParty(secondaryTwoLabel, 'Donald Duck');
+              break;
+            case 'signAsRepresentativeYes':
+            case 'signAsRepresentativeNoRep':
+              // check veteran content && sign as representative
+              checkContent(
+                representativeLabel,
+                representativeSignatureContent,
+                mockRepresentativeSignatureContent,
+              );
+              signAsParty(representativeLabel, 'Mini Mouse');
+
+              // Check primary caregiver && sign
+              checkContent(
+                primaryLabel,
+                primaryCaregiverContent,
+                mockPrimaryCaregiverContent,
+              );
+              signAsParty(primaryLabel, 'Mini Mouse');
               break;
             default:
               // check veteran content && sign

--- a/src/applications/caregivers/tests/e2e/fixtures/data/signAsRepresentativeNo.json
+++ b/src/applications/caregivers/tests/e2e/fixtures/data/signAsRepresentativeNo.json
@@ -1,0 +1,45 @@
+{
+  "view:hasSecondaryCaregiverOne": false,
+  "view:hasPrimaryCaregiver": true,
+  "primaryHasHealthInsurance": false,
+  "primaryAddress": {
+    "street": "1375 E Buena Vista Dr",
+    "city": "Orlando",
+    "state": "FL",
+    "postalCode": "32830"
+  },
+  "primaryPrimaryPhoneNumber": "7887754588",
+  "primaryVetRelationship": "Spouse",
+  "primaryFullName": {
+    "first": "Mini",
+    "last": "Mouse"
+  },
+  "primarySignature": "Mini Mouse",
+  "primaryDateOfBirth": "1928-11-18",
+  "primaryGender": "F",
+  "veteranPreferredFacility": {
+    "veteranFacilityState": "FL",
+    "plannedClinic": "675"
+  },
+  "veteranAddress": {
+    "street": "1375 E Buena Vista Dr",
+    "city": "Orlando",
+    "state": "FL",
+    "postalCode": "32830"
+  },
+  "veteranPrimaryPhoneNumber": "7153874113",
+  "veteranFullName": {
+    "first": "Micky",
+    "last": "Mouse"
+  },
+  "veteranSignature": "Micky Mouse",
+  "veteranSsnOrTin": "788775458",
+  "veteranDateOfBirth": "1948-11-18",
+  "veteranGender": "M",
+  "secondaryOneFullName": {},
+  "secondaryOneAddress": {},
+  "secondaryTwoFullName": {},
+  "secondaryTwoAddress": {},
+  "AGREED": false,
+  "signAsRepresentativeYesNo": "no"
+}

--- a/src/applications/caregivers/tests/e2e/fixtures/data/signAsRepresentativeNoRep.json
+++ b/src/applications/caregivers/tests/e2e/fixtures/data/signAsRepresentativeNoRep.json
@@ -1,0 +1,45 @@
+{
+  "view:hasSecondaryCaregiverOne": false,
+  "view:hasPrimaryCaregiver": true,
+  "primaryHasHealthInsurance": false,
+  "primaryAddress": {
+    "street": "1375 E Buena Vista Dr",
+    "city": "Orlando",
+    "state": "FL",
+    "postalCode": "32830"
+  },
+  "primaryPrimaryPhoneNumber": "7887754588",
+  "primaryVetRelationship": "Spouse",
+  "primaryFullName": {
+    "first": "Mini",
+    "last": "Mouse"
+  },
+  "primarySignature": "Mini Mouse",
+  "primaryDateOfBirth": "1928-11-18",
+  "primaryGender": "F",
+  "veteranPreferredFacility": {
+    "veteranFacilityState": "FL",
+    "plannedClinic": "675"
+  },
+  "veteranAddress": {
+    "street": "1375 E Buena Vista Dr",
+    "city": "Orlando",
+    "state": "FL",
+    "postalCode": "32830"
+  },
+  "veteranPrimaryPhoneNumber": "7153874113",
+  "veteranFullName": {
+    "first": "Micky",
+    "last": "Mouse"
+  },
+  "veteranSignature": "Micky Mouse",
+  "veteranSsnOrTin": "788775458",
+  "veteranDateOfBirth": "1948-11-18",
+  "veteranGender": "M",
+  "secondaryOneFullName": {},
+  "secondaryOneAddress": {},
+  "secondaryTwoFullName": {},
+  "secondaryTwoAddress": {},
+  "AGREED": false,
+  "signAsRepresentativeYesNo": "noRep"
+}

--- a/src/applications/caregivers/tests/e2e/fixtures/data/signAsRepresentativeYes.json
+++ b/src/applications/caregivers/tests/e2e/fixtures/data/signAsRepresentativeYes.json
@@ -1,0 +1,51 @@
+{
+  "view:hasSecondaryCaregiverOne": false,
+  "view:hasPrimaryCaregiver": true,
+  "primaryHasHealthInsurance": false,
+  "primaryAddress": {
+    "street": "1375 E Buena Vista Dr",
+    "city": "Orlando",
+    "state": "FL",
+    "postalCode": "32830"
+  },
+  "primaryPrimaryPhoneNumber": "7887754588",
+  "primaryVetRelationship": "Spouse",
+  "primaryFullName": {
+    "first": "Mini",
+    "last": "Mouse"
+  },
+  "primarySignature": "Mini Mouse",
+  "primaryDateOfBirth": "1928-11-18",
+  "primaryGender": "F",
+  "veteranPreferredFacility": {
+    "veteranFacilityState": "FL",
+    "plannedClinic": "675"
+  },
+  "veteranAddress": {
+    "street": "1375 E Buena Vista Dr",
+    "city": "Orlando",
+    "state": "FL",
+    "postalCode": "32830"
+  },
+  "veteranPrimaryPhoneNumber": "7153874113",
+  "veteranFullName": {
+    "first": "Micky",
+    "last": "Mouse"
+  },
+  "veteranSignature": "Micky Mouse",
+  "veteranSsnOrTin": "788775458",
+  "veteranDateOfBirth": "1948-11-18",
+  "veteranGender": "M",
+  "secondaryOneFullName": {},
+  "secondaryOneAddress": {},
+  "secondaryTwoFullName": {},
+  "secondaryTwoAddress": {},
+  "AGREED": false,
+  "signAsRepresentativeYesNo": "yes",
+  "signAsRepresentativeDocumentUpload": [
+    {
+      "guid": "85b7edad-0f51-41d2-9eab-dffcc8dabb79",
+      "name": "fake_poa_9_25_15.pdf"
+    }
+  ]
+}

--- a/src/applications/caregivers/tests/e2e/fixtures/mocks/feature-toggles.json
+++ b/src/applications/caregivers/tests/e2e/fixtures/mocks/feature-toggles.json
@@ -110,7 +110,6 @@
         "name": "vaViewDependentsAccess",
         "value": true
       },
-      
       {
         "name": "gibctEybBottomSheet",
         "value": true
@@ -129,6 +128,14 @@
       },
       {
         "name": "gibctCh33BenefitRateUpdate",
+        "value": true
+      },
+      {
+        "name": "canUpload1010cgPOA",
+        "value": true
+      },
+      {
+        "name": "can_upload_10_10cg_poa",
         "value": true
       }
     ]

--- a/src/applications/caregivers/tests/e2e/fixtures/mocks/mock-upload.json
+++ b/src/applications/caregivers/tests/e2e/fixtures/mocks/mock-upload.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "id": "544",
+    "type": "form1010cg_attachments",
+    "attributes": { "guid": "56e911dc-71e8-4e2f-870a-9259f872cc99" }
+  }
+}


### PR DESCRIPTION
## Description
We need to test the sign as representative work with cypress test so we can move quickly in the future without the worry of breaking the user experience. 

## Testing done
- [ ] e2e added

## Screenshots


## Acceptance criteria
- [ ] We are testing the yes/no/no POA page
- [ ] We are testing the document upload page
- [ ] We are testing the sign as representative signature box on review page

## Definition of done
- [ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/24552)
