### PR TITLE
Restrict lodash/fp import in eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -60,7 +60,7 @@ module.exports = {
       2,
       { args: 'after-used', argsIgnorePattern: '^_', vars: 'local' },
     ],
-    'no-restricted-imports': ['error', 'raven'],
+    'no-restricted-imports': ['error', 'raven', 'lodash/fp'],
     'prefer-rest-params': 2,
 
     /* || va custom plugin || */


### PR DESCRIPTION
## Description
Now that we've completely removed `lodash/fp` imports from the repo, we can restrict it in our eslint config. I'll make an announcement to other developers before merging this PR.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#1678


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
