### PR TITLE
Only include pending and cancelled requests on request list page

### DIFF
--- a/src/applications/vaos/appointment-list/redux/selectors.js
+++ b/src/applications/vaos/appointment-list/redux/selectors.js
@@ -16,6 +16,7 @@ import {
   isCanceledConfirmed,
   isUpcomingAppointment,
   sortByCreatedDateDescending,
+  isPendingOrCancelledRequest,
 } from '../../services/appointment';
 import {
   selectFeatureCovid19Vaccine,
@@ -120,7 +121,7 @@ export const selectPendingAppointments = createSelector(
   state => state.appointments.pending,
   pending =>
     pending
-      ?.filter(a => !a.vaos.isExpressCare)
+      ?.filter(isPendingOrCancelledRequest)
       .sort(sortByCreatedDateDescending) || null,
 );
 

--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -313,6 +313,21 @@ export function isUpcomingAppointmentOrRequest(appt) {
       (appt.status === APPOINTMENT_STATUS.cancelled && hasValidDate))
   );
 }
+/**
+ * Returns cancelled and pending requests, which should be visible to users
+ *
+ * @export
+ * @param {Appointment} appt The appointment to check
+ * @returns {Boolean} If the appointment should be shown or not
+ */
+export function isPendingOrCancelledRequest(appt) {
+  return (
+    !appt.vaos.isExpressCare &&
+    (appt.status === APPOINTMENT_STATUS.proposed ||
+      appt.status === APPOINTMENT_STATUS.pending ||
+      appt.status === APPOINTMENT_STATUS.cancelled)
+  );
+}
 
 /**
  * Returns true if the given Appointment is a confirmed appointment

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -15,7 +15,6 @@ const facilities983A6 = require('./var/facilities_983A6.json');
 const clinicList983 = require('./var/clinicList983.json');
 const clinicList612 = require('./var/clinicList612.json');
 const facilityDetails983 = require('./var/facility_details_983.json');
-const facilityDetails984 = require('./var/facility_details_984.json');
 const facilityData = require('./var/facility_data.json');
 const ccProviders = require('./var/cc_providers.json');
 const sitesSupportingVAR = require('./var/sites-supporting-var.json');
@@ -29,7 +28,7 @@ varSlots.data[0].attributes.appointmentTimeSlot = generateMockSlots();
 
 const responses = {
   'GET /vaos/v0/appointments': (req, res) => {
-    if (req.params.type === 'cc') {
+    if (req.query.type === 'cc') {
       return res.json(confirmedCC);
     } else {
       return res.json(confirmedVA);
@@ -60,9 +59,9 @@ const responses = {
   },
   'GET /vaos/v0/facilities': parentFacilities,
   'GET /vaos/v0/systems/:id/direct_scheduling_facilities': (req, res) => {
-    if (req.params.parent_code === '984') {
+    if (req.query.parent_code === '984') {
       return res.json(facilities984);
-    } else if (req.params.parent_code === '983A6') {
+    } else if (req.query.parent_code === '983A6') {
       return res.json(facilities983A6);
     } else {
       return res.json(facilities983);
@@ -129,11 +128,11 @@ const responses = {
     });
   },
   'GET /v1/facilities/va/:id': (req, res) => {
-    if (req.params.id === 'vha_552') {
-      return res.json(facilityDetails984);
-    }
+    const facility = facilityData.data.find(f => f.id === req.params.id);
 
-    return res.json(facilityDetails983);
+    return res.json({
+      data: facility || facilityDetails983,
+    });
   },
   'GET /v1/facilities/va': facilityData,
   'GET /v1/facilities/ccp': ccProviders,

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentsList.unit.spec.jsx
@@ -195,4 +195,38 @@ describe('VAOS <RequestedAppointmentsList>', () => {
       ),
     ).to.be.ok;
   });
+
+  it('should not show resolved requests', async () => {
+    const startDate = moment.utc();
+    const appointment = getVARequestMock();
+    appointment.attributes = {
+      ...appointment.attributes,
+      status: 'Resolved',
+      optionDate1: startDate,
+      optionTime1: 'AM',
+      purposeOfVisit: 'New Issue',
+      bestTimetoCall: ['Morning'],
+      email: 'patient.test@va.gov',
+      phoneNumber: '5555555566',
+      typeOfCareId: '323',
+      reasonForVisit: 'Back pain',
+      friendlyLocationName: 'Some VA medical center',
+      appointmentType: 'Primary Care',
+      comment: 'loss of smell',
+      facility: {
+        ...appointment.attributes.facility,
+        facilityCode: '983GC',
+      },
+    };
+    appointment.id = '1234';
+    mockAppointmentInfo({ requests: [appointment], isHomepageRefresh: true });
+
+    const screen = renderWithStoreAndRouter(<RequestedAppointmentsList />, {
+      initialState,
+      reducers,
+    });
+
+    expect(await screen.findByText(/You don’t have any appointments/i)).to
+      .exist;
+  });
 });


### PR DESCRIPTION
## Description
This PR
- Adds missing filtering in request list selector so that we only show pending and cancelled requests
- Fixes some bugs in the mock data so that we aren't duplicating appointments and returning bad facility data

## Testing done
Local and unit testing

## Acceptance criteria
- [ ] Resolved requests aren't shown

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
