### PR TITLE
HLRv2: Use new contestable issues endpoint

### DIFF
--- a/src/applications/disability-benefits/996/actions/index.js
+++ b/src/applications/disability-benefits/996/actions/index.js
@@ -14,6 +14,7 @@ export const FETCH_CONTESTABLE_ISSUES_FAILED =
 
 export const getContestableIssues = props => {
   const benefitType = props?.benefitType || DEFAULT_BENEFIT_TYPE;
+  const apiOptions = { apiVersion: props.hlrV2 ? 'v1' : 'v0' };
   return dispatch => {
     dispatch({ type: FETCH_CONTESTABLE_ISSUES_INIT });
 
@@ -33,7 +34,7 @@ export const getContestableIssues = props => {
       );
     }
 
-    return apiRequest(`${CONTESTABLE_ISSUES_API}${benefitType}`)
+    return apiRequest(`${CONTESTABLE_ISSUES_API}${benefitType}`, apiOptions)
       .then(response =>
         dispatch({
           type: FETCH_CONTESTABLE_ISSUES_SUCCEEDED,

--- a/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
@@ -56,12 +56,12 @@ export class IntroductionPage extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { contestableIssues = {}, getContestableIssues } = this.props;
+    const { contestableIssues = {}, getContestableIssues, hlrV2 } = this.props;
     const wizardComplete = this.state.status === WIZARD_STATUS_COMPLETE;
     if (wizardComplete) {
       const benefitType = sessionStorage.getItem(SAVED_CLAIM_TYPE);
       if (!contestableIssues?.status) {
-        getContestableIssues({ benefitType });
+        getContestableIssues({ benefitType, hlrV2 });
       }
 
       // set focus on h1 only after wizard completes
@@ -303,6 +303,7 @@ function mapStateToProps(state) {
     hasEmptyAddress: isEmptyAddress(
       selectVAPContactInfoField(state, FIELD_NAMES.MAILING_ADDRESS),
     ),
+    hlrV2: state.featureToggles.hlrV2,
   };
 }
 

--- a/src/applications/disability-benefits/996/tests/hlr-wizard.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr-wizard.cypress.spec.js
@@ -46,6 +46,7 @@ describe('HLR wizard', () => {
     window.dataLayer = [];
     cy.intercept('GET', '/v0/feature_toggles?*', { data: { features: [] } });
     cy.intercept('GET', `/v0${CONTESTABLE_ISSUES_API}*`, []);
+    cy.intercept('GET', `/v1${CONTESTABLE_ISSUES_API}*`, []);
     sessionStorage.removeItem(WIZARD_STATUS);
     cy.visit(BASE_URL);
     cy.injectAxe();

--- a/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
@@ -101,6 +101,11 @@ const testConfig = createTestConfig(
         `/v0${CONTESTABLE_ISSUES_API}compensation`,
         mockContestableIssues,
       );
+      cy.intercept(
+        'GET',
+        `/v1${CONTESTABLE_ISSUES_API}compensation`,
+        mockContestableIssues,
+      );
 
       cy.intercept('PUT', 'v0/in_progress_forms/20-0996', mockInProgress);
 


### PR DESCRIPTION
## Description

For Higher-Level Review v2, the backend has added a `v1` endpoint for getting contestable issues. This should be used when the feature flag is set.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/29802

## Testing done

Updated mock endpoints

## Screenshots

N/A

## Acceptance criteria
- [x] Use `v1/higher_level_reviews/contestable_issues/` for HLR v2 when the feature flag is set
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
