### PR TITLE
Remove uglify-js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -239,7 +239,6 @@
     "stylelint-scss": "^3.19.0",
     "svg-url-loader": "^2.3.2",
     "terser-webpack-plugin": "^1.3.0",
-    "uglify-js": "^3.9.4",
     "url-loader": "^0.6.2",
     "webpack": "^4.46.0",
     "webpack-bundle-analyzer": "^3.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19265,7 +19265,7 @@ uc.micro@^1.0.5:
   resolved "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz"
   integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
-uglify-js@^3.1.4, uglify-js@^3.9.4:
+uglify-js@^3.1.4:
   version "3.9.4"
   resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.4.tgz"
   integrity sha512-8RZBJq5smLOa7KslsNsVcSH+KOXf1uDU8yqLeNuVKwmT0T3FA0ZoXlinQfRad7SDcbZZRZE4ov+2v71EnxNyCA==


### PR DESCRIPTION
## Description
Remove an unused dependency and it was replaced. Tercer is being used instead

## Original issue(s)
department-of-veterans-affairs/va.gov-team#27348


## Testing done
Locally

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
