### PR TITLE
feat(1010cg): update poa file upload limit to 10MB

### DIFF
--- a/src/applications/caregivers/components/AdditionalInfo/index.jsx
+++ b/src/applications/caregivers/components/AdditionalInfo/index.jsx
@@ -283,7 +283,7 @@ export const RepresentativeDocumentUploadDescription = () => {
       <p>Guidelines for uploading a file:</p>
       <ul>
         <li>You can upload a .pdf, .jpeg, or .png file</li>
-        <li>Your file should be no larger than 25MB</li>
+        <li>Your file should be no larger than 10MB</li>
       </ul>
 
       <p>

--- a/src/applications/caregivers/config/chapters/signAsRepresentative/uploadPOADocument.js
+++ b/src/applications/caregivers/config/chapters/signAsRepresentative/uploadPOADocument.js
@@ -49,7 +49,7 @@ export default {
       multiple: false,
       fileUploadUrl: `${environment.API_URL}/v0/form1010cg/attachments`,
       fileTypes: ['pdf', 'doc', 'docx', 'jpg', 'jpeg', 'rtf', 'png'],
-      maxSize: 1024 * 1024 * 25,
+      maxSize: 1024 * 1024 * 10,
       hideLabelText: true,
       createPayload,
       parseResponse,


### PR DESCRIPTION
## Description
Restrict 1010CG POA uploads to 10MB to encourage users to only upload relevant documentation.

## Testing done
- [x] manual

## Screenshots
![image](https://user-images.githubusercontent.com/83595736/119519877-cd529080-bd47-11eb-9718-45fe8391f9c9.png)

## Acceptance criteria
- [x] Update frontend to accept 10MB files or smaller
- [x] Update `Your file should be no larger than 25MB` to `Your file should be no larger than 10MB`

## Definition of done
- [ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/25166)
