### PR TITLE
CT Sandbox - Update specialized mission "women only" and "men only" check

### DIFF
--- a/src/applications/gi-sandbox/containers/CompareLayout.jsx
+++ b/src/applications/gi-sandbox/containers/CompareLayout.jsx
@@ -169,10 +169,10 @@ const CompareLayout = ({
                   religiousAffiliations[institution.relaffil],
                 );
               }
-              if (institution.womenOnly) {
+              if (institution.womenonly) {
                 specialMission.push('Women-only');
               }
-              if (institution.menOnly) {
+              if (institution.menonly) {
                 specialMission.push('Men-only');
               }
               return specialMission.length > 0


### PR DESCRIPTION
## Description
Update field names in specialized mission check.  This was checking for `womenOnly` and `menOnly` but the fields are `womenonly` and `menonly`

## Original issue(s)
department-of-veterans-affairs/va.gov-team#29411

## Testing done
Tested locally and QA reviewed

## Screenshots
N/A

## Acceptance criteria
Please see linked issue

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
