### PR TITLE
Add simple null indicator next to checkboxes

### DIFF
--- a/src/applications/personalization/profile/components/notification-settings/NotificationChannel.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationChannel.jsx
@@ -89,6 +89,11 @@ const NotificationChannel = ({
   }
   return (
     <div>
+      {!permissionId ? (
+        <p className="vads-u-color--secondary-dark">
+          <strong>We do not have a preference for you</strong>
+        </p>
+      ) : null}
       <input
         type="checkbox"
         id={channelId}

--- a/src/applications/personalization/profile/components/notification-settings/NotificationSettings.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationSettings.jsx
@@ -96,6 +96,8 @@ const NotificationSettings = ({
       ) : null}
       {!shouldShowLoadingIndicator
         ? notificationGroups.ids.map(groupId => {
+            // we handle the health care group a little differently
+            // TODO: I don't like this check. what does `group3` even mean?
             if (groupId === 'group3') {
               if (!isPatient) {
                 return null;

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/happy-loading-path.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/happy-loading-path.cypress.spec.js
@@ -44,6 +44,7 @@ describe('Notification Settings', () => {
           'match',
           /You can manage your health care email notifications through my healthevet/i,
         );
+      cy.findAllByText(/we do not have a preference/i).should('have.length', 3);
     });
   });
   context('when user is not a VA patient', () => {

--- a/src/applications/personalization/profile/tests/fixtures/communication-preferences/get-200-maximal.json
+++ b/src/applications/personalization/profile/tests/fixtures/communication-preferences/get-200-maximal.json
@@ -25,7 +25,11 @@
                 {
                   "id": 2,
                   "name": "Email",
-                  "description": "Email Notification"
+                  "description": "Email Notification",
+                  "communicationPermission": {
+                    "id": 1234,
+                    "allowed": false
+                  }
                 }
               ]
             }

--- a/src/applications/personalization/profile/tests/fixtures/communication-preferences/get-200-maximal.json
+++ b/src/applications/personalization/profile/tests/fixtures/communication-preferences/get-200-maximal.json
@@ -25,11 +25,7 @@
                 {
                   "id": 2,
                   "name": "Email",
-                  "description": "Email Notification",
-                  "communicationPermission": {
-                    "id": 1234,
-                    "allowed": false
-                  }
+                  "description": "Email Notification"
                 }
               ]
             }
@@ -76,7 +72,11 @@
                 {
                   "id": 1,
                   "name": "Text",
-                  "description": "SMS Notification"
+                  "description": "SMS Notification",
+                  "communicationPermission": {
+                    "id": 1234,
+                    "allowed": false
+                  }
                 }
               ]
             }


### PR DESCRIPTION
## Description
Adds a simple red label above checkboxes when VA Profile does not know if the user has opted in or out of notifications via a particular channel.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#28489

## Testing done
TDD via a new simple Cypress assertion

## Screenshots
<img width="766" alt="Screen Shot 2021-08-12 at 10 00 40 AM" src="https://user-images.githubusercontent.com/20728956/129238506-76bb58a2-cfb7-4559-a5bf-f3c16a703ecc.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs