### PR TITLE
Feature: Adds mhv mappings for external redirects

### DIFF
--- a/package.json
+++ b/package.json
@@ -236,7 +236,7 @@
   },
   "private": true,
   "dependencies": {
-    "@department-of-veterans-affairs/component-library": "^3.0.1",
+    "@department-of-veterans-affairs/component-library": "^3.0.2",
     "@department-of-veterans-affairs/formation": "6.16.4",
     "@department-of-veterans-affairs/formulate": "0.0.1",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",

--- a/src/applications/facility-locator/components/search-results-items/Covid19Result.jsx
+++ b/src/applications/facility-locator/components/search-results-items/Covid19Result.jsx
@@ -86,6 +86,7 @@ const Covid19Result = ({
           showCovidVaccineWalkInAvailabilityText={
             showCovidVaccineWalkInAvailabilityText
           }
+          labelId={`${location.id}-phoneLabel`}
         />
         {infoURL && (
           <span className="vads-u-margin-top--2 vads-u-display--block">

--- a/src/applications/facility-locator/components/search-results-items/common/CCProviderPhoneLink.jsx
+++ b/src/applications/facility-locator/components/search-results-items/common/CCProviderPhoneLink.jsx
@@ -19,7 +19,7 @@ const CCProviderPhoneLink = ({ location, query }) => {
 
   return (
     <div>
-      {renderPhoneNumber('Main number', null, phone, true)}
+      {renderPhoneNumber('Main number', null, phone, true, location)}
       {isCCProvider && (
         <p id={'referral-message'}>
           If you don’t have a referral, contact your local VA medical center.

--- a/src/applications/facility-locator/components/search-results-items/common/Covid19PhoneLink.jsx
+++ b/src/applications/facility-locator/components/search-results-items/common/Covid19PhoneLink.jsx
@@ -6,6 +6,7 @@ const Covid19PhoneLink = ({
   phone,
   showCovidVaccineSchedulingLink,
   showCovidVaccineWalkInAvailabilityText,
+  labelId,
 }) => {
   if (!phone) {
     return null;
@@ -29,7 +30,7 @@ const Covid19PhoneLink = ({
 
   return (
     <div>
-      <strong>
+      <strong id={labelId}>
         {labelText}
         :&nbsp;
       </strong>
@@ -37,6 +38,7 @@ const Covid19PhoneLink = ({
         className="vads-u-margin-left--0p25"
         contact={contact}
         extension={extension || parsedExtension}
+        ariaDescribedById={labelId}
       />
     </div>
   );

--- a/src/applications/facility-locator/components/search-results-items/common/LocationPhoneLink.jsx
+++ b/src/applications/facility-locator/components/search-results-items/common/LocationPhoneLink.jsx
@@ -5,7 +5,13 @@ import { LocationType } from '../../../constants';
 import { parsePhoneNumber } from '../../../utils/phoneNumbers';
 import CCProviderPhoneLink from './CCProviderPhoneLink';
 
-export const renderPhoneNumber = (title, subTitle = null, phone, from) => {
+export const renderPhoneNumber = (
+  title,
+  subTitle = null,
+  phone,
+  from,
+  location,
+) => {
   if (!phone) {
     return null;
   }
@@ -18,12 +24,14 @@ export const renderPhoneNumber = (title, subTitle = null, phone, from) => {
     return null;
   }
 
+  const phoneNumberId = `${location.id}-${title.replaceAll(/\s+/g, '')}`;
+
   return (
     <div>
       {from === 'FacilityDetail' && (
         <i aria-hidden="true" role="presentation" className="fa fa-phone" />
       )}
-      {title && <strong>{title}: </strong>}
+      {title && <strong id={phoneNumberId}>{title}: </strong>}
       {subTitle}
       <Telephone
         className={
@@ -31,6 +39,7 @@ export const renderPhoneNumber = (title, subTitle = null, phone, from) => {
         }
         contact={contact}
         extension={extension}
+        ariaDescribedById={phoneNumberId}
       >
         {formattedPhoneNumber}
       </Telephone>
@@ -57,9 +66,15 @@ const LocationPhoneLink = ({ location, from, query }) => {
 
   return (
     <div className="facility-phone-group vads-u-margin-top--2">
-      {renderPhoneNumber('Main number', null, phone.main, from)}
+      {renderPhoneNumber('Main number', null, phone.main, from, location)}
       {phone.mentalHealthClinic && <div style={{ minHeight: '20px' }} />}
-      {renderPhoneNumber('Mental health', null, phone.mentalHealthClinic, from)}
+      {renderPhoneNumber(
+        'Mental health',
+        null,
+        phone.mentalHealthClinic,
+        from,
+        location,
+      )}
     </div>
   );
 };

--- a/src/applications/gi-sandbox/components/Checkbox.jsx
+++ b/src/applications/gi-sandbox/components/Checkbox.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import _ from 'lodash';
 import classNames from 'classnames';
 
-import { handleScrollOnInputFocus } from '../utils/helpers';
+import { createId, handleScrollOnInputFocus } from '../utils/helpers';
 
 const Checkbox = ({
   checked,
@@ -15,6 +15,8 @@ const Checkbox = ({
   onChange,
   onFocus,
   required,
+  ariaLabel,
+  ariaLabelInputLegendId,
 }) => {
   const inputId = _.uniqueId('errorable-checkbox-');
   const hasErrors = !!errorMessage;
@@ -34,13 +36,16 @@ const Checkbox = ({
         type="checkbox"
         onChange={onChange}
         onFocus={onFocus}
+        aria-labelledby={`${ariaLabelInputLegendId} ${createId(name)}-label`}
       />
       <label
         className={classNames('gi-checkbox-label', {
           'usa-input-error-label': hasErrors,
         })}
+        id={`${createId(name)}-label`}
         name={`${name}-label`}
         htmlFor={inputId}
+        aria-label={ariaLabel}
       >
         {label}
         {required && <span className="form-required-span">*</span>}

--- a/src/applications/gi-sandbox/components/CheckboxGroup.jsx
+++ b/src/applications/gi-sandbox/components/CheckboxGroup.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
-import { handleScrollOnInputFocus } from '../utils/helpers';
+import { handleScrollOnInputFocus, createId } from '../utils/helpers';
 
 const CheckboxGroup = ({ errorMessage, label, onChange, onFocus, options }) => {
   const inputId = _.uniqueId('checkbox-group-');
@@ -19,11 +19,13 @@ const CheckboxGroup = ({ errorMessage, label, onChange, onFocus, options }) => {
             type="checkbox"
             onFocus={() => onFocus(`${inputId}-${index}`)}
             onChange={onChange}
-            aria-labelledby={`${inputId}-legend ${name}-${index}-label`}
+            aria-labelledby={`${inputId}-legend ${createId(
+              name,
+            )}-${index}-label`}
           />
           <label
             className="gi-checkbox-label"
-            id={`${name}-${index}-label`}
+            id={`${createId(name)}-${index}-label`}
             name={`${name}-label`}
             htmlFor={`${inputId}-${index}`}
           >

--- a/src/applications/gi-sandbox/containers/FilterYourResults.jsx
+++ b/src/applications/gi-sandbox/containers/FilterYourResults.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import SearchAccordion from '../components/SearchAccordion';
 import Checkbox from '../components/Checkbox';
@@ -51,6 +51,7 @@ export function FilterYourResults({
     search.tab === TABS.name ? search.name.facets : search.location.facets;
 
   const [showAllSchoolTypes, setShowAllSchoolTypes] = useState(false);
+  const SEE_LESS_SIZE = 4;
 
   const updateInstitutionFilters = (name, value) => {
     dispatchFilterChange({ ...filters, [name]: value });
@@ -132,10 +133,15 @@ export function FilterYourResults({
     modalClose();
   };
 
+  const setFocusByName = name => {
+    const element = document.getElementsByName(name)[0];
+    if (element) element.focus();
+  };
+
   const excludedSchoolTypesGroup = () => {
     const options = (showAllSchoolTypes
       ? INSTITUTION_TYPES
-      : INSTITUTION_TYPES.slice(0, 4)
+      : INSTITUTION_TYPES.slice(0, SEE_LESS_SIZE)
     ).map(type => {
       return {
         name: type.toUpperCase(),
@@ -175,47 +181,65 @@ export function FilterYourResults({
     );
   };
 
+  useEffect(
+    () => {
+      if (showAllSchoolTypes) {
+        setFocusByName(
+          `${INSTITUTION_TYPES[SEE_LESS_SIZE].toUpperCase()}-label`,
+        );
+      } else {
+        setFocusByName(
+          `${INSTITUTION_TYPES[SEE_LESS_SIZE - 1].toUpperCase()}-label`,
+        );
+      }
+    },
+    [showAllSchoolTypes],
+  );
+
   const schoolAttributes = () => {
+    const options = [
+      {
+        name: 'excludeCautionFlags',
+        checked: excludeCautionFlags,
+        optionLabel: (
+          <LearnMoreLabel
+            text="Has no cautionary warnings"
+            onClick={() => dispatchShowModal('cautionaryWarnings')}
+            ariaLabel="Learn more about VA education and training programs"
+          />
+        ),
+      },
+      {
+        name: 'accredited',
+        checked: accredited,
+        optionLabel: (
+          <LearnMoreLabel
+            text="Is accredited"
+            onClick={() => dispatchShowModal('accredited')}
+            ariaLabel="Learn more about VA education and training programs"
+          />
+        ),
+      },
+      {
+        name: 'studentVeteran',
+        checked: studentVeteran,
+        optionLabel: 'Has a Student Veteran Group',
+      },
+      {
+        name: 'yellowRibbonScholarship',
+        checked: yellowRibbonScholarship,
+        optionLabel: 'Offers Yellow Ribbon Program',
+      },
+    ];
+
     return (
-      <>
-        <p>About the school</p>
-        <Checkbox
-          checked={excludeCautionFlags}
-          name="excludeCautionFlags"
-          label={
-            <LearnMoreLabel
-              text="Has no cautionary warnings"
-              onClick={() => dispatchShowModal('cautionaryWarnings')}
-              ariaLabel="Learn more about VA education and training programs"
-            />
-          }
-          onChange={onChangeCheckbox}
-        />
-        <Checkbox
-          checked={accredited}
-          name="accredited"
-          label={
-            <LearnMoreLabel
-              text="Is accredited"
-              onClick={() => dispatchShowModal('accredited')}
-              ariaLabel="Learn more about VA education and training programs"
-            />
-          }
-          onChange={onChangeCheckbox}
-        />
-        <Checkbox
-          checked={studentVeteran}
-          name="studentVeteran"
-          label="Has a Student Veteran Group"
-          onChange={onChangeCheckbox}
-        />
-        <Checkbox
-          checked={yellowRibbonScholarship}
-          name="yellowRibbonScholarship"
-          label="Offers Yellow Ribbon Program"
-          onChange={onChangeCheckbox}
-        />
-      </>
+      <CheckboxGroup
+        label={
+          <div className="vads-u-margin-left--neg0p25">About the school:</div>
+        }
+        onChange={onChangeCheckbox}
+        options={options}
+      />
     );
   };
 
@@ -252,10 +276,18 @@ export function FilterYourResults({
   };
 
   const typeOfInstitution = () => {
+    const name = 'Type of institution';
+    const legendId = `${createId(name)}-legend`;
     return (
       <>
         <div className="vads-u-margin-bottom--4">
-          <h3 className="vads-u-margin-bottom--3">Type of institution</h3>
+          <h3
+            className="vads-u-margin-bottom--3"
+            aria-label={`${name}:`}
+            id={legendId}
+          >
+            {name}
+          </h3>
           <ExpandingGroup open={schools}>
             <Checkbox
               checked={schools}
@@ -263,6 +295,7 @@ export function FilterYourResults({
               label="Schools"
               onChange={handleSchoolChange}
               className="expanding-header-checkbox"
+              ariaLabelInputLegendId={legendId}
             />
             <div className="school-types expanding-group-children">
               {excludedSchoolTypesGroup()}
@@ -277,6 +310,7 @@ export function FilterYourResults({
           label="On-the-job training and apprenticeships"
           onChange={onChangeCheckbox}
           className="vads-u-margin-bottom--4"
+          ariaLabelInputLegendId={legendId}
         />
         <ExpandingGroup open={vettec}>
           <Checkbox
@@ -285,6 +319,7 @@ export function FilterYourResults({
             label="VET TEC providers"
             onChange={handleVetTecChange}
             className="expanding-header-checkbox"
+            ariaLabelInputLegendId={legendId}
           />
           <div className="expanding-group-children">
             <Checkbox
@@ -292,6 +327,8 @@ export function FilterYourResults({
               name="preferredProvider"
               label="Preferred providers"
               onChange={handlePreferredProviderChange}
+              ariaLabel="VET TEC Preferred providers"
+              ariaLabelInputLegendId={legendId}
             />
           </div>
         </ExpandingGroup>

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -17,6 +17,9 @@ export const externalRedirects = {
   myvahealth: environment.isProduction()
     ? 'https://patientportal.myhealth.va.gov/'
     : 'https://staging-patientportal.myhealth.va.gov/',
+  mhv: environment.isProduction()
+    ? 'https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/'
+    : 'https://mhv-syst.myhealth.va.gov/mhv-portal-web/web/myhealthevet/',
 };
 
 export const ssoKeepAliveEndpoint = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1578,10 +1578,10 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@department-of-veterans-affairs/component-library@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-3.0.1.tgz#dc471ac652316bf4c3e4d3c7232c7da54df1dfc5"
-  integrity sha512-Xk+nqVJaPCASIufwGOI01MewU7rFFjOPkK9mHbI5A1ONu7mc7KtpDP88j3D5jRm/oiLhnl1Fz/trxRu0pMKZ0Q==
+"@department-of-veterans-affairs/component-library@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-3.0.2.tgz#64850770d936204ececaecdb9370f5c6c815ecf2"
+  integrity sha512-dx7UAeTGwJD6qHWFfs9BS7+j9KiXboIn+eDo94WXRo1YksGeEv+eH/H5Zd72XSC4THerrNt3CR0MdfgtQNpLSA==
   dependencies:
     classnames "^2.2.6"
     core-js "^3.9.0"


### PR DESCRIPTION
## Description
This creates additional mappings for external redirects for My HealtheVet (MHV).  The updated flow for MHV is the following paradigm:

1. User starts on My HealtheVet website and clicks 'Sign In'
2. User is redirected to VA.gov Sign In page (ex https://va.gov/sign-in/?application=mhv&to=secure-messaging).**
3. User authenticates using a service provider and eAuth
4. User navigates back to VA.gov (session is established) and redirects back to MHV.

**In the URI the `application` parameter refers to the full MHV URL and the `to` parameter refers to the location.  In the example above the full redirected URL would be www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/secure-messaging.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done
Unit testing / Manual

## Screenshots

https://user-images.githubusercontent.com/67602137/132051954-f63ebbfe-4fd7-4fe6-8490-758f711a16c2.mp4

## Acceptance criteria
- [x] Providing an application=mhv & to parameter redirects a user to MHV.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
