### PR TITLE
Upgrade Downshift under an alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -290,6 +290,7 @@
     "dotenv": "^10.0.0",
     "downloadjs": "^1.4.7",
     "downshift": "^1.22.5",
+    "downshift-next": "npm:downshift@1.27.0",
     "express": "^4.17.1",
     "fast-levenshtein": "^2.0.6",
     "fine-uploader": "^5.16.2",

--- a/package.json
+++ b/package.json
@@ -289,7 +289,7 @@
     "date-fns": "^2.17.0",
     "dotenv": "^10.0.0",
     "downloadjs": "^1.4.7",
-    "downshift": "^1.22.5",
+    "downshift": "1.22.5",
     "downshift-next": "npm:downshift@1.27.0",
     "express": "^4.17.1",
     "fast-levenshtein": "^2.0.6",

--- a/src/applications/facility-locator/components/ServiceTypeAhead.jsx
+++ b/src/applications/facility-locator/components/ServiceTypeAhead.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import Downshift from 'downshift';
+import Downshift from 'downshift-next';
 import { getProviderSpecialties } from '../actions';
 import classNames from 'classnames';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6623,9 +6623,15 @@ downloadjs@^1.4.7:
   resolved "https://registry.npmjs.org/downloadjs/-/downloadjs-1.4.7.tgz"
   integrity sha1-9p+W+UDg0FU9rCkROYZaPNAQHjw=
 
+"downshift-next@npm:downshift@1.27.0":
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-1.27.0.tgz#e04987a6ee37c99772e76febad0955f874dd0696"
+  integrity sha512-y4f7+pKOgL6bi5jf2ut1KF4X79DFTLFCayHjdn4KOa4C6C1anxotVWFoLVRBgLlqOR/WtekDJ7rjOTCxsZdPgw==
+
 downshift@^1.22.5:
-  version "1.22.5"
-  resolved "https://registry.npmjs.org/downshift/-/downshift-1.22.5.tgz"
+  version "1.31.16"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-1.31.16.tgz#acd81631539502d4112d01bd573654419fd9f640"
+  integrity sha512-RskXmiGSoz0EHAyBrmTBGSLHg6+NYDGuLu2W3GpmuOe6hmZEWhCiQrq5g6DWzhnUaJD41xHbbfC6j1Fe86YqgA==
 
 duplexer2@^0.1.2, duplexer2@~0.1.0, duplexer2@~0.1.2, duplexer2@~0.1.4:
   version "0.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6628,10 +6628,10 @@ downloadjs@^1.4.7:
   resolved "https://registry.yarnpkg.com/downshift/-/downshift-1.27.0.tgz#e04987a6ee37c99772e76febad0955f874dd0696"
   integrity sha512-y4f7+pKOgL6bi5jf2ut1KF4X79DFTLFCayHjdn4KOa4C6C1anxotVWFoLVRBgLlqOR/WtekDJ7rjOTCxsZdPgw==
 
-downshift@^1.22.5:
-  version "1.31.16"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-1.31.16.tgz#acd81631539502d4112d01bd573654419fd9f640"
-  integrity sha512-RskXmiGSoz0EHAyBrmTBGSLHg6+NYDGuLu2W3GpmuOe6hmZEWhCiQrq5g6DWzhnUaJD41xHbbfC6j1Fe86YqgA==
+downshift@1.22.5:
+  version "1.22.5"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-1.22.5.tgz#48103b2f80259157b01b96d6bdc344c51ce0743e"
+  integrity sha512-33eMUva26B2UNS7LgtXN4khwq+ODq0j7RqM5DUb2sj45Cfd/emwsKP11jQeZrETxfgN7Kawjisf90aQdu2Ftpw==
 
 duplexer2@^0.1.2, duplexer2@~0.1.0, duplexer2@~0.1.2, duplexer2@~0.1.4:
   version "0.1.4"


### PR DESCRIPTION
## Description
This PR includes discovery work done to determine if it is reasonable to upgrade Downshift.

It is concluded that the best course of action would be to upgrade Downshift to a version that does not cause any issues with the Facility Locator (FL). That version is found to be `1.27.0`.This upgrade would be made under an alias so that we do not disturb the current global version of Downshift. In this way, we could import that updated version within the FL files only.

Manual testing **must** be done to verify that there are no changes in behavior within FL.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/28359

## Acceptance criteria
- [ ] When searching for Community Providers and typing in an acceptable service type, search results should display with no issues. Overall, there should be no changes in behavior within FL.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
