### PR TITLE
CT sandbox updated estimates selector to use institutions attributes

### DIFF
--- a/src/applications/gi-sandbox/selectors/estimator.js
+++ b/src/applications/gi-sandbox/selectors/estimator.js
@@ -5,7 +5,7 @@ const getConstants = state => state.constants.constants;
 const getEligibilityDetails = state => state.eligibility;
 
 const getRequiredAttributes = (state, props) => {
-  const { type, bah, dodBah, country } = props;
+  const { type, bah, dodBah, country } = props.institution;
   return {
     type: type && type.toLowerCase(),
     bah,


### PR DESCRIPTION
## Description
CT Redesign: Housing benefit displaying incorrect amount
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/24780
Backend PR: https://github.com/department-of-veterans-affairs/gibct-data-service/pull/818
## Testing done
local testing

## Screenshots
![Screen Shot 2021-05-17 at 4 59 55 PM](https://user-images.githubusercontent.com/50601724/118556130-81915d00-b731-11eb-9620-41f7b7cd1005.png)
![Screen Shot 2021-05-17 at 5 00 51 PM](https://user-images.githubusercontent.com/50601724/118556175-8fdf7900-b731-11eb-8831-4ee27a70d2a9.png)


## Acceptance criteria
- [ ]

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
