### PR TITLE
NOD: Conditionally set additional issues view

### DIFF
--- a/src/applications/appeals/10182/components/AddIssuesField.jsx
+++ b/src/applications/appeals/10182/components/AddIssuesField.jsx
@@ -11,6 +11,7 @@ import {
 import { setArrayRecordTouched } from 'platform/forms-system/src/js/helpers';
 import { errorSchemaIsValid } from 'platform/forms-system/src/js/validation';
 import { scrollToFirstError } from 'platform/utilities/ui';
+import { setData } from 'platform/forms-system/src/js/actions';
 
 import { scrollAndFocus } from '../utils/ui';
 import { isEmptyObject, someSelected } from '../utils/helpers';
@@ -31,9 +32,17 @@ const AddIssuesField = props => {
     registry,
     formContext,
     onBlur,
+    fullFormData,
   } = props;
 
   const uiOptions = uiSchema['ui:options'] || {};
+
+  if (!fullFormData['view:hasIssuesToAdd']) {
+    props.setFormData({
+      ...fullFormData,
+      'view:hasIssuesToAdd': true,
+    });
+  }
 
   const initialEditingState = uiOptions.setInitialEditMode?.(formData);
   // Editing state: 1 = new edit, true = update edit & false = view state
@@ -164,7 +173,7 @@ const AddIssuesField = props => {
   // first issue does not have a header or grey card background
   const singleIssue = items.length === 1;
   const hasSelected =
-    someSelected(formData) || someSelected(props.contestableIssues);
+    someSelected(formData) || someSelected(fullFormData.contestableIssues);
   const showError = formContext.submitted && !hasSelected;
 
   const content = items.map((item, index) => {
@@ -298,10 +307,17 @@ AddIssuesField.propTypes = {
   }),
 };
 
+const mapDispatchToProps = {
+  setFormData: setData,
+};
+
 const mapStateToProps = state => ({
-  contestableIssues: state.form.data?.contestableIssues || [],
+  fullFormData: state.form.data || {},
 });
 
 export { AddIssuesField };
 
-export default connect(mapStateToProps)(AddIssuesField);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(AddIssuesField);

--- a/src/applications/appeals/10182/config/form.js
+++ b/src/applications/appeals/10182/config/form.js
@@ -20,7 +20,7 @@ import {
   canUploadEvidence,
   wantsToUploadEvidence,
   showAddIssueQuestion,
-  showAddIssues,
+  showAddIssuesPage,
   needsHearingType,
   appStateSelector,
   getIssueName,
@@ -151,14 +151,10 @@ const formConfig = {
         additionalIssues: {
           title: 'Add issues for review',
           path: 'additional-issues',
-          depends: showAddIssues,
+          depends: showAddIssuesPage,
           uiSchema: additionalIssues.uiSchema,
           schema: additionalIssues.schema,
           appStateSelector,
-          initialData: {
-            'view:hasIssuesToAdd': true,
-            additionalIssues: [{}],
-          },
         },
         areaOfDisagreementFollowUp: {
           title: getIssueName,

--- a/src/applications/appeals/10182/tests/components/AddIssuesField.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/AddIssuesField.unit.spec.jsx
@@ -27,6 +27,9 @@ const getProps = ({
   errorSchema,
   idSchema: { $id: 'additionalIssues' },
   formData,
+  fullFormData: {
+    'view:hasIssuesToAdd': true,
+  },
   registry: {
     definitions: {},
     fields: {
@@ -42,6 +45,7 @@ const getProps = ({
   },
   onBlur: f => f,
   onChange,
+  setFormData: () => {},
 });
 
 describe('<AddIssuesField>', () => {
@@ -195,5 +199,18 @@ describe('<AddIssuesField>', () => {
       );
       wrapper.unmount();
     });
+  });
+  it('should set view additional issues flag when visible', () => {
+    const setFormData = sinon.spy();
+    const wrapper = shallow(
+      <AddIssuesField
+        {...getProps()}
+        setFormData={setFormData}
+        fullFormData={{}}
+      />,
+    );
+    expect(setFormData.called).to.be.true;
+    expect(setFormData.args[0][0]['view:hasIssuesToAdd']).to.be.true;
+    wrapper.unmount();
   });
 });

--- a/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
@@ -6,6 +6,7 @@ import {
   hasSomeSelected,
   getSelected,
   getIssueName,
+  showAddIssuesPage,
   showAddIssueQuestion,
   isEmptyObject,
   setInitialEditMode,
@@ -102,6 +103,42 @@ describe('getIssueName', () => {
   });
   it('should return an added issue name', () => {
     expect(getIssueName({ issue: 'test2' })).to.eq('test2');
+  });
+});
+
+describe('showAddIssuesPage', () => {
+  it('should show add issue page when no contestable issues selected', () => {
+    expect(showAddIssuesPage({})).to.be.true;
+    expect(showAddIssuesPage({ contestableIssues: [{}] })).to.be.true;
+  });
+  it('should show add issue page when question is set to "yes"', () => {
+    expect(showAddIssuesPage({ 'view:hasIssuesToAdd': true })).to.be.true;
+    expect(
+      showAddIssuesPage({
+        'view:hasIssuesToAdd': true,
+        contestableIssues: [{ [SELECTED]: true }],
+      }),
+    ).to.be.true;
+    expect(
+      showAddIssuesPage({
+        'view:hasIssuesToAdd': true,
+        contestableIssues: [{}],
+      }),
+    ).to.be.true;
+  });
+  it('should not show issue page when "no" is chosen', () => {
+    expect(
+      showAddIssuesPage({
+        'view:hasIssuesToAdd': false,
+        contestableIssues: [{ [SELECTED]: true }],
+      }),
+    ).to.be.false;
+    expect(
+      showAddIssuesPage({
+        'view:hasIssuesToAdd': false,
+        contestableIssues: [{}],
+      }),
+    ).to.be.false;
   });
 });
 

--- a/src/applications/appeals/10182/utils/helpers.js
+++ b/src/applications/appeals/10182/utils/helpers.js
@@ -3,6 +3,9 @@ import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import { SELECTED } from '../constants';
 
+export const someSelected = issues =>
+  (issues || []).some(issue => issue[SELECTED]);
+
 // checks
 export const hasRepresentative = formData => formData['view:hasRep'];
 export const canUploadEvidence = formData =>
@@ -11,12 +14,14 @@ export const needsHearingType = formData =>
   formData.boardReviewOption === 'hearing';
 export const wantsToUploadEvidence = formData =>
   canUploadEvidence(formData) && formData['view:additionalEvidence'];
-export const showAddIssues = formData => formData['view:hasIssuesToAdd'];
+export const showAddIssuesPage = formData =>
+  formData['view:hasIssuesToAdd'] !== false &&
+  (formData.constestableIssues?.length
+    ? !someSelected(formData.contestableIssues)
+    : true);
 export const otherTypeSelected = ({ areaOfDisagreement } = {}, index) =>
   areaOfDisagreement?.[index]?.disagreementOptions?.other;
 
-export const someSelected = issues =>
-  (issues || []).some(issue => issue[SELECTED]);
 export const hasSomeSelected = ({ contestableIssues, additionalIssues } = {}) =>
   someSelected(contestableIssues) || someSelected(additionalIssues);
 export const showAddIssueQuestion = ({ contestableIssues }) =>


### PR DESCRIPTION
## Description

The Notice of Disagreement form previously has the add additional issues yes/no question set to "yes" as a default. This PR does not set the flag (`view:hasIssuesToAdd`) initially, but instead dynamically sets it as true when the additional issues page becomes visible. This is to prevent confusion if the Veteran chooses to select an API-provided eligible issue on the review & submit page - an undefined add additional question will appear even though the Veteran had already added issues.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/24990

## Testing done

Updated unit tests

## Screenshots

Review & submit page screenshots:

<details><summary>No API-provided issue selected (additional issue question hidden)</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-05-24 at 3 00 39 PM](https://user-images.githubusercontent.com/136959/119401336-fa983380-bca0-11eb-9d37-bdf7e1e6a400.png)</details>

<details><summary>Visible yes/no question when API-provided issue selected</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-05-24 at 3 01 34 PM](https://user-images.githubusercontent.com/136959/119401331-f9670680-bca0-11eb-81bd-151ecd512af3.png)</details>

## Acceptance criteria
- [x] Add additional issues question has no default
- [x] Question page is bypassed when no API-provided eligible issues is selected
- [x] Question choice is set to "yes" when additional issues page becomes visible. 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
