### PR TITLE
Kelsonic 25001 safari button outline

### DIFF
--- a/package.json
+++ b/package.json
@@ -263,7 +263,7 @@
   "private": true,
   "dependencies": {
     "@department-of-veterans-affairs/component-library": "2.5.5",
-    "@department-of-veterans-affairs/formation": "6.16.2",
+    "@department-of-veterans-affairs/formation": "6.16.3",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "@formatjs/intl-datetimeformat": "^3.2.7",
     "@formatjs/intl-getcanonicallocales": "^1.5.3",

--- a/src/applications/gi-sandbox/sass/partials/_gi-back-to-top.scss
+++ b/src/applications/gi-sandbox/sass/partials/_gi-back-to-top.scss
@@ -26,7 +26,6 @@
       padding: 0;
       pointer-events: none;
       position: inherit;
-      transition: all 250ms ease-in;
       right: auto;
       width: 44px;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1536,10 +1536,10 @@
     react-transition-group "1"
     recast "^0.14.4"
 
-"@department-of-veterans-affairs/formation@6.16.2":
-  version "6.16.2"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-6.16.2.tgz#c4f48b6dd861410d581bedb87cd410d178b892a2"
-  integrity sha512-zMND0kayf/m8Ae1Vo5K9HHRQkNnIk+5i6oJIcPb1OSb1hjwieEnnNc1O29Jp0RiwEuLA1/aX+LivAaWYWsgu2g==
+"@department-of-veterans-affairs/formation@6.16.3":
+  version "6.16.3"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-6.16.3.tgz#5e986b6bdcda1d4bf96d4e1725e29340acc9f98f"
+  integrity sha512-QtQgz5ewSz8XyQE8FeUsjdOWYtC5b7GZE1WxdtvL+4pcsBSXCR6kqb75cVQ5tPBf7q488UNm9+BIaSJqHZRrHQ==
   dependencies:
     "@fortawesome/fontawesome-free" "^5.6.3"
     domready "^1.0.8"


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/25001

This PR removes the transition property from the back to top button.

**Related PRs:**

https://github.com/department-of-veterans-affairs/vets-website/pull/18065
https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/649

## Testing done
https://github.com/department-of-veterans-affairs/va.gov-team/issues/25001#issuecomment-889413479

## Screenshots
https://github.com/department-of-veterans-affairs/va.gov-team/issues/25001#issuecomment-889413479

## Acceptance criteria
- [x] Back to top button should show outline when focused on Safari

## Definition of done
- [x] Changes have been tested in vets-website
- [x] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
