### PR TITLE
Use deep links in payment info update errors

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/PaymentInformationEditError.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/PaymentInformationEditError.jsx
@@ -96,15 +96,13 @@ function UpdateAddressError() {
 }
 
 function UpdatePhoneNumberError({ phoneNumberType = 'home' }) {
+  const editLink = `/profile/personal-information#edit-${phoneNumberType}-phone-number`;
   return (
     <p>
       We’re sorry. We couldn’t update your direct deposit bank information
       because your {phoneNumberType} phone number is missing or invalid. Please
-      go back to{' '}
-      <a href="/profile/personal-information#edit-home-phone-number">
-        your profile
-      </a>{' '}
-      and fill in this required information.
+      go back to <a href={editLink}>your profile</a> and fill in this required
+      information.
     </p>
   );
 }

--- a/src/applications/personalization/profile/components/direct-deposit/PaymentInformationEditError.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/PaymentInformationEditError.jsx
@@ -87,8 +87,10 @@ function UpdateAddressError() {
     <p>
       We’re sorry. We couldn’t update your direct deposit bank information
       because your mailing address is missing or invalid. Please go back to{' '}
-      <a href="/profile/personal-information">your profile</a> and fill in this
-      required information.
+      <a href="/profile/personal-information#edit-mailing-address">
+        your profile
+      </a>{' '}
+      and fill in this required information.
     </p>
   );
 }
@@ -98,8 +100,11 @@ function UpdatePhoneNumberError({ phoneNumberType = 'home' }) {
     <p>
       We’re sorry. We couldn’t update your direct deposit bank information
       because your {phoneNumberType} phone number is missing or invalid. Please
-      go back to <a href="/profile/personal-information">your profile</a> and
-      fill in this required information.
+      go back to{' '}
+      <a href="/profile/personal-information#edit-home-phone-number">
+        your profile
+      </a>{' '}
+      and fill in this required information.
     </p>
   );
 }

--- a/src/applications/personalization/profile/tests/components/direct-deposit/PaymentInformationEditError.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/direct-deposit/PaymentInformationEditError.unit.spec.jsx
@@ -283,7 +283,7 @@ describe('<PaymentInformationEditError />', () => {
       />,
     );
     expect(wrapper.html()).to.contain(
-      'We’re sorry. We couldn’t update your direct deposit bank information because your mailing address is missing or invalid. Please go back to <a href="/profile/personal-information">your profile</a> and fill in this required information.',
+      'We’re sorry. We couldn’t update your direct deposit bank information because your mailing address is missing or invalid. Please go back to <a href="/profile/personal-information#edit-mailing-address">your profile</a> and fill in this required information.',
     );
     wrapper.unmount();
   });
@@ -295,7 +295,7 @@ describe('<PaymentInformationEditError />', () => {
       />,
     );
     expect(wrapper.html()).to.contain(
-      'We’re sorry. We couldn’t update your direct deposit bank information because your work phone number is missing or invalid. Please go back to <a href="/profile/personal-information">your profile</a> and fill in this required information.',
+      'We’re sorry. We couldn’t update your direct deposit bank information because your work phone number is missing or invalid. Please go back to <a href="/profile/personal-information#edit-work-phone-number">your profile</a> and fill in this required information.',
     );
     wrapper.unmount();
 
@@ -305,7 +305,7 @@ describe('<PaymentInformationEditError />', () => {
       />,
     );
     expect(wrapper.html()).to.contain(
-      'We’re sorry. We couldn’t update your direct deposit bank information because your home phone number is missing or invalid. Please go back to <a href="/profile/personal-information">your profile</a> and fill in this required information.',
+      'We’re sorry. We couldn’t update your direct deposit bank information because your home phone number is missing or invalid. Please go back to <a href="/profile/personal-information#edit-home-phone-number">your profile</a> and fill in this required information.',
     );
     wrapper.unmount();
   });


### PR DESCRIPTION
## Description
We have some old error message that direct people to update their contact info. This PR updates those existing links with deep-link URLs.

## Original issue(s)

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs