### PR TITLE
[184] Push Coverage Report to S3 Bucket instead of Upload/Download Artifact

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -120,7 +120,7 @@ jobs:
         run: node script/app-coverage-report.js > test-results/coverage_report.txt
 
       - name: Configure AWS credentials (1)
-        if: ${{ github.ref == 'refs/heads/184--coverage-report-logic-move' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -128,14 +128,14 @@ jobs:
           aws-region: us-gov-west-1
 
       - name: Get AWS IAM role
-        if: ${{ github.ref == 'refs/heads/184--coverage-report-logic-move' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: marvinpinto/action-inject-ssm-secrets@latest
         with:
           ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
           env_variable_name: AWS_FRONTEND_NONPROD_ROLE
 
       - name: Configure AWS Credentials (2)
-        if: ${{ github.ref == 'refs/heads/184--coverage-report-logic-move' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -146,7 +146,7 @@ jobs:
           role-session-name: vsp-frontendteam-githubaction
 
       - name: Upload coverage report to S3
-        if: ${{ github.ref == 'refs/heads/184--coverage-report-logic-move' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         run: aws s3 cp coverage/test-coverage-report.json s3://apps.dev.va.gov/coverage/test-coverage-report.json --acl public-read --region us-gov-west-1
 
       - name: Get code coverage

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -68,13 +68,6 @@ jobs:
           BUILDTIME=$(date +%s)
           EOF
 
-      - name: Download coverage report
-        uses: actions/download-artifact@v2
-        if: ${{ github.ref == 'refs/heads/master' }}
-        with:
-          name: test-coverage-report
-          path: build/${{ matrix.buildtype }}/test-coverage-report.json
-
       - name: Compress and archive build
         run: tar -C build/${{ matrix.buildtype }} -cjf ${{ matrix.buildtype }}.tar.bz2 .
 
@@ -126,12 +119,35 @@ jobs:
       - name: Generate coverage report by app
         run: node script/app-coverage-report.js > test-results/coverage_report.txt
 
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v2
-        if: ${{ github.ref == 'refs/heads/master' }}
+      - name: Configure AWS credentials (1)
+        if: ${{ github.ref == 'refs/heads/184--coverage-report-logic-move' }}
+        uses: aws-actions/configure-aws-credentials@v1
         with:
-          name: test-coverage-report
-          path: coverage/test-coverage-report.json
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Get AWS IAM role
+        if: ${{ github.ref == 'refs/heads/184--coverage-report-logic-move' }}
+        uses: marvinpinto/action-inject-ssm-secrets@latest
+        with:
+          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
+          env_variable_name: AWS_FRONTEND_NONPROD_ROLE
+
+      - name: Configure AWS Credentials (2)
+        if: ${{ github.ref == 'refs/heads/184--coverage-report-logic-move' }}
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+          role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
+          role-duration-seconds: 900
+          role-session-name: vsp-frontendteam-githubaction
+
+      - name: Upload coverage report to S3
+        if: ${{ github.ref == 'refs/heads/184--coverage-report-logic-move' }}
+        run: aws s3 cp coverage/test-coverage-report.json s3://apps.dev.va.gov/coverage/test-coverage-report.json --acl public-read --region us-gov-west-1
 
       - name: Get code coverage
         id: code-coverage

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -115,11 +115,6 @@ def archive(dockerContainer, String ref, String envName) {
     withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'vetsgov-website-builds-s3-upload',
                      usernameVariable: 'AWS_ACCESS_KEY', passwordVariable: 'AWS_SECRET_KEY']]) {
       sh "echo \"${buildDetails}\" > /application/build/${envName}/BUILD.txt"
-
-      sh "cd /application && yarn test:coverage-only"
-      sh "cd /application && node script/app-coverage-report.js"
-      sh "cp /application/coverage/test-coverage-report.json /application/build/${envName}/test-coverage-report.json"
-
       if(envName == 'vagovdev' || envName == 'vagovstaging') {
         sh "tar -C /application/build/${envName} -cf /application/build/apps.${envName}.tar.bz2 ."
         sh "aws s3 cp /application/build/apps.${envName}.tar.bz2 s3://vetsgov-website-builds-s3-upload/application-build/${ref}/${envName}.tar.bz2 --acl public-read --region us-gov-west-1 --quiet"


### PR DESCRIPTION
## Description
This PR modifies the logic that was uploading/downloading an artifact of the coverage report to now push directly to an S3 bucket in the unit tests job.

## Acceptance criteria
- [ ] Coverage report is pushed to S3 bucket in unit tests job