### PR TITLE
stop skipping tests

### DIFF
--- a/src/applications/personalization/dashboard/tests/e2e/messaging-error.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/messaging-error.cypress.spec.js
@@ -6,7 +6,7 @@ import {
   mockLocalStorage,
 } from '~/applications/personalization/dashboard/tests/e2e/dashboard-e2e-helpers';
 
-describe.skip('MyVA Dashboard - Messaging', () => {
+describe('MyVA Dashboard - Messaging', () => {
   describe('when there is an error fetching the inbox data', () => {
     beforeEach(() => {
       mockLocalStorage();
@@ -17,7 +17,6 @@ describe.skip('MyVA Dashboard - Messaging', () => {
       });
 
       cy.login(mockUser);
-      // login() calls cy.server() so we can now mock routes
       cy.intercept('GET', '/v0/messaging/health/folders/0', {
         statusCode: 400,
         body: ERROR_400,

--- a/src/platform/user/profile/vap-svc/tests/selectors.unit.spec.js
+++ b/src/platform/user/profile/vap-svc/tests/selectors.unit.spec.js
@@ -334,7 +334,7 @@ describe('selectVAPServiceInitializationStatus', () => {
     );
   });
 
-  it.skip('returns INITIALIZED if Vet360 is found in the services array', () => {
+  it('returns INITIALIZED if Vet360 is found in the services array', () => {
     const result = selectors.selectVAPServiceInitializationStatus(state);
     expect(result.status).to.be.equal(
       VAP_SERVICE_INITIALIZATION_STATUS.INITIALIZED,
@@ -363,7 +363,7 @@ describe('selectVAPServiceInitializationStatus', () => {
     );
   });
 
-  it.skip('returns INITIALIZATION_FAILURE if there is a failed transaction', () => {
+  it('returns INITIALIZATION_FAILURE if there is a failed transaction', () => {
     const transactionId = 'transaction_1';
     state.user.profile.services = [];
     state.vapService.transactions = [


### PR DESCRIPTION
## Description
Over the past few weeks a couple of unit tests were disabled that never should have been disabled. This PR stops skipping them.

This PR also stops skipping a Cypress test that _was_ legit breaking some time ago, but the code was fixed a while ago and the test now passes.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs