### PR TITLE
BDD: Show separation location for qualified activated reservists

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -213,13 +213,6 @@ const formConfig = {
               state.form.data?.serviceInformation?.servicePeriods || [],
           }),
         },
-        separationLocation: {
-          title: 'Separation location',
-          path: 'review-veteran-details/separation-location',
-          depends: showSeparationLocation,
-          uiSchema: separationLocation.uiSchema,
-          schema: separationLocation.schema,
-        },
         claimType: {
           title: 'Claim type',
           path: 'claim-type',
@@ -244,6 +237,13 @@ const formConfig = {
           depends: form => hasGuardOrReservePeriod(form.serviceInformation),
           uiSchema: federalOrders.uiSchema,
           schema: federalOrders.schema,
+        },
+        separationLocation: {
+          title: 'Separation location',
+          path: 'review-veteran-details/separation-location',
+          depends: showSeparationLocation,
+          uiSchema: separationLocation.uiSchema,
+          schema: separationLocation.schema,
         },
         separationPay: {
           title: 'Separation or severance pay',

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -213,14 +213,6 @@ const formConfig = {
               state.form.data?.serviceInformation?.servicePeriods || [],
           }),
         },
-        claimType: {
-          title: 'Claim type',
-          path: 'claim-type',
-          depends: formData => hasRatedDisabilities(formData),
-          uiSchema: claimType.uiSchema,
-          schema: claimType.schema,
-          onContinue: captureEvents.claimType,
-        },
         reservesNationalGuardService: {
           title: 'Reserves and National Guard service',
           path:
@@ -274,6 +266,14 @@ const formConfig = {
     disabilities: {
       title: 'Disabilities', // this probably needs to change
       pages: {
+        claimType: {
+          title: 'Claim type',
+          path: 'claim-type',
+          depends: formData => hasRatedDisabilities(formData),
+          uiSchema: claimType.uiSchema,
+          schema: claimType.schema,
+          onContinue: captureEvents.claimType,
+        },
         disabilitiesOrientation: {
           title: '',
           path: DISABILITY_SHARED_CONFIG.orientation.path,

--- a/src/applications/disability-benefits/all-claims/tests/migrations/migrations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/migrations/migrations.unit.spec.js
@@ -38,7 +38,7 @@ describe('526 v2 migrations', () => {
     });
     // Sanity check
     it('/claim-type should be a valid url', () => {
-      expect(formConfig.chapters.veteranDetails.pages.claimType.path).to.equal(
+      expect(formConfig.chapters.disabilities.pages.claimType.path).to.equal(
         'claim-type',
       );
     });

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -44,6 +44,7 @@ import {
   show526Wizard,
   isUndefined,
   isDisabilityPtsd,
+  showSeparationLocation,
 } from '../utils';
 
 describe('526 helpers', () => {
@@ -1114,6 +1115,112 @@ describe('526 v2 depends functions', () => {
       expect(check('a', '2020-01-31', '2020-XX-14')).to.be.false;
       expect(check('a', '2020-01-31', '2020-02-XX')).to.be.false;
       expect(check('a', '2020-02-14', '2020-01-31')).to.be.false;
+    });
+  });
+
+  describe('showSeparationLocation', () => {
+    const getDays = days =>
+      moment()
+        .add(days, 'days')
+        .format('YYYY-MM-DD');
+    const getFormData = (activeDate, reserveDate) => ({
+      serviceInformation: {
+        servicePeriods: [{ dateRange: { to: activeDate } }],
+        reservesNationalGuardService: {
+          title10Activation: {
+            anticipatedSeparationDate: reserveDate,
+          },
+        },
+      },
+    });
+    it('should return false for empty values', () => {
+      expect(showSeparationLocation({})).to.be.false;
+      expect(showSeparationLocation({ serviceInformation: {} })).to.be.false;
+      expect(
+        showSeparationLocation({ serviceInformation: { servicePeriods: '' } }),
+      ).to.be.false;
+      expect(
+        showSeparationLocation({
+          serviceInformation: {
+            servicePeriods: [],
+            reservesNationalGuardService: {},
+          },
+        }),
+      ).to.be.false;
+      expect(
+        showSeparationLocation({
+          serviceInformation: {
+            servicePeriods: '',
+            reservesNationalGuardService: {
+              title10Activation: {},
+            },
+          },
+        }),
+      ).to.be.false;
+      expect(showSeparationLocation(getFormData())).to.be.false;
+    });
+
+    const days190 = getDays(190);
+    it('should return false for active duty release outside of the range', () => {
+      expect(showSeparationLocation(getFormData(getDays(-1), ''))).to.be.false;
+      expect(showSeparationLocation(getFormData(getDays(), ''))).to.be.false;
+      expect(showSeparationLocation(getFormData(days190, ''))).to.be.false;
+    });
+    it('should return false for active reserve release outside of the range', () => {
+      expect(showSeparationLocation(getFormData('', getDays(-1)))).to.be.false;
+      expect(showSeparationLocation(getFormData('', getDays()))).to.be.false;
+      expect(showSeparationLocation(getFormData('', days190))).to.be.false;
+    });
+
+    const days1 = getDays(1);
+    const days90 = getDays(90);
+    const days180 = getDays(180);
+    it('should return true for active duty release inside of the range', () => {
+      expect(showSeparationLocation(getFormData(days1, ''))).to.be.true;
+      expect(showSeparationLocation(getFormData(days90, ''))).to.be.true;
+      expect(showSeparationLocation(getFormData(days180, ''))).to.be.true;
+    });
+
+    it('should return true for active reserve release inside of the range', () => {
+      expect(showSeparationLocation(getFormData('', days1))).to.be.true;
+      expect(showSeparationLocation(getFormData('', days90))).to.be.true;
+      expect(showSeparationLocation(getFormData('', days180))).to.be.true;
+    });
+    it('should return true for any release inside of the range', () => {
+      expect(showSeparationLocation(getFormData(days1, days1))).to.be.true;
+      expect(showSeparationLocation(getFormData(days1, days90))).to.be.true;
+      expect(showSeparationLocation(getFormData(days1, days180))).to.be.true;
+      expect(showSeparationLocation(getFormData(days90, days1))).to.be.true;
+      expect(showSeparationLocation(getFormData(days90, days90))).to.be.true;
+      expect(showSeparationLocation(getFormData(days90, days180))).to.be.true;
+      expect(showSeparationLocation(getFormData(days180, days1))).to.be.true;
+      expect(showSeparationLocation(getFormData(days180, days90))).to.be.true;
+      expect(showSeparationLocation(getFormData(days180, days180))).to.be.true;
+    });
+
+    it('should return true after finding the most recent service period', () => {
+      const bddData = {
+        serviceInformation: {
+          servicePeriods: [
+            { dateRange: { to: '2000-01-01' } },
+            { dateRange: { to: days90 } },
+            { dateRange: { to: '2020-01-01' } },
+          ],
+        },
+      };
+      expect(showSeparationLocation(bddData)).to.be.true;
+    });
+    it('should return false after finding the most recent service period', () => {
+      const nonBddData = {
+        serviceInformation: {
+          servicePeriods: [
+            { dateRange: { to: '2000-01-01' } },
+            { dateRange: { to: days190 } },
+            { dateRange: { to: '2020-01-01' } },
+          ],
+        },
+      };
+      expect(showSeparationLocation(nonBddData)).to.be.false;
     });
   });
 });


### PR DESCRIPTION
## Description

Benefits Delivery at Discharge qualified reservists that have been title 10 activated are not being shown the separation location question, and EVSS is rejecting future separation dates without a separation location. This PR updates the flow:
- Moves separation location question after federal orders question
- Updates separation location logic - shows question for activated reservists with a future separation date < 180 days
- Moves claim type (checkboxes for existing or adding new issues) to step 2 after the separation location question, immediately before the issues pages (last page shown in the screenshot)

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/25888
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/22582

## Testing done

Added unit tests for separation location logic

## Screenshots

<details><summary>Updated flow </summary>

<!-- leave a blank line above -->
![bdd](https://user-images.githubusercontent.com/136959/121561327-017faf80-c9de-11eb-8e66-535df0f6da12.gif)</details>

## Acceptance criteria
- [x] Separation location page shows up for qualified activated reservists
- [x] Updated form flow

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
