### PR TITLE
Use radio buttons on Notification Settings screen

### DIFF
--- a/src/applications/personalization/profile/components/notification-settings/NotificationChannel.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationChannel.jsx
@@ -46,6 +46,8 @@ const NotificationChannel = ({
     [itemId],
   );
 
+  // radio button option values are strings, so we need to convert the isOptedIn
+  // bool to a string
   const currentValue = React.useMemo(
     () => (isOptedIn === null ? isOptedIn : isOptedIn.toString()),
     [isOptedIn],
@@ -57,8 +59,6 @@ const NotificationChannel = ({
   return (
     <div>
       <NotificationRadioButtons
-        // radio button option values are strings, so we need to convert the
-        // isOptedIn bool to a string
         value={{ value: currentValue }}
         label={itemName}
         options={[

--- a/src/applications/personalization/profile/components/notification-settings/NotificationItem.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationItem.jsx
@@ -10,7 +10,7 @@ const NotificationItem = ({ itemName, channelIds }) => {
   return (
     <div>
       <h3 className="vads-u-font-size--h4 vads-u-font-family--sans vads-u-margin-top--2">
-        {itemName}
+        {/* {itemName} */}
       </h3>
 
       {channelIds.map(channelId => (

--- a/src/applications/personalization/profile/components/notification-settings/NotificationItem.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationItem.jsx
@@ -6,12 +6,13 @@ import { selectCommunicationPreferences } from '@@profile/reducers';
 
 import NotificationChannel from './NotificationChannel';
 
-const NotificationItem = ({ itemName, channelIds }) => {
+const NotificationItem = ({ channelIds }) => {
   return (
     <div>
-      <h3 className="vads-u-font-size--h4 vads-u-font-family--sans vads-u-margin-top--2">
-        {/* {itemName} */}
-      </h3>
+      {/* Leaving this here for future reference since we might need to bring the item name back to this component. Not that to re-enable the h3, we need to add itemName to the destructured props up on line 9 */}
+      {/* <h3 className="vads-u-font-size--h4 vads-u-font-family--sans vads-u-margin-top--2">
+        {itemName}
+      </h3> */}
 
       {channelIds.map(channelId => (
         <NotificationChannel channelId={channelId} key={channelId} />

--- a/src/applications/personalization/profile/components/notification-settings/NotificationRadioButtons.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationRadioButtons.jsx
@@ -13,6 +13,7 @@ import { makeField } from '~/platform/forms/fields';
  * - `additionalLegendClass` String for any additional legend classes.
  * - `errorMessage` String Error message for the radio button group
  * - `warningMessage` String Warning message for the radio button group
+ * - `loadingMessage` String Loading message for the radio button group
  * - `successMessage` String Success message for the radio button group
  * - `label` String for the group field label.
  * - `name` String for the name attribute.
@@ -31,6 +32,7 @@ const NotificationRadioButtons = ({
   additionalLegendClass,
   errorMessage,
   warningMessage,
+  loadingMessage,
   successMessage,
   label,
   name,
@@ -41,6 +43,7 @@ const NotificationRadioButtons = ({
   ariaDescribedby,
   onMouseDown,
   onKeyDown,
+  disabled,
 }) => {
   const handleChange = domEvent => {
     const optionValue = domEvent.target.value;
@@ -53,7 +56,11 @@ const NotificationRadioButtons = ({
   if (errorMessage) {
     errorSpanId = `${id}-error-message`;
     errorSpan = (
-      <span className="rb-input-error-message" role="alert" id={errorSpanId}>
+      <span
+        className="rb-input-message rb-input-message-error"
+        role="alert"
+        id={errorSpanId}
+      >
         <i
           className="fas fa-exclamation-circle vads-u-margin-x--1"
           aria-hidden="true"
@@ -69,7 +76,7 @@ const NotificationRadioButtons = ({
     warningSpanId = `${id}-warning-message`;
     warningSpan = (
       <span
-        className="rb-input-warning-message"
+        className="rb-input-message rb-input-message-warning"
         role="alert"
         id={warningSpanId}
       >
@@ -82,13 +89,32 @@ const NotificationRadioButtons = ({
     );
   }
 
+  let loadingSpan = '';
+  let loadingSpanId = undefined;
+  if (loadingMessage) {
+    loadingSpanId = `${id}-loading-message`;
+    loadingSpan = (
+      <span
+        className="rb-input-message rb-input-message-loading"
+        role="alert"
+        id={loadingSpanId}
+      >
+        <i
+          className="fas fa-spinner fa-spin vads-u-margin-x--1"
+          aria-hidden="true"
+        />{' '}
+        {loadingMessage}
+      </span>
+    );
+  }
+
   let successSpan = '';
   let successSpanId = undefined;
   if (successMessage) {
     successSpanId = `${id}-success-message`;
     successSpan = (
       <span
-        className="rb-input-success-message"
+        className="rb-input-message rb-input-message-success"
         role="alert"
         id={successSpanId}
       >
@@ -112,6 +138,7 @@ const NotificationRadioButtons = ({
   const optionElements = buttonOptions.map((option, optionIndex) => {
     let optionLabel;
     let optionValue;
+    let optionAriaLabel;
     let optionAdditional;
     if (isString(option)) {
       optionLabel = option;
@@ -119,6 +146,7 @@ const NotificationRadioButtons = ({
     } else {
       optionLabel = option.label;
       optionValue = option.value;
+      optionAriaLabel = option.ariaLabel;
       if (option.additional) {
         optionAdditional = <div>{option.additional}</div>;
       }
@@ -147,6 +175,7 @@ const NotificationRadioButtons = ({
           <label
             name={`${name}-${optionIndex}-label`}
             htmlFor={`${id}-${optionIndex}`}
+            aria-label={optionAriaLabel}
           >
             {optionLabel}
           </label>
@@ -160,9 +189,10 @@ const NotificationRadioButtons = ({
     'rb-fieldset-input',
     additionalFieldsetClass,
     {
-      'rb-input-error': errorMessage,
-      'rb-input-warning': warningMessage,
-      'rb-input-success': successMessage,
+      'rb-input rb-input-error': errorMessage,
+      'rb-input rb-input-warning': warningMessage,
+      'rb-input rb-input-success': successMessage,
+      'rb-input rb-input-loading': loadingMessage,
     },
   );
 
@@ -172,14 +202,15 @@ const NotificationRadioButtons = ({
   );
 
   return (
-    <fieldset className={fieldsetClass}>
+    <fieldset className={fieldsetClass} disabled={disabled}>
       <span className={legendClass}>
         {label}
         {requiredSpan}
       </span>
-      {!successMessage && !warningMessage && errorSpan}
-      {!errorMessage && !successMessage && warningSpan}
-      {!errorMessage && !warningMessage && successSpan}
+      {!loadingMessage && !successMessage && !warningMessage && errorSpan}
+      {!loadingMessage && !errorMessage && !successMessage && warningSpan}
+      {!loadingMessage && !errorMessage && !warningMessage && successSpan}
+      {!errorMessage && !successMessage && !warningMessage && loadingSpan}
       {optionElements}
     </fieldset>
   );

--- a/src/applications/personalization/profile/ducks/communicationPreferences.js
+++ b/src/applications/personalization/profile/ducks/communicationPreferences.js
@@ -107,7 +107,7 @@ export const saveCommunicationPreferenceChannel = (channelId, apiCallInfo) => {
       dispatch(saveChannelSucceeded(channelId, response.bio));
     } catch (error) {
       const errors = error.errors ?? [error];
-      dispatch(saveChannelFailed(channelId, !apiCallInfo.isAllowed, errors));
+      dispatch(saveChannelFailed(channelId, apiCallInfo.wasAllowed, errors));
     }
   };
 };
@@ -171,7 +171,7 @@ function communicationChannelsReducer(accumulator, item) {
     const communicationChannel = {
       channelType: channel.id,
       parentItem: itemId,
-      isAllowed: channel.communicationPermission?.allowed ?? false,
+      isAllowed: channel.communicationPermission?.allowed ?? null,
       permissionId: channel.communicationPermission?.id ?? null,
       ui: {
         updateStatus: LOADING_STATES.idle,

--- a/src/applications/personalization/profile/models/CommunicationChannel.js
+++ b/src/applications/personalization/profile/models/CommunicationChannel.js
@@ -1,5 +1,5 @@
 class CommunicationChannel {
-  constructor({ type, parentItemId, permissionId, isAllowed }) {
+  constructor({ type, parentItemId, permissionId, isAllowed, wasAllowed }) {
     if (typeof type !== 'number' || type < 1 || type > 2) {
       throw new Error(
         'Invalid Argument: options.type must be a valid channel type',
@@ -14,6 +14,7 @@ class CommunicationChannel {
     this.parentItemId = parentItemId;
     this.permissionId = permissionId;
     this.isAllowed = !!isAllowed;
+    this.wasAllowed = wasAllowed;
   }
 
   setIsAllowed(isAllowed) {
@@ -53,6 +54,7 @@ class CommunicationChannel {
         },
       },
       isAllowed: allowed,
+      wasAllowed: this.wasAllowed,
     };
   }
 

--- a/src/applications/personalization/profile/sass/notification-radio-buttons.scss
+++ b/src/applications/personalization/profile/sass/notification-radio-buttons.scss
@@ -1,5 +1,5 @@
 .rb-fieldset-input {
-  margin-top: 3rem;
+  margin-bottom: 2rem;
   position: relative;
   right: calc(1.9rem - 4px); //this is to account for the border
 }
@@ -12,56 +12,55 @@
   padding-bottom: 1rem;
 }
 
-//warning
-.rb-input-warning {
-  border-left: 4px solid $color-gold;
-  margin-top: 3rem;
+.rb-input {
+  border-left: 4px solid;
   position: relative;
   right: 1.9rem;
 }
 
-.rb-input-warning-message {
-  background: $color-gold-lightest;
+.rb-input-message {
   display: block;
   font-size: 1.7rem;
   font-weight: 700;
   padding-bottom: 3px;
   padding-top: 3px;
+}
+
+//warning
+.rb-input-warning {
+  border-left-color: $color-gold;
+}
+
+.rb-input-message-warning {
+  background: $color-gold-lightest;
 }
 
 //error
-
 .rb-input-error {
-  border-left: 4px solid $color-red;
-  margin-top: 3rem;
-  position: relative;
-  right: 1.9rem;
+  border-left-color: $color-red;
 }
 
-.rb-input-error-message {
+.rb-input-message-error {
   background: $color-red-lightest;
-  display: block;
-  font-size: 1.7rem;
-  font-weight: 700;
-  padding-bottom: 3px;
-  padding-top: 3px;
 }
 
 //success
 .rb-input-success {
-  border-left: 4px solid $color-green;
-  margin-top: 3rem;
-  position: relative;
-  right: 1.9rem;
+  border-left-color: $color-green;
 }
 
-.rb-input-success-message {
+.rb-input-message-success {
   background: $color-green-lightest;
-  display: block;
-  font-size: 1.7rem;
-  font-weight: 700;
-  padding-bottom: 3px;
-  padding-top: 3px;
+}
+
+// loading
+.rb-input-loading {
+  border-left-color: transparent;
+}
+
+.rb-input-message-loading {
+  font-weight: normal;
+  font-style: italic;
 }
 
 .rb-buttons {

--- a/src/applications/personalization/profile/sass/profile.scss
+++ b/src/applications/personalization/profile/sass/profile.scss
@@ -6,7 +6,7 @@
 @import "./profile-mobile-subnav";
 @import "./connected-apps";
 @import "./personal-contact-information";
-@import "./notification-radio-buttons.scss";
+@import "./notification-radio-buttons";
 
 [tabindex="-1"]:focus {
   outline: 0;

--- a/src/applications/personalization/profile/sass/profile.scss
+++ b/src/applications/personalization/profile/sass/profile.scss
@@ -6,6 +6,7 @@
 @import "./profile-mobile-subnav";
 @import "./connected-apps";
 @import "./personal-contact-information";
+@import "./notification-radio-buttons.scss";
 
 [tabindex="-1"]:focus {
   outline: 0;
@@ -53,8 +54,7 @@
   width: 100%;
   padding: 0 5px;
 
-
-  [type=radio] + label::before {
+  [type="radio"] + label::before {
     min-width: 1.4rem;
   }
 }

--- a/src/applications/personalization/profile/tests/ducks/communicationPreferences.unit.spec.js
+++ b/src/applications/personalization/profile/tests/ducks/communicationPreferences.unit.spec.js
@@ -105,7 +105,7 @@ describe('fetching communication preferences', () => {
             'channel1-2': {
               channelType: 2,
               parentItem: 'item1',
-              isAllowed: false,
+              isAllowed: null,
               permissionId: null,
               ui: {
                 errors: null,
@@ -316,7 +316,7 @@ describe('saveCommunicationPreferenceChannel', () => {
             'channel1-2': {
               channelType: 2,
               parentItem: 'item1',
-              isAllowed: false,
+              isAllowed: null,
               permissionId: null,
               ui: {
                 updateStatus: LOADING_STATES.idle,
@@ -371,6 +371,7 @@ describe('saveCommunicationPreferenceChannel', () => {
             endpoint: apiURL,
             body: {},
             isAllowed: true,
+            wasAllowed: null,
           }),
         );
         // it should set that part of the UI as loading
@@ -398,6 +399,7 @@ describe('saveCommunicationPreferenceChannel', () => {
             endpoint: apiURL,
             body: {},
             isAllowed: true,
+            wasAllowed: null,
           }),
         );
         channelState = selectChannelById(store.getState(), channelId);
@@ -435,6 +437,7 @@ describe('saveCommunicationPreferenceChannel', () => {
             endpoint: `${apiURL}/1728`,
             body: {},
             isAllowed: false,
+            wasAllowed: true,
           }),
         );
         // it should set that part of the UI as loading
@@ -460,6 +463,7 @@ describe('saveCommunicationPreferenceChannel', () => {
             endpoint: `${apiURL}/1728`,
             body: {},
             isAllowed: false,
+            wasAllowed: true,
           }),
         );
         // it should set that part of the UI as loading

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/happy-editing-path.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/happy-editing-path.cypress.spec.js
@@ -38,10 +38,14 @@ describe('Updating Notification Settings', () => {
       cy.login(mockPatient);
       cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
 
-      // the checkbox will start off unchecked because of the mocked response
-      // from mockCommunicationPreferences
-      cy.findByRole('checkbox', {
-        name: /notify me of.*hearing reminder.*by email/i,
+      // both radio buttons will start off unchecked because of the mocked
+      // response from mockCommunicationPreferences
+      cy.findByRole('radio', {
+        name: /^do not notify me of.*hearing reminder.*by email/i,
+      }).should('not.be.checked');
+
+      cy.findByRole('radio', {
+        name: /^notify me of.*hearing reminder.*by email/i,
       })
         .should('not.be.checked')
         .click()
@@ -49,12 +53,15 @@ describe('Updating Notification Settings', () => {
         .should('be.disabled');
 
       // we should now see a saving indicator
-      cy.findByText(/^Saving/).should('exist');
+      cy.findByText(/^Saving.../).should('exist');
       // after the POST call resolves:
-      cy.findByText(/^Saving/).should('not.exist');
-      cy.findByText(/you’ve updated your.*notifications/i).should('exist');
-      cy.findByRole('checkbox', {
-        name: /notify me of.*hearing reminder.*by email/i,
+      cy.findByText(/^Saving.../).should('not.exist');
+      cy.findByText(/update saved/i).should('exist');
+      cy.findByRole('radio', {
+        name: /^do not notify me of.*hearing reminder.*by email/i,
+      }).should('not.be.checked');
+      cy.findByRole('radio', {
+        name: /^notify me of.*hearing reminder.*by email/i,
       })
         .should('be.checked')
         .should('not.be.disabled');
@@ -64,25 +71,31 @@ describe('Updating Notification Settings', () => {
       cy.login(mockPatient);
       cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
 
-      // the checkbox will start off checked because of the mocked response
-      // from mockCommunicationPreferences
-      cy.findByRole('checkbox', {
-        name: /notify me of.*hearing reminder.*by text/i,
+      // the "do not notify" radio button will start off checked because of the
+      // mocked response from mockCommunicationPreferences
+      cy.findByRole('radio', {
+        name: /^notify me of.*hearing reminder.*by text/i,
+      }).should('be.checked');
+      cy.findByRole('radio', {
+        name: /^do not notify me of.*hearing reminder.*by text/i,
       })
-        .should('be.checked')
-        .click()
         .should('not.be.checked')
+        .click()
+        .should('be.checked')
         .should('be.disabled');
 
       // we should now see a saving indicator
       cy.findByText(/^Saving/).should('exist');
       // after the PATCH call resolves:
       cy.findByText(/^Saving/).should('not.exist');
-      cy.findByText(/you’ve updated your.*notifications/i).should('exist');
-      cy.findByRole('checkbox', {
-        name: /notify me of.*hearing reminder.*by text/i,
+      cy.findByText(/update saved/i).should('exist');
+      cy.findByRole('radio', {
+        name: /^notify me of.*hearing reminder.*by text/i,
+      }).should('not.be.checked');
+      cy.findByRole('radio', {
+        name: /^do not notify me of.*hearing reminder.*by text/i,
       })
-        .should('not.be.checked')
+        .should('be.checked')
         .should('not.be.disabled');
     });
   });

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/happy-loading-path.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/happy-loading-path.cypress.spec.js
@@ -44,7 +44,7 @@ describe('Notification Settings', () => {
           'match',
           /You can manage your health care email notifications through my healthevet/i,
         );
-      cy.findAllByText(/we do not have a preference/i).should('have.length', 3);
+      cy.findAllByText(/^select an option/i).should('have.length', 3);
     });
   });
   context('when user is not a VA patient', () => {

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/sad-editing-path.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/sad-editing-path.cypress.spec.js
@@ -38,10 +38,13 @@ describe('Updating Notification Settings', () => {
       cy.login(mockPatient);
       cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
 
-      // the checkbox will start off unchecked because of the mocked response
-      // from mockCommunicationPreferences
-      cy.findByRole('checkbox', {
-        name: /notify me of.*hearing reminder.*by email/i,
+      // both radio buttons will start off unchecked because of the mocked
+      // response from mockCommunicationPreferences
+      cy.findByRole('radio', {
+        name: /^do not notify me of.*hearing reminder.*by email/i,
+      }).should('not.be.checked');
+      cy.findByRole('radio', {
+        name: /^notify me of.*hearing reminder.*by email/i,
       })
         .should('not.be.checked')
         .click()
@@ -52,40 +55,47 @@ describe('Updating Notification Settings', () => {
       cy.findByText(/^Saving/).should('exist');
       // after the POST call fails:
       cy.findByText(/^Saving/).should('not.exist');
-      cy.findByText(/you’ve updated your.*notifications/i).should('not.exist');
       cy.findByText(/we’re sorry.*try again/i).should('exist');
-      cy.findByRole('checkbox', {
-        name: /notify me of.*hearing reminder.*by email/i,
+      cy.findByRole('radio', {
+        name: /^notify me of.*hearing reminder.*by email/i,
       })
         .should('not.be.checked')
         .should('not.be.disabled');
     });
 
-    it('should handle 500 error when opting out of getting notifications', () => {
-      cy.login(mockPatient);
-      cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
+    // it('should handle 500 error when opting out of getting notifications', () => {
+    //   cy.login(mockPatient);
+    //   cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
 
-      // the checkbox will start off checked because of the mocked response
-      // from mockCommunicationPreferences
-      cy.findByRole('checkbox', {
-        name: /notify me of.*hearing reminder.*by text/i,
-      })
-        .should('be.checked')
-        .click()
-        .should('not.be.checked')
-        .should('be.disabled');
+    //   // the "notify me" radio button will start off checked because of the
+    //   // mocked response from mockCommunicationPreferences
+    //   cy.findByRole('radio', {
+    //     name: /^notify me of.*hearing reminder.*by text/i,
+    //   }).should('be.checked');
+    //   cy.findByRole('radio', {
+    //     name: /^do not notify me of.*hearing reminder.*by text/i,
+    //   })
+    //     .should('not.be.checked')
+    //     .click()
+    //     .should('be.checked')
+    //     .should('be.disabled');
 
-      // we should now see a saving indicator
-      cy.findByText(/^Saving/).should('exist');
-      // after the PATCH call fails:
-      cy.findByText(/^Saving/).should('not.exist');
-      cy.findByText(/you’ve updated your.*notifications/i).should('not.exist');
-      cy.findByText(/we’re sorry.*try again/i).should('exist');
-      cy.findByRole('checkbox', {
-        name: /notify me of.*hearing reminder.*by text/i,
-      })
-        .should('be.checked')
-        .should('not.be.disabled');
-    });
+    //   // we should now see a saving indicator
+    //   cy.findByText(/^Saving.../).should('exist');
+    //   // after the PATCH call fails:
+    //   cy.findByText(/^Saving/).should('not.exist');
+    //   cy.findByText(/update saved/i).should('not.exist');
+    //   cy.findByText(/we’re sorry.*try again/i).should('exist');
+    //   cy.findByRole('radio', {
+    //     name: /^notify me of.*hearing reminder.*by text/i,
+    //   })
+    //     .should('be.checked')
+    //     .should('not.be.disabled');
+    //   cy.findByRole('radio', {
+    //     name: /^do not notify me of.*hearing reminder.*by text/i,
+    //   })
+    //     .should('not.be.checked')
+    //     .should('not.be.disabled');
+    // });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/sad-editing-path.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/sad-editing-path.cypress.spec.js
@@ -63,39 +63,39 @@ describe('Updating Notification Settings', () => {
         .should('not.be.disabled');
     });
 
-    // it('should handle 500 error when opting out of getting notifications', () => {
-    //   cy.login(mockPatient);
-    //   cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
+    it('should handle 500 error when opting out of getting notifications', () => {
+      cy.login(mockPatient);
+      cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
 
-    //   // the "notify me" radio button will start off checked because of the
-    //   // mocked response from mockCommunicationPreferences
-    //   cy.findByRole('radio', {
-    //     name: /^notify me of.*hearing reminder.*by text/i,
-    //   }).should('be.checked');
-    //   cy.findByRole('radio', {
-    //     name: /^do not notify me of.*hearing reminder.*by text/i,
-    //   })
-    //     .should('not.be.checked')
-    //     .click()
-    //     .should('be.checked')
-    //     .should('be.disabled');
+      // the "notify me" radio button will start off checked because of the
+      // mocked response from mockCommunicationPreferences
+      cy.findByRole('radio', {
+        name: /^notify me of.*hearing reminder.*by text/i,
+      }).should('be.checked');
+      cy.findByRole('radio', {
+        name: /^do not notify me of.*hearing reminder.*by text/i,
+      })
+        .should('not.be.checked')
+        .click()
+        .should('be.checked')
+        .should('be.disabled');
 
-    //   // we should now see a saving indicator
-    //   cy.findByText(/^Saving.../).should('exist');
-    //   // after the PATCH call fails:
-    //   cy.findByText(/^Saving/).should('not.exist');
-    //   cy.findByText(/update saved/i).should('not.exist');
-    //   cy.findByText(/we’re sorry.*try again/i).should('exist');
-    //   cy.findByRole('radio', {
-    //     name: /^notify me of.*hearing reminder.*by text/i,
-    //   })
-    //     .should('be.checked')
-    //     .should('not.be.disabled');
-    //   cy.findByRole('radio', {
-    //     name: /^do not notify me of.*hearing reminder.*by text/i,
-    //   })
-    //     .should('not.be.checked')
-    //     .should('not.be.disabled');
-    // });
+      // we should now see a saving indicator
+      cy.findByText(/^Saving.../).should('exist');
+      // after the PATCH call fails:
+      cy.findByText(/^Saving/).should('not.exist');
+      cy.findByText(/update saved/i).should('not.exist');
+      cy.findByText(/we’re sorry.*try again/i).should('exist');
+      cy.findByRole('radio', {
+        name: /^notify me of.*hearing reminder.*by text/i,
+      })
+        .should('be.checked')
+        .should('not.be.disabled');
+      cy.findByRole('radio', {
+        name: /^do not notify me of.*hearing reminder.*by text/i,
+      })
+        .should('not.be.checked')
+        .should('not.be.disabled');
+    });
   });
 });


### PR DESCRIPTION
## Description
This PR switches from checkboxes to the `NotificationRadioButtons` that @tmitchellgcio built.

I had to update the existing checkbox Cypress tests to look for radio buttons.

Also had to modify how the UI "resets" itself after a failed API call. Checkboxes were easy because we only had to worry about true or false. This new UI needs to account for true, false, or null, and reseting to null after a failed API did not work with the existing logic.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#28502

## Testing done
Cypress + update unit tests

## Screenshots
<img width="914" alt="warning idle" src="https://user-images.githubusercontent.com/20728956/130237791-d2f8a401-aaa5-4e8d-9127-551eaa110d8e.png">
<img width="902" alt="warning saved" src="https://user-images.githubusercontent.com/20728956/130237804-41e6e1b4-2d18-433e-a44f-132a57cf3ae9.png">
<img width="671" alt="warning saving" src="https://user-images.githubusercontent.com/20728956/130237820-e62510c0-a437-4c3d-bb4a-a0b3b3d7522d.png">
<img width="696" alt="warning error idle" src="https://user-images.githubusercontent.com/20728956/130237828-4738591c-1611-47b3-8473-fd716b17b89b.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs