### PR TITLE
Minimized retention of temporary artifacts.

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           name: ${{ matrix.buildtype }}.tar.bz2
           path: ${{ matrix.buildtype }}.tar.bz2
+          retention-days: 1
 
   unit-tests:
     name: Unit Tests
@@ -374,9 +375,10 @@ jobs:
         with:
           name: cypress-mochawesome-test-results-artifact-${{ matrix.ci_node_index }}
           path: cypress/results
+          retention-days: 1
 
   mochawesome-report:
-    name: Generate Mochawesome Report
+    name: Mochawesome Report
     runs-on: ubuntu-latest
     needs: cypress-tests
     if: ${{ always() && (needs.cypress-tests.result == 'success' || needs.cypress-tests.result == 'failure') }}


### PR DESCRIPTION
## Description
Some artifacts are uploaded just as a way to pass data between jobs.
- Builds have served their purpose after tests and S3 uploads, so they don't need to be kept as artifacts.
- We're done using Cypress Mochawesome results after they've been reported to BigQuery.

Since they no longer need to be retained, I've reduced their retention time to the minimum of 1 day. The default retention is 90 days ([more info](https://docs.github.com/en/actions/reference/usage-limits-billing-and-administration#artifact-and-log-retention-policy)).

The `@actions/artifact` package does provide an API to purge artifacts on demand, but I didn't think the overhead of implementing that was really worth it. On the other hand, it may still be useful for debugging purposes to keep them around for a brief period of time.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
