### PR TITLE
Update community care detail page

### DIFF
--- a/src/applications/vaos/appointment-list/components/CommunityCareAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/CommunityCareAppointmentDetailsPage.jsx
@@ -123,7 +123,7 @@ function CommunityCareAppointmentDetailsPage({
         {!!appointment.comment && (
           <div className="vads-u-flex--1 vads-u-margin-bottom--2 vaos-u-word-break--break-word">
             <h2 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-bottom--0">
-              Special instructions
+              You shared these details about your concern
             </h2>
             <div>{appointment.comment}</div>
           </div>
@@ -133,7 +133,7 @@ function CommunityCareAppointmentDetailsPage({
       <div className="vads-u-margin-top--3 vaos-appts__block-label vaos-hide-for-print">
         <i
           aria-hidden="true"
-          className="far fa-calendar vads-u-margin-right--1"
+          className="far fa-calendar vads-u-margin-right--1 vads-u-color--link-default"
         />
         <AddToCalendar
           summary={calendarData.summary}
@@ -149,7 +149,10 @@ function CommunityCareAppointmentDetailsPage({
       </div>
 
       <div className="vads-u-margin-top--2 vaos-appts__block-label vaos-hide-for-print">
-        <i aria-hidden="true" className="fas fa-print vads-u-margin-right--1" />
+        <i
+          aria-hidden="true"
+          className="fas fa-print vads-u-margin-right--1 vads-u-color--link-default"
+        />
         <button className="va-button-link" onClick={() => window.print()}>
           Print
         </button>
@@ -161,7 +164,7 @@ function CommunityCareAppointmentDetailsPage({
         headline="Need to make changes?"
         backgroundOnly
       >
-        Contact this facility if you need to reschedule or cancel your
+        Contact this provider if you need to reschedule or cancel your
         appointment.
       </AlertBox>
 

--- a/src/applications/vaos/appointment-list/components/CommunityCareAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/CommunityCareAppointmentDetailsPage.jsx
@@ -123,7 +123,7 @@ function CommunityCareAppointmentDetailsPage({
         {!!appointment.comment && (
           <div className="vads-u-flex--1 vads-u-margin-bottom--2 vaos-u-word-break--break-word">
             <h2 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-bottom--0">
-              You shared these details about your concern
+              Special instructions
             </h2>
             <div>{appointment.comment}</div>
           </div>

--- a/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
@@ -104,7 +104,10 @@ describe('VAOS <CommunityCareAppointmentDetailsPage>', () => {
     expect(screen.getByRole('link', { name: /7 0 3. 5 5 5. 1 2 6 4./ })).to.be
       .ok;
     expect(
-      screen.getByRole('heading', { level: 2, name: /Special instructions/ }),
+      screen.getByRole('heading', {
+        level: 2,
+        name: /You shared these details about your concern/,
+      }),
     ).to.be.ok;
     expect(screen.getByText(/Bring your glasses/)).to.be.ok;
     expect(

--- a/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
@@ -106,7 +106,7 @@ describe('VAOS <CommunityCareAppointmentDetailsPage>', () => {
     expect(
       screen.getByRole('heading', {
         level: 2,
-        name: /You shared these details about your concern/,
+        name: /Special instructions/,
       }),
     ).to.be.ok;
     expect(screen.getByText(/Bring your glasses/)).to.be.ok;


### PR DESCRIPTION
## Description

This PR updates community care detail pages under the homepage refresh feature flag.

Ticket: [24803](https://github.com/department-of-veterans-affairs/va.gov-team/issues/24803)

## Testing done

- local, unit testing

## Screenshots

<img width="697" alt="Screen Shot 2021-05-26 at 10 07 22 AM" src="https://user-images.githubusercontent.com/9746156/119702326-313d8d80-be0a-11eb-9ab7-19a6258e95c3.png">

## Acceptance criteria
- [x] Changes are behind the va_online_scheduling_homepage_refresh feature flag
- [x] CONTENT - Content matches the copy doc
- [x] DESIGN - Designs match the specs (copy is FPO)
Desktop
Tablet
Mobile
Heading layout reference overview and content detail
- [x] Note:
icon colors are changed in new design

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

