### PR TITLE
DT-26761 discharge wizard alertbox migration

### DIFF
--- a/src/applications/discharge-wizard/components/AlertMessage.jsx
+++ b/src/applications/discharge-wizard/components/AlertMessage.jsx
@@ -1,0 +1,34 @@
+// Dependencies
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * @param {(string|JSX)} content
+ * @param {boolean} isVisible
+ * @param {string} status
+ * @returns {JSX}
+ *
+ * This function is a friendly wrapper for the va-alert web component
+ * See => https://design.va.gov/storybook/?path=/docs/components-va-alert--default for usage and more props to add.
+ */
+const AlertMessage = ({ content, isVisible, status }) => {
+  return (
+    <va-alert visible={isVisible} status={status}>
+      <div className="usa-alert-text vads-u-font-size--base">
+        {content || null}
+      </div>
+    </va-alert>
+  );
+};
+
+AlertMessage.propTypes = {
+  content: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node,
+    PropTypes.element,
+  ]),
+  isVisible: PropTypes.bool,
+  status: PropTypes.string,
+};
+
+export default AlertMessage;

--- a/src/applications/discharge-wizard/components/CarefulConsiderationStatement.jsx
+++ b/src/applications/discharge-wizard/components/CarefulConsiderationStatement.jsx
@@ -1,10 +1,10 @@
-// Dependencies
+// Dependencies imports
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 
-// Relative Imports
-import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
+// Relative imports
+import AlertMessage from './AlertMessage';
 
 const reasonStatement = formValues => {
   const reason = formValues['4_reason'];
@@ -89,7 +89,9 @@ const priorServiceStatement = formValues => {
   switch (formValues['12_priorService']) {
     case '1':
       return (
-        <AlertBox
+        <AlertMessage
+          isVisible
+          status="info"
           content={
             <div>
               <h4 className="usa-alert-heading">
@@ -110,50 +112,50 @@ const priorServiceStatement = formValues => {
               </p>
             </div>
           }
-          isVisible
-          status="info"
         />
       );
     case '2':
       return (
-        <AlertBox
+        <AlertMessage
+          isVisible
+          status="info"
           content={
-            <div>
+            <div className="usa-alert-text">
               <h4 className="usa-alert-heading">
                 You can apply for VA benefits using your honorable
                 characterization.
               </h4>
-              <p>
-                Because you served honorably in one period of service, you can
-                apply for VA benefits using that honorable characterization. You
-                earned your benefits during the period in which you served
-                honorably. You don’t need a DD214 to apply for VA benefits—you
-                only need to specifically mention this period of honorable
-                service. (VA may do a Character of Discharge review to confirm
-                your eligibility.)
-              </p>
-              <p>
-                The only exception is for service-connected disability
-                compensation. If your disability began during your less than
-                honorable period of service, you won’t be eligible to earn
-                disability compensation unless you get that discharge upgraded.
-                The instructions below this box tell you how to apply to an
-                upgrade or correction for your final, less than honorable period
-                of service.
-              </p>
-              <p>
-                If you want a DD214 for your period of honorable service for
-                other reasons, unrelated to applying for VA benefits, you can
-                request one.{' '}
-                <Link to="/request-dd214" target="_blank">
-                  Find out how to request a DD214 for your period of honorable
-                  service
-                </Link>
-              </p>
+              <div className="vads-u-font-size--base">
+                <p className="vads-u-margin-top--2">
+                  Because you served honorably in one period of service, you can
+                  apply for VA benefits using that honorable characterization.
+                  You earned your benefits during the period in which you served
+                  honorably. You don’t need a DD214 to apply for VA benefits—you
+                  only need to specifically mention this period of honorable
+                  service. (VA may do a Character of Discharge review to confirm
+                  your eligibility.)
+                </p>
+                <p>
+                  The only exception is for service-connected disability
+                  compensation. If your disability began during your less than
+                  honorable period of service, you won’t be eligible to earn
+                  disability compensation unless you get that discharge
+                  upgraded. The instructions below this box tell you how to
+                  apply to an upgrade or correction for your final, less than
+                  honorable period of service.
+                </p>
+                <p>
+                  If you want a DD214 for your period of honorable service for
+                  other reasons, unrelated to applying for VA benefits, you can
+                  request one.{' '}
+                  <Link to="/request-dd214" target="_blank">
+                    Find out how to request a DD214 for your period of honorable
+                    service
+                  </Link>
+                </p>
+              </div>
             </div>
           }
-          isVisible
-          status="info"
         />
       );
     default:

--- a/src/applications/discharge-wizard/components/gpMinorComponents/Warnings.jsx
+++ b/src/applications/discharge-wizard/components/gpMinorComponents/Warnings.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 
 // Relative imports
-import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
+import AlertMessage from '../AlertMessage';
 import { branchOfService, board } from '../../helpers';
 import { venueWarning, upgradeVenueWarning } from '../../constants';
 
@@ -20,12 +20,12 @@ const Warnings = ({ formValues }) => {
 
     return (
       <div>
-        <AlertBox
+        <AlertMessage
           content={venueWarning}
           isVisible={prevAppType === '4' && reason !== '8'}
           status="warning"
         />
-        <AlertBox
+        <AlertMessage
           content={upgradeVenueWarning}
           isVisible={prevAppType === '4' && reason === '8' && !oldDischarge}
           status="warning"
@@ -49,7 +49,7 @@ const Warnings = ({ formValues }) => {
     );
 
     return (
-      <AlertBox
+      <AlertMessage
         content={alertContent}
         isVisible={boardToSubmit.abbr === 'DRB' && prevAppType === '3'}
         status="warning"
@@ -73,7 +73,7 @@ const Warnings = ({ formValues }) => {
     );
 
     return (
-      <AlertBox
+      <AlertMessage
         content={alertContent}
         isVisible={reason === '8' && prevAppType === '3'}
         status="warning"

--- a/src/applications/discharge-wizard/components/gpSteps/StepOne.jsx
+++ b/src/applications/discharge-wizard/components/gpSteps/StepOne.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 // Relative imports
-import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
+import AlertMessage from '../AlertMessage';
 import { board, formData } from '../../helpers';
 
 const StepOne = ({ formValues }) => {
@@ -169,7 +169,7 @@ const StepOne = ({ formValues }) => {
         >
           Download Form {form.num}
         </a>
-        <AlertBox
+        <AlertMessage
           content={
             <div>
               <h4 className="usa-alert-heading">

--- a/src/applications/discharge-wizard/constants/index.js
+++ b/src/applications/discharge-wizard/constants/index.js
@@ -1,11 +1,5 @@
 export const DW_UPDATE_FIELD = 'discharge-wizard/UPDATE_FIELD';
 
-export const labels = {
-  drb: 'Discharge Review Board',
-  bcmr: 'Board for Correction of Military Records (BCMR)',
-  bcnr: 'Board for Correction of Naval Records (BCNR)',
-};
-
 export const venueWarning =
   "You answered that you weren't sure where you applied for an upgrade before. The instructions below are for Veterans who have never applied for a discharge upgrade, so your process may be different. For more reliable information on your discharge upgrade process, please review your records to find out which board you sent your earlier application to, and complete the questions again.";
 

--- a/src/applications/discharge-wizard/helpers/index.jsx
+++ b/src/applications/discharge-wizard/helpers/index.jsx
@@ -198,12 +198,6 @@ export const formData = formValues => {
   };
 };
 
-export const elementTopOffset = el => {
-  const rect = el.getBoundingClientRect();
-  const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-  return rect.top + scrollTop;
-};
-
 export const answerReview = (key, formValues) => {
   const ans = formValues[key];
   const dischargeYearLabel = prevApplicationYearCutoff[formValues['4_reason']];

--- a/src/applications/discharge-wizard/reducers/discharge-wizard.js
+++ b/src/applications/discharge-wizard/reducers/discharge-wizard.js
@@ -1,5 +1,5 @@
 import { DW_UPDATE_FIELD } from '../constants';
-import _ from 'lodash';
+import { set } from 'lodash';
 import moment from 'moment';
 
 const initialState = {
@@ -150,7 +150,7 @@ export default (state = initialState, action) => {
         const num = k.split('_')[0];
         const nextNum = action.key.split('_')[0];
         if (parseInt(num, 10) > parseInt(nextNum, 10)) {
-          return _.set(a, k, initialState[k]);
+          return set(a, k, initialState[k]);
         }
         return a;
       }, {}),

--- a/src/applications/discharge-wizard/tests/components/CarefulConsiderationStatement.unit.spec.js
+++ b/src/applications/discharge-wizard/tests/components/CarefulConsiderationStatement.unit.spec.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { mount, shallow } from 'enzyme';
-import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
+import AlertMessage from '../../components/AlertMessage';
 
 // Relative Imports
 import CarefulConsiderationStatement from '../../components/CarefulConsiderationStatement';
@@ -31,7 +31,7 @@ describe('Discharge Wizard <CarefulConsiderationStatement />', () => {
         }}
       />,
     );
-    expect(wrapper.find(AlertBox)).to.have.lengthOf(1);
+    expect(wrapper.find(AlertMessage)).to.have.lengthOf(1);
     wrapper.unmount();
   });
 


### PR DESCRIPTION
## Issue
https://github.com/department-of-veterans-affairs/va.gov-team/issues/26761

## Description
Migrate Alert Boxes to new web component in the Discharge wizard

## Testing done
Ran e2e, unit, and spun up local env.

## Screenshots
![Screen Shot 2021-07-01 at 3 37 27 PM](https://user-images.githubusercontent.com/26075258/124310613-6e4c1c80-db3a-11eb-8be3-fedd53b589fa.png)
![Screen Shot 2021-07-01 at 3 37 51 PM](https://user-images.githubusercontent.com/26075258/124310619-6f7d4980-db3a-11eb-8e27-a7a08f8519c3.png)
![Screen Shot 2021-07-01 at 3 38 13 PM](https://user-images.githubusercontent.com/26075258/124310621-7015e000-db3a-11eb-85f7-dce82929e345.png)


## Acceptance criteria
- [x] Alert Boxes switched, All work as they do now in Prod.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
