### PR TITLE
Added code to hold off popping our modal

### DIFF
--- a/src/applications/static-pages/dependency-verification/components/dependencyVerificationModal.jsx
+++ b/src/applications/static-pages/dependency-verification/components/dependencyVerificationModal.jsx
@@ -11,8 +11,7 @@ import DependencyVerificationList from './dependencyVerificationList';
 import DependencyVerificationFooter from './dependencyVerificationFooter';
 
 const DependencyVerificationModal = props => {
-  const targetNode = document.getElementsByTagName('body');
-  const [nodeToWatch] = useState(targetNode[0]);
+  const nodeToWatch = document.getElementsByTagName('body')[0];
   const [otherModal, setOtherModal] = useState(null);
 
   const openModal = () => {


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/28897)

During testing it was discovered that if it is the Veteran's first time logging in they are presented with a SSO modal that tells them about VA.gov. On the view dependents page our modal then opens up behind the SSO modal and a class is added to the div containing the SSO modal that disables pointer events, making it so that the Veteran cannot dismiss the SSO modal. 

Upon further investigation it was discovered that the class that is being added to the div containing the SSO modal is coming from Medium.js, a library we use for accessibility, so it cannot be removed. 

This means we need to adjust our modal so that it detects if there is already a modal open on the page and if there is it needs to wait till that modal is gone before ours fires. This PR does that by adding a function that checks for an open modal and then if there is one it sets state so that another function added can set up a MutationObserver and wait for a change indicating that the first modal has been closed.

## Testing done
Tested locally, e2e tests will be included in a subsiquent PR

## Acceptance criteria
- [x]  Solution has been found, if it exists
- [x] a solution has been implemented and a PR has been requested for merging (just in case)
