### PR TITLE
Fix JS filter for files changed in Github Actions

### DIFF
--- a/script/github-actions/filter-files-changed.js
+++ b/script/github-actions/filter-files-changed.js
@@ -1,5 +1,5 @@
 const args = process.argv.slice(2);
 const files = args[0].slice(1, -1).split(','); // remove unnecessary characters
-const filteredFiles = files.filter(file => /.+\.jsx?/.test(file)).join(' ');
+const filteredFiles = files.filter(file => /.+\.jsx?$/.test(file)).join(' ');
 
 console.log(`::set-output name=FILES::${filteredFiles}`); // eslint-disable-line no-console


### PR DESCRIPTION
## Description

add $ to regex for JS filter

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
