### PR TITLE
526: Move initial route to `/start` page

### DIFF
--- a/src/applications/disability-benefits/all-claims/containers/ITFWrapper.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ITFWrapper.jsx
@@ -17,7 +17,7 @@ const fetchWaitingStates = [requestStates.notCalled, requestStates.pending];
 
 export class ITFWrapper extends React.Component {
   static defaultProps = {
-    noITFPages: [/\/introduction/, /\/confirmation/],
+    noITFPages: [/\/start/, /\/introduction/, /\/confirmation/],
   };
 
   // When we first enter the form...

--- a/src/applications/disability-benefits/all-claims/routes.jsx
+++ b/src/applications/disability-benefits/all-claims/routes.jsx
@@ -1,7 +1,9 @@
 import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/helpers';
+import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
 
 import Form526EZApp from './Form526EZApp';
 import formConfig from './config/form';
+import { WIZARD_STATUS } from './constants';
 import WizardContainer from './containers/WizardContainer';
 
 const routes = [
@@ -12,7 +14,14 @@ const routes = [
   {
     path: '/',
     component: Form526EZApp,
-    indexRoute: { onEnter: (nextState, replace) => replace('/introduction') },
+    indexRoute: {
+      onEnter: (nextState, replace) =>
+        replace(
+          sessionStorage.getItem(WIZARD_STATUS) === WIZARD_STATUS_COMPLETE
+            ? '/introduction'
+            : '/start',
+        ),
+    },
     childRoutes: createRoutesWithSaveInProgress(formConfig),
   },
 ];

--- a/src/applications/disability-benefits/all-claims/tests/routes.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/routes.unit.spec.js
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
+
+import routes from '../routes';
+import { WIZARD_STATUS } from '../constants';
+
+describe('Form 526 routes', () => {
+  const { onEnter } = routes[1].indexRoute;
+  afterEach(() => {
+    sessionStorage.removeItem(WIZARD_STATUS);
+  });
+
+  it('should redirect from root to /start', () => {
+    const replace = sinon.spy();
+    sessionStorage.removeItem(WIZARD_STATUS);
+    onEnter(null, replace);
+    expect(replace.calledWith('/start')).to.be.true;
+  });
+  it('should redirect from the root to /introduction', () => {
+    const replace = sinon.spy();
+    sessionStorage.setItem(WIZARD_STATUS, WIZARD_STATUS_COMPLETE);
+    onEnter(null, replace);
+    expect(replace.calledWith('/introduction')).to.be.true;
+  });
+});

--- a/src/applications/disability-benefits/wizard/WizardLink.jsx
+++ b/src/applications/disability-benefits/wizard/WizardLink.jsx
@@ -13,7 +13,7 @@ import { show526Wizard } from 'applications/disability-benefits/all-claims/utils
 const WizardLink = ({ showWizard, module }) => {
   const { Wizard, pages } = module.default;
   return showWizard ? (
-    <a href={manifest.rootUrl} className="vads-c-action-link--green">
+    <a href={`${manifest.rootUrl}/start`} className="vads-c-action-link--green">
       Let&apos;s get started
     </a>
   ) : (


### PR DESCRIPTION
## Description

In an IA review, it was noted that 526 would initially redirect to `/introduction` before going to the `/start` page. This PR fixes the routing, but because the wizard existing on the `/start` page is behind a feature flag, and accessing the list of features on the route page isn't possible, this PR won't be merged until the 526 wizard flag is at 100%.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/26867

## Testing done

Added router `onEnter` unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Veteran is rerouted to the `/start` page when wizard flag isn't set as complete
- [x] Wait until 526 wizard feature is at 100% before merging this PR

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
