### PR TITLE
HLR v2: Submit time fix

### DIFF
--- a/src/applications/disability-benefits/996/config/submit-transformer.js
+++ b/src/applications/disability-benefits/996/config/submit-transformer.js
@@ -3,6 +3,7 @@ import { DEFAULT_BENEFIT_TYPE } from '../constants';
 import {
   getRep,
   getConferenceTimes,
+  getConferenceTime, // v2
   addIncludedIssues,
   getContact,
   getAddress,
@@ -44,7 +45,7 @@ export function transform(formConfig, form) {
       if (version1) {
         attributes.informalConferenceTimes = getConferenceTimes(formData);
       } else {
-        attributes.informalConferenceTime = formData.informalConferenceTime;
+        attributes.informalConferenceTime = getConferenceTime(formData);
       }
       if (formData.informalConference === 'rep') {
         attributes.informalConferenceRep = getRep(formData);

--- a/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
+++ b/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
@@ -179,6 +179,10 @@ dl.review .additional-issue.review-row {
   font-weight: bold;
 }
 
+.review-row > dd {
+  word-break: break-word;
+}
+
 /* IE11 hack to fix edit button placement, see
  * https://github.com/department-of-veterans-affairs/va.gov-team/issues/25108
  */

--- a/src/applications/disability-benefits/996/tests/fixtures/data/transformed/maximal-test-v2.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/data/transformed/maximal-test-v2.json
@@ -5,7 +5,7 @@
       "benefitType": "compensation",
       "informalConference": true,
       "informalConferenceContact": "representative",
-      "informalConferenceTime": "time0800to1200",
+      "informalConferenceTime": "800-1200 ET",
       "informalConferenceRep": {
         "firstName": "James",
         "lastName": "Sullivan",

--- a/src/applications/disability-benefits/996/tests/utils/submit.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/utils/submit.unit.spec.js
@@ -6,6 +6,7 @@ import {
   createIssueName,
   getContestedIssues,
   getConferenceTimes,
+  getConferenceTime,
   removeEmptyEntries,
   getRep,
   getAddress,
@@ -188,35 +189,36 @@ describe('getRep', () => {
 });
 
 describe('getConferenceTimes', () => {
-  const wrap = (times, v = 'v1') => ({
-    hlrV2: v === 'v2',
-    informalConferenceTimes: times,
-  });
   it('should return v1 times', () => {
-    expect(getConferenceTimes(wrap({ time1: 'time0800to1000' }))).to.deep.equal(
-      ['800-1000 ET'],
-    );
-    expect(getConferenceTimes(wrap({ time1: 'time1230to1400' }))).to.deep.equal(
-      ['1230-1400 ET'],
-    );
     expect(
-      getConferenceTimes(
-        wrap({ time1: 'time0800to1000', time2: 'time1400to1630' }),
-      ),
+      getConferenceTimes({
+        informalConferenceTimes: { time1: 'time0800to1000' },
+      }),
+    ).to.deep.equal(['800-1000 ET']);
+    expect(
+      getConferenceTimes({
+        informalConferenceTimes: { time1: 'time1230to1400' },
+      }),
+    ).to.deep.equal(['1230-1400 ET']);
+    expect(
+      getConferenceTimes({
+        informalConferenceTimes: {
+          time1: 'time0800to1000',
+          time2: 'time1400to1630',
+        },
+      }),
     ).to.deep.equal(['800-1000 ET', '1400-1630 ET']);
   });
+});
+
+describe('getConferenceTime', () => {
   it('should return v2 times', () => {
     expect(
-      getConferenceTimes(wrap({ time1: 'time0800to1200' }, 'v2')),
-    ).to.deep.equal(['800-1200 ET']);
+      getConferenceTime({ informalConferenceTime: 'time0800to1200' }),
+    ).to.deep.equal('800-1200 ET');
     expect(
-      getConferenceTimes(wrap({ time1: 'time1200to1630' }, 'v2')),
-    ).to.deep.equal(['1200-1630 ET']);
-    expect(
-      getConferenceTimes(
-        wrap({ time1: 'time0800to1200', time2: 'time1200to1630' }, 'v2'),
-      ),
-    ).to.deep.equal(['800-1200 ET', '1200-1630 ET']);
+      getConferenceTime({ informalConferenceTime: 'time1200to1630' }),
+    ).to.deep.equal('1200-1630 ET');
   });
 });
 

--- a/src/applications/disability-benefits/996/utils/submit.js
+++ b/src/applications/disability-benefits/996/utils/submit.js
@@ -55,19 +55,16 @@ export const getRep = formData => {
   });
 };
 
+// schema v1
 export const getConferenceTimes = (formData = {}) => {
   const { informalConferenceTimes = [] } = formData;
-  const times = apiVersion1(formData)
-    ? CONFERENCE_TIMES_V1
-    : CONFERENCE_TIMES_V2;
-  const xRef = Object.keys(times).reduce(
+  const xRef = Object.keys(CONFERENCE_TIMES_V1).reduce(
     (timesAndApi, time) => ({
       ...timesAndApi,
-      [time]: times[time].submit,
+      [time]: CONFERENCE_TIMES_V1[time].submit,
     }),
     {},
   );
-
   return ['time1', 'time2'].reduce((setTimes, key) => {
     const value = informalConferenceTimes[key] || '';
     if (value) {
@@ -75,6 +72,12 @@ export const getConferenceTimes = (formData = {}) => {
     }
     return setTimes;
   }, []);
+};
+
+// schema v2
+export const getConferenceTime = (formData = {}) => {
+  const { informalConferenceTime = '' } = formData;
+  return CONFERENCE_TIMES_V2[informalConferenceTime]?.submit || '';
 };
 
 export const getTimeZone = () =>


### PR DESCRIPTION
## Description

When submitting an Higher-Level Review v2 form, the informal conference time was malformed. This PR fixes that problem.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/29674

## Testing done

Updated unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Fix submitted informal conference time to allow a successful submission

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
