### PR TITLE
NOD: Make address optional if homeless

### DIFF
--- a/src/applications/appeals/10182/components/ContactInformation.jsx
+++ b/src/applications/appeals/10182/components/ContactInformation.jsx
@@ -13,14 +13,14 @@ import { selectProfile } from '~/platform/user/selectors';
 
 import { readableList } from '../utils/helpers';
 
-export const ContactInfoDescription = ({ formContext, profile }) => {
+export const ContactInfoDescription = ({ formContext, profile, homeless }) => {
   const [hadError, setHadError] = useState(false);
 
   /* use vapContactInfo because it comes directly from the profile. We're using
    * VAP components to render the information along with an edit button. Editing
    * and updating will refresh the store user > profile > vapContactInfo. Once
    * that is done, the FormApp outer wrapper _should_ automatically update the
-   * formData.veteran for email, phone & address - the validation functio then
+   * formData.veteran for email, phone & address - the validation function then
    * checks for these values and prevents or allows advancement in the form -
    * this is convoluted but it's the only way to block the form system continue
    * button to prevent continuing on in the form when we're missing essential
@@ -31,10 +31,13 @@ export const ContactInfoDescription = ({ formContext, profile }) => {
     profile?.vapContactInfo || {};
   const { submitted } = formContext || {};
 
+  // Don't require an address if the Veteran is homeless
+  const requireAddress = homeless ? '' : 'address';
+
   const missingInfo = [
     email?.emailAddress ? '' : 'email',
     mobilePhone?.phoneNumber ? '' : 'phone',
-    mailingAddress.addressLine1 ? '' : 'address',
+    mailingAddress.addressLine1 ? '' : requireAddress,
   ].filter(Boolean);
 
   const list = readableList(missingInfo);
@@ -160,9 +163,11 @@ ContactInfoDescription.propTypes = {
       }),
     }),
   }).isRequired,
+  homeless: PropTypes.bool,
 };
 
 const mapStateToProps = state => ({
+  homeless: state.form.data.homeless,
   profile: selectProfile(state),
 });
 

--- a/src/applications/appeals/10182/config/form.js
+++ b/src/applications/appeals/10182/config/form.js
@@ -101,21 +101,17 @@ const formConfig = {
           schema: veteranInfo.schema,
           // initialData,
         },
-        contactInformation: {
-          title: 'Contact information',
-          path: 'contact-information',
-          uiSchema: contactInfo.uiSchema,
-          schema: contactInfo.schema,
-          initialData: {
-            // stop the mobile phone modal from showing SMS checkbox inline
-            'view:showSMSCheckbox': false,
-          },
-        },
         homeless: {
           title: 'Homelessness question',
           path: 'homeless',
           uiSchema: homeless.uiSchema,
           schema: homeless.schema,
+        },
+        contactInformation: {
+          title: 'Contact information',
+          path: 'contact-information',
+          uiSchema: contactInfo.uiSchema,
+          schema: contactInfo.schema,
         },
       },
     },

--- a/src/applications/appeals/10182/tests/components/ContactInformation.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/ContactInformation.unit.spec.jsx
@@ -9,6 +9,7 @@ const getData = ({
   mobile = true,
   address = true,
   submitted = false,
+  homeless = false,
 } = {}) => {
   const data = {};
   if (email) {
@@ -38,6 +39,7 @@ const getData = ({
   return {
     formContext: { submitted },
     profile: { vapContactInfo: data },
+    homeless,
   };
 };
 
@@ -76,6 +78,23 @@ describe('Veteran information review content', () => {
     expect(text).to.contain('Your email, phone and address are missing');
     tree.unmount();
   });
+  it('should render note about missing address if not homeless', () => {
+    const data = getData({ email: false, address: false, homeless: false });
+    const tree = shallow(<ContactInfoDescription {...data} />);
+    const text = tree.find('va-alert').text();
+
+    expect(text).to.contain('Your email and address are missing');
+    tree.unmount();
+  });
+  it('should should not include missing address if homeless', () => {
+    const data = getData({ email: false, address: false, homeless: true });
+    const tree = shallow(<ContactInfoDescription {...data} />);
+    const text = tree.find('va-alert').text();
+
+    expect(text).to.contain('Your email is missing');
+    tree.unmount();
+  });
+
   it('should render an error if info is not actually updated', () => {
     const data = getData({
       submitted: false,

--- a/src/applications/appeals/10182/tests/validations.unit.spec.js
+++ b/src/applications/appeals/10182/tests/validations.unit.spec.js
@@ -164,12 +164,18 @@ describe('validateDate & isValidDate', () => {
 });
 
 describe('contactInfoValidation', () => {
-  const getData = ({ email = true, phone = true, address = true } = {}) => ({
+  const getData = ({
+    email = true,
+    phone = true,
+    address = true,
+    homeless = false,
+  } = {}) => ({
     veteran: {
       email: email ? 'placeholder' : '',
       phone: phone ? { phoneNumber: 'placeholder' } : {},
       address: address ? { addressLine1: 'placeholder' } : {},
     },
+    homeless,
   });
   it('should not show an error when data is available', () => {
     const addError = sinon.spy();
@@ -204,6 +210,15 @@ describe('contactInfoValidation', () => {
     expect(addError.firstCall.args[0]).to.contain('add an email');
     expect(addError.secondCall.args[0]).to.contain('add a phone');
     expect(addError.thirdCall.args[0]).to.contain('add an address');
+  });
+  it('should not include address when homeless is true', () => {
+    const addError = sinon.spy();
+    contactInfoValidation(
+      { addError },
+      null,
+      getData({ address: false, homeless: true }),
+    );
+    expect(addError.called).to.be.false;
   });
 });
 

--- a/src/applications/appeals/10182/validations.js
+++ b/src/applications/appeals/10182/validations.js
@@ -79,14 +79,14 @@ export const isValidDate = dateString => {
 };
 
 export const contactInfoValidation = (errors, _fieldData, formData) => {
-  const { veteran = {} } = formData;
+  const { veteran = {}, homeless } = formData;
   if (!veteran.email) {
     errors.addError('Please add an email address to your profile');
   }
   if (!veteran.phone?.phoneNumber) {
     errors.addError('Please add a phone number to your profile');
   }
-  if (!veteran.address?.addressLine1) {
+  if (!homeless && !veteran.address?.addressLine1) {
     errors.addError('Please add an address to your profile');
   }
 };


### PR DESCRIPTION
## Description

A recent update to the NOD schema made the address required if the Veteran selects the choice that they are not homeless. The address is not required if they are homeless.

## Original issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/29015

## Testing done

Updated unit tests

## Screenshots

N/A - no visual change, only a flow change.

## Acceptance criteria
- [x] Set address requirement dynamically based on answer to homeless question
- [x] Update unit tests
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
