### PR TITLE
Use the mock facilities API for Cypress tests

### DIFF
--- a/src/applications/facility-locator/api/index.js
+++ b/src/applications/facility-locator/api/index.js
@@ -1,14 +1,10 @@
 import MockApi from './MockLocatorApi';
 import LiveApi from './LocatorApi';
-import environment from 'platform/utilities/environment';
 
 const getAPI = () => {
   const isUnitTest = window.Mocha;
-  const isReviewEnvironment = environment.API_URL.includes('review.vetsgov');
-  const isLocal = environment.isLocalhost();
   const isCypress = window.Cypress;
 
-  if (isLocal || isReviewEnvironment) return LiveApi;
   if (isUnitTest || isCypress) return MockApi;
 
   return LiveApi;


### PR DESCRIPTION
## Description
A recent [PR](https://github.com/department-of-veterans-affairs/vets-website/pull/17206) broke the Cypress tests in local and Github Actions environments.

This PR should fix that.

Note: the goal here is to use the mock API for testing, and the live API everywhere else, including local development.