### PR TITLE
Add accordion-section-label to accordion analytics event

### DIFF
--- a/src/applications/static-pages/subscribeAccordionEvents.js
+++ b/src/applications/static-pages/subscribeAccordionEvents.js
@@ -2,7 +2,7 @@ import recordEvent from 'platform/monitoring/record-event';
 
 // This function assumes the accordion element is in a <section> tag
 // which has a data-label attribute set.
-const getSectionLabel = node => {
+export const getSectionLabel = node => {
   let currentNode = node;
   while (
     currentNode &&

--- a/src/applications/static-pages/tests/subscribeAccordionEvents.unit.spec.js
+++ b/src/applications/static-pages/tests/subscribeAccordionEvents.unit.spec.js
@@ -1,0 +1,37 @@
+import { expect } from 'chai';
+import { getSectionLabel } from '../subscribeAccordionEvents';
+
+describe('subscribeAccordionEvents', () => {
+  describe('getSectionLabel', () => {
+    it('should return the data-label for the given node if it is a section', () => {
+      const testNode = {
+        nodeName: 'section',
+        tagName: 'section',
+        dataset: {
+          label: 'Test Label',
+        },
+      };
+
+      expect(getSectionLabel(testNode)).to.equal('Test Label');
+    });
+
+    it('should return the data-label for the most immediate parent', () => {
+      const testNode = {
+        nodeName: 'button',
+        tagName: 'button',
+        parentNode: {
+          nodeName: 'button',
+          tagName: 'button',
+          parentNode: {
+            nodeName: 'section',
+            tagName: 'section',
+            dataset: { label: 'Parent Label' },
+          },
+        },
+        dataset: { label: 'Child Label' },
+      };
+
+      expect(getSectionLabel(testNode)).to.equal('Parent Label');
+    });
+  });
+});

--- a/src/platform/site-wide/component-library-analytics-setup.js
+++ b/src/platform/site-wide/component-library-analytics-setup.js
@@ -4,6 +4,7 @@
  */
 import _recordEvent from 'platform/monitoring/record-event';
 import { kebabCase } from 'lodash';
+import { getSectionLabel } from 'applications/static-pages/subscribeAccordionEvents';
 
 const analyticsEvents = {
   Modal: [{ action: 'show', event: 'int-modal-show' }],
@@ -61,6 +62,14 @@ export function subscribeComponentAnalyticsEvents(
 
           dataLayer[newKey] = e.detail.details[key];
         }
+      }
+
+      if (
+        ['int-accordion-expand', 'int-accordion-collapse'].includes(
+          action.event,
+        )
+      ) {
+        dataLayer['accordion-section-label'] = getSectionLabel(e.target);
       }
 
       recordEvent(dataLayer);


### PR DESCRIPTION
## Description
This adds a missing attribute `accordion-section-label` to the analytics events for `va-accordion`
See original issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/21555
and related pr: https://github.com/department-of-veterans-affairs/content-build/pull/378
## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/27200


## Testing done
Manual

## Screenshots
![Screen Shot 2021-07-20 at 5 32 33 PM](https://user-images.githubusercontent.com/3144003/126398346-71a949dc-9437-4af4-81b1-d278167dfad7.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
