### PR TITLE
Remove confirmation email from FSR

### DIFF
--- a/src/applications/financial-status-report/config/form.js
+++ b/src/applications/financial-status-report/config/form.js
@@ -103,7 +103,6 @@ const formConfig = {
               },
               telephoneNumber: '',
               emailAddress: '',
-              confirmationEmail: '',
             },
           },
           path: 'contact-information',

--- a/src/applications/financial-status-report/pages/veteran/contact.js
+++ b/src/applications/financial-status-report/pages/veteran/contact.js
@@ -208,29 +208,6 @@ export const uiSchema = {
         classNames: 'input-size-7',
       },
     },
-    confirmationEmail: {
-      ...emailUI('Re-enter email address'),
-      'ui:description': (
-        <p className="formfield-subtitle">
-          To receive a confirmation email when you submit your request, you must
-          re-enter your email address.
-        </p>
-      ),
-      'ui:options': {
-        classNames: 'input-size-7',
-        hideOnReview: true,
-      },
-      'ui:validations': [
-        {
-          validator: (errors, fieldData, formData) => {
-            const { emailAddress, confirmationEmail } = formData.personalData;
-            if (emailAddress !== confirmationEmail) {
-              errors.addError('Email does not match');
-            }
-          },
-        },
-      ],
-    },
   },
 };
 
@@ -265,7 +242,6 @@ export const schema = {
         },
         telephoneNumber: SCHEMA_DEFINITIONS.telephoneNumber,
         emailAddress: SCHEMA_DEFINITIONS.emailAddress,
-        confirmationEmail: SCHEMA_DEFINITIONS.emailAddress,
       },
     },
   },

--- a/src/applications/financial-status-report/tests/e2e/fixtures/data/maximal.json
+++ b/src/applications/financial-status-report/tests/e2e/fixtures/data/maximal.json
@@ -224,7 +224,6 @@
     },
     "telephoneNumber": "4445551212",
     "emailAddress": "test2@test1.net",
-    "confirmationEmail": "test2@test1.net",
     "veteranFullName": {
       "first": "Mark",
       "middle": "",

--- a/src/applications/financial-status-report/tests/e2e/fixtures/data/minimal.json
+++ b/src/applications/financial-status-report/tests/e2e/fixtures/data/minimal.json
@@ -40,7 +40,6 @@
     },
     "telephoneNumber": "4445551212",
     "emailAddress": "test2@test1.net",
-    "confirmationEmail": "test2@test1.net",
     "veteranFullName": {
       "first": "Mark",
       "last": "Webb",


### PR DESCRIPTION
## Description
After discussing it with the DSVA #design channel, we found that the secondary email input on the FSR contact page is unnecessary and can be removed! 

[ticket](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/24930)

![image.png](https://images.zenhubusercontent.com/5da618a29c4ddf0001b2fd8e/95c62769-2ce0-471e-862a-1e9621b775d3)
**[UXPin link](https://preview.uxpin.com/803dc24213cf723bfce6c5e3eaef5a2c3f3e344b#/pages/133701777/simulate/sitemap)**

## Testing done
- Manual testing
- E2E testing

## Screenshots
TBA

## Acceptance criteria
- [x] Confirmation email on FSR is no longer present
- [x] All associated data with confirmation email is removed

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
