### PR TITLE
Show the inProgressMessage also in the div

### DIFF
--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -113,7 +113,10 @@ export default function FormNav(props) {
             </h2>
           )}
           {!showHeader && (
-            <div className="vads-u-font-size--h4">{stepText}</div>
+            <div className="vads-u-font-size--h4">
+              {stepText}
+              {inProgressMessage}
+            </div>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Description
This should fix a flaky test. The test checks for the in-progress ID, but we weren't rendering it in that `div` when we should have. It sometimes passed because the test sometimes caught the `h2`, but when it failed, that's because it caught the `div`.