### PR TITLE
Remove lodash/fp from forms system components

### DIFF
--- a/src/platform/forms-system/src/js/components/FieldTemplate.jsx
+++ b/src/platform/forms-system/src/js/components/FieldTemplate.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from 'lodash/fp'; // eslint-disable-line no-restricted-imports
+import get from '../../../../utilities/data/get';
 import classNames from 'classnames';
 import { isReactComponent } from '../../../../utilities/ui';
 // import environment from 'platform/utilities/environment';
@@ -60,7 +60,7 @@ export default function FieldTemplate(props) {
   const containerClassNames = classNames(
     'schemaform-field-template',
     errorClass,
-    _.get(['ui:options', 'classNames'], uiSchema),
+    get(['ui:options', 'classNames'], uiSchema),
   );
   const labelClassNames = classNames({
     'usa-input-error-label': hasErrors && !isDateField,

--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import _ from 'lodash/fp'; // eslint-disable-line no-restricted-imports
+import uniq from 'lodash/uniq';
 
 import SegmentedProgressBar from '@department-of-veterans-affairs/component-library/SegmentedProgressBar';
 
@@ -32,7 +32,7 @@ export default function FormNav(props) {
 
   const eligiblePageList = getActiveExpandedPages(pageList, formData);
 
-  const chapters = _.uniq(
+  const chapters = uniq(
     eligiblePageList.map(p => p.chapterKey).filter(key => !!key),
   );
 

--- a/src/platform/forms-system/src/js/components/ProgressButton.jsx
+++ b/src/platform/forms-system/src/js/components/ProgressButton.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import _ from 'lodash/fp'; // eslint-disable-line no-restricted-imports
+import uniqueId from 'lodash/uniqueId';
 
 /**
  * A component for the continue button to navigate through panels of questions.
@@ -9,7 +9,7 @@ import _ from 'lodash/fp'; // eslint-disable-line no-restricted-imports
 class ProgressButton extends React.Component {
   /* eslint-disable-next-line camelcase */
   UNSAFE_componentWillMount() {
-    this.id = _.uniqueId();
+    this.id = uniqueId();
   }
 
   render() {

--- a/src/platform/forms-system/src/js/components/SchemaForm.jsx
+++ b/src/platform/forms-system/src/js/components/SchemaForm.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import _ from 'lodash/fp'; // eslint-disable-line no-restricted-imports
+import { merge, once } from 'lodash';
+import set from '../../../../utilities/data/set';
 import Form from '@department-of-veterans-affairs/react-jsonschema-form';
 import { deepEquals } from '@department-of-veterans-affairs/react-jsonschema-form/lib/utils';
 
@@ -56,7 +57,7 @@ class SchemaForm extends React.Component {
       this.setState(this.getEmptyState(newProps));
     } else if (newProps.title !== this.props.title) {
       this.setState({
-        formContext: _.set('pageTitle', newProps.title, this.state.formContext),
+        formContext: set('pageTitle', newProps.title, this.state.formContext),
       });
     } else if (!!newProps.reviewMode !== !!this.state.formContext.reviewMode) {
       this.setState(this.getEmptyState(newProps));
@@ -89,14 +90,14 @@ class SchemaForm extends React.Component {
   }
 
   onError() {
-    const formContext = _.set('submitted', true, this.state.formContext);
+    const formContext = set('submitted', true, this.state.formContext);
     this.setState({ formContext });
     scrollToFirstError();
   }
 
   onBlur(id) {
     if (!this.state.formContext.touched[id]) {
-      const formContext = _.set(['touched', id], true, this.state.formContext);
+      const formContext = set(['touched', id], true, this.state.formContext);
       this.setState({ formContext });
     }
   }
@@ -137,8 +138,8 @@ class SchemaForm extends React.Component {
   }
 
   setTouched(touchedItem, setStateCallback) {
-    const touched = _.merge(this.state.formContext.touched, touchedItem);
-    const formContext = _.set('touched', touched, this.state.formContext);
+    const touched = merge({}, this.state.formContext.touched, touchedItem);
+    const formContext = set('touched', touched, this.state.formContext);
     this.setState({ formContext }, setStateCallback);
   }
 
@@ -198,7 +199,7 @@ class SchemaForm extends React.Component {
         schema={schema}
         uiSchema={uiSchema}
         idSchema={idSchema}
-        validate={_.once(this.validate)}
+        validate={once(this.validate)}
         showErrorList={false}
         formData={data}
         widgets={useReviewMode ? reviewWidgets : widgets}

--- a/src/platform/forms-system/src/js/containers/FormPage.jsx
+++ b/src/platform/forms-system/src/js/containers/FormPage.jsx
@@ -3,7 +3,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import Scroll from 'react-scroll';
-import _ from 'lodash/fp'; // eslint-disable-line no-restricted-imports
+import get from '../../../../utilities/data/get';
+import set from '../../../../utilities/data/set';
 import classNames from 'classnames';
 
 import FormNavButtons from '../components/FormNavButtons';
@@ -41,7 +42,7 @@ class FormPage extends React.Component {
     if (
       prevProps.route.pageConfig.pageKey !==
         this.props.route.pageConfig.pageKey ||
-      _.get('params.index', prevProps) !== _.get('params.index', this.props)
+      get('params.index', prevProps) !== get('params.index', this.props)
     ) {
       scrollToTop();
       focusForm();
@@ -54,7 +55,7 @@ class FormPage extends React.Component {
     if (pageConfig.showPagePerItem) {
       // If this is a per item page, the formData object will have data for a particular
       // row in an array, so we need to update the full form data object and then call setData
-      newData = _.set(
+      newData = set(
         [this.props.route.pageConfig.arrayPath, this.props.params.index],
         formData,
         this.props.form.data,
@@ -75,7 +76,7 @@ class FormPage extends React.Component {
     // necessary. Additionally, it should NOT setData for a CustomPage. The
     // CustomPage should take care of that itself.
     if (route.pageConfig.showPagePerItem && !route.pageConfig.CustomPage) {
-      const newData = _.set(
+      const newData = set(
         [route.pageConfig.arrayPath, params.index],
         formData,
         form.data,
@@ -96,7 +97,7 @@ class FormPage extends React.Component {
     // If it's an array page, return only the data for that array item
     // Otherwise, return the data for the entire form
     return this.props.route.pageConfig.showPagePerItem
-      ? _.get(
+      ? get(
           [pageConfig.arrayPath, this.props.params.index],
           this.props.form.data,
         )


### PR DESCRIPTION
## Description
This PR removes `lodash/fp` from the forms system components.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#1678


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
