### PR TITLE
Daily Deploy (Github Actions) -- change workflow order (notification)

### DIFF
--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -82,7 +82,6 @@ jobs:
   notify-start:
     name: Notify Start
     runs-on: ubuntu-latest
-    needs: validate-build-status
 
     steps:
       - name: Configure AWS credentials
@@ -130,7 +129,7 @@ jobs:
   create-release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: [set-env, notify-start]
+    needs: [set-env, notify-start, validate-build-status]
 
     steps:
       - name: Waiting to release 


### PR DESCRIPTION
## Description

Currently, in order for the notification to get sent on Slack, it must pass the `validate-build-status`. That being said, if the validate-build-status is still pending, until it passes/fails it could be mins/hours before notification, which could be misleading that the workflow is never triggered.

This PR does the following:
Send notification as soon as workflow gets triggered. Remainder of workflow remains the same (build only proceeds if `validate-build-status` succeeds)

