### PR TITLE
Properly handle appointment fetching errors

### DIFF
--- a/src/applications/personalization/appointments/actions/index.js
+++ b/src/applications/personalization/appointments/actions/index.js
@@ -108,28 +108,28 @@ export function fetchConfirmedFutureAppointments() {
 
         // This catches partial errors on the meta object
         if (
-          vaAppointmentsResponse?.meta?.errors?.length > 0 ||
-          ccAppointmentsResponse?.meta?.errors?.length > 0
+          vaAppointmentsResponse.meta?.errors?.length > 0 ||
+          ccAppointmentsResponse.meta?.errors?.length > 0
         ) {
           dispatch({
             type: FETCH_CONFIRMED_FUTURE_APPOINTMENTS_FAILED,
             errors: [
-              ...(vaAppointmentsResponse?.meta?.errors || []),
-              ...(ccAppointmentsResponse?.meta?.errors || []),
+              ...(vaAppointmentsResponse.meta?.errors || []),
+              ...(ccAppointmentsResponse.meta?.errors || []),
             ],
           });
           return;
         }
 
-        vaAppointments = vaAppointmentsResponse?.data;
-        ccAppointments = ccAppointmentsResponse?.data;
+        vaAppointments = vaAppointmentsResponse.data;
+        ccAppointments = ccAppointmentsResponse.data;
       }
 
       const facilityIDs = uniq(
         vaAppointments?.map(
           appointment =>
-            getStagingID(appointment?.attributes?.sta6aid)
-              ? `vha_${getStagingID(appointment?.attributes?.sta6aid)}`
+            getStagingID(appointment.attributes?.sta6aid)
+              ? `vha_${getStagingID(appointment.attributes?.sta6aid)}`
               : undefined,
         ),
       );
@@ -153,22 +153,19 @@ export function fetchConfirmedFutureAppointments() {
         {},
       );
     } catch (error) {
+      const errors = error.errors ?? [error];
       dispatch({
         type: FETCH_CONFIRMED_FUTURE_APPOINTMENTS_FAILED,
-        errors: [
-          ...(vaAppointmentsResponse?.errors || []),
-          ...(ccAppointmentsResponse?.errors || []),
-          ...(facilitiesResponse?.data?.errors || []),
-        ],
+        errors,
       });
     }
 
     const formattedVAAppointments = vaAppointments?.reduce(
       (accumulator, appointment) => {
-        const startDate = moment(appointment?.attributes?.startDate);
+        const startDate = moment(appointment.attributes?.startDate);
         const now = moment();
         const appointmentStatus =
-          appointment?.attributes?.vdsAppointments?.[0]?.currentStatus;
+          appointment.attributes?.vdsAppointments?.[0]?.currentStatus;
 
         // Past appointments should be filtered out already on the api side, this is a safe guard.
         if (startDate.isBefore(now)) {
@@ -182,7 +179,7 @@ export function fetchConfirmedFutureAppointments() {
 
         // Derive the facility.
         const facility =
-          facilitiesLookup[getStagingID(appointment?.attributes?.facilityId)];
+          facilitiesLookup[getStagingID(appointment.attributes?.facilityId)];
 
         accumulator.push({
           additionalInfo: getAdditionalInfo(appointment),
@@ -204,7 +201,7 @@ export function fetchConfirmedFutureAppointments() {
 
     const formattedCCAppointments = ccAppointments?.reduce(
       (accumulator, appointment) => {
-        const startDate = moment(appointment?.attributes?.appointmentTime);
+        const startDate = moment(appointment.attributes?.appointmentTime);
         const now = moment();
 
         // Escape early if the appointment is in the past.

--- a/src/applications/personalization/dashboard-2/utils/appointments.js
+++ b/src/applications/personalization/dashboard-2/utils/appointments.js
@@ -1,5 +1,5 @@
 const oneDayInMS = 24 * 60 * 60 * 1000;
-const fourtyDays = Date.now() + oneDayInMS * 40;
+const fortyDays = Date.now() + oneDayInMS * 40;
 const tomorrow = Date.now() + oneDayInMS;
 const dayAfterTomorrow = Date.now() + oneDayInMS * 2;
 const nextWeek = Date.now() + oneDayInMS * 7;
@@ -71,7 +71,7 @@ export const upcomingCCAppointment = [
 ];
 
 export const farFutureAppointments = [
-  ccAppointment(fourtyDays),
-  videoAppointment(fourtyDays),
-  vaInPersonAppointment(fourtyDays),
+  ccAppointment(fortyDays),
+  videoAppointment(fortyDays),
+  vaInPersonAppointment(fortyDays),
 ];

--- a/src/applications/personalization/dashboard-2/utils/mocks/appointments/MOCK_VA_APPOINTMENTS_PARTIAL_ERROR.js
+++ b/src/applications/personalization/dashboard-2/utils/mocks/appointments/MOCK_VA_APPOINTMENTS_PARTIAL_ERROR.js
@@ -1,10 +1,18 @@
 export default {
+  data: [],
   meta: {
+    pagination: {
+      currentPage: 0,
+      perPage: 0,
+      totalPages: 0,
+      totalEntries: 0,
+    },
     errors: [
       {
-        code: 112,
-        source: 'test',
-        summary: 'test summary',
+        code: 500,
+        source: '987',
+        summary:
+          'Could not get appointments from VistA Scheduling Service (15a8ac60-c604-4694-80f4-c6c20366b0e5)',
       },
     ],
   },


### PR DESCRIPTION
## Description
I discovered some issues with the existing appointment error Cypress tests.

- The 4th and final test was looking for the wrong error message. When I updated it to look for the correct error message, the test failed. 🤔 
- I also noticed that the facilities API was not mocked correctly; Cypress was set up to mock the wrong endpoint 😱  When I fixed that issue, the first two tests failed.
- I also noticed that the error mocks were still mocked with 200 status codes.

After some digging I discovered that the Redux actions were not properly handling most errors from the appointments or facilities APIs. Fixing that made the tests work.

## Testing done
Fixed the Cypress tests that were set up incorrectly. Then adjusted the code to make the tests pass.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs