### PR TITLE
HLR: Add v2 representative info page

### DIFF
--- a/src/applications/disability-benefits/996/config/form.js
+++ b/src/applications/disability-benefits/996/config/form.js
@@ -22,6 +22,7 @@ import homeless from '../pages/homeless';
 import contestedIssuesPage from '../pages/contestedIssues';
 import informalConference from '../pages/informalConference';
 import informalConferenceRep from '../pages/informalConferenceRep';
+import informalConferenceRepV2 from '../pages/informalConferenceRepV2';
 import informalConferenceTimes from '../pages/informalConferenceTimes';
 import sameOffice from '../pages/sameOffice';
 
@@ -150,9 +151,20 @@ const formConfig = {
         representativeInfo: {
           path: 'informal-conference/representative-information',
           title: 'Representative’s information',
-          depends: formData => formData?.informalConference === 'rep',
+          depends: formData =>
+            formData?.informalConference === 'rep' && apiVersion1(formData),
           uiSchema: informalConferenceRep.uiSchema,
           schema: informalConferenceRep.schema,
+        },
+        representativeInfoV2: {
+          // changing path from v1, but this shouldn't matter since the
+          // migration code returns the Veteran to the contact info page
+          path: 'informal-conference/representative-info',
+          title: 'Representative’s information',
+          depends: formData =>
+            formData?.informalConference === 'rep' && apiVersion2(formData),
+          uiSchema: informalConferenceRepV2.uiSchema,
+          schema: informalConferenceRepV2.schema,
         },
         availability: {
           path: 'informal-conference/availability',

--- a/src/applications/disability-benefits/996/config/submit-transformer.js
+++ b/src/applications/disability-benefits/996/config/submit-transformer.js
@@ -9,11 +9,12 @@ import {
   getPhone,
   getTimeZone,
 } from '../utils/submit';
+import { apiVersion1 } from '../utils/helpers';
 
 export function transform(formConfig, form) {
   // https://dev-developer.va.gov/explore/appeals/docs/decision_reviews?version=current
   const mainTransform = formData => {
-    const version = formData.hlrV2 ? 2 : 1;
+    const version1 = apiVersion1(formData);
     const informalConference = formData.informalConference !== 'no';
     const attributes = {
       // This value may empty if the user restarts the form; see
@@ -24,14 +25,14 @@ export function transform(formConfig, form) {
 
       veteran: {
         timezone: getTimeZone(),
-        address: getAddress(formData, version),
+        address: getAddress(formData),
       },
     };
 
-    if (version === 1) {
+    if (version1) {
       attributes.sameOffice = formData.sameOffice || false;
     }
-    if (version > 1) {
+    if (!version1) {
       attributes.veteran.homeless = formData.homeless;
       attributes.veteran.phone = getPhone(formData);
       attributes.veteran.email = formData?.veteran.email;
@@ -39,14 +40,11 @@ export function transform(formConfig, form) {
 
     // Add informal conference data
     if (informalConference) {
-      attributes.informalConferenceTimes = getConferenceTimes(
-        formData,
-        version,
-      );
+      attributes.informalConferenceTimes = getConferenceTimes(formData);
       if (formData.informalConference === 'rep') {
-        attributes.informalConferenceRep = getRep(formData, version);
+        attributes.informalConferenceRep = getRep(formData);
       }
-      if (version > 1) {
+      if (!version1) {
         attributes.informalConferenceContact = getContact(formData);
       }
     }

--- a/src/applications/disability-benefits/996/constants.js
+++ b/src/applications/disability-benefits/996/constants.js
@@ -43,8 +43,13 @@ export const errorMessages = {
   endDateInPast: 'End date must be in the future',
   endDateBeforeStart: 'End date must be after start date',
   informalConferenceContactChoice: 'Please choose an option',
-  informalConferenceContactName: 'Please enter a name',
-  informalConferenceContactPhone: 'Please enter a number',
+  informalConferenceContactName: 'Please enter your representative’s name',
+  informalConferenceContactFirstName:
+    'Please enter your representative’s first name',
+  informalConferenceContactLastName:
+    'Please enter your representative’s last name',
+  informalConferenceContactPhone:
+    'Please enter your representative’s phone number',
   informalConferenceContactPhonePattern:
     'Please enter a 10-digit phone number (with or without dashes)',
   informalConferenceTimes: 'Please select a time',

--- a/src/applications/disability-benefits/996/content/GetFormHelp.jsx
+++ b/src/applications/disability-benefits/996/content/GetFormHelp.jsx
@@ -3,13 +3,15 @@ import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
 
+import { srSubstitute } from 'platform/forms-system/src/js/utilities/ui/mask-string';
+
 const GetFormHelp = () => (
   <>
     <p className="help-talk">
       If you have questions or need help filling out this form, please call our{' '}
-      <span aria-label="My. VA. 4 1 1.">MYVA411</span> main information line at{' '}
+      {srSubstitute('MYVA411', 'My V. A. 4 1 1.')} main information line at{' '}
       <Telephone contact={CONTACTS.HELP_DESK} /> and select 0. We’re here{' '}
-      <abbr title="24 hours a day, 7 days a week">24/7</abbr>.
+      {srSubstitute('24/7', '24 hours a day, 7 days a week')}.
     </p>
     <p className="u-vads-margin-bottom--0">
       If you have hearing loss, call TTY:{' '}

--- a/src/applications/disability-benefits/996/content/InformalConference.jsx
+++ b/src/applications/disability-benefits/996/content/InformalConference.jsx
@@ -29,8 +29,14 @@ export const ContactRepresentativeTitle =
   'Provide your representative’s contact information.';
 
 export const RepresentativeNameTitle = 'Representative’s name';
+export const RepresentativeFirstNameTitle = 'Representative’s first name';
+export const RepresentativeLastNameTitle = 'Representative’s last name';
 
 export const RepresentativePhoneTitle = 'Representative’s phone number';
+export const RepresentativePhoneExtensionTitle =
+  'Representative’s phone extension';
+
+export const RepresentativeEmailTitle = 'Representative’s email address';
 
 // Using CSS to use article[data-contact-choice] attribute to set visibility
 const contacts = (

--- a/src/applications/disability-benefits/996/pages/informalConferenceRepV2.js
+++ b/src/applications/disability-benefits/996/pages/informalConferenceRepV2.js
@@ -1,0 +1,96 @@
+import PhoneNumberWidget from 'platform/forms-system/src/js/widgets/PhoneNumberWidget';
+import PhoneNumberReviewWidget from 'platform/forms-system/src/js/review/PhoneNumberWidget';
+import emailUI from 'platform/forms-system/src/js/definitions/email';
+
+import { errorMessages } from '../constants';
+
+import {
+  ContactRepresentativeTitle,
+  RepresentativeFirstNameTitle,
+  RepresentativeLastNameTitle,
+  RepresentativePhoneTitle,
+  RepresentativePhoneExtensionTitle,
+  RepresentativeEmailTitle,
+} from '../content/InformalConference';
+
+import { validatePhone } from '../validations';
+
+export default {
+  uiSchema: {
+    'ui:title': ' ',
+    'ui:options': {
+      forceDivWrapper: true,
+    },
+    informalConferenceRep: {
+      'ui:title': ContactRepresentativeTitle,
+      firstName: {
+        'ui:title': RepresentativeFirstNameTitle,
+        'ui:required': formData => formData?.informalConference === 'rep',
+        'ui:errorMessages': {
+          required: errorMessages.informalConferenceContactFirstName,
+        },
+      },
+      lastName: {
+        'ui:title': RepresentativeLastNameTitle,
+        'ui:required': formData => formData?.informalConference === 'rep',
+        'ui:errorMessages': {
+          required: errorMessages.informalConferenceContactLastName,
+        },
+      },
+      phone: {
+        'ui:title': RepresentativePhoneTitle,
+        'ui:widget': PhoneNumberWidget,
+        'ui:reviewWidget': PhoneNumberReviewWidget,
+        'ui:required': formData => formData?.informalConference === 'rep',
+        'ui:errorMessages': {
+          pattern: errorMessages.informalConferenceContactPhonePattern,
+          required: errorMessages.informalConferenceContactPhone,
+        },
+        'ui:validations': [validatePhone],
+      },
+      extension: {
+        'ui:title': RepresentativePhoneExtensionTitle,
+      },
+      email: emailUI(RepresentativeEmailTitle),
+    },
+  },
+
+  // https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/appeals_api/config/schemas/v2/200996.json#L79-L92
+  schema: {
+    type: 'object',
+    required: ['informalConference'],
+    properties: {
+      informalConferenceRep: {
+        type: 'object',
+        properties: {
+          'view:ContactRepresentativeInfo': {
+            type: 'object',
+            properties: {},
+          },
+          firstName: {
+            type: 'string',
+            maxLength: 30,
+          },
+          lastName: {
+            type: 'string',
+            maxLength: 40,
+          },
+          phone: {
+            type: 'string',
+            pattern: '[0-9]+',
+          },
+          extension: {
+            type: 'string',
+            pattern: '^[0-9]{1,10}$',
+          },
+          email: {
+            type: 'string',
+            format: 'email',
+            minLength: 6,
+            maxLength: 255,
+          },
+        },
+      },
+    },
+  },
+};

--- a/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
+++ b/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
@@ -197,6 +197,7 @@ article[data-contact-choice="me"] .contact-choice.selected-me {
   display: inline-block;
 }
 
+article[data-location="informal-conference/representative-info"],
 article[data-location="informal-conference/representative-information"] {
   .schemaform-field-container {
     margin-top: 0;

--- a/src/applications/disability-benefits/996/tests/fixtures/data/maximal-test-v2.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/data/maximal-test-v2.json
@@ -29,7 +29,9 @@
     "informalConferenceRep": {
       "firstName": "James",
       "lastName": "Sullivan",
-      "phone": "8005551212"
+      "phone": "8005551212",
+      "extension": "1234",
+      "email": "sully@pixar.com"
     },
     "informalConferenceTimes": {
       "time1": "time0800to1200",

--- a/src/applications/disability-benefits/996/tests/fixtures/data/transformed/maximal-test-v2.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/data/transformed/maximal-test-v2.json
@@ -12,8 +12,10 @@
         "phone": {
           "countryCode": "1",
           "areaCode": "800",
-          "phoneNumber": "5551212"
-        }
+          "phoneNumber": "5551212",
+          "phoneNumberExt": "1234"
+        },
+        "email": "sully@pixar.com"
       },
       "veteran": {
         "address": {

--- a/src/applications/disability-benefits/996/tests/fixtures/mocks/profile-status.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/mocks/profile-status.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "id": "",
+    "type": "async_transaction_va_profile_address_transactions",
+    "attributes": {
+      "transactionId": "bfedd909-9dc4-4b27-abc2-a6cccaece35d",
+      "transactionStatus": "COMPLETED_SUCCESS",
+      "type": "AsyncTransaction::VAProfile::AddressTransaction",
+      "metadata": []
+    }
+  }
+}

--- a/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
@@ -8,6 +8,7 @@ import manifest from '../manifest.json';
 import { mockContestableIssues } from './hlr.cypress.helpers';
 import mockInProgress from './fixtures/mocks/in-progress-forms.json';
 import mockSubmit from './fixtures/mocks/application-submit.json';
+import mockStatus from './fixtures/mocks/profile-status.json';
 import mockUser from './fixtures/mocks/user.json';
 import { CONTESTABLE_ISSUES_API, WIZARD_STATUS } from '../constants';
 
@@ -15,7 +16,7 @@ const testConfig = createTestConfig(
   {
     dataPrefix: 'data',
 
-    dataSets: ['maximal-test-v1', 'minimal-test-v1'],
+    dataSets: ['maximal-test-v1', 'minimal-test-v1', 'maximal-test-v2'],
 
     fixtures: {
       data: path.join(__dirname, 'fixtures', 'data'),
@@ -52,7 +53,7 @@ const testConfig = createTestConfig(
 
       cy.login(mockUser);
 
-      cy.intercept('GET', '/v0/feature_toggles?*', { data: { features: [] } });
+      cy.intercept('GET', '/v0/profile/status', mockStatus);
 
       cy.intercept(
         'GET',
@@ -67,6 +68,9 @@ const testConfig = createTestConfig(
       cy.get('@testData').then(testData => {
         cy.intercept('GET', '/v0/in_progress_forms/20-0996', testData);
         cy.intercept('PUT', 'v0/in_progress_forms/20-0996', testData);
+
+        const features = testData.hlrV2 ? [{ name: 'hlrV2', value: true }] : [];
+        cy.intercept('GET', '/v0/feature_toggles?*', { data: { features } });
       });
     },
   },

--- a/src/applications/disability-benefits/996/tests/pages/informalConferenceRepV1.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/pages/informalConferenceRepV1.unit.spec.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import ReactTestUtils from 'react-dom/test-utils';
+
+import {
+  DefinitionTester,
+  getFormDOM,
+} from 'platform/testing/unit/schemaform-utils.jsx';
+
+import formConfig from '../../config/form';
+import { $$ } from '../../utils/ui';
+
+describe('HLR informal conference rep v1 page', () => {
+  const {
+    schema,
+    uiSchema,
+  } = formConfig.chapters.informalConference.pages.representativeInfo;
+
+  it('should render', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+        definitions={{}}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{ informalConference: 'rep' }}
+      />,
+    );
+    const formDOM = getFormDOM(form);
+
+    expect($$('input', formDOM).length).to.equal(2);
+  });
+  it('should allow submit', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+        definitions={{}}
+        schema={schema}
+        uiSchema={uiSchema}
+        onSubmit={onSubmit}
+        data={{ informalConference: 'rep' }}
+      />,
+    );
+    const formDOM = getFormDOM(form);
+
+    formDOM.fillData('#root_informalConferenceRep_name', 'James Sullivan');
+    formDOM.fillData('#root_informalConferenceRep_phone', '8005551212');
+
+    formDOM.submitForm(form);
+    expect($$('.usa-input-error', formDOM).length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+  });
+  it('should prevent continuing when data is missing', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+        definitions={{}}
+        schema={schema}
+        uiSchema={uiSchema}
+        onSubmit={onSubmit}
+        data={{ informalConference: 'rep' }}
+      />,
+    );
+    const formDOM = getFormDOM(form);
+
+    formDOM.submitForm(form);
+    expect($$('.usa-input-error', formDOM).length).to.equal(2);
+    expect(onSubmit.called).to.be.false;
+  });
+  it('should prevent continuing when phone is missing', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+        definitions={{}}
+        schema={schema}
+        uiSchema={uiSchema}
+        onSubmit={onSubmit}
+        data={{ informalConference: 'rep' }}
+      />,
+    );
+    const formDOM = getFormDOM(form);
+
+    formDOM.fillData('#root_informalConferenceRep_name', 'James Sullivan');
+    formDOM.submitForm(form);
+    expect($$('.usa-input-error', formDOM).length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
+  });
+});

--- a/src/applications/disability-benefits/996/tests/pages/informalConferenceRepV2.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/pages/informalConferenceRepV2.unit.spec.js
@@ -1,0 +1,92 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import ReactTestUtils from 'react-dom/test-utils';
+
+import {
+  DefinitionTester,
+  getFormDOM,
+} from 'platform/testing/unit/schemaform-utils.jsx';
+
+import formConfig from '../../config/form';
+import { $$ } from '../../utils/ui';
+
+describe('HLR informal conference rep v2 page', () => {
+  const {
+    schema,
+    uiSchema,
+  } = formConfig.chapters.informalConference.pages.representativeInfoV2;
+
+  it('should render', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+        definitions={{}}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{ hlrV2: true }}
+      />,
+    );
+    const formDOM = getFormDOM(form);
+
+    expect($$('input', formDOM).length).to.equal(5);
+  });
+  it('should allow submit', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+        definitions={{}}
+        schema={schema}
+        uiSchema={uiSchema}
+        onSubmit={onSubmit}
+        data={{ informalConference: 'rep', hlrV2: true }}
+      />,
+    );
+    const formDOM = getFormDOM(form);
+
+    formDOM.fillData('#root_informalConferenceRep_firstName', 'James');
+    formDOM.fillData('#root_informalConferenceRep_lastName', 'Sullivan');
+    formDOM.fillData('#root_informalConferenceRep_phone', '8005551212');
+    formDOM.fillData('#root_informalConferenceRep_extension', '1234');
+    formDOM.fillData('#root_informalConferenceRep_email', 'x@x.com');
+
+    formDOM.submitForm(form);
+    expect($$('.usa-input-error', formDOM).length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+  });
+  it('should prevent continuing when data is missing', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+        definitions={{}}
+        schema={schema}
+        uiSchema={uiSchema}
+        onSubmit={onSubmit}
+        data={{ informalConference: 'rep', hlrV2: true }}
+      />,
+    );
+    const formDOM = getFormDOM(form);
+
+    formDOM.submitForm();
+    expect($$('.usa-input-error', formDOM).length).to.equal(3);
+    expect(onSubmit.called).to.be.false;
+  });
+  it('should prevent continuing when phone is missing', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+        definitions={{}}
+        schema={schema}
+        uiSchema={uiSchema}
+        onSubmit={onSubmit}
+        data={{ informalConference: 'rep', hlrV2: true }}
+      />,
+    );
+    const formDOM = getFormDOM(form);
+
+    formDOM.fillData('#root_informalConferenceRep_firstName', 'James');
+    formDOM.fillData('#root_informalConferenceRep_lastName', 'Sullivan');
+    formDOM.submitForm(form);
+    expect($$('.usa-input-error', formDOM).length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
+  });
+});

--- a/src/applications/disability-benefits/996/tests/pages/informalConferenceTimes.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/pages/informalConferenceTimes.unit.spec.js
@@ -10,7 +10,7 @@ import {
 
 import formConfig from '../../config/form';
 
-describe('HLR homeless page', () => {
+describe('HLR conference times page', () => {
   const {
     schema,
     uiSchema,


### PR DESCRIPTION
## Description

In version 2 of the Higher-Level Review form, the representative page makes the following changes:
- Rep name changes from full name input to two separate first name & last name inputs
- Add rep phone extension input
- Add rep email input

## Original issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/28414

## Testing done

- Updated & added unit tests
- Updated E2E test

## Screenshots

<details><summary>Rep info page with errors</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-08-10 at 3 30 47 PM](https://user-images.githubusercontent.com/136959/128931568-68cf2704-d7a8-499c-9923-2f460ecbea97.png)</details>

## Acceptance criteria
- [x] Split rep name into first & last name fields
- [x] Add rep phone extension field
- [x] Add rep email field
- [x] Show v1 & v2 pages based on a feature flag

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
