### PR TITLE
Updated search tabs to be tabbable and announce to screen readers

### DIFF
--- a/src/applications/gi-sandbox/components/search/SearchTabs.jsx
+++ b/src/applications/gi-sandbox/components/search/SearchTabs.jsx
@@ -45,9 +45,9 @@ export default function SearchTabs({ onChange, search }) {
     );
 
     return (
-      <div className={tabClasses} onClick={() => onChange(tabName)}>
+      <button className={tabClasses} onClick={() => onChange(tabName)}>
         {label}
-      </div>
+      </button>
     );
   };
 

--- a/src/applications/gi-sandbox/sass/partials/_gi-search-form.scss
+++ b/src/applications/gi-sandbox/sass/partials/_gi-search-form.scss
@@ -21,10 +21,15 @@
 
   .active-search-tab {
     border-top: 4px solid $color-primary;
+    border-radius: 0%;
+    height: 2.8em;
+    margin-bottom: -1px;
   }
 
   .inactive-search-tab {
     border-top: 2px solid $color-gray-light;
+    border-radius: 0%;
+    margin-bottom: -1px;
   }
 
   .search-tab {


### PR DESCRIPTION
## Description
Platform Issue
HTML markup isn't valid.

Issue Details
Search by Name and Search by Location tabs are not announcing themselves to screen readers and do not meet functional or semantic requirements for ARIA markup.

VA.gov Experience Standard
Cateogy Number 09, Issue Number 01

Other References
WCAG SC 1.3.1_A

## Original issue(s)
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/29355


## Testing done
local

## Screenshots
![cttabs](https://user-images.githubusercontent.com/50601724/131179617-fa3b133e-8c5c-4f10-be25-30b3a11440f9.gif)

## Acceptance criteria
- [ ]

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
