### PR TITLE
NOD: Fix headers on review & submit page

### DIFF
--- a/src/applications/appeals/10182/content/areaOfDisagreement.jsx
+++ b/src/applications/appeals/10182/content/areaOfDisagreement.jsx
@@ -10,12 +10,14 @@ export const missingAreaOfDisagreementOtherErrorMessage =
 // formContext.pagePerItemIndex is undefined here? Use index added to data :(
 export const issueName = ({ formData, formContext } = {}) => {
   const index = formContext.pagePerItemIndex || formData.index;
+  // https://github.com/department-of-veterans-affairs/va.gov-team/issues/27096
+  const Header = formContext.onReviewPage ? 'h4' : 'h3';
   return (
     <legend
       className="schemaform-block-title schemaform-title-underline"
       aria-describedby={`area-of-disagreement-label-${index}`}
     >
-      <h3 className="vads-u-margin-top--0">{getIssueName(formData)}</h3>
+      <Header className="vads-u-margin-top--0">{getIssueName(formData)}</Header>
     </legend>
   );
 };


### PR DESCRIPTION
## Description

Fix header levels in the Notice of Disagreement review & submit page. When editing an area of disagreement page, the header level jumps from `h4` to an `h3`. It needs to stay as an `h4` on the review & submit page, and as an `h3` within the form flow.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/27096#issuecomment-881549828

## Testing done

Manual & visual testing

## Screenshots

![](https://user-images.githubusercontent.com/14154792/125975181-c13f9a3c-b941-4a3f-9454-a694838ad173.png)

## Acceptance criteria
- [x] Area of disagreement header is an `h4` while editing on the review & submit page
- [x] The header is an `h3` within the form flow

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
