### PR TITLE
Remove new label from covid type of care

### DIFF
--- a/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
@@ -59,16 +59,6 @@ export default function TypeOfCarePage() {
           careA.name.toLowerCase() > careB.name.toLowerCase() ? 1 : -1,
       );
 
-      const covidLabel = (
-        <>
-          <span className="sr-only">New type of care</span>
-          COVID-19 vaccine
-          <span className="usa-label vads-u-margin-left--1" aria-hidden="true">
-            New
-          </span>
-        </>
-      );
-
       return {
         type: 'object',
         required: ['typeOfCareId'],
@@ -76,12 +66,7 @@ export default function TypeOfCarePage() {
           typeOfCareId: {
             type: 'string',
             enum: sortedCare.map(care => care.id || care.ccId),
-            enumNames: sortedCare.map(care => {
-              if (care.id === 'covid') {
-                return covidLabel;
-              }
-              return care.label || care.name;
-            }),
+            enumNames: sortedCare.map(care => care.label || care.name),
           },
         },
       };

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfCarePage.unit.spec.jsx
@@ -384,7 +384,6 @@ describe('VAOS <TypeOfCarePage>', () => {
 
     expect((await screen.findAllByRole('radio')).length).to.equal(12);
     fireEvent.click(await screen.findByLabelText(/COVID-19 vaccine/i));
-    expect(screen.queryAllByText(/NEW/i).length).to.equal(2);
 
     fireEvent.click(screen.getByText(/Continue/));
     await waitFor(() =>


### PR DESCRIPTION
## Description
This PR removes the `NEW` label from covid type of care.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#26063


## Testing done
- local, unit testing

## Screenshots
<img width="768" alt="Screen Shot 2021-08-04 at 11 09 57 AM" src="https://user-images.githubusercontent.com/9746156/128232489-237d4b58-0b98-4689-bb1f-0e3876a450c3.png">

## Acceptance criteria
- [x] On the type of care page, the "new" label does **not** appear next to the COVID-19 vaccine 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
