### PR TITLE
vets-website update schema dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -323,7 +323,7 @@
     "url-search-params-polyfill": "^8.1.0",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#ae2902bf06f05ef43c934a7d9cd7f8d207e0a30d",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#dc9443a28e7f26b947ddb6d7b9df486350155f57",
     "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.6.1",
     "whatwg-fetch": "^2.0.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -19941,9 +19941,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#ae2902bf06f05ef43c934a7d9cd7f8d207e0a30d":
-  version "20.3.4"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#ae2902bf06f05ef43c934a7d9cd7f8d207e0a30d"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#dc9443a28e7f26b947ddb6d7b9df486350155f57":
+  version "20.3.5"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#dc9443a28e7f26b947ddb6d7b9df486350155f57"
 
 vfile-message@^2.0.0:
   version "2.0.4"


### PR DESCRIPTION
Remove form from schema [594](https://github.com/department-of-veterans-affairs/vets-json-schema/pull/594)

 vets-website to update the vets-json-schema dependency after the removal of combat zone form.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
