### PR TITLE
Add extra assertions and timeouts to try and avoid failure

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -371,7 +371,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
         env:
-          YARN_CACHE_FOLDER: ~/.cache/yarn
+          YARN_CACHE_FOLDER: .cache/yarn
 
       # - name: Set port for server
       #   run: echo "SERVER_PORT=$(( ( RANDOM % 2000 ) + 3001 ))" >> $GITHUB_ENV

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -371,7 +371,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
         env:
-          YARN_CACHE_FOLDER: .cache/yarn
+          YARN_CACHE_FOLDER: ~/.cache/yarn
 
       # - name: Set port for server
       #   run: echo "SERVER_PORT=$(( ( RANDOM % 2000 ) + 3001 ))" >> $GITHUB_ENV

--- a/src/applications/check-in/tests/errors/check-in-failed.cypress.spec.js
+++ b/src/applications/check-in/tests/errors/check-in-failed.cypress.spec.js
@@ -1,6 +1,7 @@
 import features from '../mocks/enabled.json';
 import mockCheckIn from '../../api/local-mock-api/mocks/check.in.response';
 import mockValidate from '../../api/local-mock-api/mocks/validate.responses';
+import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   beforeEach(function() {
@@ -25,6 +26,8 @@ describe('Check In Experience -- ', () => {
     cy.get('[data-testid="no-button"]').click();
     cy.get('h1').contains('Your appointment');
     cy.get('.usa-button').click();
-    cy.get('h1').contains('staff member');
+    cy.get('h1', { timeout: Timeouts.slow })
+      .should('be.visible')
+      .and('contain', 'staff member');
   });
 });


### PR DESCRIPTION
## Description
Restructured the last line of the test here to assert that the element is visible before testing its contents.  Additionally, I added a timeout to the `get` to ensure that the element has enough time to load before failing. I've run this test through CI 4x now and have had 4 successes, so I'm hopeful it may be fixed! 



## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
