### PR TITLE
remove references to the dashboard_2 feature flag

### DIFF
--- a/src/applications/personalization/dashboard/tests/e2e/appointments-error.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/appointments-error.cypress.spec.js
@@ -1,5 +1,4 @@
 import moment from 'moment';
-import { mockFeatureToggles } from './helpers';
 import { mockUser } from '@@profile/tests/fixtures/users/user';
 
 import ERROR_400 from '~/applications/personalization/dashboard/utils/mocks/ERROR_400';
@@ -47,7 +46,6 @@ describe('MyVA Dashboard - Appointments', () => {
   beforeEach(() => {
     mockLocalStorage();
     cy.login(mockUser);
-    mockFeatureToggles();
     getFacilitiesStub = cy.stub();
   });
   context('when there is a 500 error fetching VA appointments', () => {

--- a/src/applications/personalization/dashboard/tests/e2e/appointments.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/appointments.cypress.spec.js
@@ -9,7 +9,6 @@ import MOCK_VA_APPOINTMENTS from '../../utils/mocks/appointments/MOCK_VA_APPOINT
 import MOCK_CC_APPOINTMENTS from '../../utils/mocks/appointments/MOCK_CC_APPOINTMENTS';
 
 import moment from 'moment';
-import { mockFeatureToggles } from './helpers';
 import MOCK_FACILITIES from '../../utils/mocks/appointments/MOCK_FACILITIES.json';
 
 const startOfToday = () =>
@@ -39,7 +38,6 @@ describe('The My VA Dashboard - Appointments', () => {
   beforeEach(() => {
     mockLocalStorage();
     cy.login(mockUser);
-    mockFeatureToggles();
     cy.visit('my-va/');
     cy.intercept('/v0/profile/service_history', serviceHistory);
     cy.intercept('/v0/profile/full_name', fullName);

--- a/src/applications/personalization/dashboard/tests/e2e/benefits-of-interest.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/benefits-of-interest.cypress.spec.js
@@ -10,7 +10,6 @@ import {
   disabilityCompensationExists,
   educationBenefitExists,
   healthCareInfoExists,
-  mockFeatureToggles,
 } from './helpers';
 import { VA_FORM_IDS } from '~/platform/forms/constants';
 
@@ -30,7 +29,6 @@ describe('The My VA Dashboard', () => {
       cy.intercept('/v0/health_care_applications/enrollment_status', notInESR);
       cy.intercept('/v0/profile/ch33_bank_accounts', dd4eduNotEnrolled);
       cy.login(user);
-      mockFeatureToggles();
       cy.visit(manifest.rootUrl);
     });
     it('should show info about disability benefits, health care, and education benefits', () => {
@@ -57,7 +55,6 @@ describe('The My VA Dashboard', () => {
       );
       cy.intercept('/v0/profile/ch33_bank_accounts', dd4eduNotEnrolled);
       cy.login(user);
-      mockFeatureToggles();
       cy.visit(manifest.rootUrl);
     });
     it('should show info about disability benefits and education benefits, but not health care', () => {
@@ -77,7 +74,6 @@ describe('The My VA Dashboard', () => {
     beforeEach(() => {
       cy.intercept('/v0/profile/ch33_bank_accounts', dd4eduNotEnrolled);
       cy.login(makeMockUser());
-      mockFeatureToggles();
       cy.visit(manifest.rootUrl);
     });
     it('should show info about disability benefits and education benefits, but not health care', () => {
@@ -97,7 +93,6 @@ describe('The My VA Dashboard', () => {
     beforeEach(() => {
       cy.intercept('/v0/profile/ch33_bank_accounts', dd4eduEnrolled);
       cy.login(makeMockUser());
-      mockFeatureToggles();
       cy.visit(manifest.rootUrl);
     });
     it('should show info about disability benefits benefits, but not health care or education benefits', () => {
@@ -147,7 +142,6 @@ describe('The My VA Dashboard', () => {
       cy.intercept('/v0/health_care_applications/enrollment_status', notInESR);
       cy.intercept('/v0/profile/ch33_bank_accounts', getBankInfoStub);
       cy.login(user);
-      mockFeatureToggles();
       cy.visit(manifest.rootUrl);
     });
     it('should show info about disability benefits, health care, and not education benefits', () => {

--- a/src/applications/personalization/dashboard/tests/e2e/claims-and-appeals.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/claims-and-appeals.cypress.spec.js
@@ -9,8 +9,6 @@ import error500 from '@@profile/tests/fixtures/500.json';
 
 import manifest from '~/applications/personalization/dashboard/manifest.json';
 
-import { mockFeatureToggles } from './helpers';
-
 describe('The My VA Dashboard Claims and Appeals section', () => {
   beforeEach(() => {
     cy.login(mockUser);
@@ -29,7 +27,6 @@ describe('The My VA Dashboard Claims and Appeals section', () => {
         cy.intercept('/v0/appeals', appealsSuccess(10));
       });
       it('should show details about the updated claim because it was updated more recently than the appeal', () => {
-        mockFeatureToggles();
         cy.visit(manifest.rootUrl);
 
         // make sure that the Claims and Appeals section is shown
@@ -59,7 +56,6 @@ describe('The My VA Dashboard Claims and Appeals section', () => {
         cy.intercept('/v0/appeals', appealsSuccess(31));
       });
       it('should show a CTA but not details about the most recently updated claim or appeal ', () => {
-        mockFeatureToggles();
         cy.visit(manifest.rootUrl);
 
         // make sure that the Claims and Appeals section and CTA is shown
@@ -102,7 +98,6 @@ describe('The My VA Dashboard Claims and Appeals section', () => {
         });
       });
       it('should show an error in the Claims and Appeals section', () => {
-        mockFeatureToggles();
         cy.visit(manifest.rootUrl);
 
         // should show a loading indicator
@@ -136,7 +131,6 @@ describe('The My VA Dashboard Claims and Appeals section', () => {
         });
       });
       it('should hide the entire Claims and Appeals section', () => {
-        mockFeatureToggles();
         cy.visit(manifest.rootUrl);
 
         // should show a loading indicator

--- a/src/applications/personalization/dashboard/tests/e2e/downtime.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/downtime.cypress.spec.js
@@ -7,8 +7,6 @@ import appealsSuccess from '@@profile/tests/fixtures/appeals-success';
 
 import manifest from 'applications/personalization/dashboard/manifest.json';
 
-import { mockFeatureToggles } from './helpers';
-
 /**
  *
  * @param {boolean} mobile - test on a mobile viewport or not
@@ -27,7 +25,6 @@ describe('The My VA Dashboard', () => {
       '/v0/disability_compensation_form/rating_info',
       disabilityRating,
     );
-    mockFeatureToggles();
   });
   it('should show a dismissible modal if a dependent service has downtime approaching in the next hour', () => {
     // start time is one minute from now

--- a/src/applications/personalization/dashboard/tests/e2e/health-care-cerner.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/health-care-cerner.cypress.spec.js
@@ -1,7 +1,5 @@
 import enrollmentStatusEnrolled from '@@profile/tests/fixtures/enrollment-system/enrolled.json';
 
-import { mockFeatureToggles } from './helpers';
-
 import {
   makeUserObject,
   mockLocalStorage,
@@ -25,7 +23,6 @@ describe('MyVA Dashboard - Cerner Widget', () => {
         '/v0/health_care_applications/enrollment_status',
         enrollmentStatusEnrolled,
       );
-      mockFeatureToggles();
     });
     it('should not show the Cerner alert', () => {
       cy.visit('my-va/');
@@ -54,7 +51,6 @@ describe('MyVA Dashboard - Cerner Widget', () => {
         '/v0/health_care_applications/enrollment_status',
         enrollmentStatusEnrolled,
       );
-      mockFeatureToggles();
     });
     it('should show the Cerner alert', () => {
       cy.visit('my-va/');

--- a/src/applications/personalization/dashboard/tests/e2e/health-care-cta-gating.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/health-care-cta-gating.cypress.spec.js
@@ -1,7 +1,5 @@
 import enrollmentStatusEnrolled from '@@profile/tests/fixtures/enrollment-system/enrolled.json';
 
-import { mockFeatureToggles } from './helpers';
-
 import { mockFolderResponse } from '../../utils/mocks/messaging/folder';
 
 import {
@@ -30,8 +28,6 @@ describe('MyVA Dashboard - CTA Links', () => {
         enrollmentStatusEnrolled,
       );
       cy.intercept('GET', '/v0/messaging/health/folders/0', mockFolderResponse);
-
-      mockFeatureToggles();
     });
     it('should show the rx and messaging CTAs', () => {
       cy.visit('my-va/');
@@ -61,7 +57,6 @@ describe('MyVA Dashboard - CTA Links', () => {
         '/v0/health_care_applications/enrollment_status',
         enrollmentStatusEnrolled,
       );
-      mockFeatureToggles();
     });
     it('should not show the rx and messaging CTAs', () => {
       cy.visit('my-va/');

--- a/src/applications/personalization/dashboard/tests/e2e/helpers.js
+++ b/src/applications/personalization/dashboard/tests/e2e/helpers.js
@@ -1,22 +1,3 @@
-export const mockFeatureToggles = () => {
-  cy.server();
-  cy.route({
-    method: 'GET',
-    status: 200,
-    url: '/v0/feature_toggles*',
-    response: {
-      data: {
-        features: [
-          {
-            name: 'dashboard_show_dashboard_2',
-            value: true,
-          },
-        ],
-      },
-    },
-  });
-};
-
 // Helper to make sure that the "health care" info does or doesn't exist
 export function healthCareInfoExists(exists) {
   const assertion = exists ? 'exist' : 'not.exist';

--- a/src/applications/personalization/dashboard/tests/e2e/in-progress-forms.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/in-progress-forms.cypress.spec.js
@@ -5,8 +5,6 @@ import disabilityRating from '@@profile/tests/fixtures/disability-rating-success
 
 import manifest from 'applications/personalization/dashboard/manifest.json';
 
-import { mockFeatureToggles } from './helpers';
-
 describe('The My VA Dashboard', () => {
   const oneDayInSeconds = 24 * 60 * 60;
   const oneWeekInSeconds = 24 * 60 * 60 * 7;
@@ -102,7 +100,6 @@ describe('The My VA Dashboard', () => {
       ];
       mockUser.data.attributes.inProgressForms = savedForms;
       cy.login(mockUser);
-      mockFeatureToggles();
       cy.visit(manifest.rootUrl);
     });
     it('should show benefit applications that were saved in progress and have not expired', () => {
@@ -148,7 +145,6 @@ describe('The My VA Dashboard', () => {
       ];
       mockUser.data.attributes.inProgressForms = savedForms;
       cy.login(mockUser);
-      mockFeatureToggles();
       cy.visit(manifest.rootUrl);
     });
     it('should show fallback content when there are no benefit applications saved in progress', () => {

--- a/src/applications/personalization/dashboard/tests/e2e/loa1.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/loa1.cypress.spec.js
@@ -2,8 +2,6 @@ import loa1User from '@@profile/tests/fixtures/users/user-loa1.json';
 
 import manifest from '~/applications/personalization/dashboard/manifest.json';
 
-import { mockFeatureToggles } from './helpers';
-
 /**
  *
  * @param {boolean} mobile - test on a mobile viewport or not
@@ -14,7 +12,6 @@ import { mockFeatureToggles } from './helpers';
  * - checks that focus is managed correctly, and performs an aXe scan
  */
 function loa1DashboardTest(mobile, stubs) {
-  mockFeatureToggles();
   cy.visit(manifest.rootUrl);
 
   if (mobile) {

--- a/src/applications/personalization/dashboard/tests/e2e/loa3.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/loa3.cypress.spec.js
@@ -20,8 +20,6 @@ import MOCK_CC_APPOINTMENTS from '../../utils/mocks/appointments/MOCK_CC_APPOINT
 import { mockFolderResponse } from '../../utils/mocks/messaging/folder';
 import { mockMessagesResponse } from '../../utils/mocks/messaging/messages';
 
-import { mockFeatureToggles } from './helpers';
-
 /**
  *
  * @param {boolean} mobile - test on a mobile viewport or not
@@ -31,7 +29,6 @@ import { mockFeatureToggles } from './helpers';
  *   checks that focus is managed correctly, and performs an aXe scan
  */
 function loa3DashboardTest(mobile) {
-  mockFeatureToggles();
   cy.visit(manifest.rootUrl);
 
   if (mobile) {
@@ -100,7 +97,6 @@ describe('The My VA Dashboard', () => {
       });
     });
     it('should totally hide the disability rating in the header', () => {
-      mockFeatureToggles();
       cy.visit(manifest.rootUrl);
       nameTagRendersWithoutDisabilityRating();
       nameTagIsFocused();
@@ -114,7 +110,6 @@ describe('The My VA Dashboard', () => {
       });
     });
     it('should show the fallback link in the header', () => {
-      mockFeatureToggles();
       cy.visit(manifest.rootUrl);
       nameTagRendersWithFallbackLink();
       nameTagIsFocused();

--- a/src/applications/personalization/dashboard/tests/e2e/messaging-error.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/messaging-error.cypress.spec.js
@@ -1,5 +1,4 @@
 import ERROR_400 from '~/applications/personalization/dashboard/utils/mocks/ERROR_400';
-import { mockFeatureToggles } from './helpers';
 
 import {
   makeUserObject,
@@ -21,7 +20,6 @@ describe('MyVA Dashboard - Messaging', () => {
         statusCode: 400,
         body: ERROR_400,
       });
-      mockFeatureToggles();
     });
     it('should show the messaging link with the generic copy', () => {
       cy.visit('my-va/');

--- a/src/applications/personalization/dashboard/tests/e2e/mpi-connection-error.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/mpi-connection-error.cypress.spec.js
@@ -5,7 +5,6 @@ import {
   disabilityCompensationExists,
   educationBenefitExists,
   healthCareInfoExists,
-  mockFeatureToggles,
 } from './helpers';
 
 describe('MyVA Dashboard', () => {
@@ -14,7 +13,6 @@ describe('MyVA Dashboard', () => {
       mockLocalStorage();
 
       cy.login(mockMPIErrorUser);
-      mockFeatureToggles();
     });
     it('should show an MPI error in place of the claims/appeals and health care sections', () => {
       cy.visit('my-va/');

--- a/src/applications/personalization/profile/tests/e2e/helpers.js
+++ b/src/applications/personalization/profile/tests/e2e/helpers.js
@@ -63,10 +63,6 @@ export const mockFeatureToggles = () => {
       data: {
         features: [
           {
-            name: 'dashboard_show_dashboard_2',
-            value: true,
-          },
-          {
             name: 'profile_notification_settings',
             value: true,
           },

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/feature-toggles.json
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/feature-toggles.json
@@ -5,10 +5,6 @@
       {
         "name": "profile_notification_settings",
         "value": true
-      },
-      {
-        "name": "dashboard_show_dashboard_2",
-        "value": true
       }
     ]
   }


### PR DESCRIPTION
## Description
we no longer need to use this feature flag in the test since [the feature stopped being gated quite a while ago](https://github.com/department-of-veterans-affairs/vets-website/pull/17940).

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs