### PR TITLE
CT Sandbox - Compare Page Header Profile Link

### DIFF
--- a/src/applications/gi-sandbox/components/CompareHeader.jsx
+++ b/src/applications/gi-sandbox/components/CompareHeader.jsx
@@ -87,17 +87,14 @@ export default function({
                   />
                   <div className="header-fields">
                     <div className="institution-name">
-                      {smallScreen && institution.name}
-                      {!smallScreen && (
-                        <Link
-                          to={{
-                            pathname: profileLink,
-                            state: { prevPath: location.pathname },
-                          }}
-                        >
-                          {institution.name}
-                        </Link>
-                      )}
+                      <Link
+                        to={{
+                          pathname: profileLink,
+                          state: { prevPath: location.pathname },
+                        }}
+                      >
+                        {institution.name}
+                      </Link>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Description
Restore profile link on compare page header

## Original issue(s)
department-of-veterans-affairs/va.gov-team#29341

## Testing done
Tested locally and QA reviewed

## Screenshots
![image](https://user-images.githubusercontent.com/41960449/132381945-ed4be2ae-5a0e-4271-87cc-89943bb6d2df.png)

## Acceptance criteria
- [x] Institution compare header profile links work on mobile 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
