### PR TITLE
NOD: Fix evidence upload bug

### DIFF
--- a/src/applications/appeals/10182/tests/utils/submit.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/submit.unit.spec.js
@@ -255,6 +255,7 @@ describe('addAreaOfDisagreement', () => {
 
 describe('addUploads', () => {
   const getData = (checked, files) => ({
+    boardReviewOption: 'evidence_submission',
     'view:additionalEvidence': checked,
     evidence: files.map(name => ({ name, confirmationCode: '123' })),
   });
@@ -264,7 +265,14 @@ describe('addUploads', () => {
       { name: 'test2', confirmationCode: '123' },
     ]);
   });
-  it('should not add uploads', () => {
+  it('should not add uploads if not submitting more evidence', () => {
+    const data = {
+      ...getData(true, ['test1', 'test2']),
+      boardReviewOption: 'hearing',
+    };
+    expect(addUploads(data)).to.deep.equal([]);
+  });
+  it('should not add uploads if submit later is selected', () => {
     expect(addUploads(getData(false, ['test1', 'test2']))).to.deep.equal([]);
   });
 });

--- a/src/applications/appeals/10182/utils/submit.js
+++ b/src/applications/appeals/10182/utils/submit.js
@@ -268,6 +268,7 @@ export const addAreaOfDisagreement = (issues, { areaOfDisagreement } = {}) => {
  * @returns {Evidence~Submittable[]}
  */
 export const addUploads = formData =>
+  formData.boardReviewOption === 'evidence_submission' &&
   formData['view:additionalEvidence']
     ? formData.evidence.map(({ name, confirmationCode }) => ({
         name,


### PR DESCRIPTION
## Description

Choosing to upload evidence, then going back to choose a different board review option was previously expecting evidence to have been uploaded for submission. This change ensures that no evidence will be uploaded if the option isn't selected

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/26090

## Testing done

Updated unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Evidence will not be uploaded if the board review option isn't selected

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
