### PR TITLE
Remove Call to Action Widget for ES and TAG

### DIFF
--- a/src/applications/static-pages/covid-vaccine-updates-cta/createCovidVaccineUpdatesWidget.js
+++ b/src/applications/static-pages/covid-vaccine-updates-cta/createCovidVaccineUpdatesWidget.js
@@ -5,8 +5,8 @@ import { Provider } from 'react-redux';
 export default function createCovidVaccineUpdatesWidget(store, _widgetType) {
   const covidVaccineUpdatesPaths = new Set([
     // '/health-care/covid-19-vaccine/',
-    '/health-care/covid-19-vaccine-esp/',
-    '/health-care/covid-19-vaccine-tag/',
+    // '/health-care/covid-19-vaccine-esp/',
+    // '/health-care/covid-19-vaccine-tag/',
   ]);
   const isCovidVaccineUpdatesPage = covidVaccineUpdatesPaths.has(
     document.location.pathname,


### PR DESCRIPTION
## Description
This PR removes the CTA for the ES and TAG language pages at:
* /health-care/covid-19-vaccine-esp/
* /health-care/covid-19-vaccine-tag/

## Issue
* https://github.com/department-of-veterans-affairs/va.gov-team/issues/27392

## Testing done
* manual testing

## Acceptance criteria
- [ ] CTA does not display for ES
- [ ] CTA does not display for TAG

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
