### PR TITLE
Fix Skip to Content link

### DIFF
--- a/src/applications/facility-locator/containers/FacilitiesMap.jsx
+++ b/src/applications/facility-locator/containers/FacilitiesMap.jsx
@@ -601,7 +601,7 @@ const FacilitiesMap = props => {
 
   return (
     <>
-      <div id="content">
+      <div>
         <div className="title-section">
           <h1>Find VA locations</h1>
         </div>

--- a/src/applications/facility-locator/containers/FacilitiesMap.jsx
+++ b/src/applications/facility-locator/containers/FacilitiesMap.jsx
@@ -601,7 +601,7 @@ const FacilitiesMap = props => {
 
   return (
     <>
-      <div>
+      <div id="content">
         <div className="title-section">
           <h1>Find VA locations</h1>
         </div>

--- a/src/platform/landing-pages/dev-template.ejs
+++ b/src/platform/landing-pages/dev-template.ejs
@@ -35,6 +35,17 @@
     <%= modifyScriptTags(htmlWebpackPlugin.tags.bodyTags) %>
 
     <script nonce="**CSP_NONCE**" type="text/javascript">
+      function scrollToContent(e) {
+        e.preventDefault();
+        e.target.hidden = true;
+        const contentRoot = document.querySelector('#content');
+        const contentH1 = document.querySelector('#content h1');
+        if (contentH1) {
+        window.scrollTo(0, contentH1.offsetTop);
+        } else {
+          window.scrollTo(0, contentRoot.offsetTop);
+        }
+      }
       window.VetsGov = window.VetsGov || {};
       window.VetsGov.headerFooter = <%= JSON.stringify(headerFooterData) %>;
     </script>
@@ -42,7 +53,7 @@
   </head>
 
   <body class="merger">
-    <a class="show-on-focus" href="#content">Skip to Content</a>
+    <a class="show-on-focus" href="#" onclick="scrollToContent(event)">Skip to Content</a>
 
     <header class="header">
       <div class="incompatible-browser-warning">
@@ -149,7 +160,7 @@
     <% } %>
 
     <!-- React root -->
-    <div id="react-root">
+    <div id="content">
       <main id="main" class="main">
         <% if (widgetType) { %>
           <div class="usa-grid usa-grid-full vads-u-padding-top--3">

--- a/src/platform/landing-pages/dev-template.ejs
+++ b/src/platform/landing-pages/dev-template.ejs
@@ -149,7 +149,7 @@
     <% } %>
 
     <!-- React root -->
-    <div id="content">
+    <div id="react-root">
       <main id="main" class="main">
         <% if (widgetType) { %>
           <div class="usa-grid usa-grid-full vads-u-padding-top--3">

--- a/src/platform/landing-pages/dev-template.ejs
+++ b/src/platform/landing-pages/dev-template.ejs
@@ -53,7 +53,7 @@
   </head>
 
   <body class="merger">
-    <a class="show-on-focus" href="#" onclick="scrollToContent(event)">Skip to Content</a>
+    <a class="show-on-focus" href="#content" onclick="scrollToContent(event)">Skip to Content</a>
 
     <header class="header">
       <div class="incompatible-browser-warning">

--- a/src/platform/landing-pages/dev-template.ejs
+++ b/src/platform/landing-pages/dev-template.ejs
@@ -1,3 +1,7 @@
+<!--
+  IMPORTANT: This template is only used when running vets-website in standalone mode for development.
+  Changes to this file must also be made to src/site/layouts/page-react.html in the content-build repository.
+-->
 <html lang="en">
   <head>
     <meta charset="utf-8">
@@ -35,16 +39,13 @@
     <%= modifyScriptTags(htmlWebpackPlugin.tags.bodyTags) %>
 
     <script nonce="**CSP_NONCE**" type="text/javascript">
-      function scrollToContent(e) {
+      function focusContent(e) {
         e.preventDefault();
         e.target.hidden = true;
-        const contentRoot = document.querySelector('#content');
-        const contentH1 = document.querySelector('#content h1');
-        if (contentH1) {
-          window.scrollTo(0, contentH1.offsetTop);
-        } else {
-          window.scrollTo(0, contentRoot.offsetTop);
-        }
+        const contentElement = document.querySelector('#content h1') || document.querySelector('#content');
+        contentElement.setAttribute('tabindex', '-1');
+        window.scrollTo(0, contentElement.offsetTop);
+        contentElement.focus();
       }
       window.VetsGov = window.VetsGov || {};
       window.VetsGov.headerFooter = <%= JSON.stringify(headerFooterData) %>;
@@ -53,7 +54,7 @@
   </head>
 
   <body class="merger">
-    <a class="show-on-focus" href="#content" onclick="scrollToContent(event)">Skip to Content</a>
+    <a class="show-on-focus" href="#content" onclick="focusContent(event)">Skip to Content</a>
 
     <header class="header">
       <div class="incompatible-browser-warning">

--- a/src/platform/landing-pages/dev-template.ejs
+++ b/src/platform/landing-pages/dev-template.ejs
@@ -44,6 +44,9 @@
         e.target.hidden = true;
         const contentElement = document.querySelector('#content h1') || document.querySelector('#content');
         contentElement.setAttribute('tabindex', '-1');
+        contentElement.addEventListener('blur', (event) => {
+          event.target.removeAttribute('tabindex');
+        }, true);
         window.scrollTo(0, contentElement.offsetTop);
         contentElement.focus();
       }

--- a/src/platform/landing-pages/dev-template.ejs
+++ b/src/platform/landing-pages/dev-template.ejs
@@ -41,7 +41,7 @@
         const contentRoot = document.querySelector('#content');
         const contentH1 = document.querySelector('#content h1');
         if (contentH1) {
-        window.scrollTo(0, contentH1.offsetTop);
+          window.scrollTo(0, contentH1.offsetTop);
         } else {
           window.scrollTo(0, contentRoot.offsetTop);
         }


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/va.gov-team/issues/27445

TL:DR - the Skip to Content link currently skips to the breadcrumbs, which is confusing for non-sighted users.
This change makes it skip to the first H1 on the page, if one exists. If not, the current behavior is preserved.
To access the Skip to Content link you must use a screen reader navigator or hit shift-TAB several times.