### PR TITLE
Update vets-json-schema dep to include HLR 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -324,7 +324,7 @@
     "url-search-params-polyfill": "^8.1.0",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#3bec07e95054fb4c6d7892d1ad700a8f4c3b009c",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#c53691977e6fd6ea717ceb0c4c2bc740f477168b",
     "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.9.1",
     "whatwg-fetch": "^3.6.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -19795,9 +19795,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#3bec07e95054fb4c6d7892d1ad700a8f4c3b009c":
-  version "20.8.0"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#3bec07e95054fb4c6d7892d1ad700a8f4c3b009c"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#c53691977e6fd6ea717ceb0c4c2bc740f477168b":
+  version "20.9.0"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#c53691977e6fd6ea717ceb0c4c2bc740f477168b"
 
 vfile-message@^2.0.0:
   version "2.0.4"


### PR DESCRIPTION
## Description
Lighthouse HLR 2 json schema was added to vets-json-schema.  Update this repo to include latest vets-json-schema version 2.9.0 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#28112


## Testing done
Non breaking change, new schema is not used in this repo

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
