### PR TITLE
Update LocationSearchResults.jsx

### DIFF
--- a/src/applications/gi-sandbox/containers/search/LocationSearchResults.jsx
+++ b/src/applications/gi-sandbox/containers/search/LocationSearchResults.jsx
@@ -188,9 +188,9 @@ function LocationSearchResults({
         if (streetAddress.searchString === location) {
           currentLocationMapMarker(locationBounds);
         }
-        setMapState({ changed: false, distance: null });
         map.current.fitBounds(locationBounds, { padding: 20 });
       }
+      setMapState({ changed: false, distance: null });
     },
     [results],
   );


### PR DESCRIPTION
## Description
Moving setting value to false to occur both when value is true or false after rendering results.
This will prevent an issue where continues to render as if map was moved if using the search input and distance dropdown.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
