### PR TITLE
properly restore global window object

### DIFF
--- a/src/platform/forms/tests/components/SignInLink.unit.spec.jsx
+++ b/src/platform/forms/tests/components/SignInLink.unit.spec.jsx
@@ -16,6 +16,7 @@ const response = {
 
 const setup = () => {
   mockFetch(response);
+  oldWindow = global.window;
   global.window = Object.create(global.window);
   Object.assign(global.window, {
     dataLayer: [],


### PR DESCRIPTION
## Description
I happened to see [this failing unit test run on Jenkins](http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fvets-website/detail/27514-update-686-url/4/tests/) and traced it to a bug that's fixed with this PR.

<img width="941" alt="Screen Shot 2021-08-09 at 5 03 01 PM" src="https://user-images.githubusercontent.com/20728956/128789384-2447dd3c-b918-4c5a-bfd3-f563d52c4b3d.png">

Basically the `global.window` was set to `undefined` and when `msw` tried to do its setup, it would blow up when trying to set something on `window`.

You can easily replicate the failing test locally if you are on _any_ recent commit and run the `SignInLink.unit.spec.jsx` before the `BankInfoCNP.unit.spec.jsx` by:

1. commenting-out [`choma` in the `mocha.json`](https://github.com/department-of-veterans-affairs/vets-website/blob/e912eb0ac29862e80a2eb7b7d6c8db90086a0623/config/mocha.json#L6-L7)
2. then running `yarn test:unit --reporter=spec src/platform/forms/tests/components/SignInLink.unit.spec.jsx src/applications/personalization/profile/tests/components/direct-deposit/BankInfoCNP.unit.spec.jsx`

The bug that this is fixing was introduced in [this PR](https://github.com/department-of-veterans-affairs/vets-website/commit/8e50552df8a4e5a5dadf613b8d36cc2fb2b78f1f#diff-c79ccd89742ffef4dd240e57f8d5b3c8627741d581ea6623344467d7a940d2d2L20)

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs