### PR TITLE
HLR: remove v2 wizard legacy step

### DIFF
--- a/src/applications/disability-benefits/996/tests/hlr-wizard.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr-wizard.cypress.spec.js
@@ -138,4 +138,49 @@ describe('HLR wizard', () => {
     cy.injectAxe();
     cy.axeCheck();
   });
+
+  // v2 skip legacy appeals question
+  it('should show skip legacy appeals question & show form start for HLR v2', () => {
+    cy.intercept('GET', '/v0/feature_toggles?*', {
+      data: {
+        type: 'feature_toggles',
+        features: [{ name: 'hlrV2', value: true }],
+      },
+    });
+    // reload the page, so the intercept override takes effect
+    // cy.visit(BASE_URL);
+    cy.reload();
+    cy.injectAxe();
+
+    const h1Text = 'Request a Higher-Level Review';
+    // starts with focus on breadcrumb
+    cy.focused().should('have.attr', 'id', 'va-breadcrumbs-list');
+    cy.get('h1', { timeout: Timeouts.slow })
+      .should('be.visible')
+      .and('have.text', h1Text);
+
+    cy.get('[type="radio"][value="compensation"]').check(checkOpt);
+    cy.checkStorage(SAVED_CLAIM_TYPE, 'compensation');
+    cy.checkFormChange({
+      label: 'For what type of claim are you requesting a Higher-Level Review?',
+      value: 'compensation',
+    });
+
+    // start form
+    const h1Addition = ' with VA Form 20-0996';
+    cy.findAllByText(/higher-level review online/i, { selector: 'a' })
+      .first()
+      .click();
+
+    cy.location('pathname').should('eq', `${BASE_URL}/introduction`);
+    // title changes & gets focus
+    cy.get('h1', { timeout: Timeouts.slow })
+      .should('be.visible')
+      .and('have.text', h1Text + h1Addition);
+    cy.focused().should('have.text', h1Text + h1Addition);
+    cy.checkStorage(WIZARD_STATUS, 'complete');
+    cy.injectAxe();
+    cy.axeCheck();
+    Cypress.config('features', '');
+  });
 });

--- a/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
@@ -43,10 +43,14 @@ const testConfig = createTestConfig(
       introduction: ({ afterHook }) => {
         afterHook(() => {
           if (Cypress.env('CI')) {
-            cy.get('[type="radio"][value="compensation"]').click();
-            cy.get('[type="radio"][value="legacy-no"]').click();
-            cy.axeCheck();
-            cy.findByText(/review online/i, { selector: 'a' }).click();
+            cy.get('@testData').then(testData => {
+              cy.get('[type="radio"][value="compensation"]').click();
+              if (!testData.hlrV2) {
+                cy.get('[type="radio"][value="legacy-no"]').click();
+              }
+              cy.axeCheck();
+              cy.findByText(/review online/i, { selector: 'a' }).click();
+            });
           }
           // Hit the start button
           cy.findAllByText(/start/i, { selector: 'button' })

--- a/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
@@ -29,11 +29,15 @@ const testConfig = createTestConfig(
 
     pageHooks: {
       start: () => {
-        // wizard
-        cy.get('[type="radio"][value="compensation"]').click();
-        cy.get('[type="radio"][value="legacy-no"]').click();
-        cy.axeCheck();
-        cy.findByText(/review online/i, { selector: 'a' }).click();
+        cy.get('@testData').then(testData => {
+          // wizard
+          cy.get('[type="radio"][value="compensation"]').click();
+          if (!testData.hlrV2) {
+            cy.get('[type="radio"][value="legacy-no"]').click();
+          }
+          cy.axeCheck();
+          cy.findByText(/review online/i, { selector: 'a' }).click();
+        });
       },
 
       introduction: ({ afterHook }) => {

--- a/src/applications/disability-benefits/996/wizard/pages/claimType.jsx
+++ b/src/applications/disability-benefits/996/wizard/pages/claimType.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import RadioButtons from '@department-of-veterans-affairs/component-library/RadioButtons';
+
 import recordEvent from 'platform/monitoring/record-event';
 
 import { SAVED_CLAIM_TYPE } from '../../constants';
@@ -21,7 +23,7 @@ const options = [
 
 const name = 'higher-level-review-option';
 
-const ClaimType = ({ setPageState, state = {} }) => {
+const ClaimType = ({ setPageState, state = {}, hlrV2 }) => {
   const setState = ({ value }) => {
     recordEvent({
       event: 'howToWizard-formChange',
@@ -31,9 +33,9 @@ const ClaimType = ({ setPageState, state = {} }) => {
       'form-field-value': value,
     });
 
-    // Show 'other' or 'legacyChoice' page
-    const page =
-      pageNames[value !== pageNames.other ? 'legacyChoice' : 'other'];
+    // Show 'other', or 'legacyChoice'(v1)/'legacyNo'(v2) page
+    const hlrV2Page = hlrV2 ? 'legacyNo' : 'legacyChoice';
+    const page = pageNames[value !== pageNames.other ? hlrV2Page : 'other'];
     setPageState({ selected: value }, page);
 
     if (value === pageNames.other) {
@@ -57,7 +59,11 @@ const ClaimType = ({ setPageState, state = {} }) => {
   );
 };
 
+const mapStateToProps = state => ({
+  hlrV2: state.featureToggles.hlrV2,
+});
+
 export default {
   name: pageNames.claimType,
-  component: ClaimType,
+  component: connect(mapStateToProps)(ClaimType),
 };


### PR DESCRIPTION
## Description

The Higher-Level Review form v2 will allow adding issues and an additional question regarding opting into the new appeals process, so the question in the wizard blocking Veterans from filing an online Higher-Level Review form needs to be removed.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/30597

## Testing done

Updated Cypress tests

## Screenshots

<details><summary>HLR v2 Wizard</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-09-28 at 11 28 12 AM](https://user-images.githubusercontent.com/136959/135128018-2b42271a-6e8b-41f5-aca4-5d5ad9259b0a.png)</details>

## Acceptance criteria
- [x] Dynamically remove legeacy appeal question in HLR v2
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
