### PR TITLE
Use correct id for clinic based appointments

### DIFF
--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import * as Sentry from '@sentry/browser';
 import recordEvent from 'platform/monitoring/record-event';
 import {
   GA_PREFIX,
@@ -255,6 +256,14 @@ export function fetchFutureAppointments() {
         }
       } catch (error) {
         captureError(error);
+      }
+
+      if (
+        data[0]
+          ?.filter(appt => appt.videoData.kind === VIDEO_TYPES.clinic)
+          .some(appt => !appt.sta6aid)
+      ) {
+        Sentry.captureMessage('VAOS clinic based appointment missing sta6aid');
       }
     } catch (error) {
       captureError(error);

--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -261,7 +261,7 @@ export function fetchFutureAppointments() {
       if (
         data[0]
           ?.filter(appt => appt.videoData.kind === VIDEO_TYPES.clinic)
-          .some(appt => !appt.sta6aid)
+          .some(appt => !appt.location?.stationId)
       ) {
         Sentry.captureMessage('VAOS clinic based appointment missing sta6aid');
       }

--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -234,7 +234,8 @@ export function isVAPhoneAppointment(appointment) {
 export function getVAAppointmentLocationId(appointment) {
   if (
     appointment?.vaos.isVideo &&
-    appointment?.vaos.appointmentType === APPOINTMENT_TYPES.vaAppointment
+    appointment?.vaos.appointmentType === APPOINTMENT_TYPES.vaAppointment &&
+    appointment?.videoData.kind !== VIDEO_TYPES.clinic
   ) {
     return appointment?.location.vistaId;
   }

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.video.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.video.unit.spec.jsx
@@ -516,7 +516,9 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
         ...appointment.attributes,
         facilityId: '983',
         clinicId: '123',
-        sta6aid: '983',
+        // This should be different from facilityId to test that correct facility
+        // is used
+        sta6aid: '983GD',
         startDate: startDate.format(),
         clinicFriendlyName: 'CHY PC VAR2',
       };
@@ -543,10 +545,10 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       });
 
       const facility = {
-        id: 'vha_442',
+        id: 'vha_442GD',
         attributes: {
           ...getVAFacilityMock().attributes,
-          uniqueId: '442',
+          uniqueId: '442GD',
           name: 'Cheyenne VA Medical Center',
           address: {
             physical: {
@@ -561,7 +563,7 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
           },
         },
       };
-      mockFacilitiesFetch('vha_442', [facility]);
+      mockFacilitiesFetch('vha_442GD', [facility]);
 
       const screen = renderWithStoreAndRouter(
         <AppointmentList featureHomepageRefresh />,


### PR DESCRIPTION
## Description
This PR
- Updates our location id logic to use the sta6aid instead of facilityId for clinic based video appointments

## Testing done
Unit testing

## Acceptance criteria
- [ ] Correct id is used

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
