### PR TITLE
28563 remove filter for not on award

### DIFF
--- a/src/applications/static-pages/dependency-verification/components/dependencyVerificationList.jsx
+++ b/src/applications/static-pages/dependency-verification/components/dependencyVerificationList.jsx
@@ -1,32 +1,23 @@
 import React from 'react';
 
-const NOTONAWARD = 'NAWDDEP';
-
 const DependencyVerificationList = ({ dependents }) => {
   return (
     <div className="vads-u-margin-top--4">
-      {dependents
-        .filter(dependent => {
-          return (
-            dependent.dependencyStatusType &&
-            dependent.dependencyStatusType !== NOTONAWARD
-          );
-        })
-        .map((dependent, index) => {
-          return (
-            <div
-              key={index}
-              className="vads-l-row vads-u-background-color--gray-lightest vads-u-margin-top--0 vads-u-margin-bottom--2 vads-u-padding--2"
-            >
-              <h3 className="vads-u-margin--0 vads-u-font-size--h5">
-                {dependent.fullName}
-              </h3>
-              <p className="vads-l-col--12 vads-u-margin-bottom--0">
-                {dependent.dependencyStatusTypeDescription}
-              </p>
-            </div>
-          );
-        })}
+      {dependents.map((dependent, index) => {
+        return (
+          <div
+            key={index}
+            className="vads-l-row vads-u-background-color--gray-lightest vads-u-margin-top--0 vads-u-margin-bottom--2 vads-u-padding--2"
+          >
+            <h3 className="vads-u-margin--0 vads-u-font-size--h5">
+              {dependent.fullName}
+            </h3>
+            <p className="vads-l-col--12 vads-u-margin-bottom--0">
+              {dependent.dependencyStatusTypeDescription}
+            </p>
+          </div>
+        );
+      })}
     </div>
   );
 };


### PR DESCRIPTION
## Description
This filter is no longer needed since we are performing it in [vets-api](https://github.com/department-of-veterans-affairs/vets-api/blob/01eabf5372c6504e649df37b6b5e46240baa4277/app/services/bgs/dependency_verification_service.rb#L52) now.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#28563


## Testing done
- local

## Acceptance criteria
- [x] filter removed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
