### PR TITLE
HLR: Add v2 API call

### DIFF
--- a/src/applications/disability-benefits/996/config/form.js
+++ b/src/applications/disability-benefits/996/config/form.js
@@ -1,4 +1,3 @@
-import environment from 'platform/utilities/environment';
 import { VA_FORM_IDS } from 'platform/forms/constants';
 import { externalServices as services } from 'platform/monitoring/DowntimeNotification';
 
@@ -45,7 +44,7 @@ import manifest from '../manifest.json';
 const formConfig = {
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
-  submitUrl: `${environment.API_URL}/v0/higher_level_reviews`,
+  submitUrl: 'higher_level_reviews',
   submit: submitForm,
   trackingPrefix: 'decision-reviews-va20-0996-',
   downtime: {

--- a/src/applications/disability-benefits/996/config/submitForm.js
+++ b/src/applications/disability-benefits/996/config/submitForm.js
@@ -1,3 +1,4 @@
+import environment from 'platform/utilities/environment';
 import { submitToUrl } from 'platform/forms-system/src/js/actions';
 import { transformForSubmit } from 'platform/forms-system/src/js/helpers';
 
@@ -20,9 +21,12 @@ const submitForm = (form, formConfig) => {
     ? formConfig.transformForSubmit(formConfig, form)
     : transformForSubmit(formConfig, form);
 
+  const version = form.data.hlrV2 ? '1' : '0';
+  const url = `${environment.API_URL}/v${version}/${submitUrl}`;
+
   // eventData for analytics
   const eventData = buildEventData(form.data);
-  return submitToUrl(body, submitUrl, trackingPrefix, eventData);
+  return submitToUrl(body, url, trackingPrefix, eventData);
 };
 
 export default submitForm;

--- a/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
@@ -105,6 +105,7 @@ const testConfig = createTestConfig(
       cy.intercept('PUT', 'v0/in_progress_forms/20-0996', mockInProgress);
 
       cy.intercept('POST', '/v0/higher_level_reviews', mockSubmit);
+      cy.intercept('POST', '/v1/higher_level_reviews', mockSubmit);
 
       cy.get('@testData').then(testData => {
         cy.intercept('GET', '/v0/in_progress_forms/20-0996', testData);

--- a/src/applications/disability-benefits/996/tests/schema/submitForm.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/schema/submitForm.unit.spec.js
@@ -1,6 +1,11 @@
 import { expect } from 'chai';
+import sinon from 'sinon';
 
-import { buildEventData } from '../../config/submitForm';
+import formConfig from '../../config/form';
+import maximalTestV1 from '../fixtures/data/maximal-test-v1.json';
+import maximalTestV2 from '../fixtures/data/maximal-test-v2.json';
+
+import submitForm, { buildEventData } from '../../config/submitForm';
 
 describe('HLR submit event data', () => {
   it('should build submit event data', () => {
@@ -22,5 +27,32 @@ describe('HLR submit event data', () => {
       'decision-reviews-same-office-to-review': 'no',
       'decision-reviews-informalConf': 'yes',
     });
+  });
+});
+
+describe('submitForm', () => {
+  let xhr;
+  let requests;
+
+  beforeEach(() => {
+    xhr = sinon.useFakeXMLHttpRequest();
+    requests = [];
+    xhr.onCreate = createdXhr => requests.push(createdXhr);
+  });
+
+  afterEach(() => {
+    global.XMLHttpRequest = window.XMLHttpRequest;
+    xhr.restore();
+  });
+
+  it('should use v0 endpoint', done => {
+    submitForm(maximalTestV1, formConfig);
+    expect(requests[0].url).to.contain('/v0/higher_level_reviews');
+    done();
+  });
+  it('should use v1 endpoint', done => {
+    submitForm(maximalTestV2, formConfig);
+    expect(requests[0].url).to.contain('/v1/higher_level_reviews');
+    done();
   });
 });


### PR DESCRIPTION
## Description

When submitting the Higher-Level Review v2 data, we need to use the `v1` API endpoint (not to be confused with Lighthouse's v2 endpoint).

## Original issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/28879

## Testing done

Added unit tests for v1 & v2 submissions

## Screenshots

N/A

## Acceptance criteria
- [x] Call API v1 endpoint for HLR v2
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
