### PR TITLE
NOD: sort issues

### DIFF
--- a/src/applications/appeals/10182/components/ContactInformation.jsx
+++ b/src/applications/appeals/10182/components/ContactInformation.jsx
@@ -15,7 +15,7 @@ export const ContactInfoDescription = ({ veteran }) => {
   const { email, phone, address } = veteran || {};
   const { street, cityStateZip, country } = formatAddress(address || {});
   // phone.phoneType is in all caps
-  const phoneType = titleCase((phone.phoneType || '').toLowerCase());
+  const phoneType = titleCase((phone?.phoneType || '').toLowerCase());
 
   return (
     <>

--- a/src/applications/appeals/10182/containers/FormApp.jsx
+++ b/src/applications/appeals/10182/containers/FormApp.jsx
@@ -12,6 +12,7 @@ import {
   getSelected,
   getIssueName,
   copyAreaOfDisagreementOptions,
+  sortContestableIssues,
 } from '../utils/helpers';
 
 import { showWorkInProgress } from '../content/WorkInProgressMessage';
@@ -58,7 +59,7 @@ export const FormApp = ({
               phone,
               email: email?.emailAddress,
             },
-            contestableIssues: contestableIssues?.issues || [],
+            contestableIssues: sortContestableIssues(contestableIssues?.issues),
           });
         } else if (
           areaOfDisagreement?.length !== formData.areaOfDisagreement?.length ||

--- a/src/applications/appeals/10182/sass/10182-nod.scss
+++ b/src/applications/appeals/10182/sass/10182-nod.scss
@@ -79,6 +79,7 @@ dl.review {
     margin-inline-start: 0; /* override user agent */
     text-align: left;
     margin: 3rem 3.5rem 0 5rem;
+    width: 100%;
   }
 
   dd.widget-content.widget-edit {
@@ -123,7 +124,7 @@ dl.review {
  * https://github.com/department-of-veterans-affairs/va.gov-team/issues/25108
  */
  _:-ms-fullscreen, :root dl.review dd.widget-content.widget-edit .widget-content-wrap {
-  width: calc(100% - 125px); /* 125px ~= width of the edit button x2 */
+  width: calc(100% - 175px); /* 175px ~= width of the edit button x2.5 */
 }
 /* IE11 fix legend not wrapping on small screens */
 legend.schemaform-block-title {

--- a/src/applications/appeals/10182/tests/containers/FormApp.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/containers/FormApp.unit.spec.jsx
@@ -167,11 +167,22 @@ describe('FormApp', () => {
           type: 'contestableIssue',
           attributes: {
             ratingIssueSubjectText: 'tinnitus',
-            approxDecisionDate: '1900-01-01',
+            approxDecisionDate: '2020-01-01',
             decisionIssueId: 1,
             ratingIssueReferenceId: '2',
             ratingDecisionReferenceId: '3',
             ratingIssuePercentNumber: '10',
+          },
+        },
+        {
+          type: 'contestableIssue',
+          attributes: {
+            ratingIssueSubjectText: 'Sore foot',
+            approxDecisionDate: '2021-01-01',
+            decisionIssueId: 2,
+            ratingIssueReferenceId: '3',
+            ratingDecisionReferenceId: '2',
+            ratingIssuePercentNumber: '1',
           },
         },
       ],
@@ -197,6 +208,10 @@ describe('FormApp', () => {
     };
     expect(formData.veteran).to.deep.equal(result);
     expect(formData.contestableIssues).to.deep.equal(contestableIssues.issues);
+    // check sorted
+    expect(
+      formData.contestableIssues[0].attributes.approxDecisionDate,
+    ).to.equal('2021-01-01');
 
     tree.unmount();
   });

--- a/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
@@ -12,6 +12,7 @@ import {
   setInitialEditMode,
   issuesNeedUpdating,
   copyAreaOfDisagreementOptions,
+  sortContestableIssues,
 } from '../../utils/helpers';
 import { getDate } from '../../utils/dates';
 
@@ -303,5 +304,37 @@ describe('copyAreaOfDisagreementOptions', () => {
     expect(
       copyAreaOfDisagreementOptions([{ issue: 'test' }], result),
     ).to.deep.equal(result);
+  });
+});
+
+describe('sortContestableIssues', () => {
+  const getIssues = dates =>
+    dates.map(date => ({
+      attributes: { approxDecisionDate: date },
+    }));
+  const getDates = dates =>
+    dates.map(date => date.attributes.approxDecisionDate);
+
+  it('should return an empty array with undefined issues', () => {
+    expect(getDates(sortContestableIssues())).to.deep.equal([]);
+  });
+  it('should sort issues spanning months with newest date first', () => {
+    const dates = ['2020-02-01', '2020-03-01', '2020-01-01'];
+    const result = sortContestableIssues(getIssues(dates));
+    expect(getDates(result)).to.deep.equal([
+      '2020-03-01',
+      '2020-02-01',
+      '2020-01-01',
+    ]);
+  });
+  it('should sort issues spanning a year & months with newest date first', () => {
+    const dates = ['2021-01-31', '2020-12-01', '2021-02-02', '2021-02-01'];
+    const result = sortContestableIssues(getIssues(dates));
+    expect(getDates(result)).to.deep.equal([
+      '2021-02-02',
+      '2021-02-01',
+      '2021-01-31',
+      '2020-12-01',
+    ]);
   });
 });

--- a/src/applications/appeals/10182/utils/helpers.js
+++ b/src/applications/appeals/10182/utils/helpers.js
@@ -53,12 +53,30 @@ export const setInitialEditMode = (formData = []) =>
       !issue || !decisionDate || !isValidDate(decisionDate),
   );
 
+export const sortContestableIssues = contestableIssues => {
+  const regexDash = /-/g;
+  const getDate = entry =>
+    (entry.attributes?.approxDecisionDate || '').replace(regexDash, '');
+
+  return (contestableIssues || []).sort((a, b) => {
+    const dateA = getDate(a);
+    const dateB = getDate(b);
+    if (dateA === dateB) {
+      return 0;
+    }
+    // YYYYMMDD string comparisons will work in place of using moment
+    return dateA > dateB ? -1 : 1;
+  });
+};
+
 export const issuesNeedUpdating = (loadedIssues = [], existingIssues = []) => {
   if (loadedIssues.length !== existingIssues.length) {
     return true;
   }
-  return !loadedIssues.every(({ attributes }, index) => {
-    const existing = existingIssues[index]?.attributes || {};
+  // sort both arrays so we don't end up in an endless loop
+  const issues = sortContestableIssues(existingIssues);
+  return !sortContestableIssues(loadedIssues).every(({ attributes }, index) => {
+    const existing = issues[index]?.attributes || {};
     return (
       attributes.ratingIssueSubjectText === existing.ratingIssueSubjectText &&
       attributes.approxDecisionDate === existing.approxDecisionDate


### PR DESCRIPTION
## Description

This PR sorts the contestable issues with the most recent first to make it easier for Veteran's to find relevant issues. Especially repeated issues with different decision dates. This is sorted before stored in the form data to ensure that followup area of disagreement pages maintain the order.

Also fixed are a JS error that pops up when no phone number is defined (in testing) and issue card content alignment with certain data.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/25889
- https://github.com/department-of-veterans-affairs/vets-api-mockdata/pull/167

## Testing done

Updated unit tests
Tested CSS changes in IE11

## Screenshots

N/A (need mock data with different decision dates - see https://github.com/department-of-veterans-affairs/vets-api-mockdata/pull/167)

## Acceptance criteria
- [x] Eligible issue cards maintain decision dates in descending order

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
