### PR TITLE
HLR: remove feature flag

### DIFF
--- a/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
@@ -22,7 +22,7 @@ import {
   getContestableIssues as getContestableIssuesAction,
   FETCH_CONTESTABLE_ISSUES_INIT,
 } from '../actions';
-import { higherLevelReviewFeature, scrollToTop } from '../helpers';
+import { scrollToTop } from '../helpers';
 import {
   BASE_URL,
   SAVED_CLAIM_TYPE,
@@ -34,7 +34,6 @@ import {
 import {
   noContestableIssuesFound,
   showContestableIssueError,
-  showWorkInProgress,
   showHasEmptyAddress,
 } from '../content/contestableIssueAlerts';
 import WizardContainer from '../wizard/WizardContainer';
@@ -53,13 +52,9 @@ export class IntroductionPage extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const {
-      contestableIssues = {},
-      getContestableIssues,
-      allowHlr,
-    } = this.props;
+    const { contestableIssues = {}, getContestableIssues } = this.props;
     const wizardComplete = this.state.status === WIZARD_STATUS_COMPLETE;
-    if (allowHlr && wizardComplete) {
+    if (wizardComplete) {
       const benefitType = sessionStorage.getItem(SAVED_CLAIM_TYPE);
       if (!contestableIssues?.status) {
         getContestableIssues({ benefitType });
@@ -151,26 +146,15 @@ export class IntroductionPage extends React.Component {
   };
 
   render() {
-    const { allowHlr, user, hasEmptyAddress } = this.props;
+    const { user, hasEmptyAddress } = this.props;
     const callToActionContent = this.getCallToActionContent();
-    const showWizard = allowHlr && this.state.status !== WIZARD_STATUS_COMPLETE;
+    const showWizard = this.state.status !== WIZARD_STATUS_COMPLETE;
 
     // Change page title once wizard has closed to provide a Veteran using a
     // screenreader some indication that the content has changed
     const pageTitle = `Request a Higher-Level Review${
       showWizard ? '' : ' with VA Form 20-0996'
     }`;
-
-    // check feature flag
-    if (!allowHlr) {
-      return (
-        <article className="schemaform-intro">
-          <FormTitle title={pageTitle} />
-          <p>Equal to VA Form 20-0996 (Higher-Level Review).</p>
-          {showWorkInProgress}
-        </article>
-      );
-    }
 
     // check if user has address
     if (user?.login?.currentlyLoggedIn && hasEmptyAddress) {
@@ -318,7 +302,6 @@ function mapStateToProps(state) {
     form,
     user,
     contestableIssues,
-    allowHlr: higherLevelReviewFeature(state),
     hasEmptyAddress: isEmptyAddress(
       selectVAPContactInfoField(state, FIELD_NAMES.MAILING_ADDRESS),
     ),

--- a/src/applications/disability-benefits/996/content/contestableIssueAlerts.jsx
+++ b/src/applications/disability-benefits/996/content/contestableIssueAlerts.jsx
@@ -7,7 +7,7 @@ import Telephone, {
 import recordEvent from 'platform/monitoring/record-event';
 
 import { disabilitiesExplanationAlert } from './contestedIssues';
-import { PROFILE_URL, HLR_INFO_URL } from '../constants';
+import { PROFILE_URL } from '../constants';
 
 const noIssuesMessage = (
   <>
@@ -70,29 +70,6 @@ export const showContestableIssueError = ({ error, status } = {}, delay) => {
   }
   return <AlertBox status="error" headline={headline} content={content} />;
 };
-
-export const showWorkInProgress = (
-  <AlertBox
-    status="info"
-    headline="We’re still working on this feature"
-    content={
-      <>
-        <p>
-          We’re rolling out the Higher-Level Review form in stages. It’s not
-          quite ready yet. Please check back again soon.
-        </p>
-        <p>
-          <a
-            href={HLR_INFO_URL}
-            className="u-vads-display--block u-vads-margin-top--2"
-          >
-            Return to Higher-Level Review information page
-          </a>
-        </p>
-      </>
-    }
-  />
-);
 
 export const showHasEmptyAddress = (
   <AlertBox

--- a/src/applications/disability-benefits/996/helpers.js
+++ b/src/applications/disability-benefits/996/helpers.js
@@ -1,13 +1,6 @@
 import Scroll from 'react-scroll';
 import moment from 'moment';
 
-// import the toggleValues helper
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
-
-export const higherLevelReviewFeature = state =>
-  toggleValues(state)[FEATURE_FLAG_NAMES.form996HigherLevelReview];
-
 // testing
 export const $ = (selector, DOM) => DOM.querySelector(selector);
 export const $$ = (selector, DOM) => DOM.querySelectorAll(selector);

--- a/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
@@ -63,17 +63,6 @@ describe('IntroductionPage', () => {
     sessionStorage.removeItem(WIZARD_STATUS);
   });
 
-  it('should render a work in progress message', () => {
-    const tree = shallow(
-      <IntroductionPage {...defaultProps} allowHlr={false} />,
-    );
-
-    const AlertBox = tree.find('AlertBox');
-    expect(AlertBox.length).to.equal(1);
-    expect(AlertBox.props().headline).to.contain('working on this feature');
-    tree.unmount();
-  });
-
   it('should show has empty address message', () => {
     const user = {
       login: {

--- a/src/applications/disability-benefits/996/tests/fixtures/mocks/feature-toggles.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/mocks/feature-toggles.json
@@ -1,9 +1,0 @@
-{
-  "data": {
-    "type": "feature_toggles",
-    "features": [{
-      "name": "form996HigherLevelReview",
-      "value": true
-    }]
-  }
-}

--- a/src/applications/disability-benefits/996/tests/hlr-wizard.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr-wizard.cypress.spec.js
@@ -1,4 +1,3 @@
-import mockFeatureToggles from './fixtures/mocks/feature-toggles.json';
 import {
   BASE_URL,
   WIZARD_STATUS,
@@ -39,7 +38,6 @@ const checkOpt = {
 describe('HLR wizard', () => {
   beforeEach(() => {
     window.dataLayer = [];
-    cy.intercept('GET', '/v0/feature_toggles?*', mockFeatureToggles);
     cy.intercept('GET', `/v0${CONTESTABLE_ISSUES_API}*`, []);
     sessionStorage.removeItem(WIZARD_STATUS);
     cy.visit(BASE_URL);

--- a/src/applications/disability-benefits/996/tests/hlr-wizard.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr-wizard.cypress.spec.js
@@ -38,6 +38,7 @@ const checkOpt = {
 describe('HLR wizard', () => {
   beforeEach(() => {
     window.dataLayer = [];
+    cy.intercept('GET', '/v0/feature_toggles?*', { data: { features: [] } });
     cy.intercept('GET', `/v0${CONTESTABLE_ISSUES_API}*`, []);
     sessionStorage.removeItem(WIZARD_STATUS);
     cy.visit(BASE_URL);

--- a/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
@@ -6,7 +6,6 @@ import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-test
 import formConfig from '../config/form';
 import manifest from '../manifest.json';
 import { mockContestableIssues } from './hlr.cypress.helpers';
-import mockFeatureToggles from './fixtures/mocks/feature-toggles.json';
 import mockInProgress from './fixtures/mocks/in-progress-forms.json';
 import mockSubmit from './fixtures/mocks/application-submit.json';
 import mockUser from './fixtures/mocks/user.json';
@@ -42,8 +41,6 @@ const testConfig = createTestConfig(
       window.sessionStorage.removeItem(WIZARD_STATUS);
 
       cy.login(mockUser);
-
-      cy.intercept('GET', '/v0/feature_toggles?*', mockFeatureToggles);
 
       cy.intercept(
         'GET',

--- a/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
@@ -42,6 +42,8 @@ const testConfig = createTestConfig(
 
       cy.login(mockUser);
 
+      cy.intercept('GET', '/v0/feature_toggles?*', { data: { features: [] } });
+
       cy.intercept(
         'GET',
         `/v0${CONTESTABLE_ISSUES_API}compensation`,

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -33,7 +33,6 @@ export default Object.freeze({
   form10182Nod: 'form10182_nod',
   form526BDD: 'form526BenefitsDeliveryAtDischarge',
   form526OriginalClaims: 'form526OriginalClaims',
-  form996HigherLevelReview: 'form996HigherLevelReview',
   gibctEybBottomSheet: 'gibctEybBottomSheet',
   gibctSchoolRatings: 'gibctSchoolRatings',
   languageSupport: 'language_support',


### PR DESCRIPTION
## Description

The Higher-Level Review form 20-0996 has been 100% enabled in production and no longer needs the feature flag.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/25829

## Testing done

Updated unit tests & Cypress

## Screenshots

N/A

## Acceptance criteria
- [x] Removed HLR feature flag
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
