### PR TITLE
Remove style-loader dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -234,7 +234,6 @@
     "sinon": "^3.2.1",
     "skin-deep": "^1.0.0",
     "start-server-and-test": "^1.11.0",
-    "style-loader": "^1.2.1",
     "stylelint": "^13.13.1",
     "stylelint-order": "^4.1.0",
     "stylelint-scss": "^3.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17259,7 +17259,7 @@ schema-utils@^2.0.0:
     ajv "^6.12.4"
     ajv-keywords "^3.5.2"
 
-schema-utils@^2.6.1, schema-utils@^2.6.6, schema-utils@^2.7.0:
+schema-utils@^2.6.1, schema-utils@^2.7.0:
   version "2.7.0"
   resolved "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz"
   integrity sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==
@@ -18320,14 +18320,6 @@ strip-json-comments@~1.0.1:
   version "1.0.4"
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
   integrity sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=
-
-style-loader@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/style-loader/-/style-loader-1.2.1.tgz"
-  integrity sha512-ByHSTQvHLkWE9Ir5+lGbVOXhxX10fbprhLvdg96wedFZb4NDekDPxVKv5Fwmio+QcMlkkNfuK+5W1peQ5CUhZg==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^2.6.6"
 
 style-search@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## Description
Remove an unused dependency. We used to use style-loader in Webpack but not anymore. The utilization of this dependency was removed about a year ago [here](https://github.com/department-of-veterans-affairs/vets-website/commit/1b632a7555ffa7d41cd4365031000bda34340f18#diff-c49a22733230fd83e34ff3bc78014ee352ad46ce10c7c502dd2a7c3982adb0a5) by J Balboni

## Original issue(s)
department-of-veterans-affairs/va.gov-team#27348


## Testing done
Locally

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
