### PR TITLE
Centralize the scroll inside the scrollToEnrollment function

### DIFF
--- a/src/applications/post-911-gib-status/components/EnrollmentPeriod.jsx
+++ b/src/applications/post-911-gib-status/components/EnrollmentPeriod.jsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Scroll from 'react-scroll';
 
 import InfoPair from './InfoPair';
 
 import { formatDateParsedZoneShort } from 'platform/utilities/date';
 import { getScrollOptions } from 'platform/utilities/ui';
-
-const scroller = Scroll.scroller;
+import scrollTo from 'platform/utilities/ui/scrollTo';
 
 class EnrollmentPeriod extends React.Component {
   constructor() {
@@ -23,7 +21,7 @@ class EnrollmentPeriod extends React.Component {
       delay: 2,
       smooth: true,
     });
-    scroller.scrollTo(this.props.id, options);
+    scrollTo(this.props.id, options);
   }
 
   toggleHistory() {


### PR DESCRIPTION
## Description
Centralize scroll inside `scrollToEnrollment` function as a precursor to accessibility efforts around scrolling.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/6844