### PR TITLE
Try and avoid some of the testing-reports errors

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -615,12 +615,12 @@ jobs:
           name: cypress-video-artifacts
           path: testing-reports/cypress-reports/videos/${{ env.UUID }}
 
-      - name: Add changes
-        run: git add .
-        working-directory: testing-reports
-
       - name: Pull any changes since checkout
         run: git pull origin master
+        working-directory: testing-reports
+
+      - name: Add changes
+        run: git add .
         working-directory: testing-reports
 
       - name: Commit and push changes

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -619,6 +619,9 @@ jobs:
         run: git add .
         working-directory: testing-reports
 
+      - name: Pull any changes since checkout
+        run: git pull origin master
+
       - name: Commit and push changes
         uses: actions-js/push@master
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -621,6 +621,7 @@ jobs:
 
       - name: Pull any changes since checkout
         run: git pull origin master
+        working-directory: testing-reports
 
       - name: Commit and push changes
         uses: actions-js/push@master


### PR DESCRIPTION
## Description
About half the errors we are seeing currently are related to the repository that's checked out being outdated by the time the artifact download process is completed.  This aims to be a quick band-aid to relieve some of those, while we work on other solutions and switching this to S3.


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
