### PR TITLE
Add two more parallel steps to Cypress E2E tests on GitHub Actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -322,9 +322,9 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 6
+      max-parallel: 8
       matrix:
-        ci_node_index: [0, 1, 2, 3, 4, 5]
+        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7]
 
     env:
       CHROMEDRIVER_FILEPATH: /share/chrome_driver/chromedriver
@@ -390,7 +390,7 @@ jobs:
 
       - name: Run Cypress tests
         run: node script/github-actions/run-cypress-tests.js
-        timeout-minutes: 60
+        timeout-minutes: 30
         env:
           # CYPRESS_BASE_URL: http://localhost:3001
           CYPRESS_CI: true

--- a/script/github-actions/run-cypress-tests.js
+++ b/script/github-actions/run-cypress-tests.js
@@ -5,7 +5,7 @@ const { integrationFolder, testFiles } = require('../../config/cypress.json');
 
 const pattern = path.join(__dirname, '../..', integrationFolder, testFiles);
 const tests = glob.sync(pattern);
-const divider = Math.ceil(tests.length / 6);
+const divider = Math.ceil(tests.length / 8);
 const batch = tests
   .slice(
     Number(process.env.STEP) * divider,


### PR DESCRIPTION
## Description
This PR adds two more parallel steps to the Cypress E2E test workflow on GitHub Actions in order to reduce build times.

## Acceptance criteria
- [ ] Cypress E2E tests run in eight parallel steps on GitHub Actions.
- [ ] Tests pass on CI.