### PR TITLE
Deprecates v0 logins

### DIFF
--- a/src/applications/login/components/VerifyPage.jsx
+++ b/src/applications/login/components/VerifyPage.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 
 import recordEvent from 'platform/monitoring/record-event';
 import {
@@ -9,7 +8,7 @@ import {
   verify,
 } from 'platform/user/authentication/utilities';
 
-function handleClick(version) {
+function handleClick(version = 'v1') {
   // For first-time users attempting to navigate to My VA Health, The user must
   // be LOA3. If they aren't, they will get directed to verify here,
   // with a valid redirect URL already in sessionStorage. In that case,
@@ -27,28 +26,22 @@ function handleClick(version) {
 export default function VerifyPage() {
   return (
     <div className="row">
-      <AlertBox
-        content={
-          <div>
-            <h4 className="usa-alert-heading">
-              Please verify your identity before continuing to My VA Health
-            </h4>
-            <p>
-              We take your privacy seriously, and we’re committed to protecting
-              your information. You’ll need to verify your identity before we
-              can give you access to your personal health information.
-            </p>
-            <button
-              onClick={() => handleClick('v1')}
-              className="usa-button-primary va-button-primary"
-            >
-              Verify your identity
-            </button>
-          </div>
-        }
-        isVisible
-        status="continue"
-      />
+      <va-alert visible status="continue">
+        <h4 slot="headline" className="usa-alert-heading">
+          Please verify your identity before continuing to My VA Health
+        </h4>
+        <p>
+          We take your privacy seriously, and we’re committed to protecting your
+          information. You’ll need to verify your identity before we can give
+          you access to your personal health information.
+        </p>
+        <button
+          onClick={() => handleClick('v1')}
+          className="usa-button-primary va-button-primary"
+        >
+          Verify your identity
+        </button>
+      </va-alert>
     </div>
   );
 }

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -24,7 +24,7 @@ export const ssoKeepAliveEndpoint = () => {
   return `https://${envPrefix}eauth.va.gov/keepalive`;
 };
 
-export function sessionTypeUrl(type = '', version = 'v0', queryParams = {}) {
+export function sessionTypeUrl(type = '', version = 'v1', queryParams = {}) {
   const base =
     version === 'v1'
       ? `${environment.API_URL}/v1/sessions`
@@ -102,7 +102,7 @@ function redirect(redirectUrl, clickedEvent) {
 
 export function login(
   policy,
-  version = 'v0',
+  version = 'v1',
   queryParams = {},
   clickedEvent = 'login-link-clicked-modal',
 ) {
@@ -111,16 +111,16 @@ export function login(
   return redirect(url, clickedEvent);
 }
 
-export function mfa(version = 'v0') {
+export function mfa(version = 'v1') {
   return redirect(sessionTypeUrl('mfa', version), 'multifactor-link-clicked');
 }
 
-export function verify(version = 'v0') {
+export function verify(version = 'v1') {
   return redirect(sessionTypeUrl('verify', version), 'verify-link-clicked');
 }
 
 export function logout(
-  version = 'v0',
+  version = 'v1',
   clickedEvent = 'logout-link-clicked',
   queryParams = {},
 ) {
@@ -128,6 +128,6 @@ export function logout(
   return redirect(sessionTypeUrl('slo', version, queryParams), clickedEvent);
 }
 
-export function signup(version = 'v0') {
+export function signup(version = 'v1') {
   return redirect(sessionTypeUrl('signup', version), 'register-link-clicked');
 }

--- a/src/platform/user/tests/authentication/utilities.unit.spec.js
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.js
@@ -26,7 +26,7 @@ describe('authentication URL helpers', () => {
 
   it('should redirect for signup', () => {
     signup();
-    expect(global.window.location).to.include('/sessions/signup/new');
+    expect(global.window.location).to.include('/v1/sessions/signup/new');
   });
 
   it('should redirect for signup v1', () => {
@@ -36,7 +36,7 @@ describe('authentication URL helpers', () => {
 
   it('should redirect for login', () => {
     login('idme');
-    expect(global.window.location).to.include('/sessions/idme/new');
+    expect(global.window.location).to.include('/v1/sessions/idme/new');
   });
 
   it('should redirect for login v1', () => {
@@ -52,7 +52,7 @@ describe('authentication URL helpers', () => {
 
   it('should redirect for logout', () => {
     logout();
-    expect(global.window.location).to.include('/sessions/slo/new');
+    expect(global.window.location).to.include('/v1/sessions/slo/new');
   });
 
   it('should redirect for logout v1', () => {
@@ -68,7 +68,7 @@ describe('authentication URL helpers', () => {
 
   it('should redirect for MFA', () => {
     mfa();
-    expect(global.window.location).to.include('/sessions/mfa/new');
+    expect(global.window.location).to.include('/v1/sessions/mfa/new');
   });
 
   it('should redirect for MFA v1', () => {
@@ -78,7 +78,7 @@ describe('authentication URL helpers', () => {
 
   it('should redirect for verify', () => {
     verify();
-    expect(global.window.location).to.include('/sessions/verify/new');
+    expect(global.window.location).to.include('/v1/sessions/verify/new');
   });
 
   it('should redirect for verify v1', () => {


### PR DESCRIPTION
## Description
After updating the ssoe feature flag from 50% to 100% there are still login sessions on the `v0` in production. This PR updates the default parameters to use `v1` in all auth functions related to signing in.  This will help reduce and/or eliminate the number of `v0` sessions happening on va.gov

## Original issue(s)
department-of-veterans-affairs/va.gov-team#27772

## Testing done
Unit tests, manual QA

## Screenshots
n/a

## Acceptance criteria
- [x] No `v0` sessions are established
- [x] Only `v1` sessions are used

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
