### PR TITLE
NOD: Fix IE11 edit button placement

### DIFF
--- a/src/applications/appeals/10182/sass/10182-nod.scss
+++ b/src/applications/appeals/10182/sass/10182-nod.scss
@@ -121,6 +121,13 @@ dl.review {
   }
 }
 
+/* IE11 hack to fix edit button placement, see
+ * https://github.com/department-of-veterans-affairs/va.gov-team/issues/25108
+ */
+ _:-ms-fullscreen, :root dl.review dd.widget-content.widget-edit .widget-content-wrap {
+  width: calc(100% - 125px); /* 125px ~= width of the edit button x2 */
+}
+
 .additional-issues {
   .schemaform-label,
   .usa-input-error {


### PR DESCRIPTION
## Description

Using an CSS hack to fix IE11 edit button placement.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/25108

## Testing done

Manual testing in IE11

## Screenshots

![](https://user-images.githubusercontent.com/587583/119243031-24721e80-bb18-11eb-902b-2ac9ea9be756.png)

## Acceptance criteria
- [x] Button placement fixed in IE11

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
