### PR TITLE
526: Fix word break

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
@@ -393,6 +393,7 @@ export default class ArrayField extends React.Component {
                         {legendText}
                         {uiOptions.includeRequiredLabelInTitle && (
                           <span className="schemaform-required-span vads-u-font-weight--normal">
+                            {' '}
                             (*Required)
                           </span>
                         )}

--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -18,7 +18,7 @@
 }
 
 .word-break {
-  word-break: break-all;
+  word-break: break-word;
 }
 
 .clearfix:after {


### PR DESCRIPTION
## Description

The 526 new disability card is wrapping text in the middle of the word. Switching this to break on words.

## Original issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/28181

## Testing done

Visual (CSS changes)

## Screenshots

<details><summary>Before</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-08-02 at 12 36 57 PM](https://user-images.githubusercontent.com/136959/127901707-bcb94f28-6c3e-4fc7-9448-71bed38569e7.png)</details>

<details><summary>After</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-08-02 at 12 32 59 PM](https://user-images.githubusercontent.com/136959/127901468-d5ca6f54-fa55-4216-9235-6e655fa554ab.png)
</details>

## Acceptance criteria

- [x] Text wraps on word breaks

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
