### PR TITLE
Update README with using entry option for build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ To **build all applications**, run the following:
 yarn build
 ```
 
+To **build one or more applications**, you can use the `--entry` option:
+
+```sh
+yarn build --entry static-pages,auth
+```
+
 To **recompile your application when you make changes**, run:
 
 ```sh


### PR DESCRIPTION
## Description
The `README` only has instructions on how to limit the applications Webpack builds when using the `watch` command. It doesn't specify how to build only one or more applications when using the `build` command (which is technically the same option, but without `env` attached to it).

The reason why `env` doesn't need to be attached to the option when using `yarn build` is because the `build` command executes a shell script that has [logic](https://github.com/department-of-veterans-affairs/vets-website/blob/master/script/build.sh#L13-L14) to add `env` to all arguments passed. The `watch` commands executes a node script that runs the `webpack-dev-server` directly, which needs to have options passed as Webpack environment variables.

We have a [ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/28041) open for cleaning up the build script so that `build` and `watch` will accept similarly formatted arguments.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
