### PR TITLE
add source app header

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/submitForm.js
+++ b/src/applications/disability-benefits/all-claims/config/submitForm.js
@@ -20,7 +20,6 @@ const submitFormFor = eventName =>
     // 2. Sends the Authorization header with the user token
     return new Promise((resolve, reject) => {
       const req = new XMLHttpRequest();
-      //
       req.open('POST', formConfig.submitUrl);
 
       req.withCredentials = true;

--- a/src/applications/disability-benefits/all-claims/config/submitForm.js
+++ b/src/applications/disability-benefits/all-claims/config/submitForm.js
@@ -20,6 +20,7 @@ const submitFormFor = eventName =>
     // 2. Sends the Authorization header with the user token
     return new Promise((resolve, reject) => {
       const req = new XMLHttpRequest();
+      //
       req.open('POST', formConfig.submitUrl);
 
       req.withCredentials = true;
@@ -75,6 +76,7 @@ const submitFormFor = eventName =>
       req.setRequestHeader('X-Key-Inflection', 'camel');
       req.setRequestHeader('Content-Type', 'application/json');
       req.setRequestHeader('X-CSRF-Token', csrfTokenStored);
+      req.setRequestHeader('Source-App-Name', window.appName);
 
       // Log an error after the timeout fires
       timer = setTimeout(() => {


### PR DESCRIPTION
## Description
vets-website calls `/v0/disability_compensation_form/submit_all_claim` without a `Source-App-Name` header.  The header is used in grafana and sentry to find which app the error comes from . 

tl;dr I found code in one spot and pasted it.