### PR TITLE
remove circle CI references in cypress specs

### DIFF
--- a/src/applications/discharge-wizard/tests/e2e/discharge-wizard.cypress.spec.js
+++ b/src/applications/discharge-wizard/tests/e2e/discharge-wizard.cypress.spec.js
@@ -10,10 +10,6 @@ function axeTestPage() {
 }
 
 describe('functionality of discharge wizard', () => {
-  before(function() {
-    if (Cypress.env('CIRCLECI')) this.skip();
-  });
-
   it('fill out the form and expect the form to have elements', () => {
     // navigate to discharge wizard and make an axe check
     // landing page

--- a/src/applications/find-forms/tests/e2e/find-forms-required.cypress.spec.js
+++ b/src/applications/find-forms/tests/e2e/find-forms-required.cypress.spec.js
@@ -26,10 +26,6 @@ function axeTestPage() {
 }
 
 describe('functionality of Find Forms', () => {
-  before(function() {
-    if (Cypress.env('CIRCLECI')) this.skip();
-  });
-
   it('search the form and expect dom to have elements', () => {
     cy.intercept('GET', '/v0/feature_toggles*', {
       data: {

--- a/src/applications/search/tests/e2e/00-required.cypress.spec.js
+++ b/src/applications/search/tests/e2e/00-required.cypress.spec.js
@@ -15,10 +15,6 @@ function axeTestPage() {
 }
 
 describe('Sitewide Search smoke test', () => {
-  before(function() {
-    if (Cypress.env('CIRCLECI')) this.skip();
-  });
-
   it('successfully searches and renders results from the global search', () => {
     cy.server();
     cy.route({

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/tests/index.cypress.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/tests/index.cypress.spec.js
@@ -30,10 +30,6 @@ const setup = ({ authenticated, isCerner } = {}) => {
 };
 
 describe('The schedule view VA appointments page', () => {
-  before(function() {
-    if (Cypress.env('CIRCLECI')) this.skip();
-  });
-
   it('Shows the correct CTA widget when unauthenticated', () => {
     // Set up the test.
     setup({ authenticated: false });

--- a/src/applications/yellow-ribbon/e2e/tests/yellow-ribbon.cypress.spec.js
+++ b/src/applications/yellow-ribbon/e2e/tests/yellow-ribbon.cypress.spec.js
@@ -22,10 +22,6 @@ function axeTestPage() {
 }
 
 describe('functionality of Yellow Ribbons', () => {
-  before(function() {
-    if (Cypress.env('CIRCLECI')) this.skip();
-  });
-
   it('search the form and expect dom to have elements on success', () => {
     cy.server();
     cy.route({

--- a/src/platform/site-wide/side-nav/tests/e2e/sideNav.cypress.spec.js
+++ b/src/platform/site-wide/side-nav/tests/e2e/sideNav.cypress.spec.js
@@ -11,10 +11,6 @@ Cypress.Commands.add('tabFocus', el => {
 });
 
 describe('Facilities VAMC SideNav', () => {
-  before(function() {
-    if (Cypress.env('CIRCLECI')) this.skip();
-  });
-
   it('should tab access the links on the left nav and verify focus', () => {
     cy.visit('/pittsburgh-health-care');
     cy.injectAxe();

--- a/src/platform/site-wide/user-nav/tests/e2e/00-required.cypress.spec.js
+++ b/src/platform/site-wide/user-nav/tests/e2e/00-required.cypress.spec.js
@@ -59,10 +59,6 @@ const mockFetchSuggestions = () => {
 };
 
 describe('Site-wide Search general functionality', () => {
-  before(function() {
-    if (Cypress.env('CIRCLECI')) this.skip();
-  });
-
   beforeEach(function() {
     cy.server();
   });
@@ -97,10 +93,6 @@ describe('Site-wide Search general functionality', () => {
 });
 
 describe('Site-wide Search functionality with typeahead disabled', () => {
-  before(function() {
-    if (Cypress.env('CIRCLECI')) this.skip();
-  });
-
   beforeEach(function() {
     cy.server();
   });
@@ -120,10 +112,6 @@ describe('Site-wide Search functionality with typeahead disabled', () => {
 });
 
 describe('Site-wide Search functionality with typeahead enabled', () => {
-  before(function() {
-    if (Cypress.env('CIRCLECI')) this.skip();
-  });
-
   beforeEach(function() {
     cy.server();
   });


### PR DESCRIPTION
## Description
The goal here was to remove any remaining Circle CI references in Cypress specs.  The only ones that were found were code specifying to skip the test if Circle was defined in the environment.  As these tests have been running in CI since the switch off  Circle, and passing, this code was removed.

## Testing done
These test specs seem to be running and passing in CI regularly.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
