### PR TITLE
HLR: Fix v2 conference times

### DIFF
--- a/src/applications/disability-benefits/996/config/form.js
+++ b/src/applications/disability-benefits/996/config/form.js
@@ -26,6 +26,7 @@ import informalConference from '../pages/informalConference';
 import informalConferenceRep from '../pages/informalConferenceRep';
 import informalConferenceRepV2 from '../pages/informalConferenceRepV2';
 import informalConferenceTimes from '../pages/informalConferenceTimes';
+import informalConferenceTime from '../pages/informalConferenceTimeV2';
 import optIn from '../pages/optIn';
 import issueSummary from '../pages/issueSummary';
 import sameOffice from '../pages/sameOffice';
@@ -214,9 +215,18 @@ const formConfig = {
         availability: {
           path: 'informal-conference/availability',
           title: 'Scheduling availability',
-          depends: formData => formData?.informalConference !== 'no',
+          depends: formData =>
+            formData?.informalConference !== 'no' && apiVersion1(formData),
           uiSchema: informalConferenceTimes.uiSchema,
           schema: informalConferenceTimes.schema,
+        },
+        conferenceTime: {
+          path: 'informal-conference/conference-availability',
+          title: 'Scheduling availability',
+          depends: formData =>
+            formData?.informalConference !== 'no' && apiVersion2(formData),
+          uiSchema: informalConferenceTime.uiSchema,
+          schema: informalConferenceTime.schema,
         },
       },
     },

--- a/src/applications/disability-benefits/996/config/submit-transformer.js
+++ b/src/applications/disability-benefits/996/config/submit-transformer.js
@@ -41,7 +41,11 @@ export function transform(formConfig, form) {
 
     // Add informal conference data
     if (informalConference) {
-      attributes.informalConferenceTimes = getConferenceTimes(formData);
+      if (version1) {
+        attributes.informalConferenceTimes = getConferenceTimes(formData);
+      } else {
+        attributes.informalConferenceTime = formData.informalConferenceTime;
+      }
       if (formData.informalConference === 'rep') {
         attributes.informalConferenceRep = getRep(formData);
       }

--- a/src/applications/disability-benefits/996/content/InformalConference.jsx
+++ b/src/applications/disability-benefits/996/content/InformalConference.jsx
@@ -74,6 +74,23 @@ export const InformalConferenceTimesDescription = (
   </>
 );
 
+export const InformalConferenceTimesDescriptionV2 = (
+  <>
+    <p>
+      First we’ll call {contacts} to schedule the informal conference. Please
+      indicate <span className="contact-choice selected-me">your</span>
+      <span className="contact-choice selected-rep">their</span> availability by
+      providing a preferred time for a call.
+    </p>
+    <p>
+      <strong>We’ll make two attempts to call {contacts}.</strong> If no one
+      answers, we’ll leave a voice mail and a number for {contacts} to return
+      the call. If we aren’t able to get in touch with {contacts} after 2
+      attempts, we’ll proceed with the Higher-Level Review.
+    </p>
+  </>
+);
+
 export const informalConferenceTimeSelectTitles = {
   first: <>Choose the best time for us to call {contacts}</>,
   second: 'Choose another time for us to call',

--- a/src/applications/disability-benefits/996/pages/informalConferenceTimeV2.js
+++ b/src/applications/disability-benefits/996/pages/informalConferenceTimeV2.js
@@ -1,0 +1,35 @@
+import { checkConferenceTimes } from '../validations';
+import { errorMessages, CONFERENCE_TIMES_V2 } from '../constants';
+
+import {
+  InformalConferenceTimesTitle,
+  InformalConferenceTimesDescriptionV2,
+  informalConferenceTimeSelectTitles,
+} from '../content/InformalConference';
+
+// HLR version 2
+export default {
+  uiSchema: {
+    'ui:title': InformalConferenceTimesTitle,
+    'ui:description': InformalConferenceTimesDescriptionV2,
+    informalConferenceTime: {
+      'ui:title': informalConferenceTimeSelectTitles.first,
+      'ui:widget': 'radio',
+      'ui:required': formData => formData?.informalConference !== 'no',
+      'ui:validations': [checkConferenceTimes],
+      'ui:errorMessages': {
+        required: errorMessages.informalConferenceTimes,
+      },
+    },
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      informalConferenceTime: {
+        type: 'string',
+        enum: Object.keys(CONFERENCE_TIMES_V2),
+        enumNames: Object.values(CONFERENCE_TIMES_V2).map(name => name.label),
+      },
+    },
+  },
+};

--- a/src/applications/disability-benefits/996/pages/informalConferenceTimes.js
+++ b/src/applications/disability-benefits/996/pages/informalConferenceTimes.js
@@ -1,10 +1,5 @@
 import { checkConferenceTimes } from '../validations';
-import {
-  errorMessages,
-  CONFERENCE_TIMES_V1,
-  CONFERENCE_TIMES_V2,
-} from '../constants';
-import { apiVersion2 } from '../utils/helpers';
+import { errorMessages, CONFERENCE_TIMES_V1 } from '../constants';
 
 import {
   InformalConferenceTimesTitle,
@@ -12,6 +7,7 @@ import {
   informalConferenceTimeSelectTitles,
 } from '../content/InformalConference';
 
+// HLR version 1
 export default {
   uiSchema: {
     'ui:title': InformalConferenceTimesTitle,
@@ -21,13 +17,12 @@ export default {
       'ui:options': {
         forceDivWrapper: true,
         updateSchema: formData => {
-          const data = apiVersion2(formData)
-            ? CONFERENCE_TIMES_V2
-            : CONFERENCE_TIMES_V1;
           const time1Setting = formData?.informalConferenceTimes?.time1 || '';
           const time2Setting = formData?.informalConferenceTimes?.time2 || '';
-          const enums = Object.keys(data);
-          const enumNames = Object.values(data).map(name => name.label);
+          const enums = Object.keys(CONFERENCE_TIMES_V1);
+          const enumNames = Object.values(CONFERENCE_TIMES_V1).map(
+            name => name.label,
+          );
           return {
             type: 'object',
             properties: {
@@ -35,14 +30,14 @@ export default {
                 type: 'string',
                 enum: enums.filter(val => val !== time2Setting),
                 enumNames: enumNames.filter(
-                  label => label !== data[time2Setting]?.label,
+                  label => label !== CONFERENCE_TIMES_V1[time2Setting]?.label,
                 ),
               },
               time2: {
                 type: 'string',
                 enum: enums.filter(val => val !== time1Setting),
                 enumNames: enumNames.filter(
-                  label => label !== data[time1Setting]?.label,
+                  label => label !== CONFERENCE_TIMES_V1[time1Setting]?.label,
                 ),
               },
             },

--- a/src/applications/disability-benefits/996/tests/fixtures/data/maximal-test-v2.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/data/maximal-test-v2.json
@@ -34,10 +34,7 @@
       "email": "sully@pixar.com"
     },
     "socOptIn": true,
-    "informalConferenceTimes": {
-      "time1": "time0800to1200",
-      "time2": "time1200to1630"
-    },
+    "informalConferenceTime": "time0800to1200",
     "contestedIssues": [
       {
         "type": "contestableIssue",

--- a/src/applications/disability-benefits/996/tests/fixtures/data/transformed/maximal-test-v2.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/data/transformed/maximal-test-v2.json
@@ -5,7 +5,7 @@
       "benefitType": "compensation",
       "informalConference": true,
       "informalConferenceContact": "representative",
-      "informalConferenceTimes": ["800-1200 ET", "1200-1630 ET"],
+      "informalConferenceTime": "time0800to1200",
       "informalConferenceRep": {
         "firstName": "James",
         "lastName": "Sullivan",

--- a/src/applications/disability-benefits/996/tests/pages/informalConferenceTimeV2.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/pages/informalConferenceTimeV2.unit.spec.js
@@ -14,8 +14,8 @@ describe('HLR conference times page', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.informalConference.pages.availability;
-  const firstSelect = 'select[name="root_informalConferenceTimes_time1"]';
+  } = formConfig.chapters.informalConference.pages.conferenceTime;
+  const v2 = { hlrV2: true };
 
   it('should render', () => {
     const form = mount(
@@ -23,28 +23,12 @@ describe('HLR conference times page', () => {
         definitions={{}}
         schema={schema}
         uiSchema={uiSchema}
-        data={{}}
-        formData={{}}
+        data={v2}
+        formData={v2}
       />,
     );
 
-    expect(form.find('select').length).to.equal(2);
-    form.unmount();
-  });
-
-  it('should show v1 options', () => {
-    const form = mount(
-      <DefinitionTester
-        definitions={{}}
-        schema={schema}
-        uiSchema={uiSchema}
-        data={{}}
-        formData={{}}
-      />,
-    );
-
-    // v1 = 1 empty option + 4 time slots
-    expect(form.find(`${firstSelect} option`).length).to.equal(5);
+    expect(form.find('input[type="radio"]').length).to.equal(2);
     form.unmount();
   });
 
@@ -55,13 +39,13 @@ describe('HLR conference times page', () => {
         definitions={{}}
         schema={schema}
         uiSchema={uiSchema}
-        data={{}}
-        formData={{}}
+        data={v2}
+        formData={v2}
         onSubmit={onSubmit}
       />,
     );
 
-    fillData(form, firstSelect, 'time1000to1230');
+    fillData(form, '#root_informalConferenceTime_0', 'time0800to1200');
     form.find('form').simulate('submit');
     expect(form.find('.usa-input-error-message').length).to.equal(0);
     expect(onSubmit.called).to.be.true;
@@ -76,8 +60,8 @@ describe('HLR conference times page', () => {
         definitions={{}}
         schema={schema}
         uiSchema={uiSchema}
-        data={{}}
-        formData={{}}
+        data={v2}
+        formData={v2}
         onSubmit={onSubmit}
       />,
     );


### PR DESCRIPTION
## Description

The Higher-Level Review v2 only allows a single time selection. Add a new conference times page as we will switch from using two selects to a radio button group - see screenshot

## Original issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/28910

## Testing done

Updated & added tests
Verified e2e tests still working

## Screenshots

<details><summary>Version 2 conference times page</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-08-18 at 3 33 11 PM](https://user-images.githubusercontent.com/136959/129972905-aa4fe9a1-d3df-40e3-89ae-b7e4fd09f680.png)</details>

## Acceptance criteria
- [x] Update HLR informal conference times UI
- [x] Update time schema
- [x] Update submitted data
- [x] Update tests

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
