### PR TITLE
526: Add Sentry tag with account & sip ID

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
@@ -48,7 +48,9 @@ describe('Form 526EZ Entry Page', () => {
         loadedStatus: 'success',
         savedStatus: '',
         loadedData: {
-          metadata: {},
+          metadata: {
+            inProgressFormId: '234',
+          },
         },
       },
       user: {
@@ -61,6 +63,7 @@ describe('Form 526EZ Entry Page', () => {
           loading: false,
           status: '',
           dob,
+          accountUuid: 'uuid',
         },
       },
       currentLocation: {


### PR DESCRIPTION
## Description

Adding Sentry tags for the account uuid and in-progress form ID to the start of Form 526. This is in hopes that Sentry events that catch errors will provide this data and make it easier to troubleshoot the cause of the error.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/29893

## Testing done

All unit tests passing

## Screenshots

N/A

## Acceptance criteria

- [x] Add account & in-progress IDs to Sentry

## Definition of done

- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
