### PR TITLE
Clean up "update saved" alert more aggressively

### DIFF
--- a/src/applications/personalization/profile/components/personal-information/PersonalInformation.jsx
+++ b/src/applications/personalization/profile/components/personal-information/PersonalInformation.jsx
@@ -12,6 +12,7 @@ import { focusElement } from '~/platform/utilities/ui';
 
 import PaymentInformationBlocked from '@@profile/components/direct-deposit/PaymentInformationBlocked';
 import { cnpDirectDepositIsBlocked } from '@@profile/selectors';
+import { clearMostRecentlySavedField } from '@@vap-svc/actions/transactions';
 
 import { handleDowntimeForSection } from '../alerts/DowntimeBanner';
 import Headline from '../ProfileSectionHeadline';
@@ -27,13 +28,18 @@ const getScrollTarget = hash => {
 };
 
 const PersonalInformation = ({
-  showDirectDepositBlockedError,
+  clearSuccessAlert,
   hasUnsavedEdits,
   hasVAPServiceError,
+  showDirectDepositBlockedError,
 }) => {
   const lastLocation = useLastLocation();
   useEffect(() => {
     document.title = `Personal And Contact Information | Veterans Affairs`;
+
+    return () => {
+      clearSuccessAlert();
+    };
   }, []);
 
   useEffect(
@@ -114,7 +120,11 @@ const mapStateToProps = state => ({
   hasVAPServiceError: hasVAPServiceConnectionError(state),
 });
 
+const mapDispatchToProps = {
+  clearSuccessAlert: clearMostRecentlySavedField,
+};
+
 export default connect(
   mapStateToProps,
-  null,
+  mapDispatchToProps,
 )(PersonalInformation);

--- a/src/applications/personalization/profile/tests/e2e/helpers.js
+++ b/src/applications/personalization/profile/tests/e2e/helpers.js
@@ -54,12 +54,9 @@ export const mockGETEndpoints = (
 };
 
 export const mockFeatureToggles = () => {
-  cy.server();
-  cy.route({
-    method: 'GET',
-    status: 200,
-    url: '/v0/feature_toggles*',
-    response: {
+  cy.intercept('GET', '/v0/feature_toggles*', {
+    statusCode: 200,
+    body: {
       data: {
         features: [
           {

--- a/src/applications/personalization/profile/tests/e2e/post-edit-mobile-phone-cta.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/post-edit-mobile-phone-cta.cypress.spec.js
@@ -36,9 +36,7 @@ describe('Return to Notification Settings CTA', () => {
       body: userWithMobilePhone,
     });
   });
-  // TODO remove the skip once we can confirm this works well on staging and we
-  // confirm the non-CTA message to show in the
-  // ContactInformationSaveSuccessAlert component
+  // TODO remove the skip once we can confirm this works well on staging
   it.skip('should be shown after adding mobile phone number', () => {
     cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
     cy.findByRole('link', { name: /add.*mobile phone/i }).click();

--- a/src/platform/user/profile/vap-svc/actions/transactions.js
+++ b/src/platform/user/profile/vap-svc/actions/transactions.js
@@ -18,6 +18,7 @@ import {
   isFailedTransaction,
 } from '../util/transactions';
 
+export const VAP_SERVICE_CLEAR_LAST_SAVED = 'VAP_SERVICE_CLEAR_LAST_SAVED';
 export const VAP_SERVICE_TRANSACTIONS_FETCH_SUCCESS =
   'VAP_SERVICE_TRANSACTIONS_FETCH_SUCCESS';
 export const VAP_SERVICE_TRANSACTION_REQUESTED =
@@ -60,6 +61,12 @@ export function fetchTransactions() {
     } catch (err) {
       // If we sync transactions in the background and fail, is it worth telling the user?
     }
+  };
+}
+
+export function clearMostRecentlySavedField() {
+  return {
+    type: VAP_SERVICE_CLEAR_LAST_SAVED,
   };
 }
 

--- a/src/platform/user/profile/vap-svc/reducers/index.js
+++ b/src/platform/user/profile/vap-svc/reducers/index.js
@@ -1,6 +1,7 @@
 import {
   UPDATE_PROFILE_FORM_FIELD,
   OPEN_MODAL,
+  VAP_SERVICE_CLEAR_LAST_SAVED,
   VAP_SERVICE_TRANSACTIONS_FETCH_SUCCESS,
   VAP_SERVICE_TRANSACTION_REQUESTED,
   VAP_SERVICE_TRANSACTION_REQUEST_SUCCEEDED,
@@ -154,6 +155,12 @@ export default function vapService(state = initialState, action) {
         transactionsAwaitingUpdate: state.transactionsAwaitingUpdate.filter(
           tid => tid !== transactionId,
         ),
+      };
+    }
+
+    case VAP_SERVICE_CLEAR_LAST_SAVED: {
+      return {
+        ...state,
         mostRecentlySavedField: null,
       };
     }
@@ -250,6 +257,7 @@ export default function vapService(state = initialState, action) {
         modalData: action.modalData,
         hasUnsavedEdits: false,
         initialFormFields: {},
+        mostRecentlySavedField: null,
       };
 
     case ADDRESS_VALIDATION_INITIALIZE:


### PR DESCRIPTION
## Description
With this PR the "Update saved" alert that is shown after making an update to contact information will be removed:
- whenever someone starts to edit another piece of contact info
- whenever the Personal Information section unmounts (so that when someone comes back to the page, the alerts are no longer there)

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs