### PR TITLE
Remove find modal and close it part to side nav e2e test

### DIFF
--- a/src/platform/site-wide/side-nav/tests/e2e/sideNav.cypress.spec.js
+++ b/src/platform/site-wide/side-nav/tests/e2e/sideNav.cypress.spec.js
@@ -16,14 +16,6 @@ describe('Facilities VAMC SideNav', () => {
     cy.injectAxe();
     cy.axeCheck();
 
-    // Accept initial modal and start atop
-    if (Cypress.$('body').find('#modal-announcement')) {
-      cy.get('#modal-announcement')
-        .get('.va-modal-close')
-        .first()
-        .click();
-    }
-
     // Start tab access
     cy.get('.va-sidenav-item-label')
       .first()


### PR DESCRIPTION
# Description

We removed the VAMC Pittsburgh announcement modal as per requested by Dave Conlon. As a follow-up now that e2e tests are being run, we need to omit part of a test that was testing for it.