### PR TITLE
526: Remove empty ratedDisabilities from submission

### DIFF
--- a/src/applications/disability-benefits/all-claims/submit-transformer.js
+++ b/src/applications/disability-benefits/all-claims/submit-transformer.js
@@ -61,7 +61,7 @@ export function transform(formConfig, form) {
     );
 
   const addBackRatedDisabilities = formData =>
-    savedRatedDisabilities
+    savedRatedDisabilities?.length
       ? _.set('ratedDisabilities', savedRatedDisabilities, formData)
       : formData;
 

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-bdd-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-bdd-test.json
@@ -152,6 +152,7 @@
           "view:descriptionInfo": {}
         }
       ],
+      "ratedDisabilities": [],
       "view:disabilitiesClarification": {},
       "serviceInformation": {
         "reservesNationalGuardService": {

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/minimal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/minimal-test.json
@@ -19,6 +19,7 @@
     "view:contactInfoDescription": {},
     "view:hasEvidence": false,
     "view:powStatus": false,
+    "newDisabilities": [],
     "ratedDisabilities": [
       {
         "name": "Diabetes mellitus0",

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/newOnly-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/newOnly-test.json
@@ -66,6 +66,7 @@
         "view:descriptionInfo": {}
       }
     ],
+    "ratedDisabilities": [],
     "view:hasAlternateName": true,
     "alternateNames": [
       {


### PR DESCRIPTION
## Description

When 526 is submitted with an empty `ratedDisabilities` array, there is a validation error. This PR adds a check and updates the mock data to check this issue.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/30236

## Testing done

Updated mock data

## Screenshots

N/A

## Acceptance criteria
- [x] Remove empty `ratedDisabilities` value when submitting
- [x] All tests pass 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
