### PR TITLE
Fixed COVID-19 vaccines typo

### DIFF
--- a/src/applications/facility-locator/tests/helpers/formatServiceName.unit.spec.js
+++ b/src/applications/facility-locator/tests/helpers/formatServiceName.unit.spec.js
@@ -21,4 +21,9 @@ describe('formatServiceName', () => {
     const serviceTest = formatServiceName(null);
     expect(serviceTest).to.be.null;
   });
+
+  it('Should display Covid19 vaccine as COVID-19 vaccines', () => {
+    const serviceTest = formatServiceName('Covid19 vaccine');
+    expect(serviceTest).to.equal('COVID-19 vaccines');
+  });
 });

--- a/src/applications/facility-locator/utils/formatServiceName.js
+++ b/src/applications/facility-locator/utils/formatServiceName.js
@@ -11,6 +11,7 @@ export const formatServiceName = service => {
     .replace(/\s+/g, ' ')
     .toLowerCase()
     .replace(/veteran/g, 'Veteran')
+    .replace(/covid19 vaccine/g, 'COVID-19 vaccines')
     .trim();
   return lowerCaseService.charAt(0).toUpperCase() + lowerCaseService.slice(1);
 };


### PR DESCRIPTION
## Description
Resolves issue linked below

To test use - http://localhost:3001/find-locations/facility/vha_668

## Screenshots

<details>
<summary>screenshot of typo fixed to now say COVID-19 vaccines</summary>
<img width="581" alt="Screen Shot 2021-09-08 at 3 00 48 PM" src="https://user-images.githubusercontent.com/84030819/132569126-fc0fd8f2-5b51-49b8-a3b6-633ce34f1a73.png">

</details>

