### PR TITLE
HLR wizard: Change start button to an action link

### DIFF
--- a/src/applications/disability-benefits/996/wizard/pages/legacyNo.jsx
+++ b/src/applications/disability-benefits/996/wizard/pages/legacyNo.jsx
@@ -41,7 +41,7 @@ const LegacyNo = ({ setWizardStatus }) => {
           });
           setWizardStatus(WIZARD_STATUS_COMPLETE);
         }}
-        className="usa-button-primary va-button-primary"
+        className="vads-c-action-link--green"
         aria-describedby="other_ways_to_request_hlr"
       >
         Request a Higher-Level Review online


### PR DESCRIPTION
## Description

To update the pattern to match the new Design System guidelines, the HLR wizard "Request a Higher-Level Review" button is to be changed from a green primary button to an action link

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/28654

## Testing done

Visual

## Screenshots

![Screen Shot 2021-08-12 at 3 23 08 PM](https://user-images.githubusercontent.com/136959/129264438-41ec75a2-46e2-40d5-bb4f-a9ed04b15481.png)

## Acceptance criteria
- [x] HLR wizard start primary button changed to an action link

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
