### PR TITLE
GIthub Actions (CI) -- Add continue-on-error for testing-reports step

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -617,6 +617,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [cypress-tests-prep, cypress-tests]
     if: ${{ always() && needs.cypress-tests-prep.outputs.num_containers > 0 && (needs.cypress-tests.result == 'success' || needs.cypress-tests.result == 'failure') }}
+    continue-on-error: true
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
## Description

This PR adds `continue-on-error` flag for `testing-reports` step in CI workflow. It is not a necessary step needed for merge-blocker

## Testing done

[REST API](https://api.github.com/repos/department-of-veterans-affairs/vets-website/actions/runs/1136438335)
