### PR TITLE
Skipping flaky test from forms system

### DIFF
--- a/src/platform/forms-system/test/js/utilities/ui.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/ui.unit.spec.js
@@ -158,7 +158,7 @@ describe('getFocuableElements', () => {
     const focusableElements = getFocusableElements(dom);
     expect(focusableElements.length).to.eq(0);
   });
-  it('should return an empty array from hidden elements', () => {
+  it.skip('should return an empty array from hidden elements', () => {
     setOffset('offsetHeight', offsets.height);
     setOffset('offsetWidth', offsets.width);
     /* eslint-disable jsx-a11y/no-noninteractive-tabindex */


### PR DESCRIPTION
## Description
Experienced multiple master failures on this test. One example: https://github.com/department-of-veterans-affairs/vets-website/runs/3599057404

Alerting @Mottie, @bkjohnson and @cvalarida in case if can be fixed instead of skipped.