### PR TITLE
Add CommunicationChannel model class

### DIFF
--- a/src/applications/personalization/profile/ducks/communicationPreferences.js
+++ b/src/applications/personalization/profile/ducks/communicationPreferences.js
@@ -76,7 +76,7 @@ export const saveCommunicationPreferenceGroup = (groupId, apiCalls) => {
         apiCalls.map(callInfo => {
           return apiRequest(callInfo.endpoint, {
             method: callInfo.method,
-            body: callInfo.body,
+            body: callInfo.payload,
             headers: { 'Content-Type': 'application/json' },
           });
         }),

--- a/src/applications/personalization/profile/models/CommunicationChannel.js
+++ b/src/applications/personalization/profile/models/CommunicationChannel.js
@@ -1,0 +1,62 @@
+class CommunicationChannel {
+  constructor({ id, parentItemId, permissionId, isAllowed = null }) {
+    if (typeof id !== 'number') {
+      throw new Error('Invalid Argument: options.id must be a number');
+    }
+    if (typeof parentItemId !== 'number') {
+      throw new Error(
+        'Invalid Argument: options.parentItemId must be a number',
+      );
+    }
+    this.id = id;
+    this.parentItemId = parentItemId;
+    this.permissionId = permissionId;
+    this.isAllowed = isAllowed;
+  }
+
+  setIsAllowed(isAllowed) {
+    this.isAllowed = isAllowed;
+  }
+
+  getApiCallObject() {
+    const method = this.permissionId ? 'PATCH' : 'POST';
+    const endpoint = this.permissionId
+      ? `/profile/communication_preferences/${this.permissionId}`
+      : '/profile/communication_preferences';
+    const allowed = this.isAllowed;
+
+    return {
+      method,
+      endpoint,
+      payload: {
+        communicationItem: {
+          id: this.parentItemId,
+          communicationChannel: {
+            id: this.id,
+            communicationPermission: {
+              allowed,
+            },
+          },
+        },
+      },
+    };
+  }
+
+  isIdenticalTo(otherCommunicationChannel) {
+    if (!(otherCommunicationChannel instanceof CommunicationChannel)) {
+      throw new Error(
+        'Invalid Argument: argument must be an instance of CommunicationChannel',
+      );
+    }
+    // compare all of this instance's properties to the
+    // otherCommunicationChannel's corresponding properties
+    return Object.entries(this).reduce((acc, [key, value]) => {
+      if (otherCommunicationChannel[key] !== value) {
+        return false;
+      }
+      return acc;
+    }, true);
+  }
+}
+
+export default CommunicationChannel;

--- a/src/applications/personalization/profile/models/CommunicationChannel.js
+++ b/src/applications/personalization/profile/models/CommunicationChannel.js
@@ -18,6 +18,17 @@ class CommunicationChannel {
     this.isAllowed = isAllowed;
   }
 
+  /**
+   * Method that returns an object that can easily handled by the
+   * saveCommunicationPreferenceGroup() thunk creator.
+   *
+   * @returns an object with the following keys:
+   * - endpoint: '/profile/communication_preferences' or
+   *   '/profile/communication_preferences/:id'
+   * - method: 'POST' or 'PATCH'
+   * - payload: object that can used as the request body by either endpoint
+   * @memberof CommunicationChannel
+   */
   getApiCallObject() {
     const method = this.permissionId ? 'PATCH' : 'POST';
     const endpoint = this.permissionId
@@ -42,6 +53,8 @@ class CommunicationChannel {
     };
   }
 
+  // returns true if the argument is a CommunicationChannel with identical
+  // property values as this instance
   isIdenticalTo(otherCommunicationChannel) {
     if (!(otherCommunicationChannel instanceof CommunicationChannel)) {
       throw new Error(

--- a/src/applications/personalization/profile/models/CommunicationChannel.unit.spec.js
+++ b/src/applications/personalization/profile/models/CommunicationChannel.unit.spec.js
@@ -1,0 +1,130 @@
+import { expect } from 'chai';
+
+import CommunicationChannel from './CommunicationChannel';
+
+describe('CommunicationChannel model', () => {
+  describe('constructor', () => {
+    it('throws an error when `options.id` is not included or not a number', () => {
+      expect(() => {
+        // eslint-disable-next-line no-new
+        new CommunicationChannel({ parentItemId: 1 });
+      }).to.throw(Error, /Invalid Argument/i);
+      expect(() => {
+        // eslint-disable-next-line no-new
+        new CommunicationChannel({ id: '1' });
+      }).to.throw(Error, /Invalid Argument/i);
+    });
+    it('throws an error when `options.parentItemId` is not included or not a number', () => {
+      expect(() => {
+        // eslint-disable-next-line no-new
+        new CommunicationChannel({ id: 1 });
+      }).to.throw(Error, /Invalid Argument/i);
+      expect(() => {
+        // eslint-disable-next-line no-new
+        new CommunicationChannel({ parentItemId: '1' });
+      }).to.throw(Error, /Invalid Argument/i);
+    });
+  });
+
+  describe('getApiCallObject()', () => {
+    context('when no permissions have been set yet', () => {
+      it('returns an object with the correct shape that we can use with the `saveCommunicationPreferencesGroup` thunk creator', () => {
+        const commChannel = new CommunicationChannel({
+          id: 1,
+          parentItemId: 1,
+        });
+        commChannel.setIsAllowed(true);
+        const apiCallObject = commChannel.getApiCallObject();
+        expect(apiCallObject.method).to.equal('POST');
+        expect(apiCallObject.endpoint).to.equal(
+          '/profile/communication_preferences',
+        );
+        expect(apiCallObject.payload).to.deep.equal({
+          communicationItem: {
+            id: 1,
+            communicationChannel: {
+              id: 1,
+              communicationPermission: {
+                allowed: true,
+              },
+            },
+          },
+        });
+      });
+    });
+    context('when permission is flipped from true to false', () => {
+      it('returns an object with the correct shape that we can use with the `saveCommunicationPreferencesGroup` thunk creator', () => {
+        const commChannel = new CommunicationChannel({
+          id: 1,
+          parentItemId: 1,
+          permissionId: 1001,
+          isAllowed: true,
+        });
+        commChannel.setIsAllowed(false);
+        const apiCallObject = commChannel.getApiCallObject();
+        expect(apiCallObject.method).to.equal('PATCH');
+        expect(apiCallObject.endpoint).to.equal(
+          '/profile/communication_preferences/1001',
+        );
+        expect(apiCallObject.payload).to.deep.equal({
+          communicationItem: {
+            id: 1,
+            communicationChannel: {
+              id: 1,
+              communicationPermission: {
+                allowed: false,
+              },
+            },
+          },
+        });
+      });
+    });
+  });
+
+  describe('isIdenticalTo()', () => {
+    let commChannel1;
+    let commChannel2;
+    beforeEach(() => {
+      commChannel1 = new CommunicationChannel({
+        id: 1,
+        parentItemId: 1,
+        permissionId: 1000,
+        isAllowed: true,
+      });
+      commChannel2 = new CommunicationChannel({
+        id: 1,
+        parentItemId: 1,
+        permissionId: 1000,
+        isAllowed: true,
+      });
+    });
+    context('when it is not passed-in a communication-channel', () => {
+      it('throws an error', () => {
+        expect(() => {
+          commChannel1.isIdenticalTo();
+        }).to.throw(Error, /Invalid Argument/i);
+        expect(() => {
+          commChannel1.isIdenticalTo({});
+        }).to.throw(Error, /Invalid Argument/i);
+      });
+    });
+    context(
+      'when it is identical to the passed-in communication channel',
+      () => {
+        it('returns true', () => {
+          expect(commChannel1.isIdenticalTo(commChannel2)).to.be.true;
+        });
+      },
+    );
+    context(
+      'when the passed-in communication channel is different than itself',
+      () => {
+        it('returns false', () => {
+          // this serves as a test of the setIsAllowed() method
+          commChannel2.setIsAllowed(false);
+          expect(commChannel1.isIdenticalTo(commChannel2)).to.be.false;
+        });
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Description
Adds a helper class so we can easily determine:
- which API to call to update a preference
- if two CommunicationChannels are different in any meaningful way

## Testing done
Unit tests written in a TDD fashion

## Screenshots
n/a

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs