### PR TITLE
Add timeout to Cypress tests on GitHub Actions

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -37,6 +37,7 @@ jobs:
 
       - name: Start Cypress tests
         run: yarn cy:test:gha
+        timeout-minutes: 60
 
       - name: Publish test results
         if: ${{ always() }}


### PR DESCRIPTION
## Description
This PR adds a one hour timeout for Cypress tests on GitHub Actions to abort builds with hanging tests.