### PR TITLE
Remove action link import from gi-sandbox

### DIFF
--- a/src/applications/gi-sandbox/sass/gi.scss
+++ b/src/applications/gi-sandbox/sass/gi.scss
@@ -1,8 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-action-link";
 @import "~@department-of-veterans-affairs/formation/sass/modules/va-pagination";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-action-link";
 @import "partials/gi-vet-tec";
 @import "partials/gi-preview-banner";
 @import "partials/gi-autocomplete";


### PR DESCRIPTION
## Description

With the change from #18024 we no longer need to import the action link sass module on an app-by-app basis. This PR is to remove the now duplicate CSS.

I'm not sure why the module was imported twice :shrug: 

## Testing done
None for this app specifically, but I verified the same change to `facility-locator` in the browser.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
