### PR TITLE
Run Nightwatch tests in GitHub default runner.

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -265,10 +265,7 @@ jobs:
   nightwatch:
     name: Nightwatch E2E Tests
 
-    runs-on: self-hosted
-
-    env:
-      NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
+    runs-on: ubuntu-latest
 
     needs: [build]
 


### PR DESCRIPTION
## Description
- Changing the runner to the default to avoid any port contention. No port randomization and management needed.
- The Nightwatch tests still only take 2.5 minutes to run in the default runner (vs 1.5 minutes in the self-hosted).
- The performance hit is negligible, and the Cypress tests will continue being the bottleneck, so the self-hosted runner didn't seem necessary.

## Testing done
CI passes.

## Acceptance criteria
- [ ] Nightwatch tests should continue to pass with a reasonable runtime.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
