### PR TITLE
Coverage report jenkins fix

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -120,7 +120,7 @@ jobs:
         run: node script/app-coverage-report.js > test-results/coverage_report.txt
 
       - name: Configure AWS credentials (1)
-        if: ${{ github.ref == 'refs/heads/coverage-report-jenkins-fix' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -128,14 +128,14 @@ jobs:
           aws-region: us-gov-west-1
 
       - name: Get AWS IAM role
-        if: ${{ github.ref == 'refs/heads/coverage-report-jenkins-fix' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: marvinpinto/action-inject-ssm-secrets@latest
         with:
           ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
           env_variable_name: AWS_FRONTEND_NONPROD_ROLE
 
       - name: Configure AWS Credentials (2)
-        if: ${{ github.ref == 'refs/heads/coverage-report-jenkins-fix' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -146,8 +146,8 @@ jobs:
           role-session-name: vsp-frontendteam-githubaction
 
       - name: Upload coverage report to S3
-        if: ${{ github.ref == 'refs/heads/coverage-report-jenkins-fix' }}
-        run: aws s3 cp coverage/test-coverage-report.json s3://apps.dev.va.gov/coverage-report/test-coverage-report.json --acl public-read --region us-gov-west-1
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: aws s3 cp coverage/test-coverage-report.json s3://apps.dev.va.gov/coverage/test-coverage-report.json --acl public-read --region us-gov-west-1
 
       - name: Get code coverage
         id: code-coverage

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -120,7 +120,7 @@ jobs:
         run: node script/app-coverage-report.js > test-results/coverage_report.txt
 
       - name: Configure AWS credentials (1)
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/coverage-report-jenkins-fix' }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -128,14 +128,14 @@ jobs:
           aws-region: us-gov-west-1
 
       - name: Get AWS IAM role
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/coverage-report-jenkins-fix' }}
         uses: marvinpinto/action-inject-ssm-secrets@latest
         with:
           ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
           env_variable_name: AWS_FRONTEND_NONPROD_ROLE
 
       - name: Configure AWS Credentials (2)
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/coverage-report-jenkins-fix' }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -146,7 +146,7 @@ jobs:
           role-session-name: vsp-frontendteam-githubaction
 
       - name: Upload coverage report to S3
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/coverage-report-jenkins-fix' }}
         run: aws s3 cp coverage/test-coverage-report.json s3://apps.dev.va.gov/coverage/test-coverage-report.json --acl public-read --region us-gov-west-1
 
       - name: Get code coverage

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -120,7 +120,7 @@ jobs:
         run: node script/app-coverage-report.js > test-results/coverage_report.txt
 
       - name: Configure AWS credentials (1)
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/coverage-report-jenkins-fix' }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -128,14 +128,14 @@ jobs:
           aws-region: us-gov-west-1
 
       - name: Get AWS IAM role
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/coverage-report-jenkins-fix' }}
         uses: marvinpinto/action-inject-ssm-secrets@latest
         with:
           ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
           env_variable_name: AWS_FRONTEND_NONPROD_ROLE
 
       - name: Configure AWS Credentials (2)
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/coverage-report-jenkins-fix' }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -146,8 +146,8 @@ jobs:
           role-session-name: vsp-frontendteam-githubaction
 
       - name: Upload coverage report to S3
-        if: ${{ github.ref == 'refs/heads/master' }}
-        run: aws s3 cp coverage/test-coverage-report.json s3://apps.dev.va.gov/coverage/test-coverage-report.json --acl public-read --region us-gov-west-1
+        if: ${{ github.ref == 'refs/heads/coverage-report-jenkins-fix' }}
+        run: aws s3 cp coverage/test-coverage-report.json s3://apps.dev.va.gov/coverage-report/test-coverage-report.json --acl public-read --region us-gov-west-1
 
       - name: Get code coverage
         id: code-coverage

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -120,7 +120,7 @@ jobs:
         run: node script/app-coverage-report.js > test-results/coverage_report.txt
 
       - name: Configure AWS credentials (1)
-        if: ${{ github.ref == 'refs/heads/coverage-report-jenkins-fix' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -128,14 +128,14 @@ jobs:
           aws-region: us-gov-west-1
 
       - name: Get AWS IAM role
-        if: ${{ github.ref == 'refs/heads/coverage-report-jenkins-fix' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: marvinpinto/action-inject-ssm-secrets@latest
         with:
           ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
           env_variable_name: AWS_FRONTEND_NONPROD_ROLE
 
       - name: Configure AWS Credentials (2)
-        if: ${{ github.ref == 'refs/heads/coverage-report-jenkins-fix' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -146,7 +146,7 @@ jobs:
           role-session-name: vsp-frontendteam-githubaction
 
       - name: Upload coverage report to S3
-        if: ${{ github.ref == 'refs/heads/coverage-report-jenkins-fix' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         run: aws s3 cp coverage/test-coverage-report.json s3://apps.dev.va.gov/coverage/test-coverage-report.json --acl public-read --region us-gov-west-1
 
       - name: Get code coverage

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -119,36 +119,6 @@ jobs:
       - name: Generate coverage report by app
         run: node script/app-coverage-report.js > test-results/coverage_report.txt
 
-      - name: Configure AWS credentials (1)
-        if: ${{ github.ref == 'refs/heads/master' }}
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-
-      - name: Get AWS IAM role
-        if: ${{ github.ref == 'refs/heads/master' }}
-        uses: marvinpinto/action-inject-ssm-secrets@latest
-        with:
-          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
-          env_variable_name: AWS_FRONTEND_NONPROD_ROLE
-
-      - name: Configure AWS Credentials (2)
-        if: ${{ github.ref == 'refs/heads/master' }}
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
-          role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
-          role-duration-seconds: 900
-          role-session-name: vsp-frontendteam-githubaction
-
-      - name: Upload coverage report to S3
-        if: ${{ github.ref == 'refs/heads/master' }}
-        run: aws s3 cp coverage/test-coverage-report.json s3://apps.dev.va.gov/coverage/test-coverage-report.json --acl public-read --region us-gov-west-1
-
       - name: Get code coverage
         id: code-coverage
         run: echo ::set-output name=MARKDOWN::$(node ./script/github-actions/code-coverage-format-report.js)

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -117,7 +117,7 @@ def archive(dockerContainer, String ref, String envName) {
       sh "echo \"${buildDetails}\" > /application/build/${envName}/BUILD.txt"
 
       sh "cd /application && yarn test:coverage-only"
-      sh "node script/app-coverage-report.js"
+      sh "node /application/script/app-coverage-report.js"
 
       if(envName == 'vagovdev' || envName == 'vagovstaging') {
         sh "tar -C /application/build/${envName} -cf /application/build/apps.${envName}.tar.bz2 ."

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -115,6 +115,10 @@ def archive(dockerContainer, String ref, String envName) {
     withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'vetsgov-website-builds-s3-upload',
                      usernameVariable: 'AWS_ACCESS_KEY', passwordVariable: 'AWS_SECRET_KEY']]) {
       sh "echo \"${buildDetails}\" > /application/build/${envName}/BUILD.txt"
+
+      sh "cd /application && yarn test:coverage-only"
+      sh "node script/app-coverage-report.js"
+
       if(envName == 'vagovdev' || envName == 'vagovstaging') {
         sh "tar -C /application/build/${envName} -cf /application/build/apps.${envName}.tar.bz2 ."
         sh "aws s3 cp /application/build/apps.${envName}.tar.bz2 s3://vetsgov-website-builds-s3-upload/application-build/${ref}/${envName}.tar.bz2 --acl public-read --region us-gov-west-1 --quiet"

--- a/script/app-coverage-report.js
+++ b/script/app-coverage-report.js
@@ -107,7 +107,7 @@ const logCoverage = coverageResults => {
     if (err) {
       throw err;
     }
-    console.log('JSON data is saved.');
+    console.log(`JSON data is saved to ${outputFile}`);
   });
 };
 

--- a/script/app-coverage-report.js
+++ b/script/app-coverage-report.js
@@ -98,10 +98,7 @@ const logCoverage = coverageResults => {
   const data = JSON.stringify(coverageResults, null, 4);
 
   // write coverageResults string to file
-  const outputFile = path.join(
-    __dirname,
-    '../coverage/test-coverage-report.json',
-  );
+  const outputFile = path.join(__dirname, '../build/test-coverage-report.json');
   fs.writeFile(outputFile, data, err => {
     if (err) {
       throw err;

--- a/script/app-coverage-report.js
+++ b/script/app-coverage-report.js
@@ -98,7 +98,11 @@ const logCoverage = coverageResults => {
   const data = JSON.stringify(coverageResults, null, 4);
 
   // write coverageResults string to file
-  const outputFile = path.join(__dirname, '../build/test-coverage-report.json');
+  const buildDirectoryPath = path.join(__dirname, '../build');
+  const coverageDirectoryPath = path.join(__dirname, '../coverage');
+  const outputFile = fs.existsSync(buildDirectoryPath)
+    ? path.join(buildDirectoryPath, '/test-coverage-report.json')
+    : path.join(coverageDirectoryPath, '/test-coverage-report.json');
   fs.writeFile(outputFile, data, err => {
     if (err) {
       throw err;


### PR DESCRIPTION
## Description
The code coverage report json that we were uploading to dev separately is being deleted when Jenkins deploys to dev. We need to include it as part of the build tar in order to make sure it doesn't get deleted.

## Original issue(s)


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
