### PR TITLE
Create unique IDs for array content

### DIFF
--- a/src/platform/forms-system/src/js/fields/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/fields/ObjectField.jsx
@@ -197,6 +197,27 @@ class ObjectField extends React.Component {
       'schemaform-block': title && !isRoot,
     });
 
+    // Fix array nested ids (one-level deep)
+    const processIds = (originalIds = {}) =>
+      // pagePerItemIndex is zero-based
+      typeof formContext?.pagePerItemIndex !== 'undefined' &&
+      formContext.onReviewPage
+        ? Object.keys(originalIds).reduce(
+            (ids, key) => ({
+              ...ids,
+              [key]: originalIds[key].$id
+                ? {
+                    ...originalIds[key],
+                    $id: `${originalIds[key].$id}_${
+                      formContext.pagePerItemIndex
+                    }`,
+                  }
+                : originalIds[key],
+            }),
+            {},
+          )
+        : originalIds;
+
     const renderProp = propName => (
       <div key={propName}>
         <SchemaField
@@ -205,7 +226,7 @@ class ObjectField extends React.Component {
           schema={schema.properties[propName]}
           uiSchema={uiSchema[propName]}
           errorSchema={errorSchema[propName]}
-          idSchema={idSchema[propName]}
+          idSchema={processIds(idSchema[propName])}
           formData={formData[propName]}
           onChange={this.onPropertyChange(propName)}
           onBlur={onBlur}

--- a/src/platform/forms-system/test/js/fields/ObjectField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/fields/ObjectField.unit.spec.jsx
@@ -443,6 +443,87 @@ describe('Schemaform: ObjectField', () => {
     expect(id0).to.equal('root_test__title');
     expect(id1).to.equal('root_test2__title');
   });
+  it('should render unique IDs for array items on review & submit page', () => {
+    // This occurs on form 526 when "ratedDisabilities" &
+    // "unempolyabilityDisabilities" both render the same list of rated
+    // disabilities
+    const onChange = sinon.spy();
+    const onBlur = sinon.spy();
+    const schema = {
+      properties: {
+        type: 'object',
+        nested: {
+          type: 'object',
+          properties: {
+            testA: {
+              type: 'boolean',
+            },
+            testB: {
+              type: 'boolean',
+            },
+          },
+        },
+      },
+    };
+    const uiSchema = {
+      'ui:title': 'Blah',
+      nested: {
+        testA: {
+          'ui:title': 'test A',
+        },
+        testB: {
+          'ui:title': 'test B',
+        },
+      },
+    };
+    const idSchema = {
+      $id: 'root',
+      nested: {
+        testA: {
+          $id: 'root_testA',
+        },
+        testB: {
+          $id: 'root_testB',
+        },
+      },
+    };
+    const form = ReactTestUtils.renderIntoDocument(
+      <div>
+        <ObjectField
+          formContext={{
+            onReviewPage: true,
+            pagePerItemIndex: 0,
+          }}
+          uiSchema={uiSchema}
+          schema={schema}
+          idSchema={idSchema}
+          formData={{}}
+          onChange={onChange}
+          onBlur={onBlur}
+        />
+        <ObjectField
+          formContext={{
+            onReviewPage: true,
+            pagePerItemIndex: 1,
+          }}
+          uiSchema={uiSchema}
+          schema={schema}
+          idSchema={idSchema}
+          formData={{}}
+          onChange={onChange}
+          onBlur={onBlur}
+        />
+      </div>,
+    );
+    const formDOM = getFormDOM(form);
+    const ids = formDOM.querySelectorAll('input');
+    expect(ids).to.have.length(4);
+    expect(ids[0].id).to.equal('root_testA_0');
+    expect(ids[1].id).to.equal('root_testB_0');
+    expect(ids[2].id).to.equal('root_testA_1');
+    expect(ids[3].id).to.equal('root_testB_1');
+  });
+
   it('should render with a fieldset and legend when forceDivWrapper is false', () => {
     const onChange = sinon.spy();
     const onBlur = sinon.spy();


### PR DESCRIPTION
## Description

The Notice of Disagreement form shows a dynamic group of pages based on user selections. In the page are 4 checkboxes using the [checkbox group pattern](https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/forms/available-features-and-usage-guidelines#checkbox-group). Each checkbox label gets a unique ID based on the schema & path. But, on the review & submit page, these same pages do not include a unique ID - see https://github.com/department-of-veterans-affairs/va.gov-team/issues/24897 for more details.

This PR adds the page index to the ID of each element within the page rendered on the review & submit page. For example, on the [NOD review & submit page](https://staging.va.gov/decision-reviews/board-appeal/request-board-appeal-form-10182/review-and-submit), the ID `root_disagreementOptions_serviceConnection` is currently duplicated when more than one page is edited. This PR changes the ID to `root_disagreementOptions_serviceConnection_0` (where `_0` is the zero-based page index).

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/24897
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/21054

## Testing done

Added unit tests

## Screenshots

<details><summary>Unique IDs</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-05-19 at 12 58 47 PM](https://user-images.githubusercontent.com/136959/118861354-0602ed80-b8a2-11eb-9bab-0b161473ada2.png)</details>

## Acceptance criteria
- [x] IDs are made unique for pages within an array
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
