### PR TITLE
wrap payload in form convention

### DIFF
--- a/src/applications/static-pages/dependency-verification/actions/index.js
+++ b/src/applications/static-pages/dependency-verification/actions/index.js
@@ -51,7 +51,9 @@ export function updateDiariesService(shouldUpdate) {
       try {
         const response = await apiRequest(DEPENDENCY_VERIFICATION_URI, {
           method: 'POST',
-          body: JSON.stringify({ updateDiaries: 'true' }),
+          body: JSON.stringify({
+            dependencyVerificationClaim: { form: { updateDiaries: 'true' } },
+          }),
           credentials: 'include',
           mode: 'cors',
           headers: {


### PR DESCRIPTION
## Description
To keep things in convention with how we submit traditional forms, this PR wraps the payload for dependency verification the same way.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
