### PR TITLE
Github Actions (CI) -- Fix notify failure

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,7 +8,7 @@ on:
       - '**'
 
 env:
-  CHANNEL_ID: C37M86Y8G #devops-deploys
+  DEVOPS_CHANNEL_ID: C37M86Y8G #devops-deploys
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
   NEXUS_REGISTRY: https://devops.va.gov/dots-nexus/repository/platform-npm-group-nocache/
 
@@ -991,4 +991,4 @@ jobs:
           slack_app_token: ${{ env.SLACK_APP_TOKEN }}
           slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
           attachments: '[{"mrkdwn_in": ["text"], "color": "danger", "text": "vets-website master branch CI failed!: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}>"}]'
-          channel_id: ${{ env.CHANNEL_ID }}
+          channel_id: ${{ env.DEVOPS_CHANNEL_ID }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -947,7 +947,7 @@ jobs:
   notify-failure:
     name: Notify Failure
     runs-on: ubuntu-latest
-    if: ${{ failure() || cancelled() }}
+    if: ${{ github.ref == 'refs/heads/master' && (failure() || cancelled()) }}
     needs: deploy
 
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -986,7 +986,6 @@ jobs:
           path: ./.github/actions/vsp-github-actions
 
       - name: Notify Slack
-        if: ${{ env.DSVA_SCHEDULE_ENABLED == 'true' }}
         uses: ./.github/actions/vsp-github-actions/slack-socket
         with:
           slack_app_token: ${{ env.SLACK_APP_TOKEN }}


### PR DESCRIPTION
## Description

It looks like the `if` statement block was not removed on `notify-failure`.

I also notice that `build` is firing despite it not being explicitly called. I suspected since `CHANNEL_ID` is global, it must be treating it as an array
