### PR TITLE
Fix stylelint errors in gi-sandbox

### DIFF
--- a/src/applications/gi-sandbox/sass/gi.scss
+++ b/src/applications/gi-sandbox/sass/gi.scss
@@ -172,7 +172,7 @@
     margin-top: 50px;
 
     button {
-      margin-top:.5em;
+      margin-top: 0.5em;
       width: auto;
     }
 

--- a/src/applications/gi-sandbox/sass/partials/_gi-search-controls.scss
+++ b/src/applications/gi-sandbox/sass/partials/_gi-search-controls.scss
@@ -71,12 +71,12 @@
 }
 .update-results-form {
   margin-top: -2em;
-  border-left: solid #f1f1f1;
-  border-right: solid #f1f1f1;
+  border-left: solid $color-gray-lightest;
+  border-right: solid $color-gray-lightest;
 }
 .update-results {
   height: 4.5em;
-  background-color: #f1f1f1;
+  background-color: $color-gray-lightest;
 }
 .update-results-header {
   margin-top: -0.04em;


### PR DESCRIPTION
## Description

This is a follow-up to #17305. It fixes the `stylelint` errors on the `gi-sandbox` app.


## Testing done

- `npx stylelint "src/applications/gi-*/**/*.scss"`


## Screenshots

Before:

![image](https://user-images.githubusercontent.com/2008881/119417561-ee18d880-bcaa-11eb-818f-6e0af9f46666.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
