### PR TITLE
Fix flaky Facility Locator Cypress test

### DIFF
--- a/src/applications/facility-locator/tests/e2e/map-zoom.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/map-zoom.cypress.spec.js
@@ -50,28 +50,26 @@ Cypress.Commands.add('verifySearchArea', () => {
   cy.get('#search-area-control').click();
 });
 
-for (let i = 0; i < 30; i += 1) {
-  it('finds community care pharmacies', () => {
-    cy.visit('/find-locations');
+it('finds community care pharmacies', () => {
+  cy.visit('/find-locations');
 
-    cy.get('#street-city-state-zip').type('Austin, TX');
-    cy.get('#facility-type-dropdown').select(
-      'Community pharmacies (in VA’s network)',
-    );
-    cy.get('#facility-search')
-      .click({ force: true })
-      .then(() => {
-        cy.get('#search-results-subheader').contains(
-          'Results for "Community pharmacies (in VA’s network)" near "Austin, Texas"',
-        );
-        cy.get('#other-tools').should('exist');
+  cy.get('#street-city-state-zip').type('Austin, TX');
+  cy.get('#facility-type-dropdown').select(
+    'Community pharmacies (in VA’s network)',
+  );
+  cy.get('#facility-search')
+    .click({ force: true })
+    .then(() => {
+      cy.get('#search-results-subheader').contains(
+        'Results for "Community pharmacies (in VA’s network)" near "Austin, Texas"',
+      );
+      cy.get('#other-tools').should('exist');
 
-        cy.injectAxe();
-        cy.axeCheck();
+      cy.injectAxe();
+      cy.axeCheck();
 
-        cy.get('.facility-result h3').contains('CVS');
-        cy.get('.va-pagination').should('not.exist');
-        cy.verifySearchArea();
-      });
-  });
-}
+      cy.get('.facility-result h3').contains('CVS');
+      cy.get('.va-pagination').should('not.exist');
+      cy.verifySearchArea();
+    });
+});

--- a/src/applications/facility-locator/tests/e2e/map-zoom.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/map-zoom.cypress.spec.js
@@ -50,26 +50,28 @@ Cypress.Commands.add('verifySearchArea', () => {
   cy.get('#search-area-control').click();
 });
 
-it('finds community care pharmacies', () => {
-  cy.visit('/find-locations');
+for (let i = 0; i < 30; i += 1) {
+  it('finds community care pharmacies', () => {
+    cy.visit('/find-locations');
 
-  cy.get('#street-city-state-zip').type('Austin, TX');
-  cy.get('#facility-type-dropdown').select(
-    'Community pharmacies (in VA’s network)',
-  );
-  cy.get('#facility-search')
-    .click()
-    .then(() => {
-      cy.get('#search-results-subheader').contains(
-        'Results for "Community pharmacies (in VA’s network)" near "Austin, Texas"',
-      );
-      cy.get('#other-tools').should('exist');
+    cy.get('#street-city-state-zip').type('Austin, TX');
+    cy.get('#facility-type-dropdown').select(
+      'Community pharmacies (in VA’s network)',
+    );
+    cy.get('#facility-search')
+      .click({ force: true })
+      .then(() => {
+        cy.get('#search-results-subheader').contains(
+          'Results for "Community pharmacies (in VA’s network)" near "Austin, Texas"',
+        );
+        cy.get('#other-tools').should('exist');
 
-      cy.injectAxe();
-      cy.axeCheck();
+        cy.injectAxe();
+        cy.axeCheck();
 
-      cy.get('.facility-result h3').contains('CVS');
-      cy.get('.va-pagination').should('not.exist');
-      cy.verifySearchArea();
-    });
-});
+        cy.get('.facility-result h3').contains('CVS');
+        cy.get('.va-pagination').should('not.exist');
+        cy.verifySearchArea();
+      });
+  });
+}


### PR DESCRIPTION
## Description
This PR fixes an occasional Cypress test failure seen on GitHub Actions. Cypress could not click on an element because it would sometimes still be animating when the click was attempted.

## Acceptance criteria
- [ ] Cypress tests pass on CI.