### PR TITLE
[DO NOT MERGE, POC] Update how we derive the emergency banner content

### DIFF
--- a/src/platform/site-wide/banners/components/Banners/index.js
+++ b/src/platform/site-wide/banners/components/Banners/index.js
@@ -1,50 +1,95 @@
 // Node modules.
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import * as Sentry from '@sentry/browser';
 import EmergencyBanner from '@department-of-veterans-affairs/component-library/EmergencyBanner';
 import MaintenanceBanner from '@department-of-veterans-affairs/component-library/MaintenanceBanner';
 // Relative imports.
 import config from '../../config/maintenanceBanner';
 import recordEvent from 'platform/monitoring/record-event';
+import { apiRequest } from 'platform/utilities/api';
+
+const EMERGENCY_BANNER_CONFIG_URL =
+  'https://raw.githubusercontent.com/department-of-veterans-affairs/vagov-content/master/fragments/home/banner.json';
 
 export const Banners = ({
-  homepageBannerContent,
-  homepageBannerTitle,
-  homepageBannerType,
-  homepageBannerVisible,
-}) => (
-  <>
-    {/* Homepage Banner */}
-    <EmergencyBanner
-      content={homepageBannerContent}
-      localStorage={localStorage}
-      recordEvent={recordEvent}
-      showClose
-      title={homepageBannerTitle}
-      type={homepageBannerType}
-      visible={homepageBannerVisible === 'true'}
-    />
+  emergencyBannerContent,
+  emergencyBannerTitle,
+  emergencyBannerType,
+  emergencyBannerVisible,
+}) => {
+  // Derive the state for the emergency banner.
+  const [fetching, setFetching] = useState(false);
+  const [content, setContent] = useState(emergencyBannerContent);
+  const [title, setTitle] = useState(emergencyBannerTitle);
+  const [type, setType] = useState(emergencyBannerType);
+  const [visible, setVisible] = useState(emergencyBannerVisible);
 
-    {/* Maintenance Banner */}
-    <MaintenanceBanner
-      content={config.content}
-      expiresAt={config.expiresAt}
-      id={config.id}
-      localStorage={localStorage}
-      startsAt={config.startsAt}
-      title={config.title}
-      warnContent={config.warnContent}
-      warnStartsAt={config.warnStartsAt}
-      warnTitle={config.warnTitle}
-    />
-  </>
-);
+  const fetchEmergencyBannerConfig = async () => {
+    // Show fetching state.
+    setFetching(true);
+
+    try {
+      // Fetch the emergency banner content.
+      const response = await apiRequest(EMERGENCY_BANNER_CONFIG_URL, {
+        mode: 'no-cors',
+      });
+
+      // Set the emergency banner content.
+      setContent(response?.content);
+      setTitle(response?.title);
+      setType(response?.type);
+      setVisible(response?.visible);
+    } catch (error) {
+      // If there was an error, log it.
+      Sentry.captureException(error);
+    }
+
+    // Hide fetching state.
+    setFetching(false);
+  };
+
+  // Fetch the emergency banner config when the component mounts.
+  useEffect(() => {
+    fetchEmergencyBannerConfig();
+  }, []);
+
+  return (
+    <>
+      {/* Homepage Banner */}
+      {!fetching && (
+        <EmergencyBanner
+          content={content}
+          localStorage={localStorage}
+          recordEvent={recordEvent}
+          showClose
+          title={title}
+          type={type}
+          visible={visible === 'true'}
+        />
+      )}
+
+      {/* Maintenance Banner */}
+      <MaintenanceBanner
+        content={config.content}
+        expiresAt={config.expiresAt}
+        id={config.id}
+        localStorage={localStorage}
+        startsAt={config.startsAt}
+        title={config.title}
+        warnContent={config.warnContent}
+        warnStartsAt={config.warnStartsAt}
+        warnTitle={config.warnTitle}
+      />
+    </>
+  );
+};
 
 Banners.propTypes = {
-  homepageBannerContent: PropTypes.string.isRequired,
-  homepageBannerTitle: PropTypes.string.isRequired,
-  homepageBannerType: PropTypes.string.isRequired,
-  homepageBannerVisible: PropTypes.string.isRequired,
+  emergencyBannerContent: PropTypes.string.isRequired,
+  emergencyBannerTitle: PropTypes.string.isRequired,
+  emergencyBannerType: PropTypes.string.isRequired,
+  emergencyBannerVisible: PropTypes.string.isRequired,
 };
 
 export default Banners;

--- a/src/platform/site-wide/banners/components/Banners/index.unit.spec.js
+++ b/src/platform/site-wide/banners/components/Banners/index.unit.spec.js
@@ -9,13 +9,13 @@ import MaintenanceBanner from '@department-of-veterans-affairs/component-library
 
 describe('<Banners>', () => {
   const defaultProps = {
-    homepageBannerContent: `<p>For questions about COVID-19 and how it affects VA health care and benefit services, visit our <a href="/coronavirus-veteran-frequently-asked-questions/">coronavirus FAQs</a> or read <a href="https://www.publichealth.va.gov/n-coronavirus/">VA’s public health response</a>.</p>↵↵<p>Please contact us first before going to any <a href="/find-locations">VA location</a>. Contacting us first helps us keep you safe.</p>↵↵<p>For the latest coronavirus information, visit the <a href="https://www.cdc.gov/coronavirus/2019-ncov/index.html">CDC website</a>.</p>↵`,
-    homepageBannerTitle: 'Coronavirus',
-    homepageBannerType: 'warning',
-    homepageBannerVisible: 'true',
+    emergencyBannerContent: `<p>For questions about COVID-19 and how it affects VA health care and benefit services, visit our <a href="/coronavirus-veteran-frequently-asked-questions/">coronavirus FAQs</a> or read <a href="https://www.publichealth.va.gov/n-coronavirus/">VA’s public health response</a>.</p>↵↵<p>Please contact us first before going to any <a href="/find-locations">VA location</a>. Contacting us first helps us keep you safe.</p>↵↵<p>For the latest coronavirus information, visit the <a href="https://www.cdc.gov/coronavirus/2019-ncov/index.html">CDC website</a>.</p>↵`,
+    emergencyBannerTitle: 'Coronavirus',
+    emergencyBannerType: 'warning',
+    emergencyBannerVisible: 'true',
   };
 
-  it('should render homepage banner', () => {
+  it('should render emergency banner', () => {
     const wrapper = shallow(<Banners {...defaultProps} />);
     expect(wrapper.find(EmergencyBanner)).to.not.equal(null);
     wrapper.unmount();


### PR DESCRIPTION
# Description

**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/27701

This PR makes it so that the homepage/emergency banner content is fetched whenever someone lands on https://www.va.gov, making it update on refresh as opposed to the current implementation which requires a content-build deployment.

This does not actually work at the moment due to CORS protections for public github user content. The current proposal is to move the banner config to AWS S3 so that we can fetch it without CORS issues.

**Related PRs:**
https://github.com/department-of-veterans-affairs/vagov-content/pull/784
https://github.com/department-of-veterans-affairs/vets-website/pull/17968
https://github.com/department-of-veterans-affairs/content-build/pull/389