### PR TITLE
Remove lodash/fp from gi app

### DIFF
--- a/src/applications/gi/tests/selectors/calculator.unit.spec.js
+++ b/src/applications/gi/tests/selectors/calculator.unit.spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { set } from 'lodash/fp';
+import set from 'platform/utilities/data/set';
 
 import { getCalculatedBenefits } from '../../selectors/calculator';
 import { formatCurrency } from '../../utils/helpers';

--- a/src/applications/gi/tests/selectors/estimator.unit.spec.js
+++ b/src/applications/gi/tests/selectors/estimator.unit.spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { set } from 'lodash/fp';
+import set from 'platform/utilities/data/set';
 
 import { estimatedBenefits } from '../../selectors/estimator';
 import { getDefaultState } from '../helpers';

--- a/src/applications/gi/tests/selectors/vetTecCalculator.unit.spec.js
+++ b/src/applications/gi/tests/selectors/vetTecCalculator.unit.spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { set } from 'lodash/fp';
+import set from 'platform/utilities/data/set';
 
 import { getCalculatedBenefits } from '../../selectors/vetTecCalculator';
 import { getDefaultState } from '../helpers';


### PR DESCRIPTION
## Description
This PR removes `lodash/fp` from the gi application. This is part of the effort to remove `lodash/fp` from the repo.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#1678


## Testing done
Ran unit tests locally and in CI.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
