### PR TITLE
Unit Test Fix

### DIFF
--- a/src/applications/edu-benefits/10203/tests/actions/post-911-gib-status.unit.spec.js
+++ b/src/applications/edu-benefits/10203/tests/actions/post-911-gib-status.unit.spec.js
@@ -8,7 +8,7 @@ const GET_REMAINING_ENTITLEMENT_SUCCESS = 'GET_REMAINING_ENTITLEMENT_SUCCESS';
 let oldWindow;
 const setup = () => {
   mockFetch();
-  setFetchJSONResponse(global.fetch.onCall(0), {});
+  oldWindow = global.window;
   global.window = Object.create(global.window);
   Object.assign(global.window, {
     dataLayer: [],


### PR DESCRIPTION
## Description
This should resolve an issue we were seeing where, when the unit tests were run in a particular order, many (20-50) tests would fail.

## Testing done
All unit tests should be passing.

I don't have a CHOMA_SEED that works with the current unit test suite (tests have been added since the last time we saw a failure like this, so the CHOMA_SEEDs have reset), but if you want to check it locally, you can check out commit # `8ef6d7b153f61544e3169d4ce6146a5207ae764c` and run the tests with `CHOMA_SEED=oIpM9VpBi4 yarn test:unit --reporter=spec`. You should see a bunch of tests fail first. If you then apply the change I made in this PR and run the tests again, they should all pass.

## Screenshots


## Acceptance criteria
- [ ] All unit tests are passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
