### PR TITLE
29831: Remove 75b alert from the debt portal

### DIFF
--- a/src/applications/debt-letters/components/DebtLettersSummary.jsx
+++ b/src/applications/debt-letters/components/DebtLettersSummary.jsx
@@ -3,24 +3,11 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
 import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
-
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import HowDoIPay from './HowDoIPay';
 import NeedHelp from './NeedHelp';
 import DebtCardsList from './DebtCardsList';
-import ExpandableAlert from './ExpandableAlert';
 import { OnThisPageLinks } from './OnThisPageLinks';
-
-const Chapter33Alert = () => (
-  <ExpandableAlert
-    className="vads-u-margin-top--3"
-    iconType="triangle"
-    status="limited"
-    trackingPrefix="-debt-letters-ch33"
-    label="If you got an email about Chapter 33 tuition debt with code 75B"
-    content="This is a debt assigned to your school. You won’t find it listed here. Before you make a payment on this debt, check with your school. They may have already paid."
-  />
-);
 
 const ErrorAlert = () => (
   <section
@@ -103,8 +90,6 @@ const DebtLettersSummary = ({ isError, isVBMSError, debts, debtLinks }) => {
 
             {!allDebtsFetchFailure && (
               <>
-                <Chapter33Alert />
-
                 <OnThisPageLinks />
 
                 <DebtCardsList />

--- a/src/applications/debt-letters/components/OnThisPageLinks.jsx
+++ b/src/applications/debt-letters/components/OnThisPageLinks.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export const OnThisPageLinks = ({ isDetailsPage, hasHistory }) => (
   <div>
-    <h2 className="vads-u-font-size--h3">On this page</h2>
+    <h2>On this page</h2>
     <div className="vads-u-font-family--sans vads-u-display--flex vads-u-flex-direction--column">
       {!isDetailsPage && (
         <a href="#currentDebts" className="vads-u-margin-y--2">


### PR DESCRIPTION
## Description
DMC has verified the 75b debt email notification issue has been resolved 75b alert has been removed from the debt portal

slack: https://dsva.slack.com/archives/CPE4AJ6Q0/p1631210571080300

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/29831

## Testing done

## Screenshots


## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs