### PR TITLE
Change heading level of My VA v2 Cerner widget

### DIFF
--- a/src/applications/personalization/dashboard/components/cerner-widgets.js
+++ b/src/applications/personalization/dashboard/components/cerner-widgets.js
@@ -14,6 +14,7 @@ const CernerAlertBox = ({
   secondaryCtaButtonText,
   secondaryCtaButtonUrl,
   facilityNames,
+  level = 3,
 }) => {
   // Helper component that takes an array of facility names and a separator string and returns some JSX to style the list of facility names.
   const FacilityList = ({ facilities, separator }) => {
@@ -44,6 +45,7 @@ const CernerAlertBox = ({
     <AlertBox
       status="warning"
       headline="Your VA health care team may be using our new My VA Health portal"
+      level={level}
     >
       <h3>Our records show you’re registered at:</h3>
       <h4 className="vads-u-font-family--sans">
@@ -143,6 +145,7 @@ export const GeneralCernerWidget = ({
       primaryCtaText="Manage health care at:"
       secondaryCtaButtonText="Go to My HealtheVet"
       secondaryCtaButtonUrl={mhvUrl(authenticatedWithSSOe, 'home')}
+      level={2}
     />
   </div>
 );


### PR DESCRIPTION
## Description
Bump up the heading level of the Cerner alert that is shown on My VA v2.

## Testing done
Local in Cypress using `health-care-cerner.cypress.spec.js`

## Screenshots
![image](https://user-images.githubusercontent.com/20728956/119861640-76c28f00-becc-11eb-9951-a63dbd3b3dbe.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs