### PR TITLE
feat(1010cg): send Source-App-Name header with every request

### DIFF
--- a/src/applications/caregivers/app-entry.jsx
+++ b/src/applications/caregivers/app-entry.jsx
@@ -11,4 +11,5 @@ startApp({
   url: manifest.rootUrl,
   reducer,
   routes,
+  entryName: manifest.entryName,
 });

--- a/src/applications/caregivers/components/SubmitError/DownloadLink.jsx
+++ b/src/applications/caregivers/components/SubmitError/DownloadLink.jsx
@@ -29,7 +29,7 @@ const DownLoadLink = ({ form }) => {
         body: transformedData,
         headers: {
           'Content-Type': 'application/json',
-          'Source-App-Name': 'caregivers-10-10cg-',
+          'Source-App-Name': window.appName,
         },
       },
     )

--- a/src/platform/forms-system/src/js/actions.js
+++ b/src/platform/forms-system/src/js/actions.js
@@ -143,6 +143,7 @@ export function submitToUrl(body, submitUrl, trackingPrefix, eventData) {
     req.setRequestHeader('X-Key-Inflection', 'camel');
     req.setRequestHeader('Content-Type', 'application/json');
     req.setRequestHeader('X-CSRF-Token', csrfTokenStored);
+    req.setRequestHeader('Source-App-Name', window.appName);
     req.withCredentials = true;
 
     req.send(body);
@@ -338,6 +339,7 @@ export function uploadFile(
 
     req.setRequestHeader('X-Key-Inflection', 'camel');
     req.setRequestHeader('X-CSRF-Token', csrfTokenStored);
+    req.setRequestHeader('Source-App-Name', window.appName);
     req.withCredentials = true;
     req.send(payload);
 


### PR DESCRIPTION
## Description
Send `Source-App-Name` with all requests to the backend for 1010cg. Update FileUpload component request as well as Forms System submit request to send `Source-App-Name`. This fixes up `not_provided` and `not_in_allowlist` in this [gragana dashboard](http://grafana.vfs.va.gov/d/zGS4XzkMk/backend-to-frontend-app-mapping?orgId=1&var-data_source=Prometheus%20(Production)&var-backend_controller=v0%2Fcaregivers_assistance_claims&var-frontend_app=All&from=now-7d&to=now)

## Testing done
- [ ] Manual

## Screenshots
![image](https://user-images.githubusercontent.com/83595736/119553263-7a89d080-bd69-11eb-84e9-9fab078bf1f6.png)
![image](https://user-images.githubusercontent.com/83595736/119553277-7eb5ee00-bd69-11eb-8dcd-da51f886e576.png)
![image](https://user-images.githubusercontent.com/83595736/119553292-82497500-bd69-11eb-9b5c-4aa37ae5af68.png)


## Acceptance criteria
- [x] Send `Source-App-Name` with file upload request
- [x] Send `Source-App-Name` with Forms System submit
- [x] Send `Source-App-Name` of  `1010cg-application-caregiver-assistance` not `caregivers-10-10cg-`

## Definition of done
- [ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/21126)
