### PR TITLE
Fix disabled Next button bug

### DIFF
--- a/src/applications/vaos/components/calendar/CalendarWidget.jsx
+++ b/src/applications/vaos/components/calendar/CalendarWidget.jsx
@@ -44,30 +44,16 @@ function getFirstDayOfMonth(momentDate) {
  * Gets the maximum month based on inputs
  *
  * @param {string} maxDate YYYY-DD-MM
- * @param {string} startMonth YYYY-MM
- * @returns {string|Moment} YYYY-MM
+ * @returns {string} YYYY-MM
  */
-export function getMaxMonth(maxDate, startMonth) {
+export function getMaxMonth(maxDate) {
   const defaultMaxMonth = moment()
     .add(DEFAULT_MAX_DAYS_AHEAD, 'days')
     .format('YYYY-MM');
+  const maxMonth = moment(maxDate).startOf('month');
 
-  // If provided start month is beyond our default, set that month as max month
-  // This is needed in the case of direct schedule if the user selects a date
-  // beyond the max date
-  if (startMonth && startMonth > defaultMaxMonth) {
-    return startMonth;
-  }
-
-  if (
-    maxDate &&
-    moment(maxDate)
-      .startOf('month')
-      .isAfter(defaultMaxMonth)
-  ) {
-    return moment(maxDate)
-      .startOf('month')
-      .format('YYYY-MM');
+  if (maxDate && maxMonth.isAfter(defaultMaxMonth)) {
+    return maxMonth.format('YYYY-MM');
   }
 
   // If no available dates array provided, set max to default from now
@@ -282,7 +268,7 @@ function CalendarWidget({
     return null;
   });
   const currentDate = moment();
-  const maxMonth = getMaxMonth(maxDate, startMonth);
+  const maxMonth = getMaxMonth(maxDate);
   const [months, setMonths] = useState([moment(startMonth || minDate)]);
   const exceededMaximumSelections = value.length > maxSelections;
   const hasError = (required && showValidation) || exceededMaximumSelections;

--- a/src/applications/vaos/tests/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
@@ -851,6 +851,7 @@ describe('VAOS <DateTimeSelectPage>', () => {
   });
 
   it('should start calendar on preferred date month', async () => {
+    // Given a user eligible for direct scheduling
     mockEligibilityFetches({
       siteId: '983',
       facilityId: '983',
@@ -873,13 +874,14 @@ describe('VAOS <DateTimeSelectPage>', () => {
       pastClinics: true,
     });
 
+    // And a preferred date and available slot several months in the future
     const slot309Date = moment()
-      .add(2, 'months')
+      .add(4, 'months')
       .day(11)
       .hour(13)
       .minute(0)
       .second(0);
-    const preferredDate = moment().add(2, 'months');
+    const preferredDate = moment().add(4, 'months');
 
     mockAppointmentSlotFetch({
       siteId: '983',
@@ -905,6 +907,7 @@ describe('VAOS <DateTimeSelectPage>', () => {
     await setClinic(store, /Yes/i);
     await setPreferredDate(store, preferredDate);
 
+    // When the page is displayed
     const screen = renderWithStoreAndRouter(
       <Route component={DateTimeSelectPage} />,
       {
@@ -918,14 +921,23 @@ describe('VAOS <DateTimeSelectPage>', () => {
       await waitForElementToBeRemoved(overlay);
     }
 
+    // Then the calendar is on the month of the preferred date
     expect(
       screen.getByRole('heading', {
         level: 2,
         name: moment()
-          .add(2, 'months')
+          .add(4, 'months')
           .format('MMMM YYYY'),
       }),
     ).to.be.ok;
+
+    // And the user is able to continue to the next month
+    expect(
+      // It takes 1.5s to search for buttons by role on this page, this is quicker
+      screen.getByText(
+        (content, el) => el.textContent === 'Next' && el.type === 'button',
+      ),
+    ).to.not.have.attribute('disabled');
   });
 
   it('should fetch slots when moving between months', async () => {


### PR DESCRIPTION
## Description
This PR
- Fixes bug where if you chose a preferred date over 90 days in the future, the Next button was disabled
- Adds a test that catches this scenario

## Original issue(s)
department-of-veterans-affairs/va.gov-team#28597


## Testing done
Unit and local testing

## Screenshots
Updated test scenario:

```
Scenario: should start calendar on preferred date month
  Given a user eligible for direct scheduling
    And a preferred date and available slot several months in the future
  When the page is displayed
  Then the calendar is on the month of the preferred date
    And the user is able to continue to the next month
```

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
