### PR TITLE
feat(file upload): update error span for a11y

### DIFF
--- a/src/platform/forms-system/src/js/fields/FileField.jsx
+++ b/src/platform/forms-system/src/js/fields/FileField.jsx
@@ -359,8 +359,8 @@ class FileField extends React.Component {
                     )}
                   {!file.uploading &&
                     hasErrors && (
-                      <span className="usa-input-error-message">
-                        {errors[0]}
+                      <span className="usa-input-error-message" role="alert">
+                        <span className="sr-only">Error</span> {errors[0]}
                       </span>
                     )}
                   {showPasswordInput && (

--- a/src/platform/forms-system/test/js/fields/FileField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/fields/FileField.unit.spec.jsx
@@ -335,7 +335,11 @@ describe('Schemaform <FileField>', () => {
       />,
     );
 
-    expect(tree.find('.va-growable-background').text()).to.contain('Bad error');
+    // Prepend 'Error' for screenreader
+    expect(tree.find('.va-growable-background').text()).to.contain(
+      'Error Bad error',
+    );
+    expect(tree.find('span[role="alert"]').exists()).to.be.true;
     tree.unmount();
   });
 


### PR DESCRIPTION
## Description
Update the file upload error message to align with error message conventions in other areas or Va.gov

## Testing done
- [ ] manual

## Screenshots
![image](https://user-images.githubusercontent.com/83595736/124275794-046b4d00-db11-11eb-9131-fd43852be45c.png)

## Acceptance criteria
- [ ] Update error span with `role="alert"` and to prepend `<span className="sr-only">Error</span>` before error message

## Definition of done
- [ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/26843)
