### PR TITLE
Record GA events when GET claims succeeds/fails/times out

### DIFF
--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -5,7 +5,7 @@ import recordEvent from 'platform/monitoring/record-event';
 import environment from 'platform/utilities/environment';
 import localStorage from 'platform/utilities/storage/localStorage';
 import { apiRequest } from 'platform/utilities/api';
-import { makeAuthRequest } from '../utils/helpers';
+import { makeAuthRequest, roundToNearest } from '../utils/helpers';
 import {
   getErrorStatus,
   USER_FORBIDDEN_ERROR,
@@ -192,6 +192,32 @@ export function getSyncStatus(claimsAsyncResponse) {
   return get('meta.syncStatus', claimsAsyncResponse, null);
 }
 
+// TODO: waiting on confirmation from Brian Martin that:
+// 1. The analytics event keys should be snake_case
+// 2. The `api_latency_ms` key is a good name and it can accept numbers
+// 3. We can record api latency when the API fails or times out
+// https://github.com/department-of-veterans-affairs/va.gov-team/issues/26703
+const recordClaimsAPIEvent = ({ startTime, success, error }) => {
+  /* eslint-disable camelcase */
+  const event = {
+    event: 'api_call',
+    api_name: 'GET claims',
+    api_status: success ? 'successful' : 'failed',
+  };
+  if (error) {
+    event['error-key'] = error;
+  }
+  if (startTime) {
+    const apiLatencyMs = roundToNearest({
+      interval: 5000,
+      value: Date.now() - startTime,
+    });
+    event.api_latency_ms = apiLatencyMs;
+  }
+  /* eslint-enable camelcase */
+  recordEvent(event);
+};
+
 export function getClaimsV2(options = {}) {
   // Throw an error if an unsupported value is on the `options` object
   const recognizedOptions = ['poll', 'pollingExpiration'];
@@ -205,6 +231,7 @@ export function getClaimsV2(options = {}) {
     }
   });
   const { poll = pollRequest, pollingExpiration } = options;
+  const startTimestampMs = Date.now();
   return dispatch => {
     dispatch({ type: FETCH_CLAIMS_PENDING });
 
@@ -219,9 +246,30 @@ export function getClaimsV2(options = {}) {
             );
           });
         }
+        // This onError callback will be called with a null response arg when
+        // the API takes too long to return data
+        if (response === null) {
+          recordClaimsAPIEvent({
+            startTime: startTimestampMs,
+            success: false,
+            error: '504 Timed out - API took too long',
+          });
+        } else {
+          recordClaimsAPIEvent({
+            startTime: startTimestampMs,
+            success: false,
+            error: errorCode,
+          });
+        }
         dispatch({ type: FETCH_CLAIMS_ERROR });
       },
-      onSuccess: response => dispatch(fetchClaimsSuccess(response)),
+      onSuccess: response => {
+        recordClaimsAPIEvent({
+          startTime: startTimestampMs,
+          success: true,
+        });
+        dispatch(fetchClaimsSuccess(response));
+      },
       pollingExpiration,
       pollingInterval: window.VetsGov.pollTimeout || 5000,
       shouldFail: response => getSyncStatus(response) === 'FAILED',

--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -192,17 +192,11 @@ export function getSyncStatus(claimsAsyncResponse) {
   return get('meta.syncStatus', claimsAsyncResponse, null);
 }
 
-// TODO: waiting on confirmation from Brian Martin that:
-// 1. The analytics event keys should be snake_case
-// 2. The `api_latency_ms` key is a good name and it can accept numbers
-// 3. We can record api latency when the API fails or times out
-// https://github.com/department-of-veterans-affairs/va.gov-team/issues/26703
 const recordClaimsAPIEvent = ({ startTime, success, error }) => {
-  /* eslint-disable camelcase */
   const event = {
     event: 'api_call',
-    api_name: 'GET claims',
-    api_status: success ? 'successful' : 'failed',
+    'api-name': 'GET claims',
+    'api-status': success ? 'successful' : 'failed',
   };
   if (error) {
     event['error-key'] = error;
@@ -212,9 +206,8 @@ const recordClaimsAPIEvent = ({ startTime, success, error }) => {
       interval: 5000,
       value: Date.now() - startTime,
     });
-    event.api_latency_ms = apiLatencyMs;
+    event['api-latency-ms'] = apiLatencyMs;
   }
-  /* eslint-enable camelcase */
   recordEvent(event);
 };
 

--- a/src/applications/claims-status/tests/actions.unit.spec.js
+++ b/src/applications/claims-status/tests/actions.unit.spec.js
@@ -306,15 +306,13 @@ describe('Actions', () => {
 
         pollStatusSpy.firstCall.args[0].onError({ errors: [] });
 
-        /* eslint-disable camelcase */
         expect(global.window.dataLayer[0]).to.eql({
           event: 'api_call',
-          api_name: 'GET claims',
-          api_status: 'failed',
+          'api-name': 'GET claims',
+          'api-status': 'failed',
           'error-key': 'unknown',
-          api_latency_ms: 0,
+          'api-latency-ms': 0,
         });
-        /* eslint-enable camelcase */
       });
     });
     describe('onSuccess callback', () => {
@@ -334,14 +332,12 @@ describe('Actions', () => {
 
         pollStatusSpy.firstCall.args[0].onSuccess({ data: [] });
 
-        /* eslint-disable camelcase */
         expect(global.window.dataLayer[0]).to.eql({
           event: 'api_call',
-          api_name: 'GET claims',
-          api_status: 'successful',
-          api_latency_ms: 0,
+          'api-name': 'GET claims',
+          'api-status': 'successful',
+          'api-latency-ms': 0,
         });
-        /* eslint-enable camelcase */
       });
     });
     describe('shouldFail predicate', () => {

--- a/src/applications/claims-status/tests/actions.unit.spec.js
+++ b/src/applications/claims-status/tests/actions.unit.spec.js
@@ -269,9 +269,20 @@ describe('Actions', () => {
     });
   });
   describe('getClaimsV2', () => {
+    let dispatchSpy;
+    let pollStatusSpy;
+    let oldDataLayer;
+    beforeEach(() => {
+      oldDataLayer = global.window.dataLayer;
+      global.window.dataLayer = [];
+      dispatchSpy = sinon.spy();
+      pollStatusSpy = sinon.spy();
+    });
+    afterEach(() => {
+      global.window.dataLayer = oldDataLayer;
+    });
+
     it('should call dispatch and pollStatus', () => {
-      const dispatchSpy = sinon.spy();
-      const pollStatusSpy = sinon.spy();
       getClaimsV2({ poll: pollStatusSpy })(dispatchSpy);
 
       expect(dispatchSpy.firstCall.args[0]).to.eql({
@@ -282,8 +293,6 @@ describe('Actions', () => {
 
     describe('onError callback', () => {
       it('should dispatch a FETCH_CLAIMS_ERROR action', () => {
-        const dispatchSpy = sinon.spy();
-        const pollStatusSpy = sinon.spy();
         getClaimsV2({ poll: pollStatusSpy })(dispatchSpy);
 
         pollStatusSpy.firstCall.args[0].onError({ errors: [] });
@@ -292,11 +301,24 @@ describe('Actions', () => {
           type: 'FETCH_CLAIMS_ERROR',
         });
       });
+      it('should record the correct event to the data layer', () => {
+        getClaimsV2({ poll: pollStatusSpy })(dispatchSpy);
+
+        pollStatusSpy.firstCall.args[0].onError({ errors: [] });
+
+        /* eslint-disable camelcase */
+        expect(global.window.dataLayer[0]).to.eql({
+          event: 'api_call',
+          api_name: 'GET claims',
+          api_status: 'failed',
+          'error-key': 'unknown',
+          api_latency_ms: 0,
+        });
+        /* eslint-enable camelcase */
+      });
     });
     describe('onSuccess callback', () => {
       it('should dispatch a FETCH_CLAIMS_SUCCESS action', () => {
-        const dispatchSpy = sinon.spy();
-        const pollStatusSpy = sinon.spy();
         getClaimsV2({ poll: pollStatusSpy })(dispatchSpy);
 
         pollStatusSpy.firstCall.args[0].onSuccess({ data: [] });
@@ -307,11 +329,23 @@ describe('Actions', () => {
           pages: 0,
         });
       });
+      it('should record the correct event to the data layer', () => {
+        getClaimsV2({ poll: pollStatusSpy })(dispatchSpy);
+
+        pollStatusSpy.firstCall.args[0].onSuccess({ data: [] });
+
+        /* eslint-disable camelcase */
+        expect(global.window.dataLayer[0]).to.eql({
+          event: 'api_call',
+          api_name: 'GET claims',
+          api_status: 'successful',
+          api_latency_ms: 0,
+        });
+        /* eslint-enable camelcase */
+      });
     });
     describe('shouldFail predicate', () => {
       it('should return true when response.meta.syncStatus is FAILED', () => {
-        const dispatchSpy = sinon.spy();
-        const pollStatusSpy = sinon.spy();
         getClaimsV2({ poll: pollStatusSpy })(dispatchSpy);
 
         const shouldFail = pollStatusSpy.firstCall.args[0].shouldFail({
@@ -321,8 +355,6 @@ describe('Actions', () => {
         expect(shouldFail).to.be.true;
       });
       it('should return false when response.meta.syncStatus is not FAILED', () => {
-        const dispatchSpy = sinon.spy();
-        const pollStatusSpy = sinon.spy();
         getClaimsV2({ poll: pollStatusSpy })(dispatchSpy);
 
         const shouldFail = pollStatusSpy.firstCall.args[0].shouldFail({});
@@ -332,8 +364,6 @@ describe('Actions', () => {
     });
     describe('shouldSucceed predicate', () => {
       it('should return true when response.meta.syncStatus is SUCCESS', () => {
-        const dispatchSpy = sinon.spy();
-        const pollStatusSpy = sinon.spy();
         getClaimsV2({ poll: pollStatusSpy })(dispatchSpy);
 
         const shouldSucceed = pollStatusSpy.firstCall.args[0].shouldSucceed({
@@ -343,8 +373,6 @@ describe('Actions', () => {
         expect(shouldSucceed).to.be.true;
       });
       it('should return false when response.meta.syncStatus is not SUCCESS', () => {
-        const dispatchSpy = sinon.spy();
-        const pollStatusSpy = sinon.spy();
         getClaimsV2({ poll: pollStatusSpy })(dispatchSpy);
 
         const shouldSucceed = pollStatusSpy.firstCall.args[0].shouldSucceed({});

--- a/src/applications/claims-status/tests/utils/helpers.unit.spec.js
+++ b/src/applications/claims-status/tests/utils/helpers.unit.spec.js
@@ -18,6 +18,7 @@ import {
   makeAuthRequest,
   getClaimType,
   mockData,
+  roundToNearest,
 } from '../../utils/helpers';
 
 import {
@@ -662,6 +663,14 @@ describe('Disability benefits helpers: ', () => {
     it('should return undefined if no appeal matches the id given', () => {
       const appeal = isolateAppeal(state, 'non-existent id');
       expect(appeal).to.be.undefined;
+    });
+  });
+
+  describe('roundToNearest', () => {
+    it('returns a number rounded to the nearest interval', () => {
+      expect(roundToNearest({ interval: 5000, value: 2000 })).to.equal(0);
+      expect(roundToNearest({ interval: 5000, value: 23123 })).to.equal(25000);
+      expect(roundToNearest({ interval: 1000, value: 11450 })).to.equal(11000);
     });
   });
 });

--- a/src/applications/claims-status/utils/helpers.js
+++ b/src/applications/claims-status/utils/helpers.js
@@ -891,3 +891,10 @@ export const mockData = {
     },
   ],
 };
+
+// returns the value rounded to the nearest interval
+// ex: roundToNearest({interval: 5000, value: 13000}) => 15000
+// ex: roundToNearest({interval: 5000, value: 6500}) => 5000
+export function roundToNearest({ interval, value }) {
+  return Math.round(value / interval) * interval;
+}


### PR DESCRIPTION
## Description
This PR adds additional analytics to track the performance of the `GET evss_claims_async` API. This API is known to be slow and flaky. With these additions it should be easy for us to see:
1. How often it is able to get claims data and how long it took to get the data
2. How often the API returns errors and how long it took to return an error
3. How frequently the API was taking so long to succeed or fail that the FE stopped trying

## Testing done
Existing unit tests pass + added a couple simple tests to make sure the GA data layer is getting called

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs