### PR TITLE
Example for on-demand runner

### DIFF
--- a/.github/workflows/test-on-demand-runner.yml
+++ b/.github/workflows/test-on-demand-runner.yml
@@ -1,0 +1,95 @@
+on:
+  workflow_dispatch
+
+name: Test Role
+env:
+  INSTANCE_TYPE: c5.4xlarge # Define instance size here OR later in the 'start-runner' step
+
+jobs:
+  start-runner:
+    runs-on: ubuntu-latest
+    outputs:
+      label: ${{ steps.start-ec2-runner.outputs.label }}
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Get bot token from Parameter Store 
+        uses: marvinpinto/action-inject-ssm-secrets@latest 
+        with: 
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN  
+
+      - name: Get latest GHA Runner AMI ID # AMI images are rebuilt every 15 days, use the latest one
+        run: |
+          echo "RUNNER_AMI_ID=aws ec2 describe-images \
+          --owners 008577686731 \
+          --filters Name=name,Values=packer-gha-runner-ubuntu2004* \
+          --query 'sort_by(Images,&CreationDate)[-1].ImageId'" >> $GITHUB_ENV
+
+      - name: Get Subnet with the most free IPs # We will run these in the dsva-vagov-utility-2x subnet, so filter for those
+        run: |
+          echo "SUBNET_ID=aws ec2 describe-subnets \
+          --filters "Name=tag:Name,Values=dsva-vagov-utility-subnet-2*" \
+          --query 'sort_by(Subnets,&AvailableIpAddressCount)[-1].SubnetId'" >> $GITHUB_ENV
+
+      - name: Start EC2 Runner
+        id: start-ec2-runner
+        uses: machulav/ec2-github-runner@v2
+        with:
+          mode: start
+          github-token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
+          ec2-image-id: ${{ env.RUNNER_AMI_ID }}
+          ec2-instance-type: ${{ env.INSTANCE_TYPE }}
+          subnet-id: ${{ env.SUBNET_ID }}
+          security-group-id: sg-0e23b56be3798e3a1
+          iam-role-name: dsva-vagov-vets-website-gha-runner-role
+          aws-resource-tags: >
+            [
+              {"Key": "Name", "Value": "dsva-vagov-vets-website-on-demand-runner"},
+              {"Key": "project", "Value": "vagov"},
+              {"Key": "office", "Value": "dsva"},
+              {"Key": "application", "Value": "on-demand-gha-runner"},
+              {"Key": "VAECID", "Value": "AWG20180517003"},
+              {"Key": "environment", "Value": "utility"}
+            ]
+
+  test-job:
+    name: Test On Demand Runner
+    needs: start-runner
+    runs-on: ${{ needs.start-runner.outputs.label }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Hello World
+      run: echo 'Hello World!'
+
+  stop-runner:
+    name: Stop on-demand-runner
+    needs: 
+      - start-runner
+      - test-job
+    runs-on: ubuntu-latest
+    if: ${{ always() }} # Even if an error happened, let's stop the runner
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Stop Runner
+        uses: machulav/ec2-github-runner@v2
+        with:
+          mode: stop
+          github-token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
+          label: ${{ needs.start-runner.outputs.label }}
+          ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}


### PR DESCRIPTION
## Description
This is an example Github Actions workflow for utilizing an on-demand self-hosted runner

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [ ] Workflow is able to start an instance and run the hello world job on it

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
