### PR TITLE
Remove POA attachment if yes/no/no is not yes

### DIFF
--- a/src/applications/caregivers/helpers.js
+++ b/src/applications/caregivers/helpers.js
@@ -78,7 +78,7 @@ export const submitTransform = (formConfig, form) => {
       if (key === 'signAsRepresentativeDocumentUpload') {
         /* if user submits a document via upload page, add the guid to the formData
           otherwise delete object and move on to next keys */
-        if (isEmpty(data[key])) {
+        if (isEmpty(data[key]) || data.signAsRepresentativeYesNo !== 'yes') {
           return delete sortedDataByChapter.poaAttachmentId;
         }
 

--- a/src/applications/caregivers/tests/e2e/fixtures/data/signAsRepresentativeNo.json
+++ b/src/applications/caregivers/tests/e2e/fixtures/data/signAsRepresentativeNo.json
@@ -41,5 +41,11 @@
   "secondaryTwoFullName": {},
   "secondaryTwoAddress": {},
   "AGREED": false,
-  "signAsRepresentativeYesNo": "no"
+  "signAsRepresentativeYesNo": "no",
+  "signAsRepresentativeDocumentUpload": [
+    {
+      "guid": "85b7edad-0f51-41d2-9eab-dffcc8dabb79",
+      "name": "fake_poa_9_25_15.pdf"
+    }
+  ]
 }

--- a/src/applications/caregivers/tests/helpers.unit.spec.js
+++ b/src/applications/caregivers/tests/helpers.unit.spec.js
@@ -13,6 +13,7 @@ import requiredOnly from './e2e/fixtures/data/requiredOnly.json';
 import secondaryTwoOnly from './e2e/fixtures/data/secondaryOneOnly.json';
 import oneSecondaryCaregivers from './e2e/fixtures/data/oneSecondaryCaregivers.json';
 import twoSecondaryCaregivers from './e2e/fixtures/data/twoSecondaryCaregivers.json';
+import signAsRepresentativeNo from './e2e/fixtures/data/signAsRepresentativeNo.json';
 
 describe('Caregivers helpers', () => {
   it('should transform required parties correctly (minimal with primary)', () => {
@@ -197,6 +198,44 @@ describe('Caregivers helpers', () => {
       'dateOfBirth',
       'gender',
     ]);
+  });
+
+  it('should remove POA ID if yes/no/no is no', () => {
+    const form = {
+      data: signAsRepresentativeNo,
+    };
+
+    const transformedData = submitTransform(formConfig, form);
+    const payloadData = JSON.parse(transformedData);
+    const payloadObject = JSON.parse(
+      payloadData.caregiversAssistanceClaim.form,
+    );
+
+    const veteranKeys = Object.keys(payloadObject.veteran);
+    const primaryKeys = Object.keys(payloadObject.primaryCaregiver);
+
+    expect(veteranKeys).to.deep.equal([
+      'plannedClinic',
+      'address',
+      'primaryPhoneNumber',
+      'fullName',
+      'signature',
+      'ssnOrTin',
+      'dateOfBirth',
+      'gender',
+    ]);
+    expect(primaryKeys).to.deep.equal([
+      'hasHealthInsurance',
+      'address',
+      'primaryPhoneNumber',
+      'vetRelationship',
+      'fullName',
+      'signature',
+      'dateOfBirth',
+      'gender',
+    ]);
+
+    expect(payloadObject.poaAttachmentId).to.be.undefined;
   });
 
   it('isSSNUnique should not count a party that is not present', () => {


### PR DESCRIPTION
## Description
We found a bug where if you say you want to upload a document, upload a document, then go back and select no. The POA document ID is still being sent to BE. This PR adds a check so if yes is not selected ID is deleted onSubmit.

[Ticket](https://app.zenhub.com/workspaces/vsa---caregiver-5fff0cfd1462b6000e320fc7/issues/department-of-veterans-affairs/va.gov-team/25083)

## Testing done
- Manual
- Unit testing

## Screenshots
### Should delete POA ID
![Screen Shot 2021-05-21 at 1 31 33 PM](https://user-images.githubusercontent.com/23741323/119179733-4a76c080-ba3d-11eb-89a1-ce0fea28ce39.png)


### Should retain POA ID


![Screen Shot 2021-05-21 at 1 30 15 PM](https://user-images.githubusercontent.com/23741323/119179744-4ea2de00-ba3d-11eb-97ea-b682bc17d8ba.png)




## Acceptance criteria
- [x] If anything but yes is selected on POA question delete document ID on submit

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
