### PR TITLE
Get type of care name by id instead of using appointmentType for requests

### DIFF
--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -10,6 +10,10 @@ import {
   EXPRESS_CARE,
   UNABLE_TO_REACH_VETERAN_DETCODE,
   TYPE_OF_VISIT,
+  TYPES_OF_EYE_CARE,
+  TYPES_OF_SLEEP_CARE,
+  AUDIOLOGY_TYPES_OF_CARE,
+  TYPES_OF_CARE,
 } from '../../utils/constants';
 import { getTimezoneBySystemId } from '../../utils/timezone';
 import {
@@ -457,6 +461,19 @@ export function transformConfirmedAppointments(appointments) {
   return appointments.map(appt => transformConfirmedAppointment(appt));
 }
 
+function getTypeOfCareById(id) {
+  const allTypesOfCare = [
+    ...TYPES_OF_EYE_CARE,
+    ...TYPES_OF_SLEEP_CARE,
+    ...AUDIOLOGY_TYPES_OF_CARE,
+    ...TYPES_OF_CARE,
+  ];
+
+  return allTypesOfCare.find(
+    care => care.idV2 === id || care.ccId === id || care.id === id,
+  );
+}
+
 /**
  * Transforms a VAR appointment request to FHIR appointment resource
  *
@@ -489,7 +506,7 @@ export function transformPendingAppointment(appt) {
       coding: [
         {
           code: appt.typeOfCareId,
-          display: appt.appointmentType,
+          display: getTypeOfCareById(appt.typeOfCareId)?.name,
         },
       ],
     },

--- a/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/index.cancel.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/index.cancel.unit.spec.jsx
@@ -503,7 +503,7 @@ describe('VAOS <AppointmentsPage> cancellation:', () => {
     appointment.attributes = {
       ...appointment.attributes,
       status: 'Submitted',
-      appointmentType: 'Primary care',
+      typeOfCareId: '323',
       optionDate1: moment()
         .add(3, 'days')
         .format('MM/DD/YYYY'),

--- a/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/index.unit.spec.jsx
@@ -45,7 +45,7 @@ describe('VAOS <AppointmentsPage>', () => {
     request.attributes = {
       ...request.attributes,
       status: 'Submitted',
-      appointmentType: 'Primary care',
+      typeOfCareId: '323',
       optionDate1: firstDate.format('MM/DD/YYYY'),
       optionTime1: 'AM',
     };
@@ -110,7 +110,7 @@ describe('VAOS <AppointmentsPage>', () => {
     request.attributes = {
       ...request.attributes,
       status: 'Submitted',
-      appointmentType: 'Primary care',
+      typeOfCareId: '323',
       optionDate1: moment()
         .add(4, 'days')
         .format('MM/DD/YYYY'),
@@ -121,14 +121,14 @@ describe('VAOS <AppointmentsPage>', () => {
       ...request,
       attributes: {
         ...request.attributes,
-        appointmentType: 'Audiology',
+        typeOfCareId: '203',
       },
     });
     requests.push({
       ...request,
       attributes: {
         ...request.attributes,
-        appointmentType: 'Mental health',
+        typeOfCareId: '502',
       },
     });
     mockAppointmentInfo({
@@ -149,7 +149,7 @@ describe('VAOS <AppointmentsPage>', () => {
     ).map(card => card.textContent.trim());
 
     expect(dateHeadings).to.deep.equal([
-      'Audiology appointment',
+      'Audiology and speech appointment',
       'Mental health appointment',
       'Primary care appointment',
     ]);

--- a/src/applications/vaos/tests/appointment-list/components/FutureAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/FutureAppointmentsList.unit.spec.jsx
@@ -31,7 +31,7 @@ describe('VAOS <AppointmentsPage> pending appointments', () => {
       appointment.attributes = {
         ...appointment.attributes,
         status: 'Submitted',
-        appointmentType: 'Primary care',
+        typeOfCareId: '323',
         optionDate1: moment()
           .add(3, 'days')
           .format('MM/DD/YYYY'),
@@ -101,7 +101,7 @@ describe('VAOS <AppointmentsPage> pending appointments', () => {
       appointment.attributes = {
         ...appointment.attributes,
         status: 'Submitted',
-        appointmentType: 'Primary care',
+        typeOfCareId: '323',
         optionDate1: moment()
           .add(3, 'days')
           .format('MM/DD/YYYY'),
@@ -165,7 +165,7 @@ describe('VAOS <AppointmentsPage> pending appointments', () => {
       appointment.attributes = {
         ...appointment.attributes,
         status: 'Cancelled',
-        appointmentType: 'Primary care',
+        typeOfCareId: '323',
         optionDate1: moment()
           .add(3, 'days')
           .format('MM/DD/YYYY'),
@@ -201,7 +201,7 @@ describe('VAOS <AppointmentsPage> pending appointments', () => {
       appointment.attributes = {
         ...appointment.attributes,
         status: 'Cancelled',
-        appointmentType: 'Primary care',
+        typeOfCareId: '323',
         optionDate1: moment()
           .add(-3, 'days')
           .format('MM/DD/YYYY'),
@@ -298,7 +298,7 @@ describe('VAOS <AppointmentsPage> pending appointments', () => {
       appointment.attributes = {
         ...appointment.attributes,
         status: 'Submitted',
-        appointmentType: 'Primary care',
+        typeOfCareId: '323',
         optionDate1: moment()
           .add(3, 'days')
           .format('MM/DD/YYYY'),
@@ -361,7 +361,6 @@ describe('VAOS <AppointmentsPage> pending appointments', () => {
       appointment.attributes = {
         ...appointment.attributes,
         status: 'Submitted',
-        appointmentType: 'Primary care',
         optionDate1: moment()
           .add(3, 'days')
           .format('MM/DD/YYYY'),
@@ -407,7 +406,7 @@ describe('VAOS <AppointmentsPage> pending appointments', () => {
         initialState,
       });
 
-      const dateHeader = await findByText(/primary care appointment/i);
+      const dateHeader = await findByText(/hearing aid support appointment/i);
       expect(queryByText(/You don’t have any appointments/i)).not.to.exist;
 
       expect(baseElement).to.contain.text('Community Care');

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
@@ -66,7 +66,6 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
       ...appointment.attributes,
       typeOfCareId: '323',
       status: 'Submitted',
-      appointmentType: 'Primary care',
       optionDate1: moment(testDate)
         .add(3, 'days')
         .format('MM/DD/YYYY'),
@@ -198,7 +197,7 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
 
     appointment.attributes = {
       ...appointment.attributes,
-      appointmentType: 'Primary care',
+      typeOfCareId: '323',
       optionDate1: moment(testDate)
         .add(3, 'days')
         .format('MM/DD/YYYY'),
@@ -278,7 +277,7 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
     expect(
       screen.getByRole('heading', {
         level: 1,
-        name: 'Pending audiology (hearing aid support) appointment',
+        name: 'Pending hearing aid support appointment',
       }),
     ).to.be.ok;
 
@@ -336,7 +335,7 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
     appointment.id = '1234';
     appointment.attributes = {
       ...appointment.attributes,
-      appointmentType: 'Primary care',
+      typeOfCareId: '323',
       optionDate1: moment(testDate)
         .add(3, 'days')
         .format('MM/DD/YYYY'),
@@ -424,7 +423,7 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
     appointment.id = '1234';
     appointment.attributes = {
       ...appointment.attributes,
-      appointmentType: 'Primary care',
+      typeOfCareId: '323',
       optionDate1: moment(testDate)
         .add(3, 'days')
         .format('MM/DD/YYYY'),
@@ -470,7 +469,7 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
 
     await waitFor(() => {
       expect(global.document.title).to.equal(
-        `Pending Community care audiology (hearing aid support) appointment`,
+        `Pending Community care hearing aid support appointment`,
       );
     });
   });
@@ -480,7 +479,7 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
 
     appointment.attributes = {
       ...appointment.attributes,
-      appointmentType: 'Primary care',
+      typeOfCareId: '323',
       optionDate1: moment(testDate)
         .add(3, 'days')
         .format('MM/DD/YYYY'),
@@ -515,7 +514,7 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
     appointment.id = '1234';
     appointment.attributes = {
       ...appointment.attributes,
-      appointmentType: 'Primary care',
+      typeOfCareId: '323',
       optionDate1: moment(testDate)
         .add(3, 'days')
         .format('MM/DD/YYYY'),
@@ -567,7 +566,7 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
 
     await waitFor(() => {
       expect(global.document.title).to.equal(
-        `Pending Community care audiology (hearing aid support) appointment`,
+        `Pending Community care hearing aid support appointment`,
       );
     });
     expect(screen.baseElement).to.contain('.usa-alert-success');
@@ -584,7 +583,7 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
     appointment.id = '1234';
     appointment.attributes = {
       ...appointment.attributes,
-      appointmentType: 'Primary care',
+      typeOfCareId: '323',
       optionDate1: moment(testDate)
         .add(3, 'days')
         .format('MM/DD/YYYY'),

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentsList.unit.spec.jsx
@@ -54,7 +54,6 @@ describe('VAOS <RequestedAppointmentsList>', () => {
       typeOfCareId: '323',
       reasonForVisit: 'Back pain',
       friendlyLocationName: 'Some VA medical center',
-      appointmentType: 'Primary Care',
       comment: 'loss of smell',
       facility: {
         ...appointment.attributes.facility,
@@ -124,7 +123,7 @@ describe('VAOS <RequestedAppointmentsList>', () => {
       reducers,
     });
 
-    expect(await screen.findByText('Audiology (hearing aid support)')).to.be.ok;
+    expect(await screen.findByText('Hearing aid support')).to.be.ok;
     expect(screen.baseElement).to.contain.text('Community care');
     expect(screen.queryByText(/You don’t have any appointments/i)).not.to.exist;
   });
@@ -171,7 +170,7 @@ describe('VAOS <RequestedAppointmentsList>', () => {
       reducers,
     });
 
-    expect(await screen.findByText('Audiology (hearing aid support)')).to.be.ok;
+    expect(await screen.findByText('Hearing aid support')).to.be.ok;
     expect(screen.baseElement).to.contain.text('Scripps Health Clinic');
     expect(screen.baseElement).not.to.contain.text('Community care');
     expect(screen.queryByText(/You don’t have any appointments/i)).not.to.exist;
@@ -217,7 +216,6 @@ describe('VAOS <RequestedAppointmentsList>', () => {
       typeOfCareId: '323',
       reasonForVisit: 'Back pain',
       friendlyLocationName: 'Some VA medical center',
-      appointmentType: 'Primary Care',
       comment: 'loss of smell',
       facility: {
         ...appointment.attributes.facility,

--- a/src/applications/vaos/tests/services/appointment/transformers.unit.spec.js
+++ b/src/applications/vaos/tests/services/appointment/transformers.unit.spec.js
@@ -793,9 +793,7 @@ describe('VAOS Appointment transformer', () => {
 
     it('should set appointment type', () => {
       expect(data.type.coding[0].code).to.equal('CCAUDHEAR');
-      expect(data.type.coding[0].display).to.equal(
-        'Audiology (hearing aid support)',
-      );
+      expect(data.type.coding[0].display).to.equal('Hearing aid support');
     });
 
     it('should set requestedPeriods (FHIR 4.0.1)', () => {


### PR DESCRIPTION
## Description
This PR
- Updates the v0 transformer to set the request type of care name from our type of care constants name instead of appointmentType in the var-resources request object
- Updates all the tests that used appointmentType

## Original issue(s)
department-of-veterans-affairs/va.gov-team#27502

## Testing done
Unit testing

## Screenshots
![Screen Shot 2021-07-26 at 2 01 29 PM](https://user-images.githubusercontent.com/634932/127036622-39e48cdd-5297-4f5e-8aec-68e0ed021701.png)


## Acceptance criteria
- [ ] Type of care comes from id instead of text field

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
