### PR TITLE
Added COE dependent message to intro page and removed redirection

### DIFF
--- a/src/applications/lgy/coe/actions/index.js
+++ b/src/applications/lgy/coe/actions/index.js
@@ -7,7 +7,7 @@ export const SKIP_AUTOMATIC_COE_CHECK = 'SKIP_AUTOMATIC_COE_CHECK';
 const mockApiCall = () => {
   return new Promise(resolve => {
     setTimeout(() => {
-      resolve({ status: 'ineligible' });
+      resolve({ status: 'unable-to-determine-eligibility' });
     }, 2000);
   });
   //   return new Promise(reject => {

--- a/src/applications/lgy/coe/components/COEIntroPageBox.jsx
+++ b/src/applications/lgy/coe/components/COEIntroPageBox.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+const COEIntroPageBox = props => {
+  let content;
+  if (props.coe) {
+    content = (
+      <div className="vads-u-padding-bottom--2">
+        <h2 className="vads-u-margin-top--1">Review and download your COE</h2>
+        <a href="/housing-assistance/home-loans/apply-for-coe-form-26-1880/eligibility">
+          Your VA home loan Certificate of Eligibility
+        </a>
+        <p>
+          Follow the steps on this page to reapply for a VA home loan COE if you
+          need to:
+        </p>
+        <ul>
+          <li>
+            Make changes to your COE (correct an error or update your
+            information), or
+          </li>
+          <li>Apply for a restoration of entitlement</li>
+        </ul>
+      </div>
+    );
+  } else {
+    content = <></>;
+  }
+  return <>{content}</>;
+};
+
+export default COEIntroPageBox;

--- a/src/applications/lgy/coe/components/CoeNotApplicable.jsx
+++ b/src/applications/lgy/coe/components/CoeNotApplicable.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
+
+export const CoeNotApplicable = () => (
+  <div className="row vads-u-margin-bottom--1">
+    <div className="medium-8 columns">
+      <va-alert status="info">
+        <h2 slot="headline" className="vads-u-font-size--h3">
+          We don’t have a COE on file for you
+        </h2>
+        <p>
+          We can’t find a VA home loan Certificate of Eligibility for you. To
+          apply for a COE, you’ll need to fill out and submit a Request for a
+          Certificate of Eligibility (VA Form 26-1880)
+        </p>
+        <a href="/housing-assistance/home-loans/">
+          Learn more about VA-backed home loans
+        </a>
+      </va-alert>
+      <h2>Can I get a VA home loan COE?</h2>
+      <p>
+        You may be able to get a COE if you didn’t receive a dishonorable
+        discharge and you meet the minimum active-duty service requirement based
+        on when you served.
+      </p>
+      <a href="/housing-assistance/home-loans/eligibility/">
+        Find out about eligibility requirements for VA home loan programs.
+      </a>
+      <p>
+        know you qualify for a VA home loan COE and you have all the information
+        we’ll need, you can apply online
+      </p>
+      <a
+        className="vads-c-action-link--green"
+        href="/housing-assistance/home-loans/apply-for-coe-form-26-1880/introduction"
+      >
+        Apply for a Certificate of Eligibility
+      </a>
+      <h3>
+        You can also apply for a VA home loan COE through you lender or by mail
+      </h3>
+      <p>
+        In some cases, you can get your COE through your lender using our WebLGY
+        system. Ask your lender about this option.
+      </p>
+      <p>
+        o apply by mail, fill out a Request for a Certificate of Eligibility (VA
+        Form 26-1880) and mail it to the address listed on the form. Please keep
+        in mind that this may take longer than applying online or through our
+        Web LGY system.
+      </p>
+      <a href="/find-forms/about-form-26-1880/">Download VA form 26-1880</a>
+      <h2>What if I have more questions?</h2>
+      <p>
+        If you have any questions that your lender can’t answer, please call
+        your VA regional loan center at <Telephone contact="8778273702" /> We’re
+        here Monday through Friday, 8:00 a.m. to 6:00 p.m. ET.
+      </p>
+      <a
+        className="vads-u-margin-bottom--5 vads-u-display--block"
+        href="https://benefits.va.gov/HOMELOANS/contact_rlc_info.asp"
+      >
+        Find your regional loan center
+      </a>
+    </div>
+  </div>
+);

--- a/src/applications/lgy/coe/containers/EligibilityApp.jsx
+++ b/src/applications/lgy/coe/containers/EligibilityApp.jsx
@@ -16,7 +16,6 @@ import {
 
 const EligibilityApp = props => {
   const {
-    router,
     loggedIn,
     certificateOfEligibility: { generateAutoCoeStatus, profileIsUpdating, coe },
     hasSavedForm,
@@ -28,9 +27,7 @@ const EligibilityApp = props => {
 
   useEffect(
     () => {
-      if (!profileIsUpdating && !loggedIn) {
-        router.push('/');
-      } else if (!profileIsUpdating && loggedIn && !hasSavedForm && !coe) {
+      if (!profileIsUpdating && loggedIn && !hasSavedForm && !coe) {
         props.generateCoe();
       }
     },
@@ -63,7 +60,7 @@ const EligibilityApp = props => {
         content = <LoadingIndicator message="Loading..." />;
     }
   } else {
-    router.push('/introduction');
+    content = <p>failed</p>;
   }
 
   return (

--- a/src/applications/lgy/coe/containers/EligibilityApp.jsx
+++ b/src/applications/lgy/coe/containers/EligibilityApp.jsx
@@ -3,11 +3,13 @@ import { connect } from 'react-redux';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import { isLoggedIn } from 'platform/user/selectors';
-
+import backendServices from 'platform/user/profile/constants/backendServices';
+import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
 import { generateCoe } from '../actions';
 import { CoeEligible } from '../components/CoeEligible';
 import { CoeIneligible } from '../components/CoeIneligible';
 import { CoePending } from '../components/CoePending';
+import { CoeNotApplicable } from '../components/CoeNotApplicable';
 import {
   CALLSTATUS,
   COE_FORM_NUMBER,
@@ -57,24 +59,30 @@ const EligibilityApp = props => {
         content = <CoePending />;
         break;
       default:
-        content = <LoadingIndicator message="Loading..." />;
+        content = <CoeNotApplicable />;
     }
   } else {
-    content = <p>failed</p>;
+    content = <CoeNotApplicable />;
   }
 
   return (
     <>
-      <header className="row vads-u-padding-x--1">
-        <FormTitle title="Apply for a VA home loan Certificate of Eligibility" />
-        <p>Request for a Certificate of Eligibility (VA Form 26-1880)</p>
-      </header>
-      {content}
+      <RequiredLoginView
+        serviceRequired={backendServices.USER_PROFILE}
+        user={props.user}
+      >
+        <header className="row vads-u-padding-x--1">
+          <FormTitle title="Apply for a VA home loan Certificate of Eligibility" />
+          <p>Request for a Certificate of Eligibility (VA Form 26-1880)</p>
+        </header>
+        {content}
+      </RequiredLoginView>
     </>
   );
 };
 
 const mapStateToProps = state => ({
+  user: state.user,
   loggedIn: isLoggedIn(state),
   certificateOfEligibility: state.certificateOfEligibility,
   hasSavedForm: state?.user?.profile?.savedForms.some(

--- a/src/applications/lgy/coe/containers/IntroductionPage.jsx
+++ b/src/applications/lgy/coe/containers/IntroductionPage.jsx
@@ -3,7 +3,8 @@ import { connect } from 'react-redux';
 import { focusElement } from 'platform/utilities/ui';
 import { isLoggedIn } from 'platform/user/selectors';
 import { notLoggedInContent } from './introduction-content/notLoggedInContent.jsx';
-import { loggedInContent } from './introduction-content/loggedInContent.jsx';
+import COEIntroPageBox from '../components/COEIntroPageBox';
+import LoggedInContent from './introduction-content/loggedInContent.jsx';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import { CALLSTATUS } from '../constants';
 
@@ -23,7 +24,12 @@ function IntroductionPage(props) {
     content = notLoggedInContent(props);
   }
   if (props.loggedIn && coeCallEnded.includes(props.status)) {
-    content = loggedInContent();
+    content = (
+      <div>
+        <COEIntroPageBox coe={props.coe} />
+        <LoggedInContent />
+      </div>
+    );
   }
 
   return <div>{content}</div>;
@@ -31,6 +37,7 @@ function IntroductionPage(props) {
 
 const mapStateToProps = state => ({
   status: state.certificateOfEligibility.generateAutoCoeStatus,
+  coe: state.certificateOfEligibility.coe,
   loggedIn: isLoggedIn(state),
 });
 

--- a/src/applications/lgy/coe/containers/introduction-content/loggedInContent.jsx
+++ b/src/applications/lgy/coe/containers/introduction-content/loggedInContent.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 import OMBInfo from '@department-of-veterans-affairs/component-library/OMBInfo';
 
-export const loggedInContent = () => (
+const LoggedInContent = () => (
   <>
     <h2 className="vads-u-margin-top--1">
       Follow these steps to apply for a VA home loan COE
@@ -104,3 +104,5 @@ export const loggedInContent = () => (
     </div>
   </>
 );
+
+export default LoggedInContent;


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/28945)

Now that the designs for the COE form are farther along we need to add the call for a COE to the introduction page of the form and then provide a link to the COE eligibility app if the Veteran has a COE. We also need to add a page on the COR eligibility app for if the Veteran does not have a COE. This PR does both of those things.

## Testing done
All existing unit test still pass

## Screenshots

Mockup - https://preview.uxpin.com/65c0623a799c268173fe1a3cb4375f9ce00ad820#/pages/140646596/simulate/sitemap

Screenshot

![screencapture-localhost-3001-housing-assistance-home-loans-apply-for-coe-form-26-1880-introduction-2021-09-07-10_41_03](https://user-images.githubusercontent.com/1899695/132387859-2c32f1e0-5787-4274-ae9b-36826501308d.png)

## Acceptance criteria
- [x] A PR has been requested for merging

