### PR TITLE
Remove action link sass import from hcq

### DIFF
--- a/src/applications/check-in/sass/check-in.scss
+++ b/src/applications/check-in/sass/check-in.scss
@@ -1,5 +1,4 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-action-link";
 
 
 dt{

--- a/src/applications/health-care-questionnaire/list/sass/questionnaire.scss
+++ b/src/applications/health-care-questionnaire/list/sass/questionnaire.scss
@@ -1,5 +1,4 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-action-link";
 @import "../../shared/sass/ie";
 
 .questionnaire-list-tabs-container{

--- a/src/applications/health-care-questionnaire/questionnaire/sass/questionnaire.scss
+++ b/src/applications/health-care-questionnaire/questionnaire/sass/questionnaire.scss
@@ -6,7 +6,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";
 @import "../../../../platform/forms/sass/m-form-confirmation";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-action-link";
 @import "../../shared/sass/ie";
 
 


### PR DESCRIPTION
## Description

With the change from #18024 we no longer need to import the action link sass module on an app-by-app basis. This PR is to remove the now duplicate CSS.

## Testing done

Nothing specific for this application, but I used a browser to verify the same change in `facility-locator`

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
