### PR TITLE
Remove lodash/fp from post-911-gib-status

### DIFF
--- a/src/applications/post-911-gib-status/reducers/index.js
+++ b/src/applications/post-911-gib-status/reducers/index.js
@@ -1,4 +1,4 @@
-import set from 'lodash/fp/set';
+import set from 'platform/utilities/data/set';
 
 import {
   BACKEND_AUTHENTICATION_ERROR,


### PR DESCRIPTION
## Description
Remove `lodash/fp` from the Post 9/11 GI Bill Status application.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#1678


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
