### PR TITLE
Update link styles on My VA

### DIFF
--- a/src/applications/personalization/components/NameTag.jsx
+++ b/src/applications/personalization/components/NameTag.jsx
@@ -37,15 +37,17 @@ const DisabilityRatingContent = ({ rating }) => {
           className="vads-u-color--white"
           style={{ whiteSpace: 'nowrap' }}
         >
-          {rating ? (
-            <>{rating}% service connected </>
-          ) : (
-            <>View disability rating </>
-          )}
+          <strong>
+            {rating ? (
+              <>{rating}% service connected </>
+            ) : (
+              <>View disability rating </>
+            )}
+          </strong>
           <i
             aria-hidden="true"
             role="img"
-            className="fas fa-angle-double-right vads-u-padding-left--0p5"
+            className="fas fa-chevron-right vads-u-padding-left--0p5"
           />
         </a>
       </dd>

--- a/src/applications/personalization/dashboard/components/CTALink.jsx
+++ b/src/applications/personalization/dashboard/components/CTALink.jsx
@@ -1,12 +1,9 @@
 import React from 'react';
 
-import useLastWord from '../useLastWord';
-
 const CTALink = ({ ariaLabel, className, href, text, onClick, newTab }) => {
   const relProp = newTab ? 'noreferrer noopener' : undefined;
   const targetProp = newTab ? '_blank' : undefined;
 
-  const [lastWord, firstWords] = useLastWord(text);
   const classNames = `vads-u-display--inline-block ${className}`;
 
   return (
@@ -18,14 +15,7 @@ const CTALink = ({ ariaLabel, className, href, text, onClick, newTab }) => {
       onClick={onClick || undefined}
       className={classNames}
     >
-      {`${firstWords} `}
-      <span style={{ whiteSpace: 'nowrap' }}>
-        {lastWord}
-        <i
-          aria-hidden="true"
-          className="fas fa-xs fa-chevron-right vads-u-margin-left--1"
-        />
-      </span>
+      {text}
     </a>
   );
 };

--- a/src/applications/personalization/dashboard/components/IconCTALink.jsx
+++ b/src/applications/personalization/dashboard/components/IconCTALink.jsx
@@ -42,10 +42,12 @@ const IconCTALink = ({
           {`${firstWords} `}
           <span style={{ whiteSpace: 'nowrap' }}>
             {lastWord}
-            <i
-              aria-hidden="true"
-              className="fas fa-xs fa-chevron-right vads-u-margin-left--1"
-            />
+            {boldText ? (
+              <i
+                aria-hidden="true"
+                className="fas fa-xs fa-chevron-right vads-u-margin-left--1"
+              />
+            ) : null}
           </span>
         </span>
       </span>


### PR DESCRIPTION
## Description
Updates visuals for most links on My VA and the Profile/My VA "name tag"

## Original issue(s)
department-of-veterans-affairs/va.gov-team#28302

## Testing done


## Screenshots
<img width="723" alt="Screen Shot 2021-08-12 at 10 45 08 AM" src="https://user-images.githubusercontent.com/20728956/129245263-0c598de8-8694-4525-9df6-da0c6ece9862.png">

<img width="920" alt="Screen Shot 2021-08-12 at 10 52 58 AM" src="https://user-images.githubusercontent.com/20728956/129245272-91eb194a-6f93-4762-8fa9-2e3c9b592e23.png">

<img width="932" alt="Screen Shot 2021-08-12 at 10 53 15 AM" src="https://user-images.githubusercontent.com/20728956/129245285-4bfd3d9d-6790-46ba-a9aa-494256f76905.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs