### PR TITLE
Add typographical quote eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -73,6 +73,7 @@ module.exports = {
         aliases: ['applications', 'platform', 'site', '@@vap-svc', '@@profile'],
       },
     ],
+    'va/correct-apostrophe': 2,
 
     /* || fp plugin || */
     'fp/no-proxy': 2, // IE 11 has no polyfill for Proxy

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -73,7 +73,7 @@ module.exports = {
         aliases: ['applications', 'platform', 'site', '@@vap-svc', '@@profile'],
       },
     ],
-    'va/correct-apostrophe': 2,
+    'va/correct-apostrophe': 1,
 
     /* || fp plugin || */
     'fp/no-proxy': 2, // IE 11 has no polyfill for Proxy

--- a/script/eslint-plugin-va/index.js
+++ b/script/eslint-plugin-va/index.js
@@ -5,6 +5,7 @@ module.exports = {
     'use-resolved-path': require('./rules/use-resolved-path.js'),
     'resolved-path-on-required': require('./rules/resolved-path-on-required.js'),
     'axe-check-required': require('./rules/axe-e2e-tests.js'),
+    'correct-apostrophe': require('./rules/correct-apostrophe'),
   },
   rulesConfig: {
     'proptypes-camel-cased': 2,
@@ -22,5 +23,6 @@ module.exports = {
       },
     ],
     'axe-check-required': 1,
+    'correct-apostrophe': 1,
   },
 };

--- a/script/eslint-plugin-va/package.json
+++ b/script/eslint-plugin-va/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-va",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "index.js",
   "peerDependency": {
     "eslint": "^4.18.2"

--- a/script/eslint-plugin-va/rules/correct-apostrophe.js
+++ b/script/eslint-plugin-va/rules/correct-apostrophe.js
@@ -1,0 +1,61 @@
+const description = 'Typographic apostrophes should be used within the content';
+const message = 'Replace single quote with typographic apostrophe';
+
+// https://en.wikipedia.org/wiki/Wikipedia:List_of_English_contractions
+const contractionEndings = [
+  'clock', // o'clock
+  'd', // we'd, that'd
+  'll', // we'll, it'll
+  're', // we're
+  's', // it's, let's
+  't', // don't, won't, shouldn't, etc
+  've', // could've
+];
+
+const regexpReplacer = /'/g;
+const regexpApostrophe = new RegExp(
+  `(?:[a-z]')(?:${contractionEndings.join('|')})\\b`,
+  'gmi',
+);
+
+const contentTypes = ['TemplateLiteral', 'JSXText', 'JSXAttribute'];
+
+const rule = {
+  meta: {
+    type: 'suggestion',
+    fixable: 'code',
+    docs: {
+      description,
+      category: 'best practices',
+      recommended: true,
+    },
+    schema: [],
+  },
+  create: context => {
+    const sourceCode = context.getSourceCode();
+    const replacer = node =>
+      node.value.replace(regexpApostrophe, match =>
+        match.replace(regexpReplacer, '’'),
+      );
+
+    return {
+      VariableDeclarator: outerNode => {
+        const nodes = sourceCode.getTokens(outerNode);
+        for (const node of nodes) {
+          if (
+            contentTypes.includes(node.type) &&
+            regexpApostrophe.test(node.value)
+          ) {
+            context.report({
+              node,
+              message,
+              fix: fixer => fixer.replaceText(node, replacer(node)),
+            });
+          }
+        }
+      },
+    };
+  },
+};
+
+module.exports = rule;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7411,7 +7411,7 @@ eslint-plugin-unicorn@^20.0.0:
     semver "^7.3.2"
 
 eslint-plugin-va@./script/eslint-plugin-va:
-  version "1.0.2"
+  version "1.0.3"
 
 eslint-scope@^4.0.3:
   version "4.0.3"


### PR DESCRIPTION
## Description

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/9268

Adding an eslint rule that highlights content that contains single quotes used within a contracted word, e.g. `we'll`. A fix function is included that will replace the single quote with a typographical apostrophe as recommended by the design system.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/9268

## Testing done

Manual testing

## Screenshots

![Screen Shot 2021-07-19 at 9 07 50 AM](https://user-images.githubusercontent.com/136959/126173268-cb9443f5-0fda-4c62-bee1-f4fa85a52dd9.png)

## Acceptance criteria
- [x] Eslint highlights content containing single quotes instead of typographical apostrophes
- [x] Eslint quick fix replaces single quotes with the typographical apostrophe

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
