### PR TITLE
CT: Fix use my location

### DIFF
--- a/src/applications/gi-sandbox/containers/search/LocationSearchResults.jsx
+++ b/src/applications/gi-sandbox/containers/search/LocationSearchResults.jsx
@@ -252,7 +252,7 @@ function LocationSearchResults({
       streetAddress.position.longitude,
       streetAddress.position.latitude,
     ]);
-    markers.current.push(currentMarkerElement);
+    markers.push(currentMarkerElement);
   };
 
   /**


### PR DESCRIPTION
## Description
To reproduce issue

1. Go to Location Tab
2. Click “use my location”
3. Click “search”

When swapping from `useRef` to `useState` missed a usage of `.current`
See screenshot for error

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots

![Screen Shot 2021-08-20 at 3 38 24 PM](https://user-images.githubusercontent.com/1094999/130285282-ce586096-51ae-4863-9e4d-ab30fbcbe98c.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
