### PR TITLE
526: Add title 10 separation date validation

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/federalOrders.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/federalOrders.jsx
@@ -1,8 +1,9 @@
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
-import _ from 'lodash/fp';
 
 import dateUI from 'platform/forms-system/src/js/definitions/date';
-import { title10DatesRequired, isInFuture } from '../utils';
+import { validateDate } from 'platform/forms-system/src/js/validation';
+
+import { title10DatesRequired, isInFuture, title10BeforeRad } from '../utils';
 
 const {
   title10Activation,
@@ -11,6 +12,7 @@ const {
 export const uiSchema = {
   'ui:title': 'Federal Orders',
   serviceInformation: {
+    'ui:validations': [title10BeforeRad],
     reservesNationalGuardService: {
       'view:isTitle10Activated': {
         'ui:title':
@@ -21,13 +23,15 @@ export const uiSchema = {
         'ui:options': {
           expandUnder: 'view:isTitle10Activated',
         },
-        title10ActivationDate: _.merge(dateUI('Activation date'), {
+        title10ActivationDate: {
+          ...dateUI('Activation date'),
           'ui:required': title10DatesRequired,
-        }),
-        anticipatedSeparationDate: _.merge(dateUI('Expected separation date'), {
-          'ui:validations': [isInFuture],
+        },
+        anticipatedSeparationDate: {
+          ...dateUI('Expected separation date'),
+          'ui:validations': [validateDate, isInFuture],
           'ui:required': title10DatesRequired,
-        }),
+        },
       },
     },
   },

--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -41,6 +41,13 @@ fieldset.schemaform-block,
   margin-top: 0;
 }
 
+/* federal orders */
+article[data-location$="federal-orders"] {
+  .schemaform-field-template.usa-input-error {
+    margin-top: 3rem;
+  }
+}
+
 /* Hide duplicate required span; first one in legend */
 .new-condition-description + .schemaform-required-span {
   display: none;

--- a/src/applications/disability-benefits/all-claims/tests/pages/federalOrders.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/federalOrders.unit.spec.jsx
@@ -108,4 +108,42 @@ describe('Federal orders info', () => {
     expect(onSubmit.called).to.be.true;
     form.unmount();
   });
+  it('should fail to submit when separation date is before activation', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    selectRadio(
+      form,
+      'root_serviceInformation_reservesNationalGuardService_view:isTitle10Activated',
+      'Y',
+    );
+    fillDate(
+      form,
+      'root_serviceInformation_reservesNationalGuardService_title10Activation_title10ActivationDate',
+      moment()
+        .add(11, 'months')
+        .format('YYYY-MM-DD'),
+    );
+    fillDate(
+      form,
+      'root_serviceInformation_reservesNationalGuardService_title10Activation_anticipatedSeparationDate',
+      moment()
+        .add(10, 'months')
+        .format('YYYY-MM-DD'),
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error-message').length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
+    form.unmount();
+  });
 });

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -209,6 +209,20 @@ export const isInFuture = (errors, fieldData) => {
   }
 };
 
+export const title10BeforeRad = (errors, pageData) => {
+  const { anticipatedSeparationDate, title10ActivationDate } =
+    pageData?.reservesNationalGuardService?.title10Activation || {};
+
+  const rad = moment(anticipatedSeparationDate);
+  const activation = moment(title10ActivationDate);
+
+  if (rad.isValid() && activation.isValid() && rad.isBefore(activation)) {
+    errors.reservesNationalGuardService.title10Activation.anticipatedSeparationDate.addError(
+      'Please enter an expected separation date that is after your activation date',
+    );
+  }
+};
+
 const capitalizeWord = word => {
   const capFirstLetter = word[0].toUpperCase();
   return `${capFirstLetter}${word.slice(1)}`;


### PR DESCRIPTION
## Description

Add validation to the title 10 activated on Federal orders date is before the anticipated separation date.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/28424

## Testing done

Added a unit test

## Screenshots

<details><summary>Error shown when activation date is before anticipated separation date</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-08-11 at 1 58 29 PM](https://user-images.githubusercontent.com/136959/129089826-aad28827-3167-4aa0-85fb-c5ff817edb8a.png)</details>

## Acceptance criteria

- [x] Error shown when activation date is before separation date
- [x] Prevent continuing when an error is displayed 
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
