### PR TITLE
try removing mochawesome to check timeout stability

### DIFF
--- a/config/cypress-reporters.json
+++ b/config/cypress-reporters.json
@@ -1,5 +1,5 @@
 {
-  "reporterEnabled": "mocha-junit-reporter, mochawesome",
+  "reporterEnabled": "mocha-junit-reporter",
   "mochaJunitReporterReporterOptions": {
     "mochaFile": "test-results/e2e-test-output-[hash].xml"
   },


### PR DESCRIPTION
## Description
Attempting to diagnose if mochawesome is the cause of our regular timeouts in vets-website builds

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
