### PR TITLE
[25613]  Atlas location display

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoVisitSection.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoVisitSection.jsx
@@ -37,16 +37,17 @@ export default function VideoVisitLocation({ appointment, facility }) {
     kind !== VIDEO_TYPES.clinic &&
     kind !== VIDEO_TYPES.gfe;
 
-  if (
-    appointment.vaos.isPastAppointment &&
-    (kind === VIDEO_TYPES.clinic || isAtlas)
-  ) {
+  if (appointment.vaos.isPastAppointment && kind === VIDEO_TYPES.clinic) {
     return (
       <VAFacilityLocation
         facility={facility}
         facilityId={appointment.videoData.facilityId}
       />
     );
+  }
+
+  if (appointment.vaos.isPastAppointment && isAtlas) {
+    return <AtlasLocation appointment={appointment} />;
   }
 
   if (appointment.vaos.isPastAppointment) {

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoVisitSection.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoVisitSection.jsx
@@ -37,7 +37,10 @@ export default function VideoVisitLocation({ appointment, facility }) {
     kind !== VIDEO_TYPES.clinic &&
     kind !== VIDEO_TYPES.gfe;
 
-  if (appointment.vaos.isPastAppointment && kind === VIDEO_TYPES.clinic) {
+  if (
+    appointment.vaos.isPastAppointment &&
+    (kind === VIDEO_TYPES.clinic || isAtlas)
+  ) {
     return (
       <VAFacilityLocation
         facility={facility}

--- a/src/applications/vaos/services/mocks/var/confirmed_va.json
+++ b/src/applications/vaos/services/mocks/var/confirmed_va.json
@@ -1065,6 +1065,119 @@
           }
         ]
       }
+    },
+    {
+      "id": "c3e3e32701e23fdf389c06eae00fcb28",
+      "type": "va_appointments",
+      "attributes": {
+        "startDate": "2021-04-22T20:00:00Z",
+        "sta6aid": null,
+        "clinicId": null,
+        "clinicFriendlyName": null,
+        "facilityId": "983",
+        "communityCare": false,
+        "vdsAppointments": [],
+        "vvsAppointments": [
+          {
+            "id": "465f0120-e268-4f66-bdbf-96f44d9ad3a9",
+            "appointmentKind": "ADHOC",
+            "sourceSystem": "PV",
+            "dateTime": "2021-04-22T20:00:00Z",
+            "duration": 30,
+            "status": {
+              "description": "F",
+              "code": "FUTURE"
+            },
+            "schedulingRequestType": "NEXT_AVAILABLE_APPT",
+            "type": "REGULAR",
+            "instructionsOther": false,
+            "patients": [
+              {
+                "name": {
+                  "firstName": "JUDY",
+                  "lastName": "MORRISON"
+                },
+                "contactInformation": {
+                  "mobile": "8888888888",
+                  "preferredEmail": "test@va.gov",
+                  "timeZone": "10"
+                },
+                "location": {
+                  "type": "NonVA",
+                  "facility": {
+                    "name": "CHEYENNE VAMC",
+                    "siteCode": "983",
+                    "timeZone": "10"
+                  }
+                },
+                "patientAppointment": true,
+                "invities": [
+                  {
+                    "email": "test@va.gov",
+                    "name": {
+                      "firstName": "Jane",
+                      "lastName": "Doe"
+                    },
+                    "inviteType": "CAREGIVER"
+                  }
+                ],
+                "virtualMeetingRoom": {
+                  "conference": "VAC00064b6f",
+                  "pin": "4569928835#",
+                  "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VAC00064b6f@care2.evn.va.gov&pin=4569928835#"
+                }
+              }
+            ],
+            "providers": [
+              {
+                "name": {
+                  "firstName": "Meg",
+                  "lastName": "Smith"
+                },
+                "contactInformation": {
+                  "preferredEmail": "test@va.gov",
+                  "timeZone": "10"
+                },
+                "location": {
+                  "type": "VA",
+                  "facility": {
+                    "name": "CHEYENNE VAMC",
+                    "siteCode": "983",
+                    "timeZone": "10"
+                  }
+                },
+                "virtualMeetingRoom": {
+                  "conference": "VAC00064b6f",
+                  "pin": "5784382206#",
+                  "url": "https://care2.evn.va.gov/vvc-app/?name=Balboni%2CJeffrey&join=1&media=1&escalate=1&conference=VAC00064b6f@care2.evn.va.gov&pin=5784382206#"
+                }
+              }
+            ],
+            "tasInfo": {
+              "siteCode": "9931",
+              "slotId": "Slot8",
+              "confirmationCode": "7VBBCA",
+              "address": {
+                "streetAddress": "114 Dewey Ave",
+                "city": "Eureka",
+                "state": "MT",
+                "zipCode": "59917",
+                "country": "USA",
+                "longitude": -115.1,
+                "latitude": 48.8,
+                "additionalDetails": ""
+              },
+              "contacts": [
+                {
+                  "name": "Decker Konya",
+                  "phone": "5557582786",
+                  "email": "Decker.Konya@va.gov"
+                }
+              ]
+            }
+          }
+        ]
+      }
     }
   ],
   "meta": {


### PR DESCRIPTION
## Description
Expected Response: Atlas location should display
Actual Response: Atlas location does NOT display.

## Testing done
Local, Unit, and e2e

## Screenshots
<img width="669" alt="image" src="https://user-images.githubusercontent.com/8315447/120843096-b0823e00-c53b-11eb-991d-a7652d3c9313.png">

## Acceptance criteria
- [ ] Atlas location should display

## Definition of done
- [-] Events are logged appropriately
- [-] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
