### PR TITLE
stop using VAOS data from Dashboard app

### DIFF
--- a/src/applications/personalization/dashboard-2/utils/timezone.js
+++ b/src/applications/personalization/dashboard-2/utils/timezone.js
@@ -1,4 +1,4 @@
-import timezones from '~/applications/vaos/utils/timezones.json';
+import timezones from './timezones.json';
 
 export const stripDST = abbr => {
   if (/^[PMCE][DS]T$/.test(abbr)) {

--- a/src/applications/personalization/dashboard-2/utils/timezones.json
+++ b/src/applications/personalization/dashboard-2/utils/timezones.json
@@ -1,0 +1,794 @@
+[
+  {
+    "id": "dfn-358",
+    "name": "MANILA VAMC",
+    "timezone": "Asia/Manila",
+    "currentTZ": "PHT"
+  },
+  {
+    "id": "dfn-519",
+    "name": "WEST TEXAS HCS",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-523",
+    "name": "BOSTON HCS VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-548",
+    "name": "WEST PALM BEACH VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-552",
+    "name": "DAYTON",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-585",
+    "name": "IRON MOUNTAIN VAMC",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-657",
+    "name": "ST. LOUIS MO VAMC-JC DIVISION",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-668",
+    "name": "SPOKANE VAMC",
+    "timezone": "America/Los_Angeles",
+    "currentTZ": "PST"
+  },
+  {
+    "id": "dfn-671",
+    "name": "SOUTH TEXAS HCS",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-675",
+    "name": "ORLANDO VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-506",
+    "name": "ANN ARBOR VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-526",
+    "name": "BRONX VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-608",
+    "name": "MANCHESTER VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-632",
+    "name": "NORTHPORT VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-437",
+    "name": "FARGO VA HCS",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-518",
+    "name": "BEDFORD VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-562",
+    "name": "ERIE VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-612",
+    "name": "NORTHERN CALIFORNIA HCS",
+    "timezone": "America/Los_Angeles",
+    "currentTZ": "PST"
+  },
+  {
+    "id": "dfn-613",
+    "name": "MARTINSBURG VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-618",
+    "name": "MINNEAPOLIS VA HCS",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-629",
+    "name": "SE LOUISIANA VETERANS HCS",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-637",
+    "name": "ASHEVILLE VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-674",
+    "name": "CENTRAL TEXAS HCS",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-687",
+    "name": "WALLA WALLA VAMC",
+    "timezone": "America/Los_Angeles",
+    "currentTZ": "PST"
+  },
+  {
+    "id": "dfn-540",
+    "name": "CLARKSBURG VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-550",
+    "name": "ILLIANA HCS",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-553",
+    "name": "DETROIT, MI VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-583",
+    "name": "INDIANAPOLIS VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-642",
+    "name": "PHILADELPHIA, PA VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-660",
+    "name": "SALT LAKE CITY HCS",
+    "timezone": "America/Denver",
+    "currentTZ": "MST"
+  },
+  {
+    "id": "dfn-688",
+    "name": "WASHINGTON",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-512",
+    "name": "BALTIMORE MD VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-459",
+    "name": "VA PACIFIC ISLANDS HCS",
+    "timezone": "Pacific/Honolulu",
+    "currentTZ": "HST"
+  },
+  {
+    "id": "dfn-573",
+    "name": "N. FLORIDA/S. GEORGIA VHS",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-640",
+    "name": "PALO ALTO HCS",
+    "timezone": "America/Los_Angeles",
+    "currentTZ": "PST"
+  },
+  {
+    "id": "dfn-648",
+    "name": "PORTLAND (OR) VAMC",
+    "timezone": "America/Los_Angeles",
+    "currentTZ": "PST"
+  },
+  {
+    "id": "dfn-650",
+    "name": "PROVIDENCE VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-655",
+    "name": "SAGINAW",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-537",
+    "name": "JESSE BROWN VAMC",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-541",
+    "name": "CLEVELAND VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-556",
+    "name": "CAPTN JAMES LOVELL FED HLT CTR",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-561",
+    "name": "EAST ORANGE-VA NEW JERSEY HCS",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-564",
+    "name": "FAYETTEVILLE AR",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-596",
+    "name": "LEXINGTON-LD VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-621",
+    "name": "MOUNTAIN HOME VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-656",
+    "name": "ST. CLOUD VA HCS",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-659",
+    "name": "SALISBURY VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-693",
+    "name": "WILKES-BARRE VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-436",
+    "name": "FORT HARRISON VAMC",
+    "timezone": "America/Denver",
+    "currentTZ": "MST"
+  },
+  {
+    "id": "dfn-528",
+    "name": "UPSTATE NEW YORK HCS",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-534",
+    "name": "CHARLESTON VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-538",
+    "name": "CHILLICOTHE, OH VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-554",
+    "name": "EASTERN COLORADO HCS",
+    "timezone": "America/Denver",
+    "currentTZ": "MST"
+  },
+  {
+    "id": "dfn-603",
+    "name": "LOUISVILLE, KY VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-666",
+    "name": "SHERIDAN HCS",
+    "timezone": "America/Denver",
+    "currentTZ": "MST"
+  },
+  {
+    "id": "dfn-689",
+    "name": "CONNECTICUT HCS",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-442",
+    "name": "CHEYENNE VAMC",
+    "timezone": "America/Denver",
+    "currentTZ": "MST"
+  },
+  {
+    "id": "dfn-503",
+    "name": "ALTOONA",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-575",
+    "name": "GRAND JUNCTION (VAMC)",
+    "timezone": "America/Denver",
+    "currentTZ": "MST"
+  },
+  {
+    "id": "dfn-590",
+    "name": "HAMPTON (VAMC)",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-598",
+    "name": "CENTRAL ARKANSAS HCS",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-620",
+    "name": "HUDSON VALLEY HCS VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-623",
+    "name": "JACK C. MONTGOMERY VAMC",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-636",
+    "name": "VA NWIHS, OMAHA DIVISION",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-595",
+    "name": "LEBANON VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-593",
+    "name": "SOUTHERN NEVADA HCS",
+    "timezone": "America/Los_Angeles",
+    "currentTZ": "PST"
+  },
+  {
+    "id": "dfn-756",
+    "name": "EL PASO VA HCS",
+    "timezone": "America/Denver",
+    "currentTZ": "MST"
+  },
+  {
+    "id": "dfn-757",
+    "name": "COLUMBUS VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-405",
+    "name": "WHITE RIVER JUNCT VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-531",
+    "name": "BOISE VAMC",
+    "timezone": "America/Denver",
+    "currentTZ": "MST"
+  },
+  {
+    "id": "dfn-542",
+    "name": "COATESVILLE VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-549",
+    "name": "NORTH TEXAS HCS",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-558",
+    "name": "DURHAM VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-565",
+    "name": "FAYETTEVILLE NC VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-570",
+    "name": "CENTRAL CALIFORNIA HCS",
+    "timezone": "America/Los_Angeles",
+    "currentTZ": "PST"
+  },
+  {
+    "id": "dfn-581",
+    "name": "HUNTINGTON VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-631",
+    "name": "VA CNTRL WSTRN MASSCHUSETS HCS",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-673",
+    "name": "TAMPA VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-672",
+    "name": "SAN JUAN VAMC",
+    "timezone": "America/Argentina/San_Juan",
+    "currentTZ": "ART"
+  },
+  {
+    "id": "dfn-740",
+    "name": "TEXAS VALLEY COASTAL BEND HCS",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-463",
+    "name": "ANCHORAGE VA HCS",
+    "timezone": "America/Anchorage",
+    "currentTZ": "AKST"
+  },
+  {
+    "id": "dfn-501",
+    "name": "NEW MEXICO HCS",
+    "timezone": "America/Denver",
+    "currentTZ": "MST"
+  },
+  {
+    "id": "dfn-515",
+    "name": "BATTLE CREEK VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-568",
+    "name": "BLACK HILLS HCS",
+    "timezone": "America/Denver",
+    "currentTZ": "MST"
+  },
+  {
+    "id": "dfn-580",
+    "name": "HOUSTON VAMC",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-619",
+    "name": "CENTRAL ALABAMA HCS",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-654",
+    "name": "SIERRA NEVADA HCS",
+    "timezone": "America/Los_Angeles",
+    "currentTZ": "PST"
+  },
+  {
+    "id": "dfn-663",
+    "name": "PUGET SOUND HCS",
+    "timezone": "America/Los_Angeles",
+    "currentTZ": "PST"
+  },
+  {
+    "id": "dfn-676",
+    "name": "TOMAH VAMC",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-679",
+    "name": "TUSCALOOSA",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-402",
+    "name": "VA MAINE HCS",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-520",
+    "name": "BILOXI VAMC",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-649",
+    "name": "NORTHERN ARIZONA HCS",
+    "timezone": "America/Phoenix",
+    "currentTZ": "MST"
+  },
+  {
+    "id": "dfn-658",
+    "name": "SALEM VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-662",
+    "name": "SAN FRANCISCO VAMC",
+    "timezone": "America/Los_Angeles",
+    "currentTZ": "PST"
+  },
+  {
+    "id": "dfn-678",
+    "name": "SOUTHERN ARIZONA VA HCS",
+    "timezone": "America/Phoenix",
+    "currentTZ": "MST"
+  },
+  {
+    "id": "dfn-438",
+    "name": "SIOUX FALLS VA HCS",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-502",
+    "name": "ALEXANDRIA VAMC",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-504",
+    "name": "AMARILLO HCS",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-509",
+    "name": "AUGUSTA VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-517",
+    "name": "BECKLEY VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-539",
+    "name": "CINCINNATI",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-578",
+    "name": "HINES, IL VAMC",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-586",
+    "name": "JACKSON VAMC",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-600",
+    "name": "LONG BEACH VAMC",
+    "timezone": "America/Los_Angeles",
+    "currentTZ": "PST"
+  },
+  {
+    "id": "dfn-626",
+    "name": "TENNESSEE VALLEY HCS",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-644",
+    "name": "PHOENIX VAMC",
+    "timezone": "America/Phoenix",
+    "currentTZ": "MST"
+  },
+  {
+    "id": "dfn-646",
+    "name": "PITTSBURGH (UD), PA VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-652",
+    "name": "RICHMOND VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-664",
+    "name": "SAN DIEGO HCS",
+    "timezone": "America/Los_Angeles",
+    "currentTZ": "PST"
+  },
+  {
+    "id": "dfn-667",
+    "name": "SHREVEPORT VAMC",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-691",
+    "name": "WEST LA VAMC",
+    "timezone": "America/Los_Angeles",
+    "currentTZ": "PST"
+  },
+  {
+    "id": "dfn-460",
+    "name": "WILMINGTON VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-521",
+    "name": "BIRMINGHAM VAMC",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-529",
+    "name": "BUTLER",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-546",
+    "name": "MIAMI VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-605",
+    "name": "LOMA LINDA HCS",
+    "timezone": "America/Los_Angeles",
+    "currentTZ": "PST"
+  },
+  {
+    "id": "dfn-607",
+    "name": "WILLIAM S. MIDDLETON VAMC",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-610",
+    "name": "MARION, IN",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-630",
+    "name": "NEW YORK HHS",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-653",
+    "name": "ROSEBURG HCS",
+    "timezone": "America/Los_Angeles",
+    "currentTZ": "PST"
+  },
+  {
+    "id": "dfn-695",
+    "name": "MILWAUKEE VAMC",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-508",
+    "name": "ATLANTA VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-544",
+    "name": "COLUMBIA, SC VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-557",
+    "name": "DUBLIN VAMC",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-589",
+    "name": "VA HEARTLAND - WEST, VISN 15",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-614",
+    "name": "MEMPHIS VAMC",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-635",
+    "name": "OKLAHOMA CITY VAMC",
+    "timezone": "America/Chicago",
+    "currentTZ": "CST"
+  },
+  {
+    "id": "dfn-692",
+    "name": "WHITE CITY VAMC",
+    "timezone": "America/Los_Angeles",
+    "currentTZ": "PST"
+  },
+  {
+    "id": "dfn-516",
+    "name": "Bay Pines VA Healthcare System",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  },
+  {
+    "id": "dfn-983",
+    "name": "CHYSHR-Cheyenne VA Medical Center",
+    "timezone": "America/Denver",
+    "currentTZ": "MST"
+  },
+  {
+    "id": "dfn-984",
+    "name": "DAYTSHR-Dayton VA Medical Center",
+    "timezone": "America/New_York",
+    "currentTZ": "EST"
+  }
+]


### PR DESCRIPTION
## Description
Apps should not be importing code from other apps. This fixes an instance of that.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs