### PR TITLE
526: Submit clean mailingAddress

### DIFF
--- a/src/applications/disability-benefits/all-claims/prefill-transformer.js
+++ b/src/applications/disability-benefits/all-claims/prefill-transformer.js
@@ -64,7 +64,17 @@ export default function prefillTransformer(pages, formData, metadata) {
         newData.phoneAndEmail.primaryPhone = primaryPhone;
       }
       if (mailingAddress) {
-        newData.mailingAddress = mailingAddress;
+        newData.mailingAddress = {
+          // strip out any extra data. Maybe left over from v1?
+          // see https://github.com/department-of-veterans-affairs/va.gov-team/issues/19423
+          country: mailingAddress.country || '',
+          addressLine1: mailingAddress.addressLine1 || '',
+          addressLine2: mailingAddress.addressLine2 || '',
+          addressLine3: mailingAddress.addressLine3 || '',
+          city: mailingAddress.city || '',
+          state: mailingAddress.state || '',
+          zipCode: mailingAddress.zipCode || '',
+        };
       }
     }
 

--- a/src/applications/disability-benefits/all-claims/submit-transformer.js
+++ b/src/applications/disability-benefits/all-claims/submit-transformer.js
@@ -283,6 +283,33 @@ export const cleanUpPersonsInvolved = incident => {
   };
 };
 
+// Remove extra data that may be included
+// see https://github.com/department-of-veterans-affairs/va.gov-team/issues/19423
+export const cleanUpMailingAddress = formData => {
+  const validKeys = [
+    'country',
+    'addressLine1',
+    'addressLine2',
+    'addressLine3',
+    'city',
+    'state',
+    'zipCode',
+  ];
+  const mailingAddress = Object.entries(formData.mailingAddress).reduce(
+    (address, [key, value]) => {
+      if (value && validKeys.includes(key)) {
+        return {
+          ...address,
+          [key]: value,
+        };
+      }
+      return address;
+    },
+    {},
+  );
+  return { ...formData, mailingAddress };
+};
+
 export function transform(formConfig, form) {
   // Grab isBDD before things are changed/deleted
   const isBDDForm = isBDD(form.data);
@@ -675,6 +702,7 @@ export function transform(formConfig, form) {
     filterRatedViewFields, // Must be run after setActionTypes
     filterServicePeriods,
     removeExtraData, // Removed data EVSS does't want
+    cleanUpMailingAddress,
     addPOWSpecialIssues,
     addPTSDCause,
     addClassificationCodeToNewDisabilities,

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-test.json
@@ -28,6 +28,11 @@
       "emailAddress": "test2@test1.net"
     },
     "mailingAddress": {
+      "view:livesOnMilitaryBase": false,
+      "type": "MILITARY",
+      "militaryPostOfficeTypeCode": "APO",
+      "militaryStateCode": "AA",
+      "zipFirstFive": "27103",
       "country": "USA",
       "addressLine1": "123 Main",
       "city": "Bigcity",

--- a/src/applications/disability-benefits/all-claims/tests/prefill-transformer.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/prefill-transformer.unit.spec.js
@@ -114,10 +114,15 @@ describe('526v2 prefill transformer', () => {
           primaryPhone: '1123123123',
           emailAddress: 'a@b.c',
           mailingAddress: {
+            country: 'USA',
             addressLine1: '123 Any Street',
             city: 'Anyville',
             state: 'AK',
             zipCode: '12345',
+            // extra data that needs to be removed
+            type: 'MILITARY',
+            militaryPostOfficeTypeCode: 'APO',
+            militaryStateCode: 'AA',
           },
         },
       };
@@ -125,14 +130,22 @@ describe('526v2 prefill transformer', () => {
       const transformedData = prefillTransformer(pages, formData, metadata)
         .formData;
 
-      const { primaryPhone, emailAddress, mailingAddress } = formData.veteran;
+      const { primaryPhone, emailAddress } = formData.veteran;
       expect(transformedData).to.deep.equal({
         'view:claimType': noTransformData.formData['view:claimType'],
         phoneAndEmail: {
           primaryPhone,
           emailAddress,
         },
-        mailingAddress,
+        mailingAddress: {
+          country: 'USA',
+          addressLine1: '123 Any Street',
+          addressLine2: '',
+          addressLine3: '',
+          city: 'Anyville',
+          state: 'AK',
+          zipCode: '12345',
+        },
       });
     });
 


### PR DESCRIPTION
## Description

EVSS reported that some submissions have been including extraneous data within the mailing address

```
"currentMailingAddress": {
  "country": "USA",
  "addressLine1": "1xx Cxxxx Court",
  "type": "MILITARY",
  "militaryPostOfficeTypeCode": "APO",
  "militaryStateCode": "AA",
  "zipFirstFive": "27103"
}
```

the last 4 entries do not match the schema for the mailing address and will be removed

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/19423

## Testing done

Updated mock data and unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Extra entries within the mailing address are stripped out in prefill
- [x] Extra entries within the mailing address are stripped out from the submitted data

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
