### PR TITLE
speed up MPI error Cypress test

### DIFF
--- a/src/applications/personalization/profile/tests/e2e/profile.mpi-error.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile.mpi-error.cypress.spec.js
@@ -58,6 +58,7 @@ describe('When user is LOA3 with 2FA turned on but we cannot connect to MPI', ()
       'v0/profile/full_name',
       'v0/profile/personal_information',
       'v0/profile/service_history',
+      'v0/disability_compensation_form/rating_info',
       'v0/feature_toggles*',
     ]);
   });


### PR DESCRIPTION
## Description
This makes the entire suite run in ~6s compared to nearly 30s before this fix.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs