### PR TITLE
reset GA error-key value after sending it to GA

### DIFF
--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -209,6 +209,11 @@ const recordClaimsAPIEvent = ({ startTime, success, error }) => {
     event['api-latency-ms'] = apiLatencyMs;
   }
   recordEvent(event);
+  if (event['error-key']) {
+    recordEvent({
+      'error-key': undefined,
+    });
+  }
 };
 
 export function getClaimsV2(options = {}) {

--- a/src/applications/claims-status/tests/actions.unit.spec.js
+++ b/src/applications/claims-status/tests/actions.unit.spec.js
@@ -313,6 +313,9 @@ describe('Actions', () => {
           'error-key': 'unknown',
           'api-latency-ms': 0,
         });
+        expect(global.window.dataLayer[1]).to.eql({
+          'error-key': undefined,
+        });
       });
     });
     describe('onSuccess callback', () => {


### PR DESCRIPTION
## Description
Sends an undefined `error-key` to GA immediately after sending an `error-key` value

## Original issue(s)
department-of-veterans-affairs/va.gov-team#27845

## Testing done
Added new unit test

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs