### PR TITLE
Updated pre_entry_covid19_screener flag

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -53,7 +53,7 @@ export default Object.freeze({
   languageSupport: 'language_support',
   manageDependents: 'dependents_management',
   megaMenuMobileV2: 'mega_menu_mobile_v2',
-  preEntryCovid19Screener: 'preEntryCovid19Screener',
+  preEntryCovid19Screener: 'pre_entry_covid19_screener',
   profileNotificationSettings: 'profile_notification_settings',
   requestLockedPdfPassword: 'request_locked_pdf_password',
   searchRepresentative: 'search_representative',


### PR DESCRIPTION
## Description
Right now the frontend isn't consistently using snake_case or camelCase so we're having to return every key twice. This PR syncs up the preScreener flag to use snake_case.

Checked values against https://github.com/department-of-veterans-affairs/vets-api/blob/master/config/features.yml

## Original issue(s)
department-of-veterans-affairs/va.gov-team#12251