### PR TITLE
Fix broken VAOS cypress tests

### DIFF
--- a/src/applications/vaos/tests/e2e/appointment-list.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/appointment-list.cypress.spec.js
@@ -254,13 +254,14 @@ describe('VAOS appointment list refresh', () => {
       cy.axeCheckBestPractice();
     });
 
-    it.skip('should navigate to requested appointment details', () => {
+    it('should navigate to past appointment details', () => {
       cy.get('[data-cy=appointment-list-item]')
         .first()
         .findByText(/Details/i)
         .focus()
         .click();
-      cy.findByText(/Request detail/i).should('exist');
+      cy.findByText(/Appointment detail/i).should('exist');
+      cy.axeCheckBestPractice();
     });
 
     it('should select an updated date range', () => {

--- a/src/applications/vaos/tests/e2e/covid19-vaccine.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/covid19-vaccine.cypress.spec.js
@@ -242,7 +242,7 @@ describe('VAOS COVID-19 vaccine appointment flow', () => {
     cy.axeCheckBestPractice();
   });
 
-  it.skip('should show facility contact page when vaccine schedule is not available', () => {
+  it('should show facility contact page when vaccine schedule is not available', () => {
     initAppointmentListMock();
     initVaccineAppointmentMock({ unableToScheduleCovid: true });
 
@@ -253,6 +253,7 @@ describe('VAOS COVID-19 vaccine appointment flow', () => {
 
     // Contact Facility Page
     cy.url().should('include', '/contact-facilities');
+    cy.findByText('Your facilities');
     cy.axeCheckBestPractice();
     cy.findByText(/Continue/i).should('not.exist');
   });

--- a/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
@@ -654,9 +654,15 @@ export function initVaccineAppointmentMock({
       method: 'GET',
       url: '/vaos/v0/direct_booking_eligibility_criteria*',
       response: {
-        data: directEligibilityCriteria.data.filter(
-          facility => facility.id === 'covid',
-        ),
+        data: directEligibilityCriteria.data.map(facility => ({
+          ...facility,
+          attributes: {
+            ...facility.attributes,
+            coreSettings: facility.attributes.coreSettings.filter(
+              f => f.id !== 'covid',
+            ),
+          },
+        })),
       },
     });
   }


### PR DESCRIPTION
## Description
This PR fixes two skipped VAOS Cypress tests.

## Testing done
Cypress testing

## Acceptance criteria
- [ ] Build passes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
