### PR TITLE
Make Your Health Care the first communication preference group

### DIFF
--- a/src/applications/personalization/profile/ducks/communicationPreferences.js
+++ b/src/applications/personalization/profile/ducks/communicationPreferences.js
@@ -11,9 +11,7 @@ function communicationGroupsSorter(groupA, groupB) {
     3: -1000, // group 3, "Your health care", should come first
   };
   function getCommunicationGroupSortingPriority(groupId) {
-    return groupSortingPriorities[groupId]
-      ? groupSortingPriorities[groupId]
-      : groupId;
+    return groupSortingPriorities[groupId] ?? groupId;
   }
 
   return (


### PR DESCRIPTION
## Description
This adds some basic sorting logic to the list of communication preference groups that we get from the server. It lists the Your Health Care group, that has an id of 3, first and all other groups are sorted based on their group id.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#27118

## Testing done
Added new unit test

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs