### PR TITLE
conditionally show/hide Rx-tracking radio button hint text

### DIFF
--- a/src/applications/personalization/common/helpers.js
+++ b/src/applications/personalization/common/helpers.js
@@ -41,7 +41,8 @@ export function makeUserObject(options = {}) {
           gender: 'M',
           givenNames: ['Wesley', 'Watson'],
           isCernerPatient: options.isCerner ?? false,
-          facilities: options.facilities || [],
+          facilities:
+            options.isPatient && options.facilities ? options.facilities : null,
           vaPatient: options.isPatient ?? false,
           mhvAccountState: 'NONE',
         },

--- a/src/applications/personalization/profile/components/notification-settings/NotificationChannel.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationChannel.jsx
@@ -8,9 +8,12 @@ import {
   selectChannelById,
   selectChannelUiById,
 } from '@@profile/ducks/communicationPreferences';
+import { RX_TRACKING_SUPPORTING_FACILITIES } from '@@profile/constants';
 import { selectCommunicationPreferences } from '@@profile/reducers';
 
 import { getContactInfoSelectorByChannelType } from '@@profile/util/notification-settings';
+
+import { selectPatientFacilities } from '~/platform/user/selectors';
 
 import { LOADING_STATES } from '../../../common/constants';
 
@@ -31,6 +34,7 @@ const NotificationChannel = ({
   itemName,
   itemId,
   permissionId,
+  radioButtonDescription,
   saveSetting,
 }) => {
   // when itemId = "item2", itemIdNumber will be 2
@@ -69,11 +73,7 @@ const NotificationChannel = ({
         id={channelId}
         value={{ value: currentValue }}
         label={itemName}
-        description={
-          channelId === 'channel4-1'
-            ? 'Only available at some Asheville and Denver VA health facilities. Check with your facility first.'
-            : null
-        }
+        description={radioButtonDescription}
         options={[
           {
             label: `Notify me by ${channelTypes[channelType]}`,
@@ -145,6 +145,14 @@ const mapStateToProps = (state, ownProps) => {
     channel.channelType,
   );
   const isMissingContactInfo = !contactInfoSelector(state);
+  const facilities = selectPatientFacilities(state);
+  const allFacilitiesSupportRxTracking = facilities?.every(facility => {
+    return RX_TRACKING_SUPPORTING_FACILITIES.has(facility.facilityId);
+  });
+  const radioButtonDescription =
+    ownProps.channelId === 'channel4-1' && !allFacilitiesSupportRxTracking
+      ? 'Only available at some Asheville and Denver VA health facilities. Check with your facility first.'
+      : null;
   return {
     apiStatus: uiState.updateStatus,
     channelType: channel.channelType,
@@ -153,6 +161,7 @@ const mapStateToProps = (state, ownProps) => {
     isOptedIn: channel.isAllowed,
     isMissingContactInfo,
     permissionId: channel.permissionId,
+    radioButtonDescription,
   };
 };
 

--- a/src/applications/personalization/profile/constants.js
+++ b/src/applications/personalization/profile/constants.js
@@ -39,3 +39,8 @@ export const ACCOUNT_TYPES_OPTIONS = {
   checking: 'Checking',
   savings: 'Savings',
 };
+
+// 554: Denver
+// 637: Asheville
+// 983: test-only facility ID, used by user 36 among others
+export const RX_TRACKING_SUPPORTING_FACILITIES = new Set(['554', '637', '983']);

--- a/src/applications/personalization/profile/ducks/communicationPreferences.js
+++ b/src/applications/personalization/profile/ducks/communicationPreferences.js
@@ -3,6 +3,7 @@ import flatten from 'lodash/flatten';
 import { apiRequest } from '~/platform/utilities/api';
 
 import { LOADING_STATES } from '../../common/constants';
+import { RX_TRACKING_SUPPORTING_FACILITIES } from '../constants';
 
 // HELPERS
 
@@ -163,14 +164,10 @@ export const selectAvailableGroups = (state, { isPatient = false } = {}) => {
 
 // Makes a callback function to use with Array.filter()
 export const makeRxTrackingItemFilter = facilities => {
-  // 554: parent facility of Denver
-  // 637: parent facility of Asheville
-  // 983: test-only facility ID, used by user 36 among others
-  const supportedFacilities = new Set(['554', '637', '983']);
   return itemId => {
     if (itemId === 'item4') {
       return facilities.some(facility => {
-        return supportedFacilities.has(facility.facilityId);
+        return RX_TRACKING_SUPPORTING_FACILITIES.has(facility.facilityId);
       })
         ? itemId
         : null;


### PR DESCRIPTION
## Description
The Rx-tracking radio button group hint text will now:
- be shown if the user is registered with a mix of facilities that support and don't support Rx tracking 
- be hidden if the user is only registered with facilities that support Rx tracking

## Original issue(s)
department-of-veterans-affairs/va.gov-team#29879

## Testing done
TDD with Cypress

## Screenshots
**with:**
<img width="509" alt="Screen Shot 2021-09-13 at 4 08 11 PM" src="https://user-images.githubusercontent.com/20728956/133168760-7a97c8b0-bac9-43f6-b5b8-46f5c574cb40.png">

**without:**
<img width="509" alt="Screen Shot 2021-09-13 at 4 07 39 PM" src="https://user-images.githubusercontent.com/20728956/133168764-d0d74caa-c06b-44cf-8927-cc51ecdc46b3.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs