### PR TITLE
Add past appointment detail alert

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/index.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/index.jsx
@@ -204,6 +204,12 @@ export default function ConfirmedAppointmentDetailsPage() {
         />
       </h1>
 
+      {isPastAppointment && (
+        <AlertBox status="warning" backgroundOnly>
+          This appointment occurred in the past.
+        </AlertBox>
+      )}
+
       {canceled && (
         <AlertBox
           status="error"

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
@@ -244,6 +244,9 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       expect(document.activeElement).to.have.tagName('h1');
     });
 
+    expect(await screen.findByText(/This appointment occurred in the past./i))
+      .to.be.ok;
+
     // NOTE: This 2nd 'await' is needed due to async facilities fetch call!!!
     expect(await screen.findByText(/Fort Collins VA Clinic/)).to.be.ok;
     expect(screen.getByText(/Jennie's Lab/)).to.be.ok;

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
@@ -115,6 +115,10 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       expect(document.activeElement).to.have.tagName('h1');
     });
 
+    expect(screen.baseElement).not.to.contain.text(
+      'This appointment occurred in the past.',
+    );
+
     // NOTE: This 2nd 'await' is needed due to async facilities fetch call!!!
     expect(await screen.findByText(/Fort Collins VA Clinic/)).to.be.ok;
     expect(screen.getByText(/Jennie's Lab/)).to.be.ok;
@@ -244,8 +248,9 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       expect(document.activeElement).to.have.tagName('h1');
     });
 
-    expect(await screen.findByText(/This appointment occurred in the past./i))
-      .to.be.ok;
+    expect(screen.baseElement).to.contain.text(
+      'This appointment occurred in the past.',
+    );
 
     // NOTE: This 2nd 'await' is needed due to async facilities fetch call!!!
     expect(await screen.findByText(/Fort Collins VA Clinic/)).to.be.ok;


### PR DESCRIPTION
## Description

This PR adds an alert to the past appointment details page. The alertbox text should read `This appointment occurred in the past.`

## Testing done

- local, unit testing


## Screenshots


## Acceptance criteria
- [x]  Changes are behind the `va_online_scheduling_homepage_refresh` feature flag
- [x] CONTENT - Message copy matches: `This appointment occurred in the past.`
- [x] DESIGN - Designs match the specs (copy is FPO)
[Desktop](https://www.sketch.com/s/d4b8e6aa-2e36-47fd-aa04-52f4d3f839c3/a/v8EA1r8#Inspector)
[Tablet](https://www.sketch.com/s/d4b8e6aa-2e36-47fd-aa04-52f4d3f839c3/a/Qb0poV8#Inspector)
[Mobile](https://www.sketch.com/s/d4b8e6aa-2e36-47fd-aa04-52f4d3f839c3/a/zxlO21W#Inspector)
- [x] DESIGN - Message uses the Design System - [Alert box-background only component](https://design.va.gov/storybook/?path=/docs/components-va-alert--background-only#background-only)

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
