### PR TITLE
Add missing How to Apply link and make tool paths relative

### DIFF
--- a/src/applications/my-education-benefits/config/form.js
+++ b/src/applications/my-education-benefits/config/form.js
@@ -375,10 +375,7 @@ const formConfig = {
                     Any updates you make here to your personal information will
                     only apply to your education benefits. To update your
                     personal information for all of the benefits across VA,{' '}
-                    <a href="https://www.va.gov/profile">
-                      please go to your profile page
-                    </a>
-                    .
+                    <a href="/profile">please go to your profile page</a>.
                   </p>
                 </>
               ),
@@ -541,7 +538,7 @@ const formConfig = {
                     Any updates you make here to your contact information will
                     only apply to your education benefits. To update your
                     contact information for all of the benefits across VA,{' '}
-                    <a href="https://www.va.gov/profile/personal-information">
+                    <a href="/profile/personal-information">
                       please go to your profile page
                     </a>
                     .
@@ -645,7 +642,7 @@ const formConfig = {
                     Any updates you make here to your mailing address will only
                     apply to your education benefits. To update your mailing
                     address for all of the benefits across VA,{' '}
-                    <a href="https://www.va.gov/profile/personal-information">
+                    <a href="/profile/personal-information">
                       please go to your profile page
                     </a>
                     .

--- a/src/applications/my-education-benefits/containers/ConfirmationPage.jsx
+++ b/src/applications/my-education-benefits/containers/ConfirmationPage.jsx
@@ -52,10 +52,7 @@ const approvedPage = (
         Download a copy of your <a href="#">Certificate of Eligibility</a>.
       </li>
       <li>
-        Use our{' '}
-        <a href="https://www.va.gov/gi-bill-comparison-tool/ ">
-          GI Bill Comparison Tool
-        </a>{' '}
+        Use our <a href="/gi-bill-comparison-tool/ ">GI Bill Comparison Tool</a>{' '}
         to help you decide which education program and school is best for you.
       </li>
       <li>
@@ -65,7 +62,7 @@ const approvedPage = (
       </li>
       <li>
         Review and/or update your direct deposit information on your{' '}
-        <a href="https://www.va.gov/change-direct-deposit/">VA.gov profile</a>.
+        <a href="/change-direct-deposit/">VA.gov profile</a>.
       </li>
       <li>
         Learn more about VA benefits and programs through the{' '}
@@ -96,7 +93,7 @@ const approvedPage = (
       </a>
     </AdditionalInfo>
 
-    <a className="vads-c-action-link--green" href="https://www.va.gov/my-va/">
+    <a className="vads-c-action-link--green" href="/my-va/">
       Go to your My VA dashboard
     </a>
 
@@ -117,10 +114,7 @@ const deniedPage = (
         Your denial letter, which explains why you are ineligible, is now
         available. A physical copy will also be mailed to your mailing address.{' '}
       </p>
-      <a
-        className="usa-button"
-        href="https://www.va.gov/records/download-va-letters/"
-      >
+      <a className="usa-button" href="/records/download-va-letters/">
         Download your letter
       </a>
       <a href="https://www.va.gov/education/gi-bill/post-9-11/ch-33-benefit/ ">
@@ -158,7 +152,7 @@ const deniedPage = (
       <li>There is no further action required by you at this time.</li>
     </ul>
 
-    <a className="vads-c-action-link--green" href="https://www.va.gov/my-va/">
+    <a className="vads-c-action-link--green" href="/my-va/">
       Go to your My VA dashboard
     </a>
 
@@ -226,13 +220,10 @@ const pendingPage = (
       </li>
       <li>
         Review and/or update your direct deposit information on{' '}
-        <a href="https://www.va.gov/change-direct-deposit/">VA.gov profile</a>.
+        <a href="/change-direct-deposit/">VA.gov profile</a>.
       </li>
       <li>
-        Use our{' '}
-        <a href="https://www.va.gov/gi-bill-comparison-tool/ ">
-          GI Bill Comparison Tool
-        </a>{' '}
+        Use our <a href="/gi-bill-comparison-tool/ ">GI Bill Comparison Tool</a>{' '}
         to help you decide which education program and school is best for you.
       </li>
       <li>
@@ -252,7 +243,7 @@ const pendingPage = (
       </li>
     </ul>
 
-    <a className="vads-c-action-link--green" href="https://www.va.gov/my-va/">
+    <a className="vads-c-action-link--green" href="/my-va/">
       Go to your My VA dashboard
     </a>
 

--- a/src/applications/my-education-benefits/helpers.js
+++ b/src/applications/my-education-benefits/helpers.js
@@ -76,7 +76,7 @@ export const post911GiBillNote = (
     <p>
       Currently, you can only apply for Post-9/11 GI Bill (Chapter 33) benefits
       through this application. If you would like to apply for other benefits,
-      please visit our <a href="#">How To Apply</a> page.
+      please visit our <a href="/education/how-to-apply/">How To Apply</a> page.
     </p>
   </div>
 );


### PR DESCRIPTION
- Add missing How to Apply link
- Change links to profile, my-va, comparison tool to relative paths so they are routed correctly in staging. Otherwise, links are going to production va.gov.
