### PR TITLE
Fetch valid appointment statuses from vaos service

### DIFF
--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -27,7 +27,7 @@ import {
 } from '../../services/location';
 
 import {
-  getBookedAppointments,
+  fetchAppointments,
   getAppointmentRequests,
   getVAAppointmentLocationId,
   isVideoHome,
@@ -186,7 +186,7 @@ export function fetchFutureAppointments({ includeRequests = true } = {}) {
        * will be filtered out by date accordingly in our selectors
        */
       const promises = [
-        getBookedAppointments({
+        fetchAppointments({
           startDate: featureHomepageRefresh
             ? moment()
                 .subtract(30, 'days')
@@ -393,7 +393,7 @@ export function fetchPastAppointments(startDate, endDate, selectedIndex) {
 
     try {
       const fetches = [
-        getBookedAppointments({
+        fetchAppointments({
           startDate,
           endDate,
           useV2VA: featureVAOSServiceVAAppointments,

--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -117,7 +117,7 @@ function hasPartialResults(response) {
  * @param {Boolean} useV2CC Toggle fetching CC appointments via VAOS api services version 2
  * @returns {Appointment[]} A FHIR searchset of booked Appointment resources
  */
-export async function getBookedAppointments({
+export async function fetchAppointments({
   startDate,
   endDate,
   useV2VA = false,
@@ -128,6 +128,8 @@ export async function getBookedAppointments({
     if (useV2VA || useV2CC) {
       const allAppointments = await getAppointments(startDate, endDate, [
         'booked',
+        'arrived',
+        'fulfilled',
         'cancelled',
       ]);
 

--- a/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
@@ -614,7 +614,7 @@ describe('VAOS <CommunityCareAppointmentDetailsPage> with VAOS service', () => {
       start,
       end,
       requests: [appointment],
-      statuses: ['booked', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
     });
 
     mockSingleVAOSAppointmentFetch({ appointment });

--- a/src/applications/vaos/tests/appointment-list/components/PastAppointmentsListV2.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/PastAppointmentsListV2.unit.spec.jsx
@@ -284,7 +284,7 @@ describe('VAOS <PastAppointmentsListV2>', () => {
       start: start.format('YYYY-MM-DDTHH:mm:ssZ'),
       end: end.format('YYYY-MM-DDTHH:mm:ssZ'),
       requests: [appointment],
-      statuses: ['booked', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
     });
 
     const myInitialState = {

--- a/src/applications/vaos/tests/appointment-list/components/UpcomingAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/UpcomingAppointmentsList.unit.spec.jsx
@@ -620,7 +620,7 @@ describe('VAOS <UpcomingAppointmentsList> V2 api', () => {
       start: start.format('YYYY-MM-DD'),
       end: end.format('YYYY-MM-DD'),
       requests: [appointment],
-      statuses: ['booked', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
     });
 
     mockFacilitiesFetch();
@@ -659,7 +659,7 @@ describe('VAOS <UpcomingAppointmentsList> V2 api', () => {
       start: start.format('YYYY-MM-DD'),
       end: end.format('YYYY-MM-DD'),
       requests: [appointment],
-      statuses: ['booked', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
     });
 
     mockFacilitiesFetch();
@@ -698,7 +698,7 @@ describe('VAOS <UpcomingAppointmentsList> V2 api', () => {
       start: start.format('YYYY-MM-DD'),
       end: end.format('YYYY-MM-DD'),
       requests: [appointment],
-      statuses: ['booked', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
     });
 
     mockFacilitiesFetch();
@@ -737,7 +737,7 @@ describe('VAOS <UpcomingAppointmentsList> V2 api', () => {
       start: start.format('YYYY-MM-DD'),
       end: end.format('YYYY-MM-DD'),
       requests: [appointment],
-      statuses: ['booked', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
     });
 
     mockFacilitiesFetch();
@@ -776,7 +776,7 @@ describe('VAOS <UpcomingAppointmentsList> V2 api', () => {
       start: start.format('YYYY-MM-DD'),
       end: end.format('YYYY-MM-DD'),
       requests: [appointment],
-      statuses: ['booked', 'cancelled'],
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
     });
 
     mockFacilitiesFetch();

--- a/src/applications/vaos/tests/services/appointment/index.unit.spec.js
+++ b/src/applications/vaos/tests/services/appointment/index.unit.spec.js
@@ -9,7 +9,7 @@ import {
 import {
   isUpcomingAppointmentOrRequest,
   isValidPastAppointment,
-  getBookedAppointments,
+  fetchAppointments,
   getAppointmentRequests,
   FUTURE_APPOINTMENTS_HIDDEN_SET,
 } from '../../../services/appointment';
@@ -24,7 +24,7 @@ import {
 const now = moment();
 
 describe('VAOS Appointment service', () => {
-  describe('getBookedAppointments', () => {
+  describe('fetchAppointments', () => {
     it('should make successful request', async () => {
       mockFetch();
       setFetchJSONResponse(global.fetch, confirmed);
@@ -32,7 +32,7 @@ describe('VAOS Appointment service', () => {
       const startDate = '2020-05-01';
       const endDate = '2020-06-30';
 
-      const data = await getBookedAppointments({
+      const data = await fetchAppointments({
         startDate,
         endDate,
       });
@@ -60,7 +60,7 @@ describe('VAOS Appointment service', () => {
 
       let error;
       try {
-        await getBookedAppointments({
+        await fetchAppointments({
           startDate,
           endDate,
         });


### PR DESCRIPTION
## Description
This PR
- Updates the fetch we do for appointments to include arrived and fulfilled, so we can see past appointments
- Updates the name of the appointments fetch function, so that it doesn't assume that we're only fetching booked appointments, since that term means something different than how we were using it

## Original issue(s)
department-of-veterans-affairs/va.gov-team#28282

## Testing done
Unit testing

## Acceptance criteria
- [ ] More appointment types show up

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
