### PR TITLE
DT-25124-Fixed Discharge Wizard link

### DIFF
--- a/src/applications/discharge-wizard/components/gpSteps/StepTwo.jsx
+++ b/src/applications/discharge-wizard/components/gpSteps/StepTwo.jsx
@@ -38,7 +38,6 @@ const renderMedicalRecordInfo = formValues => {
             submitting VA Form 10-5345 to your local VA Medical Center.{' '}
             <a
               download
-              target="_blank"
               rel="noopener noreferrer"
               href="https://www.va.gov/vaforms/medical/pdf/VHA%20Form%2010-5345%20Fill-revision.pdf"
             >

--- a/src/applications/discharge-wizard/components/gpSteps/StepTwo.jsx
+++ b/src/applications/discharge-wizard/components/gpSteps/StepTwo.jsx
@@ -37,9 +37,10 @@ const renderMedicalRecordInfo = formValues => {
             You can request your <strong>VA medical records</strong> by
             submitting VA Form 10-5345 to your local VA Medical Center.{' '}
             <a
+              download
               target="_blank"
               rel="noopener noreferrer"
-              href="https://www.va.gov/vaforms/medical/pdf/vha-10-5345-fill.pdf"
+              href="https://www.va.gov/vaforms/medical/pdf/VHA%20Form%2010-5345%20Fill-revision.pdf"
             >
               Download VA Form 10-5345.
             </a>


### PR DESCRIPTION
## Issues
https://github.com/department-of-veterans-affairs/va.gov-team/issues/25124

## Description
Lnk under the form 10-5345 broke after the PDF was updated. Fixed it by pointing it to the new one.

## Testing done
Ran e2e, unit and tested locally.

## Screenshots
![Screen Shot 2021-05-24 at 2 01 22 PM](https://user-images.githubusercontent.com/26075258/119389376-873ef380-bc99-11eb-8a13-42e5469ee76c.png)


## Acceptance criteria
- [x] New link works.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
