### PR TITLE
Force long message content to wrap on request details page

### DIFF
--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
@@ -226,16 +226,16 @@ export default function RequestedAppointmentDetailsPage() {
           </li>
         ))}
       </ul>
-      <>
+      <div className="vaos-u-word-break--break-word">
         <h2 className="vads-u-margin-top--2 vaos-appts__block-label">
           {appointment.reason}
         </h2>
         <div>{message}</div>
-      </>
+      </div>
       <h2 className="vads-u-margin-top--2 vads-u-margin-bottom--0 vaos-appts__block-label">
         Your contact details
       </h2>
-      <div>
+      <div className="vaos-u-word-break--break-word">
         {getPatientTelecom(appointment, 'email')}
         <br />
         <Telephone

--- a/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
@@ -43,6 +43,7 @@ describe('VAOS <CommunityCareAppointmentDetailsPage>', () => {
   it('should navigate to community care appointments detail page', async () => {
     // CC appointment id from confirmed_cc.json
     const url = '/cc/8a4885896a22f88f016a2cb7f5de0062';
+    const startDate = moment().add(1, 'day');
 
     const appointment = getCCAppointmentMock();
     appointment.id = '8a4885896a22f88f016a2cb7f5de0062';
@@ -60,7 +61,7 @@ describe('VAOS <CommunityCareAppointmentDetailsPage>', () => {
         zipCode: '20151',
       },
       instructionsToVeteran: 'Bring your glasses',
-      appointmentTime: '05/20/2021 14:15:00',
+      appointmentTime: startDate.format('MM/DD/YYYY HH:mm:ss'),
       timeZone: 'UTC',
     };
 
@@ -90,7 +91,7 @@ describe('VAOS <CommunityCareAppointmentDetailsPage>', () => {
     expect(
       await screen.findByRole('heading', {
         level: 1,
-        name: /^Thursday, May 20, 2021/,
+        name: new RegExp(startDate.format('dddd, MMMM D, YYYY'), 'i'),
       }),
     ).to.be.ok;
 
@@ -105,7 +106,12 @@ describe('VAOS <CommunityCareAppointmentDetailsPage>', () => {
     expect(screen.getByText(/Bring your glasses/)).to.be.ok;
     expect(
       screen.getByRole('link', {
-        name: /^Add May 20, 2021 appointment to your calendar/,
+        name: new RegExp(
+          `Add ${startDate.format(
+            'MMMM D, YYYY',
+          )} appointment to your calendar`,
+          'i',
+        ),
       }),
     ).to.be.ok;
     expect(screen.getByText(/Print/)).to.be.ok;
@@ -129,7 +135,7 @@ describe('VAOS <CommunityCareAppointmentDetailsPage>', () => {
     expect(
       await screen.findByRole('heading', {
         level: 1,
-        name: /^Thursday, May 20, 2021/,
+        name: new RegExp(startDate.format('dddd, MMMM D, YYYY'), 'i'),
       }),
     ).to.be.ok;
 
@@ -190,6 +196,7 @@ describe('VAOS <CommunityCareAppointmentDetailsPage>', () => {
   it('should fire a print request when print button clicked', async () => {
     // CC appointment id from confirmed_cc.json
     const url = '/cc/8a4885896a22f88f016a2cb7f5de0062';
+    const startDate = moment().add(1, 'day');
 
     const appointment = getCCAppointmentMock();
     appointment.id = '8a4885896a22f88f016a2cb7f5de0062';
@@ -207,7 +214,7 @@ describe('VAOS <CommunityCareAppointmentDetailsPage>', () => {
         zipCode: '20151',
       },
       instructionsToVeteran: 'Bring your glasses',
-      appointmentTime: '05/20/2021 14:15:00',
+      appointmentTime: startDate.format('MM/DD/YYYY HH:mm:ss'),
       timeZone: 'UTC',
     };
 
@@ -237,15 +244,7 @@ describe('VAOS <CommunityCareAppointmentDetailsPage>', () => {
     const detailLink = detailLinks.find(l => l.getAttribute('href') === url);
     userEvent.click(detailLink);
 
-    // Verify page content...
-    expect(
-      await screen.findByRole('heading', {
-        level: 1,
-        name: /^Thursday, May 20, 2021/,
-      }),
-    ).to.be.ok;
-
-    expect(screen.getByText(/Community care/)).to.be.ok;
+    expect(await screen.findByText(/Community care/)).to.be.ok;
 
     expect(printSpy.notCalled).to.be.true;
     fireEvent.click(await screen.findByText(/Print/i));

--- a/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
@@ -40,7 +40,7 @@ describe('VAOS <CommunityCareAppointmentDetailsPage>', () => {
     MockDate.reset();
   });
 
-  it.skip('should navigate to community care appointments detail page', async () => {
+  it('should navigate to community care appointments detail page', async () => {
     // CC appointment id from confirmed_cc.json
     const url = '/cc/8a4885896a22f88f016a2cb7f5de0062';
     const startDate = moment().add(1, 'day');
@@ -193,7 +193,7 @@ describe('VAOS <CommunityCareAppointmentDetailsPage>', () => {
     expect(screen.getByText(/Rick Katz/)).to.be.ok;
   });
 
-  it.skip('should fire a print request when print button clicked', async () => {
+  it('should fire a print request when print button clicked', async () => {
     // CC appointment id from confirmed_cc.json
     const url = '/cc/8a4885896a22f88f016a2cb7f5de0062';
     const startDate = moment().add(1, 'day');


### PR DESCRIPTION
## Description
This PR
- Forces long message content on the details page to wrap like it does on the old appt list page
- Fixes two tests that started failing this morning due to hardcoded dates

## Testing done
Local and unit testing

## Screenshots
![Screen Shot 2021-05-21 at 9 56 15 AM](https://user-images.githubusercontent.com/634932/119148967-08d51e00-ba1b-11eb-9d81-189de1241f4b.png)


## Acceptance criteria
- [ ] Wrap is fixed and build passes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
