### PR TITLE
NOD: Fix unique IDs & error messaging

### DIFF
--- a/src/applications/appeals/10182/content/areaOfDisagreement.jsx
+++ b/src/applications/appeals/10182/content/areaOfDisagreement.jsx
@@ -7,36 +7,47 @@ export const missingAreaOfDisagreementErrorMessage =
 export const missingAreaOfDisagreementOtherErrorMessage =
   'Please enter a reason for disagreement';
 
-export const issueName = ({ formData } = {}) => (
-  <legend
-    className="schemaform-block-title schemaform-title-underline"
-    aria-describedby="area-of-disagreement-label"
-  >
-    {getIssueName(formData)}
-  </legend>
-);
+// formContext.pagePerItemIndex is undefined here? Use index added to data :(
+export const issueName = ({ formData, formContext } = {}) => {
+  const index = formContext.pagePerItemIndex || formData.index;
+  return (
+    <legend
+      className="schemaform-block-title schemaform-title-underline"
+      aria-describedby={`area-of-disagreement-label-${index}`}
+    >
+      {getIssueName(formData)}
+    </legend>
+  );
+};
 
 // Error revealed through CSS (need to verify this works for screenreaders)
 // "hidden" class uses an !important flag, so we're using "hide" here
-export const issusDescription = () => (
-  <div
-    id="area-of-disagreement-label"
-    className="vads-u-font-size--base vads-u-font-weight--normal"
-  >
-    Please specify the area(s) of disagreement for this issue:
-    <span className="vads-u-font-weight--normal schemaform-required-span">
-      (*Required)
-    </span>
-    <span
-      className="usa-input-error-message hide"
-      role="alert"
-      id="error-message"
+export const issusDescription = ({ formContext }) => {
+  const { pagePerItemIndex, submitted } = formContext;
+  // adding data-submitted attribute; updating the class name outside of React
+  // breaks the areaOfDisagreementWorkAround
+  return (
+    <div
+      key={pagePerItemIndex}
+      id={`area-of-disagreement-label-${pagePerItemIndex}`}
+      className="area-of-disagreement-label vads-u-font-size--base vads-u-font-weight--normal"
+      data-submitted={submitted}
     >
-      <span className="sr-only">Error</span>
-      {missingAreaOfDisagreementErrorMessage}
-    </span>
-  </div>
-);
+      Please specify the area(s) of disagreement for this issue:
+      <span className="vads-u-font-weight--normal schemaform-required-span">
+        (*Required)
+      </span>
+      <span
+        className="usa-input-error-message"
+        role="alert"
+        id={`error-message-${pagePerItemIndex}`}
+      >
+        <span className="sr-only">Error</span>
+        {missingAreaOfDisagreementErrorMessage}
+      </span>
+    </div>
+  );
+};
 
 export const serviceConnection = 'I disagree with the service connection';
 export const effectiveDate = 'I disagree with the effective date of award';

--- a/src/applications/appeals/10182/sass/10182-nod.scss
+++ b/src/applications/appeals/10182/sass/10182-nod.scss
@@ -172,21 +172,24 @@ article[data-location="representative-info"] {
 }
 
 /* Area of disagreement */
-#area-of-disagreement-label {
+.area-of-disagreement-label {
   margin-top: 0;
 }
-#area-of-disagreement-label .hide { display: none; }
-#area-of-disagreement-label:not(.usa-input-error) {
-  margin: 2rem 0;
+.area-of-disagreement-label .usa-input-error-message {
+  display: none;
 }
-#area-of-disagreement-label.usa-input-error {
+.area-of-disagreement-label[data-submitted="true"].usa-input-error {
+  .usa-input-error-message {
+    display: block;
+  }
   .input-section {
     margin-bottom: 0;
   }
-  .hide {
-    display: block;
-  }
 }
+.area-of-disagreement-label:not(.usa-input-error) {
+  margin: 2rem 0;
+}
+
 article[data-location^="area-of-disagreement"] {
   .schemaform-block-header,
   .schemaform-block-header + .usa-input-error {

--- a/src/applications/appeals/10182/tests/containers/FormApp.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/containers/FormApp.unit.spec.jsx
@@ -216,8 +216,8 @@ describe('FormApp', () => {
     const updatedFormData = setFormData.args[0][0];
     expect(updatedFormData.areaOfDisagreement.length).to.eq(2);
     expect(updatedFormData.areaOfDisagreement).to.deep.equal([
-      formData.contestableIssues[0],
-      formData.additionalIssues[0],
+      { ...formData.contestableIssues[0], index: 0 },
+      { ...formData.additionalIssues[0], index: 1 },
     ]);
 
     tree.unmount();

--- a/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
@@ -60,7 +60,7 @@ describe('getSelected', () => {
           { type: 'ok', [SELECTED]: true },
         ],
       }),
-    ).to.deep.equal([{ type: 'ok', [SELECTED]: true }]);
+    ).to.deep.equal([{ type: 'ok', [SELECTED]: true, index: 0 }]);
   });
   it('should return selected additional issues', () => {
     expect(
@@ -70,7 +70,7 @@ describe('getSelected', () => {
           { type: 'ok', [SELECTED]: true },
         ],
       }),
-    ).to.deep.equal([{ type: 'ok', [SELECTED]: true }]);
+    ).to.deep.equal([{ type: 'ok', [SELECTED]: true, index: 0 }]);
   });
   it('should return all selected issues', () => {
     expect(
@@ -85,8 +85,8 @@ describe('getSelected', () => {
         ],
       }),
     ).to.deep.equal([
-      { type: 'ok1', [SELECTED]: true },
-      { type: 'ok2', [SELECTED]: true },
+      { type: 'ok1', [SELECTED]: true, index: 0 },
+      { type: 'ok2', [SELECTED]: true, index: 1 },
     ]);
   });
 });

--- a/src/applications/appeals/10182/utils/helpers.js
+++ b/src/applications/appeals/10182/utils/helpers.js
@@ -28,7 +28,9 @@ export const showAddIssueQuestion = ({ contestableIssues }) =>
 export const getSelected = ({ contestableIssues, additionalIssues } = {}) =>
   (contestableIssues || [])
     .filter(issue => issue[SELECTED])
-    .concat((additionalIssues || []).filter(issue => issue[SELECTED]));
+    .concat((additionalIssues || []).filter(issue => issue[SELECTED]))
+    // include index to help with error messaging
+    .map((issue, index) => ({ ...issue, index }));
 
 export const getIssueName = (entry = {}) =>
   entry.issue || entry.attributes?.ratingIssueSubjectText;

--- a/src/applications/appeals/10182/utils/ui.js
+++ b/src/applications/appeals/10182/utils/ui.js
@@ -29,16 +29,17 @@ export const scrollAndFocus = ({ selector, offset = 50, timer }) => {
 };
 
 // work-around for error message not showing :(
-export const areaOfDisagreementWorkAround = hasSelection => {
+export const areaOfDisagreementWorkAround = (hasSelection, index) => {
   // we can't target the fieldset because it doesn't get re-rendered on other
   // pages by React
   // see https://dsva.slack.com/archives/CBU0KDSB1/p1620840904269500
-  const label = $('#area-of-disagreement-label');
+  const label = $(`#area-of-disagreement-label-${index}`);
   if (label) {
-    label.classList.toggle('usa-input-error', !hasSelection);
+    const showError = label.dataset.submitted === 'true' && !hasSelection;
+    label.classList.toggle('usa-input-error', showError);
     label.parentElement.nextElementSibling.classList.toggle(
       'usa-input-error',
-      !hasSelection,
+      showError,
     );
   }
 };

--- a/src/applications/appeals/10182/validations.js
+++ b/src/applications/appeals/10182/validations.js
@@ -27,7 +27,12 @@ export const requireIssue = (
 
 export const areaOfDisagreementRequired = (
   errors,
-  { disagreementOptions, otherEntry } = {},
+  // added index to get around arrayIndex being null
+  { disagreementOptions, otherEntry, index } = {},
+  _formData,
+  _schema,
+  _uiSchema,
+  arrayIndex, // always null?!
 ) => {
   const keys = Object.keys(disagreementOptions || {});
   const hasSelection = keys.some(key => disagreementOptions[key]);
@@ -39,7 +44,7 @@ export const areaOfDisagreementRequired = (
   }
 
   // work-around for error message not showing :(
-  areaOfDisagreementWorkAround(hasSelection);
+  areaOfDisagreementWorkAround(hasSelection, arrayIndex || index);
 };
 
 export const optInValidation = (errors, value) => {


### PR DESCRIPTION
## Description

The area of disagreement pages within the Notice of Disagreement form are wrapped in a fieldset/legend that include an ID, but this ID is not unique when more than one area of disagreement page is edited on the review & submit page. This PR fixes the ID on the `<legend>` element and updates the error messaging to work with the checkbox group.

Note: The IDs on the labels/checkboxes are not unique. A fix would require a significant platform change. I will open a ticket and investigate and/or attempt to fix it.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/21054

## Testing done

Manual testing with the axe DevTools browser extension.

## Screenshots

N/A - no visual change

## Acceptance criteria
- [x] Legend IDs on the review & submit page are unique

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
