### PR TITLE
Fix chromedriver install in GitHub Actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,7 +3,7 @@ name: Continuous Integration
 on: [push]
 
 env:
-  CHROMEDRIVER_FILEPATH: ${{ env.CHROMEWEBDRIVER }}
+  CHROMEDRIVER_FILEPATH: $CHROMEWEBDRIVER
 
 jobs:
   unit-tests:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,7 +3,7 @@ name: Continuous Integration
 on: [push]
 
 env:
-  CHROMEDRIVER_FILEPATH: $CHROMEWEBDRIVER
+  CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
 
 jobs:
   unit-tests:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,6 +2,9 @@ name: Continuous Integration
 
 on: [push]
 
+env:
+  CHROMEDRIVER_FILEPATH: ${{ env.CHROMEWEBDRIVER }}
+
 jobs:
   unit-tests:
     name: Unit Tests

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -3,7 +3,7 @@ name: E2E Tests
 on: [push]
 
 env:
-  CHROMEDRIVER_FILEPATH: $CHROMEWEBDRIVER
+  CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
 
 jobs:
   build:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,5 +1,10 @@
 name: E2E Tests
+
 on: [push]
+
+env:
+  CHROMEDRIVER_FILEPATH: $CHROMEWEBDRIVER
+
 jobs:
   build:
     name: E2E Tests


### PR DESCRIPTION
## Description
This fix uses the existing chromedriver executable instead of downloading it during dependency installs.

## Testing done
GHA workflow passes installation step.

## Acceptance criteria
- [ ] Installing dependencies should succeed in Github Actions workflows.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
