### PR TITLE
Escape periods in id selector

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItem.jsx
@@ -73,7 +73,7 @@ export default function AppointmentListItem({ appointment, facility }) {
   const link = isCommunityCare
     ? `cc/${appointment.id}`
     : `va/${appointment.id}`;
-  const idClickable = `id-${appointment.id}`;
+  const idClickable = `id-${appointment.id.replace('.', '\\.')}`;
 
   return (
     <li

--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/RequestListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/RequestListItem.jsx
@@ -16,7 +16,7 @@ export default function RequestListItem({ appointment, facility }) {
     'MMMM D, YYYY',
   );
   const link = `requests/${appointment.id}`;
-  const idClickable = `id-${appointment.id}`;
+  const idClickable = `id-${appointment.id.replace('.', '\\.')}`;
 
   return (
     <li

--- a/src/applications/vaos/services/mocks/var/confirmed_cc.json
+++ b/src/applications/vaos/services/mocks/var/confirmed_cc.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "id": "8a4812b77035101201703a2086750033",
+      "id": "202106020000000000000000000000000000Upd.6NcgFTbmSgW0kfFTPqQ",
       "type": "cc_appointments",
       "attributes": {
         "appointmentRequestId": "8a4812b77035101201703a2086750033",


### PR DESCRIPTION
## Description
This PR
- Handles periods in appointment ids, which are causing an error currenly

## Testing done
Local testing

## Acceptance criteria
- [ ] Details links work with appointment ids with periods

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
