### PR TITLE
Add another staging site to ignore errors from

### DIFF
--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -97,7 +97,7 @@ const PAST_APPOINTMENTS_HIDDEN_SET = new Set([
 // We want to throw an error for any partial results errors from MAS,
 // but some sites in staging always errors. So, keep those in a list to
 // ignore errors from
-const BAD_STAGING_SITES = new Set(['556']);
+const BAD_STAGING_SITES = new Set(['556', '612']);
 function hasPartialResults(response) {
   return (
     response.errors?.length > 0 &&


### PR DESCRIPTION
## Description
This ignores partial results errors from 612 in staging, since one of our test patients was registered there.

## Acceptance criteria
- [ ] Build passes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
