### PR TITLE
Added BUILD.txt in archive step

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -265,7 +265,6 @@ jobs:
         run: |
           cat > ${{ matrix.buildtype }}/BUILD.txt <<EOF
           BUILDTYPE=${{ matrix.buildtype }}
-          NODE_ENV=production
           BRANCH_NAME=$(echo "${GITHUB_REF#refs/heads/}")
           RUN_ID=${{ github.run_id }}
           REF=${{ github.sha }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -261,6 +261,17 @@ jobs:
           name: build-${{ matrix.buildtype }}
           path: ${{ matrix.buildtype }}
 
+      - name: Generate build details
+        run: |
+          cat > ${{ matrix.buildtype }}/BUILD.txt <<EOF
+          BUILDTYPE=${{ matrix.buildtype }}
+          NODE_ENV=production
+          BRANCH_NAME=$(echo "${GITHUB_REF#refs/heads/}")
+          RUN_ID=${{ github.run_id }}
+          REF=${{ github.sha }}
+          BUILDTIME=$(date +%s)
+          EOF
+
       - name: Configure AWS credentials (1)
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -263,7 +263,7 @@ jobs:
 
       - name: Generate build details
         run: |
-          cat > ${{ matrix.buildtype }}/BUILD.txt <<EOF
+          cat > ${{ matrix.buildtype }}/BUILD.txt << EOF
           BUILDTYPE=${{ matrix.buildtype }}
           BRANCH_NAME=$(echo "${GITHUB_REF#refs/heads/}")
           RUN_ID=${{ github.run_id }}


### PR DESCRIPTION
## Description
Sample `BUILD.txt` generated from this workflow:
```
BUILDTYPE=vagovprod
BRANCH_NAME=gha-build-txt
RUN_ID=886921789
REF=15c670b6d30711872ec784aa6b66aa5a9e1705eb
BUILDTIME=1622238360
```

Removed `NODE_ENV` and Jenkins-specific details (`BUILD_ID`, `BUILD_NUMBER`, `CHANGE_TARGET`).

Modified some of the details to use GitHub and GHA-specific information (`RUN_ID`).

## Testing done
Verified that the `BUILD.txt` gets created and uploaded along with the build with the correct info.

## Acceptance criteria
- [ ] Archived build output should include `BUILD.txt`.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
