### PR TITLE
Set minutes duration on current confirmation page

### DIFF
--- a/src/applications/vaos/covid-19-vaccine/components/ConfirmationPage.jsx
+++ b/src/applications/vaos/covid-19-vaccine/components/ConfirmationPage.jsx
@@ -17,7 +17,13 @@ import {
 
 const pageTitle = 'We’ve scheduled your appointment';
 
-function ConfirmationPage({ data, systemId, facilityDetails, submitStatus }) {
+function ConfirmationPage({
+  data,
+  systemId,
+  slot,
+  facilityDetails,
+  submitStatus,
+}) {
   useEffect(() => {
     document.title = `${pageTitle} | Veterans Affairs`;
     scrollAndFocus();
@@ -32,6 +38,8 @@ function ConfirmationPage({ data, systemId, facilityDetails, submitStatus }) {
     moment(data.date1, 'YYYY-MM-DDTHH:mm:ssZ').format(
       'dddd, MMMM D, YYYY [at] h:mm a ',
     ) + getTimezoneAbbrBySystemId(systemId);
+
+  const appointmentLength = moment(slot.end).diff(slot.start, 'minutes');
 
   return (
     <div>
@@ -83,7 +91,7 @@ function ConfirmationPage({ data, systemId, facilityDetails, submitStatus }) {
             }}
             location={formatFacilityAddress(facilityDetails)}
             startDateTime={data.date1[0]}
-            duration={30}
+            duration={appointmentLength}
           />
         </div>
       </div>


### PR DESCRIPTION
## Description
This PR
- Sets the duration for the calendar to the difference between the slot start and end date, like how the V2 page calculates it.

## Testing done
Unit testing

## Acceptance criteria
- [ ] Duration is correct

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
