### PR TITLE
run yarn in mochawesome-report job in cypress gha workflow

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -237,9 +237,7 @@ jobs:
           node-version: '14'
 
       - name: Install Modules
-        uses: borales/actions-yarn@v2.3.0
-        with:
-          cmd: install 
+        run: yarn install
 
       - name: Generate UUID
         id: generate-uuid

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -236,6 +236,11 @@ jobs:
         with:
           node-version: '14'
 
+      - name: Install Modules
+        uses: borales/actions-yarn@v2.3.0
+        with:
+          cmd: install 
+
       - name: Generate UUID
         id: generate-uuid
         uses: filipstefansson/uuid-action@v1


### PR DESCRIPTION
I'm planning to remove the `node_modules` folder from the [testing tools team data repo](https://github.com/department-of-veterans-affairs/testing-tools-team-dashboard-data), which is checked-out in the `mochawesome-report` job, in the `cypress.yml` workflow. The public modules will need to be installed... 
