### PR TITLE
Remove action link import from static-pages

### DIFF
--- a/src/applications/static-pages/sass/static-pages.scss
+++ b/src/applications/static-pages/sass/static-pages.scss
@@ -2,7 +2,6 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-action-link";
 
 // ----- VA LAYOUTS (GRIDS/HEADER/FOOTER) ---- //
 @import "layouts/l-playbook";


### PR DESCRIPTION
## Description

With the change from #18024 we no longer need to import the action link sass module on an app-by-app basis. This PR is to remove the now duplicate CSS.

## Testing done
None for `static-pages`, but I tested the same change in `facility-locator`

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
