### PR TITLE
Remove lodash/fp from personalization

### DIFF
--- a/src/applications/personalization/dashboard/reducers/folders.js
+++ b/src/applications/personalization/dashboard/reducers/folders.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import set from 'lodash/fp/set';
+import set from 'platform/utilities/data/set';
 
 import {
   FETCH_FOLDER_SUCCESS,

--- a/src/applications/personalization/dashboard/reducers/folders.js
+++ b/src/applications/personalization/dashboard/reducers/folders.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import set from 'platform/utilities/data/set';
+import set from '~/platform/utilities/data/set';
 
 import {
   FETCH_FOLDER_SUCCESS,

--- a/src/applications/personalization/dashboard/reducers/prescriptions.js
+++ b/src/applications/personalization/dashboard/reducers/prescriptions.js
@@ -1,5 +1,4 @@
-import assign from 'lodash/fp/assign';
-import set from 'lodash/fp/set';
+import set from 'platform/utilities/data/set';
 
 const initialState = {
   currentItem: null,
@@ -69,7 +68,7 @@ export default function prescriptions(state = initialState, action) {
         };
       }
 
-      return assign(state, newState);
+      return { ...state, ...newState };
     }
 
     default:

--- a/src/applications/personalization/dashboard/reducers/prescriptions.js
+++ b/src/applications/personalization/dashboard/reducers/prescriptions.js
@@ -1,4 +1,4 @@
-import set from 'platform/utilities/data/set';
+import set from '~/platform/utilities/data/set';
 
 const initialState = {
   currentItem: null,


### PR DESCRIPTION
## Description
Remove `lodash/fp` from the `personalization` directory.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#1678


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
