### PR TITLE
Fixed archive step's dependency on skipped linting job in PRs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -364,7 +364,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ success() && github.ref == 'refs/heads/master' }}
     needs: archive
 
     strategy:
@@ -412,6 +412,7 @@ jobs:
     name: Run Jenkins CI
     runs-on: ubuntu-latest
     needs: archive
+    if: ${{ success() }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -364,7 +364,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    if: ${{ success() && github.ref == 'refs/heads/master' }}
+    if: ${{ always() && github.ref == 'refs/heads/master' && needs.archive.result == 'success' }}
     needs: archive
 
     strategy:
@@ -412,7 +412,7 @@ jobs:
     name: Run Jenkins CI
     runs-on: ubuntu-latest
     needs: archive
-    if: ${{ success() }}
+    if: ${{ always() && needs.archive.result == 'success' }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -329,7 +329,15 @@ jobs:
     needs: [contract-tests, linting, nightwatch, security-audit, unit-tests]
 
     # Prevent archive from being skipped when linting is skipped (in PRs).
-    if: ${{ always() && (needs.linting.result == 'success' || needs.linting.result == 'skipped') }}
+    if: |
+      ${{
+        always() &&
+        needs.nightwatch.result == 'success' &&
+        needs.unit-tests.result == 'success' &&
+        needs.contract-tests.result == 'success' &&
+        needs.security-audit.result == 'success' &&
+        (needs.linting.result == 'success' || needs.linting.result == 'skipped')
+      }}
 
     steps:
       - name: Download build artifact

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -326,6 +326,8 @@ jobs:
 
     needs: [unit-tests, linting, contract-tests, security-audit, nightwatch]
 
+    if: ${{ always() && (needs.linting.result == 'success' || needs.linting.result == 'skipped') }}
+
     steps:
       - name: Download build artifact
         uses: actions/download-artifact@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -326,7 +326,11 @@ jobs:
 
     needs: [contract-tests, linting, nightwatch, security-audit, unit-tests]
 
-    # Prevent archive from being skipped when linting is skipped (in PRs).
+    # Archive should still run even when linting is skipped (as in PRs).
+    # This if overrides the dependency on linting success to include skipped.
+    # Because of always(), the rest of the needed jobs have to be checked too.
+    # By doing this, later jobs that need this job require similar overrides
+    # or else they will also be skipped when linting is skipped.
     if: |
       success() &&
       needs.nightwatch.result == 'success' &&

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -324,7 +324,7 @@ jobs:
       matrix:
         buildtype: [vagovdev, vagovstaging, vagovprod]
 
-    needs: [unit-tests, linting, contract-tests, security-audit, nightwatch]
+    needs: [contract-tests, linting, nightwatch, security-audit, unit-tests]
 
     # Prevent archive from being skipped when linting is skipped (in PRs).
     if: ${{ always() && (needs.linting.result == 'success' || needs.linting.result == 'skipped') }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -105,6 +105,8 @@ jobs:
     name: Contract Tests
     runs-on: ubuntu-latest
     steps:
+      - run: exit 1
+
       - name: Checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -71,6 +71,7 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
+      - run: exit 1
       - name: Checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -6,6 +6,67 @@ env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
 
 jobs:
+  build:
+    name: Build
+    runs-on: self-hosted
+
+    env:
+      NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
+
+    strategy:
+      matrix:
+        buildtype: [vagovdev, vagovstaging, vagovprod]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Get Node version
+        id: get-node-version
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
+
+      - name: Cache dependencies
+        id: cache-dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/yarn
+            node_modules
+          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-e2e-${{ hashFiles('yarn.lock') }}
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --prefer-offline
+        env:
+          YARN_CACHE_FOLDER: ~/.cache/yarn
+
+      - name: Build
+        run: yarn build --verbose --buildtype=${{ matrix.buildtype }}
+        timeout-minutes: 30
+
+      - name: Generate build details
+        run: |
+          cat > build/${{ matrix.buildtype }}/BUILD.txt << EOF
+          BUILDTYPE=${{ matrix.buildtype }}
+          BRANCH_NAME=$(echo "${GITHUB_REF#refs/heads/}")
+          RUN_ID=${{ github.run_id }}
+          REF=${{ github.sha }}
+          BUILDTIME=$(date +%s)
+          EOF
+
+      - name: Compress and archive build
+        run: tar -C build/${{ matrix.buildtype }} -cjf ${{ matrix.buildtype }}.tar.bz2 .
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.buildtype }}.tar.bz2
+          path: ${{ matrix.buildtype }}.tar.bz2
+
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
@@ -59,47 +120,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: 'test-results/unit-tests.xml'
           summary: ${{ steps.code-coverage.outputs.MARKDOWN }}
-
-  linting:
-    name: Linting (All)
-    if: ${{ github.ref == 'refs/heads/master' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Get Node version
-        id: get-node-version
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
-
-      - name: Cache dependencies
-        id: cache-dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cache/yarn
-            node_modules
-          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile --prefer-offline
-        env:
-          YARN_CACHE_FOLDER: ~/.cache/yarn
-
-      - name: Annotate ESLint results
-        run: yarn run eslint --ext .js --ext .jsx --format ./script/github-actions/eslint-annotation-format.js .
-
-      - name: Run Stylelint
-        run: yarn run stylelint verbose --output-file stylelint-report.json --formatter json src/**/*.scss
-
-      - name: Annotate Stylelint results
-        if: ${{ always() }}
-        run: node ./script/github-actions/stylelint-annotation-format.js
 
   contract-tests:
     name: Contract Tests
@@ -201,17 +221,10 @@ jobs:
       - name: Audit dependencies
         run: yarn security-check
 
-  build:
-    name: Build
-    runs-on: self-hosted
-
-    env:
-      NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
-
-    strategy:
-      matrix:
-        buildtype: [vagovdev, vagovstaging, vagovprod]
-
+  linting:
+    name: Linting (All)
+    if: ${{ github.ref == 'refs/heads/master' }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -232,35 +245,22 @@ jobs:
           path: |
             ~/.cache/yarn
             node_modules
-          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-e2e-${{ hashFiles('yarn.lock') }}
+          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
         env:
           YARN_CACHE_FOLDER: ~/.cache/yarn
 
-      - name: Build
-        run: yarn build --verbose --buildtype=${{ matrix.buildtype }}
-        timeout-minutes: 30
+      - name: Annotate ESLint results
+        run: yarn run eslint --ext .js --ext .jsx --format ./script/github-actions/eslint-annotation-format.js .
 
-      - name: Generate build details
-        run: |
-          cat > build/${{ matrix.buildtype }}/BUILD.txt << EOF
-          BUILDTYPE=${{ matrix.buildtype }}
-          BRANCH_NAME=$(echo "${GITHUB_REF#refs/heads/}")
-          RUN_ID=${{ github.run_id }}
-          REF=${{ github.sha }}
-          BUILDTIME=$(date +%s)
-          EOF
+      - name: Run Stylelint
+        run: yarn run stylelint verbose --output-file stylelint-report.json --formatter json src/**/*.scss
 
-      - name: Compress and archive build
-        run: tar -C build/${{ matrix.buildtype }} -cjf ${{ matrix.buildtype }}.tar.bz2 .
-
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.buildtype }}.tar.bz2
-          path: ${{ matrix.buildtype }}.tar.bz2
+      - name: Annotate Stylelint results
+        if: ${{ always() }}
+        run: node ./script/github-actions/stylelint-annotation-format.js
 
   nightwatch:
     name: Nightwatch E2E Tests
@@ -324,7 +324,7 @@ jobs:
       matrix:
         buildtype: [vagovdev, vagovstaging, vagovprod]
 
-    needs: [contract-tests, linting, nightwatch, security-audit, unit-tests]
+    needs: [nightwatch, unit-tests, contract-tests, security-audit, linting]
 
     # Archive should still run even when linting is skipped (as in PRs).
     # This if overrides the dependency on linting success to include skipped.

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -71,7 +71,6 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - run: exit 1
       - name: Checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -105,8 +105,6 @@ jobs:
     name: Contract Tests
     runs-on: ubuntu-latest
     steps:
-      - run: exit 1
-
       - name: Checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -324,7 +324,7 @@ jobs:
       matrix:
         buildtype: [vagovdev, vagovstaging, vagovprod]
 
-    needs: [unit-tests, contract-tests, security-audit, nightwatch]
+    needs: [unit-tests, linting, contract-tests, security-audit, nightwatch]
 
     steps:
       - name: Download build artifact

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -326,6 +326,7 @@ jobs:
 
     needs: [unit-tests, linting, contract-tests, security-audit, nightwatch]
 
+    # Prevent archive from being skipped when linting is skipped (in PRs).
     if: ${{ always() && (needs.linting.result == 'success' || needs.linting.result == 'skipped') }}
 
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -270,7 +270,7 @@ jobs:
     env:
       NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
 
-    needs: [build]
+    needs: build
 
     steps:
       - name: Checkout vets-website

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -332,7 +332,7 @@ jobs:
     # By doing this, later jobs that need this job require similar overrides
     # or else they will also be skipped when linting is skipped.
     if: |
-      success() &&
+      always() &&
       needs.nightwatch.result == 'success' &&
       needs.unit-tests.result == 'success' &&
       needs.contract-tests.result == 'success' &&

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -330,14 +330,12 @@ jobs:
 
     # Prevent archive from being skipped when linting is skipped (in PRs).
     if: |
-      ${{
-        always() &&
-        needs.nightwatch.result == 'success' &&
-        needs.unit-tests.result == 'success' &&
-        needs.contract-tests.result == 'success' &&
-        needs.security-audit.result == 'success' &&
-        (needs.linting.result == 'success' || needs.linting.result == 'skipped')
-      }}
+      success() &&
+      needs.nightwatch.result == 'success' &&
+      needs.unit-tests.result == 'success' &&
+      needs.contract-tests.result == 'success' &&
+      needs.security-audit.result == 'success' &&
+      (needs.linting.result == 'success' || needs.linting.result == 'skipped')
 
     steps:
       - name: Download build artifact


### PR DESCRIPTION
## Description
Made archive depend on linting again. Previously removed it since a skipped job in the `needs` list of a job will cause the dependent job to be skipped.

Rearranged the list order of parallel jobs so that linting is last so that when it's skipped, it will display as such at the bottom of that group.

## Testing done
- Verified that skipping linting doesn't cause archive (and the jobs that depend on archive) to be skipped.
- Confirmed that a failed job that archive needs will still result in skipping it as well as the jobs that depend on archive.

## Screenshots

Skipped linting doesn't stop archive and subsequent jobs from running.
> ![image](https://user-images.githubusercontent.com/1067024/122431478-7f096980-cf62-11eb-8c81-c4af2583866d.png)

Non-linting job failure prevents archive and subsequent steps from running.
> ![image](https://user-images.githubusercontent.com/1067024/122436594-f2ad7580-cf66-11eb-8bde-1d3d6e7f134c.png)

## Acceptance criteria
- [ ] The archive step should depend on the linting step.
- [ ] Skipping linting should not prevent archive and subsequent steps from running.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs