### PR TITLE
Add instructions about rating increments to calculator

### DIFF
--- a/src/applications/disability-benefits/disability-rating-calculator/components/DisabilityRatingCalculator.jsx
+++ b/src/applications/disability-benefits/disability-rating-calculator/components/DisabilityRatingCalculator.jsx
@@ -143,7 +143,13 @@ export default class DisabilityRatingCalculator extends React.Component {
           <p>
             Enter each of your disability ratings separately below. You can also
             add a description of each for your notes, if you'd like. Then click{' '}
-            <strong>Calculate</strong> to get your combined rating.
+            <strong>Calculate</strong> to get your combined rating.{' '}
+            <strong className="vads-u-display--inline small-screen:vads-u-display--none">
+              Disability ratings are given in 10% increments, from 0 to 100.
+            </strong>
+            <span className="vads-u-display--none small-screen:vads-u-display--inline">
+              Disability ratings are given in 10% increments, from 0 to 100.
+            </span>
           </p>
           <div className="vads-l-grid-container--full">
             <div className="vads-l-row">
@@ -152,6 +158,9 @@ export default class DisabilityRatingCalculator extends React.Component {
                 id="ratingLabel"
               >
                 Disability rating
+                <span className="vads-u-color--gray-medium vads-u-display--none small-screen:vads-u-display--block">
+                  In 10% increments
+                </span>
               </div>
               <div
                 className="vads-l-col--6 small-screen:vads-l-col--6"


### PR DESCRIPTION
## Description
Added description about rating increments that bold when viewed on mobile, and when on desktop include hint text just above inputs.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/1045


## Testing done
local and Cypress

## Screenshots
Desktop:
<img width="1790" alt="Screen Shot 2021-08-18 at 9 48 27 AM" src="https://user-images.githubusercontent.com/3144003/129909796-5b86ca12-1214-4032-8697-3056dddffd19.png">
Mobile:
<img width="423" alt="Screen Shot 2021-08-18 at 9 48 09 AM" src="https://user-images.githubusercontent.com/3144003/129909803-f0ea72ba-fedb-42d1-987c-27ab5cd3e4a8.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
