### PR TITLE
Hid pension income questions in production

### DIFF
--- a/src/applications/disability-benefits/686c-674/config/chapters/add-a-child/child-place-of-birth/child-place-of-birth.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/add-a-child/child-place-of-birth/child-place-of-birth.js
@@ -1,6 +1,7 @@
 import merge from 'lodash/merge';
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
 import { validateBooleanGroup } from 'platform/forms-system/src/js/validation';
+import environment from 'platform/utilities/environment';
 import { isChapterFieldRequired } from '../../../helpers';
 import { addChild } from '../../../utilities';
 import { TASK_KEYS } from '../../../constants';
@@ -107,6 +108,9 @@ export const uiSchema = {
         },
       },
       childIncome: {
+        'ui:options': {
+          hideIf: () => environment.isProduction(),
+        },
         'ui:title': 'Did this child have income in the last 365 days?',
         'ui:description':
           'Answer this question only if you are adding this dependent to your pension.',

--- a/src/applications/disability-benefits/686c-674/config/chapters/household-income/householdIncome.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/household-income/householdIncome.js
@@ -1,10 +1,14 @@
 import { netWorthCalculation, netWorthTitle } from './helpers';
 import { householdIncome } from '../../utilities';
+import environment from 'platform/utilities/environment';
 
 export const schema = householdIncome;
 
 export const uiSchema = {
   householdIncome: {
+    'ui:options': {
+      hideIf: () => environment.isProduction(),
+    },
     'ui:title': netWorthCalculation,
     'ui:description': netWorthTitle,
     'ui:widget': 'yesNo',

--- a/src/applications/disability-benefits/686c-674/config/chapters/report-add-a-spouse/does-live-with-spouse/doesLiveWithSpouse.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/report-add-a-spouse/does-live-with-spouse/doesLiveWithSpouse.js
@@ -1,4 +1,5 @@
 import cloneDeep from 'platform/utilities/data/cloneDeep';
+import environment from 'platform/utilities/environment';
 import { buildAddressSchema, addressUISchema } from '../../../address-schema';
 import { addSpouse } from '../../../utilities';
 import { doesLiveTogether, liveWithYouTitle } from './helpers';
@@ -46,6 +47,9 @@ export const uiSchema = {
       },
     },
     spouseIncome: {
+      'ui:options': {
+        hideIf: () => environment.isProduction(),
+      },
       'ui:title': 'Did your spouse have income in the last 365 days?',
       'ui:description':
         'Answer this question only if you are adding this dependent to your pension.',

--- a/src/applications/disability-benefits/686c-674/config/chapters/report-child-stopped-attending-school/child-information/childInformation.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/report-child-stopped-attending-school/child-information/childInformation.js
@@ -1,6 +1,7 @@
 import merge from 'lodash/merge';
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
 import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
+import environment from 'platform/utilities/environment';
 import { TASK_KEYS } from '../../../constants';
 import {
   isChapterFieldRequired,
@@ -73,6 +74,9 @@ export const uiSchema = {
       },
     },
     dependentIncome: {
+      'ui:options': {
+        hideIf: () => environment.isProduction(),
+      },
       'ui:title': PensionIncomeRemovalQuestionTitle,
       'ui:widget': 'yesNo',
     },

--- a/src/applications/disability-benefits/686c-674/config/chapters/report-dependent-death/dependent-additional-information/dependentAdditionalInformation.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/report-dependent-death/dependent-additional-information/dependentAdditionalInformation.js
@@ -1,4 +1,5 @@
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
+import environment from 'platform/utilities/environment';
 import { TASK_KEYS } from '../../../constants';
 import {
   isChapterFieldRequired,
@@ -30,6 +31,9 @@ export const uiSchema = {
         'reportDeath',
       ),
       dependentIncome: {
+        'ui:options': {
+          hideIf: () => environment.isProduction(),
+        },
         'ui:title': PensionIncomeRemovalQuestionTitle,
         'ui:widget': 'yesNo',
       },

--- a/src/applications/disability-benefits/686c-674/config/chapters/report-divorce/former-spouse-information/formerSpouseInformation.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/report-divorce/former-spouse-information/formerSpouseInformation.js
@@ -1,6 +1,7 @@
 import merge from 'lodash/merge';
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
 import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
+import environment from 'platform/utilities/environment';
 import { validateName, reportDivorce } from '../../../utilities';
 import { TASK_KEYS } from '../../../constants';
 import {
@@ -86,6 +87,9 @@ export const uiSchema = {
       },
     },
     spouseIncome: {
+      'ui:options': {
+        hideIf: () => environment.isProduction(),
+      },
       'ui:title': PensionIncomeRemovalQuestionTitle,
       'ui:widget': 'yesNo',
     },

--- a/src/applications/disability-benefits/686c-674/config/chapters/report-marriage-of-child/child-information/childInformation.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/report-marriage-of-child/child-information/childInformation.js
@@ -1,6 +1,7 @@
 import merge from 'lodash/merge';
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
 import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
+import environment from 'platform/utilities/environment';
 import { TASK_KEYS } from '../../../constants';
 import { validateName, reportChildMarriage } from '../../../utilities';
 import {
@@ -68,6 +69,9 @@ export const uiSchema = {
         ),
     }),
     dependentIncome: {
+      'ui:options': {
+        hideIf: () => environment.isProduction(),
+      },
       'ui:title': PensionIncomeRemovalQuestionTitle,
       'ui:widget': 'yesNo',
     },


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/25376)

The Pension line of business asked us to add a few questions to the workflows for the 686c form however the back end system that is going to receive these questions is not ready yet so we need to hide them in production. We cannot however simply remove the questions because the pension line of business still needs to be able to test the questions in staging so we need to hide the questions based on the environment. This PR ads the code to hide them in production only.

## Testing done
Tested locally by inverting the logic to hide the questions in any environment except production and it worked. Switched the logic back to hide them in production and will test again once this PR is merged.

## Acceptance criteria
- [x] The Pension questions are only visible, in non-prod environments
- [x] A PR has been requested for merging
