### PR TITLE
Run longest-running Cypress test in its own Docker container on Jenkins

### DIFF
--- a/script/run-cypress-tests-docker.js
+++ b/script/run-cypress-tests-docker.js
@@ -17,7 +17,7 @@ exec("find src -name '*.cypress.*.js' | tr '\n' ','", function(_err, stdout) {
     )
     .join(',');
 
-  if (process.env.STEP === 5) {
+  if (Number(process.env.STEP) === 5) {
     runCommand(
       `CYPRESS_BASE_URL=http://vets-website:3001 CYPRESS_CI=${
         process.env.CI

--- a/script/run-cypress-tests-docker.js
+++ b/script/run-cypress-tests-docker.js
@@ -3,6 +3,12 @@ const exec = require('child_process').exec;
 
 exec("find src -name '*.cypress.*.js' | tr '\n' ','", function(_err, stdout) {
   const strings = stdout.split(',').sort();
+  const index = strings.indexOf(
+    'src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js',
+  );
+  if (index > -1) {
+    strings.splice(index, 1);
+  }
   const divider = Math.ceil(strings.length / 6);
   const tests = strings
     .slice(
@@ -11,11 +17,21 @@ exec("find src -name '*.cypress.*.js' | tr '\n' ','", function(_err, stdout) {
     )
     .join(',');
 
-  runCommand(
-    `CYPRESS_BASE_URL=http://vets-website:3001 CYPRESS_CI=${
-      process.env.CI
-    } XDG_CONFIG_HOME=/tmp/cyhome${
-      process.env.STEP
-    } yarn cy:run --config video=false --spec '${tests}'`,
-  );
+  if (process.env.STEP === 5) {
+    runCommand(
+      `CYPRESS_BASE_URL=http://vets-website:3001 CYPRESS_CI=${
+        process.env.CI
+      } XDG_CONFIG_HOME=/tmp/cyhome${
+        process.env.STEP
+      } yarn cy:run --config video=false --spec 'src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js'`,
+    );
+  } else {
+    runCommand(
+      `CYPRESS_BASE_URL=http://vets-website:3001 CYPRESS_CI=${
+        process.env.CI
+      } XDG_CONFIG_HOME=/tmp/cyhome${
+        process.env.STEP
+      } yarn cy:run --config video=false --spec '${tests}'`,
+    );
+  }
 });

--- a/script/run-cypress-tests-docker.js
+++ b/script/run-cypress-tests-docker.js
@@ -2,36 +2,34 @@ const { runCommand } = require('./utils');
 const exec = require('child_process').exec;
 
 exec("find src -name '*.cypress.*.js' | tr '\n' ','", function(_err, stdout) {
+  const stepNumber = Number(process.env.STEP);
+  const longestTest =
+    'src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js';
   const strings = stdout.split(',').sort();
-  const index = strings.indexOf(
-    'src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js',
-  );
+  const index = strings.indexOf(longestTest);
+
   if (index > -1) {
     strings.splice(index, 1);
   }
   const divider = Math.ceil(strings.length / 6);
-  const tests = strings
-    .slice(
-      Number(process.env.STEP) * divider,
-      (Number(process.env.STEP) + 1) * divider,
-    )
-    .join(',');
 
-  if (Number(process.env.STEP) === 5) {
-    runCommand(
-      `CYPRESS_BASE_URL=http://vets-website:3001 CYPRESS_CI=${
-        process.env.CI
-      } XDG_CONFIG_HOME=/tmp/cyhome${
-        process.env.STEP
-      } yarn cy:run --config video=false --spec 'src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js'`,
-    );
+  let tests;
+  if (stepNumber === 5) {
+    tests = longestTest;
   } else {
-    runCommand(
-      `CYPRESS_BASE_URL=http://vets-website:3001 CYPRESS_CI=${
-        process.env.CI
-      } XDG_CONFIG_HOME=/tmp/cyhome${
-        process.env.STEP
-      } yarn cy:run --config video=false --spec '${tests}'`,
-    );
+    tests = strings
+      .slice(
+        Number(process.env.STEP) * divider,
+        (Number(process.env.STEP) + 1) * divider,
+      )
+      .join(',');
   }
+
+  runCommand(
+    `CYPRESS_BASE_URL=http://vets-website:3001 CYPRESS_CI=${
+      process.env.CI
+    } XDG_CONFIG_HOME=/tmp/cyhome${
+      process.env.STEP
+    } yarn cy:run --config video=false --spec '${tests}'`,
+  );
 });


### PR DESCRIPTION
## Description
This PR modifies the Jenkins configuration so that the longest-running Cypress test, `src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js`, runs in its own Docker container. This will balance Cypress tests more evenly among the six parallel steps.


## Acceptance criteria
- [ ] The Cypress test `src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js` is the only test that runs in the `cypress-6` step on Jenkins.