### PR TITLE
Upgraded WHATWG-fetch to latest for better error reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -336,7 +336,7 @@
     "vanilla-lazyload": "^16.1.0",
     "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#d95589c438c1415f4ea8607e2f50ca82ea00b9c4",
     "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.7.0",
-    "whatwg-fetch": "^2.0.3"
+    "whatwg-fetch": "^3.6.2"
   },
   "resolutions": {
     "**/lodash": "4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20203,9 +20203,10 @@ whatwg-fetch@>=0.10.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz"
 
-whatwg-fetch@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
+whatwg-fetch@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
 whatwg-mimetype@^2.1.0:
   version "2.2.0"


### PR DESCRIPTION
## Description
Working through a Sentry error that is passing through our fetch polyfill, I needed better error reporting so we're updated the package.


## Testing done
Tested the site in browserstack IE11 and all fetch calls (spot checked) are still functioning as expected
