### PR TITLE
Bug: Fix wizard form start link

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/all-claims-wizard.cypress.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/all-claims-wizard.cypress.spec.js
@@ -163,6 +163,7 @@ describe('526 wizard', () => {
       'eq',
       `${DISABILITY_526_V2_ROOT_URL}/introduction`,
     );
+    cy.injectAxe();
     cy.axeCheck();
   });
 });

--- a/src/applications/disability-benefits/wizard/wizard-utils.js
+++ b/src/applications/disability-benefits/wizard/wizard-utils.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Link } from 'react-router';
 
 import recordEvent from 'platform/monitoring/record-event';
 
@@ -16,8 +15,8 @@ export const formStartButton = ({
     event: 'howToWizard-cta-displayed',
   });
   return (
-    <Link
-      to={`${DISABILITY_526_V2_ROOT_URL}/introduction`}
+    <a
+      href={`${DISABILITY_526_V2_ROOT_URL}/introduction`}
       className="usa-button-primary va-button-primary"
       onClick={() => {
         setWizardStatus(WIZARD_STATUS_COMPLETE);
@@ -34,6 +33,6 @@ export const formStartButton = ({
       aria-describedby={ariaId}
     >
       {label}
-    </Link>
+    </a>
   );
 };


### PR DESCRIPTION
## Description

The wizard start button in production is not including an `href` attribute. In PR #17669 the `<a>` was changed to a router `<Link>` component, but this apparently does not include the `href`. Reverting this part of the change.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/26669

## Testing done

- Unit tests still passing
- Will validate this change on staging to ensure it will work in production

## Screenshots

`<Link>` in production

![Screen Shot 2021-06-28 at 9 57 45 AM](https://user-images.githubusercontent.com/136959/123662097-c2819480-d7fa-11eb-9d60-a9da9c351c22.png)

## Acceptance criteria
- [ ] 526 start link works in staging, and production

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
