### PR TITLE
Fix MASTER_BUILD bug in Cypress Test Selection

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,9 +10,9 @@ on:
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
 
-# concurrency:
-#   group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha  }}
-#   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+concurrency:
+  group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha  }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
   build:
@@ -445,12 +445,6 @@ jobs:
           else
               echo "MASTER_BUILD=false" >> $GITHUB_ENV
           fi
-        
-      - name: Echo github.ref
-        run: echo ${{ github.ref }}
-
-      - name: Echo MASTER_BUILD
-        run: echo ${{ env.MASTER_BUILD }}
 
       - name: List changed files
         id: changed-files

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -440,7 +440,7 @@ jobs:
 
       - name: Set MASTER_BUILD
         run: |
-          if [[ github.ref == 'refs/heads/master' ]]; then
+          if [[ ${{ github.ref }} == 'refs/heads/master' ]]; then
               echo "MASTER_BUILD=true" >> $GITHUB_ENV
           else
               echo "MASTER_BUILD=false" >> $GITHUB_ENV

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,9 +10,9 @@ on:
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
 
-concurrency:
-  group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha  }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+# concurrency:
+#   group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha  }}
+#   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
   build:
@@ -445,6 +445,12 @@ jobs:
           else
               echo "MASTER_BUILD=false" >> $GITHUB_ENV
           fi
+        
+      - name: Echo github.ref
+        run: echo ${{ github.ref }}
+
+      - name: Echo MASTER_BUILD
+        run: echo ${{ env.MASTER_BUILD }}
 
       - name: List changed files
         id: changed-files

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -456,21 +456,21 @@ jobs:
         id: changed-files
         run: echo ::set-output name=all_changed_files::$(git diff --name-only origin/master...)
 
-      - name: Get number of containers needed
+      - name: Set NUM_CONTAINERS, CI_NODE_INDEX, TESTS variables
         run: node script/github-actions/select-cypress-tests.js
         env:
           MASTER_BUILD: ${{ env.MASTER_BUILD }}
           CHANGED_FILE_PATHS: ${{ steps.changed-files.outputs.all_changed_files }}
 
-      - name: Set output of number of containers
+      - name: Set output of NUM_CONTAINERS
         id: containers
         run: echo ::set-output name=num::$NUM_CONTAINERS
 
-      - name: Set output of ci_node_index value for matrix
+      - name: Set output of CI_NODE_INDEX
         id: matrix
         run: echo ::set-output name=ci_node_index::$CI_NODE_INDEX
 
-      - name: Set output of tests to run
+      - name: Set output of TESTS
         id: tests
         run: echo ::set-output name=selected::$TESTS
 

--- a/script/github-actions/select-cypress-tests.js
+++ b/script/github-actions/select-cypress-tests.js
@@ -3,6 +3,12 @@ const path = require('path');
 const glob = require('glob');
 const { integrationFolder, testFiles } = require('../../config/cypress.json');
 
+// eslint-disable-next-line no-console
+console.log('MASTER_BUILD: ', process.env.MASTER_BUILD);
+
+// eslint-disable-next-line no-console
+console.log('typeof MASTER_BUILD: ', typeof process.env.MASTER_BUILD);
+
 const MASTER_BUILD = process.env.MASTER_BUILD === 'true';
 const pathsOfChangedFiles = process.env.CHANGED_FILE_PATHS.split(' ');
 

--- a/script/github-actions/select-cypress-tests.js
+++ b/script/github-actions/select-cypress-tests.js
@@ -3,12 +3,6 @@ const path = require('path');
 const glob = require('glob');
 const { integrationFolder, testFiles } = require('../../config/cypress.json');
 
-// eslint-disable-next-line no-console
-console.log('MASTER_BUILD: ', process.env.MASTER_BUILD);
-
-// eslint-disable-next-line no-console
-console.log('typeof MASTER_BUILD: ', typeof process.env.MASTER_BUILD);
-
 const MASTER_BUILD = process.env.MASTER_BUILD === 'true';
 const pathsOfChangedFiles = process.env.CHANGED_FILE_PATHS.split(' ');
 


### PR DESCRIPTION
## Description
`MASTER_BUILD` should be `true` to bypass test selection when tests are run against the `master` build (on merge to `master`). There's a bug, because it's set to `false` [here](https://github.com/department-of-veterans-affairs/vets-website/runs/3305392970). Here's a pic:

![image](https://user-images.githubusercontent.com/9326247/129123527-4ccfe58f-f712-458d-a2fe-084e29aed9fd.png)

This PR should fix this.

I also updated some step names.