### PR TITLE
CT Redesign: Limit max distance for location searches

### DIFF
--- a/src/applications/gi-sandbox/constants.js
+++ b/src/applications/gi-sandbox/constants.js
@@ -44,6 +44,8 @@ export const TABS = Object.freeze({
   location: 'location',
 });
 
+export const MAX_SEARCH_DISTANCE = 150;
+
 export const ariaLabels = Object.freeze({
   learnMore: {
     giBillBenefits: 'Learn more about VA education and training programs',

--- a/src/applications/gi-sandbox/constants.js
+++ b/src/applications/gi-sandbox/constants.js
@@ -45,6 +45,7 @@ export const TABS = Object.freeze({
 });
 
 export const MAX_SEARCH_DISTANCE = 150;
+export const MILE_METER_CONVERSION_RATE = 1609.34;
 
 export const ariaLabels = Object.freeze({
   learnMore: {

--- a/src/applications/gi-sandbox/containers/search/LocationSearchResults.jsx
+++ b/src/applications/gi-sandbox/containers/search/LocationSearchResults.jsx
@@ -7,7 +7,11 @@ import LoadingIndicator from '@department-of-veterans-affairs/component-library/
 
 import SearchResultCard from '../../containers/SearchResultCard';
 import { mapboxToken } from '../../utils/mapboxToken';
-import { MapboxInit, MAX_SEARCH_DISTANCE } from '../../constants';
+import {
+  MapboxInit,
+  MAX_SEARCH_DISTANCE,
+  MILE_METER_CONVERSION_RATE,
+} from '../../constants';
 import TuitionAndHousingEstimates from '../../containers/TuitionAndHousingEstimates';
 import RefineYourSearch from '../../containers/RefineYourSearch';
 import { numberToLetter, createId } from '../../utils/helpers';
@@ -16,8 +20,6 @@ import {
   updateEligibilityAndFilters,
 } from '../../actions';
 import { connect } from 'react-redux';
-
-const MILE_METER_CONVERSION_RATE = 1609.34;
 
 function LocationSearchResults({
   search,

--- a/src/applications/gi-sandbox/containers/search/LocationSearchResults.jsx
+++ b/src/applications/gi-sandbox/containers/search/LocationSearchResults.jsx
@@ -7,7 +7,7 @@ import LoadingIndicator from '@department-of-veterans-affairs/component-library/
 
 import SearchResultCard from '../../containers/SearchResultCard';
 import { mapboxToken } from '../../utils/mapboxToken';
-import { MapboxInit } from '../../constants';
+import { MapboxInit, MAX_SEARCH_DISTANCE } from '../../constants';
 import TuitionAndHousingEstimates from '../../containers/TuitionAndHousingEstimates';
 import RefineYourSearch from '../../containers/RefineYourSearch';
 import { numberToLetter, createId } from '../../utils/helpers';
@@ -200,14 +200,14 @@ function LocationSearchResults({
     e.preventDefault();
     const bounds = map.current.getBounds();
 
-    const diagonalDistance =
+    const diagonalToCenterDistance =
       bounds.getNorthEast().distanceTo(bounds.getCenter()) /
       MILE_METER_CONVERSION_RATE;
 
     dispatchFetchSearchByLocationCoords(
       search.query.location,
       map.current.getCenter().toArray(),
-      diagonalDistance,
+      Math.min(diagonalToCenterDistance, MAX_SEARCH_DISTANCE),
       filters,
       preview.version,
     );


### PR DESCRIPTION
## Description

Use Math.min() to pick smaller value between 150 and distance between Northeast and center of viewable area on the map

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
