### PR TITLE
Github Actions (CI) -- Add retry to nightwatch 

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -467,8 +467,11 @@ jobs:
           YARN_CACHE_FOLDER: .cache/yarn
 
       - name: Run Nightwatch tests
-        run: yarn test:e2e:headless
-        timeout-minutes: 30
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: yarn test:e2e:headless
         env:
           BUILDTYPE: vagovprod
           NODE_ENV: production

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -467,11 +467,8 @@ jobs:
           YARN_CACHE_FOLDER: .cache/yarn
 
       - name: Run Nightwatch tests
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          command: yarn test:e2e:headless
+        run: yarn test:e2e:headless --suiteRetries 3
+        timeout-minutes: 30
         env:
           BUILDTYPE: vagovprod
           NODE_ENV: production


### PR DESCRIPTION
## Description

I have noticed that sometimes Nightwatch fails insertion (due to flakiness). This PR attempts to retry 3 times and not have to re-trigger the entire pipeline if it fails. 

## Testing done

[run](https://github.com/department-of-veterans-affairs/vets-website/actions/runs/1075677924)
