### PR TITLE
NOD: Use mobile over home phone

### DIFF
--- a/src/applications/appeals/10182/containers/FormApp.jsx
+++ b/src/applications/appeals/10182/containers/FormApp.jsx
@@ -31,9 +31,8 @@ export const FormApp = ({
   getContestableIssues,
   contestableIssues = {},
 }) => {
-  const { email = {}, mobilePhone = {}, homePhone = {}, mailingAddress = {} } =
+  const { email = {}, mobilePhone = {}, mailingAddress = {} } =
     profile?.vapContactInfo || {};
-  const phone = mobilePhone?.phoneNumber ? mobilePhone : homePhone;
 
   // Update profile data changes in the form data dynamically
   useEffect(
@@ -45,7 +44,7 @@ export const FormApp = ({
           getContestableIssues();
         } else if (
           email?.emailAddress !== veteran.email ||
-          phone?.updatedAt !== veteran.phone?.updatedAt ||
+          mobilePhone?.updatedAt !== veteran.phone?.updatedAt ||
           mailingAddress?.updatedAt !== veteran.address?.updatedAt ||
           issuesNeedUpdating(
             contestableIssues?.issues,
@@ -57,7 +56,7 @@ export const FormApp = ({
             veteran: {
               ...veteran,
               address: mailingAddress,
-              phone,
+              phone: mobilePhone,
               email: email?.emailAddress,
             },
             contestableIssues: processContestableIssues(
@@ -87,7 +86,7 @@ export const FormApp = ({
       showNod,
       loggedIn,
       email,
-      phone,
+      mobilePhone,
       mailingAddress,
       formData,
       setFormData,

--- a/src/applications/appeals/10182/tests/containers/FormApp.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/containers/FormApp.unit.spec.jsx
@@ -12,7 +12,7 @@ const profile = {
     email: {
       emailAddress: 'test@user.com',
     },
-    homePhone: {
+    mobilePhone: {
       countryCode: '2',
       areaCode: '345',
       phoneNumber: '6789012',
@@ -139,7 +139,6 @@ describe('FormApp', () => {
     const mockProfile = {
       vapContactInfo: {
         email: null,
-        homePhone: null,
         mobilePhone: null,
         mailingAddress: null,
       },
@@ -203,7 +202,7 @@ describe('FormApp', () => {
     const formData = setFormData.args[0][0];
     const result = {
       address: profile.vapContactInfo.mailingAddress,
-      phone: profile.vapContactInfo.homePhone,
+      phone: profile.vapContactInfo.mobilePhone,
       email: profile.vapContactInfo.email.emailAddress,
     };
     expect(formData.veteran).to.deep.equal(result);
@@ -240,7 +239,7 @@ describe('FormApp', () => {
       additionalIssues: [{ issue: 'other issue', [SELECTED]: true }],
       veteran: {
         email: profile.vapContactInfo.email.emailAddress,
-        phone: profile.vapContactInfo.homePhone,
+        phone: profile.vapContactInfo.mobilePhone,
         address: profile.vapContactInfo.mailingAddress,
       },
     };

--- a/src/applications/appeals/10182/tests/fixtures/mocks/user.json
+++ b/src/applications/appeals/10182/tests/fixtures/mocks/user.json
@@ -88,7 +88,7 @@
           "zipCode": "94608",
           "zipCodeSuffix": null
         },
-        "homePhone": {
+        "mobilePhone": {
           "areaCode": "510",
           "countryCode": "1",
           "createdAt": "2020-06-12T16:56:37.000+00:00",
@@ -109,7 +109,7 @@
           "updatedAt": "2020-07-14T19:07:46.000+00:00",
           "vet360Id": "1273780"
         },
-        "mobilePhone": {},
+        "homePhone": {},
         "workPhone": {},
         "temporaryPhone": null,
         "faxNumber": null,


### PR DESCRIPTION
## Description

The Notice of Disagreement phone validation still includes a home phone fallback, which breaks the contact info validation by allowing Veterans to navigate past the contact page when their mobile phone is missing.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/27137

## Testing done

Updated tests

## Screenshots

N/A

## Acceptance criteria
- [x] Remove home phone fallback. Use _only_ mobile phone

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
