### PR TITLE
CST: Use promise methods for API

### DIFF
--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -108,12 +108,10 @@ export function fetchAppealsSuccess(response) {
 export function getAppealsV2() {
   return dispatch => {
     dispatch({ type: FETCH_APPEALS_PENDING });
-    return apiRequest(
-      '/appeals',
-      null,
-      appeals => dispatch(fetchAppealsSuccess(appeals)),
-      response => {
-        const status = getErrorStatus(response);
+    return apiRequest('/appeals')
+      .then(appeals => dispatch(fetchAppealsSuccess(appeals)))
+      .catch(error => {
+        const status = getErrorStatus(error);
         const action = { type: '' };
         switch (status) {
           case '403':
@@ -137,8 +135,7 @@ export function getAppealsV2() {
           Sentry.captureException(`vets_appeals_v2_err_get_appeals ${status}`);
         });
         return dispatch(action);
-      },
-    );
+      });
   };
 }
 


### PR DESCRIPTION
## Description

Switch Claim Status Tool API methods from using callbacks to using Promise methods

## Original issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/28893

## Testing done

Unit tests still working

## Screenshots

N/A

## Acceptance criteria
- [x] API uses Promise methods
- [x] All tests passing 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
