### PR TITLE
Notification Settings display bugfix

### DIFF
--- a/src/applications/personalization/profile/components/notification-settings/NotificationSettings.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationSettings.jsx
@@ -133,7 +133,7 @@ const NotificationSettings = ({
           mobilePhoneNumber={mobilePhoneNumber}
         />
       ) : null}
-      {!shouldShowLoadingIndicator
+      {showContactInfoOnFile
         ? notificationGroups.ids.map(groupId => {
             // we handle the health care group a little differently
             // TODO: I don't like this check. what does `group3` even mean?


### PR DESCRIPTION
## Description
Fixes a minor edge-case bug where a user without an email address or mobile phone could see notification items.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#27864

## Testing done
None actually. Mocking the APIs to replicate this bug is frankly too much work to bother for such a minor visual bug that would only be seen by a sliver of users. We have plenty of tests to make sure things work in the normal happy and sad paths to ensure this one-line change doesn't has adverse effects.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs