### PR TITLE
Defend against null nearby Vet Center data

### DIFF
--- a/src/applications/static-pages/facilities/vet-center/nearByVetCenters.jsx
+++ b/src/applications/static-pages/facilities/vet-center/nearByVetCenters.jsx
@@ -12,7 +12,8 @@ const NearByVetCenters = props => {
     () => {
       const notPublishedFacilities = props.vetCenters
         .map(
-          v => !v.entity.entityPublished && v.entity.fieldFacilityLocatorApiId,
+          v =>
+            !v.entity?.entityPublished && v.entity?.fieldFacilityLocatorApiId,
         )
         .join(',');
       apiRequest(`/facilities/va?ids=${notPublishedFacilities}`, {
@@ -59,7 +60,7 @@ const NearByVetCenters = props => {
     mainVetCenterPhone,
   ) => {
     const publishedVetCenters = vetCenters
-      .filter(v => v.entity.entityPublished)
+      .filter(v => v.entity?.entityPublished)
       .map(v => v.entity);
     const unPublishedVetCenters = facilitiesVetCenters.map(vc => ({
       entityBundle: vc.attributes.facilityType,


### PR DESCRIPTION
## Description
Bug reported by @mmiddaugh in [Slack](https://dsva.slack.com/archives/C0FQSS30V/p1631534403231700).

Sometimes the nearbyVetCenter data comes back with a null entity from Drupal. We need to defend against this, or the entire Nearby Vet Center section will not render (and other bad things could happen).