### PR TITLE
Ignore VAOS docs css files during linting

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,7 +1,8 @@
 {
   "plugins": ["stylelint-scss", "stylelint-order"],
   "ignoreFiles": [
-    "src/applications/proxy-rewrite/sass/style-consolidated.scss"
+    "src/applications/proxy-rewrite/sass/style-consolidated.scss",
+    "src/applications/vaos/docs/styles/*.css"
   ],
   "rules": {
     "at-rule-disallowed-list": ["debug", "extend"],


### PR DESCRIPTION
## Description
This PR configures stylelint to ignore VAOS JSDoc styles.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#29741


## Testing done
- local

## Errors fixed

```
ERROR in 
src/applications/vaos/docs/styles/jsdoc.css
  11:10  ✖  Unexpected hex color "#4d4e53"   color-no-hex
  12:21  ✖  Unexpected named color "white"   color-named 
  25:10  ✖  Unexpected hex color "#606"      color-no-hex
  34:28  ✖  Unexpected hex color "#ddd"      color-no-hex
  38:24  ✖  Unexpected hex color "#222"      color-no-hex
  55:10  ✖  Unexpected hex color "#000"      color-no-hex
  86:10  ✖  Unexpected hex color "#4d4e53"   color-no-hex
  90:10  ✖  Unexpected hex color "#fff"      color-no-hex
...
```

## Acceptance criteria
- [x] No build errors when running `yarn watch`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
