### PR TITLE
NOD: Update additional issues page content

### DIFF
--- a/src/applications/appeals/10182/containers/FormApp.jsx
+++ b/src/applications/appeals/10182/containers/FormApp.jsx
@@ -10,7 +10,7 @@ import {
   noticeOfDisagreementFeature,
   issuesNeedUpdating,
   getSelected,
-  getIssueName,
+  getIssueNameAndDate,
   processContestableIssues,
 } from '../utils/helpers';
 
@@ -67,8 +67,8 @@ export const FormApp = ({
           areaOfDisagreement?.length !== formData.areaOfDisagreement?.length ||
           !areaOfDisagreement.every(
             (entry, index) =>
-              getIssueName(entry) ===
-              getIssueName(formData.areaOfDisagreement[index]),
+              getIssueNameAndDate(entry) ===
+              getIssueNameAndDate(formData.areaOfDisagreement[index]),
           )
         ) {
           setFormData({

--- a/src/applications/appeals/10182/content/additionalIssues.jsx
+++ b/src/applications/appeals/10182/content/additionalIssues.jsx
@@ -36,7 +36,8 @@ export const AdditionalIssuesLabel = (
     <span className="vads-u-font-weight--normal vads-u-font-size--base vads-u-font-family--sans">
       Add an issue and our decision date on this issue. You can find the
       decision date on your decision notice (the letter you got in the mail from
-      us).
+      us). You can request a Board Appeal up to 1 year from the date on your
+      decision notice.
     </span>
     <p className="vads-u-font-weight--normal vads-u-font-size--base vads-u-font-family--sans">
       <strong>Note:</strong> You can only add an issue that you’ve already


### PR DESCRIPTION
## Description

The Notice of Disagreement additional issues page content is updated based on feedback from the Board.

Additionally, fixed an issue where the area of disagreement page would show "Invalid date" in the page title.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/29914

## Testing done

N/A

## Screenshots

<details><summary>Invalid date in title (before fix)</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-09-14 at 11 51 49 AM](https://user-images.githubusercontent.com/136959/133300576-887457fb-a5d6-4406-a138-963bd07b7888.png)</details>

<details><summary>Additional issue page (updated)</summary>

<!-- leave a blank line above -->
![](https://user-images.githubusercontent.com/136959/133279287-c12925bd-c161-4cba-a4e8-ffbdf02a0450.png)</details>

## Acceptance criteria
- [x] Content updated
- [x] Fix date in title

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
