### PR TITLE
Update Docker image used for Cypress tests on GitHub Actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -562,7 +562,7 @@ jobs:
     needs: [build, cypress-tests-prep]
     if: ${{ needs.cypress-tests-prep.outputs.num_containers > 0 }}
     container:
-      image: public.ecr.aws/cypress-io/cypress/browsers:node14.16.0-chrome89-ff77
+      image: public.ecr.aws/cypress-io/cypress/browsers:node14.16.0-chrome90-ff88
       options: -u 1001:1001 -v /usr/local/share:/share
 
     strategy:


### PR DESCRIPTION
## Description
This PR updates the Docker image used for Cypress tests on GitHub Actions. The new image has a more recent version of Chrome (`v90`).

## Acceptance criteria
- [ ] Cypress tests run and pass on GitHub Actions.