### PR TITLE
NOD: Remove DC-specific reference

### DIFF
--- a/src/applications/appeals/10182/content/hearingType.js
+++ b/src/applications/appeals/10182/content/hearingType.js
@@ -9,8 +9,8 @@ export const hearingTypeContent = {
         You can attend your hearing on a computer, mobile phone, or tablet from
         a location you choose. You just need to be somewhere that has a Wi-Fi
         connection. Your accredited representative can be with you or in a
-        separate location. The Veterans Law Judge will be located in Washington,
-        D.C.
+        separate location. The Veterans Law Judge will be located in a separate
+        location.
       </p>
     </>
   ),
@@ -21,7 +21,7 @@ export const hearingTypeContent = {
       <p className="hide-on-review">
         You and your accredited representative can attend your hearing by video
         at a VA regional office near you. The Veterans Law Judge will be located
-        in Washington, D.C.
+        in a separate location.
       </p>
       <p className="hide-on-review">
         <strong>Note:</strong> Fewer Veterans will be able to use this option


### PR DESCRIPTION
## Description

For the Notice of Disagreement tele-hearing and video hearing options, it’s not actually accurate anymore to say the VLJ will be located in Washington, D.C., as most VLJs are conducting these hearings from home and could be living outside of Washington, D.C.  Change both options to “The Veterans Law Judge will be located in a separate location.”

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/30250

## Testing done

N/A

## Screenshots

![Screen Shot 2021-09-22 at 9 48 25 AM](https://user-images.githubusercontent.com/136959/134366458-3a27ec2a-8c7c-416b-8eca-14e5ea9f0848.png)

## Acceptance criteria
- [x] Remove DC-specific reference in Board review options

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
