### PR TITLE
526: Move wizard to /start

### DIFF
--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -1,16 +1,14 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
-import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
+// import moment from 'moment';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
 import backendServices from 'platform/user/profile/constants/backendServices';
 import {
-  restartShouldRedirect,
-  WIZARD_STATUS_NOT_STARTED,
   WIZARD_STATUS_COMPLETE,
-  WIZARD_STATUS_RESTARTED,
+  WIZARD_STATUS_RESTARTING,
 } from 'platform/site-wide/wizard';
 
 import formConfig from './config/form';
@@ -19,31 +17,19 @@ import ITFWrapper from './containers/ITFWrapper';
 import { MissingServices, MissingId } from './containers/MissingServices';
 
 import { MVI_ADD_SUCCEEDED } from './actions';
-import WizardContainer from './containers/WizardContainer';
 import { WIZARD_STATUS, PDF_SIZE_FEATURE, SHOW_8940_4192 } from './constants';
 import {
   show526Wizard,
   isBDD,
   getPageTitle,
   showSubform8940And4192,
+  wrapWithBreadcrumb,
+  isExpired,
 } from './utils';
 import { uploadPdfLimitFeature } from './config/selectors';
 
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { focusElement } from 'platform/utilities/ui';
-
-const wrapInBreadcrumb = (title, component) => (
-  <>
-    <Breadcrumbs>
-      <a href="/">Home</a>
-      <a href="/disability">Disability Benefits</a>
-      <span className="vads-u-color--black">
-        <strong>{title}</strong>
-      </span>
-    </Breadcrumbs>
-    {component}
-  </>
-);
 
 export const serviceRequired = [
   backendServices.FORM526,
@@ -63,9 +49,6 @@ export const hasRequiredServices = user =>
 export const hasRequiredId = user =>
   idRequired.some(service => user.profile.services.includes(service));
 
-export const getWizardStatus = () =>
-  sessionStorage.getItem(WIZARD_STATUS) || WIZARD_STATUS_NOT_STARTED;
-
 export const Form526Entry = ({
   location,
   user,
@@ -76,17 +59,17 @@ export const Form526Entry = ({
   pdfLimit,
   router,
   showSubforms,
+  savedForms,
 }) => {
-  const defaultWizardState = getWizardStatus();
-  const [wizardState, setWizardState] = useState(defaultWizardState);
+  const wizardStatus = sessionStorage.getItem(WIZARD_STATUS);
+
+  const hasSavedForm = savedForms.some(
+    form =>
+      form.form === formConfig.formId && !isExpired(form.metaData?.expiresAt),
+  );
 
   const title = getPageTitle(isBDDForm);
   document.title = title;
-
-  const setWizardStatus = value => {
-    sessionStorage.setItem(WIZARD_STATUS, value);
-    setWizardState(value);
-  };
 
   // start focus on breadcrumb nav when wizard is visible
   const setPageFocus = focusTarget => {
@@ -95,38 +78,41 @@ export const Form526Entry = ({
   };
 
   useEffect(() => {
-    if (restartShouldRedirect(WIZARD_STATUS)) {
-      setWizardStatus(WIZARD_STATUS_RESTARTED);
-      router.push('/');
-    } else if (
-      window.location.pathname.endsWith('/introduction') &&
-      defaultWizardState === WIZARD_STATUS_COMPLETE
+    if (
+      wizardStatus === WIZARD_STATUS_COMPLETE &&
+      window.location.pathname.endsWith('/introduction')
     ) {
       setPageFocus('h1');
-      setWizardStatus(WIZARD_STATUS_COMPLETE);
       // save feature flag for 8940/4192
       sessionStorage.setItem(SHOW_8940_4192, showSubforms);
-    } else if (defaultWizardState === WIZARD_STATUS_NOT_STARTED) {
-      setPageFocus('.va-nav-breadcrumbs-list');
     }
   });
 
-  // showWizard feature flag loads _after_ page has render causing the full page
-  // content to render, then the wizard to render if this flag is true, so we
-  // show a loading indicator until the feature flags are available. This can be
-  // removed once the feature flag is removed
+  // showWizard feature flag loads _after_ page has rendered causing the full
+  // page content to render, then the wizard to render if this flag is true, so
+  // we show a loading indicator until the feature flags are available. This
+  // can be removed once the feature flag is removed
   if (typeof showWizard === 'undefined') {
-    return wrapInBreadcrumb(
+    return wrapWithBreadcrumb(
       title,
-      <LoadingIndicator message="Please wait while we load the application for you." />,
+      <h1>
+        <LoadingIndicator message="Please wait while we load the application for you." />
+      </h1>,
     );
   }
 
   // showWizard feature flag is initially undefined
-  if (showWizard && wizardState !== WIZARD_STATUS_COMPLETE) {
-    return wrapInBreadcrumb(
+  if (
+    showWizard &&
+    ((!hasSavedForm && wizardStatus !== WIZARD_STATUS_COMPLETE) ||
+      (hasSavedForm && wizardStatus === WIZARD_STATUS_RESTARTING))
+  ) {
+    router.push('/start');
+    return wrapWithBreadcrumb(
       title,
-      <WizardContainer setWizardStatus={setWizardStatus} />,
+      <h1>
+        <LoadingIndicator message="Please wait while we restart the application for you." />
+      </h1>,
     );
   }
 
@@ -140,7 +126,7 @@ export const Form526Entry = ({
   // Not logged in, so show the rendered content. The RoutedSavableApp shows
   // an alert with the sign in button
   if (!user.login.currentlyLoggedIn) {
-    return wrapInBreadcrumb(title, content);
+    return wrapWithBreadcrumb(title, content);
   }
   // "add-person" service means the user has a edipi and SSN in the system, but
   // is missing either a BIRLS or participant ID
@@ -148,7 +134,7 @@ export const Form526Entry = ({
     user.profile.services.includes('add-person') &&
     mvi?.addPersonState !== MVI_ADD_SUCCEEDED
   ) {
-    return wrapInBreadcrumb(title, <AddPerson title={title} />);
+    return wrapWithBreadcrumb(title, <AddPerson title={title} />);
   }
 
   // RequiredLoginView will handle unverified users by showing the
@@ -156,11 +142,11 @@ export const Form526Entry = ({
   if (user.profile.verified) {
     // User is missing either their SSN, EDIPI, or BIRLS ID
     if (!hasRequiredId(user)) {
-      return wrapInBreadcrumb(title, <MissingId title={title} />);
+      return wrapWithBreadcrumb(title, <MissingId title={title} />);
     }
     // User doesn't have the required services. Show an alert
     if (!hasRequiredServices(user)) {
-      return wrapInBreadcrumb(title, <MissingServices title={title} />);
+      return wrapWithBreadcrumb(title, <MissingServices title={title} />);
     }
   }
 
@@ -169,7 +155,7 @@ export const Form526Entry = ({
   // bypass the intro page.
   sessionStorage.setItem(PDF_SIZE_FEATURE, pdfLimit);
 
-  return wrapInBreadcrumb(
+  return wrapWithBreadcrumb(
     title,
     <article id="form-526" data-location={`${location?.pathname?.slice(1)}`}>
       <RequiredLoginView serviceRequired={serviceRequired} user={user} verify>
@@ -189,6 +175,7 @@ const mapStateToProps = state => ({
   isBDDForm: isBDD(state?.form?.data),
   pdfLimit: uploadPdfLimitFeature(state),
   isStartingOver: state.form?.isStartingOver,
+  savedForms: state?.user?.profile?.savedForms || [],
 });
 
 export default connect(mapStateToProps)(Form526Entry);

--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
-// import moment from 'moment';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -20,6 +20,7 @@ import {
   DISABILITY_526_V2_ROOT_URL,
   WIZARD_STATUS,
 } from '../constants';
+import { WIZARD_STATUS_RESTARTING } from 'platform/site-wide/wizard';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {
@@ -92,17 +93,17 @@ class IntroductionPage extends React.Component {
         {itfNotice}
         <h2 className="vads-u-font-size--h4">{subwayTitle}</h2>
         <div className="process schemaform-process">
-          <p className="vads-u-margin-top--0">
+          <p id="restart-wizard" className="vads-u-margin-top--0">
             if you don’t think this is the right form for you,{' '}
             <a
+              aria-describedby="restart-wizard"
               href={
                 this.props.showWizard
-                  ? DISABILITY_526_V2_ROOT_URL
+                  ? `${DISABILITY_526_V2_ROOT_URL}/start`
                   : '/disability/how-to-file-claim/'
               }
-              className="va-button-link"
               onClick={() => {
-                sessionStorage.removeItem(WIZARD_STATUS);
+                sessionStorage.setItem(WIZARD_STATUS, WIZARD_STATUS_RESTARTING);
                 recordEvent({ event: 'howToWizard-start-over' });
               }}
             >

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -83,6 +83,7 @@ class IntroductionPage extends React.Component {
         )}
         <SaveInProgressIntro
           hideUnauthedStartLink
+          headingLevel={2}
           prefillEnabled={formConfig.prefillEnabled}
           formId={this.props.formId}
           pageList={pageList}

--- a/src/applications/disability-benefits/all-claims/routes.jsx
+++ b/src/applications/disability-benefits/all-claims/routes.jsx
@@ -2,8 +2,13 @@ import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/
 
 import Form526EZApp from './Form526EZApp';
 import formConfig from './config/form';
+import WizardContainer from './containers/WizardContainer';
 
 const routes = [
+  {
+    path: '/start',
+    component: WizardContainer,
+  },
   {
     path: '/',
     component: Form526EZApp,

--- a/src/applications/disability-benefits/all-claims/tests/all-claims-wizard.cypress.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/all-claims-wizard.cypress.spec.js
@@ -70,12 +70,12 @@ describe('526 wizard', () => {
     sessionStorage.removeItem(WIZARD_STATUS);
     sessionStorage.removeItem(FORM_STATUS_BDD);
     sessionStorage.removeItem(SAVED_SEPARATION_DATE);
-    cy.visit(DISABILITY_526_V2_ROOT_URL);
+    cy.visit(`${DISABILITY_526_V2_ROOT_URL}/start`);
     cy.injectAxe();
   });
 
   it('should show the form wizard', () => {
-    cy.url().should('include', DISABILITY_526_V2_ROOT_URL);
+    cy.url().should('include', `${DISABILITY_526_V2_ROOT_URL}/start`);
     cy.get('h1').should('have.text', 'File for disability compensation');
     cy.axeCheck();
   });
@@ -159,6 +159,10 @@ describe('526 wizard', () => {
     cy.get('h1').should('have.text', h1Text + h1Addition);
     cy.focused().should('have.text', h1Text + h1Addition);
     cy.checkStorage(WIZARD_STATUS, 'complete');
+    cy.location('pathname').should(
+      'eq',
+      `${DISABILITY_526_V2_ROOT_URL}/introduction`,
+    );
     cy.axeCheck();
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
@@ -10,6 +10,7 @@ import mockLocations from './fixtures/mocks/separation-locations.json';
 import mockPayment from './fixtures/mocks/payment-information.json';
 import mockSubmit from './fixtures/mocks/application-submit.json';
 import mockUpload from './fixtures/mocks/document-upload.json';
+import mockUser from './fixtures/mocks/user.json';
 
 import formConfig from '../config/form';
 import manifest from '../manifest.json';
@@ -18,8 +19,10 @@ import {
   MOCK_SIPS_API,
   WIZARD_STATUS,
   FORM_STATUS_BDD,
+  SHOW_8940_4192,
   SAVED_SEPARATION_DATE,
 } from '../constants';
+import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
 
 const todayPlus120 = moment()
   .add(120, 'days')
@@ -46,6 +49,11 @@ const testConfig = createTestConfig(
     },
 
     pageHooks: {
+      start: () => {
+        // skip wizard
+        cy.findByText(/apply now/i).click();
+      },
+
       introduction: () => {
         cy.get('@testData').then(data => {
           if (data['view:isBddData']) {
@@ -53,26 +61,9 @@ const testConfig = createTestConfig(
               SAVED_SEPARATION_DATE,
               todayPlus120.join('-'),
             );
-            cy.get('[type="radio"][value="bdd"]').check({
-              waitForAnimations: true,
-            });
-            cy.get('select[name="discharge-dateMonth"]').select(
-              todayPlus120[1],
-            );
-            cy.get('select[name="discharge-dateDay"]').select(todayPlus120[2]);
-            cy.get('input[name="discharge-dateYear"]')
-              .clear()
-              .type(todayPlus120[0]);
           } else {
-            cy.get('[type="radio"][value="appeals"]').check({
-              waitForAnimations: true,
-            });
-            cy.get('[type="radio"][value="file-claim"]').check({
-              waitForAnimations: true,
-            });
+            window.sessionStorage.removeItem(SAVED_SEPARATION_DATE);
           }
-          // close wizard & render intro page content
-          cy.get('.va-button-primary').click({ waitForAnimations: true });
           // Start form
           cy.findAllByText(/start/i, { selector: 'button' })
             .first()
@@ -134,7 +125,11 @@ const testConfig = createTestConfig(
     },
 
     setupPerTest: () => {
-      cy.login();
+      window.sessionStorage.setItem(SHOW_8940_4192, 'true');
+      window.sessionStorage.removeItem(WIZARD_STATUS, WIZARD_STATUS_COMPLETE);
+      window.sessionStorage.removeItem(FORM_STATUS_BDD);
+
+      cy.login(mockUser);
 
       cy.intercept('GET', '/v0/feature_toggles*', mockFeatureToggles);
 
@@ -170,8 +165,6 @@ const testConfig = createTestConfig(
       // Pre-fill with the expected ratedDisabilities,
       // but without view:selected, since that's not pre-filled
       cy.get('@testData').then(data => {
-        window.sessionStorage.removeItem(WIZARD_STATUS);
-        window.sessionStorage.removeItem(FORM_STATUS_BDD);
         const sanitizedRatedDisabilities = (data.ratedDisabilities || []).map(
           ({ 'view:selected': _, ...obj }) => obj,
         );

--- a/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
@@ -17,6 +17,7 @@ import {
   MVI_ADD_FAILED,
 } from '../../actions';
 import { WIZARD_STATUS } from '../../constants';
+import formConfig from '../../config/form';
 
 const fakeSipsIntro = user => {
   const { profile, login } = user;
@@ -37,6 +38,7 @@ describe('Form 526EZ Entry Page', () => {
     verified = false,
     currentlyLoggedIn = true,
     services = [],
+    savedForms = [],
     mvi = '',
     show526Wizard = true,
   } = {}) => {
@@ -85,6 +87,8 @@ describe('Form 526EZ Entry Page', () => {
           location={initialState.currentLocation}
           user={initialState.user}
           showWizard={initialState.showWizard}
+          router={[]}
+          savedForms={savedForms}
         >
           <main>
             <h1>{fakeSipsIntro(initialState.user)}</h1>
@@ -94,13 +98,17 @@ describe('Form 526EZ Entry Page', () => {
     );
   };
 
+  beforeEach(() => {
+    sessionStorage.removeItem(WIZARD_STATUS);
+  });
+
   // Not logged in
   it('should render content when not logged in', () => {
     sessionStorage.setItem(WIZARD_STATUS, WIZARD_STATUS_COMPLETE);
     const tree = testPage({
       currentlyLoggedIn: false,
     });
-    expect(tree.find('h1')).to.have.lengthOf(1);
+    expect(tree.find('h1').text()).to.contain('Log in');
     expect(tree.find('RoutedSavableApp')).to.have.lengthOf(1);
     expect(tree.find('main').text()).to.contain('Log in');
     tree.unmount();
@@ -115,7 +123,7 @@ describe('Form 526EZ Entry Page', () => {
       services: [],
     });
     expect(tree.find('main')).to.have.lengthOf(0);
-    expect(tree.find('h1')).to.have.lengthOf(1);
+    expect(tree.find('h1').text()).to.contain('File for disability');
     expect(tree.find('AlertBox')).to.have.lengthOf(1);
     expect(tree.find('AlertBox').text()).to.contain('BIRLS ID');
     const recordedEvent = getLastEvent();
@@ -134,7 +142,7 @@ describe('Form 526EZ Entry Page', () => {
       services: [idRequired[0]],
     });
     expect(tree.find('main')).to.have.lengthOf(0);
-    expect(tree.find('h1')).to.have.lengthOf(1);
+    expect(tree.find('h1').text()).to.contain('File for disability');
     expect(tree.find('AlertBox')).to.have.lengthOf(1);
     expect(tree.find('AlertBox').text()).to.contain('need some information');
     const recordedEvent = getLastEvent();
@@ -151,8 +159,8 @@ describe('Form 526EZ Entry Page', () => {
       verified: true,
       services: serviceRequired,
     });
-    expect(tree.find('h1')).to.have.lengthOf(1);
-    expect(tree.find('main').text()).to.contain('Start the form');
+    expect(tree.find('main')).to.have.lengthOf(1);
+    expect(tree.find('h1').text()).to.contain('Start the form');
     tree.unmount();
   });
 
@@ -166,8 +174,8 @@ describe('Form 526EZ Entry Page', () => {
       services: serviceRequired,
     });
     localStorage.removeItem('hasSession');
-    expect(tree.find('h1')).to.have.lengthOf(1);
-    expect(tree.find('main').text()).to.contain('Need to be verified');
+    expect(tree.find('main')).to.have.lengthOf(1);
+    expect(tree.find('h1').text()).to.contain('Need to be verified');
 
     tree.unmount();
   });
@@ -183,7 +191,8 @@ describe('Form 526EZ Entry Page', () => {
       mvi: MVI_ADD_INITIATED,
     });
     localStorage.removeItem('hasSession');
-    expect(tree.find('h1')).to.have.lengthOf(1);
+
+    expect(tree.find('h1').text()).to.contain('File for disability');
     expect(tree.find('main')).to.have.lengthOf(0);
     expect(tree.find('LoadingIndicator')).to.have.lengthOf(1);
     expect(tree.find('LoadingIndicator').text()).to.contain('additional work');
@@ -202,8 +211,8 @@ describe('Form 526EZ Entry Page', () => {
       mvi: MVI_ADD_SUCCEEDED,
     });
     localStorage.removeItem('hasSession');
-    expect(tree.find('h1')).to.have.lengthOf(1);
-    expect(tree.find('main').text()).to.contain('Start the form');
+    expect(tree.find('main')).to.have.lengthOf(1);
+    expect(tree.find('h1').text()).to.contain('Start the form');
     tree.unmount();
   });
 
@@ -216,7 +225,7 @@ describe('Form 526EZ Entry Page', () => {
       services: ['add-person'],
       mvi: MVI_ADD_FAILED,
     });
-    expect(tree.find('h1')).to.have.lengthOf(1);
+    expect(tree.find('h1').text()).to.contain('File for disability');
     expect(tree.find('main')).to.have.lengthOf(0);
     expect(tree.find('AlertBox')).to.have.lengthOf(1);
     expect(tree.find('AlertBox p').text()).to.contain(
@@ -231,34 +240,41 @@ describe('Form 526EZ Entry Page', () => {
   });
 
   // Wizard
-  it('should render wizard when not logged in', () => {
+  it('should redirect to the wizard when not logged in', () => {
     sessionStorage.removeItem(WIZARD_STATUS);
     const tree = testPage({
       currentlyLoggedIn: false,
     });
-    expect(tree.find('h1')).to.have.lengthOf(1);
-    expect(tree.find('WizardContainer')).to.have.lengthOf(1);
+    expect(tree.find('h1').text()).to.contain('restart the app');
     tree.unmount();
   });
-  it('should render wizard when logged in', () => {
+  it('should redirect to the wizard when logged in', () => {
     localStorage.setItem('hasSession', true);
     sessionStorage.removeItem(WIZARD_STATUS);
     const tree = testPage({
       currentlyLoggedIn: false,
     });
     localStorage.removeItem('hasSession');
-    expect(tree.find('h1')).to.have.lengthOf(1);
-    expect(tree.find('WizardContainer')).to.have.lengthOf(1);
+    expect(tree.find('h1').text()).to.contain('restart the app');
     tree.unmount();
   });
-  it('should not render wizard when feature is off', () => {
+  it('should not redirect to the wizard there is a saved form', () => {
+    sessionStorage.removeItem(WIZARD_STATUS);
+    const tree = testPage({
+      currentlyLoggedIn: false,
+      show526Wizard: false,
+      savedForms: [formConfig.formId],
+    });
+    expect(tree.find('h1').text()).to.contain('Log in');
+    tree.unmount();
+  });
+  it('should redirect to the wizard when restarting', () => {
     sessionStorage.removeItem(WIZARD_STATUS);
     const tree = testPage({
       currentlyLoggedIn: false,
       show526Wizard: false,
     });
-    expect(tree.find('h1')).to.have.lengthOf(1);
-    expect(tree.find('WizardContainer')).to.have.lengthOf(0);
+    expect(tree.find('h1').text()).to.contain('Log in');
     tree.unmount();
   });
   it('should render loading indicator when feature is undefined', () => {
@@ -290,6 +306,7 @@ describe('Form 526EZ Entry Page', () => {
         <Form526Entry
           location={initialState.currentLocation}
           user={initialState.user}
+          router={[]}
         >
           <main>
             <h1>{fakeSipsIntro(initialState.user)}</h1>

--- a/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
@@ -87,15 +87,15 @@ describe('<IntroductionPage/>', () => {
 
   it('should render reset wizard link to info page', () => {
     const wrapper = shallow(<IntroductionPage {...defaultProps} />);
-    expect(wrapper.find('.va-button-link').props().href).to.contain(
+    expect(wrapper.find('#restart-wizard a').props().href).to.contain(
       'how-to-file-claim',
     );
     wrapper.unmount();
   });
   it('should render reset wizard link to intro page', () => {
     const wrapper = shallow(<IntroductionPage {...defaultProps} showWizard />);
-    expect(wrapper.find('.va-button-link').props().href).to.equal(
-      DISABILITY_526_V2_ROOT_URL,
+    expect(wrapper.find('#restart-wizard a').props().href).to.equal(
+      `${DISABILITY_526_V2_ROOT_URL}/start`,
     );
     wrapper.unmount();
   });

--- a/src/applications/disability-benefits/all-claims/tests/containers/WizardContainer.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/WizardContainer.unit.spec.jsx
@@ -11,7 +11,7 @@ describe('Wizard Container', () => {
   beforeEach(() => {
     sessionStorage.removeItem(WIZARD_STATUS);
   });
-  after(() => {
+  afterEach(() => {
     sessionStorage.removeItem(WIZARD_STATUS);
   });
 

--- a/src/applications/disability-benefits/all-claims/tests/containers/WizardContainer.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/WizardContainer.unit.spec.jsx
@@ -5,29 +5,32 @@ import { shallow } from 'enzyme';
 import WizardContainer from '../../containers/WizardContainer';
 import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
 
+import { WIZARD_STATUS } from '../../constants';
+
 describe('Wizard Container', () => {
-  global.status = '';
-  const props = {
-    setWizardStatus: value => {
-      global.status = value;
-    },
-  };
+  beforeEach(() => {
+    sessionStorage.removeItem(WIZARD_STATUS);
+  });
+  after(() => {
+    sessionStorage.removeItem(WIZARD_STATUS);
+  });
 
   it('should render', () => {
-    const tree = shallow(<WizardContainer {...props} />);
+    const tree = shallow(<WizardContainer />);
     expect(tree.find('FormTitle')).to.have.lengthOf(1);
     expect(tree.find('.wizard-container')).to.have.lengthOf(1);
     expect(tree.find('FormFooter')).to.have.lengthOf(1);
     tree.unmount();
   });
   it('should update wizard status on bypass click', () => {
-    global.status = '';
-    const tree = shallow(<WizardContainer {...props} />);
+    const tree = shallow(<WizardContainer />);
     tree.find('.skip-wizard-link').simulate('click', {
       preventDefault: () => {},
     });
     expect(tree.find('.wizard-container')).to.have.lengthOf(1);
-    expect(global.status).to.equal(WIZARD_STATUS_COMPLETE);
+    expect(sessionStorage.getItem(WIZARD_STATUS)).to.equal(
+      WIZARD_STATUS_COMPLETE,
+    );
     tree.unmount();
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/mocks/user.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/mocks/user.json
@@ -1,0 +1,100 @@
+{
+  "data": {
+    "id": "",
+    "type": "users_scaffolds",
+    "attributes": {
+      "services": [
+        "facilities",
+        "hca",
+        "edu-benefits",
+        "form-save-in-progress",
+        "form-prefill",
+        "evss-claims",
+        "form526",
+        "user-profile",
+        "appeals-status",
+        "identity-proofed"
+      ],
+      "account": {
+        "accountUuid": "6af59b36-f14d-482e-88b4-3d7820422343"
+      },
+      "profile": {
+        "email": "vets.gov.user+228@gmail.com",
+        "firstName": "MARK",
+        "middleName": null,
+        "lastName": "WEBB",
+        "birthDate": "1950-10-04",
+        "gender": "M",
+        "zip": null,
+        "lastSignedIn": "2020-06-18T21:15:19.664Z",
+        "loa": {
+          "current": 3,
+          "highest": 3
+        },
+        "multifactor": true,
+        "verified": true,
+        "signIn": {
+          "serviceName": "idme",
+          "accountType": "N/A"
+        },
+        "authnContext": "http://idmanagement.gov/ns/assurance/loa/3/vets"
+      },
+      "vaProfile": {
+        "status": "OK",
+        "birthDate": "19501004",
+        "familyName": "Webb-ster",
+        "gender": "M",
+        "givenNames": ["Mark"],
+        "isCernerPatient": false,
+        "facilities": [
+          {
+            "facilityId": "556",
+            "isCerner": false
+          },
+          {
+            "facilityId": "668",
+            "isCerner": false
+          }
+        ],
+        "vaPatient": true,
+        "mhvAccountState": "NONE"
+      },
+      "veteranStatus": null,
+      "inProgressForms": [],
+      "prefillsAvailable": [
+        "21-686C",
+        "40-10007",
+        "22-1990",
+        "22-1990N",
+        "22-1990E",
+        "22-1995",
+        "22-1995S",
+        "22-5490",
+        "22-5495",
+        "22-0993",
+        "22-0994",
+        "FEEDBACK-TOOL",
+        "22-10203",
+        "21-526EZ",
+        "1010ez",
+        "21P-530",
+        "21P-527EZ",
+        "686C-674",
+        "20-0996",
+        "MDOT"
+      ],
+      "vet360ContactInformation": {}
+    }
+  },
+  "meta": {
+    "errors": [
+      {
+        "externalService": "EMIS",
+        "startTime": "2021-06-18T21:15:34Z",
+        "endTime": null,
+        "description": "IOError, Betamocks default response requested but none exist. Please create one at: [/cache/emis/veteran_status/default.yml]., Betamocks default response requested but none exist. Please create one at: [/cache/emis/veteran_status/default.yml].",
+        "status": 503
+      }
+    ]
+  }
+}

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -45,6 +45,7 @@ import {
   isUndefined,
   isDisabilityPtsd,
   showSeparationLocation,
+  isExpired,
 } from '../utils';
 
 describe('526 helpers', () => {
@@ -1222,5 +1223,27 @@ describe('526 v2 depends functions', () => {
       };
       expect(showSeparationLocation(nonBddData)).to.be.false;
     });
+  });
+});
+
+describe('isExpired', () => {
+  const oneDayInSeconds = 24 * 60 * 60;
+  const getDays = days =>
+    moment()
+      .add(days, 'days')
+      .format('YYYY-MM-DD');
+  it('should return true for dates that are invalid or in the past', () => {
+    const expiredSeconds = Date.now() / 1000 - oneDayInSeconds;
+    expect(isExpired('')).to.be.true;
+    expect(isExpired(0)).to.be.true;
+    expect(isExpired(getDays(-1))).to.be.true;
+    expect(isExpired(expiredSeconds)).to.be.true;
+  });
+  it('should return false for dates in the past', () => {
+    const futureSeconds = Date.now() / 1000 + oneDayInSeconds;
+    expect(isExpired(getDays(0))).to.be.false;
+    expect(isExpired(getDays(1))).to.be.false;
+    expect(isExpired(getDays(365))).to.be.false;
+    expect(isExpired(futureSeconds)).to.be.false;
   });
 });

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -7,6 +7,8 @@ import { createSelector } from 'reselect';
 import { omit } from 'lodash';
 import merge from 'lodash/merge';
 import fastLevenshtein from 'fast-levenshtein';
+import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
+
 import { apiRequest } from 'platform/utilities/api';
 import environment from 'platform/utilities/environment';
 import _ from 'platform/utilities/data';
@@ -1028,3 +1030,27 @@ export const show526Wizard = state => toggleValues(state).show526Wizard;
 
 export const showSubform8940And4192 = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.subform89404192];
+
+export const wrapWithBreadcrumb = (title, component) => (
+  <>
+    <Breadcrumbs>
+      <a href="/">Home</a>
+      <a href="/disability">Disability Benefits</a>
+      <span className="vads-u-color--black">
+        <strong>{title}</strong>
+      </span>
+    </Breadcrumbs>
+    {component}
+  </>
+);
+
+export const isExpired = date => {
+  if (!date) {
+    return true;
+  }
+  const today = moment().endOf('day');
+  // expiresAt: Ruby saves as time from Epoch date in seconds (not milliseconds)
+  // we plan to update the expiresAt date to "YYYY-MM-DD" format in the future
+  const expires = moment(isNaN(date) ? date : date * 1000);
+  return !(expires.isValid() && expires.endOf('day').isSameOrAfter(today));
+};

--- a/src/applications/disability-benefits/wizard/wizard-utils.js
+++ b/src/applications/disability-benefits/wizard/wizard-utils.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router';
 
 import recordEvent from 'platform/monitoring/record-event';
 
@@ -15,15 +16,11 @@ export const formStartButton = ({
     event: 'howToWizard-cta-displayed',
   });
   return (
-    <a
-      href={`${DISABILITY_526_V2_ROOT_URL}/introduction`}
+    <Link
+      to={`${DISABILITY_526_V2_ROOT_URL}/introduction`}
       className="usa-button-primary va-button-primary"
-      onClick={event => {
-        /* Remove this check, keep the preventDefault once show526Wizard flipper
-            is at 100% */
-        if (window.location.pathname.includes(DISABILITY_526_V2_ROOT_URL)) {
-          event.preventDefault();
-        }
+      onClick={() => {
+        setWizardStatus(WIZARD_STATUS_COMPLETE);
         recordEvent({
           event: 'howToWizard-hidden',
           'reason-for-hidden-wizard': eventReason,
@@ -33,11 +30,10 @@ export const formStartButton = ({
           'button-type': 'primary',
           'button-click-label': label,
         });
-        setWizardStatus(WIZARD_STATUS_COMPLETE);
       }}
       aria-describedby={ariaId}
     >
       {label}
-    </a>
+    </Link>
   );
 };

--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -141,12 +141,13 @@ const performPageActions = (pathname, _13647Exception = false) => {
 
   cy.execHook(pathname).then(({ hookExecuted, postHook }) => {
     const shouldAutofill = !pathname.match(
-      /\/(introduction|confirmation|review-and-submit)$/,
+      /\/(start|introduction|confirmation|review-and-submit)$/,
     );
 
     if (!hookExecuted && shouldAutofill) cy.fillPage();
 
     cy.expandAccordions();
+    cy.injectAxe();
     cy.axeCheck('main', { _13647Exception });
 
     const postHookPromise = new Promise(resolve => {
@@ -201,7 +202,7 @@ const defaultPostHook = pathname => {
   }
 
   // No-op on introduction and confirmation pages.
-  if (pathname.match(/\/(introduction|confirmation)$/)) {
+  if (pathname.match(/\/(start|introduction|confirmation)$/)) {
     return () => {};
   }
 


### PR DESCRIPTION
## Description

Per the new IA recommendations, the form wizards shouldn't share the `/introduction` path with the introduction page content. They are to be moved to a new `/start` path ([ref](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/information-architecture/ia-reviews/wizard-disability.md)).

This PR also needed to update the Cypress form tester to ignore the `/start` path.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/26264
- https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/information-architecture/ia-reviews/wizard-disability.md
- https://dsva.slack.com/archives/CBU0KDSB1/p1624386916190700?thread_ts=1624305807.150600&cid=CBU0KDSB1

## Testing done

- Updated unit tests
- Updated Cypress tests for wizard & introduction page

## Screenshots

N/A - The visual appearance hasn't changed, only the path

## Acceptance criteria
- [x] Wizard flow matches IA recommendations
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
