### PR TITLE
remove alt text for the decorative gears in connected apps.

### DIFF
--- a/src/applications/personalization/profile/components/connected-apps/ConnectedApp.jsx
+++ b/src/applications/personalization/profile/components/connected-apps/ConnectedApp.jsx
@@ -33,7 +33,7 @@ export class ConnectedApp extends Component {
         <img
           className="va-connected-app-account-logo vads-u-margin-right--2p5"
           src={logo}
-          alt={`${title} logo`}
+          alt={``}
         />
         <div className="vads-u-flex--4 vads-u-align-items--flex-start">
           <div className="vads-u-display--flex vads-u-justify-content--space-between vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">


### PR DESCRIPTION
## Description
Remove the alt text

## Testing done
ran pericles screen reader and made sure all tests pass locally

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
