### PR TITLE
Set MASTER_BUILD and NUM_CONTAINERS in 'Create report and post results to BigQuery' step

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -737,7 +737,6 @@ jobs:
         run: yarn cypress-mochawesome-to-bigquery
         working-directory: testing-tools-team-dashboard-data
         env:
-          IS_MASTER_BUILD: ${{ jobs.cypress-tests-prep.env.IS_MASTER_BUILD }}
           IS_MASTER_BUILD: ${{ needs.cypress-tests-prep.outputs.is_master_build }}
 
       - name: Upload Mochawesome report artifact

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -725,6 +725,9 @@ jobs:
       - name: Set UUID for Mochawesome report
         run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
 
+      - name: Echo MASTER_BUILD
+        run: echo ${{ env.MASTER_BUILD }}
+
       - name: Create report and post results to BigQuery
         run: yarn cypress-mochawesome-to-bigquery
         working-directory: testing-tools-team-dashboard-data

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,9 +10,9 @@ on:
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
 
-# concurrency:
-#   group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha  }}
-#   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+concurrency:
+  group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha  }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
   build:
@@ -729,9 +729,6 @@ jobs:
 
       - name: Set UUID for Mochawesome report
         run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
-
-      - name: Echo IS_MASTER_BUILD
-        run: echo ${{ needs.cypress-tests-prep.outputs.is_master_build }}
 
       - name: Create report and post results to BigQuery
         run: yarn cypress-mochawesome-to-bigquery

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -739,7 +739,7 @@ jobs:
         env:
           IS_MASTER_BUILD: ${{ github.workflow.jobs.cypress-tests-prep.env.IS_MASTER_BUILD }}
           # IS_MASTER_BUILD: ${{ needs.cypress-tests-prep.outputs.is_master_build }}
-          NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
+          NUM_CONTAINERS: ${{ github.workflow.jobs.cypress-tests-prep.outputs.num_containers }}
 
       - name: Upload Mochawesome report artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,9 +10,9 @@ on:
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
 
-concurrency:
-  group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha  }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+# concurrency:
+#   group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha  }}
+#   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
   build:
@@ -404,7 +404,7 @@ jobs:
       num_containers: ${{ steps.containers.outputs.num }}
       ci_node_index: ${{ steps.matrix.outputs.ci_node_index }}
       tests: ${{ steps.tests.outputs.selected }}
-      is_master_build: ${{ steps.build.outputs.is_master_build }}
+      # is_master_build: ${{ steps.build.outputs.is_master_build }}
 
     steps:
       - name: Checkout
@@ -469,9 +469,9 @@ jobs:
         id: tests
         run: echo ::set-output name=selected::$TESTS
 
-      - name: Set output of IS_MASTER_BUILD
-        id: build
-        run: echo ::set-output name=is_master_build::${{ env.IS_MASTER_BUILD}}
+      # - name: Set output of IS_MASTER_BUILD
+      #   id: build
+      #   run: echo ::set-output name=is_master_build::${{ env.IS_MASTER_BUILD}}
 
   cypress-tests:
     name: Cypress E2E Tests
@@ -730,11 +730,15 @@ jobs:
       - name: Set UUID for Mochawesome report
         run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
 
+      - name: Echo IS_MASTER_BUILD
+        run: echo ${{ jobs.cypress-tests-prep.env.IS_MASTER_BUILD }}
+
       - name: Create report and post results to BigQuery
         run: yarn cypress-mochawesome-to-bigquery
         working-directory: testing-tools-team-dashboard-data
         env:
-          IS_MASTER_BUILD: ${{ needs.cypress-tests-prep.outputs.is_master_build }}
+          IS_MASTER_BUILD: ${{ jobs.cypress-tests-prep.env.IS_MASTER_BUILD }}
+          # IS_MASTER_BUILD: ${{ needs.cypress-tests-prep.outputs.is_master_build }}
           NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
 
       - name: Upload Mochawesome report artifact

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,9 +10,9 @@ on:
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
 
-concurrency:
-  group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha  }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+# concurrency:
+#   group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha  }}
+#   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
   build:
@@ -728,6 +728,9 @@ jobs:
       - name: Create report and post results to BigQuery
         run: yarn cypress-mochawesome-to-bigquery
         working-directory: testing-tools-team-dashboard-data
+        env:
+          MASTER_BUILD: ${{ env.MASTER_BUILD }}
+          NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
 
       - name: Upload Mochawesome report artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -404,7 +404,7 @@ jobs:
       num_containers: ${{ steps.containers.outputs.num }}
       ci_node_index: ${{ steps.matrix.outputs.ci_node_index }}
       tests: ${{ steps.tests.outputs.selected }}
-      is_master_build: ${{ env.IS_MASTER_BUILD }}
+      is_master_build: ${{ steps.build.outputs.is_master_build }}
 
     steps:
       - name: Checkout
@@ -469,9 +469,9 @@ jobs:
         id: tests
         run: echo ::set-output name=selected::$TESTS
 
-      # - name: Set output of IS_MASTER_BUILD
-      #   id: build
-      #   run: echo ::set-output name=is_master_build::${{ env.IS_MASTER_BUILD}}
+      - name: Set output of IS_MASTER_BUILD
+        id: build
+        run: echo ::set-output name=is_master_build::${{ env.IS_MASTER_BUILD}}
 
   cypress-tests:
     name: Cypress E2E Tests
@@ -738,6 +738,7 @@ jobs:
         working-directory: testing-tools-team-dashboard-data
         env:
           IS_MASTER_BUILD: ${{ needs.cypress-tests-prep.outputs.is_master_build }}
+          NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
 
       - name: Upload Mochawesome report artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -404,7 +404,7 @@ jobs:
       num_containers: ${{ steps.containers.outputs.num }}
       ci_node_index: ${{ steps.matrix.outputs.ci_node_index }}
       tests: ${{ steps.tests.outputs.selected }}
-      # is_master_build: ${{ steps.build.outputs.is_master_build }}
+      is_master_build: ${{ env.IS_MASTER_BUILD }}
 
     steps:
       - name: Checkout
@@ -730,16 +730,15 @@ jobs:
       - name: Set UUID for Mochawesome report
         run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
 
-      - name: DELETE - Echo IS_MASTER_BUILD
-        run: echo ${{ needs.cypress-tests-prep.env.IS_MASTER_BUILD }}
+      - name: Echo IS_MASTER_BUILD
+        run: echo ${{ needs.cypress-tests-prep.outputs.is_master_build }}
 
       - name: Create report and post results to BigQuery
         run: yarn cypress-mochawesome-to-bigquery
         working-directory: testing-tools-team-dashboard-data
         env:
-          IS_MASTER_BUILD: ${{ github.workflow.jobs.cypress-tests-prep.env.IS_MASTER_BUILD }}
-          # IS_MASTER_BUILD: ${{ needs.cypress-tests-prep.outputs.is_master_build }}
-          NUM_CONTAINERS: ${{ github.workflow.jobs.cypress-tests-prep.outputs.num_containers }}
+          IS_MASTER_BUILD: ${{ jobs.cypress-tests-prep.env.IS_MASTER_BUILD }}
+          IS_MASTER_BUILD: ${{ needs.cypress-tests-prep.outputs.is_master_build }}
 
       - name: Upload Mochawesome report artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -404,6 +404,7 @@ jobs:
       num_containers: ${{ steps.containers.outputs.num }}
       ci_node_index: ${{ steps.matrix.outputs.ci_node_index }}
       tests: ${{ steps.tests.outputs.selected }}
+      master_build: ${{ steps.build.outputs.master_build }}
 
     steps:
       - name: Checkout
@@ -467,6 +468,10 @@ jobs:
       - name: Set output of TESTS
         id: tests
         run: echo ::set-output name=selected::$TESTS
+
+      - name: Set output of MASTER_BUILD
+        id: build
+        run: echo ::set-output name=master_build::${{ env.MASTER_BUILD}}
 
   cypress-tests:
     name: Cypress E2E Tests
@@ -726,13 +731,13 @@ jobs:
         run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
 
       - name: Echo MASTER_BUILD
-        run: echo ${{ env.MASTER_BUILD }}
+        run: echo ${{ needs.cypress-tests-prep.outputs.master_build }}
 
       - name: Create report and post results to BigQuery
         run: yarn cypress-mochawesome-to-bigquery
         working-directory: testing-tools-team-dashboard-data
         env:
-          MASTER_BUILD: ${{ env.MASTER_BUILD }}
+          MASTER_BUILD: ${{ needs.cypress-tests-prep.outputs.master_build }}
           NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
 
       - name: Upload Mochawesome report artifact

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,9 +10,9 @@ on:
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
 
-# concurrency:
-#   group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha  }}
-#   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+concurrency:
+  group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha  }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
   build:
@@ -469,10 +469,6 @@ jobs:
         id: tests
         run: echo ::set-output name=selected::$TESTS
 
-      # - name: Set output of IS_MASTER_BUILD
-      #   id: build
-      #   run: echo ::set-output name=is_master_build::${{ env.IS_MASTER_BUILD}}
-
   cypress-tests:
     name: Cypress E2E Tests
     runs-on: self-hosted
@@ -729,9 +725,6 @@ jobs:
 
       - name: Set UUID for Mochawesome report
         run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
-
-      - name: Echo IS_MASTER_BUILD
-        run: echo ${{ needs.cypress-tests-prep.outputs.is_master_build }}
 
       - name: Create report and post results to BigQuery
         run: yarn cypress-mochawesome-to-bigquery

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -737,7 +737,7 @@ jobs:
         run: yarn cypress-mochawesome-to-bigquery
         working-directory: testing-tools-team-dashboard-data
         env:
-          IS_MASTER_BUILD: ${{ jobs.cypress-tests-prep.env.IS_MASTER_BUILD }}
+          IS_MASTER_BUILD: ${{ needs.cypress-tests-prep.env.IS_MASTER_BUILD }}
           # IS_MASTER_BUILD: ${{ needs.cypress-tests-prep.outputs.is_master_build }}
           NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -404,7 +404,7 @@ jobs:
       num_containers: ${{ steps.containers.outputs.num }}
       ci_node_index: ${{ steps.matrix.outputs.ci_node_index }}
       tests: ${{ steps.tests.outputs.selected }}
-      master_build: ${{ steps.build.outputs.master_build }}
+      is_master_build: ${{ steps.build.outputs.is_master_build }}
 
     steps:
       - name: Checkout
@@ -439,12 +439,12 @@ jobs:
         env:
           YARN_CACHE_FOLDER: .cache/yarn
 
-      - name: Set MASTER_BUILD
+      - name: Set IS_MASTER_BUILD
         run: |
           if [[ ${{ github.ref }} == 'refs/heads/master' ]]; then
-              echo "MASTER_BUILD=true" >> $GITHUB_ENV
+              echo "IS_MASTER_BUILD=true" >> $GITHUB_ENV
           else
-              echo "MASTER_BUILD=false" >> $GITHUB_ENV
+              echo "IS_MASTER_BUILD=false" >> $GITHUB_ENV
           fi
 
       - name: List changed files
@@ -454,7 +454,7 @@ jobs:
       - name: Set NUM_CONTAINERS, CI_NODE_INDEX, TESTS variables
         run: node script/github-actions/select-cypress-tests.js
         env:
-          MASTER_BUILD: ${{ env.MASTER_BUILD }}
+          IS_MASTER_BUILD: ${{ env.IS_MASTER_BUILD }}
           CHANGED_FILE_PATHS: ${{ steps.changed-files.outputs.all_changed_files }}
 
       - name: Set output of NUM_CONTAINERS
@@ -469,9 +469,9 @@ jobs:
         id: tests
         run: echo ::set-output name=selected::$TESTS
 
-      - name: Set output of MASTER_BUILD
+      - name: Set output of IS_MASTER_BUILD
         id: build
-        run: echo ::set-output name=master_build::${{ env.MASTER_BUILD}}
+        run: echo ::set-output name=is_master_build::${{ env.IS_MASTER_BUILD}}
 
   cypress-tests:
     name: Cypress E2E Tests
@@ -730,14 +730,14 @@ jobs:
       - name: Set UUID for Mochawesome report
         run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
 
-      - name: Echo MASTER_BUILD
-        run: echo ${{ needs.cypress-tests-prep.outputs.master_build }}
+      - name: Echo IS_MASTER_BUILD
+        run: echo ${{ needs.cypress-tests-prep.outputs.is_master_build }}
 
       - name: Create report and post results to BigQuery
         run: yarn cypress-mochawesome-to-bigquery
         working-directory: testing-tools-team-dashboard-data
         env:
-          MASTER_BUILD: ${{ needs.cypress-tests-prep.outputs.master_build }}
+          IS_MASTER_BUILD: ${{ needs.cypress-tests-prep.outputs.is_master_build }}
           NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
 
       - name: Upload Mochawesome report artifact

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -731,7 +731,7 @@ jobs:
         run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
 
       - name: DELETE - Echo IS_MASTER_BUILD
-        run: echo ${{ jobs.cypress-tests-prep.env.IS_MASTER_BUILD }}
+        run: echo ${{ needs.cypress-tests-prep.env.IS_MASTER_BUILD }}
 
       - name: Create report and post results to BigQuery
         run: yarn cypress-mochawesome-to-bigquery

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,9 +10,9 @@ on:
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
 
-concurrency:
-  group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha  }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+# concurrency:
+#   group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha  }}
+#   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
   build:
@@ -404,7 +404,7 @@ jobs:
       num_containers: ${{ steps.containers.outputs.num }}
       ci_node_index: ${{ steps.matrix.outputs.ci_node_index }}
       tests: ${{ steps.tests.outputs.selected }}
-      is_master_build: ${{ steps.build.outputs.is_master_build }}
+      is_master_build: ${{ env.IS_MASTER_BUILD }}
 
     steps:
       - name: Checkout
@@ -469,9 +469,9 @@ jobs:
         id: tests
         run: echo ::set-output name=selected::$TESTS
 
-      - name: Set output of IS_MASTER_BUILD
-        id: build
-        run: echo ::set-output name=is_master_build::${{ env.IS_MASTER_BUILD}}
+      # - name: Set output of IS_MASTER_BUILD
+      #   id: build
+      #   run: echo ::set-output name=is_master_build::${{ env.IS_MASTER_BUILD}}
 
   cypress-tests:
     name: Cypress E2E Tests
@@ -729,6 +729,9 @@ jobs:
 
       - name: Set UUID for Mochawesome report
         run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
+
+      - name: Echo IS_MASTER_BUILD
+        run: echo ${{ needs.cypress-tests-prep.outputs.is_master_build }}
 
       - name: Create report and post results to BigQuery
         run: yarn cypress-mochawesome-to-bigquery

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -737,7 +737,7 @@ jobs:
         run: yarn cypress-mochawesome-to-bigquery
         working-directory: testing-tools-team-dashboard-data
         env:
-          IS_MASTER_BUILD: ${{ github.jobs.cypress-tests-prep.env.IS_MASTER_BUILD }}
+          IS_MASTER_BUILD: ${{ github.workflow.jobs.cypress-tests-prep.env.IS_MASTER_BUILD }}
           # IS_MASTER_BUILD: ${{ needs.cypress-tests-prep.outputs.is_master_build }}
           NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -737,7 +737,7 @@ jobs:
         run: yarn cypress-mochawesome-to-bigquery
         working-directory: testing-tools-team-dashboard-data
         env:
-          IS_MASTER_BUILD: ${{ needs.cypress-tests-prep.env.IS_MASTER_BUILD }}
+          IS_MASTER_BUILD: ${{ github.jobs.cypress-tests-prep.env.IS_MASTER_BUILD }}
           # IS_MASTER_BUILD: ${{ needs.cypress-tests-prep.outputs.is_master_build }}
           NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -730,7 +730,7 @@ jobs:
       - name: Set UUID for Mochawesome report
         run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
 
-      - name: Echo IS_MASTER_BUILD
+      - name: DELETE - Echo IS_MASTER_BUILD
         run: echo ${{ jobs.cypress-tests-prep.env.IS_MASTER_BUILD }}
 
       - name: Create report and post results to BigQuery

--- a/script/github-actions/select-cypress-tests.js
+++ b/script/github-actions/select-cypress-tests.js
@@ -3,7 +3,7 @@ const path = require('path');
 const glob = require('glob');
 const { integrationFolder, testFiles } = require('../../config/cypress.json');
 
-const MASTER_BUILD = process.env.MASTER_BUILD === 'true';
+const IS_MASTER_BUILD = process.env.IS_MASTER_BUILD === 'true';
 const pathsOfChangedFiles = process.env.CHANGED_FILE_PATHS.split(' ');
 
 function selectedTests() {
@@ -42,7 +42,7 @@ function allTests() {
 
 let tests;
 
-if (MASTER_BUILD) {
+if (IS_MASTER_BUILD) {
   tests = allTests();
 } else {
   let allMdFiles = true;


### PR DESCRIPTION
## Description
Regarding ticket [28644](https://app.zenhub.com/workspaces/vsp-5cedc9cce6e3335dc5a49fc4/issues/department-of-veterans-affairs/va.gov-team/28644)

Set the following env vars in the `Create report and post results to BigQuery` step in the `testing-reports` job:
- `IS_MASTER_BUILD`
- `NUM_CONTAINERS`

This will allow us to add `is_master_build` and `num_containers` columns to `cypress_test_suite_executions` BigQuery table which will allow us to report data regarding Cypress tests run on push (selected tests) and Cypress tests run on merge to master (all tests) and the average of the two in DOMO.

The new columns are being populated as expected in the `cypress_test_suite_executions` BigQuery table. Click through to the ticket noted above for more details.

Related PRs in the `testing-tools-team-dashboard-data` repo:
- https://github.com/department-of-veterans-affairs/testing-tools-team-dashboard-data/pull/51
- https://github.com/department-of-veterans-affairs/testing-tools-team-dashboard-data/pull/52

---

I also changed the name of `MASTER_BUILD` to `IS_MASTER_BUILD`