### PR TITLE
526: Add validation for activated separation date

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/federalOrders.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/federalOrders.jsx
@@ -3,7 +3,8 @@ import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import dateUI from 'platform/forms-system/src/js/definitions/date';
 import { validateDate } from 'platform/forms-system/src/js/validation';
 
-import { title10DatesRequired, isInFuture, title10BeforeRad } from '../utils';
+import { title10DatesRequired } from '../utils';
+import { title10BeforeRad, isLessThan180DaysInFuture } from '../validations';
 
 const {
   title10Activation,
@@ -29,7 +30,7 @@ export const uiSchema = {
         },
         anticipatedSeparationDate: {
           ...dateUI('Expected separation date'),
-          'ui:validations': [validateDate, isInFuture],
+          'ui:validations': [validateDate, isLessThan180DaysInFuture],
           'ui:required': title10DatesRequired,
         },
       },

--- a/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
@@ -91,6 +91,26 @@ const testConfig = createTestConfig(
         });
       },
 
+      'review-veteran-details/military-service-history/federal-orders': () => {
+        cy.get('@testData').then(data => {
+          cy.fillPage();
+          if (
+            data.serviceInformation.reservesNationalGuardService[
+              'view:isTitle10Activated'
+            ]
+          ) {
+            // active title 10 activation puts this into BDD flow
+            cy.get('select[name$="SeparationDateMonth"]').select(
+              todayPlus120[1],
+            );
+            cy.get('select[name$="SeparationDateDay"]').select(todayPlus120[2]);
+            cy.get('input[name$="SeparationDateYear"]')
+              .clear()
+              .type(todayPlus120[0]);
+          }
+        });
+      },
+
       'review-veteran-details/separation-location': () => {
         cy.get('@testData').then(data => {
           cy.get(

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-test.json
@@ -239,11 +239,7 @@
     "view:disabilitiesClarification": {},
     "serviceInformation": {
       "reservesNationalGuardService": {
-        "view:isTitle10Activated": true,
-        "title10Activation": {
-          "title10ActivationDate": "2015-01-01",
-          "anticipatedSeparationDate": "2120-01-01"
-        },
+        "view:isTitle10Activated": false,
         "obligationTermOfServiceDateRange": {
           "from": "2007-05-22",
           "to": "2008-06-05"

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/secondary-new-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/secondary-new-test.json
@@ -184,11 +184,7 @@
     "view:disabilitiesClarification": {},
     "serviceInformation": {
       "reservesNationalGuardService": {
-        "view:isTitle10Activated": true,
-        "title10Activation": {
-          "title10ActivationDate": "2015-01-01",
-          "anticipatedSeparationDate": "2120-01-01"
-        },
+        "view:isTitle10Activated": false,
         "obligationTermOfServiceDateRange": {
           "from": "2007-05-22",
           "to": "2008-06-05"

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/maximal-test.json
@@ -90,10 +90,6 @@
     ],
     "serviceInformation": {
       "reservesNationalGuardService": {
-        "title10Activation": {
-          "title10ActivationDate": "2015-01-01",
-          "anticipatedSeparationDate": "2120-01-01"
-        },
         "obligationTermOfServiceDateRange": {
           "from": "2007-05-22",
           "to": "2008-06-05"

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/secondary-new-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/secondary-new-test.json
@@ -70,10 +70,6 @@
     ],
     "serviceInformation": {
       "reservesNationalGuardService": {
-        "title10Activation": {
-          "title10ActivationDate": "2015-01-01",
-          "anticipatedSeparationDate": "2120-01-01"
-        },
         "obligationTermOfServiceDateRange": {
           "from": "2007-05-22",
           "to": "2008-06-05"

--- a/src/applications/disability-benefits/all-claims/tests/pages/federalOrders.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/federalOrders.unit.spec.jsx
@@ -99,7 +99,7 @@ describe('Federal orders info', () => {
       form,
       'root_serviceInformation_reservesNationalGuardService_title10Activation_anticipatedSeparationDate',
       moment()
-        .add(1, 'year')
+        .add(160, 'days') // < 180 days
         .format('YYYY-MM-DD'),
     );
 
@@ -130,14 +130,52 @@ describe('Federal orders info', () => {
       form,
       'root_serviceInformation_reservesNationalGuardService_title10Activation_title10ActivationDate',
       moment()
-        .add(11, 'months')
+        .add(100, 'days')
         .format('YYYY-MM-DD'),
     );
     fillDate(
       form,
       'root_serviceInformation_reservesNationalGuardService_title10Activation_anticipatedSeparationDate',
       moment()
-        .add(10, 'months')
+        .add(90, 'days')
+        .format('YYYY-MM-DD'),
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error-message').length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
+    form.unmount();
+  });
+  it('should fail to submit when separation date is > 180 days in the future', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    selectRadio(
+      form,
+      'root_serviceInformation_reservesNationalGuardService_view:isTitle10Activated',
+      'Y',
+    );
+    fillDate(
+      form,
+      'root_serviceInformation_reservesNationalGuardService_title10Activation_title10ActivationDate',
+      moment()
+        .add(-10, 'days')
+        .format('YYYY-MM-DD'),
+    );
+    fillDate(
+      form,
+      'root_serviceInformation_reservesNationalGuardService_title10Activation_anticipatedSeparationDate',
+      moment()
+        .add(190, 'days')
         .format('YYYY-MM-DD'),
     );
 

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -1,4 +1,3 @@
-import sinon from 'sinon';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import moment from 'moment';
@@ -21,7 +20,6 @@ import {
   increaseOnly,
   isAnswering781aQuestions,
   isAnswering781Questions,
-  isInFuture,
   isUploading781aForm,
   isUploading781aSupportingDocuments,
   isUploading781Form,
@@ -146,26 +144,6 @@ describe('526 helpers', () => {
       };
 
       expect(ReservesGuardDescription(form)).to.equal(null);
-    });
-  });
-
-  describe('isInFuture', () => {
-    it('adds an error when entered date is today or earlier', () => {
-      const addError = sinon.spy();
-      const errors = { addError };
-      const fieldData = '2018-04-12';
-
-      isInFuture(errors, fieldData);
-      expect(addError.calledOnce).to.be.true;
-    });
-
-    it('does not add an error when the entered date is in the future', () => {
-      const addError = sinon.spy();
-      const errors = { addError };
-      const fieldData = '2099-04-12';
-
-      isInFuture(errors, fieldData);
-      expect(addError.callCount).to.equal(0);
     });
   });
 

--- a/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
@@ -12,6 +12,9 @@ import {
   validateBooleanGroup,
   validateAge,
   validateSeparationDate,
+  isInFuture,
+  isLessThan180DaysInFuture,
+  title10BeforeRad,
 } from '../validations';
 
 import disabilityLabels from '../content/disabilityLabels';
@@ -531,6 +534,83 @@ describe('526 All Claims validations', () => {
       );
 
       expect(errors.addError.called).to.be.false;
+    });
+  });
+
+  describe('isInFuture', () => {
+    it('adds an error when entered date is today or earlier', () => {
+      const addError = sinon.spy();
+      const errors = { addError };
+      const fieldData = '2018-04-12';
+
+      isInFuture(errors, fieldData);
+      expect(addError.calledOnce).to.be.true;
+    });
+
+    it('does not add an error when the entered date is in the future', () => {
+      const addError = sinon.spy();
+      const errors = { addError };
+      const fieldData = '2099-04-12';
+
+      isInFuture(errors, fieldData);
+      expect(addError.callCount).to.equal(0);
+    });
+  });
+
+  describe('isLessThan180DaysInFuture', () => {
+    it('adds an error when date is > 180 days in the future', () => {
+      const addError = sinon.spy();
+      const errors = { addError };
+      const fieldData = daysFromToday(190);
+
+      isLessThan180DaysInFuture(errors, fieldData);
+      expect(addError.calledOnce).to.be.true;
+    });
+
+    it('does not add an error when the entered date is < 180 days in the future', () => {
+      const addError = sinon.spy();
+      const errors = { addError };
+      const fieldData = daysFromToday(170);
+
+      isLessThan180DaysInFuture(errors, fieldData);
+      expect(addError.callCount).to.equal(0);
+    });
+  });
+
+  describe('title10BeforeRad', () => {
+    const getErrors = addError => ({
+      reservesNationalGuardService: {
+        title10Activation: {
+          anticipatedSeparationDate: {
+            addError,
+          },
+        },
+      },
+    });
+    const getData = (start, end) => ({
+      reservesNationalGuardService: {
+        title10Activation: {
+          title10ActivationDate: daysFromToday(start),
+          anticipatedSeparationDate: daysFromToday(end),
+        },
+      },
+    });
+    it('adds an error when date is > 180 days in the future', () => {
+      const addError = sinon.spy();
+      const errors = getErrors(addError);
+      const fieldData = getData(150, 140);
+
+      title10BeforeRad(errors, fieldData);
+      expect(addError.calledOnce).to.be.true;
+    });
+
+    it('does not add an error when the entered date is < 180 days in the future', () => {
+      const addError = sinon.spy();
+      const errors = getErrors(addError);
+      const fieldData = getData(140, 150);
+
+      title10BeforeRad(errors, fieldData);
+      expect(addError.callCount).to.equal(0);
     });
   });
 });

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -202,27 +202,6 @@ export const title10DatesRequired = formData =>
     false,
   );
 
-export const isInFuture = (errors, fieldData) => {
-  const enteredDate = new Date(fieldData);
-  if (enteredDate < Date.now()) {
-    errors.addError('Expected separation date must be in the future');
-  }
-};
-
-export const title10BeforeRad = (errors, pageData) => {
-  const { anticipatedSeparationDate, title10ActivationDate } =
-    pageData?.reservesNationalGuardService?.title10Activation || {};
-
-  const rad = moment(anticipatedSeparationDate);
-  const activation = moment(title10ActivationDate);
-
-  if (rad.isValid() && activation.isValid() && rad.isBefore(activation)) {
-    errors.reservesNationalGuardService.title10Activation.anticipatedSeparationDate.addError(
-      'Please enter an expected separation date that is after your activation date',
-    );
-  }
-};
-
 const capitalizeWord = word => {
   const capFirstLetter = word[0].toUpperCase();
   return `${capFirstLetter}${word.slice(1)}`;

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -178,6 +178,34 @@ export const isInFuture = (err, fieldData) => {
   }
 };
 
+export const isLessThan180DaysInFuture = (errors, fieldData) => {
+  const enteredDate = moment(fieldData);
+  const in180Days = moment().add(180, 'days');
+  if (enteredDate.isValid()) {
+    if (enteredDate.isBefore()) {
+      errors.addError('Please enter a future separation date');
+    } else if (enteredDate.isSameOrAfter(in180Days)) {
+      errors.addError(
+        'Please enter a separation date less than 180 days in the future',
+      );
+    }
+  }
+};
+
+export const title10BeforeRad = (errors, pageData) => {
+  const { anticipatedSeparationDate, title10ActivationDate } =
+    pageData?.reservesNationalGuardService?.title10Activation || {};
+
+  const rad = moment(anticipatedSeparationDate);
+  const activation = moment(title10ActivationDate);
+
+  if (rad.isValid() && activation.isValid() && rad.isBefore(activation)) {
+    errors.reservesNationalGuardService.title10Activation.anticipatedSeparationDate.addError(
+      'Please enter an expected separation date that is after your activation date',
+    );
+  }
+};
+
 export const isValidYear = (err, fieldData) => {
   const parsedInt = Number.parseInt(fieldData, 10);
 


### PR DESCRIPTION
## Description

Add validation to `anticipatedSeparationDate` for title 10 activated guard/reservist. This date can’t be more than 180 days in the future.

Also moved validation functions out of `utils` file & into `validations` file

## Original issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/29013

## Testing done

Updated unit tests

## Screenshots

<details><summary>Not in future error</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-08-20 at 4 09 28 PM](https://user-images.githubusercontent.com/136959/130293596-0f482a01-77ca-42f5-ae50-65b3e047affb.png)</details>

<details><summary>Activation before separation error</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-08-20 at 4 09 06 PM](https://user-images.githubusercontent.com/136959/130293599-118965f4-bd81-491b-9f78-abc6249d7b66.png)</details>

<details><summary>Separation > 180 days in future</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-08-20 at 4 08 34 PM](https://user-images.githubusercontent.com/136959/130293601-0655ce79-3d64-48ba-b6e4-58955b3540e9.png)</details>

## Acceptance criteria
- [x] Add validation for separation dates > 180 days in the future
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
