### PR TITLE
526: Fix address prefill

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/contactInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/contactInformation.js
@@ -133,9 +133,15 @@ export const uiSchema = {
     },
     addressLine2: {
       'ui:title': 'Street address line 2 (20 characters maximum)',
+      'ui:errorMessages': {
+        pattern: 'Please enter a valid street address',
+      },
     },
     addressLine3: {
       'ui:title': 'Street address line 3 (20 characters maximum)',
+      'ui:errorMessages': {
+        pattern: 'Please enter a valid street address',
+      },
     },
     city: {
       'ui:errorMessages': {

--- a/src/applications/disability-benefits/all-claims/prefill-transformer.js
+++ b/src/applications/disability-benefits/all-claims/prefill-transformer.js
@@ -69,8 +69,8 @@ export default function prefillTransformer(pages, formData, metadata) {
           // see https://github.com/department-of-veterans-affairs/va.gov-team/issues/19423
           country: mailingAddress.country || '',
           addressLine1: mailingAddress.addressLine1 || '',
-          addressLine2: mailingAddress.addressLine2 || '',
-          addressLine3: mailingAddress.addressLine3 || '',
+          addressLine2: mailingAddress.addressLine2 || null,
+          addressLine3: mailingAddress.addressLine3 || null,
           city: mailingAddress.city || '',
           state: mailingAddress.state || '',
           zipCode: mailingAddress.zipCode || '',

--- a/src/applications/disability-benefits/all-claims/tests/prefill-transformer.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/prefill-transformer.unit.spec.js
@@ -140,8 +140,8 @@ describe('526v2 prefill transformer', () => {
         mailingAddress: {
           country: 'USA',
           addressLine1: '123 Any Street',
-          addressLine2: '',
-          addressLine3: '',
+          addressLine2: null,
+          addressLine3: null,
           city: 'Anyville',
           state: 'AK',
           zipCode: '12345',


### PR DESCRIPTION
## Description

Form 526 mailing address does not allow empty string address line 2 & address line 3. This fixes the prefill which defaults the fields to empty strings. Setting them to `null` doesn't not reproduce the error. This PR should also fix future instances since it defaults the value to `null`.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/25441

## Testing done

Updated unit test

## Screenshots

<details><summary>Updated error message</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-06-01 at 11 12 37 AM](https://user-images.githubusercontent.com/136959/120356824-5cbcee00-c2ca-11eb-8bec-9ced89f7e61f.png)</details>

## Acceptance criteria
- [x] Allow empty street address line 2 & 3
- [x] Update street address line 2 & 3 error message

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
