### PR TITLE
Notification Settings fixes

### DIFF
--- a/src/applications/personalization/profile/components/notification-settings/NotificationRadioButtons.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationRadioButtons.jsx
@@ -102,7 +102,7 @@ const NotificationRadioButtons = ({
   if (loadingMessage) {
     loadingSpanId = `${id}-loading-message`;
     loadingSpan = (
-      <MessageWrapper id={loadingSpanId}>
+      <MessageWrapper id={loadingSpanId} classes="vads-u-font-weight--normal">
         <i
           className="fas fa-spinner fa-spin vads-u-margin-right--1"
           aria-hidden="true"
@@ -189,12 +189,12 @@ const NotificationRadioButtons = ({
   const fieldsetClass = classNames(
     'rb-fieldset-input',
     'rb-input',
-    additionalFieldsetClass,
     {
       'rb-input-error': errorMessage,
       'rb-input-warning': warningMessage,
       'rb-input-success': successMessage,
     },
+    additionalFieldsetClass,
   );
 
   const legendClass = classNames(

--- a/src/applications/personalization/profile/components/notification-settings/NotificationSettings.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationSettings.jsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import AlertBox, {
-  ALERT_TYPE,
-} from '@department-of-veterans-affairs/component-library/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 
 import {
@@ -34,30 +31,25 @@ import NotificationGroup from './NotificationGroup';
 const SelectNotificationOptionsAlert = ({ firstChannelId }) => {
   return (
     <div data-testid="select-options-alert">
-      <AlertBox
-        status={ALERT_TYPE.WARNING}
-        headline="Select your notification options"
-        level={2}
-      >
-        <div>
-          <p>
-            We’ve added notification options to your profile. Tell us how you’d
-            like us to contact you.
-          </p>
-          <p>
-            <a
-              href={`#${firstChannelId}`}
-              className="vads-u-text-decoration--none vads-u-padding--1 vads-u-margin-left--neg1 vads-u-margin-top--neg1 vads-u-margin-bottom--neg1"
-            >
-              <i
-                aria-hidden="true"
-                className="fas fa-arrow-down vads-u-margin-right--1"
-              />{' '}
-              Select your notification options
-            </a>
-          </p>
-        </div>
-      </AlertBox>
+      <va-alert status="warning">
+        <h2 slot="headline">Select your notification options</h2>
+        <p>
+          We’ve added notification options to your profile. Tell us how you’d
+          like us to contact you.
+        </p>
+        <p>
+          <a
+            href={`#${firstChannelId}`}
+            className="vads-u-text-decoration--none vads-u-padding--1 vads-u-margin-left--neg1 vads-u-margin-top--neg1 vads-u-margin-bottom--neg1"
+          >
+            <i
+              aria-hidden="true"
+              className="fas fa-arrow-down vads-u-margin-right--1"
+            />{' '}
+            Select your notification options
+          </a>
+        </p>
+      </va-alert>
     </div>
   );
 };
@@ -112,9 +104,9 @@ const NotificationSettings = ({
 
   const firstChannelIdThatNeedsSelection = React.useMemo(
     () => {
-      return unselectedChannels.ids[0];
+      return !shouldShowLoadingIndicator && unselectedChannels.ids[0];
     },
-    [unselectedChannels],
+    [shouldShowLoadingIndicator, unselectedChannels],
   );
 
   return (


### PR DESCRIPTION
## Description
Makes the following adjustments:
- "Loading..." is now regular weight, not bold
- The "select your options..." jump link now updates its `href` correctly
- The "select your options" alert now longer shows below the loading spinner when you re-visit the Notification Settings page

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Testing done
Locally in Cypress

## Screenshots
![alert](https://user-images.githubusercontent.com/20728956/132404904-46c5d0ed-9f4a-4cb2-822f-838d2b500076.gif)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs