### PR TITLE
centralize scroll to top for personalization applications

### DIFF
--- a/src/applications/personalization/search-representative/containers/ConfirmationPage.jsx
+++ b/src/applications/personalization/search-representative/containers/ConfirmationPage.jsx
@@ -1,23 +1,14 @@
 import React from 'react';
 import moment from 'moment';
 import { connect } from 'react-redux';
-import Scroll from 'react-scroll';
 
+import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { focusElement } from 'platform/utilities/ui';
-
-const scroller = Scroll.scroller;
-const scrollToTop = () => {
-  scroller.scrollTo('topScrollElement', {
-    duration: 500,
-    delay: 0,
-    smooth: true,
-  });
-};
 
 export class ConfirmationPage extends React.Component {
   componentDidMount() {
     focusElement('.schemaform-title > h1');
-    scrollToTop();
+    scrollToTop('topScrollElement');
   }
 
   render() {

--- a/src/applications/personalization/view-dependents/components/ViewDependentsList/ViewDependentsListItem.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsList/ViewDependentsListItem.jsx
@@ -1,20 +1,12 @@
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
-import Scroll from 'react-scroll';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import classNames from 'classnames';
+
+import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { focusElement } from 'platform/utilities/ui';
 import ManageDependents from '../../manage-dependents/containers/ManageDependentsApp';
-
-const scroller = Scroll.scroller;
-const scrollToTop = el => {
-  scroller.scrollTo(el, {
-    duration: 500,
-    delay: 0,
-    smooth: true,
-  });
-};
 
 function ViewDependentsListItem(props) {
   const [open, setOpen] = useState(false);


### PR DESCRIPTION
## Description
Centralize scroll to top for personalization applications. This is a precursor to accessibility efforts around scrolling.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/6844

