### PR TITLE
stringify api request body

### DIFF
--- a/src/applications/personalization/profile/ducks/communicationPreferences.js
+++ b/src/applications/personalization/profile/ducks/communicationPreferences.js
@@ -93,7 +93,7 @@ export const saveCommunicationPreferenceChannel = (channelId, apiCallInfo) => {
     try {
       const response = await apiRequest(apiCallInfo.endpoint, {
         method: apiCallInfo.method,
-        body: apiCallInfo.payload,
+        body: JSON.stringify(apiCallInfo.payload),
         headers: { 'Content-Type': 'application/json' },
       });
       // It's possible that a 200 from the API is not _really_ a successful


### PR DESCRIPTION
## Description
All attempts to update comm prefs fail on staging because I was sending a JS object for the request body 🤦 

<img width="860" alt="Screen Shot 2021-07-30 at 12 43 23 PM" src="https://user-images.githubusercontent.com/20728956/127704207-1c0e0cf6-16f6-43c7-9f2c-75843a53670f.png">

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs