### PR TITLE
Add mock-api command to VAOS readme

### DIFF
--- a/src/applications/vaos/README.md
+++ b/src/applications/vaos/README.md
@@ -34,7 +34,7 @@ npx nodemon --exec "yarn jsdoc -c src/applications/vaos/jsdoc.json" --watch src/
 
 ## Organization
 
-The application has four major sections
+The application has three major sections
 
 - /appointment-list
   - The code for the appointment list and detail pages
@@ -70,3 +70,11 @@ Those services are:
   - VA facility data
 - Community care provider search (PPMS)
   - Community care provider listing
+
+### Mock API
+
+Local development of the application requires use of the [mock API](https://github.com/department-of-veterans-affairs/vets-website#running-a-mock-api-for-local-development). Run the following command to provide the mock API VAOS specific mock data:
+
+```
+yarn mock-api --responses src/applications/vaos/services/mocks/index.js
+```


### PR DESCRIPTION
## Description
This PR adds a reference to the VAOS specific mock-api command to the VAOS README.

## Original issue(s)
N/A

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] VAOS mock-api command in README

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
