### PR TITLE
fix VAR appt transformer to display type of visit

### DIFF
--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
@@ -248,7 +248,7 @@ export default function RequestedAppointmentDetailsPage() {
           You shared these details about your concern
         </h2>
         {!isCCRequest && apptDetails}
-        {isCCRequest && <>{apptDetails || 'none'}</>}
+        {isCCRequest && <>{comment || 'none'}</>}
       </div>
       <div>
         <h2 className="vads-u-margin-top--2 vads-u-margin-bottom--0 vaos-appts__block-label">

--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
@@ -248,7 +248,7 @@ export default function RequestedAppointmentDetailsPage() {
           You shared these details about your concern
         </h2>
         {!isCCRequest && apptDetails}
-        {isCCRequest && <>{comment || 'none'}</>}
+        {isCCRequest && <>{apptDetails || 'none'}</>}
       </div>
       <div>
         <h2 className="vads-u-margin-top--2 vads-u-margin-bottom--0 vaos-appts__block-label">

--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -9,6 +9,7 @@ import {
   PURPOSE_TEXT,
   EXPRESS_CARE,
   UNABLE_TO_REACH_VETERAN_DETCODE,
+  TYPE_OF_VISIT,
 } from '../../utils/constants';
 import { getTimezoneBySystemId } from '../../utils/timezone';
 import {
@@ -435,6 +436,16 @@ export function transformConfirmedAppointment(appt) {
 }
 
 /**
+ * Gets the type of visit that matches our array of visit constant
+ *
+ * @param {Object} appt VAOS Service appointment object
+ * @returns {String} type of visit string
+ */
+function getTypeOfVisit(appt) {
+  return TYPE_OF_VISIT.find(type => type.serviceName === appt.visitType)?.name;
+}
+
+/**
  * Transforms MAS appointment to FHIR appointment resource
  *
  * @export
@@ -496,6 +507,7 @@ export function transformPendingAppointment(appt) {
       appointmentType: getAppointmentType(appt),
       isCommunityCare: isCC,
       isExpressCare,
+      requestVisitType: getTypeOfVisit(appt),
       apiData: appt,
     },
   };

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
@@ -79,6 +79,7 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
         .add(5, 'days')
         .format('MM/DD/YYYY'),
       optionTime3: 'PM',
+      visitType: 'Office Visit',
       facility: {
         ...getVARequestMock().attributes.facility,
         facilityCode: '983GC',
@@ -134,13 +135,13 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
         name: 'Pending primary care appointment',
       }),
     );
-
+    // show alert message
     expect(screen.baseElement).to.contain('.usa-alert-info');
     expect(screen.baseElement).to.contain.text(
       'The time and date of this appointment are still to be determined.',
     );
 
-    expect(screen.getByText('Cheyenne VA Medical Center')).to.be.ok;
+    expect(screen.getByText(/Cheyenne VA Medical Center/i)).to.be.ok;
     expect(screen.baseElement).to.contain.text(
       'Pending primary care appointment',
     );
@@ -168,8 +169,24 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
         'ddd, MMMM D, YYYY',
       )} in the afternoon`,
     );
-    expect(screen.baseElement).to.contain.text('New issue');
 
+    expect(
+      screen.getByRole('heading', {
+        level: 2,
+        name: 'Preferred type of appointment',
+      }),
+    ).to.be.ok;
+
+    expect(screen.baseElement).to.contain.text('Office visit');
+
+    expect(
+      screen.getByRole('heading', {
+        level: 2,
+        name: 'You shared these details about your concern',
+      }),
+    ).to.be.ok;
+
+    expect(screen.baseElement).to.contain.text('New issue');
     expect(await screen.findByText(/A message from the patient/i)).to.be.ok;
     expect(screen.baseElement).to.contain.text('patient.test@va.gov');
     expect(screen.baseElement).to.contain.text('703-652-0000');
@@ -225,7 +242,7 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
       email: 'joe.blow@va.gov',
       optionDate1: '02/21/2020',
       optionTime1: 'AM',
-      purposeOfVisit: 'routine-follow-up',
+      purposeOfVisit: 'new-issue',
       typeOfCareId: 'CCAUDHEAR',
     };
 
@@ -296,7 +313,9 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
         name: 'You shared these details about your concern',
       }),
     ).to.be.ok;
-    expect(await screen.findByText('A message from the patient')).to.be.ok;
+
+    expect(screen.baseElement).to.contain.text('New issue');
+    expect(await screen.findByText(/A message from the patient/i)).to.be.ok;
 
     expect(
       screen.getByRole('heading', {
@@ -830,7 +849,7 @@ describe('VAOS <RequestedAppointmentDetailsPage> with VAOS service', () => {
         name: 'You shared these details about your concern',
       }),
     ).to.be.ok;
-    expect(screen.getByText('A message from the patient')).to.be.ok;
+    expect(await screen.findByText(/A message from the patient/i)).to.be.ok;
 
     expect(
       screen.getByRole('heading', {

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
@@ -242,7 +242,6 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
       email: 'joe.blow@va.gov',
       optionDate1: '02/21/2020',
       optionTime1: 'AM',
-      purposeOfVisit: 'new-issue',
       typeOfCareId: 'CCAUDHEAR',
     };
 
@@ -314,7 +313,6 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
       }),
     ).to.be.ok;
 
-    expect(screen.baseElement).to.contain.text('New issue');
     expect(await screen.findByText(/A message from the patient/i)).to.be.ok;
 
     expect(


### PR DESCRIPTION
## Description
Preferred types are not displaying in the staging environment. Reviewing the local environment reveals Preferred type of visit is indeed not displaying. A fix to show type of visit is address in this ticket 
 
The veteran message under "You shared these detail about your concern" heading is working as expected. The error may be coming from the BE side.  Jeff created a ticket https://issues.mobilehealth.va.gov/browse/VAOSR-2161

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done
unit and local test

## Screenshots
![image](https://user-images.githubusercontent.com/54327023/126357453-9fe9f7bc-80f5-4f62-af83-c9693156f9af.png)


## Acceptance criteria
- [ ] The veteran preferred type of visit displays on the VA appointment request confirmation page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
