### PR TITLE
Add aria-label to SideNav button

### DIFF
--- a/src/platform/site-wide/side-nav/components/SideNav.js
+++ b/src/platform/site-wide/side-nav/components/SideNav.js
@@ -147,6 +147,7 @@ class SideNav extends Component {
           )}
           onClick={this.toggleUlClass}
           id="sidenav-menu"
+          aria-label="In this section menu"
         >
           <span className="sr-only">View sub-navigation for </span>
           In this section

--- a/src/platform/site-wide/side-nav/tests/components/SideNav.unit.spec.js
+++ b/src/platform/site-wide/side-nav/tests/components/SideNav.unit.spec.js
@@ -5,6 +5,7 @@ import { expect } from 'chai';
 import { uniqueId } from 'lodash';
 // Relative
 import SideNav from '../../components/SideNav';
+import { axeCheck } from 'platform/forms-system/test/config/helpers';
 
 describe('<SideNav>', () => {
   const firstID = uniqueId('sidenav_');
@@ -46,4 +47,6 @@ describe('<SideNav>', () => {
     expect(wrapper.type()).to.not.equal(null);
     wrapper.unmount();
   });
+
+  it('should pass axe check', () => axeCheck(<SideNav {...defaultProps} />));
 });


### PR DESCRIPTION
## Description
Closes ticket [#28698](https://github.com/department-of-veterans-affairs/va.gov-team/issues/28698)

Adds `aria-label="In this section menu"` to the button in the `SideNav` component.

## Original issue(s)


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
