### PR TITLE
DT-12547-Yellow Ribbon remove aira labels causing issues in screen reader

### DIFF
--- a/src/applications/yellow-ribbon/containers/SearchForm/index.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchForm/index.jsx
@@ -161,7 +161,6 @@ export class SearchForm extends Component {
         </label>
         <div className="vads-u-flex--1">
           <input
-            aria-label="Name of institution"
             className="usa-input"
             id="yr-search-name"
             name="yr-search-name"
@@ -183,7 +182,6 @@ export class SearchForm extends Component {
         </label>
         <div className="vads-u-flex--1">
           <select
-            aria-label="State of institution"
             id="yr-search-state"
             name="yr-search-state"
             onChange={onReactStateChange('state')}
@@ -210,7 +208,6 @@ export class SearchForm extends Component {
         </label>
         <div className="vads-u-flex--1">
           <input
-            aria-label="City of institution"
             className="usa-input"
             id="yr-search-city"
             name="yr-search-city"


### PR DESCRIPTION
## Issue
https://github.com/department-of-veterans-affairs/va.gov-team/issues/12547

## Description
Removing aria label due to label `for` attribute and input `id` attribute does the job for screen readers.

## Testing done
Ran unit, e2e, and spun up locally.

## Screenshots
![Screen Shot 2021-06-28 at 3 33 20 PM](https://user-images.githubusercontent.com/26075258/123694943-f6bf7a00-d827-11eb-9314-26726f202c70.png)

## Acceptance criteria
- [x] Screen reader reads the input field as desired.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
