### PR TITLE
Update Profile buttons and how we handle missing contact info

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
@@ -120,12 +120,12 @@ export const BankInfoCNP = ({
   );
 
   const editButtonClasses = [
-    'va-button-link',
-    ...prefixUtilityClasses(['margin-top--1p5']),
+    'usa-button-secondary',
+    ...prefixUtilityClasses(['margin--0', 'margin-top--1p5', 'width--auto']),
   ];
 
   const editButtonClassesMedium = prefixUtilityClasses(
-    ['flex--auto', 'margin-top--0'],
+    ['flex--auto', 'margin-top--0', 'margin-left--4'],
     'medium',
   );
 
@@ -290,7 +290,7 @@ export const BankInfoCNP = ({
             aria-label="update your bank information for compensation and pension benefits"
             type="submit"
             loadingText="saving bank information"
-            className="usa-button-primary vads-u-margin-top--0 vads-u-width--full small-screen:vads-u-width--auto"
+            className="usa-button-primary vads-u-margin-top--0 vads-u-width--auto"
             isLoading={directDepositUiState.isSaving}
           >
             Update
@@ -299,7 +299,7 @@ export const BankInfoCNP = ({
             aria-label="cancel updating your bank information for compensation and pension benefits"
             type="button"
             disabled={directDepositUiState.isSaving}
-            className="va-button-link vads-u-margin-left--1"
+            className="usa-button-secondary vads-u-width--auto"
             onClick={closeDDForm}
             data-qa="cancel-button"
           >

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
@@ -113,12 +113,12 @@ export const DirectDepositEDU = ({
   );
 
   const editButtonClasses = [
-    'va-button-link',
-    ...prefixUtilityClasses(['margin-top--1p5']),
+    'usa-button-secondary',
+    ...prefixUtilityClasses(['margin--0', 'margin-top--1p5', 'width--auto']),
   ];
 
   const editButtonClassesMedium = prefixUtilityClasses(
-    ['flex--auto', 'margin-top--0'],
+    ['flex--auto', 'margin-top--0', 'margin-left--4'],
     'medium',
   );
 
@@ -256,7 +256,7 @@ export const DirectDepositEDU = ({
             aria-label="update your bank information for education benefits"
             type="submit"
             loadingText="saving bank information"
-            className="usa-button-primary vads-u-margin-top--0 vads-u-width--full small-screen:vads-u-width--auto"
+            className="usa-button-primary vads-u-margin-top--0 vads-u-width--auto"
             isLoading={directDepositUiState.isSaving}
           >
             Update
@@ -265,7 +265,7 @@ export const DirectDepositEDU = ({
             aria-label="cancel updating your bank information for education benefits"
             type="button"
             disabled={directDepositUiState.isSaving}
-            className="va-button-link vads-u-margin-left--1"
+            className="usa-button-secondary vads-u-width--auto"
             onClick={closeDDForm}
             data-qa="cancel-button"
           >

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
@@ -59,12 +59,12 @@ const wrapperClassesMedium = prefixUtilityClasses(
 );
 
 const editButtonClasses = [
-  'va-button-link',
-  ...prefixUtilityClasses(['margin-top--1p5']),
+  'usa-button-secondary',
+  ...prefixUtilityClasses(['width--auto', 'margin--0', 'margin-top--1p5']),
 ];
 
 const editButtonClassesMedium = prefixUtilityClasses(
-  ['flex--auto', 'margin-top--0'],
+  ['flex--auto', 'margin-top--0', 'margin-left--4'],
   'medium',
 );
 

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
@@ -159,8 +159,8 @@ class ContactInformationField extends React.Component {
     this.props.clearTransactionRequest(this.props.fieldName);
   };
 
-  onEdit = () => {
-    this.captureEvent('edit-link');
+  onEdit = (event = 'edit-link') => {
+    this.captureEvent(event);
     this.openEditModal();
   };
 
@@ -244,14 +244,20 @@ class ContactInformationField extends React.Component {
     // default the content to the read-view
     let content = wrapInTransaction(
       <div className={classes.wrapper}>
-        <ContactInformationView data={data} fieldName={fieldName} />
+        <ContactInformationView
+          data={data}
+          fieldName={fieldName}
+          title={title}
+        />
 
         {this.isEditLinkVisible() && (
           <button
             aria-label={`Edit ${title}`}
             type="button"
             data-action="edit"
-            onClick={this.onEdit}
+            onClick={() => {
+              this.onEdit(isEmpty ? 'add-link' : 'edit-link');
+            }}
             id={`${fieldName}-edit-link`}
             className={classes.editButton}
           >
@@ -260,22 +266,6 @@ class ContactInformationField extends React.Component {
         )}
       </div>,
     );
-
-    if (isEmpty) {
-      content = wrapInTransaction(
-        <button
-          type="button"
-          onClick={() => {
-            this.captureEvent('add-link');
-            this.openEditModal();
-          }}
-          className="va-button-link va-profile-btn"
-          id={`${fieldName}-edit-link`}
-        >
-          Please add your {title.toLowerCase()}
-        </button>,
-      );
-    }
 
     if (showEditView) {
       content = (

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationView.jsx
@@ -15,9 +15,9 @@ import {
 import ReceiveAppointmentReminders from './ReceiveAppointmentReminders';
 
 const ContactInformationView = props => {
-  const { data, fieldName } = props;
+  const { data, fieldName, title } = props;
   if (!data) {
-    return null;
+    return <span>Edit your profile to add a {title.toLowerCase()}.</span>;
   }
 
   if (fieldName === FIELD_NAMES.EMAIL) {

--- a/src/applications/personalization/profile/tests/components/ContactInformationField.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/ContactInformationField.unit.spec.jsx
@@ -49,8 +49,8 @@ describe('<ContactInformationField/>', () => {
     component = enzyme.shallow(<ContactInformationField {...isEmptyProps} />);
     expect(
       component.find('ContactInformationView'),
-      'the ContactInformationView was NOT rendered',
-    ).to.have.lengthOf(0);
+      'the ContactInformationView was rendered',
+    ).to.have.lengthOf(1);
 
     expect(
       component.html(),

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.delete-address.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.delete-address.unit.spec.jsx
@@ -24,17 +24,11 @@ let view;
 let server;
 
 function getEditButton(addressName) {
-  let editButton = view.queryByText(new RegExp(`add.*${addressName}`, 'i'), {
-    selector: 'button',
+  // Need to use `queryByRole` since the visible label is simply `Edit`, but
+  // the aria-label is more descriptive
+  return view.queryByRole('button', {
+    name: new RegExp(`edit.*${addressName}`, 'i'),
   });
-  if (!editButton) {
-    // Need to use `queryByRole` since the visible label is simply `Edit`, but
-    // the aria-label is more descriptive
-    editButton = view.queryByRole('button', {
-      name: new RegExp(`edit.*${addressName}`, 'i'),
-    });
-  }
-  return editButton;
 }
 
 function deleteAddress(addressName) {
@@ -83,18 +77,10 @@ async function testQuickSuccess(addressName) {
   // wait for the edit mode to exit
   await waitForElementToBeRemoved(cityInput);
 
-  // the edit address button should not exist
-  expect(
-    view.queryByText(new RegExp(`edit.*${addressName}`, 'i'), {
-      selector: 'button',
-    }),
-  ).not.to.exist;
-  // and the add address button should exist
-  expect(
-    view.getByText(new RegExp(`add.*${addressName}`, 'i'), {
-      selector: 'button',
-    }),
-  ).to.exist;
+  // the edit address button should still exist
+  view.getByRole('button', { name: new RegExp(`edit.*${addressName}`, 'i') });
+  // and the add text should exist
+  view.getByText(new RegExp(`add.*${addressName}`, 'i'));
 }
 
 // When the update happens but not until after the Edit View has exited and the
@@ -120,18 +106,10 @@ async function testSlowSuccess(addressName) {
 
   await waitForElementToBeRemoved(deletingMessage);
 
-  // the edit phone number button should not exist
-  expect(
-    view.queryByText(new RegExp(`edit.*${addressName}`, 'i'), {
-      selector: 'button',
-    }),
-  ).not.to.exist;
-  // and the add phone number button should exist
-  expect(
-    view.getByText(new RegExp(`add.*${addressName}`, 'i'), {
-      selector: 'button',
-    }),
-  ).to.exist;
+  // the edit button should exist
+  view.getByRole('button', { name: new RegExp(`edit.*${addressName}`, 'i') });
+  // and the add address text should exist
+  expect(view.getByText(new RegExp(`add.*${addressName}`, 'i'))).to.exist;
 }
 
 // When the initial transaction creation request fails

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.delete-email-address.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.delete-email-address.unit.spec.jsx
@@ -35,7 +35,7 @@ function getEditButton() {
   return editButton;
 }
 
-// helper function that enters the `Edit email address` view and clicks on the `Remove` and `Confirm` buttons
+// helper function that enters the `Edit contact email address` view and clicks on the `Remove` and `Confirm` buttons
 function deleteEmailAddress() {
   const editButton = getEditButton();
   editButton.click();
@@ -44,7 +44,7 @@ function deleteEmailAddress() {
   expect(emailAddressInput).to.exist;
 
   // delete
-  view.getByText('Remove email address').click();
+  view.getByText('Remove contact email address').click();
   const confirmDeleteButton = view.getByText('Confirm', { selector: 'button' });
   const cancelDeleteButton = view.getByText('Cancel', { selector: 'button' });
   confirmDeleteButton.click();
@@ -96,14 +96,12 @@ describe('Deleting email address', () => {
     // wait for the edit mode to exit
     await waitForElementToBeRemoved(emailAddressInput);
 
-    // the edit email button should not exist
-    expect(view.queryByRole('button', { name: /edit.*email address/i })).not.to
-      .exist;
+    // the edit email button should still exist
+    view.getByRole('button', { name: /edit.*email address/i });
     // and the email address should not exist
     expect(view.queryByText(emailAddress)).not.to.exist;
-    // and the add email button should exist
-    expect(view.getByText(/add.*email address/i, { selector: 'button' })).to
-      .exist;
+    // and the add email text should exist
+    view.getByText(/add.*email address/i);
   });
   it('should handle a deletion that does not succeed until after the edit view exits', async () => {
     server.use(...mocks.transactionPending);
@@ -115,7 +113,7 @@ describe('Deleting email address', () => {
 
     // check that the "we're saving your..." message appears
     const deletingMessage = await view.findByText(
-      /We’re in the process of deleting your email address. We’ll remove this information soon./i,
+      /We’re in the process of deleting your contact email address. We’ll remove this information soon./i,
     );
     expect(deletingMessage).to.exist;
 
@@ -123,14 +121,12 @@ describe('Deleting email address', () => {
 
     await waitForElementToBeRemoved(deletingMessage);
 
-    // the edit email button should not exist
-    expect(view.queryByRole('button', { name: /edit.*email address/i })).not.to
-      .exist;
+    // the edit email button should still exist
+    view.getByRole('button', { name: /edit.*email address/i });
     // and the email address should not exist
     expect(view.queryByText(emailAddress)).not.to.exist;
-    // and the add email button should exist
-    expect(view.getByText(/add.*email address/i, { selector: 'button' })).to
-      .exist;
+    // and the add email text should exist
+    view.getByText(/add.*email address/i);
   });
   it('should show an error and not exit edit mode if the transaction cannot be created', async () => {
     server.use(...mocks.createTransactionFailure);
@@ -141,7 +137,7 @@ describe('Deleting email address', () => {
     const alert = await view.findByTestId('edit-error-alert');
     expect(alert).to.have.descendant('div.usa-alert-error');
     expect(alert).to.contain.text(
-      'We’re sorry. We couldn’t update your email address. Please try again.',
+      'We’re sorry. We couldn’t update your contact email address. Please try again.',
     );
 
     // make sure that edit mode is not automatically exited
@@ -172,7 +168,7 @@ describe('Deleting email address', () => {
     const alert = await view.findByTestId('edit-error-alert');
     expect(alert).to.have.descendant('div.usa-alert-error');
     expect(alert).to.contain.text(
-      'We’re sorry. We couldn’t update your email address. Please try again.',
+      'We’re sorry. We couldn’t update your contact email address. Please try again.',
     );
 
     // the buttons should be enabled again
@@ -196,7 +192,7 @@ describe('Deleting email address', () => {
 
     // check that the "we're saving your..." message appears
     const deletingMessage = await view.findByText(
-      /We’re in the process of deleting your email address. We’ll remove this information soon./i,
+      /We’re in the process of deleting your contact email address. We’ll remove this information soon./i,
     );
     expect(deletingMessage).to.exist;
 
@@ -207,7 +203,7 @@ describe('Deleting email address', () => {
     // make sure the error message appears
     expect(
       view.getByText(
-        /We couldn’t save your recent email address update. Please try again later/i,
+        /We couldn’t save your recent contact email address update. Please try again later/i,
       ),
     ).to.exist;
 

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.delete-telephone.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.delete-telephone.unit.spec.jsx
@@ -86,18 +86,10 @@ async function testQuickSuccess(numberName) {
   // wait for the edit mode to exit
   await waitForElementToBeRemoved(phoneNumberInput);
 
-  // the edit phone number button should not exist
-  expect(
-    view.queryByText(new RegExp(`edit.*${numberName}`, 'i'), {
-      selector: 'button',
-    }),
-  ).not.to.exist;
-  // and the add phone number button should exist
-  expect(
-    view.getByText(new RegExp(`add.*${numberName}`, 'i'), {
-      selector: 'button',
-    }),
-  ).to.exist;
+  // the edit phone number button should still exist
+  view.getByRole('button', { name: new RegExp(`edit.*${numberName}`, 'i') });
+  // and the add phone number text should exist
+  view.getByText(new RegExp(`add.*${numberName}`, 'i'));
 }
 
 // When the update happens but not until after the Edit View has exited and the
@@ -123,18 +115,10 @@ async function testSlowSuccess(numberName) {
 
   await waitForElementToBeRemoved(deletingMessage);
 
-  // the edit phone number button should not exist
-  expect(
-    view.queryByText(new RegExp(`edit.*${numberName}`, 'i'), {
-      selector: 'button',
-    }),
-  ).not.to.exist;
-  // and the add phone number button should exist
-  expect(
-    view.getByText(new RegExp(`add.*${numberName}`, 'i'), {
-      selector: 'button',
-    }),
-  ).to.exist;
+  // the edit phone number button should still exist
+  view.getByRole('button', { name: new RegExp(`edit.*${numberName}`, 'i') });
+  // and the add phone number text should exist
+  view.getByText(new RegExp(`add.*${numberName}`, 'i'));
 }
 
 // When the initial transaction creation request fails

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.edit-email-address.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.edit-email-address.unit.spec.jsx
@@ -16,7 +16,7 @@ import {
 import { beforeEach } from 'mocha';
 
 const errorText =
-  'We’re sorry. We couldn’t update your email address. Please try again.';
+  'We’re sorry. We couldn’t update your contact email address. Please try again.';
 const newEmailAddress = 'new-address@domain.com';
 const ui = (
   <MemoryRouter>
@@ -87,7 +87,7 @@ async function testSlowSuccess() {
 
   // check that the "we're saving your..." message appears
   const savingMessage = await view.findByText(
-    /We’re working on saving your new email address. We’ll show it here once it’s saved./i,
+    /We’re working on saving your new contact email address. We’ll show it here once it’s saved./i,
   );
   expect(savingMessage).to.exist;
 
@@ -154,7 +154,7 @@ async function testSlowFailure() {
 
   // check that the "we're saving your..." message appears
   const savingMessage = await view.findByText(
-    /We’re working on saving your new email address. We’ll show it here once it’s saved./i,
+    /We’re working on saving your new contact email address. We’ll show it here once it’s saved./i,
   );
   expect(savingMessage).to.exist;
 
@@ -165,7 +165,7 @@ async function testSlowFailure() {
   // make sure the error message appears
   expect(
     view.getByText(
-      /We couldn’t save your recent email address update. Please try again later/i,
+      /We couldn’t save your recent contact email address update. Please try again later/i,
     ),
   ).to.exist;
 

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.unit.spec.jsx
@@ -80,9 +80,7 @@ describe('PersonalInformation', () => {
     expect(view.getByText('804-205-5544, ext. 17747')).to.exist;
     expect(view.getByText('214-718-2112', { exact: false })).to.exist;
 
-    expect(
-      view.getByText(/please add your fax number/i, { selector: 'button' }),
-    ).to.exist;
+    expect(view.getByText(/to add a fax number/i)).to.exist;
     expect(view.getByText('me@me.com')).to.exist;
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/modals.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/modals.cypress.spec.js
@@ -101,7 +101,7 @@ describe('Modals on the personal information and content page', () => {
     checkModals({
       otherSectionName: 'mailing address',
       editLineId: 'root_emailAddress',
-      sectionName: 'email address',
+      sectionName: 'contact email address',
     });
   });
 
@@ -140,7 +140,7 @@ describe('Modals on the personal information and content page', () => {
     checkModals({
       otherSectionName: 'mailing address',
       editLineId: 'root_emailAddress',
-      sectionName: 'email address',
+      sectionName: 'contact email address',
     });
   });
 });

--- a/src/platform/user/profile/vap-svc/constants/index.js
+++ b/src/platform/user/profile/vap-svc/constants/index.js
@@ -73,7 +73,7 @@ export const FIELD_TITLES = {
   [FIELD_NAMES.WORK_PHONE]: 'Work phone number',
   [FIELD_NAMES.TEMP_PHONE]: 'Temporary phone number',
   [FIELD_NAMES.FAX_NUMBER]: 'Fax number',
-  [FIELD_NAMES.EMAIL]: 'Email address',
+  [FIELD_NAMES.EMAIL]: 'Contact email address',
   [FIELD_NAMES.MAILING_ADDRESS]: 'Mailing address',
   [FIELD_NAMES.RESIDENTIAL_ADDRESS]: 'Home address',
 };


### PR DESCRIPTION
## Description
This PR makes three changes to the Profile, addressing the following tickets:
1. department-of-veterans-affairs/va.gov-team#23660
2. department-of-veterans-affairs/va.gov-team#23917
3. department-of-veterans-affairs/va.gov-team#23661

- Updates style of "edit" buttons on contact info and direct deposit sections
- Updates style of "cancel" button on direct deposit edit form, to match the contact info edit forms
- Updates how mission contact info fields are displayed

## Testing done
I had to update a good number of existing integrated RTL tests that depended on the old contact info no-data state. For example, there are tests that delete a piece of contact info and those tests had checks to make sure the "Edit" button no longer existed (but now it always exists) and also checked for the old "add <contact info field>" button, which has been replaced by new, non-clickable text.

Also used existing Cypress tests to preview the changes.

## Screenshots
**Updates style of "edit" buttons and no-data state on the Personal and Contact Info section:**
<img width="503" alt="Screen Shot 2021-06-22 at 3 46 53 PM" src="https://user-images.githubusercontent.com/20728956/123101629-1cdcb880-d3e9-11eb-8968-0c885d01083f.png">

**Updates style of "edit" buttons in Direct Deposit:**
<img width="667" alt="Screen Shot 2021-06-22 at 4 22 35 PM" src="https://user-images.githubusercontent.com/20728956/123101710-2ebe5b80-d3e9-11eb-85a9-bebaa2fc6e50.png">

**Updates style of "cancel" buttons in Direct Deposit edit forms** (to match the contact info edit forms):
<img width="656" alt="Screen Shot 2021-06-22 at 4 22 46 PM" src="https://user-images.githubusercontent.com/20728956/123101875-53b2ce80-d3e9-11eb-827c-2e6ea0fd6b91.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs