### PR TITLE
Fix incorrect community care provider fetch

### DIFF
--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -558,6 +558,7 @@ export function fetchConfirmedAppointmentDetails(id, type) {
 
       if (
         featureVAOSServiceCCAppointments &&
+        appointment.vaos.isCommunityCare &&
         appointment.practitioners?.length
       ) {
         appointment.communityCareProvider = await getCommunityProvider(

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.video.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.video.unit.spec.jsx
@@ -1547,9 +1547,9 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       expect(tokens.get('END')).includes('VCALENDAR');
     });
   });
-  describe('video appointments with VAOS service', () => {
+  describe('video appointments fetched from VAOS service', () => {
     beforeEach(() => mockFetch());
-    it('should show confirmed appointments detail page', async () => {
+    it('video appointment detail with practitioners', async () => {
       // Given VAOS service community care appointments are enabled
       const myInitialState = {
         ...initialState,

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.video.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.video.unit.spec.jsx
@@ -1563,7 +1563,7 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       const url = '/va/1234';
       const futureDate = moment.utc();
 
-      // And a future video appointment with practitioners
+      // And the user has a future video appointment with practitioners
       const appointment = getVAOSAppointmentMock();
       appointment.id = '1234';
       appointment.attributes = {
@@ -1586,7 +1586,7 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
 
       mockSingleVAOSAppointmentFetch({ appointment });
 
-      // And associated facility information
+      // And the appointment has associated facility information
       const facility = getV2FacilityMock({
         id: '983',
         name: 'Cheyenne VA Medical Center',
@@ -1613,7 +1613,7 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
         expect(document.activeElement).to.have.tagName('h1');
       });
 
-      // And the time is displayed in the facility timezone
+      // And the appointment time is displayed in the facility timezone
       expect(
         screen.getByRole('heading', {
           level: 1,


### PR DESCRIPTION
## Description
This PR
- Skips fetching community care providers when the appointment is not CC, but it does have practitioners

## Original issue(s)
department-of-veterans-affairs/va.gov-team#28673

## Testing done
Unit and local testing

```
Feature: VAOS <ConfirmedAppointmentDetailsPage>

  Background: video appointments fetched from VAOS service

    Scenario: video appointment detail with practitioners
      Given VAOS service community care appointments are enabled
        And the user has a future video appointment with practitioners
        And the appointment has associated facility information
      When the page is displayed
      Then the main header has focus
        And the appointment time is displayed in the facility timezone
        And the facility information is shown
        And practitioners are displayed
        And the calendar link is shown with the appropriate name
        And the appointment is not marked as being in the past
```

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
