### PR TITLE
29374: Add compare details to bread crumbs when coming from compare only

### DIFF
--- a/src/applications/gi-sandbox/components/CompareHeader.jsx
+++ b/src/applications/gi-sandbox/components/CompareHeader.jsx
@@ -89,7 +89,14 @@ export default function({
                     <div className="institution-name">
                       {smallScreen && institution.name}
                       {!smallScreen && (
-                        <Link to={profileLink}>{institution.name}</Link>
+                        <Link
+                          to={{
+                            pathname: profileLink,
+                            state: { prevPath: location.pathname },
+                          }}
+                        >
+                          {institution.name}
+                        </Link>
                       )}
                     </div>
                   </div>

--- a/src/applications/gi-sandbox/components/GiBillBreadcrumbs.jsx
+++ b/src/applications/gi-sandbox/components/GiBillBreadcrumbs.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
-import { useRouteMatch, Link } from 'react-router-dom';
+import { useRouteMatch, Link, useHistory } from 'react-router-dom';
 import { useQueryParams } from '../utils/helpers';
 
 const GiBillBreadcrumbs = () => {
@@ -8,6 +8,7 @@ const GiBillBreadcrumbs = () => {
   const compareMatch = useRouteMatch('/compare');
   const queryParams = useQueryParams();
   const version = queryParams.get('version');
+  const history = useHistory();
 
   const root = version
     ? {
@@ -26,6 +27,12 @@ const GiBillBreadcrumbs = () => {
       GI Bill® Comparison Tool
     </Link>,
   ];
+
+  if (history.location?.state?.prevPath) {
+    crumbs.push(
+      <Link onClick={() => history.goBack()}>Compare institutions</Link>,
+    );
+  }
 
   if (profileMatch) {
     crumbs.push(


### PR DESCRIPTION
## Description
Breadcrumb doesn't include the compare schools if my click path is Comparison Tool > Compare Schools > School Detail.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/29374


## Testing done
Testing passes locally

## Screenshots
<img width="619" alt="Screen Shot 2021-08-30 at 3 55 35 PM" src="https://user-images.githubusercontent.com/48804834/131397645-24944f3f-993a-4a0d-8124-b2b9f77548fa.png">


## Acceptance criteria
- [x] Breadcrumb is added for compare institutions on profile page when coming from profile page.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
