### PR TITLE
25244 Showing both cancelled and occurred in the past boxes for cancelled appointments in the past

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/index.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/index.jsx
@@ -164,6 +164,25 @@ export default function ConfirmedAppointmentDetailsPage() {
     facility: facilityData[locationId],
   });
 
+  let alertBox = null;
+  if (isPastAppointment) {
+    alertBox = (
+      <AlertBox status="warning" backgroundOnly>
+        This appointment occurred in the past.
+      </AlertBox>
+    );
+  } else if (canceled) {
+    alertBox = (
+      <AlertBox
+        status="error"
+        className="vads-u-display--block vads-u-margin-bottom--2"
+        backgroundOnly
+      >
+        {`${canceler} canceled this appointment.`}
+      </AlertBox>
+    );
+  }
+
   return (
     <PageLayout>
       <Breadcrumbs>
@@ -177,21 +196,7 @@ export default function ConfirmedAppointmentDetailsPage() {
         />
       </h1>
 
-      {isPastAppointment && (
-        <AlertBox status="warning" backgroundOnly>
-          This appointment occurred in the past.
-        </AlertBox>
-      )}
-
-      {canceled && (
-        <AlertBox
-          status="error"
-          className="vads-u-display--block vads-u-margin-bottom--2"
-          backgroundOnly
-        >
-          {`${canceler} canceled this appointment.`}
-        </AlertBox>
-      )}
+      {alertBox}
 
       {isVideo && (
         <>

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/index.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/index.jsx
@@ -165,13 +165,7 @@ export default function ConfirmedAppointmentDetailsPage() {
   });
 
   let alertBox = null;
-  if (isPastAppointment) {
-    alertBox = (
-      <AlertBox status="warning" backgroundOnly>
-        This appointment occurred in the past.
-      </AlertBox>
-    );
-  } else if (canceled) {
+  if (canceled) {
     alertBox = (
       <AlertBox
         status="error"
@@ -179,6 +173,12 @@ export default function ConfirmedAppointmentDetailsPage() {
         backgroundOnly
       >
         {`${canceler} canceled this appointment.`}
+      </AlertBox>
+    );
+  } else if (isPastAppointment) {
+    alertBox = (
+      <AlertBox status="warning" backgroundOnly>
+        This appointment occurred in the past.
       </AlertBox>
     );
   }

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
@@ -550,7 +550,7 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
     ).to.exist;
   });
 
-  it('should display past appointment', async () => {
+  it('should display who canceled the appointment for past appointments', async () => {
     const url = '/va/21cdc6741c00ac67b6cbf6b972d084c1';
 
     const appointment = getVAAppointmentMock();
@@ -559,7 +559,9 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       clinicId: '308',
       facilityId: '983',
       sta6aid: '983GC',
-      startDate: moment().subtract(1, 'day'),
+      startDate: moment()
+        .subtract(1, 'day')
+        .format('YYYY-MM-DDThh:mm:[00Z]'),
       vdsAppointments: [
         {
           currentStatus: 'CANCELLED BY CLINIC',
@@ -591,15 +593,18 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
     });
 
     // NOTE: This 2nd 'await' is needed due to async facilities fetch call!!!
-    expect(await screen.findByText(/This appointment occurred in the past./i))
-      .to.exist;
-
-    // The past appointment and canceled appointment alerts are mutually exclusive.
-    // So, the past appointment alert should display only when the appointment start date
-    // is in the past even when the appointment has a status of 'cancelled'.
     expect(
-      screen.queryByText('Fort Collins VA Clinic canceled this appointment.'),
-    ).not.to.exist;
+      await screen.findByText(
+        /Fort Collins VA Clinic canceled this appointment./i,
+      ),
+    ).to.exist;
+
+    // The canceled appointment and past appointment alerts are mutually exclusive
+    // with the canceled appointment status having 1st priority. So, the canceled
+    // appointment alert should display even when the appointment is a past
+    // appointment.
+    expect(screen.queryByText('This appointment occurred in the past.')).not.to
+      .exist;
   });
 
   it('should fire a print request when print button clicked', async () => {

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
@@ -550,6 +550,58 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
     ).to.exist;
   });
 
+  it('should display past appointment', async () => {
+    const url = '/va/21cdc6741c00ac67b6cbf6b972d084c1';
+
+    const appointment = getVAAppointmentMock();
+    appointment.attributes = {
+      ...appointment.attributes,
+      clinicId: '308',
+      facilityId: '983',
+      sta6aid: '983GC',
+      startDate: moment().subtract(1, 'day'),
+      vdsAppointments: [
+        {
+          currentStatus: 'CANCELLED BY CLINIC',
+        },
+      ],
+    };
+    mockSingleAppointmentFetch({
+      appointment,
+    });
+
+    const facility = {
+      id: 'vha_442GC',
+      attributes: {
+        ...getVAFacilityMock().attributes,
+        uniqueId: '442GC',
+        name: 'Fort Collins VA Clinic',
+      },
+    };
+
+    mockFacilityFetch('vha_442GC', facility);
+
+    const screen = renderWithStoreAndRouter(<AppointmentList />, {
+      initialState,
+      path: url,
+    });
+
+    await waitFor(() => {
+      expect(document.activeElement).to.have.tagName('h1');
+    });
+
+    // NOTE: This 2nd 'await' is needed due to async facilities fetch call!!!
+    expect(await screen.findByText(/This appointment occurred in the past./i))
+      .to.exist;
+
+    // The past appointment and canceled appointment alerts are mutually exclusive.
+    // So, the past appointment alert should display only when the appointment start date
+    // is in the past even when the appointment has a status of 'cancelled'.
+    expect(
+      screen.queryByText('Fort Collins VA Clinic canceled this appointment.'),
+    ).not.to.exist;
+  });
+
   it('should fire a print request when print button clicked', async () => {
     const url = '/va/21cdc6741c00ac67b6cbf6b972d084c1';
 


### PR DESCRIPTION
## Description
This PR does the following:

- Fixes issue with displaying past and cancelled appointment alerts at the same time.

## Testing done
Unit testing

## Screenshots
Appointment date is in the past
![localhost_3001_health-care_schedule-view-va-appointments_appointments_va_f183c1079a800aa475a6752261284bf0](https://user-images.githubusercontent.com/3587066/120498715-0fea1d80-c385-11eb-9151-ad0bd4e855cf.png)
---
![localhost_3001_health-care_schedule-view-va-appointments_appointments_va_f183c1079a800aa475a6752261284bf0 (1)](https://user-images.githubusercontent.com/3587066/120498752-18425880-c385-11eb-8064-cab7de2d4e53.png)

## Acceptance criteria
- [ ] All test should pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
