### PR TITLE
WIP - va-accordion section heading analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -306,7 +306,7 @@
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
     "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#fc6d6a217164f49d2baf5ad2c803923c6ba21206",
-    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.9.4",
+    "web-components": "https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.9.6",
     "whatwg-fetch": "^3.6.2"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18455,9 +18455,9 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   dependencies:
     minimalistic-assert "^1.0.0"
 
-"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.9.4":
-  version "0.9.4"
-  resolved "https://github.com/department-of-veterans-affairs/component-library.git#05ef4c289b259dabf02d6eae091c00e0ba8d6e6d"
+"web-components@https://github.com/department-of-veterans-affairs/component-library.git#wc-v0.9.6":
+  version "0.9.6"
+  resolved "https://github.com/department-of-veterans-affairs/component-library.git#cfffd5588044c7c2f37a5bae0be625aa50f8c1af"
   dependencies:
     "@stencil/core" "^2.0.1"
     "@stencil/postcss" "^2.0.0"


### PR DESCRIPTION
## Description
We have added the `section heading` to the `va-accordion` web component analytics.  We _should_ be able to back out Ryan Leahy's temporary fix in `src/platform/site-wide/component-library-analytics-setup.js`.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/29777


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
