### PR TITLE
27572 add ga event chp31

### DIFF
--- a/src/applications/vre/28-1900/orientation/StepComponent.jsx
+++ b/src/applications/vre/28-1900/orientation/StepComponent.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router';
+import recordEvent from 'platform/monitoring/record-event';
 import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
 import { orientationSteps } from './utils';
 
@@ -64,6 +65,9 @@ const StepComponent = props => {
           to="/"
           className="vads-c-action-link--green vads-u-padding-left--0"
           onClick={() => {
+            recordEvent({
+              event: 'howToWizard-complete-orientation',
+            });
             clickHandler(WIZARD_STATUS_COMPLETE);
           }}
         >


### PR DESCRIPTION
## Description
This pull request adds a new GA event to the chapter 31 orientation that tracks when a user has gone through the orientation slideshow and completed it. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#27572
department-of-veterans-affairs/va.gov-team/issues/25246


## Testing done
- local

## Screenshots
<img width="467" alt="Screen Shot 2021-07-21 at 12 02 21 PM" src="https://user-images.githubusercontent.com/15097156/126529998-31218885-b19b-422d-bc1a-3a22c2dca059.png">


## Acceptance criteria
- [ ] event fires

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
