### PR TITLE
Add simple Notification Settings page to the Profile

### DIFF
--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -40,6 +40,7 @@ import {
   cnpDirectDepositIsSetUp,
   eduDirectDepositInformation,
   eduDirectDepositIsSetUp,
+  showNotificationSettings,
 } from '@@profile/selectors';
 import {
   fetchCNPPaymentInformation as fetchCNPPaymentInformationAction,
@@ -154,6 +155,7 @@ class Profile extends Component {
   mainContent = () => {
     const routesOptions = {
       removeDirectDeposit: !this.props.shouldShowDirectDeposit,
+      removeNotificationSettings: !this.props.shouldShowNotificationSettings,
     };
 
     // We need to pass in a config to hide forbidden routes
@@ -207,6 +209,7 @@ class Profile extends Component {
               />
 
               {/* fallback handling: redirect to root route */}
+              {/* Should we consider making a 404 page for this instead? */}
               <Route path="*">
                 <Redirect to={PROFILE_PATHS.PROFILE_ROOT} />
               </Route>
@@ -356,6 +359,7 @@ const mapStateToProps = state => {
     shouldFetchEDUDirectDepositInformation,
     shouldFetchTotalDisabilityRating,
     shouldShowDirectDeposit: shouldShowDirectDeposit(),
+    shouldShowNotificationSettings: showNotificationSettings(state),
     isDowntimeWarningDismissed: state.scheduledDowntime?.dismissedDowntimeWarnings?.includes(
       'profile',
     ),

--- a/src/applications/personalization/profile/components/notification-settings/NotificationSettings.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationSettings.jsx
@@ -1,0 +1,20 @@
+import React, { useEffect } from 'react';
+
+import Headline from '../ProfileSectionHeadline';
+import { PROFILE_PATH_NAMES } from '../../constants';
+
+const NotificationSettings = () => {
+  useEffect(() => {
+    document.title = `Notification Settings | Veterans Affairs`;
+  }, []);
+
+  return (
+    <>
+      <Headline>{PROFILE_PATH_NAMES.NOTIFICATION_SETTINGS}</Headline>
+    </>
+  );
+};
+
+NotificationSettings.propTypes = {};
+
+export default NotificationSettings;

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
@@ -41,6 +41,8 @@ import AddressValidationView from '@@vap-svc/containers/AddressValidationView';
 import ContactInformationEditView from '@@profile/components/personal-information/ContactInformationEditView';
 import ContactInformationView from '@@profile/components/personal-information/ContactInformationView';
 
+import { showNotificationSettings } from '@@profile/selectors';
+
 import { getInitialFormValues } from '@@profile/util/contact-information/formValues';
 
 import getContactInfoFieldAttributes from '~/applications/personalization/profile/util/contact-information/getContactInfoFieldAttributes';
@@ -347,7 +349,9 @@ export const mapStateToProps = (state, ownProps) => {
     activeEditView === ACTIVE_EDIT_VIEWS.ADDRESS_VALIDATION;
   const isEnrolledInVAHealthCare = isVAPatient(state);
   const showSMSCheckbox =
-    ownProps.fieldName === FIELD_NAMES.MOBILE_PHONE && isEnrolledInVAHealthCare;
+    ownProps.fieldName === FIELD_NAMES.MOBILE_PHONE &&
+    isEnrolledInVAHealthCare &&
+    !showNotificationSettings(state);
 
   const { title } = getContactInfoFieldAttributes(fieldName);
   return {

--- a/src/applications/personalization/profile/components/personal-information/ReceiveAppointmentReminders.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ReceiveAppointmentReminders.jsx
@@ -3,6 +3,8 @@ import { connect } from 'react-redux';
 
 import { isVAPatient } from '~/platform/user/selectors';
 
+import { showNotificationSettings } from '@@profile/selectors';
+
 const ReceiveAppointmentReminders = ({ hideContent, isReceivingReminders }) => {
   if (hideContent) {
     return null;
@@ -22,7 +24,7 @@ const ReceiveAppointmentReminders = ({ hideContent, isReceivingReminders }) => {
 
 export function mapStateToProps(state) {
   return {
-    hideContent: !isVAPatient(state),
+    hideContent: !isVAPatient(state) || showNotificationSettings(state),
   };
 }
 

--- a/src/applications/personalization/profile/constants.js
+++ b/src/applications/personalization/profile/constants.js
@@ -16,17 +16,12 @@ export const SERVICE_BADGE_IMAGE_PATHS = new Map([
   [USA_MILITARY_BRANCHES.marineCorps, '/img/vic-usmc-emblem.png'],
 ]);
 
-export const BREAKPOINTS = Object.freeze({
-  medium: 768,
-});
-
-export const PROFILE_VERSION = 'PROFILE_VERSION';
-
 export const PROFILE_PATHS = Object.freeze({
   PROFILE_ROOT: '/profile',
   DIRECT_DEPOSIT: '/profile/direct-deposit',
   PERSONAL_INFORMATION: '/profile/personal-information',
   MILITARY_INFORMATION: '/profile/military-information',
+  NOTIFICATION_SETTINGS: '/profile/notifications',
   CONNECTED_APPLICATIONS: '/profile/connected-applications',
   ACCOUNT_SECURITY: '/profile/account-security',
 });
@@ -35,6 +30,7 @@ export const PROFILE_PATH_NAMES = Object.freeze({
   DIRECT_DEPOSIT: 'Direct deposit information',
   PERSONAL_INFORMATION: 'Personal and contact information',
   MILITARY_INFORMATION: 'Military information',
+  NOTIFICATION_SETTINGS: 'Notification settings',
   CONNECTED_APPLICATIONS: 'Connected apps',
   ACCOUNT_SECURITY: 'Account security',
 });

--- a/src/applications/personalization/profile/routes.js
+++ b/src/applications/personalization/profile/routes.js
@@ -3,6 +3,7 @@ import PersonalInformation from './components/personal-information/PersonalInfor
 import MilitaryInformation from './components/military-information/MilitaryInformation';
 import DirectDeposit from './components/direct-deposit/DirectDeposit';
 import ConnectedApplications from './components/connected-apps/ConnectedApps';
+import NotificationSettings from './components/notification-settings/NotificationSettings';
 import { PROFILE_PATHS, PROFILE_PATH_NAMES } from './constants';
 
 const getRoutes = options => {
@@ -29,6 +30,13 @@ const getRoutes = options => {
       requiresMVI: true,
     },
     {
+      component: NotificationSettings,
+      name: PROFILE_PATH_NAMES.NOTIFICATION_SETTINGS,
+      path: PROFILE_PATHS.NOTIFICATION_SETTINGS,
+      requiresLOA3: true,
+      requiresMVI: true,
+    },
+    {
       component: AccountSecurity,
       name: PROFILE_PATH_NAMES.ACCOUNT_SECURITY,
       path: PROFILE_PATHS.ACCOUNT_SECURITY,
@@ -45,7 +53,15 @@ const getRoutes = options => {
   ];
 
   if (options.removeDirectDeposit) {
-    routes = routes.filter(route => route.component !== DirectDeposit);
+    routes = routes.filter(
+      route => route.name !== PROFILE_PATH_NAMES.DIRECT_DEPOSIT,
+    );
+  }
+
+  if (options.removeNotificationSettings) {
+    routes = routes.filter(
+      route => route.name !== PROFILE_PATH_NAMES.NOTIFICATION_SETTINGS,
+    );
   }
 
   return routes;

--- a/src/applications/personalization/profile/selectors.js
+++ b/src/applications/personalization/profile/selectors.js
@@ -1,3 +1,6 @@
+import { toggleValues } from '~/platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from '~/platform/utilities/feature-toggles/featureFlagNames';
+
 import {
   cnpDirectDepositBankInfo,
   isEligibleForCNPDirectDeposit,
@@ -76,3 +79,6 @@ export const personalInformationLoadError = state => {
 export const militaryInformationLoadError = state => {
   return state.vaProfile?.militaryInformation?.serviceHistory?.error;
 };
+
+export const showNotificationSettings = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.profileNotificationSettings];

--- a/src/applications/personalization/profile/tests/components/Profile.unit.spec.js
+++ b/src/applications/personalization/profile/tests/components/Profile.unit.spec.js
@@ -275,6 +275,7 @@ describe('mapStateToProps', () => {
       'shouldFetchEDUDirectDepositInformation',
       'shouldFetchTotalDisabilityRating',
       'shouldShowDirectDeposit',
+      'shouldShowNotificationSettings',
       'isDowntimeWarningDismissed',
     ];
     expect(Object.keys(props)).to.deep.equal(expectedKeys);

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.sms-reminders.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.sms-reminders.unit.spec.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { expect } from 'chai';
 
+import featureFlagNames from '~/platform/utilities/feature-toggles/featureFlagNames';
+
 import PersonalInformation from '@@profile/components/personal-information/PersonalInformation';
 
 import {
@@ -42,6 +44,32 @@ context('When not enrolled in health care', () => {
     expect(view.queryByLabelText(checkboxLabel)).to.not.exist;
   });
 });
+
+context(
+  'When enrolled in health care, signed up for text message reminders, but the profileNotificationSettings feature flag is turned on',
+  () => {
+    beforeEach(() => {
+      const initialState = createBasicInitialState();
+      initialState.user.profile.vaPatient = true;
+      initialState.user.profile.vapContactInfo.mobilePhone.isTextPermitted = true;
+      initialState.featureToggles = {
+        loading: false,
+        [featureFlagNames.profileNotificationSettings]: true,
+      };
+      view = renderWithProfileReducers(ui, {
+        initialState,
+      });
+    });
+    it('info about appointment reminders should not be shown under the mobile phone number', () => {
+      expect(view.queryByText(remindersTurnedOnMessage)).to.not.exist;
+      expect(view.queryByText(remindersTurnedOffMessage)).to.not.exist;
+    });
+    it('the text messages checkbox should not be shown in edit mode', () => {
+      view.getByRole('button', { name: /edit mobile phone/i }).click();
+      expect(view.queryByLabelText(checkboxLabel)).to.not.exist;
+    });
+  },
+);
 
 context('When enrolled in health care', () => {
   let initialState;

--- a/src/applications/personalization/profile/tests/components/personal-information/ReceiveAppointmentReminders.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/ReceiveAppointmentReminders.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 
 import { renderInReduxProvider as render } from '~/platform/testing/unit/react-testing-library-helpers';
+import featureFlagNames from '~/platform/utilities/feature-toggles/featureFlagNames';
 
 import ReceiveAppointmentReminders, {
   ReceiveAppointmentReminders as UnconnectedReceiveAppointmentReminders,
@@ -52,4 +53,21 @@ describe('ReceiveAppointmentReminders', () => {
       expect(view.container.firstChild).to.be.null;
     });
   });
+
+  context(
+    'when user has VA health care but the profileNotificationSettings feature flag is turned on',
+    () => {
+      it('renders nothing at all', () => {
+        initialState.user.profile.vaPatient = true;
+        initialState.featureToggles = {
+          loading: false,
+          [featureFlagNames.profileNotificationSettings]: true,
+        };
+        view = render(<ReceiveAppointmentReminders />, {
+          initialState,
+        });
+        expect(view.container.firstChild).to.be.null;
+      });
+    },
+  );
 });

--- a/src/applications/personalization/profile/tests/e2e/helpers.js
+++ b/src/applications/personalization/profile/tests/e2e/helpers.js
@@ -14,12 +14,13 @@ export function subNavOnlyContainsAccountSecurity(mobile) {
 }
 
 export function onlyAccountSecuritySectionIsAccessible() {
-  [
-    PROFILE_PATHS.CONNECTED_APPLICATIONS,
-    PROFILE_PATHS.DIRECT_DEPOSIT,
-    PROFILE_PATHS.MILITARY_INFORMATION,
-    PROFILE_PATHS.PERSONAL_INFORMATION,
-  ].forEach(path => {
+  // get all of the PROFILE_PATHS _except_ for account security
+  const profilePathsExcludingAccountSecurity = Object.entries(
+    PROFILE_PATHS,
+  ).filter(([key]) => {
+    return key !== 'ACCOUNT_SECURITY';
+  });
+  profilePathsExcludingAccountSecurity.forEach(([_, path]) => {
     cy.visit(path);
     cy.url().should(
       'eq',
@@ -55,6 +56,10 @@ export const mockFeatureToggles = () => {
         features: [
           {
             name: 'dashboard_show_dashboard_2',
+            value: true,
+          },
+          {
+            name: 'profile_notification_settings',
             value: true,
           },
         ],

--- a/src/applications/personalization/profile/tests/e2e/notification-settings.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings.cypress.spec.js
@@ -1,0 +1,64 @@
+import serviceHistory from '@@profile/tests/fixtures/service-history-success.json';
+import fullName from '@@profile/tests/fixtures/full-name-success.json';
+import error500 from '@@profile/tests/fixtures/500.json';
+
+import { mockUser } from '../fixtures/users/user';
+import { mockFeatureToggles } from './helpers';
+import { PROFILE_PATHS, PROFILE_PATH_NAMES } from '../../constants';
+
+describe('Notification Settings', () => {
+  beforeEach(() => {
+    cy.login(mockUser);
+    cy.intercept('/v0/profile/service_history', serviceHistory);
+    cy.intercept('/v0/profile/full_name', fullName);
+    // Explicitly mocking these APIs as failures, causes the tests to run faster
+    cy.intercept('/v0/profile/personal_information', error500);
+    cy.intercept('/v0/profile/ch33_bank_accounts', error500);
+    cy.intercept('/v0/ppiu/payment_information', error500);
+    cy.intercept('/v0/mhv_account', error500);
+  });
+  context('when the feature flag is turned on', () => {
+    it('is available in the side nav and the section loads', () => {
+      mockFeatureToggles();
+      // go to the root of the Profile
+      cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+      // click on the Notification settings item in the side nav
+      cy.findByRole('link', {
+        name: PROFILE_PATH_NAMES.NOTIFICATION_SETTINGS,
+      }).click();
+      // make sure the url is correct
+      cy.url().should(
+        'eq',
+        `${Cypress.config().baseUrl}${PROFILE_PATHS.NOTIFICATION_SETTINGS}`,
+      );
+      // make sure the page loads
+      cy.findByRole('heading', {
+        name: PROFILE_PATH_NAMES.NOTIFICATION_SETTINGS,
+      });
+    });
+  });
+  context('when the feature flag is turned off', () => {
+    it('is not available in the side nav and the path redirects to the personal info section', () => {
+      // go to the root of the Profile
+      cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+      // this assertion is only here to make sure the following "not.exist" does
+      // not pass as a false positive. i.e., we need to make sure the side nav
+      // is visible before we check to make sure a particular element does not
+      // exist in the side nav
+      cy.findByRole('link', {
+        name: PROFILE_PATH_NAMES.PERSONAL_INFORMATION,
+      }).should('exist');
+      // make sure there is no Notification settings item in the side nav
+      cy.findByRole('link', {
+        name: PROFILE_PATH_NAMES.NOTIFICATION_SETTINGS,
+      }).should('not.exist');
+      // try to go directly to the Notification settings URL
+      cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
+      // make sure the user is directed back to the root of the Profile
+      cy.url().should(
+        'eq',
+        `${Cypress.config().baseUrl}${PROFILE_PATHS.PERSONAL_INFORMATION}`,
+      );
+    });
+  });
+});

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -38,6 +38,7 @@ export default Object.freeze({
   languageSupport: 'language_support',
   manageDependents: 'dependents_management',
   preEntryCovid19Screener: 'preEntryCovid19Screener',
+  profileNotificationSettings: 'profile_notification_settings',
   requestLockedPdfPassword: 'request_locked_pdf_password',
   searchRepresentative: 'search_representative',
   searchTypeaheadEnabled: 'search_typeahead_enabled',


### PR DESCRIPTION
## Description
This PR accomplishes a few things:
- adds a very basic Notification Settings section to the Profile
- it only shows that section if the profileNotificationSettings feature flag is turned on
- also, when the profileNotificationSettings feature flag is turned on, it hides everything related to the existing health care appointment SMS reminders feature.

## Testing done
Added new Cypress tests to confirm the new bare-bones Notification Settings section appears only when the feature flag is turned on.
Updates existing unit tests to make sure the existing SMS appointment reminders checkbox/status is hidden when the profileNotificationSettings feature flag is turned on.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs