### PR TITLE
NOD: Add opt-in page

### DIFF
--- a/src/applications/appeals/10182/components/OptInWidget.jsx
+++ b/src/applications/appeals/10182/components/OptInWidget.jsx
@@ -15,7 +15,14 @@ import { OptInLabel, optInErrorMessage } from '../content/OptIn';
 const OptInWidget = props => {
   const { value, formContext, onChange } = props;
 
-  return (
+  const onReviewPage = formContext?.onReviewPage || false;
+  // inReviewMode = true (review page view, not in edit mode)
+  // inReviewMode = false (in edit mode)
+  const inReviewMode = (onReviewPage && formContext.reviewMode) || false;
+
+  return onReviewPage && inReviewMode ? (
+    <span>True</span>
+  ) : (
     <Checkbox
       name="root_socOptIn"
       errorMessage={!value && formContext.submitted ? optInErrorMessage : ''}

--- a/src/applications/appeals/10182/components/OptInWidget.jsx
+++ b/src/applications/appeals/10182/components/OptInWidget.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Checkbox from '@department-of-veterans-affairs/component-library/Checkbox';
+
+import { OptInLabel, optInErrorMessage } from '../content/OptIn';
+
+/**
+ * Using a custom checkbox widget because the built-in checkbox will duplicate
+ * the label (no checkbox); it is then followed by the error message, then
+ * checkbox + label. With this widget, we hide the label (no checkbox), and the
+ * error message appears below the proper label per design pattern
+ */
+
+const OptInWidget = props => {
+  const { value, formContext, onChange } = props;
+
+  return (
+    <Checkbox
+      name="root_socOptIn"
+      errorMessage={!value && formContext.submitted ? optInErrorMessage : ''}
+      label={OptInLabel}
+      ariaLabelledBy="opt-in-description"
+      onValueChange={val => onChange(val)}
+      checked={value}
+      required
+    />
+  );
+};
+
+OptInWidget.propTypes = {
+  formContext: PropTypes.shape({
+    submitted: PropTypes.bool,
+  }),
+  onChange: PropTypes.func,
+  value: PropTypes.boolean,
+};
+
+export default OptInWidget;

--- a/src/applications/appeals/10182/config/form.js
+++ b/src/applications/appeals/10182/config/form.js
@@ -36,6 +36,7 @@ import contestableIssues from '../pages/contestableIssues';
 import additionalIssuesIntro from '../pages/additionalIssuesIntro';
 import additionalIssues from '../pages/additionalIssues';
 import areaOfDisagreementFollowUp from '../pages/areaOfDisagreement';
+import optIn from '../pages/optIn';
 import boardReview from '../pages/boardReview';
 import evidenceIntro from '../pages/evidenceIntro';
 import evidenceUpload from '../pages/evidenceUpload';
@@ -165,6 +166,12 @@ const formConfig = {
           arrayPath: 'areaOfDisagreement',
           uiSchema: areaOfDisagreementFollowUp.uiSchema,
           schema: areaOfDisagreementFollowUp.schema,
+        },
+        optIn: {
+          title: 'Opt in',
+          path: 'opt-in',
+          uiSchema: optIn.uiSchema,
+          schema: optIn.schema,
         },
       },
     },

--- a/src/applications/appeals/10182/content/OptIn.jsx
+++ b/src/applications/appeals/10182/content/OptIn.jsx
@@ -48,5 +48,13 @@ export const OptInLabel = (
   </strong>
 );
 
+// children should always be "True"
+export const OptInReviewField = ({ children }) => (
+  <div className="review-row">
+    <dt>{OptInLabel}</dt>
+    <dd>{children}</dd>
+  </div>
+);
+
 export const optInErrorMessage =
   'Please opt into the new decision review process to proceed';

--- a/src/applications/appeals/10182/content/OptIn.jsx
+++ b/src/applications/appeals/10182/content/OptIn.jsx
@@ -1,19 +1,51 @@
 import React from 'react';
 
-export const OptInTitle = (
-  <strong className="opt-in-title">
-    I understand that if any issues I’ve selected are from the legacy appeal
-    process, I’m opting them into the new decision review process.
-  </strong>
-);
+import { getSelected } from '../utils/helpers';
+import { getDate } from '../utils/dates';
+import { FORMAT_READABLE } from '../constants';
 
-export const optInDescription = (
-  <span className="hide-on-review">
-    By checking this box, you’re withdrawing any issues you’ve selected from the
-    legacy appeals process (this is the process for decisions received before
-    February 19, 2019). Instead, the Board will consider your claim for this
-    condition under the new process.
-  </span>
+export const OptInDescription = ({ formData }) => {
+  // Change this once we figure out which issues are legacy, switch to getLegacyAppeals
+  const issues = getSelected(formData); // getLegacyAppeals(formData);
+  return (
+    <div id="opt-in-description">
+      The issue(s) listed here may be in our old appeals process:
+      <ul>
+        {issues.map((issue, index) => (
+          <li key={index}>
+            <strong className="capitalize">
+              {issue.attributes?.ratingIssueSubjectText || issue.issue || ''}
+            </strong>
+            <div>
+              Decision date:{' '}
+              {getDate({
+                date:
+                  issue.attributes?.approxDecisionDate ||
+                  issue.decisionDate ||
+                  '',
+                pattern: FORMAT_READABLE,
+              })}
+            </div>
+          </li>
+        ))}
+      </ul>
+      <p>
+        If you’re requesting a Board Appeal on an issue in an older claim,
+        you’ll need to opt in to the new decision review process by checking the
+        box. This moves your issue out of the old appeals process. As part of
+        the Appeals Modernization Act, our new process means you’ll likely get a
+        faster decision.
+      </p>
+    </div>
+  );
+};
+
+export const OptInLabel = (
+  <strong className="opt-in-title">
+    I understand that I’m opting in to the new decision review process any
+    issues I’d like reviewed that are part of a claim VA decided before February
+    19, 2019.
+  </strong>
 );
 
 export const optInErrorMessage =

--- a/src/applications/appeals/10182/pages/optIn.js
+++ b/src/applications/appeals/10182/pages/optIn.js
@@ -1,0 +1,38 @@
+import { OptInDescription, optInErrorMessage } from '../content/OptIn';
+import { optInValidation } from '../validations';
+import OptInWidget from '../components/OptInWidget';
+
+export default {
+  // 'ui:description': OptInDescription,
+  uiSchema: {
+    'ui:title': OptInDescription,
+    'ui:options': {
+      forceDivWrapper: true,
+    },
+    socOptIn: {
+      'ui:title': ' ',
+      'ui:widget': OptInWidget,
+      'ui:required': () => true,
+      'ui:validations': [optInValidation],
+      'ui:errorMessages': {
+        enum: optInErrorMessage,
+        required: optInErrorMessage,
+      },
+      'ui:options': {
+        showFieldLabel: false,
+        forceDivWrapper: true,
+        keepInPageOnReview: false,
+      },
+    },
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      socOptIn: {
+        type: 'boolean',
+        enum: [true],
+        enumNames: ['Yes'],
+      },
+    },
+  },
+};

--- a/src/applications/appeals/10182/pages/optIn.js
+++ b/src/applications/appeals/10182/pages/optIn.js
@@ -1,9 +1,12 @@
-import { OptInDescription, optInErrorMessage } from '../content/OptIn';
+import {
+  OptInDescription,
+  optInErrorMessage,
+  OptInReviewField,
+} from '../content/OptIn';
 import { optInValidation } from '../validations';
 import OptInWidget from '../components/OptInWidget';
 
 export default {
-  // 'ui:description': OptInDescription,
   uiSchema: {
     'ui:title': OptInDescription,
     'ui:options': {
@@ -12,6 +15,7 @@ export default {
     socOptIn: {
       'ui:title': ' ',
       'ui:widget': OptInWidget,
+      'ui:reviewField': OptInReviewField,
       'ui:required': () => true,
       'ui:validations': [optInValidation],
       'ui:errorMessages': {

--- a/src/applications/appeals/10182/sass/10182-nod.scss
+++ b/src/applications/appeals/10182/sass/10182-nod.scss
@@ -202,6 +202,16 @@ article[data-location^="area-of-disagreement"] {
   margin-top: 0;
 }
 
+/* Opt in */
+.capitalize {
+  text-transform: capitalize;
+}
+/* hide duplicate "required" checkbox label & error message above checkbox */
+#root_socOptIn-label,
+#root_socOptIn-label + span {
+  display: none;
+}
+
 /* additional evidence */
 article[data-location$="/upload"] {
   #root_evidence_add_label {

--- a/src/applications/appeals/10182/tests/components/OptInWidget.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/OptInWidget.unit.spec.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import sinon from 'sinon';
+
+import OptInWidget from '../../components/OptInWidget';
+
+describe('<OptInWidget>', () => {
+  const getProps = ({ submitted = false, onChange = () => {} } = {}) => ({
+    id: 'id',
+    value: false,
+    additionalIssues: [],
+    onChange,
+    formContext: {
+      submitted,
+    },
+  });
+
+  it('should render a check box', () => {
+    const props = getProps();
+    const wrapper = mount(<OptInWidget {...props} />);
+    expect(wrapper.find('Checkbox')).to.exist;
+    wrapper.unmount();
+  });
+
+  it('should call onChange when the checkbox is toggled', () => {
+    const onChange = sinon.spy();
+    const props = getProps({ onChange });
+    const wrapper = mount(<OptInWidget {...props} />);
+
+    // "Click" the option
+    // .simulate('click') wasn't calling the onChange handler for some reason
+    wrapper
+      .find('input')
+      .props()
+      .onChange({ target: { checked: true } });
+
+    // Check that it changed
+    expect(onChange.callCount).to.equal(1);
+    expect(onChange.firstCall.args[0]).to.be.true;
+
+    // "Click" the option
+    wrapper
+      .find('input')
+      .props()
+      .onChange({ target: { checked: false } });
+
+    // Check that it changed back
+    expect(onChange.callCount).to.equal(2);
+    expect(onChange.secondCall.args[0]).to.be.false;
+
+    wrapper.unmount();
+  });
+  it('should not show an error when submitted with no selections in eligible issues', () => {
+    const props = getProps({ submitted: true });
+    const wrapper = mount(<OptInWidget {...props} value />);
+    wrapper
+      .find('input')
+      .props()
+      .onChange({ target: { checked: true } });
+
+    expect(wrapper.find('.usa-input-error').length).to.equal(0);
+    wrapper.unmount();
+  });
+});

--- a/src/applications/appeals/10182/tests/pages/optIn.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/pages/optIn.unit.spec.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import sinon from 'sinon';
+
+import {
+  DefinitionTester,
+  selectCheckbox,
+} from 'platform/testing/unit/schemaform-utils.jsx';
+
+import formConfig from '../../config/form';
+
+describe('NOD has representative page', () => {
+  const { schema, uiSchema } = formConfig.chapters.conditions.pages.optIn;
+
+  it('should render', () => {
+    const form = mount(
+      <DefinitionTester
+        definitions={{}}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+      />,
+    );
+
+    expect(form.find('input[type="checkbox"]').length).to.equal(1);
+    form.unmount();
+  });
+  it('should not render a fieldset', () => {
+    const form = mount(
+      <DefinitionTester
+        definitions={{}}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+      />,
+    );
+
+    expect(form.find('fieldset').length).to.equal(0);
+    form.unmount();
+  });
+
+  it('should not allow submit when opt-in is unchecked', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={{}}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+    // One error message (above the checkbox) is hidden using CSS
+    // this message doesn't match the design
+    // https://design.va.gov/patterns/form-feedback#error-message-below-checkbox
+    expect(form.find('.usa-input-error-message').length).to.equal(2);
+    expect(onSubmit.called).to.be.false;
+    form.unmount();
+  });
+
+  it('should allow submit when opt-in checked', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={{}}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    selectCheckbox(form, 'root_socOptIn', true);
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error-message').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+    form.unmount();
+  });
+});


### PR DESCRIPTION
## Description

Add opt in to new appeals process page, per design. Included a custom checkbox widget and review field for the review & submit page.

Currently, all issues are displayed on this page. Once Lighthouse provides a method to distinguish modern versus legacy appeals, only legacy appeals & manually added issues will appear on this page.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/24394
- Design: https://vsateams.invisionapp.com/console/share/8Y10I6K7DU9R/615292874

## Testing done

Updated unit tests
Verified e2e tests pass

## Screenshots

<details><summary>Checkbox with error</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-05-17 at 1 29 13 PM](https://user-images.githubusercontent.com/136959/118543839-7252e500-b71a-11eb-9c4c-ba90a7889b0c.png)</details>

<details><summary>Review & submit page view</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-05-17 at 2 03 22 PM](https://user-images.githubusercontent.com/136959/118544113-ceb60480-b71a-11eb-9251-38bc617f7429.png)</details>

## Acceptance criteria
- [x] Add opt-in checkbox page
- [x] Axe a11y checks pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
