### PR TITLE
NOD: Fix additionalIssues validation

### DIFF
--- a/src/applications/appeals/10182/pages/additionalIssues.js
+++ b/src/applications/appeals/10182/pages/additionalIssues.js
@@ -7,16 +7,20 @@ import {
 } from '../content/additionalIssues';
 
 import { IssueCard } from '../components/IssueCard';
-import { requireIssue, validateDate } from '../validations';
+import {
+  requireIssue,
+  validateDate,
+  validAdditionalIssue,
+} from '../validations';
 import { SELECTED } from '../constants';
-import { setInitialEditMode, hasSomeSelected } from '../utils/helpers';
+import { setInitialEditMode, showAddIssuesPage } from '../utils/helpers';
 
 import dateUiSchema from 'platform/forms-system/src/js/definitions/date';
 
 export default {
   uiSchema: {
     'ui:title': AdditionalIssuesLabel,
-    'ui:validations': [requireIssue],
+    'ui:validations': [requireIssue, validAdditionalIssue],
     additionalIssues: {
       'ui:title': '',
       'ui:field': AddIssuesField,
@@ -25,10 +29,15 @@ export default {
         itemName: 'issue',
         keepInPageOnReview: true,
         setInitialEditMode,
+        updateSchema: (formData, schema) => ({
+          ...schema,
+          minItems: showAddIssuesPage(formData) ? 1 : 0,
+        }),
       },
-      'ui:required': !hasSomeSelected,
+      'ui:required': showAddIssuesPage,
       'ui:errorMessages': {
         required: missingIssuesErrorMessage,
+        atLeastOne: missingIssuesErrorMessage,
       },
       items: {
         issue: {
@@ -51,6 +60,7 @@ export default {
       additionalIssues: {
         type: 'array',
         maxItems: 100,
+        minItems: 1,
         items: {
           type: 'object',
           required: ['issue', 'decisionDate'],

--- a/src/applications/appeals/10182/tests/components/AddIssuesField.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/AddIssuesField.unit.spec.jsx
@@ -6,6 +6,7 @@ import sinon from 'sinon';
 import { AddIssuesField } from '../../components/AddIssuesField';
 import additionalIssues from '../../pages/additionalIssues';
 import { MAX_NEW_CONDITIONS } from '../../constants';
+import { getDate } from '../../utils/dates';
 
 const { items } = additionalIssues.schema.properties.additionalIssues;
 
@@ -49,6 +50,7 @@ const getProps = ({
 });
 
 describe('<AddIssuesField>', () => {
+  const validDate = getDate({ offset: { months: -2 } });
   it('should render wrapper & add button', () => {
     const wrapper = shallow(<AddIssuesField {...getProps()} />);
     expect(wrapper.find('.additional-issues-wrap').length).to.equal(1);
@@ -58,8 +60,8 @@ describe('<AddIssuesField>', () => {
   });
   it('should render item cards', () => {
     const formData = [
-      { issue: 'test', decisionDate: '2020-01-01' },
-      { issue: 'test2', decisionDate: '2020-01-02' },
+      { issue: 'test', decisionDate: validDate },
+      { issue: 'test2', decisionDate: validDate },
     ];
     const wrapper = mount(<AddIssuesField {...getProps({ formData })} />);
 
@@ -82,7 +84,7 @@ describe('<AddIssuesField>', () => {
     wrapper.unmount();
   });
   it('should render 2 item cards with one in edit mode', () => {
-    const formData = [{ issue: 'test2', decisionDate: '2020-01-01' }, {}];
+    const formData = [{ issue: 'test2', decisionDate: validDate }, {}];
     const wrapper = mount(<AddIssuesField {...getProps({ formData })} />);
 
     expect(wrapper.find('.widget-outline').length).to.equal(1); // card
@@ -96,7 +98,7 @@ describe('<AddIssuesField>', () => {
 
   describe('should handle', () => {
     it('edit', () => {
-      const formData = [{ issue: 'test2', decisionDate: '2020-01-01' }];
+      const formData = [{ issue: 'test2', decisionDate: validDate }];
       const wrapper = mount(<AddIssuesField {...getProps({ formData })} />);
 
       expect(wrapper.find('.widget-outline').length).to.equal(1);
@@ -107,7 +109,7 @@ describe('<AddIssuesField>', () => {
       wrapper.unmount();
     });
     it('update when valid', () => {
-      const formData = [{ issue: 'test2', decisionDate: '2020-01-01' }];
+      const formData = [{ issue: 'test2', decisionDate: validDate }];
       const wrapper = mount(<AddIssuesField {...getProps({ formData })} />);
 
       expect(wrapper.find('.widget-outline').length).to.equal(1);
@@ -156,7 +158,7 @@ describe('<AddIssuesField>', () => {
     it('add', () => {
       const onChange = sinon.spy();
       const props = getProps({
-        formData: [{ issue: 'test', decisionDate: '2020-01-01' }],
+        formData: [{ issue: 'test', decisionDate: validDate }],
         onChange,
       });
       const wrapper = mount(<AddIssuesField {...props} />);
@@ -172,7 +174,7 @@ describe('<AddIssuesField>', () => {
       expect(formData).to.deep.equal([
         {
           issue: 'test',
-          decisionDate: '2020-01-01',
+          decisionDate: validDate,
         },
         {
           issue: undefined,
@@ -186,7 +188,7 @@ describe('<AddIssuesField>', () => {
       const props = getProps({
         formData: new Array(MAX_NEW_CONDITIONS + 2).fill({
           issue: 'x',
-          decisionDate: '2020-01-01',
+          decisionDate: validDate,
         }),
         onChange,
       });

--- a/src/applications/appeals/10182/tests/pages/additionalIssues.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/pages/additionalIssues.unit.spec.jsx
@@ -11,6 +11,7 @@ import {
 
 import formConfig from '../../config/form';
 import { SELECTED } from '../../constants';
+import { getDate } from '../../utils/dates';
 
 const mockStore = () => ({
   getState: () => ({
@@ -35,6 +36,7 @@ describe('add issues page', () => {
     schema,
     uiSchema,
   } = formConfig.chapters.conditions.pages.additionalIssues;
+  const validDate = getDate({ offset: { months: -2 } });
 
   it('should render', () => {
     const form = mount(
@@ -88,12 +90,12 @@ describe('add issues page', () => {
             additionalIssues: [
               {
                 issue: 'Back sprain',
-                decisionDate: '2020-11-15',
+                decisionDate: validDate,
                 [SELECTED]: false,
               },
               {
                 issue: 'Ankle sprain',
-                decisionDate: '2020-11-16',
+                decisionDate: validDate,
               },
             ],
           }}
@@ -114,12 +116,12 @@ describe('add issues page', () => {
       additionalIssues: [
         {
           issue: 'Back sprain',
-          decisionDate: '2020-11-15',
+          decisionDate: validDate,
           // [SELECTED]: true,
         },
         {
           issue: 'Ankle sprain',
-          decisionDate: '2020-11-16',
+          decisionDate: validDate,
         },
       ],
     };

--- a/src/applications/appeals/10182/tests/pages/contestableIssues.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/pages/contestableIssues.unit.spec.jsx
@@ -10,12 +10,14 @@ import {
 
 import formConfig from '../../config/form';
 import { SELECTED } from '../../constants';
+import { getDate } from '../../utils/dates';
 
 describe('eligible issues page', () => {
   const {
     schema,
     uiSchema,
   } = formConfig.chapters.conditions.pages.contestableIssues;
+  const validDate = getDate({ offset: { months: -2 } });
 
   it('should render', () => {
     const form = mount(
@@ -62,7 +64,7 @@ describe('eligible issues page', () => {
                 ratingIssueSubjectText: 'Tinnitus',
                 description: 'Rinnging in the ears.',
                 ratingIssuePercentNumber: 10,
-                approxDecisionDate: '2020-11-01',
+                approxDecisionDate: validDate,
               },
               [SELECTED]: false,
             },
@@ -72,7 +74,7 @@ describe('eligible issues page', () => {
                 ratingIssueSubjectText: 'Headaches',
                 description: 'Acute chronic head pain',
                 ratingIssuePercentNumber: 50,
-                approxDecisionDate: '2020-11-10',
+                approxDecisionDate: validDate,
               },
             },
           ],

--- a/src/applications/appeals/10182/tests/schema/initialData.js
+++ b/src/applications/appeals/10182/tests/schema/initialData.js
@@ -21,7 +21,7 @@ export default {
         description: `Rinnging in the ears. More intense in right ear. This is
           more text so the description goes into the second line.`,
         ratingIssuePercentNumber: 10,
-        approxDecisionDate: '2020-11-01',
+        approxDecisionDate: '2021-06-03',
         decisionIssueId: 42,
         ratingIssueReferenceId: '52',
         ratingDecisionReferenceId: '',
@@ -34,7 +34,7 @@ export default {
         ratingIssueSubjectText: 'Headaches',
         description: 'Acute chronic head pain',
         ratingIssuePercentNumber: 50,
-        approxDecisionDate: '2020-11-10',
+        approxDecisionDate: '2021-06-04',
         decisionIssueId: 44,
         ratingIssueReferenceId: '66',
         ratingDecisionReferenceId: '',
@@ -45,12 +45,12 @@ export default {
   additionalIssues: [
     {
       issue: 'Back sprain',
-      decisionDate: '2020-11-15',
+      decisionDate: '2021-06-05',
       'view:selected': false,
     },
     {
       issue: 'Ankle sprain',
-      decisionDate: '2020-11-16',
+      decisionDate: '2021-06-06',
       'view:selected': false,
     },
   ],

--- a/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
@@ -13,6 +13,7 @@ import {
   issuesNeedUpdating,
   copyAreaOfDisagreementOptions,
 } from '../../utils/helpers';
+import { getDate } from '../../utils/dates';
 
 describe('someSelected', () => {
   it('should return true for issues that have some selected values', () => {
@@ -173,11 +174,12 @@ describe('isEmptyObject', () => {
 });
 
 describe('setInitialEditMode', () => {
+  const validDate = getDate({ offset: { months: -2 } });
   it('should set edit mode when missing data', () => {
     [
       [{}],
       [{ issue: 'test' }],
-      [{ decisionDate: '2000-01-01' }],
+      [{ decisionDate: validDate }],
       [{ issue: '', decisionDate: '' }],
       [{ issue: undefined, decisionDate: undefined }],
     ].forEach(test => {
@@ -185,19 +187,34 @@ describe('setInitialEditMode', () => {
     });
     expect(
       setInitialEditMode([
-        { issue: '', decisionDate: '2000-01-01' },
+        { issue: '', decisionDate: validDate },
         { issue: 'test', decisionDate: '' },
       ]),
     ).to.deep.equal([true, true]);
   });
+  it('should set edit mode when there is an invalid date', () => {
+    [
+      [{ issue: 'test', decisionDate: getDate({ offset: { months: 1 } }) }],
+      [{ issue: 'test', decisionDate: '1899-01-01' }],
+      [{ issue: 'test', decisionDate: '2000-01-01' }],
+    ].forEach(test => {
+      expect(setInitialEditMode(test)).to.deep.equal([true]);
+    });
+    expect(
+      setInitialEditMode([
+        { issue: 'test', decisionDate: validDate },
+        { issue: 'test', decisionDate: '2000-01-01' },
+      ]),
+    ).to.deep.equal([false, true]);
+  });
   it('should not set edit mode when data exists', () => {
     expect(
-      setInitialEditMode([{ issue: 'test', decisionDate: '2000-01-01' }]),
+      setInitialEditMode([{ issue: 'test', decisionDate: validDate }]),
     ).to.deep.equal([false]);
     expect(
       setInitialEditMode([
-        { issue: 'test', decisionDate: '2000-01-01' },
-        { issue: 'test2', decisionDate: '2000-01-02' },
+        { issue: 'test', decisionDate: validDate },
+        { issue: 'test2', decisionDate: getDate({ offset: { months: -10 } }) },
       ]),
     ).to.deep.equal([false, false]);
   });

--- a/src/applications/appeals/10182/tests/utils/submit.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/submit.unit.spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
-import moment from 'moment';
-import { SELECTED, FORMAT_YMD } from '../../constants';
+import { SELECTED } from '../../constants';
+import { getDate } from '../../utils/dates';
 
 import {
   getEligibleContestableIssues,
@@ -16,13 +16,14 @@ import {
   getTimeZone,
 } from '../../utils/submit';
 
+const validDate1 = getDate({ offset: { months: -2 } });
 const issue1 = {
   raw: {
     type: 'contestableIssue',
     attributes: {
       ratingIssueSubjectText: 'tinnitus',
       description: 'both ears',
-      approxDecisionDate: '2020-01-01',
+      approxDecisionDate: validDate1,
       decisionIssueId: 1,
       ratingIssueReferenceId: '2',
       ratingDecisionReferenceId: '3',
@@ -33,7 +34,7 @@ const issue1 = {
     type: 'contestableIssue',
     attributes: {
       issue: 'tinnitus - 10% - both ears',
-      decisionDate: '2020-01-01',
+      decisionDate: validDate1,
       decisionIssueId: 1,
       ratingIssueReferenceId: '2',
       ratingDecisionReferenceId: '3',
@@ -41,12 +42,13 @@ const issue1 = {
   },
 };
 
+const validDate2 = getDate({ offset: { months: -4 } });
 const issue2 = {
   raw: {
     type: 'contestableIssue',
     attributes: {
       ratingIssueSubjectText: 'left knee',
-      approxDecisionDate: '2020-01-02',
+      approxDecisionDate: validDate2,
       decisionIssueId: 4,
       ratingIssueReferenceId: '5',
     },
@@ -55,7 +57,7 @@ const issue2 = {
     type: 'contestableIssue',
     attributes: {
       issue: 'left knee - 0%',
-      decisionDate: '2020-01-02',
+      decisionDate: validDate2,
       decisionIssueId: 4,
       ratingIssueReferenceId: '5',
     },
@@ -65,7 +67,22 @@ const issue2 = {
 describe('getEligibleContestableIssues', () => {
   it('should remove ineligible dates', () => {
     expect(
-      getEligibleContestableIssues([issue1.raw, issue2.raw]),
+      getEligibleContestableIssues([
+        {
+          type: 'contestableIssue',
+          attributes: {
+            ...issue1.raw.attributes,
+            approxDecisionDate: '2020-01-01',
+          },
+        },
+        {
+          type: 'contestableIssue',
+          attributes: {
+            ...issue2.raw.attributes,
+            approxDecisionDate: '2020-01-02',
+          },
+        },
+      ]),
     ).to.deep.equal([]);
   });
   it('should keep eligible dates', () => {
@@ -73,13 +90,11 @@ describe('getEligibleContestableIssues', () => {
       type: 'contestableIssue',
       attributes: {
         ...issue1.raw.attributes,
-        approxDecisionDate: moment()
-          .subtract(2, 'months')
-          .format(FORMAT_YMD),
+        approxDecisionDate: '2020-01-01',
       },
     };
     expect(getEligibleContestableIssues([issue, issue2.raw])).to.deep.equal([
-      issue,
+      issue2.raw,
     ]);
   });
 });
@@ -130,7 +145,7 @@ describe('addIncludedIssues', () => {
   it('should add additional items to contestableIssues array', () => {
     const issue = {
       type: 'contestableIssue',
-      attributes: { issue: 'test', decisionDate: '2000-01-01' },
+      attributes: { issue: 'test', decisionDate: validDate1 },
     };
     const formData = {
       contestableIssues: [
@@ -139,7 +154,7 @@ describe('addIncludedIssues', () => {
       ],
       'view:hasIssuesToAdd': true,
       additionalIssues: [
-        { issue: 'not-added', decisionDate: '2000-01-02', [SELECTED]: false },
+        { issue: 'not-added', decisionDate: validDate2, [SELECTED]: false },
         { ...issue.attributes, [SELECTED]: true },
       ],
     };
@@ -151,7 +166,7 @@ describe('addIncludedIssues', () => {
   it('should not add additional items to contestableIssues array', () => {
     const issue = {
       type: 'contestableIssue',
-      attributes: { issue: 'test', decisionDate: '2000-01-01' },
+      attributes: { issue: 'test', decisionDate: validDate1 },
     };
     const formData = {
       contestableIssues: [
@@ -160,7 +175,7 @@ describe('addIncludedIssues', () => {
       ],
       'view:hasIssuesToAdd': false,
       additionalIssues: [
-        { issue: 'not-added', decisionDate: '2000-01-02', [SELECTED]: false },
+        { issue: 'not-added', decisionDate: validDate2, [SELECTED]: false },
         { ...issue.attributes, [SELECTED]: true },
       ],
     };

--- a/src/applications/appeals/10182/tests/validations.unit.spec.js
+++ b/src/applications/appeals/10182/tests/validations.unit.spec.js
@@ -6,6 +6,7 @@ import {
   requireIssue,
   validateDate,
   isValidDate,
+  validAdditionalIssue,
   areaOfDisagreementRequired,
   optInValidation,
 } from '../validations';
@@ -71,6 +72,51 @@ describe('requireIssue validation', () => {
     };
     requireIssue(errors, _, _, _, _, _, data);
     expect(errorMessage).to.equal('');
+  });
+});
+
+describe('validAdditionalIssue', () => {
+  it('should not show an error for valid additional issues', () => {
+    const errors = { addError: sinon.spy() };
+    expect(
+      validAdditionalIssue(errors, {
+        additionalIssues: [
+          { issue: 'foo', decisionDate: getDate({ offset: { months: -1 } }) },
+        ],
+      }),
+    );
+    expect(errors.addError.called).to.be.false;
+  });
+  it('should show an error for additional issues with no name', () => {
+    const errors = { addError: sinon.spy() };
+    expect(
+      validAdditionalIssue(errors, {
+        additionalIssues: [
+          { issue: '', decisionDate: getDate({ offset: { months: -1 } }) },
+        ],
+      }),
+    );
+    expect(errors.addError.called).to.be.true;
+  });
+  it('should show an error for additional issues with an empty decision date', () => {
+    const errors = { addError: sinon.spy() };
+    expect(
+      validAdditionalIssue(errors, {
+        additionalIssues: [{ issue: 'test', decisionDate: '' }],
+      }),
+    );
+    expect(errors.addError.called).to.be.true;
+  });
+  it('should show an error for additional issues with an old decision date', () => {
+    const errors = { addError: sinon.spy() };
+    expect(
+      validAdditionalIssue(errors, {
+        additionalIssues: [
+          { issue: 'test', decisionDate: getDate({ offset: { months: -15 } }) },
+        ],
+      }),
+    );
+    expect(errors.addError.called).to.be.true;
   });
 });
 

--- a/src/applications/appeals/10182/tests/validations.unit.spec.js
+++ b/src/applications/appeals/10182/tests/validations.unit.spec.js
@@ -5,6 +5,7 @@ import { getDate } from '../utils/dates';
 import {
   requireIssue,
   validateDate,
+  isValidDate,
   areaOfDisagreementRequired,
   optInValidation,
 } from '../validations';
@@ -73,7 +74,7 @@ describe('requireIssue validation', () => {
   });
 });
 
-describe('validateDate', () => {
+describe('validateDate & isValidDate', () => {
   let errorMessage = '';
   const errors = {
     addError: message => {
@@ -86,24 +87,32 @@ describe('validateDate', () => {
   });
 
   it('should allow valid dates', () => {
-    validateDate(errors, getDate({ offset: { weeks: -1 } }));
+    const date = getDate({ offset: { weeks: -1 } });
+    validateDate(errors, date);
     expect(errorMessage).to.equal('');
+    expect(isValidDate(date)).to.be.true;
   });
   it('should throw a invalid date error', () => {
     validateDate(errors, '200');
-    expect(errorMessage).to.contain('valid date');
+    expect(errorMessage).to.contain('provide a valid date');
+    expect(isValidDate('200')).to.be.false;
   });
   it('should throw a range error for dates too old', () => {
     validateDate(errors, '1899');
     expect(errorMessage).to.contain('enter a year between');
+    expect(isValidDate('1899')).to.be.false;
   });
   it('should throw an error for dates in the future', () => {
-    validateDate(errors, getDate({ offset: { weeks: 1 } }));
+    const date = getDate({ offset: { weeks: 1 } });
+    validateDate(errors, date);
     expect(errorMessage).to.contain('past decision date');
+    expect(isValidDate(date)).to.be.false;
   });
   it('should throw an error for dates more than a year in the past', () => {
-    validateDate(errors, getDate({ offset: { weeks: -60 } }));
+    const date = getDate({ offset: { weeks: -60 } });
+    validateDate(errors, date);
     expect(errorMessage).to.contain('date less than a year');
+    expect(isValidDate(date)).to.be.false;
   });
 });
 

--- a/src/applications/appeals/10182/utils/helpers.js
+++ b/src/applications/appeals/10182/utils/helpers.js
@@ -2,6 +2,7 @@
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import { SELECTED } from '../constants';
+import { isValidDate } from '../validations';
 
 export const someSelected = issues =>
   (issues || []).some(issue => issue[SELECTED]);
@@ -47,7 +48,10 @@ export const isEmptyObject = obj =>
     : false;
 
 export const setInitialEditMode = (formData = []) =>
-  formData.map(({ issue, decisionDate } = {}) => !issue || !decisionDate);
+  formData.map(
+    ({ issue, decisionDate } = {}) =>
+      !issue || !decisionDate || !isValidDate(decisionDate),
+  );
 
 export const issuesNeedUpdating = (loadedIssues = [], existingIssues = []) => {
   if (loadedIssues.length !== existingIssues.length) {

--- a/src/applications/appeals/10182/validations.js
+++ b/src/applications/appeals/10182/validations.js
@@ -57,6 +57,20 @@ export const validateDate = (errors, dateString) => {
   }
 };
 
+/**
+ * Use above validation to set initial edit state
+ */
+export const isValidDate = dateString => {
+  let isValid = true;
+  const errors = {
+    addError: () => {
+      isValid = false;
+    },
+  };
+  validateDate(errors, dateString);
+  return isValid;
+};
+
 export const areaOfDisagreementRequired = (
   errors,
   // added index to get around arrayIndex being null

--- a/src/applications/appeals/10182/validations.js
+++ b/src/applications/appeals/10182/validations.js
@@ -71,6 +71,23 @@ export const isValidDate = dateString => {
   return isValid;
 };
 
+export const validAdditionalIssue = (
+  errors,
+  { additionalIssues = [] } = {},
+) => {
+  if (errors.addError) {
+    additionalIssues.forEach(entry => {
+      if (
+        !entry.issue ||
+        !entry.decisionDate ||
+        !isValidDate(entry.decisionDate)
+      ) {
+        errors.addError(missingIssuesErrorMessageText);
+      }
+    });
+  }
+};
+
 export const areaOfDisagreementRequired = (
   errors,
   // added index to get around arrayIndex being null


### PR DESCRIPTION
## Description

NOD fixes:
- Set additional issue card edit mode based decision date (`isValidDate`)
- Add decision date validation to page checks (`validAdditionalIssue`)
- Dynamically set additional issues `minItems` based on question choice
- Fix static decision dates in unit tests

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/25799
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/25573

## Testing done

Added & updated unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Additional issue cards with invalid dates will switch to edit mode on return
- [x] Show validation error message

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
