### PR TITLE
29336: Focus state isn't visible

### DIFF
--- a/src/applications/gi-sandbox/containers/GiBillApp.jsx
+++ b/src/applications/gi-sandbox/containers/GiBillApp.jsx
@@ -37,6 +37,19 @@ export function GiBillApp({
   const shouldEnterPreviewMode = !preview.display && versionChange;
   const location = useLocation();
 
+  document.addEventListener(
+    'focus',
+    () => {
+      const focussedElement = document.getElementById(
+        document.activeElement.id,
+      );
+      if (focussedElement) {
+        focussedElement.scrollIntoView();
+      }
+    },
+    true,
+  );
+
   useEffect(
     () => {
       if (shouldExitPreviewMode) {

--- a/src/applications/gi-sandbox/containers/GiBillApp.jsx
+++ b/src/applications/gi-sandbox/containers/GiBillApp.jsx
@@ -12,7 +12,7 @@ import {
 import GiBillBreadcrumbs from '../components/GiBillBreadcrumbs';
 import PreviewBanner from '../components/PreviewBanner';
 import Modals from './Modals';
-import { useQueryParams } from '../utils/helpers';
+import { scrollToFocusedElement, useQueryParams } from '../utils/helpers';
 import ServiceError from '../components/ServiceError';
 import AboutThisTool from '../components/content/AboutThisTool';
 import Disclaimer from '../components/content/Disclaimer';
@@ -37,18 +37,13 @@ export function GiBillApp({
   const shouldEnterPreviewMode = !preview.display && versionChange;
   const location = useLocation();
 
-  document.addEventListener(
-    'focus',
-    () => {
-      const focussedElement = document.getElementById(
-        document.activeElement.id,
-      );
-      if (focussedElement) {
-        focussedElement.scrollIntoView();
-      }
-    },
-    true,
-  );
+  useEffect(() => {
+    document.addEventListener('focus', scrollToFocusedElement, true);
+
+    return () => {
+      document.removeEventListener('focus', scrollToFocusedElement);
+    };
+  }, []);
 
   useEffect(
     () => {

--- a/src/applications/gi-sandbox/utils/helpers.js
+++ b/src/applications/gi-sandbox/utils/helpers.js
@@ -223,3 +223,9 @@ export const boolYesNo = field => {
 };
 
 export const isSmallScreen = () => matchMedia('(max-width: 480px)').matches;
+
+export const scrollToFocusedElement = () => {
+  if (document.activeElement) {
+    document.activeElement.scrollIntoView();
+  }
+};


### PR DESCRIPTION
## Description
The Compare Institutions tray overlaps content on the GIBCT search page and school detail page. Focus gets hidden behind it and makes keyboard navigation difficult.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/29336


## Testing done
Manual testing passese

## Screenshots
N/A

## Acceptance criteria
- [x] Focussed items are visible and not blocked by the compare tray

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
