### PR TITLE
Added 16px of right margin to profile page header

### DIFF
--- a/src/applications/gi-sandbox/containers/ProfilePageHeader.jsx
+++ b/src/applications/gi-sandbox/containers/ProfilePageHeader.jsx
@@ -83,9 +83,13 @@ const ProfilePageHeader = ({
   const displayStars =
     gibctSchoolRatings && stars && ratingCount >= MINIMUM_RATING_COUNT;
 
-  const titleClasses = classNames('small-screen-header', {
-    'vads-u-margin-bottom--0': displayStars,
-  });
+  const titleClasses = classNames(
+    'small-screen-header',
+    'vads-u-margin-right--2',
+    {
+      'vads-u-margin-bottom--0': displayStars,
+    },
+  );
 
   const starClasses = classNames(
     'vads-u-margin-bottom--1',


### PR DESCRIPTION
## Description
On the School Details page, CSS might need to be modified so that long school names do not come as close to the edge of the School box.

## Original issue(s)
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/29434

## Testing done
local

## Screenshots
<img width="679" alt="Screen Shot 2021-09-08 at 10 38 49 AM" src="https://user-images.githubusercontent.com/50601724/132530643-8cbe4444-7205-4251-b5db-cb7146684b29.png">


## Acceptance criteria
- [x] The card title has 16px of right margin.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
