### PR TITLE
NOD: Show alert when max issues have been selected

### DIFF
--- a/src/applications/appeals/10182/components/AddIssues.jsx
+++ b/src/applications/appeals/10182/components/AddIssues.jsx
@@ -4,17 +4,17 @@ import Scroll from 'react-scroll';
 import { toIdSchema } from '@department-of-veterans-affairs/react-jsonschema-form/lib/utils';
 
 import { isEmptyObject, getItemSchema } from '../utils/helpers';
-
 import { SELECTED } from '../constants';
 import { IssueCard } from './IssueCard';
 import {
   missingIssuesErrorMessage,
   noneSelected,
+  MaxSelectionsAlert,
 } from '../content/additionalIssues';
 
 const Element = Scroll.Element;
 
-export const getContent = ({
+export const GetContent = ({
   handlers,
   registry,
   items,
@@ -125,19 +125,20 @@ export const getContent = ({
   });
 };
 
-export const renderPage = ({
+export const RenderPage = ({
   id,
   isReviewMode,
   isEditing,
   hasSelected,
-  showError,
+  showNoneSelectedError,
   showContent,
   showCheckbox,
-  atMax,
+  maxItemsLength,
   content,
   handlers,
+  showErrorModal,
 }) => {
-  const addButton = !atMax &&
+  const addButton = !maxItemsLength &&
     showCheckbox && (
       <button
         type="button"
@@ -150,21 +151,23 @@ export const renderPage = ({
 
   return isReviewMode ? (
     <>
-      {!showError && !hasSelected && noneSelected}
-      {showError && missingIssuesErrorMessage}
+      {!showNoneSelectedError && !hasSelected && noneSelected}
+      {showNoneSelectedError && missingIssuesErrorMessage}
       {content}
     </>
   ) : (
     <div
       className={`schemaform-field-container additional-issues-wrap ${
-        showError ? 'usa-input-error vads-u-margin-top--0' : ''
+        showNoneSelectedError ? 'usa-input-error vads-u-margin-top--0' : ''
       }`}
     >
       <Element name={`topOfTable_${id}`} />
-      {showError && missingIssuesErrorMessage}
+      {showNoneSelectedError && missingIssuesErrorMessage}
       {showContent && <dl className="va-growable review">{content}</dl>}
       {isEditing ? null : addButton}
-      {atMax && <p>You’ve entered the maximum number of items allowed.</p>}
+      {showErrorModal && (
+        <MaxSelectionsAlert showModal closeModal={handlers.closeModal} />
+      )}
     </div>
   );
 };

--- a/src/applications/appeals/10182/components/AddIssuesField.jsx
+++ b/src/applications/appeals/10182/components/AddIssuesField.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
@@ -10,9 +10,9 @@ import { scrollToFirstError } from 'platform/utilities/ui';
 import { setData } from 'platform/forms-system/src/js/actions';
 
 import { scrollAndFocus } from '../utils/ui';
-import { someSelected } from '../utils/helpers';
-import { SELECTED, MAX_NEW_CONDITIONS } from '../constants';
-import { getContent, renderPage } from './AddIssues';
+import { getSelectedCount } from '../utils/helpers';
+import { SELECTED, MAX_SELECTIONS } from '../constants';
+import { GetContent, RenderPage } from './AddIssues';
 
 /* Non-review growable table (array) field */
 const AddIssuesField = props => {
@@ -27,17 +27,35 @@ const AddIssuesField = props => {
     onBlur,
     fullFormData,
     submission,
+    setFormData,
   } = props;
 
   const id = idSchema.$id;
   const uiOptions = uiSchema['ui:options'] || {};
+  const [showErrorModal, setShowErrorModal] = useState(false);
 
-  if (!fullFormData['view:hasIssuesToAdd']) {
-    props.setFormData({
-      ...fullFormData,
-      'view:hasIssuesToAdd': true,
-    });
-  }
+  // if we have form data, use that, otherwise use an array with a single default object
+  const items = formData.length
+    ? formData
+    : [getDefaultFormState(schema.additionalItems, undefined, {})];
+  const hasSubmitted = formContext.submitted || submission?.hasAttemptedSubmit;
+  const selectedCount = getSelectedCount(fullFormData, items);
+
+  useEffect(
+    () => {
+      if (!fullFormData['view:hasIssuesToAdd']) {
+        setFormData({
+          ...fullFormData,
+          'view:hasIssuesToAdd': true,
+        });
+      }
+      // Show modal error since it's the best choice for a11y in this situation
+      if (hasSubmitted && selectedCount >= MAX_SELECTIONS) {
+        setShowErrorModal(true);
+      }
+    },
+    [fullFormData, setFormData, hasSubmitted, selectedCount],
+  );
 
   const initialEditingState = uiOptions.setInitialEditMode?.(formData);
   // Editing state: 1 = new edit, true = update edit & false = view state
@@ -46,20 +64,47 @@ const AddIssuesField = props => {
   );
 
   const handlers = {
+    closeModal: () => setShowErrorModal(false),
+    /**
+     * Change to the issue card checkbox
+     * @param {Number} indexToChange - index of current card
+     * @param {Boolean} checked - checked state
+     */
     toggleSelection: (indexToChange, checked) => {
       const newItems = formData.map((item, index) => ({
         ...item,
         [SELECTED]: index === indexToChange ? checked : item[SELECTED],
       }));
-      props.onChange(newItems);
+      const count = getSelectedCount(fullFormData, newItems);
+      if (checked && count > MAX_SELECTIONS) {
+        setShowErrorModal(true);
+      } else {
+        props.onChange(newItems);
+      }
     },
+    /**
+     * Change to the issue name/date
+     * @param {Number} indexToChange  - index of current card
+     * @param {Object} value - form element values
+     */
     onItemChange: (indexToChange, value) => {
+      const count = getSelectedCount(fullFormData, formData);
+      const selectedValue = count + 1 <= MAX_SELECTIONS;
+      // Set newly added issue as selected unless it goes over the max
+      // Doing this because it's better for UX && a11y
       const newItems = formData.map(
         (item, index) =>
-          index === indexToChange ? { ...value, [SELECTED]: true } : item,
+          index === indexToChange
+            ? { ...value, [SELECTED]: selectedValue }
+            : item,
       );
       props.onChange(newItems);
     },
+    /**
+     * Schema for each item, used to assign unique IDs
+     * @param {Number} index - index of current card
+     * @returns {Object} - item schema with IDs of nested elements
+     */
     getItemSchema: index => {
       const itemSchema = schema;
       if (itemSchema.items.length > index) {
@@ -67,9 +112,14 @@ const AddIssuesField = props => {
       }
       return itemSchema.additionalItems;
     },
+    /**
+     * Blur function passed in from json-schemaform field
+     */
     blur: onBlur,
-    /*
+    /**
      * Clicking edit on an item that’s not last and so is in view mode
+     * @param {Number} index - index of current card
+     * @param {Boolean} status - edit mode state
      */
     edit: (index, status = true) => {
       setEditing(editing.map((mode, indx) => (indx === index ? status : mode)));
@@ -78,9 +128,10 @@ const AddIssuesField = props => {
         timer: 50,
       });
     },
-    /*
-    * Clicking Update on an item that’s not last and is in edit mode
-    */
+    /**
+     * Clicking Update on an item that’s not last and is in edit mode
+     * @param {Number} index - index of current card
+     */
     update: index => {
       const { issue, decisionDate } = formData[index];
       if (errorSchemaIsValid(errorSchema[index]) && issue && decisionDate) {
@@ -99,8 +150,8 @@ const AddIssuesField = props => {
         });
       }
     },
-    /*
-     * Clicking Add another
+    /**
+     * Clicking Add another opens a new issue card
      */
     add: () => {
       const lastIndex = formData.length - 1;
@@ -124,8 +175,9 @@ const AddIssuesField = props => {
         });
       }
     },
-    /*
+    /**
      * Clicking Remove on an item in edit mode
+     * @param {Number} indexToRemove - index of card to remove
      */
     remove: indexToRemove => {
       const newItems = formData.filter((_, index) => index !== indexToRemove);
@@ -143,21 +195,14 @@ const AddIssuesField = props => {
   const isReviewMode = formContext.reviewMode;
   const showCheckbox = !onReviewPage || (onReviewPage && !isReviewMode);
 
-  // if we have form data, use that, otherwise use an array with a single default object
-  const items = formData.length
-    ? formData
-    : [getDefaultFormState(schema.additionalItems, undefined, {})];
-
-  const atMax = items.length > MAX_NEW_CONDITIONS;
-
   // first issue does not have a header or grey card background
   const singleIssue = items.length === 1;
-  const hasSelected =
-    someSelected(formData) || someSelected(fullFormData.contestableIssues);
-  const hasSubmitted = formContext.submitted || submission?.hasAttemptedSubmit;
-  const showError = hasSubmitted && !hasSelected;
+  const showContent = formData.length > 0;
+  const hasSelected = selectedCount > 0;
+  const showNoneSelectedError = hasSubmitted && !hasSelected;
+  const maxItemsLength = items.length >= schema.maxItems;
 
-  const content = getContent({
+  const content = GetContent({
     handlers,
     registry,
     items,
@@ -172,17 +217,18 @@ const AddIssuesField = props => {
     showCheckbox,
   });
 
-  return renderPage({
+  return RenderPage({
     id,
     isReviewMode,
     isEditing: editing.some(edit => edit),
     hasSelected,
-    showError,
-    showContent: formData.length > 0,
+    showNoneSelectedError,
+    showContent,
     showCheckbox,
-    atMax,
+    maxItemsLength,
     content,
     handlers,
+    showErrorModal,
   });
 };
 

--- a/src/applications/appeals/10182/constants.js
+++ b/src/applications/appeals/10182/constants.js
@@ -30,7 +30,7 @@ export const SUPPORTED_UPLOAD_TYPES = ['pdf'];
 export const MAX_FILE_SIZE_MB = 100;
 export const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 ** 2; // binary based
 
-export const MAX_NEW_CONDITIONS = 99;
+export const MAX_SELECTIONS = 100;
 
 // Values from Lighthouse maintained schema
 // see https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/appeals_api/config/schemas/v1/10182.json

--- a/src/applications/appeals/10182/content/additionalIssues.jsx
+++ b/src/applications/appeals/10182/content/additionalIssues.jsx
@@ -1,7 +1,22 @@
 import React from 'react';
 
+import Modal from '@department-of-veterans-affairs/component-library/Modal';
+
 export const missingIssueErrorMessage = 'Please add the name of an issue';
 export const noneSelected = 'Please add and select at least one issue';
+
+export const maxSelected =
+  'You’ve reached the maximum number of allowed selected issues';
+
+// Not setting "visible" as a variable since we're controlling rendering at a
+// higher level
+export const MaxSelectionsAlert = ({ closeModal }) => (
+  <Modal title={maxSelected} status="warning" onClose={closeModal} visible>
+    You are limited to 100 selected issues for each Notice of Disagreement
+    request. If you would like to select more than 100, please submit this
+    request and create a new request for the remaining issues.
+  </Modal>
+);
 
 export const missingIssuesErrorMessageText =
   'Please add and select an issue, or select an eligible issue on the previous page';

--- a/src/applications/appeals/10182/pages/additionalIssues.js
+++ b/src/applications/appeals/10182/pages/additionalIssues.js
@@ -11,6 +11,7 @@ import {
   requireIssue,
   validateDate,
   validAdditionalIssue,
+  maxIssues,
 } from '../validations';
 import { SELECTED } from '../constants';
 import { setInitialEditMode, showAddIssuesPage } from '../utils/helpers';
@@ -20,7 +21,7 @@ import dateUiSchema from 'platform/forms-system/src/js/definitions/date';
 export default {
   uiSchema: {
     'ui:title': AdditionalIssuesLabel,
-    'ui:validations': [requireIssue, validAdditionalIssue],
+    'ui:validations': [requireIssue, validAdditionalIssue, maxIssues],
     additionalIssues: {
       'ui:title': '',
       'ui:field': AddIssuesField,

--- a/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
@@ -5,6 +5,7 @@ import {
   someSelected,
   hasSomeSelected,
   getSelected,
+  getSelectedCount,
   getIssueName,
   showAddIssuesPage,
   showAddIssueQuestion,
@@ -55,56 +56,60 @@ describe('hasSomeSelected', () => {
   });
 });
 
-describe('getSelected', () => {
+describe('getSelected & getSelectedCount', () => {
   it('should return selected contestable issues', () => {
-    expect(
-      getSelected({
-        contestableIssues: [
-          { type: 'no', [SELECTED]: false },
-          { type: 'ok', [SELECTED]: true },
-        ],
-      }),
-    ).to.deep.equal([{ type: 'ok', [SELECTED]: true, index: 0 }]);
+    const data = {
+      contestableIssues: [
+        { type: 'no', [SELECTED]: false },
+        { type: 'ok', [SELECTED]: true },
+      ],
+    };
+    expect(getSelected(data)).to.deep.equal([
+      { type: 'ok', [SELECTED]: true, index: 0 },
+    ]);
+    expect(getSelectedCount(data, data.additionalIssues)).to.eq(1);
   });
   it('should not return selected additional issues when Veteran chooses not to include them', () => {
-    expect(
-      getSelected({
-        'view:hasIssuesToAdd': false,
-        additionalIssues: [
-          { type: 'no', [SELECTED]: false },
-          { type: 'ok', [SELECTED]: true },
-        ],
-      }),
-    ).to.deep.equal([]);
+    const data = {
+      'view:hasIssuesToAdd': false,
+      additionalIssues: [
+        { type: 'no', [SELECTED]: false },
+        { type: 'ok', [SELECTED]: true },
+      ],
+    };
+    expect(getSelected(data)).to.deep.equal([]);
+    expect(getSelectedCount(data, data.additionalIssues)).to.eq(0);
   });
   it('should return selected additional issues', () => {
-    expect(
-      getSelected({
-        'view:hasIssuesToAdd': true,
-        additionalIssues: [
-          { type: 'no', [SELECTED]: false },
-          { type: 'ok', [SELECTED]: true },
-        ],
-      }),
-    ).to.deep.equal([{ type: 'ok', [SELECTED]: true, index: 0 }]);
+    const data = {
+      'view:hasIssuesToAdd': true,
+      additionalIssues: [
+        { type: 'no', [SELECTED]: false },
+        { type: 'ok', [SELECTED]: true },
+      ],
+    };
+    expect(getSelected(data)).to.deep.equal([
+      { type: 'ok', [SELECTED]: true, index: 0 },
+    ]);
+    expect(getSelectedCount(data, data.additionalIssues)).to.eq(1);
   });
   it('should return all selected issues', () => {
-    expect(
-      getSelected({
-        contestableIssues: [
-          { type: 'no1', [SELECTED]: false },
-          { type: 'ok1', [SELECTED]: true },
-        ],
-        'view:hasIssuesToAdd': true,
-        additionalIssues: [
-          { type: 'no2', [SELECTED]: false },
-          { type: 'ok2', [SELECTED]: true },
-        ],
-      }),
-    ).to.deep.equal([
+    const data = {
+      contestableIssues: [
+        { type: 'no1', [SELECTED]: false },
+        { type: 'ok1', [SELECTED]: true },
+      ],
+      'view:hasIssuesToAdd': true,
+      additionalIssues: [
+        { type: 'no2', [SELECTED]: false },
+        { type: 'ok2', [SELECTED]: true },
+      ],
+    };
+    expect(getSelected(data)).to.deep.equal([
       { type: 'ok1', [SELECTED]: true, index: 0 },
       { type: 'ok2', [SELECTED]: true, index: 1 },
     ]);
+    expect(getSelectedCount(data, data.additionalIssues)).to.eq(2);
   });
 });
 

--- a/src/applications/appeals/10182/tests/validations.unit.spec.js
+++ b/src/applications/appeals/10182/tests/validations.unit.spec.js
@@ -8,11 +8,12 @@ import {
   isValidDate,
   contactInfoValidation,
   validAdditionalIssue,
+  maxIssues,
   areaOfDisagreementRequired,
   optInValidation,
 } from '../validations';
 import { optInErrorMessage } from '../content/OptIn';
-import { SELECTED } from '../constants';
+import { SELECTED, MAX_SELECTIONS } from '../constants';
 
 describe('requireIssue validation', () => {
   const _ = undefined; // placeholder
@@ -79,33 +80,27 @@ describe('requireIssue validation', () => {
 describe('validAdditionalIssue', () => {
   it('should not show an error for valid additional issues', () => {
     const errors = { addError: sinon.spy() };
-    expect(
-      validAdditionalIssue(errors, {
-        additionalIssues: [
-          { issue: 'foo', decisionDate: getDate({ offset: { months: -1 } }) },
-        ],
-      }),
-    );
+    validAdditionalIssue(errors, {
+      additionalIssues: [
+        { issue: 'foo', decisionDate: getDate({ offset: { months: -1 } }) },
+      ],
+    });
     expect(errors.addError.called).to.be.false;
   });
   it('should show an error for additional issues with no name', () => {
     const errors = { addError: sinon.spy() };
-    expect(
-      validAdditionalIssue(errors, {
-        additionalIssues: [
-          { issue: '', decisionDate: getDate({ offset: { months: -1 } }) },
-        ],
-      }),
-    );
+    validAdditionalIssue(errors, {
+      additionalIssues: [
+        { issue: '', decisionDate: getDate({ offset: { months: -1 } }) },
+      ],
+    });
     expect(errors.addError.called).to.be.true;
   });
   it('should show an error for additional issues with an empty decision date', () => {
     const errors = { addError: sinon.spy() };
-    expect(
-      validAdditionalIssue(errors, {
-        additionalIssues: [{ issue: 'test', decisionDate: '' }],
-      }),
-    );
+    validAdditionalIssue(errors, {
+      additionalIssues: [{ issue: 'test', decisionDate: '' }],
+    });
     expect(errors.addError.called).to.be.true;
   });
   it('should show an error for additional issues with an old decision date', () => {
@@ -117,6 +112,27 @@ describe('validAdditionalIssue', () => {
         ],
       }),
     );
+    expect(errors.addError.called).to.be.true;
+  });
+});
+
+describe('maxIssues', () => {
+  it('should show not show an error when the array length is less than max', () => {
+    const errors = { addError: sinon.spy() };
+    maxIssues(errors, []);
+    expect(errors.addError.called).to.be.false;
+  });
+  it('should show not show an error when the array length is greater than max', () => {
+    const errors = { addError: sinon.spy() };
+    const validDate = getDate({ offset: { months: -2 } });
+    const template = {
+      issue: 'x',
+      decisionDate: validDate,
+      [SELECTED]: true,
+    };
+    maxIssues(errors, {
+      contestableIssues: new Array(MAX_SELECTIONS + 1).fill(template),
+    });
     expect(errors.addError.called).to.be.true;
   });
 });

--- a/src/applications/appeals/10182/utils/helpers.js
+++ b/src/applications/appeals/10182/utils/helpers.js
@@ -51,6 +51,11 @@ export const getSelected = formData => {
   }));
 };
 
+// additionalIssues (items) are separate because we're checking the count before
+// the formData is updated
+export const getSelectedCount = (formData, items) =>
+  getSelected({ ...formData, additionalIssues: items }).length;
+
 export const getIssueName = (entry = {}) =>
   entry.issue || entry.attributes?.ratingIssueSubjectText;
 

--- a/src/applications/appeals/10182/validations.js
+++ b/src/applications/appeals/10182/validations.js
@@ -7,13 +7,17 @@ import {
 } from 'platform/forms-system/src/js/utilities/validations';
 
 import { $, areaOfDisagreementWorkAround } from './utils/ui';
-import { hasSomeSelected } from './utils/helpers';
+import { getSelected, hasSomeSelected } from './utils/helpers';
 import { optInErrorMessage } from './content/OptIn';
-import { missingIssuesErrorMessageText } from './content/additionalIssues';
+import {
+  missingIssuesErrorMessageText,
+  maxSelected,
+} from './content/additionalIssues';
 import {
   missingAreaOfDisagreementErrorMessage,
   missingAreaOfDisagreementOtherErrorMessage,
 } from './content/areaOfDisagreement';
+import { MAX_SELECTIONS } from './constants';
 
 export const requireIssue = (
   errors,
@@ -105,6 +109,12 @@ export const validAdditionalIssue = (
         errors.addError(missingIssuesErrorMessageText);
       }
     });
+  }
+};
+
+export const maxIssues = (error, data) => {
+  if (getSelected(data).length > MAX_SELECTIONS) {
+    error.addError(maxSelected);
   }
 };
 


### PR DESCRIPTION
## Description

In the Notice of Disagreement form, the Veteran is allowed to allowed to enter 100 new issues, but a combination of eligible issues (API loaded issues) and new issue selections have a maximum of 100 during submission. This PR adds validation and will show a modal alert when the user has selected more than 100 issues across the two pages. A modal was chosen as it would provide the best a11y experience.

## Original issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/29074

## Testing done

Added unit tests

## Screenshots

<details><summary>Max selections warning alert modal</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-08-24 at 3 49 30 PM](https://user-images.githubusercontent.com/136959/130846327-f55f2e59-66ef-432e-8ef2-86ed081db9e6.png)</details>

## Acceptance criteria
- [x] Add messaging so that the Veteran knows they have chosen the maximum number of selected issues.
- [x] Added unit tests & all tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
