### PR TITLE
Improve logging for Cypress accessibility failure details

### DIFF
--- a/package.json
+++ b/package.json
@@ -218,6 +218,7 @@
     "stylelint-scss": "^3.19.0",
     "stylelint-webpack-plugin": "^3.0.1",
     "svg-url-loader": "^2.3.2",
+    "table": "^6.7.1",
     "terser-webpack-plugin": "^1.3.0",
     "url-loader": "^0.6.2",
     "webpack": "^4.46.0",

--- a/src/platform/testing/e2e/cypress/plugins/index.js
+++ b/src/platform/testing/e2e/cypress/plugins/index.js
@@ -1,5 +1,13 @@
 const fs = require('fs');
 const webpackPreprocessor = require('@cypress/webpack-preprocessor');
+const table = require('table').table;
+
+const tableConfig = {
+  columns: {
+    0: { width: 15 },
+    1: { width: 85 },
+  },
+};
 
 module.exports = on => {
   const ENV = 'localhost';
@@ -32,7 +40,7 @@ module.exports = on => {
   on('task', {
     /* eslint-disable no-console */
     log: message => console.log(message) || null,
-    table: message => console.table(message) || null,
+    table: message => console.log(table(message, tableConfig)) || null,
     /* eslint-enable no-console */
   });
 };

--- a/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
+++ b/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
@@ -11,26 +11,17 @@ const processAxeCheckResults = violations => {
   } detected`;
 
   // Pluck specific keys to keep the table readable.
-  const violationData = violations.map(
-    ({ id, impact, description, nodes }) => ({
-      id,
-      impact,
-      description,
-      nodes: nodes.length,
-    }),
-  );
-  cy.task('log', violationMessage);
-  cy.task('table', violationData);
-  cy.task(
-    'log',
-    `
-Nodes with violations:
+  const violationData = violations.map(({ id, impact, description, nodes }) => [
+    ['id', id],
+    ['impact', impact],
+    ['description', description],
+    ['target', nodes.map(node => node.target).join('\n\n')],
+    ['html', nodes.map(node => node.html).join('\n\n')],
+    ['nodes', nodes.length],
+  ]);
 
-${violations
-      .map(v => `${v.id}:\n${v.nodes?.map(n => n.target[0]).join('\n')}`)
-      .join('\n\n')}
-`,
-  );
+  cy.task('log', violationMessage);
+  violationData.forEach(violation => cy.task('table', violation));
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -17269,7 +17269,7 @@ table@^3.7.8:
     slice-ansi "0.0.4"
     string-width "^2.0.0"
 
-table@^6.0.9, table@^6.6.0:
+table@^6.0.9, table@^6.6.0, table@^6.7.1:
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/table/-/table-6.7.1.tgz#ee05592b7143831a8c94f3cee6aae4c1ccef33e2"
   integrity sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==


### PR DESCRIPTION
## Screenshots
Before:
<img width="798" alt="Screen Shot 2021-09-10 at 1 28 09 PM" src="https://user-images.githubusercontent.com/3535749/132901769-9dafaf81-c453-4f29-8588-61846b35c45e.png">

After:
<img width="766" alt="Screen Shot 2021-09-10 at 1 38 16 PM" src="https://user-images.githubusercontent.com/3535749/132901792-f84b817d-eea4-4f16-9ea6-f3dcafb866d6.png">
