### PR TITLE
Cbonade/testing reports error

### DIFF
--- a/.github/workflows/testing-reports.yml
+++ b/.github/workflows/testing-reports.yml
@@ -130,9 +130,6 @@ jobs:
       # -------------------------
       # | Cypress Tests Summary |
       # -------------------------
-      - name: Failure catch
-        if: ${{ failure() }}
-        run: echo 'MOCHAWESOME_REPORT_RESULTS=Something went wrong generating your test results. See more at https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}' >> $GITHUB_ENV
 
       - name: Publish Cypress test results
         if: ${{ always() }}

--- a/.github/workflows/testing-reports.yml
+++ b/.github/workflows/testing-reports.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           workflow: continuous-integration.yml
-          name: cypress-mochawesome-test-results
+          name: cypress-mochawwesome-test-results
           path: testing-tools-team-dashboard-data/src/mochawesome/data
 
       - name: Get BigQuery service credentials
@@ -130,6 +130,10 @@ jobs:
       # -------------------------
       # | Cypress Tests Summary |
       # -------------------------
+      - name: Failure catch
+        if: ${{ failure() }}
+        run: echo 'MOCHAWESOME_REPORT_RESULTS=Something went wrong generating your test results. See more at https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}' >> $GITHUB_ENV
+
       - name: Publish Cypress test results
         if: ${{ always() }}
         uses: LouisBrunner/checks-action@v1.1.1

--- a/.github/workflows/testing-reports.yml
+++ b/.github/workflows/testing-reports.yml
@@ -140,3 +140,4 @@ jobs:
           conclusion: ${{ github.event.workflow_run.conclusion }}
           output: |
             {"summary":${{ env.MOCHAWESOME_REPORT_RESULTS }}}
+          details_url: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}


### PR DESCRIPTION
## Description
Added a details url that should link back to the testing-reports workflow from the CI workflow. Also introduced an intentional error by misspelling an artifact name, to ensure that this will still show a desirable result when there is an error generating the report.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
