### PR TITLE
HLR wizard: Fix legacy appeals link destination

### DIFF
--- a/src/applications/disability-benefits/996/constants.js
+++ b/src/applications/disability-benefits/996/constants.js
@@ -18,6 +18,7 @@ export const FACILITY_LOCATOR_URL = '/find-locations';
 export const GET_HELP_REVIEW_REQUEST_URL =
   '/decision-reviews/get-help-with-review-request';
 export const PROFILE_URL = '/profile';
+export const LEGACY_APPEALS_URL = '/decision-reviews/legacy-appeals/';
 
 // 8622 is the ID of the <li> wrapping the "Find addresses for other benefit
 // types" accordion

--- a/src/applications/disability-benefits/996/tests/hlr-wizard.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr-wizard.cypress.spec.js
@@ -3,6 +3,11 @@ import {
   WIZARD_STATUS,
   SAVED_CLAIM_TYPE,
   CONTESTABLE_ISSUES_API,
+  LEGACY_APPEALS_URL,
+  BENEFIT_OFFICES_URL,
+  SUPPLEMENTAL_CLAIM_URL,
+  HLR_INFO_URL,
+  FORM_URL,
 } from '../constants';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
@@ -59,9 +64,7 @@ describe('HLR wizard', () => {
     cy.get('[type="radio"][value="other"]').check(checkOpt);
     cy.checkStorage(SAVED_CLAIM_TYPE, undefined);
     // #8622 set by public websites accordion anchor ID
-    cy.get(
-      'a[href*="/decision-reviews/higher-level-review/#find-addresses-for-other-benef-8622"]',
-    ).should('exist');
+    cy.get(`a[href*="${BENEFIT_OFFICES_URL}"]`).should('exist');
     cy.checkFormChange({
       label: 'For what type of claim are you requesting a Higher-Level Review?',
       value: 'other',
@@ -73,7 +76,7 @@ describe('HLR wizard', () => {
   // legacy appeals flow
   it('should show legacy appeals question & alert', () => {
     cy.get('[type="radio"][value="compensation"]').check(checkOpt);
-    cy.get('a[href*="disability/file-an-appeal"]').should('exist');
+    cy.get(`a[href*="${LEGACY_APPEALS_URL}"]`).should('exist');
     cy.checkFormChange({
       label: 'For what type of claim are you requesting a Higher-Level Review?',
       value: 'compensation',
@@ -81,11 +84,9 @@ describe('HLR wizard', () => {
 
     cy.get('[type="radio"][value="legacy-yes"]').check(checkOpt);
     // download form link
-    cy.get('a[href*="www.vba.va.gov/pubs/forms/VBA-20-0996-ARE.pdf"]').should(
-      'exist',
-    );
+    cy.get(`a[href*="${FORM_URL}"]`).should('exist');
     // supplemental claim link
-    cy.get('a[href*="/decision-reviews/supplemental-claim"]').should('exist');
+    cy.get(`a[href*="${SUPPLEMENTAL_CLAIM_URL}"]`).should('exist');
     cy.checkFormChange({
       label: 'Is this claim going through the legacy appeals process?',
       value: 'legacy-yes',
@@ -110,10 +111,10 @@ describe('HLR wizard', () => {
       value: 'compensation',
     });
 
-    cy.get('a[href*="disability/file-an-appeal"]').should('exist');
+    cy.get(`a[href*="${LEGACY_APPEALS_URL}"]`).should('exist');
     cy.get('[type="radio"][value="legacy-no"]').check(checkOpt);
     // learn more link
-    cy.get('a[href*="/decision-reviews/higher-level-review/"]').should('exist');
+    cy.get(`a[href*="${HLR_INFO_URL}"]`).should('exist');
     cy.checkFormChange({
       label: 'Is this claim going through the legacy appeals process?',
       value: 'legacy-no',

--- a/src/applications/disability-benefits/996/wizard/pages/legacyChoice.jsx
+++ b/src/applications/disability-benefits/996/wizard/pages/legacyChoice.jsx
@@ -3,6 +3,7 @@ import RadioButtons from '@department-of-veterans-affairs/component-library/Radi
 import recordEvent from 'platform/monitoring/record-event';
 import { srSubstitute } from 'platform/forms-system/src/js/utilities/ui/mask-string';
 
+import { LEGACY_APPEALS_URL } from '../../constants';
 import pageNames from './pageNames';
 
 const label = (
@@ -10,7 +11,7 @@ const label = (
     Is this claim going through the{' '}
     <span className="sr-only">legacy appeals process?</span>
     <a
-      href="/disability/file-an-appeal/"
+      href={LEGACY_APPEALS_URL}
       onClick={() => {
         recordEvent({
           event: 'howToWizard-alert-link-click',


### PR DESCRIPTION
## Description

The link to the legacy appeals page is incorrect inside the Higher-Level Review wizard. This PR updates it to point to https://www.va.gov/decision-reviews/legacy-appeals/

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/28659

## Testing done

Manual link testing

## Screenshots

N/A

## Acceptance criteria
- [x] Link to legacy appeals has been updated to correct destination

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
