### PR TITLE
526: Move contact to beginning of form

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -194,6 +194,12 @@ const formConfig = {
           uiSchema: veteranInfo.uiSchema,
           schema: veteranInfo.schema,
         },
+        contactInformation: {
+          title: 'Veteran contact information',
+          path: 'contact-information',
+          uiSchema: contactInformation.uiSchema,
+          schema: contactInformation.schema,
+        },
         alternateNames: {
           title: 'Service under another name',
           path: 'alternate-names',
@@ -657,12 +663,6 @@ const formConfig = {
     additionalInformation: {
       title: 'Additional information',
       pages: {
-        contactInformation: {
-          title: 'Veteran contact information',
-          path: 'contact-information',
-          uiSchema: contactInformation.uiSchema,
-          schema: contactInformation.schema,
-        },
         paymentInformation: {
           title: 'Payment information',
           path: 'payment-information',

--- a/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
@@ -34,7 +34,7 @@ describe('Disability benefits 526EZ contact information', () => {
   const {
     schema,
     uiSchema,
-  } = formConfig.chapters.additionalInformation.pages.contactInformation;
+  } = formConfig.chapters.veteranDetails.pages.contactInformation;
 
   it('renders contact information form', () => {
     const form = mount(


### PR DESCRIPTION
## Description

Prior to this PR, form 526's contact info page was close to the end of the form flow. We're moving it to show up as the second page (first page is the Veteran's name, SSN, etc).

## Original issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/28716

## Testing done

Updated unit tests

## Screenshots

N/A - change in flow

## Acceptance criteria
- [x] Contact info page moved to the beginning of the form flow

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
