### PR TITLE
Daily Deploy (Github Actions) -- fix getting latest tag information

### DIFF
--- a/.github/workflows/daily-production-deploy.yml
+++ b/.github/workflows/daily-production-deploy.yml
@@ -1,7 +1,6 @@
 name: Daily Production Deploy
 
 on:
-  push:
   workflow_dispatch:
     inputs:
       release_wait:

--- a/.github/workflows/daily-production-deploy.yml
+++ b/.github/workflows/daily-production-deploy.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Get latest tag
         id: get-latest-tag

--- a/.github/workflows/daily-production-deploy.yml
+++ b/.github/workflows/daily-production-deploy.yml
@@ -1,6 +1,7 @@
 name: Daily Production Deploy
 
 on:
+  push:
   workflow_dispatch:
     inputs:
       release_wait:
@@ -25,8 +26,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: Get latest tag
         id: get-latest-tag

--- a/.github/workflows/daily-production-deploy.yml
+++ b/.github/workflows/daily-production-deploy.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Get latest tag
         id: get-latest-tag
-        run: echo ::set-output name=LATEST_TAG_VERSION::$(git fetch --all --tags > /dev/null && git tag -l | sort -V --reverse | head -n 1)
+        run: echo ::set-output name=LATEST_TAG_VERSION::$(git describe --tags --abbrev=0)
 
       - name: Get release wait time (scheduled release)
         if: ${{ github.event.schedule != '' }}


### PR DESCRIPTION
## Description

With the latest command you get the following: `v0.1.1834`

Previous command got the following: `vets.gov-final`

## Testing done

Locally
