### PR TITLE
Fix Styling Bugs on FSR Intro Wizard

### DIFF
--- a/src/applications/debt-letters/components/DebtLettersDownload.jsx
+++ b/src/applications/debt-letters/components/DebtLettersDownload.jsx
@@ -14,6 +14,7 @@ const DebtLettersDownload = ({ debtLinks, isVBMSError }) => {
     scrollToTop();
     setPageFocus('h1');
   });
+
   const renderAlert = () => (
     <div
       className="usa-alert usa-alert-error vads-u-margin-top--0 vads-u-padding--3"

--- a/src/applications/financial-status-report/sass/financial-status-report.scss
+++ b/src/applications/financial-status-report/sass/financial-status-report.scss
@@ -302,3 +302,7 @@
     max-width: 332px;
   }
 }
+
+.email {
+  text-transform: lowercase;
+}

--- a/src/applications/financial-status-report/wizard/pages/Error.jsx
+++ b/src/applications/financial-status-report/wizard/pages/Error.jsx
@@ -11,7 +11,7 @@ const DebtError = () => {
   }, []);
 
   return (
-    <div className=" vads-u-padding--2 vads-u-margin-top--2">
+    <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
       <h2
         className="vads-u-margin-top--0 vads-u-font-size--h6 vads-u-font-weight--normal vads-u-font-family--sans"
         id="wizard-results"

--- a/src/applications/financial-status-report/wizard/pages/RogersStem.jsx
+++ b/src/applications/financial-status-report/wizard/pages/RogersStem.jsx
@@ -27,7 +27,10 @@ const RogersStem = () => {
         <ul>
           <li>
             <strong>Email: </strong>
-            <a href="mailto:stem.vbauf@va.gov">STEM.VBAUF@va.gov</a>.
+            <a className="email" href="mailto:stem.vbauf@va.gov">
+              STEM.VBAUF@va.gov
+            </a>
+            .
           </li>
           <li>
             <strong>Mail: </strong>

--- a/src/applications/financial-status-report/wizard/pages/VetTec.jsx
+++ b/src/applications/financial-status-report/wizard/pages/VetTec.jsx
@@ -31,7 +31,10 @@ const VetTec = () => {
         <ul>
           <li>
             <strong>Email: </strong>
-            <a href="mailto:vettec.vbauf@va.gov">VETTEC.VBAUF@va.gov</a>.
+            <a className="email" href="mailto:vettec.vbauf@va.gov">
+              VETTEC.VBAUF@va.gov
+            </a>
+            .
           </li>
           <li>
             <strong>Phone: </strong>


### PR DESCRIPTION
## Description
- Add missing gray boxes on FSR wizard
- Make reusable css class for lowercased emails

[Ticket](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/department-of-veterans-affairs/va.gov-team/23199)

## Testing done
- Visual testing

## Screenshots
![image](https://user-images.githubusercontent.com/23741323/120495100-627a0880-c38a-11eb-9775-4f4574a92d84.png)

![image](https://user-images.githubusercontent.com/23741323/120495155-7160bb00-c38a-11eb-980d-f8bc73e7337f.png)

![image](https://user-images.githubusercontent.com/23741323/120495194-79b8f600-c38a-11eb-949f-d7c315dff04f.png)


## Acceptance criteria
- [x] Add missing gray boxes on FSR wizard
- [x] Make reusable css class for lowercased emails

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
