### PR TITLE
22593: Update aria label text for download links

### DIFF
--- a/src/applications/claims-status/components/StemDeniedDetails.jsx
+++ b/src/applications/claims-status/components/StemDeniedDetails.jsx
@@ -124,7 +124,7 @@ const StemDeniedDetails = ({
           completing VA Form 20-0995.{' '}
           <a
             href="https://www.vba.va.gov/pubs/forms/VBA-20-0995-ARE.pdf"
-            aria-label="Download Decision Review Request for Supplemental Claims VA Form 20 - 0 9 9 5. Opens in new browser tab"
+            aria-label="Download VA Form 20 - 0 9 9 5. Opens in new browser tab."
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -138,7 +138,7 @@ const StemDeniedDetails = ({
           completing VA Form 20-0996.{' '}
           <a
             href="https://www.vba.va.gov/pubs/forms/VBA-20-0996-ARE.pdf"
-            aria-label="Download Decision Review Request: Higher-Level Review VA Form 20 - 0 9 9 6. Opens in new browser tab"
+            aria-label="Download VA Form 20 - 0 9 9 6. Opens in new browser tab."
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -152,7 +152,7 @@ const StemDeniedDetails = ({
           completing VA Form 10182.{' '}
           <a
             href="https://www.va.gov/vaforms/va/pdf/VA10182.pdf"
-            aria-label="Download Decision Review Request: Board Appeal for Notice of Disagreement VA Form 1 0 1 8 2. Opens in new browser tab"
+            aria-label="Download VA Form 1 0 1 8 2. Opens in new browser tab."
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
## Description
As a screen reader user, I would like to hear the entire downloadable PDF label read without having to press DOWN_ARROW. NVDA doesn't store quite enough characters in the buffer, so it's a little confusing and I might miss the announcement that the PDF will open in a new tab.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/22593


## Testing done
Screen reader output matches text for local testing.

## Screenshots
N/A

## Acceptance criteria
- [x] Aria labels updated for 0995, 0996, and 10182 download links

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
