### PR TITLE
HLR Wizard: Fix legacy appeals link a11y

### DIFF
--- a/src/applications/disability-benefits/996/wizard/pages/legacyChoice.jsx
+++ b/src/applications/disability-benefits/996/wizard/pages/legacyChoice.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
 import recordEvent from 'platform/monitoring/record-event';
+import { srSubstitute } from 'platform/forms-system/src/js/utilities/ui/mask-string';
 
 import pageNames from './pageNames';
 
 const label = (
   <p>
     Is this claim going through the{' '}
+    <span className="sr-only">legacy appeals process?</span>
     <a
       href="/disability/file-an-appeal/"
       onClick={() => {
@@ -16,9 +18,12 @@ const label = (
         });
       }}
     >
-      legacy appeals
-    </a>{' '}
-    process?
+      {srSubstitute(
+        'legacy appeals process',
+        'Learn more about the legacy appeals process',
+      )}
+    </a>
+    <span aria-hidden="true">?</span>
   </p>
 );
 


### PR DESCRIPTION
## Description

The Higher-Level Review wizard includes a "legacy appeals" link - seen after selecting "Disability compensation claim". This link needs more context for screen readers.

This PR adds a combination of `sr-only` and `aria-hidden="true"` to make the link include more context - see screenshot.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/28657

## Testing done

- Unit & e2e tests passing
- Tested with Chrome + Voiceover (not an optimal combo, but it works)

## Screenshots

![Screen Shot 2021-08-12 at 2 47 41 PM](https://user-images.githubusercontent.com/136959/129261633-e9b8d649-d6d4-43b4-a180-94c3e6faa4b5.png)

## Acceptance criteria
- [x] Screenreader includes more context for "legacy appeals procress" link

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
