### PR TITLE
CT: Add VRRAP Participant indicator to institution profile page

### DIFF
--- a/src/applications/gi/components/profile/AdditionalInformation.jsx
+++ b/src/applications/gi/components/profile/AdditionalInformation.jsx
@@ -159,12 +159,16 @@ export class AdditionalInformation extends React.Component {
           {institution.stemIndicator ? 'Yes' : 'No'}
         </div>
         <div>
-          <div>
-            <strong>
-              Veteran Rapid Retraining Assistance Program (VRRAP):
-            </strong>
-            &nbsp; {institution.vrrap ? 'Yes' : 'No'}
-          </div>
+          {institution.vrrap === null ? (
+            ''
+          ) : (
+            <div>
+              <strong>
+                Veteran Rapid Retraining Assistance Program (VRRAP):
+              </strong>
+              &nbsp; {institution.vrrap ? 'Yes' : 'No'}
+            </div>
+          )}
         </div>
         <div>
           <strong>

--- a/src/applications/gi/components/profile/AdditionalInformation.jsx
+++ b/src/applications/gi/components/profile/AdditionalInformation.jsx
@@ -158,16 +158,14 @@ export class AdditionalInformation extends React.Component {
           &nbsp;
           {institution.stemIndicator ? 'Yes' : 'No'}
         </div>
-        <div>
-          {institution.vrrap !== null && (
-            <div>
-              <strong>
-                Veteran Rapid Retraining Assistance Program (VRRAP):
-              </strong>
-              &nbsp; {institution.vrrap ? 'Yes' : 'No'}
-            </div>
-          )}
-        </div>
+        {institution.vrrap !== null && (
+          <div>
+            <strong>
+              Veteran Rapid Retraining Assistance Program (VRRAP):
+            </strong>
+            &nbsp; {institution.vrrap ? 'Yes' : 'No'}
+          </div>
+        )}
         <div>
           <strong>
             <button

--- a/src/applications/gi/components/profile/AdditionalInformation.jsx
+++ b/src/applications/gi/components/profile/AdditionalInformation.jsx
@@ -159,6 +159,14 @@ export class AdditionalInformation extends React.Component {
           {institution.stemIndicator ? 'Yes' : 'No'}
         </div>
         <div>
+          <div>
+            <strong>
+              Veteran Rapid Retraining Assistance Program (VRRAP):
+            </strong>
+            &nbsp; {institution.vrrap ? 'Yes' : 'No'}
+          </div>
+        </div>
+        <div>
           <strong>
             <button
               type="button"

--- a/src/applications/gi/components/profile/AdditionalInformation.jsx
+++ b/src/applications/gi/components/profile/AdditionalInformation.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import recordEvent from 'platform/monitoring/record-event';
+import environment from 'platform/utilities/environment';
 
 export class AdditionalInformation extends React.Component {
   updateFiscalYear() {
@@ -158,14 +159,15 @@ export class AdditionalInformation extends React.Component {
           &nbsp;
           {institution.stemIndicator ? 'Yes' : 'No'}
         </div>
-        {institution.vrrap !== null && (
-          <div>
-            <strong>
-              Veteran Rapid Retraining Assistance Program (VRRAP):
-            </strong>
-            &nbsp; {institution.vrrap ? 'Yes' : 'No'}
-          </div>
-        )}
+        {!environment.isProduction() &&
+          institution.vrrap !== null && (
+            <div>
+              <strong>
+                Veteran Rapid Retraining Assistance Program (VRRAP):
+              </strong>
+              &nbsp; {institution.vrrap ? 'Yes' : 'No'}
+            </div>
+          )}
         <div>
           <strong>
             <button

--- a/src/applications/gi/components/profile/AdditionalInformation.jsx
+++ b/src/applications/gi/components/profile/AdditionalInformation.jsx
@@ -159,9 +159,7 @@ export class AdditionalInformation extends React.Component {
           {institution.stemIndicator ? 'Yes' : 'No'}
         </div>
         <div>
-          {institution.vrrap === null ? (
-            ''
-          ) : (
+          {institution.vrrap !== null && (
             <div>
               <strong>
                 Veteran Rapid Retraining Assistance Program (VRRAP):


### PR DESCRIPTION
## Description
As an education benefits recipient, I need a way to see if an institution is participating in the VRRAP program when browsing the comparison tool so that I can determine which benefit I am able to use at that institution.
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/24373
## Testing done
Local testing
List of schools with vrrap  approved status
![Screen Shot 2021-06-21 at 11 44 40 AM](https://user-images.githubusercontent.com/50601724/122790306-2e597f80-d286-11eb-9343-96708bec56b7.png)

## Screenshots
![Screen Shot 2021-06-21 at 11 28 30 AM](https://user-images.githubusercontent.com/50601724/122790579-724c8480-d286-11eb-9f4a-284988fd3291.png)


## Acceptance criteria
- [x] In the "Institution summary" area of the "Additional information" section:
a. "Veteran Rapid Retraining Assistance Program (VRRAP):" is displayed with a "Yes" if the institution facility code is included in the VRRAP provider data with a status of "Approved".
b. "Veteran Rapid Retraining Assistance Program (VRRAP):" is displayed with a "No" if the institution facility code is included in the VRRAP provider data with a status of "Disapproved".
c. "Veteran Rapid Retraining Assistance Program (VRRAP):" is not displayed if the institution facility code is not included in the VRRAP provider data.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
