### PR TITLE
24829 va request pending detail page updates

### DIFF
--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
@@ -136,6 +136,9 @@ export default function RequestedAppointmentDetailsPage() {
   const isCCRequest =
     appointment.vaos.appointmentType === APPOINTMENT_TYPES.ccRequest;
   const provider = appointment.preferredCommunityCareProviders?.[0];
+  const apptDetails = message
+    ? `${appointment.reason}: ${message}`
+    : appointment.reason;
 
   return (
     <PageLayout>
@@ -146,6 +149,16 @@ export default function RequestedAppointmentDetailsPage() {
       <h1>
         {canceled ? 'Canceled' : 'Pending'} {typeOfCareText} appointment
       </h1>
+      {!showConfirmMsg &&
+        !canceled && (
+          <AlertBox
+            status="info"
+            className="vads-u-display--block vads-u-margin-bottom--2"
+            backgroundOnly
+          >
+            The time and date of this appointment are still to be determined.
+          </AlertBox>
+        )}
       {showConfirmMsg && (
         <AlertBox
           status={canceled ? 'error' : 'success'}
@@ -228,9 +241,9 @@ export default function RequestedAppointmentDetailsPage() {
       </ul>
       <div className="vaos-u-word-break--break-word">
         <h2 className="vads-u-margin-top--2 vaos-appts__block-label">
-          {appointment.reason}
+          You shared these details about your concern
         </h2>
-        <div>{message}</div>
+        <div>{apptDetails}</div>
       </div>
       <h2 className="vads-u-margin-top--2 vads-u-margin-bottom--0 vaos-appts__block-label">
         Your contact details

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
@@ -120,6 +120,11 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
       }),
     );
 
+    expect(screen.baseElement).to.contain('.usa-alert-info');
+    expect(screen.baseElement).to.contain.text(
+      'The time and date of this appointment are still to be determined.',
+    );
+
     expect(screen.getByText('Cheyenne VA Medical Center')).to.be.ok;
     expect(screen.baseElement).to.contain.text(
       'Pending primary care appointment',
@@ -287,9 +292,10 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
     expect(
       screen.getByRole('heading', {
         level: 2,
-        name: 'Follow-up/Routine',
+        name: 'You shared these details about your concern',
       }),
     ).to.be.ok;
+    expect(screen.getByText('Follow-up/Routine')).to.be.ok;
 
     expect(
       screen.getByRole('heading', {


### PR DESCRIPTION
## Description
Clean up designs and copy on the request pending VA appointment detail page.
![image](https://user-images.githubusercontent.com/8315447/119557993-defb5e80-bd6e-11eb-96e0-524e5a5ff10d.png)

## Testing done
Local and unit

## Screenshots
Request Page
<img width="677" alt="image" src="https://user-images.githubusercontent.com/8315447/119557965-d7d45080-bd6e-11eb-8af8-4c562e992191.png">
Canceled Request Page
<img width="677" alt="image" src="https://user-images.githubusercontent.com/8315447/119558150-0fdb9380-bd6f-11eb-83c1-3da94282a932.png">
New Request Page
<img width="677" alt="image" src="https://user-images.githubusercontent.com/8315447/119558318-3f8a9b80-bd6f-11eb-86a1-3d6d3f1eb414.png">

## Acceptance criteria
- [ ]Changes are behind the va_online_scheduling_homepage_refresh feature flag
- CONTENT - Content matches the copy doc
- DESIGN - Designs match the specs (copy is FPO)
    Desktop
    Tablet
    Mobile
- [ ] Heading layout reference overview and content detail

## Out of Scope
Detail page navigation: breadcrumbs, back to appointments button

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
