### PR TITLE
Update web-components dependency to v0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -326,7 +326,7 @@
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
     "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#2047154b11a3c890ef8bd10c279eef6695457d0d",
-    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.6.2",
+    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.7.0",
     "whatwg-fetch": "^2.0.3"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20020,9 +20020,9 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.6.2":
+"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.7.0":
   version "0.6.2"
-  resolved "https://github.com/department-of-veterans-affairs/component-library.git#9fdda8c6b4e325194b2a7c1fccacdd42a24664f2"
+  resolved "https://github.com/department-of-veterans-affairs/component-library.git#5fc83b5285684aa4060a3e5950f2ca5e2af9542e"
   dependencies:
     "@stencil/core" "^2.0.1"
     "@stencil/postcss" "^2.0.0"


### PR DESCRIPTION
## Description
's all in the title :man_shrugging: 

For a description of what's new, see the [release notes for `wc-v0.7.0`](https://github.com/department-of-veterans-affairs/component-library/releases/tag/wc-v0.7.0).