### PR TITLE
[25601] add atlas check for provider info

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoVisitSection.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoVisitSection.jsx
@@ -73,7 +73,7 @@ export default function VideoVisitLocation({ appointment, facility }) {
             )}
           </>
         )}
-        {kind === VIDEO_TYPES.gfe && (
+        {(kind === VIDEO_TYPES.gfe || isAtlas) && (
           <div className="vads-u-margin-top--2">
             <VideoVisitProvider providers={providers} />
           </div>

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoVisitSection.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoVisitSection.jsx
@@ -73,15 +73,20 @@ export default function VideoVisitLocation({ appointment, facility }) {
             )}
           </>
         )}
-        {(kind === VIDEO_TYPES.gfe || isAtlas) && (
+        {kind === VIDEO_TYPES.gfe && (
           <div className="vads-u-margin-top--2">
             <VideoVisitProvider providers={providers} />
           </div>
         )}
         {isAtlas && (
-          <div className="vads-u-margin-top--2">
-            <AtlasLocation appointment={appointment} />
-          </div>
+          <>
+            <div className="vads-u-margin-top--2">
+              <AtlasLocation appointment={appointment} />
+            </div>
+            <div className="vads-u-margin-top--2">
+              <VideoVisitProvider providers={providers} />
+            </div>
+          </>
         )}
         {kind === VIDEO_TYPES.clinic &&
           !isAtlas && (


### PR DESCRIPTION
## Description
On Atlas appointments provider name for Atlas is not displaying

## Testing done
Local, Unit, and e2e

## Screenshots
<img width="669" alt="image" src="https://user-images.githubusercontent.com/8315447/120816504-cfbea280-c51e-11eb-92a8-dc24cbef82f3.png">

## Acceptance criteria
- [ ] On Atlas appointments provider name for Atlas is displayed

## Definition of done
- [-] Events are logged appropriately
- [-] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
