### PR TITLE
NOD: Add area of disagreement pages

### DIFF
--- a/src/applications/appeals/10182/config/form.js
+++ b/src/applications/appeals/10182/config/form.js
@@ -23,6 +23,7 @@ import {
   showAddIssues,
   needsHearingType,
   appStateSelector,
+  getIssueName,
 } from '../utils/helpers';
 
 // Pages
@@ -34,6 +35,7 @@ import repInfo from '../pages/repInfo';
 import contestableIssues from '../pages/contestableIssues';
 import additionalIssuesIntro from '../pages/additionalIssuesIntro';
 import additionalIssues from '../pages/additionalIssues';
+import areaOfDisagreementFollowUp from '../pages/areaOfDisagreement';
 import boardReview from '../pages/boardReview';
 import evidenceIntro from '../pages/evidenceIntro';
 import evidenceUpload from '../pages/evidenceUpload';
@@ -155,6 +157,14 @@ const formConfig = {
             'view:hasIssuesToAdd': true,
             additionalIssues: [{}],
           },
+        },
+        areaOfDisagreementFollowUp: {
+          title: getIssueName,
+          path: 'area-of-disagreement/:index',
+          showPagePerItem: true,
+          arrayPath: 'areaOfDisagreement',
+          uiSchema: areaOfDisagreementFollowUp.uiSchema,
+          schema: areaOfDisagreementFollowUp.schema,
         },
       },
     },

--- a/src/applications/appeals/10182/config/submit-transformer.js
+++ b/src/applications/appeals/10182/config/submit-transformer.js
@@ -1,5 +1,6 @@
 import {
   addIncludedIssues,
+  addAreaOfDisagreement,
   addUploads,
   getRepName,
   getAddress,
@@ -28,7 +29,7 @@ export function transform(formConfig, form) {
           socOptIn: true,
         },
       },
-      included: addIncludedIssues(formData),
+      included: addAreaOfDisagreement(addIncludedIssues(formData), formData),
       nodUploads: addUploads(formData),
     };
     if (formData.boardReviewOption !== 'hearing') {

--- a/src/applications/appeals/10182/constants.js
+++ b/src/applications/appeals/10182/constants.js
@@ -38,3 +38,8 @@ export const MAX_FILE_SIZE_MB = 100;
 export const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 ** 2; // binary based
 
 export const MAX_NEW_CONDITIONS = 99;
+
+// see https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/appeals_api/config/schemas/v1/10182.json
+export const MAX_ISSUE_LENGTH = 180;
+export const MAX_REP_NAME_LENGTH = 120;
+export const MAX_DISAGREEMENT_REASON_LENGTH = 90;

--- a/src/applications/appeals/10182/containers/FormApp.jsx
+++ b/src/applications/appeals/10182/containers/FormApp.jsx
@@ -9,7 +9,10 @@ import formConfig from '../config/form';
 import {
   noticeOfDisagreementFeature,
   issuesNeedUpdating,
+  getSelected,
+  getIssueName,
 } from '../utils/helpers';
+
 import { showWorkInProgress } from '../content/WorkInProgressMessage';
 
 import { getContestableIssues as getContestableIssuesAction } from '../actions';
@@ -33,6 +36,7 @@ export const FormApp = ({
     () => {
       if (showNod && loggedIn) {
         const { veteran = {} } = formData || {};
+        const areaOfDisagreement = getSelected(formData);
         if (!contestableIssues?.status) {
           getContestableIssues();
         } else if (
@@ -53,6 +57,18 @@ export const FormApp = ({
               email: email?.emailAddress,
             },
             contestableIssues: contestableIssues?.issues || [],
+          });
+        } else if (
+          areaOfDisagreement?.length !== formData.areaOfDisagreement?.length ||
+          !areaOfDisagreement.every(
+            (entry, index) =>
+              getIssueName(entry) ===
+              getIssueName(formData.areaOfDisagreement[index]),
+          )
+        ) {
+          setFormData({
+            ...formData,
+            areaOfDisagreement,
           });
         }
       }

--- a/src/applications/appeals/10182/content/areaOfDisagreement.jsx
+++ b/src/applications/appeals/10182/content/areaOfDisagreement.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+import { getIssueName } from '../utils/helpers';
+
+export const missingAreaOfDisagreementErrorMessage =
+  'Please choose an area of disagreement';
+export const missingAreaOfDisagreementOtherErrorMessage =
+  'Please enter a reason for disagreement';
+
+export const issueName = ({ formData } = {}) => (
+  <legend
+    className="schemaform-block-title schemaform-title-underline"
+    aria-describedby="area-of-disagreement-label"
+  >
+    {getIssueName(formData)}
+  </legend>
+);
+
+// Error revealed through CSS (need to verify this works for screenreaders)
+// "hidden" class uses an !important flag, so we're using "hide" here
+export const issusDescription = () => (
+  <div
+    id="area-of-disagreement-label"
+    className="vads-u-font-size--base vads-u-font-weight--normal"
+  >
+    Please specify the area(s) of disagreement for this issue:
+    <span className="vads-u-font-weight--normal schemaform-required-span">
+      (*Required)
+    </span>
+    <span
+      className="usa-input-error-message hide"
+      role="alert"
+      id="error-message"
+    >
+      <span className="sr-only">Error</span>
+      {missingAreaOfDisagreementErrorMessage}
+    </span>
+  </div>
+);
+
+export const serviceConnection = 'I disagree with the service connection';
+export const effectiveDate = 'I disagree with the effective date of award';
+export const evaluation = 'I disagree with the evaluation of the disability';
+export const other = 'Other reason';
+
+export const otherLabel = 'Please specify';

--- a/src/applications/appeals/10182/pages/areaOfDisagreement.js
+++ b/src/applications/appeals/10182/pages/areaOfDisagreement.js
@@ -1,0 +1,95 @@
+import {
+  issueName,
+  issusDescription,
+  serviceConnection,
+  effectiveDate,
+  evaluation,
+  other,
+  otherLabel,
+  missingAreaOfDisagreementErrorMessage,
+  missingAreaOfDisagreementOtherErrorMessage,
+} from '../content/areaOfDisagreement';
+
+import { areaOfDisagreementRequired } from '../validations';
+import { otherTypeSelected } from '../utils/helpers';
+
+export default {
+  uiSchema: {
+    areaOfDisagreement: {
+      items: {
+        'ui:title': issueName,
+        'ui:description': issusDescription,
+        'ui:required': () => true,
+        'ui:validations': [areaOfDisagreementRequired],
+        'ui:errorMessages': {
+          required: missingAreaOfDisagreementErrorMessage,
+        },
+        'ui:options': {
+          // this will show error messages, but breaks the title (no formData)
+          // see https://dsva.slack.com/archives/CBU0KDSB1/p1620840904269500
+          // showFieldLabel: true,
+        },
+        disagreementOptions: {
+          serviceConnection: {
+            'ui:title': serviceConnection,
+          },
+          effectiveDate: {
+            'ui:title': effectiveDate,
+          },
+          evaluation: {
+            'ui:title': evaluation,
+          },
+          other: {
+            'ui:title': other,
+          },
+        },
+        otherEntry: {
+          'ui:title': otherLabel,
+          'ui:required': otherTypeSelected,
+          'ui:options': {
+            hideIf: (formData, index) => !otherTypeSelected(formData, index),
+          },
+          'ui:errorMessages': {
+            required: missingAreaOfDisagreementOtherErrorMessage,
+          },
+        },
+      },
+    },
+  },
+
+  schema: {
+    type: 'object',
+    properties: {
+      areaOfDisagreement: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            disagreementOptions: {
+              type: 'object',
+              properties: {
+                serviceConnection: {
+                  type: 'boolean',
+                },
+                effectiveDate: {
+                  type: 'boolean',
+                },
+                evaluation: {
+                  type: 'boolean',
+                },
+                other: {
+                  type: 'boolean',
+                },
+              },
+            },
+            otherEntry: {
+              type: 'string',
+              // disagreementReason limited to 90 chars max
+              maxLength: 34,
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/src/applications/appeals/10182/sass/10182-nod.scss
+++ b/src/applications/appeals/10182/sass/10182-nod.scss
@@ -171,6 +171,37 @@ article[data-location="representative-info"] {
   }
 }
 
+/* Area of disagreement */
+#area-of-disagreement-label {
+  margin-top: 0;
+}
+#area-of-disagreement-label .hide { display: none; }
+#area-of-disagreement-label:not(.usa-input-error) {
+  margin: 2rem 0;
+}
+#area-of-disagreement-label.usa-input-error {
+  .input-section {
+    margin-bottom: 0;
+  }
+  .hide {
+    display: block;
+  }
+}
+article[data-location^="area-of-disagreement"] {
+  .schemaform-block-header,
+  .schemaform-block-header + .usa-input-error {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}
+/* override formation to maintain margin between checkboxes */
+.usa-input-error label {
+  margin-top: 3rem;
+}
+.usa-input-error > label {
+  margin-top: 0;
+}
+
 /* additional evidence */
 article[data-location$="/upload"] {
   #root_evidence_add_label {

--- a/src/applications/appeals/10182/tests/10182-notice-of-disagreement.cypress.spec.js
+++ b/src/applications/appeals/10182/tests/10182-notice-of-disagreement.cypress.spec.js
@@ -5,20 +5,20 @@ import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-test
 
 import formConfig from '../config/form';
 import manifest from '../manifest.json';
-import { mockContestableIssues } from './nod.cypress.helpers';
+import { fixDecisionDates } from './nod.cypress.helpers';
 import mockFeatureToggles from './fixtures/mocks/feature-toggles.json';
 import mockInProgress from './fixtures/mocks/in-progress-forms.json';
 import mockSubmit from './fixtures/mocks/application-submit.json';
 import mockUpload from './fixtures/mocks/mock-upload.json';
 import mockUser from './fixtures/mocks/user.json';
-import { CONTESTABLE_ISSUES_API } from '../constants';
+import { CONTESTABLE_ISSUES_API, SELECTED } from '../constants';
 
 const testConfig = createTestConfig(
   {
     dataPrefix: 'data',
 
     // Rename and modify the test data as needed.
-    dataSets: ['maximal-test'],
+    dataSets: ['maximal-test', 'minimal-test'],
 
     fixtures: {
       data: path.join(__dirname, 'fixtures', 'data'),
@@ -31,6 +31,17 @@ const testConfig = createTestConfig(
           cy.findAllByText(/start/i, { selector: 'button' })
             .last()
             .click();
+        });
+      },
+      'eligible-issues': () => {
+        cy.get('@testData').then(data => {
+          data.contestableIssues.forEach((item, index) => {
+            if (item[SELECTED]) {
+              cy.get(`input[name="root_contestableIssues_${index}"]`)
+                .first()
+                .click({ force: true });
+            }
+          });
         });
       },
       'additional-issues': () => {
@@ -57,6 +68,14 @@ const testConfig = createTestConfig(
             cy.get('.update')
               .first()
               .click();
+            if (!item[SELECTED]) {
+              cy.get(
+                `input[type="checkbox"][name="root_additionalIssues_${index}"]`,
+              )
+                .first()
+                // remove auto-check if not selected in data
+                .click({ force: true });
+            }
           });
         });
       },
@@ -67,12 +86,6 @@ const testConfig = createTestConfig(
 
       cy.intercept('GET', '/v0/feature_toggles?*', mockFeatureToggles);
 
-      cy.intercept(
-        'GET',
-        `/v0${CONTESTABLE_ISSUES_API}`,
-        mockContestableIssues,
-      );
-
       cy.intercept('PUT', 'v0/in_progress_forms/10182', mockInProgress);
 
       cy.intercept('POST', 'v0/decision_review_evidence', mockUpload);
@@ -80,13 +93,12 @@ const testConfig = createTestConfig(
       cy.route('POST', formConfig.submitUrl, mockSubmit);
 
       cy.get('@testData').then(testData => {
+        cy.intercept('GET', `/v0${CONTESTABLE_ISSUES_API}`, {
+          data: fixDecisionDates(testData.contestableIssues),
+        });
+
         cy.intercept('GET', '/v0/in_progress_forms/10182', testData);
         cy.intercept('PUT', 'v0/in_progress_forms/10182', testData);
-
-        // eventually use issues from dataSets (this doesn't work?)
-        // cy.intercept('GET', `/v0${CONTESTABLE_ISSUES_API}*`, {
-        //   data: testData.contestableIssues,
-        // });
       });
     },
 

--- a/src/applications/appeals/10182/tests/containers/FormApp.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/containers/FormApp.unit.spec.jsx
@@ -5,6 +5,7 @@ import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
 
 import { FormApp } from '../../containers/FormApp';
+import { SELECTED } from '../../constants';
 
 const profile = {
   vapContactInfo: {
@@ -170,6 +171,54 @@ describe('FormApp', () => {
     };
     expect(formData.veteran).to.deep.equal(result);
     expect(formData.contestableIssues).to.deep.equal(contestableIssues.issues);
+
+    tree.unmount();
+  });
+
+  it('should update areaOfDisagreement from selected issues', () => {
+    const setFormData = sinon.spy();
+    const { props, mockStore } = getData();
+    const contestableIssues = {
+      status: 'done', // any truthy value to skip get contestable issues action
+      issues: [
+        {
+          type: 'contestableIssue',
+          attributes: {
+            ratingIssueSubjectText: 'tinnitus',
+          },
+          [SELECTED]: true,
+        },
+      ],
+    };
+    const formData = {
+      contestableIssues: contestableIssues.issues,
+      additionalIssues: [{ issue: 'other issue', [SELECTED]: true }],
+      veteran: {
+        email: profile.vapContactInfo.email.emailAddress,
+        phone: profile.vapContactInfo.homePhone,
+        address: profile.vapContactInfo.mailingAddress,
+      },
+    };
+    const tree = mount(
+      <Provider store={mockStore}>
+        <FormApp
+          {...props}
+          setFormData={setFormData}
+          formData={formData}
+          contestableIssues={contestableIssues}
+        />
+      </Provider>,
+    );
+
+    tree.setProps();
+    expect(setFormData.called).to.be.true;
+
+    const updatedFormData = setFormData.args[0][0];
+    expect(updatedFormData.areaOfDisagreement.length).to.eq(2);
+    expect(updatedFormData.areaOfDisagreement).to.deep.equal([
+      formData.contestableIssues[0],
+      formData.additionalIssues[0],
+    ]);
 
     tree.unmount();
   });

--- a/src/applications/appeals/10182/tests/fixtures/data/maximal-test.json
+++ b/src/applications/appeals/10182/tests/fixtures/data/maximal-test.json
@@ -95,6 +95,40 @@
         "view:selected": true
       }
     ],
+    "areaOfDisagreement": [
+      {
+        "type": "contestableIssue",
+        "attributes": {
+          "ratingIssueSubjectText": "tinnitus"
+        },
+        "disagreementOptions": {
+          "serviceConnection": true,
+          "effectiveDate": true,
+          "evaluation": true,
+          "other": true
+        },
+        "otherEntry": "this is an other entry"
+      },
+      {
+        "type": "contestableIssue",
+        "attributes": {
+          "ratingIssueSubjectText": "left knee"
+        },
+        "disagreementOptions": {
+          "serviceConnection": false,
+          "effectiveDate": true
+        },
+        "otherEntry": ""
+      },
+      {
+        "issue": "right shoulder",
+        "disagreementOptions": {
+          "evaluation": true,
+          "other": true
+        },
+        "otherEntry": "this is another other entry"
+      }
+    ],
     "evidence": [
       {
         "name": "file-1.pdf",

--- a/src/applications/appeals/10182/tests/fixtures/data/minimal-test.json
+++ b/src/applications/appeals/10182/tests/fixtures/data/minimal-test.json
@@ -96,6 +96,18 @@
         "view:selected": true
       }
     ],
+    "areaOfDisagreement": [
+      {
+        "type": "contestableIssue",
+        "attributes": {
+          "ratingIssueSubjectText": "Traumatic Brain Injury"
+        },
+        "disagreementOptions": {
+          "effectiveDate": true
+        },
+        "otherEntry": ""
+      }
+    ],
     "evidence": []
   }
 }

--- a/src/applications/appeals/10182/tests/fixtures/data/transformed-maximal-test.json
+++ b/src/applications/appeals/10182/tests/fixtures/data/transformed-maximal-test.json
@@ -36,7 +36,8 @@
         "decisionDate": "2020-01-01",
         "decisionIssueId": 1,
         "ratingIssueReferenceId": "2",
-        "ratingDecisionReferenceId": "3"
+        "ratingDecisionReferenceId": "3",
+        "disagreementReason": "service connection,effective date,disability evaluation,this is an other entry"
       }
     },
     {
@@ -45,14 +46,16 @@
         "issue": "left knee - 0%",
         "decisionDate": "2020-01-02",
         "decisionIssueId": 4,
-        "ratingIssueReferenceId": "5"
+        "ratingIssueReferenceId": "5",
+        "disagreementReason": "effective date"
       }
     },
     {
       "type": "contestableIssue",
       "attributes": {
         "issue": "right shoulder",
-        "decisionDate": "2020-01-06"
+        "decisionDate": "2020-01-06",
+        "disagreementReason": "disability evaluation,this is another other entry"
       }
     }
   ],

--- a/src/applications/appeals/10182/tests/fixtures/data/transformed-minimal-test.json
+++ b/src/applications/appeals/10182/tests/fixtures/data/transformed-minimal-test.json
@@ -35,7 +35,8 @@
       "attributes": {
         "issue": "Traumatic Brain Injury - 5%",
         "decisionIssueId": 10,
-        "decisionDate": "2020-01-05"
+        "decisionDate": "2020-01-05",
+        "disagreementReason": "effective date"
       }
     }
   ],

--- a/src/applications/appeals/10182/tests/nod.cypress.helpers.js
+++ b/src/applications/appeals/10182/tests/nod.cypress.helpers.js
@@ -1,58 +1,29 @@
-export const mockContestableIssues = {
-  data: [
-    {
-      id: null,
-      type: 'contestableIssue',
-      attributes: {
-        ratingIssueReferenceId: '142926',
-        ratingIssueProfileDate: '2020-06-15',
-        ratingIssueDiagnosticCode: '6260',
-        ratingIssueSubjectText: 'Tinnitus',
-        ratingIssuePercentNumber: '0',
-        description:
-          'Service connection for Tinnitus is granted with an evaluation of 0 percent effective September 25, 2019.',
-        isRating: true,
-        latestIssuesInChain: [
-          {
-            id: null,
-            approxDecisionDate: '2020-06-15',
-          },
-        ],
-        decisionIssueId: null,
-        ratingDecisionReferenceId: null,
-        approxDecisionDate: '2020-06-15',
-        rampClaimId: null,
-        titleOfActiveReview: null,
-        sourceReviewType: null,
-        timely: true,
+import { getDate } from '../utils/dates';
+import { SELECTED } from '../constants';
+
+export const fixDecisionDates = data => {
+  return data.map(issue => {
+    const newDate = getDate({
+      offset: {
+        months: -Math.floor(Math.random() * 6 + 1),
+        days: -Math.floor(Math.random() * 10),
       },
-    },
-    {
-      id: null,
-      type: 'contestableIssue',
+    });
+    // remove selected value so Cypress can click-select
+    if (issue.decisionDate) {
+      return {
+        ...issue,
+        decisionDate: newDate,
+        [SELECTED]: false,
+      };
+    }
+    return {
+      ...issue,
       attributes: {
-        ratingIssueReferenceId: '142927',
-        ratingIssueProfileDate: '2020-06-15',
-        ratingIssueDiagnosticCode: '9411',
-        ratingIssueSubjectText: 'PTSD',
-        ratingIssuePercentNumber: '30',
-        description:
-          'Service connection for PTSD is granted with an evaluation of 30 percent effective March 5, 2019.',
-        isRating: true,
-        latestIssuesInChain: [
-          {
-            id: null,
-            approxDecisionDate: '2020-06-15',
-          },
-        ],
-        decisionIssueId: null,
-        ratingDecisionReferenceId: null,
-        approxDecisionDate: '2020-06-15',
-        rampClaimId: null,
-        titleOfActiveReview: null,
-        sourceReviewType: null,
-        timely: true,
+        ...issue.attributes,
+        approxDecisionDate: newDate,
       },
-    },
-  ],
+      [SELECTED]: false,
+    };
+  });
 };

--- a/src/applications/appeals/10182/tests/pages/areaOfDisagreement.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/pages/areaOfDisagreement.unit.spec.jsx
@@ -1,5 +1,3 @@
-// import areaOfDisagreement from '../pages/areaOfDisagreement';
-
 import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
@@ -26,9 +24,6 @@ describe('area of disagreement page', () => {
         attributes: {
           ratingIssueSubjectText: 'Tinnitus',
         },
-        // disgreementOptions: {
-        //   evaluation: true,
-        // },
       },
     ],
   };

--- a/src/applications/appeals/10182/tests/pages/areaOfDisagreement.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/pages/areaOfDisagreement.unit.spec.jsx
@@ -1,0 +1,128 @@
+// import areaOfDisagreement from '../pages/areaOfDisagreement';
+
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import sinon from 'sinon';
+
+import {
+  DefinitionTester,
+  selectCheckbox,
+  fillData,
+} from 'platform/testing/unit/schemaform-utils.jsx';
+
+import formConfig from '../../config/form';
+
+describe('area of disagreement page', () => {
+  const {
+    schema,
+    uiSchema,
+    arrayPath,
+  } = formConfig.chapters.conditions.pages.areaOfDisagreementFollowUp;
+
+  const data = {
+    areaOfDisagreement: [
+      {
+        attributes: {
+          ratingIssueSubjectText: 'Tinnitus',
+        },
+        // disgreementOptions: {
+        //   evaluation: true,
+        // },
+      },
+    ],
+  };
+
+  it('should render', () => {
+    const form = mount(
+      <DefinitionTester
+        definitions={{}}
+        arrayPath={arrayPath}
+        pagePerItemIndex={0}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={data}
+      />,
+    );
+
+    expect(form.find('input[type="checkbox"]').length).to.equal(4);
+    form.unmount();
+  });
+
+  it('should not allow submit when nothing is checked', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={{}}
+        arrayPath={arrayPath}
+        pagePerItemIndex={0}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={data}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+    expect(onSubmit.called).to.be.false;
+    form.unmount();
+  });
+  it('should not allow submit when other is checked with no additional text', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={{}}
+        arrayPath={arrayPath}
+        pagePerItemIndex={0}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={data}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    selectCheckbox(form, 'root_disagreementOptions_other', true);
+    form.find('form').simulate('submit');
+    expect(onSubmit.called).to.be.false;
+    form.unmount();
+  });
+  it('should allow submit when an area (not other) is checked', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={{}}
+        arrayPath={arrayPath}
+        pagePerItemIndex={0}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={data}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    selectCheckbox(form, 'root_disagreementOptions_serviceConnection', true);
+    form.find('form').simulate('submit');
+    expect(onSubmit.called).to.be.true;
+    form.unmount();
+  });
+  it('should allow submit when other is checked with additional text', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={{}}
+        arrayPath={arrayPath}
+        pagePerItemIndex={0}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={data}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    selectCheckbox(form, 'root_disagreementOptions_other', true);
+    fillData(form, '[name="root_otherEntry"]', 'foo');
+    form.find('form').simulate('submit');
+    expect(onSubmit.called).to.be.true;
+    form.unmount();
+  });
+});

--- a/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
@@ -4,6 +4,8 @@ import { SELECTED } from '../../constants';
 import {
   someSelected,
   hasSomeSelected,
+  getSelected,
+  getIssueName,
   showAddIssueQuestion,
   isEmptyObject,
   setInitialEditMode,
@@ -46,6 +48,60 @@ describe('hasSomeSelected', () => {
     expect(
       testIssues([{}, { [SELECTED]: false }], [{}, {}, { [SELECTED]: false }]),
     ).to.be.false;
+  });
+});
+
+describe('getSelected', () => {
+  it('should return selected contestable issues', () => {
+    expect(
+      getSelected({
+        contestableIssues: [
+          { type: 'no', [SELECTED]: false },
+          { type: 'ok', [SELECTED]: true },
+        ],
+      }),
+    ).to.deep.equal([{ type: 'ok', [SELECTED]: true }]);
+  });
+  it('should return selected additional issues', () => {
+    expect(
+      getSelected({
+        additionalIssues: [
+          { type: 'no', [SELECTED]: false },
+          { type: 'ok', [SELECTED]: true },
+        ],
+      }),
+    ).to.deep.equal([{ type: 'ok', [SELECTED]: true }]);
+  });
+  it('should return all selected issues', () => {
+    expect(
+      getSelected({
+        contestableIssues: [
+          { type: 'no1', [SELECTED]: false },
+          { type: 'ok1', [SELECTED]: true },
+        ],
+        additionalIssues: [
+          { type: 'no2', [SELECTED]: false },
+          { type: 'ok2', [SELECTED]: true },
+        ],
+      }),
+    ).to.deep.equal([
+      { type: 'ok1', [SELECTED]: true },
+      { type: 'ok2', [SELECTED]: true },
+    ]);
+  });
+});
+
+describe('getIssueName', () => {
+  it('should return undefined', () => {
+    expect(getIssueName()).to.be.undefined;
+  });
+  it('should return a contestable issue name', () => {
+    expect(
+      getIssueName({ attributes: { ratingIssueSubjectText: 'test' } }),
+    ).to.eq('test');
+  });
+  it('should return an added issue name', () => {
+    expect(getIssueName({ issue: 'test2' })).to.eq('test2');
   });
 });
 

--- a/src/applications/appeals/10182/tests/validations.unit.spec.js
+++ b/src/applications/appeals/10182/tests/validations.unit.spec.js
@@ -1,6 +1,11 @@
 import { expect } from 'chai';
+import sinon from 'sinon';
 
-import { requireIssue, optInValidation } from '../validations';
+import {
+  requireIssue,
+  areaOfDisagreementRequired,
+  optInValidation,
+} from '../validations';
 import { optInErrorMessage } from '../content/OptIn';
 import { SELECTED } from '../constants';
 
@@ -58,6 +63,34 @@ describe('requireIssue validation', () => {
     };
     requireIssue(errors, _, _, _, _, _, data);
     expect(errorMessage).to.equal('');
+  });
+});
+
+describe('areaOfDisagreementRequired', () => {
+  it('should show an error with no selections', () => {
+    const errors = { addError: sinon.spy() };
+    areaOfDisagreementRequired(errors);
+    expect(errors.addError.called).to.be.true;
+  });
+  it('should show an error with other selected, but no entry text', () => {
+    const errors = { addError: sinon.spy() };
+    areaOfDisagreementRequired(errors, {
+      disagreementOptions: { other: true },
+    });
+    expect(errors.addError.called).to.be.true;
+  });
+  it('should not show an error with a single selection', () => {
+    const errors = { addError: sinon.spy() };
+    areaOfDisagreementRequired(errors, { disagreementOptions: { foo: true } });
+    expect(errors.addError.called).to.be.false;
+  });
+  it('should not show an error with other selected with entry text', () => {
+    const errors = { addError: sinon.spy() };
+    areaOfDisagreementRequired(errors, {
+      disagreementOptions: { other: true },
+      otherEntry: 'foo',
+    });
+    expect(errors.addError.called).to.be.false;
   });
 });
 

--- a/src/applications/appeals/10182/utils/helpers.js
+++ b/src/applications/appeals/10182/utils/helpers.js
@@ -12,6 +12,8 @@ export const needsHearingType = formData =>
 export const wantsToUploadEvidence = formData =>
   canUploadEvidence(formData) && formData['view:additionalEvidence'];
 export const showAddIssues = formData => formData['view:hasIssuesToAdd'];
+export const otherTypeSelected = ({ areaOfDisagreement } = {}, index) =>
+  areaOfDisagreement?.[index]?.disagreementOptions?.other;
 
 export const someSelected = issues =>
   (issues || []).some(issue => issue[SELECTED]);
@@ -22,6 +24,14 @@ export const showAddIssueQuestion = ({ contestableIssues }) =>
   // SHOW: if contestable issues selected. HIDE: if no contestable issues are
   // selected or, there are no contestable issues
   contestableIssues?.length ? someSelected(contestableIssues) : false;
+
+export const getSelected = ({ contestableIssues, additionalIssues } = {}) =>
+  (contestableIssues || [])
+    .filter(issue => issue[SELECTED])
+    .concat((additionalIssues || []).filter(issue => issue[SELECTED]));
+
+export const getIssueName = (entry = {}) =>
+  entry.issue || entry.attributes?.ratingIssueSubjectText;
 
 // Simple one level deep check
 export const isEmptyObject = obj =>

--- a/src/applications/appeals/10182/utils/submit.js
+++ b/src/applications/appeals/10182/utils/submit.js
@@ -1,6 +1,11 @@
 import moment from 'moment';
 
-import { SELECTED } from '../constants';
+import {
+  SELECTED,
+  MAX_ISSUE_LENGTH,
+  MAX_REP_NAME_LENGTH,
+  MAX_DISAGREEMENT_REASON_LENGTH,
+} from '../constants';
 
 /**
  * @typedef FormData
@@ -85,7 +90,7 @@ export const getEligibleContestableIssues = issues => {
  * @param {ContestableIssue~Attributes} attributes
  * @returns {String} Issue name - rating % - description combined
  */
-export const getIssueName = ({ attributes } = {}) => {
+export const createIssueName = ({ attributes } = {}) => {
   const {
     ratingIssueSubjectText,
     ratingIssuePercentNumber,
@@ -98,14 +103,15 @@ export const getIssueName = ({ attributes } = {}) => {
   ]
     .filter(part => part)
     .join(' - ')
-    .substring(0, 255);
+    .substring(0, MAX_ISSUE_LENGTH);
 };
 
 /**
  * @typedef ContestableIssue~SubmittableItem
  * @type {Object}
- * @property {String} issue - title of issue returned by getIssueName function
+ * @property {String} issue - title of issue returned by createIssueName function
  * @property {String} decisionDate - decision date string (YYYY-MM-DD)
+ * @property {String} disagreementReason - area of disagreement
  * @property {Number=} decisionIssueId - decision id
  * @property {String=} ratingIssueReferenceId - issue reference number
  * @property {String=} ratingDecisionReferenceId - decision reference id
@@ -149,7 +155,7 @@ export const getContestableIssues = ({ contestableIssues }) =>
         return acc;
       },
       {
-        issue: getIssueName(issue),
+        issue: createIssueName(issue),
         decisionDate: attr.approxDecisionDate,
       },
     );
@@ -203,6 +209,36 @@ export const addIncludedIssues = formData => {
     );
   }
   return issues;
+};
+
+/**
+ * Add area of disagreement
+ * @param {ContestableIssue~Submittable} issues - selected & processed issues
+ * @param {FormData} formData
+ * @return {ContestableIssues~Submittable} issues with "disagreementReason" added
+ */
+export const addAreaOfDisagreement = (issues, { areaOfDisagreement } = {}) => {
+  const keywords = {
+    serviceConnection: () => 'service connection',
+    effectiveDate: () => 'effective date',
+    evaluation: () => 'disability evaluation',
+    other: disagreementOptions => disagreementOptions.otherEntry,
+  };
+  return issues.map((issue, index) => {
+    const entry = areaOfDisagreement[index];
+    const reasons = Object.entries(entry.disagreementOptions)
+      .map(([key, value]) => value && keywords[key](entry))
+      .filter(Boolean);
+    return {
+      ...issue,
+      attributes: {
+        ...issue.attributes,
+        disagreementReason: reasons
+          .join(',')
+          .substring(0, MAX_DISAGREEMENT_REASON_LENGTH), // max length in schema
+      },
+    };
+  });
 };
 
 /**
@@ -310,11 +346,11 @@ export const getPhone = ({ veteran = {} } = {}) =>
 /**
  * Get representative name entered by Veteran
  * @param {FormData}
- * @returns {String} Rep name with max length of 120 characters
+ * @returns {String} Rep name with max length of characters
  */
 export const getRepName = formData =>
   formData['view:hasRep']
-    ? (formData.representativesName || '').substring(0, 120)
+    ? (formData.representativesName || '').substring(0, MAX_REP_NAME_LENGTH)
     : '';
 
 /**

--- a/src/applications/appeals/10182/utils/ui.js
+++ b/src/applications/appeals/10182/utils/ui.js
@@ -27,3 +27,18 @@ export const scrollAndFocus = ({ selector, offset = 50, timer }) => {
     scrollAndFocusFunctions(selector, offset);
   }
 };
+
+// work-around for error message not showing :(
+export const areaOfDisagreementWorkAround = hasSelection => {
+  // we can't target the fieldset because it doesn't get re-rendered on other
+  // pages by React
+  // see https://dsva.slack.com/archives/CBU0KDSB1/p1620840904269500
+  const label = $('#area-of-disagreement-label');
+  if (label) {
+    label.classList.toggle('usa-input-error', !hasSelection);
+    label.parentElement.nextElementSibling.classList.toggle(
+      'usa-input-error',
+      !hasSelection,
+    );
+  }
+};

--- a/src/applications/appeals/10182/validations.js
+++ b/src/applications/appeals/10182/validations.js
@@ -1,6 +1,11 @@
 import { hasSomeSelected } from './utils/helpers';
 import { optInErrorMessage } from './content/OptIn';
 import { missingIssuesErrorMessage } from './content/additionalIssues';
+import {
+  missingAreaOfDisagreementErrorMessage,
+  missingAreaOfDisagreementOtherErrorMessage,
+} from './content/areaOfDisagreement';
+import { areaOfDisagreementWorkAround } from './utils/ui';
 
 export const requireIssue = (
   errors,
@@ -18,6 +23,23 @@ export const requireIssue = (
   if (!hasSomeSelected(data)) {
     errors.addError(missingIssuesErrorMessage);
   }
+};
+
+export const areaOfDisagreementRequired = (
+  errors,
+  { disagreementOptions, otherEntry } = {},
+) => {
+  const keys = Object.keys(disagreementOptions || {});
+  const hasSelection = keys.some(key => disagreementOptions[key]);
+
+  if (!hasSelection) {
+    errors.addError(missingAreaOfDisagreementErrorMessage);
+  } else if (disagreementOptions.other && !otherEntry) {
+    errors.addError(missingAreaOfDisagreementOtherErrorMessage);
+  }
+
+  // work-around for error message not showing :(
+  areaOfDisagreementWorkAround(hasSelection);
 };
 
 export const optInValidation = (errors, value) => {


### PR DESCRIPTION
## Description

Adding the area of disagreement pages to the Notice of Disagreement form.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/24169
- Design: https://vsateams.invisionapp.com/console/share/8Y10I6K7DU9R/615292864

## Testing done

- Added unit tests
- Updated mock data
- Updated Cypress e2e tests

## Screenshots

See Design (Can't log into local to get screenshots)

## Acceptance criteria
- [x] Area of disagreement question shows for each selected issue
- [x] Unit & e2e tests pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
