### PR TITLE
NOD: Remove header inside legend. Fix 508 defect

### DIFF
--- a/src/applications/appeals/10182/components/AddIssuesField.jsx
+++ b/src/applications/appeals/10182/components/AddIssuesField.jsx
@@ -212,13 +212,15 @@ const AddIssuesField = props => {
         <dd data-index={index}>
           <Element name={`table_${itemIdPrefix}`} />
           <fieldset className="vads-u-text-align--left">
-            <legend className="schemaform-block-header vads-u-font-size--base vads-u-font-weight--normal vads-u-margin-top--0 vads-u-padding-y--0">
+            <legend className="schemaform-block-header vads-u-margin-top--0 vads-u-padding-y--0">
               {first ? (
-                'Please add a new issue for review:'
+                <span className="vads-u-font-size--base vads-u-font-weight--normal">
+                  Please add a new issue for review:
+                </span>
               ) : (
-                <h2 className="vads-u-margin-y--0 vads-u-font-size--h4">
+                <div className="vads-u-font-size--md vads-u-font-family--serif">
                   {`${isEditing === 1 ? 'Add' : 'Update'} issue`}
-                </h2>
+                </div>
               )}
             </legend>
             <div className="input-section vads-u-margin-bottom--0 vads-u-font-weight--normal">


### PR DESCRIPTION
## Description

Based on accessibility feedback, the header inside the `<legend>` isn't necessary in the additional issue cards. This PR removes the `h2`, but maintains the styling to match the design.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/25140

## Testing done

N/A

## Screenshots

![Screen Shot 2021-06-02 at 4 23 51 PM](https://user-images.githubusercontent.com/136959/120554123-fc5ba880-c3be-11eb-8762-2864bcfcd16f.png)

## Acceptance criteria
- [x] Remove header inside `<legend>`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
