### PR TITLE
Update the va_global_downtime_notification feature flag

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -85,7 +85,7 @@ export default Object.freeze({
   stemSCOEmail: 'stem_sco_email',
   subform89404192: 'subform_8940_4192',
   useLighthouseFormsSearchLogic: 'new_va_forms_search',
-  vaGlobalDowntimeNotification: 'vaGlobalDowntimeNotification',
+  vaGlobalDowntimeNotification: 'va_global_downtime_notification',
   vaOnlineFacilitySelectionV22: 'vaOnlineFacilitySelectionV22',
   vaOnlineScheduling: 'vaOnlineScheduling',
   vaOnlineSchedulingCancel: 'vaOnlineSchedulingCancel',


### PR DESCRIPTION
## Description
Right now the frontend isn't consistently using snake_case or camelCase so we're having to return every key twice. This PR syncs up the va_global_downtime_notification flag to use snake_case.

Checked values against https://github.com/department-of-veterans-affairs/vets-api/blob/master/config/features.yml

## Original issue(s)
department-of-veterans-affairs/va.gov-team#12251