### PR TITLE
HLR: Move wizard to `/start` path

### DIFF
--- a/src/applications/disability-benefits/996/constants.js
+++ b/src/applications/disability-benefits/996/constants.js
@@ -1,4 +1,5 @@
 import { benefitTypes } from 'vets-json-schema/dist/constants.json';
+import environment from 'platform/utilities/environment';
 
 // *** URLS ***
 export const HLR_INFO_URL = '/decision-reviews/higher-level-review/';
@@ -73,3 +74,5 @@ export const SUPPORTED_BENEFIT_TYPES = benefitTypes.map(type => ({
   ...type,
   isSupported: supportedBenefitTypes.includes(type.value),
 }));
+
+export const IS_PRODUCTION = environment.isProduction();

--- a/src/applications/disability-benefits/996/containers/Form0996App.jsx
+++ b/src/applications/disability-benefits/996/containers/Form0996App.jsx
@@ -1,9 +1,36 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { connect } from 'react-redux';
+import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
-import formConfig from '../config/form';
+import scrollToTop from 'platform/utilities/ui/scrollToTop';
+import { focusElement } from 'platform/utilities/ui';
+import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
 
-export default function Form0996App({ location, children }) {
+import formConfig from '../config/form';
+import { IS_PRODUCTION } from '../constants';
+import { getHlrWizardStatus, shouldShowWizard } from '../wizard/utils';
+
+export const Form0996App = ({ location, children, router, savedForms }) => {
+  useEffect(() => {
+    if (
+      getHlrWizardStatus() === WIZARD_STATUS_COMPLETE &&
+      window.location.pathname.endsWith('/introduction')
+    ) {
+      focusElement('h1');
+      scrollToTop();
+    }
+  });
+
+  if (!IS_PRODUCTION && shouldShowWizard(formConfig.formId, savedForms)) {
+    router.push('/start');
+    return (
+      <h1>
+        <LoadingIndicator message="Please wait while we restart the application for you." />
+      </h1>
+    );
+  }
+
   // Add data-location attribute to allow styling specific pages
   return (
     <article id="form-0996" data-location={`${location?.pathname?.slice(1)}`}>
@@ -12,4 +39,10 @@ export default function Form0996App({ location, children }) {
       </RoutedSavableApp>
     </article>
   );
-}
+};
+
+const mapStateToProps = state => ({
+  savedForms: state.user?.profile?.savedForms || [],
+});
+
+export default connect(mapStateToProps)(Form0996App);

--- a/src/applications/disability-benefits/996/containers/Form0996App.jsx
+++ b/src/applications/disability-benefits/996/containers/Form0996App.jsx
@@ -25,7 +25,7 @@ export const Form0996App = ({ location, children, router, savedForms }) => {
   if (!IS_PRODUCTION && shouldShowWizard(formConfig.formId, savedForms)) {
     router.push('/start');
     return (
-      <h1>
+      <h1 className="vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal">
         <LoadingIndicator message="Please wait while we restart the application for you." />
       </h1>
     );

--- a/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import moment from 'moment';
 
 import OMBInfo from '@department-of-veterans-affairs/component-library/OMBInfo';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
@@ -17,6 +16,10 @@ import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
 import { isEmptyAddress } from 'platform/forms/address/helpers';
 import { selectVAPContactInfoField } from '@@vap-svc/selectors';
 import { FIELD_NAMES } from '@@vap-svc/constants';
+import {
+  WIZARD_STATUS_NOT_STARTED,
+  WIZARD_STATUS_COMPLETE,
+} from 'platform/site-wide/wizard';
 
 import {
   getContestableIssues as getContestableIssuesAction,
@@ -29,7 +32,7 @@ import {
   SUPPLEMENTAL_CLAIM_URL,
   FACILITY_LOCATOR_URL,
   GET_HELP_REVIEW_REQUEST_URL,
-  WIZARD_STATUS,
+  IS_PRODUCTION,
 } from '../constants';
 import {
   noContestableIssuesFound,
@@ -38,13 +41,14 @@ import {
 } from '../content/contestableIssueAlerts';
 import WizardContainer from '../wizard/WizardContainer';
 import {
-  WIZARD_STATUS_NOT_STARTED,
-  WIZARD_STATUS_COMPLETE,
-} from 'platform/site-wide/wizard';
+  getHlrWizardStatus,
+  setHlrWizardStatus,
+  shouldShowWizard,
+} from '../wizard/utils';
 
 export class IntroductionPage extends React.Component {
   state = {
-    status: sessionStorage.getItem(WIZARD_STATUS) || WIZARD_STATUS_NOT_STARTED,
+    status: getHlrWizardStatus() || WIZARD_STATUS_NOT_STARTED,
   };
 
   componentDidMount() {
@@ -79,13 +83,6 @@ export class IntroductionPage extends React.Component {
         : '.va-nav-breadcrumbs-list';
     focusElement(focusTarget);
     scrollToTop();
-  };
-
-  hasSavedForm = () => {
-    const { user } = this.props;
-    return user?.profile?.savedForms
-      .filter(f => moment.unix(f.metadata.expiresAt).isAfter())
-      .find(f => f.form === this.props.formId);
   };
 
   authenticate = e => {
@@ -140,15 +137,24 @@ export class IntroductionPage extends React.Component {
     return noContestableIssuesFound;
   };
 
+  // Used for production only
   setWizardStatus = value => {
-    sessionStorage.setItem(WIZARD_STATUS, value);
+    setHlrWizardStatus(value);
     this.setState({ status: value });
   };
 
   render() {
-    const { user, hasEmptyAddress } = this.props;
+    const {
+      user,
+      hasEmptyAddress,
+      route,
+      isProduction = IS_PRODUCTION, // for unit tests
+    } = this.props;
     const callToActionContent = this.getCallToActionContent();
-    const showWizard = this.state.status !== WIZARD_STATUS_COMPLETE;
+    const showWizard = shouldShowWizard(
+      route.formConfig.formId,
+      user.profile.savedForms,
+    );
 
     // Change page title once wizard has closed to provide a Veteran using a
     // screenreader some indication that the content has changed
@@ -167,130 +173,122 @@ export class IntroductionPage extends React.Component {
       );
     }
 
+    if (showWizard && isProduction) {
+      return <WizardContainer setWizardStatus={this.setWizardStatus} />;
+    }
+
     return (
       <article className="schemaform-intro">
         <FormTitle title={pageTitle} />
         <p>Equal to VA Form 20-0996 (Higher-Level Review).</p>
-
-        {showWizard ? (
-          <WizardContainer setWizardStatus={this.setWizardStatus} />
-        ) : (
-          <>
-            <CallToActionWidget appId="higher-level-review" headerLevel={2}>
-              {callToActionContent}
-            </CallToActionWidget>
-            <h2 className="vads-u-font-size--h3">
-              What’s a Higher-Level Review?
-            </h2>
-            <p>
-              If you or your representative disagree with VA’s decision on your
-              claim, you can request a Higher-Level Review. With a Higher-Level
-              Review, a senior reviewer will take a new look at your case and
-              the evidence you already provided. The reviewer will decide
-              whether the decision can be changed based on a difference of
-              opinion or an error.
-            </p>
-            <h2 className="vads-u-font-size--h3">
-              You can’t submit new evidence with a Higher-Level Review
-            </h2>
-            <p>
-              The senior reviewer will only review the evidence you already
-              provided. If you have new and relevant evidence, you can{' '}
-              <a href={SUPPLEMENTAL_CLAIM_URL}>file a Supplemental Claim</a>.
-            </p>
-            <div className="process schemaform-process">
-              <h2 className="vads-u-font-size--h3">
-                Follow the steps below to request a Higher-Level Review.
-              </h2>
-              <p className="vads-u-margin-top--2">
-                if you don’t think this is the right form for you,{' '}
-                <a
-                  href={BASE_URL}
-                  className="va-button-link"
-                  onClick={event => {
-                    // prevent reload, but allow opening a new tab
-                    event.preventDefault();
-                    this.setWizardStatus(WIZARD_STATUS_NOT_STARTED);
-                    this.setPageFocus();
-                    recordEvent({ event: 'howToWizard-start-over' });
-                  }}
-                >
-                  go back and answer questions again
+        <CallToActionWidget appId="higher-level-review" headerLevel={2}>
+          {callToActionContent}
+        </CallToActionWidget>
+        <h2 className="vads-u-font-size--h3">What’s a Higher-Level Review?</h2>
+        <p>
+          If you or your representative disagree with VA’s decision on your
+          claim, you can request a Higher-Level Review. With a Higher-Level
+          Review, a senior reviewer will take a new look at your case and the
+          evidence you already provided. The reviewer will decide whether the
+          decision can be changed based on a difference of opinion or an error.
+        </p>
+        <h2 className="vads-u-font-size--h3">
+          You can’t submit new evidence with a Higher-Level Review
+        </h2>
+        <p>
+          The senior reviewer will only review the evidence you already
+          provided. If you have new and relevant evidence, you can{' '}
+          <a href={SUPPLEMENTAL_CLAIM_URL}>file a Supplemental Claim</a>.
+        </p>
+        <div className="process schemaform-process">
+          <h2 className="vads-u-font-size--h3">
+            Follow the steps below to request a Higher-Level Review.
+          </h2>
+          <p className="vads-u-margin-top--2">
+            if you don’t think this is the right form for you,{' '}
+            <a
+              href={`${BASE_URL}${isProduction ? '' : '/start'}`}
+              className="va-button-link"
+              onClick={event => {
+                // prevent reload, but allow opening a new tab
+                if (isProduction) {
+                  event.preventDefault();
+                }
+                this.setWizardStatus(WIZARD_STATUS_NOT_STARTED);
+                this.setPageFocus();
+                recordEvent({ event: 'howToWizard-start-over' });
+              }}
+            >
+              go back and answer questions again
+            </a>
+            .
+          </p>
+          <ol>
+            <li className="process-step list-one">
+              <h3 className="vads-u-font-size--h4">Prepare</h3>
+              <p>To fill out this application, you’ll need your:</p>
+              <ul>
+                <li>Primary address</li>
+                <li>
+                  List of issues you disagree with and the VA decision date for
+                  each
+                </li>
+                <li>Representative’s contact information (optional)</li>
+              </ul>
+              <p>
+                <strong>What if I need help with my application?</strong>
+              </p>
+              <p>
+                If you need help requesting a Higher-Level Review, you can
+                contact a VA regional office and ask to speak to a
+                representative. To find the nearest regional office, please call{' '}
+                <Telephone contact={CONTACTS.VA_BENEFITS} />
+                {' or '}
+                <a href={FACILITY_LOCATOR_URL}>
+                  visit our facility locator tool
                 </a>
                 .
               </p>
-              <ol>
-                <li className="process-step list-one">
-                  <h3 className="vads-u-font-size--h4">Prepare</h3>
-                  <p>To fill out this application, you’ll need your:</p>
-                  <ul>
-                    <li>Primary address</li>
-                    <li>
-                      List of issues you disagree with and the VA decision date
-                      for each
-                    </li>
-                    <li>Representative’s contact information (optional)</li>
-                  </ul>
-                  <p>
-                    <strong>What if I need help with my application?</strong>
-                  </p>
-                  <p>
-                    If you need help requesting a Higher-Level Review, you can
-                    contact a VA regional office and ask to speak to a
-                    representative. To find the nearest regional office, please
-                    call <Telephone contact={CONTACTS.VA_BENEFITS} />
-                    {' or '}
-                    <a href={FACILITY_LOCATOR_URL}>
-                      visit our facility locator tool
-                    </a>
-                    .
-                  </p>
-                  <p>
-                    A Veterans Service Organization or VA-accredited attorney or
-                    agent can also help you request a decision review.
-                  </p>
-                  <a href={GET_HELP_REVIEW_REQUEST_URL}>
-                    Get help requesting a decision review
-                  </a>
-                  .
-                </li>
-                <li className="process-step list-two">
-                  <h3 className="vads-u-font-size--h4">Apply</h3>
-                  <p>
-                    Complete this Higher-Level Review form. After submitting the
-                    form, you’ll get a confirmation message. You can print this
-                    for your records.
-                  </p>
-                </li>
-                <li className="process-step list-three">
-                  <h3 className="vads-u-font-size--h4">VA Review</h3>
-                  <p>
-                    Our goal for completing a Higher-Level Review is 125 days. A
-                    review might take longer if we need to get records or
-                    schedule a new exam to correct an error.
-                  </p>
-                </li>
-                <li className="process-step list-four">
-                  <h3 className="vads-u-font-size--h4">Decision</h3>
-                  <p>
-                    Once we’ve processed your claim, you’ll get a notice in the
-                    mail with our decision.
-                  </p>
-                </li>
-              </ol>
-            </div>
-            <CallToActionWidget appId="higher-level-review" headerLevel={2}>
-              {callToActionContent}
-            </CallToActionWidget>
-            <div className="omb-info--container vads-u-padding-left--0">
-              <OMBInfo
-                resBurden={15}
-                ombNumber="2900-0862"
-                expDate="04/30/2024"
-              />
-            </div>
-          </>
-        )}
+              <p>
+                A Veterans Service Organization or VA-accredited attorney or
+                agent can also help you request a decision review.
+              </p>
+              <a href={GET_HELP_REVIEW_REQUEST_URL}>
+                Get help requesting a decision review
+              </a>
+              .
+            </li>
+            <li className="process-step list-two">
+              <h3 className="vads-u-font-size--h4">Apply</h3>
+              <p>
+                Complete this Higher-Level Review form. After submitting the
+                form, you’ll get a confirmation message. You can print this for
+                your records.
+              </p>
+            </li>
+            <li className="process-step list-three">
+              <h3 className="vads-u-font-size--h4">VA Review</h3>
+              <p>
+                Our goal for completing a Higher-Level Review is 125 days. A
+                review might take longer if we need to get records or schedule a
+                new exam to correct an error.
+              </p>
+            </li>
+            <li className="process-step list-four">
+              <h3 className="vads-u-font-size--h4">Decision</h3>
+              <p>
+                Once we’ve processed your claim, you’ll get a notice in the mail
+                with our decision.
+              </p>
+            </li>
+          </ol>
+        </div>
+        <CallToActionWidget appId="higher-level-review" headerLevel={2}>
+          {callToActionContent}
+        </CallToActionWidget>
+        <div className="omb-info--container vads-u-padding-left--0">
+          <OMBInfo resBurden={15} ombNumber="2900-0862" expDate="04/30/2024" />
+        </div>
       </article>
     );
   }

--- a/src/applications/disability-benefits/996/routes.jsx
+++ b/src/applications/disability-benefits/996/routes.jsx
@@ -1,12 +1,36 @@
 import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/helpers';
-import formConfig from './config/form';
+import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
+
 import Form0996App from './containers/Form0996App';
+import WizardContainer from './wizard/WizardContainer';
+import { IS_PRODUCTION } from './constants';
+import formConfig from './config/form';
+import { getHlrWizardStatus } from './wizard/utils';
+
+const start = IS_PRODUCTION
+  ? []
+  : [
+      {
+        path: '/start',
+        component: WizardContainer,
+      },
+    ];
+
+const onEnter = IS_PRODUCTION
+  ? (nextState, replace) => replace('/introduction')
+  : (nextState, replace) =>
+      replace(
+        getHlrWizardStatus() === WIZARD_STATUS_COMPLETE
+          ? '/introduction'
+          : '/start',
+      );
 
 const routes = [
+  ...start,
   {
     path: '/',
     component: Form0996App,
-    indexRoute: { onEnter: (nextState, replace) => replace('/introduction') },
+    indexRoute: { onEnter },
     childRoutes: createRoutesWithSaveInProgress(formConfig),
   },
 ];

--- a/src/applications/disability-benefits/996/tests/containers/FormApp.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/containers/FormApp.unit.spec.jsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import moment from 'moment';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import sinon from 'sinon';
+import { Provider } from 'react-redux';
+import { combineReducers, createStore } from 'redux';
+
+import { commonReducer } from 'platform/startup/store';
+import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
+
+import { Form0996App } from '../../containers/Form0996App';
+import reducers from '../../reducers';
+import { setHlrWizardStatus, removeHlrWizardStatus } from '../../wizard/utils';
+
+const savedHlr = [
+  {
+    form: '20-0996',
+    metadata: {
+      expiresAt: moment()
+        .add(1, 'day')
+        .unix(),
+    },
+  },
+];
+
+const testPage = ({ savedForms = savedHlr, routerPushSpy = () => {} } = {}) => {
+  const initialState = {
+    user: {
+      login: {
+        currentlyLoggedIn: true,
+      },
+      profile: {
+        savedForms,
+      },
+    },
+    currentLocation: {
+      pathname: '/introduction',
+      search: '',
+    },
+    form: {
+      loadedStatus: 'success',
+      savedStatus: '',
+      loadedData: {
+        metadata: {},
+      },
+    },
+  };
+  const fakeStore = createStore(
+    combineReducers({
+      ...commonReducer,
+      ...reducers,
+    }),
+    initialState,
+  );
+  return mount(
+    <Provider store={fakeStore}>
+      <Form0996App
+        location={initialState.currentLocation}
+        router={{ push: routerPushSpy }}
+        savedForms={initialState.user.profile.savedForms}
+      >
+        <main>
+          <h1>Intro</h1>
+        </main>
+      </Form0996App>
+    </Provider>,
+  );
+};
+
+describe('Form0996App', () => {
+  it('should render', () => {
+    setHlrWizardStatus(WIZARD_STATUS_COMPLETE);
+    const tree = testPage();
+    const article = tree.find('#form-0996');
+
+    expect(article).to.exist;
+    expect(article.props()['data-location']).to.eq('introduction');
+    expect(tree.find('h1').text()).to.eq('Intro');
+    expect(tree.find('Connect(RoutedSavableApp)')).to.exist;
+    expect(tree.find('LoadingIndicator')).to.have.lengthOf(0);
+
+    tree.unmount();
+  });
+
+  it('should redirect to /start', () => {
+    const routerPushSpy = sinon.spy();
+    removeHlrWizardStatus();
+    const tree = testPage({ savedForms: [], routerPushSpy });
+
+    expect(tree.find('#form-0996')).to.have.lengthOf(0);
+    expect(tree.find('h1').text()).to.contain('restart');
+    expect(tree.find('LoadingIndicator')).to.have.lengthOf(1);
+    expect(routerPushSpy.called).to.be.true;
+    expect(routerPushSpy.args[0][0]).to.eq('/start');
+
+    tree.unmount();
+  });
+});

--- a/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
@@ -3,13 +3,13 @@ import moment from 'moment';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import { VA_FORM_IDS } from 'platform/forms/constants';
+import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
 
 import { IntroductionPage } from '../../containers/IntroductionPage';
 import formConfig from '../../config/form';
 
 import { FETCH_CONTESTABLE_ISSUES_INIT } from '../../actions';
-import { WIZARD_STATUS } from '../../constants';
-import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
+import { setHlrWizardStatus, removeHlrWizardStatus } from '../../wizard/utils';
 
 const defaultProps = {
   getContestableIssues: () => {},
@@ -60,11 +60,12 @@ describe('IntroductionPage', () => {
   });
   afterEach(() => {
     global.window = oldWindow;
-    sessionStorage.removeItem(WIZARD_STATUS);
+    removeHlrWizardStatus();
   });
 
   it('should show has empty address message', () => {
     const user = {
+      ...defaultProps.user,
       login: {
         currentlyLoggedIn: true,
       },
@@ -81,7 +82,7 @@ describe('IntroductionPage', () => {
   });
 
   it('should render CallToActionWidget', () => {
-    sessionStorage.setItem(WIZARD_STATUS, WIZARD_STATUS_COMPLETE);
+    setHlrWizardStatus(WIZARD_STATUS_COMPLETE);
     const tree = shallow(<IntroductionPage {...defaultProps} />);
 
     const callToActionWidget = tree.find('Connect(CallToActionWidget)');
@@ -93,7 +94,7 @@ describe('IntroductionPage', () => {
   });
 
   it('should render alert showing a server error', () => {
-    sessionStorage.setItem(WIZARD_STATUS, WIZARD_STATUS_COMPLETE);
+    setHlrWizardStatus(WIZARD_STATUS_COMPLETE);
     const errorMessage = 'We can’t load your issues';
     const props = {
       ...defaultProps,
@@ -117,7 +118,7 @@ describe('IntroductionPage', () => {
     tree.unmount();
   });
   it('should render alert showing no contestable issues', () => {
-    sessionStorage.setItem(WIZARD_STATUS, WIZARD_STATUS_COMPLETE);
+    setHlrWizardStatus(WIZARD_STATUS_COMPLETE);
     const errorMessage = 'don’t have any issues on file for you';
     const props = {
       ...defaultProps,
@@ -139,7 +140,7 @@ describe('IntroductionPage', () => {
     tree.unmount();
   });
   it('should render start button', () => {
-    sessionStorage.setItem(WIZARD_STATUS, WIZARD_STATUS_COMPLETE);
+    setHlrWizardStatus(WIZARD_STATUS_COMPLETE);
     const props = {
       ...defaultProps,
       contestableIssues: {
@@ -158,7 +159,7 @@ describe('IntroductionPage', () => {
     tree.unmount();
   });
   it('should include start button with form event', () => {
-    sessionStorage.setItem(WIZARD_STATUS, WIZARD_STATUS_COMPLETE);
+    setHlrWizardStatus(WIZARD_STATUS_COMPLETE);
     const props = {
       ...defaultProps,
       contestableIssues: {
@@ -178,7 +179,7 @@ describe('IntroductionPage', () => {
   });
 
   it('should show contestable issue loading indicator', () => {
-    sessionStorage.setItem(WIZARD_STATUS, WIZARD_STATUS_COMPLETE);
+    setHlrWizardStatus(WIZARD_STATUS_COMPLETE);
     const props = {
       ...defaultProps,
       contestableIssues: {
@@ -199,9 +200,10 @@ describe('IntroductionPage', () => {
 
   // Wizard
   it('should render wizard', () => {
-    sessionStorage.removeItem(WIZARD_STATUS);
+    removeHlrWizardStatus();
     const props = {
       ...defaultProps,
+      isProduction: true,
       contestableIssues: {
         issues: [{}],
         status: 'done',
@@ -210,7 +212,6 @@ describe('IntroductionPage', () => {
     };
 
     const tree = shallow(<IntroductionPage {...props} />);
-    expect(tree.find('FormTitle')).to.have.lengthOf(1);
     expect(tree.find('WizardContainer')).to.have.lengthOf(1);
     expect(tree.find('Connect(CallToActionWidget)')).to.have.lengthOf(0);
     tree.unmount();

--- a/src/applications/disability-benefits/996/tests/hlr-wizard.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr-wizard.cypress.spec.js
@@ -117,13 +117,16 @@ describe('HLR wizard', () => {
 
     // start form
     const h1Addition = ' with VA Form 20-0996';
-    cy.findAllByText(/higher-level review online/i, { selector: 'button' })
+    cy.findAllByText(/higher-level review online/i, { selector: 'a' })
       .first()
       .click();
+
+    cy.location('pathname').should('eq', `${BASE_URL}/introduction`);
     // title changes & gets focus
     cy.get('h1').should('have.text', h1Text + h1Addition);
     cy.focused().should('have.text', h1Text + h1Addition);
     cy.checkStorage(WIZARD_STATUS, 'complete');
+    cy.injectAxe();
     cy.axeCheck();
   });
 });

--- a/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
@@ -2,6 +2,7 @@ import path from 'path';
 
 import testForm from 'platform/testing/e2e/cypress/support/form-tester';
 import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
+import environment from 'platform/utilities/environment';
 
 import formConfig from '../config/form';
 import manifest from '../manifest.json';
@@ -33,6 +34,12 @@ const testConfig = createTestConfig(
 
       introduction: ({ afterHook }) => {
         afterHook(() => {
+          if (environment.isProduction()) {
+            cy.get('[type="radio"][value="compensation"]').click();
+            cy.get('[type="radio"][value="legacy-no"]').click();
+            cy.axeCheck();
+            cy.findByText(/review online/i, { selector: 'a' }).click();
+          }
           // Hit the start button
           cy.findAllByText(/start/i, { selector: 'button' })
             .first()

--- a/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
@@ -23,11 +23,15 @@ const testConfig = createTestConfig(
     },
 
     pageHooks: {
-      introduction: ({ afterHook }) => {
+      start: () => {
+        // wizard
         cy.get('[type="radio"][value="compensation"]').click();
         cy.get('[type="radio"][value="legacy-no"]').click();
         cy.axeCheck();
-        cy.findByText(/request/i, { selector: 'button' }).click();
+        cy.findByText(/review online/i, { selector: 'a' }).click();
+      },
+
+      introduction: ({ afterHook }) => {
         afterHook(() => {
           // Hit the start button
           cy.findAllByText(/start/i, { selector: 'button' })

--- a/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
@@ -2,7 +2,6 @@ import path from 'path';
 
 import testForm from 'platform/testing/e2e/cypress/support/form-tester';
 import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
-import environment from 'platform/utilities/environment';
 
 import formConfig from '../config/form';
 import manifest from '../manifest.json';
@@ -34,7 +33,7 @@ const testConfig = createTestConfig(
 
       introduction: ({ afterHook }) => {
         afterHook(() => {
-          if (environment.isProduction()) {
+          if (Cypress.env('CI')) {
             cy.get('[type="radio"][value="compensation"]').click();
             cy.get('[type="radio"][value="legacy-no"]').click();
             cy.axeCheck();

--- a/src/applications/disability-benefits/996/tests/routes.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/routes.unit.spec.js
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
+import routes from '../routes';
+import { setHlrWizardStatus, removeHlrWizardStatus } from '../wizard/utils';
+
+describe('Form 996 routes', () => {
+  const { onEnter } = routes[1].indexRoute;
+  afterEach(() => {
+    removeHlrWizardStatus();
+  });
+  it('should redirect from root to /start', () => {
+    const replace = sinon.spy();
+    removeHlrWizardStatus();
+    onEnter(null, replace);
+    expect(replace.calledWith('/start')).to.be.true;
+  });
+  it('should redirect from the root to /introduction', () => {
+    const replace = sinon.spy();
+    setHlrWizardStatus(WIZARD_STATUS_COMPLETE);
+    onEnter(null, replace);
+    expect(replace.calledWith('/introduction')).to.be.true;
+  });
+});

--- a/src/applications/disability-benefits/996/tests/wizard/WizardContainer.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/wizard/WizardContainer.unit.spec.jsx
@@ -4,15 +4,14 @@ import { shallow } from 'enzyme';
 
 import { WIZARD_STATUS } from '../../constants';
 import WizardContainer from '../../wizard/WizardContainer';
+import { setHlrWizardStatus } from '../../wizard/utils';
 
 describe('<WizardContainer>', () => {
-  const setWizardStatus = value => {
-    sessionStorage.setItem(WIZARD_STATUS, value);
-  };
-
   it('should render', () => {
     sessionStorage.removeItem(WIZARD_STATUS);
-    const tree = shallow(<WizardContainer setWizardStatus={setWizardStatus} />);
+    const tree = shallow(
+      <WizardContainer setWizardStatus={setHlrWizardStatus} />,
+    );
     expect(tree.find('.wizard-container')).to.have.lengthOf(1);
     tree.unmount();
   });

--- a/src/applications/disability-benefits/996/tests/wizard/utils.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/wizard/utils.unit.spec.js
@@ -1,0 +1,59 @@
+import moment from 'moment';
+import { expect } from 'chai';
+
+import {
+  WIZARD_STATUS_COMPLETE,
+  WIZARD_STATUS_RESTARTING,
+} from 'platform/site-wide/wizard';
+
+import {
+  setHlrWizardStatus,
+  removeHlrWizardStatus,
+  shouldShowWizard,
+} from '../../wizard/utils';
+
+describe('wizard utils', () => {
+  describe('shouldShowWizard', () => {
+    afterEach(() => {
+      removeHlrWizardStatus();
+    });
+
+    // future date using unix seconds from epoch
+    const expiresAt = moment()
+      .add(1, 'day')
+      .unix();
+
+    it('should return false when there is a saved form', () => {
+      removeHlrWizardStatus();
+      const savedForm = [{ form: '22', metaData: { expiresAt } }];
+      expect(shouldShowWizard('22', savedForm)).to.be.false;
+    });
+    it('should return false when wizard completes with a saved form', () => {
+      setHlrWizardStatus(WIZARD_STATUS_COMPLETE);
+      const savedForm = [{ form: '22', metaData: { expiresAt } }];
+      expect(shouldShowWizard('22', savedForm)).to.be.false;
+    });
+    it('should return false when wizard completes with no saved form', () => {
+      setHlrWizardStatus(WIZARD_STATUS_COMPLETE);
+      expect(shouldShowWizard('22', [])).to.be.false;
+    });
+    it('should return false when wizard is not restarting', () => {
+      setHlrWizardStatus(WIZARD_STATUS_COMPLETE);
+      const savedForm = [{ form: '22', metaData: { expiresAt } }];
+      expect(shouldShowWizard('22', savedForm)).to.be.false;
+    });
+
+    it('should return true with no arguments', () => {
+      expect(shouldShowWizard()).to.be.true;
+    });
+    it('should return true when the wizard is not complete & there is no saved form', () => {
+      removeHlrWizardStatus();
+      expect(shouldShowWizard('22', [])).to.be.true;
+    });
+    it('should return true when wizard is complete and is restarting', () => {
+      setHlrWizardStatus(WIZARD_STATUS_RESTARTING);
+      const savedForm = [{ form: '22', metaData: { expiresAt } }];
+      expect(shouldShowWizard('22', savedForm)).to.be.true;
+    });
+  });
+});

--- a/src/applications/disability-benefits/996/wizard/WizardContainer.jsx
+++ b/src/applications/disability-benefits/996/wizard/WizardContainer.jsx
@@ -1,25 +1,72 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
-import Wizard from 'applications/static-pages/wizard';
-import pages from './pages';
+import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
+import FormFooter from 'platform/forms/components/FormFooter';
+import scrollToTop from 'platform/utilities/ui/scrollToTop';
+import { focusElement } from 'platform/utilities/ui';
+import { WIZARD_STATUS_RESTARTING } from 'platform/site-wide/wizard';
 
-const WizardContainer = ({ setWizardStatus }) => (
-  <div className="wizard-container">
-    <h2>Is this the form I need?</h2>
-    <p>
-      Use this form if you disagree with VA’s decision on your claim and want to
-      request that a senior reviewer take a new look at your case and the
-      evidence you provided. You can’t submit any new evidence with a
-      Higher-Level Review.
-    </p>
-    <p>Answer a few questions to get started.</p>
-    <Wizard pages={pages} expander={false} setWizardStatus={setWizardStatus} />
-  </div>
-);
+import Wizard from 'applications/static-pages/wizard';
+
+import pages from './pages';
+import formConfig from '../config/form';
+import { SAVED_CLAIM_TYPE, IS_PRODUCTION } from '../constants';
+import {
+  getHlrWizardStatus,
+  removeHlrWizardStatus,
+  setHlrWizardStatus,
+} from '../wizard/utils';
+
+const WizardContainer = ({ setWizardStatus }) => {
+  const { title, subTitle } = formConfig;
+
+  useEffect(() => {
+    focusElement('.va-nav-breadcrumbs-list');
+    scrollToTop();
+  });
+
+  sessionStorage.removeItem(SAVED_CLAIM_TYPE);
+  if (getHlrWizardStatus() === WIZARD_STATUS_RESTARTING) {
+    // Ensure we clear the restarting state
+    removeHlrWizardStatus();
+  }
+
+  const wizard = (
+    <>
+      <FormTitle title={title} subTitle={subTitle} />
+      <div className="wizard-container">
+        <h2>Is this the form I need?</h2>
+        <p>
+          Use this form if you disagree with VA’s decision on your claim and
+          want to request that a senior reviewer take a new look at your case
+          and the evidence you provided. You can’t submit any new evidence with
+          a Higher-Level Review.
+        </p>
+        <p>Answer a few questions to get started.</p>
+        <Wizard
+          pages={pages}
+          expander={false}
+          setWizardStatus={setWizardStatus}
+        />
+      </div>
+    </>
+  );
+
+  return IS_PRODUCTION ? (
+    wizard
+  ) : (
+    <article className="row">
+      <div className="usa-width-two-thirds medium-8 columns vads-u-margin-bottom--2">
+        {wizard}
+      </div>
+      <FormFooter formConfig={formConfig} />
+    </article>
+  );
+};
 
 WizardContainer.defaultProps = {
-  setWizardStatus: () => {},
+  setWizardStatus: setHlrWizardStatus,
 };
 
 WizardContainer.propTypes = {

--- a/src/applications/disability-benefits/996/wizard/pages/legacyNo.jsx
+++ b/src/applications/disability-benefits/996/wizard/pages/legacyNo.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import recordEvent from 'platform/monitoring/record-event';
 import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
-import { HLR_INFO_URL } from '../../constants';
 
+import { HLR_INFO_URL, BASE_URL, IS_PRODUCTION } from '../../constants';
 import pageNames from './pageNames';
 
 // Does not have a legacy appeal
@@ -14,14 +14,19 @@ const LegacyNo = ({ setWizardStatus }) => {
   recordEvent({
     event: 'howToWizard-cta-displayed',
   });
+
   return (
     <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
       <p className="vads-u-margin-top--0">
         You can request a Higher-Level Review online using{' '}
         <strong>VA Form 20-0996</strong>.
       </p>
-      <button
-        onClick={() => {
+      <a
+        href={`${BASE_URL}/introduction`}
+        onClick={event => {
+          if (IS_PRODUCTION) {
+            event.preventDefault();
+          }
           recordEvent({
             event: 'howToWizard-hidden',
             'reason-for-hidden-wizard': 'wizard completed, starting form',
@@ -37,7 +42,7 @@ const LegacyNo = ({ setWizardStatus }) => {
         aria-describedby="other_ways_to_request_hlr"
       >
         Request a Higher-Level Review online
-      </button>
+      </a>
       <p id="other_ways_to_request_hlr" className="vads-u-margin-bottom--0">
         <a
           href={HLR_INFO_URL}

--- a/src/applications/disability-benefits/996/wizard/utils.js
+++ b/src/applications/disability-benefits/996/wizard/utils.js
@@ -1,0 +1,27 @@
+import moment from 'moment';
+
+import {
+  WIZARD_STATUS_COMPLETE,
+  WIZARD_STATUS_RESTARTING,
+} from 'platform/site-wide/wizard';
+
+import { WIZARD_STATUS } from '../constants';
+
+export const getHlrWizardStatus = () => sessionStorage.getItem(WIZARD_STATUS);
+export const setHlrWizardStatus = status =>
+  sessionStorage.setItem(WIZARD_STATUS, status);
+export const removeHlrWizardStatus = () =>
+  sessionStorage.removeItem(WIZARD_STATUS);
+
+export const shouldShowWizard = (formId, savedForms = []) => {
+  const wizardStatus = getHlrWizardStatus();
+  const hasSavedForm = savedForms.some(
+    form =>
+      // expiresAt: Ruby saves as time from Epoch date in seconds (not ms)
+      form.form === formId && moment.unix(form.metaData?.expiresAt).isAfter(),
+  );
+  return (
+    (!hasSavedForm && wizardStatus !== WIZARD_STATUS_COMPLETE) ||
+    (hasSavedForm && wizardStatus === WIZARD_STATUS_RESTARTING)
+  );
+};


### PR DESCRIPTION
## Description

The current recommendation is to move all wizards from their previous location of `/introduction` to a new `/start` path. This PR moves the Higher-Level Review wizard in non-production environments to allow testing

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/27745

## Testing done

- Manual testing
- Updated unit tests
- Updated e2e tests

## Screenshots

N/A - the visual appearance, except for the location, is unchanged

## Acceptance criteria
- [x] HLR wizard to `/start` in development environments
- [x] HLR wizard still on `/introduction` in production
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
