### PR TITLE
update CC Homepage refresh details page

### DIFF
--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
@@ -201,10 +201,14 @@ export default function RequestedAppointmentDetailsPage() {
           )}
         </AlertBox>
       )}
-      <h2 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-bottom--0">
-        {!isCCRequest && isVideoRequest && 'VA Video Connect'}
-        {!isCCRequest && !isVideoRequest && 'VA Appointment'}
-      </h2>
+      {!isCCRequest && (
+        <>
+          <h2 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-bottom--0">
+            {isVideoRequest && 'VA Video Connect'}
+            {!isVideoRequest && 'VA Appointment'}
+          </h2>
+        </>
+      )}
 
       {!!facility &&
         !isCC && (
@@ -243,27 +247,33 @@ export default function RequestedAppointmentDetailsPage() {
         <h2 className="vads-u-margin-top--2 vaos-appts__block-label">
           You shared these details about your concern
         </h2>
-        <div>{apptDetails}</div>
+        {!isCCRequest && apptDetails}
+        {isCCRequest && <>{message || 'none'}</>}
       </div>
-      <h2 className="vads-u-margin-top--2 vads-u-margin-bottom--0 vaos-appts__block-label">
-        Your contact details
-      </h2>
-      <div className="vaos-u-word-break--break-word">
-        {getPatientTelecom(appointment, 'email')}
+      <div>
+        <h2 className="vads-u-margin-top--2 vads-u-margin-bottom--0 vaos-appts__block-label">
+          Your contact details
+        </h2>
+        <h3 className="vads-u-font-family--sans vads-u-display--inline vads-u-font-size--base">
+          Email:{' '}
+        </h3>
+        <span>{getPatientTelecom(appointment, 'email')}</span>
         <br />
+        <h3 className="vads-u-font-family--sans vads-u-display--inline vads-u-font-size--base">
+          Phone number:{' '}
+        </h3>
         <Telephone
           notClickable
           contact={getPatientTelecom(appointment, 'phone')}
         />
         <br />
-        <span className="vads-u-font-style--italic">
-          <ListBestTimeToCall
-            timesToCall={appointment.preferredTimesForPhoneCall}
-          />
-        </span>
+        <ListBestTimeToCall
+          timesToCall={appointment.preferredTimesForPhoneCall}
+        />
+      </div>
+      <div className="vaos-u-word-break--break-word">
         {!canceled && (
           <>
-            <br />
             <div className="vads-u-display--flex vads-u-align-items--center vads-u-color--link-default vads-u-margin-top--3">
               <i
                 aria-hidden="true"

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
@@ -248,6 +248,14 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
       requests: [ccAppointmentRequest],
       isHomepageRefresh: true,
     });
+
+    const message = getMessageMock();
+    message.attributes = {
+      ...message.attributes,
+      messageText: 'A message from the patient',
+    };
+    mockMessagesFetch('1234', [message]);
+
     const screen = renderWithStoreAndRouter(<AppointmentList />, {
       initialState,
       path: '/requested',
@@ -270,6 +278,12 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
         name: 'Pending audiology (hearing aid support) appointment',
       }),
     ).to.be.ok;
+
+    // show alert message
+    expect(screen.baseElement).to.contain('.usa-alert-info');
+    expect(screen.baseElement).to.contain.text(
+      'The time and date of this appointment are still to be determined.',
+    );
 
     // Should be able to cancel appointment
     expect(screen.getByRole('button', { name: /Cancel request/ })).to.be.ok;
@@ -295,7 +309,7 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
         name: 'You shared these details about your concern',
       }),
     ).to.be.ok;
-    expect(screen.getByText('Follow-up/Routine')).to.be.ok;
+    expect(screen.getByText('A message from the patient')).to.be.ok;
 
     expect(
       screen.getByRole('heading', {
@@ -312,6 +326,8 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
 
   it('should allow cancellation', async () => {
     const appointment = getVARequestMock();
+    const alertText =
+      'The time and date of this appointment are still to be determined.';
 
     appointment.id = '1234';
     appointment.attributes = {
@@ -338,6 +354,8 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
 
     expect(await screen.findByText('Pending primary care appointment')).to.be
       .ok;
+
+    expect(screen.baseElement).to.contain.text(alertText);
 
     expect(screen.baseElement).not.to.contain.text('Canceled');
 
@@ -367,6 +385,7 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
 
     expect(screen.queryByRole('alertdialog')).to.not.be.ok;
     expect(screen.baseElement).to.contain.text('Canceled');
+    expect(screen.baseElement).not.to.contain.text(alertText);
   });
 
   it('should show error message when single fetch errors', async () => {


### PR DESCRIPTION
## Description
Clean up design and copy for the community care details page

## Testing done
local and unit test

## Screenshots
**Show alert message for pending CC appts** 

- Title change for booking notes
- Display "none" if there's no message from patient

![image](https://user-images.githubusercontent.com/54327023/119843508-9f02bb80-bed5-11eb-8f7a-4af8beec577e.png)

<hr />

**Hide alert message for cancelled CC appts**

- Title change for booking notes and display message from patient

 
![image](https://user-images.githubusercontent.com/54327023/119844315-53044680-bed6-11eb-9f59-49483e92f4d6.png)

<hr />

**Create h3 headings for Email and Phone Number**


![image](https://user-images.githubusercontent.com/54327023/119845159-066d3b00-bed7-11eb-8feb-aadde41d9165.png)


## Acceptance criteria
- [ ] Display Alert message for pending CC appts
- [ ] Hide Alert message for canceled CC appts
- [ ] Change the Book Notes title
- [ ] Display the message from patient otherwise display "none" if there's no message
- [ ] Create h3 for Email and Phone Number heading then display the value on the same line
- [ ] Follow Heading layout reference [content detail](https://www.sketch.com/s/d4b8e6aa-2e36-47fd-aa04-52f4d3f839c3/a/nRgDbr0)
- [ ] Match [Doc Copy ](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/appointments/va-online-scheduling/content/copy-docs/appointment-details.md#request-pending-1)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
