### PR TITLE
HLR: Validation error fix

### DIFF
--- a/src/applications/disability-benefits/996/config/submit-transformer.js
+++ b/src/applications/disability-benefits/996/config/submit-transformer.js
@@ -28,8 +28,8 @@ export function transform(formConfig, form) {
       time1400to1630: '1400-1630 ET',
     };
     return ['time1', 'time2'].reduce((times, key) => {
-      const value = informalConferenceTimes[key] ?? '';
-      if (value !== '') {
+      const value = informalConferenceTimes[key] || '';
+      if (value) {
         times.push(xRef[value]);
       }
       return times;

--- a/src/applications/disability-benefits/996/tests/fixtures/data/minimal-test.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/data/minimal-test.json
@@ -14,9 +14,9 @@
         "attributes": {
           "ratingIssueSubjectText": "Headaches",
           "description": "Acute chronic head pain",
-          "ratingIssuePercentNumber": "20",
-          "approxDecisionDate": "2021-06-10",
-          "decisionIssueId": 44,
+          "ratingIssuePercentNumber": "22",
+          "approxDecisionDate": "2021-06-14",
+          "decisionIssueId": 42,
           "ratingIssueReferenceId": "66",
           "ratingDecisionReferenceId": ""
         },

--- a/src/applications/disability-benefits/996/tests/fixtures/data/one-conference-time-test.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/data/one-conference-time-test.json
@@ -1,0 +1,31 @@
+{
+  "data": {
+    "veteran": {
+      "ssnLastFour": "7821",
+      "vaFileLastFour": "2345"
+    },
+    "zipCode5": "22222",
+    "sameOffice": true,
+    "privacyAgreementAccepted": true,
+    "informalConference": "me",
+    "informalConferenceTimes": {
+      "time1": "time1400to1630",
+      "time2": ""
+    },
+    "contestedIssues": [
+      {
+        "type": "contestableIssue",
+        "attributes": {
+          "ratingIssueSubjectText": "Headaches",
+          "description": "Acute chronic head pain",
+          "ratingIssuePercentNumber": "18",
+          "approxDecisionDate": "2021-06-12",
+          "decisionIssueId": 43,
+          "ratingIssueReferenceId": "61",
+          "ratingDecisionReferenceId": null
+        },
+        "view:selected": true
+      }
+    ]
+  }
+}

--- a/src/applications/disability-benefits/996/tests/fixtures/data/transformed-minimal-test.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/data/transformed-minimal-test.json
@@ -1,0 +1,27 @@
+{
+  "data": {
+    "type": "higherLevelReview",
+    "attributes": {
+      "benefitType": "compensation",
+      "informalConference": false,
+      "sameOffice": false,
+      "veteran": {
+        "address": {
+          "zipCode5": "94608"
+        },
+        "timezone": "America/Chicago"
+      }
+    }
+  },
+  "included": [
+    {
+      "type": "contestableIssue",
+      "attributes": {
+        "issue": "Headaches - 22% - Acute chronic head pain",
+        "decisionDate": "2021-06-14",
+        "decisionIssueId": 42,
+        "ratingIssueReferenceId": "66"
+      }
+    }
+  ]
+}

--- a/src/applications/disability-benefits/996/tests/fixtures/data/transformed-one-conference-time-test.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/data/transformed-one-conference-time-test.json
@@ -1,0 +1,28 @@
+{
+  "data": {
+    "type": "higherLevelReview",
+    "attributes": {
+      "benefitType": "compensation",
+      "informalConference": true,
+      "informalConferenceTimes": ["1400-1630 ET"],
+      "sameOffice": true,
+      "veteran": {
+        "address": {
+          "zipCode5": "22222"
+        },
+        "timezone": "America/Phoenix"
+      }
+    }
+  },
+  "included": [
+    {
+      "type": "contestableIssue",
+      "attributes": {
+        "issue": "Headaches - 18% - Acute chronic head pain",
+        "decisionDate": "2021-06-12",
+        "decisionIssueId": 43,
+        "ratingIssueReferenceId": "61"
+      }
+    }
+  ]
+}

--- a/src/applications/disability-benefits/996/tests/schema/submit-transformer.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/schema/submit-transformer.unit.spec.js
@@ -4,15 +4,36 @@ import formConfig from '../../config/form';
 
 import { transform } from '../../config/submit-transformer';
 
+import minimalData from '../fixtures/data/minimal-test.json';
 import maximalData from '../fixtures/data/maximal-test.json';
+import oneConferenceTimeData from '../fixtures/data/one-conference-time-test.json';
+
+import transformedMinimalData from '../fixtures/data/transformed-minimal-test.json';
 import transformedMaximalData from '../fixtures/data/transformed-maximal-test.json';
+import transformedOneConferenceTimeData from '../fixtures/data/transformed-one-conference-time-test.json';
 
 describe('transform', () => {
-  it(`should transform maximal.json correctly`, () => {
+  it('should transform minimal-test.json correctly', () => {
+    const transformedResult = JSON.parse(transform(formConfig, minimalData));
+    // copy over variables that change based on date & location
+    transformedResult.data.attributes.veteran.timezone = 'America/Chicago';
+
+    expect(transformedResult).to.deep.equal(transformedMinimalData);
+  });
+  it('should transform maximal-test.json correctly', () => {
     const transformedResult = JSON.parse(transform(formConfig, maximalData));
     // copy over variables that change based on date & location
     transformedResult.data.attributes.veteran.timezone = 'America/Los_Angeles';
 
     expect(transformedResult).to.deep.equal(transformedMaximalData);
+  });
+  it('should transform one-conference-time.json correctly', () => {
+    const transformedResult = JSON.parse(
+      transform(formConfig, oneConferenceTimeData),
+    );
+    // copy over variables that change based on date & location
+    transformedResult.data.attributes.veteran.timezone = 'America/Phoenix';
+
+    expect(transformedResult).to.deep.equal(transformedOneConferenceTimeData);
   });
 });

--- a/src/applications/disability-benefits/996/tests/validations/validations.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/validations/validations.unit.spec.js
@@ -1,44 +1,89 @@
 import { expect } from 'chai';
+import sinon from 'sinon';
 
-import { checkConferenceTimes } from '../../validations';
-import { errorMessages } from '../../constants';
+import {
+  requireRatedDisability,
+  isFirstConferenceTimeEmpty,
+  checkConferenceTimes,
+  validatePhone,
+} from '../../validations';
+import { errorMessages, SELECTED } from '../../constants';
 
-const mockFormData = { informalConferenceChoice: 'me' };
+describe('requireRatedDisability', () => {
+  it('should show an error if no disabilities are selected', () => {
+    const errors = { addError: sinon.spy() };
+    requireRatedDisability(errors, [{}, {}]);
+    expect(errors.addError.calledWith(errorMessages.contestedIssue)).to.be.true;
+  });
+  it('should not show an error if a disabilitiy is selected', () => {
+    const errors = { addError: sinon.spy() };
+    requireRatedDisability(errors, [{}, { [SELECTED]: true }]);
+    expect(errors.addError.notCalled).to.be.true;
+  });
+});
+
+describe('isFirstConferenceTimeEmpty', () => {
+  const setTime = time1 => ({ informalConferenceTimes: { time1 } });
+  it('should return true if empty', () => {
+    expect(isFirstConferenceTimeEmpty({})).to.be.true;
+    expect(isFirstConferenceTimeEmpty(setTime())).to.be.true;
+    expect(isFirstConferenceTimeEmpty(setTime(''))).to.be.true;
+  });
+  it('should return false if not empty', () => {
+    expect(isFirstConferenceTimeEmpty(setTime('foo'))).to.be.false;
+  });
+});
 
 describe('Informal conference time validation', () => {
+  const mockFormData = { informalConferenceChoice: 'me' };
   it('should show an error if no times are selected', () => {
-    let errorMessage = '';
-    const errors = {
-      addError: message => {
-        errorMessage = message || '';
-      },
-    };
-    const times = '';
-    checkConferenceTimes(errors, times, mockFormData);
-    expect(errorMessage).to.equal(errorMessages.informalConferenceTimes);
+    const errors = { addError: sinon.spy() };
+    checkConferenceTimes(errors, '', mockFormData);
+    expect(errors.addError.calledWith(errorMessages.informalConferenceTimes)).to
+      .be.true;
   });
 
   it('should not show an error if a single time is selected', () => {
-    let errorMessage = '';
-    const errors = {
-      addError: message => {
-        errorMessage = message || '';
-      },
-    };
+    const errors = { addError: sinon.spy() };
     const times = 'time0800to1000';
     checkConferenceTimes(errors, times, mockFormData);
-    expect(errorMessage).to.equal('');
+    expect(errors.addError.notCalled).to.be.true;
   });
 
-  it('should not show an error if a two time are selected', () => {
-    let errorMessage = '';
-    const errors = {
-      addError: message => {
-        errorMessage = message || '';
-      },
-    };
+  it('should not show an error if a two times are selected', () => {
+    const errors = { addError: sinon.spy() };
     const times = 'time1000to1230';
     checkConferenceTimes(errors, times, mockFormData);
-    expect(errorMessage).to.equal('');
+    expect(errors.addError.notCalled).to.be.true;
+  });
+});
+
+describe('validatePhone', () => {
+  const phoneError = errorMessages.informalConferenceContactPhonePattern;
+  it('should show an error for an empty string', () => {
+    const errors = { addError: sinon.spy() };
+    validatePhone(errors, '');
+    expect(errors.addError.calledWith(phoneError)).to.be.true;
+  });
+  it('should show an error for short phone numbers', () => {
+    const errors = { addError: sinon.spy() };
+    validatePhone(errors, '1234');
+    expect(errors.addError.calledWith(phoneError)).to.be.true;
+  });
+  it('should show an error for long phone numbers', () => {
+    const errors = { addError: sinon.spy() };
+    validatePhone(errors, '12345678901');
+    expect(errors.addError.calledWith(phoneError)).to.be.true;
+  });
+  it('should show an error for non phone numbers', () => {
+    const errors = { addError: sinon.spy() };
+    validatePhone(errors, '123abc456');
+    expect(errors.addError.calledWith(phoneError)).to.be.true;
+  });
+
+  it('should not show an error for a 10-digit number', () => {
+    const errors = { addError: sinon.spy() };
+    validatePhone(errors, '1234567890');
+    expect(errors.addError.notCalled).to.be.true;
   });
 });

--- a/src/applications/disability-benefits/996/validations/index.js
+++ b/src/applications/disability-benefits/996/validations/index.js
@@ -24,7 +24,7 @@ export const checkConferenceTimes = (errors, values, formData) => {
 const phoneRegexp = /[0-9]+/;
 
 export const validatePhone = (errors, phone) => {
-  if (errors && phone && (!phoneRegexp.test(phone) || phone.length !== 10)) {
+  if (errors && (!phone || !phoneRegexp.test(phone) || phone.length !== 10)) {
     errors.addError(errorMessages.informalConferenceContactPhonePattern);
   }
 };


### PR DESCRIPTION
## Description

This PR adds more testing to the submit transform & validation functions in an attempt to fix this `time1` Sentry error that occurs upon submission:

```js
{
  argument: 'time1', 
  message: 'requires property "time1"', 
  name: 'required', 
  property: 'instance.informalConferenceTimes', 
  schema: {
    properties: {}, 
    required: [], 
    type: 'object'
  }, 
  stack: 'instance.informalConferenceTimes requires property "time1"'
}
```

But since Sentry isn't available right now, I can't track down the exact cause of this issue.

In addition, manual attempts at submitting the HLR form without a selected time were not successful.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/26715

## Testing done

Added & updated unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Add more & missing tests for submission & validation functions

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
