### PR TITLE
Set fail-fast to false

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -10,6 +10,7 @@ jobs:
     name: E2E Tests
     runs-on: self-hosted
     strategy:
+      fail-fast: false
       max-parallel: 6
       matrix:
         ci_node_total: [6]


### PR DESCRIPTION
## Description
Set `fail-fast` to `false` for the E2E Tests job to prevent a subset of Cypress test results from being downloaded in the Generate Mochawesome Report job when Cypress tests fails. The Generate Mochawesome Report requires all tests, or no tests.

When only a subset of tests are downloaded the E2E Metrics are thrown off in the dashboard - https://va-gov.domo.com/page/1232474697


