### PR TITLE
remove geo question for bedford c19 screener

### DIFF
--- a/src/applications/coronavirus-screener/config/questions.jsx
+++ b/src/applications/coronavirus-screener/config/questions.jsx
@@ -160,7 +160,7 @@ export const questions = [
       en: 'In the past 14 days, have you traveled outside of New England?',
       es: 'En los últimos 14 días, ¿ha viajado fuera de Nueva Inglaterra?',
     },
-    customId: ['523', '650', '689', '402', '405', '631', '518', '608', '478'],
+    customId: ['523', '650', '689', '402', '405', '631', '608', '478'],
   },
   {
     id: 'travel-ny',


### PR DESCRIPTION
## Description
Remove geography question for 518 (Bedford)


## Testing done
None (just being honest)

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
