### PR TITLE
Remove lodash/fp from forms directory

### DIFF
--- a/src/platform/forms/save-in-progress/reducers.js
+++ b/src/platform/forms/save-in-progress/reducers.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-restricted-imports
-import { merge } from 'lodash/fp';
+import { merge } from 'lodash';
 import set from '../../utilities/data/set';
 
 import {
@@ -72,7 +72,7 @@ export const saveInProgressReducers = {
 
     // if we’re prefilling, we want to use whatever initial data the form has
     if (state.prefillStatus === PREFILL_STATUSES.pending) {
-      const formData = merge(state.data, action.data.formData);
+      const formData = merge({}, state.data, action.data.formData);
       const loadedData = set('formData', formData, action.data);
       newState = set('loadedData', loadedData, state);
 

--- a/src/platform/forms/save-in-progress/savedFormRequest.js
+++ b/src/platform/forms/save-in-progress/savedFormRequest.js
@@ -1,4 +1,4 @@
-import merge from 'lodash/fp/merge';
+import merge from 'lodash/merge';
 
 import environment from '../../utilities/environment';
 import { fetchAndUpdateSessionExpiration as fetch } from '../../utilities/api';
@@ -23,7 +23,7 @@ export function savedFormRequest(
     credentials: 'include',
   };
 
-  const settings = merge(defaultSettings, optionalSettings);
+  const settings = merge({}, defaultSettings, optionalSettings);
   return fetch(url, settings)
     .then(response => {
       const data = isJson(response)

--- a/src/platform/forms/tests/save-in-progress/SaveFormLink.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveFormLink.unit.spec.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import _ from 'lodash/fp';
 import { findDOMNode } from 'react-dom';
 import { expect } from 'chai';
 import SkinDeep from 'skin-deep';
@@ -85,7 +84,7 @@ describe('Schemaform <SaveFormLink>', () => {
     const tree = SkinDeep.shallowRender(
       <SaveFormLink
         user={loggedInUser}
-        form={_.assign(form, { savedStatus: SAVE_STATUSES.failure })}
+        form={{ ...form, savedStatus: SAVE_STATUSES.failure }}
         toggleLoginModal={toggleLoginModalSpy}
         formConfig={formConfig}
       />,
@@ -100,7 +99,7 @@ describe('Schemaform <SaveFormLink>', () => {
     const tree = SkinDeep.shallowRender(
       <SaveFormLink
         user={loggedInUser}
-        form={_.assign(form, { savedStatus: SAVE_STATUSES.clientFailure })}
+        form={{ ...form, savedStatus: SAVE_STATUSES.clientFailure }}
         toggleLoginModal={toggleLoginModalSpy}
         formConfig={formConfig}
       />,
@@ -115,7 +114,7 @@ describe('Schemaform <SaveFormLink>', () => {
     const tree = SkinDeep.shallowRender(
       <SaveFormLink
         user={loggedInUser}
-        form={_.assign(form, { savedStatus: SAVE_STATUSES.noAuth })}
+        form={{ ...form, savedStatus: SAVE_STATUSES.noAuth }}
         toggleLoginModal={toggleLoginModalSpy}
         formConfig={formConfig}
       />,

--- a/src/platform/forms/tests/save-in-progress/SaveInProgressDevModal.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressDevModal.unit.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from 'lodash/fp';
+import cloneDeep from '../../../utilities/data/cloneDeep';
 import ReactDOM /* , { act } */ from 'react-dom';
 import { expect } from 'chai';
 import ReactTestUtils from 'react-dom/test-utils';
@@ -83,7 +83,7 @@ describe('Schemaform <SipsDevModal>', () => {
 
   it('should replace the form data & include return url', () => {
     setLoc();
-    const data = _.cloneDeep(props);
+    const data = cloneDeep(props);
     const newData = {
       page1: { foo: true },
       page2: { bar: 'ok' },
@@ -115,7 +115,7 @@ describe('Schemaform <SipsDevModal>', () => {
   });
   it('should replace the form data from maximal-test.json & include return url', () => {
     setLoc();
-    const data = _.cloneDeep(props);
+    const data = cloneDeep(props);
     const newData = {
       data: {
         page1: { foo: true },
@@ -150,7 +150,7 @@ describe('Schemaform <SipsDevModal>', () => {
 
   it('should merge partial data into the form data & include return url', () => {
     setLoc();
-    const data = _.cloneDeep(props);
+    const data = cloneDeep(props);
     data.form.data = {
       page1: { foo: true },
       page2: { bar: 'ok' },
@@ -184,7 +184,7 @@ describe('Schemaform <SipsDevModal>', () => {
   });
   it('should unwrap "data" & merge partial data into the form data & include return url', () => {
     setLoc();
-    const data = _.cloneDeep(props);
+    const data = cloneDeep(props);
     data.form.data = {
       page1: { foo: true },
       page2: { bar: 'ok' },

--- a/src/platform/forms/tests/save-in-progress/reducers.unit.spec.js
+++ b/src/platform/forms/tests/save-in-progress/reducers.unit.spec.js
@@ -1,4 +1,4 @@
-import _ from 'lodash/fp';
+import set from '../../../utilities/data/set';
 import { expect } from 'chai';
 
 import {
@@ -197,7 +197,7 @@ describe('schemaform createSaveInProgressInitialState', () => {
         },
         {
           type: SET_IN_PROGRESS_FORM,
-          data: _.set('formData', {}, data),
+          data: set('formData', {}, data),
           pages: {},
         },
       );


### PR DESCRIPTION
## Description
This PR removes `lodash/fp` from the `src/platform/forms` directory.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#1678


## Testing done
Tested locally and in CI.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
