### PR TITLE
526: Show wizard when logged in

### DIFF
--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -75,6 +75,7 @@ export const Form526Entry = ({
   savedForms,
 }) => {
   const wizardStatus = sessionStorage.getItem(WIZARD_STATUS);
+  const loggedIn = user.login?.currentlyLoggedIn || false;
 
   const hasSavedForm = savedForms.some(
     form =>
@@ -115,6 +116,7 @@ export const Form526Entry = ({
 
   // showWizard feature flag is initially undefined
   if (
+    loggedIn &&
     showWizard &&
     ((!hasSavedForm && wizardStatus !== WIZARD_STATUS_COMPLETE) ||
       (hasSavedForm && wizardStatus === WIZARD_STATUS_RESTARTING))
@@ -137,7 +139,7 @@ export const Form526Entry = ({
 
   // Not logged in, so show the rendered content. The RoutedSavableApp shows
   // an alert with the sign in button
-  if (!user.login.currentlyLoggedIn) {
+  if (!loggedIn) {
     return wrapWithBreadcrumb(title, content);
   }
   // "add-person" service means the user has a edipi and SSN in the system, but

--- a/src/applications/disability-benefits/all-claims/routes.jsx
+++ b/src/applications/disability-benefits/all-claims/routes.jsx
@@ -1,9 +1,7 @@
 import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/helpers';
-import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
 
 import Form526EZApp from './Form526EZApp';
 import formConfig from './config/form';
-import { WIZARD_STATUS } from './constants';
 import WizardContainer from './containers/WizardContainer';
 
 const routes = [
@@ -15,12 +13,7 @@ const routes = [
     path: '/',
     component: Form526EZApp,
     indexRoute: {
-      onEnter: (nextState, replace) =>
-        replace(
-          sessionStorage.getItem(WIZARD_STATUS) === WIZARD_STATUS_COMPLETE
-            ? '/introduction'
-            : '/start',
-        ),
+      onEnter: (nextState, replace) => replace('/introduction'),
     },
     childRoutes: createRoutesWithSaveInProgress(formConfig),
   },

--- a/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
@@ -262,21 +262,20 @@ describe('Form 526EZ Entry Page', () => {
   });
 
   // Wizard
-  it('should redirect to the wizard when not logged in', () => {
+  it('should not redirect to the wizard when not logged in', () => {
     sessionStorage.removeItem(WIZARD_STATUS);
     const tree = testPage({
       currentlyLoggedIn: false,
     });
-    expect(tree.find('h1').text()).to.contain('restart the app');
+    expect(tree.find('h1').text()).to.contain('Log in');
     tree.unmount();
   });
   it('should redirect to the wizard when logged in', () => {
     localStorage.setItem('hasSession', true);
     sessionStorage.removeItem(WIZARD_STATUS);
     const tree = testPage({
-      currentlyLoggedIn: false,
+      currentlyLoggedIn: true,
     });
-    localStorage.removeItem('hasSession');
     expect(tree.find('h1').text()).to.contain('restart the app');
     tree.unmount();
   });

--- a/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
@@ -30,12 +30,23 @@ describe('<IntroductionPage/>', () => {
         services: ['form526'],
       },
     },
+    loggedIn: true,
   };
 
   it('should render', () => {
     const wrapper = shallow(<IntroductionPage {...defaultProps} />);
     expect(wrapper.length).to.equal(1);
     expect(wrapper.type()).to.equal('div');
+    expect(wrapper.find('#restart-wizard').length).to.equal(1);
+    wrapper.unmount();
+  });
+
+  it('should not render wizard restart when logged out', () => {
+    const wrapper = shallow(
+      <IntroductionPage {...defaultProps} loggedIn={false} />,
+    );
+    expect(wrapper.find('.schemaform-process').length).to.equal(1);
+    expect(wrapper.find('#restart-wizard').length).to.equal(0);
     wrapper.unmount();
   });
 

--- a/src/applications/disability-benefits/all-claims/tests/routes.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/routes.unit.spec.js
@@ -12,12 +12,6 @@ describe('Form 526 routes', () => {
     sessionStorage.removeItem(WIZARD_STATUS);
   });
 
-  it('should redirect from root to /start', () => {
-    const replace = sinon.spy();
-    sessionStorage.removeItem(WIZARD_STATUS);
-    onEnter(null, replace);
-    expect(replace.calledWith('/start')).to.be.true;
-  });
   it('should redirect from the root to /introduction', () => {
     const replace = sinon.spy();
     sessionStorage.setItem(WIZARD_STATUS, WIZARD_STATUS_COMPLETE);

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -1227,23 +1227,19 @@ describe('526 v2 depends functions', () => {
 });
 
 describe('isExpired', () => {
-  const oneDayInSeconds = 24 * 60 * 60;
-  const getDays = days =>
-    moment()
+  const getDays = days => ({
+    expiresAt: moment()
       .add(days, 'days')
-      .format('YYYY-MM-DD');
+      .unix(),
+  });
   it('should return true for dates that are invalid or in the past', () => {
-    const expiredSeconds = Date.now() / 1000 - oneDayInSeconds;
     expect(isExpired('')).to.be.true;
     expect(isExpired(0)).to.be.true;
     expect(isExpired(getDays(-1))).to.be.true;
-    expect(isExpired(expiredSeconds)).to.be.true;
   });
-  it('should return false for dates in the past', () => {
-    const futureSeconds = Date.now() / 1000 + oneDayInSeconds;
+  it('should return false for dates in the future', () => {
     expect(isExpired(getDays(0))).to.be.false;
     expect(isExpired(getDays(1))).to.be.false;
     expect(isExpired(getDays(365))).to.be.false;
-    expect(isExpired(futureSeconds)).to.be.false;
   });
 });

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -1026,13 +1026,12 @@ export const wrapWithBreadcrumb = (title, component) => (
   </>
 );
 
+const today = moment().endOf('day');
 export const isExpired = date => {
   if (!date) {
     return true;
   }
-  const today = moment().endOf('day');
   // expiresAt: Ruby saves as time from Epoch date in seconds (not milliseconds)
-  // we plan to update the expiresAt date to "YYYY-MM-DD" format in the future
-  const expires = moment(isNaN(date) ? date : date * 1000);
+  const expires = moment.unix(date?.expiresAt);
   return !(expires.isValid() && expires.endOf('day').isSameOrAfter(today));
 };


### PR DESCRIPTION
## Description

The wizard for form 526 was previously shown to a Veteran before they logged in, and again after logging in. This change hides the wizard until after the Veteran has logged in.

## Original issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/28711

## Testing done

Updated unit tests

## Screenshots

Wizard restart sentence hidden when logged out

| Logged out |
|-------------|
| ![Screen Shot 2021-08-20 at 2 20 06 PM](https://user-images.githubusercontent.com/136959/130283937-2283c68d-6558-4ac0-85c3-01692f2fafb6.png) |
| Logged in |
|-----------|
| ![Screen Shot 2021-08-20 at 2 22 59 PM](https://user-images.githubusercontent.com/136959/130283933-b7ee51dc-3621-46d9-af06-1ff8aebcfbcc.png) |

## Acceptance criteria
- [x] Hide wizard when the Veteran is not logged in to prevent showing the wizard twice
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
