### PR TITLE
526: Update page title & breadcrumbs

### DIFF
--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -16,7 +16,13 @@ import ITFWrapper from './containers/ITFWrapper';
 import { MissingServices, MissingId } from './containers/MissingServices';
 
 import { MVI_ADD_SUCCEEDED } from './actions';
-import { WIZARD_STATUS, PDF_SIZE_FEATURE, SHOW_8940_4192 } from './constants';
+import {
+  WIZARD_STATUS,
+  PDF_SIZE_FEATURE,
+  SHOW_8940_4192,
+  PAGE_TITLE_SUFFIX,
+  DOCUMENT_TITLE_SUFFIX,
+} from './constants';
 import {
   show526Wizard,
   isBDD,
@@ -48,6 +54,8 @@ export const hasRequiredServices = user =>
 export const hasRequiredId = user =>
   idRequired.some(service => user.profile.services.includes(service));
 
+const isIntroPage = () => window.location.pathname.endsWith('/introduction');
+
 export const Form526Entry = ({
   location,
   user,
@@ -67,8 +75,10 @@ export const Form526Entry = ({
       form.form === formConfig.formId && !isExpired(form.metaData?.expiresAt),
   );
 
-  const title = getPageTitle(isBDDForm);
-  document.title = title;
+  const title = `${getPageTitle(isBDDForm)}${
+    isIntroPage() ? ` ${PAGE_TITLE_SUFFIX}` : ''
+  }`;
+  document.title = `${title}${DOCUMENT_TITLE_SUFFIX}`;
 
   // start focus on breadcrumb nav when wizard is visible
   const setPageFocus = focusTarget => {
@@ -77,10 +87,7 @@ export const Form526Entry = ({
   };
 
   useEffect(() => {
-    if (
-      wizardStatus === WIZARD_STATUS_COMPLETE &&
-      window.location.pathname.endsWith('/introduction')
-    ) {
+    if (wizardStatus === WIZARD_STATUS_COMPLETE && isIntroPage()) {
       setPageFocus('h1');
       // save feature flag for 8940/4192
       sessionStorage.setItem(SHOW_8940_4192, showSubforms);

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -19,6 +19,8 @@ import {
   BDD_INFO_URL,
   DISABILITY_526_V2_ROOT_URL,
   WIZARD_STATUS,
+  PAGE_TITLE_SUFFIX,
+  DOCUMENT_TITLE_SUFFIX,
 } from '../constants';
 import { WIZARD_STATUS_RESTARTING } from 'platform/site-wide/wizard';
 
@@ -39,8 +41,9 @@ class IntroductionPage extends React.Component {
     // be required to proceed; not changing this now in case it breaks something
 
     const isBDDForm = this.props.isBDDForm;
-    const pageTitle = getPageTitle(isBDDForm);
+    const pageTitle = `${getPageTitle(isBDDForm)} ${PAGE_TITLE_SUFFIX}`;
     const startText = getStartText(isBDDForm);
+    document.title = `${pageTitle}${DOCUMENT_TITLE_SUFFIX}`;
 
     // Remove this once form526_original_claims feature flag is removed
     if (!allowContinue) {
@@ -58,7 +61,7 @@ class IntroductionPage extends React.Component {
 
     return (
       <div className="schemaform-intro">
-        <FormTitle title={`${pageTitle} with VA Form 21-526EZ`} />
+        <FormTitle title={pageTitle} />
         {isBDDForm ? (
           <>
             <h2 className="vads-u-font-size--h4">

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -11,6 +11,9 @@ export const PAGE_TITLES = {
   BDD: 'File a Benefits Delivery at Discharge claim',
 };
 
+export const PAGE_TITLE_SUFFIX = 'with VA Form 21-526EZ';
+export const DOCUMENT_TITLE_SUFFIX = ' | Veterans Affairs';
+
 export const START_TEXT = {
   ALL: 'Start the Disability Compensation Application',
   BDD: 'Start the Benefits Disability at Discharge Application',

--- a/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
@@ -10,6 +10,8 @@ import {
   START_TEXT,
   SAVED_SEPARATION_DATE,
   DISABILITY_526_V2_ROOT_URL,
+  PAGE_TITLE_SUFFIX,
+  DOCUMENT_TITLE_SUFFIX,
 } from '../../constants';
 
 describe('<IntroductionPage/>', () => {
@@ -40,10 +42,11 @@ describe('<IntroductionPage/>', () => {
   it('should render a form title', () => {
     const wrapper = shallow(<IntroductionPage {...defaultProps} />);
     const title = wrapper.find('FormTitle');
+    const titleText = `${PAGE_TITLES.ALL} ${PAGE_TITLE_SUFFIX}`;
     expect(title.length).to.equal(1);
-    expect(title.props().title).to.equal(
-      `${PAGE_TITLES.ALL} with VA Form 21-526EZ`,
-    );
+    expect(title.props().title).to.equal(titleText);
+    expect(document.title).to.contain(titleText);
+    expect(document.title).to.contain(DOCUMENT_TITLE_SUFFIX);
     wrapper.unmount();
   });
 


### PR DESCRIPTION
## Description

An IA review noted that Form 526's introduction page breadcrumb and page title weren't matching. In addition, the document title has also been updated to match the title along with the standard suffix of ` | Veterans Affairs` seen on all other pages.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/26867

## Testing done

Updated unit tests

## Screenshots

![Screen Shot 2021-07-01 at 3 12 22 PM](https://user-images.githubusercontent.com/136959/124185824-17364100-da81-11eb-8da9-bf213009ac79.png)
![Screen Shot 2021-07-01 at 3 32 25 PM](https://user-images.githubusercontent.com/136959/124186200-93308900-da81-11eb-89bb-8eeffe11fe79.png)


## Acceptance criteria
- [x] 526 Introduction page title and breadcrumb match
- [x] Introduction page document title includes page title plus VA suffix

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
