### PR TITLE
[25388] Update feature callout for vaccine walk ins

### DIFF
--- a/src/applications/vaos/covid-19-vaccine/components/ContactFacilitiesPage.jsx
+++ b/src/applications/vaos/covid-19-vaccine/components/ContactFacilitiesPage.jsx
@@ -137,34 +137,27 @@ export default function ContactFacilitiesPage() {
           </li>
         ))}
       </ul>
-      <p className="vads-u-margin-y--3">
-        <NewTabAnchor href="/find-locations">
-          Search for more facilities
-        </NewTabAnchor>
-      </p>
       {!canUseVaccineFlow && (
-        <AlertBox
-          className="vads-u-margin-bottom--1p5"
-          level="2"
-          status="info"
-          backgroundOnly
-          headline="Sign up to stay informed"
-        >
+        <div className="feature">
+          <h2 className="vads-u-font-size--h3">
+            Find a vaccine walk-in clinic near you
+          </h2>
           <p>
-            We’re working to provide COVID-19 vaccines to Veterans as quickly
-            and safely as we can, based on CDC guidelines and available supply.
+            You can go to a VA facility's vaccine clinic during walk-in hours to
+            get the COVID-19 vaccine. You don't need an appointment, but be sure
+            to check the facility's walk-in hours before you go.
           </p>
           <a
-            href="/health-care/covid-19-vaccine"
+            href="/find-locations/?facilityType=health&serviceType=Covid19Vaccine"
             onClick={() => {
               recordEvent({
                 event: `${GA_PREFIX}-COVID-19-vaccines-at-VA-link-clicked`,
               });
             }}
           >
-            Learn how to stay informed about COVID-19 vaccines at VA.
+            Find VA facilities near you that offer COVID-19 vaccines
           </a>
-        </AlertBox>
+        </div>
       )}
       <ProgressButton
         onButtonClick={() =>

--- a/src/applications/vaos/tests/covid-19-vaccine/components/ContactFacilitiesPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/ContactFacilitiesPage.unit.spec.jsx
@@ -193,12 +193,8 @@ describe('VAOS COVID-19 Vaccine: <ContactFacilitiesPage>', () => {
         'Facility that is also enabled',
         '555-555-5556, ext. 1234',
         '711',
-        'Search for more facilities',
       ],
     );
-    expect(
-      screen.getByRole('link', { name: /search for more facilities/i }),
-    ).to.have.attribute('href', '/find-locations');
   });
 
   it('should show five facilities in alpha order when no residential address', async () => {
@@ -336,7 +332,6 @@ describe('VAOS COVID-19 Vaccine: <ContactFacilitiesPage>', () => {
         '711',
         'E facility',
         '711',
-        'Search for more facilities',
       ],
     );
   });
@@ -419,12 +414,23 @@ describe('VAOS COVID-19 Vaccine: <ContactFacilitiesPage>', () => {
       [
         'Facility that is enabled',
         '711',
-        'Search for more facilities',
-        'Learn how to stay informed about COVID-19 vaccines at VA.',
+        'Find VA facilities near you that offer COVID-19 vaccines',
       ],
     );
+    expect(screen.getByText(/Find a vaccine walk-in clinic near you/i)).to.be
+      .ok;
     expect(
-      screen.getByRole('link', { name: /search for more facilities/i }),
-    ).to.have.attribute('href', '/find-locations');
+      screen.getByText(
+        /You can go to a VA facility's vaccine clinic during walk-in hours to get the COVID-19 vaccine. You don't need an appointment, but be sure to check the facility's walk-in hours before you go./i,
+      ),
+    ).to.be.ok;
+    expect(
+      screen.getByRole('link', {
+        name: /Find VA facilities near you that offer COVID-19 vaccines/i,
+      }),
+    ).to.have.attribute(
+      'href',
+      '/find-locations/?facilityType=health&serviceType=Covid19Vaccine',
+    );
   });
 });


### PR DESCRIPTION
## Description
All VAMCs now allow walk-ins for the COVID-19 vaccine. We should update messaging to dead ends in the vaccine scheduling flow to direct users to walk-in instead of calling the VA.

![image](https://user-images.githubusercontent.com/8315447/120545472-b271c300-c3bc-11eb-8550-ca72b64010be.png)

## Testing done
Local and Unit

## Screenshots
<img width="985" alt="image" src="https://user-images.githubusercontent.com/8315447/120545570-d2a18200-c3bc-11eb-92a7-254a110f390f.png">

## Acceptance criteria
- [ ] Changes are behind the va_online_scheduling_cheetah feature flag
- [ ] "Search for more facilities" link does not appear
- [ ] CONTENT - Content matches the copy doc
- [ ] "Find VA facilities..." is a link
- [ ] If user clicks "Find VA facilities..." link, Then open `/find-locations/?facilityType=health&serviceType=Covid19Vaccine` in the same window
- [ ] DESIGN - Designs match the specs (copy is FPO)
- [ ] DESIGN - Blue box uses the featured content component from the design system

## Definition of done
- [x] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
