### PR TITLE
Turn off default watch behavior in vets-website for opening browser window

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -449,9 +449,9 @@ module.exports = async (env = {}) => {
   if (buildOptions.scaffold) {
     const scaffoldedHtml = await generateHtmlFiles(buildPath);
     baseConfig.plugins.push(...scaffoldedHtml);
+  }
 
-    // Open the browser to either --env.openTo or one of the root URLs of the
-    // apps we're scaffolding
+  if (buildOptions.open) {
     baseConfig.devServer.open = true;
     baseConfig.devServer.openPage =
       buildOptions.openTo || buildOptions.entry


### PR DESCRIPTION
## Description
The current default `watch` behavior opens a browser window. Updating this to not open a browser per VFS feedback.

The browser behavior has been update to use a flag: `yarn watch --open`

## Testing done
Local testing with: `yarn watch`, `yarn watch --open`, and `yarn watch --open false`

Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/25614

Documentation: https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/633