### PR TITLE
Don't run icon check on Draft PRs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,7 @@ name: Pull Request
 
 on: 
   pull_request:
-      types: [review_requested, ready_for_review, synchronize, edited, reopened, opened]
+    types: [review_requested, ready_for_review, synchronize, edited, reopened, opened]
 
 env:
   BOT_NAME: va-vfs-bot

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -71,7 +71,7 @@ jobs:
   icon-check:
     name: Icon Check
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: ${{ github.event.pull_request.draft == false }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,6 +1,8 @@
 name: Pull Request
 
-on: [pull_request]
+on: 
+  pull_request:
+      types: [review_requested, ready_for_review, synchronize, edited, reopened, opened]
 
 env:
   BOT_NAME: va-vfs-bot
@@ -69,6 +71,7 @@ jobs:
   icon-check:
     name: Icon Check
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
## Description
Addressing a request to have manual checks only run when a PR is ready for review.

Issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/26651

## Testing done
1. Open Draft PR (no icon checks) -> "Ready for review" (manual icon runs)
2. Open normal PR manual check runs)
3. Open Draft (no icon checks) -> -> "Ready for review" (manual icon runs) -> Edit PR (manual icon runs)