### PR TITLE
28902: Update text on search result card

### DIFF
--- a/src/applications/gi-sandbox/containers/SearchResultCard.jsx
+++ b/src/applications/gi-sandbox/containers/SearchResultCard.jsx
@@ -113,7 +113,7 @@ export function SearchResultCard({
   ) : (
     <div>
       <p>
-        <strong>School rating:</strong> Not yet rated
+        <strong>Not yet rated by Veterans</strong>
       </p>
     </div>
   );


### PR DESCRIPTION
## Description
As a developer, I need to update the ratings data retrieval to only retrieve valid ratings so that the display of ratings information and the calculations accurately reflect the aggregate ratings.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/28902


## Testing done
Testing passes locally

## Screenshots
<img width="270" alt="Screen Shot 2021-08-25 at 10 07 05 AM" src="https://user-images.githubusercontent.com/48804834/130812556-ff2e3dd8-04cc-4763-beb2-83569c6f5a1d.png">

## Acceptance criteria

- [x] On the CT Redesign search results page:
a. If the institution has the minimum number of ratings, the composite average is displayed on the card.
b. If the institution does not have the minimum number of ratings, "Not yet rated by Veterans" is displayed (replacing current content "School rating: Not yet rated")

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
