### PR TITLE
526: Add title 10 start date validation

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -236,6 +236,10 @@ const formConfig = {
           depends: form => hasGuardOrReservePeriod(form.serviceInformation),
           uiSchema: federalOrders.uiSchema,
           schema: federalOrders.schema,
+          appStateSelector: state => ({
+            servicePeriods:
+              state.form.data?.serviceInformation?.servicePeriods || [],
+          }),
         },
         separationLocation: {
           title: 'Separation location',

--- a/src/applications/disability-benefits/all-claims/pages/federalOrders.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/federalOrders.jsx
@@ -4,11 +4,18 @@ import dateUI from 'platform/forms-system/src/js/definitions/date';
 import { validateDate } from 'platform/forms-system/src/js/validation';
 
 import { title10DatesRequired } from '../utils';
-import { title10BeforeRad, isLessThan180DaysInFuture } from '../validations';
+import {
+  title10BeforeRad,
+  isLessThan180DaysInFuture,
+  validateTitle10StartDate,
+} from '../validations';
 
 const {
   title10Activation,
 } = fullSchema.properties.serviceInformation.properties.reservesNationalGuardService.properties;
+
+const activationDate = dateUI('Activation date');
+activationDate['ui:validations'].push(validateTitle10StartDate);
 
 export const uiSchema = {
   'ui:title': 'Federal Orders',
@@ -25,7 +32,7 @@ export const uiSchema = {
           expandUnder: 'view:isTitle10Activated',
         },
         title10ActivationDate: {
-          ...dateUI('Activation date'),
+          ...activationDate,
           'ui:required': title10DatesRequired,
         },
         anticipatedSeparationDate: {

--- a/src/applications/disability-benefits/all-claims/tests/pages/federalOrders.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/federalOrders.unit.spec.jsx
@@ -81,6 +81,11 @@ describe('Federal orders info', () => {
         uiSchema={uiSchema}
         data={{}}
         formData={{}}
+        appStateData={{
+          servicePeriods: [
+            { serviceBranch: 'Reserve', dateRange: { from: '2008-03-12' } },
+          ],
+        }}
         onSubmit={onSubmit}
       />,
     );
@@ -117,6 +122,11 @@ describe('Federal orders info', () => {
         uiSchema={uiSchema}
         data={{}}
         formData={{}}
+        appStateData={{
+          servicePeriods: [
+            { serviceBranch: 'Reserve', dateRange: { from: '2008-03-12' } },
+          ],
+        }}
         onSubmit={onSubmit}
       />,
     );
@@ -155,6 +165,11 @@ describe('Federal orders info', () => {
         uiSchema={uiSchema}
         data={{}}
         formData={{}}
+        appStateData={{
+          servicePeriods: [
+            { serviceBranch: 'Reserve', dateRange: { from: '2008-03-12' } },
+          ],
+        }}
         onSubmit={onSubmit}
       />,
     );

--- a/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
@@ -15,6 +15,7 @@ import {
   isInFuture,
   isLessThan180DaysInFuture,
   title10BeforeRad,
+  validateTitle10StartDate,
 } from '../validations';
 
 import disabilityLabels from '../content/disabilityLabels';
@@ -627,6 +628,63 @@ describe('526 All Claims validations', () => {
 
       title10BeforeRad(errors, fieldData);
       expect(addError.callCount).to.equal(0);
+    });
+  });
+
+  describe('validateTitle10StartDate', () => {
+    const _ = null;
+    it('should not show an error for an activation date after start date', () => {
+      const addError = sinon.spy();
+      const errors = { addError };
+      const formData = {
+        servicePeriods: [
+          { serviceBranch: 'Reserve', dateRange: { from: '2003-03-12' } },
+          { serviceBranch: 'Reserve', dateRange: { from: '2000-01-14' } },
+        ],
+      };
+      validateTitle10StartDate(errors, '2001-01-01', _, _, _, _, formData);
+      expect(addError.called).to.be.false;
+    });
+    it('should show an error for an activation date before start date', () => {
+      const addError = sinon.spy();
+      const errors = { addError };
+      const data = {
+        servicePeriods: [
+          { serviceBranch: 'Reserve', dateRange: { from: '2003-03-12' } },
+          { serviceBranch: 'Reserve', dateRange: { from: '2000-01-14' } },
+          { serviceBranch: 'Reserve', dateRange: { from: '2005-12-25' } },
+        ],
+      };
+      validateTitle10StartDate(errors, '1999-12-31', _, _, _, _, data);
+      expect(addError.called).to.be.true;
+    });
+    it('should show an error for an activation date before start date after filtering out active duty periods', () => {
+      const addError = sinon.spy();
+      const errors = { addError };
+      const data = {
+        servicePeriods: [
+          { serviceBranch: 'Army', dateRange: { from: '2000-01-14' } },
+          { serviceBranch: 'Reserve', dateRange: { from: '2003-03-12' } },
+          { serviceBranch: 'Navy', dateRange: { from: '2005-12-25' } },
+        ],
+      };
+      validateTitle10StartDate(errors, '2001-12-31', _, _, _, _, data);
+      expect(addError.called).to.be.true;
+    });
+    // should never happen since the page is only shown if a Veteran includes
+    // a Reserve/National Guard period
+    it('should show an error if there are no Reserve/National Guard periods', () => {
+      const addError = sinon.spy();
+      const errors = { addError };
+      const data = {
+        servicePeriods: [
+          { serviceBranch: 'Army', dateRange: { from: '2003-03-12' } },
+          { serviceBranch: 'Navy', dateRange: { from: '2000-01-14' } },
+          { serviceBranch: 'Marines', dateRange: { from: '2005-12-25' } },
+        ],
+      };
+      validateTitle10StartDate(errors, '2010-12-31', _, _, _, _, data);
+      expect(addError.called).to.be.true;
     });
   });
 });

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -451,3 +451,32 @@ export const validateSeparationDate = (
     errors.addError('Your separation date must be before 180 days from today');
   }
 };
+
+export const validateTitle10StartDate = (
+  errors,
+  dateString,
+  _formData,
+  _schema,
+  _uiSchema,
+  _index,
+  appStateData = {},
+) => {
+  const startTimes = (appStateData.servicePeriods || [])
+    // include only reserve/guard service periods
+    .filter(period =>
+      reservesList.some(match => period.serviceBranch.includes(match)),
+    )
+    .map(period => period.dateRange.from)
+    .sort((a, b) => {
+      // string comparison of dates in the 'YYYY-MM-DD' format work as expected
+      if (a === b) {
+        return 0;
+      }
+      return b > a ? -1 : 1;
+    });
+  if (!startTimes[0] || dateString < startTimes[0]) {
+    errors.addError(
+      'Your activation date must be after your earliest service start date for Reserves or National Guard',
+    );
+  }
+};


### PR DESCRIPTION
## Description

The title 10 activation date must be after the earliest Reserve or National Guard start date. Added a check if no Reserve or National Guard periods are entered, but this shouldn't happen since the federal orders page only shows if the Veteran adds a Reserve or National Guard service period.

The current error message should be considered a placeholder. Awaiting content review. Will update the text after a determination is made.

Related:
- Discussion: https://dsva.slack.com/archives/C8R3JS8BU/p1629381358016100
- EVSS validation rules doc: https://docs.google.com/document/d/141qH9dh5M6C_JxRxkSdS8hygxzi46LlqZh9scOgS5sA/edit
- Content recommendation: https://github.com/department-of-veterans-affairs/va.gov-team/issues/29829

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/28962

## Testing done

Added unit tests

## Screenshots

<details><summary>Title 10 activation date error message</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-09-10 at 9 46 50 AM](https://user-images.githubusercontent.com/136959/132885112-f3ea7ca1-365a-446a-80b3-9f8360b4a628.png)</details>

## Acceptance criteria
- [x] Title 10 activation date error shows if before an Reserve or National Guard start date

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
