### PR TITLE
NOD: Update user info

### DIFF
--- a/src/applications/appeals/10182/components/ContactInformation.jsx
+++ b/src/applications/appeals/10182/components/ContactInformation.jsx
@@ -1,21 +1,76 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
-
+import { selectProfile } from 'platform/user/selectors';
 import { formatAddress } from 'platform/forms/address/helpers';
 import titleCase from 'platform/utilities/data/titleCase';
+import { refreshProfile as refreshProfileAction } from 'platform/user/profile/actions';
 
 import { PROFILE_URL } from '../constants';
+import { readableList } from '../utils/helpers';
 
 const addBrAfter = line => line && [line, <br key={line} />];
 
-export const ContactInfoDescription = ({ veteran }) => {
-  const { email, phone, address } = veteran || {};
-  const { street, cityStateZip, country } = formatAddress(address || {});
+export const ContactInfoDescription = ({
+  formContext,
+  profile,
+  refreshProfile,
+}) => {
+  const [hasUpdated, setHasUpdated] = useState(false);
+  const [hadError, setHadError] = useState(false);
+
+  /* use vapContactInfo because it comes directly from the profile, so when the
+   * Veteran clicks the "I've updated" button, we refresh the in-memory profile
+   * data. Once that is done, the FormApp outer wrapper _should_ automatically
+   * update the formData.veteran for email, phone & address - this is convoluted
+   * but it's the only way to block the form system continue button to prevent
+   * continuing on in the form when we're missing essential details;
+   * alternatively, we could have added prefill form elements for all this
+   * required info, but while presenting this to the board, they remarked that
+   * the profile data isn't being updated, so the form contact info may not
+   * match what's in profile... once the profile team provides a way to inline
+   * contact info changes, we can replace this code.
+   */
+  const { email = {}, mobilePhone = {}, homePhone = {}, mailingAddress = {} } =
+    profile?.vapContactInfo || {};
+  const phone = mobilePhone?.phoneNumber ? mobilePhone : homePhone;
+  const { submitted } = formContext || {};
+  // const emails = {};
+
   // phone.phoneType is in all caps
   const phoneType = titleCase((phone?.phoneType || '').toLowerCase());
+  const { street, cityStateZip, country } = formatAddress(mailingAddress || {});
+  const missingInfo = [
+    email?.emailAddress ? '' : 'email',
+    phoneType ? '' : 'phone',
+    street ? '' : 'address',
+  ].filter(Boolean);
+
+  const list = readableList(missingInfo);
+  const plural = missingInfo.length > 1;
+
+  useEffect(
+    () => {
+      if (missingInfo.length) {
+        // page had an error flag, so we know when to show a success alert
+        setHadError(true);
+      }
+    },
+    [missingInfo],
+  );
+
+  const profileLink = text => (
+    <a
+      href={PROFILE_URL}
+      className="profile-link"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {text}
+    </a>
+  );
 
   return (
     <>
@@ -25,30 +80,78 @@ export const ContactInfoDescription = ({ veteran }) => {
       </p>
       <p className="vads-u-margin-top--1p5">
         You can{' '}
-        <a href={PROFILE_URL} target="_blank" rel="noopener noreferrer">
-          update this contact information in your VA.gov profile (opens in new
-          tab)
-        </a>
+        {profileLink(
+          'update this contact information in your VA.gov profile (opens in new tab)',
+        )}
         .
       </p>
-      {(!phoneType || !street) && (
-        <p className="vads-u-margin-top--1p5">
-          <strong>Note:</strong> A phone number and mailing address is required
-          for this application.
-        </p>
+      {hadError &&
+        hasUpdated &&
+        missingInfo.length === 0 && (
+          <div className="vads-u-margin-top--1p5">
+            <va-alert status="success" background-only>
+              <div className="vads-u-font-size--base">
+                The missing information has been added to your application. You
+                may continue.
+              </div>
+            </va-alert>
+          </div>
+        )}
+      {missingInfo.length > 0 && (
+        <>
+          <p className="vads-u-margin-top--1p5">
+            <strong>Note:</strong>
+            {missingInfo[0].startsWith('p') ? ' A ' : ' An '}
+            {list} {plural ? 'are' : 'is'} required for this application.
+          </p>
+          {(hasUpdated || submitted) && (
+            <div className="vads-u-margin-top--1p5" role="alert">
+              <va-alert status="error" background-only>
+                <div className="vads-u-font-size--base">
+                  We still don’t have your {list}. Please{' '}
+                  {profileLink(`add your ${list} in your profile.`)}
+                </div>
+              </va-alert>
+            </div>
+          )}
+          <div className="vads-u-margin-top--1p5" role="alert">
+            <va-alert status="warning" background-only>
+              <div className="vads-u-font-size--base">
+                Your {list} {plural ? 'are' : 'is'} missing. Please{' '}
+                {profileLink(`add ${plural ? 'them' : 'it'} in your profile`)}{' '}
+                and return to this page. When you’re done, please click the
+                button to confirm your {list} {plural ? 'have' : 'has'} been
+                updated.
+              </div>
+              <button
+                type="button"
+                className="vads-u-width--auto"
+                onClick={event => {
+                  event.preventDefault();
+                  setHasUpdated(true);
+                  refreshProfile(true);
+                }}
+              >
+                My contact details have been updated
+              </button>
+            </va-alert>
+          </div>
+        </>
       )}
       <div className="blue-bar-block">
         <h3 className="vads-u-font-size--h4">Phone &amp; email</h3>
         <p>
           <strong>{phoneType} phone</strong>:{' '}
-          <Telephone
-            contact={`${phone?.areaCode || ''}${phone?.phoneNumber || ''}`}
-            extension={phone?.extension}
-            notClickable
-          />
+          {phone?.phoneNumber && (
+            <Telephone
+              contact={`${phone?.areaCode || ''}${phone?.phoneNumber || ''}`}
+              extension={phone?.extension}
+              notClickable
+            />
+          )}
         </p>
         <p>
-          <strong>Email address</strong>: {email || ''}
+          <strong>Email address</strong>: {email?.emailAddress || ''}
         </p>
         <h3 className="vads-u-font-size--h4">Mailing address</h3>
         <p>
@@ -85,8 +188,16 @@ ContactInfoDescription.propTypes = {
   }).isRequired,
 };
 
+const mapDispatchToProps = {
+  refreshProfile: refreshProfileAction,
+};
+
 const mapStateToProps = state => ({
   veteran: state.form?.data.veteran,
+  profile: selectProfile(state),
 });
 
-export default connect(mapStateToProps)(ContactInfoDescription);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ContactInfoDescription);

--- a/src/applications/appeals/10182/pages/contactInfo.js
+++ b/src/applications/appeals/10182/pages/contactInfo.js
@@ -1,9 +1,12 @@
 import ContactInfoDescription from '../components/ContactInformation';
+import { contactInfoValidation } from '../validations';
 
 const contactInfo = {
   uiSchema: {
     'ui:title': ' ',
     'ui:description': ContactInfoDescription,
+    'ui:required': () => true,
+    'ui:validations': [contactInfoValidation],
     'ui:options': {
       hideOnReview: true,
       forceDivWrapper: true,

--- a/src/applications/appeals/10182/tests/10182-notice-of-disagreement.cypress.spec.js
+++ b/src/applications/appeals/10182/tests/10182-notice-of-disagreement.cypress.spec.js
@@ -5,7 +5,7 @@ import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-test
 
 import formConfig from '../config/form';
 import manifest from '../manifest.json';
-import { fixDecisionDates } from './nod.cypress.helpers';
+import { getRandomDate, fixDecisionDates } from './nod.cypress.helpers';
 import mockFeatureToggles from './fixtures/mocks/feature-toggles.json';
 import mockInProgress from './fixtures/mocks/in-progress-forms.json';
 import mockSubmit from './fixtures/mocks/application-submit.json';
@@ -57,7 +57,9 @@ const testConfig = createTestConfig(
               .first()
               .clear()
               .type(item.issue);
-            const date = item.decisionDate.replace(/-0/g, '-').split('-');
+            const date = getRandomDate()
+              .replace(/-0/g, '-')
+              .split('-');
             cy.get(`select[name$="${index}_decisionDateMonth"]`).select(
               date[1],
             );
@@ -67,7 +69,7 @@ const testConfig = createTestConfig(
               .type(date[0]);
             cy.get('.update')
               .first()
-              .click();
+              .click({ force: true });
             if (!item[SELECTED]) {
               cy.get(
                 `input[type="checkbox"][name="root_additionalIssues_${index}"]`,
@@ -99,7 +101,7 @@ const testConfig = createTestConfig(
 
       cy.intercept('POST', 'v0/decision_review_evidence', mockUpload);
 
-      cy.route('POST', formConfig.submitUrl, mockSubmit);
+      cy.intercept('POST', formConfig.submitUrl, mockSubmit);
 
       cy.get('@testData').then(testData => {
         cy.intercept('GET', `/v0${CONTESTABLE_ISSUES_API}`, {

--- a/src/applications/appeals/10182/tests/components/ContactInformation.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/ContactInformation.unit.spec.jsx
@@ -1,46 +1,79 @@
 import React from 'react';
 import { expect } from 'chai';
-import { shallow } from 'enzyme';
+import sinon from 'sinon';
+import { shallow, mount } from 'enzyme';
 
 import { ADDRESS_TYPES } from 'platform/forms/address/helpers';
 
 import { ContactInfoDescription } from '../../components/ContactInformation';
 
+const getData = ({
+  email = true,
+  mobile = true,
+  home = false,
+  address = true,
+  refreshProfile = () => {},
+  submitted = false,
+} = {}) => {
+  const data = {};
+  if (email) {
+    data.email = {
+      emailAddress: 'someone@famous.com',
+    };
+  }
+  if (mobile || home) {
+    const type = mobile ? 'mobile' : 'home';
+    data[`${type}Phone`] = {
+      phoneType: type,
+      areaCode: '555',
+      phoneNumber: '8001212',
+      extension: '1234',
+    };
+  }
+  if (address) {
+    data.mailingAddress = {
+      addressType: ADDRESS_TYPES.domestic,
+      countryName: 'United States',
+      countryCodeIso3: 'USA',
+      addressLine1: '123 Main Blvd',
+      addressLine2: 'Floor 33',
+      addressLine3: 'Suite 55',
+      city: 'Hollywood',
+      stateCode: 'CA',
+      zipCode: '90210',
+    };
+  }
+  return {
+    formContext: { submitted },
+    profile: { vapContactInfo: data },
+    refreshProfile,
+  };
+};
+
 describe('Veteran information review content', () => {
   it('should render contact information', () => {
-    const data = {
-      veteran: {
-        email: 'someone@famous.com',
-        phone: {
-          areaCode: '555',
-          phoneNumber: '8001212',
-          extension: '1234',
-        },
-        address: {
-          addressType: ADDRESS_TYPES.domestic,
-          countryName: 'United States',
-          countryCodeIso3: 'USA',
-          addressLine1: '123 Main Blvd',
-          addressLine2: 'Floor 33',
-          addressLine3: 'Suite 55',
-          city: 'Hollywood',
-          stateCode: 'CA',
-          zipCode: '90210',
-        },
-      },
-    };
-    const ContactInfo = () => <>{ContactInfoDescription(data)}</>;
-    const tree = shallow(<ContactInfo />);
+    const data = getData();
+    const tree = shallow(<ContactInfoDescription {...data} />);
     const address = tree.find('.blue-bar-block');
     const text = address.text();
 
     expect(address).to.have.lengthOf(1);
-    expect(
-      address
-        .find('Telephone')
-        .dive()
-        .text(),
-    ).to.contain('555-800-1212');
+    expect(address.find('Telephone').props().contact).to.contain('5558001212');
+    expect(text).to.contain('someone@famous.com');
+    expect(text).to.contain('123 Main Blvd');
+    expect(text).to.contain('Floor 33');
+    expect(text).to.contain('Suite 55');
+    expect(text).to.contain('Hollywood, CA 90210');
+    tree.unmount();
+  });
+  it('should fall back to home phone if mobile is missing', () => {
+    const data = getData({ mobile: false, home: true });
+    const tree = shallow(<ContactInfoDescription {...data} />);
+    const address = tree.find('.blue-bar-block');
+    const text = address.text();
+
+    expect(address).to.have.lengthOf(1);
+    expect(address.find('Telephone').props().contact).to.contain('5558001212');
     expect(text).to.contain('someone@famous.com');
     expect(text).to.contain('123 Main Blvd');
     expect(text).to.contain('Floor 33');
@@ -50,47 +83,83 @@ describe('Veteran information review content', () => {
   });
 
   it('should render note about missing phone', () => {
-    const data = {
-      veteran: {
-        email: 'someone@famous.com',
-        phone: {},
-        address: {
-          addressType: ADDRESS_TYPES.domestic,
-          countryName: 'United States',
-          countryCodeIso3: 'USA',
-          addressLine1: '123 Main Blvd',
-          addressLine2: 'Floor 33',
-          addressLine3: 'Suite 55',
-          city: 'Hollywood',
-          stateCode: 'CA',
-          zipCode: '90210',
-        },
-      },
-    };
-    const ContactInfo = () => <>{ContactInfoDescription(data)}</>;
-    const tree = shallow(<ContactInfo />);
-    const text = tree.text();
+    const data = getData({ mobile: false });
+    const tree = shallow(<ContactInfoDescription {...data} />);
+    const text = tree.find('va-alert').text();
 
-    expect(text).to.contain('address is required for this application');
+    expect(text).to.contain('Your phone is missing');
     tree.unmount();
   });
-  it('should render note about missing address', () => {
-    const data = {
-      veteran: {
-        email: 'someone@famous.com',
-        phone: {
-          areaCode: '555',
-          phoneNumber: '8001212',
-          extension: '1234',
-        },
-        address: {},
-      },
-    };
-    const ContactInfo = () => <>{ContactInfoDescription(data)}</>;
-    const tree = shallow(<ContactInfo />);
-    const text = tree.text();
+  it('should render note about missing email & phone', () => {
+    const data = getData({ mobile: false, email: false });
+    const tree = shallow(<ContactInfoDescription {...data} />);
+    const text = tree.find('va-alert').text();
 
-    expect(text).to.contain('address is required for this application');
+    expect(text).to.contain('Your email and phone are missing');
+    tree.unmount();
+  });
+  it('should render note about missing email, phone & address', () => {
+    const data = getData({ mobile: false, email: false, address: false });
+    const tree = shallow(<ContactInfoDescription {...data} />);
+    const text = tree.find('va-alert').text();
+
+    expect(text).to.contain('Your email, phone and address are missing');
+    tree.unmount();
+  });
+  it('should render an error if updated button is clicked without actually updating', () => {
+    const refreshProfile = sinon.spy();
+    const data = getData({
+      refreshProfile,
+      submitted: false,
+      email: false,
+    });
+    const tree = mount(<ContactInfoDescription {...data} />);
+    const alert = tree.find('va-alert');
+
+    expect(alert.props().status).to.eq('warning');
+    expect(alert.text()).to.contain('Your email is missing');
+
+    // simulate clicking on "My contact details have been updated" button
+    alert
+      .find('button')
+      .props()
+      .onClick({ preventDefault: () => {} });
+
+    tree.setProps(data);
+    expect(refreshProfile.called).to.be.true;
+
+    const alerts = tree.find('va-alert');
+    expect(alerts.length).to.eq(2);
+    expect(alerts.at(0).props().status).to.eq('error');
+    expect(alerts.at(1).props().status).to.eq('warning');
+
+    tree.unmount();
+  });
+  it('should render note about missing address & show success after updating', () => {
+    const refreshProfile = sinon.spy();
+    const data = getData({
+      refreshProfile,
+      submitted: false,
+      email: false,
+    });
+    const tree = mount(<ContactInfoDescription {...data} />);
+    const alert = tree.find('va-alert');
+
+    expect(alert.props().status).to.eq('warning');
+    expect(alert.text()).to.contain('Your email is missing');
+
+    // simulate clicking on "My contact details have been updated" button
+    alert
+      .find('button')
+      .props()
+      .onClick({ preventDefault: () => {} });
+    tree.setProps(getData({ refreshProfile }));
+    expect(refreshProfile.called).to.be.true;
+
+    const success = tree.find('va-alert');
+    expect(success.length).to.eq(1);
+    expect(success.props().status).to.eq('success');
+
     tree.unmount();
   });
 });

--- a/src/applications/appeals/10182/tests/fixtures/data/maximal-test.json
+++ b/src/applications/appeals/10182/tests/fixtures/data/maximal-test.json
@@ -32,7 +32,7 @@
         "type": "contestableIssue",
         "attributes": {
           "ratingIssueSubjectText": "tinnitus",
-          "approxDecisionDate": "2020-01-01",
+          "approxDecisionDate": "2021-06-01",
           "decisionIssueId": 1,
           "ratingIssueReferenceId": "2",
           "ratingDecisionReferenceId": "3",
@@ -44,7 +44,7 @@
         "type": "contestableIssue",
         "attributes": {
           "ratingIssueSubjectText": "left knee",
-          "approxDecisionDate": "2020-01-02",
+          "approxDecisionDate": "2021-06-02",
           "decisionIssueId": 4,
           "ratingIssueReferenceId": "5"
         },
@@ -54,7 +54,7 @@
         "type": "contestableIssue",
         "attributes": {
           "ratingIssueSubjectText": "right knee",
-          "approxDecisionDate": "2020-01-03",
+          "approxDecisionDate": "2021-06-03",
           "ratingIssueReferenceId": "6",
           "ratingDecisionReferenceId": "7"
         },
@@ -64,7 +64,7 @@
         "type": "contestableIssue",
         "attributes": {
           "ratingIssueSubjectText": "PTSD",
-          "approxDecisionDate": "2020-01-04",
+          "approxDecisionDate": "2021-06-04",
           "decisionIssueId": 8,
           "ratingDecisionReferenceId": "9"
         },
@@ -74,7 +74,7 @@
         "type": "contestableIssue",
         "attributes": {
           "ratingIssueSubjectText": "Traumatic Brain Injury",
-          "approxDecisionDate": "2020-01-05",
+          "approxDecisionDate": "2021-06-05",
           "decisionIssueId": 10
         },
         "view:selected": false
@@ -84,12 +84,12 @@
     "additionalIssues": [
       {
         "issue": "right arm",
-        "decisionDate": "2020-01-07",
+        "decisionDate": "2021-06-07",
         "view:selected": false
       },
       {
         "issue": "right shoulder",
-        "decisionDate": "2020-01-06",
+        "decisionDate": "2021-06-06",
         "view:selected": true
       }
     ],

--- a/src/applications/appeals/10182/tests/fixtures/data/minimal-test.json
+++ b/src/applications/appeals/10182/tests/fixtures/data/minimal-test.json
@@ -32,7 +32,7 @@
         "type": "contestableIssue",
         "attributes": {
           "ratingIssueSubjectText": "tinnitus",
-          "approxDecisionDate": "2020-01-01",
+          "approxDecisionDate": "2021-06-01",
           "decisionIssueId": 1,
           "ratingIssueReferenceId": "2",
           "ratingDecisionReferenceId": "3",
@@ -44,7 +44,7 @@
         "type": "contestableIssue",
         "attributes": {
           "ratingIssueSubjectText": "left knee",
-          "approxDecisionDate": "2020-01-02",
+          "approxDecisionDate": "2021-06-02",
           "decisionIssueId": 4,
           "ratingIssueReferenceId": "5"
         },
@@ -54,7 +54,7 @@
         "type": "contestableIssue",
         "attributes": {
           "ratingIssueSubjectText": "right knee",
-          "approxDecisionDate": "2020-01-03",
+          "approxDecisionDate": "2021-06-03",
           "ratingIssueReferenceId": "6",
           "ratingDecisionReferenceId": "7"
         },
@@ -64,7 +64,7 @@
         "type": "contestableIssue",
         "attributes": {
           "ratingIssueSubjectText": "PTSD",
-          "approxDecisionDate": "2020-01-04",
+          "approxDecisionDate": "2021-06-04",
           "decisionIssueId": 8,
           "ratingDecisionReferenceId": "9"
         },
@@ -74,7 +74,7 @@
         "type": "contestableIssue",
         "attributes": {
           "ratingIssueSubjectText": "Traumatic Brain Injury",
-          "approxDecisionDate": "2020-01-05",
+          "approxDecisionDate": "2021-06-05",
           "decisionIssueId": 10,
           "ratingIssuePercentNumber": "5"
         },
@@ -85,12 +85,12 @@
     "additionalIssues": [
       {
         "issue": "right arm",
-        "decisionDate": "2020-01-07",
+        "decisionDate": "2021-06-07",
         "view:selected": false
       },
       {
         "issue": "right shoulder",
-        "decisionDate": "2020-01-06",
+        "decisionDate": "2021-06-06",
         "view:selected": true
       }
     ],

--- a/src/applications/appeals/10182/tests/fixtures/data/transformed-maximal-test.json
+++ b/src/applications/appeals/10182/tests/fixtures/data/transformed-maximal-test.json
@@ -32,7 +32,7 @@
       "type": "contestableIssue",
       "attributes": {
         "issue": "tinnitus - 10%",
-        "decisionDate": "2020-01-01",
+        "decisionDate": "2021-06-01",
         "decisionIssueId": 1,
         "ratingIssueReferenceId": "2",
         "ratingDecisionReferenceId": "3",
@@ -43,7 +43,7 @@
       "type": "contestableIssue",
       "attributes": {
         "issue": "left knee - 0%",
-        "decisionDate": "2020-01-02",
+        "decisionDate": "2021-06-02",
         "decisionIssueId": 4,
         "ratingIssueReferenceId": "5",
         "disagreementArea": "effective date"
@@ -53,7 +53,7 @@
       "type": "contestableIssue",
       "attributes": {
         "issue": "right shoulder",
-        "decisionDate": "2020-01-06",
+        "decisionDate": "2021-06-06",
         "disagreementArea": "disability evaluation,this is another other entry"
       }
     }

--- a/src/applications/appeals/10182/tests/fixtures/data/transformed-minimal-test.json
+++ b/src/applications/appeals/10182/tests/fixtures/data/transformed-minimal-test.json
@@ -34,7 +34,7 @@
       "attributes": {
         "issue": "Traumatic Brain Injury - 5%",
         "decisionIssueId": 10,
-        "decisionDate": "2020-01-05",
+        "decisionDate": "2021-06-05",
         "disagreementArea": "effective date"
       }
     }

--- a/src/applications/appeals/10182/tests/fixtures/mocks/user.json
+++ b/src/applications/appeals/10182/tests/fixtures/mocks/user.json
@@ -55,7 +55,9 @@
       "inProgressForms": [],
       "prefillsAvailable": [],
       "vet360ContactInformation": {
-        "email": null,
+        "email": {
+          "emailAddress": "test@user.com"
+        },
         "residentialAddress": {},
         "mailingAddress": {
           "addressLine1": "1200 Park Ave",

--- a/src/applications/appeals/10182/tests/nod.cypress.helpers.js
+++ b/src/applications/appeals/10182/tests/nod.cypress.helpers.js
@@ -1,14 +1,17 @@
 import { getDate } from '../utils/dates';
 import { SELECTED } from '../constants';
 
+export const getRandomDate = () =>
+  getDate({
+    offset: {
+      months: -Math.floor(Math.random() * 6 + 1),
+      days: -Math.floor(Math.random() * 10),
+    },
+  });
+
 export const fixDecisionDates = data => {
   return data.map(issue => {
-    const newDate = getDate({
-      offset: {
-        months: -Math.floor(Math.random() * 6 + 1),
-        days: -Math.floor(Math.random() * 10),
-      },
-    });
+    const newDate = getRandomDate();
     // remove selected value so Cypress can click-select
     if (issue.decisionDate) {
       return {

--- a/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
@@ -12,6 +12,7 @@ import {
   setInitialEditMode,
   issuesNeedUpdating,
   processContestableIssues,
+  readableList,
 } from '../../utils/helpers';
 import { getDate } from '../../utils/dates';
 
@@ -321,5 +322,21 @@ describe('processContestableIssues', () => {
       '2021-01-31',
       '2020-12-01',
     ]);
+  });
+});
+
+describe('readableList', () => {
+  it('should return an empty string', () => {
+    expect(readableList([])).to.eq('');
+    expect(readableList(['', null, 0])).to.eq('');
+  });
+  it('should return a combined list with commas with "and" for the last item', () => {
+    expect(readableList(['one'])).to.eq('one');
+    expect(readableList(['', 'one', null])).to.eq('one');
+    expect(readableList(['one', 'two'])).to.eq('one and two');
+    expect(readableList([1, 2, 'three'])).to.eq('1, 2 and three');
+    expect(readableList(['v', null, 'w', 'x', '', 'y', 'z'])).to.eq(
+      'v, w, x, y and z',
+    );
   });
 });

--- a/src/applications/appeals/10182/tests/validations.unit.spec.js
+++ b/src/applications/appeals/10182/tests/validations.unit.spec.js
@@ -6,6 +6,7 @@ import {
   requireIssue,
   validateDate,
   isValidDate,
+  contactInfoValidation,
   validAdditionalIssue,
   areaOfDisagreementRequired,
   optInValidation,
@@ -159,6 +160,50 @@ describe('validateDate & isValidDate', () => {
     validateDate(errors, date);
     expect(errorMessage).to.contain('date less than a year');
     expect(isValidDate(date)).to.be.false;
+  });
+});
+
+describe('contactInfoValidation', () => {
+  const getData = ({ email = true, phone = true, address = true } = {}) => ({
+    veteran: {
+      email: email ? 'placeholder' : '',
+      phone: phone ? { phoneNumber: 'placeholder' } : {},
+      address: address ? { addressLine1: 'placeholder' } : {},
+    },
+  });
+  it('should not show an error when data is available', () => {
+    const addError = sinon.spy();
+    contactInfoValidation({ addError }, null, getData());
+    expect(addError.notCalled).to.be.true;
+  });
+  it('should have an error when email is missing', () => {
+    const addError = sinon.spy();
+    contactInfoValidation({ addError }, null, getData({ email: false }));
+    expect(addError.called).to.be.true;
+    expect(addError.args[0][0]).to.contain('add an email');
+  });
+  it('should have multiple errors when email & phone are missing', () => {
+    const addError = sinon.spy();
+    contactInfoValidation(
+      { addError },
+      null,
+      getData({ email: false, phone: false }),
+    );
+    expect(addError.called).to.be.true;
+    expect(addError.firstCall.args[0]).to.contain('add an email');
+    expect(addError.secondCall.args[0]).to.contain('add a phone');
+  });
+  it('should have multiple errors when everything is missing', () => {
+    const addError = sinon.spy();
+    contactInfoValidation(
+      { addError },
+      null,
+      getData({ email: false, phone: false, address: false }),
+    );
+    expect(addError.called).to.be.true;
+    expect(addError.firstCall.args[0]).to.contain('add an email');
+    expect(addError.secondCall.args[0]).to.contain('add a phone');
+    expect(addError.thirdCall.args[0]).to.contain('add an address');
   });
 });
 

--- a/src/applications/appeals/10182/utils/helpers.js
+++ b/src/applications/appeals/10182/utils/helpers.js
@@ -125,3 +125,18 @@ export const getItemSchema = (schema, index) => {
   }
   return itemSchema.additionalItems;
 };
+
+/**
+ * Convert an array into a readable list of items
+ * @param {String[]} list - Array of items. Empty entries are stripped out
+ * @returns {String}
+ * @example
+ * readableList(['1', '2', '3', '4', 'five'])
+ * // => '1, 2, 3, 4 and five'
+ */
+export const readableList = list => {
+  const cleanedList = list.filter(Boolean);
+  return [cleanedList.slice(0, -1).join(', '), cleanedList.slice(-1)[0]].join(
+    cleanedList.length < 2 ? '' : ' and ',
+  );
+};

--- a/src/applications/appeals/10182/validations.js
+++ b/src/applications/appeals/10182/validations.js
@@ -71,6 +71,19 @@ export const isValidDate = dateString => {
   return isValid;
 };
 
+export const contactInfoValidation = (errors, _fieldData, formData) => {
+  const { veteran = {} } = formData;
+  if (!veteran.email) {
+    errors.addError('Please add an email address to your profile');
+  }
+  if (!veteran.phone?.phoneNumber) {
+    errors.addError('Please add a phone number to your profile');
+  }
+  if (!veteran.address?.addressLine1) {
+    errors.addError('Please add an address to your profile');
+  }
+};
+
 export const validAdditionalIssue = (
   errors,
   { additionalIssues = [] } = {},


### PR DESCRIPTION
## Description

We're implementing a temporary fix for the Notice of Disagreement form. If a user is missing any of their essential info: email, mobile/home phone or address, the contact info page will show a warning with a link to have the Veteran update their info on the profile page. Once complete, they click on the "My contact details have been updated" button to refresh the data from their profile (see first screenshot). If improperly done, an error alert will display with more explicit information (see second screenshot). Once done, a success alert will be shown and the Veteran will be allowed to proceed in the form.

As this is a temporary fix, a more permanent fix that allows editing information inline will be implemented in the future.

Related:
- Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/26013
- Design: https://www.sketch.com/s/0424c51d-7818-43ea-8821-6de91eb7ab27/a/MyWwKO7 (pages 72-74)

## Testing done

Updated unit & e2e tests

## Screenshots

<details><summary>Missing contact info</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-06-28 at 3 06 53 PM](https://user-images.githubusercontent.com/136959/123697673-cb865c00-d822-11eb-9b69-90ded34b7ec2.png)</details>

<details><summary>Still need to update error</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-06-28 at 3 07 05 PM](https://user-images.githubusercontent.com/136959/123697672-caedc580-d822-11eb-9dfb-fdd214ca4bfa.png)</details>

<details><summary>Successfully updated</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-06-28 at 3 08 02 PM](https://user-images.githubusercontent.com/136959/123697669-ca552f00-d822-11eb-8d9f-9d584d0f73e7.png)</details>

## Acceptance criteria
- [x] Missing contact info alerts will be shown to the Veteran, if applicable
- [x] All tests are passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
