### PR TITLE
Feature: Adds mhv mapping for custom redirect

### DIFF
--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -17,6 +17,9 @@ export const externalRedirects = {
   myvahealth: environment.isProduction()
     ? 'https://patientportal.myhealth.va.gov/'
     : 'https://staging-patientportal.myhealth.va.gov/',
+  mhv: environment.isProduction()
+    ? 'https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/'
+    : 'https://mhv-syst.myhealth.va.gov/mhv-portal-web/web/myhealthevet/',
 };
 
 export const ssoKeepAliveEndpoint = () => {


### PR DESCRIPTION
## Description

This creates additional mappings for external redirects for My HealtheVet (MHV).  The updated flow for MHV is the following paradigm:

1. User starts on My HealtheVet website and clicks 'Sign In'
2. User is redirected to VA.gov Sign In page (ex https://va.gov/sign-in/?application=mhv&to=secure-messaging).**
3. User authenticates using a service provider and eAuth
4. User navigates back to VA.gov (session is established) and redirects back to MHV.

**In the URI the `application` parameter refers to the full MHV URL and the `to` parameter refers to the location.  In the example above the full redirected URL would be www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/secure-messaging.

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#29729


## Testing done
Unit testing / Manual

## Screenshots

https://user-images.githubusercontent.com/67602137/132051954-f63ebbfe-4fd7-4fe6-8490-758f711a16c2.mp4

## Acceptance criteria
- [x] Providing an application=mhv & to parameter redirects a user to MHV.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
