### PR TITLE
Add IterateUptoIndex cypress env vars

### DIFF
--- a/config/cypress.json
+++ b/config/cypress.json
@@ -15,6 +15,7 @@
     "openMode": 0
   },
   "env": {
+    "vaTopMobileViewportsIterateUptoIndex": 0,
     "vaTopMobileViewports": [
       {
         "list": "VA Top Mobile Viewports",
@@ -67,6 +68,7 @@
         "height": 844
       }
     ],
+    "vaTopTabletViewportsIterateUptoIndex": 0,
     "vaTopTabletViewports": [
       {
         "list": "VA Top Tablet Viewports",
@@ -119,6 +121,7 @@
         "height": 962
       }
     ],
+    "vaTopDesktopViewportsIterateUptoIndex": 0,
     "vaTopDesktopViewports": [
       {
         "list": "VA Top Desktop Viewports",


### PR DESCRIPTION
## Description
Re ticket [#27727](https://app.zenhub.com/workspaces/vsp-5cedc9cce6e3335dc5a49fc4/issues/department-of-veterans-affairs/va.gov-team/27727)

Add the following Cypress env vars...

```
vaTopMobileViewportsIterateUptoIndex
vaTopTabletViewportsIterateUptoIndex
vaTopDesktopViewportsIterateUptoIndex
```

...so we can iterate through the 'top viewports' and `break` if the current index is greater than given Cypress 'IterateUptoIndex' env var.

PR for documentation updated - https://github.com/department-of-veterans-affairs/va.gov-team/pull/27779
