### PR TITLE
Remove action link import from vaos

### DIFF
--- a/src/applications/vaos/sass/vaos.scss
+++ b/src/applications/vaos/sass/vaos.scss
@@ -1,6 +1,5 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-action-link";
 @import "../../../platform/forms/sass/m-schemaform";
 
 @import "../new-appointment/sass/styles";


### PR DESCRIPTION
## Description

With the change from #18024 we no longer need to import the action link sass module on an app-by-app basis. This PR is to remove the now duplicate CSS.

## Testing done

Nothing VAOS specific, but I used a browser to verify the same change in `facility-locator`

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
