### PR TITLE
Fix removeDeeplyEmptyObjects bug

### DIFF
--- a/src/platform/utilities/data/removeDeeplyEmptyObjects.js
+++ b/src/platform/utilities/data/removeDeeplyEmptyObjects.js
@@ -21,6 +21,10 @@ export default function removeDeeplyEmptyObjects(root, checkEmpty = isEmpty) {
   if (typeof root !== 'object' || root === null) {
     return root;
   }
+  if (Array.isArray(root)) {
+    // see va.gov-team/issues/30211
+    return root.map(arrayItem => removeDeeplyEmptyObjects(arrayItem));
+  }
 
   let newRoot = root;
   const emptyKeys = Object.keys(newRoot).filter(key => {

--- a/src/platform/utilities/tests/data.unit.spec.js
+++ b/src/platform/utilities/tests/data.unit.spec.js
@@ -505,7 +505,37 @@ describe('data utils', () => {
       };
       expect(removeDeeplyEmptyObjects(data)).to.eql({});
     });
+    it('should not remove empty objects in an array', () => {
+      const data = {
+        int: 1,
+        obj: {
+          foo: 'bar',
+          nestedObj: {
+            nestedArray: [0, 2, 4],
+          },
+          empty: {},
+        },
+        string: 'string!',
+        array1: [{ item: '0' }, {}, { item: '2' }, { empty: {} }],
+        array2: ['0', 1, null, { s: 'thing', o: { k: 'nested', empty: {} } }],
+        // eslint-disable-next-line func-names, object-shorthand
+        func: function() {
+          return this.int;
+        },
+        arrowFunction: () => this.int,
+      };
+      expect(removeDeeplyEmptyObjects(data)).to.eql({
+        ...data,
+        obj: {
+          foo: 'bar',
+          nestedObj: data.obj.nestedObj,
+        },
+        array1: [{ item: '0' }, {}, { item: '2' }, {}],
+        array2: ['0', 1, null, { s: 'thing', o: { k: 'nested' } }],
+      });
+    });
   });
+
   describe('deduplicate', () => {
     it('should return a list of unique items', () => {
       const uniques = deduplicate([1, 1, 2, 2, 3, 3, 4, 4, 5, 5]);

--- a/src/platform/utilities/tests/data.unit.spec.js
+++ b/src/platform/utilities/tests/data.unit.spec.js
@@ -517,7 +517,19 @@ describe('data utils', () => {
         },
         string: 'string!',
         array1: [{ item: '0' }, {}, { item: '2' }, { empty: {} }],
-        array2: ['0', 1, null, { s: 'thing', o: { k: 'nested', empty: {} } }],
+        array2: [
+          '0',
+          1,
+          null,
+          {
+            s: 'thing',
+            o: {
+              k: 'nested',
+              empty: {},
+              array3: [{ a: '3', b: '4', empty: {}, empty2: [] }],
+            },
+          },
+        ],
         // eslint-disable-next-line func-names, object-shorthand
         func: function() {
           return this.int;
@@ -531,7 +543,12 @@ describe('data utils', () => {
           nestedObj: data.obj.nestedObj,
         },
         array1: [{ item: '0' }, {}, { item: '2' }, {}],
-        array2: ['0', 1, null, { s: 'thing', o: { k: 'nested' } }],
+        array2: [
+          '0',
+          1,
+          null,
+          { s: 'thing', o: { k: 'nested', array3: [{ a: '3', b: '4' }] } },
+        ],
       });
     });
   });


### PR DESCRIPTION
## Description

While troubleshooting a JS error that shows up during submission, I found a fun bug in the `src/platform/utilities/data/removeDeeplyEmptyObjects` function. If you pass in 

```js
{
  array: [ { test: '1' }, {}, { test: '3' } ],
}
```

it returns an object:

```js
{
  array: {
    0: { test: '1' },
    2: { test: '3' },
  },
}
```

## Original issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/30211
- Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/30154 - The submit transformer is trying to run `map` on an array that was converted into an object

## Testing done

- Added unit tests
- Ran 526 unit tests (all pass)

## Screenshots

N/A

## Acceptance criteria
- [x] Empty objects within an array root are not removed
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
