### PR TITLE
Cbonade/mpi error test stability

### DIFF
--- a/src/applications/personalization/profile/tests/e2e/profile.mpi-error.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile.mpi-error.cypress.spec.js
@@ -66,12 +66,10 @@ describe('When user is LOA3 with 2FA turned on but we cannot connect to MPI', ()
       'v0/feature_toggles*',
     ]);
   });
-  for (let i = 0; i < 20; i++) {
-    it('should only have access to the Account Security section at desktop size', () => {
-      test();
-    });
-    it('should only have access to the Account Security section at mobile size', () => {
-      test(true);
-    });
-  }
+  it('should only have access to the Account Security section at desktop size', () => {
+    test();
+  });
+  it('should only have access to the Account Security section at mobile size', () => {
+    test(true);
+  });
 });

--- a/src/applications/personalization/profile/tests/e2e/profile.mpi-error.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile.mpi-error.cypress.spec.js
@@ -21,7 +21,6 @@ function test(mobile = false) {
 
   // should show a loading indicator
   cy.findByRole('progressbar').should('exist');
-  cy.get('.loading-indicator-container').should('be.visible');
   cy.findByText(/loading your information/i).should('exist');
 
   // and then the loading indicator should be removed

--- a/src/applications/personalization/profile/tests/e2e/profile.mpi-error.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile.mpi-error.cypress.spec.js
@@ -1,5 +1,6 @@
 import { PROFILE_PATHS } from '../../constants';
 
+import Timeouts from 'platform/testing/e2e/timeouts';
 import mockMPIErrorUser from '../fixtures/users/user-mpi-error.json';
 
 import {
@@ -20,10 +21,14 @@ function test(mobile = false) {
 
   // should show a loading indicator
   cy.findByRole('progressbar').should('exist');
+  cy.get('.loading-indicator-container').should('be.visible');
   cy.findByText(/loading your information/i).should('exist');
 
   // and then the loading indicator should be removed
   cy.findByRole('progressbar').should('not.exist');
+  cy.get('.loading-indicator-container', { timeout: Timeouts.slow }).should(
+    'not.exist',
+  );
   cy.findByText(/loading your information/i).should('not.exist');
 
   // should redirect to profile/account-security on load
@@ -61,10 +66,12 @@ describe('When user is LOA3 with 2FA turned on but we cannot connect to MPI', ()
       'v0/feature_toggles*',
     ]);
   });
-  it('should only have access to the Account Security section at desktop size', () => {
-    test();
-  });
-  it('should only have access to the Account Security section at mobile size', () => {
-    test(true);
-  });
+  for (let i = 0; i < 20; i++) {
+    it('should only have access to the Account Security section at desktop size', () => {
+      test();
+    });
+    it('should only have access to the Account Security section at mobile size', () => {
+      test(true);
+    });
+  }
 });

--- a/src/applications/personalization/profile/tests/e2e/profile.mpi-error.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile.mpi-error.cypress.spec.js
@@ -24,7 +24,6 @@ function test(mobile = false) {
   cy.findByText(/loading your information/i).should('exist');
 
   // and then the loading indicator should be removed
-  cy.findByRole('progressbar').should('not.exist');
   cy.get('.loading-indicator-container', { timeout: Timeouts.slow }).should(
     'not.exist',
   );


### PR DESCRIPTION
## Description
This test spec has been showing some flakiness in CI (and even when looped locally) due to the url check seemingly happening before the loading spinner has gone away, therefore timing out on the assertion.  While I'm unsure of why this may be happening, as Cypress should be pausing at the first assertion, adding an extra assertion that the loading spinner container no longer exists on the page seems to have done the trick. Looped 20x in CI, it passed all 20x (prior, it was failing locally 1 out of every 4 runs).


## Testing done
Ran in CI 20x and passed all 20x


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
