### PR TITLE
Fixes for review instances

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,6 +4,5 @@ build/*
 src/applications/**/README.md
 coverage/*
 temp/*
-tmp/*
 .nyc_output/*
 script/mocha.js

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -12,7 +12,7 @@ IS_DEV_BRANCH = env.BRANCH_NAME == DEV_BRANCH
 IS_STAGING_BRANCH = env.BRANCH_NAME == STAGING_BRANCH
 IS_PROD_BRANCH = env.BRANCH_NAME == PROD_BRANCH
 
-DOCKER_ARGS = "-v ${WORKSPACE}/vets-website:/application --ulimit nofile=8192:8192"
+DOCKER_ARGS = "-v ${WORKSPACE}/vets-website:/application -v ${WORKSPACE}/vagov-content:/vagov-content -v ${WORKSPACE}/content-build:/content-build --ulimit nofile=8192:8192"
 IMAGE_TAG = java.net.URLDecoder.decode(env.BUILD_TAG).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
 DOCKER_TAG = "vets-website:" + IMAGE_TAG
 
@@ -74,6 +74,15 @@ def slackIntegrationNotify() {
 
 def setup() {
   stage("Setup") {
+
+    dir("vagov-content") {
+      checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CloneOption', noTags: true, reference: '', shallow: true]], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'va-bot', url: 'git@github.com:department-of-veterans-affairs/vagov-content.git']]]
+    }
+
+    dir("content-build") {
+      checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CloneOption', noTags: true, reference: '', shallow: true]], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'va-bot', url: 'git@github.com:department-of-veterans-affairs/content-build.git']]]
+    }
+
     dir("vets-website") {
       sh "mkdir -p build"
       sh "mkdir -p logs/selenium"

--- a/script/review-entrypoint.sh
+++ b/script/review-entrypoint.sh
@@ -3,12 +3,12 @@
 # Build vets-website
 set -e
 yarn install --production=false
-npm run build -- --buildtype localhost --api='${API_URL}' --host='${WEB_HOST}' --port='${WEB_PORT}'
+npm run build -- --buildtype=localhost --api='${API_URL}' --host='${WEB_HOST}' --port='${WEB_PORT}'
 
 # Build content-build and serve site
 cd ../content-build
 yarn install --production=false
 npm run fetch-drupal-cache
-npm run build -- --buildtype localhost --api='${API_URL}' --host='${WEB_HOST}' --port='${WEB_PORT}' --apps-directory-name=application
+npm run build -- --buildtype=localhost --api='${API_URL}' --host='${WEB_HOST}' --port='${WEB_PORT}' --apps-directory-name=application
 npm run heroku-serve -- build/localhost -p 3002
 

--- a/script/watch.js
+++ b/script/watch.js
@@ -9,7 +9,7 @@ if (process.argv[2] === 'help') {
 
 // Otherwise, run the command
 runCommand(
-  `NODE_OPTIONS=--max-old-space-size=4096 webpack-dev-server --config config/webpack.config.js --env.scaffold --env.watch ${process.argv
+  `NODE_OPTIONS=--max-old-space-size=4096 webpack-dev-server --config config/webpack.config.js --env.watch=true ${process.argv
     .slice(2)
     .join(' ')}`,
 );

--- a/src/platform/landing-pages/dev-template.ejs
+++ b/src/platform/landing-pages/dev-template.ejs
@@ -8,7 +8,7 @@
     <title><%= htmlWebpackPlugin.options.title %></title>
 
     <script nonce="**CSP_NONCE**">
-      <%= loadInlineScript('record-event.js') %>
+      <%= inlineScripts['record-event.js'] %>
     </script>
 
 
@@ -121,7 +121,7 @@
     <script nonce="**CSP_NONCE**" type="text/javascript">
     (function() {
       var module = {};
-      <%= loadInlineScript('incompatible-browser.js') %>
+      <%= inlineScripts['incompatible-browser.js'] %>
       checkBrowserCompatibility();
     })();
     </script>
@@ -212,7 +212,7 @@
     <script nonce="**CSP_NONCE**" type="text/javascript">
       (function() {
       var module = {};
-      <%= loadInlineScript('static-page-widgets.js') %>
+      <%= inlineScripts['static-page-widgets.js'] %>
       mountWidgets(document.querySelectorAll('[data-widget-type]'), 6000);
       })();
     </script>

--- a/src/platform/testing/e2e/cypress/plugins/index.js
+++ b/src/platform/testing/e2e/cypress/plugins/index.js
@@ -5,24 +5,20 @@ const webpackPreprocessor = require('@cypress/webpack-preprocessor');
 module.exports = on => {
   const ENV = 'localhost';
 
-  // Import our own Webpack config.
-  require('../../../../../../config/webpack.config.js')(ENV).then(
-    webpackConfig => {
-      const options = {
-        webpackOptions: {
-          ...webpackConfig,
+  const options = {
+    webpackOptions: {
+      // Import our own Webpack config.
+      ...require('../../../../../../config/webpack.config.js')(ENV),
 
-          // Expose some Node globals.
-          node: {
-            __dirname: true,
-            __filename: true,
-          },
-        },
-      };
-
-      on('file:preprocessor', webpackPreprocessor(options));
+      // Expose some Node globals.
+      node: {
+        __dirname: true,
+        __filename: true,
+      },
     },
-  );
+  };
+
+  on('file:preprocessor', webpackPreprocessor(options));
 
   on('task', {
     /* eslint-disable no-console */


### PR DESCRIPTION
## Description
This reverts commit `fdd25300774df79851ffc17aa959be4dcbcb7149`.

The reliance on the `tmp` directory was breaking review instances, so we're reverting the refactor in the meantime.

We also corrected an improperly formatted `buildtype` argument in the entrypoint that caused the review instance to fail.

## Testing done
Working review instance in CI.

## Acceptance criteria
- [ ] Review instances should work.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
