### PR TITLE
Add aria-labelledBy to search landmark

### DIFF
--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -220,17 +220,19 @@ class SearchApp extends React.Component {
           className="va-flex search-box vads-u-margin-top--1 vads-u-margin-bottom--0"
           data-e2e-id="search-form"
         >
-          <input
-            type="text"
-            name="query"
-            aria-label="Enter a keyword"
-            value={this.state.userInput}
-            onChange={this.handleInputChange}
-          />
-          <button type="submit">
-            <IconSearch color="#fff" />
-            <span className="button-text">Search</span>
-          </button>
+          <div role="search" aria-labelledby="h1-search-title">
+            <input
+              type="text"
+              name="query"
+              aria-label="Enter a keyword"
+              value={this.state.userInput}
+              onChange={this.handleInputChange}
+            />
+            <button type="submit">
+              <IconSearch color="#fff" />
+              <span className="button-text">Search</span>
+            </button>
+          </div>
         </form>
       </div>
     );
@@ -471,7 +473,9 @@ class SearchApp extends React.Component {
         <SearchBreadcrumbs />
         <div className="row">
           <div className="columns">
-            <h1 className="vads-u-font-size--2xl">Search VA.gov</h1>
+            <h1 className="vads-u-font-size--2xl" id="h1-search-title">
+              Search VA.gov
+            </h1>
           </div>
         </div>
         <div className="search-row">


### PR DESCRIPTION
## Description
Adds an `aria-labelledBy` pointing at the `h1` for the search page to the search landmark.
Most of the diff is indentation: https://github.com/department-of-veterans-affairs/vets-website/pull/17958/files?diff=split&w=1

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/13138


## Testing done
manual

## Screenshots
<img width="1598" alt="Screen Shot 2021-07-21 at 3 48 30 PM" src="https://user-images.githubusercontent.com/3144003/126550782-0d2c585b-1190-4b3e-b62c-e98e292bf468.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
