### PR TITLE
NOD: Fix logic bug

### DIFF
--- a/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/helpers.unit.spec.js
@@ -212,11 +212,11 @@ describe('hasDuplicates', () => {
 });
 
 describe('showAddIssuesPage', () => {
-  it('should show add issue page when no contestable issues selected', () => {
+  it('should return true when no contestable issues selected', () => {
     expect(showAddIssuesPage({})).to.be.true;
     expect(showAddIssuesPage({ contestableIssues: [{}] })).to.be.true;
   });
-  it('should show add issue page when question is set to "yes"', () => {
+  it('should return true when question is set to "yes", or no contestable issues selected', () => {
     expect(showAddIssuesPage({ 'view:hasIssuesToAdd': true })).to.be.true;
     expect(
       showAddIssuesPage({
@@ -230,22 +230,14 @@ describe('showAddIssuesPage', () => {
         contestableIssues: [{}],
       }),
     ).to.be.true;
-  });
-  it('should not show issue page when "no" is chosen', () => {
-    expect(
-      showAddIssuesPage({
-        'view:hasIssuesToAdd': false,
-        contestableIssues: [{ [SELECTED]: true }],
-      }),
-    ).to.be.false;
     expect(
       showAddIssuesPage({
         'view:hasIssuesToAdd': false,
         contestableIssues: [{}],
       }),
-    ).to.be.false;
+    ).to.be.true;
   });
-  it('should show the issue page when nothing is selected, and past the issues pages', () => {
+  it('should return true when nothing is selected, and past the issues pages', () => {
     // probably unselected stuff on the review & submit page
     expect(
       showAddIssuesPage({
@@ -262,6 +254,14 @@ describe('showAddIssuesPage', () => {
         additionalIssues: [{}],
       }),
     ).to.be.true;
+  });
+  it('should return false when "no" is chosen and there is a selected contestable issue', () => {
+    expect(
+      showAddIssuesPage({
+        'view:hasIssuesToAdd': false,
+        contestableIssues: [{ [SELECTED]: true }],
+      }),
+    ).to.be.false;
   });
 });
 

--- a/src/applications/appeals/10182/utils/helpers.js
+++ b/src/applications/appeals/10182/utils/helpers.js
@@ -19,7 +19,7 @@ export const hasSomeSelected = ({ contestableIssues, additionalIssues } = {}) =>
   someSelected(contestableIssues) || someSelected(additionalIssues);
 
 export const showAddIssuesPage = formData => {
-  const hasSelectedIssues = formData.constestableIssues?.length
+  const hasSelectedIssues = formData.contestableIssues?.length
     ? someSelected(formData.contestableIssues)
     : false;
   const noneToAdd = formData['view:hasIssuesToAdd'] !== false;
@@ -28,7 +28,7 @@ export const showAddIssuesPage = formData => {
     // nothing is selected, we need to show the additional issues page!
     return true;
   }
-  return noneToAdd && !hasSelectedIssues;
+  return noneToAdd || !hasSelectedIssues;
 };
 
 export const showAddIssueQuestion = ({ contestableIssues }) =>


### PR DESCRIPTION
## Description

Fix `showAddIssuesPage` misspelled variable & logic in the Notice of Disagreement form. The function is checking for `constestableIssues` (extra "s") instead of `contestableIssues`. Fixing this requires a fix to the internal logic and unit tests.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/30450

## Testing done

Updated unit tests

## Screenshots

N/A

## Acceptance criteria

- [x] Fix variable name & update logic
- [x] Update unit tests

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
