### PR TITLE
Update aria labels for calendar buttons

### DIFF
--- a/src/applications/vaos/components/calendar/CalendarCell.jsx
+++ b/src/applications/vaos/components/calendar/CalendarCell.jsx
@@ -16,6 +16,7 @@ const CalendarCell = ({
   onClick,
   renderIndicator,
   renderOptions,
+  renderSelectedLabel,
   selectedDates,
   id,
   timezone,
@@ -79,6 +80,13 @@ const CalendarCell = ({
   const momentDate = moment(date);
   const dateDay = momentDate.format('D');
   const ariaDate = momentDate.format('dddd, MMMM Do');
+  const buttonLabel = inSelectedArray
+    ? `${ariaDate}. ${
+        renderSelectedLabel
+          ? renderSelectedLabel(date, selectedDates)
+          : 'Date selected.'
+      }`
+    : ariaDate;
 
   const cssClasses = classNames('vaos-calendar__calendar-day', {
     'vaos-calendar__day--current': isCurrentlySelected,
@@ -100,7 +108,7 @@ const CalendarCell = ({
         id={`date-cell-${date}`}
         onClick={() => onClick(date)}
         disabled={disabled}
-        aria-label={ariaDate}
+        aria-label={buttonLabel}
         aria-expanded={isCurrentlySelected}
         type="button"
         ref={buttonRef}

--- a/src/applications/vaos/components/calendar/CalendarCell.jsx
+++ b/src/applications/vaos/components/calendar/CalendarCell.jsx
@@ -81,10 +81,10 @@ const CalendarCell = ({
   const dateDay = momentDate.format('D');
   const ariaDate = momentDate.format('dddd, MMMM Do');
   const buttonLabel = inSelectedArray
-    ? `${ariaDate}. ${
+    ? `${ariaDate}, ${
         renderSelectedLabel
           ? renderSelectedLabel(date, selectedDates)
-          : 'Date selected.'
+          : 'selected.'
       }`
     : ariaDate;
 

--- a/src/applications/vaos/components/calendar/CalendarRow.jsx
+++ b/src/applications/vaos/components/calendar/CalendarRow.jsx
@@ -50,6 +50,7 @@ export default function CalendarRow({
   minDate,
   renderIndicator,
   renderOptions,
+  renderSelectedLabel,
   rowNumber,
   selectedDates,
   id,
@@ -84,6 +85,7 @@ export default function CalendarRow({
             onClick={() => handleSelectDate(date, rowNumber)}
             selectedDates={selectedDates}
             renderIndicator={renderIndicator}
+            renderSelectedLabel={renderSelectedLabel}
             renderOptions={renderOptions}
             id={id}
             timezone={timezone}

--- a/src/applications/vaos/components/calendar/CalendarWidget.jsx
+++ b/src/applications/vaos/components/calendar/CalendarWidget.jsx
@@ -241,6 +241,7 @@ function handleNext(onClickNext, months, setMonths) {
  * @param {Function} props.onPreviousMonth
  * @param {Function} props.renderOptions
  * @param {Function} props.renderIndicator
+ * @param {Function} props.renderSelectedLabel
  * @param {boolean} props.required
  * @param {string} props.requiredMessage
  * @param {boolean} props.showValidation
@@ -264,6 +265,7 @@ function CalendarWidget({
   onPreviousMonth,
   renderOptions,
   renderIndicator,
+  renderSelectedLabel,
   required,
   requiredMessage = 'Please select a date',
   showValidation,
@@ -385,6 +387,7 @@ function CalendarWidget({
                           selectedDates={value}
                           renderIndicator={renderIndicator}
                           renderOptions={renderOptions}
+                          renderSelectedLabel={renderSelectedLabel}
                           disabled={disabled}
                           showWeekends={showWeekends}
                         />

--- a/src/applications/vaos/new-appointment/components/DateTimeRequestPage/SelectedIndicator.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeRequestPage/SelectedIndicator.jsx
@@ -1,6 +1,20 @@
 import React from 'react';
 import moment from 'moment';
 
+export function getSelectedLabel(date, selectedDates) {
+  const matchingTimes = selectedDates.filter(selected =>
+    selected.startsWith(date),
+  );
+
+  if (matchingTimes.length === 2) {
+    return 'AM and PM selected.';
+  } else if (moment(matchingTimes[0]).hours() >= 12) {
+    return 'PM selected.';
+  }
+
+  return 'AM selected.';
+}
+
 export default function SelectedIndicator({ date, selectedDates }) {
   const bubbles = selectedDates
     .reduce((selectedFieldValues, currentDate) => {

--- a/src/applications/vaos/new-appointment/components/DateTimeRequestPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeRequestPage/index.jsx
@@ -13,7 +13,7 @@ import FormButtons from '../../../components/FormButtons';
 import CalendarWidget from '../../../components/calendar/CalendarWidget';
 import { getFormPageInfo } from '../../redux/selectors';
 import DateTimeRequestOptions from './DateTimeRequestOptions';
-import SelectedIndicator from './SelectedIndicator';
+import SelectedIndicator, { getSelectedLabel } from './SelectedIndicator';
 
 const pageKey = 'requestDateTime';
 const pageTitle = 'Choose an appointment day and time';
@@ -81,6 +81,7 @@ export default function DateTimeRequestPage() {
         id="optionTime"
         renderIndicator={props => <SelectedIndicator {...props} />}
         renderOptions={props => <DateTimeRequestOptions {...props} />}
+        renderSelectedLabel={getSelectedLabel}
         required
         requiredMessage="Please select at least one preferred date for your appointment. You can select up to three dates."
         showValidation={submitted && !userSelectedSlot(selectedDates)}

--- a/src/applications/vaos/tests/new-appointment/components/DateTimeRequestPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/DateTimeRequestPage/index.unit.spec.jsx
@@ -115,6 +115,7 @@ describe('VAOS <DateTimeRequestPage>', () => {
       name: 'AM appointment',
     });
     userEvent.click(checkbox);
+    expect(buttons[0].getAttribute('aria-label')).to.contain('AM selected');
 
     // 3. Simulate user selecting another time
     checkbox = screen.getByRole('checkbox', {
@@ -124,6 +125,9 @@ describe('VAOS <DateTimeRequestPage>', () => {
 
     expect(buttons[0]).to.contain.text('AM');
     expect(buttons[0]).to.contain.text('PM');
+    expect(buttons[0].getAttribute('aria-label')).to.contain(
+      'AM and PM selected',
+    );
     // checks that the selected day matches the button used
     expect(
       screen.baseElement.querySelector('.vaos-calendar__day--selected'),

--- a/src/applications/vaos/tests/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
@@ -384,6 +384,7 @@ describe('VAOS <DateTimeSelectPage>', () => {
     userEvent.click(
       await screen.findByRole('radio', { name: '9:00 AM option selected' }),
     );
+    expect(button.getAttribute('aria-label')).to.contain('Date selected');
 
     userEvent.click(screen.getByText(/^Continue/));
     await waitFor(() => {

--- a/src/applications/vaos/tests/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
@@ -384,7 +384,7 @@ describe('VAOS <DateTimeSelectPage>', () => {
     userEvent.click(
       await screen.findByRole('radio', { name: '9:00 AM option selected' }),
     );
-    expect(button.getAttribute('aria-label')).to.contain('Date selected');
+    expect(button.getAttribute('aria-label')).to.contain(', selected');
 
     userEvent.click(screen.getByText(/^Continue/));
     await waitFor(() => {


### PR DESCRIPTION
## Description
This PR
- Adds text to the calendar button aria label to indicate if a date or AM/PM slot has been selected

## Testing done
Local and unit testing

## Screenshots
![Screen Shot 2021-05-18 at 2 56 25 PM](https://user-images.githubusercontent.com/634932/118708055-405c8400-b7e9-11eb-8b2d-8143297347fc.png)

## Acceptance criteria
- [ ] Button has correct aria text

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
