### PR TITLE
Manage focus when starting to edit Profile data

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
@@ -49,6 +49,7 @@ export const BankInfoCNP = ({
 }) => {
   const formPrefix = 'CNP';
   const editBankInfoButton = useRef();
+  const editBankInfoForm = useRef();
   const [formData, setFormData] = useState({});
   const [showConfirmCancelModal, setShowConfirmCancelModal] = useState(false);
   const wasEditingBankInfo = usePrevious(directDepositUiState.isEditing);
@@ -74,6 +75,14 @@ export const BankInfoCNP = ({
   // when we enter and exit edit mode...
   useEffect(
     () => {
+      if (isEditingBankInfo && !wasEditingBankInfo) {
+        const focusableElement = editBankInfoForm.current?.querySelector(
+          'button, input, select, a, textarea',
+        );
+        if (focusableElement) {
+          focusableElement.focus();
+        }
+      }
       if (wasEditingBankInfo && !isEditingBankInfo) {
         // clear the form data when exiting edit mode so it's blank when the
         // edit form is shown again
@@ -279,7 +288,7 @@ export const BankInfoCNP = ({
           </figure>
         </AdditionalInfo>
       </div>
-      <div data-testid={`${formPrefix}-bank-info-form`}>
+      <div data-testid={`${formPrefix}-bank-info-form`} ref={editBankInfoForm}>
         <BankInfoForm
           formChange={data => setFormData(data)}
           formData={formData}

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
@@ -47,6 +47,7 @@ export const DirectDepositEDU = ({
 }) => {
   const formPrefix = 'EDU';
   const editBankInfoButton = useRef();
+  const editBankInfoForm = useRef();
   const [formData, setFormData] = useState({});
   const [showConfirmCancelModal, setShowConfirmCancelModal] = useState(false);
   const wasEditingBankInfo = usePrevious(directDepositUiState.isEditing);
@@ -69,6 +70,14 @@ export const DirectDepositEDU = ({
   // when we enter and exit edit mode...
   useEffect(
     () => {
+      if (isEditingBankInfo && !wasEditingBankInfo) {
+        const focusableElement = editBankInfoForm.current?.querySelector(
+          'button, input, select, a, textarea',
+        );
+        if (focusableElement) {
+          focusableElement.focus();
+        }
+      }
       if (wasEditingBankInfo && !isEditingBankInfo) {
         // clear the form data when exiting edit mode so it's blank when the
         // edit form is shown again
@@ -245,7 +254,7 @@ export const DirectDepositEDU = ({
           </figure>
         </AdditionalInfo>
       </div>
-      <div data-testid={`${formPrefix}-bank-info-form`}>
+      <div data-testid={`${formPrefix}-bank-info-form`} ref={editBankInfoForm}>
         <BankInfoForm
           formChange={data => setFormData(data)}
           formData={formData}

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationEditView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationEditView.jsx
@@ -80,6 +80,13 @@ export class ContactInformationEditView extends Component {
       this.props.formSchema,
       this.props.uiSchema,
     );
+    // focus on the first focusable elements
+    setTimeout(() => {
+      const focusableElement = this.editForm.querySelector(
+        'button, input, select, a, textarea',
+      );
+      focusableElement.focus();
+    }, 1);
   }
 
   componentDidUpdate(prevProps) {
@@ -275,7 +282,11 @@ export class ContactInformationEditView extends Component {
         )}
 
         {!!field && (
-          <div>
+          <div
+            ref={el => {
+              this.editForm = el;
+            }}
+          >
             {fieldName === FIELD_NAMES.RESIDENTIAL_ADDRESS && (
               <CopyMailingAddress
                 copyMailingAddress={this.copyMailingAddress}

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationEditView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationEditView.jsx
@@ -73,6 +73,15 @@ export class ContactInformationEditView extends Component {
     validateAddress: PropTypes.func.isRequired,
   };
 
+  focusOnFirstFormElement() {
+    const focusableElement = this.editForm?.querySelector(
+      'button, input, select, a, textarea',
+    );
+    if (focusableElement) {
+      focusableElement.focus();
+    }
+  }
+
   componentDidMount() {
     const { getInitialFormValues } = this.props;
     this.onChangeFormDataAndSchemas(
@@ -80,16 +89,14 @@ export class ContactInformationEditView extends Component {
       this.props.formSchema,
       this.props.uiSchema,
     );
-    // focus on the first focusable elements
-    setTimeout(() => {
-      const focusableElement = this.editForm.querySelector(
-        'button, input, select, a, textarea',
-      );
-      focusableElement.focus();
-    }, 1);
+    this.focusOnFirstFormElement();
   }
 
   componentDidUpdate(prevProps) {
+    if (!prevProps.field && !!this.props.field) {
+      this.focusOnFirstFormElement();
+    }
+
     // if the transaction just became pending, start calling
     // refreshTransaction() on an interval
     if (

--- a/src/applications/personalization/profile/tests/e2e/direct-deposit/update-flow.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/direct-deposit/update-flow.cypress.spec.js
@@ -76,6 +76,7 @@ describe('Direct Deposit', () => {
         // register and the bank info form does not open
         force: true,
       });
+      cy.findByLabelText(/routing number/i).should('be.focused');
       fillInBankInfoForm('CNP');
       exitBankInfoForm();
       dismissUnsavedChangesModal();
@@ -119,6 +120,7 @@ describe('Direct Deposit', () => {
         // register and the bank info form does not open
         force: true,
       });
+      cy.findByLabelText(/routing number/i).should('be.focused');
       fillInBankInfoForm('EDU');
       exitBankInfoForm();
       dismissUnsavedChangesModal();

--- a/src/applications/personalization/profile/tests/e2e/helpers.js
+++ b/src/applications/personalization/profile/tests/e2e/helpers.js
@@ -37,7 +37,7 @@ export const mockGETEndpoints = (
   body = error500,
 ) => {
   endpoints.forEach(endpoint => {
-    cy.intercept(endpoint, {
+    cy.intercept('GET', endpoint, {
       statusCode,
       body,
     });

--- a/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/focus-management.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/focus-management.cypress.spec.js
@@ -1,0 +1,98 @@
+import { PROFILE_PATHS } from '@@profile/constants';
+
+import { mockUser } from '@@profile/tests/fixtures/users/user.js';
+import { mockGETEndpoints } from '@@profile/tests/e2e/helpers';
+
+const setup = () => {
+  cy.login(mockUser);
+  mockGETEndpoints([
+    'v0/profile/personal_information',
+    'v0/profile/service_history',
+    'v0/profile/full_name',
+    'v0/profile/ch33_bank_accounts',
+    'v0/profile/status',
+    'v0/mhv_account',
+    'v0/feature_toggles*',
+    'v0/ppiu/payment_information',
+  ]);
+  cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+
+  // should show a loading indicator
+  cy.findByRole('progressbar').should('exist');
+  cy.findByText(/loading your information/i).should('exist');
+
+  // and then the loading indicator should be removed
+  cy.findByText(/loading your information/i).should('not.exist');
+  cy.findByRole('progressbar').should('not.exist');
+};
+
+describe('Contact info fields', () => {
+  it('should manage focus correctly when going into edit mode', () => {
+    setup();
+    cy.injectAxe();
+
+    cy.findByRole('button', { name: /edit mailing address/i }).click();
+    cy.findByLabelText(/I live on a.*military base/i).should('be.focused');
+    cy.axeCheck();
+    cy.findByRole('button', { name: /cancel/i }).click();
+    cy.findByRole('button', { name: /edit mailing address/i }).should(
+      'be.focused',
+    );
+
+    cy.findByRole('button', { name: /edit home address/i }).click();
+    cy.findByLabelText(/my home address is the same/i).should('be.focused');
+    cy.axeCheck();
+    cy.findByRole('button', { name: /cancel/i }).click();
+    cy.findByRole('button', { name: /edit home address/i }).should(
+      'be.focused',
+    );
+
+    cy.findByRole('button', { name: /edit home.*number/i }).click();
+    cy.findByLabelText(/home.*number/i).should('be.focused');
+    cy.axeCheck();
+    cy.findByRole('button', { name: /cancel/i }).click();
+    cy.findByRole('button', { name: /edit home.*number/i }).should(
+      'be.focused',
+    );
+
+    cy.findByRole('button', { name: /edit work.*number/i }).click();
+    cy.findByLabelText(/work.*number/i).should('be.focused');
+    cy.axeCheck();
+    cy.findByRole('button', { name: /cancel/i }).click();
+    // We have to click the cancel button twice because the work number input is
+    // empty. Since that field is given focus and it is a required field, once
+    // you blur the input, form validation is triggered and results in a
+    // validation error.
+    cy.findByRole('button', { name: /cancel/i }).click();
+    cy.findByRole('button', { name: /edit work.*number/i }).should(
+      'be.focused',
+    );
+
+    cy.findByRole('button', { name: /edit mobile.*number/i }).click();
+    cy.findByLabelText(/mobile.*number/i).should('be.focused');
+    cy.axeCheck();
+    cy.findByRole('button', { name: /cancel/i }).click();
+    cy.findByRole('button', { name: /edit mobile.*number/i }).should(
+      'be.focused',
+    );
+
+    cy.findByRole('button', { name: /edit fax.*number/i }).click();
+    cy.findByLabelText(/fax.*number/i).should('be.focused');
+    cy.axeCheck();
+    cy.findByRole('button', { name: /cancel/i }).click();
+    // We have to click the cancel button twice because the fax number input is
+    // empty. Since that field is given focus and it is a required field, once
+    // you blur the input, form validation is triggered and results in a
+    // validation error.
+    cy.findByRole('button', { name: /cancel/i }).click();
+    cy.findByRole('button', { name: /edit fax.*number/i }).should('be.focused');
+
+    cy.findByRole('button', { name: /edit contact email/i }).click();
+    cy.findByLabelText(/email address/i).should('be.focused');
+    cy.axeCheck();
+    cy.findByRole('button', { name: /cancel/i }).click();
+    cy.findByRole('button', { name: /edit contact email/i }).should(
+      'be.focused',
+    );
+  });
+});


### PR DESCRIPTION
## Description
With this PR, focus correctly goes to the first interactive element when the user enters edit mode for their contact info or direct deposit bank info.

## Testing done
Cypress tests

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs