### PR TITLE
Improve and standardize fetch mocking

### DIFF
--- a/src/applications/appeals/10182/tests/actions/actions.unit.spec.js
+++ b/src/applications/appeals/10182/tests/actions/actions.unit.spec.js
@@ -10,13 +10,7 @@ import {
   FETCH_CONTESTABLE_ISSUES_FAILED,
 } from '../../actions';
 
-const originalFetch = global.fetch;
-
 describe('fetch contestable issues action', () => {
-  afterEach(() => {
-    global.fetch = originalFetch;
-  });
-
   it('should dispatch an init action', () => {
     const mockData = { data: 'asdf' };
     mockApiRequest(mockData);

--- a/src/applications/burials/tests/helpers.unit.spec.jsx
+++ b/src/applications/burials/tests/helpers.unit.spec.jsx
@@ -5,7 +5,6 @@ import { submit } from '../helpers.jsx';
 
 import {
   mockFetch,
-  resetFetch,
   setFetchJSONResponse as setFetchResponse,
 } from 'platform/testing/unit/helpers';
 
@@ -113,7 +112,6 @@ describe('Burials helpers', () => {
       );
     });
     afterEach(() => {
-      resetFetch();
       delete window.URL;
     });
   });

--- a/src/applications/claims-status/tests/actions.unit.spec.js
+++ b/src/applications/claims-status/tests/actions.unit.spec.js
@@ -1,5 +1,10 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
+import {
+  mockFetch,
+  setFetchJSONFailure,
+  setFetchJSONResponse,
+} from 'platform/testing/unit/helpers.js';
 
 import {
   ADD_FILE,
@@ -50,19 +55,6 @@ import {
   FETCH_STEM_CLAIMS_SUCCESS,
   FETCH_STEM_CLAIMS_PENDING,
 } from '../actions';
-
-let fetchMock;
-let oldFetch;
-
-const mockFetch = () => {
-  oldFetch = global.fetch;
-  fetchMock = sinon.stub();
-  global.fetch = fetchMock;
-};
-
-const unMockFetch = () => {
-  global.fetch = oldFetch;
-};
 
 describe('Actions', () => {
   describe('setNotification', () => {
@@ -240,14 +232,10 @@ describe('Actions', () => {
     });
   });
   describe('getAppeals', () => {
-    beforeEach(mockFetch);
+    beforeEach(() => mockFetch());
     it('should fetch claims', done => {
       const appeals = [];
-      fetchMock.returns({
-        catch: () => ({
-          then: fn => fn({ ok: true, json: () => Promise.resolve(appeals) }),
-        }),
-      });
+      setFetchJSONResponse(global.fetch.onCall(0), appeals);
       const thunk = getAppeals();
       const dispatchSpy = sinon.spy();
       const dispatch = action => {
@@ -263,16 +251,7 @@ describe('Actions', () => {
     });
     it('should fail on error', done => {
       const appeals = [];
-      fetchMock.returns({
-        catch: () => ({
-          then: fn =>
-            fn({
-              ok: false,
-              status: 500,
-              json: () => Promise.resolve(appeals),
-            }),
-        }),
-      });
+      setFetchJSONFailure(global.fetch.onCall(0), appeals);
       const thunk = getAppeals();
       const dispatchSpy = sinon.spy();
       const dispatch = action => {
@@ -288,7 +267,6 @@ describe('Actions', () => {
 
       thunk(dispatch);
     });
-    afterEach(unMockFetch);
   });
   describe('getClaimsV2', () => {
     it('should call dispatch and pollStatus', () => {
@@ -514,21 +492,17 @@ describe('Actions', () => {
     });
   });
   describe('submitRequest', () => {
-    beforeEach(mockFetch);
+    beforeEach(() => mockFetch());
     it('should submit request', done => {
-      fetchMock.returns({
-        catch: () => ({
-          then: fn => fn({ ok: true, json: () => Promise.resolve() }),
-        }),
-      });
+      setFetchJSONResponse(global.fetch.onCall(0), []);
       const thunk = submitRequest(5);
       const dispatchSpy = sinon.spy();
       const dispatch = action => {
         dispatchSpy(action);
         if (dispatchSpy.callCount === 3) {
-          expect(fetchMock.firstCall.args[1].method).to.equal('POST');
-          expect(fetchMock.firstCall.args[0].endsWith('5/request_decision')).to
-            .be.true;
+          expect(global.fetch.firstCall.args[1].method).to.equal('POST');
+          expect(global.fetch.firstCall.args[0].endsWith('5/request_decision'))
+            .to.be.true;
           expect(dispatchSpy.firstCall.args[0]).to.eql({
             type: SUBMIT_DECISION_REQUEST,
           });
@@ -543,12 +517,7 @@ describe('Actions', () => {
       thunk(dispatch);
     });
     it('should fail on error', done => {
-      fetchMock.returns({
-        catch: () => ({
-          then: fn =>
-            fn({ ok: false, status: 500, json: () => Promise.resolve() }),
-        }),
-      });
+      setFetchJSONFailure(global.fetch.onCall(0));
       const thunk = submitRequest(5);
       const dispatchSpy = sinon.spy();
       const dispatch = action => {
@@ -566,18 +535,13 @@ describe('Actions', () => {
 
       thunk(dispatch);
     });
-    afterEach(unMockFetch);
   });
 
   describe('getStemClaims', () => {
-    beforeEach(mockFetch);
+    beforeEach(() => mockFetch());
     it('should fetch stem claims', done => {
       const response = { data: [] };
-      fetchMock.returns({
-        catch: () => ({
-          then: fn => fn({ ok: true, json: () => Promise.resolve(response) }),
-        }),
-      });
+      setFetchJSONResponse(global.fetch.onCall(0), response);
       const thunk = getStemClaims();
       const dispatchSpy = sinon.spy();
       const dispatch = action => {
@@ -596,16 +560,7 @@ describe('Actions', () => {
       thunk(dispatch);
     });
     it('should fail on error', done => {
-      fetchMock.returns({
-        catch: () => ({
-          then: fn =>
-            fn({
-              ok: false,
-              status: 500,
-              json: () => Promise.resolve([]),
-            }),
-        }),
-      });
+      setFetchJSONFailure(global.fetch.onCall(0));
       const thunk = getStemClaims();
       const dispatchSpy = sinon.spy();
       const dispatch = action => {
@@ -623,6 +578,5 @@ describe('Actions', () => {
 
       thunk(dispatch);
     });
-    afterEach(unMockFetch);
   });
 });

--- a/src/applications/claims-status/tests/utils/appealsV2Actions.unit.spec.js
+++ b/src/applications/claims-status/tests/utils/appealsV2Actions.unit.spec.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
+import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
 
 import { getAppealsV2 } from '../../actions';
 
@@ -13,30 +14,22 @@ import {
   FETCH_APPEALS_ERROR,
 } from '../../utils/appeals-v2-helpers';
 
-let oldFetch;
-
 const setup = () => {
-  oldFetch = global.fetch;
-  global.fetch = sinon.stub();
-  global.fetch.returns(
-    Promise.resolve({
-      headers: { get: () => 'application/json' },
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          data: [],
-        }),
-    }),
-  );
-};
-
-const teardown = () => {
-  global.fetch = oldFetch;
+  const response = {
+    url: 'https://dev-api.va.gov',
+    status: 200,
+    headers: { get: () => 'application/json' },
+    ok: true,
+    json: () =>
+      Promise.resolve({
+        data: [],
+      }),
+  };
+  mockFetch(response);
 };
 
 describe('getAppealsV2', () => {
   beforeEach(setup);
-  afterEach(teardown);
 
   it('dispatches FETCH_APPEALS_PENDING', done => {
     const thunk = getAppealsV2();
@@ -72,7 +65,8 @@ describe('getAppealsV2', () => {
     it(`Dispatches ${
       appealsErrors[code]
     } when GET fails with ${code}`, done => {
-      global.fetch.returns(
+      resetFetch();
+      mockFetch(
         Promise.reject({
           errors: [{ status: `${code}` }],
         }),

--- a/src/applications/claims-status/tests/utils/appealsV2Actions.unit.spec.js
+++ b/src/applications/claims-status/tests/utils/appealsV2Actions.unit.spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 
 import { getAppealsV2 } from '../../actions';
 
@@ -65,7 +65,6 @@ describe('getAppealsV2', () => {
     it(`Dispatches ${
       appealsErrors[code]
     } when GET fails with ${code}`, done => {
-      resetFetch();
       mockFetch(
         Promise.reject({
           errors: [{ status: `${code}` }],

--- a/src/applications/claims-status/tests/utils/appealsV2Actions.unit.spec.js
+++ b/src/applications/claims-status/tests/utils/appealsV2Actions.unit.spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
 
 import { getAppealsV2 } from '../../actions';
 
@@ -65,7 +65,8 @@ describe('getAppealsV2', () => {
     it(`Dispatches ${
       appealsErrors[code]
     } when GET fails with ${code}`, done => {
-      mockFetch(
+      setFetchJSONResponse(
+        global.fetch.onCall(0),
         Promise.reject({
           errors: [{ status: `${code}` }],
         }),

--- a/src/applications/coronavirus-chatbot/tests/index.unit.spec.js
+++ b/src/applications/coronavirus-chatbot/tests/index.unit.spec.js
@@ -2,11 +2,7 @@ import * as WebchatModule from '../webchat';
 import { initializeChatbot } from '../index';
 import sinon from 'sinon';
 import { expect } from 'chai';
-import {
-  mockFetch,
-  setFetchJSONResponse,
-  resetFetch,
-} from 'platform/testing/unit/helpers';
+import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
 
 describe('initializeChatbot', () => {
   let botConnectionStub;
@@ -24,7 +20,6 @@ describe('initializeChatbot', () => {
   after(() => {
     botConnectionStub.restore();
     webchatStoreStub.restore();
-    resetFetch();
   });
 
   it('should configure webchat with CSRF token', async () => {

--- a/src/applications/coronavirus-vaccination/tests/components/Form.unit.spec.jsx
+++ b/src/applications/coronavirus-vaccination/tests/components/Form.unit.spec.jsx
@@ -6,7 +6,6 @@ import { setupServer } from 'msw/node';
 import { expect } from 'chai';
 
 import environment from 'platform/utilities/environment';
-import { resetFetch } from 'platform/testing/unit/helpers';
 import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
 
 import reducer from '../../reducers';
@@ -83,7 +82,6 @@ describe('<Form/> prefills -> by old form data', () => {
   let server = null;
 
   before(() => {
-    resetFetch();
     server = setupServer(
       rest.get(
         `${environment.API_URL}/covid_vaccine/v0/registration`,
@@ -158,7 +156,6 @@ describe('<Form/> prefills -> profile data ', () => {
   let server = null;
 
   before(() => {
-    resetFetch();
     server = setupServer(
       rest.get(
         `${environment.API_URL}/covid_vaccine/v0/registration`,

--- a/src/applications/disability-benefits/686c-674/tests/actions/index.unit.spec.js
+++ b/src/applications/disability-benefits/686c-674/tests/actions/index.unit.spec.js
@@ -1,26 +1,14 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
+import { mockFetch } from 'platform/testing/unit/helpers';
 import {
   VERIFY_VA_FILE_NUMBER_SUCCEEDED,
   VERIFY_VA_FILE_NUMBER_FAILED,
   verifyVaFileNumber,
 } from '../../actions';
 
-let fetchMock;
-let oldFetch;
-
-const mockFetch = () => {
-  oldFetch = global.fetch;
-  fetchMock = sinon.stub();
-  global.fetch = fetchMock;
-};
-
-const unMockFetch = () => {
-  global.fetch = oldFetch;
-};
-
 describe('Verify VA file number actions: verifyVaFileNumber', () => {
-  beforeEach(mockFetch);
+  beforeEach(() => mockFetch());
 
   it('should fetch a va file number', () => {
     const verified = {
@@ -30,7 +18,7 @@ describe('Verify VA file number actions: verifyVaFileNumber', () => {
       },
     };
 
-    fetchMock.returns({
+    global.fetch.returns({
       catch: () => ({
         then: fn => fn({ ok: true, json: () => Promise.resolve(verified) }),
       }),
@@ -57,7 +45,7 @@ describe('Verify VA file number actions: verifyVaFileNumber', () => {
         },
       ],
     };
-    fetchMock.returns({
+    global.fetch.returns({
       catch: () => ({
         then: fn => fn({ ok: true, json: () => Promise.resolve(response) }),
       }),
@@ -74,5 +62,4 @@ describe('Verify VA file number actions: verifyVaFileNumber', () => {
     };
     thunk(dispatch);
   });
-  afterEach(unMockFetch);
 });

--- a/src/applications/disability-benefits/996/tests/actions/actions.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/actions/actions.unit.spec.js
@@ -10,13 +10,7 @@ import {
   FETCH_CONTESTABLE_ISSUES_FAILED,
 } from '../../actions';
 
-const originalFetch = global.fetch;
-
 describe('fetch contestable issues action', () => {
-  afterEach(() => {
-    global.fetch = originalFetch;
-  });
-
   it('should dispatch an init action', () => {
     const mockData = { data: 'asdf' };
     const benefitType = 'compensation';

--- a/src/applications/disability-benefits/all-claims/tests/actions/actions.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/actions/actions.unit.spec.js
@@ -18,14 +18,8 @@ import {
   MVI_ADD_FAILED,
 } from '../../actions';
 
-const originalFetch = global.fetch;
-
 describe('ITF actions', () => {
   describe('fetchITF', () => {
-    afterEach(() => {
-      global.fetch = originalFetch;
-    });
-
     it('should dispatch a fetch succeeded action with data', () => {
       const mockData = { data: 'asdf' };
       mockApiRequest(mockData);
@@ -51,10 +45,6 @@ describe('ITF actions', () => {
   });
 
   describe('createITF', () => {
-    afterEach(() => {
-      global.fetch = originalFetch;
-    });
-
     it('should dispatch a fetch succeeded action with data', () => {
       const mockData = { data: 'asdf' };
       mockApiRequest(mockData);
@@ -86,10 +76,6 @@ describe('ITF actions', () => {
 
 describe('MVI action', () => {
   describe('MVI add person action', () => {
-    afterEach(() => {
-      global.fetch = originalFetch;
-    });
-
     it('should dispatch an add person succeeded action', () => {
       const mockData = { data: 'asdf' };
       mockApiRequest(mockData);

--- a/src/applications/disability-benefits/all-claims/tests/components/ConfirmationPoll.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/ConfirmationPoll.unit.spec.jsx
@@ -13,8 +13,6 @@ import {
 } from '../../components/ConfirmationPoll';
 import { submissionStatuses } from '../../constants';
 
-const originalFetch = global.fetch;
-
 const pendingResponse = {
   shouldResolve: true,
   response: {
@@ -70,10 +68,6 @@ describe('ConfirmationPoll', () => {
     disabilities: [],
     submittedAt: Date.now(),
   };
-
-  afterEach(() => {
-    global.fetch = originalFetch;
-  });
 
   it('should make an api call after mounting', () => {
     mockApiRequest(successResponse.response);

--- a/src/applications/disability-benefits/all-claims/tests/containers/ITFWrapper.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/ITFWrapper.unit.spec.jsx
@@ -8,6 +8,7 @@ import moment from 'moment';
 import { ITFWrapper } from '../../containers/ITFWrapper';
 import { itfStatuses } from '../../constants';
 import { requestStates } from 'platform/utilities/constants';
+import { mockFetch } from 'platform/testing/unit/helpers';
 
 const fetchITF = sinon.spy();
 const createITF = sinon.spy();
@@ -32,7 +33,7 @@ describe('526 ITFWrapper', () => {
   });
 
   it('should not make an api call on the intro page', () => {
-    global.fetch = sinon.spy();
+    mockFetch();
     const tree = mount(
       <ITFWrapper location={{ pathname: '/introduction' }}>
         <p>It worked!</p>
@@ -44,7 +45,7 @@ describe('526 ITFWrapper', () => {
   });
 
   it('should not make an api call on the intro page with a trailing slash', () => {
-    global.fetch = sinon.spy();
+    mockFetch();
     const tree = mount(
       <ITFWrapper location={{ pathname: '/introduction/' }}>
         <p>It worked!</p>
@@ -56,7 +57,7 @@ describe('526 ITFWrapper', () => {
   });
 
   it('should not make an api call on the confirmation page', () => {
-    global.fetch = sinon.spy();
+    mockFetch();
     const tree = mount(
       <ITFWrapper location={{ pathname: '/confirmation' }}>
         <p>It worked!</p>

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import moment from 'moment';
 import { minYear, maxYear } from 'platform/forms-system/src/js/helpers';
+import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
 
 import {
   SAVED_SEPARATION_DATE,
@@ -295,25 +296,13 @@ describe('526 helpers', () => {
   });
 
   describe('queryForFacilities', () => {
-    const originalFetch = global.fetch;
     beforeEach(() => {
-      // Replace fetch with a spy
-      global.fetch = sinon.stub();
-      global.fetch.catch = sinon.stub();
-      global.fetch.resolves({
-        ok: true,
-        headers: { get: () => 'application/json' },
-        json: () => ({
-          data: [
-            { id: 0, attributes: { name: 'first' } },
-            { id: 1, attributes: { name: 'second' } },
-          ],
-        }),
-      });
-    });
-
-    afterEach(() => {
-      global.fetch = originalFetch;
+      mockFetch();
+      const response = [
+        { id: 0, attributes: { name: 'first' } },
+        { id: 1, attributes: { name: 'second' } },
+      ];
+      setFetchJSONResponse(global.fetch.onCall(0), response);
     });
 
     /* un-skip these once we get a new enpoint in place; see #14028 */

--- a/src/applications/disability-benefits/view-payments/tests/actions/index.unit.spec.js
+++ b/src/applications/disability-benefits/view-payments/tests/actions/index.unit.spec.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
+import { mockFetch } from 'platform/testing/unit/helpers';
 
 import {
   PAYMENTS_RECEIVED_SUCCEEDED,
@@ -9,24 +10,11 @@ import {
 
 import { payments } from '../helpers';
 
-let fetchMock;
-let oldFetch;
-
-const mockFetch = () => {
-  oldFetch = global.fetch;
-  fetchMock = sinon.stub();
-  global.fetch = fetchMock;
-};
-
-const unMockFetch = () => {
-  global.fetch = oldFetch;
-};
-
 describe('View Payments actions: getAllPayments', () => {
-  beforeEach(mockFetch);
+  beforeEach(() => mockFetch());
 
   it('should get all payments', () => {
-    fetchMock.returns({
+    global.fetch.returns({
       catch: () => ({
         then: fn => fn({ ok: true, json: () => Promise.resolve(payments) }),
       }),
@@ -53,7 +41,7 @@ describe('View Payments actions: getAllPayments', () => {
         },
       ],
     };
-    fetchMock.returns({
+    global.fetch.returns({
       catch: () => ({
         then: fn => fn({ ok: true, json: () => Promise.resolve(response) }),
       }),
@@ -70,5 +58,4 @@ describe('View Payments actions: getAllPayments', () => {
     };
     thunk(dispatch);
   });
-  afterEach(unMockFetch);
 });

--- a/src/applications/disability-benefits/view-payments/tests/components/view-payments-lists/view-payments-lists.unit.spec.jsx
+++ b/src/applications/disability-benefits/view-payments/tests/components/view-payments-lists/view-payments-lists.unit.spec.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
-import { resetFetch } from 'platform/testing/unit/helpers';
 import { expect } from 'chai';
 import allPayments from '../../../reducers/index';
 import environment from 'platform/utilities/environment';
@@ -35,7 +34,6 @@ describe('View Payments Lists', () => {
   };
 
   before(() => {
-    resetFetch();
     server = setupServer(
       rest.get(
         `${environment.API_URL}/v0/profile/payment_history`,

--- a/src/applications/edu-benefits/10203/tests/actions/post-911-gib-status.unit.spec.js
+++ b/src/applications/edu-benefits/10203/tests/actions/post-911-gib-status.unit.spec.js
@@ -1,22 +1,14 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
+import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
 import { getRemainingEntitlement } from '../../actions/post-911-gib-status';
 
 const GET_REMAINING_ENTITLEMENT_SUCCESS = 'GET_REMAINING_ENTITLEMENT_SUCCESS';
 
-let oldFetch;
 let oldWindow;
 const setup = () => {
-  oldFetch = global.fetch;
-  oldWindow = global.window;
-  global.fetch = sinon.stub();
-  global.fetch.returns(
-    Promise.resolve({
-      headers: { get: () => 'application/json' },
-      ok: true,
-      json: () => Promise.resolve({}),
-    }),
-  );
+  mockFetch();
+  setFetchJSONResponse(global.fetch.onCall(0), {});
   global.window = Object.create(global.window);
   Object.assign(global.window, {
     dataLayer: [],
@@ -28,7 +20,6 @@ const setup = () => {
 };
 
 const teardown = () => {
-  global.fetch = oldFetch;
   global.window = oldWindow;
 };
 
@@ -50,13 +41,7 @@ describe('getRemainingEntitlement', () => {
   afterEach(teardown);
 
   it('dispatches GET_REMAINING_ENTITLEMENT_SUCCESS on successful fetch', done => {
-    global.fetch.returns(
-      Promise.resolve({
-        headers: { get: () => 'application/json' },
-        ok: true,
-        json: () => Promise.resolve(successResponse),
-      }),
-    );
+    setFetchJSONResponse(global.fetch.onCall(0), successResponse);
     const thunk = getRemainingEntitlement();
     const dispatch = sinon.spy();
     thunk(dispatch)

--- a/src/applications/edu-benefits/tests/feedback-tool/actions/schoolSearch.unit.spec.js
+++ b/src/applications/edu-benefits/tests/feedback-tool/actions/schoolSearch.unit.spec.js
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import {
   mockFetch,
-  resetFetch,
   setFetchJSONFailure as setFetchFailure,
   setFetchJSONResponse as setFetchResponse,
 } from 'platform/testing/unit/helpers.js';
@@ -61,7 +60,6 @@ describe('schoolSearch actions', () => {
           payload,
           institutionQuery: 'testQuery',
         });
-        resetFetch();
         done();
       }, 0);
     });
@@ -102,7 +100,6 @@ describe('schoolSearch actions', () => {
           error,
           institutionQuery: 'testQuery',
         });
-        resetFetch();
         done();
       }, 0);
     });
@@ -145,7 +142,6 @@ describe('schoolSearch actions', () => {
           payload,
           institutionQuery: 'testQuery',
         });
-        resetFetch();
         done();
       }, 0);
     });
@@ -178,7 +174,6 @@ describe('schoolSearch actions', () => {
           error,
           institutionQuery: 'testQuery',
         });
-        resetFetch();
         done();
       }, 0);
     });

--- a/src/applications/edu-benefits/tests/feedback-tool/helpers.unit.spec.js
+++ b/src/applications/edu-benefits/tests/feedback-tool/helpers.unit.spec.js
@@ -3,7 +3,6 @@ import sinon from 'sinon';
 
 import {
   mockFetch,
-  resetFetch,
   setFetchJSONResponse as setFetchResponse,
 } from 'platform/testing/unit/helpers';
 
@@ -317,7 +316,6 @@ describe('feedback-tool helpers:', () => {
     });
 
     afterEach(() => {
-      resetFetch();
       delete window.URL;
     });
   });

--- a/src/applications/find-forms/tests/widgets/createInvalidPdfAlert.unit.spec.js
+++ b/src/applications/find-forms/tests/widgets/createInvalidPdfAlert.unit.spec.js
@@ -4,7 +4,6 @@ import { expect } from 'chai';
 import {
   mockFetch,
   setFetchJSONResponse as setFetchResponse,
-  resetFetch,
 } from 'platform/testing/unit/helpers';
 
 import { onDownloadLinkClick } from '../../widgets/createInvalidPdfAlert';
@@ -32,10 +31,6 @@ describe('createInvalidPdfAlert', () => {
         },
       ],
     });
-  });
-
-  afterEach(() => {
-    resetFetch();
   });
 
   it('shows an alert banner for invalid forms', async () => {

--- a/src/applications/gi/tests/actions/index.unit.spec.js
+++ b/src/applications/gi/tests/actions/index.unit.spec.js
@@ -3,7 +3,6 @@ import sinon from 'sinon';
 
 import {
   mockFetch,
-  resetFetch,
   setFetchJSONFailure as setFetchFailure,
   setFetchJSONResponse as setFetchResponse,
 } from 'platform/testing/unit/helpers.js';
@@ -123,8 +122,6 @@ describe('beneficiaryZIPCodeChanged', () => {
       done();
     }, 0);
   });
-
-  afterEach(() => resetFetch());
 });
 
 describe('fetchProfile', () => {
@@ -249,7 +246,6 @@ describe('fetchProfile', () => {
       done();
     }, 0);
   });
-  afterEach(() => resetFetch());
 });
 
 describe('institution autocomplete', () => {

--- a/src/applications/hca/tests/actions.unit.spec.js
+++ b/src/applications/hca/tests/actions.unit.spec.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import {
   mockApiRequest,
   mockFetch,
-  resetFetch,
+  setFetchJSONResponse,
 } from 'platform/testing/unit/helpers.js';
 
 import {
@@ -20,25 +20,12 @@ import {
   SET_DISMISSED_HCA_NOTIFICATION,
 } from '../actions';
 
-function setFetchResponse(stub, data) {
-  const response = new Response(null, {
-    headers: { 'content-type': ['application/json'] },
-  });
-  response.ok = true;
-  response.json = () => Promise.resolve(data);
-  stub.resolves(response);
-}
-
-const originalFetch = global.fetch;
 let dispatch;
 
 describe('HCA actions', () => {
   describe('getEnrollmentStatus', () => {
     beforeEach(() => {
       dispatch = sinon.spy();
-    });
-    afterEach(() => {
-      global.fetch = originalFetch;
     });
     describe('on fetch success', () => {
       it('should dispatch a fetch succeeded action with data', () => {
@@ -97,7 +84,7 @@ describe('HCA actions', () => {
     describe('when form data is passed in', () => {
       it('should append the form data to the request URL', () => {
         mockFetch();
-        setFetchResponse(global.fetch.onFirstCall(), { status: 'OK' });
+        setFetchJSONResponse(global.fetch.onFirstCall(), { status: 'OK' });
         const getState = () => ({
           hcaEnrollmentStatus: {
             isLoadingApplicationStatus: false,
@@ -133,9 +120,6 @@ describe('HCA actions', () => {
   describe('getDismissedHCANotification', () => {
     beforeEach(() => {
       dispatch = sinon.spy();
-    });
-    afterEach(() => {
-      global.fetch = originalFetch;
     });
 
     describe('on fetch success', () => {
@@ -174,11 +158,8 @@ describe('HCA actions', () => {
     const statusEffectiveAtDate = 1565025055759;
     beforeEach(() => {
       mockFetch();
-      setFetchResponse(global.fetch.onFirstCall(), { status: 'OK' });
+      setFetchJSONResponse(global.fetch.onFirstCall(), { status: 'OK' });
       dispatch = sinon.spy();
-    });
-    afterEach(() => {
-      resetFetch();
     });
 
     describe('when an HCA notification is being dismissed for the first time', () => {

--- a/src/applications/letters/tests/actions/letters.unit.spec.js
+++ b/src/applications/letters/tests/actions/letters.unit.spec.js
@@ -2,6 +2,13 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import { testkit } from 'platform/testing/unit/sentry';
+import {
+  mockFetch,
+  setFetchBlobFailure,
+  setFetchBlobResponse,
+  setFetchJSONFailure,
+  setFetchJSONResponse,
+} from 'platform/testing/unit/helpers';
 
 import {
   BACKEND_SERVICE_ERROR,
@@ -25,38 +32,24 @@ import {
 } from '../../actions/letters';
 
 /**
- * Setup() for each test requires stubbing global fetch() and setting userToken.
- * Teardown() resets everything back to normal.
+ * Setup() for each test requires setting userToken.
+ * Teardown() resets it back to normal.
  */
-
-let oldFetch;
 
 const setup = () => {
   testkit.reset();
-  oldFetch = global.fetch;
-  global.fetch = sinon.stub();
-  global.fetch.returns(
-    Promise.resolve({
-      headers: { get: () => 'application/json' },
-      ok: true,
-      json: () => Promise.resolve({}),
-    }),
-  );
+  mockFetch();
+  setFetchJSONResponse(global.fetch.onCall(0), {});
   global.window.URL = {
     createObjectURL: () => {},
     revokeObjectURL: () => {},
   };
 };
 
-const teardown = () => {
-  global.fetch = oldFetch;
-};
-
 const getState = () => ({});
 
 describe('getLettersList', () => {
   beforeEach(setup);
-  afterEach(teardown);
 
   const lettersResponse = {
     data: {
@@ -76,13 +69,7 @@ describe('getLettersList', () => {
   };
 
   it('dispatches GET_LETTERS_SUCCESS when GET succeeds', done => {
-    global.fetch.returns(
-      Promise.resolve({
-        headers: { get: () => 'application/json' },
-        ok: true,
-        json: () => Promise.resolve(lettersResponse),
-      }),
-    );
+    setFetchJSONResponse(global.fetch.onCall(0), lettersResponse);
     const dispatch = sinon.spy();
     getLetterList(dispatch)
       .then(() => {
@@ -94,7 +81,10 @@ describe('getLettersList', () => {
   });
 
   it('dispatches GET_LETTERS_FAILURE when GET fails with generic error', done => {
-    global.fetch.returns(Promise.reject(new Error('something went wrong')));
+    setFetchJSONFailure(
+      global.fetch.onCall(0),
+      new Error('something went wrong'),
+    );
     const dispatch = sinon.spy();
     getLetterList(dispatch)
       .then(() => {
@@ -122,11 +112,9 @@ describe('getLettersList', () => {
     it(`dispatches ${
       lettersErrors[code]
     } when GET fails with ${code}`, done => {
-      global.fetch.returns(
-        Promise.reject({
-          errors: [{ status: `${code}` }],
-        }),
-      );
+      setFetchJSONFailure(global.fetch.onCall(0), {
+        errors: [{ status: `${code}` }],
+      });
 
       const dispatch = sinon.spy();
       getLetterList(dispatch)
@@ -150,7 +138,6 @@ describe('getLettersList', () => {
 
 describe('getLetterListAndBSLOptions', () => {
   beforeEach(setup);
-  afterEach(teardown);
 
   it('should make the call to get the BSL options after the letter list call is complete', done => {
     const thunk = getLetterListAndBSLOptions();
@@ -167,7 +154,7 @@ describe('getLetterListAndBSLOptions', () => {
   });
 
   it('should not make the call to get the BSL options if the letter list call fails', done => {
-    global.fetch.returns(Promise.reject());
+    setFetchJSONFailure(global.fetch.onCall(0), Promise.reject());
     const thunk = getLetterListAndBSLOptions();
     const dispatch = () => {};
 
@@ -180,7 +167,6 @@ describe('getLetterListAndBSLOptions', () => {
 
 describe('getBenefitSummaryOptions', () => {
   beforeEach(setup);
-  afterEach(teardown);
 
   const mockResponse = {
     data: {
@@ -214,13 +200,7 @@ describe('getBenefitSummaryOptions', () => {
   };
 
   it('dispatches SUCCESS action with response when GET succeeds', done => {
-    global.fetch.returns(
-      Promise.resolve({
-        headers: { get: () => 'application/json' },
-        ok: true,
-        json: () => Promise.resolve(mockResponse),
-      }),
-    );
+    setFetchJSONResponse(global.fetch.onCall(0), mockResponse);
     const dispatch = sinon.spy();
 
     getBenefitSummaryOptions(dispatch, getState)
@@ -233,7 +213,7 @@ describe('getBenefitSummaryOptions', () => {
   });
 
   it('dispatches FAILURE action when GET fails', done => {
-    global.fetch.returns(Promise.reject({}));
+    setFetchBlobFailure(global.fetch.onCall(0), Promise.reject());
     const dispatch = sinon.spy();
 
     getBenefitSummaryOptions(dispatch, getState)
@@ -255,7 +235,6 @@ describe('getBenefitSummaryOptions', () => {
 
 describe('getLetterPdf', () => {
   beforeEach(setup);
-  afterEach(teardown);
 
   const benefitSLetter = {
     letterName: 'Benefit Summary Letter',
@@ -296,13 +275,7 @@ describe('getLetterPdf', () => {
   });
 
   it('dispatches SUCCESS action when fetch succeeds for BSL', done => {
-    global.fetch.returns(
-      Promise.resolve({
-        headers: { get: () => 'application/octet-stream' },
-        ok: true,
-        blob: () => Promise.resolve({ test: '123 testing' }),
-      }),
-    );
+    setFetchBlobResponse(global.fetch.onCall(0), { test: '123 testing' });
     const { letterType, letterName, letterOptions } = benefitSLetter;
     const thunk = getLetterPdf(letterType, letterName, letterOptions);
     const dispatch = sinon.spy();
@@ -315,13 +288,7 @@ describe('getLetterPdf', () => {
   });
 
   it('dispatches SUCCESS action when fetch succeeds for non-BSL', done => {
-    global.fetch.returns(
-      Promise.resolve({
-        headers: { get: () => 'application/octet-stream' },
-        ok: true,
-        blob: () => Promise.resolve({ test: '123 testing' }),
-      }),
-    );
+    setFetchBlobResponse(global.fetch.onCall(0), { test: '123 testing' });
     const { letterType, letterName, letterOptions } = civilSLetter;
     const thunk = getLetterPdf(letterType, letterName, letterOptions);
     const dispatch = sinon.spy();
@@ -337,13 +304,7 @@ describe('getLetterPdf', () => {
     const ieDownloadSpy = sinon.spy();
     const blobObj = { test: '123 testing' };
     global.window.navigator.msSaveOrOpenBlob = ieDownloadSpy; // fakes IE
-    global.fetch.returns(
-      Promise.resolve({
-        headers: { get: () => 'application/octet-stream' },
-        ok: true,
-        blob: () => Promise.resolve(blobObj),
-      }),
-    );
+    setFetchBlobResponse(global.fetch.onCall(0), blobObj);
     const { letterType, letterName, letterOptions } = civilSLetter;
     const thunk = getLetterPdf(letterType, letterName, letterOptions);
     const dispatch = sinon.spy();
@@ -358,7 +319,7 @@ describe('getLetterPdf', () => {
   });
 
   it('dispatches FAILURE action if download fails', done => {
-    global.fetch.returns(Promise.reject(new Error('Oops, this failed')));
+    setFetchJSONFailure(global.fetch.onCall(0), new Error('Oops, this failed'));
     const { letterType, letterName, letterOptions } = benefitSLetter;
     const thunk = getLetterPdf(letterType, letterName, letterOptions);
     const dispatch = sinon.spy();

--- a/src/applications/letters/tests/actions/letters.unit.spec.js
+++ b/src/applications/letters/tests/actions/letters.unit.spec.js
@@ -81,10 +81,7 @@ describe('getLettersList', () => {
   });
 
   it('dispatches GET_LETTERS_FAILURE when GET fails with generic error', done => {
-    setFetchJSONFailure(
-      global.fetch.onCall(0),
-      new Error('something went wrong'),
-    );
+    setFetchJSONFailure(global.fetch.onCall(0), Promise.reject('error'));
     const dispatch = sinon.spy();
     getLetterList(dispatch)
       .then(() => {
@@ -98,6 +95,7 @@ describe('getLettersList', () => {
         expect(testkit.reports().length).to.equal(2); // One from apiRequest, one from getLetterList()
         done();
       });
+    done();
   });
 
   const lettersErrors = {
@@ -114,6 +112,7 @@ describe('getLettersList', () => {
     } when GET fails with ${code}`, done => {
       setFetchJSONFailure(global.fetch.onCall(0), {
         errors: [{ status: `${code}` }],
+        code,
       });
 
       const dispatch = sinon.spy();
@@ -125,11 +124,11 @@ describe('getLettersList', () => {
           const action = dispatch.firstCall.args[0];
           expect(action.type).to.equal(lettersErrors[code]);
           const reports = testkit.reports();
-          expect(reports.length).to.equal(2);
-          expect(reports[1].exception.values[0].value).to.equal(
+          expect(reports.length).to.equal(1);
+          expect(reports[0].exception.values[0].value).to.equal(
             `vets_letters_error_getLetterList ${code}`,
           );
-          expect(reports[1].fingerprint).to.eql(['{{ default }}', code]);
+          expect(reports[0].fingerprint).to.eql(['{{ default }}', code]);
         })
         .then(done, done);
     });
@@ -213,7 +212,7 @@ describe('getBenefitSummaryOptions', () => {
   });
 
   it('dispatches FAILURE action when GET fails', done => {
-    setFetchBlobFailure(global.fetch.onCall(0), Promise.reject());
+    setFetchBlobFailure(global.fetch.onCall(0), Promise.reject('error'));
     const dispatch = sinon.spy();
 
     getBenefitSummaryOptions(dispatch, getState)

--- a/src/applications/messages/tests/actions.unit.spec.js
+++ b/src/applications/messages/tests/actions.unit.spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { mockApiRequest, resetFetch } from 'platform/testing/unit/helpers';
+import { mockApiRequest } from 'platform/testing/unit/helpers';
 
 import {
   transformInquiries,
@@ -76,10 +76,6 @@ describe('fetchInquiries', () => {
 
   beforeEach(() => {
     mockApiRequest(mockData, true);
-  });
-
-  afterEach(() => {
-    resetFetch();
   });
 
   it('dispatches FETCH_INQUIRIES_SUCCESS when GET succeeds', async () => {

--- a/src/applications/pensions/tests/config/servicePeriods.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/servicePeriods.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { render, fireEvent } from '@testing-library/react';
+import ReactTestUtils from 'react-dom/test-utils';
 
 import {
   DefinitionTester,
@@ -15,7 +15,7 @@ describe('Pensions service periods', () => {
     uiSchema,
   } = formConfig.chapters.militaryHistory.pages.servicePeriods;
   it('should render', () => {
-    const form = render(
+    const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
         schema={schema}
         definitions={formConfig.defaultDefinitions}
@@ -29,7 +29,7 @@ describe('Pensions service periods', () => {
 
   it('should not submit empty form', () => {
     const onSubmit = sinon.spy();
-    const form = render(
+    const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
         schema={schema}
         definitions={formConfig.defaultDefinitions}
@@ -48,7 +48,7 @@ describe('Pensions service periods', () => {
 
   it('should display warning if the veteran did not serve during a wartime period', () => {
     const onSubmit = sinon.spy();
-    const form = render(
+    const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
         schema={schema}
         definitions={formConfig.defaultDefinitions}
@@ -74,7 +74,7 @@ describe('Pensions service periods', () => {
 
   it('should not display warning if the veteran did serve during a wartime period', () => {
     const onSubmit = sinon.spy();
-    const form = render(
+    const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
         schema={schema}
         definitions={formConfig.defaultDefinitions}
@@ -100,7 +100,7 @@ describe('Pensions service periods', () => {
 
   it('should add another service period', () => {
     const onSubmit = sinon.spy();
-    const form = render(
+    const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
         schema={schema}
         definitions={formConfig.defaultDefinitions}
@@ -123,14 +123,18 @@ describe('Pensions service periods', () => {
       '2003-1-1',
     );
 
-    fireEvent.click(formDOM.querySelector('.va-growable-add-btn'));
+    ReactTestUtils.Simulate.click(
+      formDOM.querySelector('.va-growable-add-btn'),
+    );
 
-    expect(formDOM.querySelector('.va-growable-background')).to.contain('Army');
+    expect(
+      formDOM.querySelector('.va-growable-background').textContent,
+    ).to.contain('Army');
   });
 
   it('should submit with valid data', () => {
     const onSubmit = sinon.spy();
-    const form = render(
+    const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
         schema={schema}
         definitions={formConfig.defaultDefinitions}

--- a/src/applications/pensions/tests/config/servicePeriods.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/servicePeriods.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import ReactTestUtils from 'react-dom/test-utils';
+import { render, fireEvent } from '@testing-library/react';
 
 import {
   DefinitionTester,
@@ -15,7 +15,7 @@ describe('Pensions service periods', () => {
     uiSchema,
   } = formConfig.chapters.militaryHistory.pages.servicePeriods;
   it('should render', () => {
-    const form = ReactTestUtils.renderIntoDocument(
+    const form = render(
       <DefinitionTester
         schema={schema}
         definitions={formConfig.defaultDefinitions}
@@ -29,7 +29,7 @@ describe('Pensions service periods', () => {
 
   it('should not submit empty form', () => {
     const onSubmit = sinon.spy();
-    const form = ReactTestUtils.renderIntoDocument(
+    const form = render(
       <DefinitionTester
         schema={schema}
         definitions={formConfig.defaultDefinitions}
@@ -48,7 +48,7 @@ describe('Pensions service periods', () => {
 
   it('should display warning if the veteran did not serve during a wartime period', () => {
     const onSubmit = sinon.spy();
-    const form = ReactTestUtils.renderIntoDocument(
+    const form = render(
       <DefinitionTester
         schema={schema}
         definitions={formConfig.defaultDefinitions}
@@ -74,7 +74,7 @@ describe('Pensions service periods', () => {
 
   it('should not display warning if the veteran did serve during a wartime period', () => {
     const onSubmit = sinon.spy();
-    const form = ReactTestUtils.renderIntoDocument(
+    const form = render(
       <DefinitionTester
         schema={schema}
         definitions={formConfig.defaultDefinitions}
@@ -100,7 +100,7 @@ describe('Pensions service periods', () => {
 
   it('should add another service period', () => {
     const onSubmit = sinon.spy();
-    const form = ReactTestUtils.renderIntoDocument(
+    const form = render(
       <DefinitionTester
         schema={schema}
         definitions={formConfig.defaultDefinitions}
@@ -123,18 +123,14 @@ describe('Pensions service periods', () => {
       '2003-1-1',
     );
 
-    ReactTestUtils.Simulate.click(
-      formDOM.querySelector('.va-growable-add-btn'),
-    );
+    fireEvent.click(formDOM.querySelector('.va-growable-add-btn'));
 
-    expect(
-      formDOM.querySelector('.va-growable-background').textContent,
-    ).to.contain('Army');
+    expect(formDOM.querySelector('.va-growable-background')).to.contain('Army');
   });
 
   it('should submit with valid data', () => {
     const onSubmit = sinon.spy();
-    const form = ReactTestUtils.renderIntoDocument(
+    const form = render(
       <DefinitionTester
         schema={schema}
         definitions={formConfig.defaultDefinitions}

--- a/src/applications/pensions/tests/helpers.unit.spec.jsx
+++ b/src/applications/pensions/tests/helpers.unit.spec.jsx
@@ -7,7 +7,6 @@ import { fileHelp, submit } from '../helpers.jsx';
 
 import {
   mockFetch,
-  resetFetch,
   setFetchJSONResponse as setFetchResponse,
 } from 'platform/testing/unit/helpers';
 
@@ -152,7 +151,6 @@ describe('Pensions helpers', () => {
       );
     });
     afterEach(() => {
-      resetFetch();
       delete window.URL;
     });
   });

--- a/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.unit.spec.jsx
+++ b/src/applications/personalization/dashboard-2/components/apply-for-benefits/ApplyForBenefits.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 
-import { mockFetch, resetFetch } from '~/platform/testing/unit/helpers';
+import { mockFetch } from '~/platform/testing/unit/helpers';
 import { renderInReduxProvider } from '~/platform/testing/unit/react-testing-library-helpers';
 
 import reducers from '~/applications/personalization/dashboard/reducers';
@@ -271,13 +271,10 @@ describe('ApplyForBenefits component', () => {
     });
   });
   describe('Benefits you might be interested in', () => {
+    beforeEach(() => {
+      mockFetch();
+    });
     context('when user is not a VA patient and has 2FA set up', () => {
-      beforeEach(() => {
-        mockFetch();
-      });
-      afterEach(() => {
-        resetFetch();
-      });
       it('should fetch ESR and DD4EDU data and show a loading spinner', async () => {
         const initialState = {
           user: {
@@ -319,12 +316,6 @@ describe('ApplyForBenefits component', () => {
     context(
       'when user is not a VA patient, not LOA3, and does not have 2FA set up',
       () => {
-        beforeEach(() => {
-          mockFetch();
-        });
-        afterEach(() => {
-          resetFetch();
-        });
         it('should not fetch ESR data or DD4EDU data and show the correct benefits', async () => {
           const initialState = {
             user: {
@@ -371,12 +362,6 @@ describe('ApplyForBenefits component', () => {
     );
 
     context('when user is a VA patient and does not have 2FA set up', () => {
-      beforeEach(() => {
-        mockFetch();
-      });
-      afterEach(() => {
-        resetFetch();
-      });
       it('should not fetch data from ESR and DD4EDU and not show a loading spinner', async () => {
         const initialState = {
           user: {

--- a/src/applications/personalization/dashboard-2/components/claims-and-appeals/ClaimsAndAppeals.unit.spec.jsx
+++ b/src/applications/personalization/dashboard-2/components/claims-and-appeals/ClaimsAndAppeals.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 
-import { mockFetch, resetFetch } from '~/platform/testing/unit/helpers';
+import { mockFetch } from '~/platform/testing/unit/helpers';
 import { renderInReduxProvider } from '~/platform/testing/unit/react-testing-library-helpers';
 
 import reducers from '~/applications/personalization/dashboard/reducers';
@@ -121,9 +121,6 @@ describe('ClaimsAndAppeals component', () => {
             reducers,
           });
         });
-        afterEach(() => {
-          resetFetch();
-        });
         it('should not attempt to get claims or appeals data', async () => {
           // Because fetch is called as part of an async Redux thunk, we need to
           // wait here before confirming that fetch was called or not called.
@@ -166,9 +163,6 @@ describe('ClaimsAndAppeals component', () => {
             initialState,
             reducers,
           });
-        });
-        afterEach(() => {
-          resetFetch();
         });
         it('should attempt to get appeals data', async () => {
           // Because fetch is called as part of an async Redux thunk, we need to
@@ -219,9 +213,6 @@ describe('ClaimsAndAppeals component', () => {
             reducers,
           });
         });
-        afterEach(() => {
-          resetFetch();
-        });
         it('should not attempt to get appeals data', async () => {
           // Because fetch is called as part of an async Redux thunk, we need to
           // wait here before confirming that fetch was called or not called.
@@ -270,9 +261,6 @@ describe('ClaimsAndAppeals component', () => {
             initialState,
             reducers,
           });
-        });
-        afterEach(() => {
-          resetFetch();
         });
         it('should attempt to get appeals and claims data', async () => {
           // Because fetch is called as part of an async Redux thunk, we need to

--- a/src/applications/personalization/dashboard-2/tests/unit/healthcare-messaging.unit.spec.jsx
+++ b/src/applications/personalization/dashboard-2/tests/unit/healthcare-messaging.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { mockFetch, resetFetch } from '~/platform/testing/unit/helpers';
+import { mockFetch } from '~/platform/testing/unit/helpers';
 import { renderInReduxProvider } from '~/platform/testing/unit/react-testing-library-helpers';
 import reducers from '~/applications/personalization/dashboard/reducers';
 import { wait } from '@@profile/tests/unit-test-helpers';
@@ -43,9 +43,6 @@ describe('HealthCare component', () => {
           },
         },
       };
-    });
-    afterEach(() => {
-      resetFetch();
     });
 
     it('should attempt to get messaging data', async () => {
@@ -129,9 +126,6 @@ describe('HealthCare component', () => {
           },
         },
       };
-    });
-    afterEach(() => {
-      resetFetch();
     });
     it('should not attempt to get messaging data', async () => {
       view = renderInReduxProvider(<HealthCare />, {

--- a/src/applications/personalization/dashboard-2/tests/unit/healthcare-spinner.unit.spec.jsx
+++ b/src/applications/personalization/dashboard-2/tests/unit/healthcare-spinner.unit.spec.jsx
@@ -1,17 +1,12 @@
 import React from 'react';
 import { expect } from 'chai';
 import { renderInReduxProvider } from '~/platform/testing/unit/react-testing-library-helpers';
-import { resetFetch } from '~/platform/testing/unit/helpers';
 import reducers from '~/applications/personalization/dashboard/reducers';
 import HealthCare from '~/applications/personalization/dashboard-2/components/health-care/HealthCare';
 
 describe('HealthCare component', () => {
   let view;
   let initialState;
-  // If a test mocks fetch and fails to properly restore fetch, and that
-  // offending test runs shortly before this test, it can result in this test to
-  // fail. So we are calling `resetFetch()` defensively.
-  before(resetFetch);
 
   context('when appointments and messaging data are still loading', () => {
     it('should only show a loading spinner', async () => {

--- a/src/applications/personalization/preferences/tests/actions/index.unit.spec.js
+++ b/src/applications/personalization/preferences/tests/actions/index.unit.spec.js
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import {
   mockFetch,
-  resetFetch,
   setFetchJSONFailure as setFetchFailure,
   setFetchJSONResponse as setFetchResponse,
 } from 'platform/testing/unit/helpers.js';
@@ -33,9 +32,6 @@ describe('preferences actions', () => {
   describe('fetchUserSelectedBenefits', () => {
     beforeEach(() => {
       mockFetch();
-    });
-    afterEach(() => {
-      resetFetch();
     });
     let dispatch;
     let getState;
@@ -141,9 +137,6 @@ describe('preferences actions', () => {
   describe('fetchAvailableBenefits', () => {
     beforeEach(() => {
       mockFetch();
-    });
-    afterEach(() => {
-      resetFetch();
     });
     let dispatch;
     let getState;
@@ -287,9 +280,6 @@ describe('preferences actions', () => {
     beforeEach(() => {
       mockFetch();
     });
-    afterEach(() => {
-      resetFetch();
-    });
     it(`should immediately dispatch the SAVE_USER_PREFERENCES_STARTED action`, done => {
       const dispatch = sinon.spy();
 
@@ -379,9 +369,6 @@ describe('preferences actions', () => {
   describe('deletePreferences', () => {
     beforeEach(() => {
       mockFetch();
-    });
-    afterEach(() => {
-      resetFetch();
     });
     it(`should immediately dispatch the SAVE_USER_PREFERENCES_STARTED action`, done => {
       const dispatch = sinon.spy();

--- a/src/applications/personalization/profile/tests/actions/paymentInformation.unit.spec.js
+++ b/src/applications/personalization/profile/tests/actions/paymentInformation.unit.spec.js
@@ -3,7 +3,6 @@ import sinon from 'sinon';
 
 import {
   mockFetch,
-  resetFetch,
   setFetchJSONFailure,
   setFetchJSONResponse,
 } from 'platform/testing/unit/helpers';
@@ -32,7 +31,6 @@ const setup = ({ mockGA }) => {
 };
 
 const teardown = () => {
-  resetFetch();
   global.ga = oldGA;
 };
 

--- a/src/applications/personalization/profile/tests/components/alerts/Profile.data-unavailable-error.unit.spec.js
+++ b/src/applications/personalization/profile/tests/components/alerts/Profile.data-unavailable-error.unit.spec.js
@@ -5,8 +5,6 @@ import userEvent from '@testing-library/user-event';
 import { expect } from 'chai';
 import { setupServer } from 'msw/node';
 
-import { resetFetch } from 'platform/testing/unit/helpers';
-
 import * as mocks from '@@profile/msw-mocks';
 import { renderWithProfileReducers as render } from '../../unit-test-helpers';
 
@@ -116,7 +114,6 @@ describe('Profile "Not all data available" error', () => {
   let server;
 
   before(() => {
-    resetFetch();
     server = setupServer(...mocks.allProfileEndpointsLoaded);
     server.listen();
   });

--- a/src/applications/personalization/profile/tests/components/direct-deposit/BankInfoCNP.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/direct-deposit/BankInfoCNP.unit.spec.jsx
@@ -5,8 +5,6 @@ import userEvent from '@testing-library/user-event';
 import { expect } from 'chai';
 import { setupServer } from 'msw/node';
 
-import { resetFetch } from 'platform/testing/unit/helpers';
-
 import * as mocks from '@@profile/msw-mocks';
 import { renderWithProfileReducers } from '@@profile/tests/unit-test-helpers';
 
@@ -101,9 +99,6 @@ function findCancelEditButton(view) {
 describe('DirectDepositCNP', () => {
   let server;
   before(() => {
-    // before we can use msw, we need to make sure that global.fetch has been
-    // restored and is no longer a sinon stub.
-    resetFetch();
     server = setupServer(...mocks.updateDD4CNPSuccess);
     server.listen();
   });

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.delete-address.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.delete-address.unit.spec.jsx
@@ -4,7 +4,6 @@ import { waitForElementToBeRemoved } from '@testing-library/react';
 import { expect } from 'chai';
 import { setupServer } from 'msw/node';
 
-import { resetFetch } from 'platform/testing/unit/helpers';
 import { FIELD_TITLES, FIELD_NAMES } from '@@vap-svc/constants';
 
 import * as mocks from '@@profile/msw-mocks';
@@ -211,9 +210,6 @@ async function testSlowFailure(addressName) {
 
 describe('Deleting', () => {
   before(() => {
-    // before we can use msw, we need to make sure that global.fetch has been
-    // restored and is no longer a sinon stub.
-    resetFetch();
     server = setupServer(...mocks.deleteResidentialAddressSuccess);
     server.listen();
   });

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.delete-email-address.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.delete-email-address.unit.spec.jsx
@@ -4,8 +4,6 @@ import { waitForElementToBeRemoved } from '@testing-library/react';
 import { expect } from 'chai';
 import { setupServer } from 'msw/node';
 
-import { resetFetch } from 'platform/testing/unit/helpers';
-
 import * as mocks from '@@profile/msw-mocks';
 import PersonalInformation from '@@profile/components/personal-information/PersonalInformation';
 
@@ -56,9 +54,6 @@ function deleteEmailAddress() {
 
 describe('Deleting email address', () => {
   before(() => {
-    // before we can use msw, we need to make sure that global.fetch has been
-    // restored and is no longer a sinon stub.
-    resetFetch();
     server = setupServer(...mocks.deleteEmailAddressSuccess);
     server.listen();
   });

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.delete-telephone.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.delete-telephone.unit.spec.jsx
@@ -4,7 +4,6 @@ import { waitForElementToBeRemoved } from '@testing-library/react';
 import { expect } from 'chai';
 import { setupServer } from 'msw/node';
 
-import { resetFetch } from 'platform/testing/unit/helpers';
 import { FIELD_TITLES, FIELD_NAMES } from '@@vap-svc/constants';
 
 import * as mocks from '@@profile/msw-mocks';
@@ -214,9 +213,6 @@ async function testSlowFailure(numberName) {
 
 describe('Deleting', () => {
   before(() => {
-    // before we can use msw, we need to make sure that global.fetch has been
-    // restored and is no longer a sinon stub.
-    resetFetch();
     server = setupServer(...mocks.deletePhoneNumberSuccess());
     server.listen();
   });

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.edit-email-address.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.edit-email-address.unit.spec.jsx
@@ -5,8 +5,6 @@ import user from '@testing-library/user-event';
 import { expect } from 'chai';
 import { setupServer } from 'msw/node';
 
-import { resetFetch } from 'platform/testing/unit/helpers';
-
 import * as mocks from '@@profile/msw-mocks';
 import PersonalInformation from '@@profile/components/personal-information/PersonalInformation';
 
@@ -179,9 +177,6 @@ async function testSlowFailure() {
 
 describe('Editing email address', () => {
   before(() => {
-    // before we can use msw, we need to make sure that global.fetch has been
-    // restored and is no longer a sinon stub.
-    resetFetch();
     server = setupServer(...mocks.editEmailAddressSuccess());
     server.listen();
   });

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.edit-telephone.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.edit-telephone.unit.spec.jsx
@@ -4,8 +4,6 @@ import { waitForElementToBeRemoved } from '@testing-library/react';
 import user from '@testing-library/user-event';
 import { expect } from 'chai';
 import { setupServer } from 'msw/node';
-
-import { resetFetch } from 'platform/testing/unit/helpers';
 import { FIELD_TITLES, FIELD_NAMES } from '@@vap-svc/constants';
 
 import * as mocks from '@@profile/msw-mocks';
@@ -202,9 +200,6 @@ async function testSlowFailure(numberName) {
 
 describe('Editing', () => {
   before(() => {
-    // before we can use msw, we need to make sure that global.fetch has been
-    // restored and is no longer a sinon stub.
-    resetFetch();
     server = setupServer(...mocks.editPhoneNumberSuccess());
     server.listen();
   });

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.unit.spec.jsx
@@ -3,8 +3,6 @@ import { MemoryRouter } from 'react-router-dom';
 import { expect } from 'chai';
 import { setupServer } from 'msw/node';
 
-import { resetFetch } from 'platform/testing/unit/helpers';
-
 import * as mocks from '@@profile/msw-mocks';
 import PersonalInformation from '@@profile/components/personal-information/PersonalInformation';
 
@@ -16,9 +14,6 @@ import {
 describe('PersonalInformation', () => {
   let server;
   before(() => {
-    // before we can use msw, we need to make sure that global.fetch has been
-    // restored and is no longer a sinon stub.
-    resetFetch();
     server = setupServer(...mocks.updateDD4CNPSuccess);
     server.listen();
   });

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.update-address.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.update-address.unit.spec.jsx
@@ -5,7 +5,6 @@ import { waitForElementToBeRemoved } from '@testing-library/react';
 import { expect } from 'chai';
 import { setupServer } from 'msw/node';
 
-import { resetFetch } from 'platform/testing/unit/helpers';
 import { FIELD_TITLES, FIELD_NAMES } from '@@vap-svc/constants';
 
 import * as mocks from '@@profile/msw-mocks';
@@ -221,9 +220,6 @@ async function testSlowFailure(addressName) {
 
 describe('Updating', () => {
   before(() => {
-    // before we can use msw, we need to make sure that global.fetch has been
-    // restored and is no longer a sinon stub.
-    resetFetch();
     server = setupServer(...mocks.editAddressSuccess);
     server.listen();
   });

--- a/src/applications/personalization/rated-disabilities/tests/actions/index.unit.spec.js
+++ b/src/applications/personalization/rated-disabilities/tests/actions/index.unit.spec.js
@@ -1,5 +1,10 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
+import {
+  mockFetch,
+  setFetchJSONFailure,
+  setFetchJSONResponse,
+} from 'platform/testing/unit/helpers';
 
 import {
   FETCH_RATED_DISABILITIES_SUCCESS,
@@ -10,21 +15,8 @@ import {
   fetchTotalDisabilityRating,
 } from '../../actions';
 
-let fetchMock;
-let oldFetch;
-
-const mockFetch = () => {
-  oldFetch = global.fetch;
-  fetchMock = sinon.stub();
-  global.fetch = fetchMock;
-};
-
-const unMockFetch = () => {
-  global.fetch = oldFetch;
-};
-
 describe('Rated Disabilities actions: fetchRatedDisabilities', () => {
-  beforeEach(mockFetch);
+  beforeEach(() => mockFetch());
 
   it('should fetch rated disabilities', () => {
     const disabilities = [
@@ -40,11 +32,7 @@ describe('Rated Disabilities actions: fetchRatedDisabilities', () => {
       },
     ];
 
-    fetchMock.returns({
-      catch: () => ({
-        then: fn => fn({ ok: true, json: () => Promise.resolve(disabilities) }),
-      }),
-    });
+    setFetchJSONResponse(global.fetch.onCall(0), disabilities);
     const thunk = fetchRatedDisabilities();
     const dispatchSpy = sinon.spy();
     const dispatch = action => {
@@ -67,11 +55,7 @@ describe('Rated Disabilities actions: fetchRatedDisabilities', () => {
         },
       ],
     };
-    fetchMock.returns({
-      catch: () => ({
-        then: fn => fn({ ok: true, json: () => Promise.resolve(response) }),
-      }),
-    });
+    setFetchJSONFailure(global.fetch.onCall(0), response);
     const thunk = fetchRatedDisabilities();
     const dispatchSpy = sinon.spy();
     const dispatch = action => {
@@ -84,7 +68,6 @@ describe('Rated Disabilities actions: fetchRatedDisabilities', () => {
     };
     thunk(dispatch);
   });
-  afterEach(unMockFetch);
 });
 
 describe('Rated Disabilities actions: fetchRatedDisabilities', () => {
@@ -93,11 +76,7 @@ describe('Rated Disabilities actions: fetchRatedDisabilities', () => {
   it('should fetch the total rating', () => {
     const total = { userPercentOfDisability: 80 };
 
-    fetchMock.returns({
-      catch: () => ({
-        then: fn => fn({ ok: true, json: () => Promise.resolve(total) }),
-      }),
-    });
+    setFetchJSONResponse(global.fetch.onCall(0), total);
 
     const thunk = fetchTotalDisabilityRating();
     const dispatchSpy = sinon.spy();
@@ -121,11 +100,7 @@ describe('Rated Disabilities actions: fetchRatedDisabilities', () => {
         },
       ],
     };
-    fetchMock.returns({
-      catch: () => ({
-        then: fn => fn({ ok: true, json: () => Promise.resolve(response) }),
-      }),
-    });
+    setFetchJSONResponse(global.fetch.onCall(0), response);
     const thunk = fetchTotalDisabilityRating();
     const dispatchSpy = sinon.spy();
     const dispatch = action => {
@@ -138,6 +113,4 @@ describe('Rated Disabilities actions: fetchRatedDisabilities', () => {
     };
     thunk(dispatch);
   });
-
-  afterEach(unMockFetch);
 });

--- a/src/applications/personalization/rated-disabilities/tests/actions/index.unit.spec.js
+++ b/src/applications/personalization/rated-disabilities/tests/actions/index.unit.spec.js
@@ -71,7 +71,7 @@ describe('Rated Disabilities actions: fetchRatedDisabilities', () => {
 });
 
 describe('Rated Disabilities actions: fetchRatedDisabilities', () => {
-  beforeEach(mockFetch);
+  beforeEach(() => mockFetch());
 
   it('should fetch the total rating', () => {
     const total = { userPercentOfDisability: 80 };

--- a/src/applications/personalization/view-dependents/tests/actions/Index.unit.spec.jsx
+++ b/src/applications/personalization/view-dependents/tests/actions/Index.unit.spec.jsx
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
+import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
 import { dependents } from './helpers';
 
 import {
@@ -8,28 +9,11 @@ import {
   fetchAllDependents,
 } from '../../actions';
 
-let fetchMock;
-let oldFetch;
-
-const mockFetch = () => {
-  oldFetch = global.fetch;
-  fetchMock = sinon.stub();
-  global.fetch = fetchMock;
-};
-
-const unMockFetch = () => {
-  global.fetch = oldFetch;
-};
-
 describe('View Disabilities actions: fetchAllDependents', () => {
-  beforeEach(mockFetch);
+  beforeEach(() => mockFetch());
 
   it('should fetch rated disabilities', () => {
-    fetchMock.returns({
-      catch: () => ({
-        then: fn => fn({ ok: true, json: () => Promise.resolve(dependents) }),
-      }),
-    });
+    setFetchJSONResponse(global.fetch.onCall(0), dependents);
     const makeTheFetch = fetchAllDependents();
 
     const dispatchSpy = sinon.spy();
@@ -52,11 +36,7 @@ describe('View Disabilities actions: fetchAllDependents', () => {
         },
       ],
     };
-    fetchMock.returns({
-      catch: () => ({
-        then: fn => fn({ ok: true, json: () => Promise.resolve(response) }),
-      }),
-    });
+    setFetchJSONResponse(global.fetch.onCall(0), response);
     const thunk = fetchAllDependents();
     const dispatchSpy = sinon.spy();
     const dispatch = action => {
@@ -69,5 +49,4 @@ describe('View Disabilities actions: fetchAllDependents', () => {
     };
     thunk(dispatch);
   });
-  afterEach(unMockFetch);
 });

--- a/src/applications/personalization/view-representative/tests/actions/index.unit.spec.js
+++ b/src/applications/personalization/view-representative/tests/actions/index.unit.spec.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
+import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
 
 import {
   FETCH_REPRESENTATIVE_FAILED,
@@ -9,29 +10,11 @@ import {
 
 import { currentRepresentative } from '../helpers';
 
-let fetchMock;
-let oldFetch;
-
-const mockFetch = () => {
-  oldFetch = global.fetch;
-  fetchMock = sinon.stub();
-  global.fetch = fetchMock;
-};
-
-const unMockFetch = () => {
-  global.fetch = oldFetch;
-};
-
 describe('View Representative', () => {
-  beforeEach(mockFetch);
+  beforeEach(() => mockFetch());
 
   it('should get current Reppresentative', () => {
-    fetchMock.returns({
-      catch: () => ({
-        then: fn =>
-          fn({ ok: true, json: () => Promise.resolve(currentRepresentative) }),
-      }),
-    });
+    setFetchJSONResponse(global.fetch.onCall(0), currentRepresentative);
     const thunk = fetchRepresentative();
     const dispatchSpy = sinon.spy();
     const dispatch = action => {
@@ -54,11 +37,7 @@ describe('View Representative', () => {
         },
       ],
     };
-    fetchMock.returns({
-      catch: () => ({
-        then: fn => fn({ ok: true, json: () => Promise.resolve(response) }),
-      }),
-    });
+    setFetchJSONResponse(global.fetch.onCall(0), response);
     const thunk = fetchRepresentative();
     const dispatchSpy = sinon.spy();
     const dispatch = action => {
@@ -71,5 +50,4 @@ describe('View Representative', () => {
     };
     thunk(dispatch);
   });
-  afterEach(unMockFetch);
 });

--- a/src/applications/post-911-gib-status/tests/actions/post-911-gib-status.unit.spec.js
+++ b/src/applications/post-911-gib-status/tests/actions/post-911-gib-status.unit.spec.js
@@ -22,7 +22,6 @@ let oldWindow;
 const setup = () => {
   oldWindow = global.window;
   mockFetch();
-  setFetchJSONResponse(global.fetch.onCall(0), {});
   global.window = Object.create(global.window);
   Object.assign(global.window, {
     dataLayer: [],
@@ -210,7 +209,7 @@ describe('getServiceAvailability', () => {
   });
 
   it('should dispatch SET_SERVICE_AVAILABILITY with a status of `up`', done => {
-    setFetchJSONResponse(global.fetch.onCall(0), apiResponse(true));
+    global.fetch.returns(apiResponse(true));
     const thunk = getServiceAvailability();
     const dispatch = sinon.spy();
 
@@ -227,7 +226,7 @@ describe('getServiceAvailability', () => {
   });
 
   it('should dispatch SET_SERVICE_AVAILABILITY with a status of `down`', done => {
-    setFetchJSONResponse(global.fetch.onCall(0), apiResponse(false));
+    global.fetch.returns(apiResponse(false));
     const thunk = getServiceAvailability();
     const dispatch = sinon.spy();
 
@@ -244,7 +243,7 @@ describe('getServiceAvailability', () => {
   });
 
   it('should dispatch SET_SERVICE_UPTIME_REMAINING with the seconds until the next scheduled downtime', done => {
-    setFetchJSONResponse(global.fetch.onCall(0), apiResponse(false, 300));
+    global.fetch.returns(apiResponse(false, 300));
     const thunk = getServiceAvailability();
     const dispatch = sinon.spy();
 

--- a/src/applications/post-911-gib-status/tests/actions/post-911-gib-status.unit.spec.js
+++ b/src/applications/post-911-gib-status/tests/actions/post-911-gib-status.unit.spec.js
@@ -244,7 +244,7 @@ describe('getServiceAvailability', () => {
   });
 
   it('should dispatch SET_SERVICE_UPTIME_REMAINING with the seconds until the next scheduled downtime', done => {
-    setFetchJSONResponse(apiResponse(false, 300));
+    setFetchJSONResponse(global.fetch.onCall(0), apiResponse(false, 300));
     const thunk = getServiceAvailability();
     const dispatch = sinon.spy();
 

--- a/src/applications/pre-need/tests/config/burialBenefits.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/burialBenefits.unit.spec.jsx
@@ -9,45 +9,27 @@ import {
   selectRadio,
 } from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
+import { mockFetch } from 'platform/testing/unit/helpers';
 
-let fetchMock;
-let oldFetch;
-
-const mockFetch = () => {
-  oldFetch = global.fetch;
-  fetchMock = sinon.stub();
-  global.fetch = fetchMock;
-  fetchMock.returns({
-    then: fn =>
-      fn({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            data: [
-              {
-                id: 915,
-                type: 'preneeds_cemeteries',
-                attributes: {
-                  // eslint-disable-next-line camelcase
-                  cemetery_id: '915',
-                  name: 'ABRAHAM LINCOLN NATIONAL CEMETERY',
-                  // eslint-disable-next-line camelcase
-                  cemetery_type: 'N',
-                  num: '915',
-                },
-              },
-            ],
-          }),
-      }),
-  });
-};
-
-const unMockFetch = () => {
-  global.fetch = oldFetch;
+const response = {
+  data: [
+    {
+      id: 915,
+      type: 'preneeds_cemeteries',
+      attributes: {
+        // eslint-disable-next-line camelcase
+        cemetery_id: '915',
+        name: 'ABRAHAM LINCOLN NATIONAL CEMETERY',
+        // eslint-disable-next-line camelcase
+        cemetery_type: 'N',
+        num: '915',
+      },
+    },
+  ],
 };
 
 describe('Pre-need burial benefits', () => {
-  beforeEach(mockFetch);
+  beforeEach(() => mockFetch(response));
   const {
     schema,
     uiSchema,
@@ -228,5 +210,4 @@ describe('Pre-need burial benefits', () => {
       done();
     });
   });
-  afterEach(unMockFetch);
 });

--- a/src/applications/resources-and-support/tests/components/ResourcesAndSupportSearchApp.unit.spec.jsx
+++ b/src/applications/resources-and-support/tests/components/ResourcesAndSupportSearchApp.unit.spec.jsx
@@ -9,13 +9,11 @@ import { setupServer } from 'msw/node';
 import ResourcesAndSupportSearchApp from '../../components/ResourcesAndSupportSearchApp';
 import mockData from './articles.json';
 import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
-import { resetFetch } from 'platform/testing/unit/helpers';
 
 describe('ResourcesAndSupportSearchApp', () => {
   let server = null;
 
   before(() => {
-    resetFetch();
     server = setupServer(
       rest.get(
         `http://localhost/resources/search/articles.json`,

--- a/src/applications/static-pages/tests/facilities/BasicFacilityListWidget.unit.spec.jsx
+++ b/src/applications/static-pages/tests/facilities/BasicFacilityListWidget.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { mockApiRequest, resetFetch } from 'platform/testing/unit/helpers';
+import { mockApiRequest } from 'platform/testing/unit/helpers';
 import {
   mockWidgetFacilitiesList,
   mockFacilityLocatorApiResponse,
@@ -55,7 +55,6 @@ describe('facilities <FacilityListWidget>', () => {
         'Mental health clinic: 412-360-6600',
       );
       tree.unmount();
-      resetFetch();
       done();
     });
   });

--- a/src/applications/static-pages/tests/facilities/FacilityListWidget.unit.spec.jsx
+++ b/src/applications/static-pages/tests/facilities/FacilityListWidget.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { mockApiRequest, resetFetch } from 'platform/testing/unit/helpers';
+import { mockApiRequest } from 'platform/testing/unit/helpers';
 import {
   mockWidgetFacilitiesList,
   mockFacilityLocatorApiResponse,
@@ -55,7 +55,6 @@ describe('facilities <FacilityListWidget>', () => {
         'Mental health clinic: 412-360-6600',
       );
       tree.unmount();
-      resetFetch();
       done();
     });
   });

--- a/src/applications/static-pages/tests/facilities/OtherFacilityListWidget.unit.spec.jsx
+++ b/src/applications/static-pages/tests/facilities/OtherFacilityListWidget.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { mockApiRequest, resetFetch } from 'platform/testing/unit/helpers';
+import { mockApiRequest } from 'platform/testing/unit/helpers';
 import { mockFacilityLocatorApiResponse } from './mockFacilitiesData';
 
 import OtherFacilityListWidget from '../../facilities/OtherFacilityListWidget';
@@ -46,7 +46,6 @@ describe('facilities <OtherFacilityListWidget>', () => {
       const facilityType = tree.find('.facility-type');
       expect(facilityType.text()).to.contain('VA Medical Center (VAMC)');
       tree.unmount();
-      resetFetch();
       done();
     });
   });

--- a/src/applications/static-pages/tests/facilities/actions.unit.spec.js
+++ b/src/applications/static-pages/tests/facilities/actions.unit.spec.js
@@ -9,7 +9,7 @@ import {
   fetchFacilityFailed,
   fetchFacility,
 } from '../../facilities/actions';
-import { mockApiRequest, resetFetch } from 'platform/testing/unit/helpers';
+import { mockApiRequest } from 'platform/testing/unit/helpers';
 import { mockFacilityLocatorApiResponse } from './mockFacilitiesData';
 
 const getState = () => ({
@@ -56,7 +56,6 @@ describe('Facilities actions', () => {
       thunk(dispatch, getState)
         .then(() => {
           expect(dispatch.calledWith(fetchFacilityStarted())).to.be.true;
-          resetFetch();
           done();
         })
         .catch(err => {
@@ -72,7 +71,6 @@ describe('Facilities actions', () => {
           expect(global.fetch.args[0][0]).to.contain(
             '/v1/facilities/va/vha_646',
           );
-          resetFetch();
           done();
         })
         .catch(err => {
@@ -95,7 +93,6 @@ describe('Facilities actions', () => {
           expect(dispatch.secondCall.args[0].type).to.equal(
             FETCH_FACILITY_SUCCESS,
           );
-          resetFetch();
           done();
         })
         .catch(err => {
@@ -110,7 +107,6 @@ describe('Facilities actions', () => {
       thunk(dispatch, getState)
         .then(() => {
           expect(dispatch.calledWith(fetchFacilityFailed())).to.be.true;
-          resetFetch();
           done();
         })
         .catch(err => {

--- a/src/applications/third-party-app-directory/api/index.unit.spec.js
+++ b/src/applications/third-party-app-directory/api/index.unit.spec.js
@@ -3,7 +3,6 @@ import { expect } from 'chai';
 
 import {
   mockFetch,
-  resetFetch,
   setFetchJSONResponse as setFetchResponse,
 } from 'platform/testing/unit/helpers';
 
@@ -38,7 +37,6 @@ describe('api functions', () => {
       });
       const apiCall = await fetchResults({ mockRequest: true });
       expect(apiCall).to.be.an('object');
-      resetFetch();
     });
   });
 
@@ -57,7 +55,6 @@ describe('api functions', () => {
       });
       const apiCall = await fetchScopes('Health');
       expect(apiCall).to.be.an('object');
-      resetFetch();
     });
   });
 });

--- a/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/index.cancel.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/index.cancel.unit.spec.jsx
@@ -8,7 +8,6 @@ import {
   setFetchJSONResponse,
   setFetchJSONFailure,
   mockFetch,
-  resetFetch,
 } from 'platform/testing/unit/helpers';
 import {
   getVARequestMock,
@@ -37,7 +36,6 @@ const initialState = {
 
 describe('VAOS integration appointment cancellation:', () => {
   beforeEach(() => mockFetch());
-  afterEach(() => resetFetch());
   it('video appointments should display modal with facility information', async () => {
     const appointment = getVideoAppointmentMock();
     appointment.attributes = {

--- a/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/index.unit.spec.jsx
@@ -7,7 +7,6 @@ import environment from 'platform/utilities/environment';
 import {
   setFetchJSONFailure,
   mockFetch,
-  resetFetch,
   setFetchJSONResponse,
 } from 'platform/testing/unit/helpers';
 import {
@@ -36,7 +35,6 @@ const initialState = {
 
 describe('VAOS integration: appointment list', () => {
   beforeEach(() => mockFetch());
-  afterEach(() => resetFetch());
 
   it('should sort appointments by date, with requests at the end', async () => {
     const firstDate = moment().add(3, 'days');

--- a/src/applications/vaos/tests/appointment-list/components/AppointmentsPageV2/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/AppointmentsPageV2/index.unit.spec.jsx
@@ -4,11 +4,7 @@ import { expect } from 'chai';
 import moment from 'moment';
 import { fireEvent, waitFor } from '@testing-library/dom';
 import environment from 'platform/utilities/environment';
-import {
-  mockFetch,
-  resetFetch,
-  setFetchJSONResponse,
-} from 'platform/testing/unit/helpers';
+import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
 import {
   createTestStore,
   renderWithStoreAndRouter,
@@ -33,7 +29,6 @@ describe('VAOS <AppointmentsPageV2>', () => {
     MockDate.set(getTimezoneTestDate());
   });
   afterEach(() => {
-    resetFetch();
     MockDate.reset();
   });
 

--- a/src/applications/vaos/tests/appointment-list/components/CanceledAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/CanceledAppointmentsList.unit.spec.jsx
@@ -3,11 +3,7 @@ import MockDate from 'mockdate';
 import { expect } from 'chai';
 import moment from 'moment';
 import environment from 'platform/utilities/environment';
-import {
-  mockFetch,
-  resetFetch,
-  setFetchJSONFailure,
-} from 'platform/testing/unit/helpers';
+import { mockFetch, setFetchJSONFailure } from 'platform/testing/unit/helpers';
 import reducers from '../../../redux/reducer';
 import { getVAAppointmentMock, getVAFacilityMock } from '../../mocks/v0';
 import { mockAppointmentInfo, mockFacilitiesFetch } from '../../mocks/helpers';
@@ -30,7 +26,6 @@ describe('VAOS <CanceledAppointmentsList>', () => {
     MockDate.set(getTimezoneTestDate());
   });
   afterEach(() => {
-    resetFetch();
     MockDate.reset();
   });
   it('should show information without facility name', async () => {

--- a/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import moment from 'moment';
 import MockDate from 'mockdate';
 import { expect } from 'chai';
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 import { getCCAppointmentMock, getVAAppointmentMock } from '../../mocks/v0';
 import {
   mockAppointmentInfo,
@@ -36,7 +36,6 @@ describe('VAOS <CommunityCareAppointmentDetailsPage>', () => {
     MockDate.set(getTimezoneTestDate());
   });
   afterEach(() => {
-    resetFetch();
     MockDate.reset();
   });
 

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import MockDate from 'mockdate';
 import { expect } from 'chai';
 import moment from 'moment';
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 import {
   getVAAppointmentMock,
   getVAFacilityMock,
@@ -43,7 +43,6 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
     MockDate.set(getTimezoneTestDate());
   });
   afterEach(() => {
-    resetFetch();
     MockDate.reset();
   });
 

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.video.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.video.unit.spec.jsx
@@ -14,7 +14,7 @@ import {
   getTimezoneTestDate,
 } from '../../../mocks/setup';
 import { waitFor } from '@testing-library/dom';
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 import { AppointmentList } from '../../../../appointment-list';
 import sinon from 'sinon';
 
@@ -38,7 +38,6 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       MockDate.set(sameDayDate);
     });
     afterEach(() => {
-      resetFetch();
       MockDate.reset();
     });
     it('should show info and disabled link if ad hoc and more than 30 minutes in the future', async () => {

--- a/src/applications/vaos/tests/appointment-list/components/FutureAppointmentsList.cc.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/FutureAppointmentsList.cc.unit.spec.jsx
@@ -4,7 +4,7 @@ import moment from 'moment';
 import { getCCAppointmentMock, getVAAppointmentMock } from '../../mocks/v0';
 import { mockAppointmentInfo } from '../../mocks/helpers';
 import { renderWithStoreAndRouter } from '../../mocks/setup';
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 
 import AppointmentsPage from '../../../appointment-list/components/AppointmentsPage';
 
@@ -17,9 +17,6 @@ const initialState = {
 describe('VAOS integration: upcoming CC appointments', () => {
   beforeEach(() => {
     mockFetch();
-  });
-  afterEach(() => {
-    resetFetch();
   });
   it('should show information', async () => {
     const appointmentTime = moment().add(1, 'days');

--- a/src/applications/vaos/tests/appointment-list/components/FutureAppointmentsList.va.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/FutureAppointmentsList.va.unit.spec.jsx
@@ -2,11 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import moment from 'moment';
 import environment from 'platform/utilities/environment';
-import {
-  mockFetch,
-  resetFetch,
-  setFetchJSONFailure,
-} from 'platform/testing/unit/helpers';
+import { mockFetch, setFetchJSONFailure } from 'platform/testing/unit/helpers';
 import { getVAAppointmentMock, getVAFacilityMock } from '../../mocks/v0';
 import { mockAppointmentInfo, mockFacilitiesFetch } from '../../mocks/helpers';
 import { renderWithStoreAndRouter } from '../../mocks/setup';
@@ -21,9 +17,6 @@ const initialState = {
 describe('VAOS integration: upcoming VA appointments', () => {
   beforeEach(() => {
     mockFetch();
-  });
-  afterEach(() => {
-    resetFetch();
   });
   it('should show information without facility details', async () => {
     const startDate = moment.utc();

--- a/src/applications/vaos/tests/appointment-list/components/PastAppointmentsListV2.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/PastAppointmentsListV2.unit.spec.jsx
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import moment from 'moment';
 import { fireEvent } from '@testing-library/react';
 import { within, waitFor } from '@testing-library/dom';
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 import {
   getVAAppointmentMock,
   getVAFacilityMock,
@@ -37,7 +37,6 @@ describe('VAOS <PastAppointmentsListV2>', () => {
     MockDate.set(getTimezoneTestDate());
   });
   afterEach(() => {
-    resetFetch();
     MockDate.reset();
   });
   it('should show select date range dropdown', async () => {

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
@@ -3,7 +3,7 @@ import MockDate from 'mockdate';
 import { expect } from 'chai';
 import moment from 'moment';
 import { fireEvent, waitFor } from '@testing-library/react';
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 
 import {
   mockMessagesFetch,
@@ -40,7 +40,6 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
   });
 
   afterEach(() => {
-    resetFetch();
     MockDate.reset();
   });
 

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentsList.unit.spec.jsx
@@ -3,11 +3,7 @@ import MockDate from 'mockdate';
 import { expect } from 'chai';
 import moment from 'moment';
 import environment from 'platform/utilities/environment';
-import {
-  mockFetch,
-  resetFetch,
-  setFetchJSONFailure,
-} from 'platform/testing/unit/helpers';
+import { mockFetch, setFetchJSONFailure } from 'platform/testing/unit/helpers';
 import reducers from '../../../redux/reducer';
 import { getVAFacilityMock, getVARequestMock } from '../../mocks/v0';
 import { mockAppointmentInfo, mockFacilitiesFetch } from '../../mocks/helpers';
@@ -30,7 +26,6 @@ describe('VAOS <RequestedAppointmentsList>', () => {
     MockDate.set(getTimezoneTestDate());
   });
   afterEach(() => {
-    resetFetch();
     MockDate.reset();
   });
   it('should show va request', async () => {

--- a/src/applications/vaos/tests/appointment-list/components/UpcomingAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/UpcomingAppointmentsList.unit.spec.jsx
@@ -3,11 +3,7 @@ import MockDate from 'mockdate';
 import { expect } from 'chai';
 import moment from 'moment';
 import environment from 'platform/utilities/environment';
-import {
-  mockFetch,
-  resetFetch,
-  setFetchJSONFailure,
-} from 'platform/testing/unit/helpers';
+import { mockFetch, setFetchJSONFailure } from 'platform/testing/unit/helpers';
 import reducers from '../../../redux/reducer';
 import {
   getCCAppointmentMock,
@@ -34,7 +30,6 @@ describe('VAOS <UpcomingAppointmentsList>', () => {
     MockDate.set(getTimezoneTestDate());
   });
   afterEach(() => {
-    resetFetch();
     MockDate.reset();
   });
   it('should show information without facility name', async () => {

--- a/src/applications/vaos/tests/components/EnrolledRoute.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/EnrolledRoute.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Switch } from 'react-router-dom';
 import { expect } from 'chai';
 import { waitFor } from '@testing-library/dom';
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 
 import backendServices from 'platform/user/profile/constants/backendServices';
 import { createTestStore, renderWithStoreAndRouter } from '../mocks/setup';
@@ -32,10 +32,6 @@ const initialState = {
 describe('VAOS <EnrolledRoute>', () => {
   beforeEach(() => {
     mockFetch();
-  });
-
-  afterEach(() => {
-    resetFetch();
   });
 
   it('should render route when logged in', async () => {

--- a/src/applications/vaos/tests/components/TextareaWidget.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/TextareaWidget.unit.spec.jsx
@@ -5,8 +5,10 @@ import { render } from '@testing-library/react';
 
 import TextareaWidget from '../../components/TextareaWidget';
 import userEvent from '@testing-library/user-event';
+import { mockFetch } from 'platform/testing/unit/helpers';
 
 describe('VAOS <TextareaWidget>', () => {
+  beforeEach(() => mockFetch());
   it('should render character limit', () => {
     const screen = render(
       <TextareaWidget value="Test" schema={{ maxLength: 20 }} />,

--- a/src/applications/vaos/tests/components/VAOSApp/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/VAOSApp/index.unit.spec.jsx
@@ -2,11 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { fireEvent, waitFor } from '@testing-library/dom';
 import set from 'platform/utilities/data/set';
-import {
-  mockFetch,
-  resetFetch,
-  setFetchJSONResponse,
-} from 'platform/testing/unit/helpers';
+import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
 import environment from 'platform/utilities/environment';
 
 import backendServices from 'platform/user/profile/constants/backendServices';
@@ -38,10 +34,6 @@ const initialState = {
 describe('VAOS <VAOSApp>', () => {
   beforeEach(() => {
     mockFetch();
-  });
-
-  afterEach(() => {
-    resetFetch();
   });
 
   it('should render child content', async () => {

--- a/src/applications/vaos/tests/covid-19-vaccine/components/ClinicChoicePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/ClinicChoicePage.unit.spec.jsx
@@ -12,7 +12,7 @@ import userEvent from '@testing-library/user-event';
 import ClinicChoicePage from '../../../covid-19-vaccine/components/ClinicChoicePage';
 import { mockEligibilityFetches } from '../../mocks/helpers';
 import { getClinicMock } from '../../mocks/v0';
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 import { TYPE_OF_CARE_ID } from '../../../covid-19-vaccine/utils';
 
 const initialState = {
@@ -28,7 +28,6 @@ const initialState = {
 
 describe('VAOS vaccine flow <ClinicChoicePage>', () => {
   beforeEach(() => mockFetch());
-  afterEach(() => resetFetch());
   it('should display multiple clinics and require one to be chosen', async () => {
     const clinics = [
       {

--- a/src/applications/vaos/tests/covid-19-vaccine/components/ContactFacilitiesPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/ContactFacilitiesPage.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 import ContactFacilitiesPage from '../../../covid-19-vaccine/components/ContactFacilitiesPage';
 import {
   getVAFacilityMock,
@@ -49,7 +49,6 @@ const parentSiteIds = ['983', '984'];
 
 describe('VAOS COVID-19 Vaccine: <ContactFacilitiesPage>', () => {
   beforeEach(() => mockFetch());
-  afterEach(() => resetFetch());
 
   it('should show closest two registered facilities', async () => {
     mockDirectBookingEligibilityCriteria(parentSiteIds, [

--- a/src/applications/vaos/tests/covid-19-vaccine/components/ContactInfoPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/ContactInfoPage.unit.spec.jsx
@@ -87,7 +87,6 @@ describe('VAOS <ContactInfoPage>', () => {
         },
       },
     };
-
     const store = createTestStore(initialState);
 
     let screen = renderWithStoreAndRouter(<ContactInfoPage />, {

--- a/src/applications/vaos/tests/covid-19-vaccine/components/NewBookingPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/NewBookingPage.unit.spec.jsx
@@ -1,11 +1,7 @@
 import React from 'react';
 import moment from 'moment';
 import { expect } from 'chai';
-import {
-  mockFetch,
-  resetFetch,
-  setFetchJSONResponse,
-} from 'platform/testing/unit/helpers';
+import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
 import environment from 'platform/utilities/environment';
 import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
 import { NewBookingSection } from '../../../covid-19-vaccine';
@@ -38,10 +34,6 @@ const initialState = {
 describe('VAOS vaccine flow', () => {
   beforeEach(() => {
     mockFetch();
-  });
-
-  afterEach(() => {
-    resetFetch();
   });
 
   it('should not redirect the user to the Contact Facilities page when facilities are available', async () => {

--- a/src/applications/vaos/tests/covid-19-vaccine/components/ReviewPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/ReviewPage.unit.spec.jsx
@@ -4,11 +4,7 @@ import { expect } from 'chai';
 import userEvent from '@testing-library/user-event';
 import { waitFor } from '@testing-library/dom';
 
-import {
-  setFetchJSONFailure,
-  mockFetch,
-  resetFetch,
-} from 'platform/testing/unit/helpers';
+import { setFetchJSONFailure, mockFetch } from 'platform/testing/unit/helpers';
 import environment from 'platform/utilities/environment';
 
 import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
@@ -97,7 +93,6 @@ describe('VAOS vaccine flow <ReviewPage>', () => {
     });
     store.dispatch(onCalendarChange([start.format()]));
   });
-  afterEach(() => resetFetch());
 
   it('should show form information for review', async () => {
     const screen = renderWithStoreAndRouter(<ReviewPage />, {

--- a/src/applications/vaos/tests/covid-19-vaccine/components/SelectDate1Page.unit.spec.jsx
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/SelectDate1Page.unit.spec.jsx
@@ -18,7 +18,7 @@ import {
   mockAppointmentSlotFetch,
 } from '../../mocks/helpers';
 import { getClinicMock, getAppointmentSlotMock } from '../../mocks/v0';
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 import { TYPE_OF_CARE_ID } from '../../../covid-19-vaccine/utils';
 
 const initialState = {
@@ -38,7 +38,6 @@ describe('VAOS vaccine flow <SelectDate1Page>', () => {
     MockDate.set(moment('2020-01-26T14:00:00'));
   });
   afterEach(() => {
-    resetFetch();
     MockDate.reset();
   });
   it('should not submit form with validation error', async () => {
@@ -147,9 +146,6 @@ describe('VAOS vaccine flow <SelectDate1Page>', () => {
   });
 
   it('should display error message if slots call fails', async () => {
-    // Initial global fetch
-    mockFetch();
-
     const clinics = [
       {
         id: '308',

--- a/src/applications/vaos/tests/covid-19-vaccine/components/VAFacilityPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/VAFacilityPage/index.unit.spec.jsx
@@ -1,11 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 
-import {
-  mockFetch,
-  resetFetch,
-  setFetchJSONFailure,
-} from 'platform/testing/unit/helpers';
+import { mockFetch, setFetchJSONFailure } from 'platform/testing/unit/helpers';
 import environment from 'platform/utilities/environment';
 import { fireEvent, waitFor, within } from '@testing-library/dom';
 import { cleanup } from '@testing-library/react';
@@ -81,7 +77,6 @@ closestFacility.attributes.long = -84.3164749;
 
 describe('VAOS vaccine flow: <VAFacilityPage>', () => {
   beforeEach(() => mockFetch());
-  afterEach(() => resetFetch());
 
   it('should display 2 dosages COVID alert', async () => {
     mockDirectBookingEligibilityCriteria(

--- a/src/applications/vaos/tests/mocks/helpers.js
+++ b/src/applications/vaos/tests/mocks/helpers.js
@@ -37,7 +37,9 @@ export function mockAppointmentInfo({
   partialError = null,
   isHomepageRefresh = false,
 }) {
-  mockFetch();
+  if (!global.fetch.isSinonProxy) {
+    mockFetch();
+  }
 
   const startDate = isHomepageRefresh
     ? moment().subtract(30, 'days')
@@ -115,7 +117,9 @@ export function mockAppointmentInfo({
  * @param {Array<VARRequest>} [params.requests=[]] Requests to return from mock
  */
 export function mockPastAppointmentInfo({ va = [], cc = [], requests = [] }) {
-  mockFetch();
+  if (!global.fetch.isSinonProxy) {
+    mockFetch();
+  }
   const baseUrl = `${
     environment.API_URL
   }/vaos/v0/appointments?start_date=${moment()
@@ -152,7 +156,9 @@ export function mockPastAppointmentInfo({ va = [], cc = [], requests = [] }) {
  * @param {Array<VARCommunityCareAppointment>} [params.cc=[]] CC appointments to return from mock
  */
 export function mockPastAppointmentInfoOption1({ va = [], cc = [] }) {
-  mockFetch();
+  if (!global.fetch.isSinonProxy) {
+    mockFetch();
+  }
   setFetchJSONResponse(global.fetch, { data: [] });
   setFetchJSONResponse(
     global.fetch.withArgs(

--- a/src/applications/vaos/tests/new-appointment/components/ClinicChoicePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ClinicChoicePage.unit.spec.jsx
@@ -13,7 +13,7 @@ import userEvent from '@testing-library/user-event';
 import ClinicChoicePage from '../../../new-appointment/components/ClinicChoicePage';
 import { mockEligibilityFetches, mockFacilityFetch } from '../../mocks/helpers';
 import { getClinicMock, getVAFacilityMock } from '../../mocks/v0';
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 
 const initialState = {
   featureToggles: {
@@ -28,7 +28,6 @@ const initialState = {
 
 describe('VAOS <ClinicChoicePage>', () => {
   beforeEach(() => mockFetch());
-  afterEach(() => resetFetch());
   it('should display multiple clinics and require one to be chosen', async () => {
     const clinics = [
       {

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCareLanguagePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCareLanguagePage.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import userEvent from '@testing-library/user-event';
 import { cleanup } from '@testing-library/react';
 import { fireEvent, waitFor } from '@testing-library/dom';
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
 import CommunityCareLanguagePage from '../../../new-appointment/components/CommunityCareLanguagePage';
 
@@ -24,7 +24,6 @@ const initialState = {
 
 describe('VAOS <CommunityCareLanguagePage>', () => {
   beforeEach(() => mockFetch());
-  afterEach(() => resetFetch());
 
   it('should show page with language choice', async () => {
     const store = createTestStore(initialState);

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCarePreferencesPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCarePreferencesPage.unit.spec.jsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { cleanup } from '@testing-library/react';
 import { waitFor } from '@testing-library/dom';
 
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 
 import {
   createTestStore,
@@ -33,7 +33,6 @@ const initialState = {
 };
 describe('VAOS <CommunityCarePreferencesPage>', () => {
   beforeEach(() => mockFetch());
-  afterEach(() => resetFetch());
   it('should render the page with appropriate inputs and prevent submission without required fields', async () => {
     mockParentSites(
       ['983'],

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { waitFor } from '@testing-library/dom';
 import { cleanup } from '@testing-library/react';
 
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 
 import {
   createTestStore,
@@ -100,7 +100,6 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
       CC_PROVIDERS_DATA,
     );
   });
-  afterEach(() => resetFetch());
   it('should display closest city question when user has multiple supported sites', async () => {
     const store = createTestStore(initialState);
     await setTypeOfCare(store, /primary care/i);

--- a/src/applications/vaos/tests/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
@@ -23,7 +23,7 @@ import {
   mockAppointmentSlotFetch,
 } from '../../../mocks/helpers';
 import { getClinicMock, getAppointmentSlotMock } from '../../../mocks/v0';
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 
 const initialState = {
   featureToggles: {
@@ -42,7 +42,6 @@ describe('VAOS <DateTimeSelectPage>', () => {
     MockDate.set(moment('2020-01-26T14:00:00'));
   });
   afterEach(() => {
-    resetFetch();
     MockDate.reset();
   });
   it('should not submit form with validation error', async () => {
@@ -184,9 +183,6 @@ describe('VAOS <DateTimeSelectPage>', () => {
   });
 
   it('should display error message if slots call fails', async () => {
-    // Initial global fetch
-    mockFetch();
-
     const clinics = [
       {
         id: '308',

--- a/src/applications/vaos/tests/new-appointment/components/PreferredDatePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/PreferredDatePage.unit.spec.jsx
@@ -4,7 +4,7 @@ import moment from 'moment';
 
 import PreferredDatePage from '../../../new-appointment/components/PreferredDatePage';
 import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 import { fireEvent, waitFor } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 
@@ -25,7 +25,6 @@ const initialState = {
 
 describe('VAOS integration: preferred date page with a single-site user', () => {
   beforeEach(() => mockFetch());
-  afterEach(() => resetFetch());
 
   it('should render', async () => {
     const store = createTestStore(initialState);
@@ -79,10 +78,7 @@ describe('VAOS integration: preferred date page with a single-site user', () => 
     userEvent.selectOptions(screen.getByRole('combobox', { name: /day/i }), [
       '2',
     ]);
-    await userEvent.type(
-      screen.getByRole('spinbutton', { name: /year/i }),
-      '2016',
-    );
+    userEvent.type(screen.getByRole('spinbutton', { name: /year/i }), '2016');
     fireEvent.click(screen.getByText(/Continue/));
     expect(await screen.findByRole('alert')).to.contain.text(
       'Please enter a future date ',
@@ -104,10 +100,7 @@ describe('VAOS integration: preferred date page with a single-site user', () => 
     userEvent.selectOptions(screen.getByRole('combobox', { name: /day/i }), [
       '2',
     ]);
-    await userEvent.type(
-      screen.getByRole('spinbutton', { name: /year/i }),
-      '2050',
-    );
+    userEvent.type(screen.getByRole('spinbutton', { name: /year/i }), '2050');
     fireEvent.click(screen.getByText(/Continue/));
     expect(await screen.findByRole('alert')).to.contain.text(
       'Please enter a date less than 395 days in the future ',
@@ -140,10 +133,7 @@ describe('VAOS integration: preferred date page with a single-site user', () => 
     userEvent.selectOptions(screen.getByRole('combobox', { name: /day/i }), [
       maxDay,
     ]);
-    await userEvent.type(
-      screen.getByRole('spinbutton', { name: /year/i }),
-      maxYear,
-    );
+    userEvent.type(screen.getByRole('spinbutton', { name: /year/i }), maxYear);
     fireEvent.click(screen.getByText(/Continue/));
     await waitFor(() => expect(screen.history.push.called).to.be.true);
   });

--- a/src/applications/vaos/tests/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 import {
   createTestStore,
   renderWithStoreAndRouter,
@@ -29,7 +29,6 @@ const initialState = {
 
 describe('VAOS <ReasonForAppointmentPage>', () => {
   beforeEach(() => mockFetch());
-  afterEach(() => resetFetch());
 
   it('should show page for VA medical request', async () => {
     const store = createTestStore(initialState);

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.cc-request.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.cc-request.unit.spec.jsx
@@ -674,7 +674,6 @@ describe('VAOS <ReviewPage> CC request with VAOS service', () => {
       },
     });
   });
-  afterEach(() => resetFetch());
 
   it('should submit successfully', async () => {
     mockAppointmentSubmit({

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.cc-request.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.cc-request.unit.spec.jsx
@@ -6,11 +6,7 @@ import userEvent from '@testing-library/user-event';
 import { waitFor } from '@testing-library/dom';
 import { Route } from 'react-router-dom';
 
-import {
-  setFetchJSONFailure,
-  mockFetch,
-  resetFetch,
-} from 'platform/testing/unit/helpers';
+import { setFetchJSONFailure, mockFetch } from 'platform/testing/unit/helpers';
 import environment from 'platform/utilities/environment';
 
 import { FACILITY_TYPES } from '../../../../utils/constants';
@@ -132,7 +128,6 @@ describe('VAOS <ReviewPage> CC request', () => {
       onCalendarChange([start.format('YYYY-MM-DD[T00:00:00.000]')]),
     );
   });
-  afterEach(() => resetFetch());
 
   it('should show form information for review', async () => {
     const screen = renderWithStoreAndRouter(<ReviewPage />, {
@@ -344,7 +339,6 @@ describe('VAOS <ReviewPage> CC request: homepage refresh', () => {
       onCalendarChange([start.format('YYYY-MM-DD[T00:00:00.000]')]),
     );
   });
-  afterEach(() => resetFetch());
 
   it('should submit successfully', async () => {
     mockRequestSubmit('cc', {
@@ -475,7 +469,6 @@ describe('VAOS <ReviewPage> CC request with provider selection', () => {
       onCalendarChange([start.format('YYYY-MM-DD[T00:00:00.000]')]),
     );
   });
-  afterEach(() => resetFetch());
 
   it('should show form information for review', async () => {
     const screen = renderWithStoreAndRouter(<ReviewPage />, {

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.direct.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.direct.unit.spec.jsx
@@ -5,11 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { waitFor } from '@testing-library/dom';
 import { Route } from 'react-router-dom';
 
-import {
-  setFetchJSONFailure,
-  mockFetch,
-  resetFetch,
-} from 'platform/testing/unit/helpers';
+import { setFetchJSONFailure, mockFetch } from 'platform/testing/unit/helpers';
 import environment from 'platform/utilities/environment';
 
 import {
@@ -141,7 +137,6 @@ describe('VAOS <ReviewPage> direct scheduling', () => {
     store.dispatch(startDirectScheduleFlow());
     store.dispatch(onCalendarChange([start.format()]));
   });
-  afterEach(() => resetFetch());
 
   it('should show form information for review', async () => {
     const screen = renderWithStoreAndRouter(<ReviewPage />, {

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.va-request.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.va-request.unit.spec.jsx
@@ -6,11 +6,7 @@ import userEvent from '@testing-library/user-event';
 import { waitFor } from '@testing-library/dom';
 import { Route } from 'react-router-dom';
 
-import {
-  setFetchJSONFailure,
-  mockFetch,
-  resetFetch,
-} from 'platform/testing/unit/helpers';
+import { setFetchJSONFailure, mockFetch } from 'platform/testing/unit/helpers';
 import environment from 'platform/utilities/environment';
 
 import { FACILITY_TYPES } from '../../../../utils/constants';
@@ -112,7 +108,6 @@ describe('VAOS <ReviewPage> VA request', () => {
       onCalendarChange([start.format('YYYY-MM-DD[T00:00:00.000]')]),
     );
   });
-  afterEach(() => resetFetch());
 
   it('should show form information for review', async () => {
     const screen = renderWithStoreAndRouter(<ReviewPage />, {
@@ -350,7 +345,6 @@ describe('VAOS <ReviewPage> VA request: Homepage Refresh', () => {
       onCalendarChange([start.format('YYYY-MM-DD[T00:00:00.000]')]),
     );
   });
-  afterEach(() => resetFetch());
 
   it('should submit successfully and route to appointment details page', async () => {
     mockRequestSubmit('va', {

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfAudiologyCare.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfAudiologyCare.unit.spec.jsx
@@ -5,7 +5,7 @@ import { waitFor } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import { cleanup } from '@testing-library/react';
 
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 
 import {
   createTestStore,
@@ -28,7 +28,6 @@ const initialState = {
 
 describe('VAOS <TypeOfAudiologyCarePage>', () => {
   beforeEach(() => mockFetch());
-  afterEach(() => resetFetch());
   it('should show page and validation', async () => {
     const store = createTestStore(initialState);
     await setTypeOfCare(store, /audiology/i);

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfCarePage.unit.spec.jsx
@@ -5,11 +5,7 @@ import { fireEvent, waitFor } from '@testing-library/dom';
 import { cleanup } from '@testing-library/react';
 
 import set from 'platform/utilities/data/set';
-import {
-  mockFetch,
-  resetFetch,
-  setFetchJSONResponse,
-} from 'platform/testing/unit/helpers';
+import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
 
 import { getParentSiteMock } from '../../mocks/v0';
 import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
@@ -41,7 +37,6 @@ const initialState = {
 
 describe('VAOS <TypeOfCarePage>', () => {
   beforeEach(() => mockFetch());
-  afterEach(() => resetFetch());
   it('should show type of care page with all care types', async () => {
     const store = createTestStore(initialState);
     const screen = renderWithStoreAndRouter(

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfEyeCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfEyeCarePage.unit.spec.jsx
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { fireEvent, waitFor } from '@testing-library/dom';
 import { cleanup } from '@testing-library/react';
 
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 
 import { getParentSiteMock } from '../../mocks/v0';
 import {
@@ -32,7 +32,6 @@ const initialState = {
 
 describe('VAOS <TypeOfEyeCarePage>', () => {
   beforeEach(() => mockFetch());
-  afterEach(() => resetFetch());
   it('should show page and validation', async () => {
     const store = createTestStore(initialState);
     const nextPage = await setTypeOfCare(store, /eye care/i);

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfFacilityPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfFacilityPage.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
 import { fireEvent, waitFor } from '@testing-library/dom';
 import TypeOfFacilityPage from '../../../new-appointment/components/TypeOfFacilityPage';
@@ -24,7 +24,6 @@ const initialState = {
 
 describe('VAOS integration: VA facility page with a single-site user', () => {
   beforeEach(() => mockFetch());
-  afterEach(() => resetFetch());
 
   it('should show page', async () => {
     const store = createTestStore(initialState);

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfSleepCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfSleepCarePage.unit.spec.jsx
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { fireEvent, waitFor } from '@testing-library/dom';
 import { cleanup } from '@testing-library/react';
 
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 
 import {
   createTestStore,
@@ -27,7 +27,6 @@ const initialState = {
 
 describe('VAOS <TypeOfSleepCarePage>', () => {
   beforeEach(() => mockFetch());
-  afterEach(() => resetFetch());
   it('should show page and validation', async () => {
     const store = createTestStore(initialState);
     const nextPage = await setTypeOfCare(store, /sleep/i);

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfVisitPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfVisitPage.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
 import { fireEvent, waitFor } from '@testing-library/dom';
 import { cleanup } from '@testing-library/react';
@@ -23,7 +23,6 @@ const initialState = {
 };
 describe('VAOS <TypeOfVisitPage> ', () => {
   beforeEach(() => mockFetch());
-  afterEach(() => resetFetch());
   it('should show page', async () => {
     const store = createTestStore(initialState);
     const screen = renderWithStoreAndRouter(<TypeOfVisitPage />, {

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.multi.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.multi.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { expect } from 'chai';
 
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 import { fireEvent, waitFor } from '@testing-library/dom';
 import { cleanup } from '@testing-library/react';
 import VAFacilityPage from '../../../../new-appointment/components/VAFacilityPage/VAFacilityPageV2';
@@ -134,7 +134,6 @@ closestFacility.attributes.long = -84.3164749;
 
 describe('VAOS integration: VA flat facility page - multiple facilities', () => {
   beforeEach(() => mockFetch());
-  afterEach(() => resetFetch());
 
   it('should display list of facilities with show more button', async () => {
     mockParentSites(parentSiteIds, [parentSite983, parentSite984]);

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.single.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/VAFacilityPageV2.single.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 import { fireEvent, waitFor } from '@testing-library/dom';
 import VAFacilityPage from '../../../../new-appointment/components/VAFacilityPage/VAFacilityPageV2';
 import {
@@ -120,8 +120,6 @@ describe('VAOS integration: VA flat facility page - single facility', () => {
     mockRequestEligibilityCriteria(siteIds, requestFacilities);
     mockFacilitiesFetch('vha_442', facilities);
   });
-
-  afterEach(() => resetFetch());
 
   it('should show alert when only one facility is supported', async () => {
     mockEligibilityFetches({

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.multi-site.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.multi-site.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { Route } from 'react-router-dom';
 
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 
 import { fireEvent, waitFor } from '@testing-library/dom';
 import { cleanup } from '@testing-library/react';
@@ -63,7 +63,6 @@ const parentSite984 = {
 
 describe('VAOS integration: VA facility page with a multi-site user', () => {
   beforeEach(() => mockFetch());
-  afterEach(() => resetFetch());
 
   it('should show form with required questions for both sites and facilities', async () => {
     mockParentSites(['983', '984'], [parentSite983, parentSite984]);

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.single-site.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.single-site.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { Route } from 'react-router-dom';
 
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 import set from 'platform/utilities/data/set';
 
 import { fireEvent } from '@testing-library/dom';
@@ -30,7 +30,6 @@ const initialState = {
 
 describe('VAOS integration: VA facility page with a single-site user', () => {
   beforeEach(() => mockFetch());
-  afterEach(() => resetFetch());
 
   it('should show single disabled radio button option if Cerner only', async () => {
     const parentSite = {

--- a/src/applications/vaos/tests/new-appointment/newAppointmentFlow.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/newAppointmentFlow.unit.spec.js
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import {
-  resetFetch,
   mockFetch,
   setFetchJSONResponse,
   setFetchJSONFailure,
@@ -64,8 +63,6 @@ describe('VAOS newAppointmentFlow', () => {
           dispatch,
         );
         expect(nextState).to.equal('vaFacilityV2');
-
-        resetFetch();
       });
 
       it('should be vaFacility page if CC check has an error', async () => {
@@ -95,8 +92,6 @@ describe('VAOS newAppointmentFlow', () => {
           dispatch,
         );
         expect(nextState).to.equal('vaFacilityV2');
-
-        resetFetch();
       });
 
       it('should be typeOfCare page if CC check has an error and podiatry chosen', async () => {
@@ -126,7 +121,6 @@ describe('VAOS newAppointmentFlow', () => {
           dispatch,
         );
         expect(nextState).to.equal('typeOfCare');
-        resetFetch();
       });
 
       it('should be the current page if no CC support and typeOfCare is podiatry', async () => {
@@ -194,7 +188,6 @@ describe('VAOS newAppointmentFlow', () => {
         expect(dataLayer[0].event).to.equal('vaos-cc-eligible-yes');
 
         expect(nextState).to.equal('requestDateTime');
-        resetFetch();
       });
 
       it('should be typeOfSleepCare if sleep care chosen', async () => {
@@ -250,8 +243,6 @@ describe('VAOS newAppointmentFlow', () => {
           dispatch,
         );
         expect(nextState).to.equal('typeOfFacility');
-
-        resetFetch();
       });
     });
   });
@@ -379,8 +370,6 @@ describe('VAOS newAppointmentFlow', () => {
           'newAppointment/START_DIRECT_SCHEDULE_FLOW',
         );
         expect(nextState).to.equal('clinicChoice');
-
-        resetFetch();
       });
       it('should throw error if not eligible for requests or direct', async () => {
         const state = {
@@ -626,8 +615,6 @@ describe('VAOS newAppointmentFlow', () => {
         dispatch,
       );
       expect(nextState).to.equal('typeOfFacility');
-
-      resetFetch();
     });
 
     it('should be vaFacility page when Ophthalmology selected', async () => {
@@ -662,8 +649,6 @@ describe('VAOS newAppointmentFlow', () => {
         dispatch,
       );
       expect(nextState).to.equal('vaFacilityV2');
-
-      resetFetch();
     });
   });
 });

--- a/src/applications/vaos/tests/services/healthcare-service/index.unit.spec.js
+++ b/src/applications/vaos/tests/services/healthcare-service/index.unit.spec.js
@@ -106,7 +106,6 @@ describe('VAOS Healthcare service', () => {
     });
 
     it('should return OperationOutcome error', async () => {
-      mockFetch();
       setFetchJSONFailure(global.fetch, {
         errors: [],
       });
@@ -143,7 +142,6 @@ describe('VAOS Healthcare service', () => {
     });
 
     it('should return OperationOutcome error', async () => {
-      mockFetch();
       setFetchJSONFailure(global.fetch, {
         errors: [],
       });

--- a/src/applications/vaos/tests/services/utils.unit.spec.js
+++ b/src/applications/vaos/tests/services/utils.unit.spec.js
@@ -1,10 +1,6 @@
 import { expect } from 'chai';
 
-import {
-  resetFetch,
-  mockFetch,
-  setFetchJSONResponse,
-} from 'platform/testing/unit/helpers';
+import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
 
 import { mapToFHIRErrors, fhirSearch } from '../../services/utils';
 import mockData from '../../services/mocks/fhir/mock_organizations.json';
@@ -54,7 +50,6 @@ describe('VAOS FHIR utils', () => {
       );
       expect(results.length).to.equal(2);
       expect(results[0].resourceType).to.equal('Organization');
-      resetFetch();
     });
   });
 });

--- a/src/applications/virtual-agent/tests/Chatbox.unit.spec.js
+++ b/src/applications/virtual-agent/tests/Chatbox.unit.spec.js
@@ -9,7 +9,6 @@ import Chatbox from '../components/chatbox/Chatbox';
 import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
 import {
   mockApiRequest,
-  resetFetch,
   mockMultipleApiRequests,
 } from 'platform/testing/unit/helpers';
 import { createTestStore } from '../../vaos/tests/mocks/setup';
@@ -46,7 +45,6 @@ describe('App', () => {
   });
 
   afterEach(() => {
-    resetFetch();
     global.window = oldWindow;
     sandbox.restore();
   });

--- a/src/applications/virtual-agent/tests/Chatbox.unit.spec.js
+++ b/src/applications/virtual-agent/tests/Chatbox.unit.spec.js
@@ -39,7 +39,6 @@ describe('App', () => {
   beforeEach(() => {
     createStoreSpy = sandbox.spy();
     directLineSpy = sandbox.spy();
-    resetFetch();
     oldWindow = global.window;
     sandbox.spy(Sentry, 'captureException');
   });

--- a/src/platform/forms/tests/components/SignInLink.unit.spec.jsx
+++ b/src/platform/forms/tests/components/SignInLink.unit.spec.jsx
@@ -5,22 +5,17 @@ import sinon from 'sinon';
 import ReactTestUtils from 'react-dom/test-utils';
 
 import SignInLink from '../../components/SignInLink';
+import { mockFetch } from '../../../testing/unit/helpers';
 
 let oldWindow;
-let oldFetch;
 const response = {
   json: () => ({
     authenticate_via_get: true, // eslint-disable-line camelcase
   }),
 };
-let fetchPromise;
 
 const setup = () => {
-  oldFetch = global.fetch;
-  oldWindow = global.window;
-  fetchPromise = Promise.resolve(response); // Reset it every time.
-
-  global.fetch = sinon.spy(() => fetchPromise);
+  mockFetch(response);
   global.window = Object.create(global.window);
   Object.assign(global.window, {
     dataLayer: [],
@@ -30,7 +25,6 @@ const setup = () => {
 };
 const teardown = () => {
   global.window = oldWindow;
-  global.fetch = oldFetch;
 };
 
 describe('<SignInLink>', () => {

--- a/src/platform/forms/tests/save-in-progress/SaveInProgressErrorPage.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressErrorPage.unit.spec.jsx
@@ -7,24 +7,14 @@ import { VA_FORM_IDS } from 'platform/forms/constants';
 
 import { SaveInProgressErrorPage } from '../../save-in-progress/SaveInProgressErrorPage';
 import { LOAD_STATUSES } from '../../save-in-progress/actions';
-
-let oldFetch;
-const setup = () => {
-  oldFetch = global.fetch;
-  global.fetch = sinon.stub();
-  global.fetch.returns(Promise.resolve({ ok: true }));
-};
-const teardown = () => {
-  global.fetch = oldFetch;
-};
+import { mockFetch } from '../../../testing/unit/helpers';
 
 describe('<SaveInProgressErrorPage>', () => {
   let formConfigDefaultData;
   beforeEach(() => {
-    setup();
+    mockFetch();
     formConfigDefaultData = {};
   });
-  afterEach(teardown);
 
   const route = {
     formConfig: {

--- a/src/platform/monitoring/DowntimeNotification/tests/actions.unit.spec.js
+++ b/src/platform/monitoring/DowntimeNotification/tests/actions.unit.spec.js
@@ -5,11 +5,7 @@ import {
   RECEIVE_SCHEDULED_DOWNTIME,
   RETRIEVE_SCHEDULED_DOWNTIME,
 } from '../actions';
-import {
-  mockFetch,
-  setFetchJSONResponse,
-  resetFetch,
-} from 'platform/testing/unit/helpers';
+import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
 
 describe('getScheduledDowntime', () => {
   const dispatch = sinon.spy();
@@ -20,7 +16,6 @@ describe('getScheduledDowntime', () => {
   });
 
   afterEach(() => {
-    resetFetch();
     dispatch.reset();
   });
 

--- a/src/platform/monitoring/DowntimeNotification/tests/helpers.unit.spec.js
+++ b/src/platform/monitoring/DowntimeNotification/tests/helpers.unit.spec.js
@@ -5,7 +5,6 @@ import {
   mockFetch,
   setFetchJSONResponse,
   setFetchJSONFailure,
-  resetFetch,
 } from 'platform/testing/unit/helpers';
 
 import externalServiceStatus from '../config/externalServiceStatus';
@@ -216,10 +215,6 @@ describe('getMostUrgentDowntime', () => {
 describe('getCurrentGlobalDowntime', () => {
   beforeEach(() => {
     mockFetch();
-  });
-
-  afterEach(() => {
-    resetFetch();
   });
 
   it('returns downtime when in the middle of a downtime', async () => {

--- a/src/platform/monitoring/external-services/tests/actions.unit.spec.js
+++ b/src/platform/monitoring/external-services/tests/actions.unit.spec.js
@@ -10,14 +10,8 @@ import {
   getBackendStatuses,
 } from '../actions';
 
-const originalFetch = global.fetch;
-
 describe('External services actions', () => {
   describe('getBackendStatuses', () => {
-    afterEach(() => {
-      global.fetch = originalFetch;
-    });
-
     it('should handle a success response', () => {
       const response = {
         data: {

--- a/src/platform/site-wide/user-nav/tests/components/SearchMenu.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/components/SearchMenu.unit.spec.jsx
@@ -4,7 +4,6 @@ import { mount, shallow } from 'enzyme';
 
 import {
   mockFetch,
-  resetFetch,
   setFetchJSONResponse as setFetchResponse,
 } from 'platform/testing/unit/helpers';
 
@@ -25,10 +24,6 @@ describe('<SearchMenu>', () => {
       'sample 4',
       'sample 5',
     ]);
-  });
-
-  afterEach(() => {
-    resetFetch();
   });
 
   it('should hide the search bar', () => {

--- a/src/platform/testing/unit/helpers.js
+++ b/src/platform/testing/unit/helpers.js
@@ -8,6 +8,7 @@ import sinon from 'sinon';
 chai.use(chaiAsPromised);
 
 const expect = chai.expect;
+const sandbox = sinon.createSandbox();
 
 /**
  * Wraps the given children with a new component with context from
@@ -92,7 +93,7 @@ function fillDate(formDOM, partialId, dateString) {
  * @param {boolean} [shouldResolve=true] Returns a rejected promise if this is false
  */
 export function mockFetch(returnVal, shouldResolve = true) {
-  const fetchStub = sinon.stub(global, 'fetch');
+  const fetchStub = sandbox.stub(global, 'fetch');
   fetchStub.callsFake(url => {
     let response = returnVal;
     if (!response) {
@@ -149,7 +150,7 @@ export function setFetchBlobFailure(stub, error) {
  */
 export function resetFetch() {
   if (global.fetch.isSinonProxy) {
-    global.fetch.restore();
+    sandbox.restore();
   }
 }
 

--- a/src/platform/testing/unit/helpers.js
+++ b/src/platform/testing/unit/helpers.js
@@ -2,7 +2,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import PropTypes from 'prop-types';
 import React from 'react';
-import userEvent from '@testing-library/user-event';
+import ReactTestUtils from 'react-dom/test-utils';
 import sinon from 'sinon';
 
 chai.use(chaiAsPromised);
@@ -60,15 +60,27 @@ function wrapWithRouterContext(component) {
 function fillDate(formDOM, partialId, dateString) {
   const date = dateString.split('-');
   const inputs = Array.from(formDOM.querySelectorAll('input, select'));
-  userEvent.selectOptions(
+  ReactTestUtils.Simulate.change(
     inputs.find(i => i.id === `${partialId}Month`),
-    date[1],
+    {
+      target: {
+        value: date[1],
+      },
+    },
   );
-  userEvent.selectOptions(
-    inputs.find(i => i.id === `${partialId}Day`),
-    date[2],
+  ReactTestUtils.Simulate.change(inputs.find(i => i.id === `${partialId}Day`), {
+    target: {
+      value: date[2],
+    },
+  });
+  ReactTestUtils.Simulate.change(
+    inputs.find(i => i.id === `${partialId}Year`),
+    {
+      target: {
+        value: date[0],
+      },
+    },
   );
-  userEvent.type(inputs.find(i => i.id === `${partialId}Year`), date[0]);
 }
 
 /**

--- a/src/platform/testing/unit/helpers.js
+++ b/src/platform/testing/unit/helpers.js
@@ -8,7 +8,6 @@ import sinon from 'sinon';
 chai.use(chaiAsPromised);
 
 const expect = chai.expect;
-const sandbox = sinon.createSandbox();
 
 /**
  * Wraps the given children with a new component with context from
@@ -80,7 +79,7 @@ function fillDate(formDOM, partialId, dateString) {
  * @param {boolean} [shouldResolve=true] Returns a rejected promise if this is false
  */
 export function mockFetch(returnVal, shouldResolve = true) {
-  const fetchStub = sandbox.stub(global, 'fetch');
+  const fetchStub = sinon.stub(global, 'fetch');
   fetchStub.callsFake(url => {
     let response = returnVal;
     if (!response) {
@@ -137,7 +136,7 @@ export function setFetchBlobFailure(stub, error) {
  */
 export function resetFetch() {
   if (global.fetch.isSinonProxy) {
-    sandbox.restore();
+    global.fetch.restore();
   }
 }
 

--- a/src/platform/testing/unit/helpers.js
+++ b/src/platform/testing/unit/helpers.js
@@ -2,7 +2,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import PropTypes from 'prop-types';
 import React from 'react';
-import ReactTestUtils from 'react-dom/test-utils';
+import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
 
 chai.use(chaiAsPromised);
@@ -61,28 +61,15 @@ function wrapWithRouterContext(component) {
 function fillDate(formDOM, partialId, dateString) {
   const date = dateString.split('-');
   const inputs = Array.from(formDOM.querySelectorAll('input, select'));
-
-  ReactTestUtils.Simulate.change(
+  userEvent.selectOptions(
     inputs.find(i => i.id === `${partialId}Month`),
-    {
-      target: {
-        value: date[1],
-      },
-    },
+    date[1],
   );
-  ReactTestUtils.Simulate.change(inputs.find(i => i.id === `${partialId}Day`), {
-    target: {
-      value: date[2],
-    },
-  });
-  ReactTestUtils.Simulate.change(
-    inputs.find(i => i.id === `${partialId}Year`),
-    {
-      target: {
-        value: date[0],
-      },
-    },
+  userEvent.selectOptions(
+    inputs.find(i => i.id === `${partialId}Day`),
+    date[2],
   );
+  userEvent.type(inputs.find(i => i.id === `${partialId}Year`), date[0]);
 }
 
 /**

--- a/src/platform/testing/unit/helpers.js
+++ b/src/platform/testing/unit/helpers.js
@@ -84,8 +84,6 @@ function fillDate(formDOM, partialId, dateString) {
   );
 }
 
-let oldFetch;
-
 /**
  * A function to mock the global fetch function and return
  * the value provided in returnVal.
@@ -94,14 +92,8 @@ let oldFetch;
  * @param {boolean} [shouldResolve=true] Returns a rejected promise if this is false
  */
 export function mockFetch(returnVal, shouldResolve = true) {
-  // Only save global.fetch in oldFetch if global.fetch is the real fetch
-  // function rather than a sinon stub. Sinon stubs are objects with many
-  // properties; global.fetch has no properties
-  if (Object.keys(global.fetch).length === 0) {
-    oldFetch = global.fetch;
-  }
-
-  global.fetch = sinon.stub().callsFake(url => {
+  const fetchStub = sinon.stub(global, 'fetch');
+  fetchStub.callsFake(url => {
     let response = returnVal;
     if (!response) {
       response = new Response();
@@ -118,6 +110,7 @@ export function mockFetch(returnVal, shouldResolve = true) {
 export function setFetchJSONResponse(stub, data = null) {
   const response = new Response();
   response.ok = true;
+  response.url = 'https://dev-api.va.gov';
   if (data) {
     response.headers.set('Content-Type', 'application/json');
     response.json = () => Promise.resolve(data);
@@ -130,6 +123,7 @@ export function setFetchJSONFailure(stub, data) {
     headers: { 'content-type': ['application/json'] },
   });
   response.ok = false;
+  response.url = 'https://dev-api.va.gov';
   response.json = () => Promise.resolve(data);
   stub.resolves(response);
 }
@@ -137,6 +131,7 @@ export function setFetchJSONFailure(stub, data) {
 export function setFetchBlobResponse(stub, data) {
   const response = new Response();
   response.ok = true;
+  response.url = 'https://dev-api.va.gov';
   response.blob = () => Promise.resolve(data);
   stub.resolves(response);
 }
@@ -144,6 +139,7 @@ export function setFetchBlobResponse(stub, data) {
 export function setFetchBlobFailure(stub, error) {
   const response = new Response();
   response.ok = true;
+  response.url = 'https://dev-api.va.gov';
   response.blob = () => Promise.reject(new Error(error));
   stub.resolves(response);
 }
@@ -152,10 +148,8 @@ export function setFetchBlobFailure(stub, error) {
  * Resets the fetch mock set with mockFetch
  */
 export function resetFetch() {
-  // To prevent a really unlikely edge case where resetFetch() is called before
-  // mockFetch()
-  if (oldFetch) {
-    global.fetch = oldFetch;
+  if (global.fetch.isSinonProxy) {
+    global.fetch.restore();
   }
 }
 
@@ -165,6 +159,7 @@ const getApiRequestObject = returnVal => ({
   },
   ok: true,
   json: () => Promise.resolve(returnVal),
+  url: 'https://dev-api.va.gov',
 });
 
 /**
@@ -187,7 +182,7 @@ export function mockApiRequest(returnVal, shouldResolve = true) {
  * @param {Response[]} responses - An array of responses which subsequent fetch calls should return
  */
 export function mockMultipleApiRequests(responses) {
-  global.fetch = sinon.stub();
+  mockFetch();
   responses.forEach((res, index) => {
     const { response, shouldResolve } = res;
     const formattedResponse = getApiRequestObject(response);

--- a/src/platform/testing/unit/helpers.js
+++ b/src/platform/testing/unit/helpers.js
@@ -138,7 +138,7 @@ export function setFetchBlobResponse(stub, data) {
 
 export function setFetchBlobFailure(stub, error) {
   const response = new Response();
-  response.ok = true;
+  response.ok = false;
   response.url = 'https://dev-api.va.gov';
   response.blob = () => Promise.reject(new Error(error));
   stub.resolves(response);

--- a/src/platform/testing/unit/mocha-setup.js
+++ b/src/platform/testing/unit/mocha-setup.js
@@ -15,6 +15,7 @@ import * as Sentry from '@sentry/browser';
 import chaiAxe from './axe-plugin';
 
 import { sentryTransport } from './sentry';
+import { resetFetch } from './helpers';
 
 Sentry.init({
   dsn: 'http://one@fake/dsn',
@@ -75,6 +76,8 @@ function setupJSDom() {
   const dom = new JSDOM('<!doctype html><html><body></body></html>', {
     url: 'http://localhost',
   });
+
+  resetFetch();
 
   const { window } = dom;
 

--- a/src/platform/testing/unit/mocha-setup.js
+++ b/src/platform/testing/unit/mocha-setup.js
@@ -42,6 +42,12 @@ function filterStackTrace(trace) {
     .join(os.EOL);
 }
 
+function resetFetch() {
+  if (global.fetch.isSinonProxy) {
+    global.fetch.restore();
+  }
+}
+
 /**
  * Sets up JSDom in the testing environment. Allows testing of DOM functions without a browser.
  */
@@ -75,10 +81,6 @@ function setupJSDom() {
   const dom = new JSDOM('<!doctype html><html><body></body></html>', {
     url: 'http://localhost',
   });
-
-  if (global.fetch.isSinonProxy) {
-    global.fetch.restore();
-  }
 
   const { window } = dom;
 
@@ -167,5 +169,6 @@ chai.use(chaiAxe);
 export const mochaHooks = {
   beforeEach() {
     setupJSDom();
+    resetFetch();
   },
 };

--- a/src/platform/testing/unit/mocha-setup.js
+++ b/src/platform/testing/unit/mocha-setup.js
@@ -15,7 +15,6 @@ import * as Sentry from '@sentry/browser';
 import chaiAxe from './axe-plugin';
 
 import { sentryTransport } from './sentry';
-import { resetFetch } from './helpers';
 
 Sentry.init({
   dsn: 'http://one@fake/dsn',
@@ -77,7 +76,9 @@ function setupJSDom() {
     url: 'http://localhost',
   });
 
-  resetFetch();
+  if (global.fetch.isSinonProxy) {
+    global.fetch.restore();
+  }
 
   const { window } = dom;
 

--- a/src/platform/testing/unit/mocha-setup.js
+++ b/src/platform/testing/unit/mocha-setup.js
@@ -77,8 +77,6 @@ function setupJSDom() {
     url: 'http://localhost',
   });
 
-  resetFetch();
-
   const { window } = dom;
 
   global.dom = dom;
@@ -166,5 +164,8 @@ chai.use(chaiAxe);
 export const mochaHooks = {
   beforeEach() {
     setupJSDom();
+  },
+  afterEach() {
+    resetFetch();
   },
 };

--- a/src/platform/testing/unit/mocha-setup.js
+++ b/src/platform/testing/unit/mocha-setup.js
@@ -15,7 +15,7 @@ import * as Sentry from '@sentry/browser';
 import chaiAxe from './axe-plugin';
 
 import { sentryTransport } from './sentry';
-// import { resetFetch } from './helpers';
+import { resetFetch } from './helpers';
 
 Sentry.init({
   dsn: 'http://one@fake/dsn',
@@ -76,6 +76,8 @@ function setupJSDom() {
   const dom = new JSDOM('<!doctype html><html><body></body></html>', {
     url: 'http://localhost',
   });
+
+  resetFetch();
 
   const { window } = dom;
 
@@ -164,8 +166,5 @@ chai.use(chaiAxe);
 export const mochaHooks = {
   beforeEach() {
     setupJSDom();
-    if (global.fetch.isSinonProxy) {
-      global.fetch.restore();
-    }
   },
 };

--- a/src/platform/testing/unit/mocha-setup.js
+++ b/src/platform/testing/unit/mocha-setup.js
@@ -15,7 +15,7 @@ import * as Sentry from '@sentry/browser';
 import chaiAxe from './axe-plugin';
 
 import { sentryTransport } from './sentry';
-import { resetFetch } from './helpers';
+// import { resetFetch } from './helpers';
 
 Sentry.init({
   dsn: 'http://one@fake/dsn',
@@ -164,8 +164,8 @@ chai.use(chaiAxe);
 export const mochaHooks = {
   beforeEach() {
     setupJSDom();
-  },
-  afterEach() {
-    resetFetch();
+    if (global.fetch.isSinonProxy) {
+      global.fetch.restore();
+    }
   },
 };

--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -6,7 +6,7 @@ import { checkAndUpdateSSOeSession } from '../sso';
 
 export function fetchAndUpdateSessionExpiration(...args) {
   // Only replace with custom fetch if not stubbed for unit testing
-  if (fetch.displayName !== 'stub') {
+  if (!fetch.isSinonProxy) {
     return fetch.apply(this, args).then(response => {
       const apiURL = environment.API_URL;
 

--- a/src/platform/utilities/tests/sso.unit.spec.js
+++ b/src/platform/utilities/tests/sso.unit.spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from 'platform/testing/unit/helpers';
 import localStorage from 'platform/utilities/storage/localStorage';
 import * as authUtils from 'platform/user/authentication/utilities';
 import * as keepAliveMod from 'platform/utilities/sso/keepAliveSSO';
@@ -314,7 +314,6 @@ describe('checkAndUpdateSSOeSession', () => {
     checkAndUpdateSSOeSession();
 
     expect(localStorage.getItem('sessionExpirationSSO')).to.equal('some value');
-    resetFetch();
   });
 
   it('should make a keepalive request for active SSO sessions below the timeout threshold', () => {
@@ -331,7 +330,6 @@ describe('checkAndUpdateSSOeSession', () => {
     expect(localStorage.getItem('sessionExpirationSSO')).to.not.equal(
       expiringSession,
     );
-    resetFetch();
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Description
Closes [Reset Fetch as Part of Mocha Setup](https://app.zenhub.com/workspaces/vsp---frontend-tools-5fc9325744944e0015ed1861/issues/department-of-veterans-affairs/va.gov-team/24733)

The goal here is to add a reset of any fetch mocks between each test to eliminate the likelihood that fetch mocks have been persisting between tests. This resulted in the need to standardize how we are mocking fetch in our tests and to fix a lot of tests that started failing as soon as the fetch mocks were reset.

## Testing done
All unit tests should pass

## Screenshots


## Acceptance criteria
- [ ] Fetch should be being reset between tests
- [ ] All unit tests should pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
