### PR TITLE
Fix hardcoded date in VAOS test

### DIFF
--- a/src/applications/vaos/tests/appointment-list/components/FutureAppointmentsList.va.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/FutureAppointmentsList.va.unit.spec.jsx
@@ -458,11 +458,12 @@ describe('VAOS integration: upcoming VA appointments', () => {
   });
 
   it('should verify VA phone calendar ics file format', async () => {
+    const startDate = moment.utc();
     const appointment = getVAAppointmentMock();
     appointment.attributes = {
       ...appointment.attributes,
       phoneOnly: true,
-      startDate: '2021-06-20T16:00:00Z',
+      startDate: startDate.format(),
       clinicFriendlyName: 'C&P BEV AUDIO FTC1',
       facilityId: '983',
       sta6aid: '983GC',
@@ -501,7 +502,7 @@ describe('VAOS integration: upcoming VA appointments', () => {
 
     await findByText(
       new RegExp(
-        moment(appointment.attributes.startDate).format('dddd, MMMM D, YYYY'),
+        startDate.tz('America/Denver').format('dddd, MMMM D, YYYY [at] h:mm'),
         'i',
       ),
     );


### PR DESCRIPTION
## Description
One of the dates in a VAOS test is hardcoded, and now it's in the past. Which is causing a test to fail.

## Testing done
Unit testing

## Acceptance criteria
- [ ] Build passes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
