### PR TITLE
properly handle secure messaging errors

### DIFF
--- a/src/applications/personalization/dashboard-2/tests/e2e/health-care-cta-gating.cypress.spec.js
+++ b/src/applications/personalization/dashboard-2/tests/e2e/health-care-cta-gating.cypress.spec.js
@@ -30,8 +30,12 @@ describe('MyVA Dashboard - CTA Links', () => {
         '/v0/health_care_applications/enrollment_status',
         enrollmentStatusEnrolled,
       );
-      cy.intercept('/v0/folders/0', mockFolderResponse);
-      cy.intercept('/v0/folders/0/messages', mockMessagesResponse);
+      cy.intercept(
+        '/v0/messaging/health/folders/0/messages',
+        mockMessagesResponse,
+      );
+      cy.intercept('GET', '/v0/messaging/health/folders/0', mockFolderResponse);
+
       mockFeatureToggles();
     });
     it('should show the rx and messaging CTAs', () => {
@@ -39,7 +43,7 @@ describe('MyVA Dashboard - CTA Links', () => {
       cy.findByRole('link', {
         name: /schedule and manage.*appointments/i,
       }).should('exist');
-      cy.findByRole('link', { name: /unread message/i }).should('exist');
+      cy.findByRole('link', { name: /3 unread message/i }).should('exist');
       cy.findByRole('link', {
         name: /refill and track.*prescriptions/i,
       }).should('exist');
@@ -62,8 +66,6 @@ describe('MyVA Dashboard - CTA Links', () => {
         '/v0/health_care_applications/enrollment_status',
         enrollmentStatusEnrolled,
       );
-      cy.intercept('/v0/folders/0', mockFolderResponse);
-      cy.intercept('/v0/folders/0/messages', mockMessagesResponse);
       mockFeatureToggles();
     });
     it('should not show the rx and messaging CTAs', () => {

--- a/src/applications/personalization/dashboard-2/tests/e2e/messaging-error.cypress.spec.js
+++ b/src/applications/personalization/dashboard-2/tests/e2e/messaging-error.cypress.spec.js
@@ -18,7 +18,10 @@ describe('MyVA Dashboard - Messaging', () => {
 
       cy.login(mockUser);
       // login() calls cy.server() so we can now mock routes
-      cy.intercept('GET', '/v0/messaging/health/folders/0', ERROR_400);
+      cy.intercept('GET', '/v0/messaging/health/folders/0', {
+        statusCode: 400,
+        body: ERROR_400,
+      });
       mockFeatureToggles();
     });
     it('should show the messaging link with the generic copy', () => {

--- a/src/applications/personalization/dashboard-2/utils/mocks/messaging/messages-400.js
+++ b/src/applications/personalization/dashboard-2/utils/mocks/messaging/messages-400.js
@@ -1,0 +1,10 @@
+export const mockMessagesResponse = {
+  errors: [
+    {
+      title: 'Operation failed',
+      detail: 'The Page Size must be less than total message count',
+      code: 'VA900',
+      status: '400',
+    },
+  ],
+};

--- a/src/applications/personalization/dashboard/actions/messaging.js
+++ b/src/applications/personalization/dashboard/actions/messaging.js
@@ -58,7 +58,8 @@ export const fetchFolder = (id, query = {}) => async dispatch => {
       messages: messagesResponse,
     });
   } catch (error) {
-    dispatch({ type: FETCH_FOLDER_FAILURE, errors: [] });
+    const errors = error.errors ?? [error];
+    dispatch({ type: FETCH_FOLDER_FAILURE, errors });
   }
 };
 


### PR DESCRIPTION
## Description
[When upgrading Cypress, an error was found in an existing test. Digging into it revealed the fact that we were not handling non-200 error responses when fetching secure messages data](https://github.com/department-of-veterans-affairs/vets-website/pull/17131/files#r644426293). This fixes that error.

## Testing done
First updated the Cypress test so it would fail with the incorrect error handling we already had in place. Then fixed the error handling.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs