### PR TITLE
Only show Rx-tracking notification item to eligible users

### DIFF
--- a/src/applications/personalization/common/helpers.js
+++ b/src/applications/personalization/common/helpers.js
@@ -1,3 +1,5 @@
+import { makeMockContactInfo } from '~/platform/user/profile/vap-svc/util/local-vapsvc.js';
+
 export function makeUserObject(options = {}) {
   const services = [];
   if (options.rx) {
@@ -50,7 +52,7 @@ export function makeUserObject(options = {}) {
         },
         inProgressForms: options.inProgressForms || [],
         prefillsAvailable: [],
-        vet360ContactInformation: {},
+        vet360ContactInformation: makeMockContactInfo(),
       },
     },
     meta: { errors: null },

--- a/src/applications/personalization/profile/components/notification-settings/NotificationChannel.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationChannel.jsx
@@ -33,7 +33,7 @@ const NotificationChannel = ({
   permissionId,
   saveSetting,
 }) => {
-  // when parentItem = "item2", parentItemId will be 2
+  // when itemId = "item2", itemIdNumber will be 2
   const itemIdNumber = React.useMemo(
     () => {
       if (itemId) {
@@ -69,6 +69,11 @@ const NotificationChannel = ({
         id={channelId}
         value={{ value: currentValue }}
         label={itemName}
+        description={
+          channelId === 'channel4-1'
+            ? 'Only available at some Asheville and Denver VA health facilities. Check with your facility first.'
+            : null
+        }
         options={[
           {
             label: `Notify me by ${channelTypes[channelType]}`,

--- a/src/applications/personalization/profile/components/notification-settings/NotificationGroup.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationGroup.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { selectGroupById } from '@@profile/ducks/communicationPreferences';
+import {
+  makeRxTrackingItemFilter,
+  selectGroupById,
+} from '@@profile/ducks/communicationPreferences';
 import { selectCommunicationPreferences } from '@@profile/reducers';
+import { selectPatientFacilities } from '~/platform/user/selectors';
 
 import NotificationItem from './NotificationItem';
 
@@ -22,14 +26,16 @@ const NotificationGroup = ({ children, groupName, itemIds }) => {
 };
 
 const mapStateToProps = (state, ownProps) => {
+  const facilities = selectPatientFacilities(state);
   const communicationPreferencesState = selectCommunicationPreferences(state);
   const group = selectGroupById(
     communicationPreferencesState,
     ownProps.groupId,
   );
+  const itemIds = group.items.filter(makeRxTrackingItemFilter(facilities));
   return {
     groupName: group.name,
-    itemIds: group.items,
+    itemIds,
   };
 };
 

--- a/src/applications/personalization/profile/components/notification-settings/NotificationRadioButtons.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationRadioButtons.jsx
@@ -138,7 +138,6 @@ const NotificationRadioButtons = ({
   const buttonOptions = isArray(options) ? options : [];
   const storedValue = value?.value;
   const optionElements = buttonOptions.map((option, optionIndex) => {
-    const isLastRadioButtonInGroup = optionIndex >= buttonOptions.length - 1;
     let optionLabel;
     let optionValue;
     let optionAriaLabel;
@@ -175,10 +174,7 @@ const NotificationRadioButtons = ({
           name={`${name}-${optionIndex}-label`}
           htmlFor={`${id}-${optionIndex}`}
           aria-label={optionAriaLabel}
-          className={classNames('vads-u-margin--0', 'vads-u-margin-top--1', {
-            'vads-u-margin-bottom--1': isLastRadioButtonInGroup,
-            'vads-u-margin-bottom--2p5': !isLastRadioButtonInGroup,
-          })}
+          className="vads-u-margin--0 vads-u-padding-y--1p5"
         >
           {optionLabel}
         </label>

--- a/src/applications/personalization/profile/components/notification-settings/NotificationRadioButtons.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationRadioButtons.jsx
@@ -46,6 +46,7 @@ const NotificationRadioButtons = ({
   id = uniqueId('notification-radio-buttons-'),
   additionalFieldsetClass,
   additionalLegendClass,
+  description,
   errorMessage,
   warningMessage,
   loadingMessage,
@@ -186,7 +187,7 @@ const NotificationRadioButtons = ({
     );
   });
 
-  const fieldsetClass = classNames(
+  const fieldsetClasses = classNames(
     'rb-fieldset-input',
     'rb-input',
     {
@@ -197,7 +198,7 @@ const NotificationRadioButtons = ({
     additionalFieldsetClass,
   );
 
-  const legendClass = classNames(
+  const legendClasses = classNames(
     'rb-legend',
     'vads-u-font-weight--bold',
     'vads-u-font-size--base',
@@ -206,13 +207,18 @@ const NotificationRadioButtons = ({
   );
 
   return (
-    <fieldset className={fieldsetClass} disabled={disabled} id={id}>
+    <fieldset className={fieldsetClasses} disabled={disabled} id={id}>
       <div className="clearfix">
-        <legend className={legendClass}>
+        <legend className={legendClasses}>
           {label}
           {requiredSpan}
         </legend>
       </div>
+      {description ? (
+        <p className="vads-u-margin-y--0p5 vads-u-color--gray-medium">
+          {description}
+        </p>
+      ) : null}
       {!loadingMessage && !successMessage && !warningMessage && errorSpan}
       {!loadingMessage && !errorMessage && !successMessage && warningSpan}
       {!loadingMessage && !errorMessage && !warningMessage && successSpan}

--- a/src/applications/personalization/profile/components/notification-settings/NotificationSettings.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationSettings.jsx
@@ -8,6 +8,7 @@ import {
   isVAPatient,
   // TODO: uncomment when email is a supported communication channel
   // selectVAPEmailAddress,
+  selectPatientFacilities,
   selectVAPMobilePhone,
 } from '~/platform/user/selectors';
 import { focusElement } from '~/platform/utilities/ui';
@@ -192,6 +193,7 @@ const mapStateToProps = state => {
         isPatient,
         hasEmailAddress: !!emailAddress,
         hasMobilePhone: !!mobilePhoneNumber,
+        facilities: selectPatientFacilities(state),
       },
     ),
     shouldFetchNotificationSettings,

--- a/src/applications/personalization/profile/ducks/communicationPreferences.js
+++ b/src/applications/personalization/profile/ducks/communicationPreferences.js
@@ -161,6 +161,27 @@ export const selectAvailableGroups = (state, { isPatient = false } = {}) => {
   );
 };
 
+// Makes a callback function to use with Array.filter()
+export const makeRxTrackingItemFilter = facilities => {
+  // 554: parent facility of Denver
+  // 637: parent facility of Asheville
+  // 983: test-only facility ID, used by user 36 among others
+  const supportedFacilities = new Set(['554', '637', '983']);
+  return itemId => {
+    if (itemId === 'item4') {
+      return facilities.some(facility => {
+        return supportedFacilities.has(facility.facilityId);
+      })
+        ? itemId
+        : null;
+    }
+    return itemId;
+  };
+};
+
+// Filter out the items the user does not have access to
+// 1. Filter out the Rx tracking item (item4) unless they are a patient at a
+//    facility that supports the feature
 export const selectAvailableItems = (
   state,
   { facilities = [], isPatient = false } = {},
@@ -170,17 +191,7 @@ export const selectAvailableItems = (
     availableGroups.ids.map(groupId => {
       return availableGroups.entities[groupId].items;
     }),
-  ).filter(itemId => {
-    if (itemId === 'item4') {
-      return facilities.some(facility => {
-        const supportedFacilities = new Set(['554', '637', '983']);
-        return supportedFacilities.has(facility.facilityId);
-      })
-        ? itemId
-        : null;
-    }
-    return itemId;
-  });
+  ).filter(makeRxTrackingItemFilter(facilities));
   const itemEntities = itemIds.reduce((acc, itemId) => {
     acc[itemId] = selectItemById(state, itemId);
     return acc;

--- a/src/applications/personalization/profile/sass/notification-radio-buttons.scss
+++ b/src/applications/personalization/profile/sass/notification-radio-buttons.scss
@@ -3,11 +3,18 @@
 // sheet. Unlike checkboxes, USWDS provides virtually no styling for disabled
 // radio buttons so we are setting up custom styling here. In the unlikely event
 // that VA.gov ever stops using USWDS, or upgrades to USWDS 2+, these rules will
-// probably have to updated or removed.
-$border-weight: 4px;
+// probably have to be updated or removed.
+$border-weight-left: 4px;
 $margin-left: units(1.5);
-$padding-left: calc(#{$margin-left} - #{$border-weight});
-$padding-left-negative: calc(-#{$margin-left} + #{$border-weight});
+$padding-left: calc(#{$margin-left} - #{$border-weight-left});
+$padding-left-negative: calc(-#{$margin-left} + #{$border-weight-left});
+
+input[type="radio"] {
+  height: 0;
+  width: 0;
+  margin: 0;
+  padding: 0;
+}
 
 [type="radio"]:disabled + label {
   color: $color-gray-lighter;
@@ -24,7 +31,7 @@ $padding-left-negative: calc(-#{$margin-left} + #{$border-weight});
 }
 
 .rb-fieldset-input {
-  margin-bottom: 2rem;
+  margin-bottom: units(1.5);
   position: relative;
 }
 
@@ -33,7 +40,7 @@ $padding-left-negative: calc(-#{$margin-left} + #{$border-weight});
 }
 
 .rb-input {
-  border-left: $border-weight solid transparent;
+  border-left: $border-weight-left solid transparent;
   padding-left: $padding-left;
   margin-left: -#{$margin-left};
   position: relative;

--- a/src/applications/personalization/profile/tests/ducks/communicationPreferences.unit.spec.js
+++ b/src/applications/personalization/profile/tests/ducks/communicationPreferences.unit.spec.js
@@ -539,10 +539,15 @@ describe('selectors', () => {
     });
   });
   describe('selectAvailableItems', () => {
-    context('when user is a patient', () => {
-      it('keeps the health care items', () => {
+    context('when user is a patient at 554', () => {
+      it('keeps the Rx tracking item (item 4) in the available items', () => {
         const availableItems = selectAvailableItems(state, {
           isPatient: true,
+          facilities: [
+            { facilityId: '123', isCerner: false },
+            { facilityId: '456', isCerner: true },
+            { facilityId: '554', isCerner: false },
+          ],
         });
         expect(availableItems.ids.length).to.equal(4);
         expect(availableItems.entities.item1).to.not.be.undefined;
@@ -550,6 +555,37 @@ describe('selectors', () => {
         expect(availableItems.entities.item4).to.not.be.undefined;
       });
     });
+    context('when user is a patient at 637', () => {
+      it('keeps the Rx tracking item (item 4) in the available items', () => {
+        const availableItems = selectAvailableItems(state, {
+          isPatient: true,
+          facilities: [
+            { facilityId: '123', isCerner: false },
+            { facilityId: '637', isCerner: false },
+            { facilityId: '333', isCerner: false },
+          ],
+        });
+        expect(availableItems.ids.length).to.equal(4);
+        expect(availableItems.entities.item1).to.not.be.undefined;
+        expect(availableItems.entities.item3).to.not.be.undefined;
+        expect(availableItems.entities.item4).to.not.be.undefined;
+      });
+    });
+    context(
+      'when user is a patient at a facility that does not offer prescription tracking',
+      () => {
+        it('removes the Rx tracking item (item 4) from the available items', () => {
+          const availableItems = selectAvailableItems(state, {
+            isPatient: true,
+            facilities: [{ facilityId: '558', isCerner: false }],
+          });
+          expect(availableItems.ids.length).to.equal(3);
+          expect(availableItems.entities.item1).to.not.be.undefined;
+          expect(availableItems.entities.item3).to.not.be.undefined;
+          expect(availableItems.entities.item4).to.be.undefined;
+        });
+      },
+    );
     context('when user is not a patient', () => {
       it('filters out the health care items', () => {
         const availableItems = selectAvailableItems(state, {
@@ -567,6 +603,7 @@ describe('selectors', () => {
     context('when user is patient and has all contact info on file', () => {
       it('returns the correct channels', () => {
         const availableChannels = selectAvailableChannels(state, {
+          facilities: [{ facilityId: '983' }],
           isPatient: true,
           hasMobilePhone: true,
           hasEmailAddress: true,
@@ -577,6 +614,7 @@ describe('selectors', () => {
     context('when user is patient but lacks a mobile phone', () => {
       it('returns the correct channels', () => {
         const availableChannels = selectAvailableChannels(state, {
+          facilities: [{ facilityId: '983' }],
           isPatient: true,
           hasMobilePhone: false,
           hasEmailAddress: true,
@@ -589,6 +627,7 @@ describe('selectors', () => {
     context('when user is not patient and has all contact info on file', () => {
       it('returns the correct channels', () => {
         const availableChannels = selectAvailableChannels(state, {
+          facilities: [],
           isPatient: false,
           hasMobilePhone: true,
           hasEmailAddress: true,
@@ -602,11 +641,12 @@ describe('selectors', () => {
     context('when user is a patient and has all contact info on file', () => {
       it('returns the correct channels', () => {
         const availableChannels = selectAvailableChannels(state, {
+          facilities: [{ facilityId: '123' }, { facilityId: '456' }],
           isPatient: true,
           hasMobilePhone: true,
           hasEmailAddress: true,
         });
-        expect(availableChannels.ids.length).to.equal(5);
+        expect(availableChannels.ids.length).to.equal(4);
         expect(availableChannels.entities['channel1-1']).to.not.be.undefined;
         expect(availableChannels.entities['channel1-2']).to.not.be.undefined;
         expect(availableChannels.entities['channel2-2']).to.not.be.undefined;
@@ -630,6 +670,7 @@ describe('selectors', () => {
       });
       it('returns the first channel', () => {
         const channelsWithoutSelection = selectChannelsWithoutSelection(state, {
+          facilities: [{ facilityId: '983' }],
           isPatient: true,
           hasMobilePhone: true,
           hasEmailAddress: true,
@@ -657,6 +698,7 @@ describe('selectors', () => {
       });
       it('returns no channels', () => {
         const channelsWithoutSelection = selectChannelsWithoutSelection(state, {
+          facilities: [{ facilityId: '983' }],
           isPatient: true,
           hasMobilePhone: true,
           hasEmailAddress: true,

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/happy-loading-path.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/happy-loading-path.cypress.spec.js
@@ -1,7 +1,6 @@
 import { PROFILE_PATHS } from '@@profile/constants';
 
-import mockPatient from '@@profile/tests/fixtures/users/user-36.json';
-import mockNonPatient from '@@profile/tests/fixtures/users/user-non-patient.json';
+import { makeUserObject } from '~/applications/personalization/common/helpers';
 import mockCommunicationPreferences from '@@profile/tests/fixtures/communication-preferences/get-200-maximal.json';
 
 import {
@@ -22,35 +21,81 @@ describe('Notification Settings', () => {
       body: mockCommunicationPreferences,
     });
   });
-  context('when user is a VA patient', () => {
-    it('should show the notification preferences groups with Health Care first', () => {
-      cy.login(mockPatient);
-      cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
-      cy.findByRole('heading', {
-        name: 'Notification settings',
-        level: 1,
-      }).should('exist');
-
-      cy.loadingIndicatorWorks();
-
-      cy.findByText('555-555-5559').should('exist');
-      // uncomment when email is a supported communication channel
-      // cy.findByText('alongusername@domain.com').should('exist');
-      cy.findAllByTestId('notification-group')
-        .should('have.length', 3)
-        .first()
-        .should('contain.text', 'Your health care')
-        .invoke('text')
-        .should(
-          'match',
-          /Manage your health care email notifications on My HealtheVet/i,
+  context(
+    'when user is a VA patient at a facility that supports Rx tracking',
+    () => {
+      it('should show the Health Care group first and show the Rx tracking item', () => {
+        cy.login(
+          makeUserObject({
+            isPatient: true,
+            facilities: [{ facilityId: '983' }],
+          }),
         );
-      cy.findAllByText(/^select an option/i).should('have.length', 1);
-    });
-  });
+        cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
+        cy.findByRole('heading', {
+          name: 'Notification settings',
+          level: 1,
+        }).should('exist');
+
+        cy.loadingIndicatorWorks();
+
+        cy.findByText('503-555-1234').should('exist');
+        // TODO: uncomment when email is a supported communication channel
+        // cy.findByText('veteran@gmail.com').should('exist');
+        cy.findAllByTestId('notification-group')
+          .should('have.length', 3)
+          .first()
+          .should('contain.text', 'Your health care')
+          .invoke('text')
+          .should(
+            'match',
+            /Manage your health care email notifications on My HealtheVet/i,
+          )
+          .should('match', /prescription.*shipment/i)
+          .should('match', /prescription.*tracking/i);
+        cy.findAllByText(/^select an option/i).should('have.length', 1);
+      });
+    },
+  );
+  context(
+    'when user is a VA patient at a facility that does not support Rx tracking',
+    () => {
+      it('should show the Health Care group first but not show the Rx tracking item', () => {
+        cy.login(
+          makeUserObject({
+            isPatient: true,
+            facilities: [{ facilityId: '123' }],
+          }),
+        );
+        cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
+        cy.findByRole('heading', {
+          name: 'Notification settings',
+          level: 1,
+        }).should('exist');
+
+        cy.loadingIndicatorWorks();
+
+        cy.findByText('503-555-1234').should('exist');
+        // TODO: uncomment when email is a supported communication channel
+        // cy.findByText('veteran@gmail.com').should('exist');
+        cy.findAllByTestId('notification-group')
+          .should('have.length', 3)
+          .first()
+          .should('contain.text', 'Your health care')
+          .invoke('text')
+          .should(
+            'match',
+            /Manage your health care email notifications on My HealtheVet/i,
+          )
+          .should('not.match', /prescription.*shipment/i)
+          .should('not.match', /prescription.*tracking/i);
+        cy.findAllByText(/^select an option/i).should('have.length', 1);
+      });
+    },
+  );
   context('when user is not a VA patient', () => {
     it('should not show the Health Care notification group', () => {
-      cy.login(mockNonPatient);
+      cy.login(makeUserObject({ isPatient: false }));
       cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
       cy.findByRole('heading', {
         name: 'Notification settings',
@@ -59,9 +104,9 @@ describe('Notification Settings', () => {
 
       cy.loadingIndicatorWorks();
 
-      cy.findByText('555-555-5559').should('exist');
+      cy.findByText('503-555-1234').should('exist');
       // uncomment when email is a supported communication channel
-      // cy.findByText('alongusername@domain.com').should('exist');
+      // cy.findByText('veteran@gmail.com').should('exist');
       cy.findAllByTestId('notification-group')
         .should('have.length.above', 0)
         .each($el => {


### PR DESCRIPTION
## Description
With this change the Rx-tracking notification item is removed from the presented options unless the user is a patient in an eligible facility. It also adds additional supporting text for the Rx-tracking item. This supporting text will likely change.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#28982

## Testing done
Updated Redux tests and added new Cypress tests

## Screenshots

### Refined the radio button spacing and hit-areas
**Vertical spacing overview:**
<img width="928" alt="Screen Shot 2021-09-13 at 7 46 23 AM" src="https://user-images.githubusercontent.com/20728956/133106186-4dd25e11-24ad-401f-a9f0-4e4c1122f310.png">

**Hit area is the green and blue**
<img width="654" alt="Screen Shot 2021-09-13 at 7 47 44 AM" src="https://user-images.githubusercontent.com/20728956/133106252-79db75c9-7945-430a-8d4d-d59b536dd14d.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs