### PR TITLE
Fetch clinic detail when using v2 endpoints

### DIFF
--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -566,11 +566,17 @@ export function fetchConfirmedAppointmentDetails(id, type) {
       }
 
       if (featureVAOSServiceVAAppointments && appointment.location.clinicId) {
-        const clinic = await fetchHealthcareServiceById({
-          locationId: appointment.location.stationId,
-          id: appointment.location.clinicId,
-        });
-        appointment.location.clinicName = clinic.serviceName;
+        try {
+          const clinic = await fetchHealthcareServiceById({
+            locationId: appointment.location.stationId,
+            id: appointment.location.clinicId,
+          });
+          appointment.location.clinicName = clinic.serviceName;
+        } catch (e) {
+          // We don't want to show an overall error on this page just
+          // because we don't have a clinic name, so capture the error and continue
+          captureError(e);
+        }
       }
 
       facilityId = getVAAppointmentLocationId(appointment);

--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -42,6 +42,7 @@ import {
   STARTED_NEW_VACCINE_FLOW,
 } from '../../redux/sitewide';
 import { selectAppointmentById } from './selectors';
+import { fetchHealthcareServiceById } from '../../services/healthcare-service';
 
 export const FETCH_FUTURE_APPOINTMENTS = 'vaos/FETCH_FUTURE_APPOINTMENTS';
 export const FETCH_PENDING_APPOINTMENTS = 'vaos/FETCH_PENDING_APPOINTMENTS';
@@ -562,6 +563,14 @@ export function fetchConfirmedAppointmentDetails(id, type) {
         appointment.communityCareProvider = await getCommunityProvider(
           appointment.practitioners[0].id.value,
         );
+      }
+
+      if (featureVAOSServiceVAAppointments && appointment.location.clinicId) {
+        const clinic = await fetchHealthcareServiceById({
+          locationId: appointment.location.stationId,
+          id: appointment.location.clinicId,
+        });
+        appointment.location.clinicName = clinic.serviceName;
       }
 
       facilityId = getVAAppointmentLocationId(appointment);

--- a/src/applications/vaos/services/healthcare-service/index.js
+++ b/src/applications/vaos/services/healthcare-service/index.js
@@ -82,6 +82,30 @@ export async function getSupportedHealthcareServicesAndLocations({
 
   return results.filter(item => item.resourceType === 'Location');
 }
+/**
+ * Fetches a single clinic based on the id provided from the v2 endpoints
+ *
+ * @export
+ * @param {Object} params
+ * @param {string} params.locationId The location or facility id of the clinic
+ * @param {string} params.id The clinic id
+ */
+export async function fetchHealthcareServiceById({ locationId, id }) {
+  try {
+    const results = await getClinics({
+      locationId,
+      clinicIds: [id],
+    });
+
+    return transformClinicsV2(results)[0];
+  } catch (e) {
+    if (e.errors) {
+      throw mapToFHIRErrors(e.errors);
+    }
+
+    throw e;
+  }
+}
 
 /**
  * Method to get the clinic id.

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -265,8 +265,14 @@ const responses = {
     });
   },
   'GET /vaos/v2/locations/:id/clinics': (req, res) => {
-    // Will need to modify this logic when we fetch specific clinics
-    // for the detail page
+    if (req.params.clinic_ids) {
+      return res.json({
+        data: clinicsV2.data.filter(clinic =>
+          req.params.clinic_ids.includes(clinic.id),
+        ),
+      });
+    }
+
     if (req.params.id === '983') {
       return res.json(clinicsV2);
     }

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -265,10 +265,10 @@ const responses = {
     });
   },
   'GET /vaos/v2/locations/:id/clinics': (req, res) => {
-    if (req.params.clinic_ids) {
+    if (req.query.clinic_ids) {
       return res.json({
         data: clinicsV2.data.filter(clinic =>
-          req.params.clinic_ids.includes(clinic.id),
+          req.query.clinic_ids.includes(clinic.id),
         ),
       });
     }

--- a/src/applications/vaos/services/patient/index.js
+++ b/src/applications/vaos/services/patient/index.js
@@ -151,6 +151,7 @@ async function fetchPatientEligibilityFromVAR({
  * @param {'direct'|'request'|null} [params.type=null] The type to check eligibility for. By default,
  *   will check both
  * }
+ * @param {boolean} [params.useV2=false] Use the v2 apis when making eligibility calls
  * @returns {PatientEligibility} Patient eligibility data
  */
 export async function fetchPatientEligibility({
@@ -309,6 +310,7 @@ function logEligibilityExplanation(
  * @param {TypeOfCare} params.typeOfCare Type of care object for the currently chosen type of care
  * @param {Location} params.location The current location to check eligibility against
  * @param {boolean} params.directSchedulingEnabled If direct scheduling is currently enabled
+ * @param {boolean} [params.useV2=false] Use the v2 apis when making eligibility calls
  * @returns {FlowEligibilityReturnData} Eligibility results, plus clinics and past appointments
  *   so that they can be cache and reused later
  */

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
@@ -27,6 +27,7 @@ import { fireEvent, waitFor } from '@testing-library/react';
 import { getICSTokens } from '../../../../utils/calendar';
 import { mockSingleVAOSAppointmentFetch } from '../../../mocks/helpers.v2';
 import { getVAOSAppointmentMock } from '../../../mocks/v2';
+import { mockSingleClinicFetchByVersion } from '../../../mocks/fetch';
 
 const initialState = {
   featureToggles: {
@@ -1047,6 +1048,7 @@ describe('VAOS <ConfirmedAppointmentDetailsPage> with VAOS service', () => {
     appointment.attributes = {
       ...appointment.attributes,
       kind: 'clinic',
+      clinic: '455',
       locationId: '983GC',
       id: '1234',
       preferredTimesForPhoneCall: ['Morning'],
@@ -1057,6 +1059,12 @@ describe('VAOS <ConfirmedAppointmentDetailsPage> with VAOS service', () => {
       status: 'booked',
     };
 
+    mockSingleClinicFetchByVersion({
+      clinicId: '455',
+      locationId: '983GC',
+      clinicName: 'Some fancy clinic name',
+      version: 2,
+    });
     mockSingleVAOSAppointmentFetch({ appointment });
 
     const facility = getVAFacilityMock();
@@ -1098,16 +1106,9 @@ describe('VAOS <ConfirmedAppointmentDetailsPage> with VAOS service', () => {
       }),
     ).to.be.ok;
 
-    await waitFor(() => {
-      expect(document.activeElement).to.have.tagName('h1');
-    });
-
-    expect(screen.baseElement).not.to.contain.text(
-      'This appointment occurred in the past.',
-    );
-
     // NOTE: This 2nd 'await' is needed due to async facilities fetch call!!!
     expect(await screen.findByText(/Cheyenne VA Medical Center/)).to.be.ok;
+    expect(await screen.findByText(/Some fancy clinic name/)).to.be.ok;
     expect(screen.getByRole('link', { name: /9 7 0. 2 2 4. 1 5 5 0./ })).to.be
       .ok;
     expect(
@@ -1129,5 +1130,9 @@ describe('VAOS <ConfirmedAppointmentDetailsPage> with VAOS service', () => {
     ).to.be.ok;
     expect(screen.getByText(/Print/)).to.be.ok;
     expect(screen.getByText(/Cancel appointment/)).to.be.ok;
+
+    expect(screen.baseElement).not.to.contain.text(
+      'This appointment occurred in the past.',
+    );
   });
 });

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
@@ -1135,7 +1135,7 @@ describe('VAOS <ConfirmedAppointmentDetailsPage> with VAOS service', () => {
       'This appointment occurred in the past.',
     );
   });
-  it('should show details without clinic name', async () => {
+  it('should show details without clinic name when clinic call fails', async () => {
     const myInitialState = {
       ...initialState,
       featureToggles: {

--- a/src/applications/vaos/tests/mocks/fetch.js
+++ b/src/applications/vaos/tests/mocks/fetch.js
@@ -4,6 +4,7 @@ import environment from 'platform/utilities/environment';
 import { setFetchJSONResponse } from 'platform/testing/unit/helpers';
 import { getVAAppointmentMock } from './v0';
 import { mockEligibilityFetches } from './helpers';
+import { getV2ClinicMock } from './v2';
 
 /**
  * Mocks the api calls for the various eligibility related fetches VAOS does in the new appointment flow
@@ -126,5 +127,45 @@ export function mockEligibilityFetchesByVersion({
       clinics,
       pastClinics,
     });
+  }
+}
+
+/**
+ * Fetches a single clinic with the given values
+ *
+ * @export
+ * @param {Object} params
+ * @param {string} params.locationId The full location id (sta6aid) of the clinic,
+ * @param {string} params.clinicId The id of the clinic to return,
+ * @param {string} params.clinicName The name of the clinic to return,
+ * @param {number} [params.version=2] Version of the api to use, only 2 is supported,
+ *   version = 2,
+ * }
+ */
+export function mockSingleClinicFetchByVersion({
+  locationId,
+  clinicId,
+  clinicName,
+  version = 2,
+}) {
+  if (version === 2) {
+    setFetchJSONResponse(
+      global.fetch.withArgs(
+        `${
+          environment.API_URL
+        }/vaos/v2/locations/${locationId}/clinics?clinic_ids%5B%5D=${clinicId}`,
+      ),
+      {
+        data: [
+          getV2ClinicMock({
+            id: clinicId,
+            serviceName: clinicName,
+            stationId: locationId,
+          }),
+        ],
+      },
+    );
+  } else {
+    throw new Error('This should only be used with v2 endpoints');
   }
 }


### PR DESCRIPTION
## Description
This PR
- Adds a fetch to the vaos service clinics endpoint
- Sets clinic name from the fetched clinic data, since we don't have that on appointments from vaos service
- Adds tests for both scenarios, where we successfully and unsuccessfully fetch clinic details

## Original issue(s)
department-of-veterans-affairs/va.gov-team#27642

## Testing done
Unit and local testing

## Acceptance criteria
- [ ] Clinic is fetched

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
