### PR TITLE
27437: remove additional call to debts endpoint

### DIFF
--- a/src/applications/debt-letters/components/DebtLettersWrapper.jsx
+++ b/src/applications/debt-letters/components/DebtLettersWrapper.jsx
@@ -16,11 +16,14 @@ const DebtLettersWrapper = ({
   isLoggedIn,
   getDebtLetters,
 }) => {
-  useEffect(() => {
-    if (showDebtLetters !== false) {
-      getDebtLetters();
-    }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(
+    () => {
+      if (showDebtLetters) {
+        getDebtLetters();
+      }
+    },
+    [getDebtLetters, showDebtLetters],
+  );
 
   if (isPending || isPendingVBMS || isProfileUpdating) {
     return <LoadingIndicator />;

--- a/src/applications/debt-letters/components/DebtLettersWrapper.jsx
+++ b/src/applications/debt-letters/components/DebtLettersWrapper.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
-
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import { fetchDebtLetters } from '../actions';
@@ -17,14 +16,11 @@ const DebtLettersWrapper = ({
   isLoggedIn,
   getDebtLetters,
 }) => {
-  useEffect(
-    () => {
-      if (showDebtLetters !== false) {
-        getDebtLetters();
-      }
-    },
-    [getDebtLetters, showDebtLetters],
-  );
+  useEffect(() => {
+    if (showDebtLetters !== false) {
+      getDebtLetters();
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (isPending || isPendingVBMS || isProfileUpdating) {
     return <LoadingIndicator />;


### PR DESCRIPTION
## Description
When navigating to `/manage-va-debt/your-debt/` it was noticed the debts endpoint is being called twice. On initial page load the feature toggle for showDebtLetters returns undefined is causing an additional call to the debts endpoint

## Acceptance criteria

## Screenshots

## Definition of done
- [x] Changes have been tested in vets-website
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs