### PR TITLE
NOD|508: Fix edit button aria-label

### DIFF
--- a/src/applications/appeals/10182/components/IssueCard.jsx
+++ b/src/applications/appeals/10182/components/IssueCard.jsx
@@ -93,6 +93,7 @@ export const IssueCard = ({
 
   const itemIsSelected = item[SELECTED];
   const isEditable = typeof onEdit === 'function';
+  const issueName = item.issue || item.ratingIssueSubjectText;
 
   const wrapperClass = [
     'review-row',
@@ -115,7 +116,7 @@ export const IssueCard = ({
   // item.ratingIssuesSubjectText = eligible issue from API
   const title = (
     <div className="widget-title vads-u-font-size--md vads-u-font-weight--bold vads-u-line-height--1">
-      {item.issue || item.ratingIssueSubjectText}
+      {issueName}
     </div>
   );
 
@@ -124,7 +125,7 @@ export const IssueCard = ({
       <button
         type="button"
         className="usa-button-secondary edit vads-u-flex--auto"
-        aria-label={`Edit issue`}
+        aria-label={`Edit ${issueName}`}
         onClick={onEdit}
       >
         Edit


### PR DESCRIPTION
## Description

Add a better edit button `aria-label` description. Previously, the `aria-label` included a generic "Edit issue" message, now it replaces "issue" with the entered issue name

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/25110

## Testing done

Manual

## Screenshots

![Screen Shot 2021-06-07 at 10 30 45 AM](https://user-images.githubusercontent.com/136959/121048153-2aa10580-c77c-11eb-953c-2d6cb481af6f.png)

## Acceptance criteria
- [x] Edit button `aria-label` is more descriptive

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
