### PR TITLE
[24964] Trigger requested appointment list refreshing after cancel success

### DIFF
--- a/src/applications/vaos/appointment-list/redux/reducer.js
+++ b/src/applications/vaos/appointment-list/redux/reducer.js
@@ -257,7 +257,6 @@ export default function appointmentsReducer(state = initialState, action) {
         confirmed,
         pending,
         appointmentDetails,
-        pendingStatus: FETCH_STATUS.notStarted,
         cancelAppointmentStatus: FETCH_STATUS.succeeded,
         cancelAppointmentStatusVaos400: false,
       };

--- a/src/applications/vaos/appointment-list/redux/reducer.js
+++ b/src/applications/vaos/appointment-list/redux/reducer.js
@@ -257,6 +257,7 @@ export default function appointmentsReducer(state = initialState, action) {
         confirmed,
         pending,
         appointmentDetails,
+        pendingStatus: FETCH_STATUS.notStarted,
         cancelAppointmentStatus: FETCH_STATUS.succeeded,
         cancelAppointmentStatusVaos400: false,
       };

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -148,9 +148,9 @@ const responses = {
       attributes: {},
     },
   },
-  'PUT /vaos/v0/appointment_requests': (req, res) => {
+  'PUT /vaos/v0/appointment_requests/:id': (req, res) => {
     const requestAttributes = requests.data.find(
-      item => item.id === req.body.id,
+      item => item.id === req.params.id,
     ).attributes;
 
     return res.json({


### PR DESCRIPTION
## Description
On a given requested appointment details page, it shows canceled but the status of cancel in dark grey outline is missing on the requested summary list. 

## Testing done
Local Visual

## Screenshots
n/a

## Acceptance criteria
- [ ] When cancelled and navigating back to the requested appointment list, appointment has visual canceled styling/text.

## Definition of done
- [-] Events are logged appropriately
- [-] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
