### PR TITLE
Fix spouse income section heading on FSR

### DIFF
--- a/src/applications/financial-status-report/pages/income/spouse/additionalIncome/index.js
+++ b/src/applications/financial-status-report/pages/income/spouse/additionalIncome/index.js
@@ -1,5 +1,5 @@
 export const uiSchema = {
-  'ui:title': 'Your questions information',
+  'ui:title': 'Your spouse information',
   questions: {
     spouseHasAdditionalIncome: {
       'ui:title':


### PR DESCRIPTION
## Description
During QA a few defects were found and one was left behind in the initial fix. This PR is meant to patch the last remaining fix before closing this [QA Feedback Ticket](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/department-of-veterans-affairs/va.gov-team/22349)

## Testing done
- Visual testing

## Screenshots
### Before
![Screen Shot 2021-06-15 at 12 38 25 PM](https://user-images.githubusercontent.com/23741323/122092732-43429880-cdd8-11eb-966f-63f2ee689751.png)

### After
![Screen Shot 2021-06-15 at 12 48 33 PM](https://user-images.githubusercontent.com/23741323/122092772-4f2e5a80-cdd8-11eb-8bc0-7af786c48208.png)



## Acceptance criteria
- [x] Spouse income heading is update from `Your questions information` to `Your spouse information`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
