### PR TITLE
Add HLR CTA description

### DIFF
--- a/src/platform/site-wide/cta-widget/ctaWidgets.js
+++ b/src/platform/site-wide/cta-widget/ctaWidgets.js
@@ -4,6 +4,7 @@ import { MHV_ACCOUNT_TYPES } from './constants';
 import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 import { rootUrl as addRemoveDependentsUrl } from 'applications/disability-benefits/686c-674/manifest.json';
 import { rootUrl as hearingAidSuppliesUrl } from 'applications/disability-benefits/2346/manifest.json';
+import { rootUrl as higherLevelReviewUrl } from 'applications/disability-benefits/996/manifest.json';
 import { rootUrl as viewDependentsUrl } from 'applications/personalization/view-dependents/manifest.json';
 import { rootUrl as viewPaymentHistoryUrl } from 'applications/disability-benefits/view-payments/manifest.json';
 
@@ -17,6 +18,7 @@ export const CTA_WIDGET_TYPES = {
   GI_BILL_BENEFITS: 'gi-bill-benefits',
   HEALTH_RECORDS: 'health-records',
   HEARING_AID_SUPPLIES: 'hearing-aid-supplies',
+  HIGHER_LEVEL_REVIEW: 'higher-level-review',
   LAB_AND_TEST_RESULTS: 'lab-and-test-results',
   LETTERS: 'letters',
   MANAGE_VA_DEBT: 'manage-va-debt',
@@ -140,6 +142,17 @@ export const ctaWidgetsLookup = {
     mhvToolName: null,
     requiredServices: null,
     serviceDescription: 'order hearing aid supplies',
+  },
+  [CTA_WIDGET_TYPES.HIGHER_LEVEL_REVIEW]: {
+    id: CTA_WIDGET_TYPES.HIGHER_LEVEL_REVIEW,
+    deriveToolUrlDetails: () => ({
+      url: higherLevelReviewUrl,
+      redirect: false,
+    }),
+    isHealthTool: false,
+    mhvToolName: null,
+    requiredServices: null,
+    serviceDescription: 'request a Higher-Level Review',
   },
   [CTA_WIDGET_TYPES.LAB_AND_TEST_RESULTS]: {
     id: CTA_WIDGET_TYPES.LAB_AND_TEST_RESULTS,


### PR DESCRIPTION
## Description

The Higher-Level Review (HLR) form was missing a call-to-action (CTA) service description leading to a message in the CTA stating "Please sign in to undefined" (see screenshot). This PR adds a `serviceDescription` value to resolve this problem.

## Original issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/25036
- Related: https://github.com/department-of-veterans-affairs/vets-website/pull/17999

## Testing done

Manual

## Screenshots

<details><summary>Undefined (Before)</summary>

<!-- leave a blank line above -->
![Please sign in to undefined](https://user-images.githubusercontent.com/136959/128022841-9166369d-1a42-4888-8594-acf4efc02abd.png)</details>

<details><summary>Request a Higher-Level Review (After)</summary>

<!-- leave a blank line above -->
![Please sign in to request a Higher-Level Review](https://user-images.githubusercontent.com/136959/128022837-ebd2d765-0413-4a56-8b2b-25bd075f3493.png)</details>

## Acceptance criteria
- [x] CTA includes the action for the HLR form

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
