### PR TITLE
CST: Update to use `va-alert` WC

### DIFF
--- a/src/applications/claims-status/components/ClaimEstimate.jsx
+++ b/src/applications/claims-status/components/ClaimEstimate.jsx
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import moment from 'moment';
 import { Link } from 'react-router';
-import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 
 export default function ClaimEstimate({
   maxDate,
@@ -12,11 +11,11 @@ export default function ClaimEstimate({
   // Hide until estimates are accurate
   if (showCovidMessage) {
     return (
-      <AlertBox
-        status="warning"
-        headline="Claim completion dates aren’t available right now"
-      >
-        <p>
+      <va-alert status="warning">
+        <h3 slot="headline">
+          Claim completion dates aren’t available right now
+        </h3>
+        <p className="vads-u-font-size--base">
           We can’t provide an estimated date on when your claim will be complete
           due to the affect that COVID-19 has had on scheduling in-person claim
           exams. We’re starting to schedule in-person exams again in many
@@ -26,7 +25,7 @@ export default function ClaimEstimate({
           </a>
           .
         </p>
-      </AlertBox>
+      </va-alert>
     );
   }
 

--- a/src/applications/claims-status/tests/e2e/01.claim-status-est-current.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-est-current.cypress.spec.js
@@ -44,6 +44,6 @@ describe('Claims status est current test', () => {
 
     cy.url().should('contain', '/your-claims/11/status');
 
-    cy.get('.usa-alert-text').should('contain', 'COVID-19 has had on');
+    cy.get('va-alert').should('contain', 'COVID-19 has had on');
   });
 });

--- a/src/applications/claims-status/tests/e2e/01.claim-status-est-past.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-est-past.cypress.spec.js
@@ -46,6 +46,6 @@ describe('Claims status est current test', () => {
 
     // Disabled until COVID-19 message removed
     // cy.get('.claim-completion-desc').should('contain', 'We estimated your claim would be completed by now');
-    cy.get('.usa-alert-text').should('contain', 'COVID-19 has had on');
+    cy.get('va-alert').should('contain', 'COVID-19 has had on');
   });
 });

--- a/src/applications/claims-status/tests/e2e/01.claim-status-est.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-est.cypress.spec.js
@@ -44,6 +44,6 @@ describe('Claims status est current test', () => {
 
     cy.url().should('contain', '/your-claims/11/status');
 
-    cy.get('.usa-alert-text').should('contain', 'COVID-19 has had on');
+    cy.get('va-alert').should('contain', 'COVID-19 has had on');
   });
 });


### PR DESCRIPTION
## Description

Switch the `AlertBox` component to use the `va-alert` web component in the claim status tool

## Original issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/27248

## Testing done

Updated e2e tests

## Screenshots

N/A - no visual change

## Acceptance criteria
- [x] Replace `AlertBox` with `va-alert`
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
