### PR TITLE
Bump component-library dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -236,7 +236,7 @@
   },
   "private": true,
   "dependencies": {
-    "@department-of-veterans-affairs/component-library": "^3.0.0",
+    "@department-of-veterans-affairs/component-library": "^3.0.1",
     "@department-of-veterans-affairs/formation": "6.16.4",
     "@department-of-veterans-affairs/formulate": "0.0.1",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1578,10 +1578,10 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@department-of-veterans-affairs/component-library@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-3.0.0.tgz#5752a0f531a364e2175ce0338af6d58373dab0e8"
-  integrity sha512-4XoOYZL26paLXYFeU6MFLpnKUB48yuNnWvvqVJqKplDBrcGW0SkA70FEwd7vFubDBrL6FGDIs5Yi837tmC4Rgg==
+"@department-of-veterans-affairs/component-library@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-3.0.1.tgz#dc471ac652316bf4c3e4d3c7232c7da54df1dfc5"
+  integrity sha512-Xk+nqVJaPCASIufwGOI01MewU7rFFjOPkK9mHbI5A1ONu7mc7KtpDP88j3D5jRm/oiLhnl1Fz/trxRu0pMKZ0Q==
   dependencies:
     classnames "^2.2.6"
     core-js "^3.9.0"


### PR DESCRIPTION
# Description

This PR bumps 3.0.0 to 3.0.1 for the component-library dependency.

## Before

![image](https://user-images.githubusercontent.com/12773166/132024304-6c2349ff-9f2d-42ef-be99-c9c66d64ee35.png)

## After

![image](https://user-images.githubusercontent.com/12773166/132024271-b8cb8d26-28a9-4fa6-8a43-141d030f3ecf.png)
