### PR TITLE
Fix stylelint issues in claims-status

### DIFF
--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -6,8 +6,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-action-link";
 @import "~@department-of-veterans-affairs/formation/sass/modules/va-tabs";
 
-$color-inactive: #9b9b9b;
-
 .claim-list {
   margin-bottom: 2em;
 }
@@ -748,8 +746,8 @@ h1:focus {
       border-left-color: transparent;
 
       &::before {
-        background-color: $color-inactive;
-        color: $color-inactive;
+        background-color: $color-gray-light;
+        color: $color-gray-light;
       }
     }
   }


### PR DESCRIPTION
## Description

This is a follow-up to #17305 . It fixes the `stylelint` errors in the `claims-status` app.

The `#9b9b9b` color isn't in the design system, so I tried to match it as closely as I could.

## Testing done

- `npx stylelint "src/applications/claims-status/**/*.scss"`

## Screenshots

Before:

![image](https://user-images.githubusercontent.com/2008881/119416791-45b64480-bca9-11eb-8e34-b4d9a6101fa1.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
