### PR TITLE
29336: Update scrolling functionality, add IDs to components.

### DIFF
--- a/src/applications/gi-sandbox/components/content/AboutThisTool.jsx
+++ b/src/applications/gi-sandbox/components/content/AboutThisTool.jsx
@@ -8,6 +8,7 @@ function AboutThisTool() {
           href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp"
           target="_blank"
           rel="noopener noreferrer"
+          id="about-this-tool"
         >
           About this Tool
         </a>
@@ -15,6 +16,7 @@ function AboutThisTool() {
         <a
           className="about-this-tool-mobile"
           href="https://www.benefits.va.gov/GIBILL/docs/job_aids/ComparisonToolData.xlsx"
+          id="download-all-data"
         >
           Download Data on All Schools (Excel)
         </a>

--- a/src/applications/gi-sandbox/components/content/Disclaimer.jsx
+++ b/src/applications/gi-sandbox/components/content/Disclaimer.jsx
@@ -15,6 +15,7 @@ export default function Disclaimer() {
           target="_blank"
           rel="noopener noreferrer"
           href="https://www.va.gov/ogc/apps/accreditation/index.asp"
+          id="disclaimer-link"
         >
           Search Accredited Attorneys, Claims Agents, or Veterans Service
           Organizations (VSO) Representatives

--- a/src/applications/gi-sandbox/components/profile/Academics.jsx
+++ b/src/applications/gi-sandbox/components/profile/Academics.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ariaLabels } from '../../constants';
-import { upperCaseFirstLetterOnly } from '../../utils/helpers';
+import { createId, upperCaseFirstLetterOnly } from '../../utils/helpers';
 import LearnMoreLabel from '../LearnMoreLabel';
 
 export default function Academics({ institution, onShowModal }) {
@@ -28,6 +28,7 @@ export default function Academics({ institution, onShowModal }) {
             }#accred`}
             target="_blank"
             rel="noopener noreferrer"
+            id={createId('see accreditors')}
           >
             See accreditors
           </a>
@@ -80,6 +81,7 @@ export default function Academics({ institution, onShowModal }) {
           onClick={() => onShowModal('priorityEnrollment')}
           ariaLabel={ariaLabels.learnMore.priorityEnrollment}
           buttonClassName="small-screen-font"
+          buttonId="priority-enrollment-learn-more"
         />
         :
       </strong>
@@ -114,6 +116,7 @@ export default function Academics({ institution, onShowModal }) {
           target="_blank"
           rel="noopener noreferrer"
           className="vads-c-action-link--blue"
+          id="get-started-with-careerscope"
         >
           Get started with CareerScope
         </a>

--- a/src/applications/gi-sandbox/components/profile/Academics.jsx
+++ b/src/applications/gi-sandbox/components/profile/Academics.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ariaLabels } from '../../constants';
-import { createId, upperCaseFirstLetterOnly } from '../../utils/helpers';
+import { upperCaseFirstLetterOnly } from '../../utils/helpers';
 import LearnMoreLabel from '../LearnMoreLabel';
 
 export default function Academics({ institution, onShowModal }) {
@@ -28,7 +28,7 @@ export default function Academics({ institution, onShowModal }) {
             }#accred`}
             target="_blank"
             rel="noopener noreferrer"
-            id={createId('see accreditors')}
+            id="see-accreditors"
           >
             See accreditors
           </a>

--- a/src/applications/gi-sandbox/components/profile/BenefitsForm.jsx
+++ b/src/applications/gi-sandbox/components/profile/BenefitsForm.jsx
@@ -7,6 +7,7 @@ import { ariaLabels } from '../../constants';
 import Dropdown from '../Dropdown';
 import ExpandingGroup from '@department-of-veterans-affairs/component-library/ExpandingGroup';
 import LearnMoreLabel from '../LearnMoreLabel';
+import { createId } from '../../utils/helpers';
 
 export class BenefitsForm extends React.Component {
   state = { showYourMilitaryDetails: false };
@@ -43,12 +44,13 @@ export class BenefitsForm extends React.Component {
     { optionValue: 'purple heart', optionLabel: 'Purple Heart Service: 100%' },
   ];
 
-  renderLearnMoreLabel = ({ text, modal, ariaLabel, labelFor }) => (
+  renderLearnMoreLabel = ({ text, modal, ariaLabel, labelFor, buttonId }) => (
     <LearnMoreLabel
       text={text}
       onClick={() => this.props.showModal(modal)}
       ariaLabel={ariaLabel}
       labelFor={labelFor || modal}
+      buttonId={buttonId}
     />
   );
 
@@ -108,6 +110,7 @@ export class BenefitsForm extends React.Component {
               text: 'Which GI Bill benefit do you want to use?',
               modal: 'giBillChapter',
               ariaLabel: ariaLabels.learnMore.giBillBenefits,
+              buttonId: createId('gi bill benefits learn more'),
             })}
             name="giBillChapter"
             options={[
@@ -168,6 +171,7 @@ export class BenefitsForm extends React.Component {
                 text: 'Cumulative Post-9/11 active-duty service',
                 modal: 'cumulativeService',
                 ariaLabel: ariaLabels.learnMore.post911Chapter33,
+                buttonId: createId('cumulative service learn more'),
               })}
               name="cumulativeService"
               options={this.cumulativeServiceOptions()}
@@ -182,6 +186,7 @@ export class BenefitsForm extends React.Component {
                 text: 'Completed an enlistment of:',
                 modal: 'enlistmentService',
                 ariaLabel: ariaLabels.learnMore.montgomeryGIBill,
+                buttonId: createId('enlistment service'),
               })}
               name="enlistmentService"
               options={[

--- a/src/applications/gi-sandbox/components/profile/BenefitsForm.jsx
+++ b/src/applications/gi-sandbox/components/profile/BenefitsForm.jsx
@@ -7,7 +7,6 @@ import { ariaLabels } from '../../constants';
 import Dropdown from '../Dropdown';
 import ExpandingGroup from '@department-of-veterans-affairs/component-library/ExpandingGroup';
 import LearnMoreLabel from '../LearnMoreLabel';
-import { createId } from '../../utils/helpers';
 
 export class BenefitsForm extends React.Component {
   state = { showYourMilitaryDetails: false };
@@ -110,7 +109,7 @@ export class BenefitsForm extends React.Component {
               text: 'Which GI Bill benefit do you want to use?',
               modal: 'giBillChapter',
               ariaLabel: ariaLabels.learnMore.giBillBenefits,
-              buttonId: createId('gi bill benefits learn more'),
+              buttonId: 'gi-bill-benefits-learn-more',
             })}
             name="giBillChapter"
             options={[
@@ -171,7 +170,7 @@ export class BenefitsForm extends React.Component {
                 text: 'Cumulative Post-9/11 active-duty service',
                 modal: 'cumulativeService',
                 ariaLabel: ariaLabels.learnMore.post911Chapter33,
-                buttonId: createId('cumulative service learn more'),
+                buttonId: 'cumulative-service-learn-more',
               })}
               name="cumulativeService"
               options={this.cumulativeServiceOptions()}
@@ -186,7 +185,7 @@ export class BenefitsForm extends React.Component {
                 text: 'Completed an enlistment of:',
                 modal: 'enlistmentService',
                 ariaLabel: ariaLabels.learnMore.montgomeryGIBill,
-                buttonId: createId('enlistment service'),
+                buttonId: 'enlistment-service',
               })}
               name="enlistmentService"
               options={[

--- a/src/applications/gi-sandbox/components/profile/CalculateYourBenefitsForm.jsx
+++ b/src/applications/gi-sandbox/components/profile/CalculateYourBenefitsForm.jsx
@@ -279,7 +279,7 @@ function CalculateYourBenefitsForm({
             text: 'In-state tuition and fees per year',
             modal: 'calcInStateTuition',
             ariaLabel: ariaLabels.learnMore.inStateTuitionFeesPerYear,
-            buttonId: createId('tuition and fees learn more'),
+            buttonId: 'tuition-and-fees-learn-more',
           })}
         </label>
         <input
@@ -316,7 +316,7 @@ function CalculateYourBenefitsForm({
           ? 'inStateWithLink'
           : 'inStateWithoutLink',
       ariaLabel: ariaLabels.learnMore.inState,
-      buttonId: createId('in state student learn more'),
+      buttonId: 'in-state-student-learn-more',
     });
     return (
       <ExpandingGroup open={displayedInputs.tuition && inputs.inState === 'no'}>
@@ -350,7 +350,7 @@ function CalculateYourBenefitsForm({
         {learnMoreLabel({
           modal: 'calcTuition',
           ariaLabel: ariaLabels.learnMore.tuitionFeesPerYear,
-          buttonId: createId('tuition and fees per year learn more'),
+          buttonId: 'tuition-and-fees-per-year-learn-more',
         })}
         <input
           inputMode="decimal"
@@ -419,7 +419,7 @@ function CalculateYourBenefitsForm({
             text: 'Will you be a Yellow Ribbon recipient?',
             modal: 'calcYr',
             ariaLabel: ariaLabels.learnMore.yellowRibbonProgram,
-            buttonId: createId('yellow ribbon recipient learn more'),
+            buttonId: 'yellow-ribbon-recipient-learn-more',
           })}
           name="yellowRibbonRecipient"
           options={[
@@ -506,7 +506,7 @@ function CalculateYourBenefitsForm({
             text: 'Scholarships (excluding Pell Grants)',
             modal: 'calcScholarships',
             ariaLabel: ariaLabels.learnMore.calcScholarships,
-            buttonId: createId('scholarships learn more'),
+            buttonId: 'scholarships-learn-more',
           })}
         </label>
         <input
@@ -535,7 +535,7 @@ function CalculateYourBenefitsForm({
             text: 'How much are you receiving in military tuition assistance',
             modal: 'calcTuitionAssist',
             ariaLabel: ariaLabels.learnMore.militaryTuitionAssistance,
-            buttonId: createId('military tuition assistance learn more'),
+            buttonId: 'military-tuition-assistance-learn-more',
           })}
         </label>
         <input
@@ -593,7 +593,7 @@ function CalculateYourBenefitsForm({
           modal: 'calcEnrolled',
           ariaLabel: ariaLabels.learnMore.calcEnrolled,
           labelFor: name,
-          buttonId: createId('enrolled learn more'),
+          buttonId: 'enrolled-learn-more',
         })}
         name={name}
         alt="Enrolled"
@@ -663,7 +663,7 @@ function CalculateYourBenefitsForm({
               modal: 'calcSchoolCalendar',
               ariaLabel: ariaLabels.learnMore.calcSchoolCalendar,
               labelFor: 'calendar',
-              buttonId: createId('school calendar learn more'),
+              buttonId: 'school-calendar-learn-more',
             })}
             name="calendar"
             alt="School calendar"
@@ -714,7 +714,7 @@ function CalculateYourBenefitsForm({
             text: 'Eligible for kicker bonus?',
             modal: 'calcKicker',
             ariaLabel: ariaLabels.learnMore.kickerEligible,
-            buttonId: createId('eligible kicker learn more'),
+            buttonId: 'eligible-kicker-learn-more',
           })}
           name="kickerEligible"
           options={[
@@ -847,7 +847,7 @@ function CalculateYourBenefitsForm({
             text: 'Where will you take the majority of your classes?',
             modal: 'calcBeneficiaryLocationQuestion',
             ariaLabel: ariaLabels.learnMore.majorityOfClasses,
-            buttonId: createId('majority of classes learn more'),
+            buttonId: 'majority-of-classes-learn-more',
           })}
           name="beneficiaryLocationQuestion"
           options={beneficiaryLocationQuestionOptions}
@@ -917,7 +917,7 @@ function CalculateYourBenefitsForm({
           modal: 'calcWorking',
           ariaLabel: ariaLabels.learnMore.calcWorking,
           labelFor: 'working',
-          buttonId: createId('working learn more'),
+          buttonId: 'working-learn-more',
         })}
         name="working"
         alt="Will be working"
@@ -967,7 +967,7 @@ function CalculateYourBenefitsForm({
             'Did you use your Post-9/11 GI Bill benefits for tuition, housing, or books for a term that started before January 1, 2018?',
           modal: 'whenUsedGiBill',
           ariaLabel: ariaLabels.learnMore.whenUsedGiBill,
-          buttonId: createId('used gi bill learn more'),
+          buttonId: 'used-gi-bill-learn-more',
         })}
         name="giBillBenefit"
         options={[{ value: 'yes', label: 'Yes' }, { value: 'no', label: 'No' }]}
@@ -986,7 +986,7 @@ function CalculateYourBenefitsForm({
           className="eyb-skip-link vads-u-display--block"
           aria-label="Skip to your estimated benefits"
           href="#estimated-benefits"
-          id={createId('skip to eyb')}
+          id="skip-to-eyb"
         >
           Skip to your estimated benefits
         </a>

--- a/src/applications/gi-sandbox/components/profile/CalculateYourBenefitsForm.jsx
+++ b/src/applications/gi-sandbox/components/profile/CalculateYourBenefitsForm.jsx
@@ -255,12 +255,13 @@ function CalculateYourBenefitsForm({
     }
   };
 
-  const learnMoreLabel = ({ text, modal, ariaLabel, labelFor }) => (
+  const learnMoreLabel = ({ text, modal, ariaLabel, labelFor, buttonId }) => (
     <LearnMoreLabel
       text={text}
       onClick={() => showModal(modal)}
       ariaLabel={ariaLabel}
       labelFor={labelFor}
+      buttonId={buttonId}
     />
   );
 
@@ -278,6 +279,7 @@ function CalculateYourBenefitsForm({
             text: 'In-state tuition and fees per year',
             modal: 'calcInStateTuition',
             ariaLabel: ariaLabels.learnMore.inStateTuitionFeesPerYear,
+            buttonId: createId('tuition and fees learn more'),
           })}
         </label>
         <input
@@ -314,6 +316,7 @@ function CalculateYourBenefitsForm({
           ? 'inStateWithLink'
           : 'inStateWithoutLink',
       ariaLabel: ariaLabels.learnMore.inState,
+      buttonId: createId('in state student learn more'),
     });
     return (
       <ExpandingGroup open={displayedInputs.tuition && inputs.inState === 'no'}>
@@ -347,6 +350,7 @@ function CalculateYourBenefitsForm({
         {learnMoreLabel({
           modal: 'calcTuition',
           ariaLabel: ariaLabels.learnMore.tuitionFeesPerYear,
+          buttonId: createId('tuition and fees per year learn more'),
         })}
         <input
           inputMode="decimal"
@@ -415,6 +419,7 @@ function CalculateYourBenefitsForm({
             text: 'Will you be a Yellow Ribbon recipient?',
             modal: 'calcYr',
             ariaLabel: ariaLabels.learnMore.yellowRibbonProgram,
+            buttonId: createId('yellow ribbon recipient learn more'),
           })}
           name="yellowRibbonRecipient"
           options={[
@@ -501,6 +506,7 @@ function CalculateYourBenefitsForm({
             text: 'Scholarships (excluding Pell Grants)',
             modal: 'calcScholarships',
             ariaLabel: ariaLabels.learnMore.calcScholarships,
+            buttonId: createId('scholarships learn more'),
           })}
         </label>
         <input
@@ -529,6 +535,7 @@ function CalculateYourBenefitsForm({
             text: 'How much are you receiving in military tuition assistance',
             modal: 'calcTuitionAssist',
             ariaLabel: ariaLabels.learnMore.militaryTuitionAssistance,
+            buttonId: createId('military tuition assistance learn more'),
           })}
         </label>
         <input
@@ -586,6 +593,7 @@ function CalculateYourBenefitsForm({
           modal: 'calcEnrolled',
           ariaLabel: ariaLabels.learnMore.calcEnrolled,
           labelFor: name,
+          buttonId: createId('enrolled learn more'),
         })}
         name={name}
         alt="Enrolled"
@@ -655,6 +663,7 @@ function CalculateYourBenefitsForm({
               modal: 'calcSchoolCalendar',
               ariaLabel: ariaLabels.learnMore.calcSchoolCalendar,
               labelFor: 'calendar',
+              buttonId: createId('school calendar learn more'),
             })}
             name="calendar"
             alt="School calendar"
@@ -705,6 +714,7 @@ function CalculateYourBenefitsForm({
             text: 'Eligible for kicker bonus?',
             modal: 'calcKicker',
             ariaLabel: ariaLabels.learnMore.kickerEligible,
+            buttonId: createId('eligible kicker learn more'),
           })}
           name="kickerEligible"
           options={[
@@ -837,6 +847,7 @@ function CalculateYourBenefitsForm({
             text: 'Where will you take the majority of your classes?',
             modal: 'calcBeneficiaryLocationQuestion',
             ariaLabel: ariaLabels.learnMore.majorityOfClasses,
+            buttonId: createId('majority of classes learn more'),
           })}
           name="beneficiaryLocationQuestion"
           options={beneficiaryLocationQuestionOptions}
@@ -906,6 +917,7 @@ function CalculateYourBenefitsForm({
           modal: 'calcWorking',
           ariaLabel: ariaLabels.learnMore.calcWorking,
           labelFor: 'working',
+          buttonId: createId('working learn more'),
         })}
         name="working"
         alt="Will be working"
@@ -955,6 +967,7 @@ function CalculateYourBenefitsForm({
             'Did you use your Post-9/11 GI Bill benefits for tuition, housing, or books for a term that started before January 1, 2018?',
           modal: 'whenUsedGiBill',
           ariaLabel: ariaLabels.learnMore.whenUsedGiBill,
+          buttonId: createId('used gi bill learn more'),
         })}
         name="giBillBenefit"
         options={[{ value: 'yes', label: 'Yes' }, { value: 'no', label: 'No' }]}
@@ -973,6 +986,7 @@ function CalculateYourBenefitsForm({
           className="eyb-skip-link vads-u-display--block"
           aria-label="Skip to your estimated benefits"
           href="#estimated-benefits"
+          id={createId('skip to eyb')}
         >
           Skip to your estimated benefits
         </a>

--- a/src/applications/gi-sandbox/components/profile/CautionaryInformation.jsx
+++ b/src/applications/gi-sandbox/components/profile/CautionaryInformation.jsx
@@ -5,6 +5,7 @@ import CautionFlagDetails from './CautionFlagDetails';
 import SchoolClosingDetails from './SchoolClosingDetails';
 import LearnMoreLabel from '../LearnMoreLabel';
 import { ariaLabels } from '../../constants';
+import { createId } from '../../utils/helpers';
 
 export function CautionaryInformation({ institution, showModal }) {
   const {
@@ -115,6 +116,7 @@ export function CautionaryInformation({ institution, showModal }) {
         }}
         ariaLabel={ariaLabels.learnMore.allCampusComplaints}
         buttonClassName="small-screen-font"
+        buttonId={createId('all campuses learn more')}
       />
     </div>
   );
@@ -182,6 +184,7 @@ export function CautionaryInformation({ institution, showModal }) {
               onClick={() => {
                 showModal('studentComplaints');
               }}
+              buttonId={createId('student-complaints')}
               buttonClassName="small-screen-font"
             />
           </span>
@@ -284,6 +287,7 @@ export function CautionaryInformation({ institution, showModal }) {
           href="/education/submit-school-feedback/introduction"
           target="_blank"
           rel="noopener noreferrer"
+          id="submit-a-complaint"
         >
           Submit a complaint through our Feedback System
         </a>

--- a/src/applications/gi-sandbox/components/profile/CautionaryInformation.jsx
+++ b/src/applications/gi-sandbox/components/profile/CautionaryInformation.jsx
@@ -5,7 +5,6 @@ import CautionFlagDetails from './CautionFlagDetails';
 import SchoolClosingDetails from './SchoolClosingDetails';
 import LearnMoreLabel from '../LearnMoreLabel';
 import { ariaLabels } from '../../constants';
-import { createId } from '../../utils/helpers';
 
 export function CautionaryInformation({ institution, showModal }) {
   const {
@@ -116,7 +115,7 @@ export function CautionaryInformation({ institution, showModal }) {
         }}
         ariaLabel={ariaLabels.learnMore.allCampusComplaints}
         buttonClassName="small-screen-font"
-        buttonId={createId('all campuses learn more')}
+        buttonId="all-campuses-learn-more"
       />
     </div>
   );
@@ -184,7 +183,7 @@ export function CautionaryInformation({ institution, showModal }) {
               onClick={() => {
                 showModal('studentComplaints');
               }}
-              buttonId={createId('student-complaints')}
+              buttonId="student-complaints"
               buttonClassName="small-screen-font"
             />
           </span>

--- a/src/applications/gi-sandbox/components/profile/EstimatedBenefits.jsx
+++ b/src/applications/gi-sandbox/components/profile/EstimatedBenefits.jsx
@@ -205,7 +205,7 @@ export default function EstimatedBenefits({
                   text="Book stipend"
                   onClick={() => dispatchShowModal('bookStipendInfo')}
                   ariaLabel="Learn more about the book stipend"
-                  buttonId={createId('book stipend learn more')}
+                  buttonId="book-stipend-learn-more"
                 />
               }
               id={'book-stipend'}

--- a/src/applications/gi-sandbox/components/profile/EstimatedBenefits.jsx
+++ b/src/applications/gi-sandbox/components/profile/EstimatedBenefits.jsx
@@ -116,6 +116,7 @@ export default function EstimatedBenefits({
             }}
             ariaLabel={learnMoreAriaLabel}
             bold
+            buttonId={createId(`${title} learn more`)}
           />
 
           {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
@@ -204,6 +205,7 @@ export default function EstimatedBenefits({
                   text="Book stipend"
                   onClick={() => dispatchShowModal('bookStipendInfo')}
                   ariaLabel="Learn more about the book stipend"
+                  buttonId={createId('book stipend learn more')}
                 />
               }
               id={'book-stipend'}

--- a/src/applications/gi-sandbox/components/profile/GettingStartedWithBenefits.jsx
+++ b/src/applications/gi-sandbox/components/profile/GettingStartedWithBenefits.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { createId } from '../../utils/helpers';
 
 const GettingStartedWithBenefits = () => {
   return (
@@ -11,7 +12,11 @@ const GettingStartedWithBenefits = () => {
           <hr className="vads-u-margin-top--neg0p25" />
           <ul className="getting-started-with-benefits-li">
             <li>
-              <a href="/education/eligibility/" rel="noopener noreferrer">
+              <a
+                href="/education/eligibility/"
+                rel="noopener noreferrer"
+                id={createId('find out if youre eligible')}
+              >
                 Find out if you’re eligible for VA education benefits
               </a>
             </li>
@@ -32,6 +37,7 @@ const GettingStartedWithBenefits = () => {
             <a
               href="/careers-employment/vocational-rehabilitation/how-to-apply/"
               rel="noopener noreferrer"
+              id={createId('chapter 31')}
             >
               Find out how to apply for Veteran Readiness and Employment
               (Chapter 31)
@@ -41,6 +47,7 @@ const GettingStartedWithBenefits = () => {
             <a
               href="/careers-employment/education-and-career-counseling/"
               rel="noopener noreferrer"
+              id={createId('chapter 36')}
             >
               Find out how to apply for educational and career counseling
               (Chapter 36)
@@ -86,6 +93,7 @@ const GettingStartedWithBenefits = () => {
                 href="/education/how-to-apply/"
                 rel="noopener noreferrer"
                 className="vads-c-action-link--blue"
+                id="apply-for-edu-benefits"
               >
                 Apply for education benefits
               </a>

--- a/src/applications/gi-sandbox/components/profile/GettingStartedWithBenefits.jsx
+++ b/src/applications/gi-sandbox/components/profile/GettingStartedWithBenefits.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { createId } from '../../utils/helpers';
 
 const GettingStartedWithBenefits = () => {
   return (
@@ -15,7 +14,7 @@ const GettingStartedWithBenefits = () => {
               <a
                 href="/education/eligibility/"
                 rel="noopener noreferrer"
-                id={createId('find out if youre eligible')}
+                id="find-out-if-youre-eligible"
               >
                 Find out if you’re eligible for VA education benefits
               </a>
@@ -37,7 +36,7 @@ const GettingStartedWithBenefits = () => {
             <a
               href="/careers-employment/vocational-rehabilitation/how-to-apply/"
               rel="noopener noreferrer"
-              id={createId('chapter 31')}
+              id="how-to-apply-for-chapter-31"
             >
               Find out how to apply for Veteran Readiness and Employment
               (Chapter 31)
@@ -47,7 +46,7 @@ const GettingStartedWithBenefits = () => {
             <a
               href="/careers-employment/education-and-career-counseling/"
               rel="noopener noreferrer"
-              id={createId('chapter 36')}
+              id="how-to-apply-for-chapter-36"
             >
               Find out how to apply for educational and career counseling
               (Chapter 36)

--- a/src/applications/gi-sandbox/components/profile/VeteranProgramsAndSupport.jsx
+++ b/src/applications/gi-sandbox/components/profile/VeteranProgramsAndSupport.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { formatCurrency, formatNumber } from '../../utils/helpers';
+import { createId, formatCurrency, formatNumber } from '../../utils/helpers';
 import LearnMoreLabel from '../LearnMoreLabel';
 import { ariaLabels } from '../../constants';
 
@@ -60,7 +60,12 @@ export default function VeteranProgramsAndSupport({
       (showLink && (
         <span>
           &nbsp;
-          <a href={program.link.href} target="_blank" rel="noopener noreferrer">
+          <a
+            href={program.link.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            id={createId(program.link.text)}
+          >
             {program.link.text}
           </a>
         </span>
@@ -76,6 +81,7 @@ export default function VeteranProgramsAndSupport({
             text={program.text}
             onClick={() => showModal(program.modal)}
             ariaLabel={program.ariaLabel}
+            buttonId={createId(program.text)}
           />
           {showLink && ':'}
         </strong>

--- a/src/applications/gi-sandbox/containers/CalculateYourBenefits.jsx
+++ b/src/applications/gi-sandbox/containers/CalculateYourBenefits.jsx
@@ -17,6 +17,7 @@ import EstimatedBenefits from '../components/profile/EstimatedBenefits';
 import EstimateYourBenefitsSummarySheet from '../components/profile/EstimateYourBenefitsSummarySheet';
 import recordEvent from 'platform/monitoring/record-event';
 import LearnMoreLabel from '../components/LearnMoreLabel';
+import { createId } from '../utils/helpers';
 
 export function CalculateYourBenefits({
   calculated,
@@ -174,6 +175,7 @@ export function CalculateYourBenefits({
                   href={profile.attributes.vetWebsiteLink}
                   target="_blank"
                   rel="noopener noreferrer"
+                  id={createId('view policy link')}
                 >
                   View policy
                 </a>
@@ -195,6 +197,7 @@ export function CalculateYourBenefits({
               }}
               buttonClassName="small-screen-font"
               bold
+              buttonId={createId('protection against late payments learn more')}
             />
             <strong>:</strong>
             &nbsp;
@@ -215,6 +218,7 @@ export function CalculateYourBenefits({
               }}
               buttonClassName="small-screen-font"
               bold
+              buttonId={createId('yellow ribbon additional info learn more')}
             />
             <strong>:</strong>
             &nbsp;
@@ -233,6 +237,7 @@ export function CalculateYourBenefits({
               }}
               buttonClassName="small-screen-font"
               bold
+              buttonId={createId('vrrap learn more')}
             />
             <strong>:</strong>
             &nbsp;

--- a/src/applications/gi-sandbox/containers/CalculateYourBenefits.jsx
+++ b/src/applications/gi-sandbox/containers/CalculateYourBenefits.jsx
@@ -17,7 +17,6 @@ import EstimatedBenefits from '../components/profile/EstimatedBenefits';
 import EstimateYourBenefitsSummarySheet from '../components/profile/EstimateYourBenefitsSummarySheet';
 import recordEvent from 'platform/monitoring/record-event';
 import LearnMoreLabel from '../components/LearnMoreLabel';
-import { createId } from '../utils/helpers';
 
 export function CalculateYourBenefits({
   calculated,
@@ -175,7 +174,7 @@ export function CalculateYourBenefits({
                   href={profile.attributes.vetWebsiteLink}
                   target="_blank"
                   rel="noopener noreferrer"
-                  id={createId('view policy link')}
+                  id="view-policy-link"
                 >
                   View policy
                 </a>
@@ -197,7 +196,7 @@ export function CalculateYourBenefits({
               }}
               buttonClassName="small-screen-font"
               bold
-              buttonId={createId('protection against late payments learn more')}
+              buttonId="protection-against-late-payments-learn-more"
             />
             <strong>:</strong>
             &nbsp;
@@ -218,7 +217,7 @@ export function CalculateYourBenefits({
               }}
               buttonClassName="small-screen-font"
               bold
-              buttonId={createId('yellow ribbon additional info learn more')}
+              buttonId="yellow-ribbon-additional-info-learn-more"
             />
             <strong>:</strong>
             &nbsp;
@@ -237,7 +236,7 @@ export function CalculateYourBenefits({
               }}
               buttonClassName="small-screen-font"
               bold
-              buttonId={createId('vrrap learn more')}
+              buttonId="vrrap-learn-more"
             />
             <strong>:</strong>
             &nbsp;

--- a/src/applications/gi-sandbox/containers/CompareDrawer.jsx
+++ b/src/applications/gi-sandbox/containers/CompareDrawer.jsx
@@ -251,7 +251,7 @@ export function CompareDrawer({
 
   return (
     <>
-      <div className={compareDrawerClasses} ref={drawer}>
+      <div className={compareDrawerClasses} ref={drawer} id="compare-drawer">
         <div className={expandCollapse}>
           {promptingFacilityCode && (
             <RemoveCompareSelectedModal

--- a/src/applications/gi-sandbox/containers/CompareLayout.jsx
+++ b/src/applications/gi-sandbox/containers/CompareLayout.jsx
@@ -5,6 +5,7 @@ import CompareGrid from '../components/CompareGrid';
 import {
   boolYesNo,
   convertRatingToStars,
+  createId,
   formatCurrency,
   naIfNull,
   schoolSize,
@@ -108,6 +109,7 @@ const CompareLayout = ({
                 text="GI Bill students"
                 onClick={() => dispatchShowModal('gibillstudents')}
                 ariaLabel={ariaLabels.learnMore.numberOfStudents}
+                buttonId={createId('GI Bill students compare')}
               />
             ),
             mapper: institution => naIfNull(institution.studentCount),
@@ -480,6 +482,7 @@ const CompareLayout = ({
                 text="Yellow Ribbon"
                 onClick={() => dispatchShowModal('yribbon')}
                 ariaLabel={ariaLabels.learnMore.yellowRibbonProgram}
+                buttonId="veteran-programs-yellow-ribbon"
               />
             ),
             mapper: institution => boolYesNo(institution.yr),
@@ -490,6 +493,7 @@ const CompareLayout = ({
                 text="Student Veteran Group"
                 onClick={() => dispatchShowModal('vetgroups')}
                 ariaLabel={ariaLabels.learnMore.studentVeteranGroup}
+                buttonId="student-veteran-group"
               />
             ),
             mapper: institution => boolYesNo(institution.studentVeteran),
@@ -500,6 +504,7 @@ const CompareLayout = ({
                 text="Principles of Excellence"
                 onClick={() => dispatchShowModal('poe')}
                 ariaLabel={ariaLabels.learnMore.principlesOfExcellence}
+                buttonId="principles-of-excellence"
               />
             ),
             mapper: institution => boolYesNo(institution.poe),
@@ -510,6 +515,7 @@ const CompareLayout = ({
                 text="8 Keys to Veteran Success"
                 onClick={() => dispatchShowModal('eightKeys')}
                 ariaLabel={ariaLabels.learnMore.eightKeys}
+                buttonId="eight-keys-to-veteran-success"
               />
             ),
             mapper: institution => boolYesNo(institution.eightKeys),
@@ -520,6 +526,7 @@ const CompareLayout = ({
                 text="Military Tuition Assistance (TA)"
                 onClick={() => dispatchShowModal('ta')}
                 ariaLabel={ariaLabels.learnMore.militaryTuitionAssistance}
+                buttonId="military-tuition-assistance"
               />
             ),
             mapper: institution => boolYesNo(institution.dodmou),
@@ -530,6 +537,7 @@ const CompareLayout = ({
                 text="Priority Enrollment"
                 onClick={() => dispatchShowModal('priorityEnrollment')}
                 ariaLabel={ariaLabels.learnMore.priorityEnrollment}
+                buttonId="priority-enrollments"
               />
             ),
             mapper: institution => boolYesNo(institution.priorityEnrollment),

--- a/src/applications/gi-sandbox/containers/CompareLayout.jsx
+++ b/src/applications/gi-sandbox/containers/CompareLayout.jsx
@@ -5,7 +5,6 @@ import CompareGrid from '../components/CompareGrid';
 import {
   boolYesNo,
   convertRatingToStars,
-  createId,
   formatCurrency,
   naIfNull,
   schoolSize,
@@ -109,7 +108,7 @@ const CompareLayout = ({
                 text="GI Bill students"
                 onClick={() => dispatchShowModal('gibillstudents')}
                 ariaLabel={ariaLabels.learnMore.numberOfStudents}
-                buttonId={createId('GI Bill students compare')}
+                buttonId="GI-Bill-students-compare"
               />
             ),
             mapper: institution => naIfNull(institution.studentCount),

--- a/src/applications/gi-sandbox/containers/GiBillApp.jsx
+++ b/src/applications/gi-sandbox/containers/GiBillApp.jsx
@@ -12,7 +12,7 @@ import {
 import GiBillBreadcrumbs from '../components/GiBillBreadcrumbs';
 import PreviewBanner from '../components/PreviewBanner';
 import Modals from './Modals';
-import { useQueryParams } from '../utils/helpers';
+import { scrollToFocusedElement, useQueryParams } from '../utils/helpers';
 import ServiceError from '../components/ServiceError';
 import AboutThisTool from '../components/content/AboutThisTool';
 import Disclaimer from '../components/content/Disclaimer';
@@ -36,6 +36,14 @@ export function GiBillApp({
   const shouldExitPreviewMode = preview.display && !version;
   const shouldEnterPreviewMode = !preview.display && versionChange;
   const location = useLocation();
+
+  useEffect(() => {
+    document.addEventListener('focus', scrollToFocusedElement, true);
+
+    return () => {
+      document.removeEventListener('focus', scrollToFocusedElement);
+    };
+  }, []);
 
   useEffect(
     () => {

--- a/src/applications/gi-sandbox/containers/ProfilePageHeader.jsx
+++ b/src/applications/gi-sandbox/containers/ProfilePageHeader.jsx
@@ -11,6 +11,7 @@ import {
 
 import {
   convertRatingToStars,
+  createId,
   formatNumber,
   locationInfo,
   schoolSize,
@@ -164,7 +165,12 @@ const ProfilePageHeader = ({
               {_.capitalize(localeType)} locale
             </IconWithInfo>
             <IconWithInfo icon="globe" present={website}>
-              <a href={website} target="_blank" rel="noopener noreferrer">
+              <a
+                href={website}
+                target="_blank"
+                rel="noopener noreferrer"
+                id={createId('website')}
+              >
                 {'  '}
                 {website}
               </a>
@@ -289,6 +295,7 @@ const ProfilePageHeader = ({
                   <strong>{formatNumber(studentCount)}</strong> GI Bill students
                 </>
               }
+              buttonId={createId('GI Bill students profile')}
               onClick={() => dispatchShowModal('gibillstudents')}
               ariaLabel={ariaLabels.learnMore.numberOfStudents}
             />

--- a/src/applications/gi-sandbox/containers/TuitionAndHousingEstimates.jsx
+++ b/src/applications/gi-sandbox/containers/TuitionAndHousingEstimates.jsx
@@ -5,7 +5,6 @@ import RadioButtons from '../components/RadioButtons';
 import LearnMoreLabel from '../components/LearnMoreLabel';
 import { showModal, eligibilityChange } from '../actions';
 import { connect } from 'react-redux';
-import { createId } from '../utils/helpers';
 
 export function TuitionAndHousingEstimates({
   eligibility,
@@ -85,7 +84,7 @@ export function TuitionAndHousingEstimates({
             text="Will you be taking any classes in person?"
             onClick={() => dispatchShowModal('onlineOnlyDistanceLearning')}
             ariaLabel="Learn more about how we calculate your housing allowance based on where you take classes"
-            butttonId={createId('classes in person learn more')}
+            butttonId="classes-in-person-learn-more"
           />
         }
         name="inPersonClasses"

--- a/src/applications/gi-sandbox/containers/TuitionAndHousingEstimates.jsx
+++ b/src/applications/gi-sandbox/containers/TuitionAndHousingEstimates.jsx
@@ -5,6 +5,7 @@ import RadioButtons from '../components/RadioButtons';
 import LearnMoreLabel from '../components/LearnMoreLabel';
 import { showModal, eligibilityChange } from '../actions';
 import { connect } from 'react-redux';
+import { createId } from '../utils/helpers';
 
 export function TuitionAndHousingEstimates({
   eligibility,
@@ -84,6 +85,7 @@ export function TuitionAndHousingEstimates({
             text="Will you be taking any classes in person?"
             onClick={() => dispatchShowModal('onlineOnlyDistanceLearning')}
             ariaLabel="Learn more about how we calculate your housing allowance based on where you take classes"
+            butttonId={createId('classes in person learn more')}
           />
         }
         name="inPersonClasses"

--- a/src/applications/gi-sandbox/utils/helpers.js
+++ b/src/applications/gi-sandbox/utils/helpers.js
@@ -6,6 +6,9 @@ import constants from 'vets-json-schema/dist/constants.json';
 import mbxGeo from '@mapbox/mapbox-sdk/services/geocoding';
 import mapboxClient from '../components/MapboxClient';
 
+import { scroller } from 'react-scroll';
+import { getScrollOptions } from 'platform/utilities/ui';
+
 const mbxClient = mbxGeo(mapboxClient);
 import { SMALL_SCREEN_WIDTH } from '../constants';
 
@@ -223,3 +226,14 @@ export const boolYesNo = field => {
 };
 
 export const isSmallScreen = () => matchMedia('(max-width: 480px)').matches;
+
+export const scrollToFocusedElement = () => {
+  const compareDrawerHeight = document.getElementsByClassName(
+    'compare-drawer',
+  )[0].clientHeight;
+  const activeElementBounding = document.activeElement.getBoundingClientRect();
+
+  if (activeElementBounding.bottom > window.innerHeight - compareDrawerHeight) {
+    scroller.scrollTo(document.activeElement.id, getScrollOptions());
+  }
+};

--- a/src/applications/gi-sandbox/utils/helpers.js
+++ b/src/applications/gi-sandbox/utils/helpers.js
@@ -228,9 +228,8 @@ export const boolYesNo = field => {
 export const isSmallScreen = () => matchMedia('(max-width: 480px)').matches;
 
 export const scrollToFocusedElement = () => {
-  const compareDrawerHeight = document.getElementsByClassName(
-    'compare-drawer',
-  )[0].clientHeight;
+  const compareDrawerHeight = document.getElementById('compare-drawer')
+    .clientHeight;
   const activeElementBounding = document.activeElement.getBoundingClientRect();
 
   if (activeElementBounding.bottom > window.innerHeight - compareDrawerHeight) {


### PR DESCRIPTION
## Description
The Compare Institutions tray overlaps content on the GIBCT search page and school detail page. Focus gets hidden behind it and makes keyboard navigation difficult.

## Original issue(s)
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/29336

## Testing done
Testing passes locally

## Screenshots
N/A

## Acceptance criteria
- [x] Scrolling behavior is corrected

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
