### PR TITLE
29575 - 508 defect covid 19 breadcrumbs

### DIFF
--- a/src/applications/static-pages/i18Select/utilities/constants.js
+++ b/src/applications/static-pages/i18Select/utilities/constants.js
@@ -25,7 +25,7 @@ export const TRANSLATED_LANGUAGES = [
     label: 'Español',
     code: 'es',
     urlPatterns: {
-      included: ['espanol'],
+      included: ['espanol', 'vacunas'],
       suffixed: ['-esp', '-esp/'],
     },
     onThisPage: 'En esta página',

--- a/src/applications/static-pages/i18Select/utilities/helpers.js
+++ b/src/applications/static-pages/i18Select/utilities/helpers.js
@@ -9,17 +9,13 @@ export function stripTrailingSlash(str) {
   return str.endsWith('/') ? str.slice(0, -1) : str;
 }
 
-export const getConfigFromLanguageCode = languageCode => {
-  return (
-    ALL_LANGUAGES.find(language => language.code === languageCode) ||
-    DEFAULT_LANGUAGE
-  );
-};
+export const getConfigFromLanguageCode = languageCode =>
+  ALL_LANGUAGES.find(language => language.code === languageCode) ||
+  DEFAULT_LANGUAGE;
 
 // used on page load to find translation links relating to document.location.pathname
-export const getPageTypeFromPathname = pathname => {
-  return PATHNAME_DICT?.[stripTrailingSlash(pathname)]?.pageType ?? null;
-};
+export const getPageTypeFromPathname = pathname =>
+  PATHNAME_DICT?.[stripTrailingSlash(pathname)]?.pageType ?? null;
 
 const getLinksInSelector = selector => {
   const container = document?.querySelector(selector);
@@ -52,18 +48,20 @@ const setMedalliaSurveyLangOnWindow = languageCode => {
 // links may have included words that indicate language (e.g., espanol.cdc.gov)
 // this can be used for the href of a link or the current document url
 // TODO: add better pattern matching, lang attr set directly in cms content for anchors if possible
-export const getConfigFromUrl = (url, languages) => {
-  return languages.reduce((accumulator, languageConfig) => {
+export const getConfigFromUrl = (url, languages) =>
+  languages.reduce((accumulator, languageConfig) => {
     const {
       urlPatterns: { included = [], suffixed = [] },
     } = languageConfig;
 
     const parsedUrlPatternResults = [
       ...included.map(
-        includedTerm => includedTerm && url?.includes(includedTerm),
+        includedTerm =>
+          includedTerm && url.toLowerCase()?.includes(includedTerm),
       ),
       ...suffixed.map(
-        suffixedTerm => suffixedTerm && url?.endsWith(suffixedTerm),
+        suffixedTerm =>
+          suffixedTerm && url.toLowerCase()?.endsWith(suffixedTerm),
       ),
     ];
 
@@ -71,17 +69,18 @@ export const getConfigFromUrl = (url, languages) => {
       ? languageConfig
       : accumulator;
   }, DEFAULT_LANGUAGE);
-};
 
-const adaptContentWithLangCode = langCode => {
-  // the article.content-usa element is the main translated content,
-  // so it should have it's lang attribute set
-  // TODO: improve selector for this if possible
-  const [container, links] = getLinksInSelector('article.usa-content');
+const adaptWithLangCode = (
+  langCode,
+  selector,
+  attributesToSet = ['hreflang', 'lang'],
+  setContainerAttribute = false,
+) => {
+  const [container, links] = getLinksInSelector(selector);
 
   if (!container) return;
 
-  container.setAttribute('lang', langCode);
+  if (setContainerAttribute) container.setAttribute('lang', langCode);
 
   if (!links || links.length === 0) return;
 
@@ -91,50 +90,22 @@ const adaptContentWithLangCode = langCode => {
     if (link && !link.href.includes('#') && !link.href.includes('tel')) {
       const { code } = getConfigFromUrl(link.href, TRANSLATED_LANGUAGES);
 
-      link.setAttribute('hreflang', code);
-    }
-  }
-};
-
-const adaptSidebarWithLangCode = () => {
-  const [container, links] = getLinksInSelector('#va-detailpage-sidebar');
-
-  if (!container || !links) return;
-
-  for (const link of links) {
-    // we only want to set the hreflang to valid links
-    // this excludes jumplinks and telephone links
-    if (link && !link.href.includes('#') && !link.href.includes('tel')) {
-      const { code } = getConfigFromUrl(link.href, TRANSLATED_LANGUAGES);
-
-      // sidebar links are considered to be translated to their target language,
-      // and therefore would have their hreflang and lang set to their parsed language
-      if (code !== 'en') {
-        link.setAttribute('hreflang', code);
-        link.setAttribute('lang', code);
+      for (const attribute of attributesToSet) {
+        link.setAttribute(attribute, code);
       }
     }
   }
 };
 
-const adaptBreadcrumbWithLangCode = langCode => {
-  const [container, links] = getLinksInSelector('#va-breadcrumbs-list');
-
-  if (!container || !links) return;
-
-  for (const link of links) {
-    // we only want to set the lang on breadcrumb for aria-current="page"
-    const ariaCurrent = link?.getAttribute('aria-current');
-
-    if (link && ariaCurrent && ariaCurrent === 'page') {
-      link.setAttribute('lang', langCode);
-    }
-  }
-};
-
 export const setLangAttributes = lang => {
-  adaptContentWithLangCode(lang);
-  adaptBreadcrumbWithLangCode(lang);
-  adaptSidebarWithLangCode();
+  // adapt content section
+  adaptWithLangCode(lang, 'article.usa-content', ['hreflang'], true);
+
+  // adapt breadcrumb links
+  adaptWithLangCode(lang, '#va-breadcrumbs-list', ['lang']);
+
+  // adapt sidebar links
+  adaptWithLangCode(lang, '#va-detailpage-sidebar');
+
   setMedalliaSurveyLangOnWindow(lang);
 };

--- a/src/applications/static-pages/i18Select/utilities/helpers.js
+++ b/src/applications/static-pages/i18Select/utilities/helpers.js
@@ -57,11 +57,11 @@ export const getConfigFromUrl = (url, languages) =>
     const parsedUrlPatternResults = [
       ...included.map(
         includedTerm =>
-          includedTerm && url.toLowerCase()?.includes(includedTerm),
+          includedTerm && url?.toLowerCase()?.includes(includedTerm),
       ),
       ...suffixed.map(
         suffixedTerm =>
-          suffixedTerm && url.toLowerCase()?.endsWith(suffixedTerm),
+          suffixedTerm && url?.toLowerCase()?.endsWith(suffixedTerm),
       ),
     ];
 


### PR DESCRIPTION
## Description

**Main Fix** 
The breadcrumb links lang attribute is now set appropriately when viewing a translated child page. (see screenshot below)
Impacted urls:
* https://www.va.gov/health-care/covid-19-vaccine-esp/booster-shots-and-additional-doses-esp
* https://www.va.gov/health-care/covid-19-vaccine-tag/booster-shots-and-additional-doses-tag

**Code cleanup**

* The functionality to modify the dom elements with appropriate lang or hreflang attributes has been unified into a single function instead of 3 slightly different functions for each section of dom that needs updating.
* Pattern matching for getConfigFromUrl was updated with toLowerCase used for string uniformity
* Some code formatting was updated to remove unnecessary curly braces and returns


## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/29575


## Testing done
Unit testing, manual testing of pages on review instance

Review instance urls to fixed pages:
* http://9d47bd067b07e0fe33c6cf25f9ba8a3d.review.vetsgov-internal/health-care/covid-19-vaccine-esp/booster-shots-and-additional-doses-esp/
* http://9d47bd067b07e0fe33c6cf25f9ba8a3d.review.vetsgov-internal/health-care/covid-19-vaccine-tag/booster-shots-and-additional-doses-tag/

## Screenshot

![Screen Shot 2021-09-14 at 9 11 24 AM](https://user-images.githubusercontent.com/8332986/133285444-dce8fb21-2e80-43f3-a8d8-7883832d4503.png)


## Acceptance criteria
- [x] All translated child pages have the correct lang attribute on their breadcrumb link tags

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
