### PR TITLE
NOD: Fix typo

### DIFF
--- a/src/applications/appeals/10182/containers/IntroductionPage.jsx
+++ b/src/applications/appeals/10182/containers/IntroductionPage.jsx
@@ -94,7 +94,7 @@ class IntroductionPage extends React.Component {
               <ul>
                 <li>Your mailing address</li>
                 <li>
-                  The VA decision date for each issue you’d like use to review
+                  The VA decision date for each issue you’d like us to review
                   (this is the date on the decision notice you got in the mail)
                 </li>
               </ul>


### PR DESCRIPTION
## Description

Fixed a typo reported by the Board (`use` -> `us`)

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/29519

## Testing done

N/A

## Screenshots

![Screen Shot 2021-09-10 at 12 39 28 PM](https://user-images.githubusercontent.com/136959/132895418-ba05aaf3-1a9c-44dc-852f-cc2f91bdb28c.png)

## Acceptance criteria
- [x] Typo fixed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
