### PR TITLE
Update platform data functions

### DIFF
--- a/src/platform/utilities/data/clone.js
+++ b/src/platform/utilities/data/clone.js
@@ -16,6 +16,8 @@ export default function clone(object) {
     }
     // Probably just ye olde object
     return Object.assign({}, object);
+  } else if (typeof object === 'undefined') {
+    return {};
   }
   throw new Error(`Unknown type in clone: ${typeof object}`);
   /* eslint-enable no-prototype-builtins */

--- a/src/platform/utilities/data/clone.js
+++ b/src/platform/utilities/data/clone.js
@@ -17,7 +17,7 @@ export default function clone(object) {
     // Probably just ye olde object
     return Object.assign({}, object);
   } else if (typeof object === 'undefined') {
-    return {};
+    return undefined;
   }
   throw new Error(`Unknown type in clone: ${typeof object}`);
   /* eslint-enable no-prototype-builtins */

--- a/src/platform/utilities/data/omit.js
+++ b/src/platform/utilities/data/omit.js
@@ -4,7 +4,7 @@
  * @param {Array} fields
  * @param {Object} object
  */
-export default function omit(fields, object) {
+export default function omit(fields, object = {}) {
   let fieldOmitted = false;
 
   const withOmittedFields = Object.keys(object).reduce((newObj, k) => {

--- a/src/platform/utilities/data/set.js
+++ b/src/platform/utilities/data/set.js
@@ -23,7 +23,7 @@ function baseSet(arrayPath, value, object, level = 0) {
     return value;
   }
 
-  const newObj = clone(object);
+  const newObj = clone(object) || {};
 
   const pathSegment = arrayPath[level];
   const nextPathSegment = arrayPath[level + 1];

--- a/src/platform/utilities/data/set.js
+++ b/src/platform/utilities/data/set.js
@@ -23,7 +23,7 @@ function baseSet(arrayPath, value, object, level = 0) {
     return value;
   }
 
-  const newObj = clone(object) || {};
+  const newObj = clone(object);
 
   const pathSegment = arrayPath[level];
   const nextPathSegment = arrayPath[level + 1];
@@ -69,7 +69,7 @@ function baseSet(arrayPath, value, object, level = 0) {
  * @param {Object} object
  * @return {Object} A new object with the appropriate value set
  */
-export default function set(path, value, object) {
+export default function set(path, value, object = {}) {
   const arrayPath = Array.isArray(path) ? path : deconstructPath(path);
   checkValidPath(arrayPath);
   return baseSet(arrayPath, value, object, 0);

--- a/src/platform/utilities/data/unset.js
+++ b/src/platform/utilities/data/unset.js
@@ -41,7 +41,7 @@ function baseUnset(arrayPath, object, level = 0) {
  * @param {Object} object
  * @return {Object} A new object with the appropriate value removed
  */
-export default function unset(path, object) {
+export default function unset(path, object = {}) {
   const arrayPath = Array.isArray(path) ? path : deconstructPath(path);
   checkValidPath(arrayPath);
   return baseUnset(arrayPath, object, 0);


### PR DESCRIPTION
## Description
The platform data function `clone` is used in a few other data functions, like `set` and `unset`. The `lodash/fp` version of these functions use an empty object when the `object` argument is `undefined`, whereas our platform functions do not. This is causing issues when converting some instances of the `lodash/fp`'s `set` to our platform `set` function. 

For example:
```javascript
_.set('a', true, undefined)
// => { a: true }

_.unset('a', undefined)
// => {}
```
The example above is the behavior of `lodash/fp`. Our platform `set` and `unset` functions throw errors in the cases above because `undefined` isn't handled in them. This PR updates `clone`, `set`, and `unset` to use an empty object when the `object` is `undefined`. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#1678


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
