### PR TITLE
Hide SMS checkbox

### DIFF
--- a/src/platform/user/profile/vap-svc/components/PhoneField/PhoneEditModal.jsx
+++ b/src/platform/user/profile/vap-svc/components/PhoneField/PhoneEditModal.jsx
@@ -6,6 +6,7 @@ import VAPServiceEditModal from '../base/VAPServiceEditModal';
 import { isVAPatient } from 'platform/user/selectors';
 
 import { FIELD_NAMES } from '@@vap-svc/constants';
+import { showNotificationSettings } from '@@profile/selectors';
 
 import ContactInfoForm from '../ContactInfoForm';
 
@@ -65,7 +66,9 @@ class PhoneEditModal extends React.Component {
 export function mapStateToProps(state, ownProps) {
   const isEnrolledInVAHealthCare = isVAPatient(state);
   const showSMSCheckbox =
-    ownProps.fieldName === FIELD_NAMES.MOBILE_PHONE && isEnrolledInVAHealthCare;
+    ownProps.fieldName === FIELD_NAMES.MOBILE_PHONE &&
+    isEnrolledInVAHealthCare &&
+    !showNotificationSettings(state);
   return {
     showSMSCheckbox,
   };


### PR DESCRIPTION
## Description

We are using the `PhoneEditModal` in our form's contact info page to edit the Veteran's mobile phone number. Upon opening the modal, a checkbox related to SMS messaging is visible, but should be hidden behind a feature flag.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/28355

## Testing done

Visual

## Screenshots
<details><summary>Before (showing SMS checkbox)</summary>

<!-- leave a blank line above -->
![](https://user-images.githubusercontent.com/136959/128894169-748885b6-57f8-4603-8b31-c9741dbd464e.png)</details>

<details><summary>After (no checkbox)</summary>

<!-- leave a blank line above -->
![](https://user-images.githubusercontent.com/136959/128894098-46c0999d-faa6-4c6d-87da-3f022199dd3a.png)
</details>

## Acceptance criteria

- [x] SMS checkbox is hidden in the mobile phone edit modal

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
