### PR TITLE
remove meta from title

### DIFF
--- a/src/applications/search/constants/stub.json
+++ b/src/applications/search/constants/stub.json
@@ -17,31 +17,31 @@
               "publicationDate": null
             },
             {
-              "title": "Download VA benefit letters | Veterans Affairs",
+              "title": "Download VA benefit letters",
               "url": "https://www.va.gov/records/download-va-letters/",
               "snippet": "Download your VA Benefit Summary Letter (sometimes called a VA award letter)...letter) and other benefit letters and documents online....section Download VA benefit letters To receive some benefits, Veterans need a letter...status. Access and download your VA Benefit Summary Letter (sometimes called a",
               "publicationDate": "2020-10-30"
             },
             {
-              "title": "VA benefits for spouses, dependents, survivors, and family caregivers | Veterans Affairs",
+              "title": "VA benefits for spouses, dependents, survivors, and family caregivers",
               "url": "https://www.va.gov/family-member-benefits/",
               "snippet": "Learn about VA benefits for spouses, dependents, survivors, and family caregivers...VA benefits for spouses, dependents, survivors, and family caregivers As the...member, you may qualify for certain benefits, like health care, life insurance",
               "publicationDate": "2020-12-07"
             },
             {
-              "title": "About GI Bill benefits | Veterans Affairs",
+              "title": "About GI Bill benefits",
               "url": "https://www.va.gov/education/about-gi-bill-benefits/",
               "snippet": "Learn how GI Bill benefits work and explore your options to pay for school or...training. You may qualify for VA GI Bill benefits if you're a Veteran, service member...this section About GI Bill benefits GI Bill benefits help you pay for college...training. Learn more about GI Bill benefits below—and how to apply for them. If",
               "publicationDate": "2020-12-30"
             },
             {
-              "title": "CHAMPVA benefits | Veterans Affairs",
+              "title": "CHAMPVA benefits",
               "url": "https://www.va.gov/health-care/family-caregiver-benefits/champva/",
               "snippet": "Learn about CHAMPVA benefits, which cover the cost of health care for the spouse...In this section CHAMPVA benefits Are you the spouse or surviving spouse of—or...both may now qualify for CHAMPVA benefits. Each time they need medical care",
               "publicationDate": "2020-09-18"
             },
             {
-              "title": "Add dependents to your VA disability benefits | Veterans Affairs",
+              "title": "Add dependents to your VA disability benefits",
               "url": "https://www.va.gov/disability/add-remove-dependent/",
               "snippet": "...dependents to your VA disability benefits for additional compensation. Learn...dependents to your VA disability benefits Find out how to add a dependent spouse...and/or parent to your VA disability benefits for additional compensation. Am I",
               "publicationDate": "2020-07-22"
@@ -53,19 +53,19 @@
               "publicationDate": null
             },
             {
-              "title": "VA burial benefits and memorial items | Veterans Affairs",
+              "title": "VA burial benefits and memorial items",
               "url": "https://www.va.gov/burials-memorials/",
               "snippet": "...apply for VA burial benefits. Veterans burial benefits include burial in a VA...qualify for compensation and other benefits....VA burial benefits and memorial items VA burial benefits can help service members...Find out how to apply for the burial benefits you've earned, and how to plan for",
               "publicationDate": "2020-10-30"
             },
             {
-              "title": "VA education and training benefits | Veterans Affairs",
+              "title": "VA education and training benefits",
               "url": "https://www.va.gov/education/",
               "snippet": "...and how to apply for VA education benefits for Veterans, service members, and...members. VA education and training benefits can help you pay for college tuition...education and training benefits VA education benefits help Veterans, service...manage the education and training benefits you've earned. On this page Get GI",
               "publicationDate": "2020-12-07"
             },
             {
-              "title": "Post-9/11 GI Bill Statement of Benefits | Veterans Affairs",
+              "title": "Post-9/11 GI Bill Statement of Benefits",
               "url": "https://www.va.gov/education/gi-bill/post-9-11/ch-33-benefit/",
               "snippet": "Bill education benefits, your GI Bill Statement of Benefits will show you how...how much of your benefits you’ve used and how much you have left to use for your...Statement of Benefits If you were awarded Post-9/11 GI Bill education benefits, your...Statement of Benefits will show you how much of your benefits you’ve used and",
               "publicationDate": "2020-11-13"

--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -6,7 +6,11 @@ import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 
 import { fetchSearchResults } from '../actions';
-import { formatResponseString, truncateResponseString } from '../utils';
+import {
+  formatResponseString,
+  truncateResponseString,
+  removeDoubleBars,
+} from '../utils';
 import recordEvent from 'platform/monitoring/record-event';
 import { replaceWithStagingDomain } from 'platform/utilities/environment/stagingDomains';
 
@@ -416,7 +420,9 @@ class SearchApp extends React.Component {
 
   /* eslint-disable react/no-danger */
   renderWebResult(result, snippetKey = 'snippet', isBestBet = false, index) {
-    const strippedTitle = formatResponseString(result.title, true);
+    const strippedTitle = removeDoubleBars(
+      formatResponseString(result.title, true),
+    );
     return (
       <li
         key={result.url}

--- a/src/applications/search/utils.js
+++ b/src/applications/search/utils.js
@@ -12,3 +12,7 @@ export function truncateResponseString(string, maxLength) {
   }
   return `${string.slice(0, maxLength)}...`;
 }
+
+export function removeDoubleBars(string) {
+  return string.replace('| Veterans Affairs', '');
+}


### PR DESCRIPTION
## Description
This PR adds a function to remove an unnecessary meta info from appearing in search result titles.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#27061

