### PR TITLE
NotificationSettings - load data and handle errors

### DIFF
--- a/src/applications/personalization/profile/components/notification-settings/APIErrorAlert.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/APIErrorAlert.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
+
+const APIErrorAlert = () => {
+  return (
+    <AlertBox status="error">
+      We’re sorry. We can’t access your notification settings at this time.
+      We’re working to fix this problem. Please check back soon.
+    </AlertBox>
+  );
+};
+export default APIErrorAlert;

--- a/src/applications/personalization/profile/components/notification-settings/ContactInfoOnFile.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/ContactInfoOnFile.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
+import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
+
+import { PROFILE_PATHS } from '@@profile/constants';
+
+const ContactInfoOnFile = ({ emailAddress, mobilePhoneNumber }) => {
+  return (
+    <>
+      <p>
+        We’ll use the contact information from your profile to send
+        notifications:
+      </p>
+      {emailAddress ? (
+        <p>
+          <strong>{emailAddress}</strong>
+        </p>
+      ) : null}
+      {mobilePhoneNumber ? (
+        <p>
+          <strong>
+            <Telephone
+              contact={`${mobilePhoneNumber.areaCode}${
+                mobilePhoneNumber.phoneNumber
+              }`}
+              notClickable
+            />
+          </strong>
+        </p>
+      ) : null}
+      <p>
+        <Link to={PROFILE_PATHS.PERSONAL_INFORMATION}>
+          Update your contact information
+        </Link>
+      </p>
+      <AdditionalInfo triggerText="Why can’t I get all notifications by email and text?">
+        <p>Some info about email and text notifications.</p>
+        <p className="vads-u-margin-bottom--0">
+          Some more information about email and text notifications.
+        </p>
+      </AdditionalInfo>
+    </>
+  );
+};
+
+export default ContactInfoOnFile;

--- a/src/applications/personalization/profile/components/notification-settings/MissingContactInfoAlert.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/MissingContactInfoAlert.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
+
+import { PROFILE_PATHS } from '../../constants';
+
+const MissingContactInfoAlert = ({
+  missingMobilePhone,
+  missingEmailAddress,
+}) => {
+  const missingEmailAddressContent = (
+    <p>
+      To get notifications by email, first{' '}
+      <Link to={`${PROFILE_PATHS.PERSONAL_INFORMATION}#edit-email-address`}>
+        add your email address to your profile
+      </Link>
+      .
+    </p>
+  );
+  const missingMobilePhoneContent = (
+    <p>
+      To get notifications by SMS text message, first{' '}
+      <Link
+        to={`${PROFILE_PATHS.PERSONAL_INFORMATION}#edit-mobile-phone-number`}
+      >
+        add your mobile phone number to your profile
+      </Link>
+      .
+    </p>
+  );
+  const missingAllContactInfoContent = (
+    <p>
+      We don‘t have an email address or mobile phone number for you. To manage
+      notification settings, please{' '}
+      <Link to={`${PROFILE_PATHS.PERSONAL_INFORMATION}#mobile-phone-number`}>
+        update your contact information
+      </Link>
+      .
+    </p>
+  );
+
+  const alertContents = React.useMemo(
+    () => {
+      if (missingEmailAddress && missingMobilePhone) {
+        return missingAllContactInfoContent;
+      } else if (missingEmailAddress) {
+        return missingEmailAddressContent;
+      } else if (missingMobilePhone) {
+        return missingMobilePhoneContent;
+      } else {
+        return null;
+      }
+    },
+    [
+      missingEmailAddress,
+      missingMobilePhone,
+      missingAllContactInfoContent,
+      missingEmailAddressContent,
+      missingMobilePhoneContent,
+    ],
+  );
+
+  if (alertContents) {
+    return (
+      <div data-testid="missing-contact-info-alert">
+        <AlertBox status="info" backgroundOnly>
+          {alertContents}
+        </AlertBox>
+      </div>
+    );
+  }
+
+  return null;
+};
+
+export default MissingContactInfoAlert;

--- a/src/applications/personalization/profile/components/notification-settings/NotificationSettings.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationSettings.jsx
@@ -1,20 +1,122 @@
-import React, { useEffect } from 'react';
+import React from 'react';
+import { connect } from 'react-redux';
 
+import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
+
+import {
+  hasVAPServiceConnectionError,
+  selectVAPEmailAddress,
+  selectVAPMobilePhone,
+} from '~/platform/user/selectors';
+
+import { PROFILE_PATH_NAMES } from '@@profile/constants';
+import { fetchCommunicationPreferenceGroups } from '@@profile/ducks/communicationPreferences';
+
+import { LOADING_STATES } from '../../../common/constants';
 import Headline from '../ProfileSectionHeadline';
-import { PROFILE_PATH_NAMES } from '../../constants';
+import ContactInfoOnFile from './ContactInfoOnFile';
+import APIErrorAlert from './APIErrorAlert';
+import MissingContactInfoAlert from './MissingContactInfoAlert';
 
-const NotificationSettings = () => {
-  useEffect(() => {
+const NotificationSettings = ({
+  allContactInfoOnFile,
+  fetchPrefs,
+  emailAddress,
+  mobilePhoneNumber,
+  noContactInfoOnFile,
+  shouldFetchNotificationSettings,
+  shouldShowAPIError,
+  shouldShowLoadingIndicator,
+}) => {
+  React.useEffect(() => {
     document.title = `Notification Settings | Veterans Affairs`;
   }, []);
+
+  React.useEffect(
+    () => {
+      if (shouldFetchNotificationSettings) {
+        fetchPrefs();
+      }
+    },
+    [fetchPrefs, shouldFetchNotificationSettings],
+  );
+
+  // if either phone number or email address is not set
+  const showMissingContactInfoAlert = React.useMemo(
+    () =>
+      !shouldShowLoadingIndicator &&
+      !shouldShowAPIError &&
+      !allContactInfoOnFile,
+    [allContactInfoOnFile, shouldShowAPIError, shouldShowLoadingIndicator],
+  );
+
+  // shown as long as we aren't loading data and they have at least one
+  // communication channel on file
+  const showContactInfoOnFile = React.useMemo(
+    () => {
+      return (
+        !shouldShowLoadingIndicator &&
+        !shouldShowAPIError &&
+        !noContactInfoOnFile
+      );
+    },
+    [noContactInfoOnFile, shouldShowAPIError, shouldShowLoadingIndicator],
+  );
 
   return (
     <>
       <Headline>{PROFILE_PATH_NAMES.NOTIFICATION_SETTINGS}</Headline>
+      {shouldShowLoadingIndicator ? (
+        <LoadingIndicator message="We’re loading your information." />
+      ) : null}
+      {shouldShowAPIError ? <APIErrorAlert /> : null}
+      {showMissingContactInfoAlert ? (
+        <MissingContactInfoAlert
+          missingMobilePhone={!mobilePhoneNumber}
+          missingEmailAddress={!emailAddress}
+        />
+      ) : null}
+      {showContactInfoOnFile ? (
+        <ContactInfoOnFile
+          emailAddress={emailAddress}
+          mobilePhoneNumber={mobilePhoneNumber}
+        />
+      ) : null}
     </>
   );
 };
 
 NotificationSettings.propTypes = {};
 
-export default NotificationSettings;
+const mapStateToProps = state => {
+  const communicationPreferencesState = state.communicationPreferences;
+  const hasVAPServiceError = hasVAPServiceConnectionError(state);
+  const hasLoadingError = !!communicationPreferencesState.loadingErrors;
+
+  const emailAddress = selectVAPEmailAddress(state);
+  const mobilePhoneNumber = selectVAPMobilePhone(state);
+  const noContactInfoOnFile = !emailAddress && !mobilePhoneNumber;
+  const allContactInfoOnFile = emailAddress && mobilePhoneNumber;
+  const shouldFetchNotificationSettings =
+    !noContactInfoOnFile && !hasVAPServiceError;
+  const shouldShowAPIError = hasVAPServiceError || hasLoadingError;
+  return {
+    allContactInfoOnFile,
+    emailAddress,
+    mobilePhoneNumber,
+    noContactInfoOnFile,
+    shouldShowAPIError,
+    shouldFetchNotificationSettings,
+    shouldShowLoadingIndicator:
+      communicationPreferencesState.loadingStatus === LOADING_STATES.pending,
+  };
+};
+
+const mapDispatchToProps = {
+  fetchPrefs: fetchCommunicationPreferenceGroups,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(NotificationSettings);

--- a/src/applications/personalization/profile/ducks/communicationPreferences.js
+++ b/src/applications/personalization/profile/ducks/communicationPreferences.js
@@ -3,13 +3,13 @@ import { apiRequest } from '~/platform/utilities/api';
 import { LOADING_STATES } from '../../common/constants';
 
 // ACTION TYPES
-const FETCH_STARTED = 'profile/communicationPreferences/fetchStarted';
-const FETCH_FAILED = 'profile/communicationPreferences/fetchFailed';
-const FETCH_COMPLETED = 'profile/communicationPreferences/fetchCompleted';
-const SAVE_STARTED = 'profile/communicationPreferences/saveStarted';
-const SAVE_FAILED = 'profile/communicationPreferences/saveFailed';
-const SAVE_COMPLETED = 'profile/communicationPreferences/saveCompleted';
-const TOGGLE_EDIT_MODE = 'profile/communicationPreferences/toggleEditMode';
+const FETCH_STARTED = '@@profile/communicationPreferences/fetchStarted';
+const FETCH_FAILED = '@@profile/communicationPreferences/fetchFailed';
+const FETCH_COMPLETED = '@@profile/communicationPreferences/fetchCompleted';
+const SAVE_STARTED = '@@profile/communicationPreferences/saveStarted';
+const SAVE_FAILED = '@@profile/communicationPreferences/saveFailed';
+const SAVE_COMPLETED = '@@profile/communicationPreferences/saveCompleted';
+const TOGGLE_EDIT_MODE = '@@profile/communicationPreferences/toggleEditMode';
 
 export const endpoint = '/profile/communication_preferences';
 
@@ -152,7 +152,23 @@ function communicationChannelsReducer(accumulator, item) {
 }
 
 // REDUCER
-export default function reducer(state = {}, action = {}) {
+const initialState = {
+  loadingStatus: LOADING_STATES.idle,
+  loadingErrors: null,
+  groups: {
+    ids: [],
+    entities: {},
+  },
+  items: {
+    ids: [],
+    entities: {},
+  },
+  channels: {
+    ids: [],
+    entities: {},
+  },
+};
+export default function reducer(state = initialState, action = {}) {
   switch (action.type) {
     case FETCH_STARTED: {
       return { ...state, loadingStatus: LOADING_STATES.pending };

--- a/src/applications/personalization/profile/reducers/index.js
+++ b/src/applications/personalization/profile/reducers/index.js
@@ -2,8 +2,10 @@ import vapService from '@@vap-svc/reducers';
 import hcaEnrollmentStatus from '~/applications/hca/reducers/hca-enrollment-status-reducer';
 import ratedDisabilities from '~/applications/personalization/rated-disabilities/reducers';
 import vaProfile from './vaProfile';
+import communicationPreferences from '../ducks/communicationPreferences';
 
 export default {
+  communicationPreferences,
   vaProfile,
   vapService,
   hcaEnrollmentStatus,

--- a/src/applications/personalization/profile/tests/e2e/helpers.js
+++ b/src/applications/personalization/profile/tests/e2e/helpers.js
@@ -1,5 +1,13 @@
-import { PROFILE_PATHS, PROFILE_PATH_NAMES } from '../../constants';
+import dd4eduNotEnrolled from '@@profile/tests/fixtures/dd4edu/dd4edu-not-enrolled.json';
+import disabilityRating from '@@profile/tests/fixtures/disability-rating-success.json';
+import fullName from '@@profile/tests/fixtures/full-name-success.json';
+import mockPaymentInfoNotEligible from '@@profile/tests/fixtures/dd4cnp/dd4cnp-is-not-eligible.json';
+import personalInformation from '@@profile/tests/fixtures/personal-information-success.json';
+import serviceHistory from '@@profile/tests/fixtures/service-history-success.json';
+
 import error500 from '@@profile/tests/fixtures/500.json';
+
+import { PROFILE_PATHS, PROFILE_PATH_NAMES } from '../../constants';
 
 export function subNavOnlyContainsAccountSecurity(mobile) {
   if (mobile) {
@@ -93,6 +101,22 @@ export function nameTagRendersWithoutDisabilityRating() {
   cy.findByText('Your disability rating:').should('not.exist');
   cy.findByText(/View disability rating/i).should('not.exist');
   cy.findByText(/service connected/i).should('not.exist');
+}
+
+// Mock Profile-related APIs so the Notification Settings section will load.
+// This does _not_ mock the APIs used by the Notification Setting section. It
+// only mocks the other APIs that are required by the Profile
+export function mockNotificationSettingsAPIs() {
+  mockGETEndpoints(['/v0/mhv_account']);
+  cy.intercept(
+    '/v0/disability_compensation_form/rating_info',
+    disabilityRating,
+  );
+  cy.intercept('/v0/profile/full_name', fullName);
+  cy.intercept('/v0/profile/personal_information', personalInformation);
+  cy.intercept('/v0/profile/service_history', serviceHistory);
+  cy.intercept('/v0/profile/ch33_bank_accounts', dd4eduNotEnrolled);
+  cy.intercept('/v0/ppiu/payment_information', mockPaymentInfoNotEligible);
 }
 
 export function registerCypressHelpers() {

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/feature-gating.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/feature-gating.cypress.spec.js
@@ -1,22 +1,12 @@
-import serviceHistory from '@@profile/tests/fixtures/service-history-success.json';
-import fullName from '@@profile/tests/fixtures/full-name-success.json';
-import error500 from '@@profile/tests/fixtures/500.json';
-
 import { PROFILE_PATHS, PROFILE_PATH_NAMES } from '../../../constants';
 import { mockUser } from '../../fixtures/users/user';
-
+import { mockNotificationSettingsAPIs } from '../helpers';
 import mockFeatureToggles from './feature-toggles.json';
 
 describe('Notification Settings', () => {
   beforeEach(() => {
     cy.login(mockUser);
-    cy.intercept('/v0/profile/service_history', serviceHistory);
-    cy.intercept('/v0/profile/full_name', fullName);
-    // Explicitly mocking these APIs as failures, causes the tests to run faster
-    cy.intercept('/v0/profile/personal_information', error500);
-    cy.intercept('/v0/profile/ch33_bank_accounts', error500);
-    cy.intercept('/v0/ppiu/payment_information', error500);
-    cy.intercept('/v0/mhv_account', error500);
+    mockNotificationSettingsAPIs();
   });
   context('when the feature flag is turned on', () => {
     it('is available in the side nav and the section loads', () => {

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/feature-toggles.json
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/feature-toggles.json
@@ -5,6 +5,10 @@
       {
         "name": "profile_notification_settings",
         "value": true
+      },
+      {
+        "name": "dashboard_show_dashboard_2",
+        "value": true
       }
     ]
   }

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/loading-errors.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/loading-errors.cypress.spec.js
@@ -1,17 +1,13 @@
 import { PROFILE_PATHS } from '@@profile/constants';
 
-import dd4eduNotEnrolled from '@@profile/tests/fixtures/dd4edu/dd4edu-not-enrolled.json';
-import disabilityRating from '@@profile/tests/fixtures/disability-rating-success.json';
-import fullName from '@@profile/tests/fixtures/full-name-success.json';
-import mockPaymentInfoNotEligible from '@@profile/tests/fixtures/dd4cnp/dd4cnp-is-not-eligible.json';
-import personalInformation from '@@profile/tests/fixtures/personal-information-success.json';
-import serviceHistory from '@@profile/tests/fixtures/service-history-success.json';
-
 import mockUser from '@@profile/tests/fixtures/users/user-36.json';
 import { mockUser as mockUserVAPError } from '@@profile/tests/fixtures/users/user-vap-error.js';
 import error500 from '@@profile/tests/fixtures/500.json';
 
-import { registerCypressHelpers } from '../helpers';
+import {
+  mockNotificationSettingsAPIs,
+  registerCypressHelpers,
+} from '../helpers';
 
 import mockFeatureToggles from './feature-toggles.json';
 
@@ -19,16 +15,8 @@ registerCypressHelpers();
 
 describe('Notification Settings - Load Errors', () => {
   beforeEach(() => {
+    mockNotificationSettingsAPIs();
     cy.intercept('/v0/feature_toggles?*', mockFeatureToggles);
-    cy.intercept(
-      '/v0/disability_compensation_form/rating_info',
-      disabilityRating,
-    );
-    cy.intercept('/v0/profile/full_name', fullName);
-    cy.intercept('/v0/profile/personal_information', personalInformation);
-    cy.intercept('/v0/profile/service_history', serviceHistory);
-    cy.intercept('/v0/profile/ch33_bank_accounts', dd4eduNotEnrolled);
-    cy.intercept('/v0/ppiu/payment_information', mockPaymentInfoNotEligible);
   });
   context('when VA Profile contact info is not available', () => {
     it('should show an error message and not even try to fetch current notification preferences', () => {

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/loading-errors.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/loading-errors.cypress.spec.js
@@ -1,5 +1,12 @@
 import { PROFILE_PATHS } from '@@profile/constants';
 
+import dd4eduNotEnrolled from '@@profile/tests/fixtures/dd4edu/dd4edu-not-enrolled.json';
+import disabilityRating from '@@profile/tests/fixtures/disability-rating-success.json';
+import fullName from '@@profile/tests/fixtures/full-name-success.json';
+import mockPaymentInfoNotEligible from '@@profile/tests/fixtures/dd4cnp/dd4cnp-is-not-eligible.json';
+import personalInformation from '@@profile/tests/fixtures/personal-information-success.json';
+import serviceHistory from '@@profile/tests/fixtures/service-history-success.json';
+
 import mockUser from '@@profile/tests/fixtures/users/user-36.json';
 import { mockUser as mockUserVAPError } from '@@profile/tests/fixtures/users/user-vap-error.js';
 import error500 from '@@profile/tests/fixtures/500.json';
@@ -10,9 +17,18 @@ import mockFeatureToggles from './feature-toggles.json';
 
 registerCypressHelpers();
 
-describe.skip('Notification Settings - Load Errors', () => {
+describe('Notification Settings - Load Errors', () => {
   beforeEach(() => {
-    cy.intercept('GET', '/v0/feature_toggles?*', mockFeatureToggles);
+    cy.intercept('/v0/feature_toggles?*', mockFeatureToggles);
+    cy.intercept(
+      '/v0/disability_compensation_form/rating_info',
+      disabilityRating,
+    );
+    cy.intercept('/v0/profile/full_name', fullName);
+    cy.intercept('/v0/profile/personal_information', personalInformation);
+    cy.intercept('/v0/profile/service_history', serviceHistory);
+    cy.intercept('/v0/profile/ch33_bank_accounts', dd4eduNotEnrolled);
+    cy.intercept('/v0/ppiu/payment_information', mockPaymentInfoNotEligible);
   });
   context('when VA Profile contact info is not available', () => {
     it('should show an error message and not even try to fetch current notification preferences', () => {

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/missing-contact-info.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/missing-contact-info.cypress.spec.js
@@ -1,15 +1,12 @@
-import dd4eduNotEnrolled from '@@profile/tests/fixtures/dd4edu/dd4edu-not-enrolled.json';
-import disabilityRating from '@@profile/tests/fixtures/disability-rating-success.json';
-import fullName from '@@profile/tests/fixtures/full-name-success.json';
 import mockCommunicationPreferences from '@@profile/tests/fixtures/communication-preferences/get-200-maximal.json';
 import { makeMockUser } from '@@profile/tests/fixtures/users/user';
-import mockPaymentInfoNotEligible from '@@profile/tests/fixtures/dd4cnp/dd4cnp-is-not-eligible.json';
-import personalInformation from '@@profile/tests/fixtures/personal-information-success.json';
-import serviceHistory from '@@profile/tests/fixtures/service-history-success.json';
 
 import { PROFILE_PATHS } from '@@profile/constants';
 
-import { registerCypressHelpers } from '../helpers';
+import {
+  mockNotificationSettingsAPIs,
+  registerCypressHelpers,
+} from '../helpers';
 
 import mockFeatureToggles from './feature-toggles.json';
 
@@ -19,16 +16,8 @@ describe('Notification Settings', () => {
   let getCommPrefsStub;
   beforeEach(() => {
     getCommPrefsStub = cy.stub();
+    mockNotificationSettingsAPIs();
     cy.intercept('/v0/feature_toggles?*', mockFeatureToggles);
-    cy.intercept(
-      '/v0/disability_compensation_form/rating_info',
-      disabilityRating,
-    );
-    cy.intercept('/v0/profile/full_name', fullName);
-    cy.intercept('/v0/profile/personal_information', personalInformation);
-    cy.intercept('/v0/profile/service_history', serviceHistory);
-    cy.intercept('/v0/profile/ch33_bank_accounts', dd4eduNotEnrolled);
-    cy.intercept('/v0/ppiu/payment_information', mockPaymentInfoNotEligible);
     cy.intercept('/v0/profile/communication_preferences', req => {
       getCommPrefsStub();
       req.reply({
@@ -57,11 +46,13 @@ describe('Notification Settings', () => {
       cy.findByRole('link', { name: /update your contact info/i }).should(
         'exist',
       );
-      cy.findAllByRole('link', { name: /add your mobile/i }).should(
-        'have.length.above',
-        0,
-      );
-      cy.findAllByTestId('notification-group').should('exist');
+      // TODO: finishing building NotificationSettings so these tests can be
+      // enabled:
+      // cy.findAllByRole('link', { name: /add your mobile/i }).should(
+      //   'have.length.above',
+      //   0,
+      // );
+      // cy.findAllByTestId('notification-group').should('exist');
     });
   });
   context('when user is missing email address', () => {
@@ -84,11 +75,13 @@ describe('Notification Settings', () => {
       cy.findByRole('link', { name: /update your contact info/i }).should(
         'exist',
       );
-      cy.findAllByRole('link', { name: /add your email/i }).should(
-        'have.length.above',
-        0,
-      );
-      cy.findAllByTestId('notification-group').should('exist');
+      // TODO: finishing building NotificationSettings so these tests can be
+      // enabled:
+      // cy.findAllByRole('link', { name: /add your email/i }).should(
+      //   'have.length.above',
+      //   0,
+      // );
+      // cy.findAllByTestId('notification-group').should('exist');
     });
   });
   context('when user is missing both email address and mobile phone', () => {

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/missing-contact-info.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/missing-contact-info.cypress.spec.js
@@ -1,7 +1,13 @@
-import { PROFILE_PATHS } from '@@profile/constants';
-
-import mockPatient from '@@profile/tests/fixtures/users/user-36.json';
+import dd4eduNotEnrolled from '@@profile/tests/fixtures/dd4edu/dd4edu-not-enrolled.json';
+import disabilityRating from '@@profile/tests/fixtures/disability-rating-success.json';
+import fullName from '@@profile/tests/fixtures/full-name-success.json';
 import mockCommunicationPreferences from '@@profile/tests/fixtures/communication-preferences/get-200-maximal.json';
+import { makeMockUser } from '@@profile/tests/fixtures/users/user';
+import mockPaymentInfoNotEligible from '@@profile/tests/fixtures/dd4cnp/dd4cnp-is-not-eligible.json';
+import personalInformation from '@@profile/tests/fixtures/personal-information-success.json';
+import serviceHistory from '@@profile/tests/fixtures/service-history-success.json';
+
+import { PROFILE_PATHS } from '@@profile/constants';
 
 import { registerCypressHelpers } from '../helpers';
 
@@ -9,12 +15,21 @@ import mockFeatureToggles from './feature-toggles.json';
 
 registerCypressHelpers();
 
-describe.skip('Notification Settings', () => {
+describe('Notification Settings', () => {
   let getCommPrefsStub;
   beforeEach(() => {
     getCommPrefsStub = cy.stub();
-    cy.intercept('GET', '/v0/feature_toggles?*', mockFeatureToggles);
-    cy.intercept('GET', '/v0/profile/communication_preferences', req => {
+    cy.intercept('/v0/feature_toggles?*', mockFeatureToggles);
+    cy.intercept(
+      '/v0/disability_compensation_form/rating_info',
+      disabilityRating,
+    );
+    cy.intercept('/v0/profile/full_name', fullName);
+    cy.intercept('/v0/profile/personal_information', personalInformation);
+    cy.intercept('/v0/profile/service_history', serviceHistory);
+    cy.intercept('/v0/profile/ch33_bank_accounts', dd4eduNotEnrolled);
+    cy.intercept('/v0/ppiu/payment_information', mockPaymentInfoNotEligible);
+    cy.intercept('/v0/profile/communication_preferences', req => {
       getCommPrefsStub();
       req.reply({
         statusCode: 200,
@@ -24,8 +39,9 @@ describe.skip('Notification Settings', () => {
   });
   context('when user is missing mobile phone', () => {
     it('should show the correct messages', () => {
-      mockPatient.data.attributes.vet360ContactInformation.mobilePhone = null;
-      cy.login(mockPatient);
+      const user = makeMockUser();
+      user.data.attributes.vet360ContactInformation.mobilePhone = null;
+      cy.login(user);
       cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
       cy.findByRole('heading', {
         name: 'Notification settings',
@@ -34,36 +50,10 @@ describe.skip('Notification Settings', () => {
 
       cy.loadingIndicatorWorks();
 
-      cy.findByText('alongusername@domain.com').should('exist');
+      cy.findByText('veteran@gmail.com').should('exist');
       cy.findByTestId('missing-contact-info-alert')
         .should('exist')
         .and('contain.text', 'mobile phone');
-      cy.findByRole('link', { name: /update your contact info/i }).should(
-        'exist',
-      );
-      cy.findAllByRole('link', { name: /add your email address/i }).should(
-        'have.length.above',
-        0,
-      );
-      cy.findAllByTestId('notification-group').should('exist');
-    });
-  });
-  context('when user is missing email address', () => {
-    it('should show the correct messages', () => {
-      mockPatient.data.attributes.vet360ContactInformation.email = null;
-      cy.login(mockPatient);
-      cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
-      cy.findByRole('heading', {
-        name: 'Notification settings',
-        level: 1,
-      }).should('exist');
-
-      cy.loadingIndicatorWorks();
-
-      cy.findByText('555-555-5559').should('exist');
-      cy.findByTestId('missing-contact-info-alert')
-        .should('exist')
-        .and('contain.text', 'email address');
       cy.findByRole('link', { name: /update your contact info/i }).should(
         'exist',
       );
@@ -74,11 +64,39 @@ describe.skip('Notification Settings', () => {
       cy.findAllByTestId('notification-group').should('exist');
     });
   });
+  context('when user is missing email address', () => {
+    it('should show the correct messages', () => {
+      const user = makeMockUser();
+      user.data.attributes.vet360ContactInformation.email = null;
+      cy.login(user);
+      cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
+      cy.findByRole('heading', {
+        name: 'Notification settings',
+        level: 1,
+      }).should('exist');
+
+      cy.loadingIndicatorWorks();
+
+      cy.findByText('503-555-1234').should('exist');
+      cy.findByTestId('missing-contact-info-alert')
+        .should('exist')
+        .and('contain.text', 'email address');
+      cy.findByRole('link', { name: /update your contact info/i }).should(
+        'exist',
+      );
+      cy.findAllByRole('link', { name: /add your email/i }).should(
+        'have.length.above',
+        0,
+      );
+      cy.findAllByTestId('notification-group').should('exist');
+    });
+  });
   context('when user is missing both email address and mobile phone', () => {
     it('should show the correct message, not attempt to fetch notification prefs, and hide all notification groups', () => {
-      mockPatient.data.attributes.vet360ContactInformation.email = null;
-      mockPatient.data.attributes.vet360ContactInformation.mobilePhone = null;
-      cy.login(mockPatient);
+      const user = makeMockUser();
+      user.data.attributes.vet360ContactInformation.email = null;
+      user.data.attributes.vet360ContactInformation.mobilePhone = null;
+      cy.login(user);
       cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
       cy.findByRole('heading', {
         name: 'Notification settings',
@@ -89,13 +107,13 @@ describe.skip('Notification Settings', () => {
       cy.findByRole('progressbar', { name: /loading/i }).should('not.exist');
       cy.injectAxeThenAxeCheck();
 
-      cy.should(() => {
-        expect(getCommPrefsStub).not.to.be.called;
-      });
       cy.findByTestId('missing-contact-info-alert')
         .should('exist')
         .and('contain.text', 'mobile phone')
         .and('contain.text', 'email address');
+      cy.should(() => {
+        expect(getCommPrefsStub).not.to.be.called;
+      });
       cy.findByRole('link', { name: /update your contact info/i }).should(
         'exist',
       );

--- a/src/applications/personalization/profile/tests/fixtures/users/user.js
+++ b/src/applications/personalization/profile/tests/fixtures/users/user.js
@@ -1,4 +1,4 @@
-import { mockContactInformation } from '~/platform/user/profile/vap-svc/util/local-vapsvc.js';
+import { makeMockContactInfo } from '~/platform/user/profile/vap-svc/util/local-vapsvc.js';
 
 export const makeMockUser = () => {
   return {
@@ -79,7 +79,7 @@ export const makeMockUser = () => {
           '20-0996',
           'MDOT',
         ],
-        vet360ContactInformation: mockContactInformation,
+        vet360ContactInformation: makeMockContactInfo(),
       },
     },
     meta: { errors: null },

--- a/src/platform/user/profile/vap-svc/util/local-vapsvc.js
+++ b/src/platform/user/profile/vap-svc/util/local-vapsvc.js
@@ -128,6 +128,10 @@ export const mockContactInformation = {
   },
 };
 
+export const makeMockContactInfo = () => {
+  return { ...mockContactInformation };
+};
+
 function asyncReturn(returnValue, delay = 300) {
   return new Promise(resolve => {
     setTimeout(() => {


### PR DESCRIPTION
## Description
This PR starts building some real functionality into the `NotificationSettings` section of the Profile.

It doesn't actually render the user's current notification settings, that will come next. But it does do the following:
- load data from `GET communication_preferences` and show a loading spinner while doing so
- shows error message if there is an error getting the user's contact info from VA Profile
- shows error message if there is an error getting communication prefs
- shows messaging if the user missing either an email address or a mobile phone
- shows a different message if the user is missing an email address _and_ a mobile phone

## Original issue(s)
department-of-veterans-affairs/va.gov-team#25784


## Testing done
Was able to enable a handful of the Cypress tests I had previously written

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs