### PR TITLE
hide mega-menu-mobile wrapping div on large screens

### DIFF
--- a/src/applications/proxy-rewrite/partials/header.js
+++ b/src/applications/proxy-rewrite/partials/header.js
@@ -82,8 +82,8 @@ export default `
       </a>
     </div>
     <div id="va-nav-controls"></div>
-    <div class="usa-grid usa-grid-full">
-      <div class="medium-screen:vads-u-display--none menu-rule usa-one-whole"></div>
+    <div class="medium-screen:vads-u-display--none usa-grid usa-grid-full">
+      <div class="menu-rule usa-one-whole"></div>
       <div class="mega-menu" id="mega-menu-mobile"></div>
     </div>
     <div id="login-root" class="vet-toolbar"></div>

--- a/src/applications/proxy-rewrite/partials/header.js
+++ b/src/applications/proxy-rewrite/partials/header.js
@@ -82,10 +82,6 @@ export default `
       </a>
     </div>
     <div id="va-nav-controls"></div>
-    <div class="medium-screen:vads-u-display--none usa-grid usa-grid-full">
-      <div class="menu-rule usa-one-whole"></div>
-      <div class="mega-menu" id="mega-menu-mobile"></div>
-    </div>
     <div id="login-root" class="vet-toolbar"></div>
   </div>
   <div class="usa-grid usa-grid-full">

--- a/src/applications/proxy-rewrite/sass/_m-vet-nav-px.scss
+++ b/src/applications/proxy-rewrite/sass/_m-vet-nav-px.scss
@@ -473,7 +473,17 @@ body.va-pos-fixed {
   }
 
   @media (min-width: $xsmall-screen) and (max-width: $medium-screen - 1) {
-    .mega-menu,
+    .mega-menu {
+      position: absolute;
+      bottom: 40px;
+      width: 100%;
+      left: 0;
+
+      #vetnav {
+        left: 0;
+      }
+    }
+
     #mega-menu {
       // #vetnav {
       //   min-height: unset;

--- a/src/platform/landing-pages/dev-template.ejs
+++ b/src/platform/landing-pages/dev-template.ejs
@@ -109,8 +109,8 @@
           </a>
         </div>
         <div id="va-nav-controls"></div>
-        <div class="usa-grid usa-grid-full">
-          <div class="medium-screen:vads-u-display--none menu-rule usa-one-whole"></div>
+        <div class="medium-screen:vads-u-display--none usa-grid usa-grid-full">
+          <div class="menu-rule usa-one-whole"></div>
           <div class="mega-menu" id="mega-menu-mobile"></div>
         </div>
         <div id="login-root" class="vet-toolbar"></div>


### PR DESCRIPTION
## Description
The child div around the mega-menu-mobile anchor was affecting display on va.gov/homeless
See slack thread: https://dsva.slack.com/archives/C52CL1PKQ/p1630339496089000

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/29458


## Testing done
local

## Screenshots
<img width="1790" alt="Screen Shot 2021-08-30 at 12 20 22 PM" src="https://user-images.githubusercontent.com/3144003/131371602-33cb7758-5f9a-4dda-8637-2cd6136060e2.png">

va.gov/homeless desktop with div manually removed:
<img width="1774" alt="Screen Shot 2021-08-30 at 12 26 28 PM" src="https://user-images.githubusercontent.com/3144003/131372206-a70eea7d-8706-47bc-85c8-ebd94afd7fb0.png">

va.gov/homeless mobile with div manually removed
<img width="1775" alt="Screen Shot 2021-08-30 at 12 26 18 PM" src="https://user-images.githubusercontent.com/3144003/131372222-cd027c32-4c04-4774-897a-121ebac1d6df.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
