### PR TITLE
Add pre-need codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,6 +38,7 @@ src/applications/letters @department-of-veterans-affairs/vsa-bam-1-frontend @dep
 src/applications/disability-benefits @department-of-veterans-affairs/vsa-bam-1-frontend @department-of-veterans-affairs/vsa-ebenefits-frontend
 src/applications/claims-status @department-of-veterans-affairs/vsa-bam-1-frontend @department-of-veterans-affairs/vsa-bam-2-frontend
 src/applications/appeals @department-of-veterans-affairs/vsa-bam-1-frontend @department-of-veterans-affairs/vsa-bam-2-frontend @department-of-veterans-affairs/vsa-ebenefits-frontend
+src/applications/pre-need @department-of-veterans-affairs/vsa-bam-1-frontend @department-of-veterans-affairs/vsa-bam-2-frontend @department-of-veterans-affairs/vsa-ebenefits-frontend
 
 # Benefits and Memorials 2
 src/applications/disability-benefits/2346 @department-of-veterans-affairs/vsa-bam-2-frontend @department-of-veterans-affairs/vsa-bam-1-frontend @department-of-veterans-affairs/vsa-caregiver-frontend @department-of-veterans-affairs/vsa-ebenefits-frontend


### PR DESCRIPTION
## Description

Add Claims & appeals team as primary code owner for the pre-need form-10007

## Original issue(s)

N/A

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] Add claims & appeals (bam-1) as primary codeowner for pre-need form

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
