### PR TITLE
Fix Cypress tests on Jenkins

### DIFF
--- a/script/run-cypress-tests-docker.js
+++ b/script/run-cypress-tests-docker.js
@@ -11,7 +11,7 @@ exec("find src -name '*.cypress.*.js' | tr '\n' ','", function(_err, stdout) {
   if (index > -1) {
     strings.splice(index, 1);
   }
-  const divider = Math.ceil(strings.length / 6);
+  const divider = Math.ceil(strings.length / 5);
 
   let tests;
   if (stepNumber === 5) {

--- a/src/platform/site-wide/side-nav/tests/e2e/sideNav.cypress.spec.js
+++ b/src/platform/site-wide/side-nav/tests/e2e/sideNav.cypress.spec.js
@@ -10,7 +10,7 @@ Cypress.Commands.add('tabFocus', el => {
   );
 });
 
-describe('Facilities VAMC SideNav', () => {
+describe.skip('Facilities VAMC SideNav', () => {
   it('should tab access the links on the left nav and verify focus', () => {
     cy.visit('/pittsburgh-health-care');
     cy.injectAxe();


### PR DESCRIPTION
This PR fixes an issue with running all Cypress tests on Jenkins. This PR also disables a test that is failing on CI. This test needs to be migrated to `content-build` or a different page in `vets-website` due to the page being tested being removed from `vets-website`.