### PR TITLE
Show success alert when saving contact info

### DIFF
--- a/src/applications/personalization/profile/components/alerts/ContactInformationSaveSuccessAlert.jsx
+++ b/src/applications/personalization/profile/components/alerts/ContactInformationSaveSuccessAlert.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { useLastLocation } from 'react-router-last-location';
+
+import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
+
+import { PROFILE_PATHS } from '@@profile/constants';
+import { FIELD_NAMES } from '@@vap-svc/constants';
+
+import environment from 'platform/utilities/environment';
+
+const ContactInformationSaveSuccessAlert = ({ fieldName }) => {
+  const referrer = useLastLocation();
+  const message = React.useMemo(
+    () => {
+      if (
+        referrer?.pathname === PROFILE_PATHS.NOTIFICATION_SETTINGS &&
+        fieldName === FIELD_NAMES.MOBILE_PHONE
+      ) {
+        return (
+          <>
+            Update saved. Now you can{' '}
+            <Link to={PROFILE_PATHS.NOTIFICATION_SETTINGS}>
+              manage text notifications
+            </Link>
+            .
+          </>
+        );
+      }
+      return 'Update saved';
+    },
+    [fieldName, referrer],
+  );
+
+  if (environment.isProduction()) {
+    return null;
+  }
+
+  return (
+    <AlertBox backgroundOnly status="success" className="vads-u-margin-y--1">
+      <div className="vads-u-display--flex">
+        <i
+          aria-hidden="true"
+          className="fa fa-check-circle vads-u-padding-top--0p5 vads-u-margin-right--1"
+        />
+        <p className="vads-u-margin-y--0" role="alert" aria-live="polite">
+          {message}
+        </p>
+      </div>
+    </AlertBox>
+  );
+};
+
+export default ContactInformationSaveSuccessAlert;

--- a/src/applications/personalization/profile/components/alerts/ContactInformationSaveSuccessAlert.jsx
+++ b/src/applications/personalization/profile/components/alerts/ContactInformationSaveSuccessAlert.jsx
@@ -27,7 +27,7 @@ const ContactInformationSaveSuccessAlert = ({ fieldName }) => {
           </>
         );
       }
-      return 'Update saved';
+      return 'Update saved.';
     },
     [fieldName, referrer],
   );

--- a/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
@@ -27,6 +27,7 @@ import {
   selectVAPContactInfoField,
   selectVAPServiceTransaction,
   selectEditViewData,
+  selectMostRecentlySavedField,
 } from '@@vap-svc/selectors';
 
 import { isVAPatient } from '~/platform/user/selectors';
@@ -45,6 +46,8 @@ import getContactInfoFieldAttributes from '~/applications/personalization/profil
 import CannotEditModal from './CannotEditModal';
 import ConfirmCancelModal from './ConfirmCancelModal';
 import ConfirmRemoveModal from './ConfirmRemoveModal';
+
+import SaveSuccessAlert from '../alerts/ContactInformationSaveSuccessAlert';
 
 // Helper function that generates a string that can be used for a contact info
 // field's edit button.
@@ -117,7 +120,7 @@ class ContactInformationField extends React.Component {
     // the Profile
     if (!prevProps.transaction && this.props.transaction) {
       this.closeModalTimeoutID = setTimeout(
-        () => this.closeModal(),
+        this.closeModal,
         // Using 50ms as the unit test timeout before exiting edit view while
         // waiting for an update to happen. Being too aggressive, like 5ms,
         // results in exiting the edit view before Redux has had time to do
@@ -300,6 +303,10 @@ class ContactInformationField extends React.Component {
           title={title}
         />
 
+        {this.props.showSaveSuccessAlert ? (
+          <SaveSuccessAlert fieldName={fieldName} />
+        ) : null}
+
         <div className="vads-u-width--full">
           <div>
             {this.isEditLinkVisible() && (
@@ -458,6 +465,7 @@ export const mapStateToProps = (state, ownProps) => {
     uiSchema,
     formSchema,
     isEnrolledInVAHealthCare,
+    showSaveSuccessAlert: selectMostRecentlySavedField(state) === fieldName,
   };
 };
 

--- a/src/applications/personalization/profile/tests/e2e/post-edit-mobile-phone-cta.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/post-edit-mobile-phone-cta.cypress.spec.js
@@ -36,7 +36,10 @@ describe('Return to Notification Settings CTA', () => {
       body: userWithMobilePhone,
     });
   });
-  it('should be shown after adding mobile phone number', () => {
+  // TODO remove the skip once we can confirm this works well on staging and we
+  // confirm the non-CTA message to show in the
+  // ContactInformationSaveSuccessAlert component
+  it.skip('should be shown after adding mobile phone number', () => {
     cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
     cy.findByRole('link', { name: /add.*mobile phone/i }).click();
     cy.findByRole('button', { name: /edit mobile phone/i })

--- a/src/applications/personalization/profile/tests/e2e/post-edit-mobile-phone-cta.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/post-edit-mobile-phone-cta.cypress.spec.js
@@ -36,8 +36,7 @@ describe('Return to Notification Settings CTA', () => {
       body: userWithMobilePhone,
     });
   });
-  // TODO: unskip after the functionality works
-  it.skip('should be shown after adding mobile phone number', () => {
+  it('should be shown after adding mobile phone number', () => {
     cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
     cy.findByRole('link', { name: /add.*mobile phone/i }).click();
     cy.findByRole('button', { name: /edit mobile phone/i })

--- a/src/platform/user/profile/vap-svc/constants/index.js
+++ b/src/platform/user/profile/vap-svc/constants/index.js
@@ -92,24 +92,24 @@ export const FIELD_IDS = {
 };
 
 export const PHONE_TYPE = {
-  mobilePhone: 'MOBILE',
-  workPhone: 'WORK',
-  temporaryPhone: 'TEMPORARY',
-  faxNumber: 'FAX',
-  homePhone: 'HOME',
+  [FIELD_NAMES.MOBILE_PHONE]: 'MOBILE',
+  [FIELD_NAMES.WORK_PHONE]: 'WORK',
+  [FIELD_NAMES.TEMP_PHONE]: 'TEMPORARY',
+  [FIELD_NAMES.FAX_NUMBER]: 'FAX',
+  [FIELD_NAMES.HOME_PHONE]: 'HOME',
 };
 
 export const ANALYTICS_FIELD_MAP = {
   INIT_VAP_SERVICE_ID: 'initialize-vet360-id',
   primaryTelephone: 'primary-telephone',
   alternateTelephone: 'alternative-telephone',
-  homePhone: 'home-telephone',
-  mobilePhone: 'mobile-telephone',
-  workPhone: 'work-telephone',
-  faxNumber: 'fax-telephone',
-  email: 'email',
-  mailingAddress: 'mailing-address',
-  residentialAddress: 'home-address',
+  [FIELD_NAMES.HOME_PHONE]: 'home-telephone',
+  [FIELD_NAMES.MOBILE_PHONE]: 'mobile-telephone',
+  [FIELD_NAMES.WORK_PHONE]: 'work-telephone',
+  [FIELD_NAMES.FAX_NUMBER]: 'fax-telephone',
+  [FIELD_NAMES.EMAIL]: 'email',
+  [FIELD_NAMES.MAILING_ADDRESS]: 'mailing-address',
+  [FIELD_NAMES.RESIDENTIAL_ADDRESS]: 'home-address',
   smsOptin: 'sms-optin',
   smsOptout: 'sms-optout',
 };

--- a/src/platform/user/profile/vap-svc/reducers/index.js
+++ b/src/platform/user/profile/vap-svc/reducers/index.js
@@ -154,6 +154,7 @@ export default function vapService(state = initialState, action) {
         transactionsAwaitingUpdate: state.transactionsAwaitingUpdate.filter(
           tid => tid !== transactionId,
         ),
+        mostRecentlySavedField: null,
       };
     }
 
@@ -162,6 +163,8 @@ export default function vapService(state = initialState, action) {
         action.transaction.data.attributes.transactionId;
       const fieldTransactionMap = { ...state.fieldTransactionMap };
 
+      let mostRecentlySavedField;
+
       Object.keys(fieldTransactionMap).forEach(field => {
         const transactionRequest = fieldTransactionMap[field];
         if (
@@ -169,6 +172,7 @@ export default function vapService(state = initialState, action) {
           transactionRequest.transactionId === finishedTransactionId
         ) {
           delete fieldTransactionMap[field];
+          mostRecentlySavedField = field;
         }
       });
 
@@ -185,6 +189,7 @@ export default function vapService(state = initialState, action) {
         ),
         modal: null,
         fieldTransactionMap,
+        mostRecentlySavedField,
       };
     }
 

--- a/src/platform/user/profile/vap-svc/selectors.js
+++ b/src/platform/user/profile/vap-svc/selectors.js
@@ -48,6 +48,10 @@ export function selectVAPServiceFailedTransactions(state) {
   return state.vapService.transactions.filter(isFailedTransaction);
 }
 
+export function selectMostRecentlySavedField(state) {
+  return state.vapService.mostRecentlySavedField;
+}
+
 export function selectMostRecentErroredTransaction(state) {
   const {
     vapService: {


### PR DESCRIPTION
## Description
This adds a success alert after saving contact info. It shows a generic success alert most of the time. If the user updated their mobile phone _and_ came from the Notification Settings page, it shows a CTA with a link that returns them to the Notification Settings page.

_The alert will only appear in envs lower than production._

## Original issue(s)
department-of-veterans-affairs/va.gov-team#29542

## Testing done
Added a new Cypress test for the case where someone navigates to the contact info page from the Notification Settings page, update their mobile phone, then clicks on the CTA to return to the Notification Settings page.

## Screenshots
**Showing CTA to manage text notifications**
<img width="651" alt="Screen Shot 2021-09-27 at 8 30 54 AM" src="https://user-images.githubusercontent.com/20728956/134939325-ab1fb442-7279-406b-a524-eee3d91d5b8f.png">

**When not showing the CTA**
<img width="653" alt="Screen Shot 2021-09-27 at 8 30 33 AM" src="https://user-images.githubusercontent.com/20728956/134939429-d620a24c-1a96-4d2d-b218-f524f8d6f212.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs