### PR TITLE
19738 526ez 508 defect 4 

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -116,10 +116,10 @@ class IntroductionPage extends React.Component {
           <ol>
             <li className="process-step list-one">
               <h3 className="vads-u-font-size--h4">Prepare</h3>
-              <h4 className="vads-u-font-size--h6">
+              <p>
                 When you file a disability claim, you’ll have a chance to
                 provide evidence to support your claim. Evidence could include:
-              </h4>
+              </p>
               <ul>
                 <li>
                   {isBDDForm ? 'Service treatment records, ' : ''}
@@ -210,10 +210,10 @@ class IntroductionPage extends React.Component {
               <h3 className="vads-u-font-size--h4">Apply</h3>
               {isBDDForm ? (
                 <>
-                  <h4 className="vads-u-font-size--h6">
+                  <p>
                     Complete the Benefits Delivery at Discharge form. These are
                     the steps you can expect:
-                  </h4>
+                  </p>
                   <ul>
                     <li>Provide your service member information</li>
                     <li>Provide your military history</li>


### PR DESCRIPTION
[19738](https://github.com/department-of-veterans-affairs/va.gov-team/issues/19738) 508-defect-4 [SCREENREADER]: Paragraphs should be written as paragraphs, not headings
## Description
Change headings to paragraphs to be more semantically appropriate.

## Testing done
Axe Manual/Visual - 

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
