### PR TITLE
Wrap setTimeout in a promise for chaining in the test

### DIFF
--- a/src/platform/forms-system/src/js/utilities/ui/index.js
+++ b/src/platform/forms-system/src/js/utilities/ui/index.js
@@ -19,12 +19,16 @@ export function focusElement(selectorOrElement, options) {
 
 // Set focus on target _after_ the content has been updated
 export function focusOnChange(name, target = '.edit-btn') {
-  setTimeout(() => {
-    const selector = `[name="${name}ScrollElement"]`;
-    const el = document.querySelector(selector);
-    // nextElementSibling = page form
-    const focusTarget = el?.nextElementSibling?.querySelector(target);
-    focusElement(focusTarget);
+  // This promise is only here to avoid another setTimeout() in the unit test
+  return new Promise(resolve => {
+    setTimeout(() => {
+      const selector = `[name="${name}ScrollElement"]`;
+      const el = document.querySelector(selector);
+      // nextElementSibling = page form
+      const focusTarget = el?.nextElementSibling?.querySelector(target);
+      focusElement(focusTarget);
+      resolve();
+    });
   });
 }
 

--- a/src/platform/forms-system/test/js/utilities/ui.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/ui.unit.spec.js
@@ -79,12 +79,9 @@ describe('focus on change', () => {
     global.document = dom;
     const target = '.edit-btn';
     const focused = sinon.stub(dom.querySelector(target), 'focus');
-    focusOnChange('test', target);
-
-    // setTimeout used by focusOnChange function
-    setTimeout(() => {
+    focusOnChange('test', target).then(() => {
       expect(focused.calledOnce).to.be.true;
       done();
-    }, 0);
+    });
   });
 });


### PR DESCRIPTION
## Description
This should fix the periodic failure we see here: http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing/vets-website/detail/master/11657/tests
```
done() called multiple times in test <focus on change should focus on edit button after updating a review form> of file /application/src/platform/forms-system/test/js/utilities/ui.unit.spec.js
```

## Testing done
Ran the unit test. :man_shrugging: 
I can't re-create the failure to ensure this fixes the problem, but it doesn't fail with this change.

## Screenshots
N/A

## Acceptance criteria
- [x] The test doesn't fail