### PR TITLE
Updated heading levels according to 508 feedback

### DIFF
--- a/src/applications/vre/28-8832/containers/IntroductionPage.jsx
+++ b/src/applications/vre/28-8832/containers/IntroductionPage.jsx
@@ -31,16 +31,17 @@ const IntroductionPage = props => {
         pageList={props.route.pageList}
         downtime={props.route.formConfig.downtime}
         startText="Apply for career planning and guidance"
+        headingLevel={2}
       >
         Please complete the 28-8832 form to apply for Planning and career
         guidance.
       </SaveInProgressIntro>
-      <h4>Follow the steps below to apply for career planning and guidance.</h4>
+      <h2>Follow the steps below to apply for career planning and guidance.</h2>
       <div className="process schemaform-process">
         <ol>
           <li className="process-step list-one">
-            <h5>Prepare</h5>
-            <h6>To fill out this application, you’ll need your:</h6>
+            <h3>Prepare</h3>
+            <h4>To fill out this application, you’ll need your:</h4>
             <ul>
               <li>Social Security number</li>
               <li>Date of birth</li>
@@ -59,7 +60,7 @@ const IntroductionPage = props => {
             </p>
           </li>
           <li className="process-step list-two">
-            <h5>Apply</h5>
+            <h3>Apply</h3>
             <p>Complete this career planning and guidance form.</p>
             <p>
               After submitting your application, you’ll get a confirmation
@@ -68,14 +69,14 @@ const IntroductionPage = props => {
             </p>
           </li>
           <li className="process-step list-three">
-            <h5>VA Review</h5>
+            <h3>VA Review</h3>
             <p>
               We process applications in the order we receive them. We may
               contact you if we have questions or need more information.
             </p>
           </li>
           <li className="process-step list-four">
-            <h5>Decision</h5>
+            <h3>Decision</h3>
             <p>
               If you’re eligible for career planning and guidance benefits,
               we’ll invite you to an orientation session at your nearest VA
@@ -112,10 +113,10 @@ const IntroductionPage = props => {
       <AlertBox
         content={
           <>
-            <h5 className="vads-u-font-size--h3 vads-u-margin-top--0">
+            <h2 className="vads-u-font-size--h3 vads-u-margin-top--0">
               Do you have a service-connected disability or pre-discharge
               disability rating?
-            </h5>
+            </h2>
             <p>
               If you have a service-connected or pre-discharge disability
               rating, you may be eligible for Chapter 31 Veteran Readiness and


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/19755)

During our 508 review for Chapter 36 it was discovered that the heading levels needed to be updated on the intro page as they did not convey the correct heirarchy of the information on the page. This required us to make an update to the `<SaveInProgressIntro />` component which we did in [a separate PR](https://github.com/department-of-veterans-affairs/vets-website/pull/17282). This PR uses the prop for the `<SaveInProgressIntro />` component to update that as well as updates the other headings on the page to match the feedback we recieved.

## Screenshots

![screencapture-localhost-3001-careers-employment-education-and-career-counseling-apply-career-guidance-form-28-8832-introduction-2021-06-10-10_06_37](https://user-images.githubusercontent.com/1899695/121568405-85cd3500-c9d4-11eb-8bf8-80f9f691d7a4.png)


## Acceptance criteria
- [x] Headers are updated
- [x] A PR has been requested for merging

