### PR TITLE
Update handling for missing mobile phone

### DIFF
--- a/src/applications/personalization/profile/components/notification-settings/MissingContactInfoAlert.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/MissingContactInfoAlert.jsx
@@ -30,17 +30,18 @@ const missingMobilePhoneContent = (
     </p>
   </>
 );
-const missingAllContactInfoContent = (
-  <>
-    <p>
-      We don’t have your contact email address or mobile phone number. To manage
-      your notification settings, first update your contact information.{' '}
-    </p>
-    <p>
-      <AddContactInfoLink strong missingInfo={MISSING_CONTACT_INFO.ALL} />
-    </p>
-  </>
-);
+// TODO: uncomment when email is a supported communication channel
+// const missingAllContactInfoContent = (
+//   <>
+//     <p>
+//       We don’t have your contact email address or mobile phone number. To manage
+//       your notification settings, first update your contact information.{' '}
+//     </p>
+//     <p>
+//       <AddContactInfoLink strong missingInfo={MISSING_CONTACT_INFO.ALL} />
+//     </p>
+//   </>
+// );
 
 const MissingContactInfoAlert = ({
   missingMobilePhone,
@@ -49,7 +50,9 @@ const MissingContactInfoAlert = ({
   const alertContents = React.useMemo(
     () => {
       if (missingEmailAddress && missingMobilePhone) {
-        return missingAllContactInfoContent;
+        return missingMobilePhoneContent;
+        // TODO: uncomment when email is a supported communication channel
+        // return missingAllContactInfoContent;
       } else if (missingEmailAddress) {
         return missingEmailAddressContent;
       } else if (missingMobilePhone) {
@@ -64,7 +67,9 @@ const MissingContactInfoAlert = ({
   const alertTitle = React.useMemo(
     () => {
       if (missingEmailAddress && missingMobilePhone) {
-        return 'We don’t have your contact information';
+        return 'We don’t have your mobile phone number';
+        // TODO: uncomment when email is a supported communication channel
+        // return 'We don’t have your contact information';
       } else if (missingEmailAddress) {
         return 'We don’t have your email address';
       } else if (missingMobilePhone) {

--- a/src/applications/personalization/profile/components/notification-settings/NotificationSettings.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationSettings.jsx
@@ -6,7 +6,8 @@ import LoadingIndicator from '@department-of-veterans-affairs/component-library/
 import {
   hasVAPServiceConnectionError,
   isVAPatient,
-  selectVAPEmailAddress,
+  // TODO: uncomment when email is a supported communication channel
+  // selectVAPEmailAddress,
   selectVAPMobilePhone,
 } from '~/platform/user/selectors';
 import { focusElement } from '~/platform/utilities/ui';
@@ -165,10 +166,14 @@ const mapStateToProps = state => {
   const hasVAPServiceError = hasVAPServiceConnectionError(state);
   const hasLoadingError = !!communicationPreferencesState.loadingErrors;
 
-  const emailAddress = selectVAPEmailAddress(state);
+  // TODO: uncomment when email is a supported notification channel
+  // const emailAddress = selectVAPEmailAddress(state);
+  const emailAddress = null;
   const mobilePhoneNumber = selectVAPMobilePhone(state);
   const noContactInfoOnFile = !emailAddress && !mobilePhoneNumber;
-  const allContactInfoOnFile = emailAddress && mobilePhoneNumber;
+  // TODO: uncomment when email is a supported notification channel
+  // const allContactInfoOnFile = emailAddress && mobilePhoneNumber;
+  const allContactInfoOnFile = mobilePhoneNumber;
   const shouldFetchNotificationSettings =
     !noContactInfoOnFile && !hasVAPServiceError;
   const shouldShowAPIError = hasVAPServiceError || hasLoadingError;

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/happy-editing-path.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/happy-editing-path.cypress.spec.js
@@ -38,7 +38,8 @@ describe('Updating Notification Settings', () => {
       cy.login(mockPatient);
       cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
 
-      cy.findByTestId('select-options-alert').should('exist');
+      // TODO: uncomment when email is a supported communication channel
+      // cy.findByTestId('select-options-alert').should('exist');
 
       // both radio buttons will start off unchecked because of the mocked
       // response from mockCommunicationPreferences

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/happy-loading-path.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/happy-loading-path.cypress.spec.js
@@ -34,7 +34,8 @@ describe('Notification Settings', () => {
       cy.loadingIndicatorWorks();
 
       cy.findByText('555-555-5559').should('exist');
-      cy.findByText('alongusername@domain.com').should('exist');
+      // uncomment when email is a supported communication channel
+      // cy.findByText('alongusername@domain.com').should('exist');
       cy.findAllByTestId('notification-group')
         .should('have.length', 3)
         .first()
@@ -59,7 +60,8 @@ describe('Notification Settings', () => {
       cy.loadingIndicatorWorks();
 
       cy.findByText('555-555-5559').should('exist');
-      cy.findByText('alongusername@domain.com').should('exist');
+      // uncomment when email is a supported communication channel
+      // cy.findByText('alongusername@domain.com').should('exist');
       cy.findAllByTestId('notification-group')
         .should('have.length.above', 0)
         .each($el => {

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/missing-contact-info.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/missing-contact-info.cypress.spec.js
@@ -26,100 +26,177 @@ describe('Notification Settings', () => {
       });
     });
   });
-  context('when user is missing mobile phone', () => {
-    it('should show the correct messages', () => {
-      const user = makeMockUser();
-      user.data.attributes.vet360ContactInformation.mobilePhone = null;
-      cy.login(user);
-      cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
-      cy.findByRole('heading', {
-        name: 'Notification settings',
-        level: 1,
-      }).should('exist');
+  // TODO: Re-enable these tests when the COVID-19 alerts are a supported
+  // notification item. Or whenever a notification item supports email as a
+  // notification channel
+  context.skip(
+    'when both mobile phone and email are supported communication channels',
+    () => {
+      context('when user is missing mobile phone', () => {
+        it('should show the correct messages', () => {
+          const user = makeMockUser();
+          user.data.attributes.vet360ContactInformation.mobilePhone = null;
+          cy.login(user);
+          cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
+          cy.findByRole('heading', {
+            name: 'Notification settings',
+            level: 1,
+          }).should('exist');
 
-      cy.loadingIndicatorWorks();
+          cy.loadingIndicatorWorks();
 
-      cy.findByText('veteran@gmail.com').should('exist');
-      cy.findByText('Appointment reminders').should('exist');
-      cy.findByText('Prescription shipment and tracking updates').should(
-        'exist',
-      );
-      cy.findByTestId('missing-contact-info-alert')
-        .should('exist')
-        .and('contain.text', 'mobile phone')
-        .within(() => {
-          cy.findByRole('link', { name: /add.*mobile.*profile/i }).should(
+          cy.findByText('veteran@gmail.com').should('exist');
+          cy.findByText('Appointment reminders').should('exist');
+          cy.findByText('Prescription shipment and tracking updates').should(
             'exist',
           );
-        });
-      cy.findAllByRole('link', { name: /add your mobile/i }).should(
-        'have.length.above',
-        2,
-      );
-      cy.findAllByTestId('notification-group').should('exist');
-      cy.findByRole('link', { name: /add your email/i }).should('not.exist');
-    });
-  });
-  context('when user is missing email address', () => {
-    it('should show the correct messages', () => {
-      const user = makeMockUser();
-      user.data.attributes.vet360ContactInformation.email = null;
-      cy.login(user);
-      cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
-      cy.findByRole('heading', {
-        name: 'Notification settings',
-        level: 1,
-      }).should('exist');
-
-      cy.loadingIndicatorWorks();
-
-      cy.findByText('503-555-1234').should('exist');
-      cy.findByTestId('missing-contact-info-alert')
-        .should('exist')
-        .and('contain.text', 'email address')
-        .within(() => {
-          cy.findByRole('link', { name: /add.*email.*profile/i }).should(
-            'exist',
+          cy.findByTestId('missing-contact-info-alert')
+            .should('exist')
+            .and('contain.text', 'mobile phone')
+            .within(() => {
+              cy.findByRole('link', { name: /add.*mobile.*profile/i }).should(
+                'exist',
+              );
+            });
+          cy.findAllByRole('link', { name: /add your mobile/i }).should(
+            'have.length.above',
+            2,
+          );
+          cy.findAllByTestId('notification-group').should('exist');
+          cy.findByRole('link', { name: /add your email/i }).should(
+            'not.exist',
           );
         });
-      cy.findAllByRole('link', { name: /add your email/i }).should(
-        'have.lengthOf',
-        2,
-      );
-      cy.findAllByTestId('notification-group').should('exist');
-      cy.findByRole('link', { name: /add your mobile/i }).should('not.exist');
-    });
-  });
-  context('when user is missing both email address and mobile phone', () => {
-    it('should show the correct message, not attempt to fetch notification prefs, and hide all notification groups', () => {
-      const user = makeMockUser();
-      user.data.attributes.vet360ContactInformation.email = null;
-      user.data.attributes.vet360ContactInformation.mobilePhone = null;
-      cy.login(user);
-      cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
-      cy.findByRole('heading', {
-        name: 'Notification settings',
-        level: 1,
-      }).should('exist');
-
-      // there should be no loading indicator
-      cy.findByRole('progressbar', { name: /loading/i }).should('not.exist');
-      cy.injectAxeThenAxeCheck();
-
-      cy.findByTestId('missing-contact-info-alert')
-        .should('exist')
-        .and('contain.text', 'mobile phone')
-        .and('contain.text', 'email address')
-        .invoke('text')
-        .should('match', /we don’t have your contact info/i)
-        .and('match', /update.*contact info/i);
-      cy.should(() => {
-        expect(getCommPrefsStub).not.to.be.called;
       });
-      cy.findByRole('link', { name: /update your contact info/i }).should(
-        'exist',
+      context('when user is missing email address', () => {
+        it('should show the correct messages', () => {
+          const user = makeMockUser();
+          user.data.attributes.vet360ContactInformation.email = null;
+          cy.login(user);
+          cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
+          cy.findByRole('heading', {
+            name: 'Notification settings',
+            level: 1,
+          }).should('exist');
+
+          cy.loadingIndicatorWorks();
+
+          cy.findByText('503-555-1234').should('exist');
+          cy.findByTestId('missing-contact-info-alert')
+            .should('exist')
+            .and('contain.text', 'email address')
+            .within(() => {
+              cy.findByRole('link', { name: /add.*email.*profile/i }).should(
+                'exist',
+              );
+            });
+          cy.findAllByRole('link', { name: /add your email/i }).should(
+            'have.lengthOf',
+            2,
+          );
+          cy.findAllByTestId('notification-group').should('exist');
+          cy.findByRole('link', { name: /add your mobile/i }).should(
+            'not.exist',
+          );
+        });
+      });
+      context(
+        'when user is missing both email address and mobile phone',
+        () => {
+          it('should show the correct message, not attempt to fetch notification prefs, and hide all notification groups', () => {
+            const user = makeMockUser();
+            user.data.attributes.vet360ContactInformation.email = null;
+            user.data.attributes.vet360ContactInformation.mobilePhone = null;
+            cy.login(user);
+            cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
+            cy.findByRole('heading', {
+              name: 'Notification settings',
+              level: 1,
+            }).should('exist');
+
+            // there should be no loading indicator
+            cy.findByRole('progressbar', { name: /loading/i }).should(
+              'not.exist',
+            );
+            cy.injectAxeThenAxeCheck();
+
+            cy.findByTestId('missing-contact-info-alert')
+              .should('exist')
+              .and('contain.text', 'mobile phone')
+              .and('contain.text', 'email address')
+              .invoke('text')
+              .should('match', /we don’t have your contact info/i)
+              .and('match', /update.*contact info/i);
+            cy.should(() => {
+              expect(getCommPrefsStub).not.to.be.called;
+            });
+            cy.findByRole('link', { name: /update your contact info/i }).should(
+              'exist',
+            );
+            cy.findAllByTestId('notification-group').should('not.exist');
+          });
+        },
       );
-      cy.findAllByTestId('notification-group').should('not.exist');
-    });
-  });
+    },
+  );
+  // TODO: Disable/delete these tests when the COVID-19 alerts are a supported
+  // notification item. Or whenever a notification item supports email as a
+  // notification channel
+  context(
+    'when only mobile phone is the only supported communication channel',
+    () => {
+      context('when user is missing mobile phone', () => {
+        it('should show the correct message, not attempt to fetch notification prefs, and hide all notification groups', () => {
+          const user = makeMockUser();
+          user.data.attributes.vet360ContactInformation.mobilePhone = null;
+          cy.login(user);
+          cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
+          cy.findByRole('heading', {
+            name: 'Notification settings',
+            level: 1,
+          }).should('exist');
+
+          // there should be no loading indicator
+          cy.findByRole('progressbar', { name: /loading/i }).should(
+            'not.exist',
+          );
+          cy.injectAxeThenAxeCheck();
+
+          cy.findByTestId('missing-contact-info-alert')
+            .should('exist')
+            .and('contain.text', 'mobile phone')
+            .within(() => {
+              cy.findByRole('link', { name: /add.*mobile.*profile/i }).should(
+                'exist',
+              );
+            });
+          cy.findAllByTestId('notification-group').should('not.exist');
+          cy.should(() => {
+            expect(getCommPrefsStub).not.to.be.called;
+          });
+        });
+      });
+      context('when user is missing email address', () => {
+        it('should not show an alert', () => {
+          const user = makeMockUser();
+          user.data.attributes.vet360ContactInformation.email = null;
+          cy.login(user);
+          cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
+          cy.findByRole('heading', {
+            name: 'Notification settings',
+            level: 1,
+          }).should('exist');
+
+          cy.loadingIndicatorWorks();
+
+          cy.findByText('503-555-1234').should('exist');
+          cy.findByTestId('missing-contact-info-alert').should('not.exist');
+          cy.findAllByTestId('notification-group').should('exist');
+          cy.findByRole('link', { name: /add your mobile/i }).should(
+            'not.exist',
+          );
+        });
+      });
+    },
+  );
 });


### PR DESCRIPTION
## Description
With this change, users who are missing a mobile phone number are unable to view any notification preferences and instead see the below alert.

We also stop showing the user's email address on the notification settings page, even if they have one on file.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#29773

## Testing done
Cypress

## Screenshots
<img width="1032" alt="Screen Shot 2021-09-09 at 10 52 10 AM" src="https://user-images.githubusercontent.com/20728956/132737334-97d85d6f-d98e-42e6-a6e4-4c2735ce0c0e.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs