### PR TITLE
Cbonade/search test stability

### DIFF
--- a/src/applications/search/tests/e2e/00-required.cypress.spec.js
+++ b/src/applications/search/tests/e2e/00-required.cypress.spec.js
@@ -1,3 +1,4 @@
+import Timeouts from 'platform/testing/e2e/timeouts';
 import stub from '../../constants/stub.json';
 
 const SELECTORS = {
@@ -65,8 +66,11 @@ for (let i = 0; i < 20; i += 1) {
         .then(inputElem => {
           cy.wrap(inputElem).clear();
         });
-      cy.get(`${SELECTORS.SEARCH_FORM} input[name="query"]`)
+      cy.get(`${SELECTORS.SEARCH_FORM} input[name="query"]`, {
+        timeout: Timeouts.slow,
+      })
         .should('exist')
+        .and('not.be.disabled')
         .then(inputElem => {
           cy.wrap(inputElem).type('benefits');
         });

--- a/src/applications/search/tests/e2e/00-required.cypress.spec.js
+++ b/src/applications/search/tests/e2e/00-required.cypress.spec.js
@@ -60,9 +60,21 @@ for (let i = 0; i < 20; i += 1) {
 
       // Await search results
 
-      cy.get(`${SELECTORS.SEARCH_FORM} input[name="query"]`).clear();
-      cy.get(`${SELECTORS.SEARCH_FORM} input[name="query"]`).type('benefits');
-      cy.get(`${SELECTORS.SEARCH_FORM} button[type="submit"]`).click();
+      cy.get(`${SELECTORS.SEARCH_FORM} input[name="query"]`)
+        .should('exist')
+        .then(inputElem => {
+          cy.wrap(inputElem).clear();
+        });
+      cy.get(`${SELECTORS.SEARCH_FORM} input[name="query"]`)
+        .should('exist')
+        .then(inputElem => {
+          cy.wrap(inputElem).type('benefits');
+        });
+      cy.get(`${SELECTORS.SEARCH_FORM} button[type="submit"]`)
+        .should('exist')
+        .then(button => {
+          cy.wrap(button).click();
+        });
       cy.wait('@getSearchResultsPage');
 
       // A11y check the search results.

--- a/src/applications/search/tests/e2e/00-required.cypress.spec.js
+++ b/src/applications/search/tests/e2e/00-required.cypress.spec.js
@@ -9,118 +9,104 @@ const SELECTORS = {
   ERROR_ALERT_BOX: '[data-e2e-id="alert-box"]',
 };
 
-function axeTestPage() {
-  cy.injectAxe();
-  cy.axeCheck();
+for (let i = 0; i < 20; i += 1) {
+  describe('Sitewide Search smoke test', () => {
+    it('successfully searches and renders results from the global search', () => {
+      cy.intercept('GET', '/v0/search?query=benefits', {
+        body: stub,
+        statusCode: 200,
+      }).as('getSearchResultsGlobal');
+      // navigate to page
+      cy.visit('/search?query=benefits');
+      cy.injectAxeThenAxeCheck();
+
+      // Ensure App is present
+      cy.get(SELECTORS.APP).should('exist');
+
+      // Ensure form is present
+      cy.get(SELECTORS.SEARCH_FORM).should('exist');
+
+      // Await search results
+      cy.wait('@getSearchResultsGlobal');
+
+      // A11y check the search results.
+      cy.axeCheck();
+
+      // Check results to see if variety of nodes exist.
+      cy.get(SELECTORS.SEARCH_RESULTS_TITLE)
+        // Check title.
+        .should('contain', 'Veterans Benefits Administration Home');
+
+      cy.get(`${SELECTORS.SEARCH_RESULTS} li`)
+        // Check url.
+        .should('contain', 'https://benefits.va.gov/benefits/');
+    });
+
+    it('successfully searches and renders results from the results page', () => {
+      cy.intercept('GET', '/v0/search?query=benefits&page=1', {
+        body: stub,
+        statusCode: 200,
+      }).as('getSearchResultsPage');
+
+      // navigate to page
+      cy.visit('/search/?query=X');
+      cy.injectAxeThenAxeCheck();
+
+      // Ensure App is present
+      cy.get(SELECTORS.APP).should('exist');
+
+      // Ensure form is present
+      cy.get(SELECTORS.SEARCH_FORM).should('exist');
+
+      // Await search results
+
+      cy.get(`${SELECTORS.SEARCH_FORM} input[name="query"]`).clear();
+      cy.get(`${SELECTORS.SEARCH_FORM} input[name="query"]`).type('benefits');
+      cy.get(`${SELECTORS.SEARCH_FORM} button[type="submit"]`).click();
+      cy.wait('@getSearchResultsPage');
+
+      // A11y check the search results.
+      cy.axeCheck();
+
+      // Check results to see if variety of nodes exist.
+      cy.get(SELECTORS.SEARCH_RESULTS_TITLE)
+        // Check title.
+        .should('contain', 'Veterans Benefits Administration Home');
+
+      cy.get(`${SELECTORS.SEARCH_RESULTS} li`)
+        // Check url.
+        .should('contain', 'https://benefits.va.gov/benefits/');
+    });
+
+    it('fails to search and has an error', () => {
+      cy.intercept('GET', '/v0/search?query=benefits', {
+        body: [],
+        statusCode: 500,
+      }).as('getSearchResultsFailed');
+      // navigate to page
+      cy.visit('/search/?query=benefits');
+      cy.injectAxeThenAxeCheck();
+
+      // Ensure App is present
+      cy.get(SELECTORS.APP).should('exist');
+
+      // Ensure form is present
+      cy.get(SELECTORS.SEARCH_FORM).should('exist');
+
+      // Fill out and submit the form.
+      // cy.get(`${SELECTORS.SEARCH_FORM} button[type="submit"]`).click();
+      cy.wait('@getSearchResultsFailed');
+
+      // Ensure ERROR Alert Box exists
+      cy.get(SELECTORS.ERROR_ALERT_BOX)
+        // Check contain error message
+        .should(
+          'contain',
+          "We’re sorry. Something went wrong on our end, and your search didn't go through. Please try again",
+        );
+
+      // A11y check the search results.
+      cy.axeCheck();
+    });
+  });
 }
-
-describe('Sitewide Search smoke test', () => {
-  it('successfully searches and renders results from the global search', () => {
-    cy.server();
-    cy.route({
-      method: 'GET',
-      response: stub,
-      status: 200,
-      url: '/v0/search?query=benefits',
-    }).as('getSearchResults');
-
-    // navigate to page
-    cy.visit('/search?query=benefits');
-    axeTestPage();
-
-    // Ensure App is present
-    cy.get(SELECTORS.APP);
-
-    // Ensure form is present
-    cy.get(SELECTORS.SEARCH_FORM);
-
-    // Await search results
-    cy.wait('@getSearchResults');
-
-    // A11y check the search results.
-    axeTestPage();
-
-    // Check results to see if variety of nodes exist.
-    cy.get(SELECTORS.SEARCH_RESULTS_TITLE)
-      // Check title.
-      .should('contain', 'Veterans Benefits Administration Home');
-
-    cy.get(`${SELECTORS.SEARCH_RESULTS} li`)
-      // Check url.
-      .should('contain', 'https://benefits.va.gov/benefits/');
-  });
-
-  it('successfully searches and renders results from the results page', () => {
-    cy.server();
-    cy.route({
-      method: 'GET',
-      response: stub,
-      status: 200,
-      url: '/v0/search?query=benefits&page=1',
-    }).as('getSearchResults');
-
-    // navigate to page
-    cy.visit('/search/?query=X');
-    axeTestPage();
-
-    // Ensure App is present
-    cy.get(SELECTORS.APP);
-
-    // Ensure form is present
-    cy.get(SELECTORS.SEARCH_FORM);
-
-    // Await search results
-
-    cy.get(`${SELECTORS.SEARCH_FORM} input[name="query"]`).clear();
-    cy.get(`${SELECTORS.SEARCH_FORM} input[name="query"]`).type('benefits');
-    cy.get(`${SELECTORS.SEARCH_FORM} button[type="submit"]`).click();
-    cy.wait('@getSearchResults');
-
-    // A11y check the search results.
-    axeTestPage();
-
-    // Check results to see if variety of nodes exist.
-    cy.get(SELECTORS.SEARCH_RESULTS_TITLE)
-      // Check title.
-      .should('contain', 'Veterans Benefits Administration Home');
-
-    cy.get(`${SELECTORS.SEARCH_RESULTS} li`)
-      // Check url.
-      .should('contain', 'https://benefits.va.gov/benefits/');
-  });
-
-  it('fails to search and has an error', () => {
-    cy.server();
-    cy.route({
-      method: 'GET',
-      response: [],
-      status: 500,
-      url: '/v0/search?query=benefits',
-    }).as('getSearchResults');
-
-    // navigate to page
-    cy.visit('/search/?query=benefits');
-    axeTestPage();
-
-    // Ensure App is present
-    cy.get(SELECTORS.APP);
-
-    // Ensure form is present
-    cy.get(SELECTORS.SEARCH_FORM);
-
-    // Fill out and submit the form.
-    // cy.get(`${SELECTORS.SEARCH_FORM} button[type="submit"]`).click();
-    cy.wait('@getSearchResults');
-
-    // Ensure ERROR Alert Box exists
-    cy.get(SELECTORS.ERROR_ALERT_BOX)
-      // Check contain error message
-      .should(
-        'contain',
-        "We’re sorry. Something went wrong on our end, and your search didn't go through. Please try again",
-      );
-
-    // A11y check the search results.
-    axeTestPage();
-  });
-});

--- a/src/applications/search/tests/e2e/00-required.cypress.spec.js
+++ b/src/applications/search/tests/e2e/00-required.cypress.spec.js
@@ -10,119 +10,117 @@ const SELECTORS = {
   ERROR_ALERT_BOX: '[data-e2e-id="alert-box"]',
 };
 
-for (let i = 0; i < 20; i += 1) {
-  describe('Sitewide Search smoke test', () => {
-    it('successfully searches and renders results from the global search', () => {
-      cy.intercept('GET', '/v0/search?query=benefits', {
-        body: stub,
-        statusCode: 200,
-      }).as('getSearchResultsGlobal');
-      // navigate to page
-      cy.visit('/search?query=benefits');
-      cy.injectAxeThenAxeCheck();
+describe('Sitewide Search smoke test', () => {
+  it('successfully searches and renders results from the global search', () => {
+    cy.intercept('GET', '/v0/search?query=benefits', {
+      body: stub,
+      statusCode: 200,
+    }).as('getSearchResultsGlobal');
+    // navigate to page
+    cy.visit('/search?query=benefits');
+    cy.injectAxeThenAxeCheck();
 
-      // Ensure App is present
-      cy.get(SELECTORS.APP).should('exist');
+    // Ensure App is present
+    cy.get(SELECTORS.APP).should('exist');
 
-      // Ensure form is present
-      cy.get(SELECTORS.SEARCH_FORM).should('exist');
+    // Ensure form is present
+    cy.get(SELECTORS.SEARCH_FORM).should('exist');
 
-      // Await search results
-      cy.wait('@getSearchResultsGlobal');
+    // Await search results
+    cy.wait('@getSearchResultsGlobal');
 
-      // A11y check the search results.
-      cy.axeCheck();
+    // A11y check the search results.
+    cy.axeCheck();
 
-      // Check results to see if variety of nodes exist.
-      cy.get(SELECTORS.SEARCH_RESULTS_TITLE)
-        // Check title.
-        .should('contain', 'Veterans Benefits Administration Home');
+    // Check results to see if variety of nodes exist.
+    cy.get(SELECTORS.SEARCH_RESULTS_TITLE)
+      // Check title.
+      .should('contain', 'Veterans Benefits Administration Home');
 
-      cy.get(`${SELECTORS.SEARCH_RESULTS} li`)
-        // Check url.
-        .should('contain', 'https://benefits.va.gov/benefits/');
-    });
-
-    it('successfully searches and renders results from the results page', () => {
-      cy.intercept('GET', '/v0/search?query=benefits&page=1', {
-        body: stub,
-        statusCode: 200,
-      }).as('getSearchResultsPage');
-
-      // navigate to page
-      cy.visit('/search/?query=X');
-      cy.injectAxeThenAxeCheck();
-
-      // Ensure App is present
-      cy.get(SELECTORS.APP).should('exist');
-
-      // Ensure form is present
-      cy.get(SELECTORS.SEARCH_FORM).should('exist');
-
-      // Await search results
-
-      cy.get(`${SELECTORS.SEARCH_FORM} input[name="query"]`)
-        .should('exist')
-        .then(inputElem => {
-          cy.wrap(inputElem).clear();
-        });
-      cy.get(`${SELECTORS.SEARCH_FORM} input[name="query"]`, {
-        timeout: Timeouts.slow,
-      })
-        .should('exist')
-        .and('not.be.disabled')
-        .then(inputElem => {
-          cy.wrap(inputElem).type('benefits');
-        });
-      cy.get(`${SELECTORS.SEARCH_FORM} button[type="submit"]`)
-        .should('exist')
-        .then(button => {
-          cy.wrap(button).click();
-        });
-      cy.wait('@getSearchResultsPage');
-
-      // A11y check the search results.
-      cy.axeCheck();
-
-      // Check results to see if variety of nodes exist.
-      cy.get(SELECTORS.SEARCH_RESULTS_TITLE)
-        // Check title.
-        .should('contain', 'Veterans Benefits Administration Home');
-
-      cy.get(`${SELECTORS.SEARCH_RESULTS} li`)
-        // Check url.
-        .should('contain', 'https://benefits.va.gov/benefits/');
-    });
-
-    it('fails to search and has an error', () => {
-      cy.intercept('GET', '/v0/search?query=benefits', {
-        body: [],
-        statusCode: 500,
-      }).as('getSearchResultsFailed');
-      // navigate to page
-      cy.visit('/search/?query=benefits');
-      cy.injectAxeThenAxeCheck();
-
-      // Ensure App is present
-      cy.get(SELECTORS.APP).should('exist');
-
-      // Ensure form is present
-      cy.get(SELECTORS.SEARCH_FORM).should('exist');
-
-      // Fill out and submit the form.
-      // cy.get(`${SELECTORS.SEARCH_FORM} button[type="submit"]`).click();
-      cy.wait('@getSearchResultsFailed');
-
-      // Ensure ERROR Alert Box exists
-      cy.get(SELECTORS.ERROR_ALERT_BOX)
-        // Check contain error message
-        .should(
-          'contain',
-          "We’re sorry. Something went wrong on our end, and your search didn't go through. Please try again",
-        );
-
-      // A11y check the search results.
-      cy.axeCheck();
-    });
+    cy.get(`${SELECTORS.SEARCH_RESULTS} li`)
+      // Check url.
+      .should('contain', 'https://benefits.va.gov/benefits/');
   });
-}
+
+  it('successfully searches and renders results from the results page', () => {
+    cy.intercept('GET', '/v0/search?query=benefits&page=1', {
+      body: stub,
+      statusCode: 200,
+    }).as('getSearchResultsPage');
+
+    // navigate to page
+    cy.visit('/search/?query=X');
+    cy.injectAxeThenAxeCheck();
+
+    // Ensure App is present
+    cy.get(SELECTORS.APP).should('exist');
+
+    // Ensure form is present
+    cy.get(SELECTORS.SEARCH_FORM).should('exist');
+
+    // Await search results
+
+    cy.get(`${SELECTORS.SEARCH_FORM} input[name="query"]`)
+      .should('exist')
+      .then(inputElem => {
+        cy.wrap(inputElem).clear();
+      });
+    cy.get(`${SELECTORS.SEARCH_FORM} input[name="query"]`, {
+      timeout: Timeouts.slow,
+    })
+      .should('exist')
+      .and('not.be.disabled')
+      .then(inputElem => {
+        cy.wrap(inputElem).type('benefits');
+      });
+    cy.get(`${SELECTORS.SEARCH_FORM} button[type="submit"]`)
+      .should('exist')
+      .then(button => {
+        cy.wrap(button).click();
+      });
+    cy.wait('@getSearchResultsPage');
+
+    // A11y check the search results.
+    cy.axeCheck();
+
+    // Check results to see if variety of nodes exist.
+    cy.get(SELECTORS.SEARCH_RESULTS_TITLE)
+      // Check title.
+      .should('contain', 'Veterans Benefits Administration Home');
+
+    cy.get(`${SELECTORS.SEARCH_RESULTS} li`)
+      // Check url.
+      .should('contain', 'https://benefits.va.gov/benefits/');
+  });
+
+  it('fails to search and has an error', () => {
+    cy.intercept('GET', '/v0/search?query=benefits', {
+      body: [],
+      statusCode: 500,
+    }).as('getSearchResultsFailed');
+    // navigate to page
+    cy.visit('/search/?query=benefits');
+    cy.injectAxeThenAxeCheck();
+
+    // Ensure App is present
+    cy.get(SELECTORS.APP).should('exist');
+
+    // Ensure form is present
+    cy.get(SELECTORS.SEARCH_FORM).should('exist');
+
+    // Fill out and submit the form.
+    // cy.get(`${SELECTORS.SEARCH_FORM} button[type="submit"]`).click();
+    cy.wait('@getSearchResultsFailed');
+
+    // Ensure ERROR Alert Box exists
+    cy.get(SELECTORS.ERROR_ALERT_BOX)
+      // Check contain error message
+      .should(
+        'contain',
+        "We’re sorry. Something went wrong on our end, and your search didn't go through. Please try again",
+      );
+
+    // A11y check the search results.
+    cy.axeCheck();
+  });
+});


### PR DESCRIPTION
## Description
We've seen a number of intermittent failures with the search smoke test.  The main failures were on the middle test in the spec, regarding searching another term from a search results page of a different search. A few things were done to add some stability to the test:

1) Updated Cypress `server` and `route` commands to the newer `intercept`
2) Changed the custom axe function being declared in this spec to use the globally set up ones (accomplishing the same objective)
3) Added assertions to `get` statements to stop Cypress from getting ahead of itself.
4) Added an assertion to ensure that the input field on the search is not disabled before attempting to type into it (this was causing multiple failures, specifically)

## Testing done

Pushed to CI with a loop wrapped around the test to run it 20x, passed all 20x (60 successful tests)  in CI.



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
