### PR TITLE
fix lint issue in caregivers repo

### DIFF
--- a/src/applications/caregivers/components/PreSubmitInfo/index.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/index.jsx
@@ -97,7 +97,7 @@ const PreSubmitCheckboxGroup = ({
         ...transformSignatures(signatures),
       });
     },
-    [setFormData, signatures],
+    [setFormData, signatures, formData, hasSubmittedForm, transformSignatures],
   );
 
   // when there is no unsigned signatures set AGREED (onSectionComplete) to true

--- a/src/applications/caregivers/containers/IntroductionPage.jsx
+++ b/src/applications/caregivers/containers/IntroductionPage.jsx
@@ -38,7 +38,7 @@ const IntroductionPage = ({
         'view:canUpload1010cgPOA': canUpload1010cgPOA,
       });
     },
-    [setFormData, canUpload1010cgPOA],
+    [setFormData, canUpload1010cgPOA, formData],
   );
 
   useEffect(


### PR DESCRIPTION
## Description

With Github Action now in effect, linting warnings are being displayed. In an effort to clean up the warnings, this PR applies lint error messages generated from `yarn run eslint --ext .js --ext .jsx --format ./script/github-actions/eslint-annotation-format.js` .

I recommend pulling the branch and locally testing

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
