### PR TITLE
NOD: Upload PDFs only

### DIFF
--- a/src/applications/appeals/10182/constants.js
+++ b/src/applications/appeals/10182/constants.js
@@ -24,15 +24,7 @@ export const FORMAT_READABLE = 'LL';
 // contested issue dates
 export const FORMAT_YMD = 'YYYY-MM-DD';
 
-export const SUPPORTED_UPLOAD_TYPES = [
-  'pdf',
-  'jpg',
-  'jpeg',
-  'png',
-  'gif',
-  'bmp',
-  'txt',
-];
+export const SUPPORTED_UPLOAD_TYPES = ['pdf'];
 
 export const MAX_FILE_SIZE_MB = 100;
 export const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 ** 2; // binary based

--- a/src/applications/appeals/10182/content/EvidenceUpload.jsx
+++ b/src/applications/appeals/10182/content/EvidenceUpload.jsx
@@ -4,9 +4,12 @@ import { SUPPORTED_UPLOAD_TYPES, MAX_FILE_SIZE_MB } from '../constants';
 
 export const evidenceUploadTitle = 'Additional evidence';
 
-const fileTypes = `.${SUPPORTED_UPLOAD_TYPES.slice(0, -1).join(
-  ', .',
-)} or .${SUPPORTED_UPLOAD_TYPES.slice(-1)}`;
+const fileTypes =
+  SUPPORTED_UPLOAD_TYPES.length > 1
+    ? `.${SUPPORTED_UPLOAD_TYPES.slice(0, -1).join(
+        ', .',
+      )} or .${SUPPORTED_UPLOAD_TYPES.slice(-1)}`
+    : `.${SUPPORTED_UPLOAD_TYPES}`;
 
 export const EvidenceUploadLabel = (
   <h3 className="vads-u-font-size--h4 vads-u-display--inline">

--- a/src/applications/appeals/10182/tests/fixtures/data/maximal-test.json
+++ b/src/applications/appeals/10182/tests/fixtures/data/maximal-test.json
@@ -136,7 +136,7 @@
         "isEncrypted": false
       },
       {
-        "name": "file-2.png",
+        "name": "file-2.pdf",
         "confirmationCode": "another-UUID"
       }
     ]

--- a/src/applications/appeals/10182/tests/fixtures/data/transformed-maximal-test.json
+++ b/src/applications/appeals/10182/tests/fixtures/data/transformed-maximal-test.json
@@ -65,7 +65,7 @@
       "confirmationCode": "some-UUID"
     },
     {
-      "name": "file-2.png",
+      "name": "file-2.pdf",
       "confirmationCode": "another-UUID"
     }
   ]


### PR DESCRIPTION
## Description

The upload endpoint for the Notice of Disagreement form will only accept PDF file types. This PR updates the upload descriptions and allowed upload types.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/24818

## Testing done

- Unit tests passing
- Update mock data

## Screenshots

<details><summary>PDF only</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-05-18 at 9 00 39 AM](https://user-images.githubusercontent.com/136959/118665018-90baee00-b7b7-11eb-9bac-28a27b9a8f8d.png)</details>

## Acceptance criteria
- [x] Only show/allow PDF evidence uploads

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
