### PR TITLE
remove concurrency

### DIFF
--- a/.github/workflows/testing-reports.yml
+++ b/.github/workflows/testing-reports.yml
@@ -6,10 +6,6 @@ on:
     types:
       - completed
 
-concurrency:
-  group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha  }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
-
 jobs:
   testing-reports:
     name: Testing Reports


### PR DESCRIPTION
## Description
Remove concurrency to stop workflows from being constantly cancelled when merged to master

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
