### PR TITLE
Make Profile buttons full width at smallest breakpoint

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
@@ -291,7 +291,7 @@ export const BankInfoCNP = ({
             aria-label="update your bank information for compensation and pension benefits"
             type="submit"
             loadingText="saving bank information"
-            className="usa-button-primary vads-u-margin-top--0"
+            className="usa-button-primary vads-u-margin-top--0 medium-screen:vads-u-width--auto"
             isLoading={directDepositUiState.isSaving}
           >
             Update
@@ -300,7 +300,7 @@ export const BankInfoCNP = ({
             aria-label="cancel updating your bank information for compensation and pension benefits"
             type="button"
             disabled={directDepositUiState.isSaving}
-            className="usa-button-secondary vads-u-margin-top--0"
+            className="usa-button-secondary small-screen:vads-u-margin-top--0"
             onClick={closeDDForm}
             data-qa="cancel-button"
           >

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoCNP.jsx
@@ -120,7 +120,7 @@ export const BankInfoCNP = ({
 
   const editButtonClasses = [
     'usa-button-secondary',
-    ...prefixUtilityClasses(['margin--0', 'margin-top--1p5', 'width--auto']),
+    ...prefixUtilityClasses(['margin--0', 'margin-top--1p5']),
   ];
 
   const classes = {
@@ -291,7 +291,7 @@ export const BankInfoCNP = ({
             aria-label="update your bank information for compensation and pension benefits"
             type="submit"
             loadingText="saving bank information"
-            className="usa-button-primary vads-u-margin-top--0 vads-u-width--auto"
+            className="usa-button-primary vads-u-margin-top--0"
             isLoading={directDepositUiState.isSaving}
           >
             Update
@@ -300,7 +300,7 @@ export const BankInfoCNP = ({
             aria-label="cancel updating your bank information for compensation and pension benefits"
             type="button"
             disabled={directDepositUiState.isSaving}
-            className="usa-button-secondary vads-u-width--auto"
+            className="usa-button-secondary vads-u-margin-top--0"
             onClick={closeDDForm}
             data-qa="cancel-button"
           >

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
@@ -249,7 +249,7 @@ export const DirectDepositEDU = ({
             aria-label="update your bank information for education benefits"
             type="submit"
             loadingText="saving bank information"
-            className="usa-button-primary vads-u-margin-top--0"
+            className="usa-button-primary vads-u-margin-top--0 medium-screen:vads-u-width--auto"
             isLoading={directDepositUiState.isSaving}
           >
             Update
@@ -258,7 +258,7 @@ export const DirectDepositEDU = ({
             aria-label="cancel updating your bank information for education benefits"
             type="button"
             disabled={directDepositUiState.isSaving}
-            className="usa-button-secondary vads-u-margin-top--0"
+            className="usa-button-secondary small-screen:vads-u-margin-top--0"
             onClick={closeDDForm}
             data-qa="cancel-button"
           >

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfoEDU.jsx
@@ -113,7 +113,7 @@ export const DirectDepositEDU = ({
 
   const editButtonClasses = [
     'usa-button-secondary',
-    ...prefixUtilityClasses(['margin--0', 'margin-top--1p5', 'width--auto']),
+    ...prefixUtilityClasses(['margin--0', 'margin-top--1p5']),
   ];
 
   const classes = {
@@ -249,7 +249,7 @@ export const DirectDepositEDU = ({
             aria-label="update your bank information for education benefits"
             type="submit"
             loadingText="saving bank information"
-            className="usa-button-primary vads-u-margin-top--0 vads-u-width--auto"
+            className="usa-button-primary vads-u-margin-top--0"
             isLoading={directDepositUiState.isSaving}
           >
             Update
@@ -258,7 +258,7 @@ export const DirectDepositEDU = ({
             aria-label="cancel updating your bank information for education benefits"
             type="button"
             disabled={directDepositUiState.isSaving}
-            className="usa-button-secondary vads-u-width--auto"
+            className="usa-button-secondary vads-u-margin-top--0"
             onClick={closeDDForm}
             data-qa="cancel-button"
           >

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationActionButtons.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationActionButtons.jsx
@@ -102,13 +102,15 @@ function ContactInformationActionButtons(props) {
   const renderDeleteAction = () => {
     if (props.deleteEnabled) {
       return (
-        <button
-          type="button"
-          className="va-button-link vads-u-margin-top--1p5"
-          onClick={handleDeleteInitiated}
-        >
-          Remove {toLower(props.title)}
-        </button>
+        <div>
+          <button
+            type="button"
+            className="vads-u-margin--0 usa-button-secondary"
+            onClick={handleDeleteInitiated}
+          >
+            Remove {toLower(props.title)}
+          </button>
+        </div>
       );
     }
 

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationActionButtons.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationActionButtons.jsx
@@ -105,7 +105,7 @@ function ContactInformationActionButtons(props) {
         <div>
           <button
             type="button"
-            className="vads-u-margin--0 usa-button-secondary"
+            className="vads-u-margin--0 vads-u-margin-top--1 usa-button-secondary"
             onClick={handleDeleteInitiated}
           >
             Remove {toLower(props.title)}

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationEditView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationEditView.jsx
@@ -338,7 +338,7 @@ export class ContactInformationEditView extends Component {
                   {!isLoading && (
                     <button
                       type="button"
-                      className="usa-button-secondary vads-u-margin-top--0"
+                      className="usa-button-secondary small-screen:vads-u-margin-top--0"
                       onClick={onCancel}
                     >
                       Cancel

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationEditView.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationEditView.jsx
@@ -330,7 +330,7 @@ export class ContactInformationEditView extends Component {
                     data-testid="save-edit-button"
                     isLoading={isLoading}
                     loadingText="Saving changes"
-                    className="vads-u-width--auto vads-u-margin-top--0"
+                    className="vads-u-margin-top--0"
                   >
                     Update
                   </LoadingButton>
@@ -338,7 +338,7 @@ export class ContactInformationEditView extends Component {
                   {!isLoading && (
                     <button
                       type="button"
-                      className="usa-button-secondary vads-u-margin-top--0 vads-u-width--auto"
+                      className="usa-button-secondary vads-u-margin-top--0"
                       onClick={onCancel}
                     >
                       Cancel

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
@@ -67,7 +67,7 @@ const wrapperClasses = prefixUtilityClasses([
 
 const editButtonClasses = [
   'usa-button-secondary',
-  ...prefixUtilityClasses(['width--auto', 'margin--0', 'margin-top--1p5']),
+  ...prefixUtilityClasses(['margin--0', 'margin-top--1p5']),
 ];
 
 const classes = {


### PR DESCRIPTION
## Description
This makes all buttons on the Profile full width at the smallest responsive breakpoint, as they should be.

This also makes the Remove button look like a button (rather than a link). But I need to hear back from design to make sure it looks fine with these changes.

## Testing done
Locally

## Screenshots
<img width="345" alt="Screen Shot 2021-07-14 at 6 01 45 PM" src="https://user-images.githubusercontent.com/20728956/125712244-7362b91f-908f-4b93-b4b6-02b4d7b640c0.png">
<img width="435" alt="Screen Shot 2021-07-16 at 6 52 37 AM" src="https://user-images.githubusercontent.com/20728956/125959974-3c8186cc-bac6-4a35-b1ac-5e7e3ddc4ec2.png">
<img width="620" alt="Screen Shot 2021-07-16 at 6 52 26 AM" src="https://user-images.githubusercontent.com/20728956/125959992-f9e3de33-88bf-4b77-b19e-211cc9fde7ef.png">
<img width="401" alt="Screen Shot 2021-07-14 at 6 07 22 PM" src="https://user-images.githubusercontent.com/20728956/125712288-8d33931a-08ad-4510-8f88-b855ef54763d.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs