### PR TITLE
Bump web-components version

### DIFF
--- a/package.json
+++ b/package.json
@@ -325,7 +325,7 @@
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
     "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#2047154b11a3c890ef8bd10c279eef6695457d0d",
-    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.6.1",
+    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.6.2",
     "whatwg-fetch": "^2.0.3"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19757,7 +19757,7 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
-    
+
 "vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#2047154b11a3c890ef8bd10c279eef6695457d0d":
   version "20.6.1"
   resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#2047154b11a3c890ef8bd10c279eef6695457d0d"
@@ -19929,9 +19929,9 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.6.1":
-  version "0.6.1"
-  resolved "https://github.com/department-of-veterans-affairs/component-library.git#b892c5ba2252fbe8800c0e1e7fdc9fdaa90846f5"
+"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.6.2":
+  version "0.6.2"
+  resolved "https://github.com/department-of-veterans-affairs/component-library.git#9fdda8c6b4e325194b2a7c1fccacdd42a24664f2"
   dependencies:
     "@stencil/core" "^2.0.1"
     "@stencil/postcss" "^2.0.0"


### PR DESCRIPTION
## Description

Bumping `web-components` version so the changes from https://github.com/department-of-veterans-affairs/component-library/pull/107 will be available.

The change updates the styling on `<va-alert>` to remove excess margin if there are no child nodes.

cc @mdewey 


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
