### PR TITLE
NOD: Maintain disagreement choices

### DIFF
--- a/src/applications/appeals/10182/containers/FormApp.jsx
+++ b/src/applications/appeals/10182/containers/FormApp.jsx
@@ -11,6 +11,7 @@ import {
   issuesNeedUpdating,
   getSelected,
   getIssueName,
+  copyAreaOfDisagreementOptions,
 } from '../utils/helpers';
 
 import { showWorkInProgress } from '../content/WorkInProgressMessage';
@@ -68,7 +69,11 @@ export const FormApp = ({
         ) {
           setFormData({
             ...formData,
-            areaOfDisagreement,
+            // save existing settings
+            areaOfDisagreement: copyAreaOfDisagreementOptions(
+              areaOfDisagreement,
+              formData.areaOfDisagreement,
+            ),
           });
         }
       }

--- a/src/applications/appeals/10182/pages/areaOfDisagreement.js
+++ b/src/applications/appeals/10182/pages/areaOfDisagreement.js
@@ -74,6 +74,7 @@ export default {
     properties: {
       areaOfDisagreement: {
         type: 'array',
+        minItems: 1,
         items: {
           type: 'object',
           properties: {

--- a/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
@@ -11,6 +11,7 @@ import {
   isEmptyObject,
   setInitialEditMode,
   issuesNeedUpdating,
+  copyAreaOfDisagreementOptions,
 } from '../../utils/helpers';
 
 describe('someSelected', () => {
@@ -234,5 +235,56 @@ describe('issuesNeedUpdating', () => {
         [createEntry('test', '123'), createEntry('test2', '345')],
       ),
     ).to.be.false;
+  });
+});
+
+describe('copyAreaOfDisagreementOptions', () => {
+  it('should return original issues only', () => {
+    const result = [
+      { issue: 'test' },
+      { attributes: { ratingIssueSubjectText: 'test2' } },
+    ];
+    expect(copyAreaOfDisagreementOptions(result, [])).to.deep.equal(result);
+  });
+  it('should return additional issue with included options', () => {
+    const newIssues = [
+      { issue: 'test' },
+      { attributes: { ratingIssueSubjectText: 'test2' } },
+    ];
+    const existingIssues = [
+      { issue: 'test', disagreementOptions: { test: true } },
+    ];
+    const result = [
+      { issue: 'test', disagreementOptions: { test: true }, otherEntry: '' },
+      { attributes: { ratingIssueSubjectText: 'test2' } },
+    ];
+    expect(
+      copyAreaOfDisagreementOptions(newIssues, existingIssues),
+    ).to.deep.equal(result);
+  });
+  it('should return eligible issues with included options', () => {
+    const newIssues = [
+      { issue: 'test' },
+      { attributes: { ratingIssueSubjectText: 'test2' } },
+    ];
+    const existingIssues = [
+      {
+        attributes: { ratingIssueSubjectText: 'test2' },
+        disagreementOptions: { test: true },
+        otherEntry: 'ok',
+      },
+    ];
+    expect(
+      copyAreaOfDisagreementOptions(newIssues, existingIssues),
+    ).to.deep.equal([newIssues[0], existingIssues[0]]);
+  });
+
+  it('should return disagreement options & other entry', () => {
+    const result = [
+      { issue: 'test', disagreementOptions: { test: true }, otherEntry: 'ok' },
+    ];
+    expect(
+      copyAreaOfDisagreementOptions([{ issue: 'test' }], result),
+    ).to.deep.equal(result);
   });
 });

--- a/src/applications/appeals/10182/utils/helpers.js
+++ b/src/applications/appeals/10182/utils/helpers.js
@@ -62,6 +62,23 @@ export const issuesNeedUpdating = (loadedIssues = [], existingIssues = []) => {
   });
 };
 
+export const copyAreaOfDisagreementOptions = (newIssues, existingIssues) => {
+  return newIssues.map(issue => {
+    const foundIssue = (existingIssues || []).find(
+      entry => getIssueName(entry) === getIssueName(issue),
+    );
+    if (foundIssue) {
+      const { disagreementOptions = {}, otherEntry = '' } = foundIssue;
+      return {
+        ...issue,
+        disagreementOptions,
+        otherEntry,
+      };
+    }
+    return issue;
+  });
+};
+
 export const appStateSelector = state => ({
   // Validation functions are provided the pageData and not the
   // formData on the review & submit page. For more details


### PR DESCRIPTION
## Description

When altering either eligible (API-loaded) or additional (user added) issues, the area of disagreement data pages are built with blank choices. This PR ensures that previously selected issues will maintain their area of disagreement selections after making selections. Newly checked issues will continue provide an area of disagreement page with no selections.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/25213

## Testing done

Added unit tests for new function
Verified existing tests are still passing

## Screenshots

N/A

## Acceptance criteria
- [x] Previously selected issues will maintain their area of disagreement choices

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
