### PR TITLE
Allow long email addresses to wrap in Profile

### DIFF
--- a/src/applications/personalization/profile/components/personal-information/ContactInformationView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationView.jsx
@@ -23,10 +23,21 @@ const ContactInformationView = props => {
   if (fieldName === FIELD_NAMES.EMAIL) {
     // add zero-width spaces after @ and . symbols so very long email addresses
     // will wrap at those symbols if needed
-    const wrappableEmailAddress = data.emailAddress.replace(
-      /(@|\.)/g,
-      '$1\u200B',
-    );
+    // const wrappableEmailAddress = data.emailAddress.replace(
+    //   /(@|\.)/g,
+    //   '$1\u200B',
+    // );
+    const regex = /(@|\.)/;
+    const wrappableEmailAddress = data.emailAddress
+      .split(regex)
+      .map(
+        part =>
+          regex.test(part) ? (
+            <span className="email-address-symbol">{part}</span>
+          ) : (
+            part
+          ),
+      );
     return (
       <span style={{ wordBreak: 'break-word' }}>{wrappableEmailAddress}</span>
     );

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationView.jsx
@@ -21,12 +21,9 @@ const ContactInformationView = props => {
   }
 
   if (fieldName === FIELD_NAMES.EMAIL) {
-    // add zero-width spaces after @ and . symbols so very long email addresses
-    // will wrap at those symbols if needed
-    // const wrappableEmailAddress = data.emailAddress.replace(
-    //   /(@|\.)/g,
-    //   '$1\u200B',
-    // );
+    // Use the .email-address-symbol class to add a zero-width spaces after @
+    // and . symbols so very long email addresses will wrap at those symbols if
+    // needed
     const regex = /(@|\.)/;
     const wrappableEmailAddress = data.emailAddress
       .split(regex)

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationView.jsx
@@ -21,7 +21,15 @@ const ContactInformationView = props => {
   }
 
   if (fieldName === FIELD_NAMES.EMAIL) {
-    return <span>{data.emailAddress}</span>;
+    // add zero-width spaces after @ and . symbols so very long email addresses
+    // will wrap at those symbols if needed
+    const wrappableEmailAddress = data.emailAddress.replace(
+      /(@|\.)/g,
+      '$1\u200B',
+    );
+    return (
+      <span style={{ wordBreak: 'break-word' }}>{wrappableEmailAddress}</span>
+    );
   }
 
   if (phoneNumbers.includes(fieldName)) {

--- a/src/applications/personalization/profile/sass/personal-contact-information.scss
+++ b/src/applications/personalization/profile/sass/personal-contact-information.scss
@@ -3,3 +3,7 @@
 .profile-military-domestic {
   margin-left: 1.7em;
 }
+
+.email-address-symbol::after {
+  content: "\200B";
+}

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.delete-email-address.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.delete-email-address.unit.spec.jsx
@@ -13,8 +13,6 @@ import {
   wait,
 } from '../../unit-test-helpers';
 
-let wrappableEmailAddress;
-
 const ui = (
   <MemoryRouter>
     <PersonalInformation />
@@ -53,6 +51,7 @@ function deleteEmailAddress() {
 }
 
 describe('Deleting email address', () => {
+  const userNameRegex = /alongusername/;
   before(() => {
     server = setupServer(...mocks.deleteEmailAddressSuccess);
     server.listen();
@@ -60,8 +59,6 @@ describe('Deleting email address', () => {
   beforeEach(() => {
     window.VetsGov = { pollTimeout: 1 };
     const initialState = createBasicInitialState();
-    wrappableEmailAddress = 'me@me.com';
-    // wrappableEmailAddress = /me@.me\..com/i;
 
     view = renderWithProfileReducers(ui, {
       initialState,
@@ -100,7 +97,7 @@ describe('Deleting email address', () => {
     // the edit email button should still exist
     view.getByRole('button', { name: /edit.*email address/i });
     // and the email address should not exist
-    expect(view.queryByText(wrappableEmailAddress)).not.to.exist;
+    expect(view.queryByText(userNameRegex)).not.to.exist;
     // and the add email text should exist
     view.getByText(/add.*email address/i);
   });
@@ -125,7 +122,7 @@ describe('Deleting email address', () => {
     // the edit email button should still exist
     view.getByRole('button', { name: /edit.*email address/i });
     // and the email address should not exist
-    expect(view.queryByText(wrappableEmailAddress)).not.to.exist;
+    expect(view.queryByText(userNameRegex)).not.to.exist;
     // and the add email text should exist
     view.getByText(/add.*email address/i);
   });
@@ -209,7 +206,7 @@ describe('Deleting email address', () => {
     ).to.exist;
 
     // and the email address should still exist
-    expect(view.getByText(wrappableEmailAddress)).to.exist;
+    expect(view.getByText(userNameRegex)).to.exist;
     // and the edit email button should be back
     expect(getEditButton()).to.exist;
   });

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.delete-email-address.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.delete-email-address.unit.spec.jsx
@@ -13,7 +13,7 @@ import {
   wait,
 } from '../../unit-test-helpers';
 
-let emailAddress;
+let wrappableEmailAddress;
 
 const ui = (
   <MemoryRouter>
@@ -60,7 +60,8 @@ describe('Deleting email address', () => {
   beforeEach(() => {
     window.VetsGov = { pollTimeout: 1 };
     const initialState = createBasicInitialState();
-    emailAddress = initialState.user.profile.vapContactInfo.email.emailAddress;
+    wrappableEmailAddress = 'me@me.com';
+    // wrappableEmailAddress = /me@.me\..com/i;
 
     view = renderWithProfileReducers(ui, {
       initialState,
@@ -99,7 +100,7 @@ describe('Deleting email address', () => {
     // the edit email button should still exist
     view.getByRole('button', { name: /edit.*email address/i });
     // and the email address should not exist
-    expect(view.queryByText(emailAddress)).not.to.exist;
+    expect(view.queryByText(wrappableEmailAddress)).not.to.exist;
     // and the add email text should exist
     view.getByText(/add.*email address/i);
   });
@@ -124,7 +125,7 @@ describe('Deleting email address', () => {
     // the edit email button should still exist
     view.getByRole('button', { name: /edit.*email address/i });
     // and the email address should not exist
-    expect(view.queryByText(emailAddress)).not.to.exist;
+    expect(view.queryByText(wrappableEmailAddress)).not.to.exist;
     // and the add email text should exist
     view.getByText(/add.*email address/i);
   });
@@ -208,7 +209,7 @@ describe('Deleting email address', () => {
     ).to.exist;
 
     // and the email address should still exist
-    expect(view.getByText(emailAddress)).to.exist;
+    expect(view.getByText(wrappableEmailAddress)).to.exist;
     // and the edit email button should be back
     expect(getEditButton()).to.exist;
   });

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.edit-email-address.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.edit-email-address.unit.spec.jsx
@@ -17,8 +17,9 @@ import { beforeEach } from 'mocha';
 
 const errorText =
   'We’re sorry. We couldn’t update your contact email address. Please try again.';
-const newEmailAddress = 'new-address@domain.com';
-const wrappableEmailAddress = /new-address@.domain\..com/;
+const newUserName = 'newemailaddress';
+const newUserNameRegex = new RegExp(newUserName);
+const newEmailAddress = `${newUserName}@domain.com`;
 const ui = (
   <MemoryRouter>
     <PersonalInformation />
@@ -70,7 +71,7 @@ async function testQuickSuccess() {
   // the edit email button should exist
   expect(view.getByRole('button', { name: /edit.*email address/i })).to.exist;
   // and the new email address should exist in the DOM
-  expect(view.getByText(wrappableEmailAddress)).to.exist;
+  expect(view.getByText(newUserNameRegex)).to.exist;
   // and the add email button should be gone
   expect(view.queryByText(/add.*email address/i, { selector: 'button' })).not.to
     .exist;
@@ -103,7 +104,7 @@ async function testSlowSuccess() {
     }),
   ).to.exist;
   // and the new email address should exist in the DOM
-  expect(view.getByText(wrappableEmailAddress)).to.exist;
+  expect(view.getByText(newUserNameRegex)).to.exist;
   // and the add email button should be gone
   expect(view.queryByText(/add.*email address/i, { selector: 'button' })).not.to
     .exist;
@@ -171,7 +172,7 @@ async function testSlowFailure() {
   ).to.exist;
 
   // and the new email address should not exist in the DOM
-  expect(view.queryByText(wrappableEmailAddress)).not.to.exist;
+  expect(view.queryByText(newUserNameRegex)).not.to.exist;
   // and the add/edit email button should be back
   expect(getEditButton()).to.exist;
 }

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.edit-email-address.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.edit-email-address.unit.spec.jsx
@@ -18,6 +18,7 @@ import { beforeEach } from 'mocha';
 const errorText =
   'We’re sorry. We couldn’t update your contact email address. Please try again.';
 const newEmailAddress = 'new-address@domain.com';
+const wrappableEmailAddress = /new-address@.domain\..com/;
 const ui = (
   <MemoryRouter>
     <PersonalInformation />
@@ -69,7 +70,7 @@ async function testQuickSuccess() {
   // the edit email button should exist
   expect(view.getByRole('button', { name: /edit.*email address/i })).to.exist;
   // and the new email address should exist in the DOM
-  expect(view.getByText(newEmailAddress)).to.exist;
+  expect(view.getByText(wrappableEmailAddress)).to.exist;
   // and the add email button should be gone
   expect(view.queryByText(/add.*email address/i, { selector: 'button' })).not.to
     .exist;
@@ -102,7 +103,7 @@ async function testSlowSuccess() {
     }),
   ).to.exist;
   // and the new email address should exist in the DOM
-  expect(view.getByText(newEmailAddress)).to.exist;
+  expect(view.getByText(wrappableEmailAddress)).to.exist;
   // and the add email button should be gone
   expect(view.queryByText(/add.*email address/i, { selector: 'button' })).not.to
     .exist;
@@ -170,7 +171,7 @@ async function testSlowFailure() {
   ).to.exist;
 
   // and the new email address should not exist in the DOM
-  expect(view.queryByText(newEmailAddress)).not.to.exist;
+  expect(view.queryByText(wrappableEmailAddress)).not.to.exist;
   // and the add/edit email button should be back
   expect(getEditButton()).to.exist;
 }

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.unit.spec.jsx
@@ -81,6 +81,6 @@ describe('PersonalInformation', () => {
     expect(view.getByText('214-718-2112', { exact: false })).to.exist;
 
     expect(view.getByText(/to add a fax number/i)).to.exist;
-    expect(view.getByText('me@me.com')).to.exist;
+    expect(view.getByText(/me@.me\..com/)).to.exist;
   });
 });

--- a/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/personal-information/PersonalInformation.unit.spec.jsx
@@ -44,6 +44,8 @@ describe('PersonalInformation', () => {
 
   it('should render the correct contact based on what exists in the Redux state', () => {
     initialState = createBasicInitialState();
+    initialState.user.profile.vapContactInfo.email.emailAddress =
+      'alongusername@gmail.com';
 
     const {
       residentialAddress,
@@ -81,6 +83,6 @@ describe('PersonalInformation', () => {
     expect(view.getByText('214-718-2112', { exact: false })).to.exist;
 
     expect(view.getByText(/to add a fax number/i)).to.exist;
-    expect(view.getByText(/me@.me\..com/)).to.exist;
+    expect(view.getByText(/alongusername/)).to.exist;
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/fields-check.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/fields-check.cypress.spec.js
@@ -68,7 +68,9 @@ describe('Content on the personal information section in the profile', () => {
 
     // Check email
     cy.get('div[data-field-name="email"]')
-      .contains(/veteran@gmail.com/i)
+      .contains(/veteran@/)
+      .contains(/gmail/)
+      .contains(/com/)
       .should('exist');
   });
 });

--- a/src/applications/personalization/profile/tests/unit-test-helpers.js
+++ b/src/applications/personalization/profile/tests/unit-test-helpers.js
@@ -31,7 +31,7 @@ export function getBasicContactInfoState() {
   return {
     email: {
       createdAt: '2020-07-30T23:38:04.000+00:00',
-      emailAddress: 'me@me.com',
+      emailAddress: 'alongusername@me.com',
       effectiveEndDate: null,
       effectiveStartDate: '2020-07-30T23:38:03.000+00:00',
       id: 115097,


### PR DESCRIPTION
## Description
Long email addresses were breaking the Profile layout. This change causes long email addresses to wrap nicely. The email address wraps at places that make sense (after symbols) and only breaks in the middle of words if absolutely necessary.

## Testing done
Locally in Cypress. See screenshots below.

~This does create a super minor edge case that our team is aware of. If someone copied their email address from their Profile, the copied email address would include the zero-width spaces that make this nice wrapping possible. This would result in the copied email address actually being an invalid email address (email apps wouldn't be able to send a message to the copy/pasted email address). This seems like something that would almost never actually happen in real life. And the nicer wrapping this solution allows is worth that very very minor risk.~ This bug was resolved based on [this suggestion](https://github.com/department-of-veterans-affairs/vets-website/pull/17821#discussion_r667273037)

## Screenshots
BEFORE:
<img width="741" alt="124935269-81943780-dfd3-11eb-9f4f-3ef0ce57b157" src="https://user-images.githubusercontent.com/20728956/125105730-a05a0300-e093-11eb-9885-f8030a571070.png">

AFTER:
<img width="466" alt="Screen Shot 2021-07-08 at 3 48 10 PM" src="https://user-images.githubusercontent.com/20728956/125105641-87e9e880-e093-11eb-9cb1-0f895da43fe5.png">
<img width="466" alt="Screen Shot 2021-07-08 at 3 48 25 PM" src="https://user-images.githubusercontent.com/20728956/125105650-89b3ac00-e093-11eb-9720-21809d32c4ad.png">
<img width="466" alt="Screen Shot 2021-07-08 at 3 49 13 PM" src="https://user-images.githubusercontent.com/20728956/125105657-8c160600-e093-11eb-8b73-418a580a31f6.png">
<img width="466" alt="Screen Shot 2021-07-08 at 3 49 45 PM" src="https://user-images.githubusercontent.com/20728956/125105664-8e786000-e093-11eb-935d-3eabf0d94e29.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs