### PR TITLE
feat(1010cg): update confirmation page hyperlinks

### DIFF
--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureInput.jsx
@@ -136,7 +136,7 @@ SignatureInput.propTypes = {
   hasSubmittedForm: PropTypes.bool.isRequired,
   setSignatures: PropTypes.func.isRequired,
   isRepresentative: PropTypes.bool,
-  ariaDescribedBy: PropTypes.string.isRequired,
+  ariaDescribedBy: PropTypes.string,
   required: PropTypes.bool,
 };
 

--- a/src/applications/caregivers/containers/ConfirmationPage.jsx
+++ b/src/applications/caregivers/containers/ConfirmationPage.jsx
@@ -139,7 +139,7 @@ const ConfirmationPage = props => {
           </p>
 
           <a
-            className="usa-button-primary va-button-primary vads-u-margin-top--1p5 vads-u-margin-bottom--2p5"
+            className="vads-u-display--inline-block vads-u-margin-bottom--4"
             href="https://www.va.gov/"
           >
             Go back to VA.gov

--- a/src/applications/caregivers/containers/IntroductionPage.jsx
+++ b/src/applications/caregivers/containers/IntroductionPage.jsx
@@ -228,7 +228,7 @@ export const IntroductionPage = ({
                 href={links.caregiverHelpPage.link}
                 className="vads-u-margin-left--0p5"
               >
-                www.caregiver.va.gov
+                {links.caregiverHelpPage.label}
               </a>
               , or discuss your options with your local Caregiver Support
               Coordinator.

--- a/src/applications/caregivers/definitions/content.js
+++ b/src/applications/caregivers/definitions/content.js
@@ -15,7 +15,7 @@ export const links = {
   },
   caregiverHelpPage: {
     link: 'https://www.caregiver.va.gov/',
-    label: 'www.va.caregiver.gov',
+    label: 'www.caregiver.va.gov',
   },
   applyVAHealthCare: {
     link: 'https://www.va.gov/health-care/how-to-apply/',


### PR DESCRIPTION
## Description
Update confirmation page hyperlinks on 10-10CG.

## Testing done
- [ ] manual/visual

## Screenshots
![image](https://user-images.githubusercontent.com/83595736/120655810-0a5a0980-c451-11eb-9c15-ce188967d78a.png)


## Acceptance criteria
- [ ]  link should read: www.caregiver.va.gov
- [ ]  go back to VA.gov should be a link not a button

## Definition of done
- [ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/25543)
