### PR TITLE
NOD: Filter out contestable issues with no title

### DIFF
--- a/src/applications/appeals/10182/containers/FormApp.jsx
+++ b/src/applications/appeals/10182/containers/FormApp.jsx
@@ -11,7 +11,7 @@ import {
   issuesNeedUpdating,
   getSelected,
   getIssueName,
-  sortContestableIssues,
+  processContestableIssues,
 } from '../utils/helpers';
 
 import { copyAreaOfDisagreementOptions } from '../utils/disagreement';
@@ -60,7 +60,9 @@ export const FormApp = ({
               phone,
               email: email?.emailAddress,
             },
-            contestableIssues: sortContestableIssues(contestableIssues?.issues),
+            contestableIssues: processContestableIssues(
+              contestableIssues?.issues,
+            ),
           });
         } else if (
           areaOfDisagreement?.length !== formData.areaOfDisagreement?.length ||

--- a/src/applications/appeals/10182/tests/containers/FormApp.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/containers/FormApp.unit.spec.jsx
@@ -207,7 +207,10 @@ describe('FormApp', () => {
       email: profile.vapContactInfo.email.emailAddress,
     };
     expect(formData.veteran).to.deep.equal(result);
-    expect(formData.contestableIssues).to.deep.equal(contestableIssues.issues);
+    expect(formData.contestableIssues).to.deep.equal([
+      contestableIssues.issues[1],
+      contestableIssues.issues[0],
+    ]);
     // check sorted
     expect(
       formData.contestableIssues[0].attributes.approxDecisionDate,

--- a/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
@@ -11,7 +11,7 @@ import {
   isEmptyObject,
   setInitialEditMode,
   issuesNeedUpdating,
-  sortContestableIssues,
+  processContestableIssues,
 } from '../../utils/helpers';
 import { getDate } from '../../utils/dates';
 
@@ -273,20 +273,26 @@ describe('issuesNeedUpdating', () => {
   });
 });
 
-describe('sortContestableIssues', () => {
+describe('processContestableIssues', () => {
   const getIssues = dates =>
     dates.map(date => ({
-      attributes: { approxDecisionDate: date },
+      attributes: { ratingIssueSubjectText: 'a', approxDecisionDate: date },
     }));
   const getDates = dates =>
     dates.map(date => date.attributes.approxDecisionDate);
 
   it('should return an empty array with undefined issues', () => {
-    expect(getDates(sortContestableIssues())).to.deep.equal([]);
+    expect(getDates(processContestableIssues())).to.deep.equal([]);
+  });
+  it('should filter out issues missing a title', () => {
+    const issues = getIssues(['2020-02-01', '2020-03-01', '2020-01-01']);
+    issues[0].attributes.ratingIssueSubjectText = '';
+    const result = processContestableIssues(issues);
+    expect(getDates(result)).to.deep.equal(['2020-03-01', '2020-01-01']);
   });
   it('should sort issues spanning months with newest date first', () => {
     const dates = ['2020-02-01', '2020-03-01', '2020-01-01'];
-    const result = sortContestableIssues(getIssues(dates));
+    const result = processContestableIssues(getIssues(dates));
     expect(getDates(result)).to.deep.equal([
       '2020-03-01',
       '2020-02-01',
@@ -295,7 +301,7 @@ describe('sortContestableIssues', () => {
   });
   it('should sort issues spanning a year & months with newest date first', () => {
     const dates = ['2021-01-31', '2020-12-01', '2021-02-02', '2021-02-01'];
-    const result = sortContestableIssues(getIssues(dates));
+    const result = processContestableIssues(getIssues(dates));
     expect(getDates(result)).to.deep.equal([
       '2021-02-02',
       '2021-02-01',

--- a/src/applications/appeals/10182/utils/helpers.js
+++ b/src/applications/appeals/10182/utils/helpers.js
@@ -60,12 +60,16 @@ export const setInitialEditMode = (formData = []) =>
       !issue || !decisionDate || !isValidDate(decisionDate),
   );
 
+// getEligibleContestableIssues will remove deferred issues and issues > 1 year
+// past their decision date. This function removes issues with no title & sorts
+// the list by decending (newest first) decision date
 export const processContestableIssues = contestableIssues => {
   const regexDash = /-/g;
   const getDate = entry =>
     (entry.attributes?.approxDecisionDate || '').replace(regexDash, '');
 
-  // remove issues with no title & sort by date
+  // remove issues with no title & sort by date - see
+  // https://dsva.slack.com/archives/CSKKUL36K/p1623956682119300
   return (contestableIssues || [])
     .filter(issue => getIssueName(issue))
     .sort((a, b) => {

--- a/src/applications/appeals/10182/utils/helpers.js
+++ b/src/applications/appeals/10182/utils/helpers.js
@@ -60,20 +60,24 @@ export const setInitialEditMode = (formData = []) =>
       !issue || !decisionDate || !isValidDate(decisionDate),
   );
 
-export const sortContestableIssues = contestableIssues => {
+export const processContestableIssues = contestableIssues => {
   const regexDash = /-/g;
   const getDate = entry =>
     (entry.attributes?.approxDecisionDate || '').replace(regexDash, '');
 
-  return (contestableIssues || []).sort((a, b) => {
-    const dateA = getDate(a);
-    const dateB = getDate(b);
-    if (dateA === dateB) {
-      return 0;
-    }
-    // YYYYMMDD string comparisons will work in place of using moment
-    return dateA > dateB ? -1 : 1;
-  });
+  // remove issues with no title & sort by date
+  return (contestableIssues || [])
+    .filter(issue => getIssueName(issue))
+    .sort((a, b) => {
+      const dateA = getDate(a);
+      const dateB = getDate(b);
+      if (dateA === dateB) {
+        // If the dates are the same, sort by title
+        return getIssueName(a) > getIssueName(b) ? 1 : -1;
+      }
+      // YYYYMMDD string comparisons will work in place of using moment
+      return dateA > dateB ? -1 : 1;
+    });
 };
 
 export const issuesNeedUpdating = (loadedIssues = [], existingIssues = []) => {
@@ -81,14 +85,16 @@ export const issuesNeedUpdating = (loadedIssues = [], existingIssues = []) => {
     return true;
   }
   // sort both arrays so we don't end up in an endless loop
-  const issues = sortContestableIssues(existingIssues);
-  return !sortContestableIssues(loadedIssues).every(({ attributes }, index) => {
-    const existing = issues[index]?.attributes || {};
-    return (
-      attributes.ratingIssueSubjectText === existing.ratingIssueSubjectText &&
-      attributes.approxDecisionDate === existing.approxDecisionDate
-    );
-  });
+  const issues = processContestableIssues(existingIssues);
+  return !processContestableIssues(loadedIssues).every(
+    ({ attributes }, index) => {
+      const existing = issues[index]?.attributes || {};
+      return (
+        attributes.ratingIssueSubjectText === existing.ratingIssueSubjectText &&
+        attributes.approxDecisionDate === existing.approxDecisionDate
+      );
+    },
+  );
 };
 
 export const appStateSelector = state => ({


### PR DESCRIPTION
## Description

The contestable issues endpoint for the Notice of Disagreement form sometimes returns issues with an empty `ratingIssuesSubjectText` which is used as the title of the issue. After discussions with LightHouse, it was determined that these issues can be filtered out and not shown to the Veteran.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/26294
- https://dsva.slack.com/archives/CSKKUL36K/p1623956682119300

## Testing done

Updated unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Issues with no title are filtered out

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
