### PR TITLE
[508|NOD] Create unique aria-labels on edit buttons

### DIFF
--- a/src/applications/appeals/10182/content/areaOfDisagreement.jsx
+++ b/src/applications/appeals/10182/content/areaOfDisagreement.jsx
@@ -50,20 +50,42 @@ export const issusDescription = ({ formContext }) => {
   );
 };
 
+const titles = {
+  serviceConnection: 'The service connection',
+  effectiveDate: 'The effective date of award',
+  evaluation: 'The evaluation of my condition',
+  other: 'Something else',
+};
+
 const wrapHeader = text => (
   <h3 className="vads-u-display--inline-block vads-u-font-size--base vads-u-font-family--sans vads-u-font-weight--normal vads-u-margin-y--0">
     {text}
   </h3>
 );
 
-export const serviceConnection = wrapHeader('The service connection');
-export const effectiveDate = wrapHeader('The effective date of award');
-export const evaluation = wrapHeader('The evaluation of my condition');
-export const other = wrapHeader('Something else');
+export const serviceConnection = wrapHeader(titles.serviceConnection);
+export const effectiveDate = wrapHeader(titles.effectiveDate);
+export const evaluation = wrapHeader(titles.evaluation);
+export const other = wrapHeader(titles.other);
 export const otherLabel = 'Tell us what you disagree with:';
 // Includes _{index} which is appended by the TextWidget
 export const otherDescription = ({ index }) => (
-  <span id={`other_hint_text_${index}`} className="vads-u-color--gray">
+  <div
+    id={`other_hint_text_${index}`}
+    className="vads-u-color--gray hide-on-review"
+  >
     Please explain in a few words
-  </span>
+  </div>
 );
+
+export const AreaOfDisagreementReviewField = ({ children }) =>
+  children?.props.formData ? (
+    <div className="review-row">
+      <dt>
+        <h5 className="vads-u-display--inline-block vads-u-font-size--base vads-u-font-family--sans vads-u-font-weight--normal vads-u-margin-y--0">
+          {titles[children.props.name]}
+        </h5>
+      </dt>
+      <dd>{children}</dd>
+    </div>
+  ) : null;

--- a/src/applications/appeals/10182/content/areaOfDisagreement.jsx
+++ b/src/applications/appeals/10182/content/areaOfDisagreement.jsx
@@ -57,11 +57,15 @@ const titles = {
   other: 'Something else',
 };
 
-const wrapHeader = text => (
-  <h3 className="vads-u-display--inline-block vads-u-font-size--base vads-u-font-family--sans vads-u-font-weight--normal vads-u-margin-y--0">
-    {text}
-  </h3>
-);
+const headerClasses = [
+  'vads-u-display--inline-block',
+  'vads-u-font-size--base',
+  'vads-u-font-family--sans',
+  'vads-u-font-weight--normal',
+  'vads-u-margin-y--0',
+].join(' ');
+
+const wrapHeader = text => <h3 className={headerClasses}>{text}</h3>;
 
 export const serviceConnection = wrapHeader(titles.serviceConnection);
 export const effectiveDate = wrapHeader(titles.effectiveDate);
@@ -82,9 +86,7 @@ export const AreaOfDisagreementReviewField = ({ children }) =>
   children?.props.formData ? (
     <div className="review-row">
       <dt>
-        <h5 className="vads-u-display--inline-block vads-u-font-size--base vads-u-font-family--sans vads-u-font-weight--normal vads-u-margin-y--0">
-          {titles[children.props.name]}
-        </h5>
+        <h5 className={headerClasses}>{titles[children.props.name]}</h5>
       </dt>
       <dd>{children}</dd>
     </div>

--- a/src/applications/appeals/10182/pages/areaOfDisagreement.js
+++ b/src/applications/appeals/10182/pages/areaOfDisagreement.js
@@ -5,6 +5,7 @@ import {
   effectiveDate,
   evaluation,
   other,
+  AreaOfDisagreementReviewField,
   otherLabel,
   otherDescription,
   missingAreaOfDisagreementErrorMessage,
@@ -16,6 +17,7 @@ import {
   otherTypeSelected,
   calculateOtherMaxLength,
 } from '../utils/disagreement';
+import { getIssueName } from '../utils/helpers';
 
 export default {
   uiSchema: {
@@ -29,6 +31,9 @@ export default {
           required: missingAreaOfDisagreementErrorMessage,
         },
         'ui:options': {
+          // Edit added issue button & specific area of disagreement edit button
+          // had duplicate aria-labels. This makes them unique
+          itemAriaLabel: data => `${getIssueName(data)} disagreement reasons`,
           // this will show error messages, but breaks the title (no formData)
           // see https://dsva.slack.com/archives/CBU0KDSB1/p1620840904269500
           // showFieldLabel: true,
@@ -36,27 +41,19 @@ export default {
         disagreementOptions: {
           serviceConnection: {
             'ui:title': serviceConnection,
-            'ui:options': {
-              hideEmptyValueInReview: true,
-            },
+            'ui:reviewField': AreaOfDisagreementReviewField,
           },
           effectiveDate: {
             'ui:title': effectiveDate,
-            'ui:options': {
-              hideEmptyValueInReview: true,
-            },
+            'ui:reviewField': AreaOfDisagreementReviewField,
           },
           evaluation: {
             'ui:title': evaluation,
-            'ui:options': {
-              hideEmptyValueInReview: true,
-            },
+            'ui:reviewField': AreaOfDisagreementReviewField,
           },
           other: {
             'ui:title': other,
-            'ui:options': {
-              hideEmptyValueInReview: true,
-            },
+            'ui:reviewField': AreaOfDisagreementReviewField,
           },
         },
         otherEntry: {


### PR DESCRIPTION
## Description

On the review & submit page, the edit button for an added issue "Edit {issue}" and the area of disagreement page edit button "Edit {issue}" have the same aria-label (see screenshot). These are made unique so a screen reader user can differentiate what is being edited.

Additionally the area of disagreement checkboxes included heading level 3 labels. These remain as `h3` s on the area of disagreement pages, but have been changed to an `h5` on the review & submit page

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/27096

## Testing done

Unit tests passing

## Screenshots

<details><summary>Before (duplicate <code>aria-label</code>)</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-07-08 at 12 13 56 PM](https://user-images.githubusercontent.com/136959/124975112-46096580-dff3-11eb-9af3-728db464405a.png)</details>

<details><summary>After</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-07-08 at 12 30 55 PM](https://user-images.githubusercontent.com/136959/124975106-443fa200-dff3-11eb-8d41-b7764142bb8b.png)</details>

## Acceptance criteria
- [x] Issue card edit button & area of disagreement edit button have unique aria labels
- [x] Heading levels increment properly on the review & submit page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
