### PR TITLE
Try and output full results

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -812,7 +812,7 @@ jobs:
           name: Cypress Tests Summary
           conclusion: ${{ needs.cypress-tests.result }}
           output:
-            '{"summary": "Total Tests Run: $TOTAL_TESTS_RUN, Total Tests Passed: $TOTAL_TESTS_PASSED, Total Tests Failed: $TOTAL_TESTS_FAILED, Total Tests Skipped: $TOTAL_TESTS_SKIPPED, [Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})"}',
+            {"summary: Total Tests Run: $TOTAL_TESTS_RUN, Total Tests Passed: $TOTAL_TESTS_PASSED, Total Tests Failed: $TOTAL_TESTS_FAILED, Total Tests Skipped: $TOTAL_TESTS_SKIPPED, [Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})",
 
 # archive:
 #   name: Archive

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -686,6 +686,7 @@ jobs:
           repository: department-of-veterans-affairs/testing-tools-team-dashboard-data
           token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
           path: testing-tools-team-dashboard-data
+          ref: Cbonade/custom-summary
 
       # TODO: Set .nvmrc in testing-tools-team-dashboard-data.
       # - name: Get Node version
@@ -732,6 +733,9 @@ jobs:
         env:
           IS_MASTER_BUILD: ${{ needs.cypress-tests-prep.outputs.is_master_build }}
           NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
+
+      - name: Output full results
+        run: echo $COMBINED_RESULTS
 
       - name: Upload Mochawesome report artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -811,8 +811,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: Cypress Tests Summary
           conclusion: ${{ needs.cypress-tests.result }}
-          output: |
-            {summary: "Total Tests Run: $TOTAL_TESTS_RUN, Total Tests Passed: $TOTAL_TESTS_PASSED, Total Tests Failed": $TOTAL_TESTS_FAILED, Total Tests Skipped": $TOTAL_TESTS_SKIPPED, [Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})}
+          output:
+            {
+              'summary': 'Total Tests Run: $TOTAL_TESTS_RUN, Total Tests Passed: $TOTAL_TESTS_PASSED, Total Tests Failed: $TOTAL_TESTS_FAILED, Total Tests Skipped: $TOTAL_TESTS_SKIPPED, [Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})',
+            }
 
 # archive:
 #   name: Archive

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -739,8 +739,7 @@ jobs:
       - name: Set output of Cypress tests
         id: cypress-tests-output
         run: |
-          cypress_results= echo "##Number of tests run: $TOTAL_TESTS_RUN, Total Tests Passed: $TOTAL_TESTS_PASSED, Total Tests Failed: $TOTAL_TESTS_FAILED, Total Tests Skipped: $TOTAL_TESTS_SKIPPED"
-          echo "CYPRESS_RESULTS=$cypress_results" >> $GITHUB_ENV
+          echo "CYPRESS_RESULTS='##Number of tests run: $TOTAL_TESTS_RUN, Total Tests Passed: $TOTAL_TESTS_PASSED, Total Tests Failed: $TOTAL_TESTS_FAILED, Total Tests Skipped: $TOTAL_TESTS_SKIPPED'" >> $GITHUB_ENV
 
       - name: Output full results
         run: echo ${{steps.cypress-tests-output.outputs.results }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -739,8 +739,8 @@ jobs:
       - name: Set output of Cypress tests
         id: cypress-tests-output
         run: |
-          results= echo "##Number of tests run: $TOTAL_TESTS_RUN, Total Tests Passed: $TOTAL_TESTS_PASSED, Total Tests Failed: $TOTAL_TESTS_FAILED, Total Tests Skipped: $TOTAL_TESTS_SKIPPED"
-          echo CYPRESS_RESULTS=$results >> $GITHUB_ENV
+          cypress_results= echo "##Number of tests run: $TOTAL_TESTS_RUN, Total Tests Passed: $TOTAL_TESTS_PASSED, Total Tests Failed: $TOTAL_TESTS_FAILED, Total Tests Skipped: $TOTAL_TESTS_SKIPPED"
+          echo CYPRESS_RESULTS=$cypress_results >> $GITHUB_ENV
 
       - name: Output full results
         run: echo ${{steps.cypress-tests-output.outputs.results }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,9 +10,9 @@ on:
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
 
-concurrency:
-  group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha  }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+# concurrency:
+#   group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha  }}
+#   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
   build:
@@ -740,8 +740,7 @@ jobs:
         id: cypress-tests-output
         run: |
           results= echo "##Number of tests run: $TOTAL_TESTS_RUN, Total Tests Passed: $TOTAL_TESTS_PASSED, Total Tests Failed: $TOTAL_TESTS_FAILED, Total Tests Skipped: $TOTAL_TESTS_SKIPPED"
-          echo $results
-          echo ::set-output name=results::$results
+          echo CYPRESS_RESULTS=$results >> $GITHUB_ENV
 
       - name: Output full results
         run: echo ${{steps.cypress-tests-output.outputs.results }}
@@ -817,7 +816,7 @@ jobs:
           name: Cypress Tests Summary
           conclusion: ${{ needs.cypress-tests.result }}
           output: |
-            {"summary":${{ steps.cypress-tests-results.outputs.results }}}
+            {"summary":${{ env.CYPRESS_RESULTS }}}
           # output: |
           #   {"summary":"Total Tests Run: $TOTAL_TESTS_RUN Total Tests Passed: $TOTAL_TESTS_PASSED Total Tests Failed: $TOTAL_TESTS_FAILED Total Tests Skipped: $TOTAL_TESTS_SKIPPED" [Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})}
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -812,7 +812,7 @@ jobs:
           name: Cypress Tests Summary
           conclusion: ${{ needs.cypress-tests.result }}
           output: |
-            {"summary":"Total Tests Run: $TOTAL_TESTS_RUN Total Tests Passed: $TOTAL_TESTS_PASSED Total Tests Failed: $TOTAL_TESTS_FAILED Total Tests Skipped: $TOTAL_TESTS_SKIPPED"}
+            {"summary":"Total Tests Run: ${{ $TOTAL_TESTS_RUN }} Total Tests Passed: ${{ $TOTAL_TESTS_PASSED }} Total Tests Failed: ${{ $TOTAL_TESTS_FAILED }} Total Tests Skipped: ${{ $TOTAL_TESTS_SKIPPED }}"}
           # output: |
           #   {"summary":"Total Tests Run: $TOTAL_TESTS_RUN Total Tests Passed: $TOTAL_TESTS_PASSED Total Tests Failed: $TOTAL_TESTS_FAILED Total Tests Skipped: $TOTAL_TESTS_SKIPPED" [Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})}
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -735,11 +735,12 @@ jobs:
           NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
 
       - name: Output full results
-        run: |
-          echo $COMBINED_RESULTS.stats.tests
-          echo $COMBINED_RESULTS.stats.passes
-          echo $COMBINED_RESULTS.stats.pending
-          echo $COMBINED_RESULTS.stats.failures
+        run: $COMBINED_RESULTS
+        # run: |
+        #   echo $COMBINED_RESULTS.stats.tests
+        #   echo $COMBINED_RESULTS.stats.passes
+        #   echo $COMBINED_RESULTS.stats.pending
+        #   echo $COMBINED_RESULTS.stats.failures
 
       - name: Upload Mochawesome report artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -740,7 +740,7 @@ jobs:
         id: cypress-tests-output
         run: |
           cypress_results= echo "##Number of tests run: $TOTAL_TESTS_RUN, Total Tests Passed: $TOTAL_TESTS_PASSED, Total Tests Failed: $TOTAL_TESTS_FAILED, Total Tests Skipped: $TOTAL_TESTS_SKIPPED"
-          echo CYPRESS_RESULTS=$cypress_results >> $GITHUB_ENV
+          echo "CYPRESS_RESULTS=$cypress_results" >> $GITHUB_ENV
 
       - name: Output full results
         run: echo ${{steps.cypress-tests-output.outputs.results }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -622,6 +622,8 @@ jobs:
     name: Testing Reports
     runs-on: ubuntu-latest
     needs: [cypress-tests-prep, cypress-tests]
+    outputs:
+      cypress_test_results: ${{ steps.cypress-test-results.outputs.results }}
     if: ${{ always() && needs.cypress-tests-prep.outputs.num_containers > 0 && (needs.cypress-tests.result == 'success' || needs.cypress-tests.result == 'failure') }}
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -812,9 +812,7 @@ jobs:
           name: Cypress Tests Summary
           conclusion: ${{ needs.cypress-tests.result }}
           output:
-            {
-              'summary': 'Total Tests Run: $TOTAL_TESTS_RUN, Total Tests Passed: $TOTAL_TESTS_PASSED, Total Tests Failed: $TOTAL_TESTS_FAILED, Total Tests Skipped: $TOTAL_TESTS_SKIPPED, [Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})',
-            }
+            summary: 'Total Tests Run: $TOTAL_TESTS_RUN, Total Tests Passed: $TOTAL_TESTS_PASSED, Total Tests Failed: $TOTAL_TESTS_FAILED, Total Tests Skipped: $TOTAL_TESTS_SKIPPED, [Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})',
 
 # archive:
 #   name: Archive

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -812,8 +812,7 @@ jobs:
           name: Cypress Tests Summary
           conclusion: ${{ needs.cypress-tests.result }}
           output: |
-            [{"summary": "Total Tests Run: $TOTAL_TESTS_RUN Total Tests Passed: $TOTAL_TESTS_PASSED Total Tests Failed: $TOTAL_TESTS_FAILED Total Tests Skipped: $TOTAL_TESTS_SKIPPED",
-            "text_description": "[Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})"}]
+            [{"summary":"Total Tests Run: $TOTAL_TESTS_RUN Total Tests Passed: $TOTAL_TESTS_PASSED Total Tests Failed: $TOTAL_TESTS_FAILED Total Tests Skipped: $TOTAL_TESTS_SKIPPED","text_description":"[Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})"}]
 
 # archive:
 #   name: Archive

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -725,6 +725,8 @@ jobs:
           IS_MASTER_BUILD: ${{ needs.cypress-tests-prep.outputs.is_master_build }}
           NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
 
+      # env.MOCHAWESOME_REPORT_RESULTS is set and exported during the above step when the mochawesome report is generated.  It contains the output string for the publish step at the end of the job with the numbers from the Mochawesome report.
+
       - name: Upload Mochawesome report artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,9 +10,9 @@ on:
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
 
-# concurrency:
-#   group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha  }}
-#   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+concurrency:
+  group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha  }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
   build:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -735,7 +735,11 @@ jobs:
           NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
 
       - name: Output full results
-        run: echo $COMBINED_RESULTS
+        run: |
+          echo $COMBINED_RESULTS.stats.tests
+          echo $COMBINED_RESULTS.stats.passes
+          echo $COMBINED_RESULTS.stats.pending
+          echo $COMBINED_RESULTS.stats.failures
 
       - name: Upload Mochawesome report artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -739,7 +739,7 @@ jobs:
       - name: Set output of Cypress tests
         id: cypress-tests-output
         run: |
-          echo 'CYPRESS_RESULTS="##Number of tests run: $TOTAL_TESTS_RUN, Total Tests Passed: $TOTAL_TESTS_PASSED, Total Tests Failed: $TOTAL_TESTS_FAILED, Total Tests Skipped: $TOTAL_TESTS_SKIPPED"' >> $GITHUB_ENV
+          echo 'CYPRESS_RESULTS=##Number of tests run: $TOTAL_TESTS_RUN, Total Tests Passed: $TOTAL_TESTS_PASSED, Total Tests Failed: $TOTAL_TESTS_FAILED, Total Tests Skipped: $TOTAL_TESTS_SKIPPED' >> $GITHUB_ENV
 
       - name: Output full results
         run: echo ${{steps.cypress-tests-output.outputs.results }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -742,7 +742,7 @@ jobs:
           echo ::set-output name=results::$results
 
       - name: Output full results
-        run: ${{steps.cypress-tests-output.outputs.results }}
+        run: echo ${{steps.cypress-tests-output.outputs.results }}
 
       - name: Upload Mochawesome report artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -812,7 +812,7 @@ jobs:
           name: Cypress Tests Summary
           conclusion: ${{ needs.cypress-tests.result }}
           output:
-            {"summary": "Total Tests Run: $TOTAL_TESTS_RUN Total Tests Passed: $TOTAL_TESTS_PASSED Total Tests Failed: $TOTAL_TESTS_FAILED Total Tests Skipped: $TOTAL_TESTS_SKIPPED [Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})",
+            {"summary": "Total Tests Run: $TOTAL_TESTS_RUN Total Tests Passed: $TOTAL_TESTS_PASSED Total Tests Failed: $TOTAL_TESTS_FAILED Total Tests Skipped: $TOTAL_TESTS_SKIPPED [Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})"},
 
 # archive:
 #   name: Archive

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -734,14 +734,6 @@ jobs:
           IS_MASTER_BUILD: ${{ needs.cypress-tests-prep.outputs.is_master_build }}
           NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
 
-      - name: Set output of Cypress tests
-        id: cypress-tests-output
-        run: |
-          echo 'CYPRESS_RESULTS=$MOCHAWESOME_REPORT_RESULTS' >> $GITHUB_ENV
-
-      - name: Output full results
-        run: echo ${{steps.cypress-tests-output.outputs.results }}
-
       - name: Upload Mochawesome report artifact
         uses: actions/upload-artifact@v2
         with:
@@ -813,7 +805,7 @@ jobs:
           name: Cypress Tests Summary
           conclusion: ${{ needs.cypress-tests.result }}
           output: |
-            {"summary":${{ env.CYPRESS_RESULTS }}}
+            {"summary":${{ env.MOCHAWESOME_REPORT_RESULTS }}}
           # output: |
           #   {"summary":"Total Tests Run: $TOTAL_TESTS_RUN Total Tests Passed: $TOTAL_TESTS_PASSED Total Tests Failed: $TOTAL_TESTS_FAILED Total Tests Skipped: $TOTAL_TESTS_SKIPPED" [Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})}
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -737,7 +737,7 @@ jobs:
       - name: Set output of Cypress tests
         id: cypress-tests-output
         run: |
-          results=$(Number of tests run: $TOTAL_TESTS_RUN) 
+          results= echo "Number of tests run: $TOTAL_TESTS_RUN"
           echo $results
           echo ::set-output name=results::$results
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -737,7 +737,7 @@ jobs:
       - name: Set output of Cypress tests
         id: cypress-tests-output
         run: |
-          results= echo "Number of tests run: $TOTAL_TESTS_RUN"
+          results= echo "##Number of tests run: $TOTAL_TESTS_RUN, Total Tests Passed: $TOTAL_TESTS_PASSED, Total Tests Failed: $TOTAL_TESTS_FAILED, Total Tests Skipped: $TOTAL_TESTS_SKIPPED"
           echo $results
           echo ::set-output name=results::$results
 
@@ -815,7 +815,7 @@ jobs:
           name: Cypress Tests Summary
           conclusion: ${{ needs.cypress-tests.result }}
           output: |
-            {"summary":${{ steps.cypress-tests-results.outputs.results }} }
+            {"summary":${{ steps.cypress-tests-results.outputs.results }}}
           # output: |
           #   {"summary":"Total Tests Run: $TOTAL_TESTS_RUN Total Tests Passed: $TOTAL_TESTS_PASSED Total Tests Failed: $TOTAL_TESTS_FAILED Total Tests Skipped: $TOTAL_TESTS_SKIPPED" [Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})}
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -800,12 +800,23 @@ jobs:
 
       - name: Publish Cypress test results
         if: ${{ always() }}
-        uses: mikepenz/action-junit-report@v2.4.2
+        # uses: mikepenz/action-junit-report@v2.4.2
+        # with:
+        #   check_name: 'Cypress Tests Summary'
+        #   github_token: ${{ secrets.GITHUB_TOKEN }}
+        #   report_paths: 'cypress-junit-test-results/e2e-test-output-*.xml'
+        #   summary: '[Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})'
+        uses: LouisBrunner/checks-action@v1.1.1
         with:
-          check_name: 'Cypress Tests Summary'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          report_paths: 'cypress-junit-test-results/e2e-test-output-*.xml'
-          summary: '[Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: Cypress Tests Summary
+          conclusion: ${{ needs.cypress-tests.result }}
+          output: |
+            {"Total Tests Run": $TOTAL_TESTS_RUN}
+            {"Total Tests Passed": $TOTAL_TESTS_PASSED} 
+            {"Total Tests Failed": $TOTAL_TESTS_FAILED} 
+            {"Total Tests Skipped": $TOTAL_TESTS_SKIPPED} 
+            { [Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})}
 
 # archive:
 #   name: Archive

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -739,7 +739,7 @@ jobs:
       - name: Set output of Cypress tests
         id: cypress-tests-output
         run: |
-          echo "CYPRESS_RESULTS='##Number of tests run: $TOTAL_TESTS_RUN, Total Tests Passed: $TOTAL_TESTS_PASSED, Total Tests Failed: $TOTAL_TESTS_FAILED, Total Tests Skipped: $TOTAL_TESTS_SKIPPED'" >> $GITHUB_ENV
+          echo 'CYPRESS_RESULTS="##Number of tests run: $TOTAL_TESTS_RUN, Total Tests Passed: $TOTAL_TESTS_PASSED, Total Tests Failed: $TOTAL_TESTS_FAILED, Total Tests Skipped: $TOTAL_TESTS_SKIPPED"' >> $GITHUB_ENV
 
       - name: Output full results
         run: echo ${{steps.cypress-tests-output.outputs.results }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -812,7 +812,9 @@ jobs:
           name: Cypress Tests Summary
           conclusion: ${{ needs.cypress-tests.result }}
           output: |
-            '[{"summary":"Total Tests Run: $TOTAL_TESTS_RUN Total Tests Passed: $TOTAL_TESTS_PASSED Total Tests Failed: $TOTAL_TESTS_FAILED Total Tests Skipped: $TOTAL_TESTS_SKIPPED","text_description":"[Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})"}]'
+            {"summary":"Total Tests Run: $TOTAL_TESTS_RUN Total Tests Passed: $TOTAL_TESTS_PASSED Total Tests Failed: $TOTAL_TESTS_FAILED Total Tests Skipped: $TOTAL_TESTS_SKIPPED"}
+          # output: |
+          #   {"summary":"Total Tests Run: $TOTAL_TESTS_RUN Total Tests Passed: $TOTAL_TESTS_PASSED Total Tests Failed: $TOTAL_TESTS_FAILED Total Tests Skipped: $TOTAL_TESTS_SKIPPED" [Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})}
 
 # archive:
 #   name: Archive

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -686,7 +686,6 @@ jobs:
           repository: department-of-veterans-affairs/testing-tools-team-dashboard-data
           token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
           path: testing-tools-team-dashboard-data
-          ref: Cbonade/custom-summary
 
       # TODO: Set .nvmrc in testing-tools-team-dashboard-data.
       # - name: Get Node version
@@ -793,12 +792,6 @@ jobs:
 
       - name: Publish Cypress test results
         if: ${{ always() }}
-        # uses: mikepenz/action-junit-report@v2.4.2
-        # with:
-        #   check_name: 'Cypress Tests Summary'
-        #   github_token: ${{ secrets.GITHUB_TOKEN }}
-        #   report_paths: 'cypress-junit-test-results/e2e-test-output-*.xml'
-        #   summary: '[Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})'
         uses: LouisBrunner/checks-action@v1.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -806,8 +799,6 @@ jobs:
           conclusion: ${{ needs.cypress-tests.result }}
           output: |
             {"summary":${{ env.MOCHAWESOME_REPORT_RESULTS }}}
-          # output: |
-          #   {"summary":"Total Tests Run: $TOTAL_TESTS_RUN Total Tests Passed: $TOTAL_TESTS_PASSED Total Tests Failed: $TOTAL_TESTS_FAILED Total Tests Skipped: $TOTAL_TESTS_SKIPPED" [Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})}
 
 # archive:
 #   name: Archive

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -622,8 +622,6 @@ jobs:
     name: Testing Reports
     runs-on: ubuntu-latest
     needs: [cypress-tests-prep, cypress-tests]
-    outputs:
-      cypress_test_results: ${{ steps.cypress-test-results.outputs.results }}
     if: ${{ always() && needs.cypress-tests-prep.outputs.num_containers > 0 && (needs.cypress-tests.result == 'success' || needs.cypress-tests.result == 'failure') }}
     steps:
       - name: Configure AWS credentials
@@ -739,7 +737,7 @@ jobs:
       - name: Set output of Cypress tests
         id: cypress-tests-output
         run: |
-          echo 'CYPRESS_RESULTS=##Number of tests run: $TOTAL_TESTS_RUN, Total Tests Passed: $TOTAL_TESTS_PASSED, Total Tests Failed: $TOTAL_TESTS_FAILED, Total Tests Skipped: $TOTAL_TESTS_SKIPPED' >> $GITHUB_ENV
+          echo 'CYPRESS_RESULTS=$MOCHAWESOME_REPORT_RESULTS' >> $GITHUB_ENV
 
       - name: Output full results
         run: echo ${{steps.cypress-tests-output.outputs.results }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -812,7 +812,7 @@ jobs:
           name: Cypress Tests Summary
           conclusion: ${{ needs.cypress-tests.result }}
           output: |
-            [{"summary":"Total Tests Run: $TOTAL_TESTS_RUN Total Tests Passed: $TOTAL_TESTS_PASSED Total Tests Failed: $TOTAL_TESTS_FAILED Total Tests Skipped: $TOTAL_TESTS_SKIPPED","text_description":"[Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})"}]
+            '[{"summary":"Total Tests Run: $TOTAL_TESTS_RUN Total Tests Passed: $TOTAL_TESTS_PASSED Total Tests Failed: $TOTAL_TESTS_FAILED Total Tests Skipped: $TOTAL_TESTS_SKIPPED","text_description":"[Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})"}]'
 
 # archive:
 #   name: Archive

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -812,7 +812,7 @@ jobs:
           name: Cypress Tests Summary
           conclusion: ${{ needs.cypress-tests.result }}
           output:
-            summary: 'Total Tests Run: $TOTAL_TESTS_RUN, Total Tests Passed: $TOTAL_TESTS_PASSED, Total Tests Failed: $TOTAL_TESTS_FAILED, Total Tests Skipped: $TOTAL_TESTS_SKIPPED, [Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})',
+            '{"summary": "Total Tests Run: $TOTAL_TESTS_RUN, Total Tests Passed: $TOTAL_TESTS_PASSED, Total Tests Failed: $TOTAL_TESTS_FAILED, Total Tests Skipped: $TOTAL_TESTS_SKIPPED, [Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})"}',
 
 # archive:
 #   name: Archive

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -735,12 +735,11 @@ jobs:
           NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
 
       - name: Output full results
-        run: $COMBINED_RESULTS
-        # run: |
-        #   echo $COMBINED_RESULTS.stats.tests
-        #   echo $COMBINED_RESULTS.stats.passes
-        #   echo $COMBINED_RESULTS.stats.pending
-        #   echo $COMBINED_RESULTS.stats.failures
+        run: |
+          echo $TOTAL_TESTS_RUN
+          echo $TOTAL_TESTS_PASSED
+          echo $TOTAL_TESTS_FAILED
+          echo $TOTAL_TESTS_SKIPPED
 
       - name: Upload Mochawesome report artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -812,7 +812,7 @@ jobs:
           name: Cypress Tests Summary
           conclusion: ${{ needs.cypress-tests.result }}
           output:
-            {"summary: Total Tests Run: $TOTAL_TESTS_RUN, Total Tests Passed: $TOTAL_TESTS_PASSED, Total Tests Failed: $TOTAL_TESTS_FAILED, Total Tests Skipped: $TOTAL_TESTS_SKIPPED, [Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})",
+            {"summary": "Total Tests Run: $TOTAL_TESTS_RUN Total Tests Passed: $TOTAL_TESTS_PASSED Total Tests Failed: $TOTAL_TESTS_FAILED Total Tests Skipped: $TOTAL_TESTS_SKIPPED [Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})",
 
 # archive:
 #   name: Archive

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -812,8 +812,8 @@ jobs:
           name: Cypress Tests Summary
           conclusion: ${{ needs.cypress-tests.result }}
           output: |
-            {"summary": "Total Tests Run: $TOTAL_TESTS_RUN Total Tests Passed: $TOTAL_TESTS_PASSED Total Tests Failed: $TOTAL_TESTS_FAILED Total Tests Skipped: $TOTAL_TESTS_SKIPPED",
-            "text_description": "[Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})"},
+            {"summary": "Total Tests Run: $TOTAL_TESTS_RUN Total Tests Passed: $TOTAL_TESTS_PASSED Total Tests Failed: $TOTAL_TESTS_FAILED Total Tests Skipped: $TOTAL_TESTS_SKIPPED"},
+            {"text_description": "[Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})"}
 
 # archive:
 #   name: Archive

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -550,14 +550,6 @@ jobs:
           name: cypress-screenshot-artifacts
           path: cypress/screenshots
 
-      - name: Archive JUnit test results
-        uses: actions/upload-artifact@v2
-        if: ${{ always() }}
-        with:
-          name: cypress-junit-test-results
-          path: test-results
-          retention-days: 1
-
       - name: Archive Mochawesome test results
         uses: actions/upload-artifact@v2
         if: ${{ always() }}
@@ -782,13 +774,6 @@ jobs:
       # -------------------------
       # | Cypress Tests Summary |
       # -------------------------
-
-      - name: Download Cypress JUnit test results
-        if: ${{ always() }}
-        uses: actions/download-artifact@v2
-        with:
-          name: cypress-junit-test-results
-          path: cypress-junit-test-results
 
       - name: Publish Cypress test results
         if: ${{ always() }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -812,11 +812,7 @@ jobs:
           name: Cypress Tests Summary
           conclusion: ${{ needs.cypress-tests.result }}
           output: |
-            {"Total Tests Run": $TOTAL_TESTS_RUN}
-            {"Total Tests Passed": $TOTAL_TESTS_PASSED} 
-            {"Total Tests Failed": $TOTAL_TESTS_FAILED} 
-            {"Total Tests Skipped": $TOTAL_TESTS_SKIPPED} 
-            { [Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})}
+            {summary: "Total Tests Run: $TOTAL_TESTS_RUN, Total Tests Passed: $TOTAL_TESTS_PASSED, Total Tests Failed": $TOTAL_TESTS_FAILED, Total Tests Skipped": $TOTAL_TESTS_SKIPPED, [Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})}
 
 # archive:
 #   name: Archive

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -811,8 +811,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: Cypress Tests Summary
           conclusion: ${{ needs.cypress-tests.result }}
-          output:
-            {"summary": "Total Tests Run: $TOTAL_TESTS_RUN Total Tests Passed: $TOTAL_TESTS_PASSED Total Tests Failed: $TOTAL_TESTS_FAILED Total Tests Skipped: $TOTAL_TESTS_SKIPPED [Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})"},
+          output: |
+            {"summary": "Total Tests Run: $TOTAL_TESTS_RUN Total Tests Passed: $TOTAL_TESTS_PASSED Total Tests Failed: $TOTAL_TESTS_FAILED Total Tests Skipped: $TOTAL_TESTS_SKIPPED",
+            "text_description": "[Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})"},
 
 # archive:
 #   name: Archive

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -734,12 +734,15 @@ jobs:
           IS_MASTER_BUILD: ${{ needs.cypress-tests-prep.outputs.is_master_build }}
           NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
 
-      - name: Output full results
+      - name: Set output of Cypress tests
+        id: cypress-tests-output
         run: |
-          echo $TOTAL_TESTS_RUN
-          echo $TOTAL_TESTS_PASSED
-          echo $TOTAL_TESTS_FAILED
-          echo $TOTAL_TESTS_SKIPPED
+          results=$(Number of tests run: $TOTAL_TESTS_RUN) 
+          echo $results
+          echo ::set-output name=results::$results
+
+      - name: Output full results
+        run: ${{steps.cypress-tests-output.outputs.results }}
 
       - name: Upload Mochawesome report artifact
         uses: actions/upload-artifact@v2
@@ -812,7 +815,7 @@ jobs:
           name: Cypress Tests Summary
           conclusion: ${{ needs.cypress-tests.result }}
           output: |
-            {"summary":"Total Tests Run: ${{ $TOTAL_TESTS_RUN }} Total Tests Passed: ${{ $TOTAL_TESTS_PASSED }} Total Tests Failed: ${{ $TOTAL_TESTS_FAILED }} Total Tests Skipped: ${{ $TOTAL_TESTS_SKIPPED }}"}
+            {"summary":${{ steps.cypress-tests-results.outputs.results }} }
           # output: |
           #   {"summary":"Total Tests Run: $TOTAL_TESTS_RUN Total Tests Passed: $TOTAL_TESTS_PASSED Total Tests Failed: $TOTAL_TESTS_FAILED Total Tests Skipped: $TOTAL_TESTS_SKIPPED" [Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})}
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -812,7 +812,7 @@ jobs:
           name: Cypress Tests Summary
           conclusion: ${{ needs.cypress-tests.result }}
           output: |
-            {"summary": "Total Tests Run: $TOTAL_TESTS_RUN Total Tests Passed: $TOTAL_TESTS_PASSED Total Tests Failed: $TOTAL_TESTS_FAILED Total Tests Skipped: $TOTAL_TESTS_SKIPPED"},
+            {"summary": "Total Tests Run: $TOTAL_TESTS_RUN Total Tests Passed: $TOTAL_TESTS_PASSED Total Tests Failed: $TOTAL_TESTS_FAILED Total Tests Skipped: $TOTAL_TESTS_SKIPPED"}
             {"text_description": "[Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})"}
 
 # archive:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -812,8 +812,8 @@ jobs:
           name: Cypress Tests Summary
           conclusion: ${{ needs.cypress-tests.result }}
           output: |
-            {"summary": "Total Tests Run: $TOTAL_TESTS_RUN Total Tests Passed: $TOTAL_TESTS_PASSED Total Tests Failed: $TOTAL_TESTS_FAILED Total Tests Skipped: $TOTAL_TESTS_SKIPPED"}
-            {"text_description": "[Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})"}
+            [{"summary": "Total Tests Run: $TOTAL_TESTS_RUN Total Tests Passed: $TOTAL_TESTS_PASSED Total Tests Failed: $TOTAL_TESTS_FAILED Total Tests Skipped: $TOTAL_TESTS_SKIPPED",
+            "text_description": "[Mochawesome Report](https://reimagined-telegram-c11df05a.pages.github.io/cypress-reports/${{ env.UUID }})"}]
 
 # archive:
 #   name: Archive

--- a/config/cypress-reporters.json
+++ b/config/cypress-reporters.json
@@ -1,8 +1,5 @@
 {
-  "reporterEnabled": "mocha-junit-reporter, mochawesome",
-  "mochaJunitReporterReporterOptions": {
-    "mochaFile": "test-results/e2e-test-output-[hash].xml"
-  },
+  "reporterEnabled": "mochawesome",
   "mochawesomeReporterOptions": {
     "reportDir": "cypress/results",
     "overwrite": false,


### PR DESCRIPTION
## Description
The goal of this update was to replace the JUnit reporter with a custom summary to eliminate discrepancies in reporting. The custom summary uses the same numbers that our Mochawesome report uses, therefore eliminating an extra artifact download and condensing everything into one nice neat results set.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots
![image](https://user-images.githubusercontent.com/34250637/129784295-6db01355-4722-4db1-b607-5351b1c6a832.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
