### PR TITLE
Fixed case in Facility Locator service dropdown list

### DIFF
--- a/src/applications/facility-locator/config.js
+++ b/src/applications/facility-locator/config.js
@@ -200,7 +200,7 @@ export const healthServices = {
   WomensHealth: "Women's health",
   Podiatry: 'Podiatry',
   Nutrition: 'Nutrition',
-  CaregiverSupport: 'Caregiver Support',
+  CaregiverSupport: 'Caregiver support',
 };
 
 export const ccUrgentCareLabels = {


### PR DESCRIPTION
## Description
Resolved issue linked below

## Acceptance criteria
- [ ] heath service should now read - `Caregiver support`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
