### PR TITLE
fix(1010cg): update file upload size limit to 25mb

### DIFF
--- a/src/applications/caregivers/config/chapters/signAsRepresentative/uploadPOADocument.js
+++ b/src/applications/caregivers/config/chapters/signAsRepresentative/uploadPOADocument.js
@@ -49,7 +49,7 @@ export default {
       multiple: false,
       fileUploadUrl: `${environment.API_URL}/v0/form1010cg/attachments`,
       fileTypes: ['pdf', 'doc', 'docx', 'jpg', 'jpeg', 'rtf', 'png'],
-      maxSize: 1024 * 1024 * 10,
+      maxSize: 1024 * 1024 * 25,
       hideLabelText: true,
       createPayload,
       parseResponse,


### PR DESCRIPTION
## Description
Backend allows for file upload size up to 25MB. Frontend should also allow the same sizes.

## Testing done
Manual

## Screenshots


## Acceptance criteria
- [ ] Update 1010cg file upload to allow up to 25MB files

## Definition of done
- [ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/24923)
