### PR TITLE
Enforce stylelint

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint:js:changed": "LIST=`git diff-index --diff-filter=d --name-only --cached HEAD | grep \"\\.js[x]\\{0,1\\}$\"`; if [ \"$LIST\" ]; then eslint --quiet --config changed.eslintrc.js $LIST; fi",
     "lint:js:changed:fix": "LIST=`git diff-index --diff-filter=d --name-only HEAD | grep \"\\.js[x]\\{0,1\\}$\"`; if [ \"$LIST\" ]; then eslint --fix --quiet $LIST; fi",
     "lint:js:untracked:fix": "LIST=`git ls-files --others --exclude-standard | grep \"\\.js[x]\\{0,1\\}$\"`; if [ \"$LIST\" ]; then eslint --fix --quiet $LIST; fi",
-    "lint:sass": "sass-lint --verbose",
+    "lint:sass": "npx stylelint src/**/*.scss",
     "mock-api": "node src/platform/testing/e2e/mockapi.js",
     "new:app": "yo @department-of-veterans-affairs/vets-website && npm run lint:js:untracked:fix",
     "nightwatch:docker": "nightwatch -c config/nightwatch.docker-compose.js --suiteRetries 3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint:js:changed": "LIST=`git diff-index --diff-filter=d --name-only --cached HEAD | grep \"\\.js[x]\\{0,1\\}$\"`; if [ \"$LIST\" ]; then eslint --quiet --config changed.eslintrc.js $LIST; fi",
     "lint:js:changed:fix": "LIST=`git diff-index --diff-filter=d --name-only HEAD | grep \"\\.js[x]\\{0,1\\}$\"`; if [ \"$LIST\" ]; then eslint --fix --quiet $LIST; fi",
     "lint:js:untracked:fix": "LIST=`git ls-files --others --exclude-standard | grep \"\\.js[x]\\{0,1\\}$\"`; if [ \"$LIST\" ]; then eslint --fix --quiet $LIST; fi",
-    "lint:sass": "npx stylelint src/**/*.scss",
+    "lint:sass": "stylelint src/**/*.scss",
     "mock-api": "node src/platform/testing/e2e/mockapi.js",
     "new:app": "yo @department-of-veterans-affairs/vets-website && npm run lint:js:untracked:fix",
     "nightwatch:docker": "nightwatch -c config/nightwatch.docker-compose.js --suiteRetries 3",

--- a/src/applications/gi-sandbox/sass/partials/_gi-autocomplete.scss
+++ b/src/applications/gi-sandbox/sass/partials/_gi-autocomplete.scss
@@ -1,7 +1,7 @@
 .gi-app {
 
   .suggestions-list {
-    z-index:9999;
+    z-index: 9999;
     background: $color-white;
     border: 1px solid $color-gray;
     // Box shadow only sides and bottom of suggestion list.


### PR DESCRIPTION
## Description

Related to #17305

Now that step 2 from that PR has been completed, this is step 3. This will enforce our linting rules as part of the precommit hook.

It also fixes a linting error in `gi-sandbox` that was introduced after the fixes in https://github.com/department-of-veterans-affairs/vets-website/pull/17330 were merged.

## Testing done

Local committing


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
