### PR TITLE
Removed jsonschema - duplicate dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,7 +181,6 @@
     "isomorphic-fetch": "^2.2.1",
     "jsdoc": "^3.6.7",
     "jsdom": "^15.2.1",
-    "jsonschema": "^1.1.1",
     "just-diff": "^3.1.1",
     "lint-staged": "^11.1.2",
     "mini-css-extract-plugin": "^0.9.0",


### PR DESCRIPTION
## Description
Removed because it's a duplicate dependency

## Testing done
Locally

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
