### PR TITLE
NOD: Use mobile then home phone, show note if missing

### DIFF
--- a/src/applications/appeals/10182/components/ContactInformation.jsx
+++ b/src/applications/appeals/10182/components/ContactInformation.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
 
 import { formatAddress } from 'platform/forms/address/helpers';
+import titleCase from 'platform/utilities/data/titleCase';
 
 import { PROFILE_URL } from '../constants';
 
@@ -13,6 +14,8 @@ const addBrAfter = line => line && [line, <br key={line} />];
 export const ContactInfoDescription = ({ veteran }) => {
   const { email, phone, address } = veteran || {};
   const { street, cityStateZip, country } = formatAddress(address || {});
+  // phone.phoneType is in all caps
+  const phoneType = titleCase((phone.phoneType || '').toLowerCase());
 
   return (
     <>
@@ -27,10 +30,16 @@ export const ContactInfoDescription = ({ veteran }) => {
         </a>
         .
       </p>
+      {(!phoneType || !street) && (
+        <p className="vads-u-margin-top--1p5">
+          <strong>Note:</strong> A phone number and mailing address is required
+          for this application.
+        </p>
+      )}
       <div className="blue-bar-block">
         <h3 className="vads-u-font-size--h4">Phone &amp; email</h3>
         <p>
-          <strong>Home phone</strong>:{' '}
+          <strong>{phoneType} phone</strong>:{' '}
           <Telephone
             contact={`${phone?.areaCode || ''}${phone?.phoneNumber || ''}`}
             extension={phone?.extension}

--- a/src/applications/appeals/10182/components/ReviewDescription.jsx
+++ b/src/applications/appeals/10182/components/ReviewDescription.jsx
@@ -4,38 +4,42 @@ import PropTypes from 'prop-types';
 
 import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
 
-import { selectProfile } from 'platform/user/selectors';
 import { ADDRESS_TYPES } from 'platform/forms/address/helpers';
+import titleCase from 'platform/utilities/data/titleCase';
+
 import { PROFILE_URL } from '../constants';
 
-const ReviewDescription = ({ profile }) => {
-  if (!profile) {
+const ReviewDescription = ({ veteran }) => {
+  if (!veteran) {
     return null;
   }
 
-  const { email, homePhone, mailingAddress } = profile.vapContactInfo || {};
-  const isUS = mailingAddress?.addressType !== ADDRESS_TYPES.international;
+  const { email, phone, address } = veteran || {};
+  const isUS = address?.addressType !== ADDRESS_TYPES.international;
   const stateOrProvince = isUS ? 'State' : 'Province';
+  const phoneType = `${titleCase(
+    (phone?.phoneType || '').toLowerCase(),
+  )} phone`;
 
   // Label: formatted value in (design) display order
   const display = {
-    'Phone number': () =>
-      homePhone && (
+    [phoneType]: () =>
+      phone && (
         <Telephone
-          contact={`${homePhone?.areaCode}${homePhone?.phoneNumber}`}
-          extension={homePhone?.extension || ''}
+          contact={`${phone?.areaCode}${phone?.phoneNumber}`}
+          extension={phone?.extension || ''}
           notClickable
         />
       ),
-    'Email address': () => email?.emailAddress,
-    Country: () => (isUS ? '' : mailingAddress?.countryName),
-    'Street address': () => mailingAddress?.addressLine1,
-    'Street address line 2': () => mailingAddress?.addressLine2,
-    'Street address line 3': () => mailingAddress?.addressLine3,
-    City: () => mailingAddress?.city,
-    [stateOrProvince]: () => mailingAddress?.[isUS ? 'stateCode' : 'province'],
+    'Email address': () => email,
+    Country: () => (isUS ? '' : address?.countryName),
+    'Street address': () => address?.addressLine1,
+    'Street address line 2': () => address?.addressLine2,
+    'Street address line 3': () => address?.addressLine3,
+    City: () => address?.city,
+    [stateOrProvince]: () => address?.[isUS ? 'stateCode' : 'province'],
     'Postal code': () =>
-      mailingAddress?.[isUS ? 'zipCode' : 'internationalPostalCode'],
+      address?.[isUS ? 'zipCode' : 'internationalPostalCode'],
   };
 
   return (
@@ -70,13 +74,16 @@ const ReviewDescription = ({ profile }) => {
 };
 
 ReviewDescription.propTypes = {
-  profile: PropTypes.shape({}),
+  veteran: PropTypes.shape({
+    email: PropTypes.string,
+    phone: PropTypes.shape({}),
+    address: PropTypes.shape({}),
+  }),
 };
 
-const mapStateToProps = state => {
-  const profile = selectProfile(state);
-  return { profile };
-};
+const mapStateToProps = state => ({
+  veteran: state.form.data.veteran,
+});
 
 export { ReviewDescription };
 

--- a/src/applications/appeals/10182/containers/FormApp.jsx
+++ b/src/applications/appeals/10182/containers/FormApp.jsx
@@ -29,8 +29,9 @@ export const FormApp = ({
   getContestableIssues,
   contestableIssues = {},
 }) => {
-  const { email = {}, homePhone = {}, mailingAddress = {} } =
+  const { email = {}, mobilePhone = {}, homePhone = {}, mailingAddress = {} } =
     profile?.vapContactInfo || {};
+  const phone = mobilePhone.phoneNumber ? mobilePhone : homePhone;
 
   // Update profile data changes in the form data dynamically
   useEffect(
@@ -42,7 +43,7 @@ export const FormApp = ({
           getContestableIssues();
         } else if (
           email?.emailAddress !== veteran.email ||
-          homePhone?.updatedAt !== veteran.phone?.updatedAt ||
+          phone?.updatedAt !== veteran.phone?.updatedAt ||
           mailingAddress?.updatedAt !== veteran.address?.updatedAt ||
           issuesNeedUpdating(
             contestableIssues?.issues,
@@ -54,7 +55,7 @@ export const FormApp = ({
             veteran: {
               ...veteran,
               address: mailingAddress,
-              phone: homePhone,
+              phone,
               email: email?.emailAddress,
             },
             contestableIssues: contestableIssues?.issues || [],
@@ -82,7 +83,7 @@ export const FormApp = ({
       showNod,
       loggedIn,
       email,
-      homePhone,
+      phone,
       mailingAddress,
       formData,
       setFormData,

--- a/src/applications/appeals/10182/tests/components/ContactInformation.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/ContactInformation.unit.spec.jsx
@@ -48,4 +48,49 @@ describe('Veteran information review content', () => {
     expect(text).to.contain('Hollywood, CA 90210');
     tree.unmount();
   });
+
+  it('should render note about missing phone', () => {
+    const data = {
+      veteran: {
+        email: 'someone@famous.com',
+        phone: {},
+        address: {
+          addressType: ADDRESS_TYPES.domestic,
+          countryName: 'United States',
+          countryCodeIso3: 'USA',
+          addressLine1: '123 Main Blvd',
+          addressLine2: 'Floor 33',
+          addressLine3: 'Suite 55',
+          city: 'Hollywood',
+          stateCode: 'CA',
+          zipCode: '90210',
+        },
+      },
+    };
+    const ContactInfo = () => <>{ContactInfoDescription(data)}</>;
+    const tree = shallow(<ContactInfo />);
+    const text = tree.text();
+
+    expect(text).to.contain('address is required for this application');
+    tree.unmount();
+  });
+  it('should render note about missing address', () => {
+    const data = {
+      veteran: {
+        email: 'someone@famous.com',
+        phone: {
+          areaCode: '555',
+          phoneNumber: '8001212',
+          extension: '1234',
+        },
+        address: {},
+      },
+    };
+    const ContactInfo = () => <>{ContactInfoDescription(data)}</>;
+    const tree = shallow(<ContactInfo />);
+    const text = tree.text();
+
+    expect(text).to.contain('address is required for this application');
+    tree.unmount();
+  });
 });

--- a/src/applications/appeals/10182/tests/components/ReviewDescription.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/ReviewDescription.unit.spec.jsx
@@ -9,55 +9,51 @@ import { ReviewDescription } from '../../components/ReviewDescription';
 
 describe('<ReviewDescription>', () => {
   it('should render', () => {
-    const wrapper = shallow(<ReviewDescription profile={{}} />);
+    const wrapper = shallow(<ReviewDescription veteran={{}} />);
     expect(wrapper.find('.form-review-panel-page-header-row').length).to.eq(1);
     wrapper.unmount();
   });
   it('should render profile data', () => {
-    const profile = {
-      vapContactInfo: {
-        email: {
-          emailAddress: 'test@foo.com',
-        },
-        homePhone: {
-          areaCode: '503',
-          countryCode: '1',
-          extension: '0000',
-          phoneNumber: '2222222',
-          phoneType: 'HOME',
-          updatedAt: '2018-04-21T20:09:50Z',
-        },
-        mailingAddress: {
-          addressLine1: '1493 Martin Luther King Rd',
-          addressLine2: 'Apt 1',
-          addressLine3: '',
-          addressType: ADDRESS_TYPES.domestic,
-          city: 'Fulton',
-          countryName: 'United States',
-          countryCodeFips: 'US',
-          countryCodeIso2: 'US',
-          countryCodeIso3: 'USA',
-          internationalPostalCode: '54321',
-          stateCode: 'NY',
-          updatedAt: '2018-04-21T20:09:50Z',
-          zipCode: '97062',
-          zipCodeSuffix: '1234',
-        },
+    const veteran = {
+      email: 'test@foo.com',
+      phone: {
+        areaCode: '503',
+        countryCode: '1',
+        extension: '0000',
+        phoneNumber: '2222222',
+        phoneType: 'HOME',
+        updatedAt: '2018-04-21T20:09:50Z',
+      },
+      address: {
+        addressLine1: '1493 Martin Luther King Rd',
+        addressLine2: 'Apt 1',
+        addressLine3: '',
+        addressType: ADDRESS_TYPES.domestic,
+        city: 'Fulton',
+        countryName: 'United States',
+        countryCodeFips: 'US',
+        countryCodeIso2: 'US',
+        countryCodeIso3: 'USA',
+        internationalPostalCode: '54321',
+        stateCode: 'NY',
+        updatedAt: '2018-04-21T20:09:50Z',
+        zipCode: '97062',
+        zipCodeSuffix: '1234',
       },
     };
-    const wrapper = shallow(<ReviewDescription profile={profile} />);
+    const wrapper = shallow(<ReviewDescription veteran={veteran} />);
     const text = wrapper.find('dl.review').text();
-    const { email, homePhone, mailingAddress } = profile.vapContactInfo;
-    const phone = wrapper.find('Telephone').props();
+    const { email, phone, address } = veteran;
+    const phoneProps = wrapper.find('Telephone').props();
 
     expect(wrapper.find('h4').text()).to.eq('Contact information');
     expect(wrapper.find('a').props().href).to.contain(PROFILE_URL);
-    expect(phone.contact).to.eq(homePhone.areaCode + homePhone.phoneNumber);
-    expect(phone.extension).to.eq(homePhone.extension);
+    expect(phoneProps.contact).to.eq(phone.areaCode + phone.phoneNumber);
+    expect(phoneProps.extension).to.eq(phone.extension);
 
-    expect(text).to.contain(`Email address${email.emailAddress}`);
-    expect(text).to.contain(`Street address${mailingAddress.addressLine1}`);
-    expect(text).to.contain(`Postal code${mailingAddress.zipCode}`);
+    expect(text).to.contain(`Email address${email}`);
+    expect(text).to.contain(`Street address${address.addressLine1}`);
+    expect(text).to.contain(`Postal code${address.zipCode}`);
 
     wrapper.unmount();
   });


### PR DESCRIPTION
## Description

The Notice of Disagreement form requires a phone number when submitted. This PR switches to use the Veteran's mobile phone first, then falls back to the home phone. If neither exists, it adds a note to the contact info page. Note that this does not prevent the Veteran from continuing or submitting the form at any point - the form

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/25643

## Testing done

Added & updated unit tests

## Screenshots

<details><summary>No missing info</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-06-04 at 11 23 03 AM](https://user-images.githubusercontent.com/136959/120837423-4ada8580-c52c-11eb-8d31-4a3338576f4a.png)</details>

<details><summary>Missing mobile & home phone - showing note</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-06-04 at 11 19 44 AM](https://user-images.githubusercontent.com/136959/120837489-5e85ec00-c52c-11eb-99db-1caac3521b3c.png)</details>

## Acceptance criteria
- [x] Include mobile phone, falls back to home phone
- [x] Show note if missing either phone or address

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
