### PR TITLE
Build NotificationSettings section

### DIFF
--- a/src/applications/personalization/profile/components/notification-settings/AddContactInfoLink.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/AddContactInfoLink.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+import { PROFILE_PATHS } from '../../constants';
+
+const linkMap = {
+  ALL: {
+    linkText: 'update your contact information',
+    linkTarget: `${PROFILE_PATHS.PERSONAL_INFORMATION}#phone-numbers`,
+  },
+  EMAIL: {
+    linkText: 'add your email address to your profile',
+    linkTarget: `${PROFILE_PATHS.PERSONAL_INFORMATION}#edit-email-address`,
+  },
+  MOBILE: {
+    linkText: 'add your mobile phone number to your profile',
+    linkTarget: `${
+      PROFILE_PATHS.PERSONAL_INFORMATION
+    }#edit-mobile-phone-number`,
+  },
+};
+
+const AddContactInfoLink = ({ missingInfo }) => {
+  const linkInfo = React.useMemo(
+    () => {
+      return linkMap[missingInfo];
+    },
+    [missingInfo],
+  );
+  return <Link to={linkInfo.linkTarget}>{linkInfo.linkText}</Link>;
+};
+
+AddContactInfoLink.ALL = 'ALL';
+AddContactInfoLink.EMAIL = 'EMAIL';
+AddContactInfoLink.MOBILE = 'MOBILE';
+
+export default AddContactInfoLink;

--- a/src/applications/personalization/profile/components/notification-settings/ContactInfoOnFile.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/ContactInfoOnFile.jsx
@@ -14,12 +14,12 @@ const ContactInfoOnFile = ({ emailAddress, mobilePhoneNumber }) => {
         notifications:
       </p>
       {emailAddress ? (
-        <p>
+        <p className="vads-u-margin-y--0p5">
           <strong>{emailAddress}</strong>
         </p>
       ) : null}
       {mobilePhoneNumber ? (
-        <p>
+        <p className="vads-u-margin-y--0p5">
           <strong>
             <Telephone
               contact={`${mobilePhoneNumber.areaCode}${
@@ -41,6 +41,7 @@ const ContactInfoOnFile = ({ emailAddress, mobilePhoneNumber }) => {
           Some more information about email and text notifications.
         </p>
       </AdditionalInfo>
+      <hr />
     </>
   );
 };

--- a/src/applications/personalization/profile/components/notification-settings/HealthCareGroupSupportingText.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/HealthCareGroupSupportingText.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import { mhvUrl } from '~/platform/site-wide/mhv/utilities';
+import { isAuthenticatedWithSSOe } from '~/platform/user/authentication/selectors';
+
+const HealthCareGroupSupportingText = ({ authenticatedWithSSOe }) => {
+  return (
+    <p>
+      <strong>Note:</strong> You can manage your health care email notifications
+      through{' '}
+      <a
+        href={mhvUrl(authenticatedWithSSOe, 'home')}
+        rel="noreferrer noopener"
+        target="_blank"
+      >
+        My HealtheVet
+      </a>
+    </p>
+  );
+};
+
+const mapStateToProps = state => {
+  return {
+    authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
+  };
+};
+
+export default connect(mapStateToProps)(HealthCareGroupSupportingText);

--- a/src/applications/personalization/profile/components/notification-settings/MissingContactInfoAlert.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/MissingContactInfoAlert.jsx
@@ -1,45 +1,33 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 
-import { PROFILE_PATHS } from '../../constants';
+import AddContactInfoLink from './AddContactInfoLink';
+
+const missingEmailAddressContent = (
+  <p>
+    To get notifications by email, first{' '}
+    <AddContactInfoLink missingInfo={AddContactInfoLink.EMAIL} />.
+  </p>
+);
+const missingMobilePhoneContent = (
+  <p>
+    To get notifications by SMS text message, first{' '}
+    <AddContactInfoLink missingInfo={AddContactInfoLink.MOBILE} />.
+  </p>
+);
+const missingAllContactInfoContent = (
+  <p>
+    We don‘t have an email address or mobile phone number for you. To manage
+    notification settings, please{' '}
+    <AddContactInfoLink missingInfo={AddContactInfoLink.ALL} />.
+  </p>
+);
 
 const MissingContactInfoAlert = ({
   missingMobilePhone,
   missingEmailAddress,
 }) => {
-  const missingEmailAddressContent = (
-    <p>
-      To get notifications by email, first{' '}
-      <Link to={`${PROFILE_PATHS.PERSONAL_INFORMATION}#edit-email-address`}>
-        add your email address to your profile
-      </Link>
-      .
-    </p>
-  );
-  const missingMobilePhoneContent = (
-    <p>
-      To get notifications by SMS text message, first{' '}
-      <Link
-        to={`${PROFILE_PATHS.PERSONAL_INFORMATION}#edit-mobile-phone-number`}
-      >
-        add your mobile phone number to your profile
-      </Link>
-      .
-    </p>
-  );
-  const missingAllContactInfoContent = (
-    <p>
-      We don‘t have an email address or mobile phone number for you. To manage
-      notification settings, please{' '}
-      <Link to={`${PROFILE_PATHS.PERSONAL_INFORMATION}#mobile-phone-number`}>
-        update your contact information
-      </Link>
-      .
-    </p>
-  );
-
   const alertContents = React.useMemo(
     () => {
       if (missingEmailAddress && missingMobilePhone) {
@@ -52,13 +40,7 @@ const MissingContactInfoAlert = ({
         return null;
       }
     },
-    [
-      missingEmailAddress,
-      missingMobilePhone,
-      missingAllContactInfoContent,
-      missingEmailAddressContent,
-      missingMobilePhoneContent,
-    ],
+    [missingEmailAddress, missingMobilePhone],
   );
 
   if (alertContents) {

--- a/src/applications/personalization/profile/components/notification-settings/NotificationChannel.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationChannel.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import {
+  selectItemById,
+  selectChannelById,
+} from '@@profile/ducks/communicationPreferences';
+import { selectCommunicationPreferences } from '@@profile/reducers';
+
+import { getContactInfoSelectorByChannelType } from '@@profile/util/notification-settings';
+
+import NotificationChannelUnavailable from './NotificationChannelUnavailable';
+
+const checkboxLabels = {
+  1: 'Notify by text',
+  2: 'Notify by email',
+};
+
+const channelTypes = {
+  1: 'text',
+  2: 'email',
+};
+
+const NotificationChannel = ({
+  channelId,
+  channelType,
+  isMissingContactInfo,
+  isOptedIn,
+  itemName,
+}) => {
+  if (isMissingContactInfo) {
+    return <NotificationChannelUnavailable channelType={channelType} />;
+  }
+  const checkboxAriaLabel = `Notify me of ${itemName} by ${
+    channelTypes[channelType]
+  }`;
+  return (
+    <div>
+      <input
+        type="checkbox"
+        id={channelId}
+        onChange={() => {}}
+        checked={isOptedIn}
+      />
+      <label
+        htmlFor={channelId}
+        aria-label={checkboxAriaLabel}
+        className="vads-u-margin-y--1"
+      >
+        {checkboxLabels[channelType]}
+      </label>
+    </div>
+  );
+};
+
+const mapStateToProps = (state, ownProps) => {
+  const communicationPreferencesState = selectCommunicationPreferences(state);
+  const channel = selectChannelById(
+    communicationPreferencesState,
+    ownProps.channelId,
+  );
+  const item = selectItemById(
+    communicationPreferencesState,
+    channel.parentItem,
+  );
+  const contactInfoSelector = getContactInfoSelectorByChannelType(
+    channel.channelType,
+  );
+  const isMissingContactInfo = !contactInfoSelector(state);
+  return {
+    channelType: channel.channelType,
+    itemName: item.name,
+    isOptedIn: channel.isAllowed,
+    isMissingContactInfo,
+  };
+};
+
+export default connect(mapStateToProps)(NotificationChannel);

--- a/src/applications/personalization/profile/components/notification-settings/NotificationChannelUnavailable.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationChannelUnavailable.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import AddContactInfoLink from './AddContactInfoLink';
+
+const NotificationChannelUnavailable = ({ channelType }) => {
+  const missingInfo = React.useMemo(
+    () => {
+      const map = {
+        1: AddContactInfoLink.MOBILE,
+        2: AddContactInfoLink.EMAIL,
+      };
+      return map[channelType];
+    },
+    [channelType],
+  );
+  const notificationType = React.useMemo(
+    () => {
+      let result;
+      switch (channelType) {
+        case 1:
+          result = `SMS text notifications`;
+          break;
+        case 2:
+          result = `email notifications`;
+          break;
+        default:
+          break;
+      }
+      return result;
+    },
+    [channelType],
+  );
+  return (
+    <div>
+      To get {notificationType}, first{' '}
+      {<AddContactInfoLink missingInfo={missingInfo} />}.
+    </div>
+  );
+};
+
+export default NotificationChannelUnavailable;

--- a/src/applications/personalization/profile/components/notification-settings/NotificationGroup.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationGroup.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import { selectGroupById } from '@@profile/ducks/communicationPreferences';
+import { selectCommunicationPreferences } from '@@profile/reducers';
+
+import NotificationItem from './NotificationItem';
+
+const NotificationGroup = ({ children, groupName, itemIds }) => {
+  return (
+    <div data-testid="notification-group">
+      <h2 className="vads-u-font-size--h3">{groupName}</h2>
+      {itemIds.map(itemId => {
+        return <NotificationItem key={itemId} itemId={itemId} />;
+      })}
+      {children}
+      <hr />
+    </div>
+  );
+};
+
+const mapStateToProps = (state, ownProps) => {
+  const communicationPreferencesState = selectCommunicationPreferences(state);
+  const group = selectGroupById(
+    communicationPreferencesState,
+    ownProps.groupId,
+  );
+  return {
+    groupName: group.name,
+    itemIds: group.items,
+  };
+};
+
+export default connect(mapStateToProps)(NotificationGroup);

--- a/src/applications/personalization/profile/components/notification-settings/NotificationItem.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationItem.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import { selectItemById } from '@@profile/ducks/communicationPreferences';
+import { selectCommunicationPreferences } from '@@profile/reducers';
+
+import NotificationChannel from './NotificationChannel';
+
+const NotificationItem = ({ itemName, channelIds }) => {
+  return (
+    <div>
+      <h3 className="vads-u-font-size--h4 vads-u-font-family--sans vads-u-margin-top--2">
+        {itemName}
+      </h3>
+
+      {channelIds.map(channelId => (
+        <NotificationChannel channelId={channelId} key={channelId} />
+      ))}
+    </div>
+  );
+};
+
+const mapStateToProps = (state, ownProps) => {
+  const communicationPreferencesState = selectCommunicationPreferences(state);
+  const item = selectItemById(communicationPreferencesState, ownProps.itemId);
+  return {
+    itemName: item.name,
+    channelIds: item.channels,
+  };
+};
+
+export default connect(mapStateToProps)(NotificationItem);

--- a/src/applications/personalization/profile/ducks/communicationPreferences.js
+++ b/src/applications/personalization/profile/ducks/communicationPreferences.js
@@ -120,6 +120,18 @@ export const selectGroupUi = (state, groupId) => {
 export const selectIsGroupEditing = (state, groupId) => {
   return selectGroupUi(state, groupId).ui.isEditing;
 };
+const selectItems = state => {
+  return state.items;
+};
+export const selectItemById = (state, itemId) => {
+  return selectItems(state).entities[itemId];
+};
+const selectChannels = state => {
+  return state.channels;
+};
+export const selectChannelById = (state, channelId) => {
+  return selectChannels(state).entities[channelId];
+};
 
 // REDUCERS
 function communicationGroupsReducer(accumulator, group) {

--- a/src/applications/personalization/profile/reducers/index.js
+++ b/src/applications/personalization/profile/reducers/index.js
@@ -11,3 +11,7 @@ export default {
   hcaEnrollmentStatus,
   ...ratedDisabilities,
 };
+
+export const selectCommunicationPreferences = state => {
+  return state.communicationPreferences;
+};

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/missing-contact-info.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/missing-contact-info.cypress.spec.js
@@ -46,13 +46,12 @@ describe('Notification Settings', () => {
       cy.findByRole('link', { name: /update your contact info/i }).should(
         'exist',
       );
-      // TODO: finishing building NotificationSettings so these tests can be
-      // enabled:
-      // cy.findAllByRole('link', { name: /add your mobile/i }).should(
-      //   'have.length.above',
-      //   0,
-      // );
-      // cy.findAllByTestId('notification-group').should('exist');
+      cy.findAllByRole('link', { name: /add your mobile/i }).should(
+        'have.length.above',
+        1,
+      );
+      cy.findAllByTestId('notification-group').should('exist');
+      cy.findByRole('link', { name: /add your email/i }).should('not.exist');
     });
   });
   context('when user is missing email address', () => {
@@ -75,13 +74,12 @@ describe('Notification Settings', () => {
       cy.findByRole('link', { name: /update your contact info/i }).should(
         'exist',
       );
-      // TODO: finishing building NotificationSettings so these tests can be
-      // enabled:
-      // cy.findAllByRole('link', { name: /add your email/i }).should(
-      //   'have.length.above',
-      //   0,
-      // );
-      // cy.findAllByTestId('notification-group').should('exist');
+      cy.findAllByRole('link', { name: /add your email/i }).should(
+        'have.length.above',
+        1,
+      );
+      cy.findAllByTestId('notification-group').should('exist');
+      cy.findByRole('link', { name: /add your mobile/i }).should('not.exist');
     });
   });
   context('when user is missing both email address and mobile phone', () => {

--- a/src/applications/personalization/profile/tests/fixtures/communication-preferences/get-200-maximal.json
+++ b/src/applications/personalization/profile/tests/fixtures/communication-preferences/get-200-maximal.json
@@ -19,8 +19,13 @@
                   "description": "SMS Notification",
                   "communicationPermission": {
                     "id": 4281,
-                    "allowed": false
+                    "allowed": true
                   }
+                },
+                {
+                  "id": 2,
+                  "name": "Email",
+                  "description": "Email Notification"
                 }
               ]
             }

--- a/src/applications/personalization/profile/tests/fixtures/users/user-non-patient.json
+++ b/src/applications/personalization/profile/tests/fixtures/users/user-non-patient.json
@@ -39,7 +39,18 @@
       "inProgressForms": [],
       "prefillsAvailable": [],
       "vet360ContactInformation": {
-        "email": null,
+        "email": {
+          "createdAt": "2020-07-30T23:38:04.000+00:00",
+          "emailAddress": "alongusername@domain.com",
+          "effectiveEndDate": null,
+          "effectiveStartDate": "2020-07-30T23:38:03.000+00:00",
+          "id": 115097,
+          "sourceDate": "2020-07-30T23:38:03.000+00:00",
+          "sourceSystemUser": null,
+          "transactionId": "604abf55-422b-4f51-b33d-9fb38b4daad1",
+          "updatedAt": "2020-07-30T23:38:04.000+00:00",
+          "vet360Id": "1273780"
+        },
         "residentialAddress": {
           "addressLine1": "34 Blah st",
           "addressLine2": null,

--- a/src/applications/personalization/profile/util/notification-settings.js
+++ b/src/applications/personalization/profile/util/notification-settings.js
@@ -1,0 +1,13 @@
+import {
+  selectVAPEmailAddress,
+  selectVAPMobilePhone,
+} from '~/platform/user/selectors';
+
+const contactInfoSelectorByChannelType = {
+  1: selectVAPMobilePhone,
+  2: selectVAPEmailAddress,
+};
+
+export const getContactInfoSelectorByChannelType = channelType => {
+  return contactInfoSelectorByChannelType[channelType];
+};


### PR DESCRIPTION
## Description
This builds out the Notification Settings section of the Profile so it can show the user's current settings including handling when a user is missing some contact info and handling API errors. This PR does _not_ implement the edit functionality.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#25784

## Testing done
I had previously written Cypress tests to cover the basic happy paths, the missing-contact-info cases, and the API error cases

## Screenshots
### All contact info on file
#### When user is a VA patient
<img width="569" alt="is-patient" src="https://user-images.githubusercontent.com/20728956/126853133-184986e2-ccf1-49d9-9086-e99f6137a9f1.png">

#### When user is not a patient
<img width="569" alt="is-not-patient" src="https://user-images.githubusercontent.com/20728956/126853137-00072896-e623-45b1-ba3c-55d101f5a955.png">

### Missing some contact info
#### When user is missing email address
<img width="569" alt="missing-email" src="https://user-images.githubusercontent.com/20728956/126853141-21542f1c-8dc5-4aa4-8767-6b1ef1edeb02.png">

#### When user is missing mobile phone
<img width="569" alt="missing-mobile" src="https://user-images.githubusercontent.com/20728956/126853144-64eb591d-5a97-4caf-8a74-27c616a592ec.png">

#### When user is missing both email and mobile phone
<img width="569" alt="missing-email-and-mobile" src="https://user-images.githubusercontent.com/20728956/126853147-95b68fb2-af22-43b2-a6c8-32a22a45a2bb.png">

### Error
#### When there is an error getting either the user's contact info or the user's current notification settings from VA Profile
<img width="569" alt="API-error" src="https://user-images.githubusercontent.com/20728956/126853149-a146b4f5-b4c2-4638-a003-9b2d925ad034.png">

### Mobile
<img width="499" alt="mobile" src="https://user-images.githubusercontent.com/20728956/126853125-23296b3c-0c9a-4a24-8f33-497794084fe9.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs