### PR TITLE
Fix bug when DS flag is off but DS is enabled in VATS

### DIFF
--- a/src/applications/vaos/services/patient/index.js
+++ b/src/applications/vaos/services/patient/index.js
@@ -356,7 +356,7 @@ export async function fetchFlowEligibilityAndClinics({
   ) {
     eligibility.direct = false;
     eligibility.directReasons.push(ELIGIBILITY_REASONS.error);
-  } else {
+  } else if (directSchedulingEnabled) {
     if (!results.patientEligibility.direct.hasRequiredAppointmentHistory) {
       eligibility.direct = false;
       eligibility.directReasons.push(ELIGIBILITY_REASONS.noRecentVisit);

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.multi.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.multi.unit.spec.jsx
@@ -1179,4 +1179,67 @@ describe('VAOS integration: VA flat facility page - multiple facilities', () => 
 
     expect(await screen.findAllByRole('radio')).to.have.length(2);
   });
+
+  it('should continue to requests if DS is disabled by flag and enabled in VATS', async () => {
+    mockParentSites(parentSiteIds, [parentSite983, parentSite984]);
+    mockDirectBookingEligibilityCriteria(
+      parentSiteIds,
+      directFacilities.map(f => ({
+        ...f,
+        attributes: {
+          ...f.attributes,
+          coreSettings: [
+            {
+              ...f.attributes.coreSettings[0],
+              id: '502',
+              typeOfCare: 'Outpatient Mental Health',
+            },
+          ],
+        },
+      })),
+    );
+    mockRequestEligibilityCriteria(
+      parentSiteIds,
+      requestFacilities.map(f => ({
+        ...f,
+        attributes: {
+          ...f.attributes,
+          requestSettings: [
+            {
+              ...f.attributes.requestSettings[0],
+              id: '502',
+              typeOfCare: 'Outpatient Mental Health',
+            },
+          ],
+        },
+      })),
+    );
+    mockFacilitiesFetch(vhaIds.join(','), facilities);
+    mockEligibilityFetches({
+      siteId: '983',
+      facilityId: '983',
+      typeOfCareId: '502',
+      limit: true,
+      requestPastVisits: true,
+      directPastVisits: true,
+    });
+    const store = createTestStore({
+      ...initialState,
+      featureToggles: {},
+    });
+    await setTypeOfCare(store, /mental health/i);
+
+    const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
+      store,
+    });
+
+    fireEvent.click(await screen.findByLabelText(/Fake facility name 1/i));
+    fireEvent.click(screen.getByText(/Continue/));
+
+    await waitFor(() =>
+      expect(screen.history.push.firstCall.args[0]).to.equal(
+        '/new-appointment/request-date',
+      ),
+    );
+  });
 });


### PR DESCRIPTION
## Description
This PR
- Fixes a recently introduced issue where an error was occurring if DS was enabled in VATS while the DS feature flag was off.

Sentry: http://sentry.vfs.va.gov/organizations/vsp/issues/37001/?environment=production&project=4&query=is%3Aunresolved+vaos&statsPeriod=14d

## Testing done
Local and unit testing

## Acceptance criteria
- [ ] Bug is fixed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
