### PR TITLE
Test hardcoding assets path in dev

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -119,7 +119,9 @@ module.exports = (env = {}) => {
 
   // Set the publicPath conditional so we can get dynamic modules loading from S3
   const publicAssetPath =
-    buildtype !== LOCALHOST && buildtype !== VAGOVDEV
+    buildtype !== LOCALHOST &&
+    buildtype !== VAGOVDEV &&
+    buildtype !== VAGOVSTAGING
       ? `${BUCKETS[buildtype]}/generated/`
       : '/generated/';
 

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -20,7 +20,7 @@ const scaffoldRegistry = require('../src/applications/registry.scaffold.json');
 const facilitySidebar = require('../src/site/layouts/tests/vamc/fixtures/health_care_region_page.json')
   .facilitySidebar;
 
-const { VAGOVSTAGING, VAGOVPROD, LOCALHOST, VAGOVDEV } = ENVIRONMENTS;
+const { VAGOVSTAGING, VAGOVPROD, LOCALHOST } = ENVIRONMENTS;
 
 const {
   getAppManifests,
@@ -119,9 +119,7 @@ module.exports = (env = {}) => {
 
   // Set the publicPath conditional so we can get dynamic modules loading from S3
   const publicAssetPath =
-    buildtype !== LOCALHOST &&
-    buildtype !== VAGOVDEV &&
-    buildtype !== VAGOVSTAGING
+    buildtype === VAGOVPROD
       ? `${BUCKETS[buildtype]}/generated/`
       : '/generated/';
 

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -20,7 +20,7 @@ const scaffoldRegistry = require('../src/applications/registry.scaffold.json');
 const facilitySidebar = require('../src/site/layouts/tests/vamc/fixtures/health_care_region_page.json')
   .facilitySidebar;
 
-const { VAGOVSTAGING, VAGOVPROD, LOCALHOST } = ENVIRONMENTS;
+const { VAGOVSTAGING, VAGOVPROD, LOCALHOST, VAGOVDEV } = ENVIRONMENTS;
 
 const {
   getAppManifests,
@@ -119,7 +119,7 @@ module.exports = (env = {}) => {
 
   // Set the publicPath conditional so we can get dynamic modules loading from S3
   const publicAssetPath =
-    buildtype !== LOCALHOST
+    buildtype !== LOCALHOST && buildtype !== VAGOVDEV
       ? `${BUCKETS[buildtype]}/generated/`
       : '/generated/';
 


### PR DESCRIPTION
## Description
The asset path in the Webpack config is currently setting the full path in the `file-manifest.json` file. This prevents CI from testing on local changes to assets. This PR hardcodes the asset path and tests the hardcoded path on dev.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
