### PR TITLE
move lang attribute to content, fix link langs

### DIFF
--- a/src/applications/static-pages/i18Select/I18Select.js
+++ b/src/applications/static-pages/i18Select/I18Select.js
@@ -1,80 +1,57 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import recordEvent from 'platform/monitoring/record-event';
-import { onThisPageHook, setLangAttribute } from './hooks';
+import { onThisPageHook } from './hooks';
 import { connect } from 'react-redux';
 import { langSelectedAction } from './actions';
 
-const LANGS_TO_LINK_SUFFIXES = {
-  es: '-esp/',
-  tl: '-tag/',
-};
-const I18Select = ({ baseUrls, content, dispatchLanguageSelection }) => {
-  const [lang, setLang] = useState('en');
+const I18Select = ({ baseUrls, content, languageCode }) => {
   useEffect(
     () => {
-      const contentDiv = document?.getElementById('content');
-      // this logic is specific to the temporary covid faq page url structures and cannot be abstracted
-      for (const [langCode, suffix] of Object.entries(LANGS_TO_LINK_SUFFIXES)) {
-        if (document?.location.href.endsWith(suffix)) {
-          setLang(langCode);
-          dispatchLanguageSelection(langCode);
-          if (contentDiv) {
-            contentDiv.setAttribute('lang', langCode);
-          }
-          document.documentElement.setAttribute('lang', langCode);
-        }
-      }
+      onThisPageHook(languageCode);
     },
-    [dispatchLanguageSelection],
-  );
-
-  useEffect(
-    () => {
-      onThisPageHook(lang);
-    },
-    [lang],
+    [languageCode],
   );
 
   return (
     <div className="vads-u-display--inline-block vads-u-margin-top--4 vads-u-margin-bottom--3 vads-u-border--0 vads-u-border-bottom--1px vads-u-border-style--solid vads-u-border-color--gray">
       <span>
-        {Object.entries(content).map(([languageCode, languageConfig], i) => {
-          if (!baseUrls[languageCode]) {
-            return null;
-          }
-          return (
-            <span key={i}>
-              <a
-                className={`vads-u-font-size--base vads-u-font-family--sans vads-u-padding-bottom-0p5 ${
-                  languageCode === lang
-                    ? 'vads-u-font-weight--bold vads-u-color--base vads-u-text-decoration--none'
-                    : ''
-                }`}
-                onClick={_ => {
-                  recordEvent({
-                    event: 'nav-pipe-delimited-list-click',
-                    'pipe-delimited-list-header': languageConfig.lang,
-                  });
-                  dispatchLanguageSelection(languageConfig.lang);
-                  setLangAttribute(languageConfig.lang);
-                }}
-                href={baseUrls[languageCode]}
-                hrefLang={languageConfig.lang}
-                lang={languageConfig.lang}
-              >
-                {languageConfig.label}{' '}
-              </a>
-              {i !== Object.entries(content).length - 1 && (
-                <span
-                  className=" vads-u-margin-left--0p5 vads-u-margin-right--0p5 vads-u-color--gray
-                    vads-u-height--20"
+        {Object.entries(content).map(
+          ([contentLanguageCode, languageConfig], i) => {
+            if (!baseUrls[contentLanguageCode]) {
+              return null;
+            }
+            return (
+              <span key={i}>
+                <a
+                  className={`vads-u-font-size--base vads-u-font-family--sans vads-u-padding-bottom-0p5 ${
+                    contentLanguageCode === languageCode
+                      ? 'vads-u-font-weight--bold vads-u-color--base vads-u-text-decoration--none'
+                      : ''
+                  }`}
+                  onClick={_ => {
+                    recordEvent({
+                      event: 'nav-pipe-delimited-list-click',
+                      'pipe-delimited-list-header': languageConfig.lang,
+                    });
+                  }}
+                  href={baseUrls[contentLanguageCode]}
+                  hrefLang={languageConfig.lang}
+                  lang={languageConfig.lang}
                 >
-                  |
-                </span>
-              )}
-            </span>
-          );
-        })}
+                  {languageConfig.label}{' '}
+                </a>
+                {i !== Object.entries(content).length - 1 && (
+                  <span
+                    className=" vads-u-margin-left--0p5 vads-u-margin-right--0p5 vads-u-color--gray
+                    vads-u-height--20"
+                  >
+                    |
+                  </span>
+                )}
+              </span>
+            );
+          },
+        )}
       </span>
     </div>
   );
@@ -86,7 +63,11 @@ const mapDispatchToProps = dispatch => ({
   },
 });
 
+const mapStateToProps = state => ({
+  languageCode: state.i18State.lang,
+});
+
 export default connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps,
 )(I18Select);

--- a/src/applications/static-pages/i18Select/createI18Select.js
+++ b/src/applications/static-pages/i18Select/createI18Select.js
@@ -3,6 +3,26 @@ import ReactDOM from 'react-dom';
 
 import { Provider } from 'react-redux';
 
+export const I18_CONTENT = {
+  en: {
+    label: 'English',
+    suffix: '/',
+    lang: 'en',
+  },
+  es: {
+    onThisPage: 'En esta página',
+    label: 'Español',
+    suffix: '-esp/',
+    lang: 'es',
+  },
+  tl: {
+    suffix: '-tag/',
+    label: 'Tagalog',
+    onThisPage: 'Sa pahinang ito',
+    lang: 'tl',
+  },
+};
+
 export default function createI18Select(store, widgetType) {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
 
@@ -14,6 +34,7 @@ export default function createI18Select(store, widgetType) {
     '/health-care/covid-19-vaccine-esp/',
     '/health-care/covid-19-vaccine-tag/',
   ]);
+
   const isTranslatable = translatableLinks.has(document.location.pathname);
   if (!isTranslatable) return;
   const baseUrls = {
@@ -28,28 +49,10 @@ export default function createI18Select(store, widgetType) {
       tl: '/health-care/covid-19-vaccine-tag/',
     },
   };
+
   const isFaq = document.location.pathname.includes(
     `/coronavirus-veteran-frequently-asked-questions`,
   );
-  const I18_CONTENT = {
-    en: {
-      label: 'English',
-      suffix: '/',
-      lang: 'en',
-    },
-    es: {
-      onThisPage: 'En esta página',
-      label: 'Español',
-      suffix: '-esp/',
-      lang: 'es',
-    },
-    tl: {
-      suffix: '-tag/',
-      label: 'Tagalog',
-      onThisPage: 'Sa pahinang ito',
-      lang: 'tl',
-    },
-  };
 
   if (root) {
     import(/* webpackChunkName: "i18Select" */

--- a/src/applications/static-pages/i18Select/createI18Select.js
+++ b/src/applications/static-pages/i18Select/createI18Select.js
@@ -26,6 +26,7 @@ export const I18_CONTENT = {
 export default function createI18Select(store, widgetType) {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
 
+  // these are the only urls where this widget will be rendered
   const translatableLinks = new Set([
     '/coronavirus-veteran-frequently-asked-questions/',
     '/coronavirus-veteran-frequently-asked-questions-esp/',

--- a/src/applications/static-pages/i18Select/hooks.js
+++ b/src/applications/static-pages/i18Select/hooks.js
@@ -1,4 +1,4 @@
-const onThisPageDict = {
+export const onThisPageDict = {
   es: { onThisPage: 'En esta página' },
   tl: {
     onThisPage: 'Sa pahinang ito',
@@ -8,26 +8,22 @@ const onThisPageDict = {
 export const onThisPageHook = lang => {
   if (lang && lang !== 'en') {
     const onThisPageEl = document?.getElementById('on-this-page');
+
     if (onThisPageEl) {
       onThisPageEl.innerText = onThisPageDict[lang].onThisPage;
     }
   }
 };
+
 const setMedalliaSurveyLangOnWindow = lang => {
   if (lang) {
     window.medalliaSurveyLanguage = lang;
   }
 };
-export const setLangAttribute = lang => {
-  const contentDiv = document?.getElementById('content');
-  if (contentDiv) {
-    contentDiv.setAttribute('lang', lang);
-    setMedalliaSurveyLangOnWindow(lang);
-  }
-};
 
 export const parseLangCode = url => {
   let langCode = 'en';
+  if (!url) return langCode;
   // competing URL structures ¯\_(ツ)_/¯
   // also sometimes the href ends with `tag` instead `tag/`
   if (
@@ -47,29 +43,59 @@ export const parseLangCode = url => {
   return langCode;
 };
 
-export const adaptLinksWithLangCode = (
-  setLangAttributeInReduxStore,
-  pageLangCode,
-) => {
-  const links = document.links;
-  for (const link of links) {
-    if (link) {
-      let langAttribute = link.lang || link.hreflang;
-      const correctLangAttribute = parseLangCode(link.href);
+const adaptContentWithLangCode = langCode => {
+  // the article.content-usa element is the main translated content,
+  // so it should have it's lang attribute set
+  // TODO: improve/change selector for this if possible
+  const content = document?.querySelector('article.usa-content');
 
-      if (!langAttribute) {
-        langAttribute = pageLangCode;
-        link.setAttribute('lang', pageLangCode);
-      }
+  if (!content) return;
 
-      if (correctLangAttribute !== link.lang) {
-        langAttribute = correctLangAttribute;
-        link.setAttribute('lang', langAttribute);
-      }
-      link.addEventListener('click', () => {
-        setLangAttributeInReduxStore(langAttribute);
-        setMedalliaSurveyLangOnWindow(langAttribute);
-      });
+  content.setAttribute('lang', langCode);
+
+  // links should be parsed inside the article to potentially have lang attributes set
+  const contentLinks = content?.getElementsByTagName('a');
+
+  if (!contentLinks || contentLinks.length === 0) return;
+
+  for (const link of contentLinks) {
+    // we only want to set the hreflang to valid links
+    // this excludes jumplinks and telephone links
+    if (link && !link.href.includes('#') && !link.href.includes('tel')) {
+      const linkTargetLanguage = parseLangCode(link.href);
+
+      link.setAttribute('hreflang', linkTargetLanguage);
     }
   }
+};
+
+const adaptSidebarWithLangCode = () => {
+  const sidebar = document?.getElementById('va-detailpage-sidebar');
+
+  if (!sidebar) return;
+
+  const sidebarLinks = sidebar?.getElementsByTagName('a');
+
+  if (!sidebarLinks || sidebarLinks.length === 0) return;
+
+  for (const link of sidebarLinks) {
+    // we only want to set the hreflang to valid links
+    // this excludes jumplinks and telephone links
+    if (link && !link.href.includes('#') && !link.href.includes('tel')) {
+      const linkTargetLanguage = parseLangCode(link.href);
+
+      // sidebar links are considered to be tranlated to their target language,
+      // and therefore would have their hreflang and lang set to the target language
+      if (linkTargetLanguage !== 'en') {
+        link.setAttribute('hreflang', linkTargetLanguage);
+        link.setAttribute('lang', linkTargetLanguage);
+      }
+    }
+  }
+};
+
+export const setLangAttribute = lang => {
+  adaptContentWithLangCode(lang);
+  adaptSidebarWithLangCode();
+  setMedalliaSurveyLangOnWindow(lang);
 };

--- a/src/applications/static-pages/i18Select/tests/I18Select.unit.spec.jsx
+++ b/src/applications/static-pages/i18Select/tests/I18Select.unit.spec.jsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { expect } from 'chai';
+import { onThisPageDict } from '../hooks';
+import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
+
+import I18Select from '../I18Select';
+import { I18_CONTENT } from '../createI18Select';
+
+const baseUrls = {
+  en: '/health-care/covid-19-vaccine/',
+  es: '/health-care/covid-19-vaccine-esp/',
+  tl: '/health-care/covid-19-vaccine-tag/',
+};
+
+describe('<I18Select>', () => {
+  describe('Language links and related logic', () => {
+    it('should render with ENGLISH link bolded/active', async () => {
+      const screen = renderInReduxProvider(
+        <I18Select baseUrls={baseUrls} content={I18_CONTENT} />,
+        { initialState: { i18State: { lang: 'en' } } },
+      );
+
+      const activeLink = await screen.findByText('English');
+
+      expect(activeLink).to.exist;
+
+      expect(activeLink).to.have.class('vads-u-font-weight--bold');
+    });
+
+    it('should render with SPANISH link bolded/active and set appropriate "on-this-page" innerText', async () => {
+      const languageCode = 'es';
+
+      const screen = renderInReduxProvider(
+        <div>
+          <p data-testid="onThisPage" id="on-this-page" />
+          <I18Select baseUrls={baseUrls} content={I18_CONTENT} />
+        </div>,
+        { initialState: { i18State: { lang: languageCode } } },
+      );
+
+      const onThisPageEl = screen.getByTestId('onThisPage');
+
+      expect(onThisPageEl).to.exist;
+
+      expect(onThisPageEl.innerText).to.equal(
+        onThisPageDict[languageCode].onThisPage,
+      );
+
+      const activeLink = await screen.findByText('Español');
+
+      expect(activeLink).to.exist;
+
+      expect(activeLink).to.have.class('vads-u-font-weight--bold');
+    });
+  });
+
+  it('should render with TAGOLOG link bolded/active and set appropriate "on-this-page" innerText', async () => {
+    const languageCode = 'tl';
+
+    const screen = renderInReduxProvider(
+      <div>
+        <p data-testid="onThisPage" id="on-this-page" />
+        <I18Select baseUrls={baseUrls} content={I18_CONTENT} />
+      </div>,
+      { initialState: { i18State: { lang: languageCode } } },
+    );
+
+    const onThisPageEl = screen.getByTestId('onThisPage');
+
+    expect(onThisPageEl).to.exist;
+
+    expect(onThisPageEl.innerText).to.equal(
+      onThisPageDict[languageCode].onThisPage,
+    );
+
+    const activeLink = await screen.findByText('Tagalog');
+
+    expect(activeLink).to.exist;
+
+    expect(activeLink).to.have.class('vads-u-font-weight--bold');
+  });
+});

--- a/src/applications/static-pages/i18Select/tests/I18Select.unit.spec.jsx
+++ b/src/applications/static-pages/i18Select/tests/I18Select.unit.spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { expect } from 'chai';
-import { onThisPageDict } from '../hooks';
 import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
 
 import I18Select from '../I18Select';
@@ -27,23 +26,12 @@ describe('<I18Select>', () => {
       expect(activeLink).to.have.class('vads-u-font-weight--bold');
     });
 
-    it('should render with SPANISH link bolded/active and set appropriate "on-this-page" innerText', async () => {
+    it('should render with SPANISH link bolded/active', async () => {
       const languageCode = 'es';
 
       const screen = renderInReduxProvider(
-        <div>
-          <p data-testid="onThisPage" id="on-this-page" />
-          <I18Select baseUrls={baseUrls} content={I18_CONTENT} />
-        </div>,
+        <I18Select baseUrls={baseUrls} content={I18_CONTENT} />,
         { initialState: { i18State: { lang: languageCode } } },
-      );
-
-      const onThisPageEl = screen.getByTestId('onThisPage');
-
-      expect(onThisPageEl).to.exist;
-
-      expect(onThisPageEl.innerText).to.equal(
-        onThisPageDict[languageCode].onThisPage,
       );
 
       const activeLink = await screen.findByText('Español');
@@ -54,23 +42,12 @@ describe('<I18Select>', () => {
     });
   });
 
-  it('should render with TAGOLOG link bolded/active and set appropriate "on-this-page" innerText', async () => {
+  it('should render with TAGOLOG link bolded/active', async () => {
     const languageCode = 'tl';
 
     const screen = renderInReduxProvider(
-      <div>
-        <p data-testid="onThisPage" id="on-this-page" />
-        <I18Select baseUrls={baseUrls} content={I18_CONTENT} />
-      </div>,
+      <I18Select baseUrls={baseUrls} content={I18_CONTENT} />,
       { initialState: { i18State: { lang: languageCode } } },
-    );
-
-    const onThisPageEl = screen.getByTestId('onThisPage');
-
-    expect(onThisPageEl).to.exist;
-
-    expect(onThisPageEl.innerText).to.equal(
-      onThisPageDict[languageCode].onThisPage,
     );
 
     const activeLink = await screen.findByText('Tagalog');

--- a/src/applications/static-pages/i18Select/tests/parseLangCode.unit.spec.js
+++ b/src/applications/static-pages/i18Select/tests/parseLangCode.unit.spec.js
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+import { parseLangCode } from '../hooks';
+
+describe('parseLang util', () => {
+  it('should return "es" code for various url patterns', () => {
+    const paths = [
+      '/health-care/covid-19-vaccine-esp/',
+      '/some-espanol-page',
+      '/no-forward-slash-esp',
+    ];
+
+    for (const path of paths) {
+      expect(parseLangCode(path)).to.equal('es');
+    }
+  });
+
+  it('should return "tl" code for various url patterns', () => {
+    const paths = [
+      '/health-care/covid-19-vaccine-tag/',
+      '/some-tagalog-page',
+      '/no-forward-slash-tag',
+    ];
+
+    for (const path of paths) {
+      expect(parseLangCode(path)).to.equal('tl');
+    }
+  });
+
+  it('should return "en" code for non-matching url patterns', () => {
+    const paths = [
+      '/health-care/covid-19-vaccine/',
+      '/some-english-page',
+      '/',
+      '',
+      null,
+    ];
+
+    for (const path of paths) {
+      expect(parseLangCode(path)).to.equal('en');
+    }
+  });
+});

--- a/src/platform/site-wide/va-footer/components/LanguageSupport.jsx
+++ b/src/platform/site-wide/va-footer/components/LanguageSupport.jsx
@@ -1,8 +1,6 @@
 import React, { useEffect } from 'react';
 import {
   setLangAttribute,
-  adaptLinksWithLangCode,
-  onThisPageHook,
   parseLangCode,
 } from 'applications/static-pages/i18Select/hooks';
 import { FOOTER_EVENTS } from '../helpers';
@@ -41,7 +39,6 @@ function LanguagesListTemplate({ dispatchLanguageSelection }) {
             hrefLang={link.lang}
             onClick={() => {
               dispatchLanguageSelection(link.lang);
-              setLangAttribute(link.lang);
               recordEvent({
                 event: FOOTER_EVENTS.LANGUAGE_SUPPORT,
                 lang: link.lang,
@@ -60,16 +57,19 @@ export default function LanguageSupport({
   isDesktop,
   showLangSupport,
   dispatchLanguageSelection,
+  languageCode,
 }) {
   useEffect(
     () => {
       const langCode = parseLangCode(document?.location?.pathname);
-      onThisPageHook(langCode);
+
       setLangAttribute(langCode);
+
+      if (languageCode === langCode) return;
+
       dispatchLanguageSelection(langCode);
-      adaptLinksWithLangCode(dispatchLanguageSelection, langCode);
     },
-    [dispatchLanguageSelection, showLangSupport],
+    [dispatchLanguageSelection, showLangSupport, languageCode],
   );
 
   if (showLangSupport !== true) return null;


### PR DESCRIPTION
## Description
To fix accessibility issues, the LanugageSupport and I18Select components along with associated 'hooks'/utilities were updated to more concisely update the dom with a language code on the content, and to also update links with 'hreflang' when the links send the user to translated content.

* On foreign language content, the lang attribute is now being added to the main article content element instead of the parent content element, since that was resulting in the language incorrectly being inherited for the sidebar when it was present on a page. This more targeted lang code also means that all links within the main content would inherit that lang attribute as well and would not need to be set explicitly.
* Only the links for translated content are parsed and manipulated if needed and not the entire document. This was kind of a major oversight in that the old `adaptLinksWithLangCode` function would manipulate all links in the document on _all pages_ and not just translated pages.
* The sidebar links are also parsed and manipulated as needed only when the sidebar is present.
* Local state wasn't actually needed in the I18Select component, and utilizing `mapStateToProps` allows elimination of local state along with adding the ability to check if the current page's language differs from the redux language and only firing actions when needed.
* 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#27619


## Testing done
There were no unit tests present for this code, so a preliminary set of 6 tests was added, and will be expanded upon with future refactors.

Language state persistence and link attributes were verified throughout the translated pages listed below.

Covid vaccine pages:
/health-care/covid-19-vaccine/
/health-care/covid-19-vaccine-esp/
/health-care/covid-19-vaccine-tag/

Language assistence pages:
/tagalog-wika-mapagkukunan-at-tulong/
/asistencia-y-recursos-en-espanol/

Coronavirus FAQ pages:
/coronavirus-veteran-frequently-asked-questions/
/coronavirus-veteran-frequently-asked-questions-esp/
/coronavirus-veteran-frequently-asked-questions-tag/

## Screenshots
![Screen Shot 2021-07-28 at 10 50 56 AM](https://user-images.githubusercontent.com/8332986/127364842-cd9df102-0516-4dda-b043-e14603497469.png)


## Acceptance criteria
- [x] All Spanish content are children of an element with the lang="es" attribute or have the lang="es" attribute
- [x] Spanish content does not have the lang="en" attribute

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
