### PR TITLE
Remove quick_check dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -224,7 +224,6 @@
     "postcss-loader": "^3.0.0",
     "prettier": "^1.14.3",
     "puppeteer": "^3.3.0",
-    "quick_check": "^0.7.0",
     "react-test-renderer": "^16.13.1",
     "recursive-uncache": "^0.1.1",
     "request": "^2.88.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15856,11 +15856,6 @@ quick-lru@^4.0.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
-quick_check@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.npmjs.org/quick_check/-/quick_check-0.7.0.tgz"
-  integrity sha1-cv3lWcz/StkCkslhg+nkuLrm0BQ=
-
 quickselect@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz"


### PR DESCRIPTION
## Description
Remove an unused dependency. This dependency has not being maintained for over 5 years 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#27348


## Testing done
Locally

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
