### PR TITLE
Track direct scheduling errors better

### DIFF
--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -797,7 +797,11 @@ export function submitAppointmentOrRequest(history) {
           history.push('/new-appointment/confirmation');
         }
       } catch (error) {
-        captureError(error, true);
+        const extraData = {
+          vaFacility: data?.vaFacility,
+          clinicId: data?.clinicId,
+        };
+        captureError(error, true, 'Direct submission failure', extraData);
         dispatch({
           type: FORM_SUBMIT_FAILED,
           isVaos400Error: has400LevelError(error),


### PR DESCRIPTION
## Description
This PR adds a specific Sentry error name for direct submissions failures, like we have for requests. This means we can track them more easily

## Acceptance criteria
- [ ] Tests pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
