### PR TITLE
526: Content update

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/SelectArrayItemsWidget.jsx
+++ b/src/applications/disability-benefits/all-claims/components/SelectArrayItemsWidget.jsx
@@ -227,7 +227,7 @@ SelectArrayItemsWidget.propTypes = {
   value: PropTypes.arrayOf(
     PropTypes.shape({
       name: PropTypes.string.isRequired,
-      ratingPercentage: PropTypes.number.isRequired,
+      ratingPercentage: PropTypes.number,
       decisionCode: PropTypes.string.isRequired,
       decisionText: PropTypes.string.isRequired,
     }),
@@ -235,7 +235,7 @@ SelectArrayItemsWidget.propTypes = {
   updatedRatedDisabilities: PropTypes.arrayOf(
     PropTypes.shape({
       name: PropTypes.string.isRequired,
-      ratingPercentage: PropTypes.number.isRequired,
+      ratingPercentage: PropTypes.number,
       decisionCode: PropTypes.string.isRequired,
       decisionText: PropTypes.string.isRequired,
     }),

--- a/src/applications/disability-benefits/all-claims/components/SelectArrayItemsWidget.jsx
+++ b/src/applications/disability-benefits/all-claims/components/SelectArrayItemsWidget.jsx
@@ -33,13 +33,13 @@ class SelectArrayItemsWidget extends React.Component {
     this.props.onChange(items);
   };
 
-  processRatedDisabilityUpdates = () => {
+  processRatedDisabilityUpdates = updatedDisabilities => {
     const { formId, value, formData, metadata } = this.props;
 
     // Whenever the rated disabilities are updated, `updatedRatedDisabilities`
     // is added to the data. This bit of code ensures that exactly matching
     // previously selected entries are still selected
-    const updatedItems = formData[this.updatedKeyValue].map(newValue => {
+    const updatedItems = updatedDisabilities.map(newValue => {
       const hasItem = (value || []).find(oldValue =>
         this.keyConstants.every(key => oldValue?.[key] === newValue?.[key]),
       );
@@ -82,9 +82,10 @@ class SelectArrayItemsWidget extends React.Component {
       formData,
     } = this.props;
 
+    const updatedDisabilities = formData[this.updatedKeyValue];
     // rated disabilities updated on the backend
-    if (Array.isArray(formData[this.updatedKeyValue])) {
-      this.processRatedDisabilityUpdates();
+    if (Array.isArray(updatedDisabilities) && updatedDisabilities.length) {
+      this.processRatedDisabilityUpdates(updatedDisabilities);
     }
 
     // Need customTitle to set error message above title.

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -221,7 +221,7 @@ const formConfig = {
           }),
         },
         reservesNationalGuardService: {
-          title: 'Reserves and National Guard service',
+          title: 'Reserve and National Guard service',
           path:
             'review-veteran-details/military-service-history/reserves-national-guard',
           depends: formData =>

--- a/src/applications/disability-benefits/all-claims/pages/federalOrders.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/federalOrders.jsx
@@ -24,7 +24,7 @@ export const uiSchema = {
     reservesNationalGuardService: {
       'view:isTitle10Activated': {
         'ui:title':
-          'Are you currently activated on federal orders in the Reserves or the National Guard?',
+          'Are you currently activated on federal orders in the Reserve or the National Guard?',
         'ui:widget': 'yesNo',
       },
       title10Activation: {

--- a/src/applications/disability-benefits/all-claims/pages/militaryDutyImpact.js
+++ b/src/applications/disability-benefits/all-claims/pages/militaryDutyImpact.js
@@ -9,13 +9,13 @@ export const uiSchema = {
     'ui:title': unemployabilityPageTitle('Impact on military duty'),
     disabilityPreventMilitaryDuties: {
       'ui:title':
-        'If you’re currently serving in the Reserves or the National Guard, does your service-connected disability prevent you from performing your military duties?',
+        'If you’re currently serving in the Reserve or the National Guard, does your service-connected disability prevent you from performing your military duties?',
       'ui:widget': 'radio',
       'ui:options': {
         labels: {
           yes: 'Yes',
           no: 'No',
-          reservesNo: 'I’m not serving in the Reserves or the National Guard.',
+          reservesNo: 'I’m not serving in the Reserve or the National Guard.',
         },
       },
       'ui:errorMessages': {

--- a/src/applications/disability-benefits/all-claims/pages/reservesNationalGuardService.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/reservesNationalGuardService.jsx
@@ -8,7 +8,7 @@ const {
 } = fullSchema.properties.serviceInformation.properties.reservesNationalGuardService;
 
 export const uiSchema = {
-  'ui:title': 'Reserves and National Guard Information',
+  'ui:title': 'Reserve and National Guard Information',
   'ui:description': ReservesGuardDescription,
   serviceInformation: {
     reservesNationalGuardService: {

--- a/src/applications/disability-benefits/all-claims/tests/components/SelectArrayItemsWidget.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/SelectArrayItemsWidget.unit.spec.jsx
@@ -3,9 +3,9 @@ import { expect } from 'chai';
 import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
 
-import { SelectArrayItemsWidget } from '../../components/SelectArrayItemsWidget';
-
 import get from 'platform/utilities/data/get';
+
+import { SelectArrayItemsWidget } from '../../components/SelectArrayItemsWidget';
 
 describe('<SelectArrayItemsWidget>', () => {
   let defaultProps = {};
@@ -150,7 +150,7 @@ describe('<SelectArrayItemsWidget>', () => {
         },
       ],
       formData: {
-        updatedRatedDisabilities: [],
+        updatedRatedDisabilities: [{}],
       },
       formId: '526',
       id: 'id',
@@ -175,7 +175,9 @@ describe('<SelectArrayItemsWidget>', () => {
     const wrapper = shallow(<SelectArrayItemsWidget {...initialProps} />);
     expect(autoSaveFormSpy.firstCall.args[0]).to.eql('526');
     expect(autoSaveFormSpy.firstCall.args[1]).to.deep.equal({
-      ratedDisabilities: [],
+      ratedDisabilities: [
+        { disabilityActionType: 'NONE', 'view:selected': false },
+      ],
     });
     expect(autoSaveFormSpy.firstCall.args[2]).to.eql(99);
     expect(autoSaveFormSpy.firstCall.args[3]).to.eql('/test');

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -476,7 +476,7 @@ export const validateTitle10StartDate = (
     });
   if (!startTimes[0] || dateString < startTimes[0]) {
     errors.addError(
-      'Your activation date must be after your earliest service start date for Reserves or National Guard',
+      'Your activation date must be after your earliest service start date for the Reserves or the National Guard',
     );
   }
 };

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -476,7 +476,7 @@ export const validateTitle10StartDate = (
     });
   if (!startTimes[0] || dateString < startTimes[0]) {
     errors.addError(
-      'Your activation date must be after your earliest service start date for the Reserves or the National Guard',
+      'Your activation date must be after your earliest service start date for the Reserve or the National Guard',
     );
   }
 };


### PR DESCRIPTION
## Description

- Update title 10 start date error message per content feedback recommendation
- Remove "s" from "Reserves" within the form
- Quick fix to ensure rated disabilities are only updated when the backend returns a non-empty array
- Remove `ratingPercentage` requirement (see screenshot)

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/29829

## Testing done

N/A

## Screenshots

<details><summary>Title10 error message</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-09-21 at 3 32 46 PM](https://user-images.githubusercontent.com/136959/134243445-3589cd48-a533-4345-8379-c73c15a49a15.png)
</details>

<details><summary>ratingPercentage error</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-09-21 at 1 00 11 PM](https://user-images.githubusercontent.com/136959/134244410-bc5960fc-7116-4120-95b4-7a57161c190d.png)
</details>

## Acceptance criteria
- [x] Error message matches content
- [x] Remove the "s" from "Reserves" in form 526
- [x] Fix rated disabilities updating
- [x] Remove `ratingPercentage` requirement

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
