### PR TITLE
Github Actions (CI) -- Remove dev from Jenkins pipeline

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -900,52 +900,52 @@ jobs:
       - name: Upload build
         run: aws s3 cp ${{ matrix.buildtype }}.tar.bz2 s3://vetsgov-website-builds-s3-upload/application-build/$GITHUB_SHA/${{ matrix.buildtype }}.tar.bz2 --acl public-read --region us-gov-west-1
 
-# deploy:
-#   name: Deploy
-#   runs-on: ubuntu-latest
-#   if: ${{ always() && github.ref == 'refs/heads/master' && needs.archive.result == 'success' }}
-#   needs: archive
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    if: ${{ always() && github.ref == 'refs/heads/master' && needs.archive.result == 'success' }}
+    needs: archive
 
-#   strategy:
-#     matrix:
-#       include:
-#         - environment: vagovdev
-#           bucket: dev-va-gov-assets
-#         - environment: vagovstaging
-#           bucket: staging-va-gov-assets
+    strategy:
+      matrix:
+        include:
+          - environment: vagovdev
+            bucket: dev-va-gov-assets
+          # - environment: vagovstaging
+          #   bucket: staging-va-gov-assets
 
-#   steps:
-#     - name: Checkout
-#       uses: actions/checkout@v2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
-#     - name: Configure AWS credentials (1)
-#       uses: aws-actions/configure-aws-credentials@v1
-#       with:
-#         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#         aws-region: us-gov-west-1
+      - name: Configure AWS credentials (1)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
 
-#     - name: Get AWS IAM role
-#       uses: marvinpinto/action-inject-ssm-secrets@latest
-#       with:
-#         ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
-#         env_variable_name: AWS_FRONTEND_NONPROD_ROLE
+      - name: Get AWS IAM role
+        uses: marvinpinto/action-inject-ssm-secrets@latest
+        with:
+          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
+          env_variable_name: AWS_FRONTEND_NONPROD_ROLE
 
-#     - name: Configure AWS Credentials (2)
-#       uses: aws-actions/configure-aws-credentials@v1
-#       with:
-#         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#         aws-region: us-gov-west-1
-#         role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
-#         role-duration-seconds: 900
-#         role-session-name: vsp-frontendteam-githubaction
+      - name: Configure AWS Credentials (2)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+          role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
+          role-duration-seconds: 900
+          role-session-name: vsp-frontendteam-githubaction
 
-#     - name: Deploy
-#       run: ./script/github-actions/deploy.sh -s $SRC -d $DEST -v
-#       env:
-#         SRC: s3://vetsgov-website-builds-s3-upload/application-build/${{ github.sha }}/${{ matrix.environment }}.tar.bz2
-#         DEST: s3://${{ matrix.bucket }}
+      - name: Deploy
+        run: ./script/github-actions/deploy.sh -s $SRC -d $DEST -v
+        env:
+          SRC: s3://vetsgov-website-builds-s3-upload/application-build/${{ github.sha }}/${{ matrix.environment }}.tar.bz2
+          DEST: s3://${{ matrix.bucket }}
 
 # jenkins:
 #   name: Run Jenkins CI

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,7 +12,7 @@ env:
   NEXUS_REGISTRY: https://devops.va.gov/dots-nexus/repository/npm-public/
 
 concurrency:
-  group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha  }}
+  group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
@@ -34,7 +34,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: 'us-gov-west-1'
+          aws-region: us-gov-west-1
 
       - name: Checkout
         uses: actions/checkout@v2
@@ -581,7 +581,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: 'us-gov-west-1'
+          aws-region: us-gov-west-1
 
       - name: Checkout vets-website
         uses: actions/checkout@v2
@@ -690,7 +690,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: 'us-gov-west-1'
+          aws-region: us-gov-west-1
 
       - name: Get va-vsp-bot token
         uses: marvinpinto/action-inject-ssm-secrets@v1.1.1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -844,61 +844,61 @@ jobs:
           output: |
             {"summary":${{ env.MOCHAWESOME_REPORT_RESULTS }}}
 
-# archive:
-#   name: Archive
-#   runs-on: ubuntu-latest
+  archive:
+    name: Archive
+    runs-on: ubuntu-latest
 
-#   strategy:
-#     matrix:
-#       buildtype: [vagovdev, vagovstaging, vagovprod]
+    strategy:
+      matrix:
+        # buildtype: [vagovdev, vagovstaging, vagovprod] # TODO: Enable when ready
+        buildtype: [vagovdev]
 
-#   needs: [cypress-tests, nightwatch-tests, unit-tests, contract-tests, security-audit, linting]
+    needs: [cypress-tests, unit-tests, contract-tests, security-audit, linting]
 
-#   # Archive should still run even when linting is skipped (as in PRs).
-#   # This if overrides the dependency on linting success to include skipped.
-#   # Because of always(), the rest of the needed jobs have to be checked too.
-#   # By doing this, later jobs that need this job require similar overrides
-#   # or else they will also be skipped when linting is skipped.
-#   if: |
-#     always() &&
-#     needs.cypress-tests.result == 'success' &&
-#     needs.nightwatch-tests.result == 'success' &&
-#     needs.unit-tests.result == 'success' &&
-#     needs.contract-tests.result == 'success' &&
-#     needs.security-audit.result == 'success' &&
-#     (needs.linting.result == 'success' || needs.linting.result == 'skipped')
+    # Archive should still run even when linting is skipped (as in PRs).
+    # This if overrides the dependency on linting success to include skipped.
+    # Because of always(), the rest of the needed jobs have to be checked too.
+    # By doing this, later jobs that need this job require similar overrides
+    # or else they will also be skipped when linting is skipped.
+    if: |
+      always() &&
+      needs.cypress-tests.result == 'success' &&
+      needs.unit-tests.result == 'success' &&
+      needs.contract-tests.result == 'success' &&
+      needs.security-audit.result == 'success' &&
+      (needs.linting.result == 'success' || needs.linting.result == 'skipped')
 
-#   steps:
-#     - name: Download build artifact
-#       uses: actions/download-artifact@v2
-#       with:
-#         name: ${{ matrix.buildtype }}.tar.bz2
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.buildtype }}.tar.bz2
 
-#     - name: Configure AWS credentials (1)
-#       uses: aws-actions/configure-aws-credentials@v1
-#       with:
-#         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#         aws-region: us-gov-west-1
+      - name: Configure AWS credentials (1)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
 
-#     - name: Get AWS IAM role
-#       uses: marvinpinto/action-inject-ssm-secrets@latest
-#       with:
-#         ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
-#         env_variable_name: AWS_FRONTEND_NONPROD_ROLE
+      - name: Get AWS IAM role
+        uses: marvinpinto/action-inject-ssm-secrets@latest
+        with:
+          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
+          env_variable_name: AWS_FRONTEND_NONPROD_ROLE
 
-#     - name: Configure AWS Credentials (2)
-#       uses: aws-actions/configure-aws-credentials@v1
-#       with:
-#         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#         aws-region: us-gov-west-1
-#         role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
-#         role-duration-seconds: 900
-#         role-session-name: vsp-frontendteam-githubaction
+      - name: Configure AWS Credentials (2)
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+          role-to-assume: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
+          role-duration-seconds: 900
+          role-session-name: vsp-frontendteam-githubaction
 
-#     - name: Upload build
-#       run: aws s3 cp ${{ matrix.buildtype }}.tar.bz2 s3://vetsgov-website-builds-s3-upload/application-build/$GITHUB_SHA/${{ matrix.buildtype }}.tar.bz2 --acl public-read --region us-gov-west-1
+      - name: Upload build
+        run: aws s3 cp ${{ matrix.buildtype }}.tar.bz2 s3://vetsgov-website-builds-s3-upload/application-build/$GITHUB_SHA/${{ matrix.buildtype }}.tar.bz2 --acl public-read --region us-gov-west-1
 
 # deploy:
 #   name: Deploy

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -165,10 +165,10 @@ node('vetsgov-general-purpose') {
     try {
       if (!commonStages.isDeployable()) { return }
 
-      if (commonStages.IS_DEV_BRANCH && commonStages.VAGOV_BUILDTYPES.contains('vagovdev')) {
-        commonStages.runDeploy('deploys/application-build-vagovdev', ref, false)
-        commonStages.runDeploy('deploys/vets-website-vagovdev', ref, false)
-      }
+      // if (commonStages.IS_DEV_BRANCH && commonStages.VAGOV_BUILDTYPES.contains('vagovdev')) {
+      //   commonStages.runDeploy('deploys/application-build-vagovdev', ref, false)
+      //   commonStages.runDeploy('deploys/vets-website-vagovdev', ref, false)
+      // }
 
       if (commonStages.IS_STAGING_BRANCH && commonStages.VAGOV_BUILDTYPES.contains('vagovstaging')) {
         commonStages.runDeploy('deploys/application-build-vagovstaging', ref, false)

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -115,12 +115,14 @@ def archive(dockerContainer, String ref, String envName) {
     withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'vetsgov-website-builds-s3-upload',
                      usernameVariable: 'AWS_ACCESS_KEY', passwordVariable: 'AWS_SECRET_KEY']]) {
       sh "echo \"${buildDetails}\" > /application/build/${envName}/BUILD.txt"
-      if(envName == 'vagovdev' || envName == 'vagovstaging') {
+      if(envName == 'vagovstaging') {
         sh "tar -C /application/build/${envName} -cf /application/build/apps.${envName}.tar.bz2 ."
         sh "aws s3 cp /application/build/apps.${envName}.tar.bz2 s3://vetsgov-website-builds-s3-upload/application-build/${ref}/${envName}.tar.bz2 --acl public-read --region us-gov-west-1 --quiet"
       }
-      sh "tar -C /application/build/${envName} -cf /application/build/${envName}.tar.bz2 ."
-      sh "aws s3 cp /application/build/${envName}.tar.bz2 s3://vetsgov-website-builds-s3-upload/${ref}/${envName}.tar.bz2 --acl public-read --region us-gov-west-1 --quiet"
+      if(envName == 'vagovstaging' || envName == 'vagovprod') {
+        sh "tar -C /application/build/${envName} -cf /application/build/${envName}.tar.bz2 ."
+        sh "aws s3 cp /application/build/${envName}.tar.bz2 s3://vetsgov-website-builds-s3-upload/${ref}/${envName}.tar.bz2 --acl public-read --region us-gov-west-1 --quiet"
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

This PR addresses the following tickets:
- Enable archive step. department-of-veterans-affairs/va.gov-team#29254
- Partially replace Jenkins. department-of-veterans-affairs/va.gov-team#29252

We are preparing to deprecate Jenkins. The first step is to rollout `dev`. This PR removes deploy and archive step in Jenkins for `vagovdev` and enables it in GHA.


## Testing done

[GHA run](https://github.com/department-of-veterans-affairs/vets-website/actions/runs/1198854407)

[Jenkins run](http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fvets-website/detail/feat%2Fgithub-actions%2Fdev-gha/2/pipeline)
