### PR TITLE
Set focus on My VA 2.0 NameTag component

### DIFF
--- a/src/applications/personalization/components/NameTag.jsx
+++ b/src/applications/personalization/components/NameTag.jsx
@@ -173,8 +173,16 @@ const NameTag = ({
     ),
   };
 
+  const ariaLabel = showUpdatedNameTag
+    ? 'My status and disability rating'
+    : 'My status';
+
   return (
-    <div className={classes.wrapper} data-testid="name-tag">
+    <section
+      aria-label={ariaLabel}
+      className={classes.wrapper}
+      data-testid="name-tag"
+    >
       <div className={classes.innerWrapper}>
         <div className={classes.serviceBadge}>
           {showBadgeImage && (
@@ -205,7 +213,7 @@ const NameTag = ({
           </dl>
         </div>
       </div>
-    </div>
+    </section>
   );
 };
 

--- a/src/applications/personalization/dashboard-2/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard-2/components/Dashboard.jsx
@@ -95,19 +95,24 @@ const Dashboard = ({
   isLOA3,
   showLoader,
   showMPIConnectionError,
+  showNameTag,
   showNotInMPIError,
   ...props
 }) => {
   const downtimeApproachingRenderMethod = useDowntimeApproachingRenderMethod();
 
-  // focus on the header when we are done loading
+  // focus on the name tag or the header when we are done loading
   useEffect(
     () => {
       if (!showLoader) {
-        focusElement('#dashboard-title');
+        if (showNameTag) {
+          focusElement('#name-tag');
+        } else {
+          focusElement('#dashboard-title');
+        }
       }
     },
-    [showLoader],
+    [showLoader, showNameTag],
   );
 
   // fetch data when we determine they are LOA3
@@ -145,14 +150,16 @@ const Dashboard = ({
         {showLoader && <RequiredLoginLoader />}
         {!showLoader && (
           <div className="dashboard">
-            {props.showNameTag && (
-              <NameTag
-                showUpdatedNameTag
-                totalDisabilityRating={props.totalDisabilityRating}
-                totalDisabilityRatingServerError={
-                  props.totalDisabilityRatingServerError
-                }
-              />
+            {showNameTag && (
+              <div id="name-tag">
+                <NameTag
+                  showUpdatedNameTag
+                  totalDisabilityRating={props.totalDisabilityRating}
+                  totalDisabilityRatingServerError={
+                    props.totalDisabilityRatingServerError
+                  }
+                />
+              </div>
             )}
             <div className="vads-l-grid-container vads-u-padding-bottom--3 medium-screen:vads-u-padding-x--2 medium-screen:vads-u-padding-bottom--4">
               <Breadcrumbs className="vads-u-padding-x--0 vads-u-padding-y--1p5 medium-screen:vads-u-padding-y--0">

--- a/src/applications/personalization/dashboard-2/tests/e2e/loa1.cypress.spec.js
+++ b/src/applications/personalization/dashboard-2/tests/e2e/loa1.cypress.spec.js
@@ -27,7 +27,6 @@ function loa1DashboardTest(mobile, stubs) {
 
   // focus should be on the h1
   cy.focused()
-    .should('have.attr', 'id', 'dashboard-title')
     .contains('My VA')
     .and('have.prop', 'tagName')
     .should('equal', 'H1');

--- a/src/applications/personalization/dashboard-2/tests/e2e/loa3.cypress.spec.js
+++ b/src/applications/personalization/dashboard-2/tests/e2e/loa3.cypress.spec.js
@@ -46,18 +46,16 @@ function loa3DashboardTest(mobile) {
   cy.findByRole('progressbar').should('not.exist');
   cy.findByText(/loading your information/i).should('not.exist');
 
-  // focus should be on the h1
-  cy.focused()
-    .contains('My VA')
-    .and('have.prop', 'tagName')
-    .should('equal', 'H1');
-
   // name tag exists with the right data
   nameTagRendersWithDisabilityRating();
 
   // make the a11y check
   cy.injectAxe();
   cy.axeCheck();
+}
+
+function nameTagIsFocused() {
+  cy.focused().contains(/Wesley Watson Ford/i);
 }
 
 describe('The My VA Dashboard', () => {
@@ -86,10 +84,12 @@ describe('The My VA Dashboard', () => {
     });
     it('should handle LOA3 users at desktop size', () => {
       loa3DashboardTest(false);
+      nameTagIsFocused();
     });
 
     it('should handle LOA3 users at mobile phone size', () => {
       loa3DashboardTest(true);
+      nameTagIsFocused();
     });
   });
   context('when there is a 401 fetching the total disability rating', () => {
@@ -103,6 +103,7 @@ describe('The My VA Dashboard', () => {
       mockFeatureToggles();
       cy.visit(manifest.rootUrl);
       nameTagRendersWithoutDisabilityRating();
+      nameTagIsFocused();
     });
   });
   context('when there is a 500 fetching the total disability rating', () => {
@@ -116,6 +117,7 @@ describe('The My VA Dashboard', () => {
       mockFeatureToggles();
       cy.visit(manifest.rootUrl);
       nameTagRendersWithFallbackLink();
+      nameTagIsFocused();
     });
   });
 });


### PR DESCRIPTION
## Description
With this change, keyboard focus will be on the NameTag component when the My VA 2.0 Dashboard loads.

If the NameTag is _not_ visible (which happens if the user is LOA1, for example) we continue to set focus on the H1.

This PR also wraps the NameTag's contents in a `section` tag with an appropriate `aria-label`.

## Testing done
Updated the Cypress tests that check where focus is when the page loads.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs