### PR TITLE
Fix Max Year in Invalid Past Date Error Message; Remove Leading Zeros

### DIFF
--- a/src/platform/forms-system/src/js/helpers.js
+++ b/src/platform/forms-system/src/js/helpers.js
@@ -8,6 +8,7 @@ export const minYear = 1900;
 export const maxYear = moment()
   .add(100, 'year')
   .year();
+export const currentYear = moment().year();
 
 // An active page is one that will be shown to the user.
 // Pages become inactive if they are conditionally shown based
@@ -145,6 +146,7 @@ export function formatReviewDate(dateString, monthYear = false) {
 
   return undefined;
 }
+
 export function parseISODate(dateString) {
   if (typeof dateString === 'string') {
     const [year, month, day] = dateString.split('-', 3);
@@ -152,7 +154,7 @@ export function parseISODate(dateString) {
     return {
       month: month === 'XX' ? '' : Number(month).toString(),
       day: day === 'XX' ? '' : Number(day).toString(),
-      year: year === 'XXXX' ? '' : year,
+      year: year === 'XXXX' ? '' : Number(year).toString(),
     };
   }
 

--- a/src/platform/forms-system/src/js/utilities/validations/index.js
+++ b/src/platform/forms-system/src/js/utilities/validations/index.js
@@ -33,8 +33,8 @@ export function isValidSSN(value) {
   return /^\d{9}$/.test(value) || /^\d{3}-\d{2}-\d{4}$/.test(value);
 }
 
-export function isValidYear(value) {
-  return Number(value) >= minYear && Number(value) <= maxYear;
+export function isValidYear(value, maxValidYear = maxYear) {
+  return Number(value) >= minYear && Number(value) <= maxValidYear;
 }
 
 export function isValidPartialDate(day, month, year) {

--- a/src/platform/forms-system/src/js/validation.js
+++ b/src/platform/forms-system/src/js/validation.js
@@ -1,7 +1,14 @@
 import _ from 'lodash/fp'; // eslint-disable-line no-restricted-imports
 import { Validator } from 'jsonschema';
 
-import { isActivePage, parseISODate, minYear, maxYear } from './helpers';
+import {
+  isActivePage,
+  parseISODate,
+  minYear,
+  maxYear,
+  currentYear,
+} from './helpers';
+
 import {
   isValidSSN,
   isValidYear,
@@ -338,10 +345,12 @@ export function validateSSN(errors, ssn) {
   }
 }
 
-export function validateDate(errors, dateString) {
+export function validateDate(errors, dateString, maxValidYear = maxYear) {
   const { day, month, year } = parseISODate(dateString);
-  if (year?.length >= 4 && !isValidYear(year)) {
-    errors.addError(`Please enter a year between ${minYear} and ${maxYear}`);
+  if (year?.length >= 4 && !isValidYear(year, maxValidYear)) {
+    errors.addError(
+      `Please enter a year between ${minYear} and ${maxValidYear}`,
+    );
   } else if (!isValidPartialDate(day, month, year)) {
     errors.addError('Please provide a valid date');
   }
@@ -369,7 +378,7 @@ export function validateCurrentOrPastDate(
   const {
     futureDate = 'Please provide a valid current or past date',
   } = errorMessages;
-  validateDate(errors, dateString);
+  validateDate(errors, dateString, currentYear);
   const { day, month, year } = parseISODate(dateString);
   if (!isValidCurrentOrPastDate(day, month, year)) {
     errors.addError(futureDate);


### PR DESCRIPTION
## Description
Fix Max Year in Invalid Past Date Error Message; Remove Leading Zeros

## Original issue(s)


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
