### PR TITLE
Remove lodash/fp from facility-locator

### DIFF
--- a/src/applications/facility-locator/tests/components/search-results/LocationDirectionsLink.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-results/LocationDirectionsLink.unit.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from 'lodash/fp';
+import _ from 'lodash';
 import { shallow } from 'enzyme';
 import LocationDirectionsLink from '../../../components/search-results-items/common/LocationDirectionsLink';
 import { expect } from 'chai';
@@ -18,7 +18,7 @@ const verifyLink = data => {
   );
 
   const anchorProps = wrapper.find('a').props();
-  const testProps = _.pick(['href', 'rel', 'target'], anchorProps);
+  const testProps = _.pick(anchorProps, ['href', 'rel', 'target']);
 
   expect(testProps).to.eql({
     href:


### PR DESCRIPTION
## Description
This PR removes lodash/fp from the facility-locator application. This is part of the effort to remove lodash/fp from the repo.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#1678


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
