### PR TITLE
HLR: Add contact profile editing

### DIFF
--- a/src/applications/disability-benefits/996/components/ContactInformation.jsx
+++ b/src/applications/disability-benefits/996/components/ContactInformation.jsx
@@ -1,70 +1,162 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
+import InitializeVAPServiceID from '@@vap-svc/containers/InitializeVAPServiceID';
+import VAPServicePendingTransactionCategory from '@@vap-svc/containers/VAPServicePendingTransactionCategory';
+import PhoneField from '@@vap-svc/components/PhoneField/PhoneField';
+import EmailField from '@@vap-svc/components/EmailField/EmailField';
+import AddressField from '@@vap-svc/components/AddressField/AddressField';
+import { TRANSACTION_CATEGORY_TYPES, FIELD_NAMES } from '@@vap-svc/constants';
 
 import { selectProfile } from 'platform/user/selectors';
-import { formatAddress } from 'platform/forms/address/helpers';
 
-import { PROFILE_URL } from '../constants';
+import { readableList } from '../utils/helpers';
 
-const addBrAfter = line => line && [line, <br key={line} />];
+export const ContactInfoDescription = ({ formContext, profile }) => {
+  const [hadError, setHadError] = useState(false);
+  const { email = {}, mobilePhone = {}, mailingAddress = {} } =
+    profile?.vapContactInfo || {};
+  const { submitted } = formContext || {};
 
-export const ContactInfoDescription = ({ profile }) => {
-  const { email, homePhone, mailingAddress } = profile?.vapContactInfo || {};
-  const { street, cityStateZip, country } = formatAddress(mailingAddress || {});
-  const phone = `${homePhone?.areaCode || ''}${homePhone?.phoneNumber || ''}`;
+  const missingInfo = [
+    email?.emailAddress ? '' : 'email',
+    mobilePhone?.phoneNumber ? '' : 'phone',
+    mailingAddress.addressLine1 ? '' : 'address',
+  ].filter(Boolean);
+
+  const list = readableList(missingInfo);
+  const plural = missingInfo.length > 1;
+
+  useEffect(
+    () => {
+      if (missingInfo.length) {
+        // page had an error flag, so we know when to show a success alert
+        setHadError(true);
+      }
+    },
+    [missingInfo],
+  );
 
   return (
     <>
       <h3 className="vads-u-margin-top--0">Contact Information</h3>
       <p>
         This is the contact information we have on file for you. We’ll send any
-        important information about your Higher-Level Review to this address.
+        updates or information about your Higher-Level Review to this address.
       </p>
-      <p className="vads-u-margin-top--1p5">
-        You can{' '}
-        <a href={PROFILE_URL} target="_blank" rel="noopener noreferrer">
-          update this information on your profile page
-        </a>
-        .
-      </p>
-      <div className="blue-bar-block">
-        <h4 className="vads-u-font-size--h4">Phone &amp; email</h4>
-        <p>
-          <strong>Home phone</strong>:{' '}
-          <Telephone
-            contact={phone}
-            extension={homePhone?.extension}
-            notClickable
-          />
-        </p>
-        <p>
-          <strong>Email address</strong>: {email?.emailAddress || ''}
-        </p>
-        <h4 className="vads-u-font-size--h4">Mailing address</h4>
-        <p>
-          {addBrAfter(street)}
-          {addBrAfter(cityStateZip)}
-          {country}
-        </p>
+      {hadError &&
+        missingInfo.length === 0 && (
+          <div className="vads-u-margin-top--1p5">
+            <va-alert status="success" background-only>
+              <div className="vads-u-font-size--base">
+                The missing information has been added to your application. You
+                may continue.
+              </div>
+            </va-alert>
+          </div>
+        )}
+      {missingInfo.length > 0 && (
+        <>
+          <p className="vads-u-margin-top--1p5">
+            <strong>Note:</strong>
+            {missingInfo[0].startsWith('p') ? ' A ' : ' An '}
+            {list} {plural ? 'are' : 'is'} required for this application.
+          </p>
+          {submitted && (
+            <div className="vads-u-margin-top--1p5" role="alert">
+              <va-alert status="error" background-only>
+                <div className="vads-u-font-size--base">
+                  We still don’t have your {list}. Please edit and update the
+                  field.
+                </div>
+              </va-alert>
+            </div>
+          )}
+          <div className="vads-u-margin-top--1p5" role="alert">
+            <va-alert status="warning" background-only>
+              <div className="vads-u-font-size--base">
+                Your {list} {plural ? 'are' : 'is'} missing. Please edit and
+                update the {plural ? 'fields' : 'field'}.
+              </div>
+            </va-alert>
+          </div>
+        </>
+      )}
+      <div className="blue-bar-block vads-u-margin-top--4">
+        <div
+          className="va-profile-wrapper"
+          onSubmit={event => {
+            // This prevents this nested form submit event from passing to the
+            // outer form and causing a page advance
+            event.stopPropagation();
+          }}
+        >
+          <InitializeVAPServiceID>
+            <VAPServicePendingTransactionCategory
+              categoryType={TRANSACTION_CATEGORY_TYPES.PHONE}
+            >
+              <PhoneField
+                title="Mobile phone number"
+                fieldName={FIELD_NAMES.MOBILE_PHONE}
+                deleteDisabled
+                alertClosingDisabled
+              />
+            </VAPServicePendingTransactionCategory>
+            <VAPServicePendingTransactionCategory
+              categoryType={TRANSACTION_CATEGORY_TYPES.EMAIL}
+            >
+              <EmailField
+                title="Email address"
+                fieldName={FIELD_NAMES.EMAIL}
+                deleteDisabled
+              />
+            </VAPServicePendingTransactionCategory>
+            <VAPServicePendingTransactionCategory
+              categoryType={TRANSACTION_CATEGORY_TYPES.ADDRESS}
+            >
+              <AddressField
+                title="Mailing address"
+                fieldName={FIELD_NAMES.MAILING_ADDRESS}
+                deleteDisabled
+              />
+            </VAPServicePendingTransactionCategory>
+          </InitializeVAPServiceID>
+        </div>
       </div>
     </>
   );
 };
 
 ContactInfoDescription.propTypes = {
-  profile: PropTypes.shape({}),
+  profile: PropTypes.shape({
+    vapContactInfo: PropTypes.shape({
+      email: PropTypes.shape({
+        emailAddress: PropTypes.string,
+      }),
+      mobilePhone: PropTypes.shape({
+        countryCode: PropTypes.string,
+        areaCode: PropTypes.string,
+        phoneNumber: PropTypes.string,
+        extension: PropTypes.string,
+      }),
+      address: PropTypes.shape({
+        addressLine1: PropTypes.string,
+        addressLine2: PropTypes.string,
+        addressLine3: PropTypes.string,
+        city: PropTypes.string,
+        province: PropTypes.string,
+        stateCode: PropTypes.string,
+        countryCodeIso3: PropTypes.string,
+        zipCode: PropTypes.string,
+        internationalPostalCode: PropTypes.string,
+      }),
+    }),
+  }).isRequired,
 };
 
-const mapStateToProps = state => {
-  const profile = selectProfile(state);
-  const veteran = state.form?.data.veteran;
-  return {
-    profile,
-    veteran,
-  };
-};
+const mapStateToProps = state => ({
+  profile: selectProfile(state),
+});
 
 export default connect(mapStateToProps)(ContactInfoDescription);

--- a/src/applications/disability-benefits/996/components/VeteranInformation.jsx
+++ b/src/applications/disability-benefits/996/components/VeteranInformation.jsx
@@ -12,7 +12,7 @@ import { selectProfile } from 'platform/user/selectors';
 
 import { srSubstitute } from 'platform/forms-system/src/js/utilities/ui/mask-string';
 import { SELECTED } from '../constants';
-import { apiVersion2 } from '../helpers';
+import { apiVersion2 } from '../utils/helpers';
 
 // separate each number so the screenreader reads "number ending with 1 2 3 4"
 // instead of "number ending with 1,234"

--- a/src/applications/disability-benefits/996/components/createHLRApplicationStatus.jsx
+++ b/src/applications/disability-benefits/996/components/createHLRApplicationStatus.jsx
@@ -16,7 +16,7 @@ export default function createHigherLevelReviewApplicationStatus(
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
   if (root) {
     import(/* webpackChunkName: "higher-level-review-application-status" */
-    '../utils').then(module => {
+    '../utils/wizard').then(module => {
       const { ApplicationStatus, WizardLink } = module.default;
       connectFeatureToggle(store.dispatch);
 

--- a/src/applications/disability-benefits/996/config/form.js
+++ b/src/applications/disability-benefits/996/config/form.js
@@ -26,7 +26,7 @@ import informalConferenceTimes from '../pages/informalConferenceTimes';
 import sameOffice from '../pages/sameOffice';
 
 import { errorMessages, WIZARD_STATUS } from '../constants';
-import { apiVersion1, apiVersion2 } from '../helpers';
+import { apiVersion1, apiVersion2 } from '../utils/helpers';
 // import initialData from '../tests/schema/initialData';
 
 import manifest from '../manifest.json';

--- a/src/applications/disability-benefits/996/config/form.js
+++ b/src/applications/disability-benefits/996/config/form.js
@@ -100,6 +100,10 @@ const formConfig = {
           path: 'contact-information',
           uiSchema: contactInfo.uiSchema,
           schema: contactInfo.schema,
+          initialData: {
+            // stop the mobile phone modal from showing SMS checkbox inline
+            'view:showSMSCheckbox': false,
+          },
         },
         homeless: {
           title: 'Homelessness question',

--- a/src/applications/disability-benefits/996/config/submit-transformer.js
+++ b/src/applications/disability-benefits/996/config/submit-transformer.js
@@ -1,187 +1,63 @@
+import { DEFAULT_BENEFIT_TYPE } from '../constants';
+
 import {
-  DEFAULT_BENEFIT_TYPE,
-  SELECTED,
-  CONFERENCE_TIMES_V1,
-  CONFERENCE_TIMES_V2,
-} from '../constants';
+  getRep,
+  getConferenceTimes,
+  getContestedIssues,
+  getContact,
+  getAddress,
+  getPhone,
+  getTimeZone,
+} from '../utils/submit';
 
 export function transform(formConfig, form) {
-  // We require the user to input a 10-digit number; assuming we get a 3-digit
-  // area code + 7 digit number. We're not yet supporting international numbers
-  const getPhoneNumber = (phone = '') => ({
-    country: '1',
-    areaCode: phone.substring(0, 3),
-    phoneNumber: phone.substring(3),
-    // Empty string/null are not permitted values
-    // phoneNumberExt: '',
-  });
-
-  const getRep = (formData, version) => {
-    if (version === 1) {
-      return formData.informalConference === 'rep'
-        ? {
-            name: formData?.informalConferenceRep?.name,
-            phone: getPhoneNumber(formData?.informalConferenceRep?.phone),
-          }
-        : null;
-    }
-    return formData.informalConference === 'rep'
-      ? {
-          firstName: formData?.informalConferenceRep?.firstName,
-          lastName: formData?.informalConferenceRep?.lastName,
-          phone: getPhoneNumber(formData?.informalConferenceRep?.phone),
-        }
-      : null;
-  };
-
-  const getConferenceTimes = ({ informalConferenceTimes = [] }, version) => {
-    const times = version === 1 ? CONFERENCE_TIMES_V1 : CONFERENCE_TIMES_V2;
-    const xRef = Object.keys(times).reduce(
-      (timesAndApi, time) => ({
-        ...timesAndApi,
-        [time]: times[time].submit,
-      }),
-      {},
-    );
-
-    return ['time1', 'time2'].reduce((setTimes, key) => {
-      const value = informalConferenceTimes[key] || '';
-      if (value) {
-        setTimes.push(xRef[value]);
-      }
-      return setTimes;
-    }, []);
-  };
-
-  const getTimeZone = () =>
-    // supports IE11
-    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/resolvedOptions
-    Intl.DateTimeFormat().resolvedOptions().timeZone;
-
-  const getIssueName = ({ attributes } = {}) => {
-    const {
-      ratingIssueSubjectText,
-      ratingIssuePercentNumber,
-      description,
-    } = attributes;
-    return [
-      ratingIssueSubjectText,
-      `${ratingIssuePercentNumber || '0'}%`,
-      description,
-    ]
-      .filter(part => part)
-      .join(' - ')
-      .substring(0, 140);
-  };
-
-  /* submitted contested issue format
-  [{
-    "type": "contestableIssue",
-    "attributes": {
-      "issue": "tinnitus - 10% - some longer description",
-      "decisionDate": "1900-01-01",
-      "decisionIssueId": 1,
-      "ratingIssueReferenceId": "2",
-      "ratingDecisionReferenceId": "3"
-    }
-  }]
-  */
-  const getContestedIssues = ({ contestedIssues = [] }) =>
-    contestedIssues.filter(issue => issue[SELECTED]).map(issue => {
-      const attr = issue.attributes;
-      const attributes = [
-        'decisionIssueId',
-        'ratingIssueReferenceId',
-        'ratingDecisionReferenceId',
-      ].reduce(
-        (acc, key) => {
-          // Don't submit null or empty strings
-          if (attr[key]) {
-            acc[key] = attr[key];
-          }
-          return acc;
-        },
-        {
-          issue: getIssueName(issue),
-          decisionDate: attr.approxDecisionDate,
-        },
-      );
-
-      return {
-        // type: "contestableIssues"
-        type: issue.type,
-        attributes,
-      };
-    });
-
-  const getContact = ({ informalConference }) => {
-    if (informalConference === 'rep') {
-      return 'representative';
-    }
-    if (informalConference === 'me') {
-      return 'veteran';
-    }
-    return '';
-  };
-
   // https://dev-developer.va.gov/explore/appeals/docs/decision_reviews?version=current
   const mainTransform = formData => {
     const version = formData.hlrV2 ? 2 : 1;
     const informalConference = formData.informalConference !== 'no';
-    const zipCode5 = formData.zipCode5 || formData.veteran?.zipCode5 || '00000';
-    const result = {
-      data: {
-        type: 'higherLevelReview',
-        attributes: {
-          // This value may empty if the user restarts the form
-          // See va.gov-team/issues/13814
-          benefitType: formData.benefitType || DEFAULT_BENEFIT_TYPE,
-          informalConference,
+    const attributes = {
+      // This value may empty if the user restarts the form; see
+      // va.gov-team/issues/13814
+      benefitType: formData.benefitType || DEFAULT_BENEFIT_TYPE,
+      informalConference,
+      // informalConferenceRep & informalConferenceTimes are added below
 
-          veteran: {
-            timezone: getTimeZone(),
-            address: {
-              // EVSS has very restrictive address rules; so Lighthouse API will
-              // submit something like "use address on file"
-              // TODO: postalCode vs zipCode?
-              zipCode5,
-            },
-            // ** phone & email are optional **
-            // phone: getPhoneNumber(formData?.primaryPhone),
-            // emailAddressText: formData?.emailAddress,
-          },
-
-          // informalConferenceRep & informalConferenceTimes are added below
-        },
+      veteran: {
+        timezone: getTimeZone(),
+        address: getAddress(formData, version),
       },
-      included: getContestedIssues(formData),
     };
 
     if (version === 1) {
-      result.data.attributes.sameOffice = formData.sameOffice || false;
+      attributes.sameOffice = formData.sameOffice || false;
     }
     if (version > 1) {
-      result.data.attributes.veteran.homeless = formData.homeless;
+      attributes.veteran.homeless = formData.homeless;
+      attributes.veteran.phone = getPhone(formData);
+      attributes.veteran.email = formData?.veteran.email;
     }
 
     // Add informal conference data
     if (informalConference) {
-      result.data.attributes.informalConferenceTimes = getConferenceTimes(
+      attributes.informalConferenceTimes = getConferenceTimes(
         formData,
         version,
       );
       if (formData.informalConference === 'rep') {
-        result.data.attributes.informalConferenceRep = getRep(
-          formData,
-          version,
-        );
+        attributes.informalConferenceRep = getRep(formData, version);
       }
       if (version > 1) {
-        result.data.attributes.informalConferenceContact = getContact(formData);
+        attributes.informalConferenceContact = getContact(formData);
       }
     }
 
-    return result;
+    return {
+      data: {
+        type: 'higherLevelReview',
+        attributes,
+      },
+      included: getContestedIssues(formData),
+    };
   };
 
   // Not using _.cloneDeep on form data - it appears to replace `null` values

--- a/src/applications/disability-benefits/996/constants.js
+++ b/src/applications/disability-benefits/996/constants.js
@@ -53,6 +53,10 @@ export const errorMessages = {
 
 export const NULL_CONDITION_STRING = 'Unknown Condition';
 
+// contested issue dates
+export const FORMAT_YMD = 'YYYY-MM-DD';
+export const FORMAT_READABLE = 'LL';
+
 // session storage keys
 export const SAVED_CLAIM_TYPE = 'hlrClaimType';
 export const WIZARD_STATUS = 'wizardStatus996';

--- a/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
@@ -1,24 +1,15 @@
 import React from 'react';
 import moment from 'moment';
 import { connect } from 'react-redux';
-import Scroll from 'react-scroll';
 
 import { focusElement } from 'platform/utilities/ui';
 import { selectProfile } from 'platform/user/selectors';
+import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
 
 import { SELECTED, SAVED_CLAIM_TYPE, WIZARD_STATUS } from '../constants';
-
-const scroller = Scroll.scroller;
-const scrollToTop = () => {
-  scroller.scrollTo('topScrollElement', {
-    duration: 500,
-    delay: 0,
-    smooth: true,
-  });
-};
 
 export class ConfirmationPage extends React.Component {
   componentDidMount() {

--- a/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
@@ -25,7 +25,7 @@ import {
   getContestableIssues as getContestableIssuesAction,
   FETCH_CONTESTABLE_ISSUES_INIT,
 } from '../actions';
-import { scrollToTop } from '../helpers';
+import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import {
   BASE_URL,
   SAVED_CLAIM_TYPE,

--- a/src/applications/disability-benefits/996/content/contestedIssues.jsx
+++ b/src/applications/disability-benefits/996/content/contestedIssues.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import moment from 'moment';
-import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
+import Scroll from 'react-scroll';
 
+import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
@@ -13,7 +14,18 @@ import {
   NULL_CONDITION_STRING,
 } from '../constants';
 import DownloadLink from './DownloadLink';
-import { scrollTo } from '../helpers';
+
+const scroller = Scroll.scroller;
+const scrollToTop = () => {
+  scroller.scrollTo(
+    'eligibleScrollElement',
+    window.VetsGov?.scroll || {
+      duration: 500,
+      delay: 0,
+      smooth: true,
+    },
+  );
+};
 
 // We shouldn't ever see the couldn't find contestable issues message since we
 // prevent the user from navigating past the intro page; but it's here just in
@@ -150,7 +162,7 @@ export const disabilitiesExplanation = (
  * Shows the alert box only if the form has been submitted
  */
 export const ContestedIssuesAlert = ({ className = '' }) => {
-  setTimeout(() => scrollTo('eligibleScrollElement'), 300);
+  setTimeout(() => scrollToTop(), 300);
   return (
     <va-alert status="error">
       <h3

--- a/src/applications/disability-benefits/996/migrations/01-lighthouse-v2-updates.js
+++ b/src/applications/disability-benefits/996/migrations/01-lighthouse-v2-updates.js
@@ -1,4 +1,4 @@
-import { isVersion1Data } from '../helpers';
+import { isVersion1Data } from '../utils/helpers';
 
 const unaffectedPages = ['/contact-information', '/veteran-information'];
 

--- a/src/applications/disability-benefits/996/pages/contactInformation.js
+++ b/src/applications/disability-benefits/996/pages/contactInformation.js
@@ -1,9 +1,12 @@
 import ContactInfoDescription from '../components/ContactInformation';
+import { contactInfoValidation } from '../validations';
 
 const contactInfo = {
   uiSchema: {
     'ui:title': ' ',
     'ui:description': ContactInfoDescription,
+    'ui:required': () => true,
+    'ui:validations': [contactInfoValidation],
     'ui:options': {
       hideOnReview: true,
       forceDivWrapper: true,

--- a/src/applications/disability-benefits/996/pages/informalConferenceTimes.js
+++ b/src/applications/disability-benefits/996/pages/informalConferenceTimes.js
@@ -4,7 +4,7 @@ import {
   CONFERENCE_TIMES_V1,
   CONFERENCE_TIMES_V2,
 } from '../constants';
-import { apiVersion2 } from '../helpers';
+import { apiVersion2 } from '../utils/helpers';
 
 import {
   InformalConferenceTimesTitle,

--- a/src/applications/disability-benefits/996/reducers/contestableIssues.js
+++ b/src/applications/disability-benefits/996/reducers/contestableIssues.js
@@ -3,7 +3,7 @@ import {
   FETCH_CONTESTABLE_ISSUES_SUCCEEDED,
   FETCH_CONTESTABLE_ISSUES_FAILED,
 } from '../actions';
-import { getEligibleContestableIssues } from '../helpers';
+import { getEligibleContestableIssues } from '../utils/helpers';
 
 const initialState = {
   issues: [],

--- a/src/applications/disability-benefits/996/reducers/index.js
+++ b/src/applications/disability-benefits/996/reducers/index.js
@@ -1,3 +1,5 @@
+import vapService from '@@vap-svc/reducers';
+
 import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
 
 import formConfig from '../config/form';
@@ -6,4 +8,5 @@ import contestableIssues from './contestableIssues';
 export default {
   form: createSaveInProgressFormReducer(formConfig),
   contestableIssues,
+  vapService,
 };

--- a/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
+++ b/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
@@ -46,6 +46,18 @@
   }
 }
 
+/* contact info page */
+article[data-location="contact-information"] {
+  div[data-field-name="mobilePhone"] h3 {
+    margin-top: 0;
+  }
+  /* address modal is very tall and won't scroll without this fix */
+  .va-modal-body {
+    max-height: calc(100vh - 4rem);
+    overflow-y: auto;
+  }
+}
+
 /* Step 2 */
 /*** Contested issues block ***/
 

--- a/src/applications/disability-benefits/996/tests/components/ContactInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/components/ContactInformation.unit.spec.jsx
@@ -2,53 +2,120 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 
-import { ADDRESS_TYPES } from 'platform/forms/address/helpers';
-
 import { ContactInfoDescription } from '../../components/ContactInformation';
+
+const getData = ({
+  email = true,
+  mobile = true,
+  address = true,
+  submitted = false,
+} = {}) => {
+  const data = {};
+  if (email) {
+    data.email = {
+      emailAddress: 'someone@famous.com',
+    };
+  }
+  if (mobile) {
+    data.mobilePhone = {
+      areaCode: '555',
+      phoneNumber: '8001212',
+      extension: '1234',
+    };
+  }
+  if (address) {
+    data.mailingAddress = {
+      countryName: 'United States',
+      countryCodeIso3: 'USA',
+      addressLine1: '123 Main Blvd',
+      addressLine2: 'Floor 33',
+      addressLine3: 'Suite 55',
+      city: 'Hollywood',
+      stateCode: 'CA',
+      zipCode: '90210',
+    };
+  }
+  return {
+    formContext: { submitted },
+    profile: { vapContactInfo: data },
+  };
+};
 
 describe('Veteran information review content', () => {
   it('should render contact information', () => {
-    const data = {
-      profile: {
-        vapContactInfo: {
-          email: {
-            emailAddress: 'someone@famous.com',
-          },
-          homePhone: {
-            areaCode: '555',
-            phoneNumber: '8001212',
-          },
-          mailingAddress: {
-            addressType: ADDRESS_TYPES.domestic,
-            countryName: 'United States',
-            countryCodeIso3: 'USA',
-            addressLine1: '123 Main Blvd',
-            addressLine2: 'Floor 33',
-            addressLine3: 'Suite 55',
-            city: 'Hollywood',
-            stateCode: 'CA',
-            zipCode: '90210',
-          },
-        },
-      },
-    };
-    const ContactInfo = () => <>{ContactInfoDescription(data)}</>;
-    const tree = shallow(<ContactInfo />);
-    const address = tree.find('.blue-bar-block');
-    const text = address.text();
+    const data = getData();
+    const tree = shallow(<ContactInfoDescription {...data} />);
 
-    expect(address).to.have.lengthOf(1);
-    expect(
-      address
-        .find('Telephone')
-        .dive()
-        .text(),
-    ).to.contain('555-800-1212');
-    expect(text).to.contain('someone@famous.com');
-    expect(text).to.contain('123 Main Blvd');
-    expect(text).to.contain('Floor 33');
-    expect(text).to.contain('Suite 55');
-    expect(text).to.contain('Hollywood, CA 90210');
+    expect(tree.find('PhoneField')).to.exist;
+    expect(tree.find('EmailField')).to.exist;
+    expect(tree.find('MailingAddress')).to.exist;
+    tree.unmount();
+  });
+
+  it('should render note about missing phone', () => {
+    const data = getData({ mobile: false });
+    const tree = shallow(<ContactInfoDescription {...data} />);
+    const text = tree.find('va-alert').text();
+
+    expect(text).to.contain('Your phone is missing');
+    tree.unmount();
+  });
+  it('should render note about missing email & phone', () => {
+    const data = getData({ mobile: false, email: false });
+    const tree = shallow(<ContactInfoDescription {...data} />);
+    const text = tree.find('va-alert').text();
+
+    expect(text).to.contain('Your email and phone are missing');
+    tree.unmount();
+  });
+  it('should render note about missing email, phone & address', () => {
+    const data = getData({ mobile: false, email: false, address: false });
+    const tree = shallow(<ContactInfoDescription {...data} />);
+    const text = tree.find('va-alert').text();
+
+    expect(text).to.contain('Your email, phone and address are missing');
+    tree.unmount();
+  });
+  it('should render an error if info is not actually updated', () => {
+    const data = getData({
+      submitted: false,
+      email: false,
+    });
+    const tree = shallow(<ContactInfoDescription {...data} />);
+    const alert = tree.find('va-alert');
+
+    expect(alert.props().status).to.eq('warning');
+    expect(alert.text()).to.contain('Your email is missing');
+
+    data.formContext.submitted = true;
+    tree.setProps(data);
+
+    const alerts = tree.find('va-alert');
+    expect(alerts.length).to.eq(2);
+    expect(alerts.at(0).props().status).to.eq('error');
+    expect(alerts.at(1).props().status).to.eq('warning');
+
+    tree.unmount();
+  });
+  // enzyme shallow doesn't call useEffect
+  it.skip('should render note about missing address & show success after updating', () => {
+    const data = getData({
+      submitted: false,
+      email: false,
+    });
+    const tree = shallow(<ContactInfoDescription {...data} />);
+    const alert = tree.find('va-alert');
+
+    expect(alert.props().status).to.eq('warning');
+    expect(alert.text()).to.contain('Your email is missing');
+
+    tree.setProps(getData());
+    // should update & call useEffect here
+
+    const success = tree.find('va-alert');
+    expect(success.length).to.eq(1);
+    expect(success.props().status).to.eq('success');
+
     tree.unmount();
   });
 });

--- a/src/applications/disability-benefits/996/tests/components/contestedIssues.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/components/contestedIssues.unit.spec.jsx
@@ -10,7 +10,7 @@ import {
   getFormDOM,
 } from 'platform/testing/unit/schemaform-utils';
 
-import { $, $$ } from '../../helpers';
+import { $, $$ } from '../../utils/ui';
 
 import formConfig from '../../config/form.js';
 import initialData from '../schema/initialData.js';

--- a/src/applications/disability-benefits/996/tests/components/sameOffice.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/components/sameOffice.unit.spec.jsx
@@ -9,7 +9,7 @@ import {
   getFormDOM,
 } from 'platform/testing/unit/schemaform-utils';
 
-import { $$ } from '../../helpers';
+import { $$ } from '../../utils/ui';
 
 import formConfig from '../../config/form.js';
 import initialData from '../schema/initialData.js';

--- a/src/applications/disability-benefits/996/tests/content/InformalConference.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/content/InformalConference.unit.spec.jsx
@@ -9,7 +9,7 @@ import {
   getFormDOM,
 } from 'platform/testing/unit/schemaform-utils';
 
-import { $$ } from '../../helpers';
+import { $$ } from '../../utils/ui';
 
 import formConfig from '../../config/form';
 import informalConference from '../../pages/informalConference';

--- a/src/applications/disability-benefits/996/tests/content/InformalConferenceRep.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/content/InformalConferenceRep.unit.spec.jsx
@@ -9,7 +9,7 @@ import {
   getFormDOM,
 } from 'platform/testing/unit/schemaform-utils';
 
-import { $, $$ } from '../../helpers';
+import { $, $$ } from '../../utils/ui';
 
 import formConfig from '../../config/form';
 import informalConferenceRep from '../../pages/informalConferenceRep';

--- a/src/applications/disability-benefits/996/tests/content/InformalConferenceTimes.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/content/InformalConferenceTimes.unit.spec.jsx
@@ -9,7 +9,7 @@ import {
   getFormDOM,
 } from 'platform/testing/unit/schemaform-utils';
 
-import { $$ } from '../../helpers';
+import { $$ } from '../../utils/ui';
 
 import formConfig from '../../config/form';
 import informalConferenceTimes from '../../pages/informalConferenceTimes';

--- a/src/applications/disability-benefits/996/tests/fixtures/data/maximal-test-v2.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/data/maximal-test-v2.json
@@ -4,7 +4,24 @@
     "veteran": {
       "ssnLastFour": "7821",
       "vaFileLastFour": "8765",
-      "zipCode5": "94608"
+      "address": {
+        "addressLine1": "123 Main St",
+        "addressLine2": "Suite #1200",
+        "addressLine3": "Box 4",
+        "city": "New York",
+        "countryName": "United States",
+        "countryCodeIso2": "US",
+        "stateCode": "NY",
+        "zipCode": "30012",
+        "internationalPostalCode": "1"
+      },
+      "phone": {
+        "countryCode": "6",
+        "areaCode": "555",
+        "phoneNumber": "8001111",
+        "phoneNumberExt": "2"
+      },
+      "email": "user@example.com"
     },
     "homeless": false,
     "privacyAgreementAccepted": true,

--- a/src/applications/disability-benefits/996/tests/fixtures/data/transformed/maximal-test-v1.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/data/transformed/maximal-test-v1.json
@@ -8,7 +8,7 @@
       "informalConferenceRep": {
         "name": "James P. Sullivan",
         "phone": {
-          "country": "1",
+          "countryCode": "1",
           "areaCode": "800",
           "phoneNumber": "5551212"
         }

--- a/src/applications/disability-benefits/996/tests/fixtures/data/transformed/maximal-test-v2.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/data/transformed/maximal-test-v2.json
@@ -10,15 +10,29 @@
         "firstName": "James",
         "lastName": "Sullivan",
         "phone": {
-          "country": "1",
+          "countryCode": "1",
           "areaCode": "800",
           "phoneNumber": "5551212"
         }
       },
       "veteran": {
         "address": {
-          "zipCode5": "94608"
+          "addressLine1": "123 Main St",
+          "addressLine2": "Suite #1200",
+          "addressLine3": "Box 4",
+          "city": "New York",
+          "countryCodeISO2": "US",
+          "stateCode": "NY",
+          "zipCode5": "30012",
+          "internationalPostalCode": "1"
         },
+        "phone": {
+          "countryCode": "6",
+          "areaCode": "555",
+          "phoneNumber": "8001111",
+          "phoneNumberExt": "2"
+        },
+        "email": "user@example.com",
         "homeless": false,
         "timezone": "America/Los_Angeles"
       }

--- a/src/applications/disability-benefits/996/tests/fixtures/mocks/user.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/mocks/user.json
@@ -55,7 +55,9 @@
       "inProgressForms": [],
       "prefillsAvailable": [],
       "vet360ContactInformation": {
-        "email": null,
+        "email": {
+          "emailAddress": "test@user.com"
+        },
         "residentialAddress": {},
         "mailingAddress": {
           "addressLine1": "1200 Park Ave",
@@ -86,7 +88,7 @@
           "zipCode": "94608",
           "zipCodeSuffix": null
         },
-        "homePhone": {
+        "mobilePhone": {
           "areaCode": "510",
           "countryCode": "1",
           "createdAt": "2020-06-12T16:56:37.000+00:00",
@@ -107,7 +109,7 @@
           "updatedAt": "2020-07-14T19:07:46.000+00:00",
           "vet360Id": "1273780"
         },
-        "mobilePhone": {},
+        "homePhone": {},
         "workPhone": {},
         "temporaryPhone": null,
         "faxNumber": null,

--- a/src/applications/disability-benefits/996/tests/hlr.cypress.helpers.js
+++ b/src/applications/disability-benefits/996/tests/hlr.cypress.helpers.js
@@ -1,8 +1,6 @@
-import moment from 'moment';
+import { getDate } from '../utils/dates';
 
-const date = moment()
-  .subtract(2, 'months')
-  .format('YYYY-MM-DD');
+const date = getDate({ offset: { months: -2 } });
 
 export const mockContestableIssues = {
   data: [

--- a/src/applications/disability-benefits/996/tests/utils/dates.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/utils/dates.unit.spec.js
@@ -1,0 +1,30 @@
+import { expect } from 'chai';
+import moment from 'moment';
+
+import { FORMAT_YMD, FORMAT_READABLE } from '../../constants';
+import { getDate } from '../../utils/dates';
+
+describe('getDate', () => {
+  const dateString = '2021-02-10 00:00:00';
+  const date = new Date(dateString);
+
+  it('should return a date string from date object', () => {
+    expect(getDate()).to.equal(moment().format(FORMAT_YMD));
+  });
+  it('should return a date string from date string & offset', () => {
+    expect(getDate({ date, offset: { days: 3 } })).to.contain('2021-02-13');
+  });
+  it('should return a date string pattern based on date & offset', () => {
+    expect(getDate({ date, offset: { years: -1 } })).to.contain('2020-02-10');
+    expect(
+      getDate({
+        date,
+        offset: { years: -1 },
+        pattern: FORMAT_READABLE,
+      }),
+    ).to.contain('February 10, 2020');
+    expect(
+      getDate({ date: '2021-02-10 00:00:00', pattern: FORMAT_READABLE }),
+    ).to.contain('February 10, 2021');
+  });
+});

--- a/src/applications/disability-benefits/996/tests/utils/helpers.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/utils/helpers.unit.spec.js
@@ -1,24 +1,24 @@
-import { expect } from 'chai';
 import moment from 'moment';
+import { expect } from 'chai';
+
+import { getDate } from '../../utils/dates';
 
 import {
   getEligibleContestableIssues,
   apiVersion1,
   apiVersion2,
   isVersion1Data,
-} from '../helpers';
+} from '../../utils/helpers';
 
 describe('getEligibleContestableIssues', () => {
-  const today = () => moment().startOf('day');
-  const template = 'YYYY-MM-DD';
-  const format = (date, templ = template) => date.format(templ);
+  const date = moment().startOf('day');
 
   const eligibleIssue = {
     type: 'contestableIssue',
     attributes: {
       ratingIssueSubjectText: 'Issue 2',
       description: '',
-      approxDecisionDate: format(today().subtract(10, 'months')),
+      approxDecisionDate: getDate({ date, offset: { months: -10 } }),
     },
   };
   const ineligibleIssue = [
@@ -27,7 +27,7 @@ describe('getEligibleContestableIssues', () => {
       attributes: {
         ratingIssueSubjectText: 'Issue 1',
         description: '',
-        approxDecisionDate: format(today().subtract(2, 'years')),
+        approxDecisionDate: getDate({ date, offset: { years: -2 } }),
       },
     },
   ];
@@ -36,7 +36,7 @@ describe('getEligibleContestableIssues', () => {
     attributes: {
       ratingIssueSubjectText: 'Issue 2',
       description: 'this is a deferred issue',
-      approxDecisionDate: format(today().subtract(1, 'months')),
+      approxDecisionDate: getDate({ date, offset: { months: -1 } }),
     },
   };
 

--- a/src/applications/disability-benefits/996/tests/utils/submit.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/utils/submit.unit.spec.js
@@ -121,15 +121,17 @@ describe('getAddress', () => {
   it('should return a cleaned up address object', () => {
     const wrap = obj => ({ veteran: { address: obj } });
     expect(getAddress()).to.deep.equal({ zipCode5: '00000' });
-    expect(getAddress(wrap({}))).to.deep.equal({ zipCode5: '00000' });
-    expect(getAddress(wrap({ temp: 'test' }))).to.deep.equal({
+    expect(getAddress({}, 2)).to.deep.equal({});
+    expect(getAddress(wrap({}), 1)).to.deep.equal({ zipCode5: '00000' });
+    expect(getAddress(wrap({}), 2)).to.deep.equal({});
+    expect(getAddress(wrap({ temp: 'test' }), 1)).to.deep.equal({
       zipCode5: '00000',
     });
-    expect(getAddress(wrap({ addressLine1: 'test' }))).to.deep.equal({
+    expect(getAddress(wrap({ temp: 'test' }), 2)).to.deep.equal({});
+    expect(getAddress(wrap({ addressLine1: 'test' }), 2)).to.deep.equal({
       addressLine1: 'test',
-      zipCode5: '00000',
     });
-    expect(getAddress(wrap({ zipCode: '10101' }))).to.deep.equal({
+    expect(getAddress(wrap({ zipCode: '10101' }), 2)).to.deep.equal({
       zipCode5: '10101',
     });
     expect(
@@ -145,6 +147,7 @@ describe('getAddress', () => {
           internationalPostalCode: '12345',
           extra: 'will not be included',
         }),
+        2,
       ),
     ).to.deep.equal({
       addressLine1: '123 test',

--- a/src/applications/disability-benefits/996/tests/utils/submit.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/utils/submit.unit.spec.js
@@ -1,0 +1,195 @@
+import { expect } from 'chai';
+import { SELECTED } from '../../constants';
+import { getDate } from '../../utils/dates';
+
+import {
+  createIssueName,
+  getContestedIssues,
+  removeEmptyEntries,
+  getAddress,
+  getPhone,
+  getTimeZone,
+} from '../../utils/submit';
+
+const validDate1 = getDate({ offset: { months: -2 } });
+const issue1 = {
+  raw: {
+    type: 'contestableIssue',
+    attributes: {
+      ratingIssueSubjectText: 'tinnitus',
+      description: 'both ears',
+      approxDecisionDate: validDate1,
+      decisionIssueId: 1,
+      ratingIssueReferenceId: '2',
+      ratingDecisionReferenceId: '3',
+      ratingIssuePercentNumber: '10',
+    },
+  },
+  result: {
+    type: 'contestableIssue',
+    attributes: {
+      issue: 'tinnitus - 10% - both ears',
+      decisionDate: validDate1,
+      decisionIssueId: 1,
+      ratingIssueReferenceId: '2',
+      ratingDecisionReferenceId: '3',
+    },
+  },
+};
+
+const validDate2 = getDate({ offset: { months: -4 } });
+const issue2 = {
+  raw: {
+    type: 'contestableIssue',
+    attributes: {
+      ratingIssueSubjectText: 'left knee',
+      approxDecisionDate: validDate2,
+      decisionIssueId: 4,
+      ratingIssueReferenceId: '5',
+    },
+  },
+  result: {
+    type: 'contestableIssue',
+    attributes: {
+      issue: 'left knee - 0%',
+      decisionDate: validDate2,
+      decisionIssueId: 4,
+      ratingIssueReferenceId: '5',
+    },
+  },
+};
+
+describe('createIssueName', () => {
+  const getName = (name, description, percent) =>
+    createIssueName({
+      attributes: {
+        ratingIssueSubjectText: name,
+        ratingIssuePercentNumber: percent,
+        description,
+      },
+    });
+
+  it('should combine issue details into the name', () => {
+    // contestable issues only
+    expect(getName('test', 'foo', '10')).to.eq('test - 10% - foo');
+    expect(getName('test', 'xyz', null)).to.eq('test - 0% - xyz');
+    expect(getName('test')).to.eq('test - 0%');
+  });
+});
+
+describe('getContestedIssues', () => {
+  it('should return all issues', () => {
+    const formData = {
+      contestedIssues: [
+        { ...issue1.raw, [SELECTED]: true },
+        { ...issue2.raw, [SELECTED]: true },
+      ],
+    };
+    expect(getContestedIssues(formData)).to.deep.equal([
+      issue1.result,
+      issue2.result,
+    ]);
+  });
+  it('should return second issue', () => {
+    const formData = {
+      contestedIssues: [
+        { ...issue1.raw, [SELECTED]: false },
+        { ...issue2.raw, [SELECTED]: true },
+      ],
+    };
+    expect(getContestedIssues(formData)).to.deep.equal([issue2.result]);
+  });
+});
+
+describe('removeEmptyEntries', () => {
+  it('should remove empty string items', () => {
+    expect(removeEmptyEntries({ a: '', b: 1, c: 'x', d: '' })).to.deep.equal({
+      b: 1,
+      c: 'x',
+    });
+  });
+  it('should not remove null or undefined items', () => {
+    expect(removeEmptyEntries({ a: null, b: undefined, c: 3 })).to.deep.equal({
+      a: null,
+      b: undefined,
+      c: 3,
+    });
+  });
+});
+
+describe('getAddress', () => {
+  it('should return a cleaned up address object', () => {
+    const wrap = obj => ({ veteran: { address: obj } });
+    expect(getAddress()).to.deep.equal({ zipCode5: '00000' });
+    expect(getAddress(wrap({}))).to.deep.equal({ zipCode5: '00000' });
+    expect(getAddress(wrap({ temp: 'test' }))).to.deep.equal({
+      zipCode5: '00000',
+    });
+    expect(getAddress(wrap({ addressLine1: 'test' }))).to.deep.equal({
+      addressLine1: 'test',
+      zipCode5: '00000',
+    });
+    expect(getAddress(wrap({ zipCode: '10101' }))).to.deep.equal({
+      zipCode5: '10101',
+    });
+    expect(
+      getAddress(
+        wrap({
+          addressLine1: '123 test',
+          addressLine2: 'c/o foo',
+          addressLine3: 'suite 99',
+          city: 'Big City',
+          stateCode: 'NV',
+          zipCode: '10101',
+          countryCodeIso2: 'US',
+          internationalPostalCode: '12345',
+          extra: 'will not be included',
+        }),
+      ),
+    ).to.deep.equal({
+      addressLine1: '123 test',
+      addressLine2: 'c/o foo',
+      addressLine3: 'suite 99',
+      city: 'Big City',
+      stateCode: 'NV',
+      zipCode5: '10101',
+      countryCodeISO2: 'US',
+      internationalPostalCode: '12345',
+    });
+  });
+});
+
+describe('getPhone', () => {
+  it('should return a cleaned up phone object', () => {
+    const wrap = obj => ({ veteran: { phone: obj } });
+    expect(getPhone()).to.deep.equal({});
+    expect(getPhone(wrap({}))).to.deep.equal({});
+    expect(getPhone(wrap({ temp: 'test' }))).to.deep.equal({});
+    expect(getPhone(wrap({ areaCode: '111' }))).to.deep.equal({
+      areaCode: '111',
+    });
+    expect(
+      getPhone(
+        wrap({
+          countryCode: '1',
+          areaCode: '222',
+          phoneNumber: '1234567',
+          phoneNumberExt: '0000',
+          extra: 'will not be included',
+        }),
+      ),
+    ).to.deep.equal({
+      countryCode: '1',
+      areaCode: '222',
+      phoneNumber: '1234567',
+      phoneNumberExt: '0000',
+    });
+  });
+});
+
+describe('getTimeZone', () => {
+  it('should return a string', () => {
+    // result will be a location string, not stubbing for this test
+    expect(getTimeZone().length).to.be.greaterThan(1);
+  });
+});

--- a/src/applications/disability-benefits/996/utils/dates.js
+++ b/src/applications/disability-benefits/996/utils/dates.js
@@ -1,0 +1,28 @@
+import moment from 'moment';
+
+import { FORMAT_YMD } from '../constants';
+/**
+ * @typedef DateFns~offset
+ * @property {Number} years - positive or negative number
+ * @property {Number} months - positive or negative number
+ * @property {Number} weeks - positive or negative number
+ * @property {Number} days - positive or negative number
+ * @property {Number} hours - positive or negative number
+ * @property {Number} minutes - positive or negative number
+ * @property {Number} seconds - positive or negative number
+ */
+/**
+ * Get dynamic date value based on starting date and an offset
+ * @param {DateFns~offset} [offset={}] - date offset
+ * @param {Date} [date=new Date()] - starting date of offset
+ * @param {String} [pattern=FORMAT_YMD]
+ * @returns {String} - formatted as 'YYYY-MM-DD'
+ */
+export const getDate = ({
+  offset = {},
+  date = new Date(),
+  pattern = FORMAT_YMD,
+} = {}) => {
+  const dateObj = moment(date);
+  return dateObj.isValid() ? dateObj.add(offset).format(pattern) : date;
+};

--- a/src/applications/disability-benefits/996/utils/helpers.js
+++ b/src/applications/disability-benefits/996/utils/helpers.js
@@ -1,19 +1,4 @@
-import Scroll from 'react-scroll';
 import moment from 'moment';
-
-// testing
-export const $ = (selector, DOM) => DOM.querySelector(selector);
-export const $$ = (selector, DOM) => DOM.querySelectorAll(selector);
-
-export const scrollTo = (target = 'topScrollElement') => {
-  Scroll.scroller.scrollTo(target, {
-    duration: 500,
-    delay: 0,
-    smooth: true,
-  });
-};
-
-export const scrollToTop = scrollTo;
 
 /**
  * Check HLR v2 feature flag
@@ -83,4 +68,19 @@ export const getEligibleContestableIssues = issues => {
     }
     return date.add(1, 'years').isAfter(today);
   });
+};
+
+/**
+ * Convert an array into a readable list of items
+ * @param {String[]} list - Array of items. Empty entries are stripped out
+ * @returns {String}
+ * @example
+ * readableList(['1', '2', '3', '4', 'five'])
+ * // => '1, 2, 3, 4 and five'
+ */
+export const readableList = list => {
+  const cleanedList = list.filter(Boolean);
+  return [cleanedList.slice(0, -1).join(', '), cleanedList.slice(-1)[0]].join(
+    cleanedList.length < 2 ? '' : ' and ',
+  );
 };

--- a/src/applications/disability-benefits/996/utils/submit.js
+++ b/src/applications/disability-benefits/996/utils/submit.js
@@ -1,0 +1,200 @@
+import {
+  SELECTED,
+  CONFERENCE_TIMES_V1,
+  CONFERENCE_TIMES_V2,
+} from '../constants';
+
+/**
+ * Remove objects with empty string values; Lighthouse doesn't like `null`
+ *  values
+ * @param {Object}
+ * @returns {Object} minus any empty string values
+ */
+export const removeEmptyEntries = object =>
+  Object.fromEntries(
+    Object.entries(object).filter(([_, value]) => value !== ''),
+  );
+
+// We require the user to input a 10-digit number; assuming we get a 3-digit
+// area code + 7 digit number. We're not yet supporting international numbers
+export const getPhoneNumber = (phone = '') => ({
+  country: '1',
+  areaCode: phone.substring(0, 3),
+  phoneNumber: phone.substring(3),
+  // Empty string/null are not permitted values
+  // phoneNumberExt: '',
+});
+
+export const getRep = (formData, version) => {
+  if (version === 1) {
+    return formData.informalConference === 'rep'
+      ? {
+          name: formData?.informalConferenceRep?.name,
+          phone: getPhoneNumber(formData?.informalConferenceRep?.phone),
+        }
+      : null;
+  }
+  return formData.informalConference === 'rep'
+    ? {
+        firstName: formData?.informalConferenceRep?.firstName,
+        lastName: formData?.informalConferenceRep?.lastName,
+        phone: getPhoneNumber(formData?.informalConferenceRep?.phone),
+      }
+    : null;
+};
+
+export const getConferenceTimes = (
+  { informalConferenceTimes = [] },
+  version,
+) => {
+  const times = version === 1 ? CONFERENCE_TIMES_V1 : CONFERENCE_TIMES_V2;
+  const xRef = Object.keys(times).reduce(
+    (timesAndApi, time) => ({
+      ...timesAndApi,
+      [time]: times[time].submit,
+    }),
+    {},
+  );
+
+  return ['time1', 'time2'].reduce((setTimes, key) => {
+    const value = informalConferenceTimes[key] || '';
+    if (value) {
+      setTimes.push(xRef[value]);
+    }
+    return setTimes;
+  }, []);
+};
+
+export const getTimeZone = () =>
+  // supports IE11
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/resolvedOptions
+  Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+/**
+ * Combine issues values into one field
+ * @param {ContestableIssue~Attributes} attributes
+ * @returns {String} Issue name - rating % - description combined
+ */
+export const createIssueName = ({ attributes } = {}) => {
+  const {
+    ratingIssueSubjectText,
+    ratingIssuePercentNumber,
+    description,
+  } = attributes;
+  return [
+    ratingIssueSubjectText,
+    `${ratingIssuePercentNumber || '0'}%`,
+    description,
+  ]
+    .filter(part => part)
+    .join(' - ')
+    .substring(0, 140);
+};
+
+/* submitted contested issue format
+[{
+"type": "contestableIssue",
+"attributes": {
+  "issue": "tinnitus - 10% - some longer description",
+  "decisionDate": "1900-01-01",
+  "decisionIssueId": 1,
+  "ratingIssueReferenceId": "2",
+  "ratingDecisionReferenceId": "3"
+}
+}]
+*/
+export const getContestedIssues = ({ contestedIssues = [] }) =>
+  contestedIssues.filter(issue => issue[SELECTED]).map(issue => {
+    const attr = issue.attributes;
+    const attributes = [
+      'decisionIssueId',
+      'ratingIssueReferenceId',
+      'ratingDecisionReferenceId',
+    ].reduce(
+      (acc, key) => {
+        // Don't submit null or empty strings
+        if (attr[key]) {
+          acc[key] = attr[key];
+        }
+        return acc;
+      },
+      {
+        issue: createIssueName(issue),
+        decisionDate: attr.approxDecisionDate,
+      },
+    );
+
+    return {
+      // type: "contestableIssues"
+      type: issue.type,
+      attributes,
+    };
+  });
+
+export const getContact = ({ informalConference }) => {
+  if (informalConference === 'rep') {
+    return 'representative';
+  }
+  if (informalConference === 'me') {
+    return 'veteran';
+  }
+  return '';
+};
+
+/**
+ * Veteran~submittable
+ * @property {Address~submittable} address
+ * @property {Phone~submittable} phone
+ * @property {String} emailAddressText
+ * @property {Boolean} homeless
+ */
+/**
+ * Address~submittable
+ * @typedef {Object}
+ * @property {String} addressLine1
+ * @property {String} addressLine2
+ * @property {String} addressLine3
+ * @property {String} city
+ * @property {String} stateCode
+ * @property {String} zipCode5
+ * @property {String} countryCodeISO2
+ * @property {String} internationalPostalCode
+ */
+/**
+ * Phone~submittable
+ * @typedef {Object}
+ * @property {String} countryCode
+ * @property {String} areaCode
+ * @property {String} phoneNumber
+ * @property {String} phoneNumberExt
+ */
+/**
+ * Strip out extra profile home address data & rename zipCode to zipCode5
+ * @param {Veteran} veteran - Veteran formData object
+ * @returns {Object} submittable address
+ */
+export const getAddress = ({ veteran = {}, zipCode5 = '' } = {}) =>
+  removeEmptyEntries({
+    addressLine1: veteran.address?.addressLine1 || '',
+    addressLine2: veteran.address?.addressLine2 || '',
+    addressLine3: veteran.address?.addressLine3 || '',
+    city: veteran.address?.city || '',
+    stateCode: veteran.address?.stateCode || '',
+    countryCodeISO2: veteran.address?.countryCodeIso2 || '',
+    // https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/appeals_api/config/schemas/v2/200996.json#L145
+    zipCode5: zipCode5 || veteran.address?.zipCode || '00000',
+    internationalPostalCode: veteran.address?.internationalPostalCode || '',
+  });
+
+/**
+ * Strip out extra profile phone data
+ * @param {Veteran} veteran - Veteran formData object
+ * @returns {Object} submittable address
+ */
+export const getPhone = ({ veteran = {} } = {}) =>
+  removeEmptyEntries({
+    countryCode: veteran.phone?.countryCode || '',
+    areaCode: veteran.phone?.areaCode || '',
+    phoneNumber: veteran.phone?.phoneNumber || '',
+    phoneNumberExt: veteran.phone?.phoneNumberExt || '',
+  });

--- a/src/applications/disability-benefits/996/utils/submit.js
+++ b/src/applications/disability-benefits/996/utils/submit.js
@@ -18,7 +18,7 @@ export const removeEmptyEntries = object =>
 // We require the user to input a 10-digit number; assuming we get a 3-digit
 // area code + 7 digit number. We're not yet supporting international numbers
 export const getPhoneNumber = (phone = '') => ({
-  country: '1',
+  countryCode: '1',
   areaCode: phone.substring(0, 3),
   phoneNumber: phone.substring(3),
   // Empty string/null are not permitted values
@@ -173,8 +173,14 @@ export const getContact = ({ informalConference }) => {
  * @param {Veteran} veteran - Veteran formData object
  * @returns {Object} submittable address
  */
-export const getAddress = ({ veteran = {}, zipCode5 = '' } = {}) =>
-  removeEmptyEntries({
+export const getAddress = (
+  { veteran = {}, zipCode5 = '' } = {},
+  version = 1,
+) => {
+  if (version === 1) {
+    return { zipCode5: zipCode5 || '00000' };
+  }
+  return removeEmptyEntries({
     addressLine1: veteran.address?.addressLine1 || '',
     addressLine2: veteran.address?.addressLine2 || '',
     addressLine3: veteran.address?.addressLine3 || '',
@@ -182,9 +188,10 @@ export const getAddress = ({ veteran = {}, zipCode5 = '' } = {}) =>
     stateCode: veteran.address?.stateCode || '',
     countryCodeISO2: veteran.address?.countryCodeIso2 || '',
     // https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/appeals_api/config/schemas/v2/200996.json#L145
-    zipCode5: zipCode5 || veteran.address?.zipCode || '00000',
+    zipCode5: veteran.address?.zipCode || '',
     internationalPostalCode: veteran.address?.internationalPostalCode || '',
   });
+};
 
 /**
  * Strip out extra profile phone data

--- a/src/applications/disability-benefits/996/utils/ui.js
+++ b/src/applications/disability-benefits/996/utils/ui.js
@@ -1,0 +1,3 @@
+// testing
+export const $ = (selector, DOM) => DOM.querySelector(selector);
+export const $$ = (selector, DOM) => DOM.querySelectorAll(selector);

--- a/src/applications/disability-benefits/996/utils/wizard.js
+++ b/src/applications/disability-benefits/996/utils/wizard.js
@@ -1,6 +1,7 @@
 import ApplicationStatus from 'platform/forms/save-in-progress/ApplicationStatus';
-import WizardLink from './wizard/WizardLink';
+import WizardLink from '../wizard/WizardLink';
 
+// Wizard
 // helper module so that we can code split with both of these components
 // in the same bundle
 export default {

--- a/src/applications/disability-benefits/996/validations/index.js
+++ b/src/applications/disability-benefits/996/validations/index.js
@@ -28,3 +28,16 @@ export const validatePhone = (errors, phone) => {
     errors.addError(errorMessages.informalConferenceContactPhonePattern);
   }
 };
+
+export const contactInfoValidation = (errors, _fieldData, formData) => {
+  const { veteran = {} } = formData;
+  if (!veteran.email) {
+    errors.addError('Please add an email address to your profile');
+  }
+  if (!veteran.phone?.phoneNumber) {
+    errors.addError('Please add a phone number to your profile');
+  }
+  if (!veteran.address?.addressLine1) {
+    errors.addError('Please add an address to your profile');
+  }
+};


### PR DESCRIPTION
## Description

The Higher-Level Review form currently directs the Veteran to their profile page to make changes to their address, phone or email. This PR uses the profile modal components to edit this information within the contact page.

Also reorganized the utilities & helper code.

## Original issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/28355

## Testing done

Updated unit tests & e2e tests

## Screenshots

<details><summary>HLR contact page</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-08-09 at 8 25 29 AM](https://user-images.githubusercontent.com/136959/128713515-3be21bd6-ef51-4663-b493-bc3960ba7361.png)</details>

## Acceptance criteria
- [x] Contact page allows on-page editing
- [x] All unit tests passing
- [x] All e2e tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
