### PR TITLE
Move profileAddress definition to forms system

### DIFF
--- a/src/applications/lgy/coe/config/chapters/applicant/applicantContactInformation.js
+++ b/src/applications/lgy/coe/config/chapters/applicant/applicantContactInformation.js
@@ -1,7 +1,7 @@
 import emailUI from 'platform/forms-system/src/js/definitions/email';
 
 import { applicantContactInformation } from '../../schemaImports';
-import { addressUiSchema } from 'applications/vre/definitions/profileAddress';
+import addressUiSchema from 'platform/forms-system/src/js/definitions/profileAddress';
 
 const checkboxTitle =
   'I live on a United States military base outside of the U.S.';

--- a/src/applications/personalization/view-dependents/manage-dependents/schemas.js
+++ b/src/applications/personalization/view-dependents/manage-dependents/schemas.js
@@ -1,6 +1,6 @@
 import { countries, states } from 'vets-json-schema/dist/constants.json';
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
-import { addressUiSchema } from 'applications/vre/definitions/profileAddress';
+import addressUiSchema from 'platform/forms-system/src/js/definitions/profileAddress';
 
 const validateAtLeastOneSelected = (errors, fieldData, formData) => {
   if (

--- a/src/applications/vre/28-1900/config/chapters/additional-information/additionalInformation.js
+++ b/src/applications/vre/28-1900/config/chapters/additional-information/additionalInformation.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import fullSchema from 'vets-json-schema/dist/28-1900-schema.json';
-import { addressUiSchema } from 'applications/vre/definitions/profileAddress';
+import addressUiSchema from 'platform/forms-system/src/js/definitions/profileAddress';
 
 const { newAddress, isMoving, yearsOfEducation } = fullSchema.properties;
 

--- a/src/applications/vre/28-1900/config/chapters/veteran/veteran-address/veteranAddress.js
+++ b/src/applications/vre/28-1900/config/chapters/veteran/veteran-address/veteranAddress.js
@@ -1,6 +1,6 @@
 import fullSchema from 'vets-json-schema/dist/28-1900-schema.json';
 import emailUI from 'platform/forms-system/src/js/definitions/email';
-import { addressUiSchema } from 'applications/vre/definitions/profileAddress';
+import addressUiSchema from 'platform/forms-system/src/js/definitions/profileAddress';
 
 import { VeteranAddressDescription } from '../../../../components/VeteranAddressDescription';
 

--- a/src/applications/vre/28-8832/config/chapters/claimant-information/claimantAddress.js
+++ b/src/applications/vre/28-8832/config/chapters/claimant-information/claimantAddress.js
@@ -1,5 +1,5 @@
 import emailUI from 'platform/forms-system/src/js/definitions/email';
-import { addressUiSchema } from 'applications/vre/definitions/profileAddress';
+import addressUiSchema from 'platform/forms-system/src/js/definitions/profileAddress';
 import {
   claimantEmailAddress,
   claimantPhoneNumber,

--- a/src/platform/forms-system/src/js/definitions/profileAddress.js
+++ b/src/platform/forms-system/src/js/definitions/profileAddress.js
@@ -103,7 +103,11 @@ const MilitaryBaseInfo = () => (
  * 1. Path to Address nested in array - childrenToAdd[INDEX].childAddressInfo.address
  */
 
-export const addressUiSchema = (path, checkBoxTitle, uiRequiredCallback) => {
+export default function addressUiSchema(
+  path,
+  checkBoxTitle,
+  uiRequiredCallback,
+) {
   /**
    * insertArrayIndex - Used when addresses are nested in an array and need to be accessible.
    * There's no good way to handle pathing to a schema when it lives in an array with multiple entries.
@@ -294,4 +298,4 @@ export const addressUiSchema = (path, checkBoxTitle, uiRequiredCallback) => {
       },
     },
   };
-};
+}

--- a/src/platform/forms-system/src/js/definitions/profileAddress.js
+++ b/src/platform/forms-system/src/js/definitions/profileAddress.js
@@ -25,52 +25,52 @@ const filteredStates = states.USA.filter(
 );
 
 /**
- Available at https://github.com/department-of-veterans-affairs/vets-json-schema/blob/8337b2878b524867ef2b6d8600b134c682c7ac8a/src/common/definitions.js#L161
- addressSchema = {
-   type: 'object',
-   properties: {
-     isMilitary: {
-       type: 'boolean',
-     },
-     'view:militaryBaseDescription': {
-       type: 'object',
-       properties: {},
-     },
-     country: {
-       type: 'string',
-       enum: countries.map(country => country.value),
-       enumNames: countries.map(country => country.label),
-     },
-     street: {
-       type: 'string',
-       minLength: 1,
-       maxLength: 100,
-       pattern: STREET_PATTERN,
-     },
-     street2: {
-       type: 'string',
-       minLength: 1,
-       maxLength: 100,
-       pattern: STREET_PATTERN,
-     },
-     street3: {
-       type: 'string',
-       minLength: 1,
-       maxLength: 100,
-       pattern: STREET_PATTERN,
-     },
-     city: {
-       type: 'string',
-     },
-     state: {
-       type: 'string',
-     },
-     postalCode: {
-       type: 'string',
-     },
-   },
- };
- */
+  Available at https://github.com/department-of-veterans-affairs/vets-json-schema/blob/8337b2878b524867ef2b6d8600b134c682c7ac8a/src/common/definitions.js#L161
+  addressSchema = {
+    type: 'object',
+    properties: {
+      isMilitary: {
+        type: 'boolean',
+      },
+      'view:militaryBaseDescription': {
+        type: 'object',
+        properties: {},
+      },
+      country: {
+        type: 'string',
+        enum: countries.map(country => country.value),
+        enumNames: countries.map(country => country.label),
+      },
+      street: {
+        type: 'string',
+        minLength: 1,
+        maxLength: 100,
+        pattern: STREET_PATTERN,
+      },
+      street2: {
+        type: 'string',
+        minLength: 1,
+        maxLength: 100,
+        pattern: STREET_PATTERN,
+      },
+      street3: {
+        type: 'string',
+        minLength: 1,
+        maxLength: 100,
+        pattern: STREET_PATTERN,
+      },
+      city: {
+        type: 'string',
+      },
+      state: {
+        type: 'string',
+      },
+      postalCode: {
+        type: 'string',
+      },
+    },
+  };
+  */
 
 /**
  * CONSTANTS:


### PR DESCRIPTION
## Description
As part of removing cross app imports, this PR moves the `profileAddress` definition into the `forms-system` directory so that other applications aren't importing it from the `vre` application.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#30277


## Testing done
Tested locally and in CI.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
