### PR TITLE
fix(1010cg): update poa document upload file type limit

### DIFF
--- a/src/applications/caregivers/config/chapters/signAsRepresentative/uploadPOADocument.js
+++ b/src/applications/caregivers/config/chapters/signAsRepresentative/uploadPOADocument.js
@@ -48,7 +48,7 @@ export default {
       classNames: 'poa-document-upload',
       multiple: false,
       fileUploadUrl: `${environment.API_URL}/v0/form1010cg/attachments`,
-      fileTypes: ['pdf', 'doc', 'docx', 'jpg', 'jpeg', 'rtf', 'png'],
+      fileTypes: ['pdf', 'jpg', 'jpeg', 'png'],
       maxSize: 1024 * 1024 * 10,
       hideLabelText: true,
       createPayload,


### PR DESCRIPTION
## Description
Update 10-10CG power of attorney document upload to only accept jpg, jpeg, png, pdf on the frontend so that it matches the backend.

## Testing done
- [ ] manual

## Screenshots
![image](https://user-images.githubusercontent.com/83595736/119992131-37617480-bf98-11eb-8f06-2d51e885c3a6.png)


## Acceptance criteria
- [ ] Update poa file upload to only allow `jpg, jpeg, png, pdf`

## Definition of done
- [ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/25289)
