### PR TITLE
try specifying branch

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -638,6 +638,7 @@ jobs:
           github_token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
           repository: department-of-veterans-affairs/testing-reports
           directory: testing-reports
+          branch: master
 
       # -------------------------
       # | Cypress Tests Summary |


### PR DESCRIPTION
## Description
This PR fixes the errors we've been seeing with pushing to `testing-reports`.  The action that handles commit and push updated itself to have a default branch of "main" instead of "master" which was breaking our pushes.  I've now explicitly declared "master" instead of crutching on the default and it appears to be working.

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
