### PR TITLE
Github Actions (CI) -- NEXUS registry for dependency installations

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,6 +21,7 @@ jobs:
 
     env:
       NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
+      NEXUS_REGISTRY: https://devops.va.gov/dots-nexus/repository/npm-public/
 
     strategy:
       fail-fast: false
@@ -47,23 +48,40 @@ jobs:
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
-      - name: Cache dependencies
-        id: cache-dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            .cache/yarn
-            node_modules
-          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
+      # - name: Cache dependencies
+      #   id: cache-dependencies
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: |
+      #       .cache/yarn
+      #       node_modules
+      #     key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
+
+      # - name: Install dependencies
+      #   uses: nick-invision/retry@v2
+      #   with:
+      #     command: yarn install --frozen-lockfile --prefer-offline --production=false
+      #     max_attempts: 3
+      #     timeout_minutes: 5
+      #   env:
+      #     YARN_CACHE_FOLDER: .cache/yarn
+
+      - name: Change registry in yarn.lock
+        run: sed -i -e "s#https://registry.yarnpkg.com/#${{ env.NEXUS_REGISTRY }}#g" yarn.lock
+
+      - name: Authenticate NEXUS
+        run: |
+          npm config set _auth $(echo -n 'va-vsp-bot-1:${{ secrets.VA_VSP_BOT_1_TEMP }}' | openssl base64)
+          npm config set cafile ${{ env.NODE_EXTRA_CA_CERTS }}
+          npm config set registry ${{ env.NEXUS_REGISTRY }}
+          npm config set email va-vsp-bot-1@va.gov
+          npm config set always-auth true
+
+      - name: clean cache
+        run: yarn cache clean
 
       - name: Install dependencies
-        uses: nick-invision/retry@v2
-        with:
-          command: yarn install --frozen-lockfile --prefer-offline --production=false
-          max_attempts: 3
-          timeout_minutes: 5
-        env:
-          YARN_CACHE_FOLDER: .cache/yarn
+        run: yarn install --frozen-lockfile --prefer-offline --production=false --verbose --network-concurrency 1
 
       - name: Build
         run: yarn build --verbose --buildtype=${{ matrix.buildtype }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -48,14 +48,14 @@ jobs:
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
-      - name: Cache dependencies
-        id: cache-dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            .cache/yarn
-            node_modules
-          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
+      # - name: Cache dependencies
+      #   id: cache-dependencies
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: |
+      #       .cache/yarn
+      #       node_modules
+      #     key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
       # Required to change registry in yarn.lock file
       - name: Change registry in yarn.lock
@@ -70,6 +70,9 @@ jobs:
           npm config set registry ${{ env.NEXUS_REGISTRY }}
           npm config set email va-vsp-bot-1@va.gov
           npm config set always-auth true
+
+      - name: clean cache
+        run: yarn cache clean
 
       - name: Install dependencies
         uses: nick-invision/retry@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Install dependencies
         uses: nick-invision/retry@v2
         with:
-          command: yarn install --frozen-lockfile --prefer-offline --production=false --network-concurrency 1
+          command: yarn install --frozen-lockfile --prefer-offline --production=false --network-concurrency 1 --verbose
           max_attempts: 3
           timeout_minutes: 5
         env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -57,6 +57,7 @@ jobs:
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
+      # Required to change registry in yarn.lock file
       - name: Change registry in yarn.lock
         run: |
           sed -i -e "s#https://registry.yarnpkg.com/#${{ env.NEXUS_REGISTRY }}#g" yarn.lock
@@ -526,6 +527,7 @@ jobs:
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}-cypress
 
+      # Required to change registry in yarn.lock file
       - name: Change registry in yarn.lock
         run: |
           sed -i -e "s#https://registry.yarnpkg.com/#${{ env.NEXUS_REGISTRY }}#g" yarn.lock

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Install dependencies
         uses: nick-invision/retry@v2
         with:
-          command: yarn install --frozen-lockfile --prefer-offline --production=false --network-concurrency 1
+          command: yarn install --frozen-lockfile --prefer-offline --production=false --network-concurrency 1 --verbose
           max_attempts: 3
           timeout_minutes: 5
         env:
@@ -544,7 +544,7 @@ jobs:
       - name: Install dependencies
         uses: nick-invision/retry@v2
         with:
-          command: yarn install --frozen-lockfile --prefer-offline --production=false --network-concurrency 1r
+          command: yarn install --frozen-lockfile --prefer-offline --production=false --network-concurrency 1 --verbose
           max_attempts: 3
           timeout_minutes: 5
         env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -544,7 +544,7 @@ jobs:
       - name: Install dependencies
         uses: nick-invision/retry@v2
         with:
-          command: yarn install --frozen-lockfile --prefer-offline --production=false --network-concurrency 1
+          command: yarn install --frozen-lockfile --prefer-offline --production=false --network-concurrency 1 --verbose
           max_attempts: 3
           timeout_minutes: 5
         env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -516,6 +516,13 @@ jobs:
       NODE_EXTRA_CA_CERTS: /share/ca-certificates/VA-Internal-S2-RCA1-v1.cer.crt
 
     steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: 'us-gov-west-1'
+
       - name: Checkout vets-website
         uses: actions/checkout@v2
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
+  NEXUS_REGISTRY: https://devops.va.gov/dots-nexus/repository/npm-public/
 
 concurrency:
   group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha  }}
@@ -21,7 +22,6 @@ jobs:
 
     env:
       NODE_EXTRA_CA_CERTS: /etc/ssl/certs/VA-Internal-S2-RCA1-v1.cer.pem
-      NEXUS_REGISTRY: https://devops.va.gov/dots-nexus/repository/npm-public/
 
     strategy:
       fail-fast: false

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Install dependencies
         uses: nick-invision/retry@v2
         with:
-          command: yarn install --frozen-lockfile --prefer-offline --production=false --network-concurrency 1 --verbose
+          command: yarn install --frozen-lockfile --prefer-offline --production=false --network-concurrency 1
           max_attempts: 3
           timeout_minutes: 5
         env:
@@ -544,7 +544,7 @@ jobs:
       - name: Install dependencies
         uses: nick-invision/retry@v2
         with:
-          command: yarn install --frozen-lockfile --prefer-offline --production=false --network-concurrency 1 --verbose
+          command: yarn install --frozen-lockfile --prefer-offline --production=false --network-concurrency 1r
           max_attempts: 3
           timeout_minutes: 5
         env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -57,6 +57,18 @@ jobs:
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
+      - name: Get NEXUS username
+        uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_1_NEXUS_USERNAME
+          env_variable_name: VA_VSP_BOT_1_NEXUS_USERNAME
+
+      - name: Get NEXUS token
+        uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_1_NEXUS_PASSWORD
+          env_variable_name: VA_VSP_BOT_1_NEXUS_PASSWORD
+
       # Required to change registry in yarn.lock file
       - name: Change registry in yarn.lock
         run: |
@@ -65,7 +77,7 @@ jobs:
 
       - name: Authenticate NEXUS
         run: |
-          npm config set _auth $(echo -n 'va-vsp-bot-1:${{ secrets.NEXUS_SECRET_VA_VSP_BOT_1 }}' | openssl base64)
+          npm config set _auth $(echo -n '${{ env.VA_VSP_BOT_1_NEXUS_USERNAME }}:${{ env.VA_VSP_BOT_1_NEXUS_PASSWORD }}' | openssl base64)
           npm config set cafile ${{ env.NODE_EXTRA_CA_CERTS }}
           npm config set registry ${{ env.NEXUS_REGISTRY }}
           npm config set email va-vsp-bot-1@va.gov
@@ -527,6 +539,18 @@ jobs:
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}-cypress
 
+      - name: Get NEXUS username
+        uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_1_NEXUS_USERNAME
+          env_variable_name: VA_VSP_BOT_1_NEXUS_USERNAME
+
+      - name: Get NEXUS token
+        uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_1_NEXUS_PASSWORD
+          env_variable_name: VA_VSP_BOT_1_NEXUS_PASSWORD
+
       # Required to change registry in yarn.lock file
       - name: Change registry in yarn.lock
         run: |
@@ -535,7 +559,7 @@ jobs:
 
       - name: Authenticate NEXUS
         run: |
-          npm config set _auth $(echo -n 'va-vsp-bot-1:${{ secrets.NEXUS_SECRET_VA_VSP_BOT_1 }}' | openssl base64)
+          npm config set _auth $(echo -n '${{ env.VA_VSP_BOT_1_NEXUS_USERNAME }}:${{ env.VA_VSP_BOT_1_NEXUS_PASSWORD }}' | openssl base64)
           npm config set cafile ${{ env.NODE_EXTRA_CA_CERTS }}
           npm config set registry ${{ env.NEXUS_REGISTRY }}
           npm config set email va-vsp-bot-1@va.gov

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -48,14 +48,14 @@ jobs:
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
-      # - name: Cache dependencies
-      #   id: cache-dependencies
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: |
-      #       .cache/yarn
-      #       node_modules
-      #     key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
+      - name: Cache dependencies
+        id: cache-dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            .cache/yarn
+            node_modules
+          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
       # - name: Install dependencies
       #   uses: nick-invision/retry@v2
@@ -79,8 +79,8 @@ jobs:
           npm config set email va-vsp-bot-1@va.gov
           npm config set always-auth true
 
-      - name: clean cache
-        run: yarn cache clean
+      # - name: clean cache
+      #   run: yarn cache clean
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline --production=false --verbose --network-concurrency 1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -67,7 +67,9 @@ jobs:
       #     YARN_CACHE_FOLDER: .cache/yarn
 
       - name: Change registry in yarn.lock
-        run: sed -i -e "s#https://registry.yarnpkg.com/#${{ env.NEXUS_REGISTRY }}#g" yarn.lock
+        run: |
+          sed -i -e "s#https://registry.yarnpkg.com/#${{ env.NEXUS_REGISTRY }}#g" yarn.lock
+          sed -i -e "s#https://registry.npmjs.org/#${{ env.NEXUS_REGISTRY }}#g" yarn.lock
 
       - name: Authenticate NEXUS
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -48,14 +48,14 @@ jobs:
         with:
           node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
-      # - name: Cache dependencies
-      #   id: cache-dependencies
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: |
-      #       .cache/yarn
-      #       node_modules
-      #     key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
+      - name: Cache dependencies
+        id: cache-dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            .cache/yarn
+            node_modules
+          key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
       # Required to change registry in yarn.lock file
       - name: Change registry in yarn.lock
@@ -70,9 +70,6 @@ jobs:
           npm config set registry ${{ env.NEXUS_REGISTRY }}
           npm config set email va-vsp-bot-1@va.gov
           npm config set always-auth true
-
-      - name: clean cache
-        run: yarn cache clean
 
       - name: Install dependencies
         uses: nick-invision/retry@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Authenticate NEXUS
         run: |
-          npm config set _auth $(echo -n 'va-vsp-bot-1:${{ secrets.VA_VSP_BOT_1_TEMP }}' | openssl base64)
+          npm config set _auth $(echo -n 'va-vsp-bot-1:${{ secrets.NEXUS_SECRET_VA_VSP_BOT_1 }}' | openssl base64)
           npm config set cafile ${{ env.NODE_EXTRA_CA_CERTS }}
           npm config set registry ${{ env.NEXUS_REGISTRY }}
           npm config set email va-vsp-bot-1@va.gov
@@ -535,7 +535,7 @@ jobs:
 
       - name: Authenticate NEXUS
         run: |
-          npm config set _auth $(echo -n 'va-vsp-bot-1:${{ secrets.VA_VSP_BOT_1_TEMP }}' | openssl base64)
+          npm config set _auth $(echo -n 'va-vsp-bot-1:${{ secrets.NEXUS_SECRET_VA_VSP_BOT_1 }}' | openssl base64)
           npm config set cafile ${{ env.NODE_EXTRA_CA_CERTS }}
           npm config set registry ${{ env.NEXUS_REGISTRY }}
           npm config set email va-vsp-bot-1@va.gov

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -57,15 +57,6 @@ jobs:
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
 
-      # - name: Install dependencies
-      #   uses: nick-invision/retry@v2
-      #   with:
-      #     command: yarn install --frozen-lockfile --prefer-offline --production=false
-      #     max_attempts: 3
-      #     timeout_minutes: 5
-      #   env:
-      #     YARN_CACHE_FOLDER: .cache/yarn
-
       - name: Change registry in yarn.lock
         run: |
           sed -i -e "s#https://registry.yarnpkg.com/#${{ env.NEXUS_REGISTRY }}#g" yarn.lock
@@ -79,11 +70,14 @@ jobs:
           npm config set email va-vsp-bot-1@va.gov
           npm config set always-auth true
 
-      # - name: clean cache
-      #   run: yarn cache clean
-
       - name: Install dependencies
-        run: yarn install --frozen-lockfile --prefer-offline --production=false --verbose --network-concurrency 1
+        uses: nick-invision/retry@v2
+        with:
+          command: yarn install --frozen-lockfile --prefer-offline --production=false --network-concurrency 1
+          max_attempts: 3
+          timeout_minutes: 5
+        env:
+          YARN_CACHE_FOLDER: .cache/yarn
 
       - name: Build
         run: yarn build --verbose --buildtype=${{ matrix.buildtype }}
@@ -531,6 +525,19 @@ jobs:
             /github/home/.cache/Cypress
             node_modules
           key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}-cypress
+
+      - name: Change registry in yarn.lock
+        run: |
+          sed -i -e "s#https://registry.yarnpkg.com/#${{ env.NEXUS_REGISTRY }}#g" yarn.lock
+          sed -i -e "s#https://registry.npmjs.org/#${{ env.NEXUS_REGISTRY }}#g" yarn.lock
+
+      - name: Authenticate NEXUS
+        run: |
+          npm config set _auth $(echo -n 'va-vsp-bot-1:${{ secrets.VA_VSP_BOT_1_TEMP }}' | openssl base64)
+          npm config set cafile ${{ env.NODE_EXTRA_CA_CERTS }}
+          npm config set registry ${{ env.NEXUS_REGISTRY }}
+          npm config set email va-vsp-bot-1@va.gov
+          npm config set always-auth true
 
       - name: Install dependencies
         uses: nick-invision/retry@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Install dependencies
         uses: nick-invision/retry@v2
         with:
-          command: yarn install --frozen-lockfile --prefer-offline --production=false --network-concurrency 1 --verbose
+          command: yarn install --frozen-lockfile --prefer-offline --production=false --network-concurrency 1
           max_attempts: 3
           timeout_minutes: 5
         env:
@@ -544,7 +544,7 @@ jobs:
       - name: Install dependencies
         uses: nick-invision/retry@v2
         with:
-          command: yarn install --frozen-lockfile --prefer-offline --production=false --network-concurrency 1 --verbose
+          command: yarn install --frozen-lockfile --prefer-offline --production=false --network-concurrency 1
           max_attempts: 3
           timeout_minutes: 5
         env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -544,7 +544,7 @@ jobs:
       - name: Install dependencies
         uses: nick-invision/retry@v2
         with:
-          command: yarn install --frozen-lockfile --prefer-offline --production=false
+          command: yarn install --frozen-lockfile --prefer-offline --production=false --network-concurrency 1
           max_attempts: 3
           timeout_minutes: 5
         env:


### PR DESCRIPTION
## Description

This PR addresses the following:

In an effort to reduce flakiness in our Github Actions, npm from time to time gets disrupted by the TIC for our self-hosted runners. This PR uses NEXUS to proxy to public npm registry.


## Original issue(s)
https://app.zenhub.com/workspaces/vsp---frontend-tools-5fc9325744944e0015ed1861/issues/department-of-veterans-affairs/va.gov-team/27681


## Testing done

[1st Run](https://github.com/department-of-veterans-affairs/content-build/runs/3434947887?check_suite_focus=true)

[Latest Run](https://github.com/department-of-veterans-affairs/vets-website/runs/3437210323?check_suite_focus=true)