### PR TITLE
NOD: Revert disagreement validation

### DIFF
--- a/src/applications/appeals/10182/config/form.js
+++ b/src/applications/appeals/10182/config/form.js
@@ -23,7 +23,6 @@ import {
   showAddIssuesPage,
   needsHearingType,
   appStateSelector,
-  appStateSelectorDisagreement,
   getIssueName,
 } from '../utils/helpers';
 
@@ -164,7 +163,6 @@ const formConfig = {
           arrayPath: 'areaOfDisagreement',
           uiSchema: areaOfDisagreementFollowUp.uiSchema,
           schema: areaOfDisagreementFollowUp.schema,
-          appStateSelectorDisagreement,
         },
         optIn: {
           title: 'Opt in',

--- a/src/applications/appeals/10182/tests/validations.unit.spec.js
+++ b/src/applications/appeals/10182/tests/validations.unit.spec.js
@@ -86,14 +86,12 @@ describe('areaOfDisagreementRequired', () => {
   });
   it('should not show an error with a single selection', () => {
     const errors = { addError: sinon.spy() };
-    areaOfDisagreementRequired(errors, null, {
-      disagreementOptions: { foo: true },
-    });
+    areaOfDisagreementRequired(errors, { disagreementOptions: { foo: true } });
     expect(errors.addError.called).to.be.false;
   });
   it('should not show an error with other selected with entry text', () => {
     const errors = { addError: sinon.spy() };
-    areaOfDisagreementRequired(errors, null, {
+    areaOfDisagreementRequired(errors, {
       disagreementOptions: { other: true },
       otherEntry: 'foo',
     });

--- a/src/applications/appeals/10182/utils/helpers.js
+++ b/src/applications/appeals/10182/utils/helpers.js
@@ -87,9 +87,5 @@ export const appStateSelector = state => ({
   additionalIssues: state.form?.data?.additionalIssues || [],
 });
 
-export const appStateSelectorDisagreement = state => ({
-  areaOfDisagreement: state.form?.data?.areaOfDisagreement || [],
-});
-
 export const noticeOfDisagreementFeature = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.form10182Nod];

--- a/src/applications/appeals/10182/validations.js
+++ b/src/applications/appeals/10182/validations.js
@@ -28,18 +28,14 @@ export const requireIssue = (
 export const areaOfDisagreementRequired = (
   errors,
   // added index to get around arrayIndex being null
-  _fieldData,
+  { disagreementOptions, otherEntry, index } = {},
   formData,
   _schema,
   _uiSchema,
   arrayIndex, // always null?!
-  appStateData,
 ) => {
-  const data = Object.keys(appStateData || {}).length ? appStateData : formData;
-  const { disagreementOptions, otherEntry, index } = data || {};
-  const hasSelection = Object.keys(disagreementOptions || {}).some(
-    key => disagreementOptions[key],
-  );
+  const keys = Object.keys(disagreementOptions || {});
+  const hasSelection = keys.some(key => disagreementOptions[key]);
 
   if (!hasSelection) {
     errors.addError(missingAreaOfDisagreementErrorMessage);


### PR DESCRIPTION
## Description

Reverting a validation change that prevents form submission.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/25285

## Testing done

Updated unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] NOD submits properly
- [x] Unit tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
