### PR TITLE
add logic to clear suggestions

### DIFF
--- a/src/platform/site-wide/user-nav/components/SearchMenu.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchMenu.jsx
@@ -35,6 +35,15 @@ export class SearchMenu extends React.Component {
     const { userInput } = this.state;
     const { searchTypeaheadEnabled, isOpen } = this.props;
 
+    // focus the query input when the search menu is opened
+    const inputField = document.getElementById('query');
+    if (isOpen && !prevProps.isOpen && inputField) {
+      inputField.focus();
+    }
+    if (userInput.length <= 2 && prevState.userInput.length > 2) {
+      this.clearSuggestions();
+    }
+
     // if userInput has changed, fetch suggestions for the typeahead experience
     const inputChanged = prevState.userInput !== userInput;
     if (inputChanged && searchTypeaheadEnabled) {
@@ -57,13 +66,11 @@ export class SearchMenu extends React.Component {
         sessionStorage.setItem('searchTypeaheadLogged', JSON.stringify(true));
       }
     }
-
-    // focus the query input when the search menu is opened
-    const inputField = document.getElementById('query');
-    if (isOpen && !prevProps.isOpen && inputField) {
-      inputField.focus();
-    }
   }
+
+  clearSuggestions = () => {
+    this.setState({ suggestions: [], savedSuggestions: [] });
+  };
 
   isUserInputValid = () => {
     const { userInput } = this.state;
@@ -83,7 +90,7 @@ export class SearchMenu extends React.Component {
 
     // end early / clear suggestions if user input is too short
     if (userInput?.length <= 2) {
-      this.setState({ suggestions: [], savedSuggestions: [] });
+      this.clearSuggestions();
       return;
     }
 


### PR DESCRIPTION
## Description
This PR fixes an issue that wasn't clearing suggestions when a user cleared the query field

## Testing done
manual testing

## Screenshots


## Acceptance criteria
- [x] - suggestions clear when a user deletes their query

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
