### PR TITLE
Made compare drawer a button

### DIFF
--- a/src/applications/gi-sandbox/containers/CompareDrawer.jsx
+++ b/src/applications/gi-sandbox/containers/CompareDrawer.jsx
@@ -189,7 +189,7 @@ export function CompareDrawer({
             className="compare-header vads-l-grid-container"
             onClick={expandOnClick}
           >
-            <div className={headerLabelClasses}>{headerLabel}</div>
+            <button className={headerLabelClasses}>{headerLabel}</button>
           </div>
 
           <div className="compare-body vads-l-grid-container">

--- a/src/applications/gi-sandbox/sass/partials/_gi-compare-drawer.scss
+++ b/src/applications/gi-sandbox/sass/partials/_gi-compare-drawer.scss
@@ -54,6 +54,8 @@
       width: auto;
       text-align: center;
       vertical-align: middle;
+      background-color: transparent;
+      margin-top: -5px;
     }
 
     .header-label::after {
@@ -63,6 +65,7 @@
       vertical-align: middle;
       padding-left: 0.5em;
       margin-top: -4px;
+      background-color: transparent;
     }
 
     .header-label.open::after {


### PR DESCRIPTION
## Description
Platform Issue
Page functionality isn't keyboard accessible.

Issue Details
Compare Institutions bar can't be toggled open or closed with keyboard. It appears it's a div with an event listener instead of a button.

## Original issue(s)
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/29339


## Testing done
local

## Screenshots
![Screen Shot 2021-08-27 at 11 23 34 AM](https://user-images.githubusercontent.com/50601724/131152084-124bce5f-a4a4-420b-a3c2-54318a19547b.png)


## Acceptance criteria
- [ ]

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
