### PR TITLE
Changed incorrect omb date to 01/31/2022 on FT

### DIFF
--- a/src/applications/edu-benefits/feedback-tool/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/feedback-tool/containers/IntroductionPage.jsx
@@ -109,7 +109,7 @@ class IntroductionPage extends React.Component {
               expDate="12/31/2018"
             />
           ) : (
-            <OMBInfo resBurden={15} ombNumber="2900-0797" expDate="12/31/2018">
+            <OMBInfo resBurden={15} ombNumber="2900-0797" expDate="01/31/2022">
               <EducationModalContent resBurden={15} ombNumber="2900-0797" />
             </OMBInfo>
           )}


### PR DESCRIPTION
## Description
Changed incorrect omb date on introduction page of the FT to correct date. Date was changed outside of the the scope of prod to not affect the production environment.

## Original issue(s)
Feedback Tool: Incorrect OMB date #29085

## Testing done
Visual confirmation in the local environment show that the date has expiration date has been changed to the correct one.

## Screenshots
<img width="596" alt="29085 staging fix" src="https://user-images.githubusercontent.com/86262790/130636535-2925f465-9751-4ab2-a806-3eaebbebae37.png">

## Acceptance criteria
- [ ] The correct date of 12/31/2018 is no longer displayed in staging.

## Definition of done
- [ ] The correct date of 01/31/2022 is displayed.
