### PR TITLE
Fix Cypress caching issue on GitHub Actions

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -15,15 +15,6 @@ jobs:
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
-      - name: Cache dependencies
-        id: cache-dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cache/yarn
-            node_modules
-          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
-
       - name: Install vets-website dependencies
         run: yarn install --frozen-lockfile --prefer-offline
         env:


### PR DESCRIPTION
## Description
The caching step in the Cypress GitHub Actions workflow is not properly managing the installation of Cypress. This PR removes the caching step so that Cypress is installed correctly.

## Testing done
- [ ] Cypress tests run without issues on GitHub Actions

## Acceptance criteria
- [ ] Cypress tests run without issues on GitHub Actions