### PR TITLE
Stop calling scroller.scrollTo with a long timeout in unit tests

### DIFF
--- a/script/run-unit-test.js
+++ b/script/run-unit-test.js
@@ -43,7 +43,7 @@ if (options.help) {
   process.exit(0);
 }
 
-const mochaPath = `BABEL_ENV=test mocha ${reporterOption}`;
+const mochaPath = `BABEL_ENV=test NODE_ENV=test mocha ${reporterOption}`;
 const coveragePath = `NODE_ENV=test nyc --all ${coverageInclude} --reporter=lcov --reporter=text --reporter=json-summary mocha --reporter mocha-junit-reporter --no-color --retries 5`;
 const testRunner = options.coverage ? coveragePath : mochaPath;
 const configFile = 'config/mocha.json';

--- a/src/platform/forms-system/src/js/review/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/review/ArrayField.jsx
@@ -15,6 +15,7 @@ import findDuplicateIndexes from '../utilities/data/findDuplicateIndexes';
 
 const Element = Scroll.Element;
 const scroller = Scroll.scroller;
+const scrollToTimeout = process.env.NODE_ENV === 'test' ? 0 : 100;
 
 /* Growable table (Array) field on the Review page
  *
@@ -106,7 +107,7 @@ class ArrayField extends React.Component {
           },
         );
         focusElement(`[name="${scrollElementName}"] ${focusElementSelector}`);
-      }, window.Mocha ? 0 : 100);
+      }, scrollToTimeout);
     }
   }
 
@@ -121,7 +122,7 @@ class ArrayField extends React.Component {
           offset: 0,
         },
       );
-    }, window.Mocha ? 0 : 100);
+    }, scrollToTimeout);
   }
 
   /*

--- a/src/platform/forms-system/src/js/review/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/review/ArrayField.jsx
@@ -106,7 +106,7 @@ class ArrayField extends React.Component {
           },
         );
         focusElement(`[name="${scrollElementName}"] ${focusElementSelector}`);
-      }, 100);
+      }, window.Mocha ? 0 : 100);
     }
   }
 
@@ -121,7 +121,7 @@ class ArrayField extends React.Component {
           offset: 0,
         },
       );
-    }, 100);
+    }, window.Mocha ? 0 : 100);
   }
 
   /*


### PR DESCRIPTION
## Description
1. Check out the latest `master` (or `c59a7d4d373353d7b29d631db03e8e3fdd26c111`)
2. Make one of the tests in `src/platform/user/profile/vap-svc/tests/selectors.unit.spec.js` slow by inserting an `await wait(200)` in one of the `it()` calls (you'll need to `import { wait } from '@@profile/tests/unit-test-helpers';` and mark the `it()` with `async`)
3. then run these two tests with CHOMA_SEED `3zlDundt9z` to make the `ArrayField` tests run first: `yarn test:unit src/platform/user/profile/vap-svc/tests/selectors.unit.spec.js src/platform/forms-system/test/js/review/ArrayField.unit.spec.jsx`

That should result in a failure like this:

```
  1) selectVAPServiceInitializationStatus
       returns UNINITIALIZED if Vet360 is not found in the services array and there is not an associated transaction:
     Uncaught TypeError: document.getElementById is not a function
      at Object.get (node_modules/react-scroll/modules/mixins/scroller.js:41:39)
      at Object.scrollTo (node_modules/react-scroll/modules/mixins/scroller.js:54:23)
      at Timeout.<anonymous> (src/platform/forms-system/src/js/review/ArrayField.jsx:101:16)
      at Timeout.sentryWrapped [as _onTimeout] (node_modules/@sentry/browser/src/helpers.ts:87:17)
      at listOnTimeout (internal/timers.js:554:17)
      at processTimers (internal/timers.js:497:7)
```

4. Now, get rid of the timeouts in `src/platform/forms-system/src/js/review/ArrayField.jsx` when running in unit tests at lines 95 and 110
5. Rerun `yarn test:unit src/platform/user/profile/vap-svc/tests/selectors.unit.spec.js src/platform/forms-system/test/js/review/ArrayField.unit.spec.jsx` with seed `3zlDundt9z` and things should pass.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs