### PR TITLE
NOD: Add headings to checkbox labels

### DIFF
--- a/src/applications/appeals/10182/content/areaOfDisagreement.jsx
+++ b/src/applications/appeals/10182/content/areaOfDisagreement.jsx
@@ -50,9 +50,14 @@ export const issusDescription = ({ formContext }) => {
   );
 };
 
-export const serviceConnection = 'The service connection';
-export const effectiveDate = 'The effective date of award';
-export const evaluation = 'The evaluation of my condition';
-export const other = 'Something else';
+const wrapHeader = text => (
+  <h3 className="vads-u-display--inline-block vads-u-font-size--base vads-u-font-family--sans vads-u-font-weight--normal vads-u-margin-y--0">
+    {text}
+  </h3>
+);
 
+export const serviceConnection = wrapHeader('The service connection');
+export const effectiveDate = wrapHeader('The effective date of award');
+export const evaluation = wrapHeader('The evaluation of my condition');
+export const other = wrapHeader('Something else');
 export const otherLabel = 'Tell us what you disagree with:';


### PR DESCRIPTION
## Description

Per a11y recommendations, the checkbox group used on the Notice of Disagreement form's area of disagreement page should include `h3` headers inside the checkbox labels. This PR adds the `h3` and adjusts the styling.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/25185

## Testing done

Visual

## Screenshots

<details><summary>Checkbox label with nested <code>h3</code></summary>

<!-- leave a blank line above -->
![Screen Shot 2021-06-04 at 9 05 23 AM](https://user-images.githubusercontent.com/136959/120813953-04792c80-c514-11eb-8b0a-f554d47492b8.png)</details>

## Acceptance criteria
- [x] Headers added inside group checkbox labels

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
