### PR TITLE
Bump formation to 6.17.2 for in-page link styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -237,7 +237,7 @@
   "private": true,
   "dependencies": {
     "@department-of-veterans-affairs/component-library": "^3.1.1",
-    "@department-of-veterans-affairs/formation": "6.17.1",
+    "@department-of-veterans-affairs/formation": "6.17.2",
     "@department-of-veterans-affairs/formulate": "0.0.1",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "@formatjs/intl-datetimeformat": "^3.2.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1993,10 +1993,10 @@
     react-transition-group "1"
     recast "^0.14.4"
 
-"@department-of-veterans-affairs/formation@6.17.1":
-  version "6.17.1"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-6.17.1.tgz#db532447f006e6c3e1731559588f0e44e8750e49"
-  integrity sha512-PiE0hxHA+yVB+LGTbWYpDI16YU3pX8n+dYjk2QSjt3xptZQ7mm1mbwjnWOY5FHzYuLjAb+379nnYYINJvMeQRA==
+"@department-of-veterans-affairs/formation@6.17.2":
+  version "6.17.2"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-6.17.2.tgz#4daef23cbf01edfc3aff0b5b1750556bc641cf99"
+  integrity sha512-nhOecnMZfFQTgECSvTKe5DxQk7GXZ8Qaqh67aLyb0AkWTTA6/nffbEgehjIeoWlgkhJCV4WstqtrMRSIEvNhCA==
   dependencies:
     "@fortawesome/fontawesome-free" "^5.6.3"
     domready "^1.0.8"


### PR DESCRIPTION
## Description
Styles `.va-nav-linkslist-link` as `cursor: default`

https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/master/packages/formation/sass/modules/_m-nav-linkslist.scss#L61-L63

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/15244


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
