### PR TITLE
Remove babel-core dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,6 @@
     "append-query": "2.0.1",
     "autoprefixer": "^9.5.1",
     "axe-core": "^4.1.3",
-    "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^23.4.2",
     "babel-loader": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3461,11 +3461,6 @@ babel-core@^6.0.0, babel-core@^6.26.0:
     slash "^1.0.0"
     source-map "^0.5.7"
 
-babel-core@^7.0.0-bridge.0:
-  version "7.0.0-bridge.0"
-  resolved "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz"
-  integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
-
 babel-eslint@^10.1.0:
   version "10.1.0"
   resolved "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz"


### PR DESCRIPTION
## Description
`babel-core` version 6 was replaced by `@babel/core` version 7. `babel-core` is no longer needed

## Related ticket
https://github.com/department-of-veterans-affairs/va.gov-team/issues/27348

## Testing done
Locally

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
