### PR TITLE
Fix ProfileInfoTable title x-padding and corner radii

### DIFF
--- a/src/applications/personalization/profile/components/ProfileInfoTable.jsx
+++ b/src/applications/personalization/profile/components/ProfileInfoTable.jsx
@@ -4,10 +4,30 @@ import PropTypes from 'prop-types';
 import prefixUtilityClasses from '~/platform/utilities/prefix-utility-classes';
 import { numberBetween } from '../../common/proptypeValidators';
 
-const TableTitle = ({ namedAnchor, className, children, level }) => {
+const titleClasses = prefixUtilityClasses([
+  'background-color--gray-lightest',
+  'border--1px',
+  'border-color--gray-lighter',
+  'color--gray-darkest',
+  'margin--0',
+  'padding-x--2',
+  'padding-y--1p5',
+  'font-size--h3',
+]);
+const titleClassesMedium = prefixUtilityClasses(
+  ['padding-x--4', 'padding-y--2'],
+  'medium',
+);
+const titleClassesCombined = [
+  ...titleClasses,
+  ...titleClassesMedium,
+  'heading',
+].join(' ');
+
+const TableTitle = ({ namedAnchor, children, level }) => {
   const Header = `h${level}`;
   return (
-    <Header className={className} id={namedAnchor}>
+    <Header className={titleClassesCombined} id={namedAnchor}>
       {children}
     </Header>
   );
@@ -23,21 +43,6 @@ const ProfileInfoTable = ({
 }) => {
   // TODO: move all these class var outside of the component so they aren't
   // recomputed on every render
-  const titleClasses = prefixUtilityClasses([
-    'background-color--gray-lightest',
-    'border--1px',
-    'border-color--gray-lighter',
-    'color--gray-darkest',
-    'margin--0',
-    'padding-x--2',
-    'padding-y--1p5',
-    'font-size--h3',
-  ]);
-  const titleClassesMedium = prefixUtilityClasses(
-    ['padding-x--3', 'padding-y--2'],
-    'medium',
-  );
-
   const tableRowClasses = prefixUtilityClasses([
     'border-color--gray-lighter',
     'color-gray-dark',
@@ -86,7 +91,6 @@ const ProfileInfoTable = ({
   // can be passed directly to a `className` attribute
   const classes = {
     table: ['profile-info-table', className].join(' '),
-    title: [...titleClasses, ...titleClassesMedium].join(' '),
     tableRow: ['table-row', ...tableRowClasses, ...tableRowClassesMedium].join(
       ' ',
     ),
@@ -99,11 +103,7 @@ const ProfileInfoTable = ({
   return (
     <section className={classes.table}>
       {title && (
-        <TableTitle
-          className={classes.title}
-          namedAnchor={namedAnchor}
-          level={level}
-        >
+        <TableTitle namedAnchor={namedAnchor} level={level}>
           {title}
         </TableTitle>
       )}

--- a/src/applications/personalization/profile/sass/profile-info-table.scss
+++ b/src/applications/personalization/profile/sass/profile-info-table.scss
@@ -1,7 +1,7 @@
 $corner-size: 4px;
 
 .profile-info-table {
-  h3 {
+  .heading {
     border-top-left-radius: $corner-size;
     border-top-right-radius: $corner-size;
   }


### PR DESCRIPTION
## Description
Makes a couple minor style adjustments to the ProfileInfoTable component

## Testing done
Local

## Screenshots
- [x] The top of the table has rounded corners like the bottom
- [x] The x-padding on the table title matches the table rows

<img width="650" alt="Screen Shot 2021-07-08 at 3 03 18 PM" src="https://user-images.githubusercontent.com/20728956/124996946-b23d9680-dffe-11eb-9c9c-1c13c8aa9eb2.png">
<img width="499" alt="Screen Shot 2021-07-08 at 3 03 29 PM" src="https://user-images.githubusercontent.com/20728956/124996962-b5d11d80-dffe-11eb-875d-6fba5bc07f28.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs