### PR TITLE
move "go to profile" link below My VA header

### DIFF
--- a/src/applications/personalization/dashboard/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard/components/Dashboard.jsx
@@ -71,7 +71,7 @@ const renderWidgetDowntimeNotification = (downtime, children) => {
 
 const DashboardHeader = () => {
   return (
-    <div className="medium-screen:vads-u-display--flex medium-screen:vads-u-justify-content--space-between medium-screen:vads-u-align-items--center">
+    <div>
       <h1
         id="dashboard-title"
         data-testid="dashboard-title"
@@ -83,7 +83,7 @@ const DashboardHeader = () => {
       <CTALink
         href="/profile"
         text="Go to your profile"
-        className="vads-u-margin-top--2 medium-screen:vads-u-margin-top--0"
+        className="vads-u-margin-top--2"
         onClick={() => {
           recordEvent({
             event: 'dashboard-navigation',


### PR DESCRIPTION
## Description
On medium+ screens, move "go to profile" link from next to the My VA header to below the My VA header

## Original issue(s)
department-of-veterans-affairs/va.gov-team#25052


## Testing done
Previewed in Cypress

## Screenshots
<img width="872" alt="Screen Shot 2021-08-12 at 10 14 44 AM" src="https://user-images.githubusercontent.com/20728956/129239935-6930ca81-b835-4c83-9c61-0c87436781c9.png">

<img width="319" alt="Screen Shot 2021-08-12 at 10 15 17 AM" src="https://user-images.githubusercontent.com/20728956/129239947-457a32c4-67b2-4a13-94ce-184925a3402d.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs