### PR TITLE
CT Redesign: Back To Top on mobile fixes

### DIFF
--- a/src/applications/gi-sandbox/components/BackToTop.jsx
+++ b/src/applications/gi-sandbox/components/BackToTop.jsx
@@ -38,10 +38,10 @@ export default function BackToTop({
    */
   useEffect(
     () => {
-      if (smallScreen && compareOpen) {
+      if (smallScreen && compare.open) {
         setFloating(false);
         setScrolled(false);
-      } else if (scrolled) {
+      } else if (scrolled || (smallScreen && !compare.open)) {
         const profilePageHeader = document.getElementById(profilePageHeaderId);
         if (!profilePageHeader || !placeholder.current) return;
 
@@ -62,8 +62,9 @@ export default function BackToTop({
         setFloating(headerNotVisible && footerNotVisible);
         setScrolled(false);
       }
+      setCompareOpen(compare.open);
     },
-    [scrolled, smallScreen, compareOpen],
+    [scrolled, smallScreen, compare.open],
   );
 
   const resize = () => {
@@ -91,13 +92,6 @@ export default function BackToTop({
       resize();
     },
     [floating],
-  );
-
-  useEffect(
-    () => {
-      setCompareOpen(compare.open);
-    },
-    [compare.open],
   );
 
   const backToTopClasses = classNames('back-to-top', {


### PR DESCRIPTION
## Description
Fixing issue when doing
- Scroll down far enough to get the back to top button to show up
- Open compare drawer
- Close compare drawer
- Back to top button doesn’t show up until you scroll more

## Original issue(s)
department-of-veterans-affairs/va.gov-team#28702


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
