### PR TITLE
Update Profile table layouts so they pass the straw test

### DIFF
--- a/src/applications/personalization/profile/components/ProfileInfoTable.jsx
+++ b/src/applications/personalization/profile/components/ProfileInfoTable.jsx
@@ -51,10 +51,7 @@ const ProfileInfoTable = ({
     'padding-x--2',
     'padding-y--1p5',
   ]);
-  const tableRowClassesMedium = prefixUtilityClasses(
-    ['flex-direction--row', 'padding--4'],
-    'medium',
-  );
+  const tableRowClassesMedium = prefixUtilityClasses(['padding--4'], 'medium');
 
   const tableRowTitleClasses = prefixUtilityClasses([
     'font-family--sans',
@@ -64,28 +61,11 @@ const ProfileInfoTable = ({
     'margin--0',
     'margin-bottom--1',
   ]);
-  const tableRowTitleClassesMedium = prefixUtilityClasses(
-    ['margin-bottom--0', 'margin-right--2'],
-    'medium',
-  );
 
   const tableRowValueClasses = prefixUtilityClasses([
     'margin--0',
     'width--full',
   ]);
-
-  const tableRowValueClassesMedium = prefixUtilityClasses(
-    ['padding-left--5'],
-    'medium',
-  );
-
-  const dataContainsVerified = data.some(row => row.verified === true);
-
-  // When a table includes a 'Verified' checkmark in any of its rows, we need to add left padding to its values
-  // so that the data lines up correctly
-  const computedTableRowValueClasses = dataContainsVerified
-    ? [...tableRowValueClasses, ...tableRowValueClassesMedium].join(' ')
-    : [...tableRowValueClasses].join(' ');
 
   // an object where each value is a string of space-separated class names that
   // can be passed directly to a `className` attribute
@@ -94,10 +74,8 @@ const ProfileInfoTable = ({
     tableRow: ['table-row', ...tableRowClasses, ...tableRowClassesMedium].join(
       ' ',
     ),
-    tableRowTitle: [
-      ...tableRowTitleClasses,
-      ...tableRowTitleClassesMedium,
-    ].join(' '),
+    tableRowTitle: tableRowTitleClasses.join(' '),
+    tableRowValue: tableRowValueClasses.join(' '),
   };
 
   return (
@@ -129,9 +107,7 @@ const ProfileInfoTable = ({
               {row.verified && row.value}
 
               {!row.verified && (
-                <span className={computedTableRowValueClasses}>
-                  {row.value}
-                </span>
+                <span className={classes.tableRowValue}>{row.value}</span>
               )}
             </li>
           ))}

--- a/src/applications/personalization/profile/components/account-security/Verified.jsx
+++ b/src/applications/personalization/profile/components/account-security/Verified.jsx
@@ -12,7 +12,7 @@ const Verified = ({ children }) => (
       aria-hidden="true"
       role="img"
     />
-    <p className="vads-u-margin--0 vads-u-padding-left--1 medium-screen:vads-u-padding-left--3">
+    <p className="vads-u-margin--0 vads-u-padding-left--1 medium-screen:vads-u-padding-left--2">
       {children}
     </p>
   </span>

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
@@ -118,29 +118,13 @@ export const BankInfoCNP = ({
     saveBankInformation(payload, isDirectDepositSetUp);
   };
 
-  const bankInfoClasses = prefixUtilityClasses(
-    [
-      'display--flex',
-      'align-items--flex-start',
-      'flex-direction--row',
-      'justify-content--space-between',
-    ],
-    'medium',
-  );
-
   const editButtonClasses = [
     'usa-button-secondary',
     ...prefixUtilityClasses(['margin--0', 'margin-top--1p5', 'width--auto']),
   ];
 
-  const editButtonClassesMedium = prefixUtilityClasses(
-    ['flex--auto', 'margin-top--0', 'margin-left--4'],
-    'medium',
-  );
-
   const classes = {
-    bankInfo: [...bankInfoClasses].join(' '),
-    editButton: [...editButtonClasses, ...editButtonClassesMedium].join(' '),
+    editButton: editButtonClasses.join(' '),
   };
 
   const closeDDForm = () => {
@@ -154,7 +138,7 @@ export const BankInfoCNP = ({
 
   // When direct deposit is already set up we will show the current bank info
   const bankInfoContent = (
-    <div className={classes.bankInfo}>
+    <div>
       <dl className="vads-u-margin-y--0 vads-u-line-height--6">
         <dt className="sr-only">Bank name:</dt>
         <dd>{directDepositAccountInfo?.financialInstitutionName}</dd>
@@ -185,8 +169,10 @@ export const BankInfoCNP = ({
 
   // When direct deposit is not set up, we will show
   const notSetUpContent = (
-    <div className={classes.bankInfo}>
-      <span>Edit your profile to add your bank information.</span>
+    <div>
+      <p className="vads-u-margin--0">
+        Edit your profile to add your bank information.
+      </p>
       <button
         className={classes.editButton}
         aria-label={

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
@@ -111,29 +111,13 @@ export const DirectDepositEDU = ({
     saveBankInformation(payload);
   };
 
-  const bankInfoClasses = prefixUtilityClasses(
-    [
-      'display--flex',
-      'align-items--flex-start',
-      'flex-direction--row',
-      'justify-content--space-between',
-    ],
-    'medium',
-  );
-
   const editButtonClasses = [
     'usa-button-secondary',
     ...prefixUtilityClasses(['margin--0', 'margin-top--1p5', 'width--auto']),
   ];
 
-  const editButtonClassesMedium = prefixUtilityClasses(
-    ['flex--auto', 'margin-top--0', 'margin-left--4'],
-    'medium',
-  );
-
   const classes = {
-    bankInfo: [...bankInfoClasses].join(' '),
-    editButton: [...editButtonClasses, ...editButtonClassesMedium].join(' '),
+    editButton: editButtonClasses.join(' '),
   };
 
   const closeDDForm = () => {
@@ -147,7 +131,7 @@ export const DirectDepositEDU = ({
 
   // When direct deposit is set up we will show the current bank info
   const bankInfoContent = (
-    <div className={classes.bankInfo}>
+    <div>
       <dl className="vads-u-margin-y--0 vads-u-line-height--6">
         <dt className="sr-only">Bank name:</dt>
         <dd>{directDepositAccountInfo?.financialInstitutionName}</dd>

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
@@ -65,24 +65,14 @@ const wrapperClasses = prefixUtilityClasses([
   'align-items--flex-start',
 ]);
 
-const wrapperClassesMedium = prefixUtilityClasses(
-  ['flex-direction--row', 'justify-content--space-between'],
-  'medium',
-);
-
 const editButtonClasses = [
   'usa-button-secondary',
   ...prefixUtilityClasses(['width--auto', 'margin--0', 'margin-top--1p5']),
 ];
 
-const editButtonClassesMedium = prefixUtilityClasses(
-  ['flex--auto', 'margin-top--0', 'margin-left--4'],
-  'medium',
-);
-
 const classes = {
-  wrapper: [...wrapperClasses, ...wrapperClassesMedium].join(' '),
-  editButton: [...editButtonClasses, ...editButtonClassesMedium].join(' '),
+  wrapper: wrapperClasses.join(' '),
+  editButton: editButtonClasses.join(' '),
 };
 
 class ContactInformationField extends React.Component {


### PR DESCRIPTION
## Description
On medium+ screen sizes, the table rows now stack their content vertically rather than distribute them horizontally.

## Testing done
Locally in Cypress

## Screenshots
<img width="676" alt="Screen Shot 2021-07-14 at 5 18 45 PM" src="https://user-images.githubusercontent.com/20728956/125709350-3142f60c-2299-492a-adba-ad180b03ad75.png">
<img width="873" alt="Screen Shot 2021-07-14 at 5 19 27 PM" src="https://user-images.githubusercontent.com/20728956/125709360-c5947133-e953-4912-b9d8-a31874f03f71.png">
<img width="906" alt="Screen Shot 2021-07-14 at 5 17 36 PM" src="https://user-images.githubusercontent.com/20728956/125709367-394324fd-2245-429a-8e15-d5b2401deedb.png">
<img width="905" alt="Screen Shot 2021-07-14 at 5 17 48 PM" src="https://user-images.githubusercontent.com/20728956/125709383-ba695b2c-d5c9-4770-8bd2-1357b5b56f8a.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs