### PR TITLE
Try reenabling dependency caching with Docker and new cache path to s…

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -365,6 +365,7 @@ jobs:
         with:
           path: |
             .cache/yarn
+            /github/home/.cache/Cypress
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -358,7 +358,6 @@ jobs:
       #   with:
       #     chrome-version: stable
 
-      # Disabling caching due to cypress breaking - to be evaluated at a later date
       - name: Cache dependencies
         id: cache-dependencies
         uses: actions/cache@v2
@@ -367,7 +366,7 @@ jobs:
             .cache/yarn
             /github/home/.cache/Cypress
             node_modules
-          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
+          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}-cypress
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -359,14 +359,14 @@ jobs:
       #     chrome-version: stable
 
       # Disabling caching due to cypress breaking - to be evaluated at a later date
-      # - name: Cache dependencies
-      #   id: cache-dependencies
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: |
-      #       .cache/yarn
-      #       node_modules
-      #     key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
+      - name: Cache dependencies
+        id: cache-dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            .cache/yarn
+            node_modules
+          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline


### PR DESCRIPTION
…ee preliminary result

## Description
Aside from uncommenting what was there, I added an additional cache path as requested by Cypress, to avoid Cypress being unable to start.  This seems to have stabilized caching and it seems to be making it through the test suite with greatly reduced dependency cache times.


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
