### PR TITLE
Github Actions (CI) -- fix dev bucket

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -917,7 +917,7 @@ jobs:
       matrix:
         include:
           - environment: vagovdev
-            bucket: dev-va-gov-assets
+            bucket: apps.dev.va.gov
           # - environment: vagovstaging
           #   bucket: staging-va-gov-assets
 


### PR DESCRIPTION
## Description

This PR fixes bucket name to deploy to `dev` in Github Actions

