### PR TITLE
Add additional check for scrolling behavior in sandbox to prevent error

### DIFF
--- a/src/applications/gi-sandbox/utils/helpers.js
+++ b/src/applications/gi-sandbox/utils/helpers.js
@@ -229,10 +229,13 @@ export const isSmallScreen = () => matchMedia('(max-width: 480px)').matches;
 
 export const scrollToFocusedElement = () => {
   const compareDrawerHeight = document.getElementById('compare-drawer')
-    .clientHeight;
+    ?.clientHeight;
   const activeElementBounding = document.activeElement.getBoundingClientRect();
 
-  if (activeElementBounding.bottom > window.innerHeight - compareDrawerHeight) {
+  if (
+    compareDrawerHeight &&
+    activeElementBounding.bottom > window.innerHeight - compareDrawerHeight
+  ) {
     scroller.scrollTo(document.activeElement.id, getScrollOptions());
   }
 };


### PR DESCRIPTION
## Description
Remove error regarding `clientHeight` for compare drawer.

## Original issue(s)
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/29336


## Testing done
Testing passes locally

## Screenshots
N/A

## Acceptance criteria
- [x] Error is no longer present

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
