### PR TITLE
HLR: Update to use `va-alert` WC

### DIFF
--- a/src/applications/disability-benefits/996/content/contestableIssueAlerts.jsx
+++ b/src/applications/disability-benefits/996/content/contestableIssueAlerts.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
+
 import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
@@ -10,31 +10,35 @@ import { disabilitiesExplanationAlert } from './contestedIssues';
 import { PROFILE_URL } from '../constants';
 
 const noIssuesMessage = (
-  <>
+  <p className="vads-u-font-size--base">
     If you think this is an error, please call us at{' '}
     <Telephone contact={CONTACTS.VA_BENEFITS} />. We’re here Monday through
     Friday, 8:00 a.m. to 9:00 p.m. ET.
     {disabilitiesExplanationAlert}
-  </>
+  </p>
 );
 
 const networkError = (
-  <p>
+  <p className="vads-u-font-size--base">
     We’re having some connection issues on our end. Please refresh this page to
     try again.
   </p>
 );
 
 const benefitError = type => (
-  <p>We don’t currently support the "{type}" benefit type</p>
+  <p className="vads-u-font-size--base">
+    We don’t currently support the "{type}" benefit type
+  </p>
 );
 
 export const noContestableIssuesFound = (
-  <AlertBox
-    status="warning"
-    headline="We don’t have any issues on file for you that are eligible for a Higher-Level Review"
-    content={noIssuesMessage}
-  />
+  <va-alert status="warning">
+    <h3 slot="headline">
+      We don’t have any issues on file for you that are eligible for a
+      Higher-Level Review
+    </h3>
+    {noIssuesMessage}
+  </va-alert>
 );
 
 let timeoutId;
@@ -68,21 +72,21 @@ export const showContestableIssueError = ({ error, status } = {}, delay) => {
   } else {
     record(); // no delay in unit tests
   }
-  return <AlertBox status="error" headline={headline} content={content} />;
+  return (
+    <va-alert status="error">
+      <h3 slot="headline">{headline}</h3>
+      {content}
+    </va-alert>
+  );
 };
 
 export const showHasEmptyAddress = (
-  <AlertBox
-    status="info"
-    headline="You need to have an address on file"
-    content={
-      <>
-        <p>
-          To request a Higher-Level Review, you need to have an address in your
-          VA.gov profile. To add an address,{' '}
-          <a href={PROFILE_URL}>please go to your profile page.</a>
-        </p>
-      </>
-    }
-  />
+  <va-alert status="info">
+    <h3 slot="headline">You need to have an address on file</h3>
+    <p className="vads-u-font-size--base">
+      To request a Higher-Level Review, you need to have an address in your
+      VA.gov profile. To add an address,{' '}
+      <a href={PROFILE_URL}>please go to your profile page.</a>
+    </p>
+  </va-alert>
 );

--- a/src/applications/disability-benefits/996/content/contestedIssues.jsx
+++ b/src/applications/disability-benefits/996/content/contestedIssues.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import moment from 'moment';
 import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
-import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
+
 import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
@@ -149,13 +149,16 @@ export const disabilitiesExplanation = (
 /**
  * Shows the alert box only if the form has been submitted
  */
-export const ContestedIssuesAlert = ({ className }) => {
+export const ContestedIssuesAlert = ({ className = '' }) => {
   setTimeout(() => scrollTo('eligibleScrollElement'), 300);
   return (
-    <AlertBox
-      status="error"
-      className={`eligible-issues-error vads-u-margin-x--2 vads-u-margin-y--1 vads-u-padding-x--3 vads-u-padding-y--2 ${className}`}
-      headline="Please choose an eligible issue so we can process your request"
-    />
+    <va-alert status="error">
+      <h3
+        slot="headline"
+        className={`eligible-issues-error vads-u-margin-x--2 vads-u-margin-y--1 vads-u-padding-x--3 vads-u-padding-y--2 ${className}`}
+      >
+        Please choose an eligible issue so we can process your request
+      </h3>
+    </va-alert>
   );
 };

--- a/src/applications/disability-benefits/996/tests/components/contestedIssues.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/components/contestedIssues.unit.spec.jsx
@@ -51,7 +51,7 @@ describe('Higher-Level Review 0996 choose contested issues', () => {
     const formDOM = getFormDOM(form);
     formDOM.setCheckbox('#root_contestedIssues_0', true);
     submitForm(form);
-    expect($$('.usa-alert-error', formDOM).length).to.equal(0);
+    expect($$('va-alert', formDOM).length).to.equal(0);
     expect(onSubmit.called).to.be.true;
   });
 
@@ -67,7 +67,7 @@ describe('Higher-Level Review 0996 choose contested issues', () => {
 
     const formDOM = getFormDOM(form);
     submitForm(form);
-    expect($$('.usa-alert-error', formDOM).length).to.equal(1);
+    expect($$('va-alert', formDOM).length).to.equal(1);
   });
 
   it('renders the information about each disability', () => {

--- a/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
@@ -74,11 +74,9 @@ describe('IntroductionPage', () => {
       <IntroductionPage {...defaultProps} user={user} hasEmptyAddress />,
     );
 
-    const AlertBox = tree.find('AlertBox');
-    expect(AlertBox.length).to.equal(1);
-    expect(AlertBox.props().headline).to.contain(
-      'need to have an address on file',
-    );
+    const alert = tree.find('va-alert');
+    expect(alert.length).to.equal(1);
+    expect(alert.text()).to.contain('need to have an address on file');
     tree.unmount();
   });
 
@@ -111,8 +109,8 @@ describe('IntroductionPage', () => {
 
     const tree = shallow(<IntroductionPage {...props} />);
 
-    const AlertBox = tree.find('AlertBox').first();
-    expect(AlertBox.render().text()).to.include(errorMessage);
+    const alert = tree.find('va-alert').first();
+    expect(alert.render().text()).to.include(errorMessage);
     const recordedEvent = gaData[gaData.length - 1];
     expect(recordedEvent.event).to.equal('visible-alert-box');
     expect(recordedEvent['alert-box-heading']).to.include(errorMessage);
@@ -133,8 +131,8 @@ describe('IntroductionPage', () => {
 
     const tree = shallow(<IntroductionPage {...props} />);
 
-    const AlertBox = tree.find('AlertBox').first();
-    expect(AlertBox.render().text()).to.include(errorMessage);
+    const alert = tree.find('va-alert').first();
+    expect(alert.render().text()).to.include(errorMessage);
     const recordedEvent = gaData[gaData.length - 1];
     expect(recordedEvent.event).to.equal('visible-alert-box');
     expect(recordedEvent['alert-box-heading']).to.include(errorMessage);


### PR DESCRIPTION
## Description

Switch the `AlertBox` component to use the `va-alert` web component in the Higher-Level Review form.

## Original issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/27250

## Testing done

Updated unit tests

## Screenshots

N/A - no appearance change

## Acceptance criteria
- [x] Replace `AlertBox` with `va-alert`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
