### PR TITLE
HLR v2: Add unique issues & max selected validations

### DIFF
--- a/src/applications/disability-benefits/996/components/AddIssues.jsx
+++ b/src/applications/disability-benefits/996/components/AddIssues.jsx
@@ -4,17 +4,17 @@ import Scroll from 'react-scroll';
 import { toIdSchema } from '@department-of-veterans-affairs/react-jsonschema-form/lib/utils';
 
 import { isEmptyObject, getItemSchema } from '../utils/helpers';
-
 import { SELECTED } from '../constants';
 import { IssueCard } from './IssueCard';
 import {
   missingIssuesErrorMessage,
   noneSelected,
+  MaxSelectionsAlert,
 } from '../content/additionalIssues';
 
 const Element = Scroll.Element;
 
-export const getContent = ({
+export const GetContent = ({
   handlers,
   registry,
   items,
@@ -125,19 +125,20 @@ export const getContent = ({
   });
 };
 
-export const renderPage = ({
+export const RenderPage = ({
   id,
   isReviewMode,
   isEditing,
   hasSelected,
-  showError,
+  showNoneSelectedError,
   showContent,
   showCheckbox,
-  atMax,
+  maxItemsLength,
   content,
   handlers,
+  showErrorModal,
 }) => {
-  const addButton = !atMax &&
+  const addButton = !maxItemsLength &&
     showCheckbox && (
       <button
         type="button"
@@ -150,21 +151,23 @@ export const renderPage = ({
 
   return isReviewMode ? (
     <>
-      {!showError && !hasSelected && noneSelected}
-      {showError && missingIssuesErrorMessage}
+      {!showNoneSelectedError && !hasSelected && noneSelected}
+      {showNoneSelectedError && missingIssuesErrorMessage}
       {content}
     </>
   ) : (
     <div
       className={`schemaform-field-container additional-issues-wrap ${
-        showError ? 'usa-input-error vads-u-margin-top--0' : ''
+        showNoneSelectedError ? 'usa-input-error vads-u-margin-top--0' : ''
       }`}
     >
       <Element name={`topOfTable_${id}`} />
-      {showError && missingIssuesErrorMessage}
+      {showNoneSelectedError && missingIssuesErrorMessage}
       {showContent && <dl className="va-growable review">{content}</dl>}
       {isEditing ? null : addButton}
-      {atMax && <p>You’ve entered the maximum number of items allowed.</p>}
+      {showErrorModal && (
+        <MaxSelectionsAlert showModal closeModal={handlers.closeModal} />
+      )}
     </div>
   );
 };

--- a/src/applications/disability-benefits/996/components/AddIssuesField.jsx
+++ b/src/applications/disability-benefits/996/components/AddIssuesField.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
@@ -10,9 +10,9 @@ import { scrollToFirstError } from 'platform/utilities/ui';
 import { setData } from 'platform/forms-system/src/js/actions';
 
 import { scrollAndFocus } from '../utils/ui';
-import { someSelected } from '../utils/helpers';
-import { SELECTED, MAX_NEW_CONDITIONS } from '../constants';
-import { getContent, renderPage } from './AddIssues';
+import { getSelectedCount, hasDuplicates } from '../utils/helpers';
+import { SELECTED, MAX_SELECTIONS } from '../constants';
+import { GetContent, RenderPage } from './AddIssues';
 
 /* Non-review growable table (array) field */
 const AddIssuesField = props => {
@@ -27,39 +27,84 @@ const AddIssuesField = props => {
     onBlur,
     fullFormData,
     submission,
+    setFormData,
   } = props;
 
   const id = idSchema.$id;
   const uiOptions = uiSchema['ui:options'] || {};
+  const [showErrorModal, setShowErrorModal] = useState(false);
 
-  if (!fullFormData['view:hasIssuesToAdd']) {
-    props.setFormData({
-      ...fullFormData,
-      'view:hasIssuesToAdd': true,
-    });
-  }
+  // if we have form data, use that, otherwise use an array with a single default object
+  const items = formData.length
+    ? formData
+    : [getDefaultFormState(schema.additionalItems, undefined, {})];
+  const hasSubmitted = formContext.submitted || submission?.hasAttemptedSubmit;
+  const selectedCount = getSelectedCount(fullFormData, items);
 
-  const initialEditingState = uiOptions.setInitialEditMode?.(formData);
+  useEffect(
+    () => {
+      if (!fullFormData['view:hasIssuesToAdd']) {
+        setFormData({
+          ...fullFormData,
+          'view:hasIssuesToAdd': true,
+        });
+      }
+      // Show modal error since it's the best choice for a11y in this situation
+      if (hasSubmitted && selectedCount >= MAX_SELECTIONS) {
+        setShowErrorModal(true);
+      }
+    },
+    [fullFormData, setFormData, hasSubmitted, selectedCount],
+  );
+
+  const initialEditingState = uiOptions.setInitialEditMode?.(fullFormData);
   // Editing state: 1 = new edit, true = update edit & false = view state
   const [editing, setEditing] = useState(
     initialEditingState?.length ? initialEditingState : [1],
   );
 
   const handlers = {
+    closeModal: () => setShowErrorModal(false),
+    /**
+     * Change to the issue card checkbox
+     * @param {Number} indexToChange - index of current card
+     * @param {Boolean} checked - checked state
+     */
     toggleSelection: (indexToChange, checked) => {
       const newItems = formData.map((item, index) => ({
         ...item,
         [SELECTED]: index === indexToChange ? checked : item[SELECTED],
       }));
-      props.onChange(newItems);
+      const count = getSelectedCount(fullFormData, newItems);
+      if (checked && count > MAX_SELECTIONS) {
+        setShowErrorModal(true);
+      } else {
+        props.onChange(newItems);
+      }
     },
+    /**
+     * Change to the issue name/date
+     * @param {Number} indexToChange  - index of current card
+     * @param {Object} value - form element values
+     */
     onItemChange: (indexToChange, value) => {
+      const count = getSelectedCount(fullFormData, formData);
+      const selectedValue = count + 1 <= MAX_SELECTIONS;
+      // Set newly added issue as selected unless it goes over the max
+      // Doing this because it's better for UX && a11y
       const newItems = formData.map(
         (item, index) =>
-          index === indexToChange ? { ...value, [SELECTED]: true } : item,
+          index === indexToChange
+            ? { ...value, [SELECTED]: selectedValue }
+            : item,
       );
       props.onChange(newItems);
     },
+    /**
+     * Schema for each item, used to assign unique IDs
+     * @param {Number} index - index of current card
+     * @returns {Object} - item schema with IDs of nested elements
+     */
     getItemSchema: index => {
       const itemSchema = schema;
       if (itemSchema.items.length > index) {
@@ -67,9 +112,14 @@ const AddIssuesField = props => {
       }
       return itemSchema.additionalItems;
     },
+    /**
+     * Blur function passed in from json-schemaform field
+     */
     blur: onBlur,
-    /*
+    /**
      * Clicking edit on an item that’s not last and so is in view mode
+     * @param {Number} index - index of current card
+     * @param {Boolean} status - edit mode state
      */
     edit: (index, status = true) => {
       setEditing(editing.map((mode, indx) => (indx === index ? status : mode)));
@@ -78,12 +128,19 @@ const AddIssuesField = props => {
         timer: 50,
       });
     },
-    /*
-    * Clicking Update on an item that’s not last and is in edit mode
-    */
+    /**
+     * Clicking Update on an item that’s not last and is in edit mode
+     * @param {Number} index - index of current card
+     */
     update: index => {
       const { issue, decisionDate } = formData[index];
-      if (errorSchemaIsValid(errorSchema[index]) && issue && decisionDate) {
+      if (
+        errorSchemaIsValid(errorSchema[index]) &&
+        issue &&
+        decisionDate &&
+        // prevent saving on return to page (hit back then continue)
+        !hasDuplicates(fullFormData)
+      ) {
         setEditing(
           editing.map((mode, indx) => (indx === index ? false : mode)),
         );
@@ -99,8 +156,8 @@ const AddIssuesField = props => {
         });
       }
     },
-    /*
-     * Clicking Add another
+    /**
+     * Clicking Add another opens a new issue card
      */
     add: () => {
       const lastIndex = formData.length - 1;
@@ -124,8 +181,9 @@ const AddIssuesField = props => {
         });
       }
     },
-    /*
+    /**
      * Clicking Remove on an item in edit mode
+     * @param {Number} indexToRemove - index of card to remove
      */
     remove: indexToRemove => {
       const newItems = formData.filter((_, index) => index !== indexToRemove);
@@ -143,21 +201,14 @@ const AddIssuesField = props => {
   const isReviewMode = formContext.reviewMode;
   const showCheckbox = !onReviewPage || (onReviewPage && !isReviewMode);
 
-  // if we have form data, use that, otherwise use an array with a single default object
-  const items = formData.length
-    ? formData
-    : [getDefaultFormState(schema.additionalItems, undefined, {})];
-
-  const atMax = items.length > MAX_NEW_CONDITIONS;
-
   // first issue does not have a header or grey card background
   const singleIssue = items.length === 1;
-  const hasSelected =
-    someSelected(formData) || someSelected(fullFormData.contestedIssues);
-  const hasSubmitted = formContext.submitted || submission?.hasAttemptedSubmit;
-  const showError = hasSubmitted && !hasSelected;
+  const showContent = formData.length > 0;
+  const hasSelected = selectedCount > 0;
+  const showNoneSelectedError = hasSubmitted && !hasSelected;
+  const maxItemsLength = items.length >= schema.maxItems;
 
-  const content = getContent({
+  const content = GetContent({
     handlers,
     registry,
     items,
@@ -172,17 +223,18 @@ const AddIssuesField = props => {
     showCheckbox,
   });
 
-  return renderPage({
+  return RenderPage({
     id,
     isReviewMode,
     isEditing: editing.some(edit => edit),
     hasSelected,
-    showError,
-    showContent: formData.length > 0,
+    showNoneSelectedError,
+    showContent,
     showCheckbox,
-    atMax,
+    maxItemsLength,
     content,
     handlers,
+    showErrorModal,
   });
 };
 

--- a/src/applications/disability-benefits/996/constants.js
+++ b/src/applications/disability-benefits/996/constants.js
@@ -67,7 +67,7 @@ export const FORMAT_READABLE = 'LL';
 export const SAVED_CLAIM_TYPE = 'hlrClaimType';
 export const WIZARD_STATUS = 'wizardStatus996';
 
-export const MAX_NEW_CONDITIONS = 99;
+export const MAX_SELECTIONS = 100;
 
 // Values from benefitTypes in vets-json-schema constants
 const supportedBenefitTypes = [

--- a/src/applications/disability-benefits/996/content/additionalIssues.jsx
+++ b/src/applications/disability-benefits/996/content/additionalIssues.jsx
@@ -1,7 +1,26 @@
 import React from 'react';
 
+import Modal from '@department-of-veterans-affairs/component-library/Modal';
+
+import { MAX_SELECTIONS } from '../constants';
+
 export const missingIssueErrorMessage = 'Please add the name of an issue';
 export const noneSelected = 'Please add and select at least one issue';
+export const uniqueIssueErrorMessage = 'Please enter a unique condition name';
+
+export const maxSelected =
+  'You’ve reached the maximum number of allowed selected issues';
+
+// Not setting "visible" as a variable since we're controlling rendering at a
+// higher level
+export const MaxSelectionsAlert = ({ closeModal }) => (
+  <Modal title={maxSelected} status="warning" onClose={closeModal} visible>
+    You are limited to {MAX_SELECTIONS} selected issues for each Higher-Level
+    Review request. If you would like to select more than {MAX_SELECTIONS},
+    please submit this request and create a new request for the remaining
+    issues.
+  </Modal>
+);
 
 export const missingIssuesErrorMessageText =
   'Please add and select an issue, or select an eligible issue on the previous page';

--- a/src/applications/disability-benefits/996/pages/additionalIssues.js
+++ b/src/applications/disability-benefits/996/pages/additionalIssues.js
@@ -11,6 +11,8 @@ import {
   requireIssue,
   validateDate,
   validAdditionalIssue,
+  uniqueIssue,
+  maxIssues,
 } from '../validations/issues';
 import { SELECTED } from '../constants';
 import { setInitialEditMode, showAddIssuesPage } from '../utils/helpers';
@@ -20,7 +22,7 @@ import dateUiSchema from 'platform/forms-system/src/js/definitions/date';
 export default {
   uiSchema: {
     'ui:title': AdditionalIssuesLabel,
-    'ui:validations': [requireIssue, validAdditionalIssue],
+    'ui:validations': [requireIssue, validAdditionalIssue, maxIssues],
     additionalIssues: {
       'ui:title': '',
       'ui:field': AddIssuesField,
@@ -45,6 +47,7 @@ export default {
           'ui:errorMessages': {
             required: missingIssueErrorMessage,
           },
+          'ui:validations': [uniqueIssue],
         },
         decisionDate: {
           ...dateUiSchema('Date of decision'),

--- a/src/applications/disability-benefits/996/tests/components/AddIssuesField.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/components/AddIssuesField.unit.spec.js
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 
 import { AddIssuesField } from '../../components/AddIssuesField';
 import additionalIssues from '../../pages/additionalIssues';
-import { MAX_NEW_CONDITIONS } from '../../constants';
+import { MAX_SELECTIONS, SELECTED } from '../../constants';
 import { getDate } from '../../utils/dates';
 
 const { items } = additionalIssues.schema.properties.additionalIssues;
@@ -13,6 +13,7 @@ const { items } = additionalIssues.schema.properties.additionalIssues;
 const getProps = ({
   onChange = () => {},
   formData = [{}],
+  contestedIssues = [],
   errorSchema = [],
   touched = {},
   onReviewPage,
@@ -29,7 +30,9 @@ const getProps = ({
   idSchema: { $id: 'additionalIssues' },
   formData,
   fullFormData: {
+    additionalIssues: formData,
     'view:hasIssuesToAdd': true,
+    contestedIssues,
   },
   registry: {
     definitions: {},
@@ -186,10 +189,11 @@ describe('<AddIssuesField>', () => {
     it('max conditions by hiding the add button', () => {
       const onChange = sinon.spy();
       const props = getProps({
-        formData: new Array(MAX_NEW_CONDITIONS + 2).fill({
-          issue: 'x',
+        formData: new Array(MAX_SELECTIONS + 2).fill({}).map((_, index) => ({
+          issue: `x${index}`,
           decisionDate: validDate,
-        }),
+          [SELECTED]: true,
+        })),
         onChange,
       });
       const wrapper = mount(<AddIssuesField {...props} />);
@@ -197,14 +201,57 @@ describe('<AddIssuesField>', () => {
       expect(wrapper.find('.va-growable-add-btn').length).to.equal(0);
       expect(wrapper.find('.editing').length).to.equal(0);
       expect(wrapper.find('.widget-outline').length).to.equal(
-        MAX_NEW_CONDITIONS + 2,
+        MAX_SELECTIONS + 2,
       );
       wrapper.unmount();
     });
   });
-  it('should set view additional issues flag when visible', () => {
+  it('should show an alert when max selected issues are exceeded', () => {
+    const onChange = sinon.spy();
+    const props = getProps({
+      // one extra to push us over the max selections limit
+      formData: new Array(MAX_SELECTIONS + 1).fill({}).map((_, index) => ({
+        issue: `x${index}`,
+        decisionDate: validDate,
+        [SELECTED]: true,
+      })),
+      onChange,
+    });
+
+    const wrapper = mount(<AddIssuesField {...props} />);
+
+    wrapper
+      .find('.widget-checkbox-wrap input[type="checkbox"]')
+      .first()
+      .simulate('change'); // change instead of click
+
+    expect(wrapper.find('.va-modal').length).to.eq(1);
+    wrapper.unmount();
+  });
+  it('should show an alert when max selected issues are exceeded after trying to submit', () => {
+    const onChange = sinon.spy();
+    const props = getProps({
+      contestedIssues: [
+        { attributes: { ratingIssueSubjectText: 'issue-1', [SELECTED]: true } },
+      ],
+      formData: new Array(MAX_SELECTIONS).fill({}).map((_, index) => ({
+        issue: `x${index}`,
+        decisionDate: validDate,
+        [SELECTED]: true,
+      })),
+      onChange,
+    });
+    const wrapper = mount(
+      <AddIssuesField {...props} submission={{ hasAttemptedSubmit: true }} />,
+    );
+
+    expect(wrapper.find('.va-modal').length).to.eq(1);
+    wrapper.unmount();
+  });
+
+  it.skip('should set view additional issues flag when visible', () => {
     const setFormData = sinon.spy();
-    const wrapper = shallow(
+    const wrapper = mount(
       <AddIssuesField
         {...getProps()}
         setFormData={setFormData}

--- a/src/applications/disability-benefits/996/tests/pages/additionalIssues.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/pages/additionalIssues.unit.spec.js
@@ -13,11 +13,12 @@ import formConfig from '../../config/form';
 import { SELECTED } from '../../constants';
 import { getDate } from '../../utils/dates';
 
-const mockStore = () => ({
+const mockStore = data => ({
   getState: () => ({
     form: {
       data: {
-        contestableIssues: [],
+        ...data,
+        contestedIssues: [],
       },
     },
     formContext: {
@@ -78,27 +79,29 @@ describe('add issues page', () => {
   // the widget
   it('should render additional issues cards', () => {
     const onSubmit = sinon.spy();
+    const data = {
+      // commenting this next line out will cause a React render error
+      // contestedIssues: [],
+      additionalIssues: [
+        {
+          issue: 'Back sprain',
+          decisionDate: validDate,
+          [SELECTED]: false,
+        },
+        {
+          issue: 'Ankle sprain',
+          decisionDate: validDate,
+          [SELECTED]: true,
+        },
+      ],
+    };
     const form = mount(
-      <Provider store={mockStore()}>
+      <Provider store={mockStore(data)}>
         <DefinitionTester
           definitions={{}}
           schema={schema}
           uiSchema={uiSchema}
-          data={{
-            // commenting this next line out will cause a React render error
-            // contestableIssues: [],
-            additionalIssues: [
-              {
-                issue: 'Back sprain',
-                decisionDate: validDate,
-                [SELECTED]: false,
-              },
-              {
-                issue: 'Ankle sprain',
-                decisionDate: validDate,
-              },
-            ],
-          }}
+          data={data}
           onSubmit={onSubmit}
         />
       </Provider>,
@@ -108,7 +111,7 @@ describe('add issues page', () => {
     form.unmount();
   });
 
-  // Test not working - contestableIssues isn't being passed to widget
+  // Test not working - contestedIssues isn't being passed to widget
   it('should submit when an added issue is checked', () => {
     const onSubmit = sinon.spy();
     const onError = sinon.spy();
@@ -126,7 +129,7 @@ describe('add issues page', () => {
       ],
     };
     const form = mount(
-      <Provider store={mockStore()}>
+      <Provider store={mockStore(data)}>
         <DefinitionTester
           definitions={{}}
           schema={schema}

--- a/src/applications/disability-benefits/996/tests/utils/helpers.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/utils/helpers.unit.spec.js
@@ -1,6 +1,7 @@
 import moment from 'moment';
 import { expect } from 'chai';
 
+import { SELECTED } from '../../constants';
 import { getDate } from '../../utils/dates';
 
 import {
@@ -8,6 +9,19 @@ import {
   apiVersion1,
   apiVersion2,
   isVersion1Data,
+  someSelected,
+  hasSomeSelected,
+  getSelected,
+  getSelectedCount,
+  getIssueName,
+  getIssueNameAndDate,
+  hasDuplicates,
+  showAddIssuesPage,
+  showAddIssueQuestion,
+  isEmptyObject,
+  setInitialEditMode,
+  processContestableIssues,
+  readableList,
 } from '../../utils/helpers';
 
 describe('getEligibleContestableIssues', () => {
@@ -93,5 +107,402 @@ describe('isVersion1Data', () => {
   it('should return false when feature flag is not set', () => {
     expect(isVersion1Data()).to.be.false;
     expect(isVersion1Data({ zipCode5: '' })).to.be.false;
+  });
+});
+
+describe('someSelected', () => {
+  it('should return true for issues that have some selected values', () => {
+    expect(someSelected([{ [SELECTED]: true }, {}])).to.be.true;
+    expect(someSelected([{}, { [SELECTED]: true }, {}])).to.be.true;
+    expect(someSelected([{}, {}, {}, { [SELECTED]: true }])).to.be.true;
+  });
+  it('should return false for issues with no selected values', () => {
+    expect(someSelected()).to.be.false;
+    expect(someSelected([])).to.be.false;
+    expect(someSelected([{}, {}])).to.be.false;
+    expect(someSelected([{}, { [SELECTED]: false }, {}])).to.be.false;
+    expect(someSelected([{}, {}, {}, { [SELECTED]: false }])).to.be.false;
+  });
+});
+
+describe('hasSomeSelected', () => {
+  const testIssues = (contestedIssues, additionalIssues) =>
+    hasSomeSelected({ contestedIssues, additionalIssues });
+  it('should return true for issues that have some selected values', () => {
+    expect(testIssues([{ [SELECTED]: true }], [{}])).to.be.true;
+    expect(testIssues([{}], [{ [SELECTED]: true }, {}])).to.be.true;
+    expect(testIssues([{}], [{}, {}, { [SELECTED]: true }])).to.be.true;
+    expect(
+      testIssues([{}, { [SELECTED]: true }], [{}, {}, { [SELECTED]: true }]),
+    ).to.be.true;
+  });
+  it('should return false for no selected issues', () => {
+    expect(testIssues()).to.be.false;
+    expect(testIssues([], [])).to.be.false;
+    expect(testIssues([{}], [{}])).to.be.false;
+    expect(testIssues([{ [SELECTED]: false }], [{}])).to.be.false;
+    expect(testIssues([{}], [{ [SELECTED]: false }, {}])).to.be.false;
+    expect(testIssues([{}], [{}, {}, { [SELECTED]: false }])).to.be.false;
+    expect(
+      testIssues([{}, { [SELECTED]: false }], [{}, {}, { [SELECTED]: false }]),
+    ).to.be.false;
+  });
+});
+
+describe('getSelected & getSelectedCount', () => {
+  it('should return selected contested issues', () => {
+    const data = {
+      contestedIssues: [
+        { type: 'no', [SELECTED]: false },
+        { type: 'ok', [SELECTED]: true },
+      ],
+    };
+    expect(getSelected(data)).to.deep.equal([
+      { type: 'ok', [SELECTED]: true, index: 0 },
+    ]);
+    expect(getSelectedCount(data, data.additionalIssues)).to.eq(1);
+  });
+  it('should not return selected additional issues when Veteran chooses not to include them', () => {
+    const data = {
+      'view:hasIssuesToAdd': false,
+      additionalIssues: [
+        { type: 'no', [SELECTED]: false },
+        { type: 'ok', [SELECTED]: true },
+      ],
+    };
+    expect(getSelected(data)).to.deep.equal([]);
+    expect(getSelectedCount(data, data.additionalIssues)).to.eq(0);
+  });
+  it('should return selected additional issues', () => {
+    const data = {
+      'view:hasIssuesToAdd': true,
+      additionalIssues: [
+        { type: 'no', [SELECTED]: false },
+        { type: 'ok', [SELECTED]: true },
+      ],
+    };
+    expect(getSelected(data)).to.deep.equal([
+      { type: 'ok', [SELECTED]: true, index: 0 },
+    ]);
+    expect(getSelectedCount(data, data.additionalIssues)).to.eq(1);
+  });
+  it('should return all selected issues', () => {
+    const data = {
+      contestedIssues: [
+        { type: 'no1', [SELECTED]: false },
+        { type: 'ok1', [SELECTED]: true },
+      ],
+      'view:hasIssuesToAdd': true,
+      additionalIssues: [
+        { type: 'no2', [SELECTED]: false },
+        { type: 'ok2', [SELECTED]: true },
+      ],
+    };
+    expect(getSelected(data)).to.deep.equal([
+      { type: 'ok1', [SELECTED]: true, index: 0 },
+      { type: 'ok2', [SELECTED]: true, index: 1 },
+    ]);
+    expect(getSelectedCount(data, data.additionalIssues)).to.eq(2);
+  });
+});
+
+describe('getIssueName', () => {
+  it('should return undefined', () => {
+    expect(getIssueName()).to.be.undefined;
+  });
+  it('should return a contested issue name', () => {
+    expect(
+      getIssueName({ attributes: { ratingIssueSubjectText: 'test' } }),
+    ).to.eq('test');
+  });
+  it('should return an added issue name', () => {
+    expect(getIssueName({ issue: 'test2' })).to.eq('test2');
+  });
+});
+
+describe('getIssueNameAndDate', () => {
+  it('should return empty string', () => {
+    expect(getIssueNameAndDate()).to.equal('');
+  });
+  it('should return a contested issue name', () => {
+    expect(
+      getIssueNameAndDate({
+        attributes: {
+          ratingIssueSubjectText: 'test',
+          approxDecisionDate: '2021-01-01',
+        },
+      }),
+    ).to.eq('test2021-01-01');
+  });
+  it('should return an added issue name', () => {
+    expect(
+      getIssueNameAndDate({ issue: 'test2', decisionDate: '2021-02-02' }),
+    ).to.eq('test22021-02-02');
+  });
+});
+
+describe('hasDuplicates', () => {
+  const contestedIssues = [
+    {
+      attributes: {
+        ratingIssueSubjectText: 'test',
+        approxDecisionDate: '2021-01-01',
+      },
+    },
+  ];
+
+  it('should be false with no duplicate additional issues', () => {
+    const result = hasDuplicates();
+    expect(result).to.be.false;
+  });
+  it('should be false when there are duplicate contestable issues', () => {
+    const result = hasDuplicates({
+      contestedIssues: [contestedIssues[0], contestedIssues[0]],
+    });
+    expect(result).to.be.false;
+  });
+  it('should be false when there are no duplicate issues (only date differs)', () => {
+    const result = hasDuplicates({
+      contestedIssues,
+      additionalIssues: [{ issue: 'test', decisionDate: '2021-01-02' }],
+    });
+    expect(result).to.be.false;
+  });
+  it('should be true when there is a duplicate additional issue', () => {
+    const result = hasDuplicates({
+      contestedIssues,
+      additionalIssues: [{ issue: 'test', decisionDate: '2021-01-01' }],
+    });
+    expect(result).to.be.true;
+  });
+  it('should be true when there is are multiple duplicate additional issues', () => {
+    const result = hasDuplicates({
+      contestedIssues,
+      additionalIssues: [
+        { issue: 'test2', decisionDate: '2021-02-01' },
+        { issue: 'test2', decisionDate: '2021-02-01' },
+      ],
+    });
+    expect(result).to.be.true;
+  });
+});
+
+describe('showAddIssuesPage', () => {
+  it('should return true when no contestable issues selected', () => {
+    expect(showAddIssuesPage({})).to.be.true;
+    expect(showAddIssuesPage({ contestedIssues: [{}] })).to.be.true;
+  });
+  it('should return true when question is set to "yes", or no contestable issues selected', () => {
+    expect(showAddIssuesPage({ 'view:hasIssuesToAdd': true })).to.be.true;
+    expect(
+      showAddIssuesPage({
+        'view:hasIssuesToAdd': true,
+        contestedIssues: [{ [SELECTED]: true }],
+      }),
+    ).to.be.true;
+    expect(
+      showAddIssuesPage({
+        'view:hasIssuesToAdd': true,
+        contestedIssues: [{}],
+      }),
+    ).to.be.true;
+    expect(
+      showAddIssuesPage({
+        'view:hasIssuesToAdd': false,
+        contestedIssues: [{}],
+      }),
+    ).to.be.true;
+  });
+  it('should show the issue page when nothing is selected, and past the issues pages', () => {
+    // probably unselected stuff on the review & submit page
+    expect(
+      showAddIssuesPage({
+        'view:hasIssuesToAdd': true,
+        contestedIssues: [{}],
+        additionalIssues: [{}],
+      }),
+    ).to.be.true;
+    expect(
+      showAddIssuesPage({
+        'view:hasIssuesToAdd': false,
+        boardReviewOption: 'foo', // we're past the issues page
+        contestedIssues: [{}],
+        additionalIssues: [{}],
+      }),
+    ).to.be.true;
+  });
+  it('should return false when "no" is chosen and there is a selected contested issue', () => {
+    expect(
+      showAddIssuesPage({
+        'view:hasIssuesToAdd': false,
+        contestedIssues: [{ [SELECTED]: true }],
+      }),
+    ).to.be.false;
+  });
+});
+
+describe('showAddIssueQuestion', () => {
+  it('should show add issue question when contestable issues selected', () => {
+    expect(showAddIssueQuestion({ contestedIssues: [{ [SELECTED]: true }] })).to
+      .be.true;
+  });
+  it('should not show add issue question when no issues or none selected', () => {
+    expect(showAddIssueQuestion({ contestedIssues: [] })).to.be.false;
+    expect(showAddIssueQuestion({ contestedIssues: [{}] })).to.be.false;
+    expect(showAddIssueQuestion({ contestedIssues: [{ [SELECTED]: false }] }))
+      .to.be.false;
+  });
+});
+
+describe('isEmptyObject', () => {
+  it('should return true for an empty object', () => {
+    expect(isEmptyObject({})).to.be.true;
+  });
+  it('should return true for non objects or filled objects', () => {
+    expect(isEmptyObject()).to.be.false;
+    expect(isEmptyObject('')).to.be.false;
+    expect(isEmptyObject([])).to.be.false;
+    expect(isEmptyObject('test')).to.be.false;
+    expect(isEmptyObject(null)).to.be.false;
+    expect(isEmptyObject(true)).to.be.false;
+    expect(isEmptyObject(() => {})).to.be.false;
+    expect(isEmptyObject({ test: '' })).to.be.false;
+  });
+});
+
+describe('setInitialEditMode', () => {
+  const validDate = getDate({ offset: { months: -2 } });
+  it('should set edit mode when missing data', () => {
+    [
+      [{}],
+      [{ issue: 'test' }],
+      [{ decisionDate: validDate }],
+      [{ issue: '', decisionDate: '' }],
+      [{ issue: undefined, decisionDate: undefined }],
+    ].forEach(additionalIssues => {
+      expect(setInitialEditMode({ additionalIssues })).to.deep.equal([true]);
+    });
+    expect(
+      setInitialEditMode({
+        additionalIssues: [
+          { issue: '', decisionDate: validDate },
+          { issue: 'test', decisionDate: '' },
+        ],
+      }),
+    ).to.deep.equal([true, true]);
+  });
+  it('should set edit mode when there is an invalid date', () => {
+    [
+      [{ issue: 'test', decisionDate: getDate({ offset: { months: 1 } }) }],
+      [{ issue: 'test', decisionDate: '1899-01-01' }],
+      [{ issue: 'test', decisionDate: '2000-01-01' }],
+    ].forEach(additionalIssues => {
+      expect(setInitialEditMode({ additionalIssues })).to.deep.equal([true]);
+    });
+    expect(
+      setInitialEditMode({
+        additionalIssues: [
+          { issue: 'test', decisionDate: validDate },
+          { issue: 'test', decisionDate: '2000-01-01' },
+        ],
+      }),
+    ).to.deep.equal([false, true]);
+  });
+  it('should set edit mode when there is a duplicate contestable issue', () => {
+    expect(
+      setInitialEditMode({
+        contestedIssues: [
+          {
+            attributes: {
+              ratingIssueSubjectText: 'test',
+              approxDecisionDate: validDate,
+            },
+          },
+        ],
+        additionalIssues: [{ issue: 'test', decisionDate: validDate }],
+      }),
+    ).to.deep.equal([true]);
+  });
+  it('should set edit mode when there is a duplicate additional issue', () => {
+    expect(
+      setInitialEditMode({
+        additionalIssues: [
+          { issue: 'test', decisionDate: validDate },
+          { issue: 'test', decisionDate: validDate },
+        ],
+      }),
+    ).to.deep.equal([true, true]);
+  });
+  it('should not set edit mode when data exists', () => {
+    expect(
+      setInitialEditMode({
+        additionalIssues: [{ issue: 'test', decisionDate: validDate }],
+      }),
+    ).to.deep.equal([false]);
+    expect(
+      setInitialEditMode({
+        additionalIssues: [
+          { issue: 'test', decisionDate: validDate },
+          {
+            issue: 'test2',
+            decisionDate: getDate({ offset: { months: -10 } }),
+          },
+        ],
+      }),
+    ).to.deep.equal([false, false]);
+  });
+});
+
+describe('processContestableIssues', () => {
+  const getIssues = dates =>
+    dates.map(date => ({
+      attributes: { ratingIssueSubjectText: 'a', approxDecisionDate: date },
+    }));
+  const getDates = dates =>
+    dates.map(date => date.attributes.approxDecisionDate);
+
+  it('should return an empty array with undefined issues', () => {
+    expect(getDates(processContestableIssues())).to.deep.equal([]);
+  });
+  it('should filter out issues missing a title', () => {
+    const issues = getIssues(['2020-02-01', '2020-03-01', '2020-01-01']);
+    issues[0].attributes.ratingIssueSubjectText = '';
+    const result = processContestableIssues(issues);
+    expect(getDates(result)).to.deep.equal(['2020-03-01', '2020-01-01']);
+  });
+  it('should sort issues spanning months with newest date first', () => {
+    const dates = ['2020-02-01', '2020-03-01', '2020-01-01'];
+    const result = processContestableIssues(getIssues(dates));
+    expect(getDates(result)).to.deep.equal([
+      '2020-03-01',
+      '2020-02-01',
+      '2020-01-01',
+    ]);
+  });
+  it('should sort issues spanning a year & months with newest date first', () => {
+    const dates = ['2021-01-31', '2020-12-01', '2021-02-02', '2021-02-01'];
+    const result = processContestableIssues(getIssues(dates));
+    expect(getDates(result)).to.deep.equal([
+      '2021-02-02',
+      '2021-02-01',
+      '2021-01-31',
+      '2020-12-01',
+    ]);
+  });
+});
+
+describe('readableList', () => {
+  it('should return an empty string', () => {
+    expect(readableList([])).to.eq('');
+    expect(readableList(['', null, 0])).to.eq('');
+  });
+  it('should return a combined list with commas with "and" for the last item', () => {
+    expect(readableList(['one'])).to.eq('one');
+    expect(readableList(['', 'one', null])).to.eq('one');
+    expect(readableList(['one', 'two'])).to.eq('one and two');
+    expect(readableList([1, 2, 'three'])).to.eq('1, 2 and three');
+    expect(readableList(['v', null, 'w', 'x', '', 'y', 'z'])).to.eq(
+      'v, w, x, y and z',
+    );
   });
 });

--- a/src/applications/disability-benefits/996/tests/validations/issues.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/validations/issues.unit.spec.js
@@ -1,0 +1,80 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { getDate } from '../../utils/dates';
+import { SELECTED, MAX_SELECTIONS } from '../../constants';
+
+import { uniqueIssue, maxIssues } from '../../validations/issues';
+
+describe('uniqueIssue', () => {
+  const _ = null;
+  const contestedIssues = [
+    {
+      attributes: {
+        ratingIssueSubjectText: 'test',
+        approxDecisionDate: '2021-01-01',
+      },
+    },
+  ];
+
+  it('should not show an error when there are no issues', () => {
+    const errors = { addError: sinon.spy() };
+    uniqueIssue(errors, _, _, _, _, _, {});
+    expect(errors.addError.notCalled).to.be.true;
+  });
+  it('should not show an error when there are duplicate contested issues', () => {
+    const errors = { addError: sinon.spy() };
+    uniqueIssue(errors, _, _, _, _, _, {
+      contestedIssues: [contestedIssues[0], contestedIssues[0]],
+    });
+    expect(errors.addError.notCalled).to.be.true;
+  });
+  it('should not show an error when there are no duplicate issues (only date differs)', () => {
+    const errors = { addError: sinon.spy() };
+    uniqueIssue(errors, _, _, _, _, _, {
+      contestedIssues,
+      additionalIssues: [{ issue: 'test', decisionDate: '2021-01-02' }],
+    });
+    expect(errors.addError.notCalled).to.be.true;
+  });
+  it('should show an error when there is a duplicate additional issue', () => {
+    const errors = { addError: sinon.spy() };
+    uniqueIssue(errors, _, _, _, _, _, {
+      contestedIssues,
+      additionalIssues: [{ issue: 'test', decisionDate: '2021-01-01' }],
+    });
+    expect(errors.addError.called).to.be.true;
+  });
+  it('should show an error when there are multiple duplicate additional issue', () => {
+    const errors = { addError: sinon.spy() };
+    uniqueIssue(errors, _, _, _, _, _, {
+      contestedIssues,
+      additionalIssues: [
+        { issue: 'test2', decisionDate: '2021-02-01' },
+        { issue: 'test2', decisionDate: '2021-02-01' },
+      ],
+    });
+    expect(errors.addError.called).to.be.true;
+  });
+});
+
+describe('maxIssues', () => {
+  it('should not show an error when the array length is less than max', () => {
+    const errors = { addError: sinon.spy() };
+    maxIssues(errors, []);
+    expect(errors.addError.called).to.be.false;
+  });
+  it('should show not show an error when the array length is greater than max', () => {
+    const errors = { addError: sinon.spy() };
+    const validDate = getDate({ offset: { months: -2 } });
+    const template = {
+      issue: 'x',
+      decisionDate: validDate,
+      [SELECTED]: true,
+    };
+    maxIssues(errors, {
+      contestedIssues: new Array(MAX_SELECTIONS + 1).fill(template),
+    });
+    expect(errors.addError.called).to.be.true;
+  });
+});

--- a/src/applications/disability-benefits/996/utils/helpers.js
+++ b/src/applications/disability-benefits/996/utils/helpers.js
@@ -106,12 +106,13 @@ export const showAddIssuesPage = formData => {
   const hasSelectedIssues = formData.contestedIssues?.length
     ? someSelected(formData.contestedIssues)
     : false;
+  const noneToAdd = formData['view:hasIssuesToAdd'] !== false;
   // are we past the informal conference page?
   if (formData.informalConference && !hasSomeSelected(formData)) {
     // nothing is selected, we need to show the additional issues page!
     return true;
   }
-  return !hasSelectedIssues || formData['view:hasIssuesToAdd'] !== false;
+  return noneToAdd || !hasSelectedIssues;
 };
 
 export const showAddIssueQuestion = ({ contestedIssues }) =>
@@ -134,8 +135,30 @@ export const getSelected = formData => {
   }));
 };
 
+// additionalIssues (items) are separate because we're checking the count before
+// the formData is updated
+export const getSelectedCount = (formData, items) =>
+  getSelected({ ...formData, additionalIssues: items }).length;
+
 export const getIssueName = (entry = {}) =>
   entry.issue || entry.attributes?.ratingIssueSubjectText;
+
+export const getIssueNameAndDate = (entry = {}) =>
+  `${(getIssueName(entry) || '').toLowerCase()}${entry.decisionDate ||
+    entry.attributes?.approxDecisionDate ||
+    ''}`;
+
+const processIssues = (array = []) =>
+  array.filter(Boolean).map(entry => getIssueNameAndDate(entry));
+
+export const hasDuplicates = (data = {}) => {
+  const contestedIssues = processIssues(data.contestedIssues);
+  const additionalIssues = processIssues(data.additionalIssues);
+  // ignore duplicate contestable issues (if any)
+  const fullList = [...new Set(contestedIssues)].concat(additionalIssues);
+
+  return fullList.length !== new Set(fullList).size;
+};
 
 // Simple one level deep check
 export const isEmptyObject = obj =>
@@ -143,11 +166,50 @@ export const isEmptyObject = obj =>
     ? Object.keys(obj)?.length === 0 || false
     : false;
 
-export const setInitialEditMode = (formData = []) =>
-  formData.map(
-    ({ issue, decisionDate } = {}) =>
-      !issue || !decisionDate || !isValidDate(decisionDate),
+export const setInitialEditMode = (formData = {}) => {
+  const contestedIssues = (formData.contestedIssues || []).map(entry =>
+    getIssueNameAndDate(entry),
   );
+  const additionalIssues = (formData.additionalIssues || []).map(entry =>
+    getIssueNameAndDate(entry),
+  );
+  return (formData.additionalIssues || []).map((issue = {}, index) => {
+    const currentIssue = getIssueNameAndDate(issue);
+    return (
+      !issue.issue ||
+      !issue.decisionDate ||
+      !isValidDate(issue.decisionDate) ||
+      // check for duplicates
+      contestedIssues.includes(currentIssue) ||
+      additionalIssues.lastIndexOf(currentIssue) !== index ||
+      additionalIssues.indexOf(currentIssue) !== index
+    );
+  });
+};
+
+// getEligibleContestableIssues will remove deferred issues and issues > 1 year
+// past their decision date. This function removes issues with no title & sorts
+// the list by descending (newest first) decision date
+export const processContestableIssues = contestableIssues => {
+  const regexDash = /-/g;
+  const getDate = entry =>
+    (entry.attributes?.approxDecisionDate || '').replace(regexDash, '');
+
+  // remove issues with no title & sort by date - see
+  // https://dsva.slack.com/archives/CSKKUL36K/p1623956682119300
+  return (contestableIssues || [])
+    .filter(issue => getIssueName(issue))
+    .sort((a, b) => {
+      const dateA = getDate(a);
+      const dateB = getDate(b);
+      if (dateA === dateB) {
+        // If the dates are the same, sort by title
+        return getIssueName(a) > getIssueName(b) ? 1 : -1;
+      }
+      // YYYYMMDD string comparisons will work in place of using moment
+      return dateA > dateB ? -1 : 1;
+    });
+};
 
 export const getItemSchema = (schema, index) => {
   const itemSchema = schema;

--- a/src/applications/disability-benefits/996/validations/issues.js
+++ b/src/applications/disability-benefits/996/validations/issues.js
@@ -7,8 +7,13 @@ import {
 } from 'platform/forms-system/src/js/utilities/validations';
 
 import { $ } from '../utils/ui';
-import { hasSomeSelected } from '../utils/helpers';
-import { missingIssuesErrorMessageText } from '../content/additionalIssues';
+import { getSelected, hasSomeSelected, hasDuplicates } from '../utils/helpers';
+import {
+  missingIssuesErrorMessageText,
+  uniqueIssueErrorMessage,
+  maxSelected,
+} from '../content/additionalIssues';
+import { MAX_SELECTIONS } from '../constants';
 
 export const requireIssue = (
   errors,
@@ -100,5 +105,26 @@ export const validAdditionalIssue = (
         errors.addError(missingIssuesErrorMessageText);
       }
     });
+  }
+};
+
+// Alert Veteran to duplicates based on name & decision date
+export const uniqueIssue = (
+  errors,
+  _fieldData,
+  _formData,
+  _schema,
+  _uiSchema,
+  _index,
+  appStateData,
+) => {
+  if (errors?.addError && hasDuplicates(appStateData)) {
+    errors.addError(uniqueIssueErrorMessage);
+  }
+};
+
+export const maxIssues = (error, data) => {
+  if (getSelected(data).length > MAX_SELECTIONS) {
+    error.addError(maxSelected);
   }
 };


### PR DESCRIPTION
## Description

For Higher-Level Review v2, we copied validation code from the Notice of Disagreement form. This was done to prevent Veterans from entering duplicate additional issues and show a modal alert when the max number of issues has been selected (100 max).

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/30255

## Testing done

Added unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Prevent duplicate additional issues validation
- [x] Show max selected issues modal
- [x] Add unit tests
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
