### PR TITLE
update compare cards

### DIFF
--- a/src/applications/gi-sandbox/containers/ComparePage.jsx
+++ b/src/applications/gi-sandbox/containers/ComparePage.jsx
@@ -221,7 +221,7 @@ export function ComparePage({
           ref={headerRef}
         >
           <div className="row vads-l-grid-container">
-            <div className="vads-l-row compare-header-row">
+            <div className="vads-l-row compare-header-row vads-u-padding-bottom--6">
               <div className="medium-screen:vads-l-col--3">
                 <div className="compare-header vads-u-padding-right--1">
                   <div className="compare-page-description-label">

--- a/src/applications/gi-sandbox/sass/partials/_gi-compare-page.scss
+++ b/src/applications/gi-sandbox/sass/partials/_gi-compare-page.scss
@@ -27,7 +27,7 @@
   }
 
   .compare-header {
-    height: 12em;
+    height: 16em;
     position: relative;
   }
 

--- a/src/applications/gi-sandbox/sass/partials/_gi-compare-page.scss
+++ b/src/applications/gi-sandbox/sass/partials/_gi-compare-page.scss
@@ -27,7 +27,7 @@
   }
 
   .compare-header {
-    height: 16em;
+    height: 100%;
     position: relative;
   }
 


### PR DESCRIPTION
## Description
Compare cards has overlapping text bug

## Original issue(s)
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/27795


## Testing done
local testing

## Screenshots
![Screen Shot 2021-07-26 at 12 55 57 PM](https://user-images.githubusercontent.com/50601724/127028657-5b5b7ca3-8a94-4e04-85e4-fe58c3ae55d1.png)
![Screen Shot 2021-07-26 at 12 54 53 PM](https://user-images.githubusercontent.com/50601724/127028664-17064cc1-b3e1-4cf8-b81a-aff76e104bc5.png)


## Acceptance criteria
- [x] Text does not overlap

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
