### PR TITLE
NOD: Add area of disagreement hint text

### DIFF
--- a/src/applications/appeals/10182/constants.js
+++ b/src/applications/appeals/10182/constants.js
@@ -32,7 +32,17 @@ export const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 ** 2; // binary based
 
 export const MAX_NEW_CONDITIONS = 99;
 
+// Values from Lighthouse maintained schema
 // see https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/appeals_api/config/schemas/v1/10182.json
 export const MAX_ISSUE_LENGTH = 180;
 export const MAX_REP_NAME_LENGTH = 120;
 export const MAX_DISAGREEMENT_REASON_LENGTH = 90;
+
+// Using MAX_DISAGREEMENT_REASON_LENGTH (90) and with all checkboxes selected,
+// this string is submitted - the numbers constitute the "other" typed in value
+// "service connection,effective date,disability evaluation,1234567890123456789012345678901234"
+export const SUBMITTED_DISAGREEMENTS = {
+  serviceConnection: 'service connection',
+  effectiveDate: 'effective date',
+  evaluation: 'disability evaluation',
+};

--- a/src/applications/appeals/10182/containers/FormApp.jsx
+++ b/src/applications/appeals/10182/containers/FormApp.jsx
@@ -11,9 +11,10 @@ import {
   issuesNeedUpdating,
   getSelected,
   getIssueName,
-  copyAreaOfDisagreementOptions,
   sortContestableIssues,
 } from '../utils/helpers';
+
+import { copyAreaOfDisagreementOptions } from '../utils/disagreement';
 
 import { showWorkInProgress } from '../content/WorkInProgressMessage';
 

--- a/src/applications/appeals/10182/content/OptIn.jsx
+++ b/src/applications/appeals/10182/content/OptIn.jsx
@@ -13,7 +13,7 @@ export const OptInDescription = () => {
       {ShowIssuesList({ issues })} */}
       <p>
         If you’re requesting a Board Appeal on an issue in an initial claim we
-        decided before Februray 19, 2019, you’ll need to opt in to the new
+        decided before February 19, 2019, you’ll need to opt in to the new
         decision review process. To do this, please check the box here. We’ll
         move your issue from the old appeals process to the new decision review
         process.

--- a/src/applications/appeals/10182/content/areaOfDisagreement.jsx
+++ b/src/applications/appeals/10182/content/areaOfDisagreement.jsx
@@ -61,3 +61,6 @@ export const effectiveDate = wrapHeader('The effective date of award');
 export const evaluation = wrapHeader('The evaluation of my condition');
 export const other = wrapHeader('Something else');
 export const otherLabel = 'Tell us what you disagree with:';
+export const otherDescription = () => (
+  <span className="vads-u-color--gray">Please explain in a few words</span>
+);

--- a/src/applications/appeals/10182/content/areaOfDisagreement.jsx
+++ b/src/applications/appeals/10182/content/areaOfDisagreement.jsx
@@ -62,5 +62,7 @@ export const evaluation = wrapHeader('The evaluation of my condition');
 export const other = wrapHeader('Something else');
 export const otherLabel = 'Tell us what you disagree with:';
 export const otherDescription = () => (
-  <span className="vads-u-color--gray">Please explain in a few words</span>
+  <span id="other-hint-text" className="vads-u-color--gray">
+    Please explain in a few words
+  </span>
 );

--- a/src/applications/appeals/10182/pages/areaOfDisagreement.js
+++ b/src/applications/appeals/10182/pages/areaOfDisagreement.js
@@ -6,12 +6,16 @@ import {
   evaluation,
   other,
   otherLabel,
+  otherDescription,
   missingAreaOfDisagreementErrorMessage,
   missingAreaOfDisagreementOtherErrorMessage,
 } from '../content/areaOfDisagreement';
 
 import { areaOfDisagreementRequired } from '../validations';
-import { otherTypeSelected } from '../utils/helpers';
+import {
+  otherTypeSelected,
+  calculateOtherMaxLength,
+} from '../utils/disagreement';
 
 export default {
   uiSchema: {
@@ -57,9 +61,16 @@ export default {
         },
         otherEntry: {
           'ui:title': otherLabel,
+          'ui:description': otherDescription,
           'ui:required': otherTypeSelected,
           'ui:options': {
             hideIf: (formData, index) => !otherTypeSelected(formData, index),
+            updateSchema: (formData, _schema, uiSchema, index) => ({
+              type: 'string',
+              maxLength: calculateOtherMaxLength(
+                formData.areaOfDisagreement[index],
+              ),
+            }),
           },
           'ui:errorMessages': {
             required: missingAreaOfDisagreementOtherErrorMessage,

--- a/src/applications/appeals/10182/pages/areaOfDisagreement.js
+++ b/src/applications/appeals/10182/pages/areaOfDisagreement.js
@@ -71,6 +71,7 @@ export default {
                 formData.areaOfDisagreement[index],
               ),
             }),
+            ariaDescribedby: 'other-hint-text',
           },
           'ui:errorMessages': {
             required: missingAreaOfDisagreementOtherErrorMessage,

--- a/src/applications/appeals/10182/tests/utils/disagreement.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/disagreement.unit.spec.js
@@ -1,0 +1,105 @@
+import { expect } from 'chai';
+
+import {
+  MAX_DISAGREEMENT_REASON_LENGTH,
+  SUBMITTED_DISAGREEMENTS,
+} from '../../constants';
+import {
+  copyAreaOfDisagreementOptions,
+  calculateOtherMaxLength,
+} from '../../utils/disagreement';
+
+describe('copyAreaOfDisagreementOptions', () => {
+  it('should return original issues only', () => {
+    const result = [
+      { issue: 'test' },
+      { attributes: { ratingIssueSubjectText: 'test2' } },
+    ];
+    expect(copyAreaOfDisagreementOptions(result, [])).to.deep.equal(result);
+  });
+  it('should return additional issue with included options', () => {
+    const newIssues = [
+      { issue: 'test' },
+      { attributes: { ratingIssueSubjectText: 'test2' } },
+    ];
+    const existingIssues = [
+      { issue: 'test', disagreementOptions: { test: true } },
+    ];
+    const result = [
+      { issue: 'test', disagreementOptions: { test: true }, otherEntry: '' },
+      { attributes: { ratingIssueSubjectText: 'test2' } },
+    ];
+    expect(
+      copyAreaOfDisagreementOptions(newIssues, existingIssues),
+    ).to.deep.equal(result);
+  });
+  it('should return eligible issues with included options', () => {
+    const newIssues = [
+      { issue: 'test' },
+      { attributes: { ratingIssueSubjectText: 'test2' } },
+    ];
+    const existingIssues = [
+      {
+        attributes: { ratingIssueSubjectText: 'test2' },
+        disagreementOptions: { test: true },
+        otherEntry: 'ok',
+      },
+    ];
+    expect(
+      copyAreaOfDisagreementOptions(newIssues, existingIssues),
+    ).to.deep.equal([newIssues[0], existingIssues[0]]);
+  });
+
+  it('should return disagreement options & other entry', () => {
+    const result = [
+      { issue: 'test', disagreementOptions: { test: true }, otherEntry: 'ok' },
+    ];
+    expect(
+      copyAreaOfDisagreementOptions([{ issue: 'test' }], result),
+    ).to.deep.equal(result);
+  });
+});
+
+describe('calculateOtherMaxLength', () => {
+  const keys = Object.keys(SUBMITTED_DISAGREEMENTS);
+  const values = Object.values(SUBMITTED_DISAGREEMENTS);
+  const getData = settings => {
+    const disagreementOptions = keys.reduce((finalOptions, key, index) => {
+      if (settings[index]) {
+        return { ...finalOptions, [key]: true };
+      }
+      return finalOptions;
+    }, {});
+    return { disagreementOptions };
+  };
+  const calcLength = settings => {
+    const string = values.filter((value, index) => settings[index]).join(',');
+    // add 1 to string length for the final comma
+    return MAX_DISAGREEMENT_REASON_LENGTH - (string.length + 1);
+  };
+  it('should return max length when nothing is selected', () => {
+    expect(calculateOtherMaxLength(getData([]))).to.eq(
+      MAX_DISAGREEMENT_REASON_LENGTH,
+    );
+  });
+  it('should return appropriate length with 1 selection', () => {
+    const data = [true];
+    const length = calcLength(data);
+    expect(calculateOtherMaxLength(getData(data))).to.eq(length);
+  });
+  it('should return appropriate length with 2 selections', () => {
+    const data = [true, false, true];
+    const length = calcLength(data);
+    expect(calculateOtherMaxLength(getData(data))).to.eq(length);
+  });
+  it('should return appropriate length with 2 different selections', () => {
+    const data = [false, true, true];
+    const length = calcLength(data);
+    expect(calculateOtherMaxLength(getData(data))).to.eq(length);
+  });
+  it('should return appropriate length with 3 selections', () => {
+    const data = [true, true, true];
+    const length = calcLength(data);
+    expect(calculateOtherMaxLength(getData(data))).to.eq(length);
+  });
+});

--- a/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
@@ -11,7 +11,6 @@ import {
   isEmptyObject,
   setInitialEditMode,
   issuesNeedUpdating,
-  copyAreaOfDisagreementOptions,
   sortContestableIssues,
 } from '../../utils/helpers';
 import { getDate } from '../../utils/dates';
@@ -253,57 +252,6 @@ describe('issuesNeedUpdating', () => {
         [createEntry('test', '123'), createEntry('test2', '345')],
       ),
     ).to.be.false;
-  });
-});
-
-describe('copyAreaOfDisagreementOptions', () => {
-  it('should return original issues only', () => {
-    const result = [
-      { issue: 'test' },
-      { attributes: { ratingIssueSubjectText: 'test2' } },
-    ];
-    expect(copyAreaOfDisagreementOptions(result, [])).to.deep.equal(result);
-  });
-  it('should return additional issue with included options', () => {
-    const newIssues = [
-      { issue: 'test' },
-      { attributes: { ratingIssueSubjectText: 'test2' } },
-    ];
-    const existingIssues = [
-      { issue: 'test', disagreementOptions: { test: true } },
-    ];
-    const result = [
-      { issue: 'test', disagreementOptions: { test: true }, otherEntry: '' },
-      { attributes: { ratingIssueSubjectText: 'test2' } },
-    ];
-    expect(
-      copyAreaOfDisagreementOptions(newIssues, existingIssues),
-    ).to.deep.equal(result);
-  });
-  it('should return eligible issues with included options', () => {
-    const newIssues = [
-      { issue: 'test' },
-      { attributes: { ratingIssueSubjectText: 'test2' } },
-    ];
-    const existingIssues = [
-      {
-        attributes: { ratingIssueSubjectText: 'test2' },
-        disagreementOptions: { test: true },
-        otherEntry: 'ok',
-      },
-    ];
-    expect(
-      copyAreaOfDisagreementOptions(newIssues, existingIssues),
-    ).to.deep.equal([newIssues[0], existingIssues[0]]);
-  });
-
-  it('should return disagreement options & other entry', () => {
-    const result = [
-      { issue: 'test', disagreementOptions: { test: true }, otherEntry: 'ok' },
-    ];
-    expect(
-      copyAreaOfDisagreementOptions([{ issue: 'test' }], result),
-    ).to.deep.equal(result);
   });
 });
 

--- a/src/applications/appeals/10182/utils/disagreement.js
+++ b/src/applications/appeals/10182/utils/disagreement.js
@@ -1,0 +1,73 @@
+import {
+  MAX_DISAGREEMENT_REASON_LENGTH,
+  SUBMITTED_DISAGREEMENTS,
+} from '../constants';
+import { getIssueName } from './helpers';
+
+/**
+ * @typedef AreaOfDisagreement~Options
+ * @type {object}
+ * @property {boolean} serviceConnection
+ * @property {boolean} effectiveDate
+ * @property {boolean} evaluation
+ * @property {boolean} other
+ */
+/**
+ * @typedef AreaOfDisagreement~Page
+ * @type {object}
+ * @property {object} attributes - Attributes of issue
+ * @property {AreaOfDisagreement~Options} disagreementOptions
+ * @property {string} otherEntry - Free text entered when "other" is selected
+ */
+/**
+ * @typedef FormData~AreaOfDisagreement
+ * @type {AreaOfDisagreement~Page[]}
+ */
+
+export const otherTypeSelected = ({ areaOfDisagreement } = {}, index) =>
+  areaOfDisagreement?.[index]?.disagreementOptions?.other;
+
+/**
+ * Compare currently selected issues with previously selected issues and copy
+ * over the area of disagreement selections if the issue persists
+ * @param {array} newIssues - currently selected issues
+ * @param {array} existingIssues - previously selected issues
+ * @returns {FormData~AreaOfDisagreement}
+ */
+export const copyAreaOfDisagreementOptions = (newIssues, existingIssues) => {
+  return newIssues.map(issue => {
+    const foundIssue = (existingIssues || []).find(
+      entry => getIssueName(entry) === getIssueName(issue),
+    );
+    if (foundIssue) {
+      const { disagreementOptions = {}, otherEntry = '' } = foundIssue;
+      return {
+        ...issue,
+        disagreementOptions,
+        otherEntry,
+      };
+    }
+    return issue;
+  });
+};
+
+/**
+ * Calculate schema max length of area of disagreement "other" free text input
+ * for a specific page
+ * @param {AreaOfDisagreement~Page} formData
+ * @returns {number}
+ */
+export const calculateOtherMaxLength = formData => {
+  // Schema has a max length of 90 characters for the areaOfDisagreement value
+  // We include fixed text for each selected option with the left over for the
+  // free-text "other reason" input to use up the remaining characters
+  const options = formData?.disagreementOptions || {};
+  const stringLength = Object.keys(options).reduce((totalLength, key) => {
+    if (key !== 'other' && options[key]) {
+      // add one for the comma
+      return totalLength + SUBMITTED_DISAGREEMENTS[key].length + 1;
+    }
+    return totalLength;
+  }, 0);
+  return MAX_DISAGREEMENT_REASON_LENGTH - stringLength;
+};

--- a/src/applications/appeals/10182/utils/helpers.js
+++ b/src/applications/appeals/10182/utils/helpers.js
@@ -20,8 +20,6 @@ export const showAddIssuesPage = formData =>
   (formData.constestableIssues?.length
     ? !someSelected(formData.contestableIssues)
     : true);
-export const otherTypeSelected = ({ areaOfDisagreement } = {}, index) =>
-  areaOfDisagreement?.[index]?.disagreementOptions?.other;
 
 export const hasSomeSelected = ({ contestableIssues, additionalIssues } = {}) =>
   someSelected(contestableIssues) || someSelected(additionalIssues);
@@ -81,23 +79,6 @@ export const issuesNeedUpdating = (loadedIssues = [], existingIssues = []) => {
       attributes.ratingIssueSubjectText === existing.ratingIssueSubjectText &&
       attributes.approxDecisionDate === existing.approxDecisionDate
     );
-  });
-};
-
-export const copyAreaOfDisagreementOptions = (newIssues, existingIssues) => {
-  return newIssues.map(issue => {
-    const foundIssue = (existingIssues || []).find(
-      entry => getIssueName(entry) === getIssueName(issue),
-    );
-    if (foundIssue) {
-      const { disagreementOptions = {}, otherEntry = '' } = foundIssue;
-      return {
-        ...issue,
-        disagreementOptions,
-        otherEntry,
-      };
-    }
-    return issue;
   });
 };
 

--- a/src/applications/appeals/10182/utils/submit.js
+++ b/src/applications/appeals/10182/utils/submit.js
@@ -5,6 +5,7 @@ import {
   MAX_ISSUE_LENGTH,
   MAX_REP_NAME_LENGTH,
   MAX_DISAGREEMENT_REASON_LENGTH,
+  SUBMITTED_DISAGREEMENTS,
 } from '../constants';
 
 /**
@@ -219,9 +220,9 @@ export const addIncludedIssues = formData => {
  */
 export const addAreaOfDisagreement = (issues, { areaOfDisagreement } = {}) => {
   const keywords = {
-    serviceConnection: () => 'service connection',
-    effectiveDate: () => 'effective date',
-    evaluation: () => 'disability evaluation',
+    serviceConnection: () => SUBMITTED_DISAGREEMENTS.serviceConnection,
+    effectiveDate: () => SUBMITTED_DISAGREEMENTS.effectiveDate,
+    evaluation: () => SUBMITTED_DISAGREEMENTS.evaluation,
     other: disagreementOptions => disagreementOptions.otherEntry,
   };
   return issues.map((issue, index) => {


### PR DESCRIPTION
## Description

The area of disagreement "other" choice reveals an input that has a max length assigned to it. We need to inform the Veteran that it has limited characters, but the actual limit varies based on their choices. We decided not to show the actual limit value to discourage unselecting choices to get more length.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/25930
- https://github.com/department-of-veterans-affairs/vets-website/pull/17590

## Testing done

Added unit tests for max length calculation

## Screenshots

![Screen Shot 2021-06-14 at 9 47 12 AM](https://user-images.githubusercontent.com/136959/121928569-e37bbd00-cd05-11eb-93ff-05ff5c708c6d.png)

## Acceptance criteria
- [x] Add hint text to "other" selection text input
- [x] Dynamically update max length of content based on choices

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
