### PR TITLE
Removes extra comma in the first accordion

### DIFF
--- a/src/applications/virtual-agent/components/page/Disclaimer.jsx
+++ b/src/applications/virtual-agent/components/page/Disclaimer.jsx
@@ -69,7 +69,7 @@ export default function Disclaimer() {
       <va-accordion>
         <va-accordion-item header="What to know if you need help now">
           <p>
-            <b>If you’re a Veteran in crisis or concerned about one</b>, call
+            <b>If you’re a Veteran in crisis or concerned about one,</b> call
             the Veterans Crisis Line at{' '}
             <a aria-label="8 0 0. 2 7 3. 8 2 5 5." href="tel:800-273-8255">
               800-273-8255
@@ -95,7 +95,7 @@ export default function Disclaimer() {
             </a>
           </p>
           <p>
-            <b>If you have other questions about VA benefits and services,</b>,
+            <b>If you have other questions about VA benefits and services,</b>
             contact us or access our online resources and support.
           </p>
           <a href="/contact-us">Contact Us</a>


### PR DESCRIPTION
## Description
Removes the extra comma in the first accordion of the virtual agent study disclaimer

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
