### PR TITLE
NOD: Various fixes

### DIFF
--- a/src/applications/appeals/10182/components/AddIssuesField.jsx
+++ b/src/applications/appeals/10182/components/AddIssuesField.jsx
@@ -64,7 +64,8 @@ const AddIssuesField = props => {
 
   const onItemChange = (indexToChange, value) => {
     const newItems = formData.map(
-      (item, index) => (index === indexToChange ? value : item),
+      (item, index) =>
+        index === indexToChange ? { ...value, [SELECTED]: true } : item,
     );
     props.onChange(newItems);
   };
@@ -94,8 +95,6 @@ const AddIssuesField = props => {
   const handleUpdate = index => {
     const { issue, decisionDate } = formData[index];
     if (errorSchemaIsValid(errorSchema[index]) && issue && decisionDate) {
-      // check the updated issue
-      toggleSelection(index, true);
       setEditing(editing.map((mode, indx) => (indx === index ? false : mode)));
       scrollAndFocus({
         selector: `dd[data-index="${index}"] .edit`,

--- a/src/applications/appeals/10182/content/issueSummary.js
+++ b/src/applications/appeals/10182/content/issueSummary.js
@@ -1,12 +1,14 @@
 import React from 'react';
-import { Link } from 'react-router';
 
 import formConfig from '../config/form';
 import { getSelected } from '../utils/helpers';
 import { ShowIssuesList } from '../components/ShowIssuesList';
 
 export const SummaryTitle = ({ formData }) => {
-  const { path } = formConfig.chapters.conditions.pages.contestableIssues;
+  const { pages } = formConfig.chapters.conditions;
+  const pathname = formData.contestableIssues?.length
+    ? pages.contestableIssues.path
+    : pages.additionalIssues.path;
   const issues = getSelected(formData);
 
   return (
@@ -14,15 +16,12 @@ export const SummaryTitle = ({ formData }) => {
       <p>
         These are the issues you’re asking the Board to review. If an issue is
         missing, please{' '}
-        <Link
+        <a
           aria-label="go back and add any missing issues for review"
-          to={{
-            pathname: path,
-            search: '?redirect',
-          }}
+          href={`${pathname}?redirect`}
         >
           go back and add it
-        </Link>
+        </a>
         .
       </p>
       {ShowIssuesList({ issues })}

--- a/src/applications/appeals/10182/sass/10182-nod.scss
+++ b/src/applications/appeals/10182/sass/10182-nod.scss
@@ -22,8 +22,6 @@
 
 /* Contested issue cards (contested issue page & review/submit page) */
 dl.review {
-  border-bottom: 0;
-
   .widget-wrapper {
     position: relative;
 
@@ -150,6 +148,10 @@ legend.schemaform-block-title {
 
 /* issues page */
 article[data-location="eligible-issues"] {
+  dl.review {
+    border-bottom: 0;
+  }
+
   .input-section {
     .schemaform-block-header {
       display: flex;
@@ -166,6 +168,13 @@ article[data-location="eligible-issues"] {
     .schemaform-field-container {
       margin-top: 2rem;
     }
+  }
+}
+
+article[data-location="additional-issues"] {
+  /* remove unnecessary border */
+  dl.review {
+    border-bottom: 0;
   }
 }
 

--- a/src/applications/appeals/10182/tests/pages/issueSummary.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/pages/issueSummary.unit.spec.jsx
@@ -13,6 +13,7 @@ describe('NOD selected issues summary page', () => {
     schema,
     uiSchema,
   } = formConfig.chapters.conditions.pages.issueSummary;
+  const data = { contestableIssues: [{}] };
 
   it('should render', () => {
     const form = mount(
@@ -31,7 +32,27 @@ describe('NOD selected issues summary page', () => {
     expect(form.find('li').length).to.equal(2);
     form.unmount();
   });
-  it('should render a link', () => {
+  it('should render a link to the eligible issues page', () => {
+    const form = mount(
+      <DefinitionTester
+        definitions={{}}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={data}
+        formData={{}}
+      />,
+    );
+
+    const link = form.find('a');
+
+    expect(link.length).to.equal(1);
+    expect(link.props().children).to.contain('go back and add');
+    expect(link.props().href).to.equal(
+      `${formConfig.chapters.conditions.pages.contestableIssues.path}?redirect`,
+    );
+    form.unmount();
+  });
+  it('should render a link to the additional issues page', () => {
     const form = mount(
       <DefinitionTester
         definitions={{}}
@@ -46,6 +67,9 @@ describe('NOD selected issues summary page', () => {
 
     expect(link.length).to.equal(1);
     expect(link.props().children).to.contain('go back and add');
+    expect(link.props().href).to.equal(
+      `${formConfig.chapters.conditions.pages.additionalIssues.path}?redirect`,
+    );
     form.unmount();
   });
 
@@ -56,7 +80,7 @@ describe('NOD selected issues summary page', () => {
         definitions={{}}
         schema={schema}
         uiSchema={uiSchema}
-        data={{}}
+        data={data}
         formData={{}}
         onSubmit={onSubmit}
       />,


### PR DESCRIPTION
## Description

- Fix styling on issue pages on review & submit page
- Auto-select newly added issues using a different method - user can hit "Continue" without saving on the additional issues page
- Dynamically update "go back and add it" link if user has or doesn't have contestable issues to select

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/25575

## Testing done

Updated unit test for "go back..." link

## Screenshots

N/A

## Acceptance criteria
- [x] Borders added between issue card pages
- [x] User can continue without saving on additional issues page
- [x] Go back returns user to additional issues page if no contestable issues exist

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
