### PR TITLE
23998 - update chapter 31 education question

### DIFF
--- a/package.json
+++ b/package.json
@@ -356,7 +356,7 @@
     "url-search-params-polyfill": "^8.1.0",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#4089b6b4390f05738e0dcef402c56978565a626c",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#cd0a74dd9bc9f1a5e719578fc520f0cc3528842d",
     "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.6.1",
     "whatwg-fetch": "^2.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -356,7 +356,7 @@
     "url-search-params-polyfill": "^8.1.0",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#cd0a74dd9bc9f1a5e719578fc520f0cc3528842d",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#ae2902bf06f05ef43c934a7d9cd7f8d207e0a30d",
     "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.6.1",
     "whatwg-fetch": "^2.0.3"
   },

--- a/src/applications/vre/28-1900/config/chapters/additional-information/additionalInformation.js
+++ b/src/applications/vre/28-1900/config/chapters/additional-information/additionalInformation.js
@@ -25,15 +25,7 @@ export const schema = {
 export const uiSchema = {
   'ui:title': 'Additional Information',
   yearsOfEducation: {
-    'ui:title': 'How many years of education do you have?',
-    'ui:description': (
-      <p className="vads-u-margin--0">
-        (include K-12 and each year of college)
-      </p>
-    ),
-    'ui:errorMessages': {
-      pattern: 'Please enter a number',
-    },
+    'ui:title': 'What’s your level of education?',
     'ui:required': () => true,
   },
   isMoving: {

--- a/src/applications/vre/28-1900/tests/config/additionalInformation.unit.spec.jsx
+++ b/src/applications/vre/28-1900/tests/config/additionalInformation.unit.spec.jsx
@@ -25,7 +25,7 @@ describe('Chapter 31 Additional Information Page', () => {
         definitions={formConfig.defaultDefinitions}
       />,
     );
-    expect(form.find('input').length).to.equal(3);
+    expect(form.find('input').length).to.equal(2);
     form.unmount();
   });
 
@@ -40,7 +40,7 @@ describe('Chapter 31 Additional Information Page', () => {
       />,
     );
 
-    fillData(form, 'input#root_yearsOfEducation', '12');
+    changeDropdown(form, 'select#root_yearsOfEducation', '17');
     selectRadio(form, 'root_isMoving', 'N');
 
     form.find('form').simulate('submit');
@@ -60,7 +60,7 @@ describe('Chapter 31 Additional Information Page', () => {
       />,
     );
 
-    fillData(form, 'input#root_yearsOfEducation', '12');
+    changeDropdown(form, 'select#root_yearsOfEducation', '17');
     selectRadio(form, 'root_isMoving', 'Y');
 
     // New address

--- a/src/applications/vre/28-1900/tests/e2e/formDataSets/chapter31-maximal.json
+++ b/src/applications/vre/28-1900/tests/e2e/formDataSets/chapter31-maximal.json
@@ -10,7 +10,7 @@
     "afternoon": false,
     "other": false
   },
-  "yearsOfEducation": "10",
+  "yearsOfEducation": "17",
   "isMoving": true,
   "newAddress": {
     "view:militaryBaseDescription": {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -19782,9 +19782,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#4089b6b4390f05738e0dcef402c56978565a626c":
-  version "20.3.3"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#4089b6b4390f05738e0dcef402c56978565a626c"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#cd0a74dd9bc9f1a5e719578fc520f0cc3528842d":
+  version "20.3.4"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#cd0a74dd9bc9f1a5e719578fc520f0cc3528842d"
 
 vinyl-file@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19782,9 +19782,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#cd0a74dd9bc9f1a5e719578fc520f0cc3528842d":
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#ae2902bf06f05ef43c934a7d9cd7f8d207e0a30d":
   version "20.3.4"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#cd0a74dd9bc9f1a5e719578fc520f0cc3528842d"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#ae2902bf06f05ef43c934a7d9cd7f8d207e0a30d"
 
 vinyl-file@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description
This pull request updates the years of education question in the chapter 31 form.

## Testing done
- local

## Screenshots
<img width="737" alt="Screen Shot 2021-05-20 at 10 12 37 AM" src="https://user-images.githubusercontent.com/15097156/118995405-1f18a680-b955-11eb-8e68-708c3c56a09d.png">
<img width="779" alt="Screen Shot 2021-05-20 at 10 12 44 AM" src="https://user-images.githubusercontent.com/15097156/118995408-1fb13d00-b955-11eb-97b6-0b00c4c9a6aa.png">


## Acceptance criteria
- [x] tests pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
