### PR TITLE
24576: Heading levels should only increase by one

### DIFF
--- a/src/applications/edu-benefits/1990s/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/1990s/containers/IntroductionPage.jsx
@@ -35,16 +35,20 @@ class IntroductionPage extends React.Component {
       <div className="schemaform-intro">
         <FormTitle title="Apply for the Veteran Rapid Retraining Assistance Program (VRRAP)" />
         {this.loginPrompt()}
-        <h4>Follow these steps to apply</h4>
+        <h2 className="vads-u-font-size--h4">Follow these steps to apply</h2>
         <div className="process schemaform-process">
           <ol>
             <li className="process-step list-one">
-              <h5>Make sure you're eligible</h5>
+              <h3 className="vads-u-font-size--h5">
+                Make sure you're eligible
+              </h3>
               <p>
                 To be eligible for Veteran Rapid Retraining Assistance Program
                 (VRRAP), you must meet all the requirements listed here.
               </p>
-              <h6>All of these must be true. You're:</h6>
+              <h4 className="vads-u-font-size--h6">
+                All of these must be true. You're:
+              </h4>
               <ul>
                 <li>
                   At least 22 years old, but not older than 66,{' '}
@@ -103,8 +107,10 @@ class IntroductionPage extends React.Component {
               </p>
             </li>
             <li className="process-step list-two">
-              <h5>Prepare</h5>
-              <h6>To fill out this application, you’ll need your:</h6>
+              <h3 className="vads-u-font-size--h5">Prepare</h3>
+              <h4 className="vads-u-font-size--h6">
+                To fill out this application, you’ll need your:
+              </h4>
               <ul>
                 <li>Social Security number</li>
                 <li>Bank account direct deposit information</li>
@@ -120,7 +126,7 @@ class IntroductionPage extends React.Component {
               </p>
             </li>
             <li className="process-step list-three">
-              <h5>Apply</h5>
+              <h3 className="vads-u-font-size--h5">Apply</h3>
               <p>Complete this education benefits form.</p>
               <p>
                 After submitting the form, you’ll get a confirmation message.
@@ -128,7 +134,7 @@ class IntroductionPage extends React.Component {
               </p>
             </li>
             <li className="process-step list-four">
-              <h5>VA review</h5>
+              <h3 className="vads-u-font-size--h5">VA review</h3>
               <p>
                 We usually make a decision within 30 days. We’ll let you know by
                 mail if we need more information.
@@ -140,7 +146,7 @@ class IntroductionPage extends React.Component {
               </p>
             </li>
             <li className="process-step list-five">
-              <h5>Decision</h5>
+              <h3 className="vads-u-font-size--h5">Decision</h3>
               <p>
                 If we approve your application, you’ll get a Certificate of
                 Eligibility (COE), or award letter, in the mail. Bring this COE

--- a/src/applications/edu-benefits/components/ConfirmationPageContent.jsx
+++ b/src/applications/edu-benefits/components/ConfirmationPageContent.jsx
@@ -12,9 +12,9 @@ export function ConfirmationPageContent({
   formName = 'Education benefit application',
   guidance = (
     <>
-      <h4 className="confirmation-guidance-heading">
+      <h3 className="confirmation-guidance-heading vads-u-font-size--h4">
         What happens after I apply?
-      </h4>
+      </h3>
       <p className="confirmation-guidance-message">
         We usually decide on applications within 30 days.
       </p>
@@ -70,9 +70,9 @@ export function ConfirmationPageContent({
           </h1>
           <span>{displayFormId}</span>
         </div>
-        <h3 className="confirmation-page-title screen-only">
+        <h2 className="confirmation-page-title screen-only vads-u-font-size--h3">
           We've received your application.
-        </h3>
+        </h2>
         <h4 className="print-only">We've received your application.</h4>
         <p>
           We usually process claims within <strong>30 days</strong>.<br />
@@ -91,12 +91,12 @@ export function ConfirmationPageContent({
       {afterTitleContent}
 
       <div className="inset">
-        <h4 className="vads-u-margin-top--0 confirmation-header">
+        <h3 className="vads-u-margin-top--0 confirmation-header vads-u-font-size--h4">
           {formName}{' '}
           <span className="vads-u-margin--0 vads-u-display--inline-block">
             ({displayFormId})
           </span>
-        </h4>
+        </h3>
         {name && (
           <span className="applicant-name">
             for {name.first}
@@ -146,9 +146,9 @@ export function ConfirmationPageContent({
       <div className="confirmation-guidance-container">
         {additionalGuidance}
         {guidance}
-        <h4 className="confirmation-guidance-heading vads-u-border-bottom--3px vads-u-border-color--primary vads-u-line-height--4">
+        <h3 className="confirmation-guidance-heading vads-u-border-bottom--3px vads-u-border-color--primary vads-u-line-height--4 vads-u-font-size--h4">
           Need help?
-        </h4>
+        </h3>
 
         <p className="confirmation-guidance-message">
           If you have questions, call 1-888-GI-BILL-1 (


### PR DESCRIPTION
## Description
The introduction and confirmation pages of the VRRAP form both fail axe checks with a Heading levels should only increase by one error. The heading levels need to be adjusted so that the form meets accessibility standards.

## Original issue(s)
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/24576


## Testing done
Testing passes locally

## Screenshots
N/A

## Acceptance criteria
Intro page:
- [x] Follow these steps to apply to H2
- [x] Make sure you're eligible to H3
- [x] Prepare to H3
- [x] Apply to H3
- [x] VA review to H3
- [x] Decision to H3
- [x] All of these must be true. You're: to H4
- [x] To fill out this application, you’ll need your: to H4
Confirmation page:
- [x] We've received your application. to H2
- [x] Veteran Rapid Retraining Assistance Program (VRRAP) to H3
- [x]  What happens after I apply? to H3
- [x] Need help? to H3

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
