### PR TITLE
Update h1/title in variant test facility page

### DIFF
--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/VAFacilityPageV2.jsx
@@ -98,7 +98,7 @@ export default function VAFacilityPageV2() {
   if (singleValidVALocation) {
     pageTitle = 'Your appointment location';
   } else if (showVariant) {
-    pageTitle = 'Choose a VA Location';
+    pageTitle = 'Choose a VA location';
   } else {
     pageTitle = `Choose a VA location for your ${lowerCase(
       typeOfCare?.name,

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.unit.spec.jsx
@@ -1143,11 +1143,11 @@ describe('VAOS <VAFacilityPage>', () => {
 
         await waitFor(() => {
           expect(global.document.title).to.equal(
-            'Choose a VA Location | Veterans Affairs',
+            'Choose a VA location | Veterans Affairs',
           );
         });
 
-        expect(screen.getByText(/Choose a VA Location/i)).to.exist;
+        expect(screen.getByText(/Choose a VA location/i)).to.exist;
 
         expect(screen.baseElement).to.contain.text(
           'Select a VA facility where you’re registered that offers primary care appointments.',
@@ -1232,7 +1232,7 @@ describe('VAOS <VAFacilityPage>', () => {
         // should mean all page rendering is finished
         await screen.findAllByRole('radio');
 
-        expect(screen.getByText(/Choose a VA Location/i)).to.exist;
+        expect(screen.getByText(/Choose a VA location/i)).to.exist;
         expect(screen.baseElement).to.contain.text('By your home address');
 
         // It should sort by distance, making Closest facility the first facility


### PR DESCRIPTION
## Description

This PR updates the page title/h1 to sentence case for the variant test facility selection page.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#27989


## Testing done
- local, unit testing

## Screenshots
<img width="776" alt="Screen Shot 2021-07-28 at 9 36 18 AM" src="https://user-images.githubusercontent.com/9746156/127361865-b4e0c8d3-a863-422c-90bc-9e752465e35f.png">


## Acceptance criteria
- [x] Variant test facility selection title/header is sentence case 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
