### PR TITLE
526: Prevent `toLowerCase` of undefined error

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
@@ -85,7 +85,7 @@ export default class ArrayField extends React.Component {
         : formData.map(
             (obj, index) =>
               !obj[key] ||
-              obj[key].toLowerCase() === NULL_CONDITION_STRING.toLowerCase() ||
+              obj[key]?.toLowerCase() === NULL_CONDITION_STRING.toLowerCase() ||
               duplicates.includes(index),
           );
     }

--- a/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
@@ -8,7 +8,7 @@ import Telephone, {
 import recordEvent from 'platform/monitoring/record-event';
 
 const titleLowerCase = (title = '') =>
-  `${title[0].toLowerCase()}${title.slice(1)}`;
+  `${title[0].toLowerCase() || ''}${title.slice(1)}`;
 
 const Alert = ({ title, content }) => (
   <div className="vads-l-grid-container vads-u-padding-left--0 vads-u-padding-bottom--5">

--- a/src/applications/disability-benefits/all-claims/submit-transformer.js
+++ b/src/applications/disability-benefits/all-claims/submit-transformer.js
@@ -164,7 +164,7 @@ export function transformRelatedDisabilities(
   conditionContainer,
   claimedConditions,
 ) {
-  const findCondition = (list, name) =>
+  const findCondition = (list, name = '') =>
     list.find(
       // name should already be lower-case, but just in case...no pun intended
       claimedName => sippableId(claimedName) === name.toLowerCase(),
@@ -370,7 +370,7 @@ export function transform(formConfig, form) {
       const powDisabilities = transformRelatedDisabilities(
         clonedData.powDisabilities,
         getClaimedConditionNames(formData),
-      ).map(name => name.toLowerCase());
+      ).map(name => name?.toLowerCase());
       clonedData.newDisabilities = clonedData.newDisabilities.map(d => {
         if (powDisabilities.includes(d.condition?.toLowerCase())) {
           const newSpecialIssues = (d.specialIssues || []).slice();

--- a/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
@@ -81,6 +81,11 @@ describe('transform', () => {
 });
 
 describe('transformRelatedDisabilities', () => {
+  it('should not throw an error', () => {
+    expect(transformRelatedDisabilities({ '': true }, [undefined, ''])).to.eql(
+      [],
+    );
+  });
   it('should return an array of strings', () => {
     const claimedConditions = ['Some Condition Name', 'Another Condition Name'];
     const treatedDisabilityNames = {

--- a/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
@@ -312,6 +312,11 @@ describe('526 All Claims validations', () => {
     const tooLong =
       'et pharetra pharetra massa massa ultricies mi quis hendrerit dolor magna eget est lorem ipsum dolor sit amet consectetur adipiscing elit pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas integer eget aliquet nibh praesent';
 
+    it('should not throw a JS error when there is no data', () => {
+      const err = { addError: sinon.spy() };
+      validateDisabilityName(err);
+      expect(err.addError.calledOnce).to.be.true;
+    });
     it('should not add error when disability is in list', () => {
       const err = { addError: sinon.spy() };
       validateDisabilityName(err, disabilityLabels[7100]);

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -291,7 +291,7 @@ export const missingConditionMessage =
 
 export const validateDisabilityName = (
   err,
-  fieldData,
+  fieldData = '',
   _formData,
   _schema,
   _uiSchema,


### PR DESCRIPTION
## Description

Attempt to fix `toLowerCase` of undefined error. This PR fixes all the uses of `toLowerCase` within the 526 form code, but won't prevent errors that may be occurring elsewhere (e.g. the form system code).

## Original issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/29882
- http://sentry.vfs.va.gov/organizations/vsp/issues/47091

## Testing done

Updated unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Testing instances of `toLowerCase` to prevent JS error within 526 code

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
