### PR TITLE
[25598] add phone for home video appt facility contact

### DIFF
--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -753,6 +753,7 @@ export function getCalendarData({ appointment, facility }) {
           'You can join this meeting up to 30 minutes before the start time.',
         location: 'VA Video Connect at home',
         additionalText: [signinText],
+        phone: getFacilityPhone(facility),
       };
     } else if (isAtlas) {
       const { atlasLocation } = appointment.videoData;

--- a/src/applications/vaos/services/mocks/var/confirmed_va.json
+++ b/src/applications/vaos/services/mocks/var/confirmed_va.json
@@ -901,7 +901,7 @@
             "id": "8a74bdfa-0e66-4848-87f5-0d9bb413ae6d",
             "appointmentKind": "ADHOC",
             "sourceSystem": "SM",
-            "dateTime": "2021-02-25T15:17:00Z",
+            "dateTime": "2021-11-25T15:17:00Z",
             "duration": 20,
             "status": { "description": "F", "code": "FUTURE" },
             "schedulingRequestType": "NEXT_AVAILABLE_APPT",


### PR DESCRIPTION
## Description
Fix VVC at home should display like Atlas and how the Facility and facility phone number.

## Testing done
local, unit and e2e

## Screenshots
<img width="669" alt="image" src="https://user-images.githubusercontent.com/8315447/120690703-8c5b2a00-c473-11eb-8be7-1cb1d4bb13ba.png">

## Acceptance criteria
- [ ] VVC at home should display like Atlas and how the Facility and facility phone number.

## Definition of done
- [-] Events are logged appropriately
- [-] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
