### PR TITLE
Bah 28005

### DIFF
--- a/src/applications/gi-sandbox/components/profile/CalculateYourBenefitsForm.jsx
+++ b/src/applications/gi-sandbox/components/profile/CalculateYourBenefitsForm.jsx
@@ -970,7 +970,7 @@ function CalculateYourBenefitsForm({
     return (
       <div className="vads-u-padding-top--1 ">
         <a
-          className="va-button-link learn-more-button eyb-skip-link vads-u-display--block"
+          className="eyb-skip-link vads-u-display--block"
           aria-label="Skip to your estimated benefits"
           href="#estimated-benefits"
         >

--- a/src/applications/gi-sandbox/containers/ProfilePageHeader.jsx
+++ b/src/applications/gi-sandbox/containers/ProfilePageHeader.jsx
@@ -306,8 +306,8 @@ const ProfilePageHeader = ({
       {!expanded && !vetTecProvider && renderIconSection()}
       {!expanded && vetTecProvider && renderVetTecIconSection()}
 
-      <div className="card-bottom-cell vads-u-flex--1 vads-u-margin--0 vads-u-border-top--4px vads-u-border-color--white ">
-        <div className="vads-u-padding--0 vads-u-margin-top--neg2 vads-u-margin-bottom--0p5">
+      <div className="card-bottom-cell vads-u-flex--1 vads-u-margin--0 vads-u-border-top--4px vads-u-border-color--white vads-u-width--full">
+        <div className="vads-u-padding-bottom--1 vads-u-margin-top--neg2 vads-u-margin-bottom--0p5 vads-u-width--full compare-checkbox">
           <Checkbox
             label="Compare"
             checked={compareChecked}

--- a/src/applications/gi-sandbox/containers/ProfilePageHeader.jsx
+++ b/src/applications/gi-sandbox/containers/ProfilePageHeader.jsx
@@ -307,7 +307,7 @@ const ProfilePageHeader = ({
       {!expanded && vetTecProvider && renderVetTecIconSection()}
 
       <div className="card-bottom-cell vads-u-flex--1 vads-u-margin--0 vads-u-border-top--4px vads-u-border-color--white">
-        <div className="vads-u-padding-bottom--1 vads-u-margin-top--neg2 vads-u-margin-bottom--0p5 vads-u-width--full compare-checkbox">
+        <div className="vads-u-padding---0 vads-u-margin-top--neg2 vads-u-margin-bottom--0p5 vads-u-width--full compare-checkbox">
           <Checkbox
             label="Compare"
             checked={compareChecked}

--- a/src/applications/gi-sandbox/containers/ProfilePageHeader.jsx
+++ b/src/applications/gi-sandbox/containers/ProfilePageHeader.jsx
@@ -306,7 +306,7 @@ const ProfilePageHeader = ({
       {!expanded && !vetTecProvider && renderIconSection()}
       {!expanded && vetTecProvider && renderVetTecIconSection()}
 
-      <div className="card-bottom-cell vads-u-flex--1 vads-u-margin--0 vads-u-border-top--4px vads-u-border-color--white vads-u-width--full">
+      <div className="card-bottom-cell vads-u-flex--1 vads-u-margin--0 vads-u-border-top--4px vads-u-border-color--white">
         <div className="vads-u-padding-bottom--1 vads-u-margin-top--neg2 vads-u-margin-bottom--0p5 vads-u-width--full compare-checkbox">
           <Checkbox
             label="Compare"

--- a/src/applications/gi-sandbox/containers/ProfilePageHeader.jsx
+++ b/src/applications/gi-sandbox/containers/ProfilePageHeader.jsx
@@ -307,7 +307,7 @@ const ProfilePageHeader = ({
       {!expanded && vetTecProvider && renderVetTecIconSection()}
 
       <div className="card-bottom-cell vads-u-flex--1 vads-u-margin--0 vads-u-border-top--4px vads-u-border-color--white">
-        <div className="vads-u-padding---0 vads-u-margin-top--neg2 vads-u-margin-bottom--0p5 vads-u-width--full compare-checkbox">
+        <div className="vads-u-padding--0 vads-u-margin-top--neg2 vads-u-margin-bottom--0p5 vads-u-width--full compare-checkbox">
           <Checkbox
             label="Compare"
             checked={compareChecked}

--- a/src/applications/gi-sandbox/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi-sandbox/sass/partials/_gi-profile-page.scss
@@ -40,7 +40,7 @@
     }
 
     h4 {
-      margin-top: .5em;
+      margin-top: 0.5em;
     }
   }
 
@@ -319,7 +319,8 @@
 
   .cautionary-information {
     .table {
-      td, th {
+      td,
+      th {
         padding: 20px;
       }
       table {
@@ -634,7 +635,7 @@
 
   .eyb-skip-link {
     position: absolute;
-    top: -100rem;
+    top: -100em;
 
     &:focus {
       top: auto;
@@ -642,6 +643,12 @@
       margin-bottom: 1em;
       position: relative;
     }
+  }
+  .compare-checkbox {
+    justify-content: center;
+    align-items: center;
+    position: relative;
+    display: flex;
   }
 
   .profile-section {
@@ -660,12 +667,11 @@
       padding: 20px;
     }
 
-
     .subsection {
       border-bottom: 1px solid $color-black;
       width: 100%;
       font-family: "Bitter", "Georgia", "Cambria", "Times New Roman", "Times",
-      serif;
+        serif;
       font-size: 20px;
       font-weight: 700;
       margin-bottom: 20px;

--- a/src/applications/gi-sandbox/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi-sandbox/sass/partials/_gi-profile-page.scss
@@ -634,9 +634,11 @@
   }
 
   .eyb-skip-link {
-    position: absolute;
-    top: -100em;
-
+    &:not(:focus) {
+      position: absolute;
+      opacity: 0;
+      pointer-events: none;
+    }
     &:focus {
       top: auto;
       line-height: 50px;


### PR DESCRIPTION
## Description
As a user tabs through the various fields in the "Calculate your benefits" section of a profile page in the CT, they will eventually tab to a "Skip to your estimated benefits" link. This link should be hidden until the user tabs to it. The "Skip to your estimated benefits" should show under the "Update benefits" button for each of the four accordions under "Calculate your benefits". Currently, the link displays in various positions around the profile page header on screen 1200px wide and smaller.
## Original issue(s)
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/28005


## Testing done
local

## Screenshots

https://user-images.githubusercontent.com/50601724/127382134-d156f068-a12f-42fb-8391-392de66acce0.mov



## Acceptance criteria
- [ ] 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
