### PR TITLE
rewrite login nightwatch test in cypress

### DIFF
--- a/src/applications/login/tests/00.login-page.cypress.spec.js
+++ b/src/applications/login/tests/00.login-page.cypress.spec.js
@@ -1,0 +1,21 @@
+const Timeouts = require('../../../platform/testing/e2e/timeouts');
+// const E2eHelpers = require('../../../platform/testing/e2e/helpers');
+const manifest = require('../manifest.json');
+const environments = require('../../../site/constants/environments');
+
+describe('Login Page', () => {
+  it('Loads login page', () => {
+    if (
+      !(
+        manifest.e2eTestsDisabled &&
+        process.env.BUILDTYPE !== environments.LOCALHOST
+      )
+    ) {
+      cy.visit('/login');
+      cy.get('body').should('be.visible', { timeout: Timeouts.normal });
+      cy.injectAxeThenAxeCheck();
+    }
+  });
+});
+
+// TODO: Remove this when CI builds temporary landing pages to run e2e tests


### PR DESCRIPTION
## Description
Rewrite the login page test in cypress.  The test will visit the login page and verify the page loads, before running an axe check on the page.

## Testing done

Tested in Chrome to ensure that the conditional works with the current configuration.

## Screenshots
Test is properly skipping as the manifest has e2e tests disabled.

![image](https://user-images.githubusercontent.com/34250637/121224905-fea68280-c856-11eb-8d0f-301730fec3ec.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
