### PR TITLE
Remove lodash/fp from terms-and-conditions

### DIFF
--- a/src/applications/terms-and-conditions/tests/containers/MhvTermsAndConditions.unit.spec.jsx
+++ b/src/applications/terms-and-conditions/tests/containers/MhvTermsAndConditions.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { set } from 'lodash/fp';
+import set from 'platform/utilities/data/set';
 import sinon from 'sinon';
 
 import { MhvTermsAndConditions } from '../../containers/MhvTermsAndConditions';


### PR DESCRIPTION
## Description
Remove `lodash/fp` imports from `terms-and-conditions`.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#1678


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
