### PR TITLE
526: Truncate long descriptions in new disabilities

### DIFF
--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -1,4 +1,6 @@
 import { pciuStates as PCIU_STATES } from 'vets-json-schema/dist/constants.json';
+import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
+
 import {
   VA_FORM_IDS,
   VA_FORM_IDS_IN_PROGRESS_FORMS_API,
@@ -307,3 +309,21 @@ export const BDD_INFO_URL =
 
 // PDF upload limit feature
 export const PDF_SIZE_FEATURE = 'pdfSizeFeature';
+
+// maxLength from schema
+export const CHAR_LIMITS = [
+  'primaryDescription',
+  'causedByDisabilityDescription',
+  'worsenedDescription',
+  'worsenedEffects',
+  'vaMistreatmentDescription',
+  'vaMistreatmentLocation',
+  'vaMistreatmentDate',
+].reduce(
+  (list, key) => ({
+    ...list,
+    [key]:
+      fullSchema.definitions.newDisabilities.items.properties[key].maxLength,
+  }),
+  {},
+);

--- a/src/applications/disability-benefits/all-claims/pages/newDisabilityFollowUp.js
+++ b/src/applications/disability-benefits/all-claims/pages/newDisabilityFollowUp.js
@@ -11,7 +11,7 @@ import {
 
 import { validateLength } from 'platform/forms/validations';
 
-import { NULL_CONDITION_STRING } from '../constants';
+import { NULL_CONDITION_STRING, CHAR_LIMITS } from '../constants';
 
 const {
   cause,
@@ -95,7 +95,7 @@ export const uiSchema = {
           expandUnderCondition: 'NEW',
           hideIf: isBDD,
         },
-        'ui:validations': [validateLength(400)],
+        'ui:validations': [validateLength(CHAR_LIMITS.primaryDescription)],
       },
       'view:secondaryFollowUp': {
         'ui:options': {
@@ -134,7 +134,9 @@ export const uiSchema = {
           'ui:options': {
             hideIf: isBDD,
           },
-          'ui:validations': [validateLength(400)],
+          'ui:validations': [
+            validateLength(CHAR_LIMITS.causedByDisabilityDescription),
+          ],
         },
       },
       'view:worsenedFollowUp': {
@@ -150,7 +152,7 @@ export const uiSchema = {
             !isBDD(formData) &&
             formData.newDisabilities[index]?.cause === 'WORSENED' &&
             getDisabilitiesList(formData, index).length > 0,
-          'ui:validations': [validateLength(50)],
+          'ui:validations': [validateLength(CHAR_LIMITS.worsenedDescription)],
         },
         worsenedEffects: {
           'ui:title':
@@ -160,7 +162,7 @@ export const uiSchema = {
             !isBDD(formData) &&
             formData.newDisabilities[index]?.cause === 'WORSENED' &&
             getDisabilitiesList(formData, index).length > 0,
-          'ui:validations': [validateLength(350)],
+          'ui:validations': [validateLength(CHAR_LIMITS.worsenedEffects)],
         },
       },
       'view:vaFollowUp': {
@@ -179,7 +181,9 @@ export const uiSchema = {
           'ui:options': {
             hideIf: isBDD,
           },
-          'ui:validations': [validateLength(350)],
+          'ui:validations': [
+            validateLength(CHAR_LIMITS.vaMistreatmentDescription),
+          ],
         },
         vaMistreatmentLocation: {
           'ui:title':
@@ -187,7 +191,9 @@ export const uiSchema = {
           'ui:required': (formData, index) =>
             formData.newDisabilities[index]?.cause === 'VA' &&
             getDisabilitiesList(formData, index).length > 0,
-          'ui:validations': [validateLength(25)],
+          'ui:validations': [
+            validateLength(CHAR_LIMITS.vaMistreatmentLocation),
+          ],
         },
         vaMistreatmentDate: {
           'ui:title':
@@ -195,7 +201,7 @@ export const uiSchema = {
           'ui:required': (formData, index) =>
             formData.newDisabilities[index]?.cause === 'VA' &&
             getDisabilitiesList(formData, index).length > 0,
-          'ui:validations': [validateLength(25)],
+          'ui:validations': [validateLength(CHAR_LIMITS.vaMistreatmentDate)],
         },
       },
       'view:serviceConnectedDisability': {

--- a/src/applications/disability-benefits/all-claims/submit-transformer.js
+++ b/src/applications/disability-benefits/all-claims/submit-transformer.js
@@ -12,6 +12,7 @@ import {
   PTSD_INCIDENT_ITERATION,
   PTSD_CHANGE_LABELS,
   ATTACHMENT_KEYS,
+  CHAR_LIMITS,
   disabilityActionTypes,
   defaultDisabilityDescriptions,
 } from './constants';
@@ -21,6 +22,7 @@ import {
   hasGuardOrReservePeriod,
   isBDD,
   isDisabilityPtsd,
+  truncateDescriptions,
 } from './utils';
 
 import disabilityLabels from './content/disabilityLabels';
@@ -344,7 +346,7 @@ export function transform(formConfig, form) {
       : formData;
 
   const addBackAndTransformSeparationLocation = formData =>
-    formData.serviceInformation.separationLocation
+    formData.serviceInformation?.separationLocation
       ? _.set(
           'serviceInformation.separationLocation',
           {
@@ -482,12 +484,12 @@ export function transform(formConfig, form) {
     }
     const clonedData = _.cloneDeep(formData);
     // Split newDisabilities into primary and secondary arrays for backend
-    const newPrimaryDisabilities = clonedData.newDisabilities.filter(
-      disability => disability.cause !== causeTypes.SECONDARY,
-    );
-    const newSecondaryDisabilities = clonedData.newDisabilities.filter(
-      disability => disability.cause === causeTypes.SECONDARY,
-    );
+    const newPrimaryDisabilities = clonedData.newDisabilities
+      .filter(disability => disability.cause !== causeTypes.SECONDARY)
+      .map(entry => truncateDescriptions(entry));
+    const newSecondaryDisabilities = clonedData.newDisabilities
+      .filter(disability => disability.cause === causeTypes.SECONDARY)
+      .map(entry => truncateDescriptions(entry));
     if (newPrimaryDisabilities.length) {
       clonedData.newPrimaryDisabilities = newPrimaryDisabilities;
     }
@@ -521,7 +523,10 @@ export function transform(formConfig, form) {
           cause: causeTypes.NEW,
           classificationCode: sd.classificationCode,
           // truncate description to 400 characters
-          primaryDescription: descString.substring(0, 400),
+          primaryDescription: descString.substring(
+            0,
+            CHAR_LIMITS.primaryDescription,
+          ),
         };
       },
     );
@@ -669,7 +674,7 @@ export function transform(formConfig, form) {
     return clonedData;
   };
   // Flatten all attachment pages into attachments ARRAY
-  const addFileAttachmments = formData => {
+  const addFileAttachments = formData => {
     const clonedData = _.cloneDeep(formData);
     let attachments = [];
 
@@ -701,7 +706,7 @@ export function transform(formConfig, form) {
     setActionTypes, // Must run after addBackRatedDisabilities
     filterRatedViewFields, // Must be run after setActionTypes
     filterServicePeriods,
-    removeExtraData, // Removed data EVSS does't want
+    removeExtraData, // Removed data EVSS doesn't want
     cleanUpMailingAddress,
     addPOWSpecialIssues,
     addPTSDCause,
@@ -715,7 +720,7 @@ export function transform(formConfig, form) {
     addForm4142,
     addForm0781,
     addForm8940,
-    addFileAttachmments,
+    addFileAttachments,
     fullyDevelopedClaim,
   ].reduce(
     (formData, transformer) => transformer(formData),

--- a/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
@@ -24,6 +24,7 @@ import maximalData from './fixtures/data/maximal-test.json';
 import {
   PTSD_INCIDENT_ITERATION,
   PTSD_CHANGE_LABELS,
+  CHAR_LIMITS,
   disabilityActionTypes,
 } from '../constants';
 
@@ -343,5 +344,94 @@ describe('cleanUpPersonsInvolved', () => {
         },
       ],
     });
+  });
+});
+
+describe('Test internal transform functions', () => {
+  it('will truncate long descriptions', () => {
+    const getString = (key, diff = 0) =>
+      new Array(42)
+        .fill('1234567890')
+        .join('')
+        .substring(0, CHAR_LIMITS[key] + diff);
+    const longString = getString('primaryDescription', 20);
+    const phlebitisPrefix = 'Secondary to Diabetes Mellitus0\n';
+    const form = {
+      data: {
+        ...maximalData.data,
+        newDisabilities: [
+          {
+            cause: 'NEW',
+            primaryDescription: longString,
+            condition: 'asthma',
+            'view:descriptionInfo': {},
+          },
+          {
+            cause: 'SECONDARY',
+            'view:secondaryFollowUp': {
+              causedByDisability: 'Diabetes Mellitus0',
+              causedByDisabilityDescription: longString,
+            },
+            condition: 'phlebitis',
+            'view:descriptionInfo': {},
+          },
+          {
+            cause: 'WORSENED',
+            'view:worsenedFollowUp': {
+              worsenedDescription: longString,
+              worsenedEffects: longString,
+            },
+            condition: 'knee replacement',
+            'view:descriptionInfo': {},
+          },
+          {
+            cause: 'VA',
+            'view:vaFollowUp': {
+              vaMistreatmentDescription: longString,
+              vaMistreatmentLocation: longString,
+              vaMistreatmentDate: longString,
+            },
+            condition: 'myocardial infarction (MI)',
+            'view:descriptionInfo': {},
+          },
+        ],
+      },
+    };
+    expect(
+      JSON.parse(transform(formConfig, form)).form526.newPrimaryDisabilities,
+    ).to.deep.equal([
+      {
+        cause: 'NEW',
+        primaryDescription: getString('primaryDescription'),
+        condition: 'asthma',
+        classificationCode: '540',
+      },
+      {
+        cause: 'WORSENED',
+        worsenedDescription: getString('worsenedDescription'),
+        worsenedEffects: getString('worsenedEffects'),
+        condition: 'knee replacement',
+        specialIssues: ['POW'],
+        classificationCode: '8919',
+      },
+      {
+        cause: 'VA',
+        vaMistreatmentDescription: getString('vaMistreatmentDescription'),
+        vaMistreatmentLocation: getString('vaMistreatmentLocation'),
+        vaMistreatmentDate: getString('vaMistreatmentDate'),
+        condition: 'myocardial infarction (MI)',
+        specialIssues: ['POW'],
+        classificationCode: '4440',
+      },
+      {
+        condition: 'phlebitis',
+        cause: 'NEW',
+        classificationCode: '5300',
+        primaryDescription: `${phlebitisPrefix}${getString(
+          'primaryDescription',
+          -phlebitisPrefix.length,
+        )}`,
+      },
+    ]);
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -7,6 +7,7 @@ import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
 import {
   SAVED_SEPARATION_DATE,
   PTSD_MATCHES,
+  CHAR_LIMITS,
 } from '../../all-claims/constants';
 import {
   makeSchemaForNewDisabilities,
@@ -44,6 +45,7 @@ import {
   isDisabilityPtsd,
   showSeparationLocation,
   isExpired,
+  truncateDescriptions,
 } from '../utils';
 
 describe('526 helpers', () => {
@@ -1219,5 +1221,33 @@ describe('isExpired', () => {
     expect(isExpired(getDays(0))).to.be.false;
     expect(isExpired(getDays(1))).to.be.false;
     expect(isExpired(getDays(365))).to.be.false;
+  });
+});
+
+describe('truncateDescriptions', () => {
+  const getResult = (key, sizeDiff) =>
+    truncateDescriptions({
+      [key]: new Array(CHAR_LIMITS[key] + sizeDiff).fill('-').join(''),
+    });
+  it('should return an object untouched', () => {
+    const data = { test: 'abc', test2: 123 };
+    expect(truncateDescriptions(data)).to.deep.equal(data);
+    data.primaryDescription = 'blah';
+    expect(truncateDescriptions(data)).to.deep.equal(data);
+    const key = 'primaryDescription';
+    expect(getResult(key, -20)[key].length).to.equal(CHAR_LIMITS[key] - 20);
+  });
+  it('should truncate long descriptions', () => {
+    [
+      'primaryDescription', // 400
+      'causedByDisabilityDescription', // 400
+      'worsenedDescription', // 50
+      'worsenedEffects', // 350
+      'vaMistreatmentDescription', // 350
+      'vaMistreatmentLocation', // 25
+      'vaMistreatmentDate', // 25
+    ].forEach(key => {
+      expect(getResult(key, +20)[key].length).to.eq(CHAR_LIMITS[key]);
+    });
   });
 });

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -50,6 +50,7 @@ import {
   START_TEXT,
   FORM_STATUS_BDD,
   PDF_SIZE_FEATURE,
+  CHAR_LIMITS,
 } from './constants';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 
@@ -1014,3 +1015,33 @@ export const isExpired = date => {
   const expires = moment.unix(date?.expiresAt);
   return !(expires.isValid() && expires.endOf('day').isSameOrAfter(today));
 };
+
+/**
+ * @typedef NewDisability~entry
+ * @property {String} condition - disability name
+ * @property {String} cause - disability type
+ * @property {String} primaryDescription - new disability description
+ * @property {String} causedByDisabilityDescription - name of rated disability
+ * @property {String} worsenedDescription - worsened description
+ * @property {String} worsenedEffects - result
+ * @property {String} vaMistreatmentDescription - VA involved
+ * @property {String} vaMistreatmentLocation - location
+ * @property {String} vaMistreatmentDate - date
+ */
+/**
+ * Truncate long descriptions
+ * @param {NewDisability~entry} data - new disability array entry
+ * @returns new disability array entry with over-the-limit descriptions
+ *  truncated
+ */
+export const truncateDescriptions = data =>
+  Object.keys(data).reduce(
+    (entry, key) => ({
+      ...entry,
+      [key]:
+        key in CHAR_LIMITS
+          ? data[key].substring(0, CHAR_LIMITS[key])
+          : data[key],
+    }),
+    {},
+  );


### PR DESCRIPTION
## Description

Descriptions for new disabilities in Form 526 already have the appropriate character limits in place, but are somehow still being submitted. This PR truncates these descriptions based on the schema set `maxLength` (added in [#630](https://github.com/department-of-veterans-affairs/vets-json-schema/pull/630)).

## Original issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/29242

## Testing done

Updated unit tests

## Screenshots

N/A - no visual changes

## Acceptance criteria
- [x] Long descriptions are truncated at their `maxLength`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
