### PR TITLE
Make x-padding consistent across My VA 2.0 and Profile

### DIFF
--- a/src/applications/personalization/dashboard-2/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard-2/components/Dashboard.jsx
@@ -161,7 +161,7 @@ const Dashboard = ({
                 />
               </div>
             )}
-            <div className="vads-l-grid-container vads-u-padding-bottom--3 medium-screen:vads-u-padding-x--2 medium-screen:vads-u-padding-bottom--4">
+            <div className="vads-l-grid-container vads-u-padding-x--1 vads-u-padding-bottom--3 medium-screen:vads-u-padding-x--2 medium-screen:vads-u-padding-bottom--4">
               <Breadcrumbs className="vads-u-padding-x--0 vads-u-padding-y--1p5 medium-screen:vads-u-padding-y--0">
                 <a href="/" key="home">
                   Home

--- a/src/applications/personalization/dashboard-2/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard-2/components/Dashboard.jsx
@@ -166,9 +166,7 @@ const Dashboard = ({
                 <a href="/" key="home">
                   Home
                 </a>
-                <span className="vads-u-color--black" key="dashboard">
-                  <strong>My VA</strong>
-                </span>
+                <a href="/my-va">My VA</a>
               </Breadcrumbs>
 
               <DashboardHeader />

--- a/src/applications/personalization/profile/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile/components/ProfileWrapper.jsx
@@ -71,8 +71,11 @@ const ProfileWrapper = ({
         )}
 
       {/* Breadcrumbs */}
-      <div data-testid="breadcrumbs">
-        <Breadcrumbs className="vads-u-padding-x--1 vads-u-padding-y--1p5 medium-screen:vads-u-padding-y--0">
+      <div
+        data-testid="breadcrumbs"
+        className="vads-l-grid-container vads-u-padding-x--0"
+      >
+        <Breadcrumbs className="vads-u-padding-x--1 vads-u-padding-y--1p5 medium-screen:vads-u-padding-y--0 medium-screen:vads-u-padding-x--2">
           <a href="/">Home</a>
           <a href={activeLocation}>{`Profile: ${activeRouteName}`}</a>
         </Breadcrumbs>


### PR DESCRIPTION
## Description
- on mobile sizes, we reduced the x-padding on My VA 2.0
- on non-mobile sizes we shifted the Profile breadcrumbs to the right so they're left-aligned with the rest of the content

## Testing done
Locally in browser at multiple screen sizes

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs