### PR TITLE
29379 add covid booster pages

### DIFF
--- a/src/applications/static-pages/i18Select/I18Select.js
+++ b/src/applications/static-pages/i18Select/I18Select.js
@@ -30,7 +30,7 @@ const I18Select = ({ baseUrls, languageCode }) => {
                 onClick={_ => {
                   recordEvent({
                     event: 'nav-pipe-delimited-list-click',
-                    'pipe-delimited-list-header': languageConfig.lang,
+                    'pipe-delimited-list-header': languageConfig.code,
                   });
                 }}
                 href={baseUrls[languageConfig.code]}

--- a/src/applications/static-pages/i18Select/utilities/urls.js
+++ b/src/applications/static-pages/i18Select/utilities/urls.js
@@ -9,4 +9,9 @@ export default {
     es: '/health-care/covid-19-vaccine-esp/',
     tl: '/health-care/covid-19-vaccine-tag/',
   },
+  booster: {
+    en: '/health-care/covid-19-vaccine/booster-shots-and-additional-doses/',
+    es: '/health-care/covid-19-vaccine-esp/booster-shots-and-additional-doses/',
+    tl: '/health-care/covid-19-vaccine-tag/booster-shots-and-additional-doses/',
+  },
 };

--- a/src/applications/static-pages/i18Select/utilities/urls.js
+++ b/src/applications/static-pages/i18Select/utilities/urls.js
@@ -11,7 +11,9 @@ export default {
   },
   booster: {
     en: '/health-care/covid-19-vaccine/booster-shots-and-additional-doses/',
-    es: '/health-care/covid-19-vaccine-esp/booster-shots-and-additional-doses/',
-    tl: '/health-care/covid-19-vaccine-tag/booster-shots-and-additional-doses/',
+    es:
+      '/health-care/covid-19-vaccine-esp/booster-shots-and-additional-doses-esp/',
+    tl:
+      '/health-care/covid-19-vaccine-tag/booster-shots-and-additional-doses-tag/',
   },
 };


### PR DESCRIPTION
## Description
Adds a new series of 'booster' pages to the list of translated urls. Also adjusts analytics event to pass correct language on click event.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/29379


## Testing done
Local, unit tests


## Acceptance criteria
- [x] Widget now available on newest 'booster' pages.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
