### PR TITLE
fixes keepAlive method fetch request

### DIFF
--- a/src/platform/utilities/sso/keepAliveSSO.js
+++ b/src/platform/utilities/sso/keepAliveSSO.js
@@ -50,14 +50,15 @@ const logToSentry = data => {
 };
 
 export default async function keepAlive() {
-  // Return a TTL and authn values from the IAM keepalive endpoint that
-  // 1) indicates how long the user's current SSOe session will be alive for,
-  // 2) and the AuthN context the user used when authenticating.
-  //
-  // Any positive TTL value means the user currently has a session, a TTL of 0
-  // means they don't have an active session, and a TTL of undefined means there
-  // was a problem calling the endpoint and we can't determine if they have a
-  // session or not
+  /* Return a TTL and authn values from the IAM keepalive endpoint that
+  * 1) indicates how long the user's current SSOe session will be alive for,
+  * 2) and the AuthN context the user used when authenticating.
+
+  * Any positive TTL value means the user currently has a session, a TTL of 0
+  * means they don't have an active session, and a TTL of undefined means there
+  * was a problem calling the endpoint and we can't determine if they have a
+  * session or not
+  */
   try {
     const resp = await fetch(ssoKeepAliveEndpoint(), {
       method: 'HEAD',
@@ -65,15 +66,17 @@ export default async function keepAlive() {
       cache: 'no-store',
     });
 
+    await resp.text();
     const alive = resp.headers.get('session-alive');
 
     return {
       ttl: alive === 'true' ? Number(resp.headers.get('session-timeout')) : 0,
       transactionid: resp.headers.get('va_eauth_transactionid'),
-      // for DSLogon or mhv, use a mapped authn context value, however for
-      // idme, we need to use the provided authncontextclassref as it could be
-      // for LOA1 or LOA3.  Any other csid values should be ignored, and we
-      // should return undefined
+      /* for DSLogon or mhv, use a mapped authn context value, however for
+      * idme, we need to use the provided authncontextclassref as it could be
+      * for LOA1 or LOA3.  Any other csid values should be ignored, and we
+      * should return undefined
+      */
       authn: {
         DSLogon: 'dslogon',
         mhv: 'myhealthevet',


### PR DESCRIPTION
## Description
[Original thread](https://dsva.slack.com/archives/CSFV4QTKN/p1627483731312400)

Issue:
The `Failed to fetch` or `Fetch failed` TypeError were logged in Sentry as potential errors.  While these error logs are actually false positives they did provide insight into an error in the keepAlive method when making requests to the `/keepalive` endpoint.

Reason:
The original fetch to the `/keepalive` endpoint had a `GET` method and expected a response body.  Because the response body was not being used there was a recommendation to change the request method to `HEAD`.  The `Failed to fetch` TypeError is logging because a response body was being sent with the `HEAD` request despite it having a `status: 200` and `ok: true`.

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#28029

## Testing done
- Local
- Staging

How to replicate/test:
1. Run `yarn watch --env.api https://staging-api.va.gov`
2. In `src/platform/utilities/sso/index.js`, comment out line 19 and return the liveKeepAlive method
3. Open Chrome > Navigate to `http://localhost:3001` > Open Chrome DevTools
4. On the Console Panel > Console settings (gear icon) > Enable `Log XMLHttpRequests`

Good request
1. Refresh page
2. You will see  Fetch finished loading: HEAD "https://_.eauth.va.gov/keepalive"

Bad request
1. In `src/platform/utilities/sso/keepAliveSSO.js` comment out line 69 (the await resp.text() method)
2. Refresh page
3. See error `Fetch failed loading: HEAD "http://_.eauth.va.gov/keepalive"


## Screenshots


## Acceptance criteria
- [x] `Failed to fetch` is not logged to Sentry

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs