### PR TITLE
526|508: Add aria-describedby to wizard

### DIFF
--- a/src/applications/disability-benefits/wizard/pages/appeals.jsx
+++ b/src/applications/disability-benefits/wizard/pages/appeals.jsx
@@ -21,23 +21,26 @@ const options = [
 ];
 
 const AppealsPage = ({ setPageState, state = {} }) => (
-  <RadioButtons
-    name={`${pageNames.appeals}-option`}
-    label={label}
-    id={`${pageNames.appeals}-option`}
-    options={options}
-    onValueChange={({ value }) => {
-      recordEvent({
-        event: 'howToWizard-formChange',
-        'form-field-type': 'form-radio-buttons',
-        'form-field-label': label,
-        'form-field-value':
-          value === pageNames.fileClaim ? 'new-worse' : 'disagreeing',
-      });
-      setPageState({ selected: value }, value);
-    }}
-    value={{ value: state.selected }}
-  />
+  <div id={pageNames.appeals} className="vads-u-margin-top--2">
+    <RadioButtons
+      name={`${pageNames.appeals}-option`}
+      label={label}
+      id={`${pageNames.appeals}-option`}
+      options={options}
+      onValueChange={({ value }) => {
+        recordEvent({
+          event: 'howToWizard-formChange',
+          'form-field-type': 'form-radio-buttons',
+          'form-field-label': label,
+          'form-field-value':
+            value === pageNames.fileClaim ? 'new-worse' : 'disagreeing',
+        });
+        setPageState({ selected: value }, value);
+      }}
+      value={{ value: state.selected }}
+      ariaDescribedby={[pageNames.fileClaim, pageNames.disagreeFileClaim]}
+    />
+  </div>
 );
 
 export default {

--- a/src/applications/disability-benefits/wizard/pages/bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/bdd.jsx
@@ -87,7 +87,7 @@ const isDateInFuture = date => date?.diff(moment()) > 0;
 const isDateLessThanMax = date => date?.isBefore(maxDate);
 
 const BDDPage = ({ setPageState, state = defaultState }) => {
-  const [isNotEligible, setIsNotEligible] = useState(false);
+  const [ariaDescribedby, setAriaDescribedby] = useState('');
 
   const onChange = pageState => {
     saveDischargeDate();
@@ -96,7 +96,12 @@ const BDDPage = ({ setPageState, state = defaultState }) => {
       isDateInFuture(date) && isDateLessThanMax(date)
         ? findNextPage(pageState)
         : null;
+
+    // invalid date & page
+    setPageState(pageState, date && value === null ? 1 : value);
     if (date && value) {
+      // only set when there's a valid date
+      setAriaDescribedby(value);
       recordEvent({
         event: 'howToWizard-formChange',
         // Date component wrapper class name
@@ -104,14 +109,13 @@ const BDDPage = ({ setPageState, state = defaultState }) => {
         'form-field-label': label,
         'form-field-value': date.format('YYYY-MM-DD'),
       });
+    } else {
+      setAriaDescribedby('');
     }
-    // invalid date & page
-    setPageState(pageState, date && value === null ? 1 : value);
-    setIsNotEligible(value === pageNames.unableToFileBDD);
   };
 
   return (
-    <div className="clearfix">
+    <div id={pageNames.bdd} className="clearfix vads-u-margin-top--2">
       <Date
         label={label}
         onValueChange={onChange}
@@ -121,7 +125,7 @@ const BDDPage = ({ setPageState, state = defaultState }) => {
           valid: isDateInFuture(getDate(state)),
           message: 'Your separation date must be in the future',
         }}
-        aria-describedby={isNotEligible ? 'not-eligible-for-bdd' : ''}
+        ariaDescribedby={ariaDescribedby}
       />
     </div>
   );

--- a/src/applications/disability-benefits/wizard/pages/disagree-file-claim.jsx
+++ b/src/applications/disability-benefits/wizard/pages/disagree-file-claim.jsx
@@ -13,8 +13,8 @@ const DisagreeFileClaimPage = () => {
   });
   return (
     <div
+      id={pageNames.disagreeFileClaim}
       className="usa-alert usa-alert-info background-color-only vads-u-padding--2 vads-u-margin-top--2"
-      aria-live="polite"
     >
       <span className="sr-only">Info: </span>
       <p className="vads-u-margin-top--0">

--- a/src/applications/disability-benefits/wizard/pages/file-bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-bdd.jsx
@@ -32,8 +32,8 @@ const FileBDDClaim = ({ getPageStateFromPageName, setWizardStatus }) => {
 
   return (
     <div
+      id={pageNames.fileBDD}
       className="usa-alert usa-alert-info background-color-only vads-u-padding--2 vads-u-margin-top--2"
-      aria-live="polite"
     >
       <span className="sr-only">Info: </span>
       {daysRemainingToFileBDD < 0 ? null : (

--- a/src/applications/disability-benefits/wizard/pages/file-bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-bdd.jsx
@@ -29,6 +29,7 @@ const FileBDDClaim = ({ getPageStateFromPageName, setWizardStatus }) => {
   const dateOfLastBDDEligibility = moment()
     .add(daysRemainingToFileBDD, 'days')
     .format('MMMM D, YYYY');
+  const daysLeft = `day${daysRemainingToFileBDD > 1 ? 's' : ''} left`;
 
   return (
     <div
@@ -49,13 +50,13 @@ const FileBDDClaim = ({ getPageStateFromPageName, setWizardStatus }) => {
               </>
             ) : (
               <>
-                You have <b>{daysRemainingToFileBDD}</b> day(s) left
+                You have <b>{daysRemainingToFileBDD}</b> {daysLeft}
               </>
             )}{' '}
             to file a BDD claim. You have until{' '}
             <strong>
-              {isLastDayToFileBDD ? '' : dateOfLastBDDEligibility}
-              {' at 11:59 p.m. CST'}
+              {isLastDayToFileBDD ? '' : `${dateOfLastBDDEligibility} at `}
+              {' 11:59 p.m. CST'}
             </strong>{' '}
             to complete and submit the form.
           </p>

--- a/src/applications/disability-benefits/wizard/pages/file-claim-early.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-claim-early.jsx
@@ -10,7 +10,10 @@ const FileClaimPage = ({ setWizardStatus }) => {
   const linkText = 'Learn about other ways you can file a disability claim';
 
   return (
-    <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
+    <div
+      id={pageNames.fileClaimEarly}
+      className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2"
+    >
       <p className="vads-u-margin-top--0">
         Based on your separation date, you’ll file for disability benefits using{' '}
         <strong>VA Form 21-526EZ</strong>.

--- a/src/applications/disability-benefits/wizard/pages/file-claim.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-claim.jsx
@@ -10,7 +10,10 @@ const FileClaimPage = ({ setWizardStatus }) => {
   const linkText = 'Learn about other ways you can file a disability claim';
 
   return (
-    <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
+    <div
+      id={pageNames.fileClaim}
+      className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2"
+    >
       <p className="vads-u-margin-top--0">
         Based on your responses, you’ll file for disability benefits using{' '}
         <strong>VA Form 21-526EZ</strong>.

--- a/src/applications/disability-benefits/wizard/pages/start.jsx
+++ b/src/applications/disability-benefits/wizard/pages/start.jsx
@@ -28,6 +28,7 @@ const StartPage = ({ setPageState, state = {} }) => (
       setPageState({ selected: value }, value);
     }}
     value={{ value: state.selected }}
+    ariaDescribedby={[pageNames.bdd, pageNames.appeals]}
   />
 );
 

--- a/src/applications/disability-benefits/wizard/pages/unable-to-file-bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/unable-to-file-bdd.jsx
@@ -32,7 +32,7 @@ const UnableToFileBDDPage = ({ getPageStateFromPageName }) => {
   });
   return (
     <div
-      id="not-eligible-for-bdd"
+      id={pageNames.unableToFileBDD}
       className="usa-alert usa-alert-info background-color-only vads-u-padding--2 vads-u-margin-top--2"
     >
       <div id="not-eligbile-details" aria-live="polite">


### PR DESCRIPTION
## Description

Form 526's wizard was not reading out new content after a selection was made. After enhancements made to the specific components in the component library, we can now add an `aria-describedby` which targets the newly added wizard content.

Additional, made some minor content tweaks to improve the grammar.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/22612

## Testing done

Manually with Voiceover

## Screenshots

<details><summary>Example of added <code>aria-describedby</code> with target ID</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-06-09 at 10 13 28 AM](https://user-images.githubusercontent.com/136959/121381927-c614b080-c90b-11eb-8333-ea39059acd4b.png)</details>


## Acceptance criteria
- [x] Screen reader includes error messages and newly added content within 526's wizard

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
