### PR TITLE
Use matching clinic, rather than first clinic, on clinic page message

### DIFF
--- a/src/applications/vaos/new-appointment/components/ClinicChoicePage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/ClinicChoicePage/index.jsx
@@ -77,7 +77,6 @@ export default function ClinicChoicePage() {
   useEffect(() => {
     dispatch(openClinicPage(pageKey, uiSchema, initialSchema));
   }, []);
-
   useEffect(
     () => {
       scrollAndFocus();
@@ -94,6 +93,10 @@ export default function ClinicChoicePage() {
     return <LoadingIndicator message="Loading your facility and clinic info" />;
   }
 
+  const firstMatchingClinic = clinics?.find(
+    clinic => clinic.id === schema?.properties.clinicId.enum[0],
+  );
+
   return (
     <div>
       {schema.properties.clinicId.enum.length === 2 && (
@@ -107,7 +110,7 @@ export default function ClinicChoicePage() {
           {!usingPastClinics && (
             <>{typeOfCare.name} appointments are available at </>
           )}
-          {clinics[0].serviceName}:
+          {firstMatchingClinic.serviceName}:
           <p>
             <FacilityAddress
               name={facility.name}

--- a/src/applications/vaos/tests/mocks/helpers.js
+++ b/src/applications/vaos/tests/mocks/helpers.js
@@ -508,6 +508,7 @@ export function mockEligibilityFetches({
   requestPastVisits = false,
   directPastVisits = false,
   clinics = [],
+  matchingClinics = null,
   pastClinics = false,
 }) {
   mockRequestLimits({
@@ -558,7 +559,7 @@ export function mockEligibilityFetches({
     },
   );
 
-  const pastAppointments = clinics.map(clinic => {
+  const pastAppointments = (matchingClinics || clinics).map(clinic => {
     const appointment = getVAAppointmentMock();
     appointment.attributes = {
       ...appointment.attributes,

--- a/src/applications/vaos/tests/new-appointment/components/ClinicChoicePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ClinicChoicePage.unit.spec.jsx
@@ -361,6 +361,7 @@ describe('VAOS <ClinicChoicePage>', () => {
   });
 
   it('should show the correct clinic name when filtered to matching', async () => {
+    // Given two available clinics
     const clinics = [
       {
         id: '309',
@@ -402,6 +403,8 @@ describe('VAOS <ClinicChoicePage>', () => {
         },
       },
     };
+
+    // And the second clinic matches a past appointment
     mockEligibilityFetches({
       siteId: '983',
       facilityId: '983',
@@ -419,25 +422,21 @@ describe('VAOS <ClinicChoicePage>', () => {
     await setTypeOfCare(store, /amputation/i);
     await setVAFacility(store, '983', { facilityData });
 
+    // When the page is displayed
     const screen = renderWithStoreAndRouter(<ClinicChoicePage />, {
       store,
     });
-
     await screen.findByText(/last amputation care appointment/i);
+
+    // Then the page says the last appointment was at the matching clinic
     expect(screen.baseElement).to.contain.text(
       'Your last amputation care appointment was at Green team clinic:',
     );
 
+    // And the user is asked if they want an appt at matching clinic
     expect(screen.baseElement).to.contain.text(
       'Would you like to make an appointment at Green team clinic',
     );
-    expect(screen.getAllByRole('radio').length).to.equal(2);
-    expect(
-      screen.getByLabelText('Yes, make my appointment here'),
-    ).to.have.tagName('input');
-    expect(
-      screen.getByLabelText('No, I need a different clinic'),
-    ).to.have.tagName('input');
   });
 
   it('should retain form data after page changes', async () => {

--- a/src/applications/vaos/tests/new-appointment/components/ClinicChoicePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ClinicChoicePage.unit.spec.jsx
@@ -360,6 +360,86 @@ describe('VAOS <ClinicChoicePage>', () => {
     );
   });
 
+  it('should show the correct clinic name when filtered to matching', async () => {
+    const clinics = [
+      {
+        id: '309',
+        attributes: {
+          ...getClinicMock(),
+          siteCode: '983',
+          clinicId: '309',
+          institutionCode: '983',
+          clinicFriendlyLocationName: 'Filtered out clinic',
+        },
+      },
+      {
+        id: '308',
+        attributes: {
+          ...getClinicMock(),
+          siteCode: '983',
+          clinicId: '308',
+          institutionCode: '983',
+          clinicFriendlyLocationName: 'Green team clinic',
+        },
+      },
+    ];
+    const facilityData = {
+      id: 'vha_442',
+      attributes: {
+        ...getVAFacilityMock().attributes,
+        uniqueId: '442',
+        name: 'Cheyenne VA Medical Center',
+        address: {
+          physical: {
+            zip: '82001-5356',
+            city: 'Cheyenne',
+            state: 'WY',
+            address1: '2360 East Pershing Boulevard',
+          },
+        },
+        phone: {
+          main: '307-778-7550',
+        },
+      },
+    };
+    mockEligibilityFetches({
+      siteId: '983',
+      facilityId: '983',
+      typeOfCareId: '211',
+      limit: true,
+      requestPastVisits: true,
+      directPastVisits: true,
+      clinics,
+      matchingClinics: clinics.slice(1),
+      pastClinics: true,
+    });
+
+    const store = createTestStore(initialState);
+
+    await setTypeOfCare(store, /amputation/i);
+    await setVAFacility(store, '983', { facilityData });
+
+    const screen = renderWithStoreAndRouter(<ClinicChoicePage />, {
+      store,
+    });
+
+    await screen.findByText(/last amputation care appointment/i);
+    expect(screen.baseElement).to.contain.text(
+      'Your last amputation care appointment was at Green team clinic:',
+    );
+
+    expect(screen.baseElement).to.contain.text(
+      'Would you like to make an appointment at Green team clinic',
+    );
+    expect(screen.getAllByRole('radio').length).to.equal(2);
+    expect(
+      screen.getByLabelText('Yes, make my appointment here'),
+    ).to.have.tagName('input');
+    expect(
+      screen.getByLabelText('No, I need a different clinic'),
+    ).to.have.tagName('input');
+  });
+
   it('should retain form data after page changes', async () => {
     const clinics = [
       {


### PR DESCRIPTION
## Description
This PR
- Updates the clinic page text to mention the matching clinic, rather than the first clinic in the list, when there's only one clinic available

## Original issue(s)
department-of-veterans-affairs/va.gov-team#28960


## Testing done
Unit testing

## Screenshots
![Screen Shot 2021-08-19 at 1 56 13 PM](https://user-images.githubusercontent.com/634932/130120451-f575f87f-dc8e-4d5a-be31-5ffbcc5f2c0d.png)


## Acceptance criteria
```
Given two available clinics
  And the second clinic matches a past appointment
When the page is displayed
Then the page says the last appointment was at the matching clinic
  And the user is asked if they want an appt at matching clinic
```

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
