### PR TITLE
Add build failure notification to CI workflow in GHA

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -85,8 +85,7 @@ jobs:
   build-failure:
     name: Unit Tests
     runs-on: ubuntu-latest
-    needs: build
-    if: ${{ needs.build.status == 'failure' }}
+    if: ${{ always() }}
     steps:
       # ----------------
       # | Notify Slack |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -87,7 +87,7 @@ jobs:
       # ----------------
 
       - name: Checkout VSP actions
-        if: ${{ needs.cypress-tests.result == 'failure' }}
+        if: ${{ failure() }}
         uses: actions/checkout@v2
         with:
           repository: department-of-veterans-affairs/vsp-github-actions
@@ -97,21 +97,21 @@ jobs:
           path: ./.github/actions/vsp-github-actions
 
       - name: Get Slack app token
-        if: ${{ needs.cypress-tests.result == 'failure' }}
+        if: ${{ failure() }}
         uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
         with:
           ssm_parameter: /devops/github_actions_slack_socket_token
           env_variable_name: SLACK_APP_TOKEN
 
       - name: Get Slack bot token
-        if: ${{ needs.cypress-tests.result == 'failure' }}
+        if: ${{ failure() }}
         uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
         with:
           ssm_parameter: /devops/github_actions_slack_bot_user_token
           env_variable_name: SLACK_BOT_TOKEN
 
       - name: Notify Slack about build failures
-        if: ${{ needs.build.result == 'failure' }}
+        if: ${{ failure() }}
         uses: ./.github/actions/vsp-github-actions/slack-socket
         env:
           SSL_CERT_DIR: /etc/ssl/certs

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -66,11 +66,13 @@ jobs:
           YARN_CACHE_FOLDER: .cache/yarn
 
       - name: Build
-        run: yarnnn build --verbose --buildtype=${{ matrix.buildtype }}
+        run: yarn build --verbose --buildtype=${{ matrix.buildtype }}
         timeout-minutes: 30
-      # ----------------
-      # | Notify Slack |
-      # ----------------
+
+      # ----------------------------
+      # | Notify Slack of failures |
+      # ---------------------------
+
       - name: Get va-vsp-bot token
         if: ${{ failure() }}
         uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
@@ -113,9 +115,13 @@ jobs:
           attachments: '[{"mrkdwn_in": ["text"], "color": "danger", "text": "At least one build step in `vets-website` has failed, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}]'
           channel_id: C02AG8UF95M # gha-build-status
 
-      - name: Report Failure
+      - name: Cancel other parallel steps
         if: ${{ failure() }}
         uses: andymckay/cancel-action@0.2
+
+      # ----------------
+      # | End Notify Slack |
+      # ----------------
 
       - name: Generate build details
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -529,6 +529,17 @@ jobs:
           ssm_parameter: /devops/github_actions_slack_bot_user_token
           env_variable_name: SLACK_BOT_TOKEN
 
+      - name: Notify Slack about build failures
+        if: ${{ needs.build.result == 'failure' }}
+        uses: ./.github/actions/vsp-github-actions/slack-socket
+        env:
+          SSL_CERT_DIR: /etc/ssl/certs
+        with:
+          slack_app_token: ${{ env.SLACK_APP_TOKEN }}
+          slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
+          attachments: '[{"mrkdwn_in": ["text"], "color": "danger", "text": "At least one build step in `vets-website` has failed, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}]'
+          channel_id: C02AG8UF95M # gha-build-status
+
       - name: Notify Slack about Cypress test failures
         if: ${{ needs.cypress-tests.result == 'failure' }}
         uses: ./.github/actions/vsp-github-actions/slack-socket

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,6 +24,7 @@ jobs:
 
     strategy:
       matrix:
+        fail-fast: false
         buildtype: [vagovdev, vagovstaging, vagovprod]
 
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -85,7 +85,7 @@ jobs:
   build-failure:
     name: Unit Tests
     runs-on: ubuntu-latest
-    if: ${{ jobs.build === 'failure' }}
+    if: ${{ jobs.build.status === 'failure' }}
     steps:
       # ----------------
       # | Notify Slack |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -73,7 +73,7 @@ jobs:
           EOF
 
       - name: Compress and archive build
-        run: tar -C build/${{ matrix.buildtype }} -cjf ${{ matrix.buildtype }}.tar.bz2 .
+        run: tarssssssss -C build/${{ matrix.buildtype }} -cjf ${{ matrix.buildtype }}.tar.bz2 .
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -83,13 +83,18 @@ jobs:
           retention-days: 1
 
   build-failure:
-    name: Unit Tests
+    name: Build Failure Notification
     runs-on: ubuntu-latest
-    if: ${{ always() }}
+    if: ${{ github.workflow.jobs.build.status == 'failure' }}
     steps:
       # ----------------
       # | Notify Slack |
       # ----------------
+      - name: Get va-vsp-bot token
+        uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
       - name: Checkout VSP actions
         uses: actions/checkout@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,8 +23,8 @@ jobs:
       NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
 
     strategy:
+      fail-fast: false
       matrix:
-        fail-fast: false
         buildtype: [vagovdev, vagovstaging, vagovprod]
 
     steps:
@@ -64,7 +64,7 @@ jobs:
 
       - name: Generate build details
         run: |
-          cat > build/${{ matrix.buildtype }}/BUILD.txt << EOF
+          catsssss > build/${{ matrix.buildtype }}/BUILD.txt << EOF
           BUILDTYPE=${{ matrix.buildtype }}
           BRANCH_NAME=$(echo "${GITHUB_REF#refs/heads/}")
           RUN_ID=${{ github.run_id }}
@@ -73,7 +73,7 @@ jobs:
           EOF
 
       - name: Compress and archive build
-        run: tarssssssss -C build/${{ matrix.buildtype }} -cjf ${{ matrix.buildtype }}.tar.bz2 .
+        run: tar -C build/${{ matrix.buildtype }} -cjf ${{ matrix.buildtype }}.tar.bz2 .
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -81,6 +81,14 @@ jobs:
           name: ${{ matrix.buildtype }}.tar.bz2
           path: ${{ matrix.buildtype }}.tar.bz2
           retention-days: 1
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: 'us-gov-west-1'
+
       # ----------------
       # | Notify Slack |
       # ----------------
@@ -127,9 +135,7 @@ jobs:
 
       - name: Report Failure
         if: failure()
-        uses: actions/github-script@v2
-        with:
-          script: process.exit(1)
+        uses: andymckay/cancel-action@0.2
 
   unit-tests:
     name: Unit Tests

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -82,12 +82,16 @@ jobs:
           path: ${{ matrix.buildtype }}.tar.bz2
           retention-days: 1
 
+  build-failure:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    if: ${{ jobs.build === 'failure' }}
+    steps:
       # ----------------
       # | Notify Slack |
       # ----------------
 
       - name: Checkout VSP actions
-        if: ${{ failure() }}
         uses: actions/checkout@v2
         with:
           repository: department-of-veterans-affairs/vsp-github-actions
@@ -97,21 +101,18 @@ jobs:
           path: ./.github/actions/vsp-github-actions
 
       - name: Get Slack app token
-        if: ${{ failure() }}
         uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
         with:
           ssm_parameter: /devops/github_actions_slack_socket_token
           env_variable_name: SLACK_APP_TOKEN
 
       - name: Get Slack bot token
-        if: ${{ failure() }}
         uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
         with:
           ssm_parameter: /devops/github_actions_slack_bot_user_token
           env_variable_name: SLACK_BOT_TOKEN
 
       - name: Notify Slack about build failures
-        if: ${{ failure() }}
         uses: ./.github/actions/vsp-github-actions/slack-socket
         env:
           SSL_CERT_DIR: /etc/ssl/certs

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -59,12 +59,12 @@ jobs:
           YARN_CACHE_FOLDER: .cache/yarn
 
       - name: Build
-        run: yarn build --verbose --buildtype=${{ matrix.buildtype }}
+        run: yarnnn build --verbose --buildtype=${{ matrix.buildtype }}
         timeout-minutes: 30
 
       - name: Generate build details
         run: |
-          catsssss > build/${{ matrix.buildtype }}/BUILD.txt << EOF
+          cat > build/${{ matrix.buildtype }}/BUILD.txt << EOF
           BUILDTYPE=${{ matrix.buildtype }}
           BRANCH_NAME=$(echo "${GITHUB_REF#refs/heads/}")
           RUN_ID=${{ github.run_id }}
@@ -93,14 +93,14 @@ jobs:
       # | Notify Slack |
       # ----------------
       - name: Get va-vsp-bot token
-        if: failure()
+        if: ${{ failure() }}
         uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
         with:
           ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
           env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
       - name: Checkout VSP actions
-        if: failure()
+        if: ${{ failure() }}
         uses: actions/checkout@v2
         with:
           repository: department-of-veterans-affairs/vsp-github-actions
@@ -110,20 +110,21 @@ jobs:
           path: ./.github/actions/vsp-github-actions
 
       - name: Get Slack app token
-        if: failure()
+        if: ${{ failure() }}
         uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
         with:
           ssm_parameter: /devops/github_actions_slack_socket_token
           env_variable_name: SLACK_APP_TOKEN
 
       - name: Get Slack bot token
-        if: failure()
+        if: ${{ failure() }}
         uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
         with:
           ssm_parameter: /devops/github_actions_slack_bot_user_token
           env_variable_name: SLACK_BOT_TOKEN
 
       - name: Notify Slack about build failures
+        if: ${{ failure() }}
         uses: ./.github/actions/vsp-github-actions/slack-socket
         env:
           SSL_CERT_DIR: /etc/ssl/certs
@@ -134,7 +135,7 @@ jobs:
           channel_id: C02AG8UF95M # gha-build-status
 
       - name: Report Failure
-        if: failure()
+        if: ${{ failure() }}
         uses: andymckay/cancel-action@0.2
 
   unit-tests:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -85,7 +85,8 @@ jobs:
   build-failure:
     name: Unit Tests
     runs-on: ubuntu-latest
-    if: ${{ jobs.build.status === 'failure' }}
+    needs: build
+    if: ${{ needs.build.status === 'failure' }}
     steps:
       # ----------------
       # | Notify Slack |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -80,27 +80,18 @@ jobs:
           name: ${{ matrix.buildtype }}.tar.bz2
           path: ${{ matrix.buildtype }}.tar.bz2
           retention-days: 1
-
-      - name: Report Failure
-        if: failure()
-        uses: andymckay/cancel-action@0.2
-
-  build-failure:
-    name: Build Failure Notification
-    runs-on: ubuntu-latest
-    needs: build
-    if: ${{ github.workflow.jobs.build.status == 'failure' }}
-    steps:
       # ----------------
       # | Notify Slack |
       # ----------------
       - name: Get va-vsp-bot token
+        if: failure()
         uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
         with:
           ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
           env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
       - name: Checkout VSP actions
+        if: failure()
         uses: actions/checkout@v2
         with:
           repository: department-of-veterans-affairs/vsp-github-actions
@@ -110,12 +101,14 @@ jobs:
           path: ./.github/actions/vsp-github-actions
 
       - name: Get Slack app token
+        if: failure()
         uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
         with:
           ssm_parameter: /devops/github_actions_slack_socket_token
           env_variable_name: SLACK_APP_TOKEN
 
       - name: Get Slack bot token
+        if: failure()
         uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
         with:
           ssm_parameter: /devops/github_actions_slack_bot_user_token
@@ -130,6 +123,11 @@ jobs:
           slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
           attachments: '[{"mrkdwn_in": ["text"], "color": "danger", "text": "At least one build step in `vets-website` has failed, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}]'
           channel_id: C02AG8UF95M # gha-build-status
+
+      - name: Report Failure
+        if: failure()
+        with:
+          script: process.exit(1)
 
   unit-tests:
     name: Unit Tests

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -82,6 +82,45 @@ jobs:
           path: ${{ matrix.buildtype }}.tar.bz2
           retention-days: 1
 
+      # ----------------
+      # | Notify Slack |
+      # ----------------
+
+      - name: Checkout VSP actions
+        if: ${{ needs.cypress-tests.result == 'failure' }}
+        uses: actions/checkout@v2
+        with:
+          repository: department-of-veterans-affairs/vsp-github-actions
+          ref: refs/heads/main
+          token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
+          persist-credentials: false
+          path: ./.github/actions/vsp-github-actions
+
+      - name: Get Slack app token
+        if: ${{ needs.cypress-tests.result == 'failure' }}
+        uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
+        with:
+          ssm_parameter: /devops/github_actions_slack_socket_token
+          env_variable_name: SLACK_APP_TOKEN
+
+      - name: Get Slack bot token
+        if: ${{ needs.cypress-tests.result == 'failure' }}
+        uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
+        with:
+          ssm_parameter: /devops/github_actions_slack_bot_user_token
+          env_variable_name: SLACK_BOT_TOKEN
+
+      - name: Notify Slack about build failures
+        if: ${{ needs.build.result == 'failure' }}
+        uses: ./.github/actions/vsp-github-actions/slack-socket
+        env:
+          SSL_CERT_DIR: /etc/ssl/certs
+        with:
+          slack_app_token: ${{ env.SLACK_APP_TOKEN }}
+          slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
+          attachments: '[{"mrkdwn_in": ["text"], "color": "danger", "text": "At least one build step in `vets-website` has failed, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}]'
+          channel_id: C02AG8UF95M # gha-build-status
+
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
@@ -528,17 +567,6 @@ jobs:
         with:
           ssm_parameter: /devops/github_actions_slack_bot_user_token
           env_variable_name: SLACK_BOT_TOKEN
-
-      - name: Notify Slack about build failures
-        if: ${{ needs.build.result == 'failure' }}
-        uses: ./.github/actions/vsp-github-actions/slack-socket
-        env:
-          SSL_CERT_DIR: /etc/ssl/certs
-        with:
-          slack_app_token: ${{ env.SLACK_APP_TOKEN }}
-          slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
-          attachments: '[{"mrkdwn_in": ["text"], "color": "danger", "text": "At least one build step in `vets-website` has failed, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}]'
-          channel_id: C02AG8UF95M # gha-build-status
 
       - name: Notify Slack about Cypress test failures
         if: ${{ needs.cypress-tests.result == 'failure' }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -86,7 +86,7 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     needs: build
-    if: ${{ needs.build.status === 'failure' }}
+    if: ${{ needs.build.status == 'failure' }}
     steps:
       # ----------------
       # | Notify Slack |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -68,27 +68,6 @@ jobs:
       - name: Build
         run: yarnnn build --verbose --buildtype=${{ matrix.buildtype }}
         timeout-minutes: 30
-
-      - name: Generate build details
-        run: |
-          cat > build/${{ matrix.buildtype }}/BUILD.txt << EOF
-          BUILDTYPE=${{ matrix.buildtype }}
-          BRANCH_NAME=$(echo "${GITHUB_REF#refs/heads/}")
-          RUN_ID=${{ github.run_id }}
-          REF=${{ github.sha }}
-          BUILDTIME=$(date +%s)
-          EOF
-
-      - name: Compress and archive build
-        run: tar -C build/${{ matrix.buildtype }} -cjf ${{ matrix.buildtype }}.tar.bz2 .
-
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.buildtype }}.tar.bz2
-          path: ${{ matrix.buildtype }}.tar.bz2
-          retention-days: 1
-
       # ----------------
       # | Notify Slack |
       # ----------------
@@ -137,6 +116,26 @@ jobs:
       - name: Report Failure
         if: ${{ failure() }}
         uses: andymckay/cancel-action@0.2
+
+      - name: Generate build details
+        run: |
+          cat > build/${{ matrix.buildtype }}/BUILD.txt << EOF
+          BUILDTYPE=${{ matrix.buildtype }}
+          BRANCH_NAME=$(echo "${GITHUB_REF#refs/heads/}")
+          RUN_ID=${{ github.run_id }}
+          REF=${{ github.sha }}
+          BUILDTIME=$(date +%s)
+          EOF
+
+      - name: Compress and archive build
+        run: tar -C build/${{ matrix.buildtype }} -cjf ${{ matrix.buildtype }}.tar.bz2 .
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.buildtype }}.tar.bz2
+          path: ${{ matrix.buildtype }}.tar.bz2
+          retention-days: 1
 
   unit-tests:
     name: Unit Tests

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,7 +23,6 @@ jobs:
       NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
 
     strategy:
-      fail-fast: true
       matrix:
         buildtype: [vagovdev, vagovstaging, vagovprod]
 
@@ -81,6 +80,10 @@ jobs:
           name: ${{ matrix.buildtype }}.tar.bz2
           path: ${{ matrix.buildtype }}.tar.bz2
           retention-days: 1
+
+      - name: Report Failure
+        if: failure()
+        uses: andymckay/cancel-action@0.2
 
   build-failure:
     name: Build Failure Notification

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,6 +28,13 @@ jobs:
         buildtype: [vagovdev, vagovstaging, vagovprod]
 
     steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: 'us-gov-west-1'
+
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -81,13 +88,6 @@ jobs:
           name: ${{ matrix.buildtype }}.tar.bz2
           path: ${{ matrix.buildtype }}.tar.bz2
           retention-days: 1
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: 'us-gov-west-1'
 
       # ----------------
       # | Notify Slack |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -126,6 +126,7 @@ jobs:
 
       - name: Report Failure
         if: failure()
+        uses: actions/github-script@v2
         with:
           script: process.exit(1)
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -85,6 +85,7 @@ jobs:
   build-failure:
     name: Build Failure Notification
     runs-on: ubuntu-latest
+    needs: build
     if: ${{ github.workflow.jobs.build.status == 'failure' }}
     steps:
       # ----------------


### PR DESCRIPTION
## Description
This will add a notification in the event of a build failure or timeout so we can keep better track of build stability for vets website.  The notification will report to the channel https://dsva.slack.com/archives/C02AG8UF95M

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
