### PR TITLE
Skip errors if they're from known bad staging sites

### DIFF
--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -4,6 +4,7 @@
  */
 import moment from 'moment';
 import * as Sentry from '@sentry/browser';
+import environment from 'platform/utilities/environment';
 import {
   getCancelReasons,
   getConfirmedAppointment,
@@ -77,6 +78,18 @@ const PAST_APPOINTMENTS_HIDDEN_SET = new Set([
   'Deleted',
 ]);
 
+// We want to throw an error for any partial results errors from MAS,
+// but some sites in staging always errors. So, keep those in a list to
+// ignore errors from
+const BAD_STAGING_SITES = new Set(['556']);
+function hasPartialResults(response) {
+  return (
+    response.errors?.length > 0 &&
+    (environment.isProduction() ||
+      response.errors.some(err => !BAD_STAGING_SITES.has(err.source)))
+  );
+}
+
 /**
  * Fetch the logged in user's confirmed appointments that fall between a startDate and endDate
  *
@@ -102,7 +115,7 @@ export async function getBookedAppointments({ startDate, endDate }) {
     ]);
 
     // We might get partial results back from MAS, so throw an error if we do
-    if (appointments[0].errors?.length) {
+    if (hasPartialResults(appointments[0])) {
       throw mapToFHIRErrors(
         appointments[0].errors,
         'MAS returned partial results',


### PR DESCRIPTION
## Description
This PR
- Skips MAS errors from sites where we know VAOS can't pull appointments from in lower environments

This came out of a request from Marcy to be able to use a specific test user that has TMP appointments, but it registered a site (556) we can't use in staging.

## Testing done
Local testing

## Acceptance criteria
- [ ] when using ralph.marshall@id.me user you can see your list of appointments

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
