### PR TITLE
NOD: Fix review description styling

### DIFF
--- a/src/applications/appeals/10182/components/ReviewDescription.jsx
+++ b/src/applications/appeals/10182/components/ReviewDescription.jsx
@@ -41,7 +41,7 @@ const ReviewDescription = ({ profile }) => {
   return (
     <div className="form-review-panel-page">
       <div className="form-review-panel-page-header-row">
-        <h4 className="vads-u-font-size--h4 vads-u-margin--0">
+        <h4 className="vads-u-font-size--h5 vads-u-margin--0">
           Contact information
         </h4>
         <a


### PR DESCRIPTION
## Description

Fix "Contact information" header styling on Notice of Disagreement's review & submit page - apply `h5` styling to the `h4`

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/25211

## Testing done

N/A

## Screenshots

![Screen Shot 2021-05-25 at 11 16 01 AM](https://user-images.githubusercontent.com/136959/119534852-fd506280-bd4c-11eb-9822-12465bb691b5.png)

## Acceptance criteria
- [x] Contact information header styling matches other headers

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
