### PR TITLE
526: Add tests for form 781 submit transformer

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/utils/submit.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/utils/submit.unit.spec.js
@@ -11,6 +11,7 @@ import {
   setActionTypes,
   filterServicePeriods,
   cleanUpPersonsInvolved,
+  addForm0781,
 } from '../../utils/submit';
 import {
   PTSD_INCIDENT_ITERATION,
@@ -310,6 +311,155 @@ describe('cleanUpPersonsInvolved', () => {
           description: 'should not change',
         },
       ],
+    });
+  });
+});
+
+describe('addForm0781', () => {
+  it('should return an empty object', () => {
+    expect(addForm0781({})).to.deep.equal({});
+  });
+  it('should skip empty entries', () => {
+    const data = {
+      incident0: {
+        incidentLocation: {
+          country: 'USA',
+          state: 'AL',
+          city: 'asdf',
+          additionalDetails: 'Additional details here.',
+        },
+        incidentDescription: 'A thing happened.',
+        personsInvolved: [
+          {
+            'view:serviceMember': true,
+            name: { first: 'First', middle: 'Middle', last: 'Last' },
+            injuryDeath: 'injuredNonBattle',
+            injuryDeathDate: '2010-05-01',
+            description: 'description 0',
+          },
+          {
+            name: {},
+          },
+          {
+            'view:serviceMember': false,
+            name: {},
+            injuryDeath: 'other',
+            injuryDeathOther: 'Some other',
+            description: 'description 2',
+          },
+        ],
+        unitAssigned: 'Unit name here',
+        unitAssignedDates: {
+          from: '2010-01-01',
+          to: '2011-01-01',
+        },
+        incidentDate: '2010-05-01',
+        medalsCitations: 'None',
+      },
+      incident1: {
+        incidentLocation: {
+          country: 'USA',
+        },
+      },
+      incident2: {
+        incidentLocation: {
+          country: 'USA',
+        },
+      },
+      secondaryIncident0: {
+        incidentLocation: {
+          country: 'USA',
+        },
+      },
+      secondaryIncident1: {
+        incidentLocation: {
+          country: 'USA',
+        },
+      },
+      secondaryIncident2: {
+        incidentLocation: {
+          country: 'USA',
+        },
+      },
+      additionalRemarks781: 'additionalRemarks781',
+      additionalIncidentText: 'additionalIncidentText',
+      additionalSecondaryIncidentText: 'additionalSecondaryIncidentText',
+      physicalChanges: { lethargy: true },
+      mentalChanges: { fear: true },
+      workBehaviorChanges: { increasedLeave: true },
+      socialBehaviorChanges: { unexplained: true },
+      additionalChanges: {},
+    };
+
+    expect(addForm0781(data)).to.deep.equal({
+      form0781: {
+        incidents: [
+          {
+            incidentDescription: 'A thing happened.',
+            personsInvolved: [
+              {
+                'view:serviceMember': true,
+                name: { first: 'First', middle: 'Middle', last: 'Last' },
+                injuryDeath: 'injuredNonBattle',
+                injuryDeathDate: '2010-05-01',
+                description: 'description 0',
+              },
+              {
+                name: { first: '', middle: '', last: '' },
+                injuryDeath: 'other',
+                injuryDeathOther: 'Entry left blank',
+              },
+              {
+                'view:serviceMember': false,
+                name: { first: '', middle: '', last: '' },
+                injuryDeath: 'other',
+                injuryDeathOther: 'Some other',
+                description: 'description 2',
+              },
+            ],
+            incidentLocation: {
+              additionalDetails: 'Additional details here.',
+              city: 'asdf',
+              country: 'USA',
+              state: 'AL',
+            },
+            unitAssigned: 'Unit name here',
+            unitAssignedDates: { from: '2010-01-01', to: '2011-01-01' },
+            incidentDate: '2010-05-01',
+            medalsCitations: 'None',
+            personalAssault: false,
+          },
+          {
+            incidentLocation: { country: 'USA' },
+            personalAssault: false,
+          },
+          {
+            incidentLocation: { country: 'USA' },
+            personalAssault: false,
+          },
+          {
+            incidentLocation: { country: 'USA' },
+            personalAssault: true,
+          },
+          {
+            incidentLocation: { country: 'USA' },
+            personalAssault: true,
+          },
+          {
+            incidentLocation: { country: 'USA' },
+            personalAssault: true,
+          },
+        ],
+        additionalIncidentText: 'additionalIncidentText',
+        additionalSecondaryIncidentText: 'additionalSecondaryIncidentText',
+        otherInformation: [
+          'Lethargy',
+          'Unexplained social behavior changes',
+          'Increased fear of surroundings, inability to go to certain areas',
+          'Increased use of leave',
+        ],
+        remarks: 'additionalRemarks781',
+      },
     });
   });
 });

--- a/src/applications/disability-benefits/all-claims/utils/submit.js
+++ b/src/applications/disability-benefits/all-claims/utils/submit.js
@@ -254,7 +254,7 @@ export const stringifyRelatedDisabilities = formData => {
   return clonedData;
 };
 
-export const cleanUpPersonsInvolved = incident => {
+export const cleanUpPersonsInvolved = (incident = {}) => {
   // We don't want to require any PTSD entries, but EVSS is rejecting any
   // personsInvolved that don't have a "injuryDeath" type set. So we're
   // setting blank entries to "other" and adding a generic other description
@@ -276,10 +276,7 @@ export const cleanUpPersonsInvolved = incident => {
           injuryDeathOther: person.injuryDeathOther || 'Entry left blank',
         };
   });
-  return {
-    ...incident,
-    personsInvolved,
-  };
+  return personsInvolved?.length ? { ...incident, personsInvolved } : incident;
 };
 
 // Remove extra data that may be included


### PR DESCRIPTION
## Description

While looking for the source of a Sentry error event `t.map is not a function`, a bug in the function that removes empty objects was found (see links below). Additionally, the submit transformer for adding form 0781 content was missing. So this PR adds the missing unit tests.

## Original issue(s)

- Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/30154
- Sentry error - http://sentry.vfs.va.gov/organizations/vsp/issues/49505
- Bug report - https://github.com/department-of-veterans-affairs/va.gov-team/issues/30211
- Fix - https://github.com/department-of-veterans-affairs/vets-website/pull/18806

## Testing done

Added unit tests for form 781 submit transformer

## Screenshots

N/A

## Acceptance criteria
- [x] Unit tests for form 781 submit transformer added
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
