### PR TITLE
Updated Vet Center alert icon

### DIFF
--- a/src/applications/static-pages/facilities/vet-center/buildOperatingStatusProps.js
+++ b/src/applications/static-pages/facilities/vet-center/buildOperatingStatusProps.js
@@ -7,19 +7,19 @@ export const buildOperatingStatusProps = attrs => {
   switch (opStatus) {
     case 'limited':
       status = 'Limited services and hours';
-      iconType = 'triangle';
+      iconType = 'info-circle';
       break;
     case 'closed':
       status = 'Facility closed';
-      iconType = 'circle';
+      iconType = 'exclamation-circle';
       break;
     case 'notice':
       status = 'Facility notice';
-      iconType = 'circle';
+      iconType = 'exclamation-circle';
       break;
     default:
       status = 'Facility status';
-      iconType = 'triangle';
+      iconType = 'exclamation-triangle';
   }
 
   return {

--- a/src/applications/static-pages/sass/modules/_m-operating-status.scss
+++ b/src/applications/static-pages/sass/modules/_m-operating-status.scss
@@ -80,14 +80,14 @@
 }
 
 .limited {
-  background-color: $color-gold-lightest !important;
+  background-color: $color-primary-alt-lightest !important;
 
   span.status-label:hover {
-    background-color: $color-gold-lighter !important;
+    background-color: $color-primary-alt-light !important;
   }
 
   span.status-label:active {
-    background-color: $color-gold-lighter !important;
+    background-color: $color-primary-alt-light !important;
   }
 
 }

--- a/src/applications/static-pages/shared/ExpandableOperatingStatus.jsx
+++ b/src/applications/static-pages/shared/ExpandableOperatingStatus.jsx
@@ -45,7 +45,7 @@ const ExpandableOperatingStatus = props => {
         <i
           aria-hidden="true"
           role="img"
-          className={`fa fa-exclamation-${props.iconType} alert-icon-base`}
+          className={`fa fa-${props.iconType} alert-icon-base`}
         />
         <span className={`${props.extraInfo ? 'status-label' : null}`}>
           {props.statusLabel}

--- a/src/applications/static-pages/tests/facilities/ExpandableOperatingStatus.unit.spec.jsx
+++ b/src/applications/static-pages/tests/facilities/ExpandableOperatingStatus.unit.spec.jsx
@@ -8,7 +8,7 @@ describe('<ExpandableOperatingStatus>', () => {
     const wrapper = shallow(
       <ExpandableOperatingStatus
         operatingStatusFacility={'limited'}
-        iconType={'triangle'}
+        iconType={'exclamation-triangle'}
         statusLabel={'Limited services and hours'}
         extraInfo={
           'Lorem ipsum dolor sit amet, pro soluta utroque gubergren in. Ea cum delenit dissentiet. Sint tamquam dolorum ' +


### PR DESCRIPTION
## Description
resolved issue linked below


## Screenshots of updated icons

<details>
<summary>colorado springs vet center main page</summary>

<img width="748" alt="Screen Shot 2021-09-02 at 1 57 05 PM" src="https://user-images.githubusercontent.com/84030819/131893536-29bb7389-2934-476e-b1d1-861695fbaa10.png">

</details>

<details>
<summary>colorado springs vet center locations page</summary>

<img width="485" alt="Screen Shot 2021-09-02 at 1 56 31 PM" src="https://user-images.githubusercontent.com/84030819/131893473-e1978f2e-5bff-4ee1-ae75-a8e7f89e5e3a.png">

</details>

