### PR TITLE
feat(1010cg): update upload file type description

### DIFF
--- a/src/applications/caregivers/components/AdditionalInfo/index.jsx
+++ b/src/applications/caregivers/components/AdditionalInfo/index.jsx
@@ -6,7 +6,12 @@ import AlertBox, {
   ALERT_TYPE,
 } from '@department-of-veterans-affairs/component-library/AlertBox';
 
+import {
+  ALLOWED_FILE_TYPES,
+  MAX_FILE_SIZE_MB,
+} from 'applications/caregivers/definitions/constants';
 import { links } from 'applications/caregivers/definitions/content';
+import { arrayToSentenceString } from '../../helpers';
 
 export const VeteranSSNInfo = () => (
   <div className="vads-u-margin-y--1p5">
@@ -272,6 +277,13 @@ export const RepresentativeAdditionalInfo = () => {
 };
 
 export const RepresentativeDocumentUploadDescription = () => {
+  const prependDot = string => `.${string}`;
+  const allowedFileTypes = arrayToSentenceString(
+    ALLOWED_FILE_TYPES,
+    'or',
+    prependDot,
+  );
+
   return (
     <section>
       <p>
@@ -282,8 +294,11 @@ export const RepresentativeDocumentUploadDescription = () => {
 
       <p>Guidelines for uploading a file:</p>
       <ul>
-        <li>You can upload a .pdf, .jpeg, or .png file</li>
-        <li>Your file should be no larger than 10MB</li>
+        <li>You can upload a {allowedFileTypes} file</li>
+        <li>
+          Your file should be no larger than {MAX_FILE_SIZE_MB}
+          MB
+        </li>
       </ul>
 
       <p>

--- a/src/applications/caregivers/config/chapters/signAsRepresentative/uploadPOADocument.js
+++ b/src/applications/caregivers/config/chapters/signAsRepresentative/uploadPOADocument.js
@@ -1,7 +1,11 @@
 import React from 'react';
 import fileUploadUI from 'platform/forms-system/src/js/definitions/file';
 import environment from 'platform/utilities/environment';
-import { representativeFields } from 'applications/caregivers/definitions/constants';
+import {
+  representativeFields,
+  ALLOWED_FILE_TYPES,
+  MAX_FILE_SIZE_BYTES,
+} from 'applications/caregivers/definitions/constants';
 import { RepresentativeDocumentUploadDescription } from 'applications/caregivers/components/AdditionalInfo';
 import recordEvent from 'platform/monitoring/record-event';
 
@@ -48,8 +52,8 @@ export default {
       classNames: 'poa-document-upload',
       multiple: false,
       fileUploadUrl: `${environment.API_URL}/v0/form1010cg/attachments`,
-      fileTypes: ['pdf', 'jpg', 'jpeg', 'png'],
-      maxSize: 1024 * 1024 * 10,
+      fileTypes: ALLOWED_FILE_TYPES,
+      maxSize: MAX_FILE_SIZE_BYTES,
       hideLabelText: true,
       createPayload,
       parseResponse,

--- a/src/applications/caregivers/definitions/constants.js
+++ b/src/applications/caregivers/definitions/constants.js
@@ -63,3 +63,7 @@ export const representativeFields = {
   signAsRepresentativeYesNo: 'signAsRepresentativeYesNo',
   documentUpload: 'signAsRepresentativeDocumentUpload',
 };
+
+export const ALLOWED_FILE_TYPES = ['pdf', 'jpg', 'jpeg', 'png'];
+export const MAX_FILE_SIZE_MB = 10;
+export const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024;

--- a/src/applications/caregivers/helpers.js
+++ b/src/applications/caregivers/helpers.js
@@ -216,3 +216,26 @@ export const shouldHideAlert = formData => {
   if (!hasPrimary && !hasSecondary) return false;
   return false;
 };
+
+/**
+ * Converts an array of items into a sentence with a conjunction
+ *
+ * Note: returns blank string if items is not an array or is empty
+ * @export
+ * @param {Array<string>} items
+ * @param {string} conjunction
+ * @param {Function} transform mapper function
+ * @returns {string}
+ */
+export const arrayToSentenceString = (items, conjunction, transform) => {
+  if (!Array.isArray(items) || items.length < 1) return '';
+
+  return items.reduce((accumulator, val, index) => {
+    const item = typeof transform === 'function' ? transform(val) : val;
+
+    if (index === 0) return item.toString();
+
+    const seperator = index < items.length - 1 ? ',' : `, ${conjunction}`;
+    return `${accumulator}${seperator} ${item}`;
+  }, '');
+};

--- a/src/applications/caregivers/tests/helpers.unit.spec.js
+++ b/src/applications/caregivers/tests/helpers.unit.spec.js
@@ -1,4 +1,8 @@
-import { submitTransform, isSSNUnique } from '../helpers';
+import {
+  submitTransform,
+  isSSNUnique,
+  arrayToSentenceString,
+} from '../helpers';
 import { expect } from 'chai';
 import formConfig from 'applications/caregivers/config/form';
 import {
@@ -300,5 +304,48 @@ describe('Caregivers helpers', () => {
     const areSSNsUnique = isSSNUnique(formData);
 
     expect(areSSNsUnique).to.be.true;
+  });
+
+  describe('arrayToSentenceString', () => {
+    it('should return empty string when not an array', () => {
+      const sentence = arrayToSentenceString('array', 'or');
+
+      expect(sentence).to.equal('');
+    });
+
+    it('should return empty string when array is empty', () => {
+      const sentence = arrayToSentenceString([], 'or');
+
+      expect(sentence).to.equal('');
+    });
+
+    it('should return item unformatted when array constains only one item', () => {
+      const onlyItem = 'MyOnlyItem';
+      const sentence = arrayToSentenceString([onlyItem], 'or');
+
+      expect(sentence).to.equal(onlyItem);
+    });
+
+    it('should return item transformed without conjunction when array constains only one item', () => {
+      const transform = value => `(${value})`;
+      const sentence = arrayToSentenceString(['MyOnlyItem'], 'or', transform);
+
+      expect(sentence).to.equal('(MyOnlyItem)');
+    });
+
+    it('should return formated string with conjunction without transform function', () => {
+      const inputArray = ['Ed', 'Edd', 'Eddy'];
+      const sentence = arrayToSentenceString(inputArray, 'and');
+
+      expect(sentence).to.equal('Ed, Edd, and Eddy');
+    });
+
+    it('should return formated string with conjunction with transform function', () => {
+      const transform = value => `(${value})`;
+      const inputArray = ['*.*', '^.^', 'O.O'];
+      const sentence = arrayToSentenceString(inputArray, 'and', transform);
+
+      expect(sentence).to.equal('(*.*), (^.^), and (O.O)');
+    });
   });
 });


### PR DESCRIPTION
## Description
Update 1010cg `Guidelines for uploading a file:` to include .jpg.

## Testing done
- [ ] unit
- [ ] manual/visual

## Screenshots
![jpg_add](https://user-images.githubusercontent.com/83595736/122457958-3f9c4680-cf7d-11eb-9c4b-db1b339fcc8d.png)

## Acceptance criteria
- [ ] Update `You can upload a .pdf, .jpeg, or .png file` to `You can upload a .pdf, .jpeg, .jpg, or .png file`

## Definition of done
- [ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/25958)
