### PR TITLE
Don't fetch requests on upcoming appts page

### DIFF
--- a/src/applications/vaos/appointment-list/components/CanceledAppointmentsList.jsx
+++ b/src/applications/vaos/appointment-list/components/CanceledAppointmentsList.jsx
@@ -32,7 +32,7 @@ export default function CanceledAppointmentsList({ hasTypeChanged }) {
   useEffect(
     () => {
       if (futureStatus === FETCH_STATUS.notStarted) {
-        dispatch(fetchFutureAppointments());
+        dispatch(fetchFutureAppointments({ includeRequests: true }));
       } else if (hasTypeChanged && futureStatus === FETCH_STATUS.succeeded) {
         scrollAndFocus('#type-dropdown');
       } else if (hasTypeChanged && futureStatus === FETCH_STATUS.failed) {

--- a/src/applications/vaos/appointment-list/components/UpcomingAppointmentsList.jsx
+++ b/src/applications/vaos/appointment-list/components/UpcomingAppointmentsList.jsx
@@ -33,7 +33,7 @@ export default function UpcomingAppointmentsList() {
   useEffect(
     () => {
       if (futureStatus === FETCH_STATUS.notStarted) {
-        dispatch(fetchFutureAppointments());
+        dispatch(fetchFutureAppointments({ includeRequests: false }));
       } else if (hasTypeChanged && futureStatus === FETCH_STATUS.succeeded) {
         scrollAndFocus('#type-dropdown');
       } else if (hasTypeChanged && futureStatus === FETCH_STATUS.failed) {

--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -145,12 +145,16 @@ async function getAdditionalFacilityInfo(futureAppointments) {
   return facilityData;
 }
 
-export function fetchFutureAppointments() {
+export function fetchFutureAppointments({ includeRequests = true } = {}) {
   return async (dispatch, getState) => {
     const featureHomepageRefresh = selectFeatureHomepageRefresh(getState());
+    const featureVAOSServiceRequests = selectFeatureVAOSServiceRequests(
+      getState(),
+    );
 
     dispatch({
       type: FETCH_FUTURE_APPOINTMENTS,
+      includeRequests,
     });
 
     recordEvent({
@@ -167,7 +171,7 @@ export function fetchFutureAppointments() {
        * and requests lists, but needs confirmed to go back 30 days. Appointments
        * will be filtered out by date accordingly in our selectors
        */
-      const data = await Promise.all([
+      const promises = [
         getBookedAppointments({
           startDate: featureHomepageRefresh
             ? moment()
@@ -178,35 +182,42 @@ export function fetchFutureAppointments() {
             .add(395, 'days')
             .format('YYYY-MM-DD'),
         }),
-        getAppointmentRequests({
-          startDate: moment()
-            .subtract(featureHomepageRefresh ? 120 : 30, 'days')
-            .format('YYYY-MM-DD'),
-          endDate: moment().format('YYYY-MM-DD'),
-        })
-          .then(requests => {
-            dispatch({
-              type: FETCH_PENDING_APPOINTMENTS_SUCCEEDED,
-              data: requests,
-            });
+      ];
 
-            recordEvent({
-              event: `${GA_PREFIX}-get-pending-appointments-retrieved`,
-            });
-
-            return requests;
+      if (includeRequests) {
+        promises.push(
+          getAppointmentRequests({
+            startDate: moment()
+              .subtract(featureHomepageRefresh ? 120 : 30, 'days')
+              .format('YYYY-MM-DD'),
+            endDate: moment().format('YYYY-MM-DD'),
+            useV2: featureVAOSServiceRequests,
           })
-          .catch(resp => {
-            recordEvent({
-              event: `${GA_PREFIX}-get-pending-appointments-failed`,
-            });
-            dispatch({
-              type: FETCH_PENDING_APPOINTMENTS_FAILED,
-            });
+            .then(requests => {
+              dispatch({
+                type: FETCH_PENDING_APPOINTMENTS_SUCCEEDED,
+                data: requests,
+              });
 
-            return Promise.reject(resp);
-          }),
-      ]);
+              recordEvent({
+                event: `${GA_PREFIX}-get-pending-appointments-retrieved`,
+              });
+
+              return requests;
+            })
+            .catch(resp => {
+              recordEvent({
+                event: `${GA_PREFIX}-get-pending-appointments-failed`,
+              });
+              dispatch({
+                type: FETCH_PENDING_APPOINTMENTS_FAILED,
+              });
+
+              return Promise.reject(resp);
+            }),
+        );
+      }
+      const data = await Promise.all(promises);
 
       recordEvent({
         event: `${GA_PREFIX}-get-future-appointments-retrieved`,

--- a/src/applications/vaos/appointment-list/redux/reducer.js
+++ b/src/applications/vaos/appointment-list/redux/reducer.js
@@ -62,7 +62,9 @@ export default function appointmentsReducer(state = initialState, action) {
     case FETCH_FUTURE_APPOINTMENTS:
       return {
         ...state,
-        pendingStatus: FETCH_STATUS.loading,
+        pendingStatus: action.includeRequests
+          ? FETCH_STATUS.loading
+          : state.pendingStatus,
         confirmedStatus: FETCH_STATUS.loading,
       };
     case FETCH_FUTURE_APPOINTMENTS_SUCCEEDED: {

--- a/src/applications/vaos/appointment-list/redux/selectors.js
+++ b/src/applications/vaos/appointment-list/redux/selectors.js
@@ -244,7 +244,7 @@ export function getRequestedAppointmentListInfo(state) {
 export function getUpcomingAppointmentListInfo(state) {
   return {
     facilityData: state.appointments.facilityData,
-    futureStatus: selectFutureStatus(state),
+    futureStatus: state.appointments.confirmedStatus,
     appointmentsByMonth: selectUpcomingAppointments(state),
     isCernerOnlyPatient: selectIsCernerOnlyPatient(state),
     showScheduleButton: selectFeatureRequests(state),


### PR DESCRIPTION
## Description
This PR
- Updates the fetchFutureAppointments action creator to conditionally fetch requests
- Updates the UpcomingAppointmentList page to not fetch requests
- Adds the VAOS service feature flag to the fetchFutureAppointments request fetch so that the canceled page uses the VAOS service for requests

This fixes a bug where you would open the list page and then switch to the requested page and see requests from the v0 endpoint. Refreshing would then get you the v2 requests.

## Testing done
Local and unit testing

## Acceptance criteria
- [ ] Requests are only fetched when on the requested or canceled page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
