### PR TITLE
Add fifth podiatry speciality code

### DIFF
--- a/src/applications/vaos/services/mocks/var/cc_providers.json
+++ b/src/applications/vaos/services/mocks/var/cc_providers.json
@@ -441,7 +441,7 @@
         "uniqueId": "1255962510"
       },
       "relationships": {
-        "specialties": { "data": [{ "id": "363LP2300X", "type": "specialty" }] }
+        "specialties": { "data": [{ "id": "363LP2300X", "type": "specialty" }, { "id": "213ES0103X", "type": "specialty"}] }
       }
     },
     {

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
@@ -581,7 +581,7 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
     });
     mockCCProviderFetch(
       initialState.user.profile.vapContactInfo.residentialAddress,
-      ['213E00000X', '213EG0000X', '213EP1101X', '213ES0131X'],
+      ['213E00000X', '213EG0000X', '213EP1101X', '213ES0131X', '213ES0103X'],
       calculateBoundingBox(
         initialState.user.profile.vapContactInfo.residentialAddress.latitude,
         initialState.user.profile.vapContactInfo.residentialAddress.longitude,

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -139,7 +139,13 @@ export const TYPES_OF_CARE = [
     ccId: 'CCPOD',
     group: 'specialty',
     cceType: 'Podiatry',
-    specialties: ['213E00000X', '213EG0000X', '213EP1101X', '213ES0131X'],
+    specialties: [
+      '213E00000X',
+      '213EG0000X',
+      '213EP1101X',
+      '213ES0131X',
+      '213ES0103X',
+    ],
   },
   {
     id: 'SLEEP',


### PR DESCRIPTION
## Description

This PR adds a fifth podiatry speciality code.

## Testing done

- local, unit testing

## Screenshots

N/A

## Acceptance criteria
- [x] Update is behind VA Online Scheduling Provider Selection feature flag
- [x] If user selects Podiatry type of care, provider list results match at least one of the defined speciality codes

