### PR TITLE
NOD: Add decision date validation

### DIFF
--- a/src/applications/appeals/10182/pages/additionalIssues.js
+++ b/src/applications/appeals/10182/pages/additionalIssues.js
@@ -7,7 +7,7 @@ import {
 } from '../content/additionalIssues';
 
 import { IssueCard } from '../components/IssueCard';
-import { requireIssue } from '../validations';
+import { requireIssue, validateDate } from '../validations';
 import { SELECTED } from '../constants';
 import { setInitialEditMode, hasSomeSelected } from '../utils/helpers';
 
@@ -37,7 +37,10 @@ export default {
             required: missingIssueErrorMessage,
           },
         },
-        decisionDate: dateUiSchema('Date of decision'),
+        decisionDate: {
+          ...dateUiSchema('Date of decision'),
+          'ui:validations': [validateDate],
+        },
       },
     },
   },

--- a/src/applications/appeals/10182/tests/validations.unit.spec.js
+++ b/src/applications/appeals/10182/tests/validations.unit.spec.js
@@ -1,8 +1,10 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
+import { getDate } from '../utils/dates';
 import {
   requireIssue,
+  validateDate,
   areaOfDisagreementRequired,
   optInValidation,
 } from '../validations';
@@ -68,6 +70,40 @@ describe('requireIssue validation', () => {
     };
     requireIssue(errors, _, _, _, _, _, data);
     expect(errorMessage).to.equal('');
+  });
+});
+
+describe('validateDate', () => {
+  let errorMessage = '';
+  const errors = {
+    addError: message => {
+      errorMessage = message || '';
+    },
+  };
+
+  beforeEach(() => {
+    errorMessage = '';
+  });
+
+  it('should allow valid dates', () => {
+    validateDate(errors, getDate({ offset: { weeks: -1 } }));
+    expect(errorMessage).to.equal('');
+  });
+  it('should throw a invalid date error', () => {
+    validateDate(errors, '200');
+    expect(errorMessage).to.contain('valid date');
+  });
+  it('should throw a range error for dates too old', () => {
+    validateDate(errors, '1899');
+    expect(errorMessage).to.contain('enter a year between');
+  });
+  it('should throw an error for dates in the future', () => {
+    validateDate(errors, getDate({ offset: { weeks: 1 } }));
+    expect(errorMessage).to.contain('past decision date');
+  });
+  it('should throw an error for dates more than a year in the past', () => {
+    validateDate(errors, getDate({ offset: { weeks: -60 } }));
+    expect(errorMessage).to.contain('date less than a year');
   });
 });
 

--- a/src/applications/appeals/10182/validations.js
+++ b/src/applications/appeals/10182/validations.js
@@ -1,3 +1,11 @@
+import moment from 'moment';
+
+import { parseISODate } from 'platform/forms-system/src/js/helpers';
+import {
+  isValidYear,
+  isValidPartialDate,
+} from 'platform/forms-system/src/js/utilities/validations';
+
 import { hasSomeSelected } from './utils/helpers';
 import { optInErrorMessage } from './content/OptIn';
 import { missingIssuesErrorMessageText } from './content/additionalIssues';
@@ -22,6 +30,30 @@ export const requireIssue = (
   const data = Object.keys(appStateData || {}).length ? appStateData : formData;
   if (errors && errors?.additionalIssues?.addError && !hasSomeSelected(data)) {
     errors.additionalIssues.addError(missingIssuesErrorMessageText);
+  }
+};
+
+const minDate = moment()
+  .subtract(1, 'year')
+  .startOf('day');
+
+const maxDate = moment().endOf('day');
+
+export const validateDate = (errors, dateString) => {
+  const { day, month, year } = parseISODate(dateString);
+  const date = moment(dateString);
+  if (year?.length >= 4 && !isValidYear(year)) {
+    errors.addError(
+      `Please enter a year between ${minDate.year()} and ${maxDate.year()}`,
+    );
+  } else if (!isValidPartialDate(day, month, year)) {
+    errors.addError('Please provide a valid date');
+  } else if (date.isAfter(maxDate)) {
+    errors.addError('Please add a past decision date');
+  } else if (date.isBefore(minDate)) {
+    errors.addError(
+      'Please add an issue with a decision date less than a year old',
+    );
   }
 };
 


### PR DESCRIPTION
## Description

The Notice of Disagreement form should not allow a Veteran to enter a decision date more than a year in the past. This PR adds validation to the date.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/25466

## Testing done

Added unit tests

## Screenshots

<details><summary>All the error messages</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-06-04 at 4 00 53 PM](https://user-images.githubusercontent.com/136959/120862165-1ecffc00-c54e-11eb-940e-066de43705ca.png)
![Screen Shot 2021-06-04 at 3 59 59 PM](https://user-images.githubusercontent.com/136959/120862159-1d9ecf00-c54e-11eb-9d16-790ca7c169f8.png)
![Screen Shot 2021-06-04 at 4 00 10 PM](https://user-images.githubusercontent.com/136959/120862162-1e376580-c54e-11eb-94fe-b899979c48a3.png)
![Screen Shot 2021-06-04 at 4 00 19 PM](https://user-images.githubusercontent.com/136959/120862164-1ecffc00-c54e-11eb-9c0c-1ecee1c8c28b.png)</details>

## Acceptance criteria
- [x] Prevent entering dates in the future or older than 1 year

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
