### PR TITLE
17721/reporting improvements

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -110,22 +110,6 @@ jobs:
       run:
         working-directory: testing-tools-team-dashboard-data
     steps:
-      - name: Checkout vets-website
-        uses: actions/checkout@v2
-
-      - name: Download test results
-        uses: actions/download-artifact@v2
-        with:
-          name: cypress-test-results
-          path: test-results
-
-      - name: Publish test results
-        uses: mikepenz/action-junit-report@v2.4.2
-        with:
-          check_name: 'Cypress Tests Summary'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          report_paths: 'test-results/e2e-test-output-*.xml'
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -288,5 +272,19 @@ jobs:
           repository: department-of-veterans-affairs/testing-reports
           directory: testing-reports
 
-      - name: Access Report
-        run: echo "[See Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }}.html)"
+      - name: Checkout vets-website
+        uses: actions/checkout@v2
+
+      - name: Download test results
+        uses: actions/download-artifact@v2
+        with:
+          name: cypress-test-results
+          path: test-results
+
+      - name: Publish test results
+        uses: mikepenz/action-junit-report@v2.4.2
+        with:
+          check_name: 'Cypress Tests Summary'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          report_paths: 'test-results/e2e-test-output-*.xml'
+          summary: '<a href="https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }}.html">See Mochawesome Report</a>'

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -104,6 +104,9 @@ jobs:
       run:
         working-directory: testing-tools-team-dashboard-data
     steps:
+      - name: Checkout vets-website
+        uses: actions/checkout@v2
+
       - name: Publish test results
         if: ${{ always() }}
         uses: mikepenz/action-junit-report@v2.4.2

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -74,14 +74,6 @@ jobs:
           STEP: ${{ matrix.ci_node_index }}
           CI: true
 
-      - name: Publish test results
-        if: ${{ always() }}
-        uses: mikepenz/action-junit-report@v2.4.2
-        with:
-          check_name: 'Cypress Tests Summary'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          report_paths: 'test-results/e2e-test-output-*.xml'
-
       - name: Archive Cypress test videos
         uses: actions/upload-artifact@v2
         if: ${{ failure() }}
@@ -112,6 +104,14 @@ jobs:
       run:
         working-directory: testing-tools-team-dashboard-data
     steps:
+      - name: Publish test results
+        if: ${{ always() }}
+        uses: mikepenz/action-junit-report@v2.4.2
+        with:
+          check_name: 'Cypress Tests Summary'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          report_paths: 'test-results/e2e-test-output-*.xml'
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -120,7 +120,6 @@ jobs:
           path: test-results
 
       - name: Publish test results
-        if: ${{ always() }}
         uses: mikepenz/action-junit-report@v2.4.2
         with:
           check_name: 'Cypress Tests Summary'

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -74,6 +74,12 @@ jobs:
           STEP: ${{ matrix.ci_node_index }}
           CI: true
 
+      - name: Archive test results
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cypress-test-results
+          path: test-results
+
       - name: Archive Cypress test videos
         uses: actions/upload-artifact@v2
         if: ${{ failure() }}
@@ -106,6 +112,12 @@ jobs:
     steps:
       - name: Checkout vets-website
         uses: actions/checkout@v2
+
+      - name: Download test result artifact 0
+        uses: actions/download-artifact@v2
+        with:
+          name: cypress-test-results
+          path: test-results
 
       - name: Publish test results
         if: ${{ always() }}

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Checkout vets-website
         uses: actions/checkout@v2
 
-      - name: Download test result artifact 0
+      - name: Download test results
         uses: actions/download-artifact@v2
         with:
           name: cypress-test-results

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -110,6 +110,22 @@ jobs:
       run:
         working-directory: testing-tools-team-dashboard-data
     steps:
+      - name: Checkout vets-website
+        uses: actions/checkout@v2
+
+      - name: Download test results
+        uses: actions/download-artifact@v2
+        with:
+          name: cypress-test-results
+          path: test-results
+
+      - name: Publish test results
+        uses: mikepenz/action-junit-report@v2.4.2
+        with:
+          check_name: 'Cypress Tests Summary'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          report_paths: 'test-results/e2e-test-output-*.xml'
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -272,19 +288,5 @@ jobs:
           repository: department-of-veterans-affairs/testing-reports
           directory: testing-reports
 
-      - name: Checkout vets-website
-        uses: actions/checkout@v2
-
-      - name: Download test results
-        uses: actions/download-artifact@v2
-        with:
-          name: cypress-test-results
-          path: test-results
-
-      - name: Publish test results
-        uses: mikepenz/action-junit-report@v2.4.2
-        with:
-          check_name: 'Cypress Tests Summary'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          report_paths: 'test-results/e2e-test-output-*.xml'
-          summary: '[See Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }}.html)'
+      - name: Access Report
+        run: echo "[See Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }}.html)"

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -287,4 +287,4 @@ jobs:
           check_name: 'Cypress Tests Summary'
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: 'test-results/e2e-test-output-*.xml'
-          summary: '<a href="https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }}.html">See Mochawesome Report</a>'
+          summary: '[See Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }}.html)'

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -75,7 +75,7 @@ jobs:
           CI: true
 
       - name: Archive test results
-      - uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2
         with:
           name: cypress-test-results
           path: test-results


### PR DESCRIPTION
## Description
This PR moves the Cypress Test Summary outside of the matrix job, preventing it from only showing the most recent test run's summary.  Since this is in a separate job from the tests now, the test results are uploaded as an artifact and re-downloaded in the second job, to be compiled and summarized.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
