### PR TITLE
Remove leaflet-control-geocoder dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -294,7 +294,6 @@
     "js-cookie": "^2.2.1",
     "jsonschema": "^1.1.1",
     "leaflet": "^1.6.0",
-    "leaflet-control-geocoder": "^1.13.0",
     "libxmljs2": "^0.27.0",
     "local-storage-fallback": "^4.1.1",
     "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11800,13 +11800,6 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
-leaflet-control-geocoder@^1.13.0:
-  version "1.13.0"
-  resolved "https://registry.npmjs.org/leaflet-control-geocoder/-/leaflet-control-geocoder-1.13.0.tgz"
-  integrity sha512-mgYGx/2WA5CcvhP+IJtw7VvJwSGAe5zxX+TKe6ruYkLj2W5I5V/K/nQiLvsUtqifBojBGoKIPNZ8m0mXJNIudg==
-  optionalDependencies:
-    open-location-code "^1.0.0"
-
 leaflet@^1.6.0:
   version "1.6.0"
   resolved "https://registry.npmjs.org/leaflet/-/leaflet-1.6.0.tgz"
@@ -14215,11 +14208,6 @@ onetime@^5.1.0, onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
-
-open-location-code@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/open-location-code/-/open-location-code-1.0.3.tgz"
-  integrity sha1-XqGjTuUiHGyvoEOS4b2Qb9dIj34=
 
 open@^6.3.0:
   version "6.4.0"


### PR DESCRIPTION
## Description
`leaflet-control-geocoder` is a simple geocoder for `Leafter` but it doesn't seem to be used at all

## Original issue(s)
department-of-veterans-affairs/va.gov-team#27348


## Testing done
Locally

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
