### PR TITLE
feat(file upload): update file size, network and file type error messages

### DIFF
--- a/src/platform/forms-system/src/js/actions.js
+++ b/src/platform/forms-system/src/js/actions.js
@@ -234,7 +234,7 @@ export function uploadFile(
         name: file.name,
         errorMessage:
           'We couldn\u2019t upload your file because it\u2019s too big. ' +
-          `Please delete this file. Then upload a file that's ${fileSizeText} or less.`,
+          `Please delete this file. Then upload a file that\u2019s ${fileSizeText} or less.`,
       });
 
       onError();
@@ -242,9 +242,12 @@ export function uploadFile(
     }
 
     if (file.size < uiOptions.minSize) {
+      const fileSizeText = displayFileSize(uiOptions.minSize);
       onChange({
         name: file.name,
-        errorMessage: 'File is too small to be uploaded',
+        errorMessage:
+          'We couldn\u2019t upload your file because it\u2019s too small. ' +
+          `Please delete this file. Then upload a file that\u2019s ${fileSizeText} or more.`,
       });
 
       onError();
@@ -262,7 +265,7 @@ export function uploadFile(
         (accumulator, fileType, index, array) => {
           if (index === 0) return `.${fileType}`;
 
-          const seperator = index < array.length - 1 ? ', ' : ', or ';
+          const seperator = index < array.length - 1 ? ',' : ', or';
           return `${accumulator}${seperator} .${fileType}`;
         },
         '',
@@ -332,7 +335,8 @@ export function uploadFile(
     });
 
     req.addEventListener('error', () => {
-      const errorMessage = 'Network request failed';
+      const errorMessage =
+        'We\u2019re sorry. We had a connection problem. Please delete the file and try again.';
       if (password) {
         onChange({ name: file.name, errorMessage, password: file.password });
       } else {

--- a/src/platform/forms-system/src/js/actions.js
+++ b/src/platform/forms-system/src/js/actions.js
@@ -4,6 +4,7 @@ import { transformForSubmit } from './helpers';
 import recordEvent from 'platform/monitoring/record-event';
 import { timeFromNow } from './utilities/date';
 import localStorage from 'platform/utilities/storage/localStorage';
+import { displayFileSize } from 'platform/utilities/ui/index';
 
 export const SET_EDIT_MODE = 'SET_EDIT_MODE';
 export const SET_DATA = 'SET_DATA';
@@ -228,9 +229,12 @@ export function uploadFile(
       uiOptions.maxSize;
 
     if (file.size > maxSize) {
+      const fileSizeText = displayFileSize(maxSize);
       onChange({
         name: file.name,
-        errorMessage: 'File is too large to be uploaded',
+        errorMessage:
+          'We couldn\u2019t upload your file because it\u2019s too big. ' +
+          `Please delete this file. Then upload a file that's ${fileSizeText} or less.`,
       });
 
       onError();
@@ -254,9 +258,21 @@ export function uploadFile(
         file.name.toLowerCase().endsWith(fileType.toLowerCase()),
       )
     ) {
+      const allowedTypes = uiOptions.fileTypes.reduce(
+        (accumulator, fileType, index, array) => {
+          if (index === 0) return `.${fileType}`;
+
+          const seperator = index < array.length - 1 ? ', ' : ', or ';
+          return `${accumulator}${seperator} .${fileType}`;
+        },
+        '',
+      );
+
       onChange({
         name: file.name,
-        errorMessage: 'File is not one of the allowed types',
+        errorMessage:
+          'We couldn\u2019t upload your file because we can\u2019t accept this type ' +
+          `of file. Please delete the file. Then try again with a ${allowedTypes} file.`,
       });
 
       onError();

--- a/src/platform/forms-system/test/js/actions.unit.spec.js
+++ b/src/platform/forms-system/test/js/actions.unit.spec.js
@@ -321,7 +321,9 @@ describe('Schemaform actions:', () => {
         () => {
           expect(onChange.firstCall.args[0]).to.eql({
             name: 'jpg',
-            errorMessage: 'File is too large to be uploaded',
+            errorMessage:
+              'We couldn\u2019t upload your file because it\u2019s too big. ' +
+              `Please delete this file. Then upload a file that\u2019s 5B or less.`,
           });
           done();
         },
@@ -353,7 +355,9 @@ describe('Schemaform actions:', () => {
         () => {
           expect(onChange.firstCall.args[0]).to.eql({
             name: 'pdf',
-            errorMessage: 'File is too large to be uploaded',
+            errorMessage:
+              'We couldn\u2019t upload your file because it\u2019s too big. ' +
+              `Please delete this file. Then upload a file that\u2019s 5B or less.`,
           });
           done();
         },
@@ -385,7 +389,9 @@ describe('Schemaform actions:', () => {
         () => {
           expect(onChange.firstCall.args[0]).to.eql({
             name: 'jpg',
-            errorMessage: 'File is too small to be uploaded',
+            errorMessage:
+              'We couldn\u2019t upload your file because it\u2019s too small. ' +
+              `Please delete this file. Then upload a file that\u2019s 5B or more.`,
           });
           done();
         },
@@ -415,7 +421,42 @@ describe('Schemaform actions:', () => {
         onChange,
         () => {
           expect(onChange.firstCall.args[0]).to.eql({
-            errorMessage: 'File is not one of the allowed types',
+            errorMessage:
+              'We couldn’t upload your file because we can’t accept this type of file. ' +
+              'Please delete the file. Then try again with a .jpeg file.',
+            name: 'jpg',
+          });
+          done();
+        },
+      );
+      const dispatch = sinon.spy();
+      const getState = sinon.stub().returns({
+        form: {
+          data: {},
+        },
+      });
+
+      thunk(dispatch, getState);
+    });
+
+    it('should render wrong file type message with seperators', done => {
+      const onChange = sinon.spy();
+      const thunk = uploadFile(
+        {
+          name: 'jpg',
+          size: 5,
+        },
+        {
+          fileTypes: ['jpeg', 'pdf', 'img'],
+          maxSize: 5,
+        },
+        f => f,
+        onChange,
+        () => {
+          expect(onChange.firstCall.args[0]).to.eql({
+            errorMessage:
+              'We couldn’t upload your file because we can’t accept this type of file. ' +
+              'Please delete the file. Then try again with a .jpeg, .pdf, or .img file.',
             name: 'jpg',
           });
           done();
@@ -605,7 +646,8 @@ describe('Schemaform actions:', () => {
       });
       expect(onChange.secondCall.args[0]).to.eql({
         name: 'jpg',
-        errorMessage: 'Network request failed',
+        errorMessage:
+          'We’re sorry. We had a connection problem. Please delete the file and try again.',
       });
     });
     it('should set error if error message is bad', () => {


### PR DESCRIPTION
## Description
Update platform file upload component's error messages.

## Testing done
- [ ] manual
- [ ] unit

## Screenshots
![mult_error](https://user-images.githubusercontent.com/83595736/121927919-9dc2f280-cd0d-11eb-9f40-a7a21e37a33f.png)
![network_error](https://user-images.githubusercontent.com/83595736/121927953-a61b2d80-cd0d-11eb-94ae-074489836417.png)


## Acceptance criteria
- [ ] Update `Network request failed` 
to `We're sorry. We had a connection problem. Please delete the file and try again.`
- [ ] Update `File is too large to be uploaded`
to `We couldn't upload your file because it's too big. Please delete this file. Then upload a file that's {fileSize} or less.`
- [ ] Update `File is too small to be uploaded`
to `We couldn't upload your file because it's too small. Please delete this file. Then upload a file that's {fileSize} or more.`
- [ ] Update `File is not one of the allowed types`
to `We couldn't upload your file because we can't accept this type of file. Please delete the file. Then try again with a {fileType(s)} file.`

## Definition of done
- [ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/25405)
- [ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/25320)