### PR TITLE
Add extra logging for clinic failures

### DIFF
--- a/src/applications/vaos/services/patient/index.js
+++ b/src/applications/vaos/services/patient/index.js
@@ -411,7 +411,11 @@ export async function fetchFlowEligibilityAndClinics({
     if (!results.clinics.length) {
       eligibility.direct = false;
       eligibility.directReasons.push(ELIGIBILITY_REASONS.noClinics);
-      recordEligibilityFailure('direct-available-clinics');
+      recordEligibilityFailure(
+        'direct-available-clinics',
+        typeOfCare?.id,
+        location?.id,
+      );
     }
 
     if (


### PR DESCRIPTION
## Description
We see the no clinics eligibility check fail most often, this fills in some extra info we can use to try to narrow that down

## Original issue(s)
department-of-veterans-affairs/va.gov-team#29647

## Acceptance criteria
- [ ] Build passes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
