### PR TITLE
Fix stylelint issues in healthcare-questionnaire

### DIFF
--- a/src/applications/health-care-questionnaire/list/sass/questionnaire.scss
+++ b/src/applications/health-care-questionnaire/list/sass/questionnaire.scss
@@ -1,6 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-action-link";
-@import '../../shared/sass/ie.scss';
+@import "../../shared/sass/ie";
 
 .questionnaire-list-tabs-container{
   border-bottom: 1px solid $color-gray-light;

--- a/src/applications/health-care-questionnaire/questionnaire/sass/questionnaire.scss
+++ b/src/applications/health-care-questionnaire/questionnaire/sass/questionnaire.scss
@@ -7,9 +7,7 @@
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";
 @import "../../../../platform/forms/sass/m-form-confirmation";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-action-link";
-@import '../../shared/sass/ie.scss';
-
-
+@import "../../shared/sass/ie";
 
 .healthcare-experience {
 


### PR DESCRIPTION
## Description

This is a follow-up to #17305. It fixes the `stylelint` issues in the `health-care-questionnaire` app.

## Testing done

- `npx stylelint "src/applications/health-care-questionnaire/**/*.scss"`

## Screenshots

Before:

![image](https://user-images.githubusercontent.com/2008881/119417031-d2610280-bca9-11eb-8924-16a8edcc74f9.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
