### PR TITLE
add unit test total coverage to coverage report

### DIFF
--- a/script/app-coverage-report.js
+++ b/script/app-coverage-report.js
@@ -19,7 +19,8 @@ const printCoverage = coverageResults => {
 
   // Add each app coverage result to the table
   Object.values(coverageResults).forEach(cov => {
-    const appLocation = cov.path.substr(0, cov.path.lastIndexOf('/'));
+    const appLocation =
+      cov.path.substr(0, cov.path.lastIndexOf('/')) || 'All Files';
 
     coverageTable.push({
       [appLocation]: [
@@ -34,7 +35,7 @@ const printCoverage = coverageResults => {
   console.log(coverageTable.toString());
 };
 
-const generateCoverage = (rootDir, coverageSummary) => {
+const generateAppCoverage = (rootDir, coverageSummary) => {
   // Get application manifests & entry names
   const manifests = getAppManifests(path.join(__dirname, '../'));
 
@@ -78,6 +79,18 @@ const generateCoverage = (rootDir, coverageSummary) => {
       });
       return acc;
     }, initialCoverage);
+};
+
+const generateCoverage = (rootDir, coverageSummary) => {
+  const appCoverage = generateAppCoverage(rootDir, coverageSummary);
+
+  return {
+    'all-files': {
+      path: '/',
+      ...coverageSummary.total,
+    },
+    ...appCoverage,
+  };
 };
 
 const logCoverage = coverageResults => {


### PR DESCRIPTION
## Description
Adds coverage metrics for all files to app unit test coverage report.

## Testing done


## Screenshots
<img width="649" alt="image" src="https://user-images.githubusercontent.com/12739849/125133726-46c5f880-e0d4-11eb-9d79-90049005eb79.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
