### PR TITLE
Profile: Update alert in edit modal

### DIFF
--- a/src/applications/appeals/10182/components/ContactInformation.jsx
+++ b/src/applications/appeals/10182/components/ContactInformation.jsx
@@ -107,7 +107,7 @@ export const ContactInfoDescription = ({ formContext, profile }) => {
                 title="Mobile phone number"
                 fieldName={FIELD_NAMES.MOBILE_PHONE}
                 deleteDisabled
-                noAlertClosing
+                alertClosingDisabled
               />
             </VAPServicePendingTransactionCategory>
             <VAPServicePendingTransactionCategory

--- a/src/applications/appeals/10182/components/ContactInformation.jsx
+++ b/src/applications/appeals/10182/components/ContactInformation.jsx
@@ -107,6 +107,7 @@ export const ContactInfoDescription = ({ formContext, profile }) => {
                 title="Mobile phone number"
                 fieldName={FIELD_NAMES.MOBILE_PHONE}
                 deleteDisabled
+                noAlertClosing
               />
             </VAPServicePendingTransactionCategory>
             <VAPServicePendingTransactionCategory

--- a/src/platform/user/profile/vap-svc/components/PhoneField/PhoneField.jsx
+++ b/src/platform/user/profile/vap-svc/components/PhoneField/PhoneField.jsx
@@ -138,6 +138,7 @@ export default class PhoneField extends React.Component {
         formSchema={formSchema}
         uiSchema={uiSchema(this.props.fieldName)}
         deleteDisabled={this.props.deleteDisabled}
+        noAlertClosing={this.props.noAlertClosing}
       />
     );
   }

--- a/src/platform/user/profile/vap-svc/components/PhoneField/PhoneField.jsx
+++ b/src/platform/user/profile/vap-svc/components/PhoneField/PhoneField.jsx
@@ -138,7 +138,7 @@ export default class PhoneField extends React.Component {
         formSchema={formSchema}
         uiSchema={uiSchema(this.props.fieldName)}
         deleteDisabled={this.props.deleteDisabled}
-        noAlertClosing={this.props.noAlertClosing}
+        alertClosingDisabled={this.props.alertClosingDisabled}
       />
     );
   }

--- a/src/platform/user/profile/vap-svc/components/PhoneField/PhoneField.jsx
+++ b/src/platform/user/profile/vap-svc/components/PhoneField/PhoneField.jsx
@@ -2,7 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import pickBy from 'lodash/pickBy';
 
-import { API_ROUTES, FIELD_NAMES, PHONE_TYPE, USA } from '@@vap-svc/constants';
+import {
+  API_ROUTES,
+  FIELD_NAMES,
+  FIELD_TITLES,
+  PHONE_TYPE,
+  USA,
+} from '@@vap-svc/constants';
 
 import PhoneNumberWidget from '~/platform/forms-system/src/js/widgets/PhoneNumberWidget';
 
@@ -34,10 +40,11 @@ const formSchema = {
 };
 
 const uiSchema = fieldName => {
+  const title = FIELD_TITLES[fieldName].replace('number', '');
   return {
     inputPhoneNumber: {
       'ui:widget': PhoneNumberWidget,
-      'ui:title': `${fieldName} (U.S. numbers only)`,
+      'ui:title': `${title} (U.S. numbers only)`,
       'ui:errorMessages': {
         pattern: 'Please enter a valid 10-digit U.S. phone number.',
       },

--- a/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModal.jsx
+++ b/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModal.jsx
@@ -44,11 +44,7 @@ export default class VAPServiceEditModal extends React.Component {
     // Errors returned directly from the API request (as opposed through a transaction lookup) are
     // displayed in this modal, rather than on the page. Once the modal is closed, reset the state
     // for the next time the modal is opened by removing any existing transaction request from the store.
-    if (
-      this.props.clearErrors &&
-      this.props.transactionRequest &&
-      this.props.transactionRequest.error
-    ) {
+    if (this.props.clearErrors && this.props.transactionRequest?.error) {
       this.props.clearErrors();
     }
   }

--- a/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModal.jsx
+++ b/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModal.jsx
@@ -14,7 +14,7 @@ import VAPServiceEditModalErrorMessage from './VAPServiceEditModalErrorMessage';
 export default class VAPServiceEditModal extends React.Component {
   static propTypes = {
     analyticsSectionName: PropTypes.string.isRequired,
-    clearErrors: PropTypes.func.isRequired,
+    clearErrors: PropTypes.func,
     getInitialFormValues: PropTypes.func.isRequired,
     field: PropTypes.shape({
       value: PropTypes.object,
@@ -44,7 +44,11 @@ export default class VAPServiceEditModal extends React.Component {
     // Errors returned directly from the API request (as opposed through a transaction lookup) are
     // displayed in this modal, rather than on the page. Once the modal is closed, reset the state
     // for the next time the modal is opened by removing any existing transaction request from the store.
-    if (this.props.transactionRequest && this.props.transactionRequest.error) {
+    if (
+      this.props.clearErrors &&
+      this.props.transactionRequest &&
+      this.props.transactionRequest.error
+    ) {
       this.props.clearErrors();
     }
   }

--- a/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage.jsx
+++ b/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage.jsx
@@ -8,6 +8,7 @@ import {
   DECEASED_ERROR_CODES,
   INVALID_EMAIL_ADDRESS_ERROR_CODES,
   LOW_CONFIDENCE_ADDRESS_ERROR_CODES,
+  INVALID_PHONE_ERROR_CODES,
 } from '@@vap-svc/util/transactions';
 
 function hasError(codes, errors) {
@@ -50,6 +51,15 @@ export default function VAPServiceEditModalErrorMessage({
         <p>
           It looks like the email you entered isn’t valid. Please enter your
           email address again.
+        </p>
+      );
+      break;
+
+    case hasError(INVALID_PHONE_ERROR_CODES, errors):
+      content = (
+        <p>
+          We can’t make this update because we currently only support U.S. area
+          codes. Please provide a U.S. based phone number.
         </p>
       );
       break;

--- a/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage.jsx
+++ b/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage.jsx
@@ -60,7 +60,7 @@ export default function VAPServiceEditModalErrorMessage({
       content = (
         <p>
           We can’t make this update because we currently only support U.S. area
-          codes. Please provide a U.S. based phone number.
+          codes. Please provide a U.S.-based phone number.
         </p>
       );
       break;

--- a/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage.jsx
+++ b/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage.jsx
@@ -16,7 +16,6 @@ function hasError(codes, errors) {
 
 export default function VAPServiceEditModalErrorMessage({
   error: { errors = [] },
-  clearErrors,
   title,
 }) {
   let content = null;
@@ -69,7 +68,6 @@ export default function VAPServiceEditModalErrorMessage({
       className="vads-u-margin-top--0"
       content={<div className="columns">{content}</div>}
       isVisible
-      onCloseAlert={clearErrors}
       scrollOnShow
       status={ALERT_TYPE.ERROR}
     />

--- a/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage.jsx
+++ b/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage.jsx
@@ -17,6 +17,7 @@ function hasError(codes, errors) {
 
 export default function VAPServiceEditModalErrorMessage({
   error: { errors = [] },
+  clearErrors,
   title,
 }) {
   let content = null;
@@ -78,6 +79,7 @@ export default function VAPServiceEditModalErrorMessage({
       className="vads-u-margin-top--0"
       content={<div className="columns">{content}</div>}
       isVisible
+      onCloseAlert={clearErrors}
       scrollOnShow
       status={ALERT_TYPE.ERROR}
     />

--- a/src/platform/user/profile/vap-svc/containers/VAPServiceProfileField.jsx
+++ b/src/platform/user/profile/vap-svc/containers/VAPServiceProfileField.jsx
@@ -206,12 +206,13 @@ class VAPServiceProfileField extends React.Component {
       title,
       transaction,
       transactionRequest,
+      noAlertClosing,
     } = this.props;
 
     const childProps = {
       ...this.props,
       refreshTransaction: this.refreshTransaction,
-      clearErrors: this.clearErrors,
+      clearErrors: noAlertClosing ? null : this.clearErrors,
       onAdd: this.onAdd,
       onEdit: this.onEdit,
       onChangeFormDataAndSchemas: this.onChangeFormDataAndSchemas,
@@ -234,7 +235,7 @@ class VAPServiceProfileField extends React.Component {
             transaction={transaction}
             transactionRequest={transactionRequest}
             title={title}
-            clearErrors={this.clearErrors}
+            clearErrors={noAlertClosing ? null : this.clearErrors}
           />
         )}
         <VAPServiceTransaction

--- a/src/platform/user/profile/vap-svc/containers/VAPServiceProfileField.jsx
+++ b/src/platform/user/profile/vap-svc/containers/VAPServiceProfileField.jsx
@@ -206,13 +206,13 @@ class VAPServiceProfileField extends React.Component {
       title,
       transaction,
       transactionRequest,
-      noAlertClosing,
+      alertClosingDisabled,
     } = this.props;
 
     const childProps = {
       ...this.props,
       refreshTransaction: this.refreshTransaction,
-      clearErrors: noAlertClosing ? null : this.clearErrors,
+      clearErrors: alertClosingDisabled ? null : this.clearErrors,
       onAdd: this.onAdd,
       onEdit: this.onEdit,
       onChangeFormDataAndSchemas: this.onChangeFormDataAndSchemas,
@@ -235,7 +235,7 @@ class VAPServiceProfileField extends React.Component {
             transaction={transaction}
             transactionRequest={transactionRequest}
             title={title}
-            clearErrors={noAlertClosing ? null : this.clearErrors}
+            clearErrors={childProps.clearErrors}
           />
         )}
         <VAPServiceTransaction

--- a/src/platform/user/profile/vap-svc/tests/components/VAPServiceEditModalErrorMessage.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/components/VAPServiceEditModalErrorMessage.unit.spec.jsx
@@ -18,17 +18,36 @@ describe('<VAPServiceEditModalErrorMessage />', () => {
       ],
     };
     const wrapper = shallow(
-      <VAPServiceEditModalErrorMessage
-        clearErrors={() => {}}
-        error={invalidEmailError}
-        title=""
-      />,
+      <VAPServiceEditModalErrorMessage error={invalidEmailError} title="" />,
     );
     const alert = wrapper.find('AlertBox');
     const alertContentText = alert?.prop('content')?.props?.children?.props
       ?.children;
     expect(alertContentText).to.include(
       'It looks like the email you entered isn’t valid. Please enter your email address again.',
+    );
+    wrapper.unmount();
+  });
+  it('shows the correct error message when there is an invalid phone area code', () => {
+    const invalidPhoneError = {
+      errors: [
+        {
+          title: 'Area Code Pattern',
+          detail: 'Phone area code pattern must match "[0-9]+"',
+          code: 'VET360_PHON126',
+          source: 'Vet360::ContactInformation::Service',
+          status: '400',
+        },
+      ],
+    };
+    const wrapper = shallow(
+      <VAPServiceEditModalErrorMessage error={invalidPhoneError} title="" />,
+    );
+    const alert = wrapper.find('AlertBox');
+    const alertContentText = alert?.prop('content')?.props?.children?.props
+      ?.children;
+    expect(alertContentText).to.include(
+      'currently only support U.S. area codes. Please provide a U.S. based',
     );
     wrapper.unmount();
   });

--- a/src/platform/user/profile/vap-svc/tests/components/VAPServiceEditModalErrorMessage.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/components/VAPServiceEditModalErrorMessage.unit.spec.jsx
@@ -44,10 +44,10 @@ describe('<VAPServiceEditModalErrorMessage />', () => {
       <VAPServiceEditModalErrorMessage error={invalidPhoneError} title="" />,
     );
     const alert = wrapper.find('AlertBox');
-    const alertContentText = alert?.prop('content')?.props?.children?.props
-      ?.children;
+    const alertContentText = alert.prop('content').props.children.props
+      .children;
     expect(alertContentText).to.include(
-      'currently only support U.S. area codes. Please provide a U.S. based',
+      'currently only support U.S. area codes. Please provide a U.S.-based',
     );
     wrapper.unmount();
   });

--- a/src/platform/user/profile/vap-svc/util/transactions.js
+++ b/src/platform/user/profile/vap-svc/util/transactions.js
@@ -65,6 +65,9 @@ export const INVALID_EMAIL_ADDRESS_ERROR_CODES = new Set([
 ]);
 
 export const INVALID_PHONE_ERROR_CODES = new Set([
+  'PHON126',
+  'PHON211',
+  'PHON213',
   'VET360_PHON126', // Phone area code pattern must match "[0-9]+"
   'VET360_PHON211', // New: Area Codes do not end with the same two digits
   'VET360_PHON213', // New: Area Codes do not include 9 as the middle digit

--- a/src/platform/user/profile/vap-svc/util/transactions.js
+++ b/src/platform/user/profile/vap-svc/util/transactions.js
@@ -64,6 +64,12 @@ export const INVALID_EMAIL_ADDRESS_ERROR_CODES = new Set([
   'VET360_EMAIL305',
 ]);
 
+export const INVALID_PHONE_ERROR_CODES = new Set([
+  'VET360_PHON126', // Phone area code pattern must match "[0-9]+"
+  'VET360_PHON211', // New: Area Codes do not end with the same two digits
+  'VET360_PHON213', // New: Area Codes do not include 9 as the middle digit
+]);
+
 export function isPendingTransaction(transaction) {
   return PENDING_STATUSES.has(transaction?.data.attributes.transactionStatus);
 }


### PR DESCRIPTION
## Description

In the Notice of Disagreement form, we're using profile modals to allow updating the Veteran's phone, email and address. When an invalid phone area code is entered, a generic alert message is shown. Improvements to the API (see https://github.com/department-of-veterans-affairs/vets-api/pull/7474) and front-end content will improve the messages (see the screenshot)

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/27563

## Testing done

Added unit test

## Screenshots

![Screen Shot 2021-07-20 at 9 31 04 AM](https://user-images.githubusercontent.com/136959/126366186-ab9a0014-411d-40e8-88a1-f3ffbe48e714.png)

## Acceptance criteria
- [x] Remove alert close button
- [x] Update phone number label (`mobilePhone` -> `Mobile Phone`)
- [x] Improve displayed error message

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
