### PR TITLE
12996 add hideEmptyValueInReview to optional fields

### DIFF
--- a/src/applications/disability-benefits/686c-674/config/address-schema.js
+++ b/src/applications/disability-benefits/686c-674/config/address-schema.js
@@ -116,12 +116,14 @@ export const addressUISchema = (
         'ui:title': `${checkBoxTitleState} live on a United States military base outside of the U.S.`,
         'ui:options': {
           hideIf: () => !isMilitaryBaseAddress,
+          hideEmptyValueInReview: true,
         },
       },
       'view:livesOnMilitaryBaseInfo': {
         'ui:description': MilitaryBaseInfo,
         'ui:options': {
           hideIf: () => !isMilitaryBaseAddress,
+          hideEmptyValueInReview: true,
         },
       },
       countryName: {
@@ -169,9 +171,15 @@ export const addressUISchema = (
       },
       addressLine2: {
         'ui:title': 'Street address line 2',
+        'ui:options': {
+          hideEmptyValueInReview: true,
+        },
       },
       addressLine3: {
         'ui:title': 'Street address line 3',
+        'ui:options': {
+          hideEmptyValueInReview: true,
+        },
       },
       city: {
         'ui:required': callback,
@@ -269,6 +277,7 @@ export const addressUISchema = (
       province: {
         'ui:title': 'State/Province/Region',
         'ui:options': {
+          hideEmptyValueInReview: true,
           hideIf: (formData, index) => {
             let militaryBasePath = livesOnMilitaryBasePath;
             let countryNamePath = `${path}.countryName`;

--- a/src/applications/disability-benefits/686c-674/config/chapters/674/student-name-ssn/studentNameSSN.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/674/student-name-ssn/studentNameSSN.js
@@ -26,6 +26,9 @@ export const uiSchema = {
       },
       middle: {
         'ui:title': 'Student’s middle name',
+        'ui:options': {
+          hideEmptyValueInReview: true,
+        },
       },
       last: {
         'ui:required': formData =>
@@ -37,6 +40,7 @@ export const uiSchema = {
         'ui:title': 'Student’s suffix',
         'ui:options': {
           widgetClassNames: 'form-select-medium',
+          hideEmptyValueInReview: true,
         },
       },
     },

--- a/src/applications/disability-benefits/686c-674/config/chapters/add-a-child/child-additional-information/child-additional-information.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/add-a-child/child-additional-information/child-additional-information.js
@@ -44,6 +44,9 @@ export const uiSchema = {
           },
           middle: {
             'ui:title': 'Middle name',
+            'ui:options': {
+              hideEmptyValueInReview: true,
+            },
           },
           last: {
             'ui:title': 'Last name',
@@ -53,6 +56,7 @@ export const uiSchema = {
           suffix: {
             'ui:options': {
               hideIf: () => true,
+              hideEmptyValueInReview: true,
             },
           },
         },

--- a/src/applications/disability-benefits/686c-674/config/chapters/add-a-child/child-information/child-information.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/add-a-child/child-information/child-information.js
@@ -34,6 +34,7 @@ export const uiSchema = {
           'ui:title': 'Child’s middle name',
           'ui:options': {
             useDlWrap: true,
+            hideEmptyValueInReview: true,
           },
         },
         last: {
@@ -49,6 +50,7 @@ export const uiSchema = {
           'ui:options': {
             widgetClassNames: 'usa-input-medium',
             useDlWrap: true,
+            hideEmptyValueInReview: true,
           },
         },
       },

--- a/src/applications/disability-benefits/686c-674/config/chapters/add-a-child/child-place-of-birth/child-place-of-birth.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/add-a-child/child-place-of-birth/child-place-of-birth.js
@@ -42,15 +42,27 @@ export const uiSchema = {
         },
         biological: {
           'ui:title': 'Biological',
+          'ui:options': {
+            hideEmptyValueInReview: true,
+          },
         },
         adopted: {
           'ui:title': 'Adopted',
+          'ui:options': {
+            hideEmptyValueInReview: true,
+          },
         },
         notCapable: {
           'ui:title': 'Not capable of self-support',
+          'ui:options': {
+            hideEmptyValueInReview: true,
+          },
         },
         stepchild: {
           'ui:title': 'Stepchild',
+          'ui:options': {
+            hideEmptyValueInReview: true,
+          },
         },
         dateBecameDependent: merge(
           currentOrPastDateUI('Date stepchild became your dependent'),
@@ -110,6 +122,7 @@ export const uiSchema = {
       childIncome: {
         'ui:options': {
           hideIf: () => environment.isProduction(),
+          hideEmptyValueInReview: true,
         },
         'ui:title': 'Did this child have income in the last 365 days?',
         'ui:description':

--- a/src/applications/disability-benefits/686c-674/config/chapters/report-add-a-spouse/current-spouse-marriage-history/currentSpouseMarriageHistory.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/report-add-a-spouse/current-spouse-marriage-history/currentSpouseMarriageHistory.js
@@ -50,6 +50,7 @@ export const uiSchema = {
           'ui:title': 'Former spouse’s middle name',
           'ui:options': {
             useDlWrap: true,
+            hideEmptyValueInReview: true,
           },
         },
         last: {
@@ -65,6 +66,7 @@ export const uiSchema = {
           'ui:options': {
             widgetClassNames: 'form-select-medium',
             useDlWrap: true,
+            hideEmptyValueInReview: true,
           },
         },
       },

--- a/src/applications/disability-benefits/686c-674/config/chapters/report-add-a-spouse/does-live-with-spouse/doesLiveWithSpouse.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/report-add-a-spouse/does-live-with-spouse/doesLiveWithSpouse.js
@@ -49,6 +49,7 @@ export const uiSchema = {
     spouseIncome: {
       'ui:options': {
         hideIf: () => environment.isProduction(),
+        hideEmptyValueInReview: true,
       },
       'ui:title': 'Did your spouse have income in the last 365 days?',
       'ui:description':

--- a/src/applications/disability-benefits/686c-674/config/chapters/report-add-a-spouse/spouse-information/spouseInformation.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/report-add-a-spouse/spouse-information/spouseInformation.js
@@ -23,6 +23,9 @@ export const uiSchema = {
       },
       middle: {
         'ui:title': 'Spouse’s middle name',
+        'ui:options': {
+          hideEmptyValueInReview: true,
+        },
       },
       last: {
         'ui:required': formData =>
@@ -34,6 +37,7 @@ export const uiSchema = {
         'ui:title': 'Spouse’s suffix',
         'ui:options': {
           widgetClassNames: 'form-select-medium',
+          hideEmptyValueInReview: true,
         },
       },
     },
@@ -63,6 +67,7 @@ export const uiSchema = {
       'ui:options': {
         widgetClassNames: 'usa-input-medium',
         expandUnder: 'isVeteran',
+        hideEmptyValueInReview: true,
       },
     },
     serviceNumber: {
@@ -71,6 +76,7 @@ export const uiSchema = {
       'ui:options': {
         widgetClassNames: 'usa-input-medium',
         expandUnder: 'isVeteran',
+        hideEmptyValueInReview: true,
       },
     },
   },

--- a/src/applications/disability-benefits/686c-674/config/chapters/report-add-a-spouse/veteran-marriage-history/veteranMarriageHistory.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/report-add-a-spouse/veteran-marriage-history/veteranMarriageHistory.js
@@ -50,6 +50,7 @@ export const uiSchema = {
           'ui:title': 'Former spouse’s middle name',
           'ui:options': {
             useDlWrap: true,
+            hideEmptyValueInReview: true,
           },
         },
         last: {
@@ -65,6 +66,7 @@ export const uiSchema = {
           'ui:options': {
             widgetClassNames: 'form-select-medium',
             useDlWrap: true,
+            hideEmptyValueInReview: true,
           },
         },
       },

--- a/src/applications/disability-benefits/686c-674/config/chapters/report-child-stopped-attending-school/child-information/childInformation.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/report-child-stopped-attending-school/child-information/childInformation.js
@@ -32,7 +32,12 @@ export const uiSchema = {
         'ui:title': 'First name',
         'ui:errorMessages': { required: 'Please enter a first name' },
       },
-      middle: { 'ui:title': 'Middle name' },
+      middle: {
+        'ui:title': 'Middle name',
+        'ui:options': {
+          hideEmptyValueInReview: true,
+        },
+      },
       last: {
         'ui:required': formData =>
           isChapterFieldRequired(
@@ -44,7 +49,10 @@ export const uiSchema = {
       },
       suffix: {
         'ui:title': 'Suffix',
-        'ui:options': { widgetClassNames: 'form-select-medium' },
+        'ui:options': {
+          widgetClassNames: 'form-select-medium',
+          hideEmptyValueInReview: true,
+        },
       },
     },
     ssn: {
@@ -76,6 +84,7 @@ export const uiSchema = {
     dependentIncome: {
       'ui:options': {
         hideIf: () => environment.isProduction(),
+        hideEmptyValueInReview: true,
       },
       'ui:title': PensionIncomeRemovalQuestionTitle,
       'ui:widget': 'yesNo',

--- a/src/applications/disability-benefits/686c-674/config/chapters/report-dependent-death/dependent-additional-information/dependentAdditionalInformation.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/report-dependent-death/dependent-additional-information/dependentAdditionalInformation.js
@@ -33,6 +33,7 @@ export const uiSchema = {
       dependentIncome: {
         'ui:options': {
           hideIf: () => environment.isProduction(),
+          hideEmptyValueInReview: true,
         },
         'ui:title': PensionIncomeRemovalQuestionTitle,
         'ui:widget': 'yesNo',

--- a/src/applications/disability-benefits/686c-674/config/chapters/report-dependent-death/dependent-information/dependentInformation.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/report-dependent-death/dependent-information/dependentInformation.js
@@ -33,6 +33,7 @@ export const uiSchema = {
           'ui:title': 'Middle name',
           'ui:options': {
             useDlWrap: true,
+            hideEmptyValueInReview: true,
           },
         },
         last: {
@@ -49,6 +50,7 @@ export const uiSchema = {
           'ui:options': {
             widgetClassNames: 'form-select-medium',
             useDlWrap: true,
+            hideEmptyValueInReview: true,
           },
         },
       },

--- a/src/applications/disability-benefits/686c-674/config/chapters/report-divorce/former-spouse-information/formerSpouseInformation.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/report-divorce/former-spouse-information/formerSpouseInformation.js
@@ -27,7 +27,12 @@ export const uiSchema = {
         'ui:required': formData =>
           isChapterFieldRequired(formData, TASK_KEYS.reportDivorce),
       },
-      middle: { 'ui:title': 'Former spouse’s middle name' },
+      middle: {
+        'ui:title': 'Former spouse’s middle name',
+        'ui:options': {
+          hideEmptyValueInReview: true,
+        },
+      },
       last: {
         'ui:title': 'Former spouse’s last name',
         'ui:errorMessages': { required: 'Please enter a last name' },
@@ -89,6 +94,7 @@ export const uiSchema = {
     spouseIncome: {
       'ui:options': {
         hideIf: () => environment.isProduction(),
+        hideEmptyValueInReview: true,
       },
       'ui:title': PensionIncomeRemovalQuestionTitle,
       'ui:widget': 'yesNo',

--- a/src/applications/disability-benefits/686c-674/config/chapters/report-marriage-of-child/child-information/childInformation.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/report-marriage-of-child/child-information/childInformation.js
@@ -30,7 +30,12 @@ export const uiSchema = {
             TASK_KEYS.reportMarriageOfChildUnder18,
           ),
       },
-      middle: { 'ui:title': 'Middle name' },
+      middle: {
+        'ui:title': 'Middle name',
+        'ui:options': {
+          hideEmptyValueInReview: true,
+        },
+      },
       last: {
         'ui:title': 'Last name before marriage',
         'ui:errorMessages': { required: 'Please enter a last name' },
@@ -42,7 +47,10 @@ export const uiSchema = {
       },
       suffix: {
         'ui:title': 'Suffix',
-        'ui:options': { widgetClassNames: 'form-select-medium' },
+        'ui:options': {
+          widgetClassNames: 'form-select-medium',
+          hideEmptyValueInReview: true,
+        },
       },
     },
     ssn: {
@@ -71,6 +79,7 @@ export const uiSchema = {
     dependentIncome: {
       'ui:options': {
         hideIf: () => environment.isProduction(),
+        hideEmptyValueInReview: true,
       },
       'ui:title': PensionIncomeRemovalQuestionTitle,
       'ui:widget': 'yesNo',

--- a/src/applications/disability-benefits/686c-674/config/chapters/stepchild-no-longer-part-of-household/stepchild-information/stepchild-information.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/stepchild-no-longer-part-of-household/stepchild-information/stepchild-information.js
@@ -56,6 +56,9 @@ export const uiSchema = {
         },
         middle: {
           'ui:title': 'Middle name of parent or guardian',
+          'ui:options': {
+            hideEmptyValueInReview: true,
+          },
         },
         last: {
           'ui:title': 'Last name of parent or guardian',

--- a/src/applications/disability-benefits/686c-674/config/chapters/stepchild-no-longer-part-of-household/stepchildren/stepchildren.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/stepchild-no-longer-part-of-household/stepchildren/stepchildren.js
@@ -26,6 +26,9 @@ export const uiSchema = {
         },
         middle: {
           'ui:title': 'Stepchild’s middle name',
+          'ui:options': {
+            hideEmptyValueInReview: true,
+          },
         },
         last: {
           'ui:title': 'Stepchild’s last name',
@@ -39,6 +42,7 @@ export const uiSchema = {
           'ui:title': 'Stepchild’s suffix',
           'ui:options': {
             widgetClassNames: 'usa-input-medium',
+            hideEmptyValueInReview: true,
           },
         },
       },

--- a/src/applications/lgy/coe/config/chapters/loans/loanHistory.js
+++ b/src/applications/lgy/coe/config/chapters/loans/loanHistory.js
@@ -1,9 +1,12 @@
 import React from 'react';
-import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
 import {
   createUSAStateLabels,
   formatReviewDate,
-} from 'platform/forms-system/src/js/helpers';
+} from '~/platform/forms-system/src/js/helpers';
+import {
+  validateDate,
+  validateDateRange,
+} from '~/platform/forms-system/src/js/validation';
 import { states } from 'platform/forms/address';
 
 import { loanHistory } from '../../schemaImports';
@@ -35,17 +38,42 @@ export const uiSchema = {
     'ui:options': {
       itemName: 'VA-backed Loan',
       viewField: PreviousLoanView,
+      keepInPageOnReview: true,
     },
     items: {
       'ui:title': 'Previous loan information',
       'ui:options': {
         itemName: 'VA-backed loan',
       },
-      dateRange: dateRangeUI(
-        'Date your loan began',
-        'Date you paid off your loan (Leave this blank if it’s not paid off)',
-        'Date loan ended must be after the start of the loan',
-      ),
+      dateRange: {
+        'ui:validations': [validateDateRange],
+        'ui:errorMessages': {
+          pattern: 'Date loan ended must be after the start of the loan',
+          required: 'Please enter a date',
+        },
+        from: {
+          'ui:title': 'Date your loan began',
+          'ui:widget': 'date',
+          'ui:validations': [validateDate],
+          'ui:errorMessages': {
+            pattern: 'Please enter a valid date',
+            required: 'Please enter a date',
+          },
+        },
+        to: {
+          'ui:title':
+            'Date you paid off your loan (Leave this blank if it’s not paid off)',
+          'ui:widget': 'date',
+          'ui:validations': [validateDate],
+          'ui:errorMessages': {
+            pattern: 'Please enter a valid date',
+            required: 'Please enter a date',
+          },
+          'ui:options': {
+            hideEmptyValueInReview: true,
+          },
+        },
+      },
       address: {
         'ui:title': 'Property address',
         'ui:order': ['street', 'street2', 'city', 'state', 'postalCode'],
@@ -53,7 +81,12 @@ export const uiSchema = {
           'ui:title': 'Street',
           'ui:errorMessages': { required: 'Please enter a street address' },
         },
-        street2: { 'ui:title': 'Line 2' },
+        street2: {
+          'ui:title': 'Line 2',
+          'ui:options': {
+            hideEmptyValueInReview: true,
+          },
+        },
         city: {
           'ui:title': `City`,
           'ui:errorMessages': { required: 'Please enter a city' },
@@ -78,10 +111,16 @@ export const uiSchema = {
       isCurrentlyOwned: {
         'ui:title': 'Do you still own this property?',
         'ui:widget': 'yesNo',
+        'ui:options': {
+          hideEmptyValueInReview: true,
+        },
       },
       willRefinance: {
         'ui:title': 'Do you want to refinance this loan?',
         'ui:widget': 'yesNo',
+        'ui:options': {
+          hideEmptyValueInReview: true,
+        },
       },
     },
   },

--- a/src/applications/lgy/coe/config/chapters/service/history.js
+++ b/src/applications/lgy/coe/config/chapters/service/history.js
@@ -1,5 +1,8 @@
-import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
 import ServicePeriodView from 'platform/forms/components/ServicePeriodView';
+import {
+  validateDate,
+  validateDateRange,
+} from '~/platform/forms-system/src/js/validation';
 
 import { serviceHistory } from '../../schemaImports';
 
@@ -13,6 +16,7 @@ export const uiSchema = {
     'ui:options': {
       itemName: 'Service Period',
       viewField: ServicePeriodView,
+      keepInPageOnReview: true,
       showSave: true,
       reviewMode: true,
     },
@@ -24,11 +28,34 @@ export const uiSchema = {
       serviceBranch: {
         'ui:title': 'Branch of service',
       },
-      dateRange: dateRangeUI(
-        'Service start date',
-        'Service end date',
-        'End of service must be after start of service',
-      ),
+      dateRange: {
+        'ui:validations': [validateDateRange],
+        'ui:errorMessages': {
+          pattern: 'End of service must be after start of service',
+          required: 'Please enter a date',
+        },
+        from: {
+          'ui:title': 'Service start date',
+          'ui:widget': 'date',
+          'ui:validations': [validateDate],
+          'ui:errorMessages': {
+            pattern: 'Please enter a valid date',
+            required: 'Please enter a date',
+          },
+        },
+        to: {
+          'ui:title': 'Service end date',
+          'ui:widget': 'date',
+          'ui:validations': [validateDate],
+          'ui:errorMessages': {
+            pattern: 'Please enter a valid date',
+            required: 'Please enter a date',
+          },
+          'ui:options': {
+            hideEmptyValueInReview: true,
+          },
+        },
+      },
     },
   },
 };

--- a/src/applications/vre/definitions/profileAddress.js
+++ b/src/applications/vre/definitions/profileAddress.js
@@ -230,6 +230,7 @@ export const addressUiSchema = (path, checkBoxTitle, uiRequiredCallback) => {
         required: 'Please enter a valid State, Province, or Region',
       },
       'ui:options': {
+        hideEmptyValueInReview: true,
         /**
          * replaceSchema:
          * Necessary because military addresses require strict options.


### PR DESCRIPTION
## Description
This pull request adds `hideEmptyValueInReview` to ui:options for all optional fields in the 686, 31, and COE forms.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#12996

## Testing done
- local

## Acceptance criteria
- [x] fields are hidden on review if they are empty

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
