### PR TITLE
Speed up Profile MPI error tests

### DIFF
--- a/src/applications/personalization/profile/tests/e2e/profile.mpi-error.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile.mpi-error.cypress.spec.js
@@ -54,6 +54,7 @@ describe('When user is LOA3 with 2FA turned on but we cannot connect to MPI', ()
     cy.login(mockMPIErrorUser);
     mockGETEndpoints([
       'v0/mhv_account',
+      'v0/profile/ch33_bank_accounts',
       'v0/profile/full_name',
       'v0/profile/personal_information',
       'v0/profile/service_history',

--- a/src/applications/personalization/profile/tests/e2e/profile.not-in-mpi-error.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile.not-in-mpi-error.cypress.spec.js
@@ -52,6 +52,7 @@ describe('When user is LOA3 with 2FA turned on but we cannot connect to MPI', ()
     cy.login(mockUserNotInMPI);
     mockGETEndpoints([
       'v0/mhv_account',
+      'v0/profile/ch33_bank_accounts',
       'v0/profile/full_name',
       'v0/profile/personal_information',
       'v0/profile/service_history',


### PR DESCRIPTION
## Description
This made a couple of existing Profile Cypress tests run 3-4 _times_ faster by simply mocking one of the required APIs to fail

## Original issue(s)

## Testing done


## Screenshots
![speed-up-cypress](https://user-images.githubusercontent.com/20728956/126360420-49ee1231-ccff-4f97-b580-0b593c3c185d.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs