### PR TITLE
slight Communication Prefs refactor

### DIFF
--- a/src/applications/personalization/profile/models/CommunicationChannel.js
+++ b/src/applications/personalization/profile/models/CommunicationChannel.js
@@ -1,16 +1,16 @@
 class CommunicationChannel {
-  constructor({ id, parentItemId, permissionId, isAllowed }) {
-    if (typeof id !== 'number') {
-      throw new Error('Invalid Argument: options.id must be a number');
+  constructor({ type, parentItemId, permissionId, isAllowed }) {
+    if (typeof type !== 'number' || type < 1 || type > 2) {
+      throw new Error(
+        'Invalid Argument: options.type must be a valid channel type',
+      );
     }
     if (typeof parentItemId !== 'number') {
       throw new Error(
         'Invalid Argument: options.parentItemId must be a number',
       );
     }
-    // id is _not_ a unique id for this channel. It corresponds to the channel's
-    // type. Example: 1 = text, 2 = email
-    this.id = id;
+    this.type = type;
     this.parentItemId = parentItemId;
     this.permissionId = permissionId;
     this.isAllowed = !!isAllowed;
@@ -45,7 +45,7 @@ class CommunicationChannel {
         communicationItem: {
           id: this.parentItemId,
           communicationChannel: {
-            id: this.id,
+            id: this.type,
             communicationPermission: {
               allowed,
             },
@@ -75,7 +75,7 @@ class CommunicationChannel {
 
   clone() {
     return new CommunicationChannel({
-      id: this.id,
+      type: this.type,
       parentItemId: this.parentItemId,
       isAllowed: this.isAllowed,
       permissionId: this.permissionId,

--- a/src/applications/personalization/profile/models/CommunicationChannel.unit.spec.js
+++ b/src/applications/personalization/profile/models/CommunicationChannel.unit.spec.js
@@ -4,20 +4,24 @@ import CommunicationChannel from './CommunicationChannel';
 
 describe('CommunicationChannel model', () => {
   describe('constructor', () => {
-    it('throws an error when `options.id` is not included or not a number', () => {
+    it('throws an error when `options.type` is not included or not a valid channel type', () => {
       expect(() => {
         // eslint-disable-next-line no-new
         new CommunicationChannel({ parentItemId: 1 });
       }).to.throw(Error, /Invalid Argument/i);
       expect(() => {
         // eslint-disable-next-line no-new
-        new CommunicationChannel({ id: '1' });
+        new CommunicationChannel({ type: '1' });
+      }).to.throw(Error, /Invalid Argument/i);
+      expect(() => {
+        // eslint-disable-next-line no-new
+        new CommunicationChannel({ type: 3 });
       }).to.throw(Error, /Invalid Argument/i);
     });
     it('throws an error when `options.parentItemId` is not included or not a number', () => {
       expect(() => {
         // eslint-disable-next-line no-new
-        new CommunicationChannel({ id: 1 });
+        new CommunicationChannel({ type: 1 });
       }).to.throw(Error, /Invalid Argument/i);
       expect(() => {
         // eslint-disable-next-line no-new
@@ -30,7 +34,7 @@ describe('CommunicationChannel model', () => {
     context('when no permissions have been set yet', () => {
       it('returns an object with the correct shape that we can use with the `saveCommunicationPreferencesGroup` thunk creator', () => {
         const commChannel = new CommunicationChannel({
-          id: 1,
+          type: 1,
           parentItemId: 1,
         });
         commChannel.setIsAllowed(true);
@@ -55,7 +59,7 @@ describe('CommunicationChannel model', () => {
     context('when permission is flipped from true to false', () => {
       it('returns an object with the correct shape that we can use with the `saveCommunicationPreferencesGroup` thunk creator', () => {
         const commChannel = new CommunicationChannel({
-          id: 1,
+          type: 1,
           parentItemId: 1,
           permissionId: 1001,
           isAllowed: true,
@@ -86,13 +90,13 @@ describe('CommunicationChannel model', () => {
     let commChannel2;
     beforeEach(() => {
       commChannel1 = new CommunicationChannel({
-        id: 1,
+        type: 1,
         parentItemId: 1,
         permissionId: 1000,
         isAllowed: true,
       });
       commChannel2 = new CommunicationChannel({
-        id: 1,
+        type: 1,
         parentItemId: 1,
         permissionId: 1000,
         isAllowed: true,
@@ -131,7 +135,7 @@ describe('CommunicationChannel model', () => {
   describe('clone', () => {
     it('returns an identical new instance that can be edited independent of the source instance', () => {
       let baseChannel = new CommunicationChannel({
-        id: 1,
+        type: 1,
         parentItemId: 1,
       });
       let clone = baseChannel.clone();
@@ -141,7 +145,7 @@ describe('CommunicationChannel model', () => {
       clone.setIsAllowed(false);
       expect(baseChannel.isIdenticalTo(clone)).to.be.true;
       baseChannel = new CommunicationChannel({
-        id: 1,
+        type: 1,
         parentItemId: 1,
         isAllowed: true,
         permissionId: 123,

--- a/src/applications/personalization/profile/models/CommunicationGroup.js
+++ b/src/applications/personalization/profile/models/CommunicationGroup.js
@@ -19,7 +19,7 @@ class CommunicationGroup {
     return this.channels.reduce((updatedChannels, baseChannel) => {
       const wipChannel = wipGroup.channels.find(channel => {
         return (
-          channel.id === baseChannel.id &&
+          channel.type === baseChannel.type &&
           channel.parentItemId === baseChannel.parentItemId
         );
       });

--- a/src/applications/personalization/profile/models/CommunicationGroup.unit.spec.js
+++ b/src/applications/personalization/profile/models/CommunicationGroup.unit.spec.js
@@ -25,10 +25,10 @@ describe('CommunicationGroup model', () => {
       baseGroup = new CommunicationGroup({
         id: 1,
         communicationChannels: [
-          new CommunicationChannel({ id: 1, parentItemId: 1 }),
-          new CommunicationChannel({ id: 2, parentItemId: 1 }),
+          new CommunicationChannel({ type: 1, parentItemId: 1 }),
+          new CommunicationChannel({ type: 2, parentItemId: 1 }),
           new CommunicationChannel({
-            id: 1,
+            type: 1,
             parentItemId: 2,
             isAllowed: true,
             permissionId: 123,
@@ -45,10 +45,10 @@ describe('CommunicationGroup model', () => {
       const wipGroup = new CommunicationGroup({
         id: 2,
         communicationChannels: [
-          new CommunicationChannel({ id: 1, parentItemId: 4 }),
-          new CommunicationChannel({ id: 2, parentItemId: 4 }),
+          new CommunicationChannel({ type: 1, parentItemId: 4 }),
+          new CommunicationChannel({ type: 2, parentItemId: 4 }),
           new CommunicationChannel({
-            id: 1,
+            type: 1,
             parentItemId: 5,
             isAllowed: true,
             permissionId: 456,
@@ -75,14 +75,14 @@ describe('CommunicationGroup model', () => {
         id: 1,
         communicationChannels: [
           new CommunicationChannel({
-            id: 1,
+            type: 1,
             parentItemId: 1,
             isAllowed: true,
             permissionId: 123,
           }),
-          new CommunicationChannel({ id: 2, parentItemId: 1 }),
+          new CommunicationChannel({ type: 2, parentItemId: 1 }),
           new CommunicationChannel({
-            id: 1,
+            type: 1,
             parentItemId: 2,
             isAllowed: false,
             permissionId: 456,

--- a/src/platform/user/profile/vap-svc/tests/selectors.unit.spec.js
+++ b/src/platform/user/profile/vap-svc/tests/selectors.unit.spec.js
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
 import backendServices from '~/platform/user/profile/constants/backendServices';
 
+import { wait } from '@@profile/tests/unit-test-helpers';
+
 import {
   TRANSACTION_STATUS,
   TRANSACTION_CATEGORY_TYPES,
@@ -85,7 +87,7 @@ describe('selectors', () => {
 
   describe('selectVAPServiceTransaction', () => {
     beforeEach(hooks.beforeEach);
-    it('accepts a field name to look up a transaction and transaction request using the field-transaction map', () => {
+    it('accepts a field name to look up a transaction and transaction request using the field-transaction map', async () => {
       const fieldName = 'someField';
       const transactionId = 'transaction_1';
       const transaction = {
@@ -107,6 +109,9 @@ describe('selectors', () => {
       expect(result).to.deep.equal({ transaction, transactionRequest });
 
       result = selectors.selectVAPServiceTransaction(state, 'someOtherField');
+
+      await wait(300);
+
       expect(
         result,
         'returns a null transaction for a field that has no data in the field-transaction map',
@@ -119,7 +124,7 @@ describe('selectors', () => {
 
   describe('selectVAPServiceFailedTransactions', () => {
     beforeEach(hooks.beforeEach);
-    it('returns only failed transactions from a list of transactions', () => {
+    it('returns only failed transactions from a list of transactions', async () => {
       const failed = [
         {
           data: {
@@ -158,6 +163,8 @@ describe('selectors', () => {
           },
         },
       ];
+
+      await wait(500);
 
       const result = selectors.selectVAPServiceFailedTransactions(state);
 


### PR DESCRIPTION
## Description
This adjusts the existing CommPrefs redux code to make it ready for new actions that will be added in a subsequent PR.

## Testing done
Existing Redux tests all still pass since those tests were all integrated tests that didn't care about the action names that were being used by the `saveCommunicationPreferenceGroup()` thunk action creator.

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs