### PR TITLE
526: Remove VA treatment end date

### DIFF
--- a/package.json
+++ b/package.json
@@ -325,7 +325,7 @@
     "url-search-params-polyfill": "^8.1.0",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#2047154b11a3c890ef8bd10c279eef6695457d0d",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#ce953be5c9c3b3658d9ed9bad81d22c789950c43",
     "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.7.0",
     "whatwg-fetch": "^2.0.3"
   },

--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -94,7 +94,7 @@ export const Form526Entry = ({
   if (typeof showWizard === 'undefined') {
     return wrapWithBreadcrumb(
       title,
-      <h1>
+      <h1 className="vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal">
         <LoadingIndicator message="Please wait while we load the application for you." />
       </h1>,
     );

--- a/src/applications/disability-benefits/all-claims/config/schema.js
+++ b/src/applications/disability-benefits/all-claims/config/schema.js
@@ -708,7 +708,7 @@ const schema = {
             pattern: "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$",
           },
           treatmentDateRange: {
-            $ref: '#/definitions/dateRangeFromRequired',
+            $ref: '#/definitions/dateRange',
           },
           treatmentCenterAddress: {
             $ref: '#/definitions/vaTreatmentCenterAddress',

--- a/src/applications/disability-benefits/all-claims/content/vaMedicalRecords.jsx
+++ b/src/applications/disability-benefits/all-claims/content/vaMedicalRecords.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { formatDate, formatDateRange } from '../utils';
+import { formatDate } from '../utils';
 
 const MONTH_YEAR = 'MMMM YYYY';
 
@@ -7,17 +7,12 @@ const MONTH_YEAR = 'MMMM YYYY';
 const replaceDay = date => date.replace('XX', '01');
 
 export const treatmentView = ({ formData }) => {
-  const { from, to } = formData.treatmentDateRange;
+  const { from } = formData.treatmentDateRange;
 
   const name = formData.treatmentCenterName || '';
   let treatmentPeriod = '';
-  if (from && to) {
-    treatmentPeriod = formatDateRange(
-      { from: replaceDay(from), to: replaceDay(to) },
-      MONTH_YEAR,
-    );
-  } else if (from || to) {
-    treatmentPeriod = formatDate(replaceDay(from || to), MONTH_YEAR);
+  if (from) {
+    treatmentPeriod = formatDate(replaceDay(from), MONTH_YEAR);
   }
 
   return (

--- a/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
@@ -1,15 +1,13 @@
-import set from 'platform/utilities/data/set';
 import merge from 'lodash/merge';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import { uiSchema as autoSuggestUiSchema } from 'platform/forms-system/src/js/definitions/autosuggest';
-import dateRangeUI from 'platform/forms-system/src/js/definitions/monthYearRange';
+import dateUI from 'platform/forms-system/src/js/definitions/monthYear';
 import { treatmentView } from '../content/vaMedicalRecords';
 import { queryForFacilities, makeSchemaForAllDisabilities } from '../utils';
 import {
   validateMilitaryTreatmentCity,
   validateMilitaryTreatmentState,
   startedAfterServicePeriod,
-  hasMonthYear,
   validateBooleanGroup,
 } from '../validations';
 import { USA } from '../constants';
@@ -65,29 +63,13 @@ export const uiSchema = {
           required: 'Please select at least one condition',
         },
       },
-      treatmentDateRange: merge(
-        {},
-        dateRangeUI(
-          'When did you first visit this facility?',
-          'When was your most recent visit? (Optional)',
-          'Date of last treatment must be after date of first treatment',
-          true,
-        ),
-        {
-          from: {
-            'ui:validations': dateRangeUI().from['ui:validations'].concat([
-              startedAfterServicePeriod,
-            ]),
-          },
-        },
-        {
-          to: {
-            'ui:validations': dateRangeUI().to['ui:validations'].concat([
-              hasMonthYear,
-            ]),
-          },
-        },
-      ),
+      treatmentDateRange: {
+        from: merge({}, dateUI('When did you first visit this facility?'), {
+          'ui:validations': dateUI()['ui:validations'].concat([
+            startedAfterServicePeriod,
+          ]),
+        }),
+      },
       treatmentCenterAddress: {
         'ui:order': ['country', 'state', 'city'],
         country: {
@@ -117,10 +99,30 @@ export const schema = {
       type: 'object',
       properties: {},
     },
-    vaTreatmentFacilities: set(
-      'items.properties.treatedDisabilityNames',
-      { type: 'object', properties: {} },
-      vaTreatmentFacilities,
-    ),
+    vaTreatmentFacilities: {
+      ...vaTreatmentFacilities,
+      items: {
+        type: 'object',
+        required: ['treatmentCenterName', 'treatedDisabilityNames'],
+        properties: {
+          treatmentCenterName:
+            vaTreatmentFacilities.items.properties.treatmentCenterName,
+          treatmentDateRange: {
+            type: 'object',
+            properties: {
+              from: {
+                $ref: '#/definitions/date',
+              },
+            },
+          },
+          treatmentCenterAddress:
+            vaTreatmentFacilities.items.properties.treatmentCenterAddress,
+          treatedDisabilityNames: {
+            type: 'object',
+            properties: {},
+          },
+        },
+      },
+    },
   },
 };

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-test.json
@@ -91,8 +91,7 @@
       {
         "treatmentCenterName": "Treatment Center the First",
         "treatmentDateRange": {
-          "from": "2008-01-XX",
-          "to": "2010-01-XX"
+          "from": "2008-01-XX"
         },
         "treatmentCenterAddress": {
           "country": "USA",
@@ -108,8 +107,7 @@
       {
         "treatmentCenterName": "Treatment Center the Second",
         "treatmentDateRange": {
-          "from": "2010-01-XX",
-          "to": "2018-02-XX"
+          "from": "2010-01-XX"
         },
         "treatmentCenterAddress": {
           "country": "Uganda",

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/secondary-new-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/secondary-new-test.json
@@ -85,8 +85,7 @@
       {
         "treatmentCenterName": "Treatment Center the First",
         "treatmentDateRange": {
-          "from": "2008-01-XX",
-          "to": "2010-01-XX"
+          "from": "2008-01-XX"
         },
         "treatmentCenterAddress": {
           "country": "USA",

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/maximal-test.json
@@ -36,7 +36,7 @@
     "vaTreatmentFacilities": [
       {
         "treatmentCenterName": "Treatment Center the First",
-        "treatmentDateRange": { "from": "2008-01-XX", "to": "2010-01-XX" },
+        "treatmentDateRange": { "from": "2008-01-XX" },
         "treatmentCenterAddress": {
           "country": "USA",
           "city": "Bigcity",
@@ -50,7 +50,7 @@
       },
       {
         "treatmentCenterName": "Treatment Center the Second",
-        "treatmentDateRange": { "from": "2010-01-XX", "to": "2018-02-XX" },
+        "treatmentDateRange": { "from": "2010-01-XX" },
         "treatmentCenterAddress": {
           "country": "Uganda",
           "city": "Ugandan City"

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/secondary-new-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/secondary-new-test.json
@@ -33,7 +33,7 @@
     "vaTreatmentFacilities": [
       {
         "treatmentCenterName": "Treatment Center the First",
-        "treatmentDateRange": { "from": "2008-01-XX", "to": "2010-01-XX" },
+        "treatmentDateRange": { "from": "2008-01-XX" },
         "treatmentCenterAddress": {
           "country": "USA",
           "city": "Bigcity",

--- a/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
@@ -38,8 +38,8 @@ describe('VA Medical Records', () => {
       />,
     );
 
-    expect(form.find('input').length).to.equal(7);
-    expect(form.find('select').length).to.equal(4);
+    expect(form.find('input').length).to.equal(6);
+    expect(form.find('select').length).to.equal(3);
     form.unmount();
   });
 
@@ -59,8 +59,8 @@ describe('VA Medical Records', () => {
     );
 
     form.find('form').simulate('submit');
-    // Required fields: Facility name, related disability, and treatment start date
-    expect(form.find('.usa-input-error-message').length).to.equal(3);
+    // Required fields: Facility name and related disability
+    expect(form.find('.usa-input-error-message').length).to.equal(2);
     expect(onSubmit.called).to.be.false;
     form.unmount();
   });
@@ -82,7 +82,6 @@ describe('VA Medical Records', () => {
               },
               treatmentDateRange: {
                 from: '2001-05-XX',
-                to: '2015-09-XX',
               },
               treatmentCenterAddress: {
                 country: 'USA',
@@ -125,7 +124,6 @@ describe('VA Medical Records', () => {
               },
               treatmentDateRange: {
                 from: '2001-05-XX',
-                to: '2015-09-XX',
               },
               treatmentCenterAddress: {
                 country: 'USA',
@@ -168,7 +166,6 @@ describe('VA Medical Records', () => {
               },
               treatmentDateRange: {
                 from: '2010-04-XX',
-                to: '2015-09-XX',
               },
               treatmentCenterAddress: {
                 country: 'USA',
@@ -205,7 +202,6 @@ describe('VA Medical Records', () => {
               },
               treatmentDateRange: {
                 from: '2010-04-XX',
-                to: '2015-09-XX',
               },
               treatmentCenterAddress: {
                 country: 'USA',
@@ -242,7 +238,6 @@ describe('VA Medical Records', () => {
               },
               treatmentDateRange: {
                 from: '2010-04-XX',
-                to: '2015-09-XX',
               },
               treatmentCenterAddress: {
                 country: 'USA',

--- a/yarn.lock
+++ b/yarn.lock
@@ -19849,9 +19849,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#2047154b11a3c890ef8bd10c279eef6695457d0d":
-  version "20.6.1"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#2047154b11a3c890ef8bd10c279eef6695457d0d"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#ce953be5c9c3b3658d9ed9bad81d22c789950c43":
+  version "20.6.2"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#ce953be5c9c3b3658d9ed9bad81d22c789950c43"
 
 vfile-message@^2.0.0:
   version "2.0.4"


### PR DESCRIPTION
## Description

The newest version of Form 526 changes the VA treatment date fields. The start date range is no longer a required field, and the end date is no longer included.

To maintain maximal compatibility with in-progress forms, this PR alters the schema to remove the treatment start date requirement and still maintains the data structure.

Related:
- Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/26265
- Schema: https://github.com/department-of-veterans-affairs/vets-json-schema/pull/611
- BE: https://github.com/department-of-veterans-affairs/va.gov-team/issues/22406

## Testing done

- Updated unit tests
- Updated mock data for e2e tests

## Screenshots

<details><summary>Before</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-06-25 at 9 37 17 AM](https://user-images.githubusercontent.com/136959/123440996-fe1d2400-d598-11eb-9da4-c55904fe7b35.png)</details>

<details><summary>After</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-06-25 at 9 31 16 AM](https://user-images.githubusercontent.com/136959/123440181-20fb0880-d598-11eb-85d4-a96275b7f5ef.png)</details>

## Acceptance criteria
- [x] VA medical record treatment start date is now optional
- [x] VA medical record treatment end date has been removed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
