### PR TITLE
Added ratings section to sandbox profile page

### DIFF
--- a/src/applications/gi-sandbox/components/profile/SchoolCategoryRating.jsx
+++ b/src/applications/gi-sandbox/components/profile/SchoolCategoryRating.jsx
@@ -54,20 +54,20 @@ export default function SchoolCategoryRating({
 
   return (
     <div className="vads-u-margin-right--0 category-rating">
-      <div className="rating vads-u-border-bottom--1px vads-u-border-color--gray-lighter">
+      <div className="rating">
         <button
           aria-expanded={open}
-          className="usa-accordion-button-ratings"
+          className="usa-accordion-button vads-u-border-bottom--1px vads-u-border-color--gray-lighter"
           onClick={onClick}
         >
           <div className="category-main vads-l-row medium-screen:vads-u-padding-left--1">
-            <div className="vads-l-col--6 vads-u-font-size--sm">{title}</div>
+            <div className="vads-l-col--6 vads-u-font-size--sm ">{title}</div>
             {categoryRating.averageRating && (
               <div className="vads-l-col--6 vads-u-font-size--sm">
                 <RatingsStars rating={categoryRating.averageRating} />
-                <span className="vads-u-font-weight--normal">
+                <div className="vads-u-font-weight--normal vads-u-display--inline vads-u-padding-left--1 vads-u-margin-right--1p5">
                   {averageStars.display}
-                </span>
+                </div>
               </div>
             )}
             {!categoryRating.averageRating && (

--- a/src/applications/gi-sandbox/components/profile/SchoolRatings.jsx
+++ b/src/applications/gi-sandbox/components/profile/SchoolRatings.jsx
@@ -121,9 +121,10 @@ export default function SchoolRatings({
           </div>
         </div>
         <div className="vads-u-padding-top--4 about-ratings">
-          <span className="vads-u-font-size--h3 vads-u-font-weight--bold vads-u-font-family--serif">
+          <div className="vads-u-font-size--h3 vads-u-padding-bottom--1p5 vads-u-font-weight--bold vads-u-font-family--serif">
             About ratings
-          </span>
+          </div>
+          <hr className="vads-u-margin-top--neg1px" />
           <p>
             We ask Veterans who have used their education benefits to rate
             schools they’ve attended on a scale of 1 to 5 stars, with 5 stars

--- a/src/applications/gi-sandbox/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi-sandbox/sass/partials/_gi-profile-page.scss
@@ -112,6 +112,7 @@
       padding-left: 0;
       padding-right: 0rem;
       background-position: right 1rem center;
+      width: 18.7em;
 
       @include media-maxwidth($medium-screen - 1) {
         background-position: right 1rem center;


### PR DESCRIPTION
## Description
As a developer, I need to update the "School Ratings" component so that it is consistent with other new components of the profile page on in the CT Redesign sandbox.
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/26736

## Testing done

local testing

## Screenshots
![Screen Shot 2021-07-13 at 9 59 14 AM](https://user-images.githubusercontent.com/50601724/125465074-7641cd5b-7e26-4df1-b375-72a41db8fb70.png)

## Acceptance criteria
- [x] The name of the component is "Veteran ratings".
- [x] "About ratings" has a horizontal rule between it and the content that follows.
- [x] The header has a border.
- [x] The component has a border.
- [x] The "Ratings" jump link in the header:
a. is replaced with "Veteran ratings"
b. scrolls the page to where the header of the "Veteran ratings" section is at the top of the viewport.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
