### PR TITLE
NOD: Update show additional issues page logic

### DIFF
--- a/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
@@ -142,6 +142,24 @@ describe('showAddIssuesPage', () => {
       }),
     ).to.be.false;
   });
+  it('should show the issue page when nothing is selected, and past the issues pages', () => {
+    // probably unselected stuff on the review & submit page
+    expect(
+      showAddIssuesPage({
+        'view:hasIssuesToAdd': true,
+        contestableIssues: [{}],
+        additionalIssues: [{}],
+      }),
+    ).to.be.true;
+    expect(
+      showAddIssuesPage({
+        'view:hasIssuesToAdd': false,
+        boardReviewOption: 'foo', // we're past the issues page
+        contestableIssues: [{}],
+        additionalIssues: [{}],
+      }),
+    ).to.be.true;
+  });
 });
 
 describe('showAddIssueQuestion', () => {

--- a/src/applications/appeals/10182/utils/helpers.js
+++ b/src/applications/appeals/10182/utils/helpers.js
@@ -15,14 +15,23 @@ export const needsHearingType = formData =>
   formData.boardReviewOption === 'hearing';
 export const wantsToUploadEvidence = formData =>
   canUploadEvidence(formData) && formData['view:additionalEvidence'];
-export const showAddIssuesPage = formData =>
-  formData['view:hasIssuesToAdd'] !== false &&
-  (formData.constestableIssues?.length
-    ? !someSelected(formData.contestableIssues)
-    : true);
 
 export const hasSomeSelected = ({ contestableIssues, additionalIssues } = {}) =>
   someSelected(contestableIssues) || someSelected(additionalIssues);
+
+export const showAddIssuesPage = formData => {
+  const hasSelectedIssues = formData.constestableIssues?.length
+    ? someSelected(formData.contestableIssues)
+    : false;
+  const noneToAdd = formData['view:hasIssuesToAdd'] !== false;
+  // are we past the issues pages?
+  if (formData.boardReviewOption && !hasSomeSelected(formData)) {
+    // nothing is selected, we need to show the additional issues page!
+    return true;
+  }
+  return noneToAdd && !hasSelectedIssues;
+};
+
 export const showAddIssueQuestion = ({ contestableIssues }) =>
   // additional issues yes/no question:
   // SHOW: if contestable issues selected. HIDE: if no contestable issues are


### PR DESCRIPTION
## Description

If the Veteran attempts to submit a Notice of Disagreement with no selected issues, a generic error message is shown. To partially improve upon this, the add issues page logic needed to be updated to show the page when nothing is selected. Sadly, the accordion header doesn't highlight the error and the error message can only be seen after opening the chapter (see screenshot).

A better fix would be to show error links (see [the review & submit error links PR](https://github.com/department-of-veterans-affairs/vets-website/pull/16431).

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/25573
- https://github.com/department-of-veterans-affairs/va-forms-system-core/issues/379

## Testing done

Updated unit tests

## Screenshots

<details><summary>Error on add issues page when nothing is selected</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-06-16 at 11 00 00 AM](https://user-images.githubusercontent.com/136959/122254357-a98bf180-ce92-11eb-8360-5b513e0cedd1.png)</details>

## Acceptance criteria
- [x] Include error message when nothing is selected & a submission is attempted

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
