### PR TITLE
Fix best time to call logic

### DIFF
--- a/src/applications/vaos/appointment-list/components/cards/pending/ListBestTimeToCall.jsx
+++ b/src/applications/vaos/appointment-list/components/cards/pending/ListBestTimeToCall.jsx
@@ -2,15 +2,15 @@ import React from 'react';
 
 export default function ListBestTimeToCall({ timesToCall }) {
   const times = timesToCall?.map(t => t.toLowerCase());
-  if (times.length === 1) {
+  if (times?.length === 1) {
     return <>Call {times[0]}</>;
-  } else if (times.length === 2) {
+  } else if (times?.length === 2) {
     return (
       <>
         Call {times[0]} or {times[1]}
       </>
     );
-  } else if (times.length === 3) {
+  } else if (times?.length === 3) {
     return (
       <>
         Call {times[0]}, {times[1]}, or {times[2]}


### PR DESCRIPTION
## Description
This PR
- Fixes how we handle a null preferredTimesForPhoneCall value

## Testing done
Local testing

## Acceptance criteria
- [ ] VAOS service requests are viewable

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
