### PR TITLE
26768 standardize input length on 686

### DIFF
--- a/src/applications/disability-benefits/686c-674/config/chapters/add-a-child/child-information/child-information.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/add-a-child/child-information/child-information.js
@@ -59,6 +59,7 @@ export const uiSchema = {
           isChapterFieldRequired(formData, TASK_KEYS.addChild),
         'ui:options': {
           useDlWrap: true,
+          widgetClassNames: 'usa-input-medium',
         },
       },
       birthDate: merge(currentOrPastDateUI("Child's date of birth"), {

--- a/src/applications/disability-benefits/686c-674/config/chapters/report-dependent-death/dependent-information/dependentInformation.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/report-dependent-death/dependent-information/dependentInformation.js
@@ -59,6 +59,7 @@ export const uiSchema = {
           isChapterFieldRequired(formData, TASK_KEYS.reportDeath),
         'ui:options': {
           useDlWrap: true,
+          widgetClassNames: 'usa-input-medium',
         },
       },
       birthDate: merge(currentOrPastDateUI('Dependent’s date of birth'), {


### PR DESCRIPTION
## Description
This pull request adds the utility class `usa-input-medium` to a couple inputs on the 686 to ensure they are standardized throughout the entire form. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#26768


## Testing done
- local

## Screenshots


## Acceptance criteria
- [x] input lengths are uniform

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
