### PR TITLE
NOD: Update content

### DIFF
--- a/src/applications/appeals/10182/containers/ConfirmationPage.jsx
+++ b/src/applications/appeals/10182/containers/ConfirmationPage.jsx
@@ -105,7 +105,7 @@ export class ConfirmationPage extends React.Component {
         </p>
         <p>
           If you requested an appeal and haven’t heard back from us yet, please
-          don’t request another review. Call us at{' '}
+          don’t request another appeal. Call us at{' '}
           <Telephone contact={CONTACTS.VA_BENEFITS} />.
         </p>
         <br />

--- a/src/applications/appeals/10182/content/boardReview.jsx
+++ b/src/applications/appeals/10182/content/boardReview.jsx
@@ -12,7 +12,7 @@ export const boardReviewContent = {
         A Veterans Law Judge will review your appeal based on evidence already
         submitted. Because the Board has all your evidence, choosing this option
         will often result in a faster decision. Based on current estimates, it
-        takes the Board about <strong>1 year</strong> to make a decision for
+        takes the Board <strong>about 1 year to make a decision</strong> for
         this type of appeal.
       </p>
     </>
@@ -26,7 +26,7 @@ export const boardReviewContent = {
         Board appeal. Choose this option if you want to turn in additional
         evidence but don’t want to wait for a hearing with a Veterans Law Judge.
         Based on current estimates, it takes the Board{' '}
-        <strong>more than 1.5 years</strong> to make a decision for this type of
+        <strong>more than 1.5 years to make a decision</strong> for this type of
         appeal.
       </p>
     </>
@@ -40,9 +40,11 @@ export const boardReviewContent = {
         additional evidence within 90 days after your hearing. Please keep in
         mind that this option has the longest wait time for a decision because
         of the high number of pending hearing requests. Based on current
-        estimates, it takes the Board <strong>more than 2 years</strong> to make
-        a decision for this type of appeal.
+        estimates, it takes the Board{' '}
+        <strong>more than 2 years to make a decision</strong> for this type of
+        appeal.
       </p>
     </>
   ),
 };
+/* eslint-enable camelcase */


### PR DESCRIPTION
## Description

Notice of Disgreement form updates:
- Board request: change `review` to `appeal` on confirmation page
- Content review: Include `to make a decision` in the bolded text on the Board review option page.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/28260

## Testing done

Visual

## Screenshots

<details><summary>Confirmation page update</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-08-16 at 1 32 03 PM](https://user-images.githubusercontent.com/136959/129612985-6950f73a-9208-4303-877b-18ae1f66259a.png)</details>

<details><summary>Board review option update</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-08-16 at 1 31 40 PM](https://user-images.githubusercontent.com/136959/129612990-ef635c56-c162-4bed-9744-a3f418b3d44a.png)</details>

## Acceptance criteria

- [x] Content updated
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
