### PR TITLE
NOD: Fix Edit alignment

### DIFF
--- a/src/applications/appeals/10182/sass/10182-nod.scss
+++ b/src/applications/appeals/10182/sass/10182-nod.scss
@@ -79,7 +79,6 @@ dl.review {
     margin-inline-start: 0; /* override user agent */
     text-align: left;
     margin: 3rem 3.5rem 0 5rem;
-    width: 100%;
   }
 
   dd.widget-content.widget-edit {


### PR DESCRIPTION
## Description

A fix for the Edit button alignment in IE11 broke alignment in all other browsers. Reverting the change

## Testing done

Visual

## Screenshots

<img width="567" alt="Screen Shot 2021-06-15 at 8 58 28 AM" src="https://user-images.githubusercontent.com/136959/122065847-e0410980-cdb7-11eb-879f-2e18d89edc2d.png">

## Acceptance criteria
- [x] Update CSS

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
