### PR TITLE
Move confirmationEmail definition to forms system

### DIFF
--- a/src/applications/ask-a-question/form/contactInformation/contactInformationPage.js
+++ b/src/applications/ask-a-question/form/contactInformation/contactInformationPage.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import phoneUI from 'platform/forms-system/src/js/definitions/phone';
 import emailUI from 'platform/forms-system/src/js/definitions/email';
-import { confirmationEmailUI } from 'applications/caregivers/definitions/UIDefinitions/sharedUI';
+import confirmationEmailUI from 'platform/forms-system/src/js/definitions/confirmationEmail';
 import fullNameUI from './fullName/fullName';
 
 import fullSchema from '../0873-schema.json';

--- a/src/applications/caregivers/config/chapters/primary/primaryContact.js
+++ b/src/applications/caregivers/config/chapters/primary/primaryContact.js
@@ -2,13 +2,13 @@ import fullSchema from 'vets-json-schema/dist/10-10CG-schema.json';
 import { PrimaryCaregiverInfo } from 'applications/caregivers/components/AdditionalInfo';
 import { primaryCaregiverFields } from 'applications/caregivers/definitions/constants';
 import { primaryInputLabel } from 'applications/caregivers/definitions/UIDefinitions/caregiverUI';
+import confirmationEmailUI from 'platform/forms-system/src/js/definitions/confirmationEmail';
 import {
   emailUI,
   vetRelationshipUI,
   alternativePhoneNumberUI,
   primaryPhoneNumberUI,
   addressWithoutCountryUI,
-  confirmationEmailUI,
 } from 'applications/caregivers/definitions/UIDefinitions/sharedUI';
 
 const { primaryCaregiver } = fullSchema.properties;

--- a/src/applications/caregivers/config/chapters/secondaryOne/secondaryCaregiverContact.js
+++ b/src/applications/caregivers/config/chapters/secondaryOne/secondaryCaregiverContact.js
@@ -1,4 +1,5 @@
 import fullSchema from 'vets-json-schema/dist/10-10CG-schema.json';
+import confirmationEmailUI from 'platform/forms-system/src/js/definitions/confirmationEmail';
 import { SecondaryCaregiverInfo } from 'applications/caregivers/components/AdditionalInfo';
 import { secondaryOneFields } from 'applications/caregivers/definitions/constants';
 import {
@@ -11,7 +12,6 @@ import {
   alternativePhoneNumberUI,
   primaryPhoneNumberUI,
   addressWithoutCountryUI,
-  confirmationEmailUI,
 } from 'applications/caregivers/definitions/UIDefinitions/sharedUI';
 
 const { secondaryCaregiverOne } = fullSchema.properties;

--- a/src/applications/caregivers/config/chapters/secondaryTwo/secondaryTwoContactInfo.js
+++ b/src/applications/caregivers/config/chapters/secondaryTwo/secondaryTwoContactInfo.js
@@ -1,4 +1,5 @@
 import fullSchema from 'vets-json-schema/dist/10-10CG-schema.json';
+import confirmationEmailUI from 'platform/forms-system/src/js/definitions/confirmationEmail';
 import { SecondaryCaregiverInfo } from 'applications/caregivers/components/AdditionalInfo';
 import { secondaryTwoFields } from 'applications/caregivers/definitions/constants';
 import { secondaryTwoInputLabel } from 'applications/caregivers/definitions/UIDefinitions/caregiverUI';
@@ -8,7 +9,6 @@ import {
   alternativePhoneNumberUI,
   primaryPhoneNumberUI,
   addressWithoutCountryUI,
-  confirmationEmailUI,
 } from 'applications/caregivers/definitions/UIDefinitions/sharedUI';
 
 const { secondaryCaregiverTwo } = fullSchema.properties;

--- a/src/applications/caregivers/config/chapters/veteran/vetContactInfo.js
+++ b/src/applications/caregivers/config/chapters/veteran/vetContactInfo.js
@@ -1,4 +1,5 @@
 import fullSchema from 'vets-json-schema/dist/10-10CG-schema.json';
+import confirmationEmailUI from 'platform/forms-system/src/js/definitions/confirmationEmail';
 import { VetInfo } from 'applications/caregivers/components/AdditionalInfo';
 import { veteranFields } from 'applications/caregivers/definitions/constants';
 import { vetInputLabel } from 'applications/caregivers/definitions/UIDefinitions/veteranUI';
@@ -7,7 +8,6 @@ import {
   emailUI,
   alternativePhoneNumberUI,
   primaryPhoneNumberUI,
-  confirmationEmailUI,
   addressWithoutCountryUI,
 } from 'applications/caregivers/definitions/UIDefinitions/sharedUI';
 

--- a/src/applications/caregivers/definitions/UIDefinitions/sharedUI.js
+++ b/src/applications/caregivers/definitions/UIDefinitions/sharedUI.js
@@ -72,26 +72,6 @@ export const ssnUI = label => ({
   ],
 });
 
-export const confirmationEmailUI = (label, dataConstant) => ({
-  'ui:title': `Re-enter ${label}  email address`,
-  'ui:widget': 'email',
-  'ui:required': formData => !!formData[dataConstant],
-  'ui:validations': [
-    {
-      validator: (errors, fieldData, formData) => {
-        const doesEmailMatch = () =>
-          formData[dataConstant] === formData[`view:${dataConstant}`];
-
-        if (!doesEmailMatch()) {
-          errors.addError(
-            'This email does not match your previously entered email',
-          );
-        }
-      },
-    },
-  ],
-});
-
 export const addressWithoutCountryUI = label => ({
   'ui:title': ' ',
   'ui:order': ['street', 'street2', 'city', 'state', 'postalCode'],

--- a/src/platform/forms-system/src/js/definitions/confirmationEmail.js
+++ b/src/platform/forms-system/src/js/definitions/confirmationEmail.js
@@ -1,0 +1,21 @@
+export default function uiSchema(label, dataConstant) {
+  return {
+    'ui:title': `Re-enter ${label}  email address`,
+    'ui:widget': 'email',
+    'ui:required': formData => !!formData[dataConstant],
+    'ui:validations': [
+      {
+        validator: (errors, fieldData, formData) => {
+          const doesEmailMatch = () =>
+            formData[dataConstant] === formData[`view:${dataConstant}`];
+
+          if (!doesEmailMatch()) {
+            errors.addError(
+              'This email does not match your previously entered email',
+            );
+          }
+        },
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## Description
As part of removing cross app imports, this PR moves the `confirmationEmail` definition into the forms-system directory so that other applications aren't importing it from the `caregivers` application.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#30277


## Testing done
Tested locally and in CI.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
