### PR TITLE
Added facility name to breadcrumb in facility detail page

### DIFF
--- a/src/applications/facility-locator/containers/FacilityLocatorApp.jsx
+++ b/src/applications/facility-locator/containers/FacilityLocatorApp.jsx
@@ -43,7 +43,7 @@ class FacilityLocatorApp extends React.Component {
     if (validateIdString(location.pathname, '/facility') && selectedResult) {
       crumbs.push(
         <Link to={`/${selectedResult.id}`} key={selectedResult.id}>
-          Facility Details
+          {selectedResult.attributes.name}
         </Link>,
       );
     } else if (


### PR DESCRIPTION
## Description
Resolves issue linked below

When user uses a screen reader and navigates to a facility detail page (for example: el paso - https://www.va.gov/find-locations/facility/vha_756QB), the screen reader now announces the name of the facility within the breadcrumb when tabbing through.

<details>
<summary>screenshot: facility name now focuses in breadcrumb</summary>
<img width="676" alt="Screen Shot 2021-07-21 at 4 10 07 PM" src="https://user-images.githubusercontent.com/84030819/126553630-5bd22681-677b-48f5-8da6-af743f51c3af.png">

</details>


## Acceptance criteria
- [ ] facility name should now focus when using screen reader

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
