### PR TITLE
Remove add appt to calendar link from past appt

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/index.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/index.jsx
@@ -262,22 +262,23 @@ export default function ConfirmedAppointmentDetailsPage() {
               )}
             {!canceled && (
               <>
-                <div className="vads-u-margin-top--3 vaos-appts__block-label vaos-hide-for-print">
-                  <i
-                    aria-hidden="true"
-                    className="far fa-calendar vads-u-margin-right--1"
-                  />
-                  <AddToCalendar
-                    summary={`${header}`}
-                    description={calendarDescription}
-                    location={
-                      isPhone ? 'Phone call' : formatFacilityAddress(facility)
-                    }
-                    duration={appointment.minutesDuration}
-                    startDateTime={appointment.start}
-                  />
-                </div>
-
+                {!isPastAppointment && (
+                  <div className="vads-u-margin-top--3 vaos-appts__block-label vaos-hide-for-print">
+                    <i
+                      aria-hidden="true"
+                      className="far fa-calendar vads-u-margin-right--1"
+                    />
+                    <AddToCalendar
+                      summary={`${header}`}
+                      description={calendarDescription}
+                      location={
+                        isPhone ? 'Phone call' : formatFacilityAddress(facility)
+                      }
+                      duration={appointment.minutesDuration}
+                      startDateTime={appointment.start}
+                    />
+                  </div>
+                )}
                 <div className="vads-u-margin-top--2 vaos-appts__block-label vaos-hide-for-print">
                   <i
                     aria-hidden="true"

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
@@ -251,17 +251,15 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       .ok;
     expect(screen.getByRole('heading', { level: 2, name: /New issue/ })).to.be
       .ok;
-    expect(
-      screen.getByRole('link', {
-        name: new RegExp(
-          moment()
-            .subtract(1, 'day')
-            .tz('America/Denver')
-            .format('[Add] MMMM D, YYYY [appointment to your calendar]'),
-          'i',
-        ),
-      }),
-    ).to.be.ok;
+    expect(screen.baseElement).not.to.contain.text(
+      new RegExp(
+        moment()
+          .subtract(1, 'day')
+          .tz('America/Denver')
+          .format('[Add] MMMM D, YYYY [appointment to your calendar]'),
+        'i',
+      ),
+    );
     expect(screen.getByText(/Print/)).to.be.ok;
     expect(screen.baseElement).not.to.contain.text('Cancel appointment');
   });


### PR DESCRIPTION
## Description
Past appointments should not have the add to calendar link

### To test
1. Go to URL: health-care/schedule-view-va-appointments/appointments/past
2. from the past appointment list page, click on any appointment to a VA facility to display its detailed page

## Testing done
Local, Unit, e2e

## Screenshots
<img width="813" alt="image" src="https://user-images.githubusercontent.com/8315447/118871833-f2618200-b8b5-11eb-8e5b-66c714651283.png">


## Acceptance criteria
- [ ] Add to calendar link no longer displays in past appointments

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
