### PR TITLE
Move form tester documentation to Platform website

### DIFF
--- a/src/platform/testing/e2e/cypress/support/form-tester/README.md
+++ b/src/platform/testing/e2e/cypress/support/form-tester/README.md
@@ -1,3 +1,9 @@
+----
+# We're moving our docs! 
+### Find [the latest version of this page](https://depo-platform-documentation.scrollhelp.site/developer-docs/Cypress-Form-Tester.1870331957.html) on the Platform website.
+### Still can't find what you're looking for? Reach out to [#vfs-platform-support](https://dsva.slack.com/archives/CBU0KDSB1) on Slack.
+
+----
 # Cypress Form Tester
 
 ## Table of Contents


### PR DESCRIPTION
Add language about doc move to platform website

## Description
For this work, I created a Confluence doc that contains all of this information, moved it to Dev Docs, and published the document to the Platform website.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#25086

## Testing done
* Tested links to this doc on Platform website
* Tested link from this GH doc to Platform website version of the doc

## Screenshots
None

## Acceptance criteria
- [x] GH version of document contains disclaimer about moving documentation to Platform website
- [x] GH version of document links directly to the Platform website version of the document
- [x] Platform website version of documentation duplicates all information available here

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
