### PR TITLE
add vaccine record pages

### DIFF
--- a/src/applications/static-pages/i18Select/utilities/urls.js
+++ b/src/applications/static-pages/i18Select/utilities/urls.js
@@ -16,4 +16,9 @@ export default {
     tl:
       '/health-care/covid-19-vaccine-tag/booster-shots-and-additional-doses-tag/',
   },
+  vaccineRecord: {
+    en: '/health-care/covid-19-vaccine/vaccine-record',
+    es: '/health-care/covid-19-vaccine-esp/vaccine-record-esp',
+    tl: '/health-care/covid-19-vaccine-tag/vaccine-record-tag',
+  },
 };


### PR DESCRIPTION
## Description
Very minor change to add three newly published pages to the list of translated pages for i18select component.


## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/29790


## Testing done
Unit tests pass and regression testing done on local / review instance.

## Screenshots


## Acceptance criteria
- [x] i18select shows up on 3 new vaccine record pages

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
