### PR TITLE
Make sorting logic on staging go to prod

### DIFF
--- a/src/applications/resources-and-support/hooks/useGetSearchResults.js
+++ b/src/applications/resources-and-support/hooks/useGetSearchResults.js
@@ -2,7 +2,6 @@
 import { useEffect, useState } from 'react';
 import { orderBy } from 'lodash';
 // Relative imports.
-import environment from 'platform/utilities/environment';
 import recordEvent from 'platform/monitoring/record-event';
 import { SEARCH_IGNORE_LIST } from '../constants';
 

--- a/src/applications/resources-and-support/hooks/useGetSearchResults.js
+++ b/src/applications/resources-and-support/hooks/useGetSearchResults.js
@@ -139,37 +139,20 @@ export default function useGetSearchResults(articles, query, page) {
         };
       });
 
-      if (environment.isProduction()) {
-        // Sort first by the number of exact query matches (ignoring casing) in the title, introText, and searchableContent descending
-        // Sort ties by query word instances found in title descending
-        // Sort ties then by query word instances found in searchableContent descending
-        // Sort ties then by alphabetical descending
-        orderedResults = orderBy(
-          filteredArticles,
-          [
-            'wholePhraseMatchCountsTotal',
-            'keywordsCountsTitle',
-            'keywordsCountsContent',
-            'title',
-          ],
-          ['desc', 'desc', 'desc', 'asc'],
-        );
-      } else {
-        // Sort first by the number of exact query matches (ignoring casing) in the title, introText, and searchableContent descending
-        // Sort ties by query word instances found in title descending
-        // Sort ties then by query word instances found in introText and searchableContent descending
-        // Sort ties then by alphabetical descending
-        orderedResults = orderBy(
-          filteredArticles,
-          [
-            'wholePhraseMatchCountsTotal',
-            'keywordsCountsTitle',
-            'keywordsCountsIntroTextAndContent',
-            'title',
-          ],
-          ['desc', 'desc', 'desc', 'asc'],
-        );
-      }
+      // Sort first by the number of exact query matches (ignoring casing) in the title, introText, and searchableContent descending
+      // Sort ties by query word instances found in title descending
+      // Sort ties then by query word instances found in introText and searchableContent descending
+      // Sort ties then by alphabetical descending
+      orderedResults = orderBy(
+        filteredArticles,
+        [
+          'wholePhraseMatchCountsTotal',
+          'keywordsCountsTitle',
+          'keywordsCountsIntroTextAndContent',
+          'title',
+        ],
+        ['desc', 'desc', 'desc', 'asc'],
+      );
       // =====
       // End of ordering logic.
 


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/23911#issuecomment-868689531

This PR promotes the staging sorting logic of R&S search to prod.

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Promote sorting logic to production.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
