### PR TITLE
Make contact info alerts work better with screen readers

### DIFF
--- a/src/applications/personalization/profile/components/personal-information/ContactInformationEditView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationEditView.jsx
@@ -258,22 +258,19 @@ export class ContactInformationEditView extends Component {
 
     return (
       <>
-        <div role="alert">
-          {error && (
-            <div
-              className="vads-u-margin-bottom--2"
-              data-testid="edit-error-alert"
-            >
-              <VAPServiceEditModalErrorMessage
-                title={title}
-                error={error}
-                clearErrors={() =>
-                  this.props.clearTransactionRequest(fieldName)
-                }
-              />
-            </div>
-          )}
-        </div>
+        {error && (
+          <div
+            role="alert"
+            className="vads-u-margin-bottom--2"
+            data-testid="edit-error-alert"
+          >
+            <VAPServiceEditModalErrorMessage
+              title={title}
+              error={error}
+              clearErrors={() => this.props.clearTransactionRequest(fieldName)}
+            />
+          </div>
+        )}
 
         {!!field && (
           <div>

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationEditView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationEditView.jsx
@@ -258,18 +258,22 @@ export class ContactInformationEditView extends Component {
 
     return (
       <>
-        {error && (
-          <div
-            className="vads-u-margin-bottom--2"
-            data-testid="edit-error-alert"
-          >
-            <VAPServiceEditModalErrorMessage
-              title={title}
-              error={error}
-              clearErrors={() => this.props.clearTransactionRequest(fieldName)}
-            />
-          </div>
-        )}
+        <div role="alert">
+          {error && (
+            <div
+              className="vads-u-margin-bottom--2"
+              data-testid="edit-error-alert"
+            >
+              <VAPServiceEditModalErrorMessage
+                title={title}
+                error={error}
+                clearErrors={() =>
+                  this.props.clearTransactionRequest(fieldName)
+                }
+              />
+            </div>
+          )}
+        </div>
 
         {!!field && (
           <div>

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
@@ -288,7 +288,6 @@ class ContactInformationField extends React.Component {
               modalData: this.props.editViewData,
             })
           }
-          hasValidationError={this.props.hasValidationError}
           onCancel={this.onCancel}
           fieldName={this.props.fieldName}
         />

--- a/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
+++ b/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
@@ -253,17 +253,15 @@ class AddressValidationView extends React.Component {
 
     return (
       <>
-        <div role="alert">
-          {error && (
-            <div className="vads-u-margin-bottom--1">
-              <VAPServiceEditModalErrorMessage
-                title={title}
-                error={error}
-                clearErrors={clearErrors}
-              />
-            </div>
-          )}
-        </div>
+        {error && (
+          <div className="vads-u-margin-bottom--1" role="alert">
+            <VAPServiceEditModalErrorMessage
+              title={title}
+              error={error}
+              clearErrors={clearErrors}
+            />
+          </div>
+        )}
         <div role="alert">
           <AlertBox
             className="vads-u-margin-bottom--1 vads-u-margin-top--0"

--- a/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
+++ b/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
@@ -253,15 +253,17 @@ class AddressValidationView extends React.Component {
 
     return (
       <>
-        {error && (
-          <div className="vads-u-margin-bottom--1">
-            <VAPServiceEditModalErrorMessage
-              title={title}
-              error={error}
-              clearErrors={clearErrors}
-            />
-          </div>
-        )}
+        <div role="alert">
+          {error && (
+            <div className="vads-u-margin-bottom--1">
+              <VAPServiceEditModalErrorMessage
+                title={title}
+                error={error}
+                clearErrors={clearErrors}
+              />
+            </div>
+          )}
+        </div>
         <AlertBox
           className="vads-u-margin-bottom--1 vads-u-margin-top--0"
           level={4}

--- a/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
+++ b/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
@@ -264,15 +264,19 @@ class AddressValidationView extends React.Component {
             </div>
           )}
         </div>
-        <AlertBox
-          className="vads-u-margin-bottom--1 vads-u-margin-top--0"
-          level={4}
-          status="warning"
-          headline={addressValidationMessage.headline}
-          scrollOnShow
-        >
-          <addressValidationMessage.ModalText editFunction={this.onEditClick} />
-        </AlertBox>
+        <div role="alert">
+          <AlertBox
+            className="vads-u-margin-bottom--1 vads-u-margin-top--0"
+            level={4}
+            status="warning"
+            headline={addressValidationMessage.headline}
+            scrollOnShow
+          >
+            <addressValidationMessage.ModalText
+              editFunction={this.onEditClick}
+            />
+          </AlertBox>
+        </div>
         <form onSubmit={this.onSubmit}>
           <span className="vads-u-font-weight--bold">You entered:</span>
           {this.renderAddressOption(addressFromUser)}


### PR DESCRIPTION
## Description
This PR attempts to fix an issue with certain alerts not being read via screen readers when they appear. It adds a `role="alert"` to a few alerts to accomplish the following:

- When a user is asked to verify their address, the alert explaining the action they need to take is now read by Voiceover
- When a contact info save fails, the alert that appears is now read by Voiceover. The error alert will be read if the failure occurs on the normal edit view _or_ the address validation view

## Testing done
Locally with Voiceover in Safari

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs