### PR TITLE
Remove action link sass import from caregivers + more

### DIFF
--- a/src/applications/caregivers/sass/caregivers.scss
+++ b/src/applications/caregivers/sass/caregivers.scss
@@ -5,7 +5,6 @@
 @import "../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-action-link";
 @import "../../../platform/forms/sass/m-form-confirmation";
 @import "caregiverFooter";
 @import "./infoModal";

--- a/src/applications/personalization/search-representative/sass/search-representative.scss
+++ b/src/applications/personalization/search-representative/sass/search-representative.scss
@@ -6,4 +6,3 @@
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";
 @import "../../../../platform/forms/sass/m-form-confirmation";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-action-link";

--- a/src/applications/vre/28-1900/sass/28-1900-chapter-31.scss
+++ b/src/applications/vre/28-1900/sass/28-1900-chapter-31.scss
@@ -2,7 +2,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-progress-bar";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-action-link";
 @import "../../../../platform/forms/sass/m-schemaform";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";


### PR DESCRIPTION
## Description

With the change from #18024 we no longer need to import the action link sass module on an app-by-app basis. This PR is to remove the now duplicate CSS.

I grouped these files together since there is some overlap among the ebenefits and bam1 codeowners.


## Testing done

None for these specific apps, but I used a browser to test the same change in `facility-locator`.


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
