### PR TITLE
Bump formation to 6.17.1 to remove position relative from .usa-content

### DIFF
--- a/package.json
+++ b/package.json
@@ -238,7 +238,7 @@
   "private": true,
   "dependencies": {
     "@department-of-veterans-affairs/component-library": "^3.0.3",
-    "@department-of-veterans-affairs/formation": "6.17.0",
+    "@department-of-veterans-affairs/formation": "6.17.1",
     "@department-of-veterans-affairs/formulate": "0.0.1",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "@formatjs/intl-datetimeformat": "^3.2.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1605,10 +1605,10 @@
     react-transition-group "1"
     recast "^0.14.4"
 
-"@department-of-veterans-affairs/formation@6.17.0":
-  version "6.17.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-6.17.0.tgz#bbfd8c13e1bada7ed1d9bd44f5470fcbda148b41"
-  integrity sha512-xmTrRNrQRWW1y91CwW1ar2OJGYQdXh9LEtl5JyBwKhREBbv/kSOf0nH1hTezEZDHIvSq3mBEVI2JCorXQg2qIQ==
+"@department-of-veterans-affairs/formation@6.17.1":
+  version "6.17.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-6.17.1.tgz#db532447f006e6c3e1731559588f0e44e8750e49"
+  integrity sha512-PiE0hxHA+yVB+LGTbWYpDI16YU3pX8n+dYjk2QSjt3xptZQ7mm1mbwjnWOY5FHzYuLjAb+379nnYYINJvMeQRA==
   dependencies:
     "@fortawesome/fontawesome-free" "^5.6.3"
     domready "^1.0.8"


### PR DESCRIPTION
## Description
Upgrading Formation from 6.17.0 -> 6.17.1 to include the change from this PR: https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/670/files
This removes `position: relative` from `.usa-content` to make use of the `position: relative` that is higher up the DOM hierarchy from this pr: https://github.com/department-of-veterans-affairs/content-build/pull/505

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/29126


## Testing done
local

## Screenshots
<img width="1787" alt="Screen Shot 2021-09-13 at 4 11 52 PM" src="https://user-images.githubusercontent.com/3144003/133150325-06f467c2-006d-4e01-8cb3-b78f97fc0625.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
