### PR TITLE
Hid the pension question in review

### DIFF
--- a/src/applications/disability-benefits/686c-674/config/chapters/household-income/householdIncome.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/household-income/householdIncome.js
@@ -8,6 +8,7 @@ export const uiSchema = {
   householdIncome: {
     'ui:options': {
       hideIf: () => environment.isProduction(),
+      hideOnReview: () => environment.isProduction(),
     },
     'ui:title': netWorthCalculation,
     'ui:description': netWorthTitle,


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/25376)

We did a PR to hide the [pension questions](https://github.com/department-of-veterans-affairs/vets-website/pull/17482) in production however we did not realize we needed to hide them on the review page as well. This PR hides them on the review page.

## Acceptance criteria
- [x] The Pension questions are only visible, in non-prod environments
- [x] A PR has been requested for merging