### PR TITLE
Prompts user to sign in and hides chatbot if unauthenticated

### DIFF
--- a/src/applications/virtual-agent/components/chatbox/Chatbox.jsx
+++ b/src/applications/virtual-agent/components/chatbox/Chatbox.jsx
@@ -26,6 +26,7 @@ function useWebChat(props) {
     token: token.token,
     WebChatFramework: webchatFramework.WebChatFramework,
     loadingStatus,
+    apiSession: token.apiSession,
   };
 }
 
@@ -73,7 +74,9 @@ const ConnectedSignInAlert = connect(
 )(SignInAlert);
 
 function App(props) {
-  const { token, WebChatFramework, loadingStatus } = useWebChat(props);
+  const { token, WebChatFramework, loadingStatus, apiSession } = useWebChat(
+    props,
+  );
 
   switch (loadingStatus) {
     case ERROR:
@@ -81,7 +84,13 @@ function App(props) {
     case LOADING:
       return <LoadingIndicator message={'Loading Virtual Agent'} />;
     case COMPLETE:
-      return <WebChat token={token} WebChatFramework={WebChatFramework} />;
+      return (
+        <WebChat
+          token={token}
+          WebChatFramework={WebChatFramework}
+          apiSession={apiSession}
+        />
+      );
     default:
       throw new Error(`Invalid loading status: ${loadingStatus}`);
   }

--- a/src/applications/virtual-agent/components/chatbox/Chatbox.jsx
+++ b/src/applications/virtual-agent/components/chatbox/Chatbox.jsx
@@ -10,7 +10,7 @@ import {
   ERROR,
   LOADING,
 } from './loadingStatus';
-import {connect, useSelector} from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
 
 function useWebChat(props) {
@@ -50,13 +50,13 @@ export default function Chatbox(props) {
   );
 }
 
-function SignInAlert({ toggleLoginModal }) {
+function SignInAlert({ showLoginModal }) {
   return (
     <va-alert status="continue">
       <p>Please sign in to access the chatbot.</p>
       <button
         className="usa-button-primary"
-        onClick={() => toggleLoginModal(true)}
+        onClick={() => showLoginModal(true)}
       >
         Sign in to VA.gov
       </button>
@@ -65,7 +65,7 @@ function SignInAlert({ toggleLoginModal }) {
 }
 
 const mapDispatchToProps = {
-  toggleLoginModal,
+  showLoginModal: toggleLoginModal,
 };
 
 const ConnectedSignInAlert = connect(

--- a/src/applications/virtual-agent/components/chatbox/Chatbox.jsx
+++ b/src/applications/virtual-agent/components/chatbox/Chatbox.jsx
@@ -36,6 +36,12 @@ export default function Chatbox(props) {
           VA Virtual Agent (beta)
         </h2>
       </div>
+      <va-alert status="continue">
+        <p>Please sign in to access the chatbot.</p>
+        <button className="usa-button-primary" onClick={() => {}}>
+          Sign in to VA.gov
+        </button>
+      </va-alert>
       <App timeout={props.timeout || ONE_MINUTE} />
     </div>
   );

--- a/src/applications/virtual-agent/components/chatbox/Chatbox.jsx
+++ b/src/applications/virtual-agent/components/chatbox/Chatbox.jsx
@@ -10,6 +10,8 @@ import {
   ERROR,
   LOADING,
 } from './loadingStatus';
+import { connect } from 'react-redux';
+import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
 
 function useWebChat(props) {
   const webchatFramework = useWebChatFramework(props);
@@ -36,16 +38,34 @@ export default function Chatbox(props) {
           VA Virtual Agent (beta)
         </h2>
       </div>
-      <va-alert status="continue">
-        <p>Please sign in to access the chatbot.</p>
-        <button className="usa-button-primary" onClick={() => {}}>
-          Sign in to VA.gov
-        </button>
-      </va-alert>
+      <ConnectedSignInAlert />
       <App timeout={props.timeout || ONE_MINUTE} />
     </div>
   );
 }
+
+function SignInAlert({ toggleLoginModal }) {
+  return (
+    <va-alert status="continue">
+      <p>Please sign in to access the chatbot.</p>
+      <button
+        className="usa-button-primary"
+        onClick={() => toggleLoginModal(true)}
+      >
+        Sign in to VA.gov
+      </button>
+    </va-alert>
+  );
+}
+
+const mapDispatchToProps = {
+  toggleLoginModal,
+};
+
+const ConnectedSignInAlert = connect(
+  null,
+  mapDispatchToProps,
+)(SignInAlert);
 
 function App(props) {
   const { token, WebChatFramework, loadingStatus } = useWebChat(props);

--- a/src/applications/virtual-agent/components/chatbox/Chatbox.jsx
+++ b/src/applications/virtual-agent/components/chatbox/Chatbox.jsx
@@ -10,7 +10,7 @@ import {
   ERROR,
   LOADING,
 } from './loadingStatus';
-import { connect } from 'react-redux';
+import {connect, useSelector} from 'react-redux';
 import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
 
 function useWebChat(props) {
@@ -30,6 +30,8 @@ function useWebChat(props) {
 }
 
 export default function Chatbox(props) {
+  const isLoggedIn = useSelector(state => state.user.login.currentlyLoggedIn);
+
   const ONE_MINUTE = 1 * 60 * 1000;
   return (
     <div className="vads-u-padding--1p5 vads-u-background-color--gray-lightest">
@@ -38,8 +40,11 @@ export default function Chatbox(props) {
           VA Virtual Agent (beta)
         </h2>
       </div>
-      <ConnectedSignInAlert />
-      <App timeout={props.timeout || ONE_MINUTE} />
+      {!isLoggedIn ? (
+        <ConnectedSignInAlert />
+      ) : (
+        <App timeout={props.timeout || ONE_MINUTE} />
+      )}
     </div>
   );
 }

--- a/src/applications/virtual-agent/components/chatbox/useVirtualAgentToken.js
+++ b/src/applications/virtual-agent/components/chatbox/useVirtualAgentToken.js
@@ -29,6 +29,7 @@ function useWaitForCsrfToken(props) {
 
 export default function useVirtualAgentToken(props) {
   const [token, setToken] = useState('');
+  const [apiSession, setApiSession] = useState('');
   const [csrfTokenLoading, csrfTokenLoadingError] = useWaitForCsrfToken(props);
   const [loadingStatus, setLoadingStatus] = useState(LOADING);
 
@@ -50,6 +51,7 @@ export default function useVirtualAgentToken(props) {
           const response = await retryOnce(callVirtualAgentTokenApi);
 
           setToken(response.token);
+          setApiSession(response.apiSession);
           setLoadingStatus(COMPLETE);
         } catch (ex) {
           Sentry.captureException(
@@ -63,5 +65,5 @@ export default function useVirtualAgentToken(props) {
     [csrfTokenLoading, csrfTokenLoadingError],
   );
 
-  return { token, loadingStatus };
+  return { token, loadingStatus, apiSession };
 }

--- a/src/applications/virtual-agent/components/webchat/WebChat.jsx
+++ b/src/applications/virtual-agent/components/webchat/WebChat.jsx
@@ -1,13 +1,17 @@
 import React, { useMemo } from 'react';
 import MarkdownRenderer from './markdownRenderer';
-import makeBotGreetUser from './makeBotGreetUser';
+import GreetUser from './makeBotGreetUser';
 
 const renderMarkdown = text => MarkdownRenderer.render(text);
 
-const WebChat = ({ token, WebChatFramework }) => {
+const WebChat = ({ token, WebChatFramework, apiSession }) => {
   const { ReactWebChat, createDirectLine, createStore } = WebChatFramework;
+  const csrfToken = localStorage.getItem('csrfToken');
 
-  const store = useMemo(() => createStore({}, makeBotGreetUser), [createStore]);
+  const store = useMemo(
+    () => createStore({}, GreetUser.makeBotGreetUser(csrfToken, apiSession)),
+    [createStore],
+  );
 
   const directLine = useMemo(
     () =>

--- a/src/applications/virtual-agent/components/webchat/makeBotGreetUser.js
+++ b/src/applications/virtual-agent/components/webchat/makeBotGreetUser.js
@@ -15,6 +15,10 @@ const GreetUser = {
             // Web Chat will show the 'Greeting' System Topic message which has a trigger-phrase 'hello'
             name: 'startConversation',
             type: 'event',
+            value: {
+              csrfToken,
+              apiSession,
+            },
           },
         },
         type: 'DIRECT_LINE/POST_ACTIVITY',

--- a/src/applications/virtual-agent/components/webchat/makeBotGreetUser.js
+++ b/src/applications/virtual-agent/components/webchat/makeBotGreetUser.js
@@ -1,23 +1,27 @@
-const makeBotGreetUser = ({ dispatch }) => next => action => {
-  if (action.type === 'DIRECT_LINE/CONNECT_FULFILLED') {
-    dispatch({
-      meta: {
-        method: 'keyboard',
-      },
-      payload: {
-        activity: {
-          channelData: {
-            postBack: true,
-          },
-          // Web Chat will show the 'Greeting' System Topic message which has a trigger-phrase 'hello'
-          name: 'startConversation',
-          type: 'event',
+const GreetUser = {
+  makeBotGreetUser: (csrfToken, apiSession) => ({
+    dispatch,
+  }) => next => action => {
+    if (action.type === 'DIRECT_LINE/CONNECT_FULFILLED') {
+      dispatch({
+        meta: {
+          method: 'keyboard',
         },
-      },
-      type: 'DIRECT_LINE/POST_ACTIVITY',
-    });
-  }
-  return next(action);
+        payload: {
+          activity: {
+            channelData: {
+              postBack: true,
+            },
+            // Web Chat will show the 'Greeting' System Topic message which has a trigger-phrase 'hello'
+            name: 'startConversation',
+            type: 'event',
+          },
+        },
+        type: 'DIRECT_LINE/POST_ACTIVITY',
+      });
+    }
+    return next(action);
+  },
 };
 
-export default makeBotGreetUser;
+export default GreetUser;

--- a/src/applications/virtual-agent/tests/Chatbox.unit.spec.js
+++ b/src/applications/virtual-agent/tests/Chatbox.unit.spec.js
@@ -417,5 +417,24 @@ describe('App', () => {
 
       expect(store.getState().navigation.showLoginModal).to.be.true;
     });
+
+    it('does not display chatbot', async () => {
+      const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
+        initialState: {
+          featureToggles: {
+            loading: true,
+          },
+          user: {
+            loggedIn: {
+              currentlyLoggedIn: false,
+            },
+          },
+        },
+      });
+
+      const alertText = wrapper.queryByText('Loading Virtual Agent');
+
+      expect(alertText).to.not.exist;
+    });
   });
 });

--- a/src/applications/virtual-agent/tests/Chatbox.unit.spec.js
+++ b/src/applications/virtual-agent/tests/Chatbox.unit.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { expect } from 'chai';
-import { waitFor, screen } from '@testing-library/react';
+import { waitFor, screen, fireEvent } from '@testing-library/react';
 import sinon from 'sinon';
 import * as Sentry from '@sentry/browser';
 
@@ -377,6 +377,37 @@ describe('App', () => {
 
       expect(window.React).to.eql(React);
       expect(window.ReactDOM).to.eql(ReactDOM);
+    });
+  });
+
+  describe.only('when user is not logged in', () => {
+    it('displays a login widget', async () => {
+      const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
+        initialState: {
+          featureToggles: {
+            loading: false,
+          },
+        },
+      });
+
+      await waitFor(
+        () =>
+          expect(wrapper.getByText('Please sign in to access the chatbot.')).to
+            .exist,
+      );
+    });
+
+    it('displays sign in modal when user clicks sign in button', async () => {
+      const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
+        initialState: {
+          featureToggles: {
+            loading: false,
+          },
+        },
+      });
+      const button = wrapper.getByRole('button');
+      fireEvent.click(button);
+      expect(wrapper.getByRole('alertdialog')).to.exist;
     });
   });
 });

--- a/src/applications/virtual-agent/tests/Chatbox.unit.spec.js
+++ b/src/applications/virtual-agent/tests/Chatbox.unit.spec.js
@@ -53,334 +53,404 @@ describe('App', () => {
       setTimeout(resolve, timeout);
     });
   }
+  describe('user is logged in', () => {
+    describe('web chat script is already loaded', () => {
+      it('renders web chat', async () => {
+        loadWebChat();
+        mockApiRequest({});
 
-  describe('web chat script is already loaded', () => {
-    it('renders web chat', async () => {
-      loadWebChat();
-      mockApiRequest({});
-
-      const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
-        initialState: {
-          featureToggles: {
-            loading: false,
-          },
-        },
-      });
-
-      await waitFor(() => expect(wrapper.getByTestId('webchat')).to.exist);
-    });
-
-    it('should not create a store more than once', async () => {
-      loadWebChat();
-      mockApiRequest({});
-
-      const { getByTestId } = renderInReduxProvider(
-        <Chatbox {...defaultProps} />,
-        {
+        const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
           initialState: {
             featureToggles: {
               loading: false,
             },
+            user: {
+              login: {
+                currentlyLoggedIn: true,
+              },
+            },
           },
-        },
-      );
+        });
 
-      await waitFor(() => expect(getByTestId('webchat')).to.exist);
-
-      expect(createStoreSpy.callCount).to.equal(1);
-    });
-  });
-
-  describe('web chat script has not loaded', () => {
-    it('should not render webchat until webchat framework is loaded', async () => {
-      mockApiRequest({});
-
-      const wrapper = renderInReduxProvider(<Chatbox timeout={1000} />, {
-        initialState: {
-          featureToggles: {
-            loading: false,
-          },
-        },
+        await waitFor(() => expect(wrapper.getByTestId('webchat')).to.exist);
       });
 
-      expect(wrapper.getByRole('progressbar')).to.exist;
-      expect(wrapper.queryByTestId('webchat')).to.not.exist;
+      it('should not create a store more than once', async () => {
+        loadWebChat();
+        mockApiRequest({});
 
-      await wait(500);
+        const { getByTestId } = renderInReduxProvider(
+          <Chatbox {...defaultProps} />,
+          {
+            initialState: {
+              featureToggles: {
+                loading: false,
+              },
+              user: {
+                login: {
+                  currentlyLoggedIn: true,
+                },
+              },
+            },
+          },
+        );
 
-      loadWebChat();
+        await waitFor(() => expect(getByTestId('webchat')).to.exist);
 
-      await waitFor(() => expect(wrapper.getByTestId('webchat')).to.exist);
+        expect(createStoreSpy.callCount).to.equal(1);
+      });
     });
 
-    it('should display error if webchat does not load after x milliseconds', async () => {
-      mockApiRequest({});
+    describe('web chat script has not loaded', () => {
+      it('should not render webchat until webchat framework is loaded', async () => {
+        mockApiRequest({});
 
-      const wrapper = renderInReduxProvider(<Chatbox timeout={1500} />, {
-        initialState: {
-          featureToggles: {
-            loading: false,
+        const wrapper = renderInReduxProvider(<Chatbox timeout={1000} />, {
+          initialState: {
+            featureToggles: {
+              loading: false,
+            },
+            user: {
+              login: {
+                currentlyLoggedIn: true,
+              },
+            },
           },
-        },
+        });
+
+        expect(wrapper.getByRole('progressbar')).to.exist;
+        expect(wrapper.queryByTestId('webchat')).to.not.exist;
+
+        await wait(500);
+
+        loadWebChat();
+
+        await waitFor(() => expect(wrapper.getByTestId('webchat')).to.exist);
       });
 
-      expect(wrapper.getByRole('progressbar')).to.exist;
+      it('should display error if webchat does not load after x milliseconds', async () => {
+        mockApiRequest({});
 
-      await wait(2000);
+        const wrapper = renderInReduxProvider(<Chatbox timeout={1500} />, {
+          initialState: {
+            featureToggles: {
+              loading: false,
+            },
+            user: {
+              login: {
+                currentlyLoggedIn: true,
+              },
+            },
+          },
+        });
 
-      loadWebChat();
+        expect(wrapper.getByRole('progressbar')).to.exist;
 
-      await waitFor(
-        () => expect(wrapper.getByText(CHATBOT_ERROR_MESSAGE)).to.exist,
-      );
+        await wait(2000);
 
-      expect(wrapper.queryByRole('progressbar')).to.not.exist;
-      expect(Sentry.captureException.called).to.be.true;
-      expect(Sentry.captureException.getCall(0).args[0].message).equals(
-        'Failed to load webchat framework',
-      );
+        loadWebChat();
+
+        await waitFor(
+          () => expect(wrapper.getByText(CHATBOT_ERROR_MESSAGE)).to.exist,
+        );
+
+        expect(wrapper.queryByRole('progressbar')).to.not.exist;
+        expect(Sentry.captureException.called).to.be.true;
+        expect(Sentry.captureException.getCall(0).args[0].message).equals(
+          'Failed to load webchat framework',
+        );
+      });
     });
-  });
 
-  describe('while feature flags are loading', () => {
-    const getTokenCalled = () => {
-      return fetch.called;
-    };
+    describe('while feature flags are loading', () => {
+      const getTokenCalled = () => {
+        return fetch.called;
+      };
 
-    it('should not fetch token', () => {
-      loadWebChat();
+      it('should not fetch token', () => {
+        loadWebChat();
 
-      mockApiRequest({});
+        mockApiRequest({});
 
-      renderInReduxProvider(<Chatbox {...defaultProps} />, {
-        initialState: {
+        renderInReduxProvider(<Chatbox {...defaultProps} />, {
+          initialState: {
+            featureToggles: {
+              loading: true,
+            },
+            user: {
+              login: {
+                currentlyLoggedIn: true,
+              },
+            },
+          },
+        });
+
+        expect(getTokenCalled()).to.equal(false);
+      });
+
+      it('should display loading indicator', () => {
+        loadWebChat();
+
+        mockApiRequest({});
+
+        const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
+          initialState: {
+            featureToggles: {
+              loading: true,
+            },
+            user: {
+              login: {
+                currentlyLoggedIn: true,
+              },
+            },
+          },
+        });
+
+        expect(wrapper.getByRole('progressbar')).to.exist;
+
+        expect(wrapper.queryByTestId('webchat')).to.not.exist;
+      });
+
+      it('should display error after loading feature toggles has not finished within timeout', async () => {
+        loadWebChat();
+
+        const wrapper = renderInReduxProvider(<Chatbox timeout={100} />, {
+          initialState: {
+            featureToggles: {
+              loading: true,
+            },
+            user: {
+              login: {
+                currentlyLoggedIn: true,
+              },
+            },
+          },
+        });
+
+        expect(wrapper.getByRole('progressbar')).to.exist;
+
+        await waitFor(
+          () => expect(wrapper.getByText(CHATBOT_ERROR_MESSAGE)).to.exist,
+        );
+
+        expect(Sentry.captureException.called).to.be.true;
+        expect(Sentry.captureException.getCall(0).args[0].message).equals(
+          'Could not load feature toggles within timeout',
+        );
+      });
+
+      it('should not rerender if feature toggles load before timeout', async () => {
+        loadWebChat();
+
+        mockApiRequest({});
+
+        const store = createTestStore({
           featureToggles: {
             loading: true,
           },
-        },
+          user: {
+            login: {
+              currentlyLoggedIn: true,
+            },
+          },
+        });
+
+        const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
+          store,
+        });
+
+        expect(getTokenCalled()).to.equal(false);
+
+        expect(wrapper.getByRole('progressbar')).to.exist;
+
+        store.dispatch({ type: FETCH_TOGGLE_VALUES_SUCCEEDED, payload: {} });
+
+        wait(100);
+
+        await waitFor(() => expect(getTokenCalled()).to.equal(true));
+
+        expect(Sentry.captureException.called).to.be.false;
       });
 
-      expect(getTokenCalled()).to.equal(false);
-    });
+      it('should call token api after loading feature toggles', async () => {
+        loadWebChat();
 
-    it('should display loading indicator', () => {
-      loadWebChat();
+        mockApiRequest({});
 
-      mockApiRequest({});
-
-      const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
-        initialState: {
+        const store = createTestStore({
           featureToggles: {
             loading: true,
           },
-        },
-      });
-
-      expect(wrapper.getByRole('progressbar')).to.exist;
-
-      expect(wrapper.queryByTestId('webchat')).to.not.exist;
-    });
-
-    it('should display error after loading feature toggles has not finished within timeout', async () => {
-      loadWebChat();
-
-      const wrapper = renderInReduxProvider(<Chatbox timeout={100} />, {
-        initialState: {
-          featureToggles: {
-            loading: true,
+          user: {
+            login: {
+              currentlyLoggedIn: true,
+            },
           },
-        },
+        });
+
+        const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
+          store,
+        });
+
+        expect(getTokenCalled()).to.equal(false);
+
+        expect(wrapper.getByRole('progressbar')).to.exist;
+
+        store.dispatch({ type: FETCH_TOGGLE_VALUES_SUCCEEDED, payload: {} });
+
+        await waitFor(() => expect(getTokenCalled()).to.equal(true));
       });
-
-      expect(wrapper.getByRole('progressbar')).to.exist;
-
-      await waitFor(
-        () => expect(wrapper.getByText(CHATBOT_ERROR_MESSAGE)).to.exist,
-      );
-
-      expect(Sentry.captureException.called).to.be.true;
-      expect(Sentry.captureException.getCall(0).args[0].message).equals(
-        'Could not load feature toggles within timeout',
-      );
     });
 
-    it('should not rerender if feature toggles load before timeout', async () => {
-      loadWebChat();
+    describe('on initial load', () => {
+      it('should show loading indicator', () => {
+        loadWebChat();
+        mockApiRequest({ token: 'ANOTHERFAKETOKEN' });
+        const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
+          initialState: {
+            featureToggles: {
+              loading: false,
+            },
+            user: {
+              login: {
+                currentlyLoggedIn: true,
+              },
+            },
+          },
+        });
 
-      mockApiRequest({});
-
-      const store = createTestStore({
-        featureToggles: {
-          loading: true,
-        },
+        expect(wrapper.getByRole('progressbar')).to.exist;
       });
-
-      const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
-        store,
-      });
-
-      expect(getTokenCalled()).to.equal(false);
-
-      expect(wrapper.getByRole('progressbar')).to.exist;
-
-      store.dispatch({ type: FETCH_TOGGLE_VALUES_SUCCEEDED, payload: {} });
-
-      wait(100);
-
-      await waitFor(() => expect(getTokenCalled()).to.equal(true));
-
-      expect(Sentry.captureException.called).to.be.false;
     });
 
-    it('should call token api after loading feature toggles', async () => {
-      loadWebChat();
+    describe('when token is valid', () => {
+      it('should render web chat', async () => {
+        loadWebChat();
+        mockApiRequest({ token: 'FAKETOKEN' });
+        const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
+          initialState: {
+            featureToggles: {
+              loading: false,
+            },
+            user: {
+              login: {
+                currentlyLoggedIn: true,
+              },
+            },
+          },
+        });
 
-      mockApiRequest({});
+        await waitFor(() => expect(wrapper.getByTestId('webchat')).to.exist);
 
-      const store = createTestStore({
-        featureToggles: {
-          loading: true,
-        },
+        expect(directLineSpy.called).to.be.true;
+        expect(
+          directLineSpy.calledWith({
+            token: 'FAKETOKEN',
+            domain:
+              'https://northamerica.directline.botframework.com/v3/directline',
+          }),
+        ).to.be.true;
+      });
+    });
+
+    describe('when api returns error', () => {
+      it('should display error message', async () => {
+        loadWebChat();
+        mockApiRequest({}, false);
+        const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
+          initialState: {
+            featureToggles: {
+              loading: false,
+            },
+            user: {
+              login: {
+                currentlyLoggedIn: true,
+              },
+            },
+          },
+        });
+
+        await waitFor(
+          () => expect(wrapper.getByText(CHATBOT_ERROR_MESSAGE)).to.exist,
+        );
+
+        expect(Sentry.captureException.called).to.be.true;
+        expect(Sentry.captureException.getCall(0).args[0].message).equals(
+          'Could not retrieve virtual agent token',
+        );
+      });
+    });
+
+    describe('when api returns error one time, but works after a retry', () => {
+      it('should render web chat', async () => {
+        loadWebChat();
+        mockMultipleApiRequests([
+          { response: {}, shouldResolve: false },
+          { response: { token: 'FAKETOKEN' }, shouldResolve: true },
+        ]);
+
+        const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
+          initialState: {
+            featureToggles: {
+              loading: false,
+            },
+            user: {
+              login: {
+                currentlyLoggedIn: true,
+              },
+            },
+          },
+        });
+
+        await waitFor(() => expect(wrapper.getByTestId('webchat')).to.exist);
+
+        expect(Sentry.captureException.called).to.be.false;
+      });
+    });
+
+    describe('when chatbox is rendered', () => {
+      it.skip('loads the webchat framework via script tag', () => {
+        expect(screen.queryByTestId('webchat-framework-script')).to.not.exist;
+
+        const wrapper = renderInReduxProvider(<Chatbox timeout={10} />);
+
+        expect(wrapper.getByTestId('webchat-framework-script')).to.exist;
       });
 
-      const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
-        store,
+      it('loads the webchat framework only once', async () => {
+        loadWebChat();
+        mockApiRequest({ token: 'FAKETOKEN' });
+        const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
+          initialState: {
+            featureToggles: {
+              loading: false,
+            },
+            user: {
+              login: {
+                currentlyLoggedIn: true,
+              },
+            },
+          },
+        });
+
+        await waitFor(() => expect(wrapper.getByTestId('webchat')).to.exist);
+        expect(
+          wrapper.queryAllByTestId('webchat-framework-script'),
+        ).to.have.lengthOf(1);
       });
 
-      expect(getTokenCalled()).to.equal(false);
+      it.skip('exposes React and ReactDOM as globals for the framework to re-use so hooks still work', () => {
+        expect(window.React).to.not.exist;
+        expect(window.ReactDOM).to.not.exist;
 
-      expect(wrapper.getByRole('progressbar')).to.exist;
+        renderInReduxProvider(<Chatbox timeout={10} />);
 
-      store.dispatch({ type: FETCH_TOGGLE_VALUES_SUCCEEDED, payload: {} });
-
-      await waitFor(() => expect(getTokenCalled()).to.equal(true));
+        expect(window.React).to.eql(React);
+        expect(window.ReactDOM).to.eql(ReactDOM);
+      });
     });
   });
-
-  describe('on initial load', () => {
-    it('should show loading indicator', () => {
-      loadWebChat();
-      mockApiRequest({ token: 'ANOTHERFAKETOKEN' });
-      const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
-        initialState: {
-          featureToggles: {
-            loading: false,
-          },
-        },
-      });
-
-      expect(wrapper.getByRole('progressbar')).to.exist;
-    });
-  });
-
-  describe('when token is valid', () => {
-    it('should render web chat', async () => {
-      loadWebChat();
-      mockApiRequest({ token: 'FAKETOKEN' });
-      const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
-        initialState: {
-          featureToggles: {
-            loading: false,
-          },
-        },
-      });
-
-      await waitFor(() => expect(wrapper.getByTestId('webchat')).to.exist);
-
-      expect(directLineSpy.called).to.be.true;
-      expect(
-        directLineSpy.calledWith({
-          token: 'FAKETOKEN',
-          domain:
-            'https://northamerica.directline.botframework.com/v3/directline',
-        }),
-      ).to.be.true;
-    });
-  });
-
-  describe('when api returns error', () => {
-    it('should display error message', async () => {
-      loadWebChat();
-      mockApiRequest({}, false);
-      const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
-        initialState: {
-          featureToggles: {
-            loading: false,
-          },
-        },
-      });
-
-      await waitFor(
-        () => expect(wrapper.getByText(CHATBOT_ERROR_MESSAGE)).to.exist,
-      );
-
-      expect(Sentry.captureException.called).to.be.true;
-      expect(Sentry.captureException.getCall(0).args[0].message).equals(
-        'Could not retrieve virtual agent token',
-      );
-    });
-  });
-
-  describe('when api returns error one time, but works after a retry', () => {
-    it('should render web chat', async () => {
-      loadWebChat();
-      mockMultipleApiRequests([
-        { response: {}, shouldResolve: false },
-        { response: { token: 'FAKETOKEN' }, shouldResolve: true },
-      ]);
-
-      const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
-        initialState: {
-          featureToggles: {
-            loading: false,
-          },
-        },
-      });
-
-      await waitFor(() => expect(wrapper.getByTestId('webchat')).to.exist);
-
-      expect(Sentry.captureException.called).to.be.false;
-    });
-  });
-
-  describe('when chatbox is rendered', () => {
-    it.skip('loads the webchat framework via script tag', () => {
-      expect(screen.queryByTestId('webchat-framework-script')).to.not.exist;
-
-      const wrapper = renderInReduxProvider(<Chatbox timeout={10} />);
-
-      expect(wrapper.getByTestId('webchat-framework-script')).to.exist;
-    });
-
-    it('loads the webchat framework only once', async () => {
-      loadWebChat();
-      mockApiRequest({ token: 'FAKETOKEN' });
-      const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
-        initialState: {
-          featureToggles: {
-            loading: false,
-          },
-        },
-      });
-
-      await waitFor(() => expect(wrapper.getByTestId('webchat')).to.exist);
-      expect(
-        wrapper.queryAllByTestId('webchat-framework-script'),
-      ).to.have.lengthOf(1);
-    });
-
-    it.skip('exposes React and ReactDOM as globals for the framework to re-use so hooks still work', () => {
-      expect(window.React).to.not.exist;
-      expect(window.ReactDOM).to.not.exist;
-
-      renderInReduxProvider(<Chatbox timeout={10} />);
-
-      expect(window.React).to.eql(React);
-      expect(window.ReactDOM).to.eql(ReactDOM);
-    });
-  });
-
-  describe.only('when user is not logged in', () => {
+  describe('when user is not logged in', () => {
     it('displays a login widget', async () => {
       const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
         initialState: {
@@ -425,7 +495,7 @@ describe('App', () => {
             loading: true,
           },
           user: {
-            loggedIn: {
+            login: {
               currentlyLoggedIn: false,
             },
           },

--- a/src/applications/virtual-agent/tests/Chatbox.unit.spec.js
+++ b/src/applications/virtual-agent/tests/Chatbox.unit.spec.js
@@ -13,6 +13,7 @@ import {
 } from 'platform/testing/unit/helpers';
 import { createTestStore } from '../../vaos/tests/mocks/setup';
 import { FETCH_TOGGLE_VALUES_SUCCEEDED } from 'platform/site-wide/feature-toggles/actionTypes';
+import Main from 'platform/site-wide/user-nav/containers/Main';
 
 export const CHATBOT_ERROR_MESSAGE = /We’re making some updates to the Virtual Agent. We’re sorry it’s not working right now. Please check back soon. If you require immediate assistance please call the VA.gov help desk/i;
 
@@ -54,23 +55,28 @@ describe('App', () => {
     });
   }
   describe('user is logged in', () => {
+    const initialStoreState = {
+      initialState: {
+        featureToggles: {
+          loading: false,
+        },
+        user: {
+          login: {
+            currentlyLoggedIn: true,
+          },
+        },
+      },
+    };
+
     describe('web chat script is already loaded', () => {
       it('renders web chat', async () => {
         loadWebChat();
         mockApiRequest({});
 
-        const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
-          initialState: {
-            featureToggles: {
-              loading: false,
-            },
-            user: {
-              login: {
-                currentlyLoggedIn: true,
-              },
-            },
-          },
-        });
+        const wrapper = renderInReduxProvider(
+          <Chatbox {...defaultProps} />,
+          initialStoreState,
+        );
 
         await waitFor(() => expect(wrapper.getByTestId('webchat')).to.exist);
       });
@@ -81,18 +87,7 @@ describe('App', () => {
 
         const { getByTestId } = renderInReduxProvider(
           <Chatbox {...defaultProps} />,
-          {
-            initialState: {
-              featureToggles: {
-                loading: false,
-              },
-              user: {
-                login: {
-                  currentlyLoggedIn: true,
-                },
-              },
-            },
-          },
+          initialStoreState,
         );
 
         await waitFor(() => expect(getByTestId('webchat')).to.exist);
@@ -105,18 +100,10 @@ describe('App', () => {
       it('should not render webchat until webchat framework is loaded', async () => {
         mockApiRequest({});
 
-        const wrapper = renderInReduxProvider(<Chatbox timeout={1000} />, {
-          initialState: {
-            featureToggles: {
-              loading: false,
-            },
-            user: {
-              login: {
-                currentlyLoggedIn: true,
-              },
-            },
-          },
-        });
+        const wrapper = renderInReduxProvider(
+          <Chatbox timeout={1000} />,
+          initialStoreState,
+        );
 
         expect(wrapper.getByRole('progressbar')).to.exist;
         expect(wrapper.queryByTestId('webchat')).to.not.exist;
@@ -131,18 +118,10 @@ describe('App', () => {
       it('should display error if webchat does not load after x milliseconds', async () => {
         mockApiRequest({});
 
-        const wrapper = renderInReduxProvider(<Chatbox timeout={1500} />, {
-          initialState: {
-            featureToggles: {
-              loading: false,
-            },
-            user: {
-              login: {
-                currentlyLoggedIn: true,
-              },
-            },
-          },
-        });
+        const wrapper = renderInReduxProvider(
+          <Chatbox timeout={1500} />,
+          initialStoreState,
+        );
 
         expect(wrapper.getByRole('progressbar')).to.exist;
 
@@ -167,23 +146,26 @@ describe('App', () => {
         return fetch.called;
       };
 
+      const initialStoreStateWithLoadingToggleTrue = {
+        featureToggles: {
+          loading: true,
+        },
+        user: {
+          login: {
+            currentlyLoggedIn: true,
+          },
+        },
+      };
+
       it('should not fetch token', () => {
         loadWebChat();
 
         mockApiRequest({});
 
-        renderInReduxProvider(<Chatbox {...defaultProps} />, {
-          initialState: {
-            featureToggles: {
-              loading: true,
-            },
-            user: {
-              login: {
-                currentlyLoggedIn: true,
-              },
-            },
-          },
-        });
+        renderInReduxProvider(
+          <Chatbox {...defaultProps} />,
+          initialStoreStateWithLoadingToggleTrue,
+        );
 
         expect(getTokenCalled()).to.equal(false);
       });
@@ -194,16 +176,7 @@ describe('App', () => {
         mockApiRequest({});
 
         const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
-          initialState: {
-            featureToggles: {
-              loading: true,
-            },
-            user: {
-              login: {
-                currentlyLoggedIn: true,
-              },
-            },
-          },
+          initialState: initialStoreStateWithLoadingToggleTrue,
         });
 
         expect(wrapper.getByRole('progressbar')).to.exist;
@@ -215,16 +188,7 @@ describe('App', () => {
         loadWebChat();
 
         const wrapper = renderInReduxProvider(<Chatbox timeout={100} />, {
-          initialState: {
-            featureToggles: {
-              loading: true,
-            },
-            user: {
-              login: {
-                currentlyLoggedIn: true,
-              },
-            },
-          },
+          initialState: initialStoreStateWithLoadingToggleTrue,
         });
 
         expect(wrapper.getByRole('progressbar')).to.exist;
@@ -277,16 +241,7 @@ describe('App', () => {
 
         mockApiRequest({});
 
-        const store = createTestStore({
-          featureToggles: {
-            loading: true,
-          },
-          user: {
-            login: {
-              currentlyLoggedIn: true,
-            },
-          },
-        });
+        const store = createTestStore(initialStoreStateWithLoadingToggleTrue);
 
         const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
           store,
@@ -306,18 +261,10 @@ describe('App', () => {
       it('should show loading indicator', () => {
         loadWebChat();
         mockApiRequest({ token: 'ANOTHERFAKETOKEN' });
-        const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
-          initialState: {
-            featureToggles: {
-              loading: false,
-            },
-            user: {
-              login: {
-                currentlyLoggedIn: true,
-              },
-            },
-          },
-        });
+        const wrapper = renderInReduxProvider(
+          <Chatbox {...defaultProps} />,
+          initialStoreState,
+        );
 
         expect(wrapper.getByRole('progressbar')).to.exist;
       });
@@ -327,18 +274,10 @@ describe('App', () => {
       it('should render web chat', async () => {
         loadWebChat();
         mockApiRequest({ token: 'FAKETOKEN' });
-        const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
-          initialState: {
-            featureToggles: {
-              loading: false,
-            },
-            user: {
-              login: {
-                currentlyLoggedIn: true,
-              },
-            },
-          },
-        });
+        const wrapper = renderInReduxProvider(
+          <Chatbox {...defaultProps} />,
+          initialStoreState,
+        );
 
         await waitFor(() => expect(wrapper.getByTestId('webchat')).to.exist);
 
@@ -357,18 +296,10 @@ describe('App', () => {
       it('should display error message', async () => {
         loadWebChat();
         mockApiRequest({}, false);
-        const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
-          initialState: {
-            featureToggles: {
-              loading: false,
-            },
-            user: {
-              login: {
-                currentlyLoggedIn: true,
-              },
-            },
-          },
-        });
+        const wrapper = renderInReduxProvider(
+          <Chatbox {...defaultProps} />,
+          initialStoreState,
+        );
 
         await waitFor(
           () => expect(wrapper.getByText(CHATBOT_ERROR_MESSAGE)).to.exist,
@@ -389,18 +320,10 @@ describe('App', () => {
           { response: { token: 'FAKETOKEN' }, shouldResolve: true },
         ]);
 
-        const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
-          initialState: {
-            featureToggles: {
-              loading: false,
-            },
-            user: {
-              login: {
-                currentlyLoggedIn: true,
-              },
-            },
-          },
-        });
+        const wrapper = renderInReduxProvider(
+          <Chatbox {...defaultProps} />,
+          initialStoreState,
+        );
 
         await waitFor(() => expect(wrapper.getByTestId('webchat')).to.exist);
 
@@ -420,18 +343,10 @@ describe('App', () => {
       it('loads the webchat framework only once', async () => {
         loadWebChat();
         mockApiRequest({ token: 'FAKETOKEN' });
-        const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
-          initialState: {
-            featureToggles: {
-              loading: false,
-            },
-            user: {
-              login: {
-                currentlyLoggedIn: true,
-              },
-            },
-          },
-        });
+        const wrapper = renderInReduxProvider(
+          <Chatbox {...defaultProps} />,
+          initialStoreState,
+        );
 
         await waitFor(() => expect(wrapper.getByTestId('webchat')).to.exist);
         expect(
@@ -451,13 +366,21 @@ describe('App', () => {
     });
   });
   describe('when user is not logged in', () => {
+    const initialStateNotLoggedIn = {
+      navigation: {
+        showLoginModal: false,
+        utilitiesMenuIsOpen: { search: false },
+      },
+      user: {
+        login: {
+          currentlyLoggedIn: false,
+        },
+      },
+    };
+
     it('displays a login widget', async () => {
       const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
-        initialState: {
-          featureToggles: {
-            loading: false,
-          },
-        },
+        initialState: initialStateNotLoggedIn,
       });
 
       await waitFor(
@@ -468,37 +391,33 @@ describe('App', () => {
     });
 
     it('displays sign in modal when user clicks sign in button', async () => {
-      const store = createTestStore({
-        navigation: {
-          showLoginModal: false,
-        },
-        featureToggles: {
-          loading: true,
-        },
-      });
+      const store = createTestStore(initialStateNotLoggedIn);
 
-      const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
-        store,
-      });
-      const button = wrapper.getByRole('button');
+      const wrapper = renderInReduxProvider(
+        <>
+          <Chatbox {...defaultProps} />
+          <Main />
+        </>,
+        {
+          store,
+        },
+      );
+      const button = wrapper.getByText('Sign in to VA.gov');
+
+      expect(wrapper.queryByRole('alertdialog')).to.not.exist;
+
       await act(async () => {
         fireEvent.click(button);
       });
 
       expect(store.getState().navigation.showLoginModal).to.be.true;
+      expect(wrapper.getByRole('alertdialog')).to.exist;
     });
 
     it('does not display chatbot', async () => {
       const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
         initialState: {
-          featureToggles: {
-            loading: true,
-          },
-          user: {
-            login: {
-              currentlyLoggedIn: false,
-            },
-          },
+          initialStateNotLoggedIn,
         },
       });
 

--- a/src/applications/virtual-agent/tests/Chatbox.unit.spec.js
+++ b/src/applications/virtual-agent/tests/Chatbox.unit.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { expect } from 'chai';
-import { waitFor, screen, fireEvent } from '@testing-library/react';
+import { waitFor, screen, fireEvent, act } from '@testing-library/react';
 import sinon from 'sinon';
 import * as Sentry from '@sentry/browser';
 
@@ -398,16 +398,24 @@ describe('App', () => {
     });
 
     it('displays sign in modal when user clicks sign in button', async () => {
-      const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
-        initialState: {
-          featureToggles: {
-            loading: false,
-          },
+      const store = createTestStore({
+        navigation: {
+          showLoginModal: false,
+        },
+        featureToggles: {
+          loading: true,
         },
       });
+
+      const wrapper = renderInReduxProvider(<Chatbox {...defaultProps} />, {
+        store,
+      });
       const button = wrapper.getByRole('button');
-      fireEvent.click(button);
-      expect(wrapper.getByRole('alertdialog')).to.exist;
+      await act(async () => {
+        fireEvent.click(button);
+      });
+
+      expect(store.getState().navigation.showLoginModal).to.be.true;
     });
   });
 });


### PR DESCRIPTION
## Description
Hides chatbot behind sign in prompt if the user is not signed in
Passes csrfToken and apiSession to PVA when bot connects

## Original issue(s)
department-of-veterans-affairs/va-virtual-agent#245


## Testing done
Added unit tests

## Screenshots
<img width="1052" alt="Screen Shot 2021-09-03 at 11 33 55 AM" src="https://user-images.githubusercontent.com/9095250/132039132-99b102c0-a430-4e78-a159-eef461c69034.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
