### PR TITLE
Remove action-link sass import

### DIFF
--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -1,5 +1,4 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-action-link";
 @import "~leaflet/dist/leaflet.css";
 @import "~react-tabs/style/react-tabs";
 


### PR DESCRIPTION
## Description

The action link sass module is now in the "main" stylesheet, so we don't need to import it on an app-by-app basis.

https://github.com/department-of-veterans-affairs/vets-website/pull/18024

## Testing done

Verified that the styling still works in the browser (see Screenshots)


## Screenshots

A local change I made:

![image](https://user-images.githubusercontent.com/2008881/127370743-fb36cfe3-9b74-4d7a-b554-4b4b2d57e384.png)

Browser:

![image](https://user-images.githubusercontent.com/2008881/127370858-ea935cc6-43cb-439d-b3f1-8f0226057409.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
