### PR TITLE
Set Yarn cache in working dir instead of runner home

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -336,8 +336,8 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
-        # env:
-        #   YARN_CACHE_FOLDER: .cache/yarn
+        env:
+          YARN_CACHE_FOLDER: .cache/yarn
 
       - name: Set port for server
         run: echo "SERVER_PORT=$(( ( RANDOM % 2000 ) + 3001 ))" >> $GITHUB_ENV

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -45,14 +45,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ~/.cache/yarn
+            .cache/yarn
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
         env:
-          YARN_CACHE_FOLDER: ~/.cache/yarn
+          YARN_CACHE_FOLDER: .cache/yarn
 
       - name: Build
         run: yarn build --verbose --buildtype=${{ matrix.buildtype }}
@@ -99,14 +99,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ~/.cache/yarn
+            .cache/yarn
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
         env:
-          YARN_CACHE_FOLDER: ~/.cache/yarn
+          YARN_CACHE_FOLDER: .cache/yarn
 
       - name: Create test results folder
         run: mkdir -p test-results
@@ -172,14 +172,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ~/.cache/yarn
+            .cache/yarn
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
         env:
-          YARN_CACHE_FOLDER: ~/.cache/yarn
+          YARN_CACHE_FOLDER: .cache/yarn
 
       - name: Create test results folder
         run: mkdir -p test-results
@@ -263,14 +263,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ~/.cache/yarn
+            .cache/yarn
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
         env:
-          YARN_CACHE_FOLDER: ~/.cache/yarn
+          YARN_CACHE_FOLDER: .cache/yarn
 
       - name: Annotate ESLint results
         run: yarn run eslint --ext .js --ext .jsx --format ./script/github-actions/eslint-annotation-format.js .
@@ -330,14 +330,14 @@ jobs:
       #   uses: actions/cache@v2
       #   with:
       #     path: |
-      #       ~/.cache/yarn
+      #       .cache/yarn
       #       node_modules
       #     key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
         # env:
-        #   YARN_CACHE_FOLDER: ~/.cache/yarn
+        #   YARN_CACHE_FOLDER: .cache/yarn
 
       - name: Set port for server
         run: echo "SERVER_PORT=$(( ( RANDOM % 2000 ) + 3001 ))" >> $GITHUB_ENV
@@ -423,14 +423,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ~/.cache/yarn
+            .cache/yarn
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
         env:
-          YARN_CACHE_FOLDER: ~/.cache/yarn
+          YARN_CACHE_FOLDER: .cache/yarn
 
       - name: Run Nightwatch tests
         run: yarn test:e2e:headless
@@ -522,7 +522,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
         env:
-          YARN_CACHE_FOLDER: ~/.cache/yarn
+          YARN_CACHE_FOLDER: .cache/yarn
         working-directory: testing-tools-team-dashboard-data
 
       - name: Download Mochawesome test results
@@ -750,14 +750,14 @@ jobs:
 #       uses: actions/cache@v2
 #       with:
 #         path: |
-#           ~/.cache/yarn
+#           .cache/yarn
 #           node_modules
 #         key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
 #     - name: Install dependencies
 #       run: yarn install --frozen-lockfile --prefer-offline
 #       env:
-#         YARN_CACHE_FOLDER: ~/.cache/yarn
+#         YARN_CACHE_FOLDER: .cache/yarn
 
 #     - name: Trigger Jenkins pipeline
 #       run: node script/github-actions/trigger-jenkins.js


### PR DESCRIPTION
## Description
[We've observed some instances of corrupted or missing dependencies in cache](https://dsva.slack.com/archives/C01V94K0QNS/p1626702578323000).

This change attempts to resolve those issues by setting the cache in the working directory instead of the runner home directory.

## Testing done
Running CI workflow to verify.

## Acceptance criteria
- [ ] Dependency installation should not fail due to corrupted or missing files.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
