### PR TITLE
Add contact page tracking events

### DIFF
--- a/src/applications/vaos/new-appointment/components/ContactInfoPage.jsx
+++ b/src/applications/vaos/new-appointment/components/ContactInfoPage.jsx
@@ -69,16 +69,21 @@ function recordPopulatedEvents(email, phone) {
 }
 
 function recordChangedEvents(email, phone, data) {
-  recordEvent({
-    event: `${GA_PREFIX}-contact-info-email-${
-      email !== data.email ? 'changed' : 'not-changed'
-    }`,
-  });
-  recordEvent({
-    event: `${GA_PREFIX}-contact-info-phone-${
-      phone !== data.phoneNumber ? 'changed' : 'not-changed'
-    }`,
-  });
+  if (email) {
+    recordEvent({
+      event: `${GA_PREFIX}-contact-info-email-${
+        email !== data.email ? 'changed' : 'not-changed'
+      }`,
+    });
+  }
+
+  if (phone) {
+    recordEvent({
+      event: `${GA_PREFIX}-contact-info-phone-${
+        phone !== data.phoneNumber ? 'changed' : 'not-changed'
+      }`,
+    });
+  }
 }
 
 const phoneConfig = phoneUI('Your phone number');

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -811,6 +811,16 @@ export function submitAppointmentOrRequest(history) {
         };
       }
 
+      additionalEventData = {
+        ...additionalEventData,
+        'vaos-preferred-combination': Object.entries(data.bestTimeToCall || {})
+          .filter(item => item[1])
+          .map(item => item[0])
+          .sort()
+          .join('-')
+          .toLowerCase(),
+      };
+
       recordEvent({
         event: `${GA_PREFIX}-${eventType}-submission`,
         flow,

--- a/src/applications/vaos/tests/new-appointment/components/ContactInfoPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ContactInfoPage.unit.spec.jsx
@@ -8,7 +8,7 @@ import { cleanup, fireEvent, waitFor } from '@testing-library/react';
 import { FLOW_TYPES } from '../../../utils/constants';
 
 describe('VAOS <ContactInfoPage>', () => {
-  it('should submit with valid data', async () => {
+  it('should accept email, phone, and preferred time and continue', async () => {
     const store = createTestStore({
       user: {
         profile: {
@@ -40,6 +40,12 @@ describe('VAOS <ContactInfoPage>', () => {
     await waitFor(() => {
       expect(screen.history.push.called).to.be.true;
     });
+    expect(window.dataLayer).to.deep.include({
+      event: 'vaos-contact-info-email-not-populated',
+    });
+    expect(window.dataLayer).to.deep.include({
+      event: 'vaos-contact-info-phone-not-populated',
+    });
 
     // Expect the previously entered form data is still there if you unmount and remount the page with the same store,
     await cleanup();
@@ -57,7 +63,7 @@ describe('VAOS <ContactInfoPage>', () => {
     expect(input.value).to.equal('joe.blow@gmail.com');
   });
 
-  it('should not submit empty form', async () => {
+  it('should show validation errors for email and phone', async () => {
     let store = createTestStore();
 
     // Get default state.
@@ -88,7 +94,7 @@ describe('VAOS <ContactInfoPage>', () => {
     expect(screen.history.push.called).to.be.false;
   });
 
-  it('should prepopulate VA Profile info', async () => {
+  it('should prepopulate email and phone from VA Profile', async () => {
     const store = createTestStore({
       user: {
         profile: {
@@ -113,9 +119,30 @@ describe('VAOS <ContactInfoPage>', () => {
     await screen.findByText(/^Continue/);
     expect(screen.getByLabelText(/phone number/i).value).to.equal('5555555559');
     expect(screen.getByLabelText(/email/i).value).to.equal('test@va.gov');
+    expect(window.dataLayer).to.deep.include({
+      event: 'vaos-contact-info-email-populated',
+    });
+    expect(window.dataLayer).to.deep.include({
+      event: 'vaos-contact-info-phone-populated',
+    });
+
+    userEvent.click(screen.getByLabelText(/^Morning \(8:00 a.m. – noon\)/));
+
+    userEvent.click(screen.getByText(/^Continue/));
+
+    await waitFor(() => {
+      expect(screen.history.push.called).to.be.true;
+    });
+
+    expect(window.dataLayer).to.deep.include({
+      event: 'vaos-contact-info-email-not-changed',
+    });
+    expect(window.dataLayer).to.deep.include({
+      event: 'vaos-contact-info-phone-not-changed',
+    });
   });
 
-  it('should not display "best time to call" for direct schedule appointment', async () => {
+  it('when in direct schedule flow, should not show preferred time field', async () => {
     let store = createTestStore();
 
     // Get default state.

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.cc-request.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.cc-request.unit.spec.jsx
@@ -206,6 +206,7 @@ describe('VAOS <ReviewPage> CC request', () => {
       'health-ReasonForAppointment': undefined,
       'vaos-number-of-preferred-providers': 1,
       'vaos-community-care-preferred-language': 'english',
+      'vaos-preferred-combination': 'afternoon-evening-morning',
       flow: 'cc-request',
     });
   });

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.va-request.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.va-request.unit.spec.jsx
@@ -201,12 +201,14 @@ describe('VAOS <ReviewPage> VA request', () => {
       event: 'vaos-request-submission',
       'health-TypeOfCare': 'Primary care',
       'health-ReasonForAppointment': 'routine-follow-up',
+      'vaos-preferred-combination': 'afternoon-evening-morning',
       flow: 'va-request',
     });
     expect(dataLayer[2]).to.deep.equal({
       event: 'vaos-request-submission-successful',
       'health-TypeOfCare': 'Primary care',
       'health-ReasonForAppointment': 'routine-follow-up',
+      'vaos-preferred-combination': 'afternoon-evening-morning',
       flow: 'va-request',
     });
     expect(dataLayer[3]).to.deep.equal({
@@ -264,6 +266,7 @@ describe('VAOS <ReviewPage> VA request', () => {
       flow: 'va-request',
       'health-TypeOfCare': 'Primary care',
       'health-ReasonForAppointment': 'routine-follow-up',
+      'vaos-preferred-combination': 'afternoon-evening-morning',
     });
     expect(global.window.dataLayer[3]).to.deep.equal({
       flow: undefined,


### PR DESCRIPTION
## Description
This PR
- Adds events to track whether email and phone are prepopulated
- Adds events to track whether email and phone are changed from their prepopulated values
- Adds value to submit event to track preferred times to call choice

## Original issue(s)
department-of-veterans-affairs/va.gov-team#27455

## Testing done
Unit testing

## Acceptance criteria
- [ ] Events are correctly tracked

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
