### PR TITLE
Stop blocking Direct Deposit on prod

### DIFF
--- a/src/applications/personalization/profile/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile/components/ProfileWrapper.jsx
@@ -4,18 +4,13 @@ import PropTypes from 'prop-types';
 import { useLocation } from 'react-router-dom';
 import { isEmpty } from 'lodash';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
-import Telephone, {
-  CONTACTS,
-  PATTERNS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
 import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
 
 import { selectProfile } from '~/platform/user/selectors';
-import environment from '~/platform/utilities/environment';
 
 import {
-  // cnpDirectDepositLoadError,
-  // eduDirectDepositLoadError,
+  cnpDirectDepositLoadError,
+  eduDirectDepositLoadError,
   fullNameLoadError,
   militaryInformationLoadError,
   personalInformationLoadError,
@@ -103,47 +98,6 @@ const ProfileWrapper = ({
           </div>
           <div className="vads-l-col--12 vads-u-padding-bottom--4 vads-u-padding-x--1 medium-screen:vads-l-col--9 medium-screen:vads-u-padding-x--2 medium-screen:vads-u-padding-bottom--6 small-desktop-screen:vads-l-col--8">
             {showNotAllDataAvailableError && <NotAllDataAvailableError />}
-            {environment.isProduction() ? (
-              <AlertBox
-                status="warning"
-                isVisible
-                headline="Direct deposit isn’t available right now"
-                content={
-                  <>
-                    <p>
-                      We’re sorry. Direct deposit isn’t available right now.
-                      We’re working to fix the issue as soon as possible. Please
-                      check back after 5 p.m. ET, Monday, August 23 for an
-                      update.
-                    </p>
-                    <h4>What you can do</h4>
-                    <p>
-                      If you have questions or concerns related to your direct
-                      deposit, call us at{' '}
-                      <a
-                        href="tel:1-800-827-1000"
-                        aria-label="800. 8 2 7. 1000."
-                        title="Dial the telephone number 800-827-1000"
-                        className="no-wrap"
-                      >
-                        800-827-1000
-                      </a>{' '}
-                      (TTY:{' '}
-                      <Telephone
-                        contact={CONTACTS['711']}
-                        pattern={PATTERNS['911']}
-                      />
-                      ). We’re here Monday through Friday, 8:00 a.m. to 9:00
-                      p.m. ET. Or go to your{' '}
-                      <a href="/find-locations/?facilityType=benefits">
-                        nearest VA regional office
-                      </a>
-                      .
-                    </p>
-                  </>
-                }
-              />
-            ) : null}
             {/* children will be passed in from React Router one level up */}
             {children}
           </div>
@@ -165,8 +119,8 @@ const mapStateToProps = (state, ownProps) => {
     totalDisabilityRatingServerError: hasTotalDisabilityServerError(state),
     showNameTag: ownProps.isLOA3 && isEmpty(hero?.errors),
     showNotAllDataAvailableError:
-      // !!cnpDirectDepositLoadError(state) ||
-      // !!eduDirectDepositLoadError(state) ||
+      !!cnpDirectDepositLoadError(state) ||
+      !!eduDirectDepositLoadError(state) ||
       !!fullNameLoadError(state) ||
       !!personalInformationLoadError(state) ||
       (!!militaryInformationLoadError(state) && !invalidVeteranStatus),

--- a/src/applications/personalization/profile/components/direct-deposit/DirectDeposit.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/DirectDeposit.jsx
@@ -4,10 +4,6 @@ import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 import AlertBox, {
   ALERT_TYPE,
 } from '@department-of-veterans-affairs/component-library/AlertBox';
-import Telephone, {
-  CONTACTS,
-  PATTERNS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
 
 import DowntimeNotification, {
   externalServices,
@@ -17,7 +13,6 @@ import {
   isMultifactorEnabled,
 } from '~/platform/user/selectors';
 import { signInServiceName as signInServiceNameSelector } from '~/platform/user/authentication/selectors';
-import environment from '~/platform/utilities/environment';
 import { focusElement } from '~/platform/utilities/ui';
 import { usePrevious } from '~/platform/utilities/react-hooks';
 
@@ -138,89 +133,46 @@ const DirectDeposit = ({ cnpUiState, eduUiState, isVerifiedUser }) => {
   return (
     <>
       <Headline>Direct deposit information</Headline>
-      {environment.isProduction() ? (
-        <AlertBox
-          status="warning"
-          isVisible
-          headline="Direct deposit isn’t available right now"
-          content={
-            <>
-              <p>
-                We’re sorry. Direct deposit isn’t available right now. We’re
-                working to fix the issue as soon as possible. Please check back
-                after 5 p.m. ET, Monday, August 23 for an update.
-              </p>
-              <h4>What you can do</h4>
-              <p>
-                If you have questions or concerns related to your direct
-                deposit, call us at{' '}
-                <a
-                  href="tel:1-800-827-1000"
-                  aria-label="800. 8 2 7. 1000."
-                  title="Dial the telephone number 800-827-1000"
-                  className="no-wrap"
-                >
-                  800-827-1000
-                </a>{' '}
-                (TTY:{' '}
-                <Telephone
-                  contact={CONTACTS['711']}
-                  pattern={PATTERNS['911']}
-                />
-                ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
-                Or go to your{' '}
-                <a href="/find-locations/?facilityType=benefits">
-                  nearest VA regional office
-                </a>
-                .
-              </p>
-            </>
-          }
-        />
-      ) : (
-        <>
-          <div id="success" role="alert" aria-atomic="true">
-            <ReactCSSTransitionGroup
-              transitionName="form-expanding-group-inner"
-              transitionAppear
-              transitionAppearTimeout={bankInfoUpdatedAlertSettings.FADE_SPEED}
-              transitionEnterTimeout={bankInfoUpdatedAlertSettings.FADE_SPEED}
-              transitionLeaveTimeout={bankInfoUpdatedAlertSettings.FADE_SPEED}
-            >
-              {!!recentlySavedBankInfo && (
-                <div data-testid="bankInfoUpdateSuccessAlert">
-                  <AlertBox
-                    status={ALERT_TYPE.SUCCESS}
-                    backgroundOnly
-                    className="vads-u-margin-top--0 vads-u-margin-bottom--2"
-                    scrollOnShow
-                  >
-                    <SuccessMessage benefit={recentlySavedBankInfo} />
-                  </AlertBox>
-                </div>
-              )}
-            </ReactCSSTransitionGroup>
-          </div>
+      <div id="success" role="alert" aria-atomic="true">
+        <ReactCSSTransitionGroup
+          transitionName="form-expanding-group-inner"
+          transitionAppear
+          transitionAppearTimeout={bankInfoUpdatedAlertSettings.FADE_SPEED}
+          transitionEnterTimeout={bankInfoUpdatedAlertSettings.FADE_SPEED}
+          transitionLeaveTimeout={bankInfoUpdatedAlertSettings.FADE_SPEED}
+        >
+          {!!recentlySavedBankInfo && (
+            <div data-testid="bankInfoUpdateSuccessAlert">
+              <AlertBox
+                status={ALERT_TYPE.SUCCESS}
+                backgroundOnly
+                className="vads-u-margin-top--0 vads-u-margin-bottom--2"
+                scrollOnShow
+              >
+                <SuccessMessage benefit={recentlySavedBankInfo} />
+              </AlertBox>
+            </div>
+          )}
+        </ReactCSSTransitionGroup>
+      </div>
 
-          {showSetUp2FactorAuthentication && <SetUpVerifiedIDMeAlert />}
-          {!showSetUp2FactorAuthentication && (
-            <DowntimeNotification
-              appTitle="direct deposit"
-              render={handleDowntimeForSection(
-                'direct deposit for compensation and pension',
-              )}
-              dependencies={[externalServices.evss]}
-            >
-              <BankInfoCNP />
-            </DowntimeNotification>
+      {showSetUp2FactorAuthentication && <SetUpVerifiedIDMeAlert />}
+      {!showSetUp2FactorAuthentication && (
+        <DowntimeNotification
+          appTitle="direct deposit"
+          render={handleDowntimeForSection(
+            'direct deposit for compensation and pension',
           )}
-          <FraudVictimAlert status={ALERT_TYPE.INFO} />
-          {!showSetUp2FactorAuthentication && (
-            <>
-              <BankInfoEDU />
-              <PaymentHistory />
-            </>
-          )}
+          dependencies={[externalServices.evss]}
+        >
+          <BankInfoCNP />
+        </DowntimeNotification>
+      )}
+      <FraudVictimAlert status={ALERT_TYPE.INFO} />
+      {!showSetUp2FactorAuthentication && (
+        <>
+          <BankInfoEDU />
+          <PaymentHistory />
         </>
       )}
     </>

--- a/src/applications/personalization/profile/tests/components/alerts/Profile.data-unavailable-error.unit.spec.js
+++ b/src/applications/personalization/profile/tests/components/alerts/Profile.data-unavailable-error.unit.spec.js
@@ -36,6 +36,9 @@ function createBasicInitialState() {
           current: 3,
           highest: 3,
         },
+        signIn: {
+          serviceName: 'idme',
+        },
         vapContactInfo: {},
         multifactor: true,
         services: ['evss-claims', 'user-profile', 'vet360'],
@@ -193,7 +196,7 @@ describe('Profile "Not all data available" error', () => {
     await errorAppearsOnAllPages();
   });
 
-  it.skip('should be shown on all pages if there is an error with the DD4CNP `GET payment_information` endpoint`', async () => {
+  it('should be shown on all pages if there is an error with the DD4CNP `GET payment_information` endpoint`', async () => {
     server.use(...mocks.getDD4CNPFailure);
 
     // don't check for the error on the direct deposit page since that page is unavailable when the `GET payment_information` endpoint fails
@@ -204,7 +207,7 @@ describe('Profile "Not all data available" error', () => {
     ]);
   });
 
-  it.skip('should be shown on all pages if there is an error with the DD4EDU `GET ch33_bank_accounts` endpoint`', async () => {
+  it('should be shown on all pages if there is an error with the DD4EDU `GET ch33_bank_accounts` endpoint`', async () => {
     server.use(...mocks.getDD4EDUFailure);
 
     // don't check for the error on the direct deposit page since that page is unavailable when the `GET payment_information` endpoint fails

--- a/src/applications/personalization/profile/tests/e2e/direct-deposit/gating.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/direct-deposit/gating.cypress.spec.js
@@ -63,7 +63,7 @@ function confirmDirectDepositIsBlocked() {
   );
 }
 
-describe.skip('Direct Deposit section', () => {
+describe('Direct Deposit section', () => {
   let getPaymentInfoStub;
   beforeEach(() => {
     getPaymentInfoStub = cy.stub();

--- a/src/applications/personalization/profile/tests/e2e/direct-deposit/non-verified-idme.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/direct-deposit/non-verified-idme.cypress.spec.js
@@ -25,7 +25,7 @@ function directDepositAPIsNotCalled() {
   });
 }
 
-describe.skip('Direct Deposit', () => {
+describe('Direct Deposit', () => {
   beforeEach(() => {
     // explicitly mock all required APIs to be 500s to speed up the tests
     mockGETEndpoints([

--- a/src/applications/personalization/profile/tests/e2e/direct-deposit/update-flow.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/direct-deposit/update-flow.cypress.spec.js
@@ -60,7 +60,7 @@ function saveSuccessAlertRemoved() {
   cy.findByTestId('bankInfoUpdateSuccessAlert').should('not.exist');
 }
 
-describe.skip('Direct Deposit', () => {
+describe('Direct Deposit', () => {
   beforeEach(() => {
     cy.login(mockUserInEVSS);
     cy.intercept('GET', 'v0/ppiu/payment_information', mockDD4CNPNotEnrolled);

--- a/src/applications/personalization/profile/tests/e2e/profile.mpi-error.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile.mpi-error.cypress.spec.js
@@ -61,10 +61,10 @@ describe('When user is LOA3 with 2FA turned on but we cannot connect to MPI', ()
       'v0/feature_toggles*',
     ]);
   });
-  it.skip('should only have access to the Account Security section at desktop size', () => {
+  it('should only have access to the Account Security section at desktop size', () => {
     test();
   });
-  it.skip('should only have access to the Account Security section at mobile size', () => {
+  it('should only have access to the Account Security section at mobile size', () => {
     test(true);
   });
 });


### PR DESCRIPTION
[We are still waiting for final alert copy that will be posted here.](https://github.com/department-of-veterans-affairs/va.gov-team/issues/28986)

## Description
- Verified ID.me users (LOA3 + 2FA) will have access to direct deposit as before.
- All other users will be shown an alert on the Direct Deposit page informing them that they need to call the help desk or use a verified ID.me account to view and edit their direct deposit info.

All changes made with PR 18347 will now be applied to prod.
This PR reverts the changes made in PR 18259 that completely blocked Direct Deposit on prod.


## Original issue(s)
department-of-veterans-affairs/va.gov-team#28904

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs