### PR TITLE
fixed prefill bug

### DIFF
--- a/src/applications/edu-benefits/1990s/components/PrefillAlert.jsx
+++ b/src/applications/edu-benefits/1990s/components/PrefillAlert.jsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
+import { connect } from 'react-redux';
 
-export default function PrefillAlert({ formContext }) {
-  if (!formContext.prefilled) {
-    return null;
-  }
-
-  return (
+const PrefillAlert = ({ user, formContext }) => {
+  return formContext.prefilled && user.userFullName.first !== null ? (
     <AlertBox
       status="info"
       content="This is the personal information we have on file for you."
     />
-  );
-}
+  ) : null;
+};
+
+const mapStateToProps = state => ({
+  user: state.user.profile,
+});
+
+export default connect(mapStateToProps)(PrefillAlert);


### PR DESCRIPTION
## Description
After starting the VRRAP form, the user is given a "This is the personal information we have on file for you." message to indicate that some fields have been automatically completed. This message should only display if the user does, in fact, have data that is used to pre-fill some of the fields on the form. Currently, the message is displayed to all users even when they do not have prefilled data.
## Original issue(s)
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/25116


## Testing done
local

## Screenshots


## Acceptance criteria
- [x] "This is the personal information we have on file for you." is not present when there is no prefilled data

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
