### PR TITLE
Moved title into header and added padding on mobil

### DIFF
--- a/src/applications/static-pages/dependency-verification/components/dependencyVerificationHeader.jsx
+++ b/src/applications/static-pages/dependency-verification/components/dependencyVerificationHeader.jsx
@@ -3,6 +3,9 @@ import React from 'react';
 const DependencyVerificationHeader = () => {
   return (
     <header>
+      <h3 className="vads-u-padding-top--3 small-screen:vads-u-padding-top--0">
+        Please make sure your dependents are correct
+      </h3>
       <p>
         We have the dependents below on your VA benefits. We need to make sure
         our records are right so your benefits pay is correct. If you skip this

--- a/src/applications/static-pages/dependency-verification/components/dependencyVerificationModal.jsx
+++ b/src/applications/static-pages/dependency-verification/components/dependencyVerificationModal.jsx
@@ -78,7 +78,6 @@ const DependencyVerificationModal = props => {
         }
         cssClass="va-modal-large vads-u-padding--1"
         id="dependency-verification"
-        title="Please make sure your dependents are correct"
         contents={
           <>
             <DependencyVerificationHeader />


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/29898)

During QA testing on Dependency Verification it was discovered that on small screens that the title of the modal overlapped the close button. This could impair not only users being able to read the text but the ability to use the close button on these small devices. This PR moves the title into the Header of the modal and adds classes so that padding pushes the text down on small devices to clear the close button.

## Testing done
Tested locally

## Screenshots

![Screen Shot 2021-09-27 at 1 45 39 PM](https://user-images.githubusercontent.com/1899695/134989410-a472535f-c0a5-4991-90db-f3a300186dd3.png)


## Acceptance criteria
- [x] Title text now is below close button on small devices, all devices above small are unaffected

