### PR TITLE
Refine Notification Settings radio buttons

### DIFF
--- a/src/applications/personalization/profile/components/notification-settings/NotificationRadioButtons.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationRadioButtons.jsx
@@ -94,11 +94,7 @@ const NotificationRadioButtons = ({
   if (loadingMessage) {
     loadingSpanId = `${id}-loading-message`;
     loadingSpan = (
-      <span
-        className="rb-input-message rb-input-message-loading vads-u-font-style--italic"
-        role="alert"
-        id={loadingSpanId}
-      >
+      <span className="rb-input-message" role="alert" id={loadingSpanId}>
         <i
           className="fas fa-spinner fa-spin vads-u-margin-x--1"
           aria-hidden="true"

--- a/src/applications/personalization/profile/components/notification-settings/NotificationRadioButtons.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationRadioButtons.jsx
@@ -57,7 +57,7 @@ const NotificationRadioButtons = ({
     errorSpanId = `${id}-error-message`;
     errorSpan = (
       <span
-        className="rb-input-message rb-input-message-error"
+        className="rb-input-message rb-input-message-error vads-u-font-weight--bold"
         role="alert"
         id={errorSpanId}
       >
@@ -76,7 +76,7 @@ const NotificationRadioButtons = ({
     warningSpanId = `${id}-warning-message`;
     warningSpan = (
       <span
-        className="rb-input-message rb-input-message-warning"
+        className="rb-input-message rb-input-message-warning vads-u-font-weight--bold"
         role="alert"
         id={warningSpanId}
       >
@@ -95,7 +95,7 @@ const NotificationRadioButtons = ({
     loadingSpanId = `${id}-loading-message`;
     loadingSpan = (
       <span
-        className="rb-input-message rb-input-message-loading"
+        className="rb-input-message rb-input-message-loading vads-u-font-style--italic"
         role="alert"
         id={loadingSpanId}
       >
@@ -114,7 +114,7 @@ const NotificationRadioButtons = ({
     successSpanId = `${id}-success-message`;
     successSpan = (
       <span
-        className="rb-input-message rb-input-message-success"
+        className="rb-input-message rb-input-message-success vads-u-font-weight--bold"
         role="alert"
         id={successSpanId}
       >
@@ -128,10 +128,11 @@ const NotificationRadioButtons = ({
   }
 
   // Calculate required.
-  let requiredSpan = undefined;
-  if (required) {
-    requiredSpan = <span className="form-required-span">(*Required)</span>;
-  }
+  const requiredSpan = required ? (
+    <span className="form-required-span">(*Required)</span>
+  ) : (
+    undefined
+  );
 
   const buttonOptions = isArray(options) ? options : [];
   const storedValue = value?.value;
@@ -197,16 +198,21 @@ const NotificationRadioButtons = ({
   );
 
   const legendClass = classNames(
-    'rb-input-notify-label',
+    'rb-legend',
+    'vads-u-font-weight--bold',
+    'vads-u-font-size--base',
+    'vads-u-padding-left--1p5',
     additionalLegendClass,
   );
 
   return (
     <fieldset className={fieldsetClass} disabled={disabled}>
-      <span className={legendClass}>
-        {label}
-        {requiredSpan}
-      </span>
+      <div className="clearfix">
+        <legend className={legendClass}>
+          {label}
+          {requiredSpan}
+        </legend>
+      </div>
       {!loadingMessage && !successMessage && !warningMessage && errorSpan}
       {!loadingMessage && !errorMessage && !successMessage && warningSpan}
       {!loadingMessage && !errorMessage && !warningMessage && successSpan}

--- a/src/applications/personalization/profile/sass/notification-radio-buttons.scss
+++ b/src/applications/personalization/profile/sass/notification-radio-buttons.scss
@@ -1,3 +1,23 @@
+// These style rules for the disabled radio buttons are based on the
+// non-disabled rules as defined in USWDS 1.6.14 elements/_inputs.scss style
+// sheet. Unlike checkboxes, USWDS provides virtually no styling for disabled
+// radio buttons so we are setting up custom styling here. In the unlikely event
+// that VA.gov ever stops using USWDS, or upgrades to USWDS 2+, these rules will
+// probably have to updated or removed.
+[type="radio"]:disabled + label {
+  color: $color-gray-lighter;
+}
+
+[type="radio"]:disabled + label::before {
+  background-color: $color-white;
+  box-shadow: 0 0 0 2px $color-white, 0 0 0 3px $color-gray-lighter;
+}
+
+[type="radio"]:checked:disabled + label::before {
+  background-color: $color-primary-alt-light;
+  box-shadow: 0 0 0 2px $color-white, 0 0 0 4px $color-primary-alt-light;
+}
+
 .rb-fieldset-input {
   margin-bottom: 2rem;
   position: relative;

--- a/src/applications/personalization/profile/sass/notification-radio-buttons.scss
+++ b/src/applications/personalization/profile/sass/notification-radio-buttons.scss
@@ -1,27 +1,19 @@
 .rb-fieldset-input {
   margin-bottom: 2rem;
   position: relative;
-  right: calc(1.9rem - 4px); //this is to account for the border
 }
 
-.rb-input-notify-label {
-  display: block;
-  font-size: 1.7rem;
-  font-weight: 700;
-  padding-left: 1.2rem;
-  padding-bottom: 1rem;
+.rb-legend {
+  float: left;
 }
 
 .rb-input {
   border-left: 4px solid;
   position: relative;
-  right: 1.9rem;
 }
 
 .rb-input-message {
   display: block;
-  font-size: 1.7rem;
-  font-weight: 700;
   padding-bottom: 3px;
   padding-top: 3px;
 }
@@ -56,11 +48,6 @@
 // loading
 .rb-input-loading {
   border-left-color: transparent;
-}
-
-.rb-input-message-loading {
-  font-weight: normal;
-  font-style: italic;
 }
 
 .rb-buttons {

--- a/src/applications/personalization/profile/tests/components/NotificationRadioButton.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/NotificationRadioButton.unit.spec.jsx
@@ -83,7 +83,7 @@ describe('<NotificationRadioButtons>', () => {
     );
 
     // assert that legend element was rendered with label value as its text
-    const legendText = wrapper.find('span').text();
+    const legendText = wrapper.find('legend').text();
     expect(legendText).to.eql(labelValue);
     wrapper.unmount();
   });


### PR DESCRIPTION
## Description
This fixes the indentation of the radio buttons and also updates the styling of the disabled state. This also switched to using an actual `legend` element for the radio buttons legend.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#28987
department-of-veterans-affairs/va.gov-team#28988
department-of-veterans-affairs/va.gov-team#29002

## Testing done
This is all cosmetic stuff so no tests were added or updated. But I did preview the changes in Cypress.

## Screenshots
<img width="658" alt="Screen Shot 2021-08-27 at 6 41 34 AM" src="https://user-images.githubusercontent.com/20728956/131136727-cfe430e1-5b85-467e-a42c-698d3f5c78a8.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs