### PR TITLE
Update deconstructPath to handle numbers

### DIFF
--- a/src/platform/utilities/data/deconstructPath.js
+++ b/src/platform/utilities/data/deconstructPath.js
@@ -8,12 +8,16 @@ function coerceNumber(e) {
  * Takes a string and casts it into an array.
  * Can take strings like a.b[4].c
  *
- * @param {string} path
+ * Numbers are returned as single itemed arrays
+ *
+ * @param {string|Number} path
  * @return {Array}
  */
 export default function deconstructPath(path) {
-  return path
-    .split(/[.[\]]/)
-    .filter(e => e !== '')
-    .map(coerceNumber);
+  return typeof path === 'number'
+    ? [path]
+    : path
+        .split(/[.[\]]/)
+        .filter(e => e !== '')
+        .map(coerceNumber);
 }


### PR DESCRIPTION
## Description
The `set` platform function currently doesn't handle arrays, whereas `lodash`'s `set` function does. i.e. something like:
``` javascript
const arr = ['a'];
_.set(0, 'b', arr);
// => ['b']
```
works with `lodash`'s `set`, but not the platform's `set` function. This is due to the `deconstructPath` function not handling numbers as a parameter. By updating  `deconstructPath` to account for numbers as paths, other platform data functions like `get` and `unset` will behave more like the `lodash` functions, since they also have the same issue as `set`.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#1678


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
