### PR TITLE
Remove polyfill-function-prototype-bind dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -221,7 +221,6 @@
     "node-sass": "^4.14.1",
     "null-loader": "^0.1.1",
     "nyc": "^15.1.0",
-    "polyfill-function-prototype-bind": "0.0.1",
     "postcss-loader": "^3.0.0",
     "prettier": "^1.14.3",
     "puppeteer": "^3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15050,11 +15050,6 @@ pngjs@~2.2.0:
   resolved "https://registry.npmjs.org/pngjs/-/pngjs-2.2.0.tgz"
   integrity sha1-ZJZjYJoOurh8jwiz/nJASLUdnX8=
 
-polyfill-function-prototype-bind@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.npmjs.org/polyfill-function-prototype-bind/-/polyfill-function-prototype-bind-0.0.1.tgz"
-  integrity sha1-UGfaWLMHLK4mHdQYTRUf2kzdeOA=
-
 popsicle@^9.2.0:
   version "9.2.0"
   resolved "https://registry.npmjs.org/popsicle/-/popsicle-9.2.0.tgz"


### PR DESCRIPTION
## Description
Remove an unused dependency. This dependency has not being maintained for over 7 years and still at a version 0.0.1

## Original issue(s)
department-of-veterans-affairs/va.gov-team#27348


## Testing done
Locally

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
