### PR TITLE
Chp 36 - use action link

### DIFF
--- a/src/applications/vre/28-8832/tests/e2e/dependent-workflow.cypress.spec.js
+++ b/src/applications/vre/28-8832/tests/e2e/dependent-workflow.cypress.spec.js
@@ -19,7 +19,7 @@ const testConfig = createTestConfig(
         cy.get('#vre-benefits-1').click();
         cy.get('#education-benefits-0').click();
         cy.get('#begin-form-now-0').click();
-        cy.get('.va-button-primary').click();
+        cy.get('.vads-c-action-link--green').click();
 
         // Previous button click fully loads a new page, so we need to
         // re-inject aXe to get the automatic aXe checks working.

--- a/src/applications/vre/28-8832/tests/e2e/veteran-workflow-not-logged-in.cypress.spec.js
+++ b/src/applications/vre/28-8832/tests/e2e/veteran-workflow-not-logged-in.cypress.spec.js
@@ -19,7 +19,7 @@ const testConfig = createTestConfig(
         cy.get('#vre-benefits-1').click();
         cy.get('#education-benefits-0').click();
         cy.get('#begin-form-now-0').click();
-        cy.get('.va-button-primary').click();
+        cy.get('.vads-c-action-link--green').click();
 
         // Previous button click fully loads a new page, so we need to
         // re-inject aXe to get the automatic aXe checks working.

--- a/src/applications/vre/28-8832/wizard/pages/StartForm.jsx
+++ b/src/applications/vre/28-8832/wizard/pages/StartForm.jsx
@@ -20,7 +20,7 @@ const StartForm = props => {
     <a
       onClick={handleClick}
       href={`${PCPG_ROOT_URL}/introduction`}
-      className="usa-button-primary va-button-primary"
+      className="vads-c-action-link--green"
     >
       Apply for career planning and guidance
     </a>


### PR DESCRIPTION
## Description
This pull request updates the chapter 36 wizard to use an action link instead of button styling

## Original issue(s)
department-of-veterans-affairs/va.gov-team#19317


## Testing done
- local, cypress

## Screenshots
<img width="713" alt="Screen Shot 2021-08-19 at 1 27 09 PM" src="https://user-images.githubusercontent.com/15097156/130124655-f60a9618-7f8d-4d22-881e-cdfe08eaac15.png">


## Acceptance criteria
- [ ] link styling has been updated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
