### PR TITLE
Remove past clinics check for MH and PC direct scheduling

### DIFF
--- a/src/applications/vaos/services/patient/index.js
+++ b/src/applications/vaos/services/patient/index.js
@@ -58,6 +58,7 @@ function createErrorHandler(errorKey) {
 }
 
 const PRIMARY_CARE = '323';
+const MENTAL_HEALTH = '502';
 
 const DISABLED_LIMIT_VALUE = 0;
 
@@ -341,9 +342,12 @@ export async function fetchFlowEligibilityAndClinics({
       systemId: location.vistaId,
       useV2,
     }).catch(createErrorHandler('direct-available-clinics-error'));
-    apiCalls.pastAppointments = getLongTermAppointmentHistory().catch(
-      createErrorHandler('direct-no-matching-past-clinics-error'),
-    );
+
+    if (typeOfCare.id !== PRIMARY_CARE && typeOfCare.id !== MENTAL_HEALTH) {
+      apiCalls.pastAppointments = getLongTermAppointmentHistory().catch(
+        createErrorHandler('direct-no-matching-past-clinics-error'),
+      );
+    }
   }
 
   // This waits for all the api calls we're running in parallel to finish
@@ -410,7 +414,11 @@ export async function fetchFlowEligibilityAndClinics({
       recordEligibilityFailure('direct-available-clinics');
     }
 
-    if (!hasMatchingClinics(results.clinics, results.pastAppointments)) {
+    if (
+      typeOfCare.id !== PRIMARY_CARE &&
+      typeOfCare.id !== MENTAL_HEALTH &&
+      !hasMatchingClinics(results.clinics, results.pastAppointments)
+    ) {
       eligibility.direct = false;
       eligibility.directReasons.push(ELIGIBILITY_REASONS.noMatchingClinics);
       recordEligibilityFailure('direct-no-matching-past-clinics');

--- a/src/applications/vaos/tests/new-appointment/components/ClinicChoicePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ClinicChoicePage.unit.spec.jsx
@@ -93,7 +93,7 @@ describe('VAOS <ClinicChoicePage>', () => {
     await screen.findByText(/Choose a VA clinic/i);
 
     expect(screen.baseElement).to.contain.text(
-      'In the last 24 months you’ve had a primary care appointment at the following Cheyenne VA Medical Center clinics:',
+      'Primary care appointments are available at the following Cheyenne VA Medical Center clinics:',
     );
     expect(screen.baseElement).to.contain.text('Cheyenne VA Medical Center');
 
@@ -305,12 +305,11 @@ describe('VAOS <ClinicChoicePage>', () => {
       store,
     });
 
-    await screen.findByText(
-      /Make an amputation care appointment at your last clinic/i,
-    );
+    await screen.findByText(/last amputation care appointment/i);
     expect(screen.baseElement).to.contain.text(
       'Your last amputation care appointment was at Green team clinic:',
     );
+    expect(screen.baseElement).to.contain.text('Choose a VA clinic');
     expect(screen.baseElement).to.contain.text('Cheyenne VA Medical Center');
     expect(screen.baseElement).to.contain.text(
       'Cheyenne, WyomingWY 82001-5356',

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -73,9 +73,12 @@ export const COVID_VACCINE_ID = 'covid';
  * @property {Array<string>} specialities PPMS specialty codes associated with this type of care
  */
 
+export const PRIMARY_CARE = '323';
+export const MENTAL_HEALTH = '502';
+
 export const TYPES_OF_CARE = [
   {
-    id: '323',
+    id: PRIMARY_CARE,
     idV2: 'primaryCare',
     name: 'Primary care',
     group: 'primary',
@@ -90,7 +93,7 @@ export const TYPES_OF_CARE = [
     group: 'primary',
   },
   {
-    id: '502',
+    id: MENTAL_HEALTH,
     idV2: 'outpatientMentalHealth',
     name: 'Mental health',
     group: 'mentalHealth',
@@ -318,7 +321,6 @@ export const DISTANCES = [
   },
 ];
 
-export const MENTAL_HEALTH = '502';
 export const EXPRESS_CARE = 'CR1';
 
 export const GA_PREFIX = 'vaos';


### PR DESCRIPTION
## Description
This PR
- Removes the past clinic check for MH and PC
- Updates the clinic choice page text to not assume that a user visited the clinic in the past 24 months
- Adds new tests

## Original issue(s)
department-of-veterans-affairs/va.gov-team#28269

## Testing done
Local and unit testing

## Screenshots
![Screen Shot 2021-08-10 at 11 17 44 AM](https://user-images.githubusercontent.com/634932/128939978-3072eff2-c2c7-4324-9f6a-497f2290c235.png)
![Screen Shot 2021-08-10 at 11 17 00 AM](https://user-images.githubusercontent.com/634932/128939979-0b66b8bc-f5df-450e-88d0-dc1fc4c719c6.png)


## Acceptance criteria
- [ ] Users can direct schedule MH and PC even if they don't have matching clinics from past 24 months

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
