### PR TITLE
Update vets-json-schema dep to latest version to include HLR v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -334,7 +334,7 @@
     "url-search-params-polyfill": "^8.1.0",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#d95589c438c1415f4ea8607e2f50ca82ea00b9c4",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#c53691977e6fd6ea717ceb0c4c2bc740f477168b",
     "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.7.0",
     "whatwg-fetch": "^2.0.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -19836,9 +19836,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#d95589c438c1415f4ea8607e2f50ca82ea00b9c4":
-  version "20.6.7"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#d95589c438c1415f4ea8607e2f50ca82ea00b9c4"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#c53691977e6fd6ea717ceb0c4c2bc740f477168b":
+  version "20.9.0"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#c53691977e6fd6ea717ceb0c4c2bc740f477168b"
 
 vfile-message@^2.0.0:
   version "2.0.4"


### PR DESCRIPTION
## Description
Update vets-json-schema to latest version that includes HLR 2


## Original issue(s)
department-of-veterans-affairs/va.gov-team#28112


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
