### PR TITLE
HLR: Add aria-describedby to wizard radios

### DIFF
--- a/src/applications/disability-benefits/996/wizard/pages/claimType.jsx
+++ b/src/applications/disability-benefits/996/wizard/pages/claimType.jsx
@@ -52,6 +52,7 @@ const ClaimType = ({ setPageState, state = {} }) => {
       options={options}
       onValueChange={setState}
       value={{ value: state.selected }}
+      ariaDescribedby={[pageNames.legacyChoice, pageNames.other]}
     />
   );
 };

--- a/src/applications/disability-benefits/996/wizard/pages/index.js
+++ b/src/applications/disability-benefits/996/wizard/pages/index.js
@@ -1,7 +1,7 @@
-import claimType from './claimType';
+import start from './claimType';
 import legacyChoice from './legacyChoice';
 import legacyNo from './legacyNo';
 import legacyYes from './legacyYes';
 import other from './other';
 
-export default [claimType, legacyChoice, legacyNo, legacyYes, other];
+export default [start, legacyChoice, legacyNo, legacyYes, other];

--- a/src/applications/disability-benefits/996/wizard/pages/legacyChoice.jsx
+++ b/src/applications/disability-benefits/996/wizard/pages/legacyChoice.jsx
@@ -31,24 +31,27 @@ const name = 'higher-level-review-legacy';
 
 const LegacyChoice = ({ setPageState, state = {} }) => {
   return (
-    <RadioButtons
-      name={name}
-      id={name}
-      label={label}
-      options={options}
-      onValueChange={({ value }) => {
-        recordEvent({
-          event: 'howToWizard-formChange',
-          'form-field-type': 'form-radio-buttons',
-          'form-field-label':
-            'Is this claim going through the legacy appeals process?',
-          'form-field-value': value,
-        });
-        setPageState({ selected: value }, value);
-      }}
-      value={{ value: state.selected }}
-      additionalFieldsetClass={`${name}-legacy vads-u-margin-top--0`}
-    />
+    <div id={pageNames.legacyChoice} className="vads-u-margin-top--2">
+      <RadioButtons
+        name={name}
+        id={name}
+        label={label}
+        options={options}
+        onValueChange={({ value }) => {
+          recordEvent({
+            event: 'howToWizard-formChange',
+            'form-field-type': 'form-radio-buttons',
+            'form-field-label':
+              'Is this claim going through the legacy appeals process?',
+            'form-field-value': value,
+          });
+          setPageState({ selected: value }, value);
+        }}
+        value={{ value: state.selected }}
+        additionalFieldsetClass={`${name}-legacy vads-u-margin-top--0`}
+        ariaDescribedby={[pageNames.legacyNo, pageNames.legacyYes]}
+      />
+    </div>
   );
 };
 

--- a/src/applications/disability-benefits/996/wizard/pages/legacyNo.jsx
+++ b/src/applications/disability-benefits/996/wizard/pages/legacyNo.jsx
@@ -16,7 +16,10 @@ const LegacyNo = ({ setWizardStatus }) => {
   });
 
   return (
-    <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
+    <div
+      id={pageNames.legacyNo}
+      className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2"
+    >
       <p className="vads-u-margin-top--0">
         You can request a Higher-Level Review online using{' '}
         <strong>VA Form 20-0996</strong>.

--- a/src/applications/disability-benefits/996/wizard/pages/legacyYes.jsx
+++ b/src/applications/disability-benefits/996/wizard/pages/legacyYes.jsx
@@ -12,7 +12,10 @@ const LegacyYes = () => {
       'Veteran has, or may have, a claim in the legacy appeals process',
   });
   return (
-    <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
+    <div
+      id={pageNames.legacyYes}
+      className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2"
+    >
       <p className="vads-u-margin-top--0">
         Since your claim is in the legacy appeals process, you’ll need to opt in
         to the new decision review process within 60 days of receiving your

--- a/src/applications/disability-benefits/996/wizard/pages/other.jsx
+++ b/src/applications/disability-benefits/996/wizard/pages/other.jsx
@@ -11,7 +11,10 @@ const DecisionReviewPage = () => {
     'reason-for-alert': 'veteran wants to submit an unsupported claim type',
   });
   return (
-    <div className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">
+    <div
+      id={pageNames.other}
+      className="vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2"
+    >
       You’ll need to fill out and submit VA Form 20-0996 by mail or in person.{' '}
       <a
         href={BENEFIT_OFFICES_URL}

--- a/src/applications/disability-benefits/996/wizard/pages/pageNames.js
+++ b/src/applications/disability-benefits/996/wizard/pages/pageNames.js
@@ -1,6 +1,5 @@
 const pageNames = {
-  claimType: 'claim-type',
-  compensation: 'compensation',
+  start: 'start',
   legacyChoice: 'legacy-choice',
   legacyYes: 'legacy-yes',
   legacyNo: 'legacy-no',


### PR DESCRIPTION
## Description

Add `aria-describedby` to wizard radio button to announce additional content that is revealed when a selection is made. The `aria-describedby` solution is already in place, so I didn't use the `aria-live` region suggestion.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/28653

## Testing done

- All unit tests & e2e tests continue to pass
- Verified that additional content is read via the screenreader (Chrome + Voiceover; not optimal, but it works 😸 )

## Screenshots

![Screen Shot 2021-08-12 at 1 41 27 PM](https://user-images.githubusercontent.com/136959/129251579-e36c36b6-a930-4f25-9eda-6bf2a2847461.png)

## Acceptance criteria
- [x] Additional content revealed when a radio selection is made is read out by a screen-reader

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
