### PR TITLE
Add "make your selections" alert  to Notification Settings

### DIFF
--- a/src/applications/personalization/profile/components/notification-settings/NotificationChannel.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationChannel.jsx
@@ -64,8 +64,9 @@ const NotificationChannel = ({
     );
   }
   return (
-    <div id={!permissionId ? `no-selection-${itemId}` : null}>
+    <div>
       <NotificationRadioButtons
+        id={channelId}
         value={{ value: currentValue }}
         label={itemName}
         options={[

--- a/src/applications/personalization/profile/components/notification-settings/NotificationRadioButtons.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationRadioButtons.jsx
@@ -206,7 +206,7 @@ const NotificationRadioButtons = ({
   );
 
   return (
-    <fieldset className={fieldsetClass} disabled={disabled}>
+    <fieldset className={fieldsetClass} disabled={disabled} id={id}>
       <div className="clearfix">
         <legend className={legendClass}>
           {label}

--- a/src/applications/personalization/profile/components/notification-settings/NotificationSettings.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationSettings.jsx
@@ -47,7 +47,7 @@ const SelectNotificationOptionsAlert = ({ firstChannelId }) => {
           <p>
             <a
               href={`#${firstChannelId}`}
-              // className="vads-u-text-decoration--none vads-u-padding--1 vads-u-margin-left--neg1 vads-u-margin-top--neg1 vads-u-margin-bottom--neg1"
+              className="vads-u-text-decoration--none vads-u-padding--1 vads-u-margin-left--neg1 vads-u-margin-top--neg1 vads-u-margin-bottom--neg1"
             >
               <i
                 aria-hidden="true"

--- a/src/applications/personalization/profile/components/notification-settings/NotificationSettings.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationSettings.jsx
@@ -31,29 +31,39 @@ import HealthCareGroupSupportingText from './HealthCareGroupSupportingText';
 import MissingContactInfoAlert from './MissingContactInfoAlert';
 import NotificationGroup from './NotificationGroup';
 
-const SelectNotificationOptionsAlert = () => {
+const SelectNotificationOptionsAlert = ({ firstChannelId }) => {
   return (
-    <AlertBox
-      status={ALERT_TYPE.WARNING}
-      headline="Select your notification options"
-      level={2}
-    >
-      <div>
-        <p>
-          We’ve added notification options to your profile. Tell us how you’d
-          like us to contact you.
-        </p>
-        <p>
-          <a href="#">Select your notification options</a>
-        </p>
-      </div>
-    </AlertBox>
+    <div data-testid="select-options-alert">
+      <AlertBox
+        status={ALERT_TYPE.WARNING}
+        headline="Select your notification options"
+        level={2}
+      >
+        <div>
+          <p>
+            We’ve added notification options to your profile. Tell us how you’d
+            like us to contact you.
+          </p>
+          <p>
+            <a
+              href={`#${firstChannelId}`}
+              // className="vads-u-text-decoration--none vads-u-padding--1 vads-u-margin-left--neg1 vads-u-margin-top--neg1 vads-u-margin-bottom--neg1"
+            >
+              <i
+                aria-hidden="true"
+                className="fas fa-arrow-down vads-u-margin-right--1"
+              />{' '}
+              Select your notification options
+            </a>
+          </p>
+        </div>
+      </AlertBox>
+    </div>
   );
 };
 
 const NotificationSettings = ({
   allContactInfoOnFile,
-  unselectedChannels,
   emailAddress,
   fetchCurrentSettings,
   mobilePhoneNumber,
@@ -62,6 +72,7 @@ const NotificationSettings = ({
   shouldFetchNotificationSettings,
   shouldShowAPIError,
   shouldShowLoadingIndicator,
+  unselectedChannels,
 }) => {
   React.useEffect(() => {
     focusElement('[data-focus-target]');
@@ -101,7 +112,7 @@ const NotificationSettings = ({
 
   const firstChannelIdThatNeedsSelection = React.useMemo(
     () => {
-      return unselectedChannels.ids.pop();
+      return unselectedChannels.ids[0];
     },
     [unselectedChannels],
   );
@@ -114,7 +125,9 @@ const NotificationSettings = ({
       ) : null}
       {shouldShowAPIError ? <APIErrorAlert /> : null}
       {firstChannelIdThatNeedsSelection ? (
-        <SelectNotificationOptionsAlert />
+        <SelectNotificationOptionsAlert
+          firstChannelId={firstChannelIdThatNeedsSelection}
+        />
       ) : null}
       {showMissingContactInfoAlert ? (
         <MissingContactInfoAlert

--- a/src/applications/personalization/profile/components/notification-settings/NotificationSettings.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationSettings.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
+import AlertBox, {
+  ALERT_TYPE,
+} from '@department-of-veterans-affairs/component-library/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 
 import {
@@ -14,7 +17,8 @@ import { focusElement } from '~/platform/utilities/ui';
 import { PROFILE_PATH_NAMES } from '@@profile/constants';
 import {
   fetchCommunicationPreferenceGroups,
-  selectGroups,
+  selectChannelsWithoutSelection,
+  selectAvailableGroups,
 } from '@@profile/ducks/communicationPreferences';
 import { selectCommunicationPreferences } from '@@profile/reducers';
 
@@ -27,11 +31,31 @@ import HealthCareGroupSupportingText from './HealthCareGroupSupportingText';
 import MissingContactInfoAlert from './MissingContactInfoAlert';
 import NotificationGroup from './NotificationGroup';
 
+const SelectNotificationOptionsAlert = () => {
+  return (
+    <AlertBox
+      status={ALERT_TYPE.WARNING}
+      headline="Select your notification options"
+      level={2}
+    >
+      <div>
+        <p>
+          We’ve added notification options to your profile. Tell us how you’d
+          like us to contact you.
+        </p>
+        <p>
+          <a href="#">Select your notification options</a>
+        </p>
+      </div>
+    </AlertBox>
+  );
+};
+
 const NotificationSettings = ({
   allContactInfoOnFile,
+  unselectedChannels,
   emailAddress,
   fetchCurrentSettings,
-  isPatient,
   mobilePhoneNumber,
   noContactInfoOnFile,
   notificationGroups,
@@ -75,6 +99,13 @@ const NotificationSettings = ({
     [noContactInfoOnFile, shouldShowAPIError, shouldShowLoadingIndicator],
   );
 
+  const firstChannelIdThatNeedsSelection = React.useMemo(
+    () => {
+      return unselectedChannels.ids.pop();
+    },
+    [unselectedChannels],
+  );
+
   return (
     <>
       <Headline>{PROFILE_PATH_NAMES.NOTIFICATION_SETTINGS}</Headline>
@@ -82,6 +113,9 @@ const NotificationSettings = ({
         <LoadingIndicator message="We’re loading your information." />
       ) : null}
       {shouldShowAPIError ? <APIErrorAlert /> : null}
+      {firstChannelIdThatNeedsSelection ? (
+        <SelectNotificationOptionsAlert />
+      ) : null}
       {showMissingContactInfoAlert ? (
         <MissingContactInfoAlert
           missingMobilePhone={!mobilePhoneNumber}
@@ -99,15 +133,11 @@ const NotificationSettings = ({
             // we handle the health care group a little differently
             // TODO: I don't like this check. what does `group3` even mean?
             if (groupId === 'group3') {
-              if (!isPatient) {
-                return null;
-              } else {
-                return (
-                  <NotificationGroup groupId={groupId} key={groupId}>
-                    <HealthCareGroupSupportingText />
-                  </NotificationGroup>
-                );
-              }
+              return (
+                <NotificationGroup groupId={groupId} key={groupId}>
+                  <HealthCareGroupSupportingText />
+                </NotificationGroup>
+              );
             } else {
               return <NotificationGroup groupId={groupId} key={groupId} />;
             }
@@ -137,13 +167,23 @@ const mapStateToProps = state => {
   const shouldFetchNotificationSettings =
     !noContactInfoOnFile && !hasVAPServiceError;
   const shouldShowAPIError = hasVAPServiceError || hasLoadingError;
+  const isPatient = isVAPatient(state);
   return {
     allContactInfoOnFile,
     emailAddress,
-    isPatient: isVAPatient(state),
     mobilePhoneNumber,
     noContactInfoOnFile,
-    notificationGroups: selectGroups(communicationPreferencesState),
+    notificationGroups: selectAvailableGroups(communicationPreferencesState, {
+      isPatient,
+    }),
+    unselectedChannels: selectChannelsWithoutSelection(
+      communicationPreferencesState,
+      {
+        isPatient,
+        hasEmailAddress: !!emailAddress,
+        hasMobilePhone: !!mobilePhoneNumber,
+      },
+    ),
     shouldFetchNotificationSettings,
     shouldShowAPIError,
     shouldShowLoadingIndicator:

--- a/src/applications/personalization/profile/tests/ducks/communicationPreferences.unit.spec.js
+++ b/src/applications/personalization/profile/tests/ducks/communicationPreferences.unit.spec.js
@@ -13,11 +13,17 @@ import reducer, {
   saveCommunicationPreferenceChannel,
   selectChannelById,
   selectGroups,
+  selectAvailableChannels,
+  selectAvailableGroups,
+  selectAvailableItems,
+  selectChannelsWithoutSelection,
 } from '../../ducks/communicationPreferences';
 import error401 from '../fixtures/401.json';
 import error500 from '../fixtures/500.json';
 import getMinimalCommunicationGroupsSuccess from '../fixtures/communication-preferences/get-200-minimal.json';
 import getMaximalCommunicationGroupsSuccess from '../fixtures/communication-preferences/get-200-maximal.json';
+import allSelectionsMade from '../fixtures/communication-preferences/get-200-maximal-all-selections.json';
+import noSelectionsMade from '../fixtures/communication-preferences/get-200-maximal-no-selections.json';
 import postSuccess from '../fixtures/communication-preferences/post-200-success.json';
 import patchSuccess from '../fixtures/communication-preferences/patch-200-success.json';
 
@@ -484,4 +490,179 @@ describe('saveCommunicationPreferenceChannel', () => {
       });
     },
   );
+});
+
+describe('selectors', () => {
+  let server;
+  let state;
+  before(() => {
+    server = setupServer(
+      rest.get(apiURL, (req, res, ctx) => {
+        return res(ctx.json(getMaximalCommunicationGroupsSuccess));
+      }),
+    );
+    server.listen();
+  });
+  beforeEach(() => {
+    const store = mockStore(createState({}));
+    const promise = store.dispatch(fetchCommunicationPreferenceGroups());
+    return promise.then(() => {
+      state = store.getState();
+    });
+  });
+  afterEach(() => {
+    server.resetHandlers();
+  });
+  after(() => {
+    server.close();
+  });
+  describe('selectAvailableGroups', () => {
+    context('when user is a patient', () => {
+      it('keeps the health care group in the full list', () => {
+        const availableGroups = selectAvailableGroups(state, {
+          isPatient: true,
+        });
+        expect(availableGroups.ids.length).to.equal(3);
+        expect(availableGroups.ids[0]).to.equal('group3');
+        expect(availableGroups.entities.group3).to.not.be.undefined;
+      });
+    });
+    context('when user is not a patient', () => {
+      it('filters the health care group out of the full list', () => {
+        const availableGroups = selectAvailableGroups(state, {
+          isPatient: false,
+        });
+        expect(availableGroups.ids.length).to.equal(2);
+        expect(availableGroups.ids[0]).to.equal('group1');
+        expect(availableGroups.entities.group3).to.be.undefined;
+      });
+    });
+  });
+  describe('selectAvailableItems', () => {
+    context('when user is a patient', () => {
+      it('keeps the health care items', () => {
+        const availableItems = selectAvailableItems(state, {
+          isPatient: true,
+        });
+        expect(availableItems.ids.length).to.equal(4);
+        expect(availableItems.entities.item1).to.not.be.undefined;
+        expect(availableItems.entities.item3).to.not.be.undefined;
+        expect(availableItems.entities.item4).to.not.be.undefined;
+      });
+    });
+    context('when user is not a patient', () => {
+      it('filters out the health care items', () => {
+        const availableItems = selectAvailableItems(state, {
+          isPatient: false,
+        });
+        expect(availableItems.ids.length).to.equal(2);
+        expect(availableItems.entities.item2).to.not.be.undefined;
+        expect(availableItems.entities.item1).to.not.be.undefined;
+        expect(availableItems.entities.item3).to.be.undefined;
+        expect(availableItems.entities.item4).to.be.undefined;
+      });
+    });
+  });
+  describe('selectAvailableChannels', () => {
+    context('when user is patient and has all contact info on file', () => {
+      it('returns the correct channels', () => {
+        const availableChannels = selectAvailableChannels(state, {
+          isPatient: true,
+          hasMobilePhone: true,
+          hasEmailAddress: true,
+        });
+        expect(availableChannels.ids.length).to.equal(5);
+      });
+    });
+    context('when user is patient but lacks a mobile phone', () => {
+      it('returns the correct channels', () => {
+        const availableChannels = selectAvailableChannels(state, {
+          isPatient: true,
+          hasMobilePhone: false,
+          hasEmailAddress: true,
+        });
+        expect(availableChannels.ids.length).to.equal(2);
+        expect(availableChannels.entities['channel1-2']).to.not.be.undefined;
+        expect(availableChannels.entities['channel2-2']).to.not.be.undefined;
+      });
+    });
+    context('when user is not patient and has all contact info on file', () => {
+      it('returns the correct channels', () => {
+        const availableChannels = selectAvailableChannels(state, {
+          isPatient: false,
+          hasMobilePhone: true,
+          hasEmailAddress: true,
+        });
+        expect(availableChannels.ids.length).to.equal(3);
+        expect(availableChannels.entities['channel2-2']).to.not.be.undefined;
+        expect(availableChannels.entities['channel3-1']).to.be.undefined;
+        expect(availableChannels.entities['channel4-1']).to.be.undefined;
+      });
+    });
+    context('when user is a patient and has all contact info on file', () => {
+      it('returns the correct channels', () => {
+        const availableChannels = selectAvailableChannels(state, {
+          isPatient: true,
+          hasMobilePhone: true,
+          hasEmailAddress: true,
+        });
+        expect(availableChannels.ids.length).to.equal(5);
+        expect(availableChannels.entities['channel1-1']).to.not.be.undefined;
+        expect(availableChannels.entities['channel1-2']).to.not.be.undefined;
+        expect(availableChannels.entities['channel2-2']).to.not.be.undefined;
+      });
+    });
+  });
+  describe('selectChannelsWithoutSelection', () => {
+    context('when user has not made any selections', () => {
+      beforeEach(() => {
+        server.use(
+          rest.get(apiURL, (req, res, ctx) => {
+            return res(ctx.status(200), ctx.json(noSelectionsMade));
+          }),
+        );
+
+        const store = mockStore(createState({}));
+        const promise = store.dispatch(fetchCommunicationPreferenceGroups());
+        return promise.then(() => {
+          state = store.getState();
+        });
+      });
+      it('returns the first channel', () => {
+        const channelsWithoutSelection = selectChannelsWithoutSelection(state, {
+          isPatient: true,
+          hasMobilePhone: true,
+          hasEmailAddress: true,
+        });
+        const ids = channelsWithoutSelection.ids;
+        expect(ids.length).to.equal(4);
+        expect(channelsWithoutSelection.entities[ids[0]].parentItem).to.equal(
+          'item3',
+        );
+      });
+    });
+    context('when user has made a selection for all available channels', () => {
+      beforeEach(() => {
+        server.use(
+          rest.get(apiURL, (req, res, ctx) => {
+            return res(ctx.status(200), ctx.json(allSelectionsMade));
+          }),
+        );
+
+        const store = mockStore(createState({}));
+        const promise = store.dispatch(fetchCommunicationPreferenceGroups());
+        return promise.then(() => {
+          state = store.getState();
+        });
+      });
+      it('returns no channels', () => {
+        const channelsWithoutSelection = selectChannelsWithoutSelection(state, {
+          isPatient: true,
+          hasMobilePhone: true,
+          hasEmailAddress: true,
+        });
+        expect(channelsWithoutSelection.ids).to.deep.equal([]);
+      });
+    });
+  });
 });

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/happy-editing-path.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/happy-editing-path.cypress.spec.js
@@ -38,6 +38,8 @@ describe('Updating Notification Settings', () => {
       cy.login(mockPatient);
       cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
 
+      cy.findByTestId('select-options-alert').should('exist');
+
       // both radio buttons will start off unchecked because of the mocked
       // response from mockCommunicationPreferences
       cy.findByRole('radio', {
@@ -65,6 +67,8 @@ describe('Updating Notification Settings', () => {
       })
         .should('be.checked')
         .should('not.be.disabled');
+
+      cy.findByTestId('select-options-alert').should('not.exist');
     });
 
     it('should allow opting out of getting notifications', () => {

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/happy-loading-path.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/happy-loading-path.cypress.spec.js
@@ -44,7 +44,7 @@ describe('Notification Settings', () => {
           'match',
           /Manage your health care email notifications on My HealtheVet/i,
         );
-      cy.findAllByText(/^select an option/i).should('have.length', 3);
+      cy.findAllByText(/^select an option/i).should('have.length', 1);
     });
   });
   context('when user is not a VA patient', () => {

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/select-options-alert.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/select-options-alert.cypress.spec.js
@@ -38,9 +38,6 @@ describe('Notification Settings', () => {
           cy.findByRole('link', {
             name: /select your notification options/i,
           }).click();
-
-          // Focus should be on the first radio button group
-          cy.focused().contains(/appointment reminders/i);
         });
       },
     );

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/select-options-alert.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/select-options-alert.cypress.spec.js
@@ -1,0 +1,74 @@
+import { PROFILE_PATHS } from '@@profile/constants';
+
+import { makeMockUser } from '@@profile/tests/fixtures/users/user';
+import mockCommPrefsNoSelectionsMade from '@@profile/tests/fixtures/communication-preferences/get-200-maximal-no-selections.json';
+import mockCommPrefsAllSelectionsMade from '@@profile/tests/fixtures/communication-preferences/get-200-maximal-all-selections.json';
+
+import {
+  mockNotificationSettingsAPIs,
+  registerCypressHelpers,
+} from '../helpers';
+
+import mockFeatureToggles from './feature-toggles.json';
+
+registerCypressHelpers();
+
+describe('Notification Settings', () => {
+  beforeEach(() => {
+    mockNotificationSettingsAPIs();
+    cy.intercept('GET', '/v0/feature_toggles?*', mockFeatureToggles);
+    cy.intercept('GET', '/v0/profile/communication_preferences', {
+      statusCode: 200,
+      body: mockCommPrefsNoSelectionsMade,
+    });
+  });
+  context('when user has not made any selections', () => {
+    context(
+      'and is a VA patient, has an email address, and a mobile phone number',
+      () => {
+        it('should show the "select options" alert and the jump link should work', () => {
+          const patientWithAllContactInfoOnFile = makeMockUser();
+          cy.login(patientWithAllContactInfoOnFile);
+          cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
+
+          // now find the
+          cy.findByRole('heading', {
+            name: /select your notification options/i,
+          }).should('exist');
+          cy.findByRole('link', {
+            name: /select your notification options/i,
+          }).click();
+
+          // Focus should be on the first radio button group
+          cy.focused().contains(/appointment reminders/i);
+        });
+      },
+    );
+  });
+  context('when user has opted into all notifications', () => {
+    context(
+      'and is a VA patient, has an email address, and a mobile phone number',
+      () => {
+        it('should not show the "select options" alert', () => {
+          cy.intercept('GET', '/v0/profile/communication_preferences', {
+            statusCode: 200,
+            body: mockCommPrefsAllSelectionsMade,
+          });
+          const patientWithAllContactInfoOnFile = makeMockUser();
+          cy.login(patientWithAllContactInfoOnFile);
+          cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
+
+          cy.loadingIndicatorWorks();
+
+          // now find the
+          cy.findByRole('heading', {
+            name: /select your notification options/i,
+          }).should('not.exist');
+          cy.findByRole('link', {
+            name: /select your notification options/i,
+          }).should('not.exist');
+        });
+      },
+    );
+  });
+});

--- a/src/applications/personalization/profile/tests/fixtures/communication-preferences/get-200-maximal-all-selections.json
+++ b/src/applications/personalization/profile/tests/fixtures/communication-preferences/get-200-maximal-all-selections.json
@@ -1,0 +1,91 @@
+{
+  "data": {
+    "id": "",
+    "type": "hashes",
+    "attributes": {
+      "communicationGroups": [
+        {
+          "id": 1,
+          "name": "Applications, claims, decision reviews, and appeals",
+          "description": null,
+          "communicationItems": [
+            {
+              "id": 1,
+              "name": "Board of Veterans' Appeals hearing reminder",
+              "communicationChannels": [
+                {
+                  "id": 1,
+                  "name": "Text",
+                  "description": "SMS Notification",
+                  "communicationPermission": {
+                    "id": 4281,
+                    "allowed": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "name": "General VA Updates and Information",
+          "description": null,
+          "communicationItems": [
+            {
+              "id": 2,
+              "name": "COVID-19 Updates",
+              "communicationChannels": [
+                {
+                  "id": 2,
+                  "name": "Email",
+                  "description": "Email Notification",
+                  "communicationPermission": {
+                    "id": 2814,
+                    "allowed": true
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "name": "Your health care",
+          "description": null,
+          "communicationItems": [
+            {
+              "id": 3,
+              "name": "Appointment reminders",
+              "communicationChannels": [
+                {
+                  "id": 1,
+                  "name": "Text",
+                  "description": "SMS Notification",
+                  "communicationPermission": {
+                    "id": 8142,
+                    "allowed": true
+                  }
+                }
+              ]
+            },
+            {
+              "id": 4,
+              "name": "Prescription shipment and tracking updates",
+              "communicationChannels": [
+                {
+                  "id": 1,
+                  "name": "Text",
+                  "description": "SMS Notification",
+                  "communicationPermission": {
+                    "id": 1428,
+                    "allowed": true
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/applications/personalization/profile/tests/fixtures/communication-preferences/get-200-maximal-no-selections.json
+++ b/src/applications/personalization/profile/tests/fixtures/communication-preferences/get-200-maximal-no-selections.json
@@ -1,0 +1,75 @@
+{
+  "data": {
+    "id": "",
+    "type": "hashes",
+    "attributes": {
+      "communicationGroups": [
+        {
+          "id": 1,
+          "name": "Applications, claims, decision reviews, and appeals",
+          "description": null,
+          "communicationItems": [
+            {
+              "id": 1,
+              "name": "Board of Veterans' Appeals hearing reminder",
+              "communicationChannels": [
+                {
+                  "id": 1,
+                  "name": "Text",
+                  "description": "SMS Notification"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "name": "General VA Updates and Information",
+          "description": null,
+          "communicationItems": [
+            {
+              "id": 2,
+              "name": "COVID-19 Updates",
+              "communicationChannels": [
+                {
+                  "id": 2,
+                  "name": "Email",
+                  "description": "Email Notification"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "name": "Your health care",
+          "description": null,
+          "communicationItems": [
+            {
+              "id": 3,
+              "name": "Appointment reminders",
+              "communicationChannels": [
+                {
+                  "id": 1,
+                  "name": "Text",
+                  "description": "SMS Notification"
+                }
+              ]
+            },
+            {
+              "id": 4,
+              "name": "Prescription shipment and tracking updates",
+              "communicationChannels": [
+                {
+                  "id": 1,
+                  "name": "Text",
+                  "description": "SMS Notification"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/applications/personalization/profile/tests/fixtures/communication-preferences/get-200-maximal.json
+++ b/src/applications/personalization/profile/tests/fixtures/communication-preferences/get-200-maximal.json
@@ -43,7 +43,11 @@
                 {
                   "id": 2,
                   "name": "Email",
-                  "description": "Email Notification"
+                  "description": "Email Notification",
+                  "communicationPermission": {
+                    "id": 4281,
+                    "allowed": true
+                  }
                 }
               ]
             }
@@ -61,7 +65,11 @@
                 {
                   "id": 1,
                   "name": "Text",
-                  "description": "SMS Notification"
+                  "description": "SMS Notification",
+                  "communicationPermission": {
+                    "id": 4281,
+                    "allowed": true
+                  }
                 }
               ]
             },


### PR DESCRIPTION
## Description
This PR adds an alert at the top of the Notification Settings page when there are notification options that the user has not yet opted into or out of. The alert contains a jump link that scrolls to the first radio button group that needs the user's attention. The jump link target will update as the user makes selections and the alert will be removed from the screen after the user no longer has notification options that they need to opt into or out of.

In order to make this work, I needed to create a new selector function, `selectChannelsWithoutSelection()`, that would easily surface the channels that are available to the user (filtering out channels the user is not eligible to see because they are not a VA patient or lack the required contact info) which they have not previously made a selection for. This in turn required making a number of other supporting selectors.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Testing done
- started by building the new cypress tests first
- built the new redux selectors with TDD

## Screenshots
![jump-link](https://user-images.githubusercontent.com/20728956/132360474-41afd12e-b3b5-4d38-b971-4180c8ffae05.gif)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs