### PR TITLE
Move instructions after Next button on calendar

### DIFF
--- a/src/applications/vaos/components/calendar/CalendarNavigation.jsx
+++ b/src/applications/vaos/components/calendar/CalendarNavigation.jsx
@@ -27,14 +27,6 @@ const CalendarNavigation = ({
     >
       {momentMonth.format('MMMM YYYY')}
     </h2>
-    <div
-      className="sr-only"
-      id={`vaos-calendar-instructions-${momentMonth.month()}`}
-    >
-      Press the Enter key to expand the day you want to schedule an appointment.
-      Then press the Tab key or form shortcut key to select an appointment time.
-    </div>
-
     <button
       className="vaos-calendar__nav-links-button vads-u-display--flex vads-u-justify-content--flex-end vads-u-align-items--center vads-u-font-weight--normal vads-u-padding--0 vads-u-margin-bottom--0 vads-u-margin-top--0p5  vads-u-color--primary"
       onClick={nextOnClick}
@@ -46,6 +38,13 @@ const CalendarNavigation = ({
       </span>
       <i className="fas fa-chevron-circle-right vads-u-margin-left--1" />
     </button>
+    <div
+      className="sr-only"
+      id={`vaos-calendar-instructions-${momentMonth.month()}`}
+    >
+      Press the Enter key to expand the day you want to schedule an appointment.
+      Then press the Tab key or form shortcut key to select an appointment time.
+    </div>
   </div>
 );
 


### PR DESCRIPTION
## Description
This PR:
- Moves the screen reader only instructions to after the Next button, so they're read out after navigation

## Testing done
Local testing

## Acceptance criteria
- [ ] Build passes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
