### PR TITLE
Fix NOD edit button overlap

### DIFF
--- a/src/applications/appeals/10182/sass/10182-nod.scss
+++ b/src/applications/appeals/10182/sass/10182-nod.scss
@@ -90,6 +90,7 @@ dl.review {
 
     .widget-content-wrap {
       margin-top: 3rem;
+      margin-right: 0.5rem;
       width: 100%;
     }
 


### PR DESCRIPTION
## Description

The Notice of Disagreement issues card edit button overlaps

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/24984

## Testing done

Manual visual testing on screens between 320 and 1280 px.

## Screenshots

![Screen Shot 2021-05-24 at 9 57 17 AM](https://user-images.githubusercontent.com/136959/119366331-76c95180-bc76-11eb-9ee2-5d079c1db892.png)

![Screen Shot 2021-05-24 at 9 45 15 AM](https://user-images.githubusercontent.com/136959/119365944-13d7ba80-bc76-11eb-8b42-764aee8da07c.png)

## Acceptance criteria
- [x] Edit button does not overlap decision date

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
