### PR TITLE
HLR v2: Make address optional if homeless

### DIFF
--- a/src/applications/disability-benefits/996/components/ContactInformation.jsx
+++ b/src/applications/disability-benefits/996/components/ContactInformation.jsx
@@ -13,16 +13,18 @@ import { selectProfile } from 'platform/user/selectors';
 
 import { readableList } from '../utils/helpers';
 
-export const ContactInfoDescription = ({ formContext, profile }) => {
+export const ContactInfoDescription = ({ formContext, profile, homeless }) => {
   const [hadError, setHadError] = useState(false);
   const { email = {}, mobilePhone = {}, mailingAddress = {} } =
     profile?.vapContactInfo || {};
   const { submitted } = formContext || {};
 
+  // Don't require an address if the Veteran is homeless
+  const requireAddress = homeless ? '' : 'address';
   const missingInfo = [
     email?.emailAddress ? '' : 'email',
     mobilePhone?.phoneNumber ? '' : 'phone',
-    mailingAddress.addressLine1 ? '' : 'address',
+    mailingAddress.addressLine1 ? '' : requireAddress,
   ].filter(Boolean);
 
   const list = readableList(missingInfo);
@@ -153,9 +155,11 @@ ContactInfoDescription.propTypes = {
       }),
     }),
   }).isRequired,
+  homeless: PropTypes.bool,
 };
 
 const mapStateToProps = state => ({
+  homeless: state.form.data.homeless,
   profile: selectProfile(state),
 });
 

--- a/src/applications/disability-benefits/996/config/form.js
+++ b/src/applications/disability-benefits/996/config/form.js
@@ -106,6 +106,13 @@ const formConfig = {
           uiSchema: veteranInformation.uiSchema,
           schema: veteranInformation.schema,
         },
+        homeless: {
+          title: 'Homelessness question',
+          path: 'homeless',
+          uiSchema: homeless.uiSchema,
+          schema: homeless.schema,
+          depends: apiVersion2,
+        },
         confirmContactInformation: {
           title: 'Contact information',
           path: 'contact-information',
@@ -115,13 +122,6 @@ const formConfig = {
             // stop the mobile phone modal from showing SMS checkbox inline
             'view:showSMSCheckbox': false,
           },
-        },
-        homeless: {
-          title: 'Homelessness question',
-          path: 'homeless',
-          uiSchema: homeless.uiSchema,
-          schema: homeless.schema,
-          depends: apiVersion2,
         },
       },
     },

--- a/src/applications/disability-benefits/996/tests/components/ContactInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/components/ContactInformation.unit.spec.jsx
@@ -9,6 +9,7 @@ const getData = ({
   mobile = true,
   address = true,
   submitted = false,
+  homeless = false,
 } = {}) => {
   const data = {};
   if (email) {
@@ -38,6 +39,7 @@ const getData = ({
   return {
     formContext: { submitted },
     profile: { vapContactInfo: data },
+    homeless,
   };
 };
 
@@ -76,6 +78,23 @@ describe('Veteran information review content', () => {
     expect(text).to.contain('Your email, phone and address are missing');
     tree.unmount();
   });
+  it('should render note about missing address if not homeless', () => {
+    const data = getData({ email: false, address: false, homeless: false });
+    const tree = shallow(<ContactInfoDescription {...data} />);
+    const text = tree.find('va-alert').text();
+
+    expect(text).to.contain('Your email and address are missing');
+    tree.unmount();
+  });
+  it('should should not include missing address if homeless', () => {
+    const data = getData({ email: false, address: false, homeless: true });
+    const tree = shallow(<ContactInfoDescription {...data} />);
+    const text = tree.find('va-alert').text();
+
+    expect(text).to.contain('Your email is missing');
+    tree.unmount();
+  });
+
   it('should render an error if info is not actually updated', () => {
     const data = getData({
       submitted: false,


### PR DESCRIPTION
## Description

In the Higher-Level Review v2 form, the Veteran's address will not be required if they answer that they are homeless. Making this change requires moving the homeless question to be before the contact info page.

## Original issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/28942

## Testing done

Updated unit tests

## Screenshots

N/A - no visual change, only a flow change.

## Acceptance criteria
- [x] Set address requirement dynamically based on answer to homeless question
- [x] Update unit tests
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
