### PR TITLE
Fix 5490 relationship logic

### DIFF
--- a/src/applications/edu-benefits/5490/config/form.js
+++ b/src/applications/edu-benefits/5490/config/form.js
@@ -493,7 +493,9 @@ const formConfig = {
                 "Sponsor's date of death or date listed as MIA or POW",
               ),
               'ui:options': {
-                hideIf: formData => _.get('benefit', formData) !== 'chapter35',
+                hideIf: formData =>
+                  _.get('benefit', formData) === 'chapter33' &&
+                  _.get('relationship', formData) === 'spouse',
               },
             },
             sponsorStatus: {
@@ -507,7 +509,9 @@ const formConfig = {
                     'Died from a service-connected disability while a member of the Selected Reserve',
                   powOrMia: 'Listed as MIA or POW',
                 },
-                hideIf: formData => _.get('benefit', formData) !== 'chapter33',
+                hideIf: formData =>
+                  _.get('benefit', formData) === 'chapter35' ||
+                  _.get('relationship', formData) === 'child',
               },
             },
             'view:sponsorDateOfDeath': {
@@ -515,7 +519,9 @@ const formConfig = {
               'ui:options': {
                 expandUnder: 'sponsorStatus',
                 expandUnderCondition: status => status && status !== 'powOrMia',
-                hideIf: formData => _.get('benefit', formData) !== 'chapter33',
+                hideIf: formData =>
+                  _.get('benefit', formData) === 'chapter35' ||
+                  _.get('relationship', formData) === 'child',
               },
             },
             'view:sponsorDateListedMiaOrPow': {
@@ -523,7 +529,9 @@ const formConfig = {
               'ui:options': {
                 expandUnder: 'sponsorStatus',
                 expandUnderCondition: status => status && status === 'powOrMia',
-                hideIf: formData => _.get('benefit', formData) !== 'chapter33',
+                hideIf: formData =>
+                  _.get('benefit', formData) === 'chapter35' ||
+                  _.get('relationship', formData) === 'child',
               },
             },
           },

--- a/src/applications/edu-benefits/5490/tests/config/sponsorInformation.unit.spec.jsx
+++ b/src/applications/edu-benefits/5490/tests/config/sponsorInformation.unit.spec.jsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { findDOMNode } from 'react-dom';
 import { expect } from 'chai';
+import { mount } from 'enzyme';
 import ReactTestUtils from 'react-dom/test-utils';
 
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
@@ -18,7 +19,7 @@ describe('Edu 5490 sponsorInformation', () => {
       <DefinitionTester
         schema={schema}
         definitions={formConfig.defaultDefinitions}
-        data={{ benefit: 'chapter33' }}
+        data={{ relationship: 'child', benefit: 'chapter33' }}
         uiSchema={uiSchema}
       />,
     );
@@ -26,6 +27,75 @@ describe('Edu 5490 sponsorInformation', () => {
     const formDOM = findDOMNode(form);
 
     expect(formDOM.querySelectorAll('input,select').length).to.equal(12);
+  });
+
+  it('should display date options for chapter 33 and spouse relationship', () => {
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        definitions={formConfig.defaultDefinitions}
+        data={{ relationship: 'spouse', benefit: 'chapter33' }}
+        uiSchema={uiSchema}
+      />,
+    );
+
+    expect(form.find('#root_veteranDateOfDeathMonth').length).to.equal(0);
+    expect(form.find('#root_veteranDateOfDeathDay').length).to.equal(0);
+    expect(form.find('#root_veteranDateOfDeathYear').length).to.equal(0);
+    expect(form.find('input').length).to.equal(13);
+
+    form.unmount();
+  });
+
+  it('should display single death date for chapter 33 and child relationship', () => {
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        definitions={formConfig.defaultDefinitions}
+        data={{ relationship: 'child', benefit: 'chapter33' }}
+        uiSchema={uiSchema}
+      />,
+    );
+
+    expect(form.find('#root_veteranDateOfDeathMonth').length).to.equal(1);
+    expect(form.find('#root_veteranDateOfDeathDay').length).to.equal(1);
+    expect(form.find('#root_veteranDateOfDeathYear').length).to.equal(1);
+
+    form.unmount();
+  });
+
+  it('should display single death date for chapter 35 and child relationship', () => {
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        definitions={formConfig.defaultDefinitions}
+        data={{ relationship: 'child', benefit: 'chapter35' }}
+        uiSchema={uiSchema}
+      />,
+    );
+
+    expect(form.find('#root_veteranDateOfDeathMonth').length).to.equal(1);
+    expect(form.find('#root_veteranDateOfDeathDay').length).to.equal(1);
+    expect(form.find('#root_veteranDateOfDeathYear').length).to.equal(1);
+
+    form.unmount();
+  });
+
+  it('should display single death date for chapter 35 and spouse relationship', () => {
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        definitions={formConfig.defaultDefinitions}
+        data={{ relationship: 'spouse', benefit: 'chapter35' }}
+        uiSchema={uiSchema}
+      />,
+    );
+
+    expect(form.find('#root_veteranDateOfDeathMonth').length).to.equal(1);
+    expect(form.find('#root_veteranDateOfDeathDay').length).to.equal(1);
+    expect(form.find('#root_veteranDateOfDeathYear').length).to.equal(1);
+
+    form.unmount();
   });
 
   it('should conditionally show spouseInfo options', () => {


### PR DESCRIPTION
## Description
New 5490 date questions should only be displayed if the relationship is `spouse` and the benefit is `chapter33`

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
