### PR TITLE
Add deep links to Profile contact info section

### DIFF
--- a/src/applications/personalization/profile/components/ProfileInfoTable.jsx
+++ b/src/applications/personalization/profile/components/ProfileInfoTable.jsx
@@ -18,6 +18,8 @@ const ProfileInfoTable = ({
   className,
   namedAnchor,
 }) => {
+  // TODO: move all these class var outside of the component so they aren't
+  // recomputed on every render
   const titleClasses = prefixUtilityClasses([
     'background-color--gray-lightest',
     'border--1px',
@@ -97,7 +99,6 @@ const ProfileInfoTable = ({
           {title}
         </TableTitle>
       )}
-      {/* {title && <h3 className={classes.title}>{title}</h3>} */}
       {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
       <ol className="vads-u-margin--0 vads-u-padding--0" role="list">
         {data
@@ -106,7 +107,12 @@ const ProfileInfoTable = ({
           )
           .map((row, index) => (
             // eslint-disable-next-line jsx-a11y/no-redundant-roles
-            <li key={index} className={classes.tableRow} role="listitem">
+            <li
+              key={index}
+              className={classes.tableRow}
+              role="listitem"
+              id={row.id}
+            >
               {row.title && (
                 <dfn className={classes.tableRowTitle}>{row.title}</dfn>
               )}

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationEditView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationEditView.jsx
@@ -41,6 +41,7 @@ import { ACTIVE_EDIT_VIEWS, FIELD_NAMES, USA } from '@@vap-svc/constants';
 import { transformInitialFormValues } from '@@profile/util/contact-information/formValues';
 
 import ContactInformationActionButtons from './ContactInformationActionButtons';
+import { getEditButtonId } from './ContactInformationField';
 
 export class ContactInformationEditView extends Component {
   static propTypes = {
@@ -112,16 +113,17 @@ export class ContactInformationEditView extends Component {
     if (this.interval) {
       window.clearInterval(this.interval);
     }
+    const { fieldName } = this.props;
     // Errors returned directly from the API request (as opposed through a transaction lookup) are
     // displayed in this modal, rather than on the page. Once the modal is closed, reset the state
     // for the next time the modal is opened by removing any existing transaction request from the store.
     if (this.props.transactionRequest?.error) {
-      this.props.clearTransactionRequest(this.props.fieldName);
+      this.props.clearTransactionRequest(fieldName);
     }
 
     // AS DONE IN ADDRESSEDITVIEW, CHECK FOR CORRECTNESS
-    if (this.props.fieldName === FIELD_NAMES.RESIDENTIAL_ADDRESS) {
-      focusElement(`#${this.props.fieldName}-edit-link`);
+    if (fieldName === FIELD_NAMES.RESIDENTIAL_ADDRESS) {
+      focusElement(`#${getEditButtonId(fieldName)}`);
     }
   }
 

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { kebabCase } from 'lodash';
 
 import { focusElement } from '~/platform/utilities/ui';
 import recordEvent from '~/platform/monitoring/record-event';
@@ -46,6 +47,15 @@ import getContactInfoFieldAttributes from '~/applications/personalization/profil
 
 import CannotEditModal from './CannotEditModal';
 import ConfirmCancelModal from './ConfirmCancelModal';
+
+// Helper function that generates a string that can be used for a contact info
+// field's edit button.
+//
+// Given a valid entry from the vap-svc/constants FIELD
+// NAMES, it will return a string like `#edit-mobile-phone-number`
+export const getEditButtonId = fieldName => {
+  return `edit-${kebabCase(VAP_SERVICE.FIELD_TITLES[fieldName])}`;
+};
 
 const wrapperClasses = prefixUtilityClasses([
   'display--flex',
@@ -114,6 +124,7 @@ class ContactInformationField extends React.Component {
   closeModalTimeoutID = null;
 
   componentDidUpdate(prevProps) {
+    const { fieldName } = this.props;
     // Exit the edit view if it takes more than 5 seconds for the update/save
     // transaction to resolve. If the transaction has not resolved after 5
     // seconds we will show a "we're saving your new information..." message on
@@ -138,9 +149,9 @@ class ContactInformationField extends React.Component {
     if (this.justClosedModal(prevProps, this.props)) {
       clearTimeout(this.closeModalTimeoutID);
       if (this.props.transaction) {
-        focusElement(`div#${this.props.fieldName}-transaction-status`);
+        focusElement(`div#${fieldName}-transaction-status`);
       }
-      focusElement(`button#${this.props.fieldName}-edit-link`);
+      focusElement(`#${getEditButtonId(fieldName)}`);
     }
   }
 
@@ -258,7 +269,7 @@ class ContactInformationField extends React.Component {
             onClick={() => {
               this.onEdit(isEmpty ? 'add-link' : 'edit-link');
             }}
-            id={`${fieldName}-edit-link`}
+            id={getEditButtonId(fieldName)}
             className={classes.editButton}
           >
             Edit

--- a/src/applications/personalization/profile/components/personal-information/PersonalInformation.jsx
+++ b/src/applications/personalization/profile/components/personal-information/PersonalInformation.jsx
@@ -20,6 +20,13 @@ import PersonalInformationContent from './PersonalInformationContent';
 
 import { PROFILE_PATHS } from '../../constants';
 
+// drops the leading `edit` from the hash and looks for that element
+const getScrollTarget = _hash => {
+  const hash = _hash.replace('#', '');
+  const hashWithoutLeadingEdit = hash.replace(/^edit-/, '');
+  return document.querySelector(`#${hashWithoutLeadingEdit}`);
+};
+
 const PersonalInformation = ({
   showDirectDepositBlockedError,
   hasUnsavedEdits,
@@ -44,10 +51,17 @@ const PersonalInformation = ({
         return;
       }
       if (window.location.hash) {
-        const target = document.querySelector(window.location.hash);
-        if (target) {
-          focusElement(target);
-          target.scrollIntoView();
+        // We will always attempt to focus on the element that matches the
+        // location.hash
+        const focusTarget = document.querySelector(window.location.hash);
+        // But if the hash starts with `edit` will will scroll a different
+        // element into view
+        const scrollTarget = getScrollTarget(window.location.hash);
+        if (scrollTarget) {
+          scrollTarget.scrollIntoView();
+        }
+        if (focusTarget) {
+          focusElement(focusTarget);
           return;
         }
       }

--- a/src/applications/personalization/profile/components/personal-information/addresses/AddressesTable.jsx
+++ b/src/applications/personalization/profile/components/personal-information/addresses/AddressesTable.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { FIELD_NAMES } from '@@vap-svc/constants';
+import { FIELD_IDS, FIELD_NAMES } from '@@vap-svc/constants';
 
 import ContactInformationField from '../ContactInformationField';
 import ProfileInfoTable from '../../ProfileInfoTable';
@@ -9,15 +9,18 @@ import ProfileInfoTable from '../../ProfileInfoTable';
 const AddressesTable = ({ className }) => (
   <ProfileInfoTable
     title="Addresses"
+    namedAnchor="addresses"
     data={[
       {
         title: 'Mailing address',
+        id: FIELD_IDS[FIELD_NAMES.MAILING_ADDRESS],
         value: (
           <ContactInformationField fieldName={FIELD_NAMES.MAILING_ADDRESS} />
         ),
       },
       {
         title: 'Home address',
+        id: FIELD_IDS[FIELD_NAMES.RESIDENTIAL_ADDRESS],
         value: (
           <ContactInformationField
             fieldName={FIELD_NAMES.RESIDENTIAL_ADDRESS}

--- a/src/applications/personalization/profile/components/personal-information/email-addresses/EmailInformationSection.jsx
+++ b/src/applications/personalization/profile/components/personal-information/email-addresses/EmailInformationSection.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import React from 'react';
 
-import { FIELD_NAMES } from '@@vap-svc/constants';
+import { FIELD_IDS, FIELD_NAMES } from '@@vap-svc/constants';
 import { signInServiceName as signInServiceNameSelector } from 'platform/user/authentication/selectors';
 
 import ContactInformationField from '../ContactInformationField';
@@ -54,6 +54,7 @@ const EmailInformationSection = ({ className, signInServiceName }) => {
           },
           {
             title: 'Contact email address',
+            id: FIELD_IDS[FIELD_NAMES.EMAIL],
             value: <ContactInformationField fieldName={FIELD_NAMES.EMAIL} />,
           },
         ]}

--- a/src/applications/personalization/profile/components/personal-information/phone-numbers/PhoneNumbersTable.jsx
+++ b/src/applications/personalization/profile/components/personal-information/phone-numbers/PhoneNumbersTable.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { FIELD_NAMES } from '@@vap-svc/constants';
+import { FIELD_IDS, FIELD_NAMES } from '@@vap-svc/constants';
 
 import ContactInformationField from '../ContactInformationField';
 import ProfileInfoTable from '../../ProfileInfoTable';
@@ -13,18 +13,22 @@ const PhoneNumbersTable = ({ className }) => (
     data={[
       {
         title: 'Home',
+        id: FIELD_IDS[FIELD_NAMES.HOME_PHONE],
         value: <ContactInformationField fieldName={FIELD_NAMES.HOME_PHONE} />,
       },
       {
         title: 'Work',
+        id: FIELD_IDS[FIELD_NAMES.WORK_PHONE],
         value: <ContactInformationField fieldName={FIELD_NAMES.WORK_PHONE} />,
       },
       {
         title: 'Mobile',
+        id: FIELD_IDS[FIELD_NAMES.MOBILE_PHONE],
         value: <ContactInformationField fieldName={FIELD_NAMES.MOBILE_PHONE} />,
       },
       {
         title: 'Fax',
+        id: FIELD_IDS[FIELD_NAMES.FAX_NUMBER],
         value: <ContactInformationField fieldName={FIELD_NAMES.FAX_NUMBER} />,
       },
     ]}

--- a/src/applications/personalization/profile/tests/components/ContactInformationField.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/ContactInformationField.unit.spec.jsx
@@ -85,7 +85,7 @@ describe('<ContactInformationField/>', () => {
   it('renders the edit link', () => {
     component = enzyme.shallow(<ContactInformationField {...props} />);
 
-    let editButton = component.find('[id="homePhone-edit-link"]');
+    let editButton = component.find('[id="edit-home-phone-number"]');
 
     const onEditClick = editButton.props().onClick;
     onEditClick();

--- a/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/deep-links.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/deep-links.cypress.spec.js
@@ -7,15 +7,38 @@ const deepLinks = [
   // correctly
   {
     url: `${PROFILE_PATHS.PERSONAL_INFORMATION}#an-unsupported-deep-link`,
-    expectedTarget: 'Personal and contact information',
+    expectedTarget: {
+      role: 'heading',
+      name: 'Personal and contact information',
+    },
   },
   {
     url: `${PROFILE_PATHS.PERSONAL_INFORMATION}#email-address`,
-    expectedTarget: 'Contact email address',
+    expectedTarget: {
+      role: 'heading',
+      name: 'Contact email address',
+    },
   },
   {
     url: `${PROFILE_PATHS.PERSONAL_INFORMATION}#phone-numbers`,
-    expectedTarget: 'Phone numbers',
+    expectedTarget: {
+      role: 'heading',
+      name: 'Phone numbers',
+    },
+  },
+  {
+    url: `${PROFILE_PATHS.PERSONAL_INFORMATION}#edit-contact-email-address`,
+    expectedTarget: {
+      role: 'button',
+      name: /edit contact email address/i,
+    },
+  },
+  {
+    url: `${PROFILE_PATHS.PERSONAL_INFORMATION}#edit-mobile-phone-number`,
+    expectedTarget: {
+      role: 'button',
+      name: /edit mobile phone number/i,
+    },
   },
 ];
 
@@ -36,10 +59,12 @@ function checkAllDeepLinks(mobile = false) {
   cy.findByRole('progressbar').should('not.exist');
   cy.findByText(/loading your information/i).should('not.exist');
 
-  deepLinks.forEach(deepLink => {
-    cy.visit(deepLink.url);
-    // focus should be on the correct sub-section heading
-    cy.focused().contains(deepLink.expectedTarget);
+  deepLinks.forEach(({ url, expectedTarget }) => {
+    cy.visit(url);
+    // focus should be managed correctly
+    cy.findByRole(expectedTarget.role, {
+      name: expectedTarget.name,
+    }).should('have.focus');
   });
 }
 

--- a/src/platform/user/profile/vap-svc/constants/index.js
+++ b/src/platform/user/profile/vap-svc/constants/index.js
@@ -78,6 +78,18 @@ export const FIELD_TITLES = {
   [FIELD_NAMES.RESIDENTIAL_ADDRESS]: 'Home address',
 };
 
+// These are intended to be used as values for HTML element id attributes
+export const FIELD_IDS = {
+  [FIELD_NAMES.HOME_PHONE]: 'home-phone-number',
+  [FIELD_NAMES.MOBILE_PHONE]: 'mobile-phone-number',
+  [FIELD_NAMES.WORK_PHONE]: 'work-phone-number',
+  [FIELD_NAMES.TEMP_PHONE]: 'temporary-phone-number',
+  [FIELD_NAMES.FAX_NUMBER]: 'fax-number',
+  [FIELD_NAMES.EMAIL]: 'contact-email-address',
+  [FIELD_NAMES.MAILING_ADDRESS]: 'mailing-address',
+  [FIELD_NAMES.RESIDENTIAL_ADDRESS]: 'home-address',
+};
+
 export const PHONE_TYPE = {
   mobilePhone: 'MOBILE',
   workPhone: 'WORK',


### PR DESCRIPTION
## Description
This PR adds support for multiple deep-links to the Profile's contact info section. 

It supports:
- Links to each contact info table. Examples: `profile/personal-information#phone-numbers` or `profile/personal-information#email-address`
- Links to each contact info field. Examples: `profile/personal-information#mobile-phone-number` or `profile/personal-information#contact-email-address`
- Links to each contact info field's edit button. Examples: `profile/personal-information#edit-mobile-phone-number` or `profile/personal-information#edit-contact-email-address`

In all examples, focus will be managed appropriately and the relevant part of the DOM will be scrolled to the top of the page. This handles an edge case on mobile when a deep link to an edit button is used. The edit button gets focus, but if we scrolled the edit button to the top of the viewport, the contact info the edit button is associated with would be out of view. So when a deep link to an edit button is used, we scroll the relevant contact info field into view.

## Testing done
Added new Cypress tests to make sure that focus is managed correctly for these deep links

## Screenshots
https://user-images.githubusercontent.com/20728956/123675584-bea04300-d7f7-11eb-87ca-475aad80581d.mp4

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs