### PR TITLE
526: Fix missing `treatedDisabilityNames`

### DIFF
--- a/src/applications/disability-benefits/all-claims/migrations/06-fix-treatedDisabilityNames.js
+++ b/src/applications/disability-benefits/all-claims/migrations/06-fix-treatedDisabilityNames.js
@@ -1,0 +1,38 @@
+import clone from 'platform/utilities/data/clone';
+
+import { sippableId } from '../utils';
+
+export default function fixTreatedDisabilityNamesKey(savedData) {
+  const formData = clone(savedData.formData);
+  const facilities = formData.vaTreatmentFacilities || [];
+  const powDisabilities = formData['view:isPow']?.powDisabilities;
+  if (facilities) {
+    formData.vaTreatmentFacilities = facilities.map(entry => ({
+      ...entry,
+      treatedDisabilityNames: Object.entries(
+        entry.treatedDisabilityNames,
+      ).reduce(
+        (names, [key, value]) => ({
+          ...names,
+          [sippableId(key)]: value,
+        }),
+        {},
+      ),
+    }));
+  }
+  if (powDisabilities) {
+    formData['view:isPow'].powDisabilities = Object.entries(
+      powDisabilities,
+    ).reduce(
+      (disabilities, [key, value]) => ({
+        ...disabilities,
+        [sippableId(key)]: value,
+      }),
+      {},
+    );
+  }
+  return {
+    formData,
+    metadata: savedData.metadata,
+  };
+}

--- a/src/applications/disability-benefits/all-claims/migrations/index.js
+++ b/src/applications/disability-benefits/all-claims/migrations/index.js
@@ -3,6 +3,7 @@ import convertCountryCode from './02-convert-country-code';
 import upgradeHasSeparationPay from './03-upgrade-hasSeparationPay';
 import truncateOtherHomelessHousing from './04-truncate-otherHomelessHousing';
 import truncateOtherAtRiskHousing from './05-truncate-otherAtRiskHousing';
+import fixTreatedDisabilityNamesKey from './06-fix-treatedDisabilityNames';
 
 // We launched at version 1 and not version 0, so the first _real_ migration is at
 //  migrations[1]
@@ -16,4 +17,5 @@ export default [
   upgradeHasSeparationPay,
   truncateOtherHomelessHousing,
   truncateOtherAtRiskHousing,
+  fixTreatedDisabilityNamesKey,
 ];

--- a/src/applications/disability-benefits/all-claims/submit-transformer.js
+++ b/src/applications/disability-benefits/all-claims/submit-transformer.js
@@ -23,6 +23,7 @@ import {
   isBDD,
   isDisabilityPtsd,
   truncateDescriptions,
+  sippableId,
 } from './utils';
 
 import disabilityLabels from './content/disabilityLabels';
@@ -166,7 +167,7 @@ export function transformRelatedDisabilities(
   const findCondition = (list, name) =>
     list.find(
       // name should already be lower-case, but just in case...no pun intended
-      claimedName => claimedName.toLowerCase() === name.toLowerCase(),
+      claimedName => sippableId(claimedName) === name.toLowerCase(),
     );
 
   return (

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-test.json
@@ -99,9 +99,9 @@
           "state": "AK"
         },
         "treatedDisabilityNames": {
-          "diabetes mellitus0": true,
-          "diabetes mellitus1": true,
-          "myocardial infarction (mi)": true
+          "diabetesmellitus0": true,
+          "diabetesmellitus1": true,
+          "myocardialinfarctionmi": true
         }
       },
       {
@@ -116,7 +116,7 @@
         "treatedDisabilityNames": {
           "asthma": true,
           "phlebitis": true,
-          "knee replacement": true
+          "kneereplacement": true
         }
       }
     ],
@@ -149,8 +149,8 @@
         }
       ],
       "powDisabilities": {
-        "knee replacement": true,
-        "myocardial infarction (mi)": true
+        "kneereplacement": true,
+        "myocardialinfarctionmi": true
       }
     },
     "newDisabilities": [

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/secondary-new-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/secondary-new-test.json
@@ -93,9 +93,9 @@
           "state": "AK"
         },
         "treatedDisabilityNames": {
-          "Diabetes mellitus0": true,
-          "De-selected": false,
-          "knee replacement": true
+          "diabetesmellitus0": true,
+          "deselected": false,
+          "kneereplacement": true
         }
       }
     ],

--- a/src/applications/disability-benefits/all-claims/tests/migrations/migrations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/migrations/migrations.unit.spec.js
@@ -4,6 +4,7 @@ import redirectToClaimTypePage from '../../migrations/01-require-claim-type';
 import upgradeHasSeparationPay from '../../migrations/03-upgrade-hasSeparationPay';
 import truncateOtherHomelessHousing from '../../migrations/04-truncate-otherHomelessHousing';
 import truncateOtherAtRiskHousing from '../../migrations/05-truncate-otherAtRiskHousing';
+import fixTreatedDisabilityNamesKey from '../../migrations/06-fix-treatedDisabilityNames';
 
 import formConfig from '../../config/form';
 import { MAX_HOUSING_STRING_LENGTH } from '../../constants';
@@ -115,6 +116,66 @@ describe('526 v2 migrations', () => {
         formData: {
           otherAtRiskHousing: longString(0),
           test: true,
+        },
+        metadata: { version: 1 },
+      });
+    });
+  });
+
+  describe('06-fix-treatedDisabilityNames', () => {
+    it('should migrate treatedDisabilityNames & powDisabilities', () => {
+      const savedData = {
+        formData: {
+          vaTreatmentFacilities: [
+            {
+              treatedDisabilityNames: {
+                'diabetes mellitus 0': true,
+                'diabetes mellitus 1': true,
+                'myocardial infarction (mi)': true,
+              },
+            },
+            {
+              treatedDisabilityNames: {
+                'asthma 123': true,
+                'phlebitis (456)': true,
+                'knee replacement': true,
+              },
+            },
+          ],
+          'view:isPow': {
+            powDisabilities: {
+              'knee replacement': true,
+              'myocardial infarction (mi)': true,
+            },
+          },
+        },
+        metadata: { version: 1 },
+      };
+      const migratedData = fixTreatedDisabilityNamesKey(savedData);
+      expect(migratedData).to.deep.equal({
+        formData: {
+          vaTreatmentFacilities: [
+            {
+              treatedDisabilityNames: {
+                diabetesmellitus0: true,
+                diabetesmellitus1: true,
+                myocardialinfarctionmi: true,
+              },
+            },
+            {
+              treatedDisabilityNames: {
+                asthma123: true,
+                phlebitis456: true,
+                kneereplacement: true,
+              },
+            },
+          ],
+          'view:isPow': {
+            powDisabilities: {
+              kneereplacement: true,
+              myocardialinfarctionmi: true,
+            },
+          },
         },
         metadata: { version: 1 },
       });

--- a/src/applications/disability-benefits/all-claims/tests/pages/addDisabilities.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/addDisabilities.unit.spec.jsx
@@ -202,12 +202,12 @@ describe('Add new disabilities', () => {
       vaTreatmentFacilities: [
         {
           treatedDisabilityNames: {
-            'something with-hyphens and allcaps': true,
+            somethingwithhyphensandallcaps: true,
           },
         },
       ],
       'view:isPow': {
-        powDisabilities: { 'something with-hyphens and allcaps': true },
+        powDisabilities: { somethingwithhyphensandallcaps: true },
       },
     });
 
@@ -243,12 +243,9 @@ describe('Add new disabilities', () => {
       );
       const result = updateFormData(oldData(), newData);
       expect(
-        result.vaTreatmentFacilities[0].treatedDisabilityNames[
-          'foo-with extraz'
-        ],
+        result.vaTreatmentFacilities[0].treatedDisabilityNames.foowithextraz,
       ).to.be.true;
-      expect(result['view:isPow'].powDisabilities['foo-with extraz']).to.be
-        .true;
+      expect(result['view:isPow'].powDisabilities.foowithextraz).to.be.true;
     });
 
     it('should remove a deleted disability from treatedDisabilityNames and powDisabilities', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
@@ -78,7 +78,7 @@ describe('VA Medical Records', () => {
             {
               treatmentCenterName: 'Sommerset VA Clinic',
               treatedDisabilityNames: {
-                'Diabetes Melitus': true,
+                diabetesmelitus: true,
               },
               treatmentDateRange: {
                 from: '2001-05-XX',
@@ -120,7 +120,7 @@ describe('VA Medical Records', () => {
             {
               treatmentCenterName: 'Sommerset VA Clinic',
               treatedDisabilityNames: {
-                'Diabetes Melitus': true,
+                diabetesmelitus: true,
               },
               treatmentDateRange: {
                 from: '2001-05-XX',
@@ -162,7 +162,7 @@ describe('VA Medical Records', () => {
             {
               treatmentCenterName: 'Sommerset VA Clinic',
               treatedDisabilityNames: {
-                'Diabetes Melitus': true,
+                diabetesmelitus: true,
               },
               treatmentDateRange: {
                 from: '2010-04-XX',
@@ -198,7 +198,7 @@ describe('VA Medical Records', () => {
             {
               treatmentCenterName: 'Sommerset VA Clinic',
               treatedDisabilityNames: {
-                'Diabetes Melitus': true,
+                diabetesmelitus: true,
               },
               treatmentDateRange: {
                 from: '2010-04-XX',
@@ -234,7 +234,7 @@ describe('VA Medical Records', () => {
             {
               treatmentCenterName: 'Sommerset VA Clinic',
               treatedDisabilityNames: {
-                'Diabetes Melitus': true,
+                diabetesmelitus: true,
               },
               treatmentDateRange: {
                 from: '2010-04-XX',

--- a/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
@@ -84,9 +84,9 @@ describe('transformRelatedDisabilities', () => {
   it('should return an array of strings', () => {
     const claimedConditions = ['Some Condition Name', 'Another Condition Name'];
     const treatedDisabilityNames = {
-      'some condition name': true,
-      'another condition name': true,
-      'this condition is falsey!': false,
+      someconditionname: true,
+      anotherconditionname: true,
+      thisconditionisfalsey: false,
     };
     expect(
       transformRelatedDisabilities(treatedDisabilityNames, claimedConditions),
@@ -95,9 +95,9 @@ describe('transformRelatedDisabilities', () => {
   it('should not add conditions if they are not claimed', () => {
     const claimedConditions = ['Some Condition Name'];
     const treatedDisabilityNames = {
-      'some condition name': true,
-      'another condition name': true,
-      'this condition is falsey!': false,
+      someconditionname: true,
+      anotherconditionname: true,
+      thisconditionisfalsey: false,
     };
     expect(
       transformRelatedDisabilities(treatedDisabilityNames, claimedConditions),
@@ -122,9 +122,9 @@ describe('stringifyRelatedDisabilities', () => {
       vaTreatmentFacilities: [
         {
           treatedDisabilityNames: {
-            'some condition name': true,
-            'another condition name': true,
-            'this condition is falsey!': false,
+            someconditionname: true,
+            anotherconditionname: true,
+            thisconditionisfalsey: false,
           },
         },
       ],
@@ -149,13 +149,17 @@ describe('stringifyRelatedDisabilities', () => {
         {
           condition: 'this condition is falsey!',
         },
+        {
+          condition: 'something with symbols *($#^%$@) not in the key',
+        },
       ],
       vaTreatmentFacilities: [
         {
           treatedDisabilityNames: {
-            'some condition name': true,
-            'another condition name': true,
-            'this condition is falsey!': false,
+            someconditionname: true,
+            anotherconditionname: true,
+            thisconditionisfalsey: false,
+            somethingwithsymbolsnotinthekey: true,
           },
         },
       ],
@@ -164,7 +168,10 @@ describe('stringifyRelatedDisabilities', () => {
       stringifyRelatedDisabilities(formData).vaTreatmentFacilities,
     ).to.deep.equal([
       {
-        treatedDisabilityNames: ['some condition name'],
+        treatedDisabilityNames: [
+          'some condition name',
+          'something with symbols *($#^%$@) not in the key',
+        ],
       },
     ]);
   });

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -191,7 +191,7 @@ describe('526 helpers', () => {
       };
       expect(makeSchemaForNewDisabilities(formData)).to.eql({
         properties: {
-          'ptsd personal trauma': {
+          ptsdpersonaltrauma: {
             title: 'Ptsd Personal Trauma',
             type: 'boolean',
           },
@@ -209,7 +209,7 @@ describe('526 helpers', () => {
       };
       expect(makeSchemaForNewDisabilities(formData)).to.eql({
         properties: {
-          'period. period.': {
+          periodperiod: {
             title: 'Period. Period.',
             type: 'boolean',
           },
@@ -234,7 +234,7 @@ describe('526 helpers', () => {
       };
       expect(makeSchemaForRatedDisabilities(formData)).to.eql({
         properties: {
-          'diabetes mellitus': {
+          diabetesmellitus: {
             title: 'Diabetes Mellitus',
             type: 'boolean',
           },
@@ -264,11 +264,11 @@ describe('526 helpers', () => {
       };
       expect(makeSchemaForAllDisabilities(formData)).to.eql({
         properties: {
-          'diabetes mellitus': {
+          diabetesmellitus: {
             title: 'Diabetes Mellitus',
             type: 'boolean',
           },
-          'a new condition.': {
+          anewcondition: {
             title: 'A New Condition.',
             type: 'boolean',
           },

--- a/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
@@ -310,6 +310,7 @@ describe('526 All Claims validations', () => {
   describe('validateDisabilityName', () => {
     const tooLong =
       'et pharetra pharetra massa massa ultricies mi quis hendrerit dolor magna eget est lorem ipsum dolor sit amet consectetur adipiscing elit pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas integer eget aliquet nibh praesent';
+
     it('should not add error when disability is in list', () => {
       const err = { addError: sinon.spy() };
       validateDisabilityName(err, disabilityLabels[7100]);
@@ -329,6 +330,21 @@ describe('526 All Claims validations', () => {
       const err = { addError: sinon.spy() };
       validateDisabilityName(err, tooLong);
       expect(err.addError.calledOnce).to.be.true;
+    });
+    it('should add error when duplicate names are encountered', () => {
+      const _ = null;
+      const err = { addError: sinon.spy() };
+      const test = condition =>
+        validateDisabilityName(err, condition, _, _, _, _, {
+          newDisabilities: [{ condition: 'diabetes type 2' }, { condition }],
+        });
+
+      test('DiaBeTes type 2');
+      expect(err.addError.callCount).to.eq(1);
+      test('DIABETES TYPE 2');
+      expect(err.addError.callCount).to.eq(2);
+      test('diabetes type (2)');
+      expect(err.addError.callCount).to.eq(3);
     });
   });
 

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -294,7 +294,9 @@ export const disabilityIsSelected = disability => disability['view:selected'];
  * @param {string} str - The string to make SiP-friendly
  * @return {string} The SiP-friendly string
  */
-export const sippableId = str => (str || 'blank').toLowerCase();
+const regexNonWord = /[^\w]/g;
+export const sippableId = str =>
+  (str || 'blank').replace(regexNonWord, '').toLowerCase();
 
 const createCheckboxSchema = (schema, disabilityName) => {
   const capitalizedDisabilityName =

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -11,6 +11,7 @@ import {
   hasRatedDisabilities,
   claimingRated,
   showSeparationLocation,
+  sippableId,
 } from './utils';
 
 import {
@@ -291,7 +292,7 @@ export const missingConditionMessage =
 export const validateDisabilityName = (
   err,
   fieldData,
-  formData,
+  _formData,
   _schema,
   _uiSchema,
   _index,
@@ -322,8 +323,13 @@ export const validateDisabilityName = (
     appStateData?.newDisabilities?.map(disability =>
       disability.condition?.toLowerCase(),
     ) || [];
+  // look for full text duplicates
   const itemLowerCased = fieldData?.toLowerCase() || '';
-  const itemCount = currentList.filter(item => item === itemLowerCased);
+  // look for duplicates that may occur from stripping out
+  const itemSippableId = sippableId(fieldData || '');
+  const itemCount = currentList.filter(
+    item => item === itemLowerCased || sippableId(item) === itemSippableId,
+  );
   if (itemCount.length > 1) {
     err.addError('Please enter a unique condition name');
   }


### PR DESCRIPTION
## Description

When a Veteran is asked to associate a newly entered disability with a treatment center, the full text of the disability name is stored as a key in an object. This includes the list of disabilities that are associated with a POW-event. Since the save-in-progress data manipulates the JSON, the disability names become transformed and may not match the entered value once a form is resumed.

This PR removes all non-alphanumeric characters within the entered disability name to prevent issues with the modified save-in-progress data. To smooth this transition, the conversion is accomplished through data migration. Appropriate unit tests have been added.

## Original issue(s)

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/29246

## Testing done

- Updated & added unit tests
- Updated mock data for e2e tests

## Screenshots

N/A

## Acceptance criteria
- [x] Simplify keys for disability names associated with treatment centers
- [x] Simplify keys for disability names associated with POW events
- [x] All test passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
