### PR TITLE
Updating README local IP address instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ for doing very specific things.
 | run the app pages on the site for local development | `yarn watch --env.scaffold` |
 | run the site for local development with automatic rebuilding of Javascript and sass **with** css sourcemaps | `yarn watch:css-sourcemaps` then visit `http://localhost:3001/`. You may also set `--env.buildtype` and `NODE_ENV` though setting `NODE_ENV` to production will make incremental builds slow. |
 | run the site for local development with automatic rebuilding of code and styles for specific **apps** | `yarn watch --env.entry disability-benefits,static-pages`. Valid application names are in each app's `manifest.json` under `entryName` |
-| run the site so that devices on your local network can access it | `yarn watch --host 0.0.0.0 --public 198.162.x.x:3001` Note that we use CORS to limit what hosts can access different APIs, so accessing with a `192.168.x.x` address may run into problems |
+| run the site so that devices on your local network can access it | `yarn watch --host 0.0.0.0 --public 192.168.x.x:3001` Note that we use CORS to limit what hosts can access different APIs, so accessing with a `192.168.x.x` address may run into problems |
 | run all unit tests and watch | `yarn test:watch` |
 | run only e2e tests | Make sure the site is running locally (`yarn watch`) and run the tests with `yarn test:e2e` |
 | run e2e tests in headless mode | `yarn test:e2e:headless` |


### PR DESCRIPTION
## Description
* Switching two digits in local 192.168 instruction. Previous version of instructions listed local IP as `198.162.x.xx` which wouldn't be in a local range.

## Testing done
* Running `vets-website` locally using a correctly set local IP

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
