### PR TITLE
NOD: Various fixes

### DIFF
--- a/src/applications/appeals/10182/containers/IntroductionPage.jsx
+++ b/src/applications/appeals/10182/containers/IntroductionPage.jsx
@@ -29,6 +29,7 @@ class IntroductionPage extends React.Component {
     const sipOptions = {
       useActionLinks: true,
       hideUnauthedStartLink: true,
+      headingLevel: 2,
       formId,
       prefillEnabled,
       pageList,

--- a/src/applications/appeals/10182/tests/containers/FormApp.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/containers/FormApp.unit.spec.jsx
@@ -235,6 +235,7 @@ describe('FormApp', () => {
       ],
     };
     const formData = {
+      'view:hasIssuesToAdd': true,
       contestableIssues: contestableIssues.issues,
       additionalIssues: [{ issue: 'other issue', [SELECTED]: true }],
       veteran: {

--- a/src/applications/appeals/10182/tests/pages/issueSummary.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/pages/issueSummary.unit.spec.jsx
@@ -22,6 +22,7 @@ describe('NOD selected issues summary page', () => {
         schema={schema}
         uiSchema={uiSchema}
         data={{
+          'view:hasIssuesToAdd': true,
           contestableIssues: [{ [SELECTED]: true }],
           additionalIssues: [{ [SELECTED]: true }],
         }}

--- a/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
@@ -65,9 +65,21 @@ describe('getSelected', () => {
       }),
     ).to.deep.equal([{ type: 'ok', [SELECTED]: true, index: 0 }]);
   });
+  it('should not return selected additional issues when Veteran chooses not to include them', () => {
+    expect(
+      getSelected({
+        'view:hasIssuesToAdd': false,
+        additionalIssues: [
+          { type: 'no', [SELECTED]: false },
+          { type: 'ok', [SELECTED]: true },
+        ],
+      }),
+    ).to.deep.equal([]);
+  });
   it('should return selected additional issues', () => {
     expect(
       getSelected({
+        'view:hasIssuesToAdd': true,
         additionalIssues: [
           { type: 'no', [SELECTED]: false },
           { type: 'ok', [SELECTED]: true },
@@ -82,6 +94,7 @@ describe('getSelected', () => {
           { type: 'no1', [SELECTED]: false },
           { type: 'ok1', [SELECTED]: true },
         ],
+        'view:hasIssuesToAdd': true,
         additionalIssues: [
           { type: 'no2', [SELECTED]: false },
           { type: 'ok2', [SELECTED]: true },

--- a/src/applications/appeals/10182/utils/helpers.js
+++ b/src/applications/appeals/10182/utils/helpers.js
@@ -37,12 +37,19 @@ export const showAddIssueQuestion = ({ contestableIssues }) =>
   // selected or, there are no contestable issues
   contestableIssues?.length ? someSelected(contestableIssues) : false;
 
-export const getSelected = ({ contestableIssues, additionalIssues } = {}) =>
-  (contestableIssues || [])
-    .filter(issue => issue[SELECTED])
-    .concat((additionalIssues || []).filter(issue => issue[SELECTED]))
-    // include index to help with error messaging
-    .map((issue, index) => ({ ...issue, index }));
+export const getSelected = formData => {
+  const eligibleIssues = (formData?.contestableIssues || []).filter(
+    issue => issue[SELECTED],
+  );
+  const addedIssues = formData['view:hasIssuesToAdd']
+    ? (formData?.additionalIssues || []).filter(issue => issue[SELECTED])
+    : [];
+  // include index to help with error messaging
+  return [...eligibleIssues, ...addedIssues].map((issue, index) => ({
+    ...issue,
+    index,
+  }));
+};
 
 export const getIssueName = (entry = {}) =>
   entry.issue || entry.attributes?.ratingIssueSubjectText;


### PR DESCRIPTION
## Description

- 508 fix to update header level of save in progress intro alert when signed out
- Bug fix that will prevent including additional issues when choice set to not include

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/26483

## Testing done

Updated unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Axe check on signed out intro page doesn't include heading level error
- [x] Additional issues not included when Veteran chooses not to include  

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
