### PR TITLE
Sandbox: Fix Location Result Cards

### DIFF
--- a/src/applications/gi-sandbox/containers/SearchResultCard.jsx
+++ b/src/applications/gi-sandbox/containers/SearchResultCard.jsx
@@ -214,7 +214,11 @@ export function SearchResultCard({
   );
 
   return (
-    <div className={resultCardClasses} id={`${createId(name)}-result-card`}>
+    <div
+      key={institution.facilityCode}
+      className={resultCardClasses}
+      id={`${createId(name)}-result-card`}
+    >
       <div className={containerClasses}>
         {location && <span id={`${createId(name)}-result-card-placeholder`} />}
         {header}

--- a/src/applications/gi-sandbox/containers/search/LocationSearchResults.jsx
+++ b/src/applications/gi-sandbox/containers/search/LocationSearchResults.jsx
@@ -259,6 +259,8 @@ function LocationSearchResults({
   useEffect(
     () => {
       markers.forEach(marker => marker.remove());
+      setActiveMarker(null);
+
       let visibleResults = [];
       const mapMarkers = [];
 
@@ -327,15 +329,14 @@ function LocationSearchResults({
     );
 
     return (
-      <div key={institution.facilityCode}>
-        <SearchResultCard
-          institution={institution}
-          location
-          header={header}
-          active={activeMarker === name}
-          version={preview.version}
-        />
-      </div>
+      <SearchResultCard
+        institution={institution}
+        location
+        header={header}
+        active={activeMarker === name}
+        version={preview.version}
+        key={institution.facilityCode}
+      />
     );
   });
 

--- a/src/applications/gi-sandbox/sass/partials/_gi-search-location.scss
+++ b/src/applications/gi-sandbox/sass/partials/_gi-search-location.scss
@@ -2,7 +2,7 @@ $ct-locator-shadow: rgba(0, 0, 0, 0.5);
 
 .location-search {
   .result-card {
-    width: 100% !important;
+    flex-basis: 100% !important;
 
     &.active {
       border: $focus-outline;


### PR DESCRIPTION
## Description
Unwrap `SearchResultCard` in `LocationSearchResults`. Changed location result card css to use `flex-basis`

## Original issue(s)
department-of-veterans-affairs/va.gov-team#28074


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
