### PR TITLE
fixed router bug

### DIFF
--- a/src/applications/check-in/containers/withOnlyOnLocal.jsx
+++ b/src/applications/check-in/containers/withOnlyOnLocal.jsx
@@ -1,26 +1,15 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import { compose } from 'redux';
 
 import environment from 'platform/utilities/environment';
 
-import { checkInExperienceEnabled, loadingFeatureFlags } from '../selectors';
-
 const withOnlyOnLocal = WrappedComponent => props => {
   if (!environment.isLocalhost()) {
-    window.location.replace('/');
     return <></>;
   } else {
     return <WrappedComponent {...props} />;
   }
 };
-const mapStateToProps = state => ({
-  isCheckInEnabled: checkInExperienceEnabled(state),
-  isLoadingFeatureFlags: loadingFeatureFlags(state),
-});
 
-const composedWrapper = compose(
-  connect(mapStateToProps),
-  withOnlyOnLocal,
-);
+const composedWrapper = compose(withOnlyOnLocal);
 export default composedWrapper;


### PR DESCRIPTION
## Description
- Fixing the redirect bug in non-local environments 

### Problem 

When going to https://staging.va.gov/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287, the page is redirecting back to the home page

### Solution 

Removed the redirect caused by a copy and paste error. 

## Testing done
- Ran app in staging mode locally
