### PR TITLE
Display appointment dates correctly

### DIFF
--- a/src/applications/personalization/appointments/actions/index.js
+++ b/src/applications/personalization/appointments/actions/index.js
@@ -32,7 +32,7 @@ function isVideoVisit(appt) {
  * @param {Object} appt VAR appointment object
  * @returns {Object} Returns appointment datetime as moment object
  */
-function getMomentConfirmedDate(type, appt) {
+function getLocalAppointmentDate(type, appt) {
   if (type === 'cc') {
     const zoneSplit = appt.timeZone.split(' ');
     const offset = zoneSplit.length > 1 ? zoneSplit[0] : '+0:00';
@@ -218,7 +218,7 @@ export function fetchConfirmedFutureAppointments() {
           id: appointment.id,
           isVideo: isVideoVisit(appointment.attributes),
           providerName: facility?.attributes?.name,
-          startsAt: getMomentConfirmedDate(
+          startsAt: getLocalAppointmentDate(
             'va',
             appointment.attributes,
           ).format(),
@@ -248,7 +248,7 @@ export function fetchConfirmedFutureAppointments() {
           id: appointment.id,
           isVideo: false,
           providerName: appointment.attributes?.providerPractice,
-          startsAt: getMomentConfirmedDate(
+          startsAt: getLocalAppointmentDate(
             'cc',
             appointment.attributes,
           ).format(),

--- a/src/applications/personalization/appointments/actions/index.js
+++ b/src/applications/personalization/appointments/actions/index.js
@@ -1,7 +1,9 @@
-import moment from 'moment';
-import { replace, uniq, isEmpty } from 'lodash';
+import { replace, uniq } from 'lodash';
+
 import environment from '~/platform/utilities/environment';
 import { apiRequest } from '~/platform/utilities/api';
+
+import moment from '~/applications/personalization/dashboard-2/lib/moment-tz';
 import {
   getCCTimeZone,
   getVATimeZone,
@@ -208,15 +210,18 @@ export function fetchConfirmedFutureAppointments() {
 
         // Derive the facility.
         const facility =
-          facilitiesLookup[getStagingID(appointment.attributes?.facilityId)];
+          facilitiesLookup[getStagingID(appointment.attributes.facilityId)];
 
         accumulator.push({
           additionalInfo: getAdditionalInfo(appointment),
           facility,
-          id: appointment?.id,
-          isVideo: !isEmpty(appointment?.attributes?.vvsAppointments),
+          id: appointment.id,
+          isVideo: isVideoVisit(appointment.attributes),
           providerName: facility?.attributes?.name,
-          startsAt: startDate.toISOString(),
+          startsAt: getMomentConfirmedDate(
+            'va',
+            appointment.attributes,
+          ).format(),
           type: 'va',
           timeZone: getVATimeZone(
             getStagingID(appointment?.attributes?.facilityId),

--- a/src/applications/personalization/appointments/actions/index.unit.spec.js
+++ b/src/applications/personalization/appointments/actions/index.unit.spec.js
@@ -8,10 +8,7 @@ import environment from '~/platform/utilities/environment';
 
 import {
   FETCH_CONFIRMED_FUTURE_APPOINTMENTS,
-  // FETCH_CONFIRMED_FUTURE_APPOINTMENTS_FAILED,
   FETCH_CONFIRMED_FUTURE_APPOINTMENTS_SUCCEEDED,
-  // FUTURE_APPOINTMENTS_HIDDEN_SET,
-  // VIDEO_TYPES,
 } from '~/applications/personalization/dashboard-2/constants';
 
 import { fetchConfirmedFutureAppointments } from './index';

--- a/src/applications/personalization/appointments/actions/index.unit.spec.js
+++ b/src/applications/personalization/appointments/actions/index.unit.spec.js
@@ -1,0 +1,388 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+
+import { resetFetch } from '~/platform/testing/unit/helpers';
+import environment from '~/platform/utilities/environment';
+
+import {
+  FETCH_CONFIRMED_FUTURE_APPOINTMENTS,
+  // FETCH_CONFIRMED_FUTURE_APPOINTMENTS_FAILED,
+  FETCH_CONFIRMED_FUTURE_APPOINTMENTS_SUCCEEDED,
+  // FUTURE_APPOINTMENTS_HIDDEN_SET,
+  // VIDEO_TYPES,
+} from '~/applications/personalization/dashboard-2/constants';
+
+import { fetchConfirmedFutureAppointments } from './index';
+
+function thisYear() {
+  return new Date().getFullYear();
+}
+
+function nextYear() {
+  return new Date().getFullYear() + 1;
+}
+
+// A single appointment in Florida at midnight Jan 1 next year UTC. The action
+// will filter out any appointments in the past.
+const mockCCAppointmentData = {
+  data: [
+    {
+      id: '8a4885896a22f88f016a2c8834b1005d',
+      type: 'cc_appointments',
+      attributes: {
+        appointmentRequestId: '8a4885896a22f88f016a2c8834b1005d',
+        distanceEligibleConfirmed: true,
+        name: { firstName: '', lastName: '' },
+        providerPractice: 'Atlantic Medical Care',
+        providerPhone: '(407) 555-1212',
+        address: {
+          street: '123 Main Street',
+          city: 'Orlando',
+          state: 'FL',
+          zipCode: '32826',
+        },
+        instructionsToVeteran: 'Please arrive 15 minutes ahead of appointment.',
+        // appointmentTime timestamps are UTC
+        appointmentTime: `01/01/${nextYear()} 00:00:00`,
+        timeZone: '-05:00 EST',
+      },
+    },
+  ],
+  meta: {
+    pagination: {
+      currentPage: 0,
+      perPage: 0,
+      totalPages: 0,
+      totalEntries: 0,
+    },
+    errors: [],
+  },
+};
+
+// A single appointment at facility 442, CHEYENNE WYOMING at midnight Jan 1 next
+// year UTC. The action will filter out any appointments in the past.ß
+const mockVAAppointmentData = {
+  data: [
+    {
+      id: '202101010000983000103800000000000000',
+      type: 'va_appointments',
+      attributes: {
+        char4: 'CDQC',
+        clinicId: '1038',
+        clinicFriendlyName: 'COVID VACCINE CLIN1',
+        communityCare: false,
+        facilityId: '442',
+        phoneOnly: null,
+        startDate: `${nextYear()}-01-01T00:00:00Z`,
+        sta6aid: '442',
+        vdsAppointments: [
+          {
+            bookingNote: null,
+            appointmentLength: '15',
+            id: '1038;20210525.083000',
+            appointmentTime: `${nextYear()}-01-01T00:00:00Z`,
+            clinic: {
+              name: 'COVID VACCINE CLIN1',
+              specialty: 'GENERAL INTERNAL MEDICINE',
+              stopCode: '301',
+              askForCheckIn: false,
+              facilityCode: '442',
+            },
+            type: 'REGULAR',
+            currentStatus: 'FUTURE',
+          },
+        ],
+        vvsAppointments: [],
+      },
+    },
+  ],
+  meta: {
+    pagination: {
+      currentPage: 0,
+      perPage: 0,
+      totalPages: 0,
+      totalEntries: 0,
+    },
+    errors: [],
+  },
+};
+
+const mockEmptyAppointmentData = {
+  data: [],
+  meta: {
+    pagination: {
+      currentPage: 0,
+      perPage: 0,
+      totalPages: 0,
+      totalEntries: 0,
+    },
+    errors: [],
+  },
+};
+
+// The important part of this mock facility data is that it returns data for
+// facility ID 442 in Cheyenne, Wyoming, which matches the facility of the
+// single appointment in the mockVAAppointmentData
+const mockFacilityData = {
+  data: [
+    {
+      id: 'vha_442',
+      type: 'facility',
+      attributes: {
+        access: {
+          health: [
+            {
+              service: 'Audiology',
+              new: 18.305555,
+              established: 4.158798,
+            },
+            {
+              service: 'Cardiology',
+              new: 18.9375,
+              established: 20.305555,
+            },
+            { service: 'Dermatology', new: 0.0, established: null },
+            {
+              service: 'Gastroenterology',
+              new: 7.5,
+              established: 15.421052,
+            },
+            { service: 'Gynecology', new: 35.0, established: 15.235294 },
+            {
+              service: 'MentalHealthCare',
+              new: 6.375,
+              established: 5.204986,
+            },
+            {
+              service: 'Ophthalmology',
+              new: 14.166666,
+              established: 18.217741,
+            },
+            {
+              service: 'Optometry',
+              new: 57.536585,
+              established: 64.323076,
+            },
+            {
+              service: 'Orthopedics',
+              new: 20.943396,
+              established: 7.179487,
+            },
+            {
+              service: 'PrimaryCare',
+              new: 16.972972,
+              established: 12.035647,
+            },
+            {
+              service: 'SpecialtyCare',
+              new: 16.841079,
+              established: 10.828016,
+            },
+            { service: 'Urology', new: 62.0, established: 37.333333 },
+            { service: 'WomensHealth', new: 14.0, established: 14.723404 },
+          ],
+          effectiveDate: '2021-05-17',
+        },
+        activeStatus: 'A',
+        address: {
+          mailing: {},
+          physical: {
+            zip: '82001-5356',
+            city: 'Cheyenne',
+            state: 'WY',
+            address1: '2360 East Pershing Boulevard',
+            address2: null,
+            address3: null,
+          },
+        },
+        classification: 'VA Medical Center (VAMC)',
+        detailedServices: [
+          {
+            name: 'COVID-19 vaccines',
+            descriptionFacility: null,
+            appointmentLeadin:
+              "Your VA health care team will contact you if you’re eligible to get a vaccine during this time. As the supply of vaccine increases, we'll work with our care teams to let Veterans know their options.",
+            appointmentPhones: [
+              {
+                extension: null,
+                label: 'Main phone',
+                number: '307-778-7550',
+                type: 'tel',
+              },
+            ],
+            onlineSchedulingAvailable: null,
+            referralRequired: 'true',
+            walkInsAccepted: 'false',
+            serviceLocations: null,
+            path: 'https://www.cheyenne.va.gov/services/covid-19-vaccines.asp',
+          },
+        ],
+        facilityType: 'va_health_facility',
+        feedback: {
+          health: {
+            primaryCareUrgent: 0.6700000166893005,
+            primaryCareRoutine: 0.8399999737739563,
+            specialtyCareUrgent: 0.7200000286102295,
+            specialtyCareRoutine: 0.800000011920929,
+          },
+          effectiveDate: '2021-03-05',
+        },
+        hours: {
+          friday: '24/7',
+          monday: '24/7',
+          sunday: '24/7',
+          tuesday: '24/7',
+          saturday: '24/7',
+          thursday: '24/7',
+          wednesday: '24/7',
+        },
+        id: 'vha_442',
+        lat: 41.148027,
+        long: -104.7862575,
+        mobile: false,
+        name: 'Cheyenne VA Medical Center',
+        operatingStatus: { code: 'NORMAL' },
+        operationalHoursSpecialInstructions:
+          'More hours are available for some services. To learn more, call our main phone number. |',
+        phone: {
+          fax: '307-778-7381',
+          main: '307-778-7550',
+          pharmacy: '866-420-6337',
+          afterHours: '307-778-7550',
+          patientAdvocate: '307-778-7550 x7517',
+          mentalHealthClinic: '307-778-7349',
+          enrollmentCoordinator: '307-778-7550 x7579',
+        },
+        services: {
+          other: [],
+          health: [
+            'Audiology',
+            'Cardiology',
+            'Covid19Vaccine',
+            'DentalServices',
+            'Dermatology',
+            'EmergencyCare',
+            'Gastroenterology',
+            'Gynecology',
+            'MentalHealthCare',
+            'Nutrition',
+            'Ophthalmology',
+            'Optometry',
+            'Orthopedics',
+            'Podiatry',
+            'PrimaryCare',
+            'SpecialtyCare',
+            'Urology',
+            'WomensHealth',
+          ],
+          lastUpdated: '2021-05-17',
+        },
+        uniqueId: '442',
+        visn: '19',
+        website: 'https://www.cheyenne.va.gov/locations/directions.asp',
+      },
+    },
+  ],
+  meta: {
+    pagination: {
+      currentPage: 1,
+      prevPage: null,
+      nextPage: null,
+      totalPages: 1,
+    },
+  },
+  links: {
+    self:
+      'https://staging-api.va.gov/v1/facilities/va?ids=vha_442&page=1&per_page=10',
+    first:
+      'https://staging-api.va.gov/v1/facilities/va?ids=vha_442&per_page=10',
+    prev: null,
+    next: null,
+    last:
+      'https://staging-api.va.gov/v1/facilities/va?ids=vha_442&page=1&per_page=10',
+  },
+};
+
+// The default API mock that returns facility data
+const mocks = [
+  rest.get(`${environment.API_URL}/v1/facilities/va`, (_, res, ctx) => {
+    return res(ctx.json(mockFacilityData));
+  }),
+];
+
+describe('fetchConfirmedFutureAppointments', () => {
+  let server;
+  before(() => {
+    // before we can use msw, we need to make sure that global.fetch has been
+    // restored and is no longer a sinon stub.
+    resetFetch();
+    server = setupServer(...mocks);
+    server.listen();
+  });
+  afterEach(() => {
+    server.resetHandlers();
+  });
+  after(() => {
+    server.close();
+  });
+  it('correctly adds a timezone offset to the start date/time of CC appointments', async () => {
+    const dispatch = sinon.spy();
+    // mock the appointments API, making sure to return no VA appointments
+    server.use(
+      rest.get(
+        `${environment.API_URL}/vaos/v0/appointments`,
+        (req, res, ctx) => {
+          const type = req.url.searchParams.get('type');
+          if (type === 'cc') {
+            return res(ctx.json(mockCCAppointmentData));
+          }
+          return res(ctx.json(mockEmptyAppointmentData));
+        },
+      ),
+    );
+    return fetchConfirmedFutureAppointments()(dispatch).then(() => {
+      expect(dispatch.firstCall.args[0].type).to.equal(
+        FETCH_CONFIRMED_FUTURE_APPOINTMENTS,
+      );
+      expect(dispatch.secondCall.args[0].type).to.equal(
+        FETCH_CONFIRMED_FUTURE_APPOINTMENTS_SUCCEEDED,
+      );
+      const { appointments } = dispatch.secondCall.args[0];
+      // Midnight Jan 1 UTC is 7PM Dec 31 Florida time
+      expect(appointments[0].startsAt).to.equal(
+        `${thisYear()}-12-31T19:00:00-0500`,
+      );
+    });
+  });
+  it('correctly adds a timezone offset to the start date/time of VA appointments', () => {
+    const dispatch = sinon.spy();
+    // mock the appointments API, making sure to return no CC appointments
+    server.use(
+      rest.get(
+        `${environment.API_URL}/vaos/v0/appointments`,
+        (req, res, ctx) => {
+          const type = req.url.searchParams.get('type');
+          if (type === 'va') {
+            return res(ctx.json(mockVAAppointmentData));
+          }
+          return res(ctx.json(mockEmptyAppointmentData));
+        },
+      ),
+    );
+    return fetchConfirmedFutureAppointments()(dispatch).then(() => {
+      expect(dispatch.firstCall.args[0].type).to.equal(
+        FETCH_CONFIRMED_FUTURE_APPOINTMENTS,
+      );
+      expect(dispatch.secondCall.args[0].type).to.equal(
+        FETCH_CONFIRMED_FUTURE_APPOINTMENTS_SUCCEEDED,
+      );
+      const { appointments } = dispatch.secondCall.args[0];
+      // Midnight Jan 1 UTC is 5PM Dec 31 Cheyenne (Mountain) time
+      expect(appointments[0].startsAt).to.equal(
+        `${thisYear()}-12-31T17:00:00-0700`,
+      );
+    });
+  });
+});

--- a/src/applications/personalization/appointments/actions/index.unit.spec.js
+++ b/src/applications/personalization/appointments/actions/index.unit.spec.js
@@ -381,7 +381,7 @@ describe('fetchConfirmedFutureAppointments', () => {
       const { appointments } = dispatch.secondCall.args[0];
       // Midnight Jan 1 UTC is 5PM Dec 31 Cheyenne (Mountain) time
       expect(appointments[0].startsAt).to.equal(
-        `${thisYear()}-12-31T17:00:00-0700`,
+        `${thisYear()}-12-31T17:00:00-07:00`,
       );
     });
   });

--- a/src/applications/personalization/appointments/actions/index.unit.spec.js
+++ b/src/applications/personalization/appointments/actions/index.unit.spec.js
@@ -352,7 +352,7 @@ describe('fetchConfirmedFutureAppointments', () => {
       const { appointments } = dispatch.secondCall.args[0];
       // Midnight Jan 1 UTC is 7PM Dec 31 Florida time
       expect(appointments[0].startsAt).to.equal(
-        `${thisYear()}-12-31T19:00:00-0500`,
+        `${thisYear()}-12-31T19:00:00-05:00`,
       );
     });
   });

--- a/src/applications/personalization/appointments/actions/index.unit.spec.js
+++ b/src/applications/personalization/appointments/actions/index.unit.spec.js
@@ -339,21 +339,21 @@ describe('fetchConfirmedFutureAppointments', () => {
         },
       ),
     );
-    return fetchConfirmedFutureAppointments()(dispatch).then(() => {
-      expect(dispatch.firstCall.args[0].type).to.equal(
-        FETCH_CONFIRMED_FUTURE_APPOINTMENTS,
-      );
-      expect(dispatch.secondCall.args[0].type).to.equal(
-        FETCH_CONFIRMED_FUTURE_APPOINTMENTS_SUCCEEDED,
-      );
-      const { appointments } = dispatch.secondCall.args[0];
-      // Midnight Jan 1 UTC is 7PM Dec 31 Florida time
-      expect(appointments[0].startsAt).to.equal(
-        `${thisYear()}-12-31T19:00:00-05:00`,
-      );
-    });
+    await fetchConfirmedFutureAppointments()(dispatch);
+
+    expect(dispatch.firstCall.args[0].type).to.equal(
+      FETCH_CONFIRMED_FUTURE_APPOINTMENTS,
+    );
+    expect(dispatch.secondCall.args[0].type).to.equal(
+      FETCH_CONFIRMED_FUTURE_APPOINTMENTS_SUCCEEDED,
+    );
+    const { appointments } = dispatch.secondCall.args[0];
+    // Midnight Jan 1 UTC is 7PM Dec 31 Florida time
+    expect(appointments[0].startsAt).to.equal(
+      `${thisYear()}-12-31T19:00:00-05:00`,
+    );
   });
-  it('correctly adds a timezone offset to the start date/time of VA appointments', () => {
+  it('correctly adds a timezone offset to the start date/time of VA appointments', async () => {
     const dispatch = sinon.spy();
     // mock the appointments API, making sure to return no CC appointments
     server.use(
@@ -368,18 +368,18 @@ describe('fetchConfirmedFutureAppointments', () => {
         },
       ),
     );
-    return fetchConfirmedFutureAppointments()(dispatch).then(() => {
-      expect(dispatch.firstCall.args[0].type).to.equal(
-        FETCH_CONFIRMED_FUTURE_APPOINTMENTS,
-      );
-      expect(dispatch.secondCall.args[0].type).to.equal(
-        FETCH_CONFIRMED_FUTURE_APPOINTMENTS_SUCCEEDED,
-      );
-      const { appointments } = dispatch.secondCall.args[0];
-      // Midnight Jan 1 UTC is 5PM Dec 31 Cheyenne (Mountain) time
-      expect(appointments[0].startsAt).to.equal(
-        `${thisYear()}-12-31T17:00:00-07:00`,
-      );
-    });
+    await fetchConfirmedFutureAppointments()(dispatch);
+
+    expect(dispatch.firstCall.args[0].type).to.equal(
+      FETCH_CONFIRMED_FUTURE_APPOINTMENTS,
+    );
+    expect(dispatch.secondCall.args[0].type).to.equal(
+      FETCH_CONFIRMED_FUTURE_APPOINTMENTS_SUCCEEDED,
+    );
+    const { appointments } = dispatch.secondCall.args[0];
+    // Midnight Jan 1 UTC is 5PM Dec 31 Cheyenne (Mountain) time
+    expect(appointments[0].startsAt).to.equal(
+      `${thisYear()}-12-31T17:00:00-07:00`,
+    );
   });
 });

--- a/src/applications/personalization/dashboard-2/components/health-care/Appointments.jsx
+++ b/src/applications/personalization/dashboard-2/components/health-care/Appointments.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { format } from 'date-fns';
+import moment from 'moment';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import CTALink from '../CTALink';
 
 export const Appointments = ({ appointments, hasError }) => {
   const nextAppointment = appointments?.[0];
-  const start = new Date(nextAppointment?.startsAt);
+  const start = moment.parseZone(nextAppointment?.startsAt);
   let locationName;
 
   if (nextAppointment?.isVideo) {
@@ -55,10 +55,10 @@ export const Appointments = ({ appointments, hasError }) => {
           Next appointment
         </h4>
         <p className="vads-u-margin-bottom--1">
-          {format(start, 'EEEE, MMMM do, yyyy')}
+          {start.format('dddd, MMMM Do, YYYY')}
         </p>
         <p className="vads-u-margin-bottom--1 vads-u-margin-top--1">
-          {`Time: ${format(start, 'h:mm aaaa')} ${nextAppointment?.timeZone}`}
+          {`Time: ${start.format('h:mm a')} ${nextAppointment?.timeZone}`}
         </p>
         <p className="vads-u-margin-top--1">{locationName}</p>
         <CTALink

--- a/src/applications/personalization/dashboard-2/lib/moment-tz.js
+++ b/src/applications/personalization/dashboard-2/lib/moment-tz.js
@@ -1,0 +1,1278 @@
+/* istanbul ignore file */
+//! moment-timezone.js
+//! version : 0.5.25
+//! Copyright (c) JS Foundation and other contributors
+//! license : MIT
+//! github.com/moment/moment-timezone
+/* eslint-disable unicorn/no-abusive-eslint-disable */
+/* eslint-disable */
+(function(root, factory) {
+  'use strict';
+
+  /*global define*/
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory(require('moment')); // Node
+  } else if (typeof define === 'function' && define.amd) {
+    define(['moment'], factory); // AMD
+  } else {
+    factory(root.moment); // Browser
+  }
+})(this, function(moment) {
+  'use strict';
+
+  // Do not load moment-timezone a second time.
+  // if (moment.tz !== undefined) {
+  // 	logError('Moment Timezone ' + moment.tz.version + ' was already loaded ' + (moment.tz.dataVersion ? 'with data from ' : 'without any data') + moment.tz.dataVersion);
+  // 	return moment;
+  // }
+
+  var VERSION = '0.5.25',
+    zones = {},
+    links = {},
+    names = {},
+    guesses = {},
+    cachedGuess;
+
+  if (!moment || typeof moment.version !== 'string') {
+    logError(
+      'Moment Timezone requires Moment.js. See https://momentjs.com/timezone/docs/#/use-it/browser/',
+    );
+  }
+
+  var momentVersion = moment.version.split('.'),
+    major = +momentVersion[0],
+    minor = +momentVersion[1];
+
+  // Moment.js version check
+  if (major < 2 || (major === 2 && minor < 6)) {
+    logError(
+      'Moment Timezone requires Moment.js >= 2.6.0. You are using Moment.js ' +
+        moment.version +
+        '. See momentjs.com',
+    );
+  }
+
+  /************************************
+		Unpacking
+	************************************/
+
+  function charCodeToInt(charCode) {
+    if (charCode > 96) {
+      return charCode - 87;
+    } else if (charCode > 64) {
+      return charCode - 29;
+    }
+    return charCode - 48;
+  }
+
+  function unpackBase60(string) {
+    var i = 0,
+      parts = string.split('.'),
+      whole = parts[0],
+      fractional = parts[1] || '',
+      multiplier = 1,
+      num,
+      out = 0,
+      sign = 1;
+
+    // handle negative numbers
+    if (string.charCodeAt(0) === 45) {
+      i = 1;
+      sign = -1;
+    }
+
+    // handle digits before the decimal
+    for (i; i < whole.length; i++) {
+      num = charCodeToInt(whole.charCodeAt(i));
+      out = 60 * out + num;
+    }
+
+    // handle digits after the decimal
+    for (i = 0; i < fractional.length; i++) {
+      multiplier = multiplier / 60;
+      num = charCodeToInt(fractional.charCodeAt(i));
+      out += num * multiplier;
+    }
+
+    return out * sign;
+  }
+
+  function arrayToInt(array) {
+    for (var i = 0; i < array.length; i++) {
+      array[i] = unpackBase60(array[i]);
+    }
+  }
+
+  function intToUntil(array, length) {
+    for (var i = 0; i < length; i++) {
+      array[i] = Math.round((array[i - 1] || 0) + array[i] * 60000); // minutes to milliseconds
+    }
+
+    array[length - 1] = Infinity;
+  }
+
+  function mapIndices(source, indices) {
+    var out = [],
+      i;
+
+    for (i = 0; i < indices.length; i++) {
+      out[i] = source[indices[i]];
+    }
+
+    return out;
+  }
+
+  function unpack(string) {
+    var data = string.split('|'),
+      offsets = data[2].split(' '),
+      indices = data[3].split(''),
+      untils = data[4].split(' ');
+
+    arrayToInt(offsets);
+    arrayToInt(indices);
+    arrayToInt(untils);
+
+    intToUntil(untils, indices.length);
+
+    return {
+      name: data[0],
+      abbrs: mapIndices(data[1].split(' '), indices),
+      offsets: mapIndices(offsets, indices),
+      untils: untils,
+      population: data[5] | 0,
+    };
+  }
+
+  /************************************
+		Zone object
+	************************************/
+
+  function Zone(packedString) {
+    if (packedString) {
+      this._set(unpack(packedString));
+    }
+  }
+
+  Zone.prototype = {
+    _set: function(unpacked) {
+      this.name = unpacked.name;
+      this.abbrs = unpacked.abbrs;
+      this.untils = unpacked.untils;
+      this.offsets = unpacked.offsets;
+      this.population = unpacked.population;
+    },
+
+    _index: function(timestamp) {
+      var target = +timestamp,
+        untils = this.untils,
+        i;
+
+      for (i = 0; i < untils.length; i++) {
+        if (target < untils[i]) {
+          return i;
+        }
+      }
+    },
+
+    parse: function(timestamp) {
+      var target = +timestamp,
+        offsets = this.offsets,
+        untils = this.untils,
+        max = untils.length - 1,
+        offset,
+        offsetNext,
+        offsetPrev,
+        i;
+
+      for (i = 0; i < max; i++) {
+        offset = offsets[i];
+        offsetNext = offsets[i + 1];
+        offsetPrev = offsets[i ? i - 1 : i];
+
+        if (offset < offsetNext && tz.moveAmbiguousForward) {
+          offset = offsetNext;
+        } else if (offset > offsetPrev && tz.moveInvalidForward) {
+          offset = offsetPrev;
+        }
+
+        if (target < untils[i] - offset * 60000) {
+          return offsets[i];
+        }
+      }
+
+      return offsets[max];
+    },
+
+    abbr: function(mom) {
+      return this.abbrs[this._index(mom)];
+    },
+
+    offset: function(mom) {
+      logError('zone.offset has been deprecated in favor of zone.utcOffset');
+      return this.offsets[this._index(mom)];
+    },
+
+    utcOffset: function(mom) {
+      return this.offsets[this._index(mom)];
+    },
+  };
+
+  /************************************
+		Current Timezone
+	************************************/
+
+  function OffsetAt(at) {
+    var timeString = at.toTimeString();
+    var abbr = timeString.match(/\([a-z ]+\)/i);
+    if (abbr && abbr[0]) {
+      // 17:56:31 GMT-0600 (CST)
+      // 17:56:31 GMT-0600 (Central Standard Time)
+      abbr = abbr[0].match(/[A-Z]/g);
+      abbr = abbr ? abbr.join('') : undefined;
+    } else {
+      // 17:56:31 CST
+      // 17:56:31 GMT+0800 (台北標準時間)
+      abbr = timeString.match(/[A-Z]{3,5}/g);
+      abbr = abbr ? abbr[0] : undefined;
+    }
+
+    if (abbr === 'GMT') {
+      abbr = undefined;
+    }
+
+    this.at = +at;
+    this.abbr = abbr;
+    this.offset = at.getTimezoneOffset();
+  }
+
+  function ZoneScore(zone) {
+    this.zone = zone;
+    this.offsetScore = 0;
+    this.abbrScore = 0;
+  }
+
+  ZoneScore.prototype.scoreOffsetAt = function(offsetAt) {
+    this.offsetScore += Math.abs(
+      this.zone.utcOffset(offsetAt.at) - offsetAt.offset,
+    );
+    if (this.zone.abbr(offsetAt.at).replace(/[^A-Z]/g, '') !== offsetAt.abbr) {
+      this.abbrScore++;
+    }
+  };
+
+  function findChange(low, high) {
+    var mid, diff;
+
+    while ((diff = (((high.at - low.at) / 12e4) | 0) * 6e4)) {
+      mid = new OffsetAt(new Date(low.at + diff));
+      if (mid.offset === low.offset) {
+        low = mid;
+      } else {
+        high = mid;
+      }
+    }
+
+    return low;
+  }
+
+  function userOffsets() {
+    var startYear = new Date().getFullYear() - 2,
+      last = new OffsetAt(new Date(startYear, 0, 1)),
+      offsets = [last],
+      change,
+      next,
+      i;
+
+    for (i = 1; i < 48; i++) {
+      next = new OffsetAt(new Date(startYear, i, 1));
+      if (next.offset !== last.offset) {
+        change = findChange(last, next);
+        offsets.push(change);
+        offsets.push(new OffsetAt(new Date(change.at + 6e4)));
+      }
+      last = next;
+    }
+
+    for (i = 0; i < 4; i++) {
+      offsets.push(new OffsetAt(new Date(startYear + i, 0, 1)));
+      offsets.push(new OffsetAt(new Date(startYear + i, 6, 1)));
+    }
+
+    return offsets;
+  }
+
+  function sortZoneScores(a, b) {
+    if (a.offsetScore !== b.offsetScore) {
+      return a.offsetScore - b.offsetScore;
+    }
+    if (a.abbrScore !== b.abbrScore) {
+      return a.abbrScore - b.abbrScore;
+    }
+    return b.zone.population - a.zone.population;
+  }
+
+  function addToGuesses(name, offsets) {
+    var i, offset;
+    arrayToInt(offsets);
+    for (i = 0; i < offsets.length; i++) {
+      offset = offsets[i];
+      guesses[offset] = guesses[offset] || {};
+      guesses[offset][name] = true;
+    }
+  }
+
+  function guessesForUserOffsets(offsets) {
+    var offsetsLength = offsets.length,
+      filteredGuesses = {},
+      out = [],
+      i,
+      j,
+      guessesOffset;
+
+    for (i = 0; i < offsetsLength; i++) {
+      guessesOffset = guesses[offsets[i].offset] || {};
+      for (j in guessesOffset) {
+        if (guessesOffset.hasOwnProperty(j)) {
+          filteredGuesses[j] = true;
+        }
+      }
+    }
+
+    for (i in filteredGuesses) {
+      if (filteredGuesses.hasOwnProperty(i)) {
+        out.push(names[i]);
+      }
+    }
+
+    return out;
+  }
+
+  function rebuildGuess() {
+    // use Intl API when available and returning valid time zone
+    try {
+      var intlName = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      if (intlName && intlName.length > 3) {
+        var name = names[normalizeName(intlName)];
+        if (name) {
+          return name;
+        }
+        logError(
+          'Moment Timezone found ' +
+            intlName +
+            ' from the Intl api, but did not have that data loaded.',
+        );
+      }
+    } catch (e) {
+      // Intl unavailable, fall back to manual guessing.
+    }
+
+    var offsets = userOffsets(),
+      offsetsLength = offsets.length,
+      guesses = guessesForUserOffsets(offsets),
+      zoneScores = [],
+      zoneScore,
+      i,
+      j;
+
+    for (i = 0; i < guesses.length; i++) {
+      zoneScore = new ZoneScore(getZone(guesses[i]), offsetsLength);
+      for (j = 0; j < offsetsLength; j++) {
+        zoneScore.scoreOffsetAt(offsets[j]);
+      }
+      zoneScores.push(zoneScore);
+    }
+
+    zoneScores.sort(sortZoneScores);
+
+    return zoneScores.length > 0 ? zoneScores[0].zone.name : undefined;
+  }
+
+  function guess(ignoreCache) {
+    if (!cachedGuess || ignoreCache) {
+      cachedGuess = rebuildGuess();
+    }
+    return cachedGuess;
+  }
+
+  /************************************
+		Global Methods
+	************************************/
+
+  function normalizeName(name) {
+    return (name || '').toLowerCase().replace(/\//g, '_');
+  }
+
+  function addZone(packed) {
+    var i, name, split, normalized;
+
+    if (typeof packed === 'string') {
+      packed = [packed];
+    }
+
+    for (i = 0; i < packed.length; i++) {
+      split = packed[i].split('|');
+      name = split[0];
+      normalized = normalizeName(name);
+      zones[normalized] = packed[i];
+      names[normalized] = name;
+      addToGuesses(normalized, split[2].split(' '));
+    }
+  }
+
+  function getZone(name, caller) {
+    name = normalizeName(name);
+
+    var zone = zones[name];
+    var link;
+
+    if (zone instanceof Zone) {
+      return zone;
+    }
+
+    if (typeof zone === 'string') {
+      zone = new Zone(zone);
+      zones[name] = zone;
+      return zone;
+    }
+
+    // Pass getZone to prevent recursion more than 1 level deep
+    if (
+      links[name] &&
+      caller !== getZone &&
+      (link = getZone(links[name], getZone))
+    ) {
+      zone = zones[name] = new Zone();
+      zone._set(link);
+      zone.name = names[name];
+      return zone;
+    }
+
+    return null;
+  }
+
+  function getNames() {
+    var i,
+      out = [];
+
+    for (i in names) {
+      if (
+        names.hasOwnProperty(i) &&
+        (zones[i] || zones[links[i]]) &&
+        names[i]
+      ) {
+        out.push(names[i]);
+      }
+    }
+
+    return out.sort();
+  }
+
+  function addLink(aliases) {
+    var i, alias, normal0, normal1;
+
+    if (typeof aliases === 'string') {
+      aliases = [aliases];
+    }
+
+    for (i = 0; i < aliases.length; i++) {
+      alias = aliases[i].split('|');
+
+      normal0 = normalizeName(alias[0]);
+      normal1 = normalizeName(alias[1]);
+
+      links[normal0] = normal1;
+      names[normal0] = alias[0];
+
+      links[normal1] = normal0;
+      names[normal1] = alias[1];
+    }
+  }
+
+  function loadData(data) {
+    addZone(data.zones);
+    addLink(data.links);
+    tz.dataVersion = data.version;
+  }
+
+  function zoneExists(name) {
+    if (!zoneExists.didShowError) {
+      zoneExists.didShowError = true;
+      logError(
+        "moment.tz.zoneExists('" +
+          name +
+          "') has been deprecated in favor of !moment.tz.zone('" +
+          name +
+          "')",
+      );
+    }
+    return !!getZone(name);
+  }
+
+  function needsOffset(m) {
+    var isUnixTimestamp = m._f === 'X' || m._f === 'x';
+    return !!(m._a && m._tzm === undefined && !isUnixTimestamp);
+  }
+
+  function logError(message) {
+    if (typeof console !== 'undefined' && typeof console.error === 'function') {
+      console.error(message);
+    }
+  }
+
+  /************************************
+		moment.tz namespace
+	************************************/
+
+  function tz(input) {
+    var args = Array.prototype.slice.call(arguments, 0, -1),
+      name = arguments[arguments.length - 1],
+      zone = getZone(name),
+      out = moment.utc.apply(null, args);
+
+    if (zone && !moment.isMoment(input) && needsOffset(out)) {
+      out.add(zone.parse(out), 'minutes');
+    }
+
+    out.tz(name);
+
+    return out;
+  }
+
+  tz.version = VERSION;
+  tz.dataVersion = '';
+  tz._zones = zones;
+  tz._links = links;
+  tz._names = names;
+  tz.add = addZone;
+  tz.link = addLink;
+  tz.load = loadData;
+  tz.zone = getZone;
+  tz.zoneExists = zoneExists; // deprecated in 0.1.0
+  tz.guess = guess;
+  tz.names = getNames;
+  tz.Zone = Zone;
+  tz.unpack = unpack;
+  tz.unpackBase60 = unpackBase60;
+  tz.needsOffset = needsOffset;
+  tz.moveInvalidForward = true;
+  tz.moveAmbiguousForward = false;
+
+  /************************************
+		Interface with Moment.js
+	************************************/
+
+  var fn = moment.fn;
+
+  moment.tz = tz;
+
+  moment.defaultZone = null;
+
+  moment.updateOffset = function(mom, keepTime) {
+    var zone = moment.defaultZone,
+      offset;
+
+    if (mom._z === undefined) {
+      if (zone && needsOffset(mom) && !mom._isUTC) {
+        mom._d = moment.utc(mom._a)._d;
+        mom.utc().add(zone.parse(mom), 'minutes');
+      }
+      mom._z = zone;
+    }
+    if (mom._z) {
+      offset = mom._z.utcOffset(mom);
+      if (Math.abs(offset) < 16) {
+        offset = offset / 60;
+      }
+      if (mom.utcOffset !== undefined) {
+        var z = mom._z;
+        mom.utcOffset(-offset, keepTime);
+        mom._z = z;
+      } else {
+        mom.zone(offset, keepTime);
+      }
+    }
+  };
+
+  fn.tz = function(name, keepTime) {
+    if (name) {
+      if (typeof name !== 'string') {
+        throw new Error(
+          'Time zone name must be a string, got ' +
+            name +
+            ' [' +
+            typeof name +
+            ']',
+        );
+      }
+      this._z = getZone(name);
+      if (this._z) {
+        moment.updateOffset(this, keepTime);
+      } else {
+        logError(
+          'Moment Timezone has no data for ' +
+            name +
+            '. See http://momentjs.com/timezone/docs/#/data-loading/.',
+        );
+      }
+      return this;
+    }
+    if (this._z) {
+      return this._z.name;
+    }
+  };
+
+  function abbrWrap(old) {
+    return function() {
+      if (this._z) {
+        return this._z.abbr(this);
+      }
+      return old.call(this);
+    };
+  }
+
+  function resetZoneWrap(old) {
+    return function() {
+      this._z = null;
+      return old.apply(this, arguments);
+    };
+  }
+
+  function resetZoneWrap2(old) {
+    return function() {
+      if (arguments.length > 0) this._z = null;
+      return old.apply(this, arguments);
+    };
+  }
+
+  fn.zoneName = abbrWrap(fn.zoneName);
+  fn.zoneAbbr = abbrWrap(fn.zoneAbbr);
+  fn.utc = resetZoneWrap(fn.utc);
+  fn.local = resetZoneWrap(fn.local);
+  fn.utcOffset = resetZoneWrap2(fn.utcOffset);
+
+  moment.tz.setDefault = function(name) {
+    if (major < 2 || (major === 2 && minor < 9)) {
+      logError(
+        'Moment Timezone setDefault() requires Moment.js >= 2.9.0. You are using Moment.js ' +
+          moment.version +
+          '.',
+      );
+    }
+    moment.defaultZone = name ? getZone(name) : null;
+    return moment;
+  };
+
+  // Cloning a moment should include the _z property.
+  var momentProperties = moment.momentProperties;
+  if (Object.prototype.toString.call(momentProperties) === '[object Array]') {
+    // moment 2.8.1+
+    momentProperties.push('_z');
+    momentProperties.push('_a');
+  } else if (momentProperties) {
+    // moment 2.7.0
+    momentProperties._z = null;
+  }
+
+  loadData({
+    version: '2019a',
+    zones: [
+      'Africa/Abidjan|GMT|0|0||48e5',
+      'Africa/Nairobi|EAT|-30|0||47e5',
+      'Africa/Algiers|CET|-10|0||26e5',
+      'Africa/Lagos|WAT|-10|0||17e6',
+      'Africa/Maputo|CAT|-20|0||26e5',
+      'Africa/Cairo|EET EEST|-20 -30|01010|1M2m0 gL0 e10 mn0|15e6',
+      'Africa/Casablanca|+00 +01|0 -10|01010101010101010101010101010101|1LHC0 A00 e00 y00 11A0 uM0 e00 Dc0 11A0 s00 e00 IM0 WM0 mo0 gM0 LA0 WM0 jA0 e00 28M0 e00 2600 e00 28M0 e00 2600 gM0 2600 e00 28M0 e00|32e5',
+      'Europe/Paris|CET CEST|-10 -20|01010101010101010101010|1LHB0 1o00 11A0 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00 11A0 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00|11e6',
+      'Africa/Johannesburg|SAST|-20|0||84e5',
+      'Africa/Khartoum|EAT CAT|-30 -20|01|1Usl0|51e5',
+      'Africa/Sao_Tome|GMT WAT|0 -10|010|1UQN0 2q00',
+      'Africa/Tripoli|EET|-20|0||11e5',
+      'Africa/Windhoek|CAT WAT|-20 -10|010101010|1LKo0 11B0 1nX0 11B0 1nX0 11B0 1nX0 11B0|32e4',
+      'America/Adak|HST HDT|a0 90|01010101010101010101010|1Lzo0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0|326',
+      'America/Anchorage|AKST AKDT|90 80|01010101010101010101010|1Lzn0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0|30e4',
+      'America/Santo_Domingo|AST|40|0||29e5',
+      'America/Fortaleza|-03|30|0||34e5',
+      'America/Asuncion|-03 -04|30 40|01010101010101010101010|1LEP0 1ip0 17b0 1ip0 19X0 1fB0 19X0 1fB0 19X0 1ip0 17b0 1ip0 17b0 1ip0 19X0 1fB0 19X0 1fB0 19X0 1fB0 19X0 1ip0|28e5',
+      'America/Panama|EST|50|0||15e5',
+      'America/Mexico_City|CST CDT|60 50|01010101010101010101010|1LKw0 1lb0 14p0 1lb0 14p0 1nX0 11B0 1nX0 11B0 1nX0 14p0 1lb0 14p0 1lb0 14p0 1nX0 11B0 1nX0 11B0 1nX0 14p0 1lb0|20e6',
+      'America/Managua|CST|60|0||22e5',
+      'America/La_Paz|-04|40|0||19e5',
+      'America/Lima|-05|50|0||11e6',
+      'America/Denver|MST MDT|70 60|01010101010101010101010|1Lzl0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0|26e5',
+      'America/Campo_Grande|-03 -04|30 40|01010101010101010101010|1LqP0 1C10 On0 1zd0 On0 1zd0 On0 1zd0 On0 1HB0 FX0 1HB0 FX0 1HB0 IL0 1HB0 FX0 1HB0 IL0 1EN0 FX0 1HB0|77e4',
+      'America/Cancun|CST CDT EST|60 50 50|0102|1LKw0 1lb0 Dd0|63e4',
+      'America/Caracas|-0430 -04|4u 40|01|1QMT0|29e5',
+      'America/Chicago|CST CDT|60 50|01010101010101010101010|1Lzk0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0|92e5',
+      'America/Chihuahua|MST MDT|70 60|01010101010101010101010|1LKx0 1lb0 14p0 1lb0 14p0 1nX0 11B0 1nX0 11B0 1nX0 14p0 1lb0 14p0 1lb0 14p0 1nX0 11B0 1nX0 11B0 1nX0 14p0 1lb0|81e4',
+      'America/Phoenix|MST|70|0||42e5',
+      'America/Los_Angeles|PST PDT|80 70|01010101010101010101010|1Lzm0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0|15e6',
+      'America/New_York|EST EDT|50 40|01010101010101010101010|1Lzj0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0|21e6',
+      'America/Fort_Nelson|PST PDT MST|80 70 70|0102|1Lzm0 1zb0 Op0|39e2',
+      'America/Halifax|AST ADT|40 30|01010101010101010101010|1Lzi0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0|39e4',
+      'America/Godthab|-03 -02|30 20|01010101010101010101010|1LHB0 1o00 11A0 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00 11A0 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00|17e3',
+      'America/Grand_Turk|EST EDT AST|50 40 40|0101210101010101010|1Lzj0 1zb0 Op0 1zb0 5Ip0 1zb0 Op0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0|37e2',
+      'America/Havana|CST CDT|50 40|01010101010101010101010|1Lzh0 1zc0 Oo0 1zc0 Rc0 1zc0 Oo0 1zc0 Oo0 1zc0 Oo0 1zc0 Oo0 1zc0 Rc0 1zc0 Oo0 1zc0 Oo0 1zc0 Oo0 1zc0|21e5',
+      'America/Metlakatla|PST AKST AKDT|80 90 80|012121201212121212121|1PAa0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 uM0 jB0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0|14e2',
+      'America/Miquelon|-03 -02|30 20|01010101010101010101010|1Lzh0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0|61e2',
+      'America/Montevideo|-02 -03|20 30|0101|1Lzg0 1o10 11z0|17e5',
+      'America/Noronha|-02|20|0||30e2',
+      'America/Port-au-Prince|EST EDT|50 40|010101010101010101010|1Lzj0 1zb0 Op0 1zb0 3iN0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0|23e5',
+      'Antarctica/Palmer|-03 -04|30 40|01010|1LSP0 Rd0 46n0 Ap0|40',
+      'America/Santiago|-03 -04|30 40|010101010101010101010|1LSP0 Rd0 46n0 Ap0 1Nb0 Ap0 1Nb0 Ap0 1zb0 11B0 1nX0 11B0 1nX0 11B0 1nX0 11B0 1nX0 11B0 1qL0 11B0|62e5',
+      'America/Sao_Paulo|-02 -03|20 30|01010101010101010101010|1LqO0 1C10 On0 1zd0 On0 1zd0 On0 1zd0 On0 1HB0 FX0 1HB0 FX0 1HB0 IL0 1HB0 FX0 1HB0 IL0 1EN0 FX0 1HB0|20e6',
+      'Atlantic/Azores|-01 +00|10 0|01010101010101010101010|1LHB0 1o00 11A0 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00 11A0 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00|25e4',
+      'America/St_Johns|NST NDT|3u 2u|01010101010101010101010|1Lzhu 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0 Rd0 1zb0 Op0 1zb0 Op0 1zb0 Op0 1zb0|11e4',
+      'Antarctica/Casey|+08 +11|-80 -b0|010|1RWg0 3m10|10',
+      'Asia/Bangkok|+07|-70|0||15e6',
+      'Pacific/Port_Moresby|+10|-a0|0||25e4',
+      'Pacific/Guadalcanal|+11|-b0|0||11e4',
+      'Asia/Tashkent|+05|-50|0||23e5',
+      'Pacific/Auckland|NZDT NZST|-d0 -c0|01010101010101010101010|1LKe0 1a00 1fA0 1a00 1fA0 1a00 1fA0 1a00 1fA0 1cM0 1fA0 1a00 1fA0 1a00 1fA0 1a00 1fA0 1a00 1fA0 1a00 1io0 1a00|14e5',
+      'Asia/Baghdad|+03|-30|0||66e5',
+      'Antarctica/Troll|+00 +02|0 -20|01010101010101010101010|1LHB0 1o00 11A0 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00 11A0 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00|40',
+      'Asia/Dhaka|+06|-60|0||16e6',
+      'Asia/Amman|EET EEST|-20 -30|01010101010101010101010|1LGK0 1qM0 WM0 1qM0 11A0 1o00 11A0 1o00 11A0 1o00 11A0 1o00 11A0 1qM0 WM0 1qM0 11A0 1o00 11A0 1o00 11A0 1o00|25e5',
+      'Asia/Kamchatka|+12|-c0|0||18e4',
+      'Asia/Baku|+04 +05|-40 -50|01010|1LHA0 1o00 11A0 1o00|27e5',
+      'Asia/Barnaul|+07 +06|-70 -60|010|1N7v0 3rd0',
+      'Asia/Beirut|EET EEST|-20 -30|01010101010101010101010|1LHy0 1nX0 11B0 1nX0 11B0 1qL0 WN0 1qL0 WN0 1qL0 11B0 1nX0 11B0 1nX0 11B0 1qL0 WN0 1qL0 WN0 1qL0 11B0 1nX0|22e5',
+      'Asia/Kuala_Lumpur|+08|-80|0||71e5',
+      'Asia/Kolkata|IST|-5u|0||15e6',
+      'Asia/Chita|+10 +08 +09|-a0 -80 -90|012|1N7s0 3re0|33e4',
+      'Asia/Ulaanbaatar|+08 +09|-80 -90|01010|1O8G0 1cJ0 1cP0 1cJ0|12e5',
+      'Asia/Shanghai|CST|-80|0||23e6',
+      'Asia/Colombo|+0530|-5u|0||22e5',
+      'Asia/Damascus|EET EEST|-20 -30|01010101010101010101010|1LGK0 1qL0 WN0 1qL0 WN0 1qL0 11B0 1nX0 11B0 1nX0 11B0 1nX0 11B0 1qL0 WN0 1qL0 WN0 1qL0 11B0 1nX0 11B0 1nX0|26e5',
+      'Asia/Dili|+09|-90|0||19e4',
+      'Asia/Dubai|+04|-40|0||39e5',
+      'Asia/Famagusta|EET EEST +03|-20 -30 -30|0101012010101010101010|1LHB0 1o00 11A0 1o00 11A0 15U0 2Ks0 WM0 1qM0 11A0 1o00 11A0 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00',
+      'Asia/Gaza|EET EEST|-20 -30|01010101010101010101010|1LGK0 1nX0 1210 1nz0 1220 1qL0 WN0 1qL0 WN0 1qL0 11B0 1nX0 11B0 1qL0 WN0 1qL0 WN0 1qL0 WN0 1qL0 11B0 1nX0|18e5',
+      'Asia/Hong_Kong|HKT|-80|0||73e5',
+      'Asia/Hovd|+07 +08|-70 -80|01010|1O8H0 1cJ0 1cP0 1cJ0|81e3',
+      'Asia/Irkutsk|+09 +08|-90 -80|01|1N7t0|60e4',
+      'Europe/Istanbul|EET EEST +03|-20 -30 -30|0101012|1LI10 1nA0 11A0 1tA0 U00 15w0|13e6',
+      'Asia/Jakarta|WIB|-70|0||31e6',
+      'Asia/Jayapura|WIT|-90|0||26e4',
+      'Asia/Jerusalem|IST IDT|-20 -30|01010101010101010101010|1LGM0 1oL0 10N0 1oL0 10N0 1rz0 W10 1rz0 W10 1rz0 10N0 1oL0 10N0 1oL0 10N0 1rz0 W10 1rz0 W10 1rz0 10N0 1oL0|81e4',
+      'Asia/Kabul|+0430|-4u|0||46e5',
+      'Asia/Karachi|PKT|-50|0||24e6',
+      'Asia/Kathmandu|+0545|-5J|0||12e5',
+      'Asia/Yakutsk|+10 +09|-a0 -90|01|1N7s0|28e4',
+      'Asia/Krasnoyarsk|+08 +07|-80 -70|01|1N7u0|10e5',
+      'Asia/Magadan|+12 +10 +11|-c0 -a0 -b0|012|1N7q0 3Cq0|95e3',
+      'Asia/Makassar|WITA|-80|0||15e5',
+      'Asia/Manila|PST|-80|0||24e6',
+      'Europe/Athens|EET EEST|-20 -30|01010101010101010101010|1LHB0 1o00 11A0 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00 11A0 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00|35e5',
+      'Asia/Novosibirsk|+07 +06|-70 -60|010|1N7v0 4eN0|15e5',
+      'Asia/Omsk|+07 +06|-70 -60|01|1N7v0|12e5',
+      'Asia/Pyongyang|KST KST|-90 -8u|010|1P4D0 6BA0|29e5',
+      'Asia/Qyzylorda|+06 +05|-60 -50|01|1Xei0|73e4',
+      'Asia/Rangoon|+0630|-6u|0||48e5',
+      'Asia/Sakhalin|+11 +10|-b0 -a0|010|1N7r0 3rd0|58e4',
+      'Asia/Seoul|KST|-90|0||23e6',
+      'Asia/Srednekolymsk|+12 +11|-c0 -b0|01|1N7q0|35e2',
+      'Asia/Tehran|+0330 +0430|-3u -4u|01010101010101010101010|1LEku 1dz0 1cp0 1dz0 1cp0 1dz0 1cN0 1dz0 1cp0 1dz0 1cp0 1dz0 1cp0 1dz0 1cN0 1dz0 1cp0 1dz0 1cp0 1dz0 1cp0 1dz0|14e6',
+      'Asia/Tokyo|JST|-90|0||38e6',
+      'Asia/Tomsk|+07 +06|-70 -60|010|1N7v0 3Qp0|10e5',
+      'Asia/Vladivostok|+11 +10|-b0 -a0|01|1N7r0|60e4',
+      'Asia/Yekaterinburg|+06 +05|-60 -50|01|1N7w0|14e5',
+      'Europe/Lisbon|WET WEST|0 -10|01010101010101010101010|1LHB0 1o00 11A0 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00 11A0 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00|27e5',
+      'Atlantic/Cape_Verde|-01|10|0||50e4',
+      'Australia/Sydney|AEDT AEST|-b0 -a0|01010101010101010101010|1LKg0 1cM0 1cM0 1cM0 1cM0 1cM0 1cM0 1cM0 1cM0 1fA0 1cM0 1cM0 1cM0 1cM0 1cM0 1cM0 1cM0 1cM0 1cM0 1cM0 1fA0 1cM0|40e5',
+      'Australia/Adelaide|ACDT ACST|-au -9u|01010101010101010101010|1LKgu 1cM0 1cM0 1cM0 1cM0 1cM0 1cM0 1cM0 1cM0 1fA0 1cM0 1cM0 1cM0 1cM0 1cM0 1cM0 1cM0 1cM0 1cM0 1cM0 1fA0 1cM0|11e5',
+      'Australia/Brisbane|AEST|-a0|0||20e5',
+      'Australia/Darwin|ACST|-9u|0||12e4',
+      'Australia/Eucla|+0845|-8J|0||368',
+      'Australia/Lord_Howe|+11 +1030|-b0 -au|01010101010101010101010|1LKf0 1cMu 1cLu 1cMu 1cLu 1cMu 1cLu 1cMu 1cLu 1fAu 1cLu 1cMu 1cLu 1cMu 1cLu 1cMu 1cLu 1cMu 1cLu 1cMu 1fzu 1cMu|347',
+      'Australia/Perth|AWST|-80|0||18e5',
+      'Pacific/Easter|-05 -06|50 60|010101010101010101010|1LSP0 Rd0 46n0 Ap0 1Nb0 Ap0 1Nb0 Ap0 1zb0 11B0 1nX0 11B0 1nX0 11B0 1nX0 11B0 1nX0 11B0 1qL0 11B0|30e2',
+      'Europe/Dublin|GMT IST|0 -10|01010101010101010101010|1LHB0 1o00 11A0 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00 11A0 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00|12e5',
+      'Etc/GMT-1|+01|-10|0|',
+      'Pacific/Fakaofo|+13|-d0|0||483',
+      'Pacific/Kiritimati|+14|-e0|0||51e2',
+      'Etc/GMT-2|+02|-20|0|',
+      'Pacific/Tahiti|-10|a0|0||18e4',
+      'Pacific/Niue|-11|b0|0||12e2',
+      'Etc/GMT+12|-12|c0|0|',
+      'Pacific/Galapagos|-06|60|0||25e3',
+      'Etc/GMT+7|-07|70|0|',
+      'Pacific/Pitcairn|-08|80|0||56',
+      'Pacific/Gambier|-09|90|0||125',
+      'Etc/UTC|UTC|0|0|',
+      'Europe/Ulyanovsk|+04 +03|-40 -30|010|1N7y0 3rd0|13e5',
+      'Europe/London|GMT BST|0 -10|01010101010101010101010|1LHB0 1o00 11A0 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00 11A0 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00|10e6',
+      'Europe/Chisinau|EET EEST|-20 -30|01010101010101010101010|1LHA0 1o00 11A0 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00 11A0 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00|67e4',
+      'Europe/Kaliningrad|+03 EET|-30 -20|01|1N7z0|44e4',
+      'Europe/Kirov|+04 +03|-40 -30|01|1N7y0|48e4',
+      'Europe/Moscow|MSK MSK|-40 -30|01|1N7y0|16e6',
+      'Europe/Saratov|+04 +03|-40 -30|010|1N7y0 5810',
+      'Europe/Simferopol|EET MSK MSK|-20 -40 -30|012|1LHA0 1nW0|33e4',
+      'Europe/Volgograd|+04 +03|-40 -30|010|1N7y0 9Jd0|10e5',
+      'Pacific/Honolulu|HST|a0|0||37e4',
+      'MET|MET MEST|-10 -20|01010101010101010101010|1LHB0 1o00 11A0 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00 11A0 1o00 11A0 1qM0 WM0 1qM0 WM0 1qM0 11A0 1o00',
+      'Pacific/Chatham|+1345 +1245|-dJ -cJ|01010101010101010101010|1LKe0 1a00 1fA0 1a00 1fA0 1a00 1fA0 1a00 1fA0 1cM0 1fA0 1a00 1fA0 1a00 1fA0 1a00 1fA0 1a00 1fA0 1a00 1io0 1a00|600',
+      'Pacific/Apia|+14 +13|-e0 -d0|01010101010101010101010|1LKe0 1a00 1fA0 1a00 1fA0 1a00 1fA0 1a00 1fA0 1cM0 1fA0 1a00 1fA0 1a00 1fA0 1a00 1fA0 1a00 1fA0 1a00 1io0 1a00|37e3',
+      'Pacific/Bougainville|+10 +11|-a0 -b0|01|1NwE0|18e4',
+      'Pacific/Fiji|+13 +12|-d0 -c0|01010101010101010101010|1Lfp0 1SN0 uM0 1SM0 uM0 1VA0 s00 1VA0 s00 1VA0 s00 1VA0 uM0 1SM0 uM0 1VA0 s00 1VA0 s00 1VA0 s00 1VA0|88e4',
+      'Pacific/Guam|ChST|-a0|0||17e4',
+      'Pacific/Marquesas|-0930|9u|0||86e2',
+      'Pacific/Pago_Pago|SST|b0|0||37e2',
+      'Pacific/Norfolk|+1130 +11|-bu -b0|01|1PoCu|25e4',
+      'Pacific/Tongatapu|+13 +14|-d0 -e0|010|1S4d0 s00|75e3',
+    ],
+    links: [
+      'Africa/Abidjan|Africa/Accra',
+      'Africa/Abidjan|Africa/Bamako',
+      'Africa/Abidjan|Africa/Banjul',
+      'Africa/Abidjan|Africa/Bissau',
+      'Africa/Abidjan|Africa/Conakry',
+      'Africa/Abidjan|Africa/Dakar',
+      'Africa/Abidjan|Africa/Freetown',
+      'Africa/Abidjan|Africa/Lome',
+      'Africa/Abidjan|Africa/Monrovia',
+      'Africa/Abidjan|Africa/Nouakchott',
+      'Africa/Abidjan|Africa/Ouagadougou',
+      'Africa/Abidjan|Africa/Timbuktu',
+      'Africa/Abidjan|America/Danmarkshavn',
+      'Africa/Abidjan|Atlantic/Reykjavik',
+      'Africa/Abidjan|Atlantic/St_Helena',
+      'Africa/Abidjan|Etc/GMT',
+      'Africa/Abidjan|Etc/GMT+0',
+      'Africa/Abidjan|Etc/GMT-0',
+      'Africa/Abidjan|Etc/GMT0',
+      'Africa/Abidjan|Etc/Greenwich',
+      'Africa/Abidjan|GMT',
+      'Africa/Abidjan|GMT+0',
+      'Africa/Abidjan|GMT-0',
+      'Africa/Abidjan|GMT0',
+      'Africa/Abidjan|Greenwich',
+      'Africa/Abidjan|Iceland',
+      'Africa/Algiers|Africa/Tunis',
+      'Africa/Cairo|Egypt',
+      'Africa/Casablanca|Africa/El_Aaiun',
+      'Africa/Johannesburg|Africa/Maseru',
+      'Africa/Johannesburg|Africa/Mbabane',
+      'Africa/Lagos|Africa/Bangui',
+      'Africa/Lagos|Africa/Brazzaville',
+      'Africa/Lagos|Africa/Douala',
+      'Africa/Lagos|Africa/Kinshasa',
+      'Africa/Lagos|Africa/Libreville',
+      'Africa/Lagos|Africa/Luanda',
+      'Africa/Lagos|Africa/Malabo',
+      'Africa/Lagos|Africa/Ndjamena',
+      'Africa/Lagos|Africa/Niamey',
+      'Africa/Lagos|Africa/Porto-Novo',
+      'Africa/Maputo|Africa/Blantyre',
+      'Africa/Maputo|Africa/Bujumbura',
+      'Africa/Maputo|Africa/Gaborone',
+      'Africa/Maputo|Africa/Harare',
+      'Africa/Maputo|Africa/Kigali',
+      'Africa/Maputo|Africa/Lubumbashi',
+      'Africa/Maputo|Africa/Lusaka',
+      'Africa/Nairobi|Africa/Addis_Ababa',
+      'Africa/Nairobi|Africa/Asmara',
+      'Africa/Nairobi|Africa/Asmera',
+      'Africa/Nairobi|Africa/Dar_es_Salaam',
+      'Africa/Nairobi|Africa/Djibouti',
+      'Africa/Nairobi|Africa/Juba',
+      'Africa/Nairobi|Africa/Kampala',
+      'Africa/Nairobi|Africa/Mogadishu',
+      'Africa/Nairobi|Indian/Antananarivo',
+      'Africa/Nairobi|Indian/Comoro',
+      'Africa/Nairobi|Indian/Mayotte',
+      'Africa/Tripoli|Libya',
+      'America/Adak|America/Atka',
+      'America/Adak|US/Aleutian',
+      'America/Anchorage|America/Juneau',
+      'America/Anchorage|America/Nome',
+      'America/Anchorage|America/Sitka',
+      'America/Anchorage|America/Yakutat',
+      'America/Anchorage|US/Alaska',
+      'America/Campo_Grande|America/Cuiaba',
+      'America/Chicago|America/Indiana/Knox',
+      'America/Chicago|America/Indiana/Tell_City',
+      'America/Chicago|America/Knox_IN',
+      'America/Chicago|America/Matamoros',
+      'America/Chicago|America/Menominee',
+      'America/Chicago|America/North_Dakota/Beulah',
+      'America/Chicago|America/North_Dakota/Center',
+      'America/Chicago|America/North_Dakota/New_Salem',
+      'America/Chicago|America/Rainy_River',
+      'America/Chicago|America/Rankin_Inlet',
+      'America/Chicago|America/Resolute',
+      'America/Chicago|America/Winnipeg',
+      'America/Chicago|CST6CDT',
+      'America/Chicago|Canada/Central',
+      'America/Chicago|US/Central',
+      'America/Chicago|US/Indiana-Starke',
+      'America/Chihuahua|America/Mazatlan',
+      'America/Chihuahua|Mexico/BajaSur',
+      'America/Denver|America/Boise',
+      'America/Denver|America/Cambridge_Bay',
+      'America/Denver|America/Edmonton',
+      'America/Denver|America/Inuvik',
+      'America/Denver|America/Ojinaga',
+      'America/Denver|America/Shiprock',
+      'America/Denver|America/Yellowknife',
+      'America/Denver|Canada/Mountain',
+      'America/Denver|MST7MDT',
+      'America/Denver|Navajo',
+      'America/Denver|US/Mountain',
+      'America/Fortaleza|America/Araguaina',
+      'America/Fortaleza|America/Argentina/Buenos_Aires',
+      'America/Fortaleza|America/Argentina/Catamarca',
+      'America/Fortaleza|America/Argentina/ComodRivadavia',
+      'America/Fortaleza|America/Argentina/Cordoba',
+      'America/Fortaleza|America/Argentina/Jujuy',
+      'America/Fortaleza|America/Argentina/La_Rioja',
+      'America/Fortaleza|America/Argentina/Mendoza',
+      'America/Fortaleza|America/Argentina/Rio_Gallegos',
+      'America/Fortaleza|America/Argentina/Salta',
+      'America/Fortaleza|America/Argentina/San_Juan',
+      'America/Fortaleza|America/Argentina/San_Luis',
+      'America/Fortaleza|America/Argentina/Tucuman',
+      'America/Fortaleza|America/Argentina/Ushuaia',
+      'America/Fortaleza|America/Bahia',
+      'America/Fortaleza|America/Belem',
+      'America/Fortaleza|America/Buenos_Aires',
+      'America/Fortaleza|America/Catamarca',
+      'America/Fortaleza|America/Cayenne',
+      'America/Fortaleza|America/Cordoba',
+      'America/Fortaleza|America/Jujuy',
+      'America/Fortaleza|America/Maceio',
+      'America/Fortaleza|America/Mendoza',
+      'America/Fortaleza|America/Paramaribo',
+      'America/Fortaleza|America/Recife',
+      'America/Fortaleza|America/Rosario',
+      'America/Fortaleza|America/Santarem',
+      'America/Fortaleza|Antarctica/Rothera',
+      'America/Fortaleza|Atlantic/Stanley',
+      'America/Fortaleza|Etc/GMT+3',
+      'America/Halifax|America/Glace_Bay',
+      'America/Halifax|America/Goose_Bay',
+      'America/Halifax|America/Moncton',
+      'America/Halifax|America/Thule',
+      'America/Halifax|Atlantic/Bermuda',
+      'America/Halifax|Canada/Atlantic',
+      'America/Havana|Cuba',
+      'America/La_Paz|America/Boa_Vista',
+      'America/La_Paz|America/Guyana',
+      'America/La_Paz|America/Manaus',
+      'America/La_Paz|America/Porto_Velho',
+      'America/La_Paz|Brazil/West',
+      'America/La_Paz|Etc/GMT+4',
+      'America/Lima|America/Bogota',
+      'America/Lima|America/Eirunepe',
+      'America/Lima|America/Guayaquil',
+      'America/Lima|America/Porto_Acre',
+      'America/Lima|America/Rio_Branco',
+      'America/Lima|Brazil/Acre',
+      'America/Lima|Etc/GMT+5',
+      'America/Los_Angeles|America/Dawson',
+      'America/Los_Angeles|America/Ensenada',
+      'America/Los_Angeles|America/Santa_Isabel',
+      'America/Los_Angeles|America/Tijuana',
+      'America/Los_Angeles|America/Vancouver',
+      'America/Los_Angeles|America/Whitehorse',
+      'America/Los_Angeles|Canada/Pacific',
+      'America/Los_Angeles|Canada/Yukon',
+      'America/Los_Angeles|Mexico/BajaNorte',
+      'America/Los_Angeles|PST8PDT',
+      'America/Los_Angeles|US/Pacific',
+      'America/Los_Angeles|US/Pacific-New',
+      'America/Managua|America/Belize',
+      'America/Managua|America/Costa_Rica',
+      'America/Managua|America/El_Salvador',
+      'America/Managua|America/Guatemala',
+      'America/Managua|America/Regina',
+      'America/Managua|America/Swift_Current',
+      'America/Managua|America/Tegucigalpa',
+      'America/Managua|Canada/Saskatchewan',
+      'America/Mexico_City|America/Bahia_Banderas',
+      'America/Mexico_City|America/Merida',
+      'America/Mexico_City|America/Monterrey',
+      'America/Mexico_City|Mexico/General',
+      'America/New_York|America/Detroit',
+      'America/New_York|America/Fort_Wayne',
+      'America/New_York|America/Indiana/Indianapolis',
+      'America/New_York|America/Indiana/Marengo',
+      'America/New_York|America/Indiana/Petersburg',
+      'America/New_York|America/Indiana/Vevay',
+      'America/New_York|America/Indiana/Vincennes',
+      'America/New_York|America/Indiana/Winamac',
+      'America/New_York|America/Indianapolis',
+      'America/New_York|America/Iqaluit',
+      'America/New_York|America/Kentucky/Louisville',
+      'America/New_York|America/Kentucky/Monticello',
+      'America/New_York|America/Louisville',
+      'America/New_York|America/Montreal',
+      'America/New_York|America/Nassau',
+      'America/New_York|America/Nipigon',
+      'America/New_York|America/Pangnirtung',
+      'America/New_York|America/Thunder_Bay',
+      'America/New_York|America/Toronto',
+      'America/New_York|Canada/Eastern',
+      'America/New_York|EST5EDT',
+      'America/New_York|US/East-Indiana',
+      'America/New_York|US/Eastern',
+      'America/New_York|US/Michigan',
+      'America/Noronha|Atlantic/South_Georgia',
+      'America/Noronha|Brazil/DeNoronha',
+      'America/Noronha|Etc/GMT+2',
+      'America/Panama|America/Atikokan',
+      'America/Panama|America/Cayman',
+      'America/Panama|America/Coral_Harbour',
+      'America/Panama|America/Jamaica',
+      'America/Panama|EST',
+      'America/Panama|Jamaica',
+      'America/Phoenix|America/Creston',
+      'America/Phoenix|America/Dawson_Creek',
+      'America/Phoenix|America/Hermosillo',
+      'America/Phoenix|MST',
+      'America/Phoenix|US/Arizona',
+      'America/Santiago|Chile/Continental',
+      'America/Santo_Domingo|America/Anguilla',
+      'America/Santo_Domingo|America/Antigua',
+      'America/Santo_Domingo|America/Aruba',
+      'America/Santo_Domingo|America/Barbados',
+      'America/Santo_Domingo|America/Blanc-Sablon',
+      'America/Santo_Domingo|America/Curacao',
+      'America/Santo_Domingo|America/Dominica',
+      'America/Santo_Domingo|America/Grenada',
+      'America/Santo_Domingo|America/Guadeloupe',
+      'America/Santo_Domingo|America/Kralendijk',
+      'America/Santo_Domingo|America/Lower_Princes',
+      'America/Santo_Domingo|America/Marigot',
+      'America/Santo_Domingo|America/Martinique',
+      'America/Santo_Domingo|America/Montserrat',
+      'America/Santo_Domingo|America/Port_of_Spain',
+      'America/Santo_Domingo|America/Puerto_Rico',
+      'America/Santo_Domingo|America/St_Barthelemy',
+      'America/Santo_Domingo|America/St_Kitts',
+      'America/Santo_Domingo|America/St_Lucia',
+      'America/Santo_Domingo|America/St_Thomas',
+      'America/Santo_Domingo|America/St_Vincent',
+      'America/Santo_Domingo|America/Tortola',
+      'America/Santo_Domingo|America/Virgin',
+      'America/Sao_Paulo|Brazil/East',
+      'America/St_Johns|Canada/Newfoundland',
+      'Antarctica/Palmer|America/Punta_Arenas',
+      'Asia/Baghdad|Antarctica/Syowa',
+      'Asia/Baghdad|Asia/Aden',
+      'Asia/Baghdad|Asia/Bahrain',
+      'Asia/Baghdad|Asia/Kuwait',
+      'Asia/Baghdad|Asia/Qatar',
+      'Asia/Baghdad|Asia/Riyadh',
+      'Asia/Baghdad|Etc/GMT-3',
+      'Asia/Baghdad|Europe/Minsk',
+      'Asia/Bangkok|Antarctica/Davis',
+      'Asia/Bangkok|Asia/Ho_Chi_Minh',
+      'Asia/Bangkok|Asia/Novokuznetsk',
+      'Asia/Bangkok|Asia/Phnom_Penh',
+      'Asia/Bangkok|Asia/Saigon',
+      'Asia/Bangkok|Asia/Vientiane',
+      'Asia/Bangkok|Etc/GMT-7',
+      'Asia/Bangkok|Indian/Christmas',
+      'Asia/Dhaka|Antarctica/Vostok',
+      'Asia/Dhaka|Asia/Almaty',
+      'Asia/Dhaka|Asia/Bishkek',
+      'Asia/Dhaka|Asia/Dacca',
+      'Asia/Dhaka|Asia/Kashgar',
+      'Asia/Dhaka|Asia/Qostanay',
+      'Asia/Dhaka|Asia/Thimbu',
+      'Asia/Dhaka|Asia/Thimphu',
+      'Asia/Dhaka|Asia/Urumqi',
+      'Asia/Dhaka|Etc/GMT-6',
+      'Asia/Dhaka|Indian/Chagos',
+      'Asia/Dili|Etc/GMT-9',
+      'Asia/Dili|Pacific/Palau',
+      'Asia/Dubai|Asia/Muscat',
+      'Asia/Dubai|Asia/Tbilisi',
+      'Asia/Dubai|Asia/Yerevan',
+      'Asia/Dubai|Etc/GMT-4',
+      'Asia/Dubai|Europe/Samara',
+      'Asia/Dubai|Indian/Mahe',
+      'Asia/Dubai|Indian/Mauritius',
+      'Asia/Dubai|Indian/Reunion',
+      'Asia/Gaza|Asia/Hebron',
+      'Asia/Hong_Kong|Hongkong',
+      'Asia/Jakarta|Asia/Pontianak',
+      'Asia/Jerusalem|Asia/Tel_Aviv',
+      'Asia/Jerusalem|Israel',
+      'Asia/Kamchatka|Asia/Anadyr',
+      'Asia/Kamchatka|Etc/GMT-12',
+      'Asia/Kamchatka|Kwajalein',
+      'Asia/Kamchatka|Pacific/Funafuti',
+      'Asia/Kamchatka|Pacific/Kwajalein',
+      'Asia/Kamchatka|Pacific/Majuro',
+      'Asia/Kamchatka|Pacific/Nauru',
+      'Asia/Kamchatka|Pacific/Tarawa',
+      'Asia/Kamchatka|Pacific/Wake',
+      'Asia/Kamchatka|Pacific/Wallis',
+      'Asia/Kathmandu|Asia/Katmandu',
+      'Asia/Kolkata|Asia/Calcutta',
+      'Asia/Kuala_Lumpur|Asia/Brunei',
+      'Asia/Kuala_Lumpur|Asia/Kuching',
+      'Asia/Kuala_Lumpur|Asia/Singapore',
+      'Asia/Kuala_Lumpur|Etc/GMT-8',
+      'Asia/Kuala_Lumpur|Singapore',
+      'Asia/Makassar|Asia/Ujung_Pandang',
+      'Asia/Rangoon|Asia/Yangon',
+      'Asia/Rangoon|Indian/Cocos',
+      'Asia/Seoul|ROK',
+      'Asia/Shanghai|Asia/Chongqing',
+      'Asia/Shanghai|Asia/Chungking',
+      'Asia/Shanghai|Asia/Harbin',
+      'Asia/Shanghai|Asia/Macao',
+      'Asia/Shanghai|Asia/Macau',
+      'Asia/Shanghai|Asia/Taipei',
+      'Asia/Shanghai|PRC',
+      'Asia/Shanghai|ROC',
+      'Asia/Tashkent|Antarctica/Mawson',
+      'Asia/Tashkent|Asia/Aqtau',
+      'Asia/Tashkent|Asia/Aqtobe',
+      'Asia/Tashkent|Asia/Ashgabat',
+      'Asia/Tashkent|Asia/Ashkhabad',
+      'Asia/Tashkent|Asia/Atyrau',
+      'Asia/Tashkent|Asia/Dushanbe',
+      'Asia/Tashkent|Asia/Oral',
+      'Asia/Tashkent|Asia/Samarkand',
+      'Asia/Tashkent|Etc/GMT-5',
+      'Asia/Tashkent|Indian/Kerguelen',
+      'Asia/Tashkent|Indian/Maldives',
+      'Asia/Tehran|Iran',
+      'Asia/Tokyo|Japan',
+      'Asia/Ulaanbaatar|Asia/Choibalsan',
+      'Asia/Ulaanbaatar|Asia/Ulan_Bator',
+      'Asia/Vladivostok|Asia/Ust-Nera',
+      'Asia/Yakutsk|Asia/Khandyga',
+      'Atlantic/Azores|America/Scoresbysund',
+      'Atlantic/Cape_Verde|Etc/GMT+1',
+      'Australia/Adelaide|Australia/Broken_Hill',
+      'Australia/Adelaide|Australia/South',
+      'Australia/Adelaide|Australia/Yancowinna',
+      'Australia/Brisbane|Australia/Lindeman',
+      'Australia/Brisbane|Australia/Queensland',
+      'Australia/Darwin|Australia/North',
+      'Australia/Lord_Howe|Australia/LHI',
+      'Australia/Perth|Australia/West',
+      'Australia/Sydney|Australia/ACT',
+      'Australia/Sydney|Australia/Canberra',
+      'Australia/Sydney|Australia/Currie',
+      'Australia/Sydney|Australia/Hobart',
+      'Australia/Sydney|Australia/Melbourne',
+      'Australia/Sydney|Australia/NSW',
+      'Australia/Sydney|Australia/Tasmania',
+      'Australia/Sydney|Australia/Victoria',
+      'Etc/UTC|Etc/UCT',
+      'Etc/UTC|Etc/Universal',
+      'Etc/UTC|Etc/Zulu',
+      'Etc/UTC|UCT',
+      'Etc/UTC|UTC',
+      'Etc/UTC|Universal',
+      'Etc/UTC|Zulu',
+      'Europe/Athens|Asia/Nicosia',
+      'Europe/Athens|EET',
+      'Europe/Athens|Europe/Bucharest',
+      'Europe/Athens|Europe/Helsinki',
+      'Europe/Athens|Europe/Kiev',
+      'Europe/Athens|Europe/Mariehamn',
+      'Europe/Athens|Europe/Nicosia',
+      'Europe/Athens|Europe/Riga',
+      'Europe/Athens|Europe/Sofia',
+      'Europe/Athens|Europe/Tallinn',
+      'Europe/Athens|Europe/Uzhgorod',
+      'Europe/Athens|Europe/Vilnius',
+      'Europe/Athens|Europe/Zaporozhye',
+      'Europe/Chisinau|Europe/Tiraspol',
+      'Europe/Dublin|Eire',
+      'Europe/Istanbul|Asia/Istanbul',
+      'Europe/Istanbul|Turkey',
+      'Europe/Lisbon|Atlantic/Canary',
+      'Europe/Lisbon|Atlantic/Faeroe',
+      'Europe/Lisbon|Atlantic/Faroe',
+      'Europe/Lisbon|Atlantic/Madeira',
+      'Europe/Lisbon|Portugal',
+      'Europe/Lisbon|WET',
+      'Europe/London|Europe/Belfast',
+      'Europe/London|Europe/Guernsey',
+      'Europe/London|Europe/Isle_of_Man',
+      'Europe/London|Europe/Jersey',
+      'Europe/London|GB',
+      'Europe/London|GB-Eire',
+      'Europe/Moscow|W-SU',
+      'Europe/Paris|Africa/Ceuta',
+      'Europe/Paris|Arctic/Longyearbyen',
+      'Europe/Paris|Atlantic/Jan_Mayen',
+      'Europe/Paris|CET',
+      'Europe/Paris|Europe/Amsterdam',
+      'Europe/Paris|Europe/Andorra',
+      'Europe/Paris|Europe/Belgrade',
+      'Europe/Paris|Europe/Berlin',
+      'Europe/Paris|Europe/Bratislava',
+      'Europe/Paris|Europe/Brussels',
+      'Europe/Paris|Europe/Budapest',
+      'Europe/Paris|Europe/Busingen',
+      'Europe/Paris|Europe/Copenhagen',
+      'Europe/Paris|Europe/Gibraltar',
+      'Europe/Paris|Europe/Ljubljana',
+      'Europe/Paris|Europe/Luxembourg',
+      'Europe/Paris|Europe/Madrid',
+      'Europe/Paris|Europe/Malta',
+      'Europe/Paris|Europe/Monaco',
+      'Europe/Paris|Europe/Oslo',
+      'Europe/Paris|Europe/Podgorica',
+      'Europe/Paris|Europe/Prague',
+      'Europe/Paris|Europe/Rome',
+      'Europe/Paris|Europe/San_Marino',
+      'Europe/Paris|Europe/Sarajevo',
+      'Europe/Paris|Europe/Skopje',
+      'Europe/Paris|Europe/Stockholm',
+      'Europe/Paris|Europe/Tirane',
+      'Europe/Paris|Europe/Vaduz',
+      'Europe/Paris|Europe/Vatican',
+      'Europe/Paris|Europe/Vienna',
+      'Europe/Paris|Europe/Warsaw',
+      'Europe/Paris|Europe/Zagreb',
+      'Europe/Paris|Europe/Zurich',
+      'Europe/Paris|Poland',
+      'Europe/Ulyanovsk|Europe/Astrakhan',
+      'Pacific/Auckland|Antarctica/McMurdo',
+      'Pacific/Auckland|Antarctica/South_Pole',
+      'Pacific/Auckland|NZ',
+      'Pacific/Chatham|NZ-CHAT',
+      'Pacific/Easter|Chile/EasterIsland',
+      'Pacific/Fakaofo|Etc/GMT-13',
+      'Pacific/Fakaofo|Pacific/Enderbury',
+      'Pacific/Galapagos|Etc/GMT+6',
+      'Pacific/Gambier|Etc/GMT+9',
+      'Pacific/Guadalcanal|Antarctica/Macquarie',
+      'Pacific/Guadalcanal|Etc/GMT-11',
+      'Pacific/Guadalcanal|Pacific/Efate',
+      'Pacific/Guadalcanal|Pacific/Kosrae',
+      'Pacific/Guadalcanal|Pacific/Noumea',
+      'Pacific/Guadalcanal|Pacific/Pohnpei',
+      'Pacific/Guadalcanal|Pacific/Ponape',
+      'Pacific/Guam|Pacific/Saipan',
+      'Pacific/Honolulu|HST',
+      'Pacific/Honolulu|Pacific/Johnston',
+      'Pacific/Honolulu|US/Hawaii',
+      'Pacific/Kiritimati|Etc/GMT-14',
+      'Pacific/Niue|Etc/GMT+11',
+      'Pacific/Pago_Pago|Pacific/Midway',
+      'Pacific/Pago_Pago|Pacific/Samoa',
+      'Pacific/Pago_Pago|US/Samoa',
+      'Pacific/Pitcairn|Etc/GMT+8',
+      'Pacific/Port_Moresby|Antarctica/DumontDUrville',
+      'Pacific/Port_Moresby|Etc/GMT-10',
+      'Pacific/Port_Moresby|Pacific/Chuuk',
+      'Pacific/Port_Moresby|Pacific/Truk',
+      'Pacific/Port_Moresby|Pacific/Yap',
+      'Pacific/Tahiti|Etc/GMT+10',
+      'Pacific/Tahiti|Pacific/Rarotonga',
+    ],
+  });
+
+  return moment;
+});

--- a/src/applications/personalization/dashboard-2/tests/unit/healthcare-appointments.unit.spec.jsx
+++ b/src/applications/personalization/dashboard-2/tests/unit/healthcare-appointments.unit.spec.jsx
@@ -5,6 +5,7 @@ import reducers from '~/applications/personalization/dashboard/reducers';
 import HealthCare from '~/applications/personalization/dashboard-2/components/health-care/HealthCare';
 import {
   farFutureAppointments,
+  upcomingCCAppointment,
   upcomingVAAppointment,
 } from '~/applications/personalization/dashboard-2/utils/appointments';
 
@@ -12,7 +13,7 @@ describe('HealthCare component', () => {
   let view;
   let initialState;
 
-  describe('when the user has an appointment scheduled within the next 30 days', () => {
+  describe('when the user has a VA appointment scheduled within the next 30 days', () => {
     it('should render "Next appointment"', async () => {
       initialState = {
         user: {
@@ -52,6 +53,51 @@ describe('HealthCare component', () => {
       });
 
       expect(view.getByText(/next appointment/i));
+      expect(view.getByText(/6:00 p.m. MT/i));
+    });
+  });
+
+  describe('when the user has a CC appointment scheduled within the next 30 days', () => {
+    it('should render "Next appointment"', async () => {
+      initialState = {
+        user: {
+          profile: {
+            services: [],
+          },
+        },
+        health: {
+          appointments: {
+            fetching: false,
+            data: upcomingCCAppointment,
+          },
+          msg: {
+            folders: {
+              data: {
+                currentItem: {
+                  attributes: {
+                    unreadCount: null,
+                  },
+                  fetching: false,
+                },
+              },
+              ui: {
+                nav: {
+                  foldersExpanded: false,
+                  visible: false,
+                },
+              },
+            },
+          },
+        },
+      };
+
+      view = renderInReduxProvider(<HealthCare dataLoadingDisabled />, {
+        initialState,
+        reducers,
+      });
+
+      expect(view.getByText(/next appointment/i));
+      expect(view.getByText(/6:00 p.m. MT/i));
     });
   });
 

--- a/src/applications/personalization/dashboard-2/tests/unit/healthcare-appointments.unit.spec.jsx
+++ b/src/applications/personalization/dashboard-2/tests/unit/healthcare-appointments.unit.spec.jsx
@@ -9,43 +9,47 @@ import {
   upcomingVAAppointment,
 } from '~/applications/personalization/dashboard-2/utils/appointments';
 
+function createInitialStateWithAppointments(appointments) {
+  return {
+    user: {
+      profile: {
+        services: [],
+      },
+    },
+    health: {
+      appointments: {
+        fetching: false,
+        data: appointments,
+      },
+      msg: {
+        folders: {
+          data: {
+            currentItem: {
+              attributes: {
+                unreadCount: null,
+              },
+              fetching: false,
+            },
+          },
+          ui: {
+            nav: {
+              foldersExpanded: false,
+              visible: false,
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
 describe('HealthCare component', () => {
   let view;
   let initialState;
 
   describe('when the user has a VA appointment scheduled within the next 30 days', () => {
     it('should render "Next appointment"', async () => {
-      initialState = {
-        user: {
-          profile: {
-            services: [],
-          },
-        },
-        health: {
-          appointments: {
-            fetching: false,
-            data: upcomingVAAppointment,
-          },
-          msg: {
-            folders: {
-              data: {
-                currentItem: {
-                  attributes: {
-                    unreadCount: null,
-                  },
-                  fetching: false,
-                },
-              },
-              ui: {
-                nav: {
-                  foldersExpanded: false,
-                  visible: false,
-                },
-              },
-            },
-          },
-        },
-      };
+      initialState = createInitialStateWithAppointments(upcomingVAAppointment);
 
       view = renderInReduxProvider(<HealthCare dataLoadingDisabled />, {
         initialState,
@@ -59,37 +63,7 @@ describe('HealthCare component', () => {
 
   describe('when the user has a CC appointment scheduled within the next 30 days', () => {
     it('should render "Next appointment"', async () => {
-      initialState = {
-        user: {
-          profile: {
-            services: [],
-          },
-        },
-        health: {
-          appointments: {
-            fetching: false,
-            data: upcomingCCAppointment,
-          },
-          msg: {
-            folders: {
-              data: {
-                currentItem: {
-                  attributes: {
-                    unreadCount: null,
-                  },
-                  fetching: false,
-                },
-              },
-              ui: {
-                nav: {
-                  foldersExpanded: false,
-                  visible: false,
-                },
-              },
-            },
-          },
-        },
-      };
+      initialState = createInitialStateWithAppointments(upcomingCCAppointment);
 
       view = renderInReduxProvider(<HealthCare dataLoadingDisabled />, {
         initialState,
@@ -103,37 +77,7 @@ describe('HealthCare component', () => {
 
   describe('when the user has an appointment scheduled after the next 30 days', () => {
     beforeEach(() => {
-      initialState = {
-        user: {
-          profile: {
-            services: [],
-          },
-        },
-        health: {
-          appointments: {
-            fetching: false,
-            data: farFutureAppointments,
-          },
-          msg: {
-            folders: {
-              data: {
-                currentItem: {
-                  attributes: {
-                    unreadCount: null,
-                  },
-                  fetching: false,
-                },
-              },
-              ui: {
-                nav: {
-                  foldersExpanded: false,
-                  visible: false,
-                },
-              },
-            },
-          },
-        },
-      };
+      initialState = createInitialStateWithAppointments(farFutureAppointments);
 
       view = renderInReduxProvider(<HealthCare dataLoadingDisabled />, {
         initialState,
@@ -155,37 +99,7 @@ describe('HealthCare component', () => {
 
   describe('when the user has no appointments scheduled', () => {
     beforeEach(() => {
-      initialState = {
-        user: {
-          profile: {
-            services: [],
-          },
-        },
-        health: {
-          appointments: {
-            fetching: false,
-            data: [],
-          },
-          msg: {
-            folders: {
-              data: {
-                currentItem: {
-                  attributes: {
-                    unreadCount: null,
-                  },
-                  fetching: false,
-                },
-              },
-              ui: {
-                nav: {
-                  foldersExpanded: false,
-                  visible: false,
-                },
-              },
-            },
-          },
-        },
-      };
+      initialState = createInitialStateWithAppointments([]);
 
       view = renderInReduxProvider(<HealthCare dataLoadingDisabled />, {
         initialState,

--- a/src/applications/personalization/dashboard-2/utils/appointments.js
+++ b/src/applications/personalization/dashboard-2/utils/appointments.js
@@ -1,8 +1,31 @@
-const oneDayInMS = 24 * 60 * 60 * 1000;
-const fortyDays = Date.now() + oneDayInMS * 40;
-const tomorrow = Date.now() + oneDayInMS;
-const dayAfterTomorrow = Date.now() + oneDayInMS * 2;
-const nextWeek = Date.now() + oneDayInMS * 7;
+import moment from 'moment';
+
+// A series of date strings that match the format used by Redux. All appointment
+// dates are in the following string format: 2021-05-26T18:00:00-06:00.
+const tomorrow = moment
+  .utc()
+  .add(2, 'day')
+  .startOf('day')
+  .utcOffset(-6)
+  .format();
+const dayAfterTomorrow = moment
+  .utc()
+  .add(3, 'day')
+  .startOf('day')
+  .utcOffset(-6)
+  .format();
+const nextWeek = moment
+  .utc()
+  .add(8, 'day')
+  .startOf('day')
+  .utcOffset(-6)
+  .format();
+const fortyDays = moment
+  .utc()
+  .add(40, 'day')
+  .startOf('day')
+  .utcOffset(-6)
+  .format();
 
 const ccAppointment = date => {
   return {
@@ -11,7 +34,7 @@ const ccAppointment = date => {
     isVideo: false,
     providerName: 'Jeckle and Hyde',
     startsAt: date,
-    timeZone: '-06:00 MDT',
+    timeZone: 'MT',
     type: 'cc',
   };
 };
@@ -52,6 +75,8 @@ const videoAppointment = date => {
   };
 };
 
+// These exports are for populating the Redux store used by the Appointments
+// component. They are not for mocking API calls!
 export const upcomingVideoAppointment = [
   videoAppointment(tomorrow),
   ccAppointment(dayAfterTomorrow),

--- a/src/applications/personalization/dashboard-2/utils/timezone.js
+++ b/src/applications/personalization/dashboard-2/utils/timezone.js
@@ -8,8 +8,11 @@ export const stripDST = abbr => {
   return abbr;
 };
 
+export const getTimezoneBySystemId = id =>
+  timezones.find(z => z.id === `dfn-${id}`);
+
 export const getVATimeZone = id => {
-  const matchingZone = timezones.find(z => z.id === `dfn-${id}`);
+  const matchingZone = getTimezoneBySystemId(id);
 
   if (!matchingZone) {
     return null;


### PR DESCRIPTION
**This PR is not as massive as it seems. Over 1600 lines are a copy of a moment-tz library that already exists in VAOS plus new spec files**

## Description
Previous to this PR, we were not properly formatting appointment start dates on My VA v2. This PR fixes that and mirrors the date formatting that VAOS does.

It makes two main changes:

1. The action that fetches appointment data massages the value of the `startAt` date before the action is dispatched and handled by the reducer.
2. The `Appointments` component that actually displays the date/time now uses `moment.parseZone()` so that it displays the date/time in the time zone where the appointment takes place rather than displaying it in browser local time.

## Testing done
Did this via TDD. Tests exist to make sure the action converts dates and sets each appointment's `startAt` correctly. Tests also exist to make sure the component properly displays the `startAt` date/time.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs