### PR TITLE
CT Redesign: Filter Your Results Accessibility

### DIFF
--- a/src/applications/gi-sandbox/components/Checkbox.jsx
+++ b/src/applications/gi-sandbox/components/Checkbox.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import _ from 'lodash';
 import classNames from 'classnames';
 
-import { handleScrollOnInputFocus } from '../utils/helpers';
+import { createId, handleScrollOnInputFocus } from '../utils/helpers';
 
 const Checkbox = ({
   checked,
@@ -15,6 +15,8 @@ const Checkbox = ({
   onChange,
   onFocus,
   required,
+  ariaLabel,
+  ariaLabelInputLegendId,
 }) => {
   const inputId = _.uniqueId('errorable-checkbox-');
   const hasErrors = !!errorMessage;
@@ -34,13 +36,16 @@ const Checkbox = ({
         type="checkbox"
         onChange={onChange}
         onFocus={onFocus}
+        aria-labelledby={`${ariaLabelInputLegendId} ${createId(name)}-label`}
       />
       <label
         className={classNames('gi-checkbox-label', {
           'usa-input-error-label': hasErrors,
         })}
+        id={`${createId(name)}-label`}
         name={`${name}-label`}
         htmlFor={inputId}
+        aria-label={ariaLabel}
       >
         {label}
         {required && <span className="form-required-span">*</span>}

--- a/src/applications/gi-sandbox/components/CheckboxGroup.jsx
+++ b/src/applications/gi-sandbox/components/CheckboxGroup.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
-import { handleScrollOnInputFocus } from '../utils/helpers';
+import { handleScrollOnInputFocus, createId } from '../utils/helpers';
 
 const CheckboxGroup = ({ errorMessage, label, onChange, onFocus, options }) => {
   const inputId = _.uniqueId('checkbox-group-');
@@ -19,11 +19,13 @@ const CheckboxGroup = ({ errorMessage, label, onChange, onFocus, options }) => {
             type="checkbox"
             onFocus={() => onFocus(`${inputId}-${index}`)}
             onChange={onChange}
-            aria-labelledby={`${inputId}-legend ${name}-${index}-label`}
+            aria-labelledby={`${inputId}-legend ${createId(
+              name,
+            )}-${index}-label`}
           />
           <label
             className="gi-checkbox-label"
-            id={`${name}-${index}-label`}
+            id={`${createId(name)}-${index}-label`}
             name={`${name}-label`}
             htmlFor={`${inputId}-${index}`}
           >

--- a/src/applications/gi-sandbox/containers/FilterYourResults.jsx
+++ b/src/applications/gi-sandbox/containers/FilterYourResults.jsx
@@ -11,6 +11,7 @@ import {
   getStateNameForCode,
   sortOptionsByStateName,
   addAllOption,
+  createId,
 } from '../utils/helpers';
 import { showModal, filterChange } from '../actions';
 import { connect } from 'react-redux';
@@ -254,10 +255,18 @@ export function FilterYourResults({
   };
 
   const typeOfInstitution = () => {
+    const name = 'Type of institution';
+    const legendId = `${createId(name)}-legend`;
     return (
       <>
         <div className="vads-u-margin-bottom--4">
-          <h3 className="vads-u-margin-bottom--3">Type of institution</h3>
+          <h3
+            className="vads-u-margin-bottom--3"
+            aria-label={`${name}:`}
+            id={legendId}
+          >
+            {name}
+          </h3>
           <ExpandingGroup open={schools}>
             <Checkbox
               checked={schools}
@@ -265,6 +274,7 @@ export function FilterYourResults({
               label="Schools"
               onChange={handleSchoolChange}
               className="expanding-header-checkbox"
+              ariaLabelInputLegendId={legendId}
             />
             <div className="school-types expanding-group-children">
               {excludedSchoolTypesGroup()}
@@ -279,6 +289,7 @@ export function FilterYourResults({
           label="On-the-job training and apprenticeships"
           onChange={onChangeCheckbox}
           className="vads-u-margin-bottom--4"
+          ariaLabelInputLegendId={legendId}
         />
         <ExpandingGroup open={vettec}>
           <Checkbox
@@ -287,6 +298,7 @@ export function FilterYourResults({
             label="VET TEC providers"
             onChange={handleVetTecChange}
             className="expanding-header-checkbox"
+            ariaLabelInputLegendId={legendId}
           />
           <div className="expanding-group-children">
             <Checkbox
@@ -294,6 +306,8 @@ export function FilterYourResults({
               name="preferredProvider"
               label="Preferred providers"
               onChange={handlePreferredProviderChange}
+              ariaLabel="VET TEC Preferred providers"
+              ariaLabelInputLegendId={legendId}
             />
           </div>
         </ExpandingGroup>

--- a/src/applications/gi-sandbox/containers/FilterYourResults.jsx
+++ b/src/applications/gi-sandbox/containers/FilterYourResults.jsx
@@ -134,7 +134,8 @@ export function FilterYourResults({
   };
 
   const setFocusByName = name => {
-    document.getElementsByName(name)[0].focus();
+    const element = document.getElementsByName(name)[0];
+    if (element) element.focus();
   };
 
   const excludedSchoolTypesGroup = () => {

--- a/src/applications/gi-sandbox/containers/FilterYourResults.jsx
+++ b/src/applications/gi-sandbox/containers/FilterYourResults.jsx
@@ -175,46 +175,49 @@ export function FilterYourResults({
   };
 
   const schoolAttributes = () => {
+    const options = [
+      {
+        name: 'excludeCautionFlags',
+        checked: excludeCautionFlags,
+        optionLabel: (
+          <LearnMoreLabel
+            text="Has no cautionary warnings"
+            onClick={() => dispatchShowModal('cautionaryWarnings')}
+            ariaLabel="Learn more about VA education and training programs"
+          />
+        ),
+      },
+      {
+        name: 'accredited',
+        checked: accredited,
+        optionLabel: (
+          <LearnMoreLabel
+            text="Is accredited"
+            onClick={() => dispatchShowModal('accredited')}
+            ariaLabel="Learn more about VA education and training programs"
+          />
+        ),
+      },
+      {
+        name: 'studentVeteran',
+        checked: studentVeteran,
+        optionLabel: 'Has a Student Veteran Group',
+      },
+      {
+        name: 'yellowRibbonScholarship',
+        checked: yellowRibbonScholarship,
+        optionLabel: 'Offers Yellow Ribbon Program',
+      },
+    ];
+
     return (
-      <>
-        <p>About the school</p>
-        <Checkbox
-          checked={excludeCautionFlags}
-          name="excludeCautionFlags"
-          label={
-            <LearnMoreLabel
-              text="Has no cautionary warnings"
-              onClick={() => dispatchShowModal('cautionaryWarnings')}
-              ariaLabel="Learn more about VA education and training programs"
-            />
-          }
-          onChange={onChangeCheckbox}
-        />
-        <Checkbox
-          checked={accredited}
-          name="accredited"
-          label={
-            <LearnMoreLabel
-              text="Is accredited"
-              onClick={() => dispatchShowModal('accredited')}
-              ariaLabel="Learn more about VA education and training programs"
-            />
-          }
-          onChange={onChangeCheckbox}
-        />
-        <Checkbox
-          checked={studentVeteran}
-          name="studentVeteran"
-          label="Has a Student Veteran Group"
-          onChange={onChangeCheckbox}
-        />
-        <Checkbox
-          checked={yellowRibbonScholarship}
-          name="yellowRibbonScholarship"
-          label="Offers Yellow Ribbon Program"
-          onChange={onChangeCheckbox}
-        />
-      </>
+      <CheckboxGroup
+        label={
+          <div className="vads-u-margin-left--neg0p25">About the school:</div>
+        }
+        onChange={onChangeCheckbox}
+        options={options}
+      />
     );
   };
 

--- a/src/applications/gi-sandbox/containers/FilterYourResults.jsx
+++ b/src/applications/gi-sandbox/containers/FilterYourResults.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import SearchAccordion from '../components/SearchAccordion';
 import Checkbox from '../components/Checkbox';
@@ -51,6 +51,7 @@ export function FilterYourResults({
     search.tab === TABS.name ? search.name.facets : search.location.facets;
 
   const [showAllSchoolTypes, setShowAllSchoolTypes] = useState(false);
+  const SEE_LESS_SIZE = 4;
 
   const updateInstitutionFilters = (name, value) => {
     dispatchFilterChange({ ...filters, [name]: value });
@@ -132,10 +133,14 @@ export function FilterYourResults({
     modalClose();
   };
 
+  const setFocusByName = name => {
+    document.getElementsByName(name)[0].focus();
+  };
+
   const excludedSchoolTypesGroup = () => {
     const options = (showAllSchoolTypes
       ? INSTITUTION_TYPES
-      : INSTITUTION_TYPES.slice(0, 4)
+      : INSTITUTION_TYPES.slice(0, SEE_LESS_SIZE)
     ).map(type => {
       return {
         name: type.toUpperCase(),
@@ -174,6 +179,21 @@ export function FilterYourResults({
       </div>
     );
   };
+
+  useEffect(
+    () => {
+      if (showAllSchoolTypes) {
+        setFocusByName(
+          `${INSTITUTION_TYPES[SEE_LESS_SIZE].toUpperCase()}-label`,
+        );
+      } else {
+        setFocusByName(
+          `${INSTITUTION_TYPES[SEE_LESS_SIZE - 1].toUpperCase()}-label`,
+        );
+      }
+    },
+    [showAllSchoolTypes],
+  );
 
   const schoolAttributes = () => {
     const options = [


### PR DESCRIPTION
## Description / Original issue(s)
department-of-veterans-affairs/va.gov-team#29262
- In CheckboxGroup fixed the label's id and usage in attribute `aria-labelledby` to be a valid id

department-of-veterans-affairs/va.gov-team#29353
- In FilterYourResults swapped from 4 individual Checkboxes to a CheckboxGroup

department-of-veterans-affairs/va.gov-team#29255
- For Checkbox added `ariaLabel` and `ariaLabelInputLegendId` properties to allow for setting the input's `aria-labelledby` and the label's `aria-label` to be used by "Type of institution" checkboxes since CheckboxGroup component could not be used due to how ExpandingGroup component works

department-of-veterans-affairs/va.gov-team#29265
- For "Exclude these schools: " On click of "See more" sets focus to the fifth option in the list
- For "Exclude these schools: " On click of "See less" sets focus to the fourth option in the list


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
