### PR TITLE
526: Use wizard action link

### DIFF
--- a/src/applications/disability-benefits/wizard/WizardLink.jsx
+++ b/src/applications/disability-benefits/wizard/WizardLink.jsx
@@ -13,11 +13,8 @@ import { show526Wizard } from 'applications/disability-benefits/all-claims/utils
 const WizardLink = ({ showWizard, module }) => {
   const { Wizard, pages } = module.default;
   return showWizard ? (
-    <a href={manifest.rootUrl} className="usa-button-primary va-button-primary">
+    <a href={manifest.rootUrl} className="vads-c-action-link--green">
       Let&apos;s get started
-      <span role="img" aria-hidden="true" className="button-icon">
-        &nbsp;»
-      </span>
     </a>
   ) : (
     <Wizard pages={pages} expander buttonText="Let's get started" />


### PR DESCRIPTION
## Description

The disability form info page is currently displaying a "Let's get started" button style in staging. This PR changes it to an action link

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/26578

## Testing done

Visual

## Screenshots

![Screen Shot 2021-07-01 at 11 07 31 AM](https://user-images.githubusercontent.com/136959/124156130-da585300-da5c-11eb-8c80-4aca4b950423.png)

## Acceptance criteria
- [x] Link to 526 wizard `/start` page is an action link

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
