### PR TITLE
Allow `*` in ui:order properties

### DIFF
--- a/src/platform/forms-system/src/js/helpers.js
+++ b/src/platform/forms-system/src/js/helpers.js
@@ -372,6 +372,7 @@ export function getNonArraySchema(schema, uiSchema = {}) {
       const schemaPropertyKeys = Object.keys(newSchema.properties);
       const newUiSchema = Object.assign({}, uiSchema);
       newUiSchema['ui:order'] = uiSchema['ui:order']?.filter(item => {
+        // check item === '*' here?
         return schemaPropertyKeys.includes(item);
       });
 

--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -35,12 +35,14 @@ class ObjectField extends React.Component {
       properties =>
         orderProperties(
           properties,
-          this.props.uiSchema['ui:order']?.filter(prop =>
-            // `view:*` properties will have been removed from the schema and
-            // values by the time they reach this component. This removes them
-            // from the ui:order so we don't trigger an error in the
-            // react-json-schema library for having "extraneous properties."
-            Object.keys(this.props.schema.properties).includes(prop),
+          this.props.uiSchema['ui:order']?.filter(
+            prop =>
+              // `view:*` properties will have been removed from the schema and
+              // values by the time they reach this component. This removes them
+              // from the ui:order so we don't trigger an error in the
+              // react-json-schema library for having "extraneous properties."
+              prop === '*' ||
+              Object.keys(this.props.schema.properties).includes(prop),
           ),
         ),
       _.groupBy(item => {

--- a/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
@@ -66,6 +66,42 @@ describe('Schemaform review: ObjectField', () => {
     expect(tree.getByRole('textbox')).to.exist;
   });
 
+  it('should render fields when `*` is in the ui:order', () => {
+    const onChange = sinon.spy();
+    const onBlur = sinon.spy();
+
+    const schema = {
+      properties: {
+        test: {
+          type: 'string',
+        },
+        test2: {
+          type: 'string',
+        },
+        test3: {
+          type: 'string',
+        },
+      },
+    };
+
+    const uiSchema = {
+      'ui:order': ['test', '*'],
+    };
+
+    const tree = render(
+      <ObjectField
+        schema={schema}
+        uiSchema={uiSchema}
+        idSchema={{}}
+        requiredSchema={{}}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+
+    expect(tree.getAllByRole('textbox')).to.have.lengthOf(3);
+  });
+
   it('should not render hidden field', () => {
     const onChange = sinon.spy();
     const onBlur = sinon.spy();


### PR DESCRIPTION
## Description

In the Pre-need form, a `ui:order` definition is set using `['serviceBranch', '*']` where the `*` was causing a JS error causing the review & submit page to not render - see screenshot.

Previous work in 4/21 did not include the `*` item. And it appears that the pre-need form is the _only_ form currently including `*` in the `ui:order`.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/25109
- https://github.com/department-of-veterans-affairs/vets-website/pull/16818
- https://github.com/department-of-veterans-affairs/react-jsonschema-form#object-fields-ordering
- https://dsva.slack.com/archives/CBU0KDSB1/p1626359251129400

## Testing done

Updated unit test

## Screenshots

![Screen Shot 2021-07-15 at 11 12 21 AM](https://user-images.githubusercontent.com/136959/125821424-c5f91e46-5236-4bf1-ab72-62cf3a954e7c.png)

## Acceptance criteria
- [x] Including `*` in the `ui:order` does not throw a JS error

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
