### PR TITLE
Replace `*` in ui:order

### DIFF
--- a/src/applications/pre-need/tests/schema/error-example.json
+++ b/src/applications/pre-need/tests/schema/error-example.json
@@ -1,0 +1,84 @@
+{
+  "data": {
+    "application": {
+      "applicant": {
+        "applicantRelationshipToClaimant": "Self"
+      },
+      "veteran": {
+        "view:hasServiceName": false,
+        "serviceRecords": [
+          {
+            "dateRange": {
+              "from": "2003-01-01",
+              "to": "2005-03-02"
+            },
+            "serviceBranch": "FS",
+            "dischargeType": "1",
+            "highestRank": "Colonel?"
+          },
+          {
+            "dateRange": {
+              "from": "2007-01-01",
+              "to": "2009-03-02"
+            },
+            "serviceBranch": "C3",
+            "dischargeType": "2",
+            "highestRank": "General"
+          }
+        ],
+        "placeOfBirth": "Amherst, MA",
+        "gender": "Female",
+        "race": {
+          "isWhite": true
+        },
+        "maritalStatus": "Single",
+        "militaryStatus": "E",
+        "currentName": {},
+        "address": {
+          "country": "USA"
+        }
+      },
+      "claimant": {
+        "address": {
+          "street": "101 big sky st",
+          "street2": "Apt 2",
+          "city": "Northampton",
+          "country": "USA",
+          "state": "ME",
+          "postalCode": "01050"
+        },
+        "view:contactInfoDescription": {},
+        "phoneNumber": "2342444444",
+        "email": "test@test.com",
+        "view:desiredCemeteryNote": {},
+        "name": {
+          "first": "Joe",
+          "middle": "Scott",
+          "last": "Tester"
+        },
+        "ssn": "244-44-4444",
+        "dateOfBirth": "1978-03-02",
+        "relationshipToVet": "1"
+      },
+      "hasCurrentlyBuried": "2",
+      "preneedAttachments": [
+        {
+          "name": "tavern_hill.pdf",
+          "confirmationCode": "74c64887-f843-4ea6-9c1d-85f412c8c309",
+          "attachmentId": "1"
+        },
+        {
+          "name": "dd214.pdf",
+          "confirmationCode": "74c64887-f843-4ea6-9c1d-85f412c8c310",
+          "attachmentId": "1"
+        },
+        {
+          "name": "transfer.pdf",
+          "confirmationCode": "74c64887-f843-4ea6-9c1d-85f412c8c311",
+          "attachmentId": "6"
+        }
+      ]
+    },
+    "privacyAgreementAccepted": false
+  }
+}

--- a/src/applications/pre-need/utils/helpers.js
+++ b/src/applications/pre-need/utils/helpers.js
@@ -391,7 +391,13 @@ export const serviceRecordsUI = {
     itemName: 'Service Period',
   },
   items: {
-    'ui:order': ['serviceBranch', '*'],
+    'ui:order': [
+      'serviceBranch',
+      'dateRange',
+      'dischargeType',
+      'highestRank',
+      'nationalGuardState',
+    ],
     'ui:options': {
       itemName: 'Service Period',
     },


### PR DESCRIPTION
## Description

In the Pre-need form, a `ui:order` definition is set using `['serviceBranch', '*']` where the `*` was causing a JS error causing the review & submit page to not render - see screenshot.

I created a PR to fix the platform handling of an `*` in the `ui:order`, but I think removing the `*` in this form ensure this form doesn't have any order issues in the future.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/25109
- https://github.com/department-of-veterans-affairs/vets-website/pull/17876

## Testing done

- Unit tests passing
- Added example json for use with e2e test

## Screenshots

![](https://user-images.githubusercontent.com/136959/125821424-c5f91e46-5236-4bf1-ab72-62cf3a954e7c.png)

## Acceptance criteria
- [x] Replace `*` in `ui:order`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
