### PR TITLE
Add ESLint rule to deprecate AlertBox imports

### DIFF
--- a/changed.eslintrc.js
+++ b/changed.eslintrc.js
@@ -11,6 +11,10 @@ eslintConfig.rules = {
         '@department-of-veterans-affairs/component-library/CollapsiblePanel',
       use: '<va-accordion>',
     },
+    {
+      name: '@department-of-veterans-affairs/component-library/AlertBox',
+      use: '<va-alert>',
+    },
   ],
 };
 


### PR DESCRIPTION
## Description

Now that [`vets-website` has `<va-alert>` available](https://github.com/department-of-veterans-affairs/vets-website/pull/17027) to use, we can deprecate future imports of `AlertBox` from the component library.


## Testing done

Local changes + commit attempt (see screenshots)

## Screenshots

If I have a local change that looks like this:

![image](https://user-images.githubusercontent.com/2008881/119869497-28fe5480-bed5-11eb-80ca-71555817d83f.png)


I'll get a linting error when I try to commit:

![image](https://user-images.githubusercontent.com/2008881/119869603-47645000-bed5-11eb-9d32-21e57f6ffd62.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
