### PR TITLE
Fix covid locations not displaying

### DIFF
--- a/src/applications/vaos/services/mocks/v2/scheduling_configurations.json
+++ b/src/applications/vaos/services/mocks/v2/scheduling_configurations.json
@@ -452,7 +452,7 @@
               "patientHistoryRequired": false,
               "patientHistoryDuration": 0,
               "canCancel": true,
-              "enabled": true
+              "enabled": false
             }
           },
           {
@@ -1592,7 +1592,7 @@
               "patientHistoryRequired": false,
               "patientHistoryDuration": 0,
               "canCancel": true,
-              "enabled": true
+              "enabled": false
             }
           },
           {

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -162,6 +162,7 @@ export const TYPES_OF_CARE = [
   },
   {
     id: COVID_VACCINE_ID,
+    idV2: COVID_VACCINE_ID,
     name: 'COVID-19 vaccine',
   },
 ];


### PR DESCRIPTION
## Description
This PR fixes covid vaccine locations not displaying on the facilities page due to a missing v2 covid settings id. I've also disabled covid services on additional facilities.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#29601

## Testing done
- local, unit testing

## Screenshots
<img width="665" alt="Screen Shot 2021-09-10 at 6 17 49 AM" src="https://user-images.githubusercontent.com/9746156/132859443-ec71abc2-5c9f-4319-8a47-89c5f9185745.png">


## Acceptance criteria
- [x] Cheyenne and Dayton facilities should display on facilities page when going through covid flow

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
