### PR TITLE
Make it so that afghan promo only shows on non-prod envs

### DIFF
--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -41,7 +41,7 @@ const config = {
 
 // Add the Afghanistan banner on non-prod environments.
 if (!environment.isProduction()) {
-  config.announcements.push({
+  config.announcements.unshift({
     name: 'afghanistan-banner',
     // Only the homepage (e.g. `/`).
     paths: /^(\/)$/,

--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -4,15 +4,10 @@ import ExploreVAModal from '../components/ExploreVAModal';
 import SingleSignOnInfoModal from '../components/SingleSignOnInfoModal';
 import VAMCWelcomeModal, { VAMC_PATHS } from '../components/VAMCWelcomeModal';
 import VAPlusVetsModal from '../components/VAPlusVetsModal';
+import environment from 'platform/utilities/environment';
 
 const config = {
   announcements: [
-    {
-      name: 'afghanistan-banner',
-      // Only the homepage (e.g. `/`).
-      paths: /^(\/)$/,
-      component: AfghanistanPromoBanner,
-    },
     {
       name: 'brand-consolidation-va-plus-vets',
       // All pages.
@@ -43,5 +38,15 @@ const config = {
     },
   ],
 };
+
+// Add the Afghanistan banner on non-prod environments.
+if (!environment.isProduction()) {
+  config.announcements.push({
+    name: 'afghanistan-banner',
+    // Only the homepage (e.g. `/`).
+    paths: /^(\/)$/,
+    component: AfghanistanPromoBanner,
+  });
+}
 
 export default config;

--- a/src/platform/site-wide/announcements/containers/Announcement.jsx
+++ b/src/platform/site-wide/announcements/containers/Announcement.jsx
@@ -2,12 +2,11 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-
+// Relative imports.
 import {
   isAuthenticatedWithSSOe,
   ssoeEbenefitsLinks,
 } from 'platform/user/authentication/selectors';
-// Relative imports.
 import { isLoggedIn, selectProfile } from '../../../user/selectors';
 import { selectAnnouncement } from '../selectors';
 import { initDismissedAnnouncements, dismissAnnouncement } from '../actions';


### PR DESCRIPTION
## Description
**Slack:** https://dsva.slack.com/archives/C52CL1PKQ/p1631280578258600?thread_ts=1631279047.258000&cid=C52CL1PKQ

This PR ensures that the Afghanistan promo banner only shows on non-prod envs.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [x] Only show promo on non-prod envs

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
