### PR TITLE
Updates MHV redirect to deeplinking for SSO

### DIFF
--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -19,7 +19,7 @@ export const externalRedirects = {
     : 'https://staging-patientportal.myhealth.va.gov/',
   mhv: `https://${
     eauthEnvironmentPrefixes[environment.BUILDTYPE]
-  }eauth.va.gov/mhv-portal-web/web/myhealthevet/`,
+  }eauth.va.gov/mhv-portal-web/eauth`,
 };
 
 export const ssoKeepAliveEndpoint = () => {
@@ -74,6 +74,13 @@ function redirectWithGAClientId(redirectUrl) {
   }
 }
 
+const generatePath = (app, to) => {
+  if (app === 'mhv') {
+    return `?deeplinking=${to}`;
+  }
+  return to.startsWith('/') ? to : `/${to}`;
+};
+
 export function standaloneRedirect() {
   const searchParams = new URLSearchParams(window.location.search);
   const application = searchParams.get('application');
@@ -81,7 +88,7 @@ export function standaloneRedirect() {
   let url = externalRedirects[application] || null;
 
   if (url && to) {
-    const pathname = to.startsWith('/') ? to : `/${to}`;
+    const pathname = generatePath(application, to);
     url = url.endsWith('/') ? url.slice(0, -1) : url;
     url = `${url}${pathname}`.replace('\r\n', ''); // Prevent CRLF injection.
   }

--- a/src/platform/user/tests/authentication/utilities.unit.spec.js
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.js
@@ -112,11 +112,4 @@ describe('standaloneRedirect', () => {
       `${externalRedirects.myvahealth}some/sub/route`,
     );
   });
-
-  it('should map `to` query to deeplinking for MHV SSO', () => {
-    global.window.location.search = '?application=mhv&to=secure_messaging';
-    expect(standaloneRedirect()).to.equal(
-      `${externalRedirects.mhv}?deeplinking=secure_messaging`,
-    );
-  });
 });

--- a/src/platform/user/tests/authentication/utilities.unit.spec.js
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.js
@@ -112,4 +112,11 @@ describe('standaloneRedirect', () => {
       `${externalRedirects.myvahealth}some/sub/route`,
     );
   });
+
+  it('should map `to` query to deeplinking for MHV SSO', () => {
+    global.window.location.search = '?application=mhv&to=secure_messaging';
+    expect(standaloneRedirect()).to.equal(
+      `${externalRedirects.mhv}?deeplinking=secure_messaging`,
+    );
+  });
 });


### PR DESCRIPTION
## Description
This PR updates the MHV external redirect URL to an SSO-enabled route that will allow MHV to check the eAuth session.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#30528


## Testing done
Manual production testing (using Overrides in DevTools)
Unit testing

## Screenshots


## Acceptance criteria
- [x] I am redirected to My HealtheVet using `http://[env]va.gov/sign-in/?application=mhv&to=[sso_enabled_deeplinking_route]` example: `https://va.gov/sign-in/?application=mhv&to=secure_messaging` in a authenticated state

## Definition of done
- [x] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
