### PR TITLE
Bug: Fixes AutoSSO feature 

### DIFF
--- a/src/platform/site-wide/announcements/components/SingleSignOnInfoModal.jsx
+++ b/src/platform/site-wide/announcements/components/SingleSignOnInfoModal.jsx
@@ -4,7 +4,6 @@ import Modal from '@department-of-veterans-affairs/component-library/Modal';
 export default function SingleSignOnInfoModal({
   dismiss,
   isAuthenticatedWithSSOe,
-  useSSOeEbenefitsLinks,
 }) {
   if (!isAuthenticatedWithSSOe) {
     return null;
@@ -16,20 +15,16 @@ export default function SingleSignOnInfoModal({
         Sign in once to access the VA sites you use most
       </h1>
       <p>
-        {`Now when you sign into VA.gov, we’ll also sign you into MyHealtheVet${
-          useSSOeEbenefitsLinks ? ', eBenefits,' : ''
-        } and
-        other VA sites.`}
+        Now when you sign into VA.gov, we’ll also sign you into MyHealtheVet,
+        eBenefits, and other VA sites.
       </p>
       <p>
         <strong>With a single sign on, you can:</strong>
       </p>
       <ul>
         <li>
-          {`Track and manage your VA ${
-            useSSOeEbenefitsLinks ? 'benefits and ' : ''
-          }services with just one username
-          and password`}
+          Track and manage your VA benefits and services with just one username
+          and password
         </li>
         <li>
           Access the VA sites you use most without having to sign in each time

--- a/src/platform/site-wide/announcements/tests/components/SingleSignOnInfoModal.unit.spec.jsx
+++ b/src/platform/site-wide/announcements/tests/components/SingleSignOnInfoModal.unit.spec.jsx
@@ -6,14 +6,6 @@ import sinon from 'sinon';
 import SingleSignOnInfoModal from '../../components/SingleSignOnInfoModal';
 
 describe('Announcements <SingleSignOnInfoModal>', () => {
-  it('does not render for users that are logged in but without SSO', () => {
-    const tree = mount(<SingleSignOnInfoModal isLoggedIn />);
-
-    expect(tree.html()).to.equal(null);
-
-    tree.unmount();
-  });
-
   it('renders for logged in SSO users', () => {
     const dismiss = sinon.spy();
 

--- a/src/platform/site-wide/user-nav/containers/AutoSSO.jsx
+++ b/src/platform/site-wide/user-nav/containers/AutoSSO.jsx
@@ -2,7 +2,6 @@ import { connect } from 'react-redux';
 
 import { checkKeepAlive } from 'platform/user/authentication/actions';
 import {
-  ssoeInbound,
   hasCheckedKeepAlive,
   ssoeTransactionId,
 } from 'platform/user/authentication/selectors';
@@ -16,7 +15,6 @@ import { removeLoginAttempted } from 'platform/utilities/sso/loginAttempted';
 
 function AutoSSO(props) {
   const {
-    useInboundSSOe,
     hasCalledKeepAlive,
     transactionId,
     loggedIn,
@@ -36,7 +34,6 @@ function AutoSSO(props) {
   if (
     // avoid race condition where hasSession hasn't been set
     isValidPath &&
-    useInboundSSOe &&
     !profileLoading &&
     !hasCalledKeepAlive
   ) {
@@ -54,7 +51,6 @@ const mapStateToProps = state => ({
   hasCalledKeepAlive: hasCheckedKeepAlive(state),
   profileLoading: isProfileLoading(state),
   loggedIn: isLoggedIn(state),
-  useInboundSSOe: ssoeInbound(state),
 });
 
 const mapDispatchToProps = {

--- a/src/platform/site-wide/user-nav/tests/containers/AutoSSO.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/containers/AutoSSO.unit.spec.jsx
@@ -12,7 +12,6 @@ describe('<AutoSSO>', () => {
 
   beforeEach(() => {
     props = {
-      useInboundSSOe: false,
       hasCalledKeepAlive: false,
       transactionId: undefined,
       loggedIn: false,
@@ -43,7 +42,6 @@ describe('<AutoSSO>', () => {
   it('should not call checkAutoSession if it already has', () => {
     const stub = sinon.stub(ssoUtils, 'checkAutoSession').resolves(null);
     Object.assign(props, {
-      useInboundSSOe: true,
       profileLoading: false,
       hasCalledKeepAlive: true,
     });
@@ -56,7 +54,6 @@ describe('<AutoSSO>', () => {
   it('should call keepalive if it has yet to', () => {
     const stub = sinon.stub(ssoUtils, 'checkAutoSession').resolves(null);
     Object.assign(props, {
-      useInboundSSOe: true,
       profileLoading: false,
       hasCalledKeepAlive: false,
     });

--- a/src/platform/user/authentication/selectors.js
+++ b/src/platform/user/authentication/selectors.js
@@ -4,9 +4,6 @@ import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNa
 
 export const ssoe = state => toggleValues(state)[FEATURE_FLAG_NAMES.ssoe];
 
-export const ssoeInbound = state =>
-  toggleValues(state)[FEATURE_FLAG_NAMES.ssoeInbound];
-
 export const ssoeEbenefitsLinks = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.ssoeEbenefitsLinks];
 

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -17,9 +17,9 @@ export const externalRedirects = {
   myvahealth: environment.isProduction()
     ? 'https://patientportal.myhealth.va.gov/'
     : 'https://staging-patientportal.myhealth.va.gov/',
-  mhv: environment.isProduction()
-    ? 'https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/'
-    : 'https://mhv-syst.myhealth.va.gov/mhv-portal-web/web/myhealthevet/',
+  mhv: `https://${
+    eauthEnvironmentPrefixes[environment.BUILDTYPE]
+  }.eauth.va.gov/mhv-portal-web/web/myhealthevet/`,
 };
 
 export const ssoKeepAliveEndpoint = () => {

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -19,7 +19,7 @@ export const externalRedirects = {
     : 'https://staging-patientportal.myhealth.va.gov/',
   mhv: `https://${
     eauthEnvironmentPrefixes[environment.BUILDTYPE]
-  }.eauth.va.gov/mhv-portal-web/web/myhealthevet/`,
+  }eauth.va.gov/mhv-portal-web/web/myhealthevet/`,
 };
 
 export const ssoKeepAliveEndpoint = () => {


### PR DESCRIPTION
## Description
Because vets-api is 100% for SSOe the feature flags were removed. This PR ensures the AutoSSO functionality is not dependent on the useInboundSSO feature flag.  Additionally, this PR fixes the My HealtheVet sign-in URL for SSO functionality.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done
Unit tests

## Screenshots


## Acceptance criteria
- [x] The `sign-in/?application=mhv` with the `to` parameter sends a user to the correct environments MHV instance
- [ ] AutoSSO functionality works as intended

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
