### PR TITLE
[23008]: Example fix for unit test 404

### DIFF
--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.video.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.video.unit.spec.jsx
@@ -934,6 +934,27 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
         isHomepageRefresh: true,
       });
 
+      const facility = {
+        id: 'vha_442',
+        attributes: {
+          ...getVAFacilityMock().attributes,
+          uniqueId: '442',
+          name: 'Cheyenne VA Medical Center',
+          address: {
+            physical: {
+              zip: '82001-5356',
+              city: 'Cheyenne',
+              state: 'WY',
+              address1: '2360 East Pershing Boulevard',
+            },
+          },
+          phone: {
+            main: '307-778-7550',
+          },
+        },
+      };
+      mockFacilitiesFetch('vha_442', [facility]);
+
       const screen = renderWithStoreAndRouter(
         <AppointmentList featureHomepageRefresh />,
         {


### PR DESCRIPTION
Add 'mockFacilitiesFetch' and facility data to 'should verify Video Connect at home calendar ics file format'

## Description
We are in the process of cleaning up unit test console output and one of the problematic areas are 404 error messages during unit tests. This is mainly caused by failing to mock endpoints during specific tests. I am including a single example for how to update the tests accordingly. This will vary by application.

https://app.zenhub.com/workspaces/vsp---frontend-tools-5fc9325744944e0015ed1861/issues/department-of-veterans-affairs/va.gov-team/23008

## Testing done
- Ran the unit test file locally

## Acceptance criteria
- [x] The 'should verify Video Connect at home calendar ics file format' unit test no longer throws a 404

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
