### PR TITLE
Test running cypress tests with docker

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -302,9 +302,9 @@ jobs:
     # needs: build
     container:
       image: cypress/browsers:node14.17.0-chrome91-ff89
-      options: -u 1001:1001 -v /etc/ssl/certs:/certs
+      options: -u 1001:1001 -v /usr/local/share/ca-certificates:/certs
       env:
-        NODE_EXTRA_CA_CERTS: /certs/VA-Internal-S2-RCA1-v1.cer.pem
+        NODE_EXTRA_CA_CERTS: /certs/VA-Internal-S2-RCA1-v1.cer.crt
 
 
     strategy:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -313,8 +313,8 @@ jobs:
       matrix:
         ci_node_index: [0, 1, 2, 3, 4, 5]
 
-    env:
-      NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
+    # env:
+    #   NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
 
     steps:
       - name: Checkout vets-website

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -310,7 +310,7 @@ jobs:
       matrix:
         ci_node_index: [0, 1, 2, 3, 4, 5]
 
-     env:
+    env:
       CHROMEDRIVER_FILEPATH: /share/chrome_driver/chromedriver
       NODE_EXTRA_CA_CERTS: /share/ca-certificates/VA-Internal-S2-RCA1-v1.cer.crt
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -302,10 +302,10 @@ jobs:
     needs: build
     container:
       image: cypress/browsers:node14.17.0-chrome91-ff89
-      options: -u 1001:1001 -v /usr/local/share/ca-certificates:/certs
+      options: -u 1001:1001 -v /usr/local/share:/share
       env:
-        NODE_EXTRA_CA_CERTS: /certs/VA-Internal-S2-RCA1-v1.cer.crt
-
+        CHROMEDRIVER_FILEPATH: /share/chrome_driver/chromedriver
+        NODE_EXTRA_CA_CERTS: /share/ca-certificates/VA-Internal-S2-RCA1-v1.cer.crt
 
     strategy:
       fail-fast: false

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -299,7 +299,7 @@ jobs:
   cypress-tests:
     name: Cypress E2E Tests
     runs-on: self-hosted
-    # needs: build
+    needs: build
     container:
       image: cypress/browsers:node14.17.0-chrome91-ff89
       options: -u 1001:1001 -v /usr/local/share/ca-certificates:/certs

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -303,9 +303,6 @@ jobs:
     container:
       image: cypress/browsers:node14.17.0-chrome91-ff89
       options: -u 1001:1001 -v /usr/local/share:/share
-      env:
-        CHROMEDRIVER_FILEPATH: /share/chrome_driver/chromedriver
-        NODE_EXTRA_CA_CERTS: /share/ca-certificates/VA-Internal-S2-RCA1-v1.cer.crt
 
     strategy:
       fail-fast: false
@@ -313,8 +310,9 @@ jobs:
       matrix:
         ci_node_index: [0, 1, 2, 3, 4, 5]
 
-    # env:
-    #   NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
+     env:
+      CHROMEDRIVER_FILEPATH: /share/chrome_driver/chromedriver
+      NODE_EXTRA_CA_CERTS: /share/ca-certificates/VA-Internal-S2-RCA1-v1.cer.crt
 
     steps:
       - name: Checkout vets-website

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -299,10 +299,10 @@ jobs:
   cypress-tests:
     name: Cypress E2E Tests
     runs-on: self-hosted
-    needs: build
+    # needs: build
     container:
       image: cypress/browsers:node14.17.0-chrome91-ff89
-      options: -u node -v /etc/ssl/certs:/certs
+      options: -u 1001:1001 -v /etc/ssl/certs:/certs
       env:
         NODE_EXTRA_CA_CERTS: /certs/VA-Internal-S2-RCA1-v1.cer.pem
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -300,6 +300,12 @@ jobs:
     name: Cypress E2E Tests
     runs-on: self-hosted
     needs: build
+    container:
+      image: cypress/browsers:node14.17.0-chrome91-ff89
+      options: -u node -v /etc/ssl/certs:/certs
+      env:
+        NODE_EXTRA_CA_CERTS: /certs/VA-Internal-S2-RCA1-v1.cer.pem
+
 
     strategy:
       fail-fast: false
@@ -333,10 +339,10 @@ jobs:
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
-      - name: Install Chrome
-        uses: browser-actions/setup-chrome@latest
-        with:
-          chrome-version: stable
+      # - name: Install Chrome
+      #   uses: browser-actions/setup-chrome@latest
+      #   with:
+      #     chrome-version: stable
 
       # Disabling caching due to cypress breaking - to be evaluated at a later date
       # - name: Cache dependencies
@@ -353,17 +359,17 @@ jobs:
         # env:
         #   YARN_CACHE_FOLDER: ~/.cache/yarn
 
-      - name: Set port for server
-        run: echo "SERVER_PORT=$(( ( RANDOM % 2000 ) + 3001 ))" >> $GITHUB_ENV
+      # - name: Set port for server
+      #   run: echo "SERVER_PORT=$(( ( RANDOM % 2000 ) + 3001 ))" >> $GITHUB_ENV
 
       # Cypress env vars like this are used to either override config settings
       # or be made available to tests through Cypress.env().
       # https://docs.cypress.io/guides/guides/environment-variables#Option-3-CYPRESS_
-      - name: Set port for Cypress
-        run: echo "CYPRESS_PORT=$(( SERVER_PORT + 1 ))" >> $GITHUB_ENV
+      # - name: Set port for Cypress
+      #   run: echo "CYPRESS_PORT=$(( SERVER_PORT + 1 ))" >> $GITHUB_ENV
 
       - name: Start server
-        run: node src/platform/testing/e2e/test-server.js --buildtype vagovprod --port=$SERVER_PORT &
+        run: node src/platform/testing/e2e/test-server.js --buildtype vagovprod --port=3001 &
 
       - name: Create test results directory
         run: mkdir -p test-results
@@ -372,7 +378,7 @@ jobs:
         run: node script/github-actions/run-cypress-tests.js
         timeout-minutes: 60
         env:
-          CYPRESS_BASE_URL: http://localhost:${{ env.SERVER_PORT }}
+          # CYPRESS_BASE_URL: http://localhost:3001
           CYPRESS_CI: true
           STEP: ${{ matrix.ci_node_index }}
 


### PR DESCRIPTION
## Description
With the way our GHA self-hosted runners have been configured, Cypress tests have been interfering with each other. We hypothesize that running each job in its own container would prevent that from happening.