### PR TITLE
a11y refinements for saved-in-progress benefit applications

### DIFF
--- a/src/applications/personalization/dashboard/components/DashboardWidgetWrapper.jsx
+++ b/src/applications/personalization/dashboard/components/DashboardWidgetWrapper.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 function DashboardWidgetWrapper({ children }) {
   return (
-    <div className="vads-l-col--12 medium-screen:vads-l-col--8 small-desktop-screen:vads-l-col--6 medium-screen:vads-u-padding-right--3">
+    <div className="vads-l-col--12 medium-screen:vads-l-col--8 medium-screen:vads-u-padding-right--3 small-desktop-screen:vads-l-col--6">
       {children}
     </div>
   );

--- a/src/applications/personalization/dashboard/components/apply-for-benefits/ApplicationInProgress.jsx
+++ b/src/applications/personalization/dashboard/components/apply-for-benefits/ApplicationInProgress.jsx
@@ -33,10 +33,16 @@ const ApplicationInProgress = ({
       >
         <div className="vads-u-display--flex vads-u-width--full vads-u-flex-direction--column vads-u-justify-content--space-between vads-u-align-items--flex-start vads-u-background-color--gray-lightest vads-u-padding--2p5">
           <div className="vads-u-width--full">
-            <p className="vads-u-text-transform--uppercase vads-u-margin-y--0">
+            <p
+              id={formId}
+              className="vads-u-text-transform--uppercase vads-u-margin-y--0"
+            >
               {presentableFormId}
             </p>
-            <h4 className="vads-u-font-size--h3 vads-u-margin-top--0">
+            <h4
+              aria-describedby={formId}
+              className="vads-u-font-size--h3 vads-u-margin-top--0"
+            >
               {capitalizeFirstLetter(formTitle)}
             </h4>
             <div className="vads-u-display--flex">

--- a/src/applications/personalization/dashboard/components/apply-for-benefits/ApplicationsInProgress.jsx
+++ b/src/applications/personalization/dashboard/components/apply-for-benefits/ApplicationsInProgress.jsx
@@ -7,7 +7,7 @@ import { selectProfile } from '~/platform/user/selectors';
 import {
   filterOutExpiredForms,
   formLinks,
-  formTitles,
+  formBenefits,
   isSIPEnabledForm,
   presentableFormIDs,
   sipFormSorter,
@@ -36,7 +36,7 @@ const ApplicationsInProgress = ({ savedForms }) => {
         <div className="vads-l-row">
           {verifiedSavedForms.map(form => {
             const formId = form.form;
-            const formTitle = `application for ${formTitles[formId]}`;
+            const formTitle = `application for ${formBenefits[formId]}`;
             const presentableFormId = presentableFormIDs[formId];
             const { lastUpdated, expiresAt } = form.metadata || {};
             const lastOpenedDate = moment

--- a/src/applications/personalization/dashboard/components/apply-for-benefits/ApplicationsInProgress.jsx
+++ b/src/applications/personalization/dashboard/components/apply-for-benefits/ApplicationsInProgress.jsx
@@ -32,7 +32,7 @@ const ApplicationsInProgress = ({ savedForms }) => {
         Applications in progress
       </h3>
 
-      {verifiedSavedForms.length > 0 && (
+      {verifiedSavedForms.length > 0 ? (
         <div className="vads-l-row">
           {verifiedSavedForms.map(form => {
             const formId = form.form;
@@ -59,8 +59,7 @@ const ApplicationsInProgress = ({ savedForms }) => {
             );
           })}
         </div>
-      )}
-      {!verifiedSavedForms.length && (
+      ) : (
         <p>You have no applications in progress.</p>
       )}
     </>

--- a/src/applications/personalization/dashboard/components/apply-for-benefits/ApplyForBenefits.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/components/apply-for-benefits/ApplyForBenefits.unit.spec.jsx
@@ -267,7 +267,7 @@ describe('ApplyForBenefits component', () => {
       expect(applicationsInProgress.length).to.equal(3);
       expect(applicationsInProgress[0]).to.contain.text('21-526EZ');
       expect(applicationsInProgress[1]).to.contain.text('686C-674');
-      expect(applicationsInProgress[2]).to.contain.text('1010ez');
+      expect(applicationsInProgress[2]).to.contain.text('10-10EZ');
     });
   });
   describe('Benefits you might be interested in', () => {

--- a/src/applications/personalization/dashboard/helpers.jsx
+++ b/src/applications/personalization/dashboard/helpers.jsx
@@ -158,10 +158,11 @@ export const presentableFormIDs = Object.keys(formBenefits).reduce(
   (prefixedIDs, formID) => {
     if (formID === VA_FORM_IDS.FEEDBACK_TOOL) {
       prefixedIDs[formID] = 'FEEDBACK TOOL'; // eslint-disable-line no-param-reassign
+    } else if (formID === VA_FORM_IDS.FORM_10_10EZ) {
+      prefixedIDs[formID] = `FORM 10-10EZ`; // eslint-disable-line no-param-reassign
     } else {
       prefixedIDs[formID] = `FORM ${formID}`; // eslint-disable-line no-param-reassign
     }
-    // TODO: add an exception for 1010ez since that form ID is lowercase and lacks a dash?
     return prefixedIDs;
   },
   {},


### PR DESCRIPTION
## Description
Remove duplicative form ids from the form titles, and use aria-describedby to support the more succinct form titles

## Original issue(s)
department-of-veterans-affairs/va.gov-team#25069

## Testing done
Locally in Cypress

## Screenshots
<img width="896" alt="Screen Shot 2021-08-13 at 9 09 12 AM" src="https://user-images.githubusercontent.com/20728956/129388457-cba88800-d701-493a-bcea-cfa1a72080c9.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs