### PR TITLE
[28722] removes references to v0/sessions from tests

### DIFF
--- a/src/applications/hca/tests/hca-helpers.js
+++ b/src/applications/hca/tests/hca-helpers.js
@@ -439,7 +439,7 @@ function initSaveInProgressMock(url, client) {
 
   /* eslint-disable camelcase */
   mock(token, {
-    path: '/v0/sessions/slo/new',
+    path: '/v1/sessions/slo/new',
     verb: 'get',
     value: {
       url: 'http://fake',
@@ -447,7 +447,7 @@ function initSaveInProgressMock(url, client) {
   });
 
   mock(token, {
-    path: '/v0/sessions/new',
+    path: '/v1/sessions/new',
     verb: 'get',
     value: {
       url: 'http://fake',

--- a/src/platform/forms/tests/save-in-progress/01-sip-autosave.cypress.spec.js
+++ b/src/platform/forms/tests/save-in-progress/01-sip-autosave.cypress.spec.js
@@ -10,10 +10,10 @@ describe('SIP Autosave Test', () => {
       formSubmissionId: '123fake-submission-id-567',
       timestamp: '2016-05-16',
     });
-    cy.intercept('GET', '/v0/sessions/slo/new', {
+    cy.intercept('GET', '/v1/sessions/slo/new', {
       url: 'http://fake',
     });
-    cy.intercept('GET', '/v0/sessions/new', {
+    cy.intercept('GET', '/v1/sessions/new', {
       url: 'http://fake',
     });
     cy.intercept('GET', '/v0/user', mockUser).as('mockUser');

--- a/src/platform/forms/tests/save-in-progress/01-sip-finish-later.cypress.spec.js
+++ b/src/platform/forms/tests/save-in-progress/01-sip-finish-later.cypress.spec.js
@@ -11,10 +11,10 @@ describe('SIP Finish Later', () => {
       formSubmissionId: '123fake-submission-id-567',
       timestamp: '2016-05-16',
     });
-    cy.intercept('GET', '/v0/sessions/slo/new', {
+    cy.intercept('GET', '/v1/sessions/slo/new', {
       url: 'http://fake',
     });
-    cy.intercept('GET', '/v0/sessions/new', {
+    cy.intercept('GET', '/v1/sessions/new', {
       url: 'http://fake',
     });
     cy.intercept('GET', '/v0/user', mockUser).as('mockUser');

--- a/src/platform/forms/tests/save-in-progress/01-sip-load-fail.cypress.spec.js
+++ b/src/platform/forms/tests/save-in-progress/01-sip-load-fail.cypress.spec.js
@@ -9,10 +9,10 @@ describe('SIP Load Fail Test', () => {
       formSubmissionId: '123fake-submission-id-567',
       timestamp: '2016-05-16',
     });
-    cy.intercept('GET', '/v0/sessions/slo/new', {
+    cy.intercept('GET', '/v1/sessions/slo/new', {
       url: 'http://fake',
     });
-    cy.intercept('GET', '/v0/sessions/new', {
+    cy.intercept('GET', '/v1/sessions/new', {
       url: 'http://fake',
     });
     cy.intercept('GET', '/v0/user', mockUser).as('mockUser');

--- a/src/platform/forms/tests/save-in-progress/01-sip-review.cypress.spec.js
+++ b/src/platform/forms/tests/save-in-progress/01-sip-review.cypress.spec.js
@@ -10,10 +10,10 @@ describe('SIP Review Test', () => {
       formSubmissionId: '123fake-submission-id-567',
       timestamp: '2016-05-16',
     });
-    cy.intercept('GET', '/v0/sessions/slo/new', {
+    cy.intercept('GET', '/v1/sessions/slo/new', {
       url: 'http://fake',
     });
-    cy.intercept('GET', '/v0/sessions/new', {
+    cy.intercept('GET', '/v1/sessions/new', {
       url: 'http://fake',
     });
     cy.intercept('GET', '/v0/user', mockUser).as('mockUser');


### PR DESCRIPTION
## Description
This PR is a followup to a [backend PR](https://github.com/department-of-veterans-affairs/vets-api/pull/7744) that removes `v0/sessions_controller`, removing references to that route/controller from vets-website as well.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#28722


## Testing done
Changed unit specs pass, manual login/logout flows tested w/ ID.me
