### PR TITLE
CT Sandbox - caution flags accessibility

### DIFF
--- a/src/applications/gi-sandbox/components/CautionFlagAdditionalInfo.jsx
+++ b/src/applications/gi-sandbox/components/CautionFlagAdditionalInfo.jsx
@@ -31,6 +31,7 @@ export const CautionFlagAdditionalInfo = ({
             </div>
             <div>
               <i
+                aria-hidden="true"
                 style={{
                   float: 'right',
                   margin: '5px',

--- a/src/applications/gi-sandbox/components/CautionFlagAdditionalInfo.jsx
+++ b/src/applications/gi-sandbox/components/CautionFlagAdditionalInfo.jsx
@@ -18,29 +18,31 @@ export const CautionFlagAdditionalInfo = ({
       : `This school has ${validFlags.length} cautionary warnings`;
   return (
     <div className="usa-alert usa-alert-warning vads-u-background-color--white vads-u-padding-x--0p5 vads-u-padding-y--2">
-      <div
-        className="usa-alert-body "
-        onClick={() => toggleExpansion(!expanded)}
-      >
-        <div className="vads-u-display--flex">
-          <div>
-            <h4 className="usa-alert-heading caution-flag-alert-heading">
-              {headline}
-            </h4>
+      <div className="usa-alert-body ">
+        <button
+          className="caution-flag-toggle"
+          onClick={() => toggleExpansion(!expanded)}
+        >
+          <div className="vads-u-display--flex">
+            <div>
+              <h4 className="usa-alert-heading caution-flag-alert-heading">
+                {headline}
+              </h4>
+            </div>
+            <div>
+              <i
+                style={{
+                  float: 'right',
+                  margin: '5px',
+                }}
+                className={classNames('fa', {
+                  'fa-chevron-up': expanded,
+                  'fa-chevron-down': !expanded,
+                })}
+              />
+            </div>
           </div>
-          <div>
-            <i
-              style={{
-                float: 'right',
-                margin: '5px',
-              }}
-              className={classNames('fa', {
-                'fa-chevron-up': expanded,
-                'fa-chevron-down': !expanded,
-              })}
-            />
-          </div>
-        </div>
+        </button>
 
         {expanded && (
           <div>

--- a/src/applications/gi-sandbox/sass/gi.scss
+++ b/src/applications/gi-sandbox/sass/gi.scss
@@ -167,6 +167,18 @@
       margin-bottom: 0.625em;
     }
   }
+
+  .caution-flag-toggle {
+    display: block;
+    color: $color-gray-dark;
+    background-color: transparent;
+    padding: 0px;
+    margin: 0px;
+
+    i {
+      font-size: 16px;
+    }
+  }
 }
 
 .section-item,


### PR DESCRIPTION
## Description
Convert caution flag header clickable area to button in order to make it keyboard-navigable.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#29245


## Testing done
Tested locally and QA reviewed

## Screenshots
N/A

## Acceptance criteria
- [x] The user is able to expand the cautionary warnings section of the search results card using the keyboard

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
