### PR TITLE
Fixed null appointment id.

### DIFF
--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -405,7 +405,8 @@ export function transformConfirmedAppointment(appt) {
   const videoData = setVideoData(appt);
   return {
     resourceType: 'Appointment',
-    id: appt.id,
+    // Temporary fix until https://issues.mobilehealth.va.gov/browse/VAOSR-2058 is complete
+    id: appt.id || appt.vvsAppointments[0].id,
     status: getConfirmedStatus(appt, isPast),
     description: getVistaStatus(appt),
     start,

--- a/src/applications/vaos/tests/services/appointment/transformers.unit.spec.js
+++ b/src/applications/vaos/tests/services/appointment/transformers.unit.spec.js
@@ -645,6 +645,24 @@ describe('VAOS Appointment transformer', () => {
             expect(transformed.vaos.isPastAppointment).to.equal(true);
           });
         });
+
+        it('should use the vvsAppointment id if the appointment id is null', () => {
+          const pastAppt = {
+            ...videoAppt,
+            id: null,
+            vvsAppointments: [
+              {
+                ...videoAppt.vvsAppointments[0],
+                dateTime: moment()
+                  .subtract(235, 'minutes')
+                  .format(),
+              },
+            ],
+          };
+
+          const transformed = transformConfirmedAppointments([pastAppt])[0];
+          expect(transformed.id).to.equal(pastAppt.vvsAppointments[0].id);
+        });
       });
     });
 


### PR DESCRIPTION
## Description
This PR temporarily fixes the null appointment id for sourced video appointments. See https://issues.mobilehealth.va.gov/browse/VAOSR-2058

## Testing done
Unit testing

## Screenshots
N/A

## Acceptance criteria
- [ ] All test should pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
