### PR TITLE
Included tmp in ESLint ignore file.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,5 +4,6 @@ build/*
 src/applications/**/README.md
 coverage/*
 temp/*
+tmp/*
 .nyc_output/*
 script/mocha.js


### PR DESCRIPTION
## Description
The ignore file already includes `temp/*`, but our processes tend to store temporary files in `tmp/*`.

This updates the ignore file to include that directory.

## Testing done
Linting doesn't fail on files in tmp.

## Acceptance criteria
- [ ] The linter should not pick up temporary files.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
