### PR TITLE
Fetch 612A4 in place of 612

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoVisitSection.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoVisitSection.jsx
@@ -14,12 +14,14 @@ import AddToCalendar from 'applications/vaos/components/AddToCalendar';
 import InfoAlert from '../../../components/InfoAlert';
 import moment from 'applications/vaos/lib/moment-tz';
 import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
+import { getFacilityPhone } from '../../../services/location';
 
 export default function VideoVisitLocation({ appointment, facility }) {
   const { isAtlas, providers } = appointment.videoData;
   const isHome = isVideoHome(appointment);
   const [showMoreOpen, setShowMoreOpen] = useState(false);
   const name = facility?.name;
+  const facilityPhone = getFacilityPhone(facility);
 
   const {
     summary,
@@ -53,6 +55,16 @@ export default function VideoVisitLocation({ appointment, facility }) {
           />
         </div>
       )}
+      {isClinicVideoAppointment(appointment) && (
+        <div className="vads-u-margin-top--2">
+          <VAFacilityLocation
+            facility={facility}
+            facilityId={appointment.location.stationId}
+            clinicFriendlyName={appointment.location.clinicName}
+            isHomepageRefresh
+          />
+        </div>
+      )}
       {providers?.length > 0 && (
         <div className="vads-u-margin-top--2">
           <VideoVisitProvider
@@ -69,16 +81,6 @@ export default function VideoVisitLocation({ appointment, facility }) {
           >
             <VideoVisitInstructions instructionsType={appointment.comment} />
           </AdditionalInfo>
-        </div>
-      )}
-      {isClinicVideoAppointment(appointment) && (
-        <div className="vads-u-margin-top--2">
-          <VAFacilityLocation
-            facility={facility}
-            facilityId={appointment.location.stationId}
-            clinicFriendlyName={appointment.location.clinicName}
-            isHomepageRefresh
-          />
         </div>
       )}
       {!appointment.vaos.isPastAppointment && (
@@ -122,10 +124,10 @@ export default function VideoVisitLocation({ appointment, facility }) {
           {!!facility && (
             <span className="vads-u-display--block vads-u-margin-top--2">
               {name}
-              {phone && (
+              {facilityPhone && (
                 <>
                   <br />
-                  <FacilityPhone contact={phone} level={3} />
+                  <FacilityPhone contact={facilityPhone} level={3} />
                 </>
               )}
             </span>

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/index.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/index.jsx
@@ -142,8 +142,7 @@ export default function ConfirmedAppointmentDetailsPage() {
   const canceled = appointment.status === APPOINTMENT_STATUS.cancelled;
   const isVideo = appointment.vaos.isVideo;
   const isPastAppointment = appointment.vaos.isPastAppointment;
-  const facilityId = getVAAppointmentLocationId(appointment);
-  const facility = facilityData?.[facilityId];
+  const facility = facilityData?.[locationId];
   const isInPersonVAAppointment = !isVideo;
   const isCovid = appointment.vaos.isCOVIDVaccine;
   const canceler = appointment.description?.includes('CANCELLED BY PATIENT')
@@ -214,7 +213,7 @@ export default function ConfirmedAppointmentDetailsPage() {
           <VAFacilityLocation
             facility={facility}
             facilityName={facility?.name}
-            facilityId={facilityId}
+            facilityId={locationId}
             isHomepageRefresh
             clinicFriendlyName={appointment.location?.clinicName}
             showCovidPhone={isCovid}

--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -328,6 +328,14 @@ export function getVAAppointmentLocationId(appointment) {
     appointment?.vaos.appointmentType === APPOINTMENT_TYPES.vaAppointment &&
     !isClinicVideoAppointment(appointment)
   ) {
+    // 612 doesn't exist in the facilities api, but it's a valid VistA site
+    // So, we want to show the facility information for the actual parent location
+    // in that system, which is 612A4. This is really only visible for at home
+    // video appointments, as the facility we direct users to in order to cancel
+    if (appointment.location.vistaId === '612') {
+      return '612A4';
+    }
+
     return appointment?.location.vistaId;
   }
 

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.video.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.video.unit.spec.jsx
@@ -592,6 +592,42 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       expect(screen.queryByText(/join appointment/i)).to.not.exist;
     });
 
+    it('should direct user to valid facility for changes if using the 612 site', async () => {
+      const startDate = moment.utc().add(3, 'days');
+      const appointment = getVideoAppointmentMock({
+        id: 'some_id',
+        startDate: startDate.format(),
+        facilityId: '612',
+        appointmentKind: 'ADHOC',
+      });
+      mockFacilityFetch(
+        'vha_612A4',
+        getVAFacilityMock({ id: '612A4', name: 'Sacramento VA' }),
+      );
+      mockSingleAppointmentFetch({
+        appointment,
+      });
+
+      const screen = renderWithStoreAndRouter(<AppointmentList />, {
+        initialState,
+        path: '/va/some_id',
+      });
+
+      await screen.findByText(
+        new RegExp(
+          startDate
+            .tz('America/Los_Angeles')
+            .format('dddd, MMMM D, YYYY [at] h:mm a'),
+          'i',
+        ),
+      );
+
+      expect(screen.queryByText(/You don’t have any appointments/i)).not.to
+        .exist;
+      expect(screen.baseElement).to.contain.text('VA Video Connect at home');
+      expect(screen.baseElement).to.contain.text('Sacramento VA');
+    });
+
     it('should show address info for clinic based appointment', async () => {
       const appointment = getVideoAppointmentMock();
       const startDate = moment.utc().add(3, 'days');
@@ -1506,7 +1542,7 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       expect(tokens.get('END')).includes('VCALENDAR');
     });
   });
-  describe('video appointments (css transition check)', () => {
+  describe('VAOS video appointments (css transition check)', () => {
     beforeEach(() => {
       mockFetch();
       mockFacilitiesFetch();

--- a/src/applications/vaos/tests/mocks/v0.js
+++ b/src/applications/vaos/tests/mocks/v0.js
@@ -92,6 +92,12 @@ export function getVAFacilityMock({
  * Return a MAS appointment object, with a video appointment stub (item in vvsAppointments)
  *
  * @export
+ * @param {Object} params
+ * @param {string} params.id The appointment id
+ * @param {string} params.facilityId The site id of the appointment
+ * @param {string} params.startDate The start date of the appointment, in ISO format
+ * @param {string} params.appointmentKind The VVS appointment kind to use
+ * @param {string} params.instructionsTitle The type of instructions to use
  * @returns {MASAppointment} MAS appointment object
  */
 export function getVideoAppointmentMock({

--- a/src/applications/vaos/tests/mocks/v0.js
+++ b/src/applications/vaos/tests/mocks/v0.js
@@ -94,29 +94,36 @@ export function getVAFacilityMock({
  * @export
  * @returns {MASAppointment} MAS appointment object
  */
-export function getVideoAppointmentMock() {
+export function getVideoAppointmentMock({
+  id = '05760f00c80ae60ce49879cf37a05fc8',
+  facilityId = 'fake',
+  startDate = 'fake',
+  appointmentKind = 'fake',
+  instructionsTitle = null,
+} = {}) {
   return {
-    id: '05760f00c80ae60ce49879cf37a05fc8',
+    id,
     type: 'va_appointments',
     attributes: {
-      startDate: 'fake',
+      startDate,
       clinicId: null,
       clinicFriendlyName: null,
-      facilityId: 'fake',
+      facilityId,
       communityCare: false,
       vdsAppointments: [],
       vvsAppointments: [
         {
           id: '8a74bdfa-0e66-4848-87f5-0d9bb413ae6d',
-          appointmentKind: 'fake',
+          appointmentKind,
           sourceSystem: 'SM',
-          dateTime: 'fake',
+          dateTime: startDate,
           duration: 20,
           status: { description: null, code: 'FAKE' },
           schedulingRequestType: 'NEXT_AVAILABLE_APPT',
           type: 'REGULAR',
           bookingNotes: 'fake',
           instructionsOther: false,
+          instructionsTitle,
           patients: [
             {
               name: { firstName: 'JUDY', lastName: 'MORRISON' },


### PR DESCRIPTION
## Description
This PR
- Adjusts at home video appointments to fetch facility 612A4 instead of 612, because 612 is not in the facilities api, and 612A4 is the proper parent for that system.
- Fixes an issue displaying the phone number for video appointment cancellation directions
- Fixes an issue with the provider info displayed above the facility address for clinic video appointments

## Testing done
Local and unit testing

## Screenshots
![Screen Shot 2021-07-20 at 3 18 11 PM](https://user-images.githubusercontent.com/634932/126383713-7ea68c3b-34eb-48bd-984c-8253f3cc719a.png)


## Acceptance criteria
- [ ] At home video appointments with a facilityId of 612 display facility info for 612A4

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
