### PR TITLE
Remove CC provider selection feature flag 

### DIFF
--- a/src/applications/vaos/new-appointment/components/ConfirmationPage/ConfirmationRequestInfo.jsx
+++ b/src/applications/vaos/new-appointment/components/ConfirmationPage/ConfirmationRequestInfo.jsx
@@ -35,7 +35,7 @@ export default function ConfirmationRequestInfo({
   data,
   facilityDetails,
   pageTitle,
-  useProviderSelection,
+  hasResidentialAddress,
 }) {
   const isCommunityCare = data.facilityType === FACILITY_TYPES.COMMUNITY_CARE;
   const isVideoVisit = data.visitType === 'telehealth';
@@ -79,8 +79,8 @@ export default function ConfirmationRequestInfo({
           <div className="vads-u-flex--1 vads-u-margin-right--1 vads-u-margin-top--2 vaos-u-word-break--break-word">
             <div className="vads-u-margin--0">
               {isCommunityCare &&
-                ((!useProviderSelection && !data.hasCommunityCareProvider) ||
-                  (useProviderSelection && !hasSelectedProvider)) && (
+                ((!hasResidentialAddress && !data.hasCommunityCareProvider) ||
+                  (hasResidentialAddress && !hasSelectedProvider)) && (
                   <>
                     <h3 className="vaos-appts__block-label">
                       <strong>Preferred provider</strong>
@@ -94,7 +94,7 @@ export default function ConfirmationRequestInfo({
                   </>
                 )}
               {isCommunityCare &&
-                !useProviderSelection &&
+                !hasResidentialAddress &&
                 data.hasCommunityCareProvider && (
                   <>
                     <h3 className="vaos-appts__block-label">
@@ -131,7 +131,7 @@ export default function ConfirmationRequestInfo({
                   </>
                 )}
               {isCommunityCare &&
-                useProviderSelection &&
+                hasResidentialAddress &&
                 hasSelectedProvider && (
                   <>
                     <h3 className="vaos-appts__block-label">

--- a/src/applications/vaos/new-appointment/components/ConfirmationPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/ConfirmationPage/index.jsx
@@ -28,7 +28,7 @@ export default function ConfirmationPage() {
     clinic,
     flowType,
     slot,
-    useProviderSelection,
+    hasResidentialAddress,
     submitStatus,
   } = useSelector(selectConfirmationPage, shallowEqual);
 
@@ -77,7 +77,7 @@ export default function ConfirmationPage() {
           data={data}
           facilityDetails={facilityDetails}
           pageTitle={pageTitle}
-          useProviderSelection={useProviderSelection}
+          hasResidentialAddress={hasResidentialAddress}
         />
       )}
       {!featureHomepageRefresh && (

--- a/src/applications/vaos/new-appointment/components/ReviewPage/CommunityCareSection.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/CommunityCareSection.jsx
@@ -8,16 +8,16 @@ import SelectedProviderSection from './SelectedProviderSection';
 export default function CommunityCareSection({
   data,
   vaCityState,
-  useProviderSelection,
+  hasResidentialAddress,
 }) {
   return (
     <>
       <PreferredDatesSection data={data} />
       <hr aria-hidden="true" className="vads-u-margin-y--2" />
-      {!useProviderSelection && (
+      {!hasResidentialAddress && (
         <PreferredProviderSection data={data} vaCityState={vaCityState} />
       )}
-      {useProviderSelection && (
+      {hasResidentialAddress && (
         <SelectedProviderSection data={data} vaCityState={vaCityState} />
       )}
       <ReasonForAppointmentSection data={data} />

--- a/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo.jsx
@@ -10,7 +10,7 @@ export default function ReviewRequestInfo({
   facility,
   vaCityState,
   pageTitle,
-  useProviderSelection,
+  hasResidentialAddress,
 }) {
   const isCommunityCare = data.facilityType === FACILITY_TYPES.COMMUNITY_CARE;
   const isVAAppointment = data.facilityType === FACILITY_TYPES.VAMC;
@@ -26,7 +26,7 @@ export default function ReviewRequestInfo({
           data={data}
           facility={facility}
           vaCityState={vaCityState}
-          useProviderSelection={useProviderSelection}
+          hasResidentialAddress={hasResidentialAddress}
         />
       )}
       {isVAAppointment && (

--- a/src/applications/vaos/new-appointment/components/ReviewPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/index.jsx
@@ -24,7 +24,7 @@ export default function ReviewPage() {
     submitStatus,
     submitStatusVaos400,
     systemId,
-    useProviderSelection,
+    hasResidentialAddress,
     vaCityState,
   } = useSelector(selectReviewPage, shallowEqual);
   const history = useHistory();
@@ -67,7 +67,7 @@ export default function ReviewPage() {
           facility={facility}
           vaCityState={vaCityState}
           pageTitle={pageTitle}
-          useProviderSelection={useProviderSelection}
+          hasResidentialAddress={hasResidentialAddress}
         />
       )}
       <div className="vads-u-margin-y--2">

--- a/src/applications/vaos/new-appointment/index.jsx
+++ b/src/applications/vaos/new-appointment/index.jsx
@@ -7,9 +7,10 @@ import {
   useLocation,
   Redirect,
 } from 'react-router-dom';
+// import { selectVAPResidentialAddress } from 'platform/user/selectors';
 import {
+  hasVAPResidentialAddress,
   selectIsCernerOnlyPatient,
-  selectUseProviderSelection,
 } from '../redux/selectors';
 import newAppointmentReducer from './redux/reducer';
 import FormLayout from './components/FormLayout';
@@ -38,12 +39,8 @@ import ScheduleCernerPage from './components/ScheduleCernerPage';
 import useVariantSortMethodTracking from './hooks/useVariantSortMethodTracking';
 
 export function NewAppointment() {
-  const isCernerOnlyPatient = useSelector(state =>
-    selectIsCernerOnlyPatient(state),
-  );
-  const providerSelectionEnabled = useSelector(state =>
-    selectUseProviderSelection(state),
-  );
+  const isCernerOnlyPatient = useSelector(selectIsCernerOnlyPatient);
+  const hasResidentialAddress = useSelector(hasVAPResidentialAddress);
   const match = useRouteMatch();
   const location = useLocation();
 
@@ -112,19 +109,19 @@ export function NewAppointment() {
           path={`${match.url}/how-to-schedule`}
           component={ScheduleCernerPage}
         />
-        {!providerSelectionEnabled && (
+        {!hasResidentialAddress && (
           <Route
             path={`${match.url}/community-care-preferences`}
             component={CommunityCarePreferencesPage}
           />
         )}
-        {providerSelectionEnabled && (
+        {hasResidentialAddress && (
           <Route
             path={`${match.url}/community-care-preferences`}
             component={CommunityCareProviderSelectionPage}
           />
         )}
-        {providerSelectionEnabled && (
+        {hasResidentialAddress && (
           <Route
             path={`${match.url}/community-care-language`}
             component={CommunityCareLanguagePage}

--- a/src/applications/vaos/new-appointment/index.jsx
+++ b/src/applications/vaos/new-appointment/index.jsx
@@ -9,7 +9,7 @@ import {
 } from 'react-router-dom';
 // import { selectVAPResidentialAddress } from 'platform/user/selectors';
 import {
-  hasVAPResidentialAddress,
+  selectHasVAPResidentialAddress,
   selectIsCernerOnlyPatient,
 } from '../redux/selectors';
 import newAppointmentReducer from './redux/reducer';
@@ -40,7 +40,7 @@ import useVariantSortMethodTracking from './hooks/useVariantSortMethodTracking';
 
 export function NewAppointment() {
   const isCernerOnlyPatient = useSelector(selectIsCernerOnlyPatient);
-  const hasResidentialAddress = useSelector(hasVAPResidentialAddress);
+  const hasResidentialAddress = useSelector(selectHasVAPResidentialAddress);
   const match = useRouteMatch();
   const location = useLocation();
 

--- a/src/applications/vaos/new-appointment/newAppointmentFlow.js
+++ b/src/applications/vaos/new-appointment/newAppointmentFlow.js
@@ -1,6 +1,6 @@
 import {
+  hasVAPResidentialAddress,
   selectRegisteredCernerFacilityIds,
-  selectUseProviderSelection,
 } from '../redux/selectors';
 import {
   getChosenFacilityInfo,
@@ -205,7 +205,7 @@ export default {
   ccPreferences: {
     url: '/new-appointment/community-care-preferences',
     next(state) {
-      if (selectUseProviderSelection(state)) {
+      if (hasVAPResidentialAddress(state)) {
         return 'ccLanguage';
       }
 

--- a/src/applications/vaos/new-appointment/newAppointmentFlow.js
+++ b/src/applications/vaos/new-appointment/newAppointmentFlow.js
@@ -1,5 +1,5 @@
 import {
-  hasVAPResidentialAddress,
+  selectHasVAPResidentialAddress,
   selectRegisteredCernerFacilityIds,
 } from '../redux/selectors';
 import {
@@ -205,7 +205,7 @@ export default {
   ccPreferences: {
     url: '/new-appointment/community-care-preferences',
     next(state) {
-      if (hasVAPResidentialAddress(state)) {
+      if (selectHasVAPResidentialAddress(state)) {
         return 'ccLanguage';
       }
 

--- a/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.js
@@ -8,7 +8,7 @@ import {
   TYPE_OF_VISIT,
   LANGUAGES,
 } from '../../../utils/constants';
-import { hasVAPResidentialAddress } from '../../../redux/selectors';
+import { selectHasVAPResidentialAddress } from '../../../redux/selectors';
 import {
   getTypeOfCare,
   getFormData,
@@ -116,7 +116,7 @@ export function transformFormToVARequest(state) {
 
 export function transformFormToCCRequest(state) {
   const data = getFormData(state);
-  const hasResidentialAddress = hasVAPResidentialAddress(state);
+  const hasResidentialAddress = selectHasVAPResidentialAddress(state);
   const provider = data.communityCareProvider;
   let preferredProviders = [];
 

--- a/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.js
@@ -8,7 +8,7 @@ import {
   TYPE_OF_VISIT,
   LANGUAGES,
 } from '../../../utils/constants';
-import { selectUseProviderSelection } from '../../../redux/selectors';
+import { hasVAPResidentialAddress } from '../../../redux/selectors';
 import {
   getTypeOfCare,
   getFormData,
@@ -116,12 +116,12 @@ export function transformFormToVARequest(state) {
 
 export function transformFormToCCRequest(state) {
   const data = getFormData(state);
-  const useProviderSelection = selectUseProviderSelection(state);
+  const hasResidentialAddress = hasVAPResidentialAddress(state);
   const provider = data.communityCareProvider;
   let preferredProviders = [];
 
   if (
-    useProviderSelection &&
+    hasResidentialAddress &&
     !!data.communityCareProvider &&
     Object.keys(data.communityCareProvider).length
   ) {

--- a/src/applications/vaos/new-appointment/redux/selectors.js
+++ b/src/applications/vaos/new-appointment/redux/selectors.js
@@ -17,7 +17,7 @@ import {
 } from '../../utils/constants';
 import { getSiteIdFromFacilityId } from '../../services/location';
 import {
-  hasVAPResidentialAddress,
+  selectHasVAPResidentialAddress,
   selectFeatureCommunityCare,
   selectFeatureDirectScheduling,
   selectFeatureVariantTesting,
@@ -339,7 +339,7 @@ export function selectConfirmationPage(state) {
     submitStatus: getNewAppointment(state).submitStatus,
     flowType: getFlowType(state),
     appointmentLength: getAppointmentLength(state),
-    hasResidentialAddress: hasVAPResidentialAddress(state),
+    hasResidentialAddress: selectHasVAPResidentialAddress(state),
   };
 }
 
@@ -353,7 +353,7 @@ export function selectReviewPage(state) {
     submitStatus: state.newAppointment.submitStatus,
     submitStatusVaos400: state.newAppointment.submitStatusVaos400,
     systemId: getSiteIdForChosenFacility(state),
-    hasResidentialAddress: hasVAPResidentialAddress(state),
+    hasResidentialAddress: selectHasVAPResidentialAddress(state),
     vaCityState: getChosenVACityState(state),
   };
 }

--- a/src/applications/vaos/new-appointment/redux/selectors.js
+++ b/src/applications/vaos/new-appointment/redux/selectors.js
@@ -17,10 +17,10 @@ import {
 } from '../../utils/constants';
 import { getSiteIdFromFacilityId } from '../../services/location';
 import {
+  hasVAPResidentialAddress,
   selectFeatureCommunityCare,
   selectFeatureDirectScheduling,
   selectFeatureVariantTesting,
-  selectUseProviderSelection,
   selectRegisteredCernerFacilityIds,
 } from '../../redux/selectors';
 
@@ -339,7 +339,7 @@ export function selectConfirmationPage(state) {
     submitStatus: getNewAppointment(state).submitStatus,
     flowType: getFlowType(state),
     appointmentLength: getAppointmentLength(state),
-    useProviderSelection: selectUseProviderSelection(state),
+    hasResidentialAddress: hasVAPResidentialAddress(state),
   };
 }
 
@@ -353,7 +353,7 @@ export function selectReviewPage(state) {
     submitStatus: state.newAppointment.submitStatus,
     submitStatusVaos400: state.newAppointment.submitStatusVaos400,
     systemId: getSiteIdForChosenFacility(state),
-    useProviderSelection: selectUseProviderSelection(state),
+    hasResidentialAddress: hasVAPResidentialAddress(state),
     vaCityState: getChosenVACityState(state),
   };
 }

--- a/src/applications/vaos/redux/selectors.js
+++ b/src/applications/vaos/redux/selectors.js
@@ -35,10 +35,7 @@ export const selectFeatureToggleLoading = state => toggleValues(state).loading;
 // Use flat facility page for non Cerner patients
 export const selectUseFlatFacilityPage = state => !selectIsCernerPatient(state);
 
-const selectFeatureProviderSelection = state =>
-  toggleValues(state).vaOnlineSchedulingProviderSelection;
-export const selectUseProviderSelection = state =>
-  selectFeatureProviderSelection(state) &&
+export const hasVAPResidentialAddress = state =>
   !!selectVAPResidentialAddress(state)?.addressLine1;
 
 export const selectSystemIds = state =>

--- a/src/applications/vaos/redux/selectors.js
+++ b/src/applications/vaos/redux/selectors.js
@@ -35,7 +35,7 @@ export const selectFeatureToggleLoading = state => toggleValues(state).loading;
 // Use flat facility page for non Cerner patients
 export const selectUseFlatFacilityPage = state => !selectIsCernerPatient(state);
 
-export const hasVAPResidentialAddress = state =>
+export const selectHasVAPResidentialAddress = state =>
   !!selectVAPResidentialAddress(state)?.addressLine1;
 
 export const selectSystemIds = state =>

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -362,7 +362,6 @@ const responses = {
         { name: 'vaOnlineSchedulingPast', value: true },
         { name: 'vaOnlineSchedulingExpressCare', value: true },
         { name: 'vaOnlineSchedulingFlatFacilityPage', value: true },
-        { name: 'vaOnlineSchedulingProviderSelection', value: true },
         { name: 'vaOnlineSchedulingHomepageRefresh', value: true },
         { name: 'vaOnlineSchedulingUnenrolledVaccine', value: true },
         { name: 'vaGlobalDowntimeNotification', value: false },

--- a/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/community-care.cypress.spec.js
@@ -14,7 +14,7 @@ import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('VAOS community care flow', () => {
   it('should fill out community care form and submit request', () => {
-    initCommunityCareMock();
+    initCommunityCareMock({ withoutAddress: true });
     cy.visit(
       'health-care/schedule-view-va-appointments/appointments/new-appointment/',
     );
@@ -30,7 +30,9 @@ describe('VAOS community care flow', () => {
     // Verify primary care checked
     cy.get('input[value="323"]').should('be.checked');
     // Click continue button
-    cy.get('.usa-button').click();
+    cy.get('.usa-button')
+      .contains('Continue')
+      .click();
 
     // Choose where you want to receive your care step
     cy.url().should(
@@ -258,7 +260,7 @@ describe('VAOS community care flow', () => {
 
   it('should submit form with provider chosen from list and submit request', () => {
     initCommunityCareMock();
-    mockFeatureToggles({ providerSelectionEnabled: true });
+    mockFeatureToggles();
     cy.visit(
       'health-care/schedule-view-va-appointments/appointments/new-appointment/',
     );
@@ -468,7 +470,6 @@ describe('VAOS community care flow using VAOS service', () => {
     mockFeatureToggles({
       v2Requests: true,
       homepageRefresh: true,
-      providerSelectionEnabled: true,
       v2Facilities: true,
     });
     cy.login(mockUser);

--- a/src/applications/vaos/tests/e2e/va-request.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/va-request.cypress.spec.js
@@ -184,7 +184,6 @@ describe('VAOS VA request flow using VAOS service', () => {
     mockFeatureToggles({
       v2Requests: true,
       homepageRefresh: true,
-      providerSelectionEnabled: true,
     });
     cy.login(mockUser);
     cy.route({

--- a/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
@@ -377,7 +377,6 @@ function setupSchedulingMocks({
 } = {}) {
   vaosSetup();
   mockFeatureToggles();
-  cy.getCookies();
 
   if (cernerFacility) {
     const mockCernerUser = {

--- a/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-param-reassign */
+import unset from 'platform/utilities/data/unset';
 import { mockContactInformation } from '~/platform/user/profile/vap-svc/util/local-vapsvc.js';
 
 import moment from '../../lib/moment-tz';
@@ -397,9 +398,10 @@ function setupSchedulingMocks({
     };
     cy.login(mockCernerUser);
   } else if (withoutAddress) {
-    const mockUserWithoutAddress = JSON.parse(JSON.stringify(mockUser));
-    mockUserWithoutAddress.data.attributes.vet360ContactInformation.residentialAddress.addressLine1 =
-      '';
+    const mockUserWithoutAddress = unset(
+      'data.attributes.vet360ContactInformation.residentialAddress.addressLine1',
+      mockUser,
+    );
     cy.login(mockUserWithoutAddress);
   } else {
     cy.login(mockUser);

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.cc-request.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.cc-request.unit.spec.jsx
@@ -54,7 +54,6 @@ const initialStateVAOSService = {
     show_new_schedule_view_appointments_page: true,
     vaOnlineSchedulingHomepageRefresh: true,
     vaOnlineSchedulingVAOSServiceRequests: true,
-    vaOnlineSchedulingProviderSelection: true,
   },
 };
 
@@ -364,9 +363,6 @@ describe('VAOS <ReviewPage> CC request with provider selection', () => {
     mockFetch();
     start = moment();
     store = createTestStore({
-      featureToggles: {
-        vaOnlineSchedulingProviderSelection: true,
-      },
       user: {
         profile: {
           facilities: [{ facilityId: '983', isCerner: false }],

--- a/src/applications/vaos/tests/new-appointment/newAppointmentFlow.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/newAppointmentFlow.unit.spec.js
@@ -472,19 +472,7 @@ describe('VAOS newAppointmentFlow', () => {
 
   describe('ccPreferences page', () => {
     describe('next page', () => {
-      it('should be reasonForAppointment if provider selection is disabled', () => {
-        const state = {
-          featureToggles: {
-            loading: false,
-          },
-        };
-
-        expect(newAppointmentFlow.ccPreferences.next(state)).to.equal(
-          'reasonForAppointment',
-        );
-      });
-
-      it('should be reasonForAppointment user has no address on file', () => {
+      it('should be reasonForAppointment if user has no address on file', () => {
         const state = {
           featureToggles: {
             loading: false,

--- a/src/applications/vaos/tests/new-appointment/newAppointmentFlow.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/newAppointmentFlow.unit.spec.js
@@ -484,11 +484,10 @@ describe('VAOS newAppointmentFlow', () => {
         );
       });
 
-      it('should be reasonForAppointment if provider selection is enabled but user has no address on file', () => {
+      it('should be reasonForAppointment user has no address on file', () => {
         const state = {
           featureToggles: {
             loading: false,
-            vaOnlineSchedulingProviderSelection: true,
           },
         };
 
@@ -497,7 +496,7 @@ describe('VAOS newAppointmentFlow', () => {
         );
       });
 
-      it('should be ccLanguage if provider selection is enabled', () => {
+      it('should be ccLanguage if user has an address on file', () => {
         const state = {
           user: {
             profile: {
@@ -510,7 +509,6 @@ describe('VAOS newAppointmentFlow', () => {
           },
           featureToggles: {
             loading: false,
-            vaOnlineSchedulingProviderSelection: true,
           },
         };
 

--- a/src/applications/vaos/tests/new-appointment/redux/helpers/formSubmitTransformers.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/redux/helpers/formSubmitTransformers.unit.spec.js
@@ -650,9 +650,6 @@ describe('VAOS data transformation', () => {
 
   it('should transform form using provider selection into CC request', () => {
     const state = {
-      featureToggles: {
-        vaOnlineSchedulingProviderSelection: true,
-      },
       user: {
         profile: {
           facilities: [{ facilityId: '983', isCerner: false }],


### PR DESCRIPTION
## Description
This PR removes the `va_online_scheduling_provider_selection` feature flag and updates related unit/e2e tests.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#28572


## Testing done
- local, unit testing

## Screenshots
N/A

## Acceptance criteria
- [x] Remove FE `va_online_scheduling_provider_selection` flag

