### PR TITLE
Always show save-in-progress ID

### DIFF
--- a/src/platform/forms/save-in-progress/ApplicationStatus.jsx
+++ b/src/platform/forms/save-in-progress/ApplicationStatus.jsx
@@ -134,7 +134,7 @@ export class ApplicationStatus extends React.Component {
       if (!isExpired) {
         const lastSavedDateTime = moment
           .unix(lastSaved)
-          .format('M/D/YYYY [at] h:mm a');
+          .format('MMMM D, YYYY [at] h:mm a');
 
         return (
           <div className="usa-alert usa-alert-info background-color-only sip-application-status">
@@ -151,7 +151,7 @@ export class ApplicationStatus extends React.Component {
               You can continue {appAction} now, or come back later to finish
               your {appType}. Your {appType}{' '}
               <span className="expires">
-                will expire on {expirationDate.format('M/D/YYYY')}.
+                will expire on {expirationDate.format('MMMM D, YYYY')}.
               </span>
             </div>
             <p>

--- a/src/platform/forms/save-in-progress/FormSaved.jsx
+++ b/src/platform/forms/save-in-progress/FormSaved.jsx
@@ -52,7 +52,7 @@ class FormSaved extends React.Component {
     const { success } = this.props.route.formConfig.savedFormMessages || {};
     const expirationDate = moment
       .unix(this.props.expirationDate)
-      .format('M/D/YYYY');
+      .format('MMMM D, YYYY');
     const appType =
       this.props.route.formConfig?.customText?.appType || APP_TYPE_DEFAULT;
 
@@ -67,7 +67,7 @@ class FormSaved extends React.Component {
                 <div className="saved-form-metadata-container">
                   <span className="saved-form-metadata">
                     Last saved on{' '}
-                    {moment(lastSavedDate).format('M/D/YYYY [at] h:mm a')}
+                    {moment(lastSavedDate).format('MMMM D, YYYY [at] h:mm a')}
                   </span>
                   {expirationMessage || (
                     <p className="expires-container">

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -54,12 +54,12 @@ class SaveInProgressIntro extends React.Component {
           ? moment(this.props.lastSavedDate)
           : moment.unix(lastUpdated);
         const expiresAt = moment.unix(savedForm.metadata.expiresAt);
-        const expirationDate = expiresAt.format('MMM D, YYYY');
+        const expirationDate = expiresAt.format('MMMM D, YYYY');
         const isExpired = expiresAt.isBefore();
         const inProgressMessage = getInProgressMessage(formConfig);
 
         if (!isExpired) {
-          const lastSavedDateTime = savedAt.format('M/D/YYYY [at] h:mm a');
+          const lastSavedDateTime = savedAt.format('MMMM D, YYYY [at] h:mm a');
           const H = `h${this.props.headingLevel}`;
           const message = `Your ${appType} is in progress`;
           alert = (

--- a/src/platform/forms/save-in-progress/SaveStatus.jsx
+++ b/src/platform/forms/save-in-progress/SaveStatus.jsx
@@ -9,7 +9,12 @@ import {
 } from '../../forms-system/src/js/constants';
 
 function SaveStatus({
-  form: { lastSavedDate, autoSavedStatus, loadedData },
+  form: {
+    lastSavedDate,
+    autoSavedStatus,
+    loadedData,
+    inProgressFormId = loadedData?.metadata?.inProgressFormId,
+  },
   formConfig,
   isLoggedIn,
   showLoginModal,
@@ -19,20 +24,19 @@ function SaveStatus({
   if (lastSavedDate) {
     const savedAt = moment(lastSavedDate);
     savedAtMessage = ` It was last saved on ${savedAt.format(
-      'MMM D, YYYY [at] h:mm a',
+      'MMMM D, YYYY [at] h:mm a',
     )}`;
   } else {
     savedAtMessage = '';
   }
 
-  const formId = loadedData?.metadata?.inProgressFormId;
   const appType = formConfig?.customText?.appType || APP_TYPE_DEFAULT;
 
   const formIdMessage =
-    formId && savedAtMessage ? (
+    inProgressFormId && savedAtMessage ? (
       <>
         {' '}
-        Your {appType} ID number is <strong>{formId}</strong>.
+        Your {appType} ID number is <strong>{inProgressFormId}</strong>.
       </>
     ) : null;
 

--- a/src/platform/forms/save-in-progress/actions.js
+++ b/src/platform/forms/save-in-progress/actions.js
@@ -63,12 +63,14 @@ export function setSaveFormStatus(
   status,
   lastSavedDate = null,
   expirationDate = null,
+  inProgressFormId = null,
 ) {
   return {
     type: statusActionsByType.get(saveType),
     status,
     lastSavedDate,
     expirationDate,
+    inProgressFormId,
   };
 }
 
@@ -203,6 +205,7 @@ function saveForm(saveType, formId, formData, version, returnUrl, submission) {
             SAVE_STATUSES.success,
             savedAt,
             json.data.attributes.metadata.expiresAt,
+            json.data.id,
           ),
         );
 

--- a/src/platform/forms/save-in-progress/reducers.js
+++ b/src/platform/forms/save-in-progress/reducers.js
@@ -48,6 +48,7 @@ export const saveInProgressReducers = {
     if (action.status === SAVE_STATUSES.success) {
       newState.lastSavedDate = action.lastSavedDate;
       newState.expirationDate = action.expirationDate;
+      newState.inProgressFormId = action.inProgressFormId;
     }
 
     if (saveErrors.has(action.status)) {

--- a/src/platform/forms/tests/save-in-progress/FormSaved.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/FormSaved.unit.spec.jsx
@@ -52,7 +52,7 @@ describe('Schemaform <FormSaved>', () => {
     expect(
       tree.subTree('withRouter(FormStartControls)').props.startPage,
     ).to.equal('testing');
-    expect(tree.subTree('.usa-alert').text()).to.contain('6/12/2017 at');
+    expect(tree.subTree('.usa-alert').text()).to.contain('June 12, 2017 at');
     expect(tree.subTree('.usa-alert').text()).to.contain('will expire on');
     expect(tree.subTree('.usa-alert').text()).to.contain(
       'Your education benefits (123) application has been saved.',

--- a/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
@@ -68,7 +68,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
         .find('.saved-form-item-metadata')
         .last()
         .text(),
-    ).to.include(moment.unix(946684800).format('M/D/YYYY [at] h:mm a'));
+    ).to.include(moment.unix(946684800).format('MMMM D, YYYY [at] h:mm a'));
 
     expect(tree.find('.usa-alert').text()).to.contain(
       'Your application is in progress',

--- a/src/platform/forms/tests/save-in-progress/SaveStatus.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveStatus.unit.spec.jsx
@@ -63,11 +63,7 @@ describe('<SaveStatus>', () => {
         formId: VA_FORM_IDS.FORM_10_10EZ,
         lastSavedDate: 1505770055,
         autoSavedStatus: 'success',
-        loadedData: {
-          metadata: {
-            inProgressFormId: 98765,
-          },
-        },
+        inProgressFormId: 98765,
       },
       formConfig: {
         customText: {


### PR DESCRIPTION
## Description

When initially starting a form, altering form data shows an in-progress save message, but it doesn't include the save-in-progress ID. Once you use "Finish this application later" and return to the form, the ID will show up consistently.

## Original issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/28190

## Testing done

Updated unit tests

## Screenshots

<details><summary>Before (no ID)</summary>

<!-- leave a blank line above -->
![](https://user-images.githubusercontent.com/136959/127894648-caaf7169-3a3f-47fd-8b67-59581c739d10.png)</details>

<details><summary>After (showing ID)</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-08-02 at 11 13 43 AM](https://user-images.githubusercontent.com/136959/127896181-5bebcf40-8dc8-450d-816e-9d43b43f5eb8.png)
</details>

## Acceptance criteria
- [x] Always show save-in-progress ID
- [x] Show full dates since space isn't limited ([ref](https://design.va.gov/content-style-guide/dates-and-numbers#dates-and-years))

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
