### PR TITLE
fix deep link to edit email address

### DIFF
--- a/src/applications/personalization/profile/components/notification-settings/AddContactInfoLink.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/AddContactInfoLink.jsx
@@ -10,7 +10,9 @@ const linkMap = {
   },
   EMAIL: {
     linkText: 'add your email address to your profile',
-    linkTarget: `${PROFILE_PATHS.PERSONAL_INFORMATION}#edit-email-address`,
+    linkTarget: `${
+      PROFILE_PATHS.PERSONAL_INFORMATION
+    }#edit-contact-email-address`,
   },
   MOBILE: {
     linkText: 'add your mobile phone number to your profile',

--- a/src/applications/personalization/profile/components/personal-information/PersonalInformation.jsx
+++ b/src/applications/personalization/profile/components/personal-information/PersonalInformation.jsx
@@ -45,7 +45,8 @@ const PersonalInformation = ({
       //   the hash
       // - the user just came to this route via the root profile route. If a
       //   user got to the Profile via a link to /profile or /profile/ we want
-      //   to focus on the "Profile" sub-nav H1, not the H2 on this page
+      //   to focus on the "Profile" sub-nav H1, not the H2 on this page, for
+      //   a11y reasons
       const pathRegExp = new RegExp(`${PROFILE_PATHS.PROFILE_ROOT}/?$`);
       if (lastLocation?.pathname.match(new RegExp(pathRegExp))) {
         return;


### PR DESCRIPTION
## Description
The deep link to edit the contact email address was wrong

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs