### PR TITLE
Srsuddath improve typeahead clickthrough tracking

### DIFF
--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -141,11 +141,14 @@ class SearchApp extends React.Component {
   };
 
   onSearchResultClick = ({ bestBet, title, index, url }) => () => {
+    // clear the &t query param which is used to track typeahead searches
+    // removing this will better reflect how many typeahead searches result in at least one click
     window.history.replaceState(
       null,
       document.title,
       `${window.location.href.replace('&t=true', '')}`,
     );
+
     if (bestBet) {
       recordEvent({
         event: 'nav-searchresults',

--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -141,6 +141,11 @@ class SearchApp extends React.Component {
   };
 
   onSearchResultClick = ({ bestBet, title, index, url }) => () => {
+    window.history.replaceState(
+      null,
+      document.title,
+      `${window.location.href.replace('&t=true', '')}`,
+    );
     if (bestBet) {
       recordEvent({
         event: 'nav-searchresults',


### PR DESCRIPTION
## Description
We are currently using a query param to track when a user initiates a search using typeahead, and then clicks a search result.

There is a logic gap because a user can complete a search, click a result, and then hit "back" and click another search result. this registers two clicks, which is throwing off our analytics count.

Our intention is to only track one click after each typeahead search
