### PR TITLE
Github Actions (CI) -- Add concurrency

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,6 +10,10 @@ on:
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
 
+concurrency:
+  group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha  }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
## Description
- Cancel in-progress workflows from previous commits in feature branches.
- Allow concurrent workflows from all commits in master.

See [PR](https://github.com/department-of-veterans-affairs/content-build/pull/360) for more detail.

## Testing done

See PR mentioned above

