### PR TITLE
added VETTEC program length to compare

### DIFF
--- a/src/applications/gi-sandbox/containers/ComparePage.jsx
+++ b/src/applications/gi-sandbox/containers/ComparePage.jsx
@@ -526,6 +526,28 @@ export function ComparePage({
             showDifferences={showDifferences}
             fieldData={[
               {
+                label: 'Length of VET TEC programs',
+                mapper: institution => {
+                  if (
+                    institution.programLengthInHours &&
+                    institution.programLengthInHours.length > 0
+                  ) {
+                    const maxHours = Math.max(
+                      ...institution.programLengthInHours,
+                    );
+                    const minHours = Math.min(
+                      ...institution.programLengthInHours,
+                    );
+                    return `${
+                      minHours === maxHours
+                        ? minHours
+                        : `${minHours} - ${maxHours}`
+                    } hours`;
+                  }
+                  return 'N/A';
+                },
+              },
+              {
                 label: 'Credit for military training',
                 mapper: institution =>
                   mapBoolField(institution.creditForMilTraining),

--- a/src/applications/gi-sandbox/containers/ComparePage.jsx
+++ b/src/applications/gi-sandbox/containers/ComparePage.jsx
@@ -538,9 +538,8 @@ export function ComparePage({
             fieldData={[
               {
                 label: 'Length of VET TEC programs',
-                mapper: institution => {
-                  return programHours(institution.programLengthInHours);
-                },
+                mapper: institution =>
+                  programHours(institution.programLengthInHours),
               },
               {
                 label: 'Credit for military training',

--- a/src/applications/gi-sandbox/containers/ComparePage.jsx
+++ b/src/applications/gi-sandbox/containers/ComparePage.jsx
@@ -152,6 +152,17 @@ export function ComparePage({
     );
   }
 
+  const programHours = programLength => {
+    if (programLength && programLength.length > 0) {
+      const maxHours = Math.max(...programLength);
+      const minHours = Math.min(...programLength);
+      return `${
+        minHours === maxHours ? minHours : `${minHours} - ${maxHours}`
+      } hours`;
+    }
+    return 'N/A';
+  };
+
   return (
     <div className="compare-page">
       {promptingFacilityCode && (
@@ -528,23 +539,7 @@ export function ComparePage({
               {
                 label: 'Length of VET TEC programs',
                 mapper: institution => {
-                  if (
-                    institution.programLengthInHours &&
-                    institution.programLengthInHours.length > 0
-                  ) {
-                    const maxHours = Math.max(
-                      ...institution.programLengthInHours,
-                    );
-                    const minHours = Math.min(
-                      ...institution.programLengthInHours,
-                    );
-                    return `${
-                      minHours === maxHours
-                        ? minHours
-                        : `${minHours} - ${maxHours}`
-                    } hours`;
-                  }
-                  return 'N/A';
+                  return programHours(institution.programLengthInHours);
                 },
               },
               {

--- a/src/applications/gi-sandbox/containers/ComparePage.jsx
+++ b/src/applications/gi-sandbox/containers/ComparePage.jsx
@@ -153,9 +153,13 @@ export function ComparePage({
   }
 
   const programHours = programLength => {
-    if (programLength && programLength.length > 0) {
-      const maxHours = Math.max(...programLength);
-      const minHours = Math.min(...programLength);
+    const maxHours = Math.max(...programLength);
+    const minHours = Math.min(...programLength);
+    if (
+      programLength &&
+      programLength.length > 0 &&
+      maxHours + minHours !== 0
+    ) {
       return `${
         minHours === maxHours ? minHours : `${minHours} - ${maxHours}`
       } hours`;


### PR DESCRIPTION
## Description
As a Comparison Tool user, I need to be able to VET TEC program length for institutions that I am interested in using my benefits at so I can make an informed decision about which institution to attend.
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/26051

BE PR: https://github.com/department-of-veterans-affairs/gibct-data-service/pull/836
## Testing done
local testing 

## Screenshots
![Screen Shot 2021-06-22 at 2 59 01 PM](https://user-images.githubusercontent.com/50601724/122984423-fd9f4600-d36a-11eb-8368-9392fa6b1056.png)


## Acceptance criteria
- [x] A "Length of VET TEC programs" data row is displayed in the "Academics" section of the compare page.
- [x] If an institution is not a VET TEC institution or it is a VET TEC institution with no program data available "N/A" is displayed.
- [x] If all the program lengths are the same for a given institution "HHH hours" is displayed.
- [x] If there are a variety of program lengths for a given institution, the range from shortest to longest is displayed. (ex. HHH - HHH hours)

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
