### PR TITLE
display type of appointment on details request page

### DIFF
--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
@@ -129,6 +129,7 @@ export default function RequestedAppointmentDetailsPage() {
 
   const canceled = appointment.status === APPOINTMENT_STATUS.cancelled;
   const isCC = appointment.vaos.isCommunityCare;
+  const typeOfVisit = appointment.vaos.requestVisitType;
   const typeOfCareText = lowerCase(appointment?.type?.coding?.[0]?.display);
   const facilityId = getVAAppointmentLocationId(appointment);
   const facility = facilityData?.[facilityId];
@@ -195,7 +196,7 @@ export default function RequestedAppointmentDetailsPage() {
       )}
       {!isCCRequest && (
         <h2 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-bottom--0">
-          VA Appointment
+          VA appointment
         </h2>
       )}
 
@@ -227,7 +228,7 @@ export default function RequestedAppointmentDetailsPage() {
           <h2 className="vaos-appts__block-label vads-u-margin-bottom--0 vads-u-margin-top--2">
             Preferred type of appointment
           </h2>
-          {appointment.vaos.requestVisitType}
+          {typeOfVisit}
         </>
       )}
 

--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
@@ -129,7 +129,6 @@ export default function RequestedAppointmentDetailsPage() {
 
   const canceled = appointment.status === APPOINTMENT_STATUS.cancelled;
   const isCC = appointment.vaos.isCommunityCare;
-  const isVideoRequest = appointment.vaos.isVideo;
   const typeOfCareText = lowerCase(appointment?.type?.coding?.[0]?.display);
   const facilityId = getVAAppointmentLocationId(appointment);
   const facility = facilityData?.[facilityId];
@@ -195,12 +194,9 @@ export default function RequestedAppointmentDetailsPage() {
         </InfoAlert>
       )}
       {!isCCRequest && (
-        <>
-          <h2 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-bottom--0">
-            {isVideoRequest && 'VA Video Connect'}
-            {!isVideoRequest && 'VA Appointment'}
-          </h2>
-        </>
+        <h2 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-bottom--0">
+          VA Appointment
+        </h2>
       )}
 
       {!!facility &&
@@ -213,7 +209,7 @@ export default function RequestedAppointmentDetailsPage() {
           />
         )}
 
-      {isCCRequest && (
+      {isCCRequest ? (
         <>
           <h2 className="vaos-appts__block-label vads-u-margin-bottom--0 vads-u-margin-top--2">
             Preferred community care provider
@@ -225,6 +221,13 @@ export default function RequestedAppointmentDetailsPage() {
             </span>
           )}
           {!provider && <span>No provider selected</span>}
+        </>
+      ) : (
+        <>
+          <h2 className="vaos-appts__block-label vads-u-margin-bottom--0 vads-u-margin-top--2">
+            Preferred type of appointment
+          </h2>
+          {appointment.vaos.requestVisitType}
         </>
       )}
 

--- a/src/applications/vaos/services/appointment/transformers.v2.js
+++ b/src/applications/vaos/services/appointment/transformers.v2.js
@@ -2,6 +2,7 @@ import {
   TYPES_OF_CARE,
   APPOINTMENT_TYPES,
   PURPOSE_TEXT,
+  TYPE_OF_VISIT,
   TYPES_OF_EYE_CARE,
   TYPES_OF_SLEEP_CARE,
   AUDIOLOGY_TYPES_OF_CARE,
@@ -28,6 +29,16 @@ function getTypeOfCareById(id) {
   ];
 
   return allTypesOfCare.find(care => care.id === id);
+}
+
+/**
+ * Gets the type of visit that matches our array of visit constant
+ *
+ * @param {Object} id VAR appointment object
+ * @returns {String} type of visit string
+ */
+function getTypeOfVisit(id) {
+  return TYPE_OF_VISIT.find(type => type.id === id)?.name;
 }
 
 export function transformVAOSAppointment(appt) {
@@ -84,6 +95,7 @@ export function transformVAOSAppointment(appt) {
       appointmentType: getAppointmentType(appt),
       isCommunityCare: isCC,
       isExpressCare: false,
+      requestVisitType: getTypeOfVisit(appt.kind),
       apiData: appt,
       // TODO missing data: isPastAppointment, isCOVIDVaccine, isPhoneAppointment, timeZone
     },

--- a/src/applications/vaos/services/mocks/v2/requests.json
+++ b/src/applications/vaos/services/mocks/v2/requests.json
@@ -72,6 +72,74 @@
         "description": null,
         "comment": "I have a cold"
       }
+    },
+    {
+      "id": "25958",
+      "type": "appointments",
+      "attributes": {
+        "id": "25958",
+        "kind": "phone",
+        "status": "proposed",
+        "serviceType": "408",
+        "locationId": "983HK",
+        "clinic": null,
+        "telehealth": null,
+        "practitioners": [],
+        "reason": "Routine Follow-up",
+        "start": null,
+        "end": null,
+        "minutesDuration": null,
+        "slot": null,
+        "requestedPeriods": [
+          { "start": "2021-11-16T01:30:00Z" },
+          { "start": "2021-11-17T04:00:00Z" }
+        ],
+        "contact": {
+          "telecom": [
+            { "type": "phone", "value": "2125551212" },
+            { "type": "email", "value": "veteranemailtest@va.gov" }
+          ]
+        },
+        "preferredTimesForPhoneCall": ["Afternoon", "Evening"],
+        "priority": null,
+        "cancellationReason": null,
+        "description": null,
+        "comment": "Pink eye"
+      }
+    },
+    {
+      "id": "25959",
+      "type": "appointments",
+      "attributes": {
+        "id": "25959",
+        "kind": "telehealth",
+        "status": "proposed",
+        "serviceType": "160",
+        "locationId": "983",
+        "clinic": null,
+        "telehealth": null,
+        "practitioners": [],
+        "reason": "New Issue",
+        "start": null,
+        "end": null,
+        "minutesDuration": null,
+        "slot": null,
+        "requestedPeriods": [
+          { "start": "2021-11-16T01:30:00Z" },
+          { "start": "2021-11-17T04:00:00Z" }
+        ],
+        "contact": {
+          "telecom": [
+            { "type": "phone", "value": "2125551212" },
+            { "type": "email", "value": "veteranemailtest@va.gov" }
+          ]
+        },
+        "preferredTimesForPhoneCall": ["Afternoon", "Evening"],
+        "priority": null,
+        "cancellationReason": null,
+        "description": null,
+        "comment": "Renew medication"
+      }
     }
   ],
   "meta": {

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
@@ -690,7 +690,7 @@ describe('VAOS <RequestedAppointmentDetailsPage> with VAOS service', () => {
       'The time and date of this appointment are still to be determined.',
     );
 
-    expect(screen.getByText('Cheyenne VA Medical Center')).to.be.ok;
+    expect(screen.getByText(/Cheyenne VA Medical Center/)).to.be.ok;
     expect(screen.baseElement).to.contain.text(
       'Pending primary care appointment',
     );
@@ -702,6 +702,8 @@ describe('VAOS <RequestedAppointmentDetailsPage> with VAOS service', () => {
     );
     expect(screen.baseElement).to.contain.text('Main phone:');
     expect(screen.baseElement).to.contain.text('307-778-7550');
+    expect(screen.baseElement).to.contain.text('Preferred type of appointment');
+    expect(screen.baseElement).to.contain.text('Office visit');
     expect(screen.baseElement).to.contain.text('Preferred date and time');
     expect(screen.baseElement).to.contain.text(
       `${moment(appointment.attributes.requestedPeriods[0].start).format(

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
@@ -144,7 +144,7 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
     expect(screen.baseElement).to.contain.text(
       'Pending primary care appointment',
     );
-    expect(screen.baseElement).to.contain.text('VA Appointment');
+    expect(screen.baseElement).to.contain.text('VA appointment');
     expect(screen.baseElement).to.contain.text('Cheyenne VA Medical Center');
     expect(screen.baseElement).to.contain.text('2360 East Pershing Boulevard');
     expect(screen.baseElement).to.contain.text(
@@ -694,7 +694,7 @@ describe('VAOS <RequestedAppointmentDetailsPage> with VAOS service', () => {
     expect(screen.baseElement).to.contain.text(
       'Pending primary care appointment',
     );
-    expect(screen.baseElement).to.contain.text('VA Appointment');
+    expect(screen.baseElement).to.contain.text('VA appointment');
     expect(screen.baseElement).to.contain.text('Cheyenne VA Medical Center');
     expect(screen.baseElement).to.contain.text('2360 East Pershing Boulevard');
     expect(screen.baseElement).to.contain.text(


### PR DESCRIPTION
## Description
As a user, I like to see what mode of visit i've selected for an appointment request

## Testing done
local and unit test

## Screenshots
![image](https://user-images.githubusercontent.com/54327023/123440515-df229000-d5a0-11eb-90f9-37153df14f15.png)


## Acceptance criteria
- [ ] Add heading "Preferred type of appointment"
- [ ] Display the type of appointment requested [Office visit, Phone call, Telehealth (through VA Video Connect)]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
