### PR TITLE
25042 - zipcode restrict to 5 digits

### DIFF
--- a/src/applications/vre/definitions/profileAddress.js
+++ b/src/applications/vre/definitions/profileAddress.js
@@ -15,10 +15,10 @@ import {
 /**
  * PATTERNS
  * STREET_PATTERN - rejects white space only
- * US_POSTAL_CODE_PATTERN - Matches 5 digit zipcodes and zip+4 patterns: 12345, 12345-1234
+ * US_POSTAL_CODE_PATTERN - Matches 5 digit zipcodes
  */
 const STREET_PATTERN = '^.*\\S.*';
-const US_POSTAL_CODE_PATTERN = '^\\d{5}(?:-\\d{4})?$';
+const US_POSTAL_CODE_PATTERN = '^\\d{5}$';
 
 /**
  Available at https://github.com/department-of-veterans-affairs/vets-json-schema/blob/8337b2878b524867ef2b6d8600b134c682c7ac8a/src/common/definitions.js#L161
@@ -268,7 +268,7 @@ export const addressUiSchema = (path, checkBoxTitle, uiRequiredCallback) => {
       'ui:title': 'Postal code',
       'ui:errorMessages': {
         required: 'Postal code is required',
-        pattern: 'Please enter a valid US zip code',
+        pattern: 'Please enter a valid 5 digit US zip code',
       },
       'ui:options': {
         widgetClassNames: 'usa-input-medium',


### PR DESCRIPTION
## Description
Recently we discovered that 5+4 zips would cause a lookup error in one of our partner systems. In response, we've decided to restrict zip code entry to conventional 5 digit zip codes for US addresses. 

## Testing done
- local

## Screenshots
<img width="488" alt="Screen Shot 2021-05-21 at 1 58 52 PM" src="https://user-images.githubusercontent.com/15097156/119179927-8ca00200-ba3d-11eb-8770-6f4fe9f50033.png">


## Acceptance criteria
- [x] validation works

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
