### PR TITLE
Header in facility detail page now focuses 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -180,6 +180,8 @@ module.exports = {
     'jsx-a11y/anchor-is-valid': 0, // 19
     'jsx-a11y/label-has-associated-control': 0, // 35
     'jsx-a11y/label-has-for': 0, // 66
+    // allow non-interactive elements to receive focus
+    'jsx-a11y/no-noninteractive-tabindex': 0,
 
     'import/named': 0, // 2
     'import/no-useless-path-segments': 0, // 59  (fixable)

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -180,8 +180,6 @@ module.exports = {
     'jsx-a11y/anchor-is-valid': 0, // 19
     'jsx-a11y/label-has-associated-control': 0, // 35
     'jsx-a11y/label-has-for': 0, // 66
-    // allow non-interactive elements to receive focus
-    'jsx-a11y/no-noninteractive-tabindex': 0,
 
     'import/named': 0, // 2
     'import/no-useless-path-segments': 0, // 59  (fixable)

--- a/src/applications/facility-locator/containers/FacilityDetail.jsx
+++ b/src/applications/facility-locator/containers/FacilityDetail.jsx
@@ -3,7 +3,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import { fetchVAFacility } from '../actions';
-import { focusElement } from 'platform/utilities/ui';
+// import { focusElement } from 'platform/utilities/ui';
 import AccessToCare from '../components/AccessToCare';
 import LocationAddress from '../components/search-results-items/common/LocationAddress';
 import LocationDirectionsLink from '../components/search-results-items/common/LocationDirectionsLink';
@@ -18,6 +18,7 @@ import VABenefitsCall from '../components/VABenefitsCall';
 import { facilityLocatorShowOperationalHoursSpecialInstructions } from '../utils/featureFlagSelectors';
 
 class FacilityDetail extends Component {
+  headerRef = React.createRef();
   // eslint-disable-next-line camelcase
   UNSAFE_componentWillMount() {
     this.props.fetchVAFacility(this.props.params.id, null);
@@ -25,7 +26,10 @@ class FacilityDetail extends Component {
   }
 
   componentDidMount() {
-    focusElement('.va-nav-breadcrumbs');
+    if (this.headerRef && this.headerRef.current) {
+      this.headerRef.current.focus();
+    }
+    // focusElement('facility-name-h1');
   }
 
   componentDidUpdate(prevProps) {
@@ -111,7 +115,10 @@ class FacilityDetail extends Component {
     const isVBA = facilityType === FacilityType.VA_BENEFITS_FACILITY;
     return (
       <div>
-        <h1>{name}</h1>
+        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+        <h1 ref={this.headerRef} tabIndex={0}>
+          {name}
+        </h1>
         {this.showOperationStatus(operatingStatus, website, facilityType)}
         <div className="p1">
           <LocationAddress location={facility} />

--- a/src/applications/facility-locator/containers/FacilityDetail.jsx
+++ b/src/applications/facility-locator/containers/FacilityDetail.jsx
@@ -110,7 +110,6 @@ class FacilityDetail extends Component {
     const isVBA = facilityType === FacilityType.VA_BENEFITS_FACILITY;
     return (
       <div>
-        {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
         <h1 ref={this.headerRef} tabIndex={0}>
           {name}
         </h1>

--- a/src/applications/facility-locator/containers/FacilityDetail.jsx
+++ b/src/applications/facility-locator/containers/FacilityDetail.jsx
@@ -110,7 +110,7 @@ class FacilityDetail extends Component {
     const isVBA = facilityType === FacilityType.VA_BENEFITS_FACILITY;
     return (
       <div>
-        <h1 ref={this.headerRef} tabIndex={0}>
+        <h1 ref={this.headerRef} tabIndex={-1}>
           {name}
         </h1>
         {this.showOperationStatus(operatingStatus, website, facilityType)}

--- a/src/applications/facility-locator/containers/FacilityDetail.jsx
+++ b/src/applications/facility-locator/containers/FacilityDetail.jsx
@@ -24,12 +24,6 @@ class FacilityDetail extends Component {
     window.scrollTo(0, 0);
   }
 
-  componentDidMount() {
-    if (this.headerRef && this.headerRef.current) {
-      this.headerRef.current.focus();
-    }
-  }
-
   componentDidUpdate(prevProps) {
     const justLoaded =
       prevProps.currentQuery.inProgress && !this.props.currentQuery.inProgress;
@@ -39,6 +33,9 @@ class FacilityDetail extends Component {
       document.title = `${
         this.props.facility.attributes.name
       } | Veterans Affairs`;
+
+      // Need to wait until the data is loaded to focus
+      this.headerRef.current.focus();
     }
   }
 

--- a/src/applications/facility-locator/containers/FacilityDetail.jsx
+++ b/src/applications/facility-locator/containers/FacilityDetail.jsx
@@ -3,7 +3,6 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import { fetchVAFacility } from '../actions';
-// import { focusElement } from 'platform/utilities/ui';
 import AccessToCare from '../components/AccessToCare';
 import LocationAddress from '../components/search-results-items/common/LocationAddress';
 import LocationDirectionsLink from '../components/search-results-items/common/LocationDirectionsLink';
@@ -29,7 +28,6 @@ class FacilityDetail extends Component {
     if (this.headerRef && this.headerRef.current) {
       this.headerRef.current.focus();
     }
-    // focusElement('facility-name-h1');
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
## Description
Original issue linked below

When tabbing through the facility detail page AFTER you have selected one from the search results in Facility Locator, the header (h1) will now focus.

To test you can use a facility from El Paso- http://localhost:3001/find-locations/?zoomLevel=9&page=1&address=el%20paso&location=undefined%2Cundefined&context=El%20Paso%2C%20Texas%2C%20United%20States&facilityType=health&serviceType

## Acceptance criteria
- [ ] VoiceOver announces the header(h1) of the facility detail page.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
