### PR TITLE
Add aria-describedby option to TextWidget

### DIFF
--- a/src/platform/forms-system/src/js/widgets/TextWidget.jsx
+++ b/src/platform/forms-system/src/js/widgets/TextWidget.jsx
@@ -24,6 +24,7 @@ export default function TextWidget(props) {
     onChange: event =>
       props.onChange(event.target.value ? event.target.value : undefined),
     onFocus: props.onFocus,
+    'aria-describedby': props.options.ariaDescribedby || null,
   };
 
   return <input {...inputProps} />;
@@ -37,6 +38,10 @@ TextWidget.propTypes = {
     * input's autocomplete attribute value
     */
     autocomplete: PropTypes.string,
+    /**
+     * input's aria-describedby attribute
+     */
+    ariaDescribedby: PropTypes.string,
   }),
 };
 

--- a/src/platform/forms-system/test/js/widgets/TextWidget.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/widgets/TextWidget.unit.spec.jsx
@@ -46,6 +46,29 @@ describe('Schemaform <TextWidget>', () => {
     ).to.equal('date');
     tree.unmount();
   });
+  it('should render ariaDescribedby attribute', () => {
+    const onChange = sinon.spy();
+    const tree = mount(
+      <TextWidget
+        id="1"
+        value="testing"
+        schema={{ type: 'string' }}
+        required
+        disabled={false}
+        onChange={onChange}
+        options={{
+          ariaDescribedby: 'test-id',
+        }}
+      />,
+    );
+    expect(
+      tree
+        .find('input')
+        .getDOMNode()
+        .getAttribute('aria-describedby'),
+    ).to.equal('test-id');
+    tree.unmount();
+  });
   it('should render empty string when undefined', () => {
     const onChange = sinon.spy();
     const tree = SkinDeep.shallowRender(


### PR DESCRIPTION
## Description

To enable screenreaders to include [hint text](), an `ariaDescribedby` option is added to the `TextWidget`.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/25930
- https://design.va.gov/experimental-design/hint-text

## Testing done

Added unit test

## Screenshots

![Screen Shot 2021-06-14 at 11 34 15 AM](https://user-images.githubusercontent.com/136959/121927303-7fa4c480-cd04-11eb-9cd4-98d8ccb2e704.png)

## Acceptance criteria
- [x] `aria-describedby` added to input when option is included

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
