### PR TITLE
lighthouse renamed disagreementReason to disagreementArea

### DIFF
--- a/src/applications/appeals/10182/pages/areaOfDisagreement.js
+++ b/src/applications/appeals/10182/pages/areaOfDisagreement.js
@@ -109,7 +109,7 @@ export default {
             },
             otherEntry: {
               type: 'string',
-              // disagreementReason limited to 90 chars max
+              // disagreementArea limited to 90 chars max
               maxLength: 34,
             },
           },

--- a/src/applications/appeals/10182/tests/fixtures/data/transformed-maximal-test.json
+++ b/src/applications/appeals/10182/tests/fixtures/data/transformed-maximal-test.json
@@ -37,7 +37,7 @@
         "decisionIssueId": 1,
         "ratingIssueReferenceId": "2",
         "ratingDecisionReferenceId": "3",
-        "disagreementReason": "service connection,effective date,disability evaluation,this is an other entry"
+        "disagreementArea": "service connection,effective date,disability evaluation,this is an other entry"
       }
     },
     {
@@ -47,7 +47,7 @@
         "decisionDate": "2020-01-02",
         "decisionIssueId": 4,
         "ratingIssueReferenceId": "5",
-        "disagreementReason": "effective date"
+        "disagreementArea": "effective date"
       }
     },
     {
@@ -55,7 +55,7 @@
       "attributes": {
         "issue": "right shoulder",
         "decisionDate": "2020-01-06",
-        "disagreementReason": "disability evaluation,this is another other entry"
+        "disagreementArea": "disability evaluation,this is another other entry"
       }
     }
   ],

--- a/src/applications/appeals/10182/tests/fixtures/data/transformed-minimal-test.json
+++ b/src/applications/appeals/10182/tests/fixtures/data/transformed-minimal-test.json
@@ -36,7 +36,7 @@
         "issue": "Traumatic Brain Injury - 5%",
         "decisionIssueId": 10,
         "decisionDate": "2020-01-05",
-        "disagreementReason": "effective date"
+        "disagreementArea": "effective date"
       }
     }
   ],

--- a/src/applications/appeals/10182/tests/utils/submit.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/submit.unit.spec.js
@@ -209,10 +209,10 @@ describe('addAreaOfDisagreement', () => {
       [issue1.result, issue2.result],
       formData,
     );
-    expect(result[0].attributes.disagreementReason).to.equal(
+    expect(result[0].attributes.disagreementArea).to.equal(
       'service connection',
     );
-    expect(result[1].attributes.disagreementReason).to.equal('effective date');
+    expect(result[1].attributes.disagreementArea).to.equal('effective date');
   });
   it('should process multiple choices', () => {
     const formData = {
@@ -228,7 +228,7 @@ describe('addAreaOfDisagreement', () => {
       ],
     };
     const result = addAreaOfDisagreement([issue1.result], formData);
-    expect(result[0].attributes.disagreementReason).to.equal(
+    expect(result[0].attributes.disagreementArea).to.equal(
       'service connection,effective date,disability evaluation',
     );
   });
@@ -247,7 +247,7 @@ describe('addAreaOfDisagreement', () => {
       ],
     };
     const result = addAreaOfDisagreement([issue1.result], formData);
-    expect(result[0].attributes.disagreementReason).to.equal(
+    expect(result[0].attributes.disagreementArea).to.equal(
       'service connection,effective date,disability evaluation,this is an other entry',
     );
   });

--- a/src/applications/appeals/10182/utils/submit.js
+++ b/src/applications/appeals/10182/utils/submit.js
@@ -112,7 +112,7 @@ export const createIssueName = ({ attributes } = {}) => {
  * @type {Object}
  * @property {String} issue - title of issue returned by createIssueName function
  * @property {String} decisionDate - decision date string (YYYY-MM-DD)
- * @property {String} disagreementReason - area of disagreement
+ * @property {String} disagreementArea - area of disagreement
  * @property {Number=} decisionIssueId - decision id
  * @property {String=} ratingIssueReferenceId - issue reference number
  * @property {String=} ratingDecisionReferenceId - decision reference id
@@ -216,7 +216,7 @@ export const addIncludedIssues = formData => {
  * Add area of disagreement
  * @param {ContestableIssue~Submittable} issues - selected & processed issues
  * @param {FormData} formData
- * @return {ContestableIssues~Submittable} issues with "disagreementReason" added
+ * @return {ContestableIssues~Submittable} issues with "disagreementArea" added
  */
 export const addAreaOfDisagreement = (issues, { areaOfDisagreement } = {}) => {
   const keywords = {
@@ -234,7 +234,7 @@ export const addAreaOfDisagreement = (issues, { areaOfDisagreement } = {}) => {
       ...issue,
       attributes: {
         ...issue.attributes,
-        disagreementReason: reasons
+        disagreementArea: reasons
           .join(',')
           .substring(0, MAX_DISAGREEMENT_REASON_LENGTH), // max length in schema
       },


### PR DESCRIPTION
## Description
A simple search and replace of `disagreementReason` to `disagreementArea` due to a lighthouse schema change.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
