### PR TITLE
updated save status to use form appType instead of application

### DIFF
--- a/src/platform/forms/save-in-progress/SaveStatus.jsx
+++ b/src/platform/forms/save-in-progress/SaveStatus.jsx
@@ -26,11 +26,13 @@ function SaveStatus({
   }
 
   const formId = loadedData?.metadata?.inProgressFormId;
+  const appType = formConfig?.customText?.appType || APP_TYPE_DEFAULT;
+
   const formIdMessage =
     formId && savedAtMessage ? (
       <>
         {' '}
-        Your application ID number is <strong>{formId}</strong>.
+        Your {appType} ID number is <strong>{formId}</strong>.
       </>
     ) : null;
 
@@ -39,7 +41,6 @@ function SaveStatus({
     ((autoSavedStatus === SAVE_STATUSES.noAuth && !isLoggedIn) ||
       autoSavedStatus !== SAVE_STATUSES.noAuth);
 
-  const appType = formConfig?.customText?.appType || APP_TYPE_DEFAULT;
   const appSavedSuccessfullyMessage =
     formConfig?.customText?.appSavedSuccessfullyMessage ||
     APP_SAVED_SUCCESSFULLY_DEFAULT_MESSAGE;

--- a/src/platform/forms/tests/save-in-progress/SaveStatus.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveStatus.unit.spec.jsx
@@ -106,7 +106,8 @@ describe('<SaveStatus>', () => {
     const tree = SkinDeep.shallowRender(
       <SaveStatus {...appSavedSuccessfullyMessageProps} />,
     );
-    expect(tree.subTree('.panel').text()).to.include('custom application type');
-    expect(tree.subTree('.panel').text()).to.include('ID number is 98765');
+    expect(tree.subTree('.panel').text()).to.include(
+      'custom application type ID number is 98765',
+    );
   });
 });

--- a/src/platform/forms/tests/save-in-progress/SaveStatus.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveStatus.unit.spec.jsx
@@ -84,4 +84,29 @@ describe('<SaveStatus>', () => {
     );
     expect(tree.subTree('.panel').text()).to.include('ID number is 98765');
   });
+  it('should display the appSavedSuccessfullyMessage with custom app type & SiP ID', () => {
+    const appSavedSuccessfullyMessageProps = {
+      ...props,
+      form: {
+        formId: VA_FORM_IDS.FORM_10_10EZ,
+        lastSavedDate: 1505770055,
+        autoSavedStatus: 'success',
+        loadedData: {
+          metadata: {
+            inProgressFormId: 98765,
+          },
+        },
+      },
+      formConfig: {
+        customText: {
+          appType: 'custom application type',
+        },
+      },
+    };
+    const tree = SkinDeep.shallowRender(
+      <SaveStatus {...appSavedSuccessfullyMessageProps} />,
+    );
+    expect(tree.subTree('.panel').text()).to.include('custom application type');
+    expect(tree.subTree('.panel').text()).to.include('ID number is 98765');
+  });
 });


### PR DESCRIPTION
## Description
As we were rolling out a new form, we noticed that the SiP message still said application. Our form has been configured to be called a `questionnaire`. The message should reflect what the form is configured to be called. 

## Testing done
- unit

## Screenshots
Before
![Screen Shot 2021-06-01 at 3.36.09 PM.png](https://images.zenhubusercontent.com/5ecebb879a043b865f6cb5b6/9b7b00fd-6c10-428c-95e8-352f93da1563)

After
![Screen Shot 2021-06-03 at 9 25 20 AM](https://user-images.githubusercontent.com/1793923/120652314-a97d0200-c44d-11eb-817c-16eb155c2106.png)



## Acceptance criteria
- [ ] applicaiton text is configurable

## Definition of done
- [Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/25458)