### PR TITLE
Reset global.window after tests that modify it in letters tests

### DIFF
--- a/src/applications/letters/tests/actions/letters.unit.spec.js
+++ b/src/applications/letters/tests/actions/letters.unit.spec.js
@@ -36,20 +36,28 @@ import {
  * Teardown() resets it back to normal.
  */
 
+let oldWindow;
+
 const setup = () => {
   testkit.reset();
   mockFetch();
   setFetchJSONResponse(global.fetch.onCall(0), {});
+  oldWindow = global.window;
   global.window.URL = {
     createObjectURL: () => {},
     revokeObjectURL: () => {},
   };
 };
 
+const teardown = () => {
+  global.window = oldWindow;
+};
+
 const getState = () => ({});
 
 describe('getLettersList', () => {
   beforeEach(setup);
+  afterEach(teardown);
 
   const lettersResponse = {
     data: {
@@ -137,6 +145,7 @@ describe('getLettersList', () => {
 
 describe('getLetterListAndBSLOptions', () => {
   beforeEach(setup);
+  afterEach(teardown);
 
   it('should make the call to get the BSL options after the letter list call is complete', done => {
     const thunk = getLetterListAndBSLOptions();
@@ -166,6 +175,7 @@ describe('getLetterListAndBSLOptions', () => {
 
 describe('getBenefitSummaryOptions', () => {
   beforeEach(setup);
+  afterEach(teardown);
 
   const mockResponse = {
     data: {
@@ -234,6 +244,7 @@ describe('getBenefitSummaryOptions', () => {
 
 describe('getLetterPdf', () => {
   beforeEach(setup);
+  afterEach(teardown);
 
   const benefitSLetter = {
     letterName: 'Benefit Summary Letter',


### PR DESCRIPTION
## Description
Found an instance where global.window was being modified for some tests, but not reset. This fixes that issue.

## Original issue(s)


## Testing done
Unit tests run locally. All are passing.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
