### PR TITLE
Add CommunicationGroup model class

### DIFF
--- a/src/applications/personalization/profile/models/CommunicationChannel.js
+++ b/src/applications/personalization/profile/models/CommunicationChannel.js
@@ -1,5 +1,5 @@
 class CommunicationChannel {
-  constructor({ id, parentItemId, permissionId, isAllowed = null }) {
+  constructor({ id, parentItemId, permissionId, isAllowed }) {
     if (typeof id !== 'number') {
       throw new Error('Invalid Argument: options.id must be a number');
     }
@@ -8,10 +8,12 @@ class CommunicationChannel {
         'Invalid Argument: options.parentItemId must be a number',
       );
     }
+    // id is _not_ a unique id for this channel. It corresponds to the channel's
+    // type. Example: 1 = text, 2 = email
     this.id = id;
     this.parentItemId = parentItemId;
     this.permissionId = permissionId;
-    this.isAllowed = isAllowed;
+    this.isAllowed = !!isAllowed;
   }
 
   setIsAllowed(isAllowed) {
@@ -69,6 +71,15 @@ class CommunicationChannel {
       }
       return acc;
     }, true);
+  }
+
+  clone() {
+    return new CommunicationChannel({
+      id: this.id,
+      parentItemId: this.parentItemId,
+      isAllowed: this.isAllowed,
+      permissionId: this.permissionId,
+    });
   }
 }
 

--- a/src/applications/personalization/profile/models/CommunicationChannel.unit.spec.js
+++ b/src/applications/personalization/profile/models/CommunicationChannel.unit.spec.js
@@ -127,4 +127,31 @@ describe('CommunicationChannel model', () => {
       },
     );
   });
+
+  describe('clone', () => {
+    it('returns an identical new instance that can be edited independent of the source instance', () => {
+      let baseChannel = new CommunicationChannel({
+        id: 1,
+        parentItemId: 1,
+      });
+      let clone = baseChannel.clone();
+      expect(baseChannel.isIdenticalTo(clone)).to.be.true;
+      clone.setIsAllowed(true);
+      expect(baseChannel.isIdenticalTo(clone)).to.be.false;
+      clone.setIsAllowed(false);
+      expect(baseChannel.isIdenticalTo(clone)).to.be.true;
+      baseChannel = new CommunicationChannel({
+        id: 1,
+        parentItemId: 1,
+        isAllowed: true,
+        permissionId: 123,
+      });
+      clone = baseChannel.clone();
+      expect(baseChannel.isIdenticalTo(clone)).to.be.true;
+      clone.setIsAllowed(false);
+      expect(baseChannel.isIdenticalTo(clone)).to.be.false;
+      clone.setIsAllowed(true);
+      expect(baseChannel.isIdenticalTo(clone)).to.be.true;
+    });
+  });
 });

--- a/src/applications/personalization/profile/models/CommunicationGroup.js
+++ b/src/applications/personalization/profile/models/CommunicationGroup.js
@@ -1,0 +1,44 @@
+class CommunicationGroup {
+  constructor({ id, communicationChannels }) {
+    if (typeof id !== 'number') {
+      throw new TypeError('id should be a number');
+    }
+    if (!Array.isArray(communicationChannels)) {
+      throw new TypeError('communicationChannels should be an array');
+    }
+    this.id = id;
+    this.channels = communicationChannels;
+  }
+
+  getUpdatedChannels(wipGroup) {
+    if (this.id !== wipGroup.id) {
+      return [];
+    }
+    // loop over this instance's channels and compare each to the wipGroup's
+    // comparable channel, returning the wipGroup's channels that are different
+    return this.channels.reduce((updatedChannels, baseChannel) => {
+      const wipChannel = wipGroup.channels.find(channel => {
+        return (
+          channel.id === baseChannel.id &&
+          channel.parentItemId === baseChannel.parentItemId
+        );
+      });
+      if (!wipChannel.isIdenticalTo(baseChannel)) {
+        updatedChannels.push(wipChannel);
+      }
+      return updatedChannels;
+    }, []);
+  }
+
+  clone() {
+    const clonedChannels = this.channels.map(channel => {
+      return channel.clone();
+    });
+    return new CommunicationGroup({
+      id: this.id,
+      communicationChannels: clonedChannels,
+    });
+  }
+}
+
+export default CommunicationGroup;

--- a/src/applications/personalization/profile/models/CommunicationGroup.unit.spec.js
+++ b/src/applications/personalization/profile/models/CommunicationGroup.unit.spec.js
@@ -5,23 +5,6 @@ import CommunicationChannel from './CommunicationChannel';
 
 describe('CommunicationGroup model', () => {
   describe('constructor', () => {
-    it('takes an id and an array of CommunicationChannel objects', () => {
-      /* eslint-disable no-new */
-      new CommunicationGroup({
-        id: 1,
-        communicationChannels: [
-          new CommunicationChannel({ id: 1, parentItemId: 1 }),
-          new CommunicationChannel({ id: 2, parentItemId: 1 }),
-          new CommunicationChannel({
-            id: 1,
-            parentItemId: 2,
-            isAllowed: true,
-            permissionId: 123,
-          }),
-        ],
-      });
-      /* eslint-enable no-new */
-    });
     it('throws an error if not given an id', () => {
       expect(() => {
         // eslint-disable-next-line no-new
@@ -37,8 +20,9 @@ describe('CommunicationGroup model', () => {
   });
 
   describe('getUpdatedChannels()', () => {
-    it('returns an empty array when the groups are identical', () => {
-      const baseGroup = new CommunicationGroup({
+    let baseGroup;
+    beforeEach(() => {
+      baseGroup = new CommunicationGroup({
         id: 1,
         communicationChannels: [
           new CommunicationChannel({ id: 1, parentItemId: 1 }),
@@ -51,24 +35,13 @@ describe('CommunicationGroup model', () => {
           }),
         ],
       });
+    });
+    it('returns an empty array when the groups are identical', () => {
       const wipGroup = baseGroup.clone();
       const updatedChannels = baseGroup.getUpdatedChannels(wipGroup);
       expect(updatedChannels).to.deep.equal([]);
     });
     it("returns an empty array when the group's ids do not match", () => {
-      const baseGroup = new CommunicationGroup({
-        id: 1,
-        communicationChannels: [
-          new CommunicationChannel({ id: 1, parentItemId: 1 }),
-          new CommunicationChannel({ id: 2, parentItemId: 1 }),
-          new CommunicationChannel({
-            id: 1,
-            parentItemId: 2,
-            isAllowed: true,
-            permissionId: 123,
-          }),
-        ],
-      });
       const wipGroup = new CommunicationGroup({
         id: 2,
         communicationChannels: [
@@ -85,25 +58,14 @@ describe('CommunicationGroup model', () => {
       const updatedChannels = baseGroup.getUpdatedChannels(wipGroup);
       expect(updatedChannels).to.deep.equal([]);
     });
-    it("returns the argument's CommunicationChannels that are different", () => {
-      const baseGroup = new CommunicationGroup({
-        id: 1,
-        communicationChannels: [
-          new CommunicationChannel({ id: 1, parentItemId: 1 }),
-          new CommunicationChannel({ id: 2, parentItemId: 1 }),
-          new CommunicationChannel({
-            id: 1,
-            parentItemId: 2,
-            isAllowed: true,
-            permissionId: 123,
-          }),
-        ],
-      });
+    it("returns the argument group's CommunicationChannels that are different", () => {
       const wipGroup = baseGroup.clone();
       wipGroup.channels[0].setIsAllowed(true);
       wipGroup.channels[2].setIsAllowed(false);
       const updatedChannels = baseGroup.getUpdatedChannels(wipGroup);
       expect(updatedChannels.length).to.equal(2);
+      expect(updatedChannels[0].isAllowed).to.be.true;
+      expect(updatedChannels[1].isAllowed).to.be.false;
     });
   });
 

--- a/src/applications/personalization/profile/models/CommunicationGroup.unit.spec.js
+++ b/src/applications/personalization/profile/models/CommunicationGroup.unit.spec.js
@@ -1,0 +1,134 @@
+import { expect } from 'chai';
+
+import CommunicationGroup from './CommunicationGroup';
+import CommunicationChannel from './CommunicationChannel';
+
+describe('CommunicationGroup model', () => {
+  describe('constructor', () => {
+    it('takes an id and an array of CommunicationChannel objects', () => {
+      /* eslint-disable no-new */
+      new CommunicationGroup({
+        id: 1,
+        communicationChannels: [
+          new CommunicationChannel({ id: 1, parentItemId: 1 }),
+          new CommunicationChannel({ id: 2, parentItemId: 1 }),
+          new CommunicationChannel({
+            id: 1,
+            parentItemId: 2,
+            isAllowed: true,
+            permissionId: 123,
+          }),
+        ],
+      });
+      /* eslint-enable no-new */
+    });
+    it('throws an error if not given an id', () => {
+      expect(() => {
+        // eslint-disable-next-line no-new
+        new CommunicationGroup({ notAnId: 1, communicationChannels: [] });
+      }).to.throw(Error, /id.*number/i);
+    });
+    it('throws an error if not given a communicationChannels array', () => {
+      expect(() => {
+        // eslint-disable-next-line no-new
+        new CommunicationGroup({ id: 1 });
+      }).to.throw(Error, /channels.*array/i);
+    });
+  });
+
+  describe('getUpdatedChannels()', () => {
+    it('returns an empty array when the groups are identical', () => {
+      const baseGroup = new CommunicationGroup({
+        id: 1,
+        communicationChannels: [
+          new CommunicationChannel({ id: 1, parentItemId: 1 }),
+          new CommunicationChannel({ id: 2, parentItemId: 1 }),
+          new CommunicationChannel({
+            id: 1,
+            parentItemId: 2,
+            isAllowed: true,
+            permissionId: 123,
+          }),
+        ],
+      });
+      const wipGroup = baseGroup.clone();
+      const updatedChannels = baseGroup.getUpdatedChannels(wipGroup);
+      expect(updatedChannels).to.deep.equal([]);
+    });
+    it("returns an empty array when the group's ids do not match", () => {
+      const baseGroup = new CommunicationGroup({
+        id: 1,
+        communicationChannels: [
+          new CommunicationChannel({ id: 1, parentItemId: 1 }),
+          new CommunicationChannel({ id: 2, parentItemId: 1 }),
+          new CommunicationChannel({
+            id: 1,
+            parentItemId: 2,
+            isAllowed: true,
+            permissionId: 123,
+          }),
+        ],
+      });
+      const wipGroup = new CommunicationGroup({
+        id: 2,
+        communicationChannels: [
+          new CommunicationChannel({ id: 1, parentItemId: 4 }),
+          new CommunicationChannel({ id: 2, parentItemId: 4 }),
+          new CommunicationChannel({
+            id: 1,
+            parentItemId: 5,
+            isAllowed: true,
+            permissionId: 456,
+          }),
+        ],
+      });
+      const updatedChannels = baseGroup.getUpdatedChannels(wipGroup);
+      expect(updatedChannels).to.deep.equal([]);
+    });
+    it("returns the argument's CommunicationChannels that are different", () => {
+      const baseGroup = new CommunicationGroup({
+        id: 1,
+        communicationChannels: [
+          new CommunicationChannel({ id: 1, parentItemId: 1 }),
+          new CommunicationChannel({ id: 2, parentItemId: 1 }),
+          new CommunicationChannel({
+            id: 1,
+            parentItemId: 2,
+            isAllowed: true,
+            permissionId: 123,
+          }),
+        ],
+      });
+      const wipGroup = baseGroup.clone();
+      wipGroup.channels[0].setIsAllowed(true);
+      wipGroup.channels[2].setIsAllowed(false);
+      const updatedChannels = baseGroup.getUpdatedChannels(wipGroup);
+      expect(updatedChannels.length).to.equal(2);
+    });
+  });
+
+  describe('clone', () => {
+    it('returns an identical CommunicationGroup', () => {
+      const baseGroup = new CommunicationGroup({
+        id: 1,
+        communicationChannels: [
+          new CommunicationChannel({
+            id: 1,
+            parentItemId: 1,
+            isAllowed: true,
+            permissionId: 123,
+          }),
+          new CommunicationChannel({ id: 2, parentItemId: 1 }),
+          new CommunicationChannel({
+            id: 1,
+            parentItemId: 2,
+            isAllowed: false,
+            permissionId: 456,
+          }),
+        ],
+      });
+      const clonedGroup = baseGroup.clone();
+      expect(baseGroup.getUpdatedChannels(clonedGroup)).to.deep.equal([]);
+    });
+  });
+});


### PR DESCRIPTION
## Description
Adds a class that makes is easy to:
- clone a group of CommunicationChannel instances
- compare two groups and get the CommunicationChannel instances that have been updated

## Testing done
Unit tests, mostly written in a TDD fashion

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs