### PR TITLE
DT-26216 Find Forms removed old alert and added new

### DIFF
--- a/src/applications/find-forms/containers/SearchResults.jsx
+++ b/src/applications/find-forms/containers/SearchResults.jsx
@@ -1,7 +1,6 @@
 // Dependencies.
 import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
-import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import Pagination from '@department-of-veterans-affairs/component-library/Pagination';
 import { connect } from 'react-redux';
@@ -119,11 +118,10 @@ export const SearchResults = ({
   // Show the error alert box if there was an error.
   if (error) {
     return (
-      <AlertBox
-        headline="Something went wrong"
-        content={error}
-        status="error"
-      />
+      <va-alert status="error">
+        <h3 slot="headline">Something went wrong"</h3>
+        <div className="usa-alert-text">{error}</div>
+      </va-alert>
     );
   }
 

--- a/src/applications/find-forms/widgets/createInvalidPdfAlert.js
+++ b/src/applications/find-forms/widgets/createInvalidPdfAlert.js
@@ -2,7 +2,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import * as Sentry from '@sentry/browser';
-import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 
 import { fetchFormsApi } from '../api';
 
@@ -14,18 +13,14 @@ function InvalidFormDownload({ downloadUrl }) {
   const mailto = `mailto:VaFormsManagers@va.gov?subject=${subject}&body=${body}`;
 
   return (
-    <AlertBox
-      isVisible
-      status="error"
-      headline="This form link isn’t working"
-      content={
-        <>
-          We’re sorry, but the form you’re trying to download appears to have an
-          invalid link. Please <a href={mailto}>email the forms managers</a> for
-          help with this form.
-        </>
-      }
-    />
+    <va-alert status="error">
+      <h3 slot="headline">This form link isn’t working</h3>
+      <div className="usa-alert-text">
+        We’re sorry, but the form you’re trying to download appears to have an
+        invalid link. Please <a href={mailto}>email the forms managers</a> for
+        help with this form.
+      </div>
+    </va-alert>
   );
 }
 


### PR DESCRIPTION
## Issue
https://github.com/department-of-veterans-affairs/va.gov-team/issues/26216

## Description
Changing old components to new web components as they are migrated. 

## Testing done
Ran unit and e2e test. Spun up local to see the boxes.

## Screenshots
![Screen Shot 2021-06-17 at 3 47 30 PM](https://user-images.githubusercontent.com/26075258/122466030-c6a1ec80-cf86-11eb-91ec-6d9026011ac3.png)
![Screen Shot 2021-06-17 at 3 51 55 PM](https://user-images.githubusercontent.com/26075258/122466034-c7d31980-cf86-11eb-8716-0c8755c81e22.png)


## Acceptance criteria
- [x] Alerts work as the do on Production

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
