### PR TITLE
Fixes virtual agent refresh bug

### DIFF
--- a/src/applications/virtual-agent/components/chatbot-error/ChatbotError.jsx
+++ b/src/applications/virtual-agent/components/chatbot-error/ChatbotError.jsx
@@ -1,11 +1,21 @@
 import React from 'react';
-import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
+
+const errorMessage = (
+  <>
+    We’re making some updates to the Virtual Agent. We’re sorry it’s not working
+    right now. Please check back soon. If you require immediate assistance
+    please call the VA.gov help desk at{' '}
+    <a href="tel:800-698-2411" aria-label="8 0 0. 6 9 8. 2 4 1 1.">
+      800-698-2411
+    </a>{' '}
+    (
+    <a href="tel:711" aria-label="TTY: 7 1 1.">
+      TTY: 711
+    </a>
+    ).
+  </>
+);
 
 export default function ChatbotError() {
-  return (
-    <AlertBox
-      content="We’re making some updates to the Virtual Agent. We’re sorry it’s not working right now. Please check back soon. If you require immediate assistance please call the VA.gov help desk at 800-698-2411 (TTY: 711)."
-      status="error"
-    />
-  );
+  return <va-alert status="error">{errorMessage}</va-alert>;
 }

--- a/src/applications/virtual-agent/components/chatbox/useVirtualAgentToken.js
+++ b/src/applications/virtual-agent/components/chatbox/useVirtualAgentToken.js
@@ -22,7 +22,7 @@ function useWaitForCsrfToken(props) {
     return function cleanup() {
       clearTimeout(timeout);
     };
-  }, []);
+  });
 
   return [csrfTokenLoading, csrfTokenLoadingError];
 }


### PR DESCRIPTION
## Description
- useEffect in useWaitForCsrfToken hook runs on rerender
- makes phone numbers clickable in error message

## Testing done
unit test + manual

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
