### PR TITLE
Change afghanistan banner name for new version

### DIFF
--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -8,7 +8,7 @@ import VAPlusVetsModal from '../components/VAPlusVetsModal';
 const config = {
   announcements: [
     {
-      name: 'afghanistan-banner',
+      name: 'afghanistan-banner-v2',
       // Only the homepage (e.g. `/`).
       paths: /^(\/)$/,
       component: AfghanistanPromoBanner,


### PR DESCRIPTION
## Description
Some users dismissed the Afghanistan banner before the new version came out, and we want them to see the updated banner.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/30048


## Testing done
local

## Screenshots
<img width="1788" alt="Screen Shot 2021-09-16 at 3 22 03 PM" src="https://user-images.githubusercontent.com/3144003/133672749-14237a28-7661-4350-926f-7a0dd7c2bb04.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
