### PR TITLE
CVE-2020-7660 remediation

### DIFF
--- a/package.json
+++ b/package.json
@@ -319,6 +319,7 @@
     "redux-thunk": "^2.3.0",
     "regenerator-runtime": "^0.13.7",
     "reselect": "^2.5.4",
+    "serialize-javascript": "^3.1.0",
     "styled-components": "^5.2.3",
     "url-search-params": "^1.1.0",
     "url-search-params-polyfill": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17511,7 +17511,7 @@ serialize-javascript@^2.1.2:
 
 serialize-javascript@^3.1.0:
   version "3.1.0"
-  resolved "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-3.1.0.tgz#8bf3a9170712664ef2561b44b691eafe399214ea"
   integrity sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==
   dependencies:
     randombytes "^2.1.0"


### PR DESCRIPTION
Patch for https://github.com/department-of-veterans-affairs/vets-website/security/dependabot/yarn.lock/serialize-javascript/open