### PR TITLE
Add additional Notification Settings gating

### DIFF
--- a/src/applications/personalization/profile/tests/e2e/notification-settings/feature-gating.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/feature-gating.cypress.spec.js
@@ -1,55 +1,102 @@
-import { PROFILE_PATHS, PROFILE_PATH_NAMES } from '../../../constants';
-import { mockUser } from '../../fixtures/users/user';
+import { PROFILE_PATHS, PROFILE_PATH_NAMES } from '@@profile/constants';
+import { makeMockUser } from '../../fixtures/users/user';
 import { mockNotificationSettingsAPIs } from '../helpers';
 import mockFeatureToggles from './feature-toggles.json';
 
+function notificationSettingsSectionIsAvailable(user) {
+  cy.login(user);
+  // go to the root of the Profile
+  cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+  // click on the Notification settings item in the side nav
+  cy.findByRole('link', {
+    name: PROFILE_PATH_NAMES.NOTIFICATION_SETTINGS,
+  }).click();
+  // make sure the url is correct
+  cy.url().should(
+    'eq',
+    `${Cypress.config().baseUrl}${PROFILE_PATHS.NOTIFICATION_SETTINGS}`,
+  );
+  // make sure the page loads
+  cy.findByRole('heading', {
+    name: PROFILE_PATH_NAMES.NOTIFICATION_SETTINGS,
+  });
+}
+
+function notificationSettingsSectionIsBlocked(user) {
+  cy.login(user);
+  // go to the root of the Profile
+  cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+  // this assertion is only here to make sure the following "not.exist" does
+  // not pass as a false positive. i.e., we need to make sure the side nav
+  // is visible before we check to make sure a particular element does not
+  // exist in the side nav
+  cy.findByRole('link', {
+    name: PROFILE_PATH_NAMES.PERSONAL_INFORMATION,
+  }).should('exist');
+  // make sure there is no Notification settings item in the side nav
+  cy.findByRole('link', {
+    name: PROFILE_PATH_NAMES.NOTIFICATION_SETTINGS,
+  }).should('not.exist');
+  // try to go directly to the Notification settings URL
+  cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
+  // make sure the user is directed back to the root of the Profile
+  cy.url().should(
+    'eq',
+    `${Cypress.config().baseUrl}${PROFILE_PATHS.PERSONAL_INFORMATION}`,
+  );
+}
+
 describe('Notification Settings', () => {
+  const patientWithClaimsAndAppeals = makeMockUser();
+  const nonPatientWithoutClaimsOrAppeals = makeMockUser({
+    isPatient: false,
+    services: [
+      'edu-benefits',
+      'facilities',
+      'form-prefill',
+      'form-save-in-progress',
+      'form526',
+      'hca',
+      'id-card',
+      'identity-proofed',
+      'mhv-accounts',
+      'user-profile',
+      'vet360',
+    ],
+  });
   beforeEach(() => {
-    cy.login(mockUser);
     mockNotificationSettingsAPIs();
   });
   context('when the feature flag is turned on', () => {
-    it('is available in the side nav and the section loads', () => {
+    beforeEach(() => {
       cy.intercept('GET', '/v0/feature_toggles?*', mockFeatureToggles);
-      // go to the root of the Profile
-      cy.visit(PROFILE_PATHS.PROFILE_ROOT);
-      // click on the Notification settings item in the side nav
-      cy.findByRole('link', {
-        name: PROFILE_PATH_NAMES.NOTIFICATION_SETTINGS,
-      }).click();
-      // make sure the url is correct
-      cy.url().should(
-        'eq',
-        `${Cypress.config().baseUrl}${PROFILE_PATHS.NOTIFICATION_SETTINGS}`,
-      );
-      // make sure the page loads
-      cy.findByRole('heading', {
-        name: PROFILE_PATH_NAMES.NOTIFICATION_SETTINGS,
+    });
+    context('and user is a patient with the claims and appeals service', () => {
+      it('is available in the side nav and the section loads', () => {
+        notificationSettingsSectionIsAvailable(patientWithClaimsAndAppeals);
       });
     });
+    // NOTE: For the initial release, the Notification Settings page will only
+    // be shown if the user is determined to be a VA patient or if they have
+    // either the `appeals-status` or `evss-claims` service.
+    //
+    // NOTE: This is because the only notification settings that will exist at
+    // launch apply to health care or claims and there is no reason to show the
+    // section to Veterans who don't have health care or have claims or appeals.
+    context(
+      'and user is not a patient and lacks both the claims and appeals service',
+      () => {
+        it('is not available in the side nav and the path redirects to the personal info section', () => {
+          notificationSettingsSectionIsBlocked(
+            nonPatientWithoutClaimsOrAppeals,
+          );
+        });
+      },
+    );
   });
   context('when the feature flag is turned off', () => {
     it('is not available in the side nav and the path redirects to the personal info section', () => {
-      // go to the root of the Profile
-      cy.visit(PROFILE_PATHS.PROFILE_ROOT);
-      // this assertion is only here to make sure the following "not.exist" does
-      // not pass as a false positive. i.e., we need to make sure the side nav
-      // is visible before we check to make sure a particular element does not
-      // exist in the side nav
-      cy.findByRole('link', {
-        name: PROFILE_PATH_NAMES.PERSONAL_INFORMATION,
-      }).should('exist');
-      // make sure there is no Notification settings item in the side nav
-      cy.findByRole('link', {
-        name: PROFILE_PATH_NAMES.NOTIFICATION_SETTINGS,
-      }).should('not.exist');
-      // try to go directly to the Notification settings URL
-      cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
-      // make sure the user is directed back to the root of the Profile
-      cy.url().should(
-        'eq',
-        `${Cypress.config().baseUrl}${PROFILE_PATHS.PERSONAL_INFORMATION}`,
-      );
+      notificationSettingsSectionIsBlocked(patientWithClaimsAndAppeals);
     });
   });
 });

--- a/src/applications/personalization/profile/tests/fixtures/users/user.js
+++ b/src/applications/personalization/profile/tests/fixtures/users/user.js
@@ -1,28 +1,31 @@
 import { makeMockContactInfo } from '~/platform/user/profile/vap-svc/util/local-vapsvc.js';
 
-export const makeMockUser = () => {
+export const makeMockUser = ({
+  isPatient = true,
+  services = [
+    'appeals-status',
+    'claim_increase',
+    'edu-benefits',
+    'evss_common_client',
+    'evss-claims',
+    'facilities',
+    'form-prefill',
+    'form-save-in-progress',
+    'form526',
+    'hca',
+    'id-card',
+    'identity-proofed',
+    'mhv-accounts',
+    'user-profile',
+    'vet360',
+  ],
+} = {}) => {
   return {
     data: {
       id: '',
       type: 'users_scaffolds',
       attributes: {
-        services: [
-          'appeals-status',
-          'claim_increase',
-          'edu-benefits',
-          'evss_common_client',
-          'evss-claims',
-          'facilities',
-          'form-prefill',
-          'form-save-in-progress',
-          'form526',
-          'hca',
-          'id-card',
-          'identity-proofed',
-          'mhv-accounts',
-          'user-profile',
-          'vet360',
-        ],
+        services,
         account: { accountUuid: 'c049d895-ecdf-40a4-ac0f-7947a06ea0c2' },
         profile: {
           email: 'vets.gov.user+36@gmail.com',
@@ -47,7 +50,7 @@ export const makeMockUser = () => {
           givenNames: ['Wesley', 'Watson'],
           isCernerPatient: false,
           facilities: [{ facilityId: '983', isCerner: false }],
-          vaPatient: true,
+          vaPatient: isPatient,
           mhvAccountState: 'NONE',
         },
         veteranStatus: {


### PR DESCRIPTION
## Description
This PR adds an additional layer of gating on the Notification Settings section of the Profile.

In order to access the feature:
- the feature flag must be on
- NEW: the user must be a patient _or_ have the appeals service _or_ have the claims service
- the local storage flag can also be used to force the feature on

## Original issue(s)
Slack convo: https://dsva.slack.com/archives/C909ZG2BB/p1630529666042300


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs