### PR TITLE
add loop to test failure in CI

### DIFF
--- a/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
@@ -12,7 +12,7 @@ import facilitiesV2 from '../../services/mocks/v2/facilities.json';
 import configurations from '../../services/mocks/v2/scheduling_configurations_cc.json';
 
 describe('VAOS community care flow', () => {
-  it('should fill out community care form and submit request', () => {
+  it.skip('should fill out community care form and submit request', () => {
     initCommunityCareMock();
     cy.visit(
       'health-care/schedule-view-va-appointments/appointments/new-appointment/',
@@ -251,7 +251,7 @@ describe('VAOS community care flow', () => {
     cy.get('va-alert').contains('We’re reviewing your request');
   });
 
-  it('should submit form with provider chosen from list and submit request', () => {
+  it.skip('should submit form with provider chosen from list and submit request', () => {
     initCommunityCareMock();
     mockFeatureToggles({ providerSelectionEnabled: true });
     cy.visit(
@@ -452,7 +452,6 @@ describe('VAOS community care flow', () => {
     cy.get('va-alert').contains('We’re reviewing your request');
   });
 });
-
 describe('VAOS community care flow using VAOS service', () => {
   beforeEach(() => {
     vaosSetup();
@@ -474,235 +473,238 @@ describe('VAOS community care flow using VAOS service', () => {
     // Start flow
     cy.findByText('Start scheduling').click();
   });
-
-  it('should submit request successfully', () => {
-    const provider = {
-      id: '1497723753',
-      type: 'provider',
-      attributes: {
-        address: {
-          street: '1012 14TH ST NW STE 700',
-          city: 'WASHINGTON',
-          state: 'DC',
-          zip: '20005-3477',
+  for (let i = 0; i < 20; i++) {
+    it('should submit request successfully', () => {
+      const provider = {
+        id: '1497723753',
+        type: 'provider',
+        attributes: {
+          address: {
+            street: '1012 14TH ST NW STE 700',
+            city: 'WASHINGTON',
+            state: 'DC',
+            zip: '20005-3477',
+          },
+          caresitePhone: '202-638-0750',
+          lat: 38.903195,
+          long: -77.032382,
+          name: 'Doe, Jane',
+          phone: null,
+          uniqueId: '1497723753',
         },
-        caresitePhone: '202-638-0750',
-        lat: 38.903195,
-        long: -77.032382,
-        name: 'Doe, Jane',
-        phone: null,
-        uniqueId: '1497723753',
-      },
-    };
-    cy.route({
-      method: 'GET',
-      url: '/facilities_api/v1/ccp/provider?*',
-      response: {
-        data: [provider],
-      },
-    });
-    cy.route({
-      method: 'GET',
-      url: '/v1/facilities/ccp/*',
-      response: {
-        data: provider,
-      },
-    });
-    cy.route({
-      method: 'GET',
-      url: '/vaos/v2/facilities*',
-      response: facilitiesV2,
-    });
-    cy.route({
-      method: 'GET',
-      url: '/vaos/v2/scheduling/configurations*',
-      response: configurations,
-    });
-    cy.route({
-      method: 'GET',
-      url: '/vaos/v0/community_care/eligibility/PrimaryCare',
-      response: {
-        data: {
-          id: 'PrimaryCare',
-          type: 'cc_eligibility',
-          attributes: { eligible: true },
+      };
+      cy.route({
+        method: 'GET',
+        url: '/facilities_api/v1/ccp/provider?*',
+        response: {
+          data: [provider],
         },
-      },
-    });
-    cy.route({
-      method: 'POST',
-      url: '/vaos/v2/appointments',
-      response: {
-        data: {
-          id: '25956',
-          attributes: {},
+      });
+      cy.route({
+        method: 'GET',
+        url: '/v1/facilities/ccp/*',
+        response: {
+          data: provider,
         },
-      },
-    }).as('appointmentRequests');
-    cy.route({
-      method: 'GET',
-      url: '/vaos/v2/appointments/25956',
-      response: {
-        data: requests.data.find(r => r.id === '25956'),
-      },
-    });
-    cy.route({
-      method: 'GET',
-      url: '/v1/facilities/va/vha_442',
-      response: facilityData.data.find(f => f.id === 'vha_442'),
-    });
-    // Select primary care
-    cy.get('input[value="323"]')
-      .focus()
-      .check();
-    // Verify primary care checked
-    cy.get('input[value="323"]').should('be.checked');
-    // Click continue button
-    cy.get('.usa-button').click();
-
-    // Choose where you want to receive your care step
-    cy.url().should('contain', 'new-appointment/choose-facility-type');
-    cy.axeCheckBestPractice();
-    // Select community care
-    cy.get('#root_facilityType_1').click();
-    // Verify community care checked
-    cy.get('#root_facilityType_1').should('be.checked');
-    // Click continue button
-    cy.get('.usa-button').click();
-
-    // Choose an appointment day and time step
-    cy.url().should(
-      'contain',
-      '/health-care/schedule-view-va-appointments/appointments/new-appointment/request-date',
-    );
-    cy.axeCheckBestPractice();
-    cy.contains('button', 'Next')
-      .focus()
-      .click();
-    // Select first available appointment
-    cy.get('.vaos-calendar__calendars button[id^="date-cell"]:not([disabled])')
-      .first()
-      .click();
-    // Select AM timeslot
-    cy.get(
-      '.vaos-calendar__day--current .vaos-calendar__options input[id$="_0"]',
-    ).click();
-    cy.get(
-      '.vaos-calendar__day--current .vaos-calendar__options input[id$="_0"]',
-    ).should('be.checked');
-    // Click continue button
-    cy.get('.usa-button').click();
-
-    // Tell us your community care preferences step
-    cy.url().should(
-      'contain',
-      '/health-care/schedule-view-va-appointments/appointments/new-appointment/community-care-preferences',
-    );
-    cy.axeCheckBestPractice();
-    // Select city
-    cy.get('#root_communityCareSystemId_0').click();
-    cy.get('#root_communityCareSystemId_0').should('be.checked');
-    cy.findByText(/Choose a provider/i).click();
-
-    cy.findByLabelText(/doe, jane/i).click();
-    cy.axeCheckBestPractice();
-    cy.findByText(/Choose provider/i).click();
-    cy.findByText(/remove/i).click();
-    cy.axeCheckBestPractice();
-    cy.findByText(/cancel/i).click();
-    // Click continue button
-    cy.get('.usa-button').click();
-
-    cy.url().should(
-      'contain',
-      '/health-care/schedule-view-va-appointments/appointments/new-appointment/community-care-language',
-    );
-    cy.axeCheckBestPractice();
-    // Select preferred language
-    cy.get('#root_preferredLanguage').select('english');
-    cy.get('#root_preferredLanguage').should('have.value', 'english');
-    // Click continue button
-    cy.get('.usa-button').click();
-
-    // Tell us the reason for this appointment step
-    cy.url().should(
-      'contain',
-      '/health-care/schedule-view-va-appointments/appointments/new-appointment/reason-appointment',
-    );
-    cy.axeCheckBestPractice();
-    // Fill out reason input
-    cy.get('#root_reasonAdditionalInfo')
-      .type('This is a very good reason.')
-      .tab();
-    cy.get('#root_reasonAdditionalInfo').should(
-      'have.value',
-      'This is a very good reason.',
-    );
-    // Click continue button
-    cy.get('.usa-button').click();
-
-    // Your contact information step
-    cy.url().should(
-      'contain',
-      '/health-care/schedule-view-va-appointments/appointments/new-appointment/contact-info',
-    );
-    cy.axeCheckBestPractice();
-    // Verify phone number
-    cy.get('#root_phoneNumber').should('have.value', '5035551234');
-    // Select best times for us to call morning & evening
-    cy.get('#root_bestTimeToCall_morning').click();
-    cy.get('#root_bestTimeToCall_morning').should('be.checked');
-    cy.get('#root_bestTimeToCall_evening').click();
-    cy.get('#root_bestTimeToCall_evening').should('be.checked');
-    // Verify email address
-    cy.get('#root_email').should('have.value', 'veteran@gmail.com');
-    cy.get('#root_email').should('have.value', 'veteran@gmail.com');
-    // Click continue button
-    cy.get('.usa-button').click();
-
-    // Review your appointment details step
-    cy.url().should(
-      'contain',
-      '/health-care/schedule-view-va-appointments/appointments/new-appointment/review',
-    );
-    cy.axeCheckBestPractice();
-    // Click continue button
-    cy.get('.usa-button').click();
-
-    // Check form requestBody is as expected
-    cy.wait('@appointmentRequests').should(xhr => {
-      let date = moment()
-        .add(5, 'days')
-        .add(1, 'months')
-        .startOf('month');
-
-      // Check for weekend and select following Monday if true
-      if (date.weekday() === 0) {
-        date = date.add(1, 'days').format('YYYY-MM-DD[T]HH:mm:ss[Z]');
-      } else if (date.weekday() === 6) {
-        date = date.add(2, 'days').format('YYYY-MM-DD[T]HH:mm:ss[Z]');
-      } else {
-        date = date.format('YYYY-MM-DD[T]HH:mm:ss[Z]');
-      }
-
-      expect(xhr.status).to.eq(200);
-      expect(xhr.url, 'post url').to.contain('/vaos/v2/appointments');
-      const request = xhr.requestBody;
-      expect(request.requestedPeriods[0].start).to.equal(date);
-      expect(request.practitionerIds).to.deep.eq([
-        {
-          system: 'HSRM',
-          value: '1497723753',
+      });
+      cy.route({
+        method: 'GET',
+        url: '/vaos/v2/facilities*',
+        response: facilitiesV2,
+      });
+      cy.route({
+        method: 'GET',
+        url: '/vaos/v2/scheduling/configurations*',
+        response: configurations,
+      });
+      cy.route({
+        method: 'GET',
+        url: '/vaos/v0/community_care/eligibility/PrimaryCare',
+        response: {
+          data: {
+            id: 'PrimaryCare',
+            type: 'cc_eligibility',
+            attributes: { eligible: true },
+          },
         },
-      ]);
+      });
+      cy.route({
+        method: 'POST',
+        url: '/vaos/v2/appointments',
+        response: {
+          data: {
+            id: '25956',
+            attributes: {},
+          },
+        },
+      }).as('appointmentRequests');
+      cy.route({
+        method: 'GET',
+        url: '/vaos/v2/appointments/25956',
+        response: {
+          data: requests.data.find(r => r.id === '25956'),
+        },
+      });
+      cy.route({
+        method: 'GET',
+        url: '/v1/facilities/va/vha_442',
+        response: facilityData.data.find(f => f.id === 'vha_442'),
+      });
+      // Select primary care
+      cy.get('input[value="323"]')
+        .focus()
+        .check();
+      // Verify primary care checked
+      cy.get('input[value="323"]').should('be.checked');
+      // Click continue button
+      cy.get('.usa-button').click();
 
-      expect(request.locationId).to.eq('983');
-      expect(request).to.have.property('serviceType', 'primaryCare');
-      expect(request).to.have.property('kind', 'cc');
-      expect(request.contact.telecom[1].value).to.equal('veteran@gmail.com');
-      expect(request.contact.telecom[0].value).to.equal('5035551234');
+      // Choose where you want to receive your care step
+      cy.url().should('contain', 'new-appointment/choose-facility-type');
+      cy.axeCheckBestPractice();
+      // Select community care
+      cy.get('#root_facilityType_1').click();
+      // Verify community care checked
+      cy.get('#root_facilityType_1').should('be.checked');
+      // Click continue button
+      cy.get('.usa-button').click();
+
+      // Choose an appointment day and time step
+      cy.url().should(
+        'contain',
+        '/health-care/schedule-view-va-appointments/appointments/new-appointment/request-date',
+      );
+      cy.axeCheckBestPractice();
+      cy.contains('button', 'Next')
+        .focus()
+        .click();
+      // Select first available appointment
+      cy.get(
+        '.vaos-calendar__calendars button[id^="date-cell"]:not([disabled])',
+      )
+        .first()
+        .click();
+      // Select AM timeslot
+      cy.get(
+        '.vaos-calendar__day--current .vaos-calendar__options input[id$="_0"]',
+      ).click();
+      cy.get(
+        '.vaos-calendar__day--current .vaos-calendar__options input[id$="_0"]',
+      ).should('be.checked');
+      // Click continue button
+      cy.get('.usa-button').click();
+
+      // Tell us your community care preferences step
+      cy.url().should(
+        'contain',
+        '/health-care/schedule-view-va-appointments/appointments/new-appointment/community-care-preferences',
+      );
+      cy.axeCheckBestPractice();
+      // Select city
+      cy.get('#root_communityCareSystemId_0').click();
+      cy.get('#root_communityCareSystemId_0').should('be.checked');
+      cy.findByText(/Choose a provider/i).click();
+
+      cy.findByLabelText(/doe, jane/i).click();
+      cy.axeCheckBestPractice();
+      cy.findByText(/Choose provider/i).click();
+      cy.findByText(/remove/i).click();
+      cy.axeCheckBestPractice();
+      cy.findByText(/cancel/i).click();
+      // Click continue button
+      cy.get('.usa-button').click();
+
+      cy.url().should(
+        'contain',
+        '/health-care/schedule-view-va-appointments/appointments/new-appointment/community-care-language',
+      );
+      cy.axeCheckBestPractice();
+      // Select preferred language
+      cy.get('#root_preferredLanguage').select('english');
+      cy.get('#root_preferredLanguage').should('have.value', 'english');
+      // Click continue button
+      cy.get('.usa-button').click();
+
+      // Tell us the reason for this appointment step
+      cy.url().should(
+        'contain',
+        '/health-care/schedule-view-va-appointments/appointments/new-appointment/reason-appointment',
+      );
+      cy.axeCheckBestPractice();
+      // Fill out reason input
+      cy.get('#root_reasonAdditionalInfo')
+        .type('This is a very good reason.')
+        .tab();
+      cy.get('#root_reasonAdditionalInfo').should(
+        'have.value',
+        'This is a very good reason.',
+      );
+      // Click continue button
+      cy.get('.usa-button').click();
+
+      // Your contact information step
+      cy.url().should(
+        'contain',
+        '/health-care/schedule-view-va-appointments/appointments/new-appointment/contact-info',
+      );
+      cy.axeCheckBestPractice();
+      // Verify phone number
+      cy.get('#root_phoneNumber').should('have.value', '5035551234');
+      // Select best times for us to call morning & evening
+      cy.get('#root_bestTimeToCall_morning').click();
+      cy.get('#root_bestTimeToCall_morning').should('be.checked');
+      cy.get('#root_bestTimeToCall_evening').click();
+      cy.get('#root_bestTimeToCall_evening').should('be.checked');
+      // Verify email address
+      cy.get('#root_email').should('have.value', 'veteran@gmail.com');
+      cy.get('#root_email').should('have.value', 'veteran@gmail.com');
+      // Click continue button
+      cy.get('.usa-button').click();
+
+      // Review your appointment details step
+      cy.url().should(
+        'contain',
+        '/health-care/schedule-view-va-appointments/appointments/new-appointment/review',
+      );
+      cy.axeCheckBestPractice();
+      // Click continue button
+      cy.get('.usa-button').click();
+
+      // Check form requestBody is as expected
+      cy.wait('@appointmentRequests').should(xhr => {
+        let date = moment()
+          .add(5, 'days')
+          .add(1, 'months')
+          .startOf('month');
+
+        // Check for weekend and select following Monday if true
+        if (date.weekday() === 0) {
+          date = date.add(1, 'days').format('YYYY-MM-DD[T]HH:mm:ss[Z]');
+        } else if (date.weekday() === 6) {
+          date = date.add(2, 'days').format('YYYY-MM-DD[T]HH:mm:ss[Z]');
+        } else {
+          date = date.format('YYYY-MM-DD[T]HH:mm:ss[Z]');
+        }
+
+        expect(xhr.status).to.eq(200);
+        expect(xhr.url, 'post url').to.contain('/vaos/v2/appointments');
+        const request = xhr.requestBody;
+        expect(request.requestedPeriods[0].start).to.equal(date);
+        expect(request.practitionerIds).to.deep.eq([
+          {
+            system: 'HSRM',
+            value: '1497723753',
+          },
+        ]);
+
+        expect(request.locationId).to.eq('983');
+        expect(request).to.have.property('serviceType', 'primaryCare');
+        expect(request).to.have.property('kind', 'cc');
+        expect(request.contact.telecom[1].value).to.equal('veteran@gmail.com');
+        expect(request.contact.telecom[0].value).to.equal('5035551234');
+      });
+      cy.url().should('include', '/requests/25956');
+      cy.findByText('Preferred community care provider');
     });
-    cy.url().should('include', '/requests/25956');
-    cy.findByText('Preferred community care provider');
-  });
+  }
 });

--- a/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
@@ -10,18 +10,23 @@ import facilityData from '../../services/mocks/var/facility_data.json';
 import requests from '../../services/mocks/v2/requests.json';
 import facilitiesV2 from '../../services/mocks/v2/facilities.json';
 import configurations from '../../services/mocks/v2/scheduling_configurations_cc.json';
+import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('VAOS community care flow', () => {
-  it.skip('should fill out community care form and submit request', () => {
+  it('should fill out community care form and submit request', () => {
     initCommunityCareMock();
     cy.visit(
       'health-care/schedule-view-va-appointments/appointments/new-appointment/',
     );
     cy.injectAxe();
     // Select primary care
-    cy.get('input[value="323"]')
-      .focus()
-      .check();
+    cy.get('input[value="323"]', { timeout: Timeouts.normal })
+      .should('exist')
+      .then(checkbox => {
+        cy.wrap(checkbox)
+          .focus()
+          .check();
+      });
     // Verify primary care checked
     cy.get('input[value="323"]').should('be.checked');
     // Click continue button
@@ -251,7 +256,7 @@ describe('VAOS community care flow', () => {
     cy.get('va-alert').contains('We’re reviewing your request');
   });
 
-  it.skip('should submit form with provider chosen from list and submit request', () => {
+  it('should submit form with provider chosen from list and submit request', () => {
     initCommunityCareMock();
     mockFeatureToggles({ providerSelectionEnabled: true });
     cy.visit(
@@ -259,9 +264,13 @@ describe('VAOS community care flow', () => {
     );
     cy.injectAxe();
     // Select primary care
-    cy.get('input[value="323"]')
-      .focus()
-      .check();
+    cy.get('input[value="323"]', { timeout: Timeouts.normal })
+      .should('exist')
+      .then(checkbox => {
+        cy.wrap(checkbox)
+          .focus()
+          .check();
+      });
     // Verify primary care checked
     cy.get('input[value="323"]').should('be.checked');
     // Click continue button
@@ -452,6 +461,7 @@ describe('VAOS community care flow', () => {
     cy.get('va-alert').contains('We’re reviewing your request');
   });
 });
+
 describe('VAOS community care flow using VAOS service', () => {
   beforeEach(() => {
     vaosSetup();
@@ -473,238 +483,239 @@ describe('VAOS community care flow using VAOS service', () => {
     // Start flow
     cy.findByText('Start scheduling').click();
   });
-  for (let i = 0; i < 20; i++) {
-    it('should submit request successfully', () => {
-      const provider = {
-        id: '1497723753',
-        type: 'provider',
-        attributes: {
-          address: {
-            street: '1012 14TH ST NW STE 700',
-            city: 'WASHINGTON',
-            state: 'DC',
-            zip: '20005-3477',
-          },
-          caresitePhone: '202-638-0750',
-          lat: 38.903195,
-          long: -77.032382,
-          name: 'Doe, Jane',
-          phone: null,
-          uniqueId: '1497723753',
+
+  it('should submit request successfully', () => {
+    const provider = {
+      id: '1497723753',
+      type: 'provider',
+      attributes: {
+        address: {
+          street: '1012 14TH ST NW STE 700',
+          city: 'WASHINGTON',
+          state: 'DC',
+          zip: '20005-3477',
         },
-      };
-      cy.route({
-        method: 'GET',
-        url: '/facilities_api/v1/ccp/provider?*',
-        response: {
-          data: [provider],
-        },
-      });
-      cy.route({
-        method: 'GET',
-        url: '/v1/facilities/ccp/*',
-        response: {
-          data: provider,
-        },
-      });
-      cy.route({
-        method: 'GET',
-        url: '/vaos/v2/facilities*',
-        response: facilitiesV2,
-      });
-      cy.route({
-        method: 'GET',
-        url: '/vaos/v2/scheduling/configurations*',
-        response: configurations,
-      });
-      cy.route({
-        method: 'GET',
-        url: '/vaos/v0/community_care/eligibility/PrimaryCare',
-        response: {
-          data: {
-            id: 'PrimaryCare',
-            type: 'cc_eligibility',
-            attributes: { eligible: true },
-          },
-        },
-      });
-      cy.route({
-        method: 'POST',
-        url: '/vaos/v2/appointments',
-        response: {
-          data: {
-            id: '25956',
-            attributes: {},
-          },
-        },
-      }).as('appointmentRequests');
-      cy.route({
-        method: 'GET',
-        url: '/vaos/v2/appointments/25956',
-        response: {
-          data: requests.data.find(r => r.id === '25956'),
-        },
-      });
-      cy.route({
-        method: 'GET',
-        url: '/v1/facilities/va/vha_442',
-        response: facilityData.data.find(f => f.id === 'vha_442'),
-      });
-      // Select primary care
-      cy.get('input[value="323"]')
-        .focus()
-        .check();
-      // Verify primary care checked
-      cy.get('input[value="323"]').should('be.checked');
-      // Click continue button
-      cy.get('.usa-button').click();
-
-      // Choose where you want to receive your care step
-      cy.url().should('contain', 'new-appointment/choose-facility-type');
-      cy.axeCheckBestPractice();
-      // Select community care
-      cy.get('#root_facilityType_1').click();
-      // Verify community care checked
-      cy.get('#root_facilityType_1').should('be.checked');
-      // Click continue button
-      cy.get('.usa-button').click();
-
-      // Choose an appointment day and time step
-      cy.url().should(
-        'contain',
-        '/health-care/schedule-view-va-appointments/appointments/new-appointment/request-date',
-      );
-      cy.axeCheckBestPractice();
-      cy.contains('button', 'Next')
-        .focus()
-        .click();
-      // Select first available appointment
-      cy.get(
-        '.vaos-calendar__calendars button[id^="date-cell"]:not([disabled])',
-      )
-        .first()
-        .click();
-      // Select AM timeslot
-      cy.get(
-        '.vaos-calendar__day--current .vaos-calendar__options input[id$="_0"]',
-      ).click();
-      cy.get(
-        '.vaos-calendar__day--current .vaos-calendar__options input[id$="_0"]',
-      ).should('be.checked');
-      // Click continue button
-      cy.get('.usa-button').click();
-
-      // Tell us your community care preferences step
-      cy.url().should(
-        'contain',
-        '/health-care/schedule-view-va-appointments/appointments/new-appointment/community-care-preferences',
-      );
-      cy.axeCheckBestPractice();
-      // Select city
-      cy.get('#root_communityCareSystemId_0').click();
-      cy.get('#root_communityCareSystemId_0').should('be.checked');
-      cy.findByText(/Choose a provider/i).click();
-
-      cy.findByLabelText(/doe, jane/i).click();
-      cy.axeCheckBestPractice();
-      cy.findByText(/Choose provider/i).click();
-      cy.findByText(/remove/i).click();
-      cy.axeCheckBestPractice();
-      cy.findByText(/cancel/i).click();
-      // Click continue button
-      cy.get('.usa-button').click();
-
-      cy.url().should(
-        'contain',
-        '/health-care/schedule-view-va-appointments/appointments/new-appointment/community-care-language',
-      );
-      cy.axeCheckBestPractice();
-      // Select preferred language
-      cy.get('#root_preferredLanguage').select('english');
-      cy.get('#root_preferredLanguage').should('have.value', 'english');
-      // Click continue button
-      cy.get('.usa-button').click();
-
-      // Tell us the reason for this appointment step
-      cy.url().should(
-        'contain',
-        '/health-care/schedule-view-va-appointments/appointments/new-appointment/reason-appointment',
-      );
-      cy.axeCheckBestPractice();
-      // Fill out reason input
-      cy.get('#root_reasonAdditionalInfo')
-        .type('This is a very good reason.')
-        .tab();
-      cy.get('#root_reasonAdditionalInfo').should(
-        'have.value',
-        'This is a very good reason.',
-      );
-      // Click continue button
-      cy.get('.usa-button').click();
-
-      // Your contact information step
-      cy.url().should(
-        'contain',
-        '/health-care/schedule-view-va-appointments/appointments/new-appointment/contact-info',
-      );
-      cy.axeCheckBestPractice();
-      // Verify phone number
-      cy.get('#root_phoneNumber').should('have.value', '5035551234');
-      // Select best times for us to call morning & evening
-      cy.get('#root_bestTimeToCall_morning').click();
-      cy.get('#root_bestTimeToCall_morning').should('be.checked');
-      cy.get('#root_bestTimeToCall_evening').click();
-      cy.get('#root_bestTimeToCall_evening').should('be.checked');
-      // Verify email address
-      cy.get('#root_email').should('have.value', 'veteran@gmail.com');
-      cy.get('#root_email').should('have.value', 'veteran@gmail.com');
-      // Click continue button
-      cy.get('.usa-button').click();
-
-      // Review your appointment details step
-      cy.url().should(
-        'contain',
-        '/health-care/schedule-view-va-appointments/appointments/new-appointment/review',
-      );
-      cy.axeCheckBestPractice();
-      // Click continue button
-      cy.get('.usa-button').click();
-
-      // Check form requestBody is as expected
-      cy.wait('@appointmentRequests').should(xhr => {
-        let date = moment()
-          .add(5, 'days')
-          .add(1, 'months')
-          .startOf('month');
-
-        // Check for weekend and select following Monday if true
-        if (date.weekday() === 0) {
-          date = date.add(1, 'days').format('YYYY-MM-DD[T]HH:mm:ss[Z]');
-        } else if (date.weekday() === 6) {
-          date = date.add(2, 'days').format('YYYY-MM-DD[T]HH:mm:ss[Z]');
-        } else {
-          date = date.format('YYYY-MM-DD[T]HH:mm:ss[Z]');
-        }
-
-        expect(xhr.status).to.eq(200);
-        expect(xhr.url, 'post url').to.contain('/vaos/v2/appointments');
-        const request = xhr.requestBody;
-        expect(request.requestedPeriods[0].start).to.equal(date);
-        expect(request.practitionerIds).to.deep.eq([
-          {
-            system: 'HSRM',
-            value: '1497723753',
-          },
-        ]);
-
-        expect(request.locationId).to.eq('983');
-        expect(request).to.have.property('serviceType', 'primaryCare');
-        expect(request).to.have.property('kind', 'cc');
-        expect(request.contact.telecom[1].value).to.equal('veteran@gmail.com');
-        expect(request.contact.telecom[0].value).to.equal('5035551234');
-      });
-      cy.url().should('include', '/requests/25956');
-      cy.findByText('Preferred community care provider');
+        caresitePhone: '202-638-0750',
+        lat: 38.903195,
+        long: -77.032382,
+        name: 'Doe, Jane',
+        phone: null,
+        uniqueId: '1497723753',
+      },
+    };
+    cy.route({
+      method: 'GET',
+      url: '/facilities_api/v1/ccp/provider?*',
+      response: {
+        data: [provider],
+      },
     });
-  }
+    cy.route({
+      method: 'GET',
+      url: '/v1/facilities/ccp/*',
+      response: {
+        data: provider,
+      },
+    });
+    cy.route({
+      method: 'GET',
+      url: '/vaos/v2/facilities*',
+      response: facilitiesV2,
+    });
+    cy.route({
+      method: 'GET',
+      url: '/vaos/v2/scheduling/configurations*',
+      response: configurations,
+    });
+    cy.route({
+      method: 'GET',
+      url: '/vaos/v0/community_care/eligibility/PrimaryCare',
+      response: {
+        data: {
+          id: 'PrimaryCare',
+          type: 'cc_eligibility',
+          attributes: { eligible: true },
+        },
+      },
+    });
+    cy.route({
+      method: 'POST',
+      url: '/vaos/v2/appointments',
+      response: {
+        data: {
+          id: '25956',
+          attributes: {},
+        },
+      },
+    }).as('appointmentRequests');
+    cy.route({
+      method: 'GET',
+      url: '/vaos/v2/appointments/25956',
+      response: {
+        data: requests.data.find(r => r.id === '25956'),
+      },
+    });
+    cy.route({
+      method: 'GET',
+      url: '/v1/facilities/va/vha_442',
+      response: facilityData.data.find(f => f.id === 'vha_442'),
+    });
+    // Select primary care
+    cy.get('input[value="323"]', { timeout: Timeouts.normal })
+      .should('exist')
+      .then(checkbox => {
+        cy.wrap(checkbox)
+          .focus()
+          .check();
+      });
+    // Verify primary care checked
+    cy.get('input[value="323"]').should('be.checked');
+    // Click continue button
+    cy.get('.usa-button').click();
+
+    // Choose where you want to receive your care step
+    cy.url().should('contain', 'new-appointment/choose-facility-type');
+    cy.axeCheckBestPractice();
+    // Select community care
+    cy.get('#root_facilityType_1').click();
+    // Verify community care checked
+    cy.get('#root_facilityType_1').should('be.checked');
+    // Click continue button
+    cy.get('.usa-button').click();
+
+    // Choose an appointment day and time step
+    cy.url().should(
+      'contain',
+      '/health-care/schedule-view-va-appointments/appointments/new-appointment/request-date',
+    );
+    cy.axeCheckBestPractice();
+    cy.contains('button', 'Next')
+      .focus()
+      .click();
+    // Select first available appointment
+    cy.get('.vaos-calendar__calendars button[id^="date-cell"]:not([disabled])')
+      .first()
+      .click();
+    // Select AM timeslot
+    cy.get(
+      '.vaos-calendar__day--current .vaos-calendar__options input[id$="_0"]',
+    ).click();
+    cy.get(
+      '.vaos-calendar__day--current .vaos-calendar__options input[id$="_0"]',
+    ).should('be.checked');
+    // Click continue button
+    cy.get('.usa-button').click();
+
+    // Tell us your community care preferences step
+    cy.url().should(
+      'contain',
+      '/health-care/schedule-view-va-appointments/appointments/new-appointment/community-care-preferences',
+    );
+    cy.axeCheckBestPractice();
+    // Select city
+    cy.get('#root_communityCareSystemId_0').click();
+    cy.get('#root_communityCareSystemId_0').should('be.checked');
+    cy.findByText(/Choose a provider/i).click();
+
+    cy.findByLabelText(/doe, jane/i).click();
+    cy.axeCheckBestPractice();
+    cy.findByText(/Choose provider/i).click();
+    cy.findByText(/remove/i).click();
+    cy.axeCheckBestPractice();
+    cy.findByText(/cancel/i).click();
+    // Click continue button
+    cy.get('.usa-button').click();
+
+    cy.url().should(
+      'contain',
+      '/health-care/schedule-view-va-appointments/appointments/new-appointment/community-care-language',
+    );
+    cy.axeCheckBestPractice();
+    // Select preferred language
+    cy.get('#root_preferredLanguage').select('english');
+    cy.get('#root_preferredLanguage').should('have.value', 'english');
+    // Click continue button
+    cy.get('.usa-button').click();
+
+    // Tell us the reason for this appointment step
+    cy.url().should(
+      'contain',
+      '/health-care/schedule-view-va-appointments/appointments/new-appointment/reason-appointment',
+    );
+    cy.axeCheckBestPractice();
+    // Fill out reason input
+    cy.get('#root_reasonAdditionalInfo')
+      .type('This is a very good reason.')
+      .tab();
+    cy.get('#root_reasonAdditionalInfo').should(
+      'have.value',
+      'This is a very good reason.',
+    );
+    // Click continue button
+    cy.get('.usa-button').click();
+
+    // Your contact information step
+    cy.url().should(
+      'contain',
+      '/health-care/schedule-view-va-appointments/appointments/new-appointment/contact-info',
+    );
+    cy.axeCheckBestPractice();
+    // Verify phone number
+    cy.get('#root_phoneNumber').should('have.value', '5035551234');
+    // Select best times for us to call morning & evening
+    cy.get('#root_bestTimeToCall_morning').click();
+    cy.get('#root_bestTimeToCall_morning').should('be.checked');
+    cy.get('#root_bestTimeToCall_evening').click();
+    cy.get('#root_bestTimeToCall_evening').should('be.checked');
+    // Verify email address
+    cy.get('#root_email').should('have.value', 'veteran@gmail.com');
+    cy.get('#root_email').should('have.value', 'veteran@gmail.com');
+    // Click continue button
+    cy.get('.usa-button').click();
+
+    // Review your appointment details step
+    cy.url().should(
+      'contain',
+      '/health-care/schedule-view-va-appointments/appointments/new-appointment/review',
+    );
+    cy.axeCheckBestPractice();
+    // Click continue button
+    cy.get('.usa-button').click();
+
+    // Check form requestBody is as expected
+    cy.wait('@appointmentRequests').should(xhr => {
+      let date = moment()
+        .add(5, 'days')
+        .add(1, 'months')
+        .startOf('month');
+
+      // Check for weekend and select following Monday if true
+      if (date.weekday() === 0) {
+        date = date.add(1, 'days').format('YYYY-MM-DD[T]HH:mm:ss[Z]');
+      } else if (date.weekday() === 6) {
+        date = date.add(2, 'days').format('YYYY-MM-DD[T]HH:mm:ss[Z]');
+      } else {
+        date = date.format('YYYY-MM-DD[T]HH:mm:ss[Z]');
+      }
+
+      expect(xhr.status).to.eq(200);
+      expect(xhr.url, 'post url').to.contain('/vaos/v2/appointments');
+      const request = xhr.requestBody;
+      expect(request.requestedPeriods[0].start).to.equal(date);
+      expect(request.practitionerIds).to.deep.eq([
+        {
+          system: 'HSRM',
+          value: '1497723753',
+        },
+      ]);
+
+      expect(request.locationId).to.eq('983');
+      expect(request).to.have.property('serviceType', 'primaryCare');
+      expect(request).to.have.property('kind', 'cc');
+      expect(request.contact.telecom[1].value).to.equal('veteran@gmail.com');
+      expect(request.contact.telecom[0].value).to.equal('5035551234');
+    });
+    cy.url().should('include', '/requests/25956');
+    cy.findByText('Preferred community care provider');
+  });
 });


### PR DESCRIPTION
## Description
Adding an extra timeout and "exist" assertion to the first input that's targeted in these tests, as we had a build failure when the input was not found quickly enough on the page load.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
