### PR TITLE
NOD: Include date on area of disagreement pages

### DIFF
--- a/src/applications/appeals/10182/content/areaOfDisagreement.jsx
+++ b/src/applications/appeals/10182/content/areaOfDisagreement.jsx
@@ -17,7 +17,7 @@ export const issueName = ({ formData, formContext } = {}) => {
   const date = moment(getIssueDate(formData), FORMAT_YMD).format(
     FORMAT_READABLE,
   );
-  const title = `${getIssueName(formData)}${date ? ` \u2014 ${date}` : ''}`;
+  const title = `${getIssueName(formData)}${date ? ` \u2013 ${date}` : ''}`;
   return (
     <legend
       className="schemaform-block-title schemaform-title-underline"

--- a/src/applications/appeals/10182/content/areaOfDisagreement.jsx
+++ b/src/applications/appeals/10182/content/areaOfDisagreement.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import moment from 'moment';
 
-import { getIssueName } from '../utils/helpers';
+import { getIssueName, getIssueDate } from '../utils/helpers';
+import { FORMAT_YMD, FORMAT_READABLE } from '../constants';
 
 export const missingAreaOfDisagreementErrorMessage =
   'Please choose an area of disagreement';
@@ -12,12 +14,16 @@ export const issueName = ({ formData, formContext } = {}) => {
   const index = formContext.pagePerItemIndex || formData.index;
   // https://github.com/department-of-veterans-affairs/va.gov-team/issues/27096
   const Header = formContext.onReviewPage ? 'h4' : 'h3';
+  const date = moment(getIssueDate(formData), FORMAT_YMD).format(
+    FORMAT_READABLE,
+  );
+  const title = `${getIssueName(formData)}${date ? ` \u2014 ${date}` : ''}`;
   return (
     <legend
       className="schemaform-block-title schemaform-title-underline"
       aria-describedby={`area-of-disagreement-label-${index}`}
     >
-      <Header className="vads-u-margin-top--0">{getIssueName(formData)}</Header>
+      <Header className="vads-u-margin-top--0">{title}</Header>
     </legend>
   );
 };

--- a/src/applications/appeals/10182/content/areaOfDisagreement.jsx
+++ b/src/applications/appeals/10182/content/areaOfDisagreement.jsx
@@ -17,7 +17,7 @@ export const issueName = ({ formData, formContext } = {}) => {
   const date = moment(getIssueDate(formData), FORMAT_YMD).format(
     FORMAT_READABLE,
   );
-  const title = `${getIssueName(formData)}${date ? ` \u2013 ${date}` : ''}`;
+  const title = `${getIssueName(formData)}${date ? ` (${date})` : ''}`;
   return (
     <legend
       className="schemaform-block-title schemaform-title-underline"

--- a/src/applications/appeals/10182/tests/pages/areaOfDisagreement.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/pages/areaOfDisagreement.unit.spec.jsx
@@ -42,7 +42,7 @@ describe('area of disagreement page', () => {
     );
 
     expect(form.find('input[type="checkbox"]').length).to.equal(4);
-    expect(form.find('h3').text()).to.equal('Tinnitus \u2014 January 1, 2021');
+    expect(form.find('h3').text()).to.equal('Tinnitus \u2013 January 1, 2021');
     form.unmount();
   });
 

--- a/src/applications/appeals/10182/tests/pages/areaOfDisagreement.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/pages/areaOfDisagreement.unit.spec.jsx
@@ -42,7 +42,7 @@ describe('area of disagreement page', () => {
     );
 
     expect(form.find('input[type="checkbox"]').length).to.equal(4);
-    expect(form.find('h3').text()).to.equal('Tinnitus \u2013 January 1, 2021');
+    expect(form.find('h3').text()).to.equal('Tinnitus (January 1, 2021)');
     form.unmount();
   });
 

--- a/src/applications/appeals/10182/tests/pages/areaOfDisagreement.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/pages/areaOfDisagreement.unit.spec.jsx
@@ -23,6 +23,7 @@ describe('area of disagreement page', () => {
       {
         attributes: {
           ratingIssueSubjectText: 'Tinnitus',
+          approxDecisionDate: '2021-01-01',
         },
       },
     ],
@@ -41,6 +42,7 @@ describe('area of disagreement page', () => {
     );
 
     expect(form.find('input[type="checkbox"]').length).to.equal(4);
+    expect(form.find('h3').text()).to.equal('Tinnitus \u2014 January 1, 2021');
     form.unmount();
   });
 

--- a/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
@@ -7,6 +7,7 @@ import {
   getSelected,
   getSelectedCount,
   getIssueName,
+  getIssueDate,
   getIssueNameAndDate,
   hasDuplicates,
   showAddIssuesPage,
@@ -126,6 +127,20 @@ describe('getIssueName', () => {
   });
   it('should return an added issue name', () => {
     expect(getIssueName({ issue: 'test2' })).to.eq('test2');
+  });
+});
+
+describe('getIssueDate', () => {
+  it('should return undefined', () => {
+    expect(getIssueDate()).to.eq('');
+  });
+  it('should return a contestable issue date', () => {
+    expect(
+      getIssueDate({ attributes: { approxDecisionDate: '2021-01-01' } }),
+    ).to.eq('2021-01-01');
+  });
+  it('should return an added issue name', () => {
+    expect(getIssueDate({ decisionDate: '2021-02-01' })).to.eq('2021-02-01');
   });
 });
 

--- a/src/applications/appeals/10182/utils/helpers.js
+++ b/src/applications/appeals/10182/utils/helpers.js
@@ -59,10 +59,12 @@ export const getSelectedCount = (formData, items) =>
 export const getIssueName = (entry = {}) =>
   entry.issue || entry.attributes?.ratingIssueSubjectText;
 
+export const getIssueDate = (entry = {}) =>
+  entry.decisionDate || entry.attributes?.approxDecisionDate || '';
+
+// used for string comparison
 export const getIssueNameAndDate = (entry = {}) =>
-  `${(getIssueName(entry) || '').toLowerCase()}${entry.decisionDate ||
-    entry.attributes?.approxDecisionDate ||
-    ''}`;
+  `${(getIssueName(entry) || '').toLowerCase()}${getIssueDate(entry)}`;
 
 const processIssues = (array = []) =>
   array.filter(Boolean).map(entry => getIssueNameAndDate(entry));


### PR DESCRIPTION
## Description

The Board asked us to include the date of the issue on each Notice of Disagreement review page, the page where the area of disagreements are selected.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/29519

## Testing done

Add unit tests

## Screenshots

<details><summary>Date included in page title</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-09-09 at 1 54 40 PM](https://user-images.githubusercontent.com/136959/132746099-d7e57d15-dd22-4984-af34-7ce09aea25e3.png)</details>

## Acceptance criteria
- [x] Include readable date in page title for each selected issue
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
