### PR TITLE
Trap focus inside mega menu when open

### DIFF
--- a/src/platform/site-wide/mega-menu/components/MegaMenu.jsx
+++ b/src/platform/site-wide/mega-menu/components/MegaMenu.jsx
@@ -149,7 +149,7 @@ export default class MegaMenu extends React.Component {
               <li role="menuitem">
                 <a
                   className="vetnav-level1"
-                  data-e2e-id="mobile-home-nav-link"
+                  data-testid="mobile-home-nav-link"
                   href="/"
                   tabIndex={currentSection ? -1 : undefined}
                 >

--- a/src/platform/site-wide/mega-menu/components/MegaMenu.jsx
+++ b/src/platform/site-wide/mega-menu/components/MegaMenu.jsx
@@ -151,6 +151,7 @@ export default class MegaMenu extends React.Component {
                   className="vetnav-level1"
                   data-e2e-id="mobile-home-nav-link"
                   href="/"
+                  tabIndex={currentSection ? -1 : undefined}
                 >
                   Home
                 </a>
@@ -171,6 +172,11 @@ export default class MegaMenu extends React.Component {
                       className="vetnav-level1"
                       data-e2e-id={`${_.kebabCase(item.title)}-${i}`}
                       onClick={() => this.toggleDropDown(item.title)}
+                      tabIndex={
+                        currentSection && currentSection !== item.title
+                          ? -1
+                          : undefined
+                      }
                     >
                       {item.title}
                     </button>
@@ -181,6 +187,11 @@ export default class MegaMenu extends React.Component {
                       href={item.href}
                       onClick={linkClicked.bind(null, item)}
                       target={item.target || null}
+                      tabIndex={
+                        currentSection && currentSection !== item.title
+                          ? -1
+                          : undefined
+                      }
                     >
                       {item.title}
                     </a>

--- a/src/platform/site-wide/mega-menu/components/MenuSection.jsx
+++ b/src/platform/site-wide/mega-menu/components/MenuSection.jsx
@@ -55,7 +55,8 @@ class MenuSection extends React.Component {
       title,
     } = this.props;
 
-    const show = this.getCurrentSection(this.props) === title;
+    const currentSection = this.getCurrentSection(this.props);
+    const show = currentSection === title;
     const isPlainLink = !!href;
 
     let button = null;
@@ -68,6 +69,7 @@ class MenuSection extends React.Component {
           data-e2e-id={`vetnav-level2--${_.kebabCase(title)}`}
           href={href}
           onClick={linkClicked}
+          tabIndex={currentSection && !show ? -1 : undefined}
         >
           {title}
         </a>
@@ -81,6 +83,7 @@ class MenuSection extends React.Component {
           className="vetnav-level2"
           data-e2e-id={`vetnav-level2--${_.kebabCase(title)}`}
           onClick={() => this.updateCurrentSection()}
+          tabIndex={currentSection && !show ? -1 : undefined}
         >
           {title}
         </button>

--- a/src/platform/site-wide/mega-menu/components/SubMenu.jsx
+++ b/src/platform/site-wide/mega-menu/components/SubMenu.jsx
@@ -39,15 +39,13 @@ const SubMenu = ({
         id={id}
         role="group"
       >
-        <div>
-          <button
-            className="back-button"
-            aria-controls={`vetnav-${_.kebabCase(navTitle)}`}
-            onClick={() => handleBackToMenu()}
-          >
-            Back to Menu
-          </button>
-        </div>
+        <button
+          className="back-button"
+          aria-controls={`vetnav-${_.kebabCase(navTitle)}`}
+          onClick={() => handleBackToMenu()}
+        >
+          Back to Menu
+        </button>
 
         {seeAllLink && (
           <div className="panel-bottom-link">

--- a/src/platform/site-wide/mega-menu/components/SubMenu.jsx
+++ b/src/platform/site-wide/mega-menu/components/SubMenu.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import FocusLock from 'react-focus-lock';
 import Column from './Column';
 import _ from 'lodash';
 import ArrowRightBlueSVG from './arrow-right-blue';
@@ -40,49 +39,47 @@ const SubMenu = ({
         id={id}
         role="group"
       >
-        <FocusLock disabled={!mobileMediaQuery?.matches}>
-          <div>
-            <button
-              className="back-button"
-              aria-controls={`vetnav-${_.kebabCase(navTitle)}`}
-              onClick={() => handleBackToMenu()}
+        <div>
+          <button
+            className="back-button"
+            aria-controls={`vetnav-${_.kebabCase(navTitle)}`}
+            onClick={() => handleBackToMenu()}
+          >
+            Back to Menu
+          </button>
+        </div>
+
+        {seeAllLink && (
+          <div className="panel-bottom-link">
+            <a
+              data-e2e-id={`${_.kebabCase(seeAllLink.text)}`}
+              href={seeAllLink.href}
+              onClick={linkClicked.bind(null, seeAllLink)}
             >
-              Back to Menu
-            </button>
+              {seeAllLink.text}
+              <ArrowRightBlueSVG />
+            </a>
           </div>
+        )}
 
-          {seeAllLink && (
-            <div className="panel-bottom-link">
-              <a
-                data-e2e-id={`${_.kebabCase(seeAllLink.text)}`}
-                href={seeAllLink.href}
-                onClick={linkClicked.bind(null, seeAllLink)}
-              >
-                {seeAllLink.text}
-                <ArrowRightBlueSVG />
-              </a>
-            </div>
-          )}
-
-          {Object.keys(filteredColumns).map(keyName => (
-            <Column
-              key={keyName}
-              data={filteredColumns[keyName]}
-              keyName={keyName}
-              navTitle={navTitle}
-              panelWhite={Object.prototype.hasOwnProperty.call(
-                filteredColumns,
-                'mainColumn',
-              )}
-              linkClicked={linkClicked}
-              mobileMediaQuery={mobileMediaQuery}
-              hidden={
-                keyName === 'columnThree' && smallDesktopMediaQuery?.matches
-              }
-              columnThreeLinkClicked={columnThreeLinkClicked}
-            />
-          ))}
-        </FocusLock>
+        {Object.keys(filteredColumns).map(keyName => (
+          <Column
+            key={keyName}
+            data={filteredColumns[keyName]}
+            keyName={keyName}
+            navTitle={navTitle}
+            panelWhite={Object.prototype.hasOwnProperty.call(
+              filteredColumns,
+              'mainColumn',
+            )}
+            linkClicked={linkClicked}
+            mobileMediaQuery={mobileMediaQuery}
+            hidden={
+              keyName === 'columnThree' && smallDesktopMediaQuery?.matches
+            }
+            columnThreeLinkClicked={columnThreeLinkClicked}
+          />
+        ))}
       </div>
     );
   }

--- a/src/platform/site-wide/mega-menu/containers/Main.jsx
+++ b/src/platform/site-wide/mega-menu/containers/Main.jsx
@@ -111,7 +111,7 @@ export class Main extends Component {
     this.props.toggleMobileDisplayHidden(hidden);
   };
 
-  focusTrap = e => {
+  focusTrap = event => {
     const buttonContainer = document.getElementById('va-nav-controls');
     const megaMenuContainer = document.getElementById('mega-menu-mobile');
     const focusable = [
@@ -131,12 +131,12 @@ export class Main extends Component {
     const firstEl = focusable[0];
     const lastEl = focusable[focusable.length - 1];
 
-    if (e.keyCode === 9) {
-      if (e.shiftKey && document.activeElement === firstEl) {
-        e.preventDefault();
+    if (event.code === 'Tab') {
+      if (event.shiftKey && document.activeElement === firstEl) {
+        event.preventDefault();
         lastEl.focus();
-      } else if (!e.shiftKey && document.activeElement === lastEl) {
-        e.preventDefault();
+      } else if (!event.shiftKey && document.activeElement === lastEl) {
+        event.preventDefault();
         firstEl.focus();
       }
     }

--- a/src/platform/site-wide/mega-menu/tests/megaMenu.cypress.spec.js
+++ b/src/platform/site-wide/mega-menu/tests/megaMenu.cypress.spec.js
@@ -64,6 +64,90 @@ const testMobileMenuSections = () => {
   cy.get('.vetnav-controller-open').contains('Menu');
 };
 
+const testMobileTabFocus = () => {
+  cy.get('[data-e2e-id="about-va-1"]').should('not.be.visible');
+  cy.get('#mega-menu-desktop #vetnav').should('not.exist');
+
+  cy.get('.vetnav-controller-open').contains('Menu');
+  cy.get('.vetnav-controller-open').click();
+  cy.get('.vetnav-controller-close').contains('Close');
+
+  // tabbing through first level menu wraps around to open/close button
+  cy.get('[data-e2e-id="mobile-home-nav-link"]')
+    .tab()
+    .tab()
+    .tab()
+    .tab()
+    .tab();
+
+  cy.focused().should('have.attr', 'aria-controls', 'vetnav');
+
+  // shift tabbing through first level menu wraps around to open/close button
+  cy.get('[data-e2e-id="mobile-home-nav-link"]')
+    .tab({
+      shift: true,
+    })
+    .tab({
+      shift: true,
+    })
+    .tab({
+      shift: true,
+    })
+    .tab({
+      shift: true,
+    })
+    .tab({
+      shift: true,
+    })
+    .tab({
+      shift: true,
+    });
+
+  cy.focused().should('have.attr', 'aria-controls', 'vetnav');
+
+  // tabbing through second level menu wraps around to open/close button
+  cy.get('[data-e2e-id="mobile-home-nav-link"]')
+    .tab()
+    .click()
+    .tab()
+    .tab()
+    .tab()
+    .tab()
+    .tab()
+    .tab()
+    .tab()
+    .tab()
+    .tab()
+    .tab()
+    .tab()
+    .tab()
+    .tab()
+    .tab()
+    .tab();
+
+  cy.focused().should('have.attr', 'aria-controls', 'vetnav');
+
+  // tabbing through third level menu wraps around to open/close button
+  cy.get('[data-e2e-id="mobile-home-nav-link"]')
+    .tab()
+    .tab()
+    .click();
+  cy.get('#vetnav-health-care-ms button')
+    .tab()
+    .tab()
+    .tab()
+    .tab()
+    .tab()
+    .tab()
+    .tab()
+    .tab()
+    .tab()
+    .tab()
+    .tab();
+
+  cy.focused().should('have.attr', 'aria-controls', 'vetnav');
+};
+
 const testDesktopMenuSections = () => {
   testFirstMenuSection(false);
   testSecondMenuSection(false);
@@ -140,6 +224,12 @@ describe('Mega Menu', () => {
       // Authenticated links should appear.
       cy.get('[data-e2e-id="my-va-3"]');
       cy.get('[data-e2e-id="my-health-4"]');
+    });
+
+    it('traps focus inside mega menu when opened', () => {
+      cy.visit('/');
+
+      testMobileTabFocus();
     });
   });
 });

--- a/src/platform/site-wide/mega-menu/tests/megaMenu.cypress.spec.js
+++ b/src/platform/site-wide/mega-menu/tests/megaMenu.cypress.spec.js
@@ -51,7 +51,7 @@ const testMobileMenuSections = () => {
   cy.get('.vetnav-controller-close').contains('Close');
 
   // Check the links to make sure they all look right.
-  cy.get('[data-e2e-id="mobile-home-nav-link"]');
+  cy.findByTestId('mobile-home-nav-link');
   cy.get('[data-e2e-id="about-va-1"]').click();
   cy.get('[data-e2e-id="vetnav-level2--va-organizations"]').click();
   cy.get('[data-e2e-id="all-va-offices-and-organizations-6"]');
@@ -73,77 +73,44 @@ const testMobileTabFocus = () => {
   cy.get('.vetnav-controller-close').contains('Close');
 
   // tabbing through first level menu wraps around to open/close button
-  cy.get('[data-e2e-id="mobile-home-nav-link"]')
-    .tab()
-    .tab()
-    .tab()
-    .tab()
-    .tab();
+  cy.findByTestId('mobile-home-nav-link').focus();
+
+  for (let i = 0; i < 5; i++) {
+    cy.focused().tab();
+  }
 
   cy.focused().should('have.attr', 'aria-controls', 'vetnav');
 
   // shift tabbing through first level menu wraps around to open/close button
-  cy.get('[data-e2e-id="mobile-home-nav-link"]')
-    .tab({
-      shift: true,
-    })
-    .tab({
-      shift: true,
-    })
-    .tab({
-      shift: true,
-    })
-    .tab({
-      shift: true,
-    })
-    .tab({
-      shift: true,
-    })
-    .tab({
-      shift: true,
-    });
+
+  for (let i = 0; i < 6; i++) {
+    cy.focused().tab({ shift: true });
+  }
 
   cy.focused().should('have.attr', 'aria-controls', 'vetnav');
 
   // tabbing through second level menu wraps around to open/close button
-  cy.get('[data-e2e-id="mobile-home-nav-link"]')
+  cy.findByTestId('mobile-home-nav-link')
     .tab()
-    .click()
-    .tab()
-    .tab()
-    .tab()
-    .tab()
-    .tab()
-    .tab()
-    .tab()
-    .tab()
-    .tab()
-    .tab()
-    .tab()
-    .tab()
-    .tab()
-    .tab()
-    .tab();
+    .click();
+
+  for (let i = 0; i < 15; i++) {
+    cy.focused().tab();
+  }
 
   cy.focused().should('have.attr', 'aria-controls', 'vetnav');
 
   // tabbing through third level menu wraps around to open/close button
-  cy.get('[data-e2e-id="mobile-home-nav-link"]')
+  cy.findByTestId('mobile-home-nav-link')
     .tab()
     .tab()
     .click();
-  cy.get('#vetnav-health-care-ms button')
-    .tab()
-    .tab()
-    .tab()
-    .tab()
-    .tab()
-    .tab()
-    .tab()
-    .tab()
-    .tab()
-    .tab()
-    .tab();
+
+  cy.get('#vetnav-health-care-ms button').focus();
+
+  for (let i = 0; i < 11; i++) {
+    cy.focused().tab();
+  }
 
   cy.focused().should('have.attr', 'aria-controls', 'vetnav');
 };
@@ -165,7 +132,7 @@ describe('Mega Menu', () => {
       cy.visit('/');
 
       // Back to home button should not appear on desktop.
-      cy.get('[data-e2e-id="mobile-home-nav-link"]').should('not.be.visible');
+      cy.findByTestId('mobile-home-nav-link').should('not.be.visible');
 
       // Test the menu sections.
       testDesktopMenuSections();
@@ -183,7 +150,7 @@ describe('Mega Menu', () => {
       cy.visit('/');
 
       // Back to home button should not appear on desktop.
-      cy.get('[data-e2e-id="mobile-home-nav-link"]').should('not.be.visible');
+      cy.findByTestId('mobile-home-nav-link').should('not.be.visible');
 
       // Test the menu sections.
       testDesktopMenuSections();


### PR DESCRIPTION
## Description
When the mega menu is open on mobile we want to trap focus within the menu and the open/close button to match a11y expectations and prevent focus from entering elements that are out of view.

I recommend hiding whitespace changes: https://github.com/department-of-veterans-affairs/vets-website/pull/18604/files?diff=split&w=1

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/25659


## Testing done
local, cypress

## Screenshots

https://user-images.githubusercontent.com/3144003/132557722-4c47f46a-ca00-45d2-8705-6381097ab5c4.mov

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
