### PR TITLE
Add alert spacing on debt letters ch33 alert

### DIFF
--- a/src/applications/debt-letters/components/DebtLettersSummary.jsx
+++ b/src/applications/debt-letters/components/DebtLettersSummary.jsx
@@ -14,6 +14,7 @@ import { OnThisPageLinks } from './OnThisPageLinks';
 const Chapter33Alert = () => {
   return (
     <ExpandableAlert
+      className="vads-u-margin-top--3"
       iconType="triangle"
       status="limited"
       trackingPrefix="-debt-letters-ch33"


### PR DESCRIPTION
## Description

When checking the expandable alert from this [PR](https://github.com/department-of-veterans-affairs/vets-website/pull/17952) in staging I noticed the spacing was off with another alert showing. So I added margin to make sure the spacing is uniform.

## Original issue(s)
[Ticket](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/department-of-veterans-affairs/va.gov-team/27778)


## Testing done
- Visual testing

## Screenshots
### Before
![Screen Shot 2021-07-22 at 8 31 31 PM](https://user-images.githubusercontent.com/23741323/126725230-0c7a7d5a-2555-43e6-b682-291a2738b49b.png)


### After
![Screen Shot 2021-07-22 at 8 31 47 PM](https://user-images.githubusercontent.com/23741323/126725241-ac27151b-6f73-4d4c-9179-50c30a5bfdf8.png)



## Acceptance criteria
- [x] Spacing is uniform between alerts

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
