### PR TITLE
Refactor communication group and item filtering

### DIFF
--- a/src/applications/personalization/profile/components/notification-settings/NotificationGroup.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationGroup.jsx
@@ -1,12 +1,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import {
-  makeRxTrackingItemFilter,
-  selectGroupById,
-} from '@@profile/ducks/communicationPreferences';
+import { selectGroupById } from '@@profile/ducks/communicationPreferences';
 import { selectCommunicationPreferences } from '@@profile/reducers';
-import { selectPatientFacilities } from '~/platform/user/selectors';
 
 import NotificationItem from './NotificationItem';
 
@@ -26,13 +22,12 @@ const NotificationGroup = ({ children, groupName, itemIds }) => {
 };
 
 const mapStateToProps = (state, ownProps) => {
-  const facilities = selectPatientFacilities(state);
   const communicationPreferencesState = selectCommunicationPreferences(state);
   const group = selectGroupById(
     communicationPreferencesState,
     ownProps.groupId,
   );
-  const itemIds = group.items.filter(makeRxTrackingItemFilter(facilities));
+  const itemIds = group.items;
   return {
     groupName: group.name,
     itemIds,

--- a/src/applications/personalization/profile/components/notification-settings/SelectNotificationOptionsAlert.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/SelectNotificationOptionsAlert.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+const SelectNotificationOptionsAlert = ({ firstChannelId }) => {
+  return (
+    <div data-testid="select-options-alert">
+      <va-alert status="warning">
+        <h2 slot="headline">Select your notification options</h2>
+        <p>
+          We’ve added notification options to your profile. Tell us how you’d
+          like us to contact you.
+        </p>
+        <p>
+          <a
+            href={`#${firstChannelId}`}
+            className="vads-u-text-decoration--none vads-u-padding--1 vads-u-margin-left--neg1 vads-u-margin-top--neg1 vads-u-margin-bottom--neg1"
+          >
+            <i
+              aria-hidden="true"
+              className="fas fa-arrow-down vads-u-margin-right--1"
+            />{' '}
+            Select your notification options
+          </a>
+        </p>
+      </va-alert>
+    </div>
+  );
+};
+
+export default SelectNotificationOptionsAlert;


### PR DESCRIPTION
## Description
This change move all of the communication group and item filtering and sorting to the logic that fires after the API data is originally fetched. Previously this logic was spread across selectors and reducers, which lead to a duplication of some logic. This change dramatically simplifies the selector logic because the filtering has already been done in the reducers.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs