### PR TITLE
Add conditional default scroll values to platform/utilities/ui scroll…

### DIFF
--- a/src/platform/forms-system/src/js/utilities/ui/index.js
+++ b/src/platform/forms-system/src/js/utilities/ui/index.js
@@ -100,12 +100,12 @@ export function setGlobalScroll() {
 // Allows smooth scrolling to be overridden by our E2E tests
 export function getScrollOptions(additionalOptions) {
   const globals = window.Forms || {};
-  const reduced = window?.matchMedia('(prefers-reduced-motion: reduce)')
+  const reducedMotion = window?.matchMedia('(prefers-reduced-motion: reduce)')
     ?.matches;
   const defaults = {
-    duration: reduced ? 0 : 500,
+    duration: reducedMotion ? 0 : 500,
     delay: 0,
-    smooth: !reduced,
+    smooth: !reducedMotion,
   };
   return Object.assign({}, defaults, globals.scroll, additionalOptions);
 }

--- a/src/platform/forms-system/src/js/utilities/ui/index.js
+++ b/src/platform/forms-system/src/js/utilities/ui/index.js
@@ -100,10 +100,12 @@ export function setGlobalScroll() {
 // Allows smooth scrolling to be overridden by our E2E tests
 export function getScrollOptions(additionalOptions) {
   const globals = window.Forms || {};
+  const reduced = window?.matchMedia('(prefers-reduced-motion: reduce)')
+    ?.matches;
   const defaults = {
-    duration: 500,
+    duration: reduced ? 0 : 500,
     delay: 0,
-    smooth: true,
+    smooth: !reduced,
   };
   return Object.assign({}, defaults, globals.scroll, additionalOptions);
 }

--- a/src/platform/utilities/ui/index.js
+++ b/src/platform/utilities/ui/index.js
@@ -35,12 +35,12 @@ export function focusElement(selectorOrElement, options) {
 // Allows smooth scrolling to be overridden by our E2E tests
 export function getScrollOptions(additionalOptions) {
   const globals = window.VetsGov || {};
-  const reduced = window?.matchMedia('(prefers-reduced-motion: reduce)')
+  const reducedMotion = window?.matchMedia('(prefers-reduced-motion: reduce)')
     ?.matches;
   const defaults = {
-    duration: reduced ? 0 : 500,
+    duration: reducedMotion ? 0 : 500,
     delay: 0,
-    smooth: !reduced,
+    smooth: !reducedMotion,
   };
   return Object.assign({}, defaults, globals.scroll, additionalOptions);
 }

--- a/src/platform/utilities/ui/index.js
+++ b/src/platform/utilities/ui/index.js
@@ -35,10 +35,12 @@ export function focusElement(selectorOrElement, options) {
 // Allows smooth scrolling to be overridden by our E2E tests
 export function getScrollOptions(additionalOptions) {
   const globals = window.VetsGov || {};
+  const reduced = window?.matchMedia('(prefers-reduced-motion: reduce)')
+    ?.matches;
   const defaults = {
-    duration: 500,
+    duration: reduced ? 0 : 500,
     delay: 0,
-    smooth: true,
+    smooth: !reduced,
   };
   return Object.assign({}, defaults, globals.scroll, additionalOptions);
 }


### PR DESCRIPTION
… options

## Description
This PR adds conditional scrolling options that will disable smooth scrolling if a user has set that they prefer reduced motion.

## Original issue(s)
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/312

## Testing done



