### PR TITLE
Reduced duplicate PR workflow runs from edits and review requests.

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,8 +1,8 @@
 name: Pull Request
 
-on: 
+on:
   pull_request:
-    types: [review_requested, ready_for_review, synchronize, edited, reopened, opened]
+    types: [ready_for_review, synchronize, reopened, opened]
 
 env:
   BOT_NAME: va-vfs-bot


### PR DESCRIPTION
## Description
This narrows down the PR workflow event triggers to prevent duplicate runs and annotations.

### Context
- Previous PR to eliminate icon checks from draft PRs #17860 
- Five of the same linting alerts appeared for a line ([Thread](https://dsva.slack.com/archives/CBU0KDSB1/p1626725325269300?thread_ts=1626712500.224900&cid=CBU0KDSB1))

## Testing done
Testing in this PR.

## Acceptance criteria
- [ ] Review requests and PR edits shouldn't trigger runs and annotations.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
