### PR TITLE
Hide mobile mega-menu anchor on small screens

### DIFF
--- a/src/applications/proxy-rewrite/partials/header.js
+++ b/src/applications/proxy-rewrite/partials/header.js
@@ -83,7 +83,7 @@ export default `
     </div>
     <div id="va-nav-controls"></div>
     <div class="usa-grid usa-grid-full">
-      <div class="menu-rule usa-one-whole"></div>
+      <div class="medium-screen:vads-u-display--none menu-rule usa-one-whole"></div>
       <div class="mega-menu" id="mega-menu-mobile"></div>
     </div>
     <div id="login-root" class="vet-toolbar"></div>

--- a/src/platform/landing-pages/dev-template.ejs
+++ b/src/platform/landing-pages/dev-template.ejs
@@ -110,7 +110,7 @@
         </div>
         <div id="va-nav-controls"></div>
         <div class="usa-grid usa-grid-full">
-          <div class="menu-rule usa-one-whole"></div>
+          <div class="medium-screen:vads-u-display--none menu-rule usa-one-whole"></div>
           <div class="mega-menu" id="mega-menu-mobile"></div>
         </div>
         <div id="login-root" class="vet-toolbar"></div>


### PR DESCRIPTION
## Description
Slack thread: https://dsva.slack.com/archives/CBU0KDSB1/p1630092393051800

Adding a separate mega-menu anchor for the `<MegaMenu>` react component resulted in a small with border on the header. This was because previously it would not have displayed on mobile, but without a class hiding it it applied the border styling for the class that exists on larger screens. This hides the element on small screens.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/25659


## Testing done
local

## Screenshots
Mobile: 
<img width="416" alt="Screen Shot 2021-08-27 at 4 52 04 PM" src="https://user-images.githubusercontent.com/3144003/131187276-d8baa087-4cc9-4bcc-bfc6-550ebc2630ca.png">

Desktop:
<img width="1792" alt="Screen Shot 2021-08-27 at 4 51 57 PM" src="https://user-images.githubusercontent.com/3144003/131187286-c13fcdc6-44d5-4bf2-a63a-52807414fe8f.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
