### PR TITLE
Remove PTSD questions from BDD flow

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-bdd-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-bdd-test.json
@@ -130,6 +130,11 @@
           "view:descriptionInfo": {}
         },
         {
+          "cause": "NEW",
+          "condition": "PTSD (post traumatic stress disorder)",
+          "view:descriptionInfo": {}
+        },
+        {
           "cause": "SECONDARY",
           "view:secondaryFollowUp": {
             "causedByDisability": "Asthma"

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/maximal-bdd-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/maximal-bdd-test.json
@@ -56,6 +56,12 @@
           "classificationCode": "540"
         },
         {
+          "cause": "NEW",
+          "primaryDescription": "This disability is related to my military service.",
+          "condition": "PTSD (post traumatic stress disorder)",
+          "classificationCode": "5420"
+        },
+        {
           "cause": "WORSENED",
           "worsenedDescription": "This disability was worsened by military service.",
           "worsenedEffects": "This pre-existing disability was worsened by military service.",
@@ -111,4 +117,3 @@
       ]
     }
   }
-  

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -601,8 +601,58 @@ export const isClaimingNew = formData =>
 export const isClaimingIncrease = formData =>
   _.get('view:claimType.view:claimingIncrease', formData, false);
 
+export const isBDD = formData => {
+  const isBddDataFlag = Boolean(formData?.['view:isBddData']);
+  const servicePeriods = formData?.serviceInformation?.servicePeriods || [];
+
+  // separation date entered in the wizard
+  const separationDate = window.sessionStorage.getItem(SAVED_SEPARATION_DATE);
+
+  // this flag helps maintain the correct form title within a session
+  // Removed because of Cypress e2e tests don't have access to 'view:isBddData'
+  // window.sessionStorage.removeItem(FORM_STATUS_BDD);
+
+  // isActiveDuty is true when the user selects that option in the wizard & then
+  // enters a separation date - based on the session storage value; we then
+  // set this flag in the formData.
+  // If the user doesn't choose the active duty wizard option, but enters a
+  // future date in their service history, this may be associated with reserves
+  // and therefor should not open the BDD flow
+  const isActiveDuty = isBddDataFlag || separationDate;
+
+  if (
+    !isActiveDuty ||
+    // User hasn't started the form or the wizard
+    (servicePeriods.length === 0 && !separationDate)
+  ) {
+    return false;
+  }
+
+  const mostRecentDate = separationDate
+    ? moment(separationDate)
+    : servicePeriods
+        .filter(({ dateRange }) => dateRange?.to)
+        .map(({ dateRange }) => moment(dateRange?.to))
+        .sort((dateA, dateB) => (dateB.isBefore(dateA) ? -1 : 1))[0];
+
+  if (!mostRecentDate) {
+    window.sessionStorage.setItem(FORM_STATUS_BDD, 'false');
+    return false;
+  }
+
+  const result =
+    isActiveDuty &&
+    mostRecentDate.isAfter(moment().add(89, 'days')) &&
+    !mostRecentDate.isAfter(moment().add(180, 'days'));
+
+  // this flag helps maintain the correct form title within a session
+  window.sessionStorage.setItem(FORM_STATUS_BDD, result ? 'true' : 'false');
+  return Boolean(result);
+};
+
 export const hasNewPtsdDisability = formData =>
   isClaimingNew(formData) &&
+  !isBDD(formData) &&
   _.get('newDisabilities', formData, []).some(disability =>
     isDisabilityPtsd(disability.condition),
   );
@@ -863,55 +913,6 @@ export const activeServicePeriods = formData =>
   _.get('serviceInformation.servicePeriods', formData, []).filter(
     sp => !sp.dateRange.to || moment(sp.dateRange.to).isAfter(moment()),
   );
-
-export const isBDD = formData => {
-  const isBddDataFlag = Boolean(formData?.['view:isBddData']);
-  const servicePeriods = formData?.serviceInformation?.servicePeriods || [];
-
-  // separation date entered in the wizard
-  const separationDate = window.sessionStorage.getItem(SAVED_SEPARATION_DATE);
-
-  // this flag helps maintain the correct form title within a session
-  // Removed because of Cypress e2e tests don't have access to 'view:isBddData'
-  // window.sessionStorage.removeItem(FORM_STATUS_BDD);
-
-  // isActiveDuty is true when the user selects that option in the wizard & then
-  // enters a separation date - based on the session storage value; we then
-  // set this flag in the formData.
-  // If the user doesn't choose the active duty wizard option, but enters a
-  // future date in their service history, this may be associated with reserves
-  // and therefor should not open the BDD flow
-  const isActiveDuty = isBddDataFlag || separationDate;
-
-  if (
-    !isActiveDuty ||
-    // User hasn't started the form or the wizard
-    (servicePeriods.length === 0 && !separationDate)
-  ) {
-    return false;
-  }
-
-  const mostRecentDate = separationDate
-    ? moment(separationDate)
-    : servicePeriods
-        .filter(({ dateRange }) => dateRange?.to)
-        .map(({ dateRange }) => moment(dateRange?.to))
-        .sort((dateA, dateB) => (dateB.isBefore(dateA) ? -1 : 1))[0];
-
-  if (!mostRecentDate) {
-    window.sessionStorage.setItem(FORM_STATUS_BDD, 'false');
-    return false;
-  }
-
-  const result =
-    isActiveDuty &&
-    mostRecentDate.isAfter(moment().add(89, 'days')) &&
-    !mostRecentDate.isAfter(moment().add(180, 'days'));
-
-  // this flag helps maintain the correct form title within a session
-  window.sessionStorage.setItem(FORM_STATUS_BDD, result ? 'true' : 'false');
-  return Boolean(result);
-};
 
 export const isUploadingSTR = formData =>
   isBDD(formData) &&


### PR DESCRIPTION
## Description

An active service member will no longer be asked PTSD specific question used to fill Form 781/781a within the Benefits Delivery at Discharge flow. These questions will be asked in their exit physical.

## Original issue(s)

closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/27584

## Testing done

- Unit tests passing
- Updated mock data using in unit & e2e tests
- @annaswims verified that the data without 781/781a additions submits to EVSS

## Screenshots

<details><summary>PTSD condition without additional questions (review & submit page)</summary>

<!-- leave a blank line above -->
![](https://user-images.githubusercontent.com/136959/126512885-96070328-b2b7-4314-a334-d78fe175b935.png)</details>


## Acceptance criteria
- [x] PTSD questions removed from BDD flow
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
