### PR TITLE
Elevate LOADING_STATES constants to personalization/common

### DIFF
--- a/src/applications/personalization/common/constants.js
+++ b/src/applications/personalization/common/constants.js
@@ -1,0 +1,6 @@
+export const LOADING_STATES = Object.freeze({
+  idle: 'idle',
+  pending: 'pending',
+  error: 'error',
+  loaded: 'loaded',
+});

--- a/src/applications/personalization/preferences/constants.js
+++ b/src/applications/personalization/preferences/constants.js
@@ -1,9 +1,5 @@
+export { LOADING_STATES } from '../common/constants';
+
 export const PREFERENCE_CODES = Object.freeze({
   benefits: 'benefits',
-});
-
-export const LOADING_STATES = Object.freeze({
-  pending: 'pending',
-  error: 'error',
-  loaded: 'loaded',
 });


### PR DESCRIPTION
## Description
I want to use this collection of constants in some new Redux actions/reducers. This pulls them up into common folder so it can be shared across all apps in the `personalization` folder

## Testing done
Existing tests pass

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs