### PR TITLE
6844/centralize page scroll code

### DIFF
--- a/src/platform/utilities/ui/scrollTo.js
+++ b/src/platform/utilities/ui/scrollTo.js
@@ -3,6 +3,6 @@ import { getScrollOptions } from 'platform/utilities/ui';
 
 const scroller = Scroll.scroller;
 
-export default function scrollToTop(elem, options = getScrollOptions()) {
+export default function scrollTo(elem, options = getScrollOptions()) {
   scroller.scrollTo(elem, options);
 }

--- a/src/platform/utilities/ui/scrollTo.js
+++ b/src/platform/utilities/ui/scrollTo.js
@@ -1,0 +1,8 @@
+import Scroll from 'react-scroll';
+import { getScrollOptions } from 'platform/utilities/ui';
+
+const scroller = Scroll.scroller;
+
+export default function scrollToTop(elem, options = getScrollOptions()) {
+  scroller.scrollTo(elem, options);
+}

--- a/src/platform/utilities/ui/scrollToTop.js
+++ b/src/platform/utilities/ui/scrollToTop.js
@@ -2,8 +2,8 @@ import Scroll from 'react-scroll';
 
 const scroller = Scroll.animateScroll;
 
-export default function scrollToTop(duration = 500) {
-  scroller.scrollTo(0, {
+export default function scrollToTop(position = 0, duration = 500) {
+  scroller.scrollTo(position, {
     duration,
     delay: 0,
     smooth: true,


### PR DESCRIPTION
## Description
Alter the existing scrollToTop function to support an optional element being passed (defaulting to 0 for the top of the page) and create additional scrollTo function that will take a full config object defaulting to the common settings used around the site (getScrollOptions). This is step 1 in centralizing this code, before individual applications have their code updated to utilize them.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/6844
