### PR TITLE
add sr-only alert text to SIP form component

### DIFF
--- a/src/applications/personalization/dashboard/components/apply-for-benefits/ApplicationInProgress.jsx
+++ b/src/applications/personalization/dashboard/components/apply-for-benefits/ApplicationInProgress.jsx
@@ -44,6 +44,7 @@ const ApplicationInProgress = ({
                 aria-hidden="true"
                 className={`fas fa-fw fa-exclamation-circle vads-u-margin-right--1 vads-u-margin-top--0p5`}
               />
+              <span className="sr-only">Alert: </span>
               <div>
                 <p className="vads-u-margin-top--0">
                   Application expires on: {expirationDate}


### PR DESCRIPTION
## Description
add sr-only alert text to SIP form component

## Original issue(s)
department-of-veterans-affairs/va.gov-team#25072

## Testing done
Previewed in Cypress to confirm sr-only span appears in DOM but everything still looks the same in the browser.

## Screenshots
<img width="520" alt="Screen Shot 2021-08-12 at 11 08 12 AM" src="https://user-images.githubusercontent.com/20728956/129247212-afce0de6-b7f1-4b44-9ddb-e4b2d6824ef2.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs