### PR TITLE
Add basic Notification Settings Cypress tests

### DIFF
--- a/src/applications/personalization/profile/tests/e2e/helpers.js
+++ b/src/applications/personalization/profile/tests/e2e/helpers.js
@@ -94,3 +94,15 @@ export function nameTagRendersWithoutDisabilityRating() {
   cy.findByText(/View disability rating/i).should('not.exist');
   cy.findByText(/service connected/i).should('not.exist');
 }
+
+export function registerCypressHelpers() {
+  // The main loading indicator is shown and is then removed
+  Cypress.Commands.add('loadingIndicatorWorks', () => {
+    // should show a loading indicator
+    cy.findByRole('progressbar', { name: /loading/i }).should('exist');
+    cy.injectAxeThenAxeCheck();
+
+    // and then the loading indicator should be removed
+    cy.findByRole('progressbar', { name: /loading/i }).should('not.exist');
+  });
+}

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/feature-gating.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/feature-gating.cypress.spec.js
@@ -2,9 +2,10 @@ import serviceHistory from '@@profile/tests/fixtures/service-history-success.jso
 import fullName from '@@profile/tests/fixtures/full-name-success.json';
 import error500 from '@@profile/tests/fixtures/500.json';
 
-import { mockUser } from '../fixtures/users/user';
-import { mockFeatureToggles } from './helpers';
-import { PROFILE_PATHS, PROFILE_PATH_NAMES } from '../../constants';
+import { PROFILE_PATHS, PROFILE_PATH_NAMES } from '../../../constants';
+import { mockUser } from '../../fixtures/users/user';
+
+import mockFeatureToggles from './feature-toggles.json';
 
 describe('Notification Settings', () => {
   beforeEach(() => {
@@ -19,7 +20,7 @@ describe('Notification Settings', () => {
   });
   context('when the feature flag is turned on', () => {
     it('is available in the side nav and the section loads', () => {
-      mockFeatureToggles();
+      cy.intercept('GET', '/v0/feature_toggles?*', mockFeatureToggles);
       // go to the root of the Profile
       cy.visit(PROFILE_PATHS.PROFILE_ROOT);
       // click on the Notification settings item in the side nav

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/feature-toggles.json
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/feature-toggles.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "type": "feature_toggles",
+    "features": [
+      {
+        "name": "profile_notification_settings",
+        "value": true
+      }
+    ]
+  }
+}

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/happy-loading-path.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/happy-loading-path.cypress.spec.js
@@ -1,0 +1,58 @@
+import { PROFILE_PATHS } from '@@profile/constants';
+
+import mockPatient from '@@profile/tests/fixtures/users/user-36.json';
+import mockNonPatient from '@@profile/tests/fixtures/users/user-non-patient.json';
+import mockCommunicationPreferences from '@@profile/tests/fixtures/communication-preferences/get-200-maximal.json';
+
+import { registerCypressHelpers } from '../helpers';
+
+import mockFeatureToggles from './feature-toggles.json';
+
+registerCypressHelpers();
+
+describe.skip('Notification Settings', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '/v0/feature_toggles?*', mockFeatureToggles);
+    cy.intercept('GET', '/v0/profile/communication_preferences', {
+      statusCode: 200,
+      body: mockCommunicationPreferences,
+    });
+  });
+  context('when user is a VA patient', () => {
+    it('should show the notification preferences groups with Health Care first', () => {
+      cy.login(mockPatient);
+      cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
+      cy.findByRole('heading', {
+        name: 'Notification settings',
+        level: 1,
+      }).should('exist');
+
+      cy.loadingIndicatorWorks();
+
+      cy.findByText('555-555-5559').should('exist');
+      cy.findByText('alongusername@domain.com').should('exist');
+      cy.findAllByTestId('notification-group')
+        .first()
+        .should('contain.text', 'Your health care');
+    });
+  });
+  context('when user is not a VA patient', () => {
+    it('should not show the Health Care notification group', () => {
+      cy.login(mockNonPatient);
+      cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
+      cy.findByRole('heading', {
+        name: 'Notification settings',
+        level: 1,
+      }).should('exist');
+
+      cy.loadingIndicatorWorks();
+
+      cy.findByText('555-555-5559').should('exist');
+      cy.findByText('alongusername@domain.com').should('exist');
+      cy.findAllByTestId('notification-group').should('have.length.above', 0);
+      cy.findAllByTestId('notification-group')
+        .first()
+        .should('not.contain.text', 'Your health care');
+    });
+  });
+});

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/loading-errors.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/loading-errors.cypress.spec.js
@@ -1,0 +1,62 @@
+import { PROFILE_PATHS } from '@@profile/constants';
+
+import mockUser from '@@profile/tests/fixtures/users/user-36.json';
+import { mockUser as mockUserVAPError } from '@@profile/tests/fixtures/users/user-vap-error.js';
+import error500 from '@@profile/tests/fixtures/500.json';
+
+import { registerCypressHelpers } from '../helpers';
+
+import mockFeatureToggles from './feature-toggles.json';
+
+registerCypressHelpers();
+
+describe.skip('Notification Settings - Load Errors', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '/v0/feature_toggles?*', mockFeatureToggles);
+  });
+  context('when VA Profile contact info is not available', () => {
+    it('should show an error message and not even try to fetch current notification preferences', () => {
+      const getCommPrefsStub = cy.stub();
+      cy.intercept('GET', 'v0/profile/communication_preferences', () => {
+        getCommPrefsStub();
+      });
+
+      cy.login(mockUserVAPError);
+      cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
+      cy.findByRole('heading', {
+        name: 'Notification settings',
+        level: 1,
+      }).should('exist');
+      cy.findByText(/We can’t access your.*settings at this time\./i).should(
+        'exist',
+      );
+      cy.should(() => {
+        expect(getCommPrefsStub).not.to.be.called;
+      });
+      cy.findAllByTestId('notification-group').should('not.exist');
+      cy.injectAxeThenAxeCheck();
+    });
+  });
+  context('when we cannot fetch current notification preferences', () => {
+    it('should show an error message', () => {
+      cy.intercept('GET', 'v0/profile/communication_preferences', {
+        statusCode: 500,
+        data: error500,
+      });
+      cy.login(mockUser);
+      cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
+      cy.findByRole('heading', {
+        name: 'Notification settings',
+        level: 1,
+      }).should('exist');
+
+      cy.loadingIndicatorWorks();
+      // and an error message appears
+      cy.findByText(/We can’t access your.*settings at this time\./i).should(
+        'exist',
+      );
+      cy.findAllByTestId('notification-group').should('not.exist');
+      cy.injectAxeThenAxeCheck();
+    });
+  });
+});

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/missing-contact-info.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/missing-contact-info.cypress.spec.js
@@ -1,0 +1,105 @@
+import { PROFILE_PATHS } from '@@profile/constants';
+
+import mockPatient from '@@profile/tests/fixtures/users/user-36.json';
+import mockCommunicationPreferences from '@@profile/tests/fixtures/communication-preferences/get-200-maximal.json';
+
+import { registerCypressHelpers } from '../helpers';
+
+import mockFeatureToggles from './feature-toggles.json';
+
+registerCypressHelpers();
+
+describe.skip('Notification Settings', () => {
+  let getCommPrefsStub;
+  beforeEach(() => {
+    getCommPrefsStub = cy.stub();
+    cy.intercept('GET', '/v0/feature_toggles?*', mockFeatureToggles);
+    cy.intercept('GET', '/v0/profile/communication_preferences', req => {
+      getCommPrefsStub();
+      req.reply({
+        statusCode: 200,
+        body: mockCommunicationPreferences,
+      });
+    });
+  });
+  context('when user is missing mobile phone', () => {
+    it('should show the correct messages', () => {
+      mockPatient.data.attributes.vet360ContactInformation.mobilePhone = null;
+      cy.login(mockPatient);
+      cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
+      cy.findByRole('heading', {
+        name: 'Notification settings',
+        level: 1,
+      }).should('exist');
+
+      cy.loadingIndicatorWorks();
+
+      cy.findByText('alongusername@domain.com').should('exist');
+      cy.findByTestId('missing-contact-info-alert')
+        .should('exist')
+        .and('contain.text', 'mobile phone');
+      cy.findByRole('link', { name: /update your contact info/i }).should(
+        'exist',
+      );
+      cy.findAllByRole('link', { name: /add your email address/i }).should(
+        'have.length.above',
+        0,
+      );
+      cy.findAllByTestId('notification-group').should('exist');
+    });
+  });
+  context('when user is missing email address', () => {
+    it('should show the correct messages', () => {
+      mockPatient.data.attributes.vet360ContactInformation.email = null;
+      cy.login(mockPatient);
+      cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
+      cy.findByRole('heading', {
+        name: 'Notification settings',
+        level: 1,
+      }).should('exist');
+
+      cy.loadingIndicatorWorks();
+
+      cy.findByText('555-555-5559').should('exist');
+      cy.findByTestId('missing-contact-info-alert')
+        .should('exist')
+        .and('contain.text', 'email address');
+      cy.findByRole('link', { name: /update your contact info/i }).should(
+        'exist',
+      );
+      cy.findAllByRole('link', { name: /add your mobile/i }).should(
+        'have.length.above',
+        0,
+      );
+      cy.findAllByTestId('notification-group').should('exist');
+    });
+  });
+  context('when user is missing both email address and mobile phone', () => {
+    it('should show the correct message, not attempt to fetch notification prefs, and hide all notification groups', () => {
+      mockPatient.data.attributes.vet360ContactInformation.email = null;
+      mockPatient.data.attributes.vet360ContactInformation.mobilePhone = null;
+      cy.login(mockPatient);
+      cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
+      cy.findByRole('heading', {
+        name: 'Notification settings',
+        level: 1,
+      }).should('exist');
+
+      // there should be no loading indicator
+      cy.findByRole('progressbar', { name: /loading/i }).should('not.exist');
+      cy.injectAxeThenAxeCheck();
+
+      cy.should(() => {
+        expect(getCommPrefsStub).not.to.be.called;
+      });
+      cy.findByTestId('missing-contact-info-alert')
+        .should('exist')
+        .and('contain.text', 'mobile phone')
+        .and('contain.text', 'email address');
+      cy.findByRole('link', { name: /update your contact info/i }).should(
+        'exist',
+      );
+      cy.findAllByTestId('notification-group').should('not.exist');
+    });
+  });
+});

--- a/src/applications/personalization/profile/tests/fixtures/communication-preferences/get-200-maximal.json
+++ b/src/applications/personalization/profile/tests/fixtures/communication-preferences/get-200-maximal.json
@@ -6,45 +6,21 @@
       "communicationGroups": [
         {
           "id": 1,
-          "name": "Health Care",
-          "description": "Healthcare Appointment Reminders",
+          "name": "Applications, claims, decision reviews, and appeals",
+          "description": null,
           "communicationItems": [
             {
               "id": 1,
-              "name": "Health Appointment Reminder",
+              "name": "Board of Veterans' Appeals hearing reminder",
               "communicationChannels": [
                 {
                   "id": 1,
                   "name": "Text",
                   "description": "SMS Notification",
                   "communicationPermission": {
-                    "id": 1728,
-                    "allowed": true
+                    "id": 4281,
+                    "allowed": false
                   }
-                }
-              ]
-            },
-            {
-              "id": 2,
-              "name": "RX Prescription Refill Reminder",
-              "communicationChannels": [
-                {
-                  "id": 1,
-                  "name": "Text",
-                  "description": "SMS Notification",
-                  "communicationPermission": { "id": 341, "allowed": true }
-                }
-              ]
-            },
-            {
-              "id": 3,
-              "name": "Scheduled Appointment Confirmation",
-              "communicationChannels": [
-                {
-                  "id": 1,
-                  "name": "Text",
-                  "description": "SMS Notification",
-                  "communicationPermission": { "id": 342, "allowed": true }
                 }
               ]
             }
@@ -52,19 +28,13 @@
         },
         {
           "id": 2,
-          "name": "Education and Training",
-          "description": "Education Submission Status",
+          "name": "General VA Updates and Information",
+          "description": null,
           "communicationItems": [
             {
-              "id": 4,
-              "name": "Form 22-1990 Submission Confirmation",
+              "id": 2,
+              "name": "COVID-19 Updates",
               "communicationChannels": [
-                {
-                  "id": 1,
-                  "name": "Text",
-                  "description": "SMS Notification",
-                  "communicationPermission": { "id": 729, "allowed": true }
-                },
                 {
                   "id": 2,
                   "name": "Email",
@@ -76,136 +46,28 @@
         },
         {
           "id": 3,
-          "name": "Disability",
-          "description": "Disability Status and Reminders",
+          "name": "Your health care",
+          "description": null,
           "communicationItems": [
             {
-              "id": 5,
-              "name": "Form 526-EZ Submission Confirmation",
-              "communicationChannels": [
-                {
-                  "id": 2,
-                  "name": "Email",
-                  "description": "Email Notification",
-                  "communicationPermission": { "id": 770, "allowed": true }
-                }
-              ]
-            },
-            {
-              "id": 6,
-              "name": "Disability Compensation Status Update",
-              "communicationChannels": [
-                {
-                  "id": 2,
-                  "name": "Email",
-                  "description": "Email Notification"
-                }
-              ]
-            },
-            {
-              "id": 7,
-              "name": "Compensation and Pension (C&P) Exam Reminder",
+              "id": 3,
+              "name": "Appointment reminders",
               "communicationChannels": [
                 {
                   "id": 1,
                   "name": "Text",
-                  "description": "SMS Notification",
-                  "communicationPermission": {
-                    "id": 1729,
-                    "allowed": true
-                  }
-                },
-                {
-                  "id": 2,
-                  "name": "Email",
-                  "description": "Email Notification",
-                  "communicationPermission": {
-                    "id": 1730,
-                    "allowed": false
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "id": 4,
-          "name": "Pension",
-          "description": "Pension Notifications",
-          "communicationItems": [
-            {
-              "id": 8,
-              "name": "Pension Payment Confirmation – Monthly",
-              "communicationChannels": [
-                {
-                  "id": 2,
-                  "name": "Email",
-                  "description": "Email Notification"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "id": 5,
-          "name": "Education and Training",
-          "description": "Education Notifications",
-          "communicationItems": [
-            {
-              "id": 9,
-              "name": "Education.Accession.Empty.A21.365",
-              "communicationChannels": [
-                {
-                  "id": 2,
-                  "name": "Email",
-                  "description": "Email Notification"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "id": 6,
-          "name": "Insurance",
-          "description": "Insurance Notifications",
-          "communicationItems": [
-            {
-              "id": 10,
-              "name": "Insurance.Accession.Married.A2.1",
-              "communicationChannels": [
-                {
-                  "id": 2,
-                  "name": "Email",
-                  "description": "Email Notification"
+                  "description": "SMS Notification"
                 }
               ]
             },
             {
-              "id": 11,
-              "name": "Insurance.Accession.Empty.A.1",
+              "id": 4,
+              "name": "Prescription shipment and tracking updates",
               "communicationChannels": [
                 {
-                  "id": 2,
-                  "name": "Email",
-                  "description": "Email Notification"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "id": 7,
-          "name": "Home Loan",
-          "description": "Home Loan Notifications",
-          "communicationItems": [
-            {
-              "id": 12,
-              "name": "HomeLoan.Accession.Empty.A15.270",
-              "communicationChannels": [
-                {
-                  "id": 2,
-                  "name": "Email",
-                  "description": "Email Notification"
+                  "id": 1,
+                  "name": "Text",
+                  "description": "SMS Notification"
                 }
               ]
             }

--- a/src/applications/personalization/profile/tests/fixtures/users/user-non-patient.json
+++ b/src/applications/personalization/profile/tests/fixtures/users/user-non-patient.json
@@ -27,9 +27,9 @@
         "gender": "M",
         "givenNames": ["Wesley", "Watson"],
         "isCernerPatient": false,
-        "facilities": [{ "facilityId": "983", "isCerner": false }],
-        "vaPatient": true,
-        "mhvAccountState": "OK"
+        "facilities": null,
+        "vaPatient": false,
+        "mhvAccountState": "NONE"
       },
       "veteranStatus": {
         "status": "OK",
@@ -39,18 +39,7 @@
       "inProgressForms": [],
       "prefillsAvailable": [],
       "vet360ContactInformation": {
-        "email": {
-          "createdAt": "2020-07-30T23:38:04.000+00:00",
-          "emailAddress": "alongusername@domain.com",
-          "effectiveEndDate": null,
-          "effectiveStartDate": "2020-07-30T23:38:03.000+00:00",
-          "id": 115097,
-          "sourceDate": "2020-07-30T23:38:03.000+00:00",
-          "sourceSystemUser": null,
-          "transactionId": "604abf55-422b-4f51-b33d-9fb38b4daad1",
-          "updatedAt": "2020-07-30T23:38:04.000+00:00",
-          "vet360Id": "1273780"
-        },
+        "email": null,
         "residentialAddress": {
           "addressLine1": "34 Blah st",
           "addressLine2": null,


### PR DESCRIPTION
## Description
This adds some Cypress tests for the Notification Settings section of the Profile that has not been built yet. It will serve as a good guide when I really start building out the Notification Settings section in the next day or two.

## Testing done
This is all tests.

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs