### PR TITLE
25333 - re-insert videos into vre orientation

### DIFF
--- a/src/applications/vre/28-1900/orientation/StepComponent.jsx
+++ b/src/applications/vre/28-1900/orientation/StepComponent.jsx
@@ -11,6 +11,17 @@ const StepComponent = props => {
   if (data.isVideoStep) {
     content = (
       <>
+        {data.subTitle()}
+
+        <iframe
+          width="325px"
+          height="185px"
+          src={`https://www.youtube.com/embed/${data.path}`}
+          title={data.title}
+          frameBorder="0"
+          allowFullScreen
+          key={data.path}
+        />
         <p>{data.desc}</p>
         <ul>
           {data.list.map((item, index) => {
@@ -89,56 +100,3 @@ const StepComponent = props => {
 };
 
 export default StepComponent;
-
-/*
-Youtube videos
-Re-Employment
-<iframe
-  width="744"
-  height="422"
-  src="https://www.youtube.com/embed/1Yh6fTxvBPw"
-  frameBorder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowFullScreen
-/>;
-
-Rapid Access
-<iframe
-  width="744"
-  height="422"
-  src="https://www.youtube.com/embed/4DVbOy8iJbU"
-  frameBorder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowFullScreen
-/>;
-
-Self-Employment
-<iframe
-  width="744"
-  height="422"
-  src="https://www.youtube.com/embed/xkqhMmWzt74"
-  frameBorder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowFullScreen
-/>;
-
-Long Term Services
-<iframe
-    width="744"
-    height="422"
-    src="https://www.youtube.com/embed/IXlJndX93R8"
-    frameborder="0"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowfullscreen
-/>;
-
-Independent Living
-<iframe
-    width="744"
-    height="422"
-    src="https://www.youtube.com/embed/hHgPTZNAMxo"
-    frameborder="0"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowfullscreen
-/>
-*/

--- a/src/applications/vre/28-1900/orientation/utils.js
+++ b/src/applications/vre/28-1900/orientation/utils.js
@@ -142,7 +142,7 @@ export const orientationSteps = [
         </p>
       </>
     ),
-    path: '1Yh6fTxvBPw',
+    path: 'SkRD2CDHB_E',
     desc:
       'The Reemployment track provides support to you and your employer so you can return to your former job. This track is for claimants who served on active duty or in the National Guard and are now returning to their former job. If you’re in the Reemployment track, we’ll:',
     list: [
@@ -169,7 +169,7 @@ export const orientationSteps = [
         </p>
       </>
     ),
-    path: '4DVbOy8iJbU',
+    path: 'VkmTgQftRlk',
     desc:
       'The Rapid Access to Employment track provides services that help Veterans start working right away. This track is right for you if you already have most of the skills you’ll need to be competitive in the labor market in a suitable occupation. If you’re in the Rapid Access to Employment track, we’ll help you:',
     list: [
@@ -198,7 +198,7 @@ export const orientationSteps = [
         </p>
       </>
     ),
-    path: 'xkqhMmWzt74',
+    path: 'IYqVu3Q1Wow',
     desc:
       'The Self-Employment track provides services to Veterans and service members who have the skills to start a business and who have a disability that makes traditional employment difficult. If you’re in the Self-Employment track, we’ll support you with:',
     list: [
@@ -225,7 +225,7 @@ export const orientationSteps = [
         </p>
       </>
     ),
-    path: 'IXlJndX93R8',
+    path: '32oPJaWpUhI',
     desc:
       'The Employment Through Long-Term Services track provides Veterans with the counseling, training, and education they need to become suitably employed. If you’re in the Employment Through Long-Term Services track, we can help you get:',
     list: [
@@ -256,7 +256,7 @@ export const orientationSteps = [
         </p>
       </>
     ),
-    path: 'hHgPTZNAMxo',
+    path: '_Yd0aW_NZvA',
     desc:
       'The Independent Living track provides services to Veterans and service members who have a disability that prevents them from looking for or returning to work. If you’re in this track, we’ll help you live as independently as possible. We can help you get:',
     list: [


### PR DESCRIPTION
## Description
This pull request re-inserts chapter 31 orientation videos into the chapter 31 orientation. They were previously removed because they were not associated with an official VR&E youtube account, and therefore not manageable. 

## Testing done
local

## Screenshots
<img width="691" alt="Screen Shot 2021-05-27 at 12 24 37 PM" src="https://user-images.githubusercontent.com/15097156/119862667-bbf3ba80-bee6-11eb-994a-542f2cc18adc.png">
<img width="539" alt="Screen Shot 2021-05-27 at 12 26 41 PM" src="https://user-images.githubusercontent.com/15097156/119862740-cf9f2100-bee6-11eb-9b2a-97603718d076.png">



## Acceptance criteria
- [x] videos loaded in

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
