### PR TITLE
Disable autocorrect & spellcheck on lastName field

### DIFF
--- a/src/applications/check-in/pages/ValidateVeteran.jsx
+++ b/src/applications/check-in/pages/ValidateVeteran.jsx
@@ -66,12 +66,14 @@ const ValidateVeteran = props => {
       <p>We need some information to verify your identity to check you in.</p>
       <form onSubmit={() => false}>
         <VaTextInput
+          autoCorrect="false"
+          error={lastNameErrorMessage}
           label="Your last name"
           name="last-name"
-          value={lastName}
           onVaChange={event => setLastName(event.detail.value)}
           required
-          error={lastNameErrorMessage}
+          spellCheck="false"
+          value={lastName}
         />
         <VaTextInput
           label="Last 4 digits of your Social Security number"

--- a/src/applications/check-in/tests/e2e/phase-2-mvp/extra-validation/autocorrect.is.disabled.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-2-mvp/extra-validation/autocorrect.is.disabled.cypress.spec.js
@@ -1,0 +1,27 @@
+import mockSession from '../../../../api/local-mock-api/mocks/v1/sessions.responses';
+
+describe('Check In Experience -- ', () => {
+  describe('phase 2 -- ', () => {
+    beforeEach(function() {
+      cy.intercept('GET', '/check_in/v1/sessions/*', req => {
+        req.reply(
+          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
+        );
+      });
+    });
+    afterEach(() => {
+      cy.window().then(window => {
+        window.sessionStorage.clear();
+      });
+    });
+    it('validation failed', () => {
+      const featureRoute =
+        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
+      cy.visit(featureRoute);
+      cy.get('h1').contains('Check in at VA');
+      cy.get('[label="Your last name"]')
+        .should('have.attr', 'autocorrect', 'false')
+        .should('have.attr', 'spellcheck', 'false');
+    });
+  });
+});

--- a/src/applications/check-in/tests/e2e/phase-2-mvp/extra-validation/autocorrect.is.disabled.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-2-mvp/extra-validation/autocorrect.is.disabled.cypress.spec.js
@@ -1,3 +1,7 @@
+import { createFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
+
+import mockCheckIn from '../../../../api/local-mock-api/mocks/v1/check.in.responses';
+import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v1/patient.check.in.responses';
 import mockSession from '../../../../api/local-mock-api/mocks/v1/sessions.responses';
 
 describe('Check In Experience -- ', () => {
@@ -8,6 +12,17 @@ describe('Check In Experience -- ', () => {
           mockSession.createMockSuccessResponse('some-token', 'read.basic'),
         );
       });
+      cy.intercept('GET', '/check_in/v1/patient_check_ins/*', req => {
+        req.reply(mockPatientCheckIns.createMockSuccessResponse({}, false));
+      });
+      cy.intercept('POST', '/check_in/v1/patient_check_ins/', req => {
+        req.reply(mockCheckIn.createMockSuccessResponse({}));
+      });
+      cy.intercept(
+        'GET',
+        '/v0/feature_toggles*',
+        createFeatureToggles(true, true, false, true),
+      );
     });
     afterEach(() => {
       cy.window().then(window => {


### PR DESCRIPTION
## Description

As a Veteran, I wish to not have autocorrect enabled on the LastName field, so that my last name is not modified and I may complete the check-in process.
As a Veteran, I wish to not have spellcheck enabled on the LastName field, so that my last name is not shown as incorrect and potentially causing confusion.


## Original issue(s)
department-of-veterans-affairs/va.gov-team#30127


## Testing done

- Tested locally with & without new attributes
- Created cypress test

## Screenshots

### Before

<img width="410" alt="Screen Shot 2021-09-22 at 9 44 35 AM" src="https://user-images.githubusercontent.com/101649/134381091-4369c38d-8948-4437-a8a2-5131b3a8a1fb.png">
<img width="417" alt="Screen Shot 2021-09-22 at 9 44 15 AM" src="https://user-images.githubusercontent.com/101649/134381096-436fefff-6e75-4a1d-9c94-00aa8a9aee7c.png">

### After

<img width="409" alt="Screen Shot 2021-09-22 at 9 45 08 AM" src="https://user-images.githubusercontent.com/101649/134381135-adbf8752-e5db-42b0-b8c2-86e1104f9b78.png">

## Acceptance criteria
- [ ] 
