### PR TITLE
Fix non-wrapping text in IE11

### DIFF
--- a/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplicationInProgress.jsx
+++ b/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplicationInProgress.jsx
@@ -32,7 +32,7 @@ const ApplicationInProgress = ({
         data-testid="application-in-progress"
       >
         <div className="vads-u-display--flex vads-u-width--full vads-u-flex-direction--column vads-u-justify-content--space-between vads-u-align-items--flex-start vads-u-background-color--gray-lightest vads-u-padding--2p5">
-          <div>
+          <div className="vads-u-width--full">
             <p className="vads-u-text-transform--uppercase vads-u-margin-y--0">
               {presentableFormId}
             </p>

--- a/src/applications/personalization/dashboard-2/components/apply-for-benefits/BenefitOfInterest.jsx
+++ b/src/applications/personalization/dashboard-2/components/apply-for-benefits/BenefitOfInterest.jsx
@@ -22,7 +22,7 @@ const BenefitOfInterest = ({
         `space-between`, so this first child will be pinned to the top of the
         parent div and the following anchor tag will be pinned to the bottom of
         the parent */}
-        <div>
+        <div className="vads-u-width--full">
           <div className="vads-u-display--flex">
             <i
               className={`icon-small icon-heading hub-icon-${icon} hub-background-${icon} white vads-u-margin-right--1 vads-u-flex--auto`}


### PR DESCRIPTION
## Description
This fixes an issue in IE11 where text does not wrap when in a flexbox container. I just had to explicitly set the wrapping `div`'s width to 100% as mentioned here: https://stackoverflow.com/questions/35111090/text-in-a-flex-container-doesnt-wrap-in-ie11#comment62825260_35113633

## Testing done
In BrowserStack while running the site locally.

## Screenshots
Before:
<img src="https://user-images.githubusercontent.com/587583/118063800-a317d080-b34e-11eb-85e1-0b27ab6fcf3d.png">

After:
<img width="963" alt="Screen Shot 2021-05-24 at 7 55 11 AM" src="https://user-images.githubusercontent.com/20728956/119366722-1a5e3600-bc66-11eb-93b3-7539274f7aba.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs