### PR TITLE
Github Actions (daily-deploy & CI) -- Slack notification continue-on-error

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -136,6 +136,7 @@ jobs:
       - name: Notify Slack about build failures
         if: ${{ failure() }}
         uses: ./.github/actions/vsp-github-actions/slack-socket
+        continue-on-error: true
         env:
           SSL_CERT_DIR: /etc/ssl/certs
         with:
@@ -679,6 +680,7 @@ jobs:
       - name: Notify Slack about Cypress test failures
         if: ${{ needs.cypress-tests.result == 'failure' }}
         uses: ./.github/actions/vsp-github-actions/slack-socket
+        continue-on-error: true
         env:
           SSL_CERT_DIR: /etc/ssl/certs
         with:
@@ -987,6 +989,7 @@ jobs:
 
       - name: Notify Slack
         uses: ./.github/actions/vsp-github-actions/slack-socket
+        continue-on-error: true
         with:
           slack_app_token: ${{ env.SLACK_APP_TOKEN }}
           slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -140,6 +140,7 @@ jobs:
 
       - name: Notify Slack
         uses: ./.github/actions/vsp-github-actions/slack-socket
+        continue-on-error: true
         with:
           slack_app_token: ${{ env.SLACK_APP_TOKEN }}
           slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}
@@ -264,6 +265,7 @@ jobs:
     - name: Notify Slack
       if: ${{ env.DSVA_SCHEDULE_ENABLED == 'true' }}
       uses: ./.github/actions/vsp-github-actions/slack-socket
+      continue-on-error: true
       with:
         slack_app_token: ${{ env.SLACK_APP_TOKEN }}
         slack_bot_token: ${{ env.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Description

This PR mirrors similarly how it is in Jenkins. Jenkins uses a `try/catch` to handle notification error, but GHA uses `continue-on-error`. Added where applicable

## Original issue(s)

department-of-veterans-affairs/va.gov-team#30099


## Testing done

Latest
