### PR TITLE
Add Chapter 33 Alert Debt Letters

### DIFF
--- a/src/applications/debt-letters/components/DebtLettersList.jsx
+++ b/src/applications/debt-letters/components/DebtLettersList.jsx
@@ -16,7 +16,7 @@ const DebtLettersList = ({ debtLinks, isVBMSError }) => {
           Your debt letters are currently unavailable.
         </h3>
         <p className="vads-u-font-family--sans">
-          You can't download your debt letters because something went wrong on
+          You can’t download your debt letters because something went wrong on
           our end.
         </p>
 
@@ -48,9 +48,10 @@ const DebtLettersList = ({ debtLinks, isVBMSError }) => {
             <DebtLettersTable debtLinks={debtLinks} />
           </>
         )}
+
       <div className="vads-u-margin-bottom--6 vads-u-margin-top--3">
         <h3 className="vads-u-margin-y--0">
-          What if I don't see the letter I'm looking for?
+          What if I don’t see the letter I'm looking for?
         </h3>
         <p className="vads-u-font-family--sans vads-u-margin-bottom--0">
           If you’ve received a letter about a VA debt, but don’t see the letter

--- a/src/applications/debt-letters/components/DebtLettersSummary.jsx
+++ b/src/applications/debt-letters/components/DebtLettersSummary.jsx
@@ -16,7 +16,7 @@ const Chapter33Alert = () => {
     <ExpandableAlert
       iconType="triangle"
       status="limited"
-      trackingPrefix="debt-letters-ch33-alert"
+      trackingPrefix="-debt-letters-ch33"
       label="If you got an email about Chapter 33 tuition debt with code 75B"
       content="This is a debt assigned to your school. You won’t find it listed here. Before you make a payment on this debt, check with your school.They may have already paid."
     />

--- a/src/applications/debt-letters/components/DebtLettersSummary.jsx
+++ b/src/applications/debt-letters/components/DebtLettersSummary.jsx
@@ -1,8 +1,9 @@
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
 import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
+import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
+import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import HowDoIPay from './HowDoIPay';
@@ -10,17 +11,48 @@ import NeedHelp from './NeedHelp';
 import DebtCardsList from './DebtCardsList';
 import { OnThisPageLinks } from './OnThisPageLinks';
 
-const renderAlert = () => (
+const Chapter33Alert = () => {
+  return (
+    <va-alert background-only status="warning">
+      <h3 slot="headline">Alert headline</h3>
+
+      <i
+        aria-hidden="true"
+        className="fa fa-exclamation-triangle vads-u-font-size--sm"
+        style={{
+          position: 'absolute',
+          left: '22px',
+          top: '37px',
+        }}
+      />
+
+      <div className="vads-u-margin-left--3">
+        <AdditionalInfo triggerText="If you got an email about Chapter 33 tuition debt with code 75B">
+          <p
+            className="vads-u-font-size--base vads-u-font-family--sans"
+            style={{ width: '101%' }}
+          >
+            This is a debt assigned to your school. You won’t find it listed
+            here. Before you make a payment on this debt, check with your
+            school. They may have already paid.
+          </p>
+        </AdditionalInfo>
+      </div>
+    </va-alert>
+  );
+};
+
+const ErrorAlert = () => (
   <section
     className="usa-alert usa-alert-error vads-u-margin-top--0 vads-u-padding--3"
     role="alert"
   >
     <div className="usa-alert-body">
       <h3 className="usa-alert-heading">
-        We're sorry. Something went wrong on our end.
+        We’re sorry. Something went wrong on our end.
       </h3>
       <p className="vads-u-font-family--sans">
-        You can't view information about your current debts or download your
+        You can’t view information about your current debts or download your
         debt letters because something went wrong on our end.
       </p>
       <h4>What you can do</h4>
@@ -33,10 +65,10 @@ const renderAlert = () => (
   </section>
 );
 
-const renderEmptyAlert = () => (
+const EmptyItemsAlert = () => (
   <section className="vads-u-background-color--gray-lightest vads-u-padding--3 vads-u-margin-top--3">
     <h2 className="vads-u-font-family--serif vads-u-margin-top--0 vads-u-font-size--h4">
-      Our records show that you don't have any current debts
+      Our records show that you don’t have any current debts
     </h2>
 
     <p className="vads-u-font-family--sans vads-u-margin-bottom--0">
@@ -85,13 +117,16 @@ const DebtLettersSummary = ({ isError, isVBMSError, debts, debtLinks }) => {
               assistance.
             </p>
 
-            {allDebtsFetchFailure && renderAlert()}
+            {allDebtsFetchFailure && <ErrorAlert />}
 
-            {allDebtsEmpty && renderEmptyAlert()}
+            {allDebtsEmpty && <EmptyItemsAlert />}
 
             {!allDebtsFetchFailure && (
               <>
+                <Chapter33Alert />
+
                 <OnThisPageLinks />
+
                 <DebtCardsList />
               </>
             )}

--- a/src/applications/debt-letters/components/DebtLettersSummary.jsx
+++ b/src/applications/debt-letters/components/DebtLettersSummary.jsx
@@ -16,7 +16,7 @@ const Chapter33Alert = () => {
     <>
       <ExpandableAlert
         iconType="triangle"
-        status={'limited'}
+        status="limited"
         label="If you got an email about Chapter 33 tuition debt with code 75B"
         content={
           'This is a debt assigned to your school. You won’t find it listed here. ' +

--- a/src/applications/debt-letters/components/DebtLettersSummary.jsx
+++ b/src/applications/debt-letters/components/DebtLettersSummary.jsx
@@ -16,12 +16,9 @@ const Chapter33Alert = () => {
     <ExpandableAlert
       iconType="triangle"
       status="limited"
+      trackingPrefix="debt-letters-ch33-alert"
       label="If you got an email about Chapter 33 tuition debt with code 75B"
-      content={
-        'This is a debt assigned to your school. You won’t find it listed here. ' +
-        'Before you make a payment on this debt, check with your school.' +
-        'They may have already paid. '
-      }
+      content="This is a debt assigned to your school. You won’t find it listed here. Before you make a payment on this debt, check with your school.They may have already paid."
     />
   );
 };

--- a/src/applications/debt-letters/components/DebtLettersSummary.jsx
+++ b/src/applications/debt-letters/components/DebtLettersSummary.jsx
@@ -3,34 +3,28 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
 import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import HowDoIPay from './HowDoIPay';
 import NeedHelp from './NeedHelp';
 import DebtCardsList from './DebtCardsList';
+import ExpandableAlert from './ExpandableAlert';
 import { OnThisPageLinks } from './OnThisPageLinks';
 
 const Chapter33Alert = () => {
   return (
-    <va-alert class="chapter33-alert" background-only status="warning">
-      <h3 slot="headline">Alert headline</h3>
-
-      <i
-        aria-hidden="true"
-        className="fa fa-exclamation-triangle vads-u-font-size--sm"
+    <>
+      <ExpandableAlert
+        iconType="triangle"
+        status={'limited'}
+        label="If you got an email about Chapter 33 tuition debt with code 75B"
+        content={
+          'This is a debt assigned to your school. You won’t find it listed here. ' +
+          'Before you make a payment on this debt, check with your school.' +
+          'They may have already paid. '
+        }
       />
-
-      <div className="vads-u-margin-left--3">
-        <AdditionalInfo triggerText="If you got an email about Chapter 33 tuition debt with code 75B">
-          <p className="vads-u-font-size--base vads-u-font-family--sans">
-            This is a debt assigned to your school. You won’t find it listed
-            here. Before you make a payment on this debt, check with your
-            school. They may have already paid.
-          </p>
-        </AdditionalInfo>
-      </div>
-    </va-alert>
+    </>
   );
 };
 

--- a/src/applications/debt-letters/components/DebtLettersSummary.jsx
+++ b/src/applications/debt-letters/components/DebtLettersSummary.jsx
@@ -13,18 +13,16 @@ import { OnThisPageLinks } from './OnThisPageLinks';
 
 const Chapter33Alert = () => {
   return (
-    <>
-      <ExpandableAlert
-        iconType="triangle"
-        status="limited"
-        label="If you got an email about Chapter 33 tuition debt with code 75B"
-        content={
-          'This is a debt assigned to your school. You won’t find it listed here. ' +
-          'Before you make a payment on this debt, check with your school.' +
-          'They may have already paid. '
-        }
-      />
-    </>
+    <ExpandableAlert
+      iconType="triangle"
+      status="limited"
+      label="If you got an email about Chapter 33 tuition debt with code 75B"
+      content={
+        'This is a debt assigned to your school. You won’t find it listed here. ' +
+        'Before you make a payment on this debt, check with your school.' +
+        'They may have already paid. '
+      }
+    />
   );
 };
 

--- a/src/applications/debt-letters/components/DebtLettersSummary.jsx
+++ b/src/applications/debt-letters/components/DebtLettersSummary.jsx
@@ -13,25 +13,17 @@ import { OnThisPageLinks } from './OnThisPageLinks';
 
 const Chapter33Alert = () => {
   return (
-    <va-alert background-only status="warning">
+    <va-alert class="chapter33-alert" background-only status="warning">
       <h3 slot="headline">Alert headline</h3>
 
       <i
         aria-hidden="true"
         className="fa fa-exclamation-triangle vads-u-font-size--sm"
-        style={{
-          position: 'absolute',
-          left: '22px',
-          top: '37px',
-        }}
       />
 
       <div className="vads-u-margin-left--3">
         <AdditionalInfo triggerText="If you got an email about Chapter 33 tuition debt with code 75B">
-          <p
-            className="vads-u-font-size--base vads-u-font-family--sans"
-            style={{ width: '101%' }}
-          >
+          <p className="vads-u-font-size--base vads-u-font-family--sans">
             This is a debt assigned to your school. You won’t find it listed
             here. Before you make a payment on this debt, check with your
             school. They may have already paid.

--- a/src/applications/debt-letters/components/ExpandableAlert.jsx
+++ b/src/applications/debt-letters/components/ExpandableAlert.jsx
@@ -2,7 +2,14 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import recordEvent from 'platform/monitoring/record-event';
 
-const ExpandableAlert = ({ label, content, status, iconType, ...rest }) => {
+const ExpandableAlert = ({
+  label,
+  content,
+  status,
+  iconType,
+  trackingPrefix,
+  ...rest
+}) => {
   const [open, setOpen] = useState(false);
 
   const handleOnclick = e => {
@@ -11,7 +18,7 @@ const ExpandableAlert = ({ label, content, status, iconType, ...rest }) => {
     setOpen(!open);
     recordEvent({
       event: `int-accordion-${open ? 'expand' : 'collapse'}`,
-      'operating-status-heading': label,
+      [`${trackingPrefix}-expandable-alert`]: label,
     });
   };
 
@@ -24,6 +31,8 @@ const ExpandableAlert = ({ label, content, status, iconType, ...rest }) => {
   return (
     <div {...rest}>
       <button
+        aria-expanded={open}
+        aria-controls={`expandable-container-${trackingPrefix}`}
         type="button"
         className={`collapsible ${status}`}
         onClick={e => handleOnclick(e)}
@@ -47,6 +56,7 @@ const ExpandableAlert = ({ label, content, status, iconType, ...rest }) => {
       </button>
 
       <div
+        id={`expandable-container-${trackingPrefix}`}
         className={`content ${status} ${
           open ? 'vads-u-display--block' : 'vads-u-display--none'
         }`}
@@ -62,7 +72,8 @@ const ExpandableAlert = ({ label, content, status, iconType, ...rest }) => {
 };
 
 ExpandableAlert.propTypes = {
-  label: PropTypes.string,
+  label: PropTypes.string.isRequired,
+  trackingPrefix: PropTypes.string.isRequired,
   content: PropTypes.string,
   iconType: PropTypes.string,
   status: PropTypes.string,

--- a/src/applications/debt-letters/components/ExpandableAlert.jsx
+++ b/src/applications/debt-letters/components/ExpandableAlert.jsx
@@ -22,10 +22,10 @@ const ExpandableAlert = ({
     });
   };
 
-  const iconIndicator = info => {
-    if (info && open) return 'fa-angle-down open';
-    if (info && !open) return ' fa-angle-down close';
-    return null;
+  const iconIndicator = () => {
+    if (!content) return '';
+
+    return open ? 'fa-angle-down open' : 'fa-angle-down close';
   };
 
   return (
@@ -49,9 +49,7 @@ const ExpandableAlert = ({
         <i
           aria-hidden="true"
           role="img"
-          className={`fas ${iconIndicator(
-            content,
-          )}  more-icon vads-u-padding-left--0p5`}
+          className={`fas ${iconIndicator()}  more-icon vads-u-padding-left--0p5`}
         />
       </button>
 

--- a/src/applications/debt-letters/components/ExpandableAlert.jsx
+++ b/src/applications/debt-letters/components/ExpandableAlert.jsx
@@ -22,7 +22,7 @@ const ExpandableAlert = ({
     });
   };
 
-  const iconIndicator = () => {
+  const getCollapsibleIcon = () => {
     if (!content) return '';
 
     return open ? 'fa-angle-down open' : 'fa-angle-down close';
@@ -32,7 +32,7 @@ const ExpandableAlert = ({
     <div {...rest}>
       <button
         aria-expanded={open}
-        aria-controls={`expandable-container-${trackingPrefix}`}
+        aria-controls={`expandable-alert-${trackingPrefix}`}
         type="button"
         className={`collapsible ${status}`}
         onClick={e => handleOnclick(e)}
@@ -49,7 +49,7 @@ const ExpandableAlert = ({
         <i
           aria-hidden="true"
           role="img"
-          className={`fas ${iconIndicator()}  more-icon vads-u-padding-left--0p5`}
+          className={`fas ${getCollapsibleIcon()}  more-icon vads-u-padding-left--0p5`}
         />
       </button>
 

--- a/src/applications/debt-letters/components/ExpandableAlert.jsx
+++ b/src/applications/debt-letters/components/ExpandableAlert.jsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import recordEvent from 'platform/monitoring/record-event';
+
+const ExpandableAlert = ({ label, content, status, iconType, ...rest }) => {
+  const [open, setOpen] = useState(false);
+
+  const handleOnclick = e => {
+    if (!content) return;
+    if (e) e.target.classList.toggle('active');
+    setOpen(!open);
+    recordEvent({
+      event: `int-accordion-${open ? 'expand' : 'collapse'}`,
+      'operating-status-heading': label,
+    });
+  };
+
+  const iconIndicator = info => {
+    if (info && open) return 'fa-angle-down open';
+    if (info && !open) return ' fa-angle-down close';
+    return null;
+  };
+
+  return (
+    <div {...rest}>
+      <button
+        type="button"
+        className={`collapsible ${status}`}
+        onClick={e => handleOnclick(e)}
+      >
+        <i
+          aria-hidden="true"
+          role="img"
+          className={`fa fa-exclamation-${iconType} alert-icon-base`}
+        />
+
+        <span className={`${content ? 'status-label' : null}`}>{label}</span>
+        <span className="sr-only">Alert: </span>
+
+        <i
+          aria-hidden="true"
+          role="img"
+          className={`fas ${iconIndicator(
+            content,
+          )}  more-icon vads-u-padding-left--0p5`}
+        />
+      </button>
+
+      <div
+        className={`content ${status} ${
+          open ? 'vads-u-display--block' : 'vads-u-display--none'
+        }`}
+      >
+        {content && (
+          <p className="vads-u-font-family--sans vads-u-padding-x--1">
+            {content}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+ExpandableAlert.propTypes = {
+  label: PropTypes.string,
+  content: PropTypes.string,
+  iconType: PropTypes.string,
+  status: PropTypes.string,
+};
+
+export default ExpandableAlert;

--- a/src/applications/debt-letters/sass/debt-letters.scss
+++ b/src/applications/debt-letters/sass/debt-letters.scss
@@ -1,4 +1,5 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
+@import "./partials/expandable-alert";
 
 .right-heading {
   font-family: "Bitter";

--- a/src/applications/debt-letters/sass/debt-letters.scss
+++ b/src/applications/debt-letters/sass/debt-letters.scss
@@ -50,3 +50,19 @@ h1:focus {
 dt {
   width: 50%;
 }
+
+.chapter33-alert {
+  i {
+    position: absolute;
+    left: 22px;
+    top: 37px;
+  }
+
+  p {
+    width: 101%;
+  }
+
+  i.fas.fa-angle-down {
+    display: none;
+  }
+}

--- a/src/applications/debt-letters/sass/partials/_expandable-alert.scss
+++ b/src/applications/debt-letters/sass/partials/_expandable-alert.scss
@@ -7,13 +7,13 @@
   color: $color-gray-dark;
   cursor: pointer;
   width: 530px;
-  height: 42px;
   border: none;
   text-align: left;
   outline: none;
   font-size: 16px;
-  padding: 0;
+  padding: 8px;
   margin: 0;
+  line-height: 1.5;
   background-color: transparent;
   border-radius: 0;
 
@@ -55,10 +55,11 @@
   width: 20px !important;
   height: 18px !important;
   pointer-events: none !important;
-  padding: 12px 11px 12px 12px !important;
   font-size: unset !important;
   display: unset !important;
   align-self: flex-start;
+  margin-right: 5px;
+  margin-top: 5px;
 }
 
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
@@ -68,7 +69,6 @@
     width: 20px !important;
     height: 18px !important;
     pointer-events: none !important;
-    padding: 12px 20px 12px 12px !important;
   }
 }
 

--- a/src/applications/debt-letters/sass/partials/_expandable-alert.scss
+++ b/src/applications/debt-letters/sass/partials/_expandable-alert.scss
@@ -1,0 +1,119 @@
+@import "~@department-of-veterans-affairs/formation/sass/shared-variables";
+
+.collapsible {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: $color-gray-dark;
+  cursor: pointer;
+  width: 530px;
+  height: 42px;
+  border: none;
+  text-align: left;
+  outline: none;
+  font-size: 16px;
+  padding: 0;
+  margin: 0;
+  background-color: transparent;
+  border-radius: 0;
+
+  @media (max-width: $small-screen) {
+    width: 100%;
+  }
+}
+
+.collapsible:hover {
+  color: $color-gray-dark;
+  background-color: transparent;
+}
+
+.collapsible:active {
+  color: $color-gray-dark;
+  background-color: transparent;
+}
+
+.status-label {
+  text-decoration: underline $color-light-blue dotted;
+  text-underline-position: under;
+
+  &:active {
+    pointer-events: none;
+  }
+}
+
+.content {
+  width: 530px;
+  display: none;
+  overflow: hidden;
+
+  @media (max-width: $small-screen) {
+    width: 100%;
+  }
+}
+
+.alert-icon-base {
+  width: 20px !important;
+  height: 18px !important;
+  pointer-events: none !important;
+  padding: 12px 11px 12px 12px !important;
+  font-size: unset !important;
+  display: unset !important;
+  align-self: flex-start;
+}
+
+@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+  // IE fix for icon padding
+  //https://stackoverflow.com/questions/11173106/apply-style-only-on-ie
+  .alert-icon-base {
+    width: 20px !important;
+    height: 18px !important;
+    pointer-events: none !important;
+    padding: 12px 20px 12px 12px !important;
+  }
+}
+
+.more-info {
+  margin: 0;
+  padding: 0 12px 12px 12px;
+}
+
+.more-icon {
+  pointer-events: none;
+  margin-right: 15px;
+}
+
+.limited {
+  background-color: $color-gold-lightest !important;
+
+  span.status-label:hover {
+    background-color: $color-gold-lighter !important;
+  }
+
+  span.status-label:active {
+    background-color: $color-gold-lighter !important;
+  }
+}
+
+.closed {
+  background-color: $color-red-lightest !important;
+
+  span.status-label:hover {
+    background-color: $color-secondary-light !important;
+  }
+
+  span.status-label:active {
+    background-color: $color-secondary-light !important;
+  }
+}
+
+.notice {
+  background-color: $color-aqua-lightest !important;
+
+  span.status-label:hover {
+    background-color: $color-primary-alt-light !important;
+  }
+
+  span.status-label:active {
+    background-color: $color-primary-alt-light !important;
+  }
+}


### PR DESCRIPTION
## Description
Make Alert to inform users that Chapter 33 debts can not be seen in debt portal.



## Original issue(s)
[Ticket](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/department-of-veterans-affairs/va.gov-team/26838)


## Testing done
N/A

## Screenshots
### Mobile Small
![Screen Shot 2021-07-22 at 2 26 02 PM](https://user-images.githubusercontent.com/23741323/126690182-6259b3d1-32e5-4a9a-8efa-19f73aeb1e0b.png)


### Laptop Lg
![Screen Shot 2021-07-22 at 2 26 10 PM](https://user-images.githubusercontent.com/23741323/126690190-ba078d08-9583-440b-9721-9e55b71343e3.png)


### Desktop Gif
![expand-alert](https://user-images.githubusercontent.com/23741323/126690216-705339bf-c113-4912-b59d-d56ecd0762b1.gif)



## Acceptance criteria
- [ ] Alert appears as it does in [Mocks](https://preview.uxpin.com/067dc9cad4c5966bc8a5f3a400cf10206e6a51d4#/pages/140437273/simulate/sitemap?mode=i)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
