### PR TITLE
Remove lodash/fp import from coronavirus-screener

### DIFF
--- a/src/applications/coronavirus-screener/components/MultiQuestionForm.jsx
+++ b/src/applications/coronavirus-screener/components/MultiQuestionForm.jsx
@@ -4,7 +4,7 @@ import FormQuestion from './FormQuestion';
 import FormResult from './FormResult';
 import recordEvent from 'platform/monitoring/record-event';
 import moment from 'moment';
-import { isEqual } from 'lodash/fp';
+import { isEqual } from 'lodash';
 import {
   getEnabledQuestions,
   checkFormStatus,


### PR DESCRIPTION
## Description
This PR removes `lodash/fp` imports from the coronavirus-screener app. This is part of the effort to remove `lodash/fp` from the repo

## Original issue(s)
department-of-veterans-affairs/va.gov-team#1678


## Testing done
Tested locally and in CI.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
