### PR TITLE
NOD: Prevent adding duplicates

### DIFF
--- a/src/applications/appeals/10182/components/AddIssuesField.jsx
+++ b/src/applications/appeals/10182/components/AddIssuesField.jsx
@@ -57,7 +57,7 @@ const AddIssuesField = props => {
     [fullFormData, setFormData, hasSubmitted, selectedCount],
   );
 
-  const initialEditingState = uiOptions.setInitialEditMode?.(formData);
+  const initialEditingState = uiOptions.setInitialEditMode?.(fullFormData);
   // Editing state: 1 = new edit, true = update edit & false = view state
   const [editing, setEditing] = useState(
     initialEditingState?.length ? initialEditingState : [1],

--- a/src/applications/appeals/10182/components/AddIssuesField.jsx
+++ b/src/applications/appeals/10182/components/AddIssuesField.jsx
@@ -10,7 +10,7 @@ import { scrollToFirstError } from 'platform/utilities/ui';
 import { setData } from 'platform/forms-system/src/js/actions';
 
 import { scrollAndFocus } from '../utils/ui';
-import { getSelectedCount } from '../utils/helpers';
+import { getSelectedCount, hasDuplicates } from '../utils/helpers';
 import { SELECTED, MAX_SELECTIONS } from '../constants';
 import { GetContent, RenderPage } from './AddIssues';
 
@@ -134,7 +134,13 @@ const AddIssuesField = props => {
      */
     update: index => {
       const { issue, decisionDate } = formData[index];
-      if (errorSchemaIsValid(errorSchema[index]) && issue && decisionDate) {
+      if (
+        errorSchemaIsValid(errorSchema[index]) &&
+        issue &&
+        decisionDate &&
+        // prevent saving on return to page (hit back then continue)
+        !hasDuplicates(fullFormData)
+      ) {
         setEditing(
           editing.map((mode, indx) => (indx === index ? false : mode)),
         );

--- a/src/applications/appeals/10182/content/additionalIssues.jsx
+++ b/src/applications/appeals/10182/content/additionalIssues.jsx
@@ -4,6 +4,7 @@ import Modal from '@department-of-veterans-affairs/component-library/Modal';
 
 export const missingIssueErrorMessage = 'Please add the name of an issue';
 export const noneSelected = 'Please add and select at least one issue';
+export const uniqueIssueErrorMessage = 'Please enter a unique condition name';
 
 export const maxSelected =
   'You’ve reached the maximum number of allowed selected issues';

--- a/src/applications/appeals/10182/content/hearingType.js
+++ b/src/applications/appeals/10182/content/hearingType.js
@@ -9,7 +9,7 @@ export const hearingTypeContent = {
         You can attend your hearing on a computer, mobile phone, or tablet from
         a location you choose. You just need to be somewhere that has a Wi-Fi
         connection. Your accredited representative can be with you or in a
-        separate location. The Veterans Law judge will be located in Washington,
+        separate location. The Veterans Law Judge will be located in Washington,
         D.C.
       </p>
     </>

--- a/src/applications/appeals/10182/pages/additionalIssues.js
+++ b/src/applications/appeals/10182/pages/additionalIssues.js
@@ -11,6 +11,7 @@ import {
   requireIssue,
   validateDate,
   validAdditionalIssue,
+  uniqueIssue,
   maxIssues,
 } from '../validations';
 import { SELECTED } from '../constants';
@@ -46,6 +47,7 @@ export default {
           'ui:errorMessages': {
             required: missingIssueErrorMessage,
           },
+          'ui:validations': [uniqueIssue],
         },
         decisionDate: {
           ...dateUiSchema('Date of decision'),

--- a/src/applications/appeals/10182/sass/10182-nod.scss
+++ b/src/applications/appeals/10182/sass/10182-nod.scss
@@ -134,7 +134,7 @@ legend.schemaform-block-title {
   margin: 0;
 }
 
-.additional-issues {
+.additional-issue {
   .schemaform-label,
   .usa-input-error {
     margin-top: 0;

--- a/src/applications/appeals/10182/tests/components/AddIssuesField.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/AddIssuesField.unit.spec.jsx
@@ -30,6 +30,7 @@ const getProps = ({
   idSchema: { $id: 'additionalIssues' },
   formData,
   fullFormData: {
+    additionalIssues: formData,
     'view:hasIssuesToAdd': true,
     contestedIssues,
   },
@@ -189,11 +190,11 @@ describe('<AddIssuesField>', () => {
       const onChange = sinon.spy();
       const props = getProps({
         contestedIssues: [],
-        formData: new Array(MAX_SELECTIONS + 2).fill({
-          issue: 'x',
+        formData: new Array(MAX_SELECTIONS + 2).fill({}).map((_, index) => ({
+          issue: `x${index}`,
           decisionDate: validDate,
           [SELECTED]: true,
-        }),
+        })),
         onChange,
       });
       const wrapper = mount(<AddIssuesField {...props} />);
@@ -210,11 +211,11 @@ describe('<AddIssuesField>', () => {
     const onChange = sinon.spy();
     const props = getProps({
       // one extra to push us over the max selections limit
-      formData: new Array(MAX_SELECTIONS + 1).fill({
-        issue: 'x',
+      formData: new Array(MAX_SELECTIONS + 1).fill({}).map((_, index) => ({
+        issue: `x${index}`,
         decisionDate: validDate,
         [SELECTED]: true,
-      }),
+      })),
       onChange,
     });
 

--- a/src/applications/appeals/10182/tests/pages/additionalIssues.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/pages/additionalIssues.unit.spec.jsx
@@ -13,10 +13,11 @@ import formConfig from '../../config/form';
 import { SELECTED } from '../../constants';
 import { getDate } from '../../utils/dates';
 
-const mockStore = () => ({
+const mockStore = data => ({
   getState: () => ({
     form: {
       data: {
+        ...data,
         contestableIssues: [],
       },
     },
@@ -78,27 +79,28 @@ describe('add issues page', () => {
   // the widget
   it('should render additional issues cards', () => {
     const onSubmit = sinon.spy();
+    const data = {
+      // commenting this next line out will cause a React render error
+      // contestableIssues: [],
+      additionalIssues: [
+        {
+          issue: 'Back sprain',
+          decisionDate: validDate,
+          [SELECTED]: false,
+        },
+        {
+          issue: 'Ankle sprain',
+          decisionDate: validDate,
+        },
+      ],
+    };
     const form = mount(
-      <Provider store={mockStore()}>
+      <Provider store={mockStore(data)}>
         <DefinitionTester
           definitions={{}}
           schema={schema}
           uiSchema={uiSchema}
-          data={{
-            // commenting this next line out will cause a React render error
-            // contestableIssues: [],
-            additionalIssues: [
-              {
-                issue: 'Back sprain',
-                decisionDate: validDate,
-                [SELECTED]: false,
-              },
-              {
-                issue: 'Ankle sprain',
-                decisionDate: validDate,
-              },
-            ],
-          }}
+          data={data}
           onSubmit={onSubmit}
         />
       </Provider>,
@@ -126,7 +128,7 @@ describe('add issues page', () => {
       ],
     };
     const form = mount(
-      <Provider store={mockStore()}>
+      <Provider store={mockStore(data)}>
         <DefinitionTester
           definitions={{}}
           schema={schema}

--- a/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
@@ -7,6 +7,7 @@ import {
   getSelected,
   getSelectedCount,
   getIssueName,
+  getIssueNameAndDate,
   showAddIssuesPage,
   showAddIssueQuestion,
   isEmptyObject,
@@ -124,6 +125,27 @@ describe('getIssueName', () => {
   });
   it('should return an added issue name', () => {
     expect(getIssueName({ issue: 'test2' })).to.eq('test2');
+  });
+});
+
+describe('getIssueNameAndDate', () => {
+  it('should return empty string', () => {
+    expect(getIssueNameAndDate()).to.equal('');
+  });
+  it('should return a contestable issue name', () => {
+    expect(
+      getIssueNameAndDate({
+        attributes: {
+          ratingIssueSubjectText: 'test',
+          approxDecisionDate: '2021-01-01',
+        },
+      }),
+    ).to.eq('test2021-01-01');
+  });
+  it('should return an added issue name', () => {
+    expect(
+      getIssueNameAndDate({ issue: 'test2', decisionDate: '2021-02-02' }),
+    ).to.eq('test22021-02-02');
   });
 });
 

--- a/src/applications/appeals/10182/tests/validations.unit.spec.js
+++ b/src/applications/appeals/10182/tests/validations.unit.spec.js
@@ -155,6 +155,17 @@ describe('uniqueIssue', () => {
     });
     expect(errors.addError.called).to.be.true;
   });
+  it('should show an error when there are multiple duplicate additional issue', () => {
+    const errors = { addError: sinon.spy() };
+    uniqueIssue(errors, _, _, _, _, _, {
+      contestableIssues,
+      additionalIssues: [
+        { issue: 'test2', decisionDate: '2021-02-01' },
+        { issue: 'test2', decisionDate: '2021-02-01' },
+      ],
+    });
+    expect(errors.addError.called).to.be.true;
+  });
 });
 
 describe('maxIssues', () => {

--- a/src/applications/appeals/10182/utils/helpers.js
+++ b/src/applications/appeals/10182/utils/helpers.js
@@ -59,6 +59,11 @@ export const getSelectedCount = (formData, items) =>
 export const getIssueName = (entry = {}) =>
   entry.issue || entry.attributes?.ratingIssueSubjectText;
 
+export const getIssueNameAndDate = (entry = {}) =>
+  `${(getIssueName(entry) || '').toLowerCase()}${entry.decisionDate ||
+    entry.attributes?.approxDecisionDate ||
+    ''}`;
+
 // Simple one level deep check
 export const isEmptyObject = obj =>
   obj && typeof obj === 'object' && !Array.isArray(obj)

--- a/src/applications/appeals/10182/validations.js
+++ b/src/applications/appeals/10182/validations.js
@@ -7,10 +7,15 @@ import {
 } from 'platform/forms-system/src/js/utilities/validations';
 
 import { $, areaOfDisagreementWorkAround } from './utils/ui';
-import { getSelected, hasSomeSelected } from './utils/helpers';
+import {
+  getSelected,
+  hasSomeSelected,
+  getIssueNameAndDate,
+} from './utils/helpers';
 import { optInErrorMessage } from './content/OptIn';
 import {
   missingIssuesErrorMessageText,
+  uniqueIssueErrorMessage,
   maxSelected,
 } from './content/additionalIssues';
 import {
@@ -109,6 +114,31 @@ export const validAdditionalIssue = (
         errors.addError(missingIssuesErrorMessageText);
       }
     });
+  }
+};
+
+const processIssues = (array = []) =>
+  array.filter(Boolean).map(entry => getIssueNameAndDate(entry));
+
+// Alert Veteran to duplicates based on name & decision date
+export const uniqueIssue = (
+  errors,
+  _fieldData,
+  _formData,
+  _schema,
+  _uiSchema,
+  _index,
+  appStateData,
+) => {
+  if (errors?.addError) {
+    const contestableIssues = processIssues(appStateData?.contestableIssues);
+    const additionalIssues = processIssues(appStateData?.additionalIssues);
+    // ignore duplicate contestable issues (if any)
+    const fullList = [...new Set(contestableIssues)].concat(additionalIssues);
+
+    if (fullList.length !== new Set(fullList).size) {
+      errors.addError(uniqueIssueErrorMessage);
+    }
   }
 };
 

--- a/src/applications/appeals/10182/validations.js
+++ b/src/applications/appeals/10182/validations.js
@@ -7,11 +7,7 @@ import {
 } from 'platform/forms-system/src/js/utilities/validations';
 
 import { $, areaOfDisagreementWorkAround } from './utils/ui';
-import {
-  getSelected,
-  hasSomeSelected,
-  getIssueNameAndDate,
-} from './utils/helpers';
+import { getSelected, hasSomeSelected, hasDuplicates } from './utils/helpers';
 import { optInErrorMessage } from './content/OptIn';
 import {
   missingIssuesErrorMessageText,
@@ -117,9 +113,6 @@ export const validAdditionalIssue = (
   }
 };
 
-const processIssues = (array = []) =>
-  array.filter(Boolean).map(entry => getIssueNameAndDate(entry));
-
 // Alert Veteran to duplicates based on name & decision date
 export const uniqueIssue = (
   errors,
@@ -130,15 +123,8 @@ export const uniqueIssue = (
   _index,
   appStateData,
 ) => {
-  if (errors?.addError) {
-    const contestableIssues = processIssues(appStateData?.contestableIssues);
-    const additionalIssues = processIssues(appStateData?.additionalIssues);
-    // ignore duplicate contestable issues (if any)
-    const fullList = [...new Set(contestableIssues)].concat(additionalIssues);
-
-    if (fullList.length !== new Set(fullList).size) {
-      errors.addError(uniqueIssueErrorMessage);
-    }
+  if (errors?.addError && hasDuplicates(appStateData)) {
+    errors.addError(uniqueIssueErrorMessage);
   }
 };
 


### PR DESCRIPTION
## Description

In the Notice of Disagreement form, a Veteran can enter additional issues that aren't listed on the rating disabilities page, but there isn't any validation in place to prevent the entering of duplicates. This PR adds that validation.

- It ignores duplicate loaded contestable issues that may exist (just-in-case)
- It prevents additional issues that match a contestable issue
- It prevents duplicate additional issues

Note that the Board asked for duplicates to be based on the condition name _and_ the decision date. We will implement this as requested, but check with the Board that it was the intention to allow duplicate named conditions with different decision dates.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/29519

## Testing done

Added unit tests

## Screenshots

<details><summary>Duplicate of eligible issue</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-09-09 at 12 02 00 PM](https://user-images.githubusercontent.com/136959/132730408-e3bd9351-4d1e-4299-920c-cd33375bebe5.png)</details>

<details><summary>Duplicate on add issue page</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-09-09 at 12 00 43 PM](https://user-images.githubusercontent.com/136959/132730194-67626824-4e11-4717-b642-d0c0c5ae1667.png)</details>

## Acceptance criteria

- [x] Prevent duplicate additional issues from being added
- [x] Open card(s) with duplicate issue after returning to page

## Definition of done

- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
