### PR TITLE
NOD: Add SOC/SSOC info

### DIFF
--- a/src/applications/appeals/10182/content/additionalIssues.jsx
+++ b/src/applications/appeals/10182/content/additionalIssues.jsx
@@ -36,8 +36,10 @@ export const AdditionalIssuesLabel = (
     <span className="vads-u-font-weight--normal vads-u-font-size--base vads-u-font-family--sans">
       Add an issue and our decision date on this issue. You can find the
       decision date on your decision notice (the letter you got in the mail from
-      us). You can request a Board Appeal up to 1 year from the date on your
-      decision notice.
+      us). If you are opting-in from a Statement of the Case (SOC) or
+      Supplemental Statement of the Case (SSOC), the decision date is the date
+      of the SOC/SSOC notice letter. You can request a Board Appeal up to 1 year
+      from the date on your decision notice.
     </span>
     <p className="vads-u-font-weight--normal vads-u-font-size--base vads-u-font-family--sans">
       <strong>Note:</strong> You can only add an issue that you’ve already


### PR DESCRIPTION
## Description

The Board requested some additional changes to the additional issues page content.

> Add an issue and your decision date on this issue. You can find the decision date on your decision notice (the letter you got in the mail from us). If you are opting-in from a SOC/SSOC, the decision date is the date of the SOC/SSOC notice letter.

In addition, I defined SOC/SSOC as it was not already defined on the page - see the screenshot - per the [design system best practices](https://design.va.gov/content-style-guide/abbreviations-and-acronyms#acronyms)

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/30257

## Testing done

N/A

## Screenshots

![Screen Shot 2021-09-22 at 9 11 49 AM](https://user-images.githubusercontent.com/136959/134362446-428fe8d4-2e30-4051-adef-ac94c688afe4.png)

## Acceptance criteria
- [x] Add SOC/SSOC context to additional issues page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
