### PR TITLE
Added fs import back in Cypress plugins file.

### DIFF
--- a/src/platform/testing/e2e/cypress/plugins/index.js
+++ b/src/platform/testing/e2e/cypress/plugins/index.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const webpackPreprocessor = require('@cypress/webpack-preprocessor');
 
 module.exports = on => {
@@ -22,10 +23,9 @@ module.exports = on => {
     },
   );
 
-  // eslint-disable-next-line consistent-return
   on('after:spec', (spec, results) => {
     if (results.stats.failures === 0 && results.video) {
-      return fs.unlinkSync(results.video);
+      fs.unlinkSync(results.video);
     }
   });
 


### PR DESCRIPTION
## Description
Added back an import of `fs` that was lost after a bad merge (involving [this change from this PR](https://github.com/department-of-veterans-affairs/vets-website/pull/17409/files#diff-6678c38c23c9640bd3fa6320263aa2909a6ef4f4c83ba6e933e2cf1789021e06L1)).

The missing import is causing linting and Cypress tests to fail.

Basically, this sequence of commits to `master` happened:
1. Branch _A_ used `fs-extra` for a new Cypress event handler.
2. Branch _B_ removed `fs-extra` after removing code that used to use it.
3. Merged branch _A_. ([Commit](https://github.com/department-of-veterans-affairs/vets-website/commit/11d818b2c42450cd88bd21d41b203462d6e3c5dc#diff-6678c38c23c9640bd3fa6320263aa2909a6ef4f4c83ba6e933e2cf1789021e06R30))
4. Merged branch _B_. ([Commit](https://github.com/department-of-veterans-affairs/vets-website/commit/ff6a47298de92a565a09ec427b4998ee9e9b057d#diff-6678c38c23c9640bd3fa6320263aa2909a6ef4f4c83ba6e933e2cf1789021e06L1))

This resulted in favoring the removal of the import even though the code that still used it remained.

## Testing done
Linting and Cypress tests pass.

## Acceptance criteria
- [ ] Cypress should pass.
- [ ] Linting should pass.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
