### PR TITLE
Add missing axe checks in VAOS Cypress tests

### DIFF
--- a/src/applications/vaos/tests/e2e/appointment-list.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/appointment-list.cypress.spec.js
@@ -207,6 +207,7 @@ describe('VAOS appointment list refresh', () => {
       cy.get('[data-cy=requested-appointment-list-item]')
         .first()
         .should('exist');
+      cy.axeCheckBestPractice();
     });
 
     it('should navigate to requested appointment details', () => {
@@ -215,6 +216,7 @@ describe('VAOS appointment list refresh', () => {
         .findByText(/Details/i)
         .click();
       cy.findByText(/Request detail/i).should('exist');
+      cy.axeCheckBestPractice();
     });
   });
 

--- a/src/applications/vaos/tests/e2e/va-request.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/va-request.cypress.spec.js
@@ -104,6 +104,7 @@ function fillOutForm(facilitySelection) {
     .click();
   cy.findByText('Follow-up/Routine');
   cy.findByText('cough');
+  cy.axeCheckBestPractice();
 }
 
 describe('VAOS request flow', () => {

--- a/src/applications/vaos/tests/e2e/vaos-cypress-schedule-appointment-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-cypress-schedule-appointment-helpers.js
@@ -133,6 +133,7 @@ export function confirmationPageTest(additionalInfo) {
   cy.findByText('VA Appointment');
   cy.findByText('Follow-up/Routine');
   cy.findByText(additionalInfo);
+  cy.axeCheckBestPractice();
 }
 
 export function confirmationPageV2Test(fullReason) {
@@ -140,4 +141,5 @@ export function confirmationPageV2Test(fullReason) {
   cy.findByText('VA Appointment');
   cy.findByText('Your reason for your visit');
   cy.findByText(fullReason);
+  cy.axeCheckBestPractice();
 }


### PR DESCRIPTION
## Description
This PR
- Adds missing axe checks in our Cypress tests

## Acceptance criteria
- [ ] Build passes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
