### PR TITLE
526: Redirect to introduction page when not logged in

### DIFF
--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -62,7 +62,8 @@ export const hasRequiredId = profile =>
 
 export const hasRequiredDob = profile => !!profile.dob;
 
-const isIntroPage = ({ pathname }) => pathname.endsWith('/introduction');
+export const isIntroPage = ({ pathname = '' } = {}) =>
+  pathname.endsWith('/introduction');
 
 export const Form526Entry = ({
   children,

--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -62,7 +62,7 @@ export const hasRequiredId = profile =>
 
 export const hasRequiredDob = profile => !!profile.dob;
 
-const isIntroPage = () => window.location.pathname.endsWith('/introduction');
+const isIntroPage = ({ pathname }) => pathname.endsWith('/introduction');
 
 export const Form526Entry = ({
   children,
@@ -87,9 +87,20 @@ export const Form526Entry = ({
   );
 
   const title = `${getPageTitle(isBDDForm)}${
-    isIntroPage() ? ` ${PAGE_TITLE_SUFFIX}` : ''
+    isIntroPage(location) ? ` ${PAGE_TITLE_SUFFIX}` : ''
   }`;
   document.title = `${title}${DOCUMENT_TITLE_SUFFIX}`;
+
+  const showLoading = ({ restarting } = {}) => {
+    const message = restarting
+      ? 'Please wait while we restart the application for you.'
+      : 'Please wait while we load the application for you.';
+    return (
+      <h1 className="vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal">
+        <LoadingIndicator message={message} />
+      </h1>
+    );
+  };
 
   // start focus on breadcrumb nav when wizard is visible
   const setPageFocus = focusTarget => {
@@ -99,7 +110,7 @@ export const Form526Entry = ({
 
   useEffect(
     () => {
-      if (wizardStatus === WIZARD_STATUS_COMPLETE && isIntroPage()) {
+      if (wizardStatus === WIZARD_STATUS_COMPLETE && isIntroPage(location)) {
         setPageFocus('h1');
         // save feature flag for 8940/4192
         sessionStorage.setItem(SHOW_8940_4192, showSubforms);
@@ -111,20 +122,22 @@ export const Form526Entry = ({
         Sentry.setTag('in_progress_form_id', inProgressFormId);
       }
     },
-    [showSubforms, wizardStatus, inProgressFormId, profile],
+    [showSubforms, wizardStatus, inProgressFormId, profile, location],
   );
+
+  // The router should be doing this, but we're getting lots of Sentry errors
+  // See github.com/department-of-veterans-affairs/va.gov-team/issues/29893
+  if (!loggedIn && !isIntroPage(location)) {
+    router.push('/introduction');
+    return wrapWithBreadcrumb(title, showLoading());
+  }
 
   // showWizard feature flag loads _after_ page has rendered causing the full
   // page content to render, then the wizard to render if this flag is true, so
   // we show a loading indicator until the feature flags are available. This
   // can be removed once the feature flag is removed
   if (typeof showWizard === 'undefined') {
-    return wrapWithBreadcrumb(
-      title,
-      <h1 className="vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal">
-        <LoadingIndicator message="Please wait while we load the application for you." />
-      </h1>,
-    );
+    return wrapWithBreadcrumb(title, showLoading());
   }
 
   // showWizard feature flag is initially undefined
@@ -135,12 +148,7 @@ export const Form526Entry = ({
       (hasSavedForm && wizardStatus === WIZARD_STATUS_RESTARTING))
   ) {
     router.push('/start');
-    return wrapWithBreadcrumb(
-      title,
-      <h1>
-        <LoadingIndicator message="Please wait while we restart the application for you." />
-      </h1>,
-    );
+    return wrapWithBreadcrumb(title, showLoading({ restarting: true }));
   }
 
   // wraps the app and redirects user if they are not enrolled

--- a/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
@@ -42,6 +42,8 @@ describe('Form 526EZ Entry Page', () => {
     mvi = '',
     show526Wizard = true,
     dob = '2000-01-01',
+    pathname = '/introduction',
+    router = [],
   } = {}) => {
     const initialState = {
       form: {
@@ -67,7 +69,7 @@ describe('Form 526EZ Entry Page', () => {
         },
       },
       currentLocation: {
-        pathname: '/introduction',
+        pathname,
         search: '',
       },
       mvi: {
@@ -92,7 +94,7 @@ describe('Form 526EZ Entry Page', () => {
           location={initialState.currentLocation}
           user={initialState.user}
           showWizard={initialState.showWizard}
-          router={[]}
+          router={router}
           savedForms={savedForms}
         >
           <main>
@@ -116,6 +118,16 @@ describe('Form 526EZ Entry Page', () => {
     expect(tree.find('h1').text()).to.contain('Log in');
     expect(tree.find('RoutedSavableApp')).to.have.lengthOf(1);
     expect(tree.find('main').text()).to.contain('Log in');
+    tree.unmount();
+  });
+  it('should redirect to the intro page when on a different page & not logged in', () => {
+    const router = [];
+    const tree = testPage({
+      currentlyLoggedIn: false,
+      pathname: '/something-else',
+      router,
+    });
+    expect(router[0]).to.equal('/introduction');
     tree.unmount();
   });
 
@@ -157,7 +169,7 @@ describe('Form 526EZ Entry Page', () => {
   });
 
   // Logged in & verified, but missing DOB
-  it('should render Missing DOB aler', () => {
+  it('should render Missing DOB alert', () => {
     sessionStorage.setItem(WIZARD_STATUS, WIZARD_STATUS_COMPLETE);
     const tree = testPage({
       currentlyLoggedIn: true,
@@ -276,10 +288,13 @@ describe('Form 526EZ Entry Page', () => {
   it('should redirect to the wizard when logged in', () => {
     localStorage.setItem('hasSession', true);
     sessionStorage.removeItem(WIZARD_STATUS);
+    const router = [];
     const tree = testPage({
       currentlyLoggedIn: true,
+      router,
     });
     expect(tree.find('h1').text()).to.contain('restart the app');
+    expect(router[0]).to.equal('/start');
     tree.unmount();
   });
   it('should not redirect to the wizard there is a saved form', () => {


### PR DESCRIPTION
## Description

We're seeing lots of Sentry events with `undefined is not an object`, which includes `n.definitions`, `e.type` and `query`. These may all be related to a Veteran opening a bookmark that goes to a specific page within the 526 form. When that happens, it bypasses API calls and most of the form component data isn't loaded, causing this generic JS error.

In hopes of making a global fix, this PR redirects users to the `/introduction` page when the data  is partially missing. At least it seems that the logged in state isn't `true` when opening a form mid-flow

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/29893

## Testing done

Updated unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Redirect to the introduction page when not logged in

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
