### PR TITLE
Fix eligibility modal close button

### DIFF
--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
@@ -25,6 +25,7 @@ import {
   routeToPreviousAppointmentPage,
   updateFacilitySortMethod,
   updateFormData,
+  hideEligibilityModal,
 } from '../../redux/actions';
 
 const initialSchema = {
@@ -58,7 +59,6 @@ export default function VAFacilityPageV2() {
     eligibility,
     facilities,
     hasDataFetchingError,
-    hideEligibilityModal,
     loadingEligibilityStatus,
     noValidVAFacilities,
     pageChangeInProgress,
@@ -326,7 +326,7 @@ export default function VAFacilityPageV2() {
 
       {showEligibilityModal && (
         <EligibilityModal
-          onClose={hideEligibilityModal}
+          onClose={() => dispatch(hideEligibilityModal())}
           eligibility={eligibility}
           facilityDetails={selectedFacility}
           typeOfCare={typeOfCare}

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.multi.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.multi.unit.spec.jsx
@@ -847,6 +847,14 @@ describe('VAOS integration: VA flat facility page - multiple facilities', () => 
     fireEvent.click(screen.getByText(/Continue/));
     await screen.findByText(/We can’t find a recent appointment for you/i);
     expect(screen.getByRole('alertdialog')).to.be.ok;
+    fireEvent.click(screen.getByRole('button', { name: 'Close this modal' }));
+
+    await waitFor(
+      () =>
+        expect(
+          screen.queryByText(/We can’t find a recent appointment for you/i),
+        ).to.not.exist,
+    );
   });
 
   it('should show additional info link if there are unsupported facilities within 100 miles', async () => {


### PR DESCRIPTION
## Description
This PR
- Fixes the close button on the eligibility modal, which was broken in the conversion of this page to react-redux hooks.

## Testing done
Unit testing

## Acceptance criteria
- [ ] Build passes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
