### PR TITLE
use helper to make contact info deep links

### DIFF
--- a/src/applications/personalization/profile/components/notification-settings/AddContactInfoLink.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/AddContactInfoLink.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-import { PROFILE_PATHS } from '../../constants';
+import { getContactInfoDeepLinkURL } from '@@profile/helpers';
+
+import { FIELD_NAMES } from '@@vap-svc/constants';
 
 export const MISSING_CONTACT_INFO = {
   EMAIL: 'EMAIL',
@@ -11,15 +13,11 @@ export const MISSING_CONTACT_INFO = {
 const linkMap = {
   [MISSING_CONTACT_INFO.EMAIL]: {
     linkText: 'Add your email address',
-    linkTarget: `${
-      PROFILE_PATHS.PERSONAL_INFORMATION
-    }#edit-contact-email-address`,
+    linkTarget: getContactInfoDeepLinkURL(FIELD_NAMES.EMAIL, true),
   },
   [MISSING_CONTACT_INFO.MOBILE]: {
     linkText: 'Add your mobile phone number',
-    linkTarget: `${
-      PROFILE_PATHS.PERSONAL_INFORMATION
-    }#edit-mobile-phone-number`,
+    linkTarget: getContactInfoDeepLinkURL(FIELD_NAMES.MOBILE_PHONE, true),
   },
 };
 

--- a/src/applications/personalization/profile/components/notification-settings/ContactInfoOnFile.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/ContactInfoOnFile.jsx
@@ -3,8 +3,8 @@ import { Link } from 'react-router-dom';
 
 import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
 
-import { PROFILE_PATHS } from '@@profile/constants';
-import { FIELD_IDS, FIELD_NAMES } from '@@vap-svc/constants';
+import { getContactInfoDeepLinkURL } from '@@profile/helpers';
+import { FIELD_NAMES } from '@@vap-svc/constants';
 
 const ContactInfoOnFile = ({ emailAddress, mobilePhoneNumber }) => {
   return (
@@ -17,11 +17,7 @@ const ContactInfoOnFile = ({ emailAddress, mobilePhoneNumber }) => {
         {emailAddress ? (
           <li className="vads-u-margin-y--0p5">
             {emailAddress}{' '}
-            <Link
-              to={`${PROFILE_PATHS.PERSONAL_INFORMATION}#edit-${
-                FIELD_IDS[FIELD_NAMES.EMAIL]
-              }`}
-            >
+            <Link to={getContactInfoDeepLinkURL(FIELD_NAMES.EMAIL, true)}>
               Update email
             </Link>
           </li>
@@ -35,9 +31,7 @@ const ContactInfoOnFile = ({ emailAddress, mobilePhoneNumber }) => {
               notClickable
             />{' '}
             <Link
-              to={`${PROFILE_PATHS.PERSONAL_INFORMATION}#edit-${
-                FIELD_IDS[FIELD_NAMES.MOBILE_PHONE]
-              }`}
+              to={getContactInfoDeepLinkURL(FIELD_NAMES.MOBILE_PHONE, true)}
             >
               Update mobile phone
             </Link>

--- a/src/applications/personalization/profile/components/notification-settings/MissingContactInfoAlert.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/MissingContactInfoAlert.jsx
@@ -15,7 +15,7 @@ const missingEmailAddressContent = (
       your profile.
     </p>
     <p>
-      <AddContactInfoLink strong missingInfo={MISSING_CONTACT_INFO.EMAIL} />
+      <AddContactInfoLink missingInfo={MISSING_CONTACT_INFO.EMAIL} />
     </p>
   </>
 );
@@ -26,7 +26,7 @@ const missingMobilePhoneContent = (
       phone number to your profile.
     </p>
     <p>
-      <AddContactInfoLink strong missingInfo={MISSING_CONTACT_INFO.MOBILE} />
+      <AddContactInfoLink missingInfo={MISSING_CONTACT_INFO.MOBILE} />
     </p>
   </>
 );
@@ -38,7 +38,7 @@ const missingMobilePhoneContent = (
 //       your notification settings, first update your contact information.{' '}
 //     </p>
 //     <p>
-//       <AddContactInfoLink strong missingInfo={MISSING_CONTACT_INFO.ALL} />
+//       <AddContactInfoLink missingInfo={MISSING_CONTACT_INFO.ALL} />
 //     </p>
 //   </>
 // );

--- a/src/applications/personalization/profile/components/notification-settings/MissingContactInfoAlertLink.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/MissingContactInfoAlertLink.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-import { PROFILE_PATHS } from '../../constants';
+import { getContactInfoDeepLinkURL } from '@@profile/helpers';
+
+import { FIELD_NAMES } from '@@vap-svc/constants';
 
 export const MISSING_CONTACT_INFO = {
   ALL: 'ALL',
@@ -12,19 +14,15 @@ export const MISSING_CONTACT_INFO = {
 const linkMap = {
   [MISSING_CONTACT_INFO.ALL]: {
     linkText: 'Update your contact information',
-    linkTarget: `${PROFILE_PATHS.PERSONAL_INFORMATION}#phone-numbers`,
+    linkTarget: getContactInfoDeepLinkURL('phoneNumbers', false),
   },
   [MISSING_CONTACT_INFO.EMAIL]: {
     linkText: 'Add an email address to your profile',
-    linkTarget: `${
-      PROFILE_PATHS.PERSONAL_INFORMATION
-    }#edit-contact-email-address`,
+    linkTarget: getContactInfoDeepLinkURL(FIELD_NAMES.EMAIL, true),
   },
   [MISSING_CONTACT_INFO.MOBILE]: {
     linkText: 'Add a mobile phone number to your profile',
-    linkTarget: `${
-      PROFILE_PATHS.PERSONAL_INFORMATION
-    }#edit-mobile-phone-number`,
+    linkTarget: getContactInfoDeepLinkURL(FIELD_NAMES.MOBILE_PHONE, true),
   },
 };
 

--- a/src/applications/personalization/profile/components/personal-information/PersonalInformation.jsx
+++ b/src/applications/personalization/profile/components/personal-information/PersonalInformation.jsx
@@ -21,10 +21,9 @@ import PersonalInformationContent from './PersonalInformationContent';
 import { PROFILE_PATHS } from '../../constants';
 
 // drops the leading `edit` from the hash and looks for that element
-const getScrollTarget = _hash => {
-  const hash = _hash.replace('#', '');
-  const hashWithoutLeadingEdit = hash.replace(/^edit-/, '');
-  return document.querySelector(`#${hashWithoutLeadingEdit}`);
+const getScrollTarget = hash => {
+  const hashWithoutLeadingEdit = hash.replace(/^#edit-/, '#');
+  return document.querySelector(hashWithoutLeadingEdit);
 };
 
 const PersonalInformation = ({
@@ -55,8 +54,8 @@ const PersonalInformation = ({
         // We will always attempt to focus on the element that matches the
         // location.hash
         const focusTarget = document.querySelector(window.location.hash);
-        // But if the hash starts with `edit` will will scroll a different
-        // element into view
+        // But if the hash starts with `edit` we will scroll a different
+        // element to the top of the viewport
         const scrollTarget = getScrollTarget(window.location.hash);
         if (scrollTarget) {
           scrollTarget.scrollIntoView();

--- a/src/applications/personalization/profile/helpers.js
+++ b/src/applications/personalization/profile/helpers.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import moment from 'moment';
-import { USA_MILITARY_BRANCHES } from './constants';
+import { PROFILE_PATHS, USA_MILITARY_BRANCHES } from './constants';
+import { FIELD_IDS } from '@@vap-svc/constants';
 
 /**
  * Prefixes the serviceBranch with 'United States' if it's a valid US military
@@ -54,4 +55,13 @@ export const transformServiceHistoryEntryIntoTableRow = entry => {
       </>
     ),
   };
+};
+
+export const getContactInfoDeepLinkURL = (
+  fieldName,
+  focusOnEditButton = false,
+) => {
+  const targetId = FIELD_IDS[fieldName];
+  const fragment = focusOnEditButton ? `edit-${targetId}` : targetId;
+  return `${PROFILE_PATHS.PERSONAL_INFORMATION}#${fragment}`;
 };

--- a/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/deep-links.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/deep-links.cypress.spec.js
@@ -1,5 +1,7 @@
 import { PROFILE_PATHS } from '@@profile/constants';
 
+import { mockNotificationSettingsAPIs } from '../helpers';
+
 import mockUser from '../../fixtures/users/user-36.json';
 
 const deepLinks = [
@@ -71,6 +73,9 @@ function checkAllDeepLinks(mobile = false) {
 describe('Profile', () => {
   beforeEach(() => {
     cy.login(mockUser);
+    // These APIs are not needed for the tests. but mocking them makes
+    // everything run faster
+    mockNotificationSettingsAPIs();
   });
   it('should manage focus for all supported deep links on desktop size', () => {
     checkAllDeepLinks(false);

--- a/src/platform/user/profile/vap-svc/constants/index.js
+++ b/src/platform/user/profile/vap-svc/constants/index.js
@@ -88,6 +88,7 @@ export const FIELD_IDS = {
   [FIELD_NAMES.EMAIL]: 'contact-email-address',
   [FIELD_NAMES.MAILING_ADDRESS]: 'mailing-address',
   [FIELD_NAMES.RESIDENTIAL_ADDRESS]: 'home-address',
+  phoneNumbers: 'phone-numbers',
 };
 
 export const PHONE_TYPE = {


### PR DESCRIPTION
## Description
This PR adds a helper function that can be used to get a URL to "deep link" to a particular piece of contact information. This functionality already existed, but the code to generate the URLs did not live in a single location.

## Original issue(s)
This is part of the work for department-of-veterans-affairs/va.gov-team#29542

## Testing done
Existing tests for deep links pass, and I manually confirmed that focus and scrolling is still handled correctly.

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs