### PR TITLE
Remove node module caching from Cypress tests in GitHub Actions

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -31,20 +31,14 @@ jobs:
       - name: Set vets-website port
         run: echo "CYPRESS_PORT=$(( ( RANDOM % 2000 )  + 3001 ))" >> $GITHUB_ENV
 
+      - name: Get Node version
+        id: get-node-version
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: '14.17.2'
-
-      - name: Cache dependencies
-        id: cache-dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cache/yarn
-            ~/.cache/Cypress
-            node_modules
-          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
+          node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
       - name: Install vets-website dependencies
         run: yarn install --frozen-lockfile --prefer-offline

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: '14.15.5'
+          node-version: '14.17.2'
 
       - name: Cache dependencies
         id: cache-dependencies

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -40,6 +40,11 @@ jobs:
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
+      - name: Install Chrome
+        uses: browser-actions/setup-chrome@latest
+        with:
+          chrome-version: stable
+
       - name: Install vets-website dependencies
         run: yarn install --frozen-lockfile --prefer-offline
         env:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -31,14 +31,10 @@ jobs:
       - name: Set vets-website port
         run: echo "CYPRESS_PORT=$(( ( RANDOM % 2000 )  + 3001 ))" >> $GITHUB_ENV
 
-      - name: Get Node version
-        id: get-node-version
-        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
+          node-version: '14.15.5'
 
       - name: Cache dependencies
         id: cache-dependencies

--- a/script/run-cypress-tests-gha.js
+++ b/script/run-cypress-tests-gha.js
@@ -14,7 +14,7 @@ exec("find src -name '*.cypress.*.js' | tr '\n' ','", function(_err, stdout) {
   runCommand(
     `CYPRESS_CI=${
       process.env.CI
-    } yarn cy:run --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.json" --config baseUrl=http://localhost:${
+    } yarn cy:run --browser chrome --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.json" --config baseUrl=http://localhost:${
       process.env.CYPRESS_PORT
     } --port ${Number(process.env.CYPRESS_PORT) - 1} --spec '${tests}'`,
   );


### PR DESCRIPTION
## Description
This PR removes node module caching from the Cypress workflow in GitHub Actions. This is an attempt to fix `SIGILL` failures we've been seeing on GHA.

## Acceptance criteria
- [ ] Cypress tests pass consistently on GHA.
