### PR TITLE
DT-23017 Discharge Wizards AirFrorce Icon color

### DIFF
--- a/src/applications/discharge-wizard/components/AirForcePortalLink.jsx
+++ b/src/applications/discharge-wizard/components/AirForcePortalLink.jsx
@@ -8,7 +8,7 @@ const AirForcePortalLink = () => (
     >
       <i
         aria-hidden="true"
-        className="fas fa-chevron-circle-right fa-2x vads-u-margin-right--1"
+        className="fas fa-chevron-circle-right fa-2x vads-u-margin-right--1 vads-u-color--green"
         role="presentation"
       />
       <span className="vads-u-text-decoration--underline vads-u-font-weight--bold">

--- a/src/applications/discharge-wizard/sass/discharge-wizard.scss
+++ b/src/applications/discharge-wizard/sass/discharge-wizard.scss
@@ -94,5 +94,8 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
 
   .airForce-portal-link {
     width: max-content;
+    i:hover {
+      color: $color-green-darker !important;
+    }
   }
 }


### PR DESCRIPTION
## Description
Need to adjust Icon color.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#DT-23017 


## Testing done
Spun it up locally

## Screenshots
![Screen Shot 2021-07-23 at 3 50 36 PM](https://user-images.githubusercontent.com/26075258/126834436-ac39dfb3-eae5-4810-8670-4d8e50c4890e.png)


## Acceptance criteria
- [x] Icon color is depicted as seen here. https://github.com/department-of-veterans-affairs/va.gov-team/issues/23591#issuecomment-874870018 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
