### PR TITLE
Changed focus element on confirmation page

### DIFF
--- a/src/applications/disability-benefits/686c-674/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/686c-674/containers/ConfirmationPage.jsx
@@ -18,7 +18,7 @@ const scrollToTop = () => {
 
 export class ConfirmationPage extends React.Component {
   componentDidMount() {
-    focusElement('.schemaform-title > h1');
+    focusElement('#thank-you-message');
     scrollToTop();
   }
 
@@ -39,7 +39,10 @@ export class ConfirmationPage extends React.Component {
             Print this page for your records
           </button>
           <div className="inset">
-            <p className="vads-u-font-size--lg vads-u-font-family--serif vads-u-font-weight--bold">
+            <p
+              id="thank-you-message"
+              className="vads-u-font-size--lg vads-u-font-family--serif vads-u-font-weight--bold"
+            >
               Thank you for submitting your application
             </p>
             <p className="vads-u-font-size--base vads-u-font-family--serif vads-u-font-weight--bold vads-u-margin--0">

--- a/src/applications/vre/28-1900/containers/ConfirmationPage.jsx
+++ b/src/applications/vre/28-1900/containers/ConfirmationPage.jsx
@@ -18,7 +18,7 @@ const scrollToTop = () => {
 
 export class ConfirmationPage extends React.Component {
   componentDidMount() {
-    focusElement('.schemaform-title > h1');
+    focusElement('#thank-you-message');
     scrollToTop();
   }
 
@@ -35,7 +35,10 @@ export class ConfirmationPage extends React.Component {
           Service-Connected Disabilities)
         </p>
         <div className="inset">
-          <h2 className="vads-u-font-size--h3 vads-u-margin-top--1">
+          <h2
+            id="thank-you-message"
+            className="vads-u-font-size--h3 vads-u-margin-top--1"
+          >
             Thank you for submitting your application
           </h2>
           <h3 className="vads-u-font-size--h4">

--- a/src/applications/vre/28-8832/containers/ConfirmationPage.jsx
+++ b/src/applications/vre/28-8832/containers/ConfirmationPage.jsx
@@ -18,7 +18,7 @@ const scrollToTop = () => {
 
 export class ConfirmationPage extends React.Component {
   componentDidMount() {
-    focusElement('.schemaform-title > h1');
+    focusElement('#thank-you-message');
     scrollToTop();
   }
 
@@ -33,7 +33,10 @@ export class ConfirmationPage extends React.Component {
         <p>
           Equal to VA Form 28-8832 (Education/Vocational Counseling Application)
         </p>
-        <h2 className="vads-u-font-size--h3 vads-u-margin-top--1">
+        <h2
+          id="thank-you-message"
+          className="vads-u-font-size--h3 vads-u-margin-top--1"
+        >
           Thank you for submitting your application
         </h2>
         <div className="inset">


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/17004)

Upon QA review it was discovered that the confirmation page on the Chapter 36 form set the focus element to the title of the page when for accessibility reasons the focus should be set to the thank you message. This PR updates that focus.

## Testing done
Tested locally

## Screenshots

![Screen Shot 2021-08-16 at 2 33 26 PM](https://user-images.githubusercontent.com/1899695/129632289-9cd7c117-1c88-4a7b-898f-d6def629f1d2.png)


## Acceptance criteria
- [x] Set the focus to the page's h2 confirmation


