### PR TITLE
Remove redirect, add logic to handle empty searches

### DIFF
--- a/src/applications/search/actions/index.js
+++ b/src/applications/search/actions/index.js
@@ -1,6 +1,7 @@
 export const FETCH_SEARCH_RESULTS = 'FETCH_SEARCH_RESULTS';
 export const FETCH_SEARCH_RESULTS_SUCCESS = 'FETCH_SEARCH_RESULTS_SUCCESS';
 export const FETCH_SEARCH_RESULTS_FAILURE = 'FETCH_SEARCH_RESULTS_FAILURE';
+export const FETCH_SEARCH_RESULTS_EMPTY = 'FETCH_SEARCH_RESULTS_EMPTY';
 
 import { apiRequest } from 'platform/utilities/api';
 import recordEvent from 'platform/monitoring/record-event';
@@ -14,6 +15,11 @@ export function fetchSearchResults(query, page, options) {
 
     if (page) {
       queryString = queryString.concat(`&page=${page}`);
+    }
+    if (!query) {
+      return dispatch({
+        type: FETCH_SEARCH_RESULTS_EMPTY,
+      });
     }
 
     return apiRequest(queryString)

--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -47,10 +47,6 @@ class SearchApp extends React.Component {
       page: pageFromURL,
       typeaheadUsed,
     };
-
-    if (!userInputFromURL) {
-      window.location.href = '/';
-    }
   }
 
   componentDidMount() {
@@ -201,9 +197,6 @@ class SearchApp extends React.Component {
   renderResults() {
     const { loading, errors, currentPage, totalPages } = this.props.search;
     const hasErrors = !!(errors && errors.length > 0);
-    const nonBlankUserInput =
-      this.state.userInput &&
-      this.state.userInput.replace(/\s/g, '').length > 0;
 
     // Reusable search input
     const searchInput = (
@@ -224,7 +217,7 @@ class SearchApp extends React.Component {
             value={this.state.userInput}
             onChange={this.handleInputChange}
           />
-          <button type="submit" disabled={!nonBlankUserInput}>
+          <button type="submit">
             <IconSearch color="#fff" />
             <span className="button-text">Search</span>
           </button>
@@ -367,7 +360,7 @@ class SearchApp extends React.Component {
 
   renderResultsList() {
     const { results, loading } = this.props.search;
-
+    const query = this.props.router?.location?.query?.query || '';
     if (loading) {
       return <LoadingIndicator message="Loading results..." />;
     }
@@ -384,13 +377,25 @@ class SearchApp extends React.Component {
         </>
       );
     }
-
+    if (query) {
+      return (
+        <p
+          className={`${SCREENREADER_FOCUS_CLASSNAME}`}
+          data-e2e-id="search-results-empty"
+        >
+          We didn't find any results for "<strong>{query}</strong>
+          ." Try using different words or checking the spelling of the words
+          you're using.
+        </p>
+      );
+    }
     return (
       <p
         className={`${SCREENREADER_FOCUS_CLASSNAME}`}
         data-e2e-id="search-results-empty"
       >
-        Sorry, no results found. Try again using different (or fewer) words.
+        We didn't find any results. Enter a keyword in the search box to try
+        again.
       </p>
     );
   }

--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -195,7 +195,13 @@ class SearchApp extends React.Component {
   };
 
   renderResults() {
-    const { loading, errors, currentPage, totalPages } = this.props.search;
+    const {
+      loading,
+      errors,
+      currentPage,
+      totalPages,
+      results,
+    } = this.props.search;
     const hasErrors = !!(errors && errors.length > 0);
 
     // Reusable search input
@@ -254,12 +260,15 @@ class SearchApp extends React.Component {
         />
 
         <div className="va-flex results-footer">
-          <Pagination
-            onPageSelect={this.handlePageChange}
-            page={currentPage}
-            pages={totalPages}
-            maxPageListLength={5}
-          />
+          {results &&
+            results.length > 0 && (
+              <Pagination
+                onPageSelect={this.handlePageChange}
+                page={currentPage}
+                pages={totalPages}
+                maxPageListLength={5}
+              />
+            )}
           <span className="powered-by">Powered by Search.gov</span>
         </div>
       </div>

--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -305,6 +305,7 @@ class SearchApp extends React.Component {
       totalPages,
       totalEntries,
       loading,
+      results,
     } = this.props.search;
 
     let resultRangeEnd = currentPage * perPage;
@@ -346,24 +347,28 @@ class SearchApp extends React.Component {
 
     // regular display for how many search results total are available.
     /* eslint-disable prettier/prettier */
-    return (
-      <>
-        <h2
-          aria-live="polite"
-          aria-relevant="additions text"
-          className={`${SCREENREADER_FOCUS_CLASSNAME} vads-u-font-size--base vads-u-font-family--sans vads-u-color--gray-dark vads-u-font-weight--normal`}
-        >
-          Showing{' '}
-          {totalEntries === 0 ? '0' : `${resultRangeStart}-${resultRangeEnd}`}{' '}
-          of {totalEntries} results for "
-          <span className="vads-u-font-weight--bold">
-            {this.props.router.location.query.query}
-          </span>
-          "
-        </h2>
-        <hr className="vads-u-margin-y--3" aria-hidden="true" />
-      </>
-    );
+    if (results && results.length > 0) {
+      return (
+        <>
+          <h2
+            aria-live="polite"
+            aria-relevant="additions text"
+            className={`${SCREENREADER_FOCUS_CLASSNAME} vads-u-font-size--base vads-u-font-family--sans vads-u-color--gray-dark vads-u-font-weight--normal`}
+          >
+            Showing{' '}
+            {totalEntries === 0 ? '0' : `${resultRangeStart}-${resultRangeEnd}`}{' '}
+            of {totalEntries} results for "
+            <span className="vads-u-font-weight--bold">
+              {this.props.router.location.query.query}
+            </span>
+            "
+          </h2>
+          <hr className="vads-u-margin-y--3" aria-hidden="true" />
+        </>
+      );
+    }
+
+    return null;
     /* eslint-enable prettier/prettier */
   }
 

--- a/src/applications/search/reducers/index.js
+++ b/src/applications/search/reducers/index.js
@@ -2,6 +2,7 @@ import {
   FETCH_SEARCH_RESULTS,
   FETCH_SEARCH_RESULTS_SUCCESS,
   FETCH_SEARCH_RESULTS_FAILURE,
+  FETCH_SEARCH_RESULTS_EMPTY,
 } from '../actions';
 
 const initialState = {
@@ -57,6 +58,13 @@ function SearchReducer(state = initialState, action) {
         recommendedResults: undefined,
         errors: action.errors,
         results: undefined,
+        loading: false,
+      };
+    }
+
+    case FETCH_SEARCH_RESULTS_EMPTY: {
+      return {
+        ...state,
         loading: false,
       };
     }

--- a/src/applications/search/reducers/index.js
+++ b/src/applications/search/reducers/index.js
@@ -66,6 +66,7 @@ function SearchReducer(state = initialState, action) {
       return {
         ...state,
         loading: false,
+        spellingCorrection: undefined,
       };
     }
 

--- a/src/platform/site-wide/user-nav/components/SearchMenu.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchMenu.jsx
@@ -96,19 +96,6 @@ export class SearchMenu extends React.Component {
     this.setState({ suggestions: [], savedSuggestions: [] });
   };
 
-  isUserInputValid = () => {
-    const { userInput } = this.state;
-
-    // check to make sure user input isn't empty
-    const isCorrectLength =
-      userInput && userInput.replace(/\s/g, '').length > 0;
-    if (!isCorrectLength) {
-      return false;
-    }
-    // this will likely expand in the future
-    return true;
-  };
-
   getSuggestions = async () => {
     const { userInput } = this.state;
 
@@ -205,13 +192,9 @@ export class SearchMenu extends React.Component {
   // handle event logging and fire off a search query
   handleSearchEvent = suggestion => {
     const { suggestions, userInput, savedSuggestions } = this.state;
-    const { isUserInputValid } = this;
 
     const suggestionsList = [...suggestions, ...savedSuggestions];
-    // if the user tries to search with an empty input, escape early
-    if (!isUserInputValid()) {
-      return;
-    }
+
     // event logging, note suggestion will be undefined during a userInput search
     recordEvent({
       event: 'view_search_results',
@@ -271,7 +254,6 @@ export class SearchMenu extends React.Component {
       handleInputChange,
       handleSearchEvent,
       handleKeyUp,
-      isUserInputValid,
       formatSuggestion,
       handleSearchTab,
     } = this;
@@ -310,7 +292,6 @@ export class SearchMenu extends React.Component {
             <button
               type="submit"
               data-e2e-id="sitewide-search-submit-button"
-              disabled={!isUserInputValid()}
               className="vads-u-margin-left--0p25 vads-u-margin-right--0p5 "
             >
               <IconSearch color="#fff" />
@@ -361,7 +342,6 @@ export class SearchMenu extends React.Component {
               />
               <button
                 type="submit"
-                disabled={!isUserInputValid()}
                 id="sitewide-search-submit-button"
                 data-e2e-id="sitewide-search-submit-button"
                 className="vads-u-margin-left--0p5 vads-u-margin-y--1 vads-u-margin-right--1 vads-u-flex--1"

--- a/src/platform/site-wide/user-nav/tests/e2e/00-required.cypress.spec.js
+++ b/src/platform/site-wide/user-nav/tests/e2e/00-required.cypress.spec.js
@@ -79,17 +79,6 @@ describe('Site-wide Search general functionality', () => {
       .should('have.length', 5);
     axeTestPage();
   });
-
-  it('should have the search button disabled if no input is present', () => {
-    mockFeatureToggles();
-    mockFetchSuggestions();
-    cy.visit('/');
-    cy.get('button.sitewide-search-drop-down-panel-button').click();
-    cy.get('#query').click();
-    cy.get('[data-e2e-id="sitewide-search-submit-button"]').should(
-      'be.disabled',
-    );
-  });
 });
 
 describe('Site-wide Search functionality with typeahead disabled', () => {


### PR DESCRIPTION
## Description
This PR updates search functionality to match the UI consistency rework
- Removes the filter preventing users from searching with an empty query
- Removes the feature that disables search when query is empty
- adds logic to handle empty searches

## Testing done
local testing

## Related Tickets
https://github.com/department-of-veterans-affairs/va.gov-team/issues/24992
https://github.com/department-of-veterans-affairs/va.gov-team/issues/25264

