### PR TITLE
Show address validation screen when users use line 2 and line 3 fields

### DIFF
--- a/src/applications/personalization/profile/tests/e2e/address-validation/additional-address-lines.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/additional-address-lines.cypress.spec.js
@@ -1,0 +1,34 @@
+import { setUp } from '@@profile/tests/e2e/address-validation/setup';
+
+describe('Personal and contact information', () => {
+  context('when entering info on line two', () => {
+    it('show show the address validation screen', () => {
+      setUp('valid-address');
+
+      cy.findByLabelText(/^street address \(/i)
+        .clear()
+        .type('36320 Coronado Dr');
+      cy.findByLabelText(/^street address line 2/i)
+        .clear()
+        .type('care of Care Taker');
+      cy.findByLabelText(/^street address line 3/i).clear();
+
+      cy.findByLabelText(/City/i)
+        .clear()
+        .type('Fremont');
+      cy.findByLabelText(/^State/).select('MD');
+      cy.findByLabelText(/Zip code/i)
+        .clear()
+        .type('94536');
+
+      cy.findByTestId('save-edit-button').click({
+        force: true,
+      });
+
+      cy.findByTestId('mailingAddress').should(
+        'contain',
+        'Please confirm your address',
+      );
+    });
+  });
+});

--- a/src/applications/personalization/profile/tests/fixtures/users/user-36.json
+++ b/src/applications/personalization/profile/tests/fixtures/users/user-36.json
@@ -82,7 +82,7 @@
         },
         "mailingAddress": {
           "addressLine1": "123 Test Street",
-          "addressLine2": "123 Test Street",
+          "addressLine2": null,
           "addressLine3": null,
           "addressPou": "CORRESPONDENCE",
           "addressType": "DOMESTIC",

--- a/src/platform/user/profile/vap-svc/util/index.js
+++ b/src/platform/user/profile/vap-svc/util/index.js
@@ -80,6 +80,7 @@ export const getValidationMessageKey = (
 // - AND that single suggestion is either CONFIRMED or an international address
 // - AND that one suggestion has a confidence score > 90
 // - AND the state of the entered address matches the state of the suggestion
+// - AND the user did not use the address line 2 and line 3 fields
 //
 // FWIW: This sounds like a high bar to pass, but in fact most of the time this
 // function will return `false` unless the user made an error entering their
@@ -95,6 +96,8 @@ export const showAddressValidationModal = (
   } = firstSuggestedAddress;
 
   if (
+    !userInputAddress.addressLine2 &&
+    !userInputAddress.addressLine3 &&
     suggestedAddresses.length === 1 &&
     firstSuggestedAddress.stateCode === userInputAddress.stateCode &&
     firstSuggestedAddressMetadata.confidenceScore > 90 &&


### PR DESCRIPTION
## Description
This addresses the problem outlined in https://github.com/department-of-veterans-affairs/va.gov-team/issues/29744

## Original issue(s)
department-of-veterans-affairs/va.gov-team#29744

## Testing done
Added a Cypress test for this scenario to confirm the validation screen is shown when the user uses line 2, even though there is only a single confirmed, high confidence address from the suggestion API.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs