### PR TITLE
526: Add past date check to start date

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
+++ b/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
@@ -1,6 +1,8 @@
 import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 
+import { validateCurrentOrPastDate } from 'platform/forms-system/src/js/validation';
+
 import ValidatedServicePeriodView from '../components/ValidatedServicePeriodView';
 import ArrayField from '../components/ArrayField';
 import { isValidServicePeriod, formatDate } from '../utils';
@@ -12,7 +14,10 @@ const dateRangeUISchema = dateRangeUI(
   'End of service must be after start of service',
 );
 
-dateRangeUISchema.from['ui:validations'].push(validateAge);
+dateRangeUISchema.from['ui:validations'].push(
+  validateAge,
+  validateCurrentOrPastDate,
+);
 dateRangeUISchema.to['ui:validations'].push(validateSeparationDate);
 
 const itemAriaLabel = data => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/militaryHistory.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/militaryHistory.unit.spec.jsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import { expect } from 'chai';
+import { mount } from 'enzyme';
 import sinon from 'sinon';
+import moment from 'moment';
+
 import {
   DefinitionTester,
   fillData,
   fillDate,
 } from 'platform/testing/unit/schemaform-utils.jsx';
-import { mount } from 'enzyme';
+
 import formConfig from '../../config/form';
 
 describe('Military history', () => {
@@ -94,6 +97,108 @@ describe('Military history', () => {
       'root_serviceInformation_servicePeriods_0_dateRange_from',
       '2003-01-01',
     );
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error-message').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+    form.unmount();
+  });
+
+  it('should fail when the start date is in the future', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+        onSubmit={onSubmit}
+        appStateData={appStateData}
+      />,
+    );
+
+    fillData(
+      form,
+      'select#root_serviceInformation_servicePeriods_0_serviceBranch',
+      'Army',
+    );
+    fillDate(
+      form,
+      'root_serviceInformation_servicePeriods_0_dateRange_from',
+      moment()
+        .add(1, 'days')
+        .format('YYYY-MM-DD'),
+    );
+    fillDate(
+      form,
+      'root_serviceInformation_servicePeriods_0_dateRange_to',
+      moment()
+        .add(7, 'days')
+        .format('YYYY-MM-DD'),
+    );
+
+    form.find('form').simulate('submit');
+    const errorMsg = form.find('.usa-input-error-message');
+    expect(errorMsg.length).to.equal(1);
+    expect(errorMsg.text()).to.contain('valid current or past date');
+    expect(onSubmit.called).to.be.false;
+
+    fillDate(
+      form,
+      'root_serviceInformation_servicePeriods_0_dateRange_from',
+      moment()
+        .subtract(1, 'days')
+        .format('YYYY-MM-DD'),
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error-message').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+    form.unmount();
+  });
+
+  it('should fail when the end date is before the start date', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+        onSubmit={onSubmit}
+        appStateData={appStateData}
+      />,
+    );
+
+    fillData(
+      form,
+      'select#root_serviceInformation_servicePeriods_0_serviceBranch',
+      'Army',
+    );
+    fillDate(
+      form,
+      'root_serviceInformation_servicePeriods_0_dateRange_from',
+      '2020-02-05',
+    );
+    fillDate(
+      form,
+      'root_serviceInformation_servicePeriods_0_dateRange_to',
+      '2020-02-01',
+    );
+
+    form.find('form').simulate('submit');
+    const errorMsg = form.find('.usa-input-error-message');
+    expect(errorMsg.length).to.equal(1);
+    expect(errorMsg.text()).to.contain('must be after start');
+    expect(onSubmit.called).to.be.false;
+
+    fillDate(
+      form,
+      'root_serviceInformation_servicePeriods_0_dateRange_from',
+      '2020-01-01',
+    );
+
     form.find('form').simulate('submit');
     expect(form.find('.usa-input-error-message').length).to.equal(0);
     expect(onSubmit.called).to.be.true;


### PR DESCRIPTION
## Description

Adding validation to the military history start date to ensure it's (today or) in the past. There is also a check verified to be in place which ensures that the start date is _after_ the Veteran's 13th birthday.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/28417

## Testing done

Adding unit tests for past start dates & end dates after the start date.

## Screenshots

Test user DOB: **1950-10-04**

<details><summary>Valid start & end dates</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-08-11 at 3 58 40 PM](https://user-images.githubusercontent.com/136959/129213655-05cda2d4-e9b6-4df9-8089-e32ee2b943b7.png)</details>

<details><summary>Start date in the future error</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-08-11 at 3 59 11 PM](https://user-images.githubusercontent.com/136959/129213653-4fb9f09e-33e9-42ed-ab56-ce48acd78436.png)</details>

<details><summary>Start date in the future & end date before start</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-08-11 at 3 59 26 PM](https://user-images.githubusercontent.com/136959/129213629-ba6bd6c4-079f-4b23-85dd-72d177039206.png)</details>

<details><summary>Start before 13th birthday</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-08-11 at 3 58 17 PM](https://user-images.githubusercontent.com/136959/129213656-8d1af770-6cb1-42b9-867b-c66653a44b22.png)</details>

## Acceptance criteria

- [x] Verify 13th birthday check is in place
- [x] Add validation for past start dates
- [x] Add more test coverage

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
