### PR TITLE
Upgraded Downshift under an alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -282,6 +282,7 @@
     "dotenv": "^10.0.0",
     "downloadjs": "^1.4.7",
     "downshift": "^1.22.5",
+    "downshift-next": "npm:downshift@1.27.0",
     "express": "^4.17.1",
     "fast-levenshtein": "^2.0.6",
     "fine-uploader": "^5.16.2",

--- a/src/applications/facility-locator/components/ServiceTypeAhead.jsx
+++ b/src/applications/facility-locator/components/ServiceTypeAhead.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import Downshift from 'downshift';
+import Downshift from 'downshift-next';
 import { getProviderSpecialties } from '../actions';
 import classNames from 'classnames';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6598,6 +6598,11 @@ downloadjs@^1.4.7:
   resolved "https://registry.npmjs.org/downloadjs/-/downloadjs-1.4.7.tgz"
   integrity sha1-9p+W+UDg0FU9rCkROYZaPNAQHjw=
 
+"downshift-next@npm:downshift@1.27.0":
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-1.27.0.tgz#e04987a6ee37c99772e76febad0955f874dd0696"
+  integrity sha512-y4f7+pKOgL6bi5jf2ut1KF4X79DFTLFCayHjdn4KOa4C6C1anxotVWFoLVRBgLlqOR/WtekDJ7rjOTCxsZdPgw==
+
 downshift@^1.22.5:
   version "1.22.5"
   resolved "https://registry.npmjs.org/downshift/-/downshift-1.22.5.tgz"


### PR DESCRIPTION
## Description
This PR includes discovery work done to determine if it is reasonable to upgrade Downshift.

It is concluded that the best course of action would be to upgrade Downshift to a version that does not cause any issues with the Facility Locator (FL). That version is found to be `1.27.0`. This upgrade would be made under an alias so that we do not disturb the current global version of Downshift. In this way, we could import that updated version within the FL files only.

Manual testing must be done to verify that there are no changes in behavior within FL.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#28359

## Acceptance criteria
- [ ] When searching for Community Providers and typing in an acceptable service type, search results should display with no issues. Overall, there should be no changes in behavior within FL.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
