### PR TITLE
FSR Intro Wizard Content Updates

### DIFF
--- a/src/applications/financial-status-report/wizard/pages/Appeals.jsx
+++ b/src/applications/financial-status-report/wizard/pages/Appeals.jsx
@@ -8,7 +8,7 @@ const Appeals = () => {
     recordEvent({
       event: 'howToWizard-alert-displayed',
       'reason-for-alert':
-        'appeal the decision with the board of Veterans Appeals',
+        "appeal the decision with the Board of Veterans' Appeals",
     });
   }, []);
 

--- a/src/applications/financial-status-report/wizard/pages/Benefits.jsx
+++ b/src/applications/financial-status-report/wizard/pages/Benefits.jsx
@@ -28,10 +28,19 @@ const ContactBenefits = () => {
           <strong>
             For help with debt related to separation pay/attorney fees
           </strong>
-          , call us at <Telephone contact={'800-827-1000'} />. We're here Monday
-          through Friday, 8:00 a.m. to 8:00 p.m. ET. If you have hearing loss,
-          call TTY:{' '}
-          <Telephone contact={CONTACTS[711]} pattern={PATTERNS['3_DIGIT']} />.
+          , call us at
+          <Telephone
+            className="vads-u-margin-left--0p5"
+            contact={'800-827-1000'}
+          />
+          . We’re here Monday through Friday, 7:00 a.m. to 8:00 p.m. ET. If you
+          have hearing loss, call TTY:
+          <Telephone
+            className="vads-u-margin-left--0p5"
+            contact={CONTACTS[711]}
+            pattern={PATTERNS['3_DIGIT']}
+          />
+          .
         </p>
       </div>
     </DelayedLiveRegion>

--- a/src/applications/financial-status-report/wizard/pages/Decision.jsx
+++ b/src/applications/financial-status-report/wizard/pages/Decision.jsx
@@ -11,11 +11,11 @@ const options = [
   },
   {
     value: 'error',
-    label: 'I this this debt is due to an error.',
+    label: 'I think this debt is due to an error.',
   },
   {
     value: 'wrong',
-    label: 'I think the amout of this debt is wrong.',
+    label: 'I think the amount of this debt is wrong.',
   },
 ];
 

--- a/src/applications/financial-status-report/wizard/pages/Dependents.jsx
+++ b/src/applications/financial-status-report/wizard/pages/Dependents.jsx
@@ -22,16 +22,19 @@ const Dependents = () => {
         >
           Based on the information you provided, this isn’t the form you need.
         </h2>
+
         <p>
           <strong>
             Here’s how to request help with debt for spouses or dependents:
           </strong>
         </p>
+
         <p>
           To request help with VA education, disability compensation, or pension
-          benefit debt, fill out the PDF version of our{' '}
+          benefit debt, fill out the PDF version of our
           <a
-            href="https://www.va.gov/debtman/Financial_Status_Report.asp"
+            className="vads-u-margin-left--0p5"
+            href="https://www.va.gov/find-forms/about-form-5655/"
             onClick={() => {
               recordEvent({
                 event: 'howToWizard-alert-link-click',
@@ -43,12 +46,15 @@ const Dependents = () => {
             Financial Status Report (VA Form 5655).
           </a>
         </p>
+
         <p>
           You can use this form to request a debt waiver, compromise offer, or
           extended monthly payment plan. You’ll also need to include a personal
           statement to tell us why it’s hard for you to repay the debt.
         </p>
+
         <p>Submit your completed, signed form and statement by mail or fax.</p>
+
         <ul>
           <li>
             <strong>Mail: </strong>
@@ -61,9 +67,11 @@ const Dependents = () => {
             <Telephone contact={'1-612-970-5688'} />
           </li>
         </ul>
+
         <p>
           <strong>If you submitted VA Form 5655 in the past 6 months</strong>
         </p>
+
         <p>
           You don’t need to submit a new request unless you have changes to
           report. <ContactDMC />

--- a/src/applications/financial-status-report/wizard/pages/Dependents.jsx
+++ b/src/applications/financial-status-report/wizard/pages/Dependents.jsx
@@ -43,8 +43,9 @@ const Dependents = () => {
               });
             }}
           >
-            Financial Status Report (VA Form 5655).
+            Financial Status Report (VA Form 5655)
           </a>
+          .
         </p>
 
         <p>

--- a/src/applications/financial-status-report/wizard/pages/Disagree.jsx
+++ b/src/applications/financial-status-report/wizard/pages/Disagree.jsx
@@ -25,7 +25,7 @@ const Disagree = () => {
           <strong>
             If you disagree with the VA decision that resulted in this debt,
           </strong>{' '}
-          you can submit a supplemental claim or request a higher level review
+          you can submit a Supplemental Claim or request a Higher Level Review
           or board appeal.
         </p>
         <p className="vads-u-margin-top--1">

--- a/src/applications/financial-status-report/wizard/pages/Disagree.jsx
+++ b/src/applications/financial-status-report/wizard/pages/Disagree.jsx
@@ -73,7 +73,7 @@ const Disagree = () => {
         </p>
         <p className="vads-u-margin-top--1">
           <a
-            href="https://www.va.gov/debtman/Financial_Status_Report.asp"
+            href="https://www.va.gov/find-forms/about-form-5655/"
             onClick={() => {
               recordEvent({
                 event: 'howToWizard-alert-link-click',

--- a/src/applications/financial-status-report/wizard/pages/Disagree.jsx
+++ b/src/applications/financial-status-report/wizard/pages/Disagree.jsx
@@ -22,9 +22,9 @@ const Disagree = () => {
           Based on the information you provided, this isn’t the form you need.
         </h2>
         <p className="vads-u-margin-bottom--0">
-          <strong>
+          <strong className="vads-u-margin-right--0p5">
             If you disagree with the VA decision that resulted in this debt,
-          </strong>{' '}
+          </strong>
           you can submit a Supplemental Claim or request a Higher Level Review
           or board appeal.
         </p>

--- a/src/applications/financial-status-report/wizard/pages/Error.jsx
+++ b/src/applications/financial-status-report/wizard/pages/Error.jsx
@@ -54,9 +54,9 @@ const DebtError = () => {
       </ul>
       <p>
         <strong>Note: </strong>
-        Note: You have <strong>180 days</strong> from the date you received your
-        first debt letter to submit your dispute statement. After this time, we
-        can’t consider the request.
+        You have <strong>180 days</strong> from the date you received your first
+        debt letter to submit your dispute statement. After this time, we can’t
+        consider the request.
       </p>
       <p>
         We encourage you to submit your dispute statement within{' '}

--- a/src/applications/financial-status-report/wizard/pages/Recipients.jsx
+++ b/src/applications/financial-status-report/wizard/pages/Recipients.jsx
@@ -7,7 +7,7 @@ const label = 'Which of these best describes the person who has this debt?';
 const options = [
   {
     value: 'active-duty',
-    label: 'Active duty service member',
+    label: 'Active-duty service member',
   },
   {
     value: 'veteran',

--- a/src/applications/financial-status-report/wizard/pages/Reconsider.jsx
+++ b/src/applications/financial-status-report/wizard/pages/Reconsider.jsx
@@ -12,7 +12,7 @@ const options = [
   },
   {
     value: PAGE_NAMES.appeals,
-    label: 'I want appeal the decision with the board of Veterans Appeals.',
+    label: "I want appeal the decision with the Board of Veterans' Appeals.",
   },
 ];
 


### PR DESCRIPTION
## Description
Update content on FSR intro wizard with the updated content as described in [ticket](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/department-of-veterans-affairs/va.gov-team/23218).


## Testing done
- Visual testing

## Screenshots
![image](https://user-images.githubusercontent.com/23741323/121058582-7bb9f500-c78e-11eb-9565-c487086eed21.png)

## Acceptance criteria

- [x] Please fix typo in this sentence: `I this this debt is due to an error.` TO: `I think this debt is due to an error.`

- [x] Please delete error/ double Note in this sentence:
`Note: Note: You have 180 days from the date you received your first debt letter to submit your dispute statement. After this time, we can’t consider the request.

- [x] Fix misspelling of `amount` in this sentence: `I think the amout of this debt is wrong.`

- [x] Please update the hours for the alert under 'Separation pay' TO:
`For help with debt related to separation pay/attorney fees, call us at 800-827-1000. We’re here Monday through Friday, 7:00 a.m. to 8:00 p.m. ET. If you have hearing loss, call TTY: 711.`

- [x] Change `Active duty service member` TO `Active-duty service member` under 'Request debt relief (a waiver or compromise offer)
For the alert under 'Report an error or disagreement with a VA decision' > 'I disagree with the VA decision that resulted in this debt': 

- [x] Capitalize 'supplemental claim' and 'higher level review' as shown below
`If you disagree with the VA decision that resulted in this debt, you can submit a Supplemental Claim or request a Higher Level Review or board appeal.`

- [x] Capitalize 'Board' in this sentence: “I want to appeal the decision with the board of Veterans Appeals.” Correct name is Board of Veterans' Appeals

- [x] Under **both** the 'Spouse' and 'Dependent' options for 'Request debt relief (a waiver or compromise offer), update the link in `fill out the PDF version of our Financial Status Report (VA Form 5655).` TO `[Financial Status Report (VA Form 5655)](https://www.va.gov/find-forms/about-form-5655/)`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
