### PR TITLE
Disable flaky Cypress Dependency Verification tests

### DIFF
--- a/src/applications/static-pages/dependency-verification/tests/dependency-verification.cypress.spec.js
+++ b/src/applications/static-pages/dependency-verification/tests/dependency-verification.cypress.spec.js
@@ -6,7 +6,7 @@ import { RETRIEVE_DIARIES } from '../utils';
 
 const DEPENDENTS_ENDPOINT = 'v0/dependents_applications/show';
 
-describe('Dependency Verification', () => {
+describe.skip('Dependency Verification', () => {
   beforeEach(() => {
     cy.intercept('GET', '/v0/feature_toggles*', {
       data: {


### PR DESCRIPTION
## Description
This PR disables a group of tests that have been flaky with multiple different failures:
* https://github.com/department-of-veterans-affairs/vets-website/runs/3145865448?check_suite_focus=true
* https://github.com/department-of-veterans-affairs/vets-website/runs/3146049281?check_suite_focus=true

## Acceptance criteria
- [ ] Tests pass on CI.