### PR TITLE
Replace v0 reference

### DIFF
--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -24,12 +24,13 @@ export const ssoKeepAliveEndpoint = () => {
   return `https://${envPrefix}eauth.va.gov/keepalive`;
 };
 
-export function sessionTypeUrl(type = '', version = 'v1', queryParams = {}) {
-  const base =
-    version === 'v1'
-      ? `${environment.API_URL}/v1/sessions`
-      : `${environment.API_URL}/sessions`;
-
+export function sessionTypeUrl({
+  type = '',
+  version = 'v1',
+  queryParams = {},
+}) {
+  // force v1 regardless of version
+  const base = `${environment.API_URL}/${version}/sessions`.replace(/v0/, 'v1');
   const searchParams = new URLSearchParams(queryParams);
 
   const queryString =
@@ -106,17 +107,23 @@ export function login(
   queryParams = {},
   clickedEvent = 'login-link-clicked-modal',
 ) {
-  const url = sessionTypeUrl(policy, version, queryParams);
+  const url = sessionTypeUrl({ type: policy, version, queryParams });
   setLoginAttempted();
   return redirect(url, clickedEvent);
 }
 
 export function mfa(version = 'v1') {
-  return redirect(sessionTypeUrl('mfa', version), 'multifactor-link-clicked');
+  return redirect(
+    sessionTypeUrl({ type: 'mfa', version }),
+    'multifactor-link-clicked',
+  );
 }
 
 export function verify(version = 'v1') {
-  return redirect(sessionTypeUrl('verify', version), 'verify-link-clicked');
+  return redirect(
+    sessionTypeUrl({ type: 'verify', version }),
+    'verify-link-clicked',
+  );
 }
 
 export function logout(
@@ -125,9 +132,15 @@ export function logout(
   queryParams = {},
 ) {
   clearSentryLoginType();
-  return redirect(sessionTypeUrl('slo', version, queryParams), clickedEvent);
+  return redirect(
+    sessionTypeUrl({ type: 'slo', version, queryParams }),
+    clickedEvent,
+  );
 }
 
 export function signup(version = 'v1') {
-  return redirect(sessionTypeUrl('signup', version), 'register-link-clicked');
+  return redirect(
+    sessionTypeUrl({ type: 'signup', version }),
+    'register-link-clicked',
+  );
 }

--- a/src/platform/user/tests/authentication/utilities.unit.spec.js
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.js
@@ -24,8 +24,8 @@ const setup = () => {
 describe('authentication URL helpers', () => {
   beforeEach(setup);
 
-  it('should redirect for signup', () => {
-    signup();
+  it('should redirect for signup v0 to v1', () => {
+    signup('v0');
     expect(global.window.location).to.include('/v1/sessions/signup/new');
   });
 
@@ -34,8 +34,8 @@ describe('authentication URL helpers', () => {
     expect(global.window.location).to.include('/v1/sessions/signup/new');
   });
 
-  it('should redirect for login', () => {
-    login('idme');
+  it('should redirect for login v0 to v1', () => {
+    login('idme', 'v0');
     expect(global.window.location).to.include('/v1/sessions/idme/new');
   });
 
@@ -51,7 +51,7 @@ describe('authentication URL helpers', () => {
   });
 
   it('should redirect for logout', () => {
-    logout();
+    logout('v0');
     expect(global.window.location).to.include('/v1/sessions/slo/new');
   });
 
@@ -66,8 +66,8 @@ describe('authentication URL helpers', () => {
     expect(global.window.dataLayer[0].event).to.eq('custom-event');
   });
 
-  it('should redirect for MFA', () => {
-    mfa();
+  it('should redirect for MFA v0 to v1', () => {
+    mfa('v0');
     expect(global.window.location).to.include('/v1/sessions/mfa/new');
   });
 
@@ -76,8 +76,8 @@ describe('authentication URL helpers', () => {
     expect(global.window.location).to.include('/v1/sessions/mfa/new');
   });
 
-  it('should redirect for verify', () => {
-    verify();
+  it('should redirect for verify v0 to v1', () => {
+    verify('v0');
     expect(global.window.location).to.include('/v1/sessions/verify/new');
   });
 


### PR DESCRIPTION
## Description
The VSP Identity team is still seeing authentication on the v0 endpoints.  This PR refactors forces upgrades from v0 to v1 because the ssoe flag is set to 100%.

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#28347


## Testing done
Unit test

## Screenshots
n/a

## Acceptance criteria
- [x] v0 sign-ins are upgraded to v1 authentications

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
