### PR TITLE
Fixed megamenu test to reflect behavior seen in production.

### DIFF
--- a/src/platform/landing-pages/header-footer-data.json
+++ b/src/platform/landing-pages/header-footer-data.json
@@ -698,6 +698,64 @@
           }
         },
         {
+          "title": "Life insurance",
+          "links": {
+            "seeAllLink": {
+              "text": "View all in life insurance",
+              "href": "https://www.va.gov/life-insurance"
+            },
+            "columnOne": {
+              "title": "Get life insurance",
+              "links": [
+                {
+                  "text": "About life insurance options",
+                  "href": "https://www.va.gov/life-insurance/options-eligibility"
+                },
+                {
+                  "text": "Benefits for totally disabled or terminally ill policyholders",
+                  "href": "https://www.va.gov/life-insurance/totally-disabled-or-terminally-ill"
+                },
+                {
+                  "text": "Beneficiary financial counseling and online will preparation",
+                  "href": "https://www.benefits.va.gov/insurance/bfcs.asp"
+                }
+              ]
+            },
+            "columnTwo": {
+              "title": "Manage your life insurance",
+              "links": [
+                {
+                  "text": "Access your policy online",
+                  "href": "https://www.va.gov/life-insurance/manage-your-policy"
+                },
+                {
+                  "text": "Update your beneficiaries",
+                  "href": "https://www.benefits.va.gov/INSURANCE/updatebene.asp"
+                },
+                {
+                  "text": "File a claim for insurance benefits",
+                  "href": "https://www.benefits.va.gov/INSURANCE/sglivgli.asp"
+                },
+                {
+                  "text": "Check your appeal status",
+                  "href": "https://www.va.gov/claim-or-appeal-status"
+                }
+              ]
+            },
+            "columnThree": {
+              "img": {
+                "src": "https://www.va.gov/img/styles/3_2_medium_thumbnail/public/hub_promos/life-insurance.png",
+                "alt": ""
+              },
+              "link": {
+                "text": "SGLI Online Enrollment System (SOES)",
+                "href": "https://www.benefits.va.gov/INSURANCE/SOES.asp"
+              },
+              "description": "Learn about our new online enrollment system for Servicemembers' Group Life Insurance."
+            }
+          }
+        },
+        {
           "title": "Burials and memorials",
           "links": {
             "columnOne": {
@@ -760,64 +818,6 @@
                 "href": "https://m.va.gov/"
               },
               "description": "Locate a grave, search for cemeteries, and find benefits information and resources."
-            }
-          }
-        },
-        {
-          "title": "Life insurance",
-          "links": {
-            "seeAllLink": {
-              "text": "View all in life insurance",
-              "href": "https://www.va.gov/life-insurance"
-            },
-            "columnOne": {
-              "title": "Get life insurance",
-              "links": [
-                {
-                  "text": "About life insurance options",
-                  "href": "https://www.va.gov/life-insurance/options-eligibility"
-                },
-                {
-                  "text": "Benefits for totally disabled or terminally ill policyholders",
-                  "href": "https://www.va.gov/life-insurance/totally-disabled-or-terminally-ill"
-                },
-                {
-                  "text": "Beneficiary financial counseling and online will preparation",
-                  "href": "https://www.benefits.va.gov/insurance/bfcs.asp"
-                }
-              ]
-            },
-            "columnTwo": {
-              "title": "Manage your life insurance",
-              "links": [
-                {
-                  "text": "Access your policy online",
-                  "href": "https://www.va.gov/life-insurance/manage-your-policy"
-                },
-                {
-                  "text": "Update your beneficiaries",
-                  "href": "https://www.benefits.va.gov/INSURANCE/updatebene.asp"
-                },
-                {
-                  "text": "File a claim for insurance benefits",
-                  "href": "https://www.benefits.va.gov/INSURANCE/sglivgli.asp"
-                },
-                {
-                  "text": "Check your appeal status",
-                  "href": "https://www.va.gov/claim-or-appeal-status"
-                }
-              ]
-            },
-            "columnThree": {
-              "img": {
-                "src": "https://www.va.gov/img/styles/3_2_medium_thumbnail/public/hub_promos/life-insurance.png",
-                "alt": ""
-              },
-              "link": {
-                "text": "SGLI Online Enrollment System (SOES)",
-                "href": "https://www.benefits.va.gov/INSURANCE/SOES.asp"
-              },
-              "description": "Learn about our new online enrollment system for Servicemembers' Group Life Insurance."
             }
           }
         },

--- a/src/platform/testing/e2e/megamenu/megamenu.js
+++ b/src/platform/testing/e2e/megamenu/megamenu.js
@@ -277,7 +277,7 @@ function testDataDrivenMegamenu(client, path) {
     'css selector',
     '#vetnav-column-one-col li.mm-link-container',
     results => {
-      client.expect(results.value.length).to.equal(8);
+      client.expect(results.value.length).to.equal(7);
     },
   );
 


### PR DESCRIPTION
## Description
In the process of migrating Nightwatch to GitHub Actions, this test started failing. I decided to update the locally built header to match what's in production as well as the associated test.

- Switched "Life insurance" and "Burials and memorials" sections in the hard-coded `header-footer-data.json` to match production.
- Updated expected number of items in the test to match what would be found in production.

## Testing done
Local testing. CI passes.

## Acceptance criteria
- [ ] Megamenu test should test against a version of the header similar to the one in production.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
