### PR TITLE
Add deep links to the Profile's email address and phone numbers section

### DIFF
--- a/src/applications/personalization/profile/components/ProfileInfoTable.jsx
+++ b/src/applications/personalization/profile/components/ProfileInfoTable.jsx
@@ -1,9 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import prefixUtilityClasses from 'platform/utilities/prefix-utility-classes';
+import prefixUtilityClasses from '~/platform/utilities/prefix-utility-classes';
 
-const ProfileInfoTable = ({ data, dataTransformer, title, className }) => {
+const TableTitle = ({ namedAnchor, className, children }) => {
+  return (
+    <h3 className={className} id={namedAnchor}>
+      {children}
+    </h3>
+  );
+};
+
+const ProfileInfoTable = ({
+  data,
+  dataTransformer,
+  title,
+  className,
+  namedAnchor,
+}) => {
   const titleClasses = prefixUtilityClasses([
     'background-color--gray-lightest',
     'border--1px',
@@ -78,7 +92,12 @@ const ProfileInfoTable = ({ data, dataTransformer, title, className }) => {
 
   return (
     <section className={classes.table}>
-      {title && <h3 className={classes.title}>{title}</h3>}
+      {title && (
+        <TableTitle className={classes.title} namedAnchor={namedAnchor}>
+          {title}
+        </TableTitle>
+      )}
+      {/* {title && <h3 className={classes.title}>{title}</h3>} */}
       {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
       <ol className="vads-u-margin--0 vads-u-padding--0" role="list">
         {data
@@ -112,11 +131,7 @@ ProfileInfoTable.propTypes = {
   data: PropTypes.array.isRequired,
   dataTransformer: PropTypes.func,
   className: PropTypes.string,
-  /**
-   * When `list` is truthy, additional a11y markup will be applied to the
-   * rendered table to treat it like a list
-   */
-  list: PropTypes.bool,
+  namedAnchor: PropTypes.string,
 };
 
 export default ProfileInfoTable;

--- a/src/applications/personalization/profile/components/personal-information/PersonalInformation.jsx
+++ b/src/applications/personalization/profile/components/personal-information/PersonalInformation.jsx
@@ -32,14 +32,26 @@ const PersonalInformation = ({
 
   useEffect(
     () => {
-      // Do not manage the focus if the user just came to this route via the
-      // root profile route. If a user got to the Profile via a link to /profile
-      // or /profile/ we want to focus on the "Profile" sub-nav H1, not the
-      // H2 on this page
+      // Set the focus on the page's focus target _unless_ one of the following
+      // is true:
+      // - there is a hash in the URL and there is a named-anchor that matches
+      //   the hash
+      // - the user just came to this route via the root profile route. If a
+      //   user got to the Profile via a link to /profile or /profile/ we want
+      //   to focus on the "Profile" sub-nav H1, not the H2 on this page
       const pathRegExp = new RegExp(`${PROFILE_PATHS.PROFILE_ROOT}/?$`);
       if (lastLocation?.pathname.match(new RegExp(pathRegExp))) {
         return;
       }
+      if (window.location.hash) {
+        const target = document.querySelector(window.location.hash);
+        if (target) {
+          focusElement(target);
+          target.scrollIntoView();
+          return;
+        }
+      }
+
       focusElement('[data-focus-target]');
     },
     [lastLocation],

--- a/src/applications/personalization/profile/components/personal-information/email-addresses/EmailInformationSection.jsx
+++ b/src/applications/personalization/profile/components/personal-information/email-addresses/EmailInformationSection.jsx
@@ -33,6 +33,7 @@ const EmailInformationSection = ({ className, signInServiceName }) => {
       <ProfileInfoTable
         title="Contact email address"
         fieldName="emailAddress"
+        namedAnchor="email-address"
         data={[
           {
             value: (
@@ -56,7 +57,6 @@ const EmailInformationSection = ({ className, signInServiceName }) => {
             value: <ContactInformationField fieldName={FIELD_NAMES.EMAIL} />,
           },
         ]}
-        list
         className="vads-u-margin-y--4"
       />
     </div>

--- a/src/applications/personalization/profile/components/personal-information/phone-numbers/PhoneNumbersTable.jsx
+++ b/src/applications/personalization/profile/components/personal-information/phone-numbers/PhoneNumbersTable.jsx
@@ -9,6 +9,7 @@ import ProfileInfoTable from '../../ProfileInfoTable';
 const PhoneNumbersTable = ({ className }) => (
   <ProfileInfoTable
     title="Phone numbers"
+    namedAnchor="phone-numbers"
     data={[
       {
         title: 'Home',
@@ -27,7 +28,6 @@ const PhoneNumbersTable = ({ className }) => (
         value: <ContactInformationField fieldName={FIELD_NAMES.FAX_NUMBER} />,
       },
     ]}
-    list
     className={className}
   />
 );

--- a/src/applications/personalization/profile/tests/components/ProfileInfoTable.unit.spec.js
+++ b/src/applications/personalization/profile/tests/components/ProfileInfoTable.unit.spec.js
@@ -28,12 +28,9 @@ describe('ProfileInfoTable', () => {
   it('renders a `section`', () => {
     expect(wrapper.type()).to.equal('section');
   });
-  it('renders the title prop in an h3 tag', () => {
-    const h3 = wrapper.find('h3');
-    expect(h3.text()).to.equal(props.title);
-  });
-  it('should render an h3 tag as the first child element', () => {
-    expect(wrapper.childAt(0).type()).to.equal('h3');
+  it('renders the title prop in the DOM', () => {
+    const tableTitle = wrapper.find('TableTitle');
+    expect(tableTitle.dive().text()).to.equal(props.title);
   });
   it('renders a table row li for each entry in the data prop', () => {
     const tableRows = wrapper.find('ol > li.table-row');

--- a/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/deep-links.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/deep-links.cypress.spec.js
@@ -1,0 +1,57 @@
+import { PROFILE_PATHS } from '@@profile/constants';
+
+import mockUser from '../../fixtures/users/user-36.json';
+
+const deepLinks = [
+  // this first one is to make sure unsupported deep link urls manage focus
+  // correctly
+  {
+    url: `${PROFILE_PATHS.PERSONAL_INFORMATION}#an-unsupported-deep-link`,
+    expectedTarget: 'Personal and contact information',
+  },
+  {
+    url: `${PROFILE_PATHS.PERSONAL_INFORMATION}#email-address`,
+    expectedTarget: 'Contact email address',
+  },
+  {
+    url: `${PROFILE_PATHS.PERSONAL_INFORMATION}#phone-numbers`,
+    expectedTarget: 'Phone numbers',
+  },
+];
+
+/**
+ * @param {boolean} mobile - test on a mobile viewport or not
+ */
+function checkAllDeepLinks(mobile = false) {
+  cy.visit(PROFILE_PATHS.PERSONAL_INFORMATION);
+  if (mobile) {
+    cy.viewport('iphone-4');
+  }
+
+  // should show a loading indicator
+  cy.findByRole('progressbar').should('exist');
+  cy.findByText(/loading your information/i).should('exist');
+
+  // and then the loading indicator should be removed
+  cy.findByRole('progressbar').should('not.exist');
+  cy.findByText(/loading your information/i).should('not.exist');
+
+  deepLinks.forEach(deepLink => {
+    cy.visit(deepLink.url);
+    // focus should be on the correct sub-section heading
+    cy.focused().contains(deepLink.expectedTarget);
+  });
+}
+
+describe('Profile', () => {
+  beforeEach(() => {
+    cy.login(mockUser);
+  });
+  it('should manage focus for all supported deep links on desktop size', () => {
+    checkAllDeepLinks(false);
+  });
+
+  it('should manage focus for all supported deep links on mobile phone size', () => {
+    checkAllDeepLinks(true);
+  });
+});


### PR DESCRIPTION
## Description
This PR adds support for links to `/profile/personal-information#email-address` and `/profile/personal-information#phone-numbers`. If you enter that URL in the browser, you'll get directed to the Profile, the appropriate section header will be at the top of the browser window, and that section header will have focus.

## Testing done
Cypress

## Screenshots
I'm unable to sign in locally right now so I cannot post video caps of this in action :(

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs