### PR TITLE
Bump web-components version to 0.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -325,7 +325,7 @@
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
     "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#3bec07e95054fb4c6d7892d1ad700a8f4c3b009c",
-    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.7.1",
+    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.9.1",
     "whatwg-fetch": "^3.6.2"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19966,9 +19966,9 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.7.1":
-  version "0.7.1"
-  resolved "https://github.com/department-of-veterans-affairs/component-library.git#3e2870962dc18b4423735872473db237474a476a"
+"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.9.1":
+  version "0.9.1"
+  resolved "https://github.com/department-of-veterans-affairs/component-library.git#eb8bb9a162b63f1575723146ef4ebf38ca67d0f9"
   dependencies:
     "@stencil/core" "^2.0.1"
     "@stencil/postcss" "^2.0.0"


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/28506

This includes 2 changes to `va-accordion`

1. The multi prop/functionality on `<va-accordion>` has become the default, and a new `openSingle` prop can be used to disable the functionality
2. If a `va-accordion-item` is not within the viewport when expanding, use `scrollIntoView` to keep it visible

See release notes for more detail: 
https://github.com/department-of-veterans-affairs/component-library/releases

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/28506


## Testing done
Local and storybook

## Screenshots
<img width="816" alt="Screen Shot 2021-08-12 at 10 19 12 AM" src="https://user-images.githubusercontent.com/3144003/129213248-a72941cc-775e-4137-a51c-6be25d844b39.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
