### PR TITLE
[24795] Add blue color to appt list items chevrons

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItem.jsx
@@ -143,7 +143,7 @@ export default function AppointmentListItem({ appointment, facility }) {
           </Link>
           <i
             aria-hidden="true"
-            className="fas fa-chevron-right vads-u-margin-left--1"
+            className="fas fa-chevron-right vads-u-color--link-default vads-u-margin-left--1"
           />
         </div>
       </div>

--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/RequestListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/RequestListItem.jsx
@@ -59,7 +59,7 @@ export default function RequestListItem({ appointment, facility }) {
           </Link>
           <i
             aria-hidden="true"
-            className="fas fa-chevron-right vads-u-margin-left--1"
+            className="fas fa-chevron-right vads-u-color--link-default vads-u-margin-left--1"
           />
         </div>
       </div>


### PR DESCRIPTION


## Description
The chevron next to the Details link on the homepage refresh appointment cards is the wrong color. Details link and chevron should be #004795. Fixed via the AppointmentListItem and the RequestListItem components

## Testing done
Visual

## Screenshots
<img width="813" alt="image" src="https://user-images.githubusercontent.com/8315447/118876970-df51b080-b8bb-11eb-841c-bfba061ff03b.png">
<img width="813" alt="image" src="https://user-images.githubusercontent.com/8315447/118876988-e37dce00-b8bb-11eb-8d96-726c076a9e04.png">
<img width="813" alt="image" src="https://user-images.githubusercontent.com/8315447/118877002-eb3d7280-b8bb-11eb-8d90-a7cc5d4d6513.png">
<img width="813" alt="image" src="https://user-images.githubusercontent.com/8315447/118877021-f0022680-b8bb-11eb-9185-95bae7bb5f85.png">
<img width="813" alt="image" src="https://user-images.githubusercontent.com/8315447/118877064-fb555200-b8bb-11eb-9a90-e2effd6bd8ee.png">


## Acceptance criteria
- [x] Desired result is achieved and/or document decisions made

## Definition of done
- [-] Events are logged appropriately
- [-] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
