### PR TITLE
Make a11y updates to notification settings radio buttons

### DIFF
--- a/src/applications/personalization/profile/components/notification-settings/NotificationRadioButtons.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationRadioButtons.jsx
@@ -4,7 +4,7 @@ import { isArray, isString, uniqueId } from 'lodash';
 import classNames from 'classnames';
 import { makeField } from '~/platform/forms/fields';
 
-const MessageWrapper = ({ children, classes, id }) => {
+const MessageWrapper = ({ children, classes, id, alert }) => {
   return (
     <span
       id={id}
@@ -14,6 +14,8 @@ const MessageWrapper = ({ children, classes, id }) => {
         'vads-u-font-weight--bold',
         classes,
       )}
+      role={alert ? 'alert' : undefined}
+      aria-live={alert ? 'polite' : undefined}
     >
       {children}
     </span>
@@ -73,7 +75,7 @@ const NotificationRadioButtons = ({
   if (errorMessage) {
     errorSpanId = `${id}-error-message`;
     errorSpan = (
-      <MessageWrapper id={errorSpanId} classes={'rb-input-message-error'}>
+      <MessageWrapper id={errorSpanId} classes={'rb-input-message-error'} alert>
         <i
           className="fas fa-exclamation-circle vads-u-margin-right--1"
           aria-hidden="true"
@@ -103,7 +105,11 @@ const NotificationRadioButtons = ({
   if (loadingMessage) {
     loadingSpanId = `${id}-loading-message`;
     loadingSpan = (
-      <MessageWrapper id={loadingSpanId} classes="vads-u-font-weight--normal">
+      <MessageWrapper
+        id={loadingSpanId}
+        classes="vads-u-font-weight--normal"
+        alert
+      >
         <i
           className="fas fa-spinner fa-spin vads-u-margin-right--1"
           aria-hidden="true"
@@ -118,7 +124,11 @@ const NotificationRadioButtons = ({
   if (successMessage) {
     successSpanId = `${id}-success-message`;
     successSpan = (
-      <MessageWrapper id={successSpanId} classes={'rb-input-message-success'}>
+      <MessageWrapper
+        id={successSpanId}
+        classes={'rb-input-message-success'}
+        alert
+      >
         <i
           className="fas fa-check-circle vads-u-margin-right--1"
           aria-hidden="true"
@@ -195,20 +205,21 @@ const NotificationRadioButtons = ({
   );
 
   const legendClasses = classNames(
-    'rb-legend',
+    'vads-u-font-family--sans',
     'vads-u-font-weight--bold',
     'vads-u-font-size--base',
     'vads-u-padding--0',
+    'vads-u-margin--0',
     additionalLegendClass,
   );
 
   return (
     <fieldset className={fieldsetClasses} disabled={disabled} id={id}>
       <div className="clearfix">
-        <legend className={legendClasses}>
+        <h3 className={legendClasses}>
           {label}
           {requiredSpan}
-        </legend>
+        </h3>
       </div>
       {description ? (
         <p className="vads-u-margin-y--0p5 vads-u-color--gray-medium">

--- a/src/applications/personalization/profile/tests/components/NotificationRadioButton.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/NotificationRadioButton.unit.spec.jsx
@@ -71,7 +71,7 @@ describe('<NotificationRadioButtons>', () => {
     wrapper.unmount();
   });
 
-  it('renders a legend tag with the label attribute', () => {
+  it('renders an h3 tag with the label attribute', () => {
     const labelValue = 'test';
     const wrapper = shallow(
       <NotificationRadioButtons
@@ -83,7 +83,7 @@ describe('<NotificationRadioButtons>', () => {
     );
 
     // assert that legend element was rendered with label value as its text
-    const legendText = wrapper.find('legend').text();
+    const legendText = wrapper.find('h3').text();
     expect(legendText).to.eql(labelValue);
     wrapper.unmount();
   });


### PR DESCRIPTION
## Description
This implements a couple pieces of feedback from my a11y review with Angela this morning.

- Replaces `legend` with `h3` for easier navigation
- Make the radio button "supporting text" a polite alert

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs