### PR TITLE
526: Add alert for Veteran's missing DOB

### DIFF
--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -13,7 +13,11 @@ import {
 import formConfig from './config/form';
 import AddPerson from './containers/AddPerson';
 import ITFWrapper from './containers/ITFWrapper';
-import { MissingServices, MissingId } from './containers/MissingServices';
+import {
+  MissingServices,
+  MissingId,
+  MissingDob,
+} from './containers/MissingServices';
 
 import { MVI_ADD_SUCCEEDED } from './actions';
 import {
@@ -53,6 +57,8 @@ export const hasRequiredServices = user =>
 
 export const hasRequiredId = user =>
   idRequired.some(service => user.profile.services.includes(service));
+
+export const hasRequiredDob = user => !!user.profile.dob;
 
 const isIntroPage = () => window.location.pathname.endsWith('/introduction');
 
@@ -146,6 +152,10 @@ export const Form526Entry = ({
   // RequiredLoginView will handle unverified users by showing the
   // appropriate link
   if (user.profile.verified) {
+    // EVSS requires user DOB for submission - see #27374
+    if (!hasRequiredDob(user)) {
+      return wrapWithBreadcrumb(title, <MissingDob title={title} />);
+    }
     // User is missing either their SSN, EDIPI, or BIRLS ID
     if (!hasRequiredId(user)) {
       return wrapWithBreadcrumb(title, <MissingId title={title} />);

--- a/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
@@ -7,12 +7,13 @@ import Telephone, {
 
 import recordEvent from 'platform/monitoring/record-event';
 
-import { getPageTitle } from '../utils';
+const titleLowerCase = (title = '') =>
+  `${title[0].toLowerCase()}${title.slice(1)}`;
 
-const Alert = ({ content }) => (
+const Alert = ({ title, content }) => (
   <div className="vads-l-grid-container vads-u-padding-left--0 vads-u-padding-bottom--5">
     <div className="usa-content">
-      <h1>{getPageTitle()}</h1>
+      <h1>{title}</h1>
 
       <va-alert visible status="error">
         {content}
@@ -22,15 +23,14 @@ const Alert = ({ content }) => (
 );
 
 export const MissingServices = ({ title }) => {
-  const titleLowerCase = title?.toLowerCase();
   const content = (
     <>
       <h2 className="vads-u-display--inline-block vads-u-font-size--h3 vads-u-margin-top--0">
         We need some information for your application
       </h2>
       <p className="vads-u-font-size--base">
-        We need more information from you before you can {titleLowerCase}.
-        Please call Veterans Benefits Assistance at{' '}
+        We need more information from you before you can {titleLowerCase(title)}
+        . Please call Veterans Benefits Assistance at{' '}
         <Telephone contact={CONTACTS.VA_BENEFITS} /> (TTY:{' '}
         <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
         ), Monday through Friday, 8:00 a.m. to 9:00 p.m. ET to update your
@@ -47,11 +47,10 @@ export const MissingServices = ({ title }) => {
     'alert-box-background-only': false,
     'alert-box-closeable': false,
   });
-  return <Alert content={content} />;
+  return <Alert title={title} content={content} />;
 };
 
 export const MissingId = ({ title }) => {
-  const titleLowerCase = title?.toLowerCase() || '';
   const content = (
     <>
       <h2 className="vads-u-display--inline-block vads-u-font-size--h3 vads-u-margin-top--0">
@@ -59,8 +58,8 @@ export const MissingId = ({ title }) => {
       </h2>
       <p className="vads-u-font-size--base">
         We don’t have all of your ID information for your account. We need this
-        information before you can {titleLowerCase}. To update your account,
-        please call Veterans Benefits Assistance at{' '}
+        information before you can {titleLowerCase(title)}. To update your
+        account, please call Veterans Benefits Assistance at{' '}
         <Telephone contact={CONTACTS.VA_BENEFITS} /> (TTY:
         <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
         ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
@@ -87,5 +86,33 @@ export const MissingId = ({ title }) => {
     'alert-box-background-only': false,
     'alert-box-closeable': false,
   });
-  return <Alert content={content} />;
+  return <Alert title={title} content={content} />;
+};
+
+export const MissingDob = ({ title }) => {
+  const content = (
+    <>
+      <h2 className="vads-u-display--inline-block vads-u-font-size--h3 vads-u-margin-top--0">
+        We need some information for your application
+      </h2>
+      <p className="vads-u-font-size--base">
+        We’re sorry, you can’t continue to {titleLowerCase(title)} because we
+        can’t find your date of birth in our records. Please call Veterans
+        Benefits Assistance at <Telephone contact={CONTACTS.VA_BENEFITS} />{' '}
+        (TTY: <Telephone contact={CONTACTS['711']} />
+        ), Monday through Friday, 8:00 a.m. to 9:00 p.m. ET to update your
+        account.
+      </p>
+    </>
+  );
+  recordEvent({
+    event: 'visible-alert-box',
+    'alert-box-type': 'warning',
+    'alert-box-heading': title,
+    'error-key': 'missing_dob',
+    'alert-box-full-width': false,
+    'alert-box-background-only': false,
+    'alert-box-closeable': false,
+  });
+  return <Alert title={title} content={content} />;
 };

--- a/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
@@ -41,6 +41,7 @@ describe('Form 526EZ Entry Page', () => {
     savedForms = [],
     mvi = '',
     show526Wizard = true,
+    dob = '2000-01-01',
   } = {}) => {
     const initialState = {
       form: {
@@ -59,6 +60,7 @@ describe('Form 526EZ Entry Page', () => {
           services,
           loading: false,
           status: '',
+          dob,
         },
       },
       currentLocation: {
@@ -148,6 +150,26 @@ describe('Form 526EZ Entry Page', () => {
     const recordedEvent = getLastEvent();
     expect(recordedEvent.event).to.equal('visible-alert-box');
     expect(recordedEvent['error-key']).to.include('missing_526');
+    tree.unmount();
+  });
+
+  // Logged in & verified, but missing DOB
+  it('should render Missing DOB aler', () => {
+    sessionStorage.setItem(WIZARD_STATUS, WIZARD_STATUS_COMPLETE);
+    const tree = testPage({
+      currentlyLoggedIn: true,
+      verified: true,
+      // only include 'EVSS_CLAIMS' service
+      services: [idRequired[0]],
+      dob: '',
+    });
+    expect(tree.find('main')).to.have.lengthOf(0);
+    expect(tree.find('h1').text()).to.contain('File for disability');
+    expect(tree.find('va-alert')).to.have.lengthOf(1);
+    expect(tree.find('va-alert').text()).to.contain('your date of birth');
+    const recordedEvent = getLastEvent();
+    expect(recordedEvent.event).to.equal('visible-alert-box');
+    expect(recordedEvent['error-key']).to.include('missing_dob');
     tree.unmount();
   });
 


### PR DESCRIPTION
## Description

EVSS requires a Veteran's date of birth during submission of Form 526. This PR adds an alert to notify Veterans that they are missing this information and will need to call in to update it.

Placeholder content is in place. Content changes are pending.

## Original issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/27374
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/27986

## Testing done

Added unit test

## Screenshots

![Screen Shot 2021-07-28 at 11 47 19 AM](https://user-images.githubusercontent.com/136959/127366102-8b3f8ef5-0aab-4eb9-98da-a25ea69400d9.png)

## Acceptance criteria

- [x] Alert shown when no DOB is found for a Veteran

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
