### PR TITLE
Update direct deposit alert shown to non-ID.me users

### DIFF
--- a/src/applications/personalization/profile/components/alerts/SetUpVerifiedIDMeAlert.jsx
+++ b/src/applications/personalization/profile/components/alerts/SetUpVerifiedIDMeAlert.jsx
@@ -12,23 +12,24 @@ const SetUpVerifiedIDMeAlert = () => {
   return (
     <AlertBox
       className="vads-u-margin-bottom--2"
-      headline="You’ll need to verify your account to edit direct deposit information online."
+      headline="You’ll need to verify your identity with ID.me to update any of your direct deposit information online"
       level={2}
       content={
         <>
           <p>
-            We require this to help protect your bank account information and
-            prevent fraud.
+            We require this to protect your bank account information and prevent
+            fraud.
           </p>
-          <h3 className="vads-u-font-size--h4">What you can do</h3>
           <p>
-            If you have questions or concerns about your direct deposit, call us
-            at <Telephone contact={CONTACTS.VA_BENEFITS} /> (TTY:{' '}
+            <strong>Get help updating your direct deposit information.</strong>{' '}
+            You can call us at <Telephone contact={CONTACTS.VA_BENEFITS} />{' '}
+            (TTY:{' '}
             <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
             ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
           </p>
           <p>
-            You can also{' '}
+            <strong>Sign in with a verified ID.me account.</strong>
+            You can{' '}
             <a
               href="https://www.id.me/registration/new"
               target="_blank"
@@ -37,10 +38,11 @@ const SetUpVerifiedIDMeAlert = () => {
                 recordEvent({ event: 'multifactor-link-clicked' });
               }}
             >
-              create a verified account through ID.me
+              create a verified account on ID.me
             </a>
-            , and then use it to log into VA.gov and update your direct deposit
-            information.
+            . Or, if you already have one, please sign out and sign back in
+            using your existing verified ID.me account. Then you’ll be able to
+            update your direct deposit information online.
           </p>
         </>
       }

--- a/src/applications/personalization/profile/components/direct-deposit/DirectDeposit.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/DirectDeposit.jsx
@@ -77,7 +77,7 @@ const DirectDeposit = ({ cnpUiState, eduUiState, isVerifiedUser }) => {
   const isSavingEDUBankInfo = eduUiState.isSaving;
   const wasSavingEDUBankInfo = usePrevious(eduUiState.isSaving);
   const eduSaveError = eduUiState.responseError;
-  const showSetUp2FactorAuthentication = !isVerifiedUser;
+  const showBankInformation = isVerifiedUser;
 
   const bankInfoUpdatedAlertSettings = {
     FADE_SPEED: window.Cypress ? 1 : 500,
@@ -156,8 +156,7 @@ const DirectDeposit = ({ cnpUiState, eduUiState, isVerifiedUser }) => {
         </ReactCSSTransitionGroup>
       </div>
 
-      {showSetUp2FactorAuthentication && <SetUpVerifiedIDMeAlert />}
-      {!showSetUp2FactorAuthentication && (
+      {showBankInformation ? (
         <DowntimeNotification
           appTitle="direct deposit"
           render={handleDowntimeForSection(
@@ -167,14 +166,16 @@ const DirectDeposit = ({ cnpUiState, eduUiState, isVerifiedUser }) => {
         >
           <BankInfoCNP />
         </DowntimeNotification>
+      ) : (
+        <SetUpVerifiedIDMeAlert />
       )}
       <FraudVictimAlert status={ALERT_TYPE.INFO} />
-      {!showSetUp2FactorAuthentication && (
+      {showBankInformation ? (
         <>
           <BankInfoEDU />
           <PaymentHistory />
         </>
-      )}
+      ) : null}
     </>
   );
 };

--- a/src/applications/personalization/profile/tests/e2e/direct-deposit/non-verified-idme.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/direct-deposit/non-verified-idme.cypress.spec.js
@@ -8,10 +8,10 @@ let getDD4EDUBankInfoStub;
 
 function notIDme2FAAlertShown() {
   cy.findByRole('link', {
-    name: /create a verified account through ID\.me/i,
+    name: /create a verified account on ID\.me/i,
   }).should('exist');
   cy.findByText(
-    /You’ll need to verify your account to edit direct deposit information/i,
+    /You’ll need to verify your identity with ID.me to update any of your direct deposit information online/i,
   )
     .should('exist')
     .closest('.usa-alert-continue')


### PR DESCRIPTION
## Description
Updates the text in the alert we show non-ID.me users.

Also a slight refactor of the Direct Deposit component's rendering logic.

## Original issue(s)
content update ticket: department-of-veterans-affairs/va.gov-team#28986

## Testing done


## Screenshots
<img width="920" alt="Screen Shot 2021-08-24 at 9 22 37 AM" src="https://user-images.githubusercontent.com/20728956/130654514-8c1b8272-8b31-4ce1-a356-cbf66bea8e84.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs