### PR TITLE
HLR: Add legacy opt-in page

### DIFF
--- a/src/applications/disability-benefits/996/config/form.js
+++ b/src/applications/disability-benefits/996/config/form.js
@@ -132,6 +132,9 @@ const formConfig = {
           uiSchema: optIn.uiSchema,
           schema: optIn.schema,
           depends: apiVersion2,
+          initialData: {
+            socOptIn: false,
+          },
         },
       },
     },

--- a/src/applications/disability-benefits/996/config/form.js
+++ b/src/applications/disability-benefits/996/config/form.js
@@ -24,6 +24,7 @@ import informalConference from '../pages/informalConference';
 import informalConferenceRep from '../pages/informalConferenceRep';
 import informalConferenceRepV2 from '../pages/informalConferenceRepV2';
 import informalConferenceTimes from '../pages/informalConferenceTimes';
+import optIn from '../pages/optIn';
 import sameOffice from '../pages/sameOffice';
 
 import { errorMessages, WIZARD_STATUS } from '../constants';
@@ -124,6 +125,13 @@ const formConfig = {
           uiSchema: contestedIssuesPage.uiSchema,
           schema: contestedIssuesPage.schema,
           // initialData,
+        },
+        optIn: {
+          title: 'Opt in',
+          path: 'opt-in',
+          uiSchema: optIn.uiSchema,
+          schema: optIn.schema,
+          depends: apiVersion2,
         },
       },
     },

--- a/src/applications/disability-benefits/996/config/submit-transformer.js
+++ b/src/applications/disability-benefits/996/config/submit-transformer.js
@@ -35,7 +35,8 @@ export function transform(formConfig, form) {
     if (!version1) {
       attributes.veteran.homeless = formData.homeless;
       attributes.veteran.phone = getPhone(formData);
-      attributes.veteran.email = formData?.veteran.email;
+      attributes.veteran.email = formData.veteran?.email || '';
+      attributes.socOptIn = formData.socOptIn;
     }
 
     // Add informal conference data

--- a/src/applications/disability-benefits/996/content/OptIn.jsx
+++ b/src/applications/disability-benefits/996/content/OptIn.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export const OptInDescription = () => (
+  <div id="opt-in-description">
+    <p>
+      If you’re requesting a Board Appeal on an issue in an initial claim we
+      decided before February 19, 2019, you’ll need to opt in to the new
+      decision review process. To do this, please check the box here. We’ll move
+      your issue from the old appeals process to the new decision review
+      process.
+    </p>
+    <p>
+      Our decision review process is part of the Appeals Modernization Act. When
+      you opt in, you’re likely to get a faster decision.
+    </p>
+  </div>
+);
+
+export const OptInLabel = (
+  <strong className="opt-in-title">
+    I understand that if I want any issues reviewed that are currently in the
+    old appeals process, I’m opting them in to the new decision review process.
+  </strong>
+);

--- a/src/applications/disability-benefits/996/content/OptIn.jsx
+++ b/src/applications/disability-benefits/996/content/OptIn.jsx
@@ -22,3 +22,8 @@ export const OptInLabel = (
     old appeals process, I’m opting them in to the new decision review process.
   </strong>
 );
+
+export const OptInSelections = {
+  true: 'Yes, I choose to opt in to the new process',
+  false: 'You didn’t select this option',
+};

--- a/src/applications/disability-benefits/996/pages/optIn.js
+++ b/src/applications/disability-benefits/996/pages/optIn.js
@@ -1,4 +1,8 @@
-import { OptInDescription, OptInLabel } from '../content/OptIn';
+import {
+  OptInDescription,
+  OptInLabel,
+  OptInSelections,
+} from '../content/OptIn';
 
 export default {
   uiSchema: {
@@ -20,7 +24,7 @@ export default {
       socOptIn: {
         type: 'boolean',
         enum: [true, false],
-        enumNames: ['Yes, I understand', 'No, I don’t want to opt in'],
+        enumNames: Object.values(OptInSelections),
       },
     },
   },

--- a/src/applications/disability-benefits/996/pages/optIn.js
+++ b/src/applications/disability-benefits/996/pages/optIn.js
@@ -1,0 +1,27 @@
+import { OptInDescription, OptInLabel } from '../content/OptIn';
+
+export default {
+  uiSchema: {
+    'ui:title': OptInDescription,
+    'ui:options': {
+      forceDivWrapper: true,
+    },
+    socOptIn: {
+      'ui:title': OptInLabel,
+      'ui:options': {
+        forceDivWrapper: true,
+        keepInPageOnReview: false,
+      },
+    },
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      socOptIn: {
+        type: 'boolean',
+        enum: [true, false],
+        enumNames: ['Yes, I understand', 'No, I don’t want to opt in'],
+      },
+    },
+  },
+};

--- a/src/applications/disability-benefits/996/tests/fixtures/data/maximal-test-v2.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/data/maximal-test-v2.json
@@ -33,6 +33,7 @@
       "extension": "1234",
       "email": "sully@pixar.com"
     },
+    "socOptIn": true,
     "informalConferenceTimes": {
       "time1": "time0800to1200",
       "time2": "time1200to1630"

--- a/src/applications/disability-benefits/996/tests/fixtures/data/transformed/maximal-test-v2.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/data/transformed/maximal-test-v2.json
@@ -37,7 +37,8 @@
         "email": "user@example.com",
         "homeless": false,
         "timezone": "America/Los_Angeles"
-      }
+      },
+      "socOptIn": true
     }
   },
   "included": [

--- a/src/applications/disability-benefits/996/tests/pages/optIn.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/pages/optIn.unit.spec.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import sinon from 'sinon';
+
+import {
+  DefinitionTester,
+  selectCheckbox,
+} from 'platform/testing/unit/schemaform-utils.jsx';
+
+import formConfig from '../../config/form';
+
+describe('HLR opt-in page', () => {
+  const { schema, uiSchema } = formConfig.chapters.contestedIssues.pages.optIn;
+
+  it('should render', () => {
+    const form = mount(
+      <DefinitionTester
+        definitions={{}}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+      />,
+    );
+
+    expect(form.find('input').length).to.equal(1);
+    form.unmount();
+  });
+
+  it('should allow submit', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={{}}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    selectCheckbox(form, 'root_socOptIn', true);
+    form.find('form').simulate('submit');
+    expect(onSubmit.called).to.be.true;
+    form.unmount();
+  });
+});


### PR DESCRIPTION
## Description

For Higher-Level Review v2, we're adding an opt-in to SOC/SSOC page. We aren't able to determine if an issue is within the legacy appeals process yet, so for now, this page will always show.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/28416

## Testing done

Added unit test

## Screenshots

<details><summary>Opt-in page</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-08-13 at 1 52 29 PM](https://user-images.githubusercontent.com/136959/129405713-e0572240-ea90-4615-83c6-9a813ae1a8f0.png)</details>

<details><summary>Opt-in checked (review & submit)</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-08-13 at 1 50 09 PM](https://user-images.githubusercontent.com/136959/129405716-1ab16a16-7e0c-4701-a128-5332c2cc822a.png)</details>

<details><summary>Opt-in unchecked (review & submit)</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-08-13 at 1 49 45 PM](https://user-images.githubusercontent.com/136959/129405718-774d6124-ab61-4d97-8cb8-920b4872f9f8.png)</details>

## Acceptance criteria

- [x] Add opt-in page (not required)
- [x] Add unit tests
- [x] Update E2E test data

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
