### PR TITLE
Corrected text contrast and updated copy

### DIFF
--- a/src/applications/disability-benefits/disability-rating-calculator/components/DisabilityRatingCalculator.jsx
+++ b/src/applications/disability-benefits/disability-rating-calculator/components/DisabilityRatingCalculator.jsx
@@ -145,10 +145,10 @@ export default class DisabilityRatingCalculator extends React.Component {
             add a description of each for your notes, if you'd like. Then click{' '}
             <strong>Calculate</strong> to get your combined rating.{' '}
             <strong className="vads-u-display--inline small-screen:vads-u-display--none">
-              Disability ratings are given in 10% increments, from 0 to 100.
+              Disability ratings are given in 10% increments, between 0 and 100.
             </strong>
             <span className="vads-u-display--none small-screen:vads-u-display--inline">
-              Disability ratings are given in 10% increments, from 0 to 100.
+              Disability ratings are given in 10% increments, between 0 and 100.
             </span>
           </p>
           <div className="vads-l-grid-container--full">
@@ -158,7 +158,7 @@ export default class DisabilityRatingCalculator extends React.Component {
                 id="ratingLabel"
               >
                 Disability rating
-                <span className="vads-u-color--gray-medium vads-u-display--none small-screen:vads-u-display--block">
+                <span className="vads-u-display--none small-screen:vads-u-display--block">
                   In 10% increments
                 </span>
               </div>


### PR DESCRIPTION
## Description
This changes the hint text color to match the rest of the page as the previous color did not provide enough contrast. We also updated the description text from "from 0 to 100" to "between 0 and 100" to match validation.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/28978
https://github.com/department-of-veterans-affairs/va.gov-team/issues/1045

## Testing done
local

## Screenshots
Mobile:
<img width="422" alt="Screen Shot 2021-08-20 at 11 52 55 AM" src="https://user-images.githubusercontent.com/3144003/130260530-268a75e9-1f76-4958-a830-0ee77011b8d1.png">

Desktop:
<img width="1790" alt="Screen Shot 2021-08-20 at 11 53 05 AM" src="https://user-images.githubusercontent.com/3144003/130260545-6845dbf9-467f-46c3-ac34-fdcf701a3351.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
