### PR TITLE
NOD: Refactor code to reduce complexity

### DIFF
--- a/src/applications/appeals/10182/components/AddIssues.jsx
+++ b/src/applications/appeals/10182/components/AddIssues.jsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import Scroll from 'react-scroll';
+
+import { toIdSchema } from '@department-of-veterans-affairs/react-jsonschema-form/lib/utils';
+
+import { isEmptyObject, getItemSchema } from '../utils/helpers';
+
+import { SELECTED } from '../constants';
+import { IssueCard } from './IssueCard';
+import {
+  missingIssuesErrorMessage,
+  noneSelected,
+} from '../content/additionalIssues';
+
+const Element = Scroll.Element;
+
+export const getContent = ({
+  handlers,
+  registry,
+  items,
+  schema,
+  uiSchema,
+  errorSchema,
+  singleIssue,
+  id,
+  formData,
+  editing,
+  isReviewMode,
+  showCheckbox,
+}) => {
+  const { SchemaField } = registry.fields;
+  const uiOptions = uiSchema['ui:options'] || {};
+
+  return items.map((item, index) => {
+    const itemSchema = getItemSchema(schema, index);
+    const itemIdPrefix = `${id}_${index}`;
+    const itemIdSchema = toIdSchema(itemSchema, itemIdPrefix, {});
+    const isEditing = editing[index];
+    const itemName = item?.issue || 'issue';
+
+    // Don't show unselected items on the review & submit page in review
+    // mode
+    if (isReviewMode && (!item[SELECTED] || isEmptyObject(item))) {
+      return null;
+    }
+
+    const first = singleIssue && index === 0;
+    const className = [
+      'review-row',
+      'additional-issue',
+      'editing',
+      first ? '' : 'vads-u-background-color--gray-lightest',
+      first ? 'vads-u-border-top--0' : '',
+      first ? 'vads-u-padding--0' : 'vads-u-padding--3',
+      first ? 'vads-u-margin--0' : 'vads-u-margin-bottom--2',
+    ].join(' ');
+
+    // show edit card, but not in review mode
+    return !isReviewMode && isEditing ? (
+      <div key={index} className={className}>
+        <dt className="widget-checkbox-wrap" />
+        <dd data-index={index}>
+          <Element name={`table_${itemIdPrefix}`} />
+          <fieldset className="vads-u-text-align--left">
+            <legend className="schemaform-block-header vads-u-margin-top--0 vads-u-padding-y--0">
+              {first ? (
+                <span className="vads-u-font-size--base vads-u-font-weight--normal">
+                  Please add a new issue for review:
+                </span>
+              ) : (
+                <div className="vads-u-font-size--md vads-u-font-family--serif">
+                  {`${isEditing === 1 ? 'Add' : 'Update'} issue`}
+                </div>
+              )}
+            </legend>
+            <div className="input-section vads-u-margin-bottom--0 vads-u-font-weight--normal">
+              <SchemaField
+                key={index}
+                schema={itemSchema}
+                uiSchema={uiSchema.items}
+                errorSchema={errorSchema ? errorSchema[index] : undefined}
+                idSchema={itemIdSchema}
+                formData={item}
+                onChange={value => handlers.onItemChange(index, value)}
+                onBlur={handlers.blur}
+                registry={registry}
+                required
+              />
+            </div>
+            <div className="vads-u-margin-top--2 vads-u-display--flex vads-u-justify-content--space-between">
+              <button
+                type="button"
+                className="vads-u-margin-right--2 update"
+                aria-label={`Save ${itemName}`}
+                onClick={() => handlers.update(index)}
+              >
+                Save
+              </button>
+              {formData.length > 1 && (
+                <button
+                  type="button"
+                  className="usa-button-secondary float-right remove"
+                  aria-label={`Remove ${itemName}`}
+                  onClick={() => handlers.remove(index)}
+                >
+                  Remove
+                </button>
+              )}
+            </div>
+          </fieldset>
+        </dd>
+      </div>
+    ) : (
+      <IssueCard
+        key={index}
+        id={id}
+        index={index}
+        item={item}
+        options={uiOptions}
+        onChange={handlers.toggleSelection}
+        showCheckbox={showCheckbox}
+        onEdit={() => handlers.edit(index)}
+      />
+    );
+  });
+};
+
+export const renderPage = ({
+  id,
+  isReviewMode,
+  isEditing,
+  hasSelected,
+  showError,
+  showContent,
+  showCheckbox,
+  atMax,
+  content,
+  handlers,
+}) => {
+  const addButton = !atMax &&
+    showCheckbox && (
+      <button
+        type="button"
+        className="usa-button-secondary va-growable-add-btn vads-u-width--auto"
+        onClick={handlers.add}
+      >
+        Add another issue
+      </button>
+    );
+
+  return isReviewMode ? (
+    <>
+      {!showError && !hasSelected && noneSelected}
+      {showError && missingIssuesErrorMessage}
+      {content}
+    </>
+  ) : (
+    <div
+      className={`schemaform-field-container additional-issues-wrap ${
+        showError ? 'usa-input-error vads-u-margin-top--0' : ''
+      }`}
+    >
+      <Element name={`topOfTable_${id}`} />
+      {showError && missingIssuesErrorMessage}
+      {showContent && <dl className="va-growable review">{content}</dl>}
+      {isEditing ? null : addButton}
+      {atMax && <p>You’ve entered the maximum number of items allowed.</p>}
+    </div>
+  );
+};

--- a/src/applications/appeals/10182/components/AddIssuesField.jsx
+++ b/src/applications/appeals/10182/components/AddIssuesField.jsx
@@ -1,12 +1,8 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import Scroll from 'react-scroll';
 
-import {
-  toIdSchema,
-  getDefaultFormState,
-} from '@department-of-veterans-affairs/react-jsonschema-form/lib/utils';
+import { getDefaultFormState } from '@department-of-veterans-affairs/react-jsonschema-form/lib/utils';
 
 import { setArrayRecordTouched } from 'platform/forms-system/src/js/helpers';
 import { errorSchemaIsValid } from 'platform/forms-system/src/js/validation';
@@ -14,15 +10,9 @@ import { scrollToFirstError } from 'platform/utilities/ui';
 import { setData } from 'platform/forms-system/src/js/actions';
 
 import { scrollAndFocus } from '../utils/ui';
-import { isEmptyObject, someSelected } from '../utils/helpers';
+import { someSelected } from '../utils/helpers';
 import { SELECTED, MAX_NEW_CONDITIONS } from '../constants';
-import { IssueCard } from './IssueCard';
-import {
-  missingIssuesErrorMessage,
-  noneSelected,
-} from '../content/additionalIssues';
-
-const Element = Scroll.Element;
+import { getContent, renderPage } from './AddIssues';
 
 /* Non-review growable table (array) field */
 const AddIssuesField = props => {
@@ -39,6 +29,7 @@ const AddIssuesField = props => {
     submission,
   } = props;
 
+  const id = idSchema.$id;
   const uiOptions = uiSchema['ui:options'] || {};
 
   if (!fullFormData['view:hasIssuesToAdd']) {
@@ -54,101 +45,98 @@ const AddIssuesField = props => {
     initialEditingState?.length ? initialEditingState : [1],
   );
 
-  const toggleSelection = (indexToChange, checked) => {
-    const newItems = formData.map((item, index) => ({
-      ...item,
-      [SELECTED]: index === indexToChange ? checked : item[SELECTED],
-    }));
-    props.onChange(newItems);
-  };
-
-  const onItemChange = (indexToChange, value) => {
-    const newItems = formData.map(
-      (item, index) =>
-        index === indexToChange ? { ...value, [SELECTED]: true } : item,
-    );
-    props.onChange(newItems);
-  };
-
-  const getItemSchema = index => {
-    const itemSchema = schema;
-    if (itemSchema.items.length > index) {
-      return itemSchema.items[index];
-    }
-    return itemSchema.additionalItems;
-  };
-
-  /*
-   * Clicking edit on an item that’s not last and so is in view mode
-   */
-  const handleEdit = (index, status = true) => {
-    setEditing(editing.map((mode, indx) => (indx === index ? status : mode)));
-    scrollAndFocus({
-      selector: `dd[data-index="${index}"] legend`,
-      timer: 50,
-    });
-  };
-
-  /*
-   * Clicking Update on an item that’s not last and is in edit mode
-   */
-  const handleUpdate = index => {
-    const { issue, decisionDate } = formData[index];
-    if (errorSchemaIsValid(errorSchema[index]) && issue && decisionDate) {
-      setEditing(editing.map((mode, indx) => (indx === index ? false : mode)));
-      scrollAndFocus({
-        selector: `dd[data-index="${index}"] .edit`,
-        timer: 100,
-      });
-    } else {
-      // Set all the fields for this item as touched, so we show errors
-      const touched = setArrayRecordTouched(idSchema.$id, index);
-      formContext.setTouched(touched, () => {
-        scrollToFirstError();
-      });
-    }
-  };
-
-  /*
-   * Clicking Add another
-   */
-  const handleAdd = () => {
-    const lastIndex = formData.length - 1;
-    if (errorSchemaIsValid(errorSchema[lastIndex])) {
-      // For new entries we don't use a boolean, so we know it should be labeled
-      // as "new" and not "update"
-      setEditing(editing.concat([1]));
-
-      const newFormData = formData.concat(
-        getDefaultFormState(schema.additionalItems, undefined, {}) || {},
+  const handlers = {
+    toggleSelection: (indexToChange, checked) => {
+      const newItems = formData.map((item, index) => ({
+        ...item,
+        [SELECTED]: index === indexToChange ? checked : item[SELECTED],
+      }));
+      props.onChange(newItems);
+    },
+    onItemChange: (indexToChange, value) => {
+      const newItems = formData.map(
+        (item, index) =>
+          index === indexToChange ? { ...value, [SELECTED]: true } : item,
       );
-      props.onChange(newFormData);
+      props.onChange(newItems);
+    },
+    getItemSchema: index => {
+      const itemSchema = schema;
+      if (itemSchema.items.length > index) {
+        return itemSchema.items[index];
+      }
+      return itemSchema.additionalItems;
+    },
+    blur: onBlur,
+    /*
+     * Clicking edit on an item that’s not last and so is in view mode
+     */
+    edit: (index, status = true) => {
+      setEditing(editing.map((mode, indx) => (indx === index ? status : mode)));
       scrollAndFocus({
-        selector: `dd[data-index="${lastIndex + 1}"] legend`,
+        selector: `dd[data-index="${index}"] legend`,
         timer: 50,
       });
-    } else {
-      const touched = setArrayRecordTouched(idSchema.$id, lastIndex);
-      formContext.setTouched(touched, () => {
-        scrollToFirstError();
+    },
+    /*
+    * Clicking Update on an item that’s not last and is in edit mode
+    */
+    update: index => {
+      const { issue, decisionDate } = formData[index];
+      if (errorSchemaIsValid(errorSchema[index]) && issue && decisionDate) {
+        setEditing(
+          editing.map((mode, indx) => (indx === index ? false : mode)),
+        );
+        scrollAndFocus({
+          selector: `dd[data-index="${index}"] .edit`,
+          timer: 100,
+        });
+      } else {
+        // Set all the fields for this item as touched, so we show errors
+        const touched = setArrayRecordTouched(id, index);
+        formContext.setTouched(touched, () => {
+          scrollToFirstError();
+        });
+      }
+    },
+    /*
+     * Clicking Add another
+     */
+    add: () => {
+      const lastIndex = formData.length - 1;
+      if (errorSchemaIsValid(errorSchema[lastIndex])) {
+        // For new entries we don't use a boolean, so we know it should be labeled
+        // as "new" and not "update"
+        setEditing(editing.concat([1]));
+
+        const newFormData = formData.concat(
+          getDefaultFormState(schema.additionalItems, undefined, {}) || {},
+        );
+        props.onChange(newFormData);
+        scrollAndFocus({
+          selector: `dd[data-index="${lastIndex + 1}"] legend`,
+          timer: 50,
+        });
+      } else {
+        const touched = setArrayRecordTouched(id, lastIndex);
+        formContext.setTouched(touched, () => {
+          scrollToFirstError();
+        });
+      }
+    },
+    /*
+     * Clicking Remove on an item in edit mode
+     */
+    remove: indexToRemove => {
+      const newItems = formData.filter((_, index) => index !== indexToRemove);
+      setEditing(editing.filter((_, index) => index !== indexToRemove));
+      props.onChange(newItems);
+      scrollAndFocus({
+        selector: '.va-growable-add-btn',
+        timer: 50,
       });
-    }
+    },
   };
-
-  /*
-   * Clicking Remove on an item in edit mode
-   */
-  const handleRemove = indexToRemove => {
-    const newItems = formData.filter((_, index) => index !== indexToRemove);
-    setEditing(editing.filter((_, index) => index !== indexToRemove));
-    props.onChange(newItems);
-    scrollAndFocus({
-      selector: '.va-growable-add-btn',
-      timer: 50,
-    });
-  };
-
-  const { SchemaField } = registry.fields;
 
   const onReviewPage = formContext.onReviewPage;
   // review mode = only show selected cards on the review & submit page
@@ -162,17 +150,6 @@ const AddIssuesField = props => {
 
   const atMax = items.length > MAX_NEW_CONDITIONS;
 
-  const addButton = !atMax &&
-    showCheckbox && (
-      <button
-        type="button"
-        className="usa-button-secondary va-growable-add-btn vads-u-width--auto"
-        onClick={handleAdd}
-      >
-        Add another issue
-      </button>
-    );
-
   // first issue does not have a header or grey card background
   const singleIssue = items.length === 1;
   const hasSelected =
@@ -180,118 +157,33 @@ const AddIssuesField = props => {
   const hasSubmitted = formContext.submitted || submission?.hasAttemptedSubmit;
   const showError = hasSubmitted && !hasSelected;
 
-  const content = items.map((item, index) => {
-    const itemSchema = getItemSchema(index);
-    const itemIdPrefix = `${idSchema.$id}_${index}`;
-    const itemIdSchema = toIdSchema(itemSchema, itemIdPrefix, {});
-    const isEditing = editing[index];
-    const itemName = item?.issue || 'issue';
-
-    // Don't show unselected items on the review & submit page in review
-    // mode
-    if (isReviewMode && (!item[SELECTED] || isEmptyObject(item))) {
-      return null;
-    }
-
-    const first = singleIssue && index === 0;
-    const className = [
-      'review-row',
-      'additional-issue',
-      'editing',
-      first ? '' : 'vads-u-background-color--gray-lightest',
-      first ? 'vads-u-border-top--0' : '',
-      first ? 'vads-u-padding--0' : 'vads-u-padding--3',
-      first ? 'vads-u-margin--0' : 'vads-u-margin-bottom--2',
-    ].join(' ');
-
-    // show edit card, but not in review mode
-    return !isReviewMode && isEditing ? (
-      <div key={index} className={className}>
-        <dt className="widget-checkbox-wrap" />
-        <dd data-index={index}>
-          <Element name={`table_${itemIdPrefix}`} />
-          <fieldset className="vads-u-text-align--left">
-            <legend className="schemaform-block-header vads-u-margin-top--0 vads-u-padding-y--0">
-              {first ? (
-                <span className="vads-u-font-size--base vads-u-font-weight--normal">
-                  Please add a new issue for review:
-                </span>
-              ) : (
-                <div className="vads-u-font-size--md vads-u-font-family--serif">
-                  {`${isEditing === 1 ? 'Add' : 'Update'} issue`}
-                </div>
-              )}
-            </legend>
-            <div className="input-section vads-u-margin-bottom--0 vads-u-font-weight--normal">
-              <SchemaField
-                key={index}
-                schema={itemSchema}
-                uiSchema={uiSchema.items}
-                errorSchema={errorSchema ? errorSchema[index] : undefined}
-                idSchema={itemIdSchema}
-                formData={item}
-                onChange={value => onItemChange(index, value)}
-                onBlur={onBlur}
-                registry={registry}
-                required
-              />
-            </div>
-            <div className="vads-u-margin-top--2 vads-u-display--flex vads-u-justify-content--space-between">
-              <button
-                type="button"
-                className="vads-u-margin-right--2 update"
-                aria-label={`Save ${itemName}`}
-                onClick={() => handleUpdate(index)}
-              >
-                Save
-              </button>
-              {formData.length > 1 && (
-                <button
-                  type="button"
-                  className="usa-button-secondary float-right remove"
-                  aria-label={`Remove ${itemName}`}
-                  onClick={() => handleRemove(index)}
-                >
-                  Remove
-                </button>
-              )}
-            </div>
-          </fieldset>
-        </dd>
-      </div>
-    ) : (
-      <IssueCard
-        key={index}
-        id={idSchema.$id}
-        index={index}
-        item={item}
-        options={uiOptions}
-        onChange={toggleSelection}
-        showCheckbox={showCheckbox}
-        onEdit={() => handleEdit(index)}
-      />
-    );
+  const content = getContent({
+    handlers,
+    registry,
+    items,
+    schema,
+    uiSchema,
+    errorSchema,
+    singleIssue,
+    id,
+    formData,
+    editing,
+    isReviewMode,
+    showCheckbox,
   });
 
-  return isReviewMode ? (
-    <>
-      {!showError && !hasSelected && noneSelected}
-      {showError && missingIssuesErrorMessage}
-      {content}
-    </>
-  ) : (
-    <div
-      className={`schemaform-field-container additional-issues-wrap ${
-        showError ? 'usa-input-error vads-u-margin-top--0' : ''
-      }`}
-    >
-      <Element name={`topOfTable_${idSchema.$id}`} />
-      {showError && missingIssuesErrorMessage}
-      {formData.length > 0 && <dl className="va-growable review">{content}</dl>}
-      {editing.some(edit => edit) ? null : addButton}
-      {atMax && <p>You’ve entered the maximum number of items allowed.</p>}
-    </div>
-  );
+  return renderPage({
+    id,
+    isReviewMode,
+    isEditing: editing.some(edit => edit),
+    hasSelected,
+    showError,
+    showContent: formData.length > 0,
+    showCheckbox,
+    atMax,
+    content,
+    handlers,
+  });
 };
 
 AddIssuesField.propTypes = {

--- a/src/applications/appeals/10182/utils/helpers.js
+++ b/src/applications/appeals/10182/utils/helpers.js
@@ -89,3 +89,11 @@ export const appStateSelector = state => ({
 
 export const noticeOfDisagreementFeature = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.form10182Nod];
+
+export const getItemSchema = (schema, index) => {
+  const itemSchema = schema;
+  if (itemSchema.items.length > index) {
+    return itemSchema.items[index];
+  }
+  return itemSchema.additionalItems;
+};


### PR DESCRIPTION
## Description

The `AddIssuesField` component has an excessive code complexity as reported by the linter

> AddIssuesField.jsx:28:30:Refactor this function to reduce its Cognitive Complexity from 71 to the 50 allowed.

This PR refactors the code to eliminate this issue and clean up the code.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/25752

## Testing done

Unit tests continue to pass.

## Screenshots

![Screen Shot 2021-06-07 at 2 24 23 PM](https://user-images.githubusercontent.com/136959/121076467-166d0080-c79c-11eb-84e7-2b3742108b25.png)

## Acceptance criteria
- [x] Reduce code complexity of `AddIssuesField` component

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
