### PR TITLE
remove requested flag from triggers for workflow

### DIFF
--- a/.github/workflows/testing-reports.yml
+++ b/.github/workflows/testing-reports.yml
@@ -5,7 +5,6 @@ on:
     workflows: ['Continuous Integration']
     types:
       - completed
-      - requested
 
 jobs:
   testing-reports:


### PR DESCRIPTION
## Description
This workflow should only run once the CI workflow completes. The removal of the 'requested' param here will hopefully solve this.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
