### PR TITLE
DT-29706 Adding new Modal for PDF download alert instructions

### DIFF
--- a/src/applications/find-forms/components/FormTitle.jsx
+++ b/src/applications/find-forms/components/FormTitle.jsx
@@ -1,37 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const FormTitle = ({
-  currentPosition,
-  id,
-  formUrl,
-  title,
-  lang,
-  recordGAEvent,
-  showPDFInfoVersionTwo,
-}) => (
+const FormTitle = ({ id, formUrl, title, lang, recordGAEvent }) => (
   <div
     className="vads-u-padding-top--5 vads-u-margin--0 vads-u-border-top--1px vads-u-border-color--gray-lighter vads-u-font-weight--bold"
     data-e2e-id="result-title"
   >
-    {currentPosition === 1 && showPDFInfoVersionTwo ? (
-      <div className="vads-u-margin-bottom--1p5">
-        <va-alert status="info">
-          <div className="usa-alert-text vads-u-font-size--base">
-            <h3 slot="heading" className="vads-u-margin-top--0">
-              We recommend that you download PDF forms and open them in Adobe
-              Acrobat Reader
-            </h3>
-            <a
-              className="vads-u-font-weight--normal"
-              href="https://www.va.gov/resources/how-to-download-and-open-a-vagov-pdf-form/"
-            >
-              Get instructions for opening the form in Acrobat Reader
-            </a>
-          </div>
-        </va-alert>
-      </div>
-    ) : null}
     {formUrl ? (
       <>
         <p id={id} className="vads-u-font-weight--normal vads-u-margin--0">

--- a/src/applications/find-forms/components/SearchResult.jsx
+++ b/src/applications/find-forms/components/SearchResult.jsx
@@ -121,14 +121,7 @@ const deriveRelatedTo = ({
   return null;
 };
 
-const SearchResult = ({
-  currentPosition,
-  form,
-  formMetaInfo,
-  showPDFInfoVersionOne,
-  showPDFInfoVersionTwo,
-  showPDFInfoVersionThree,
-}) => {
+const SearchResult = ({ form, formMetaInfo, showPDFInfoVersionThree }) => {
   // Escape early if we don't have the necessary form attributes.
   if (!form?.attributes) {
     return null;
@@ -169,13 +162,11 @@ const SearchResult = ({
   return (
     <li>
       <FormTitle
-        currentPosition={currentPosition}
         id={id}
         formUrl={formDetailsUrl}
         lang={language}
         title={title}
         recordGAEvent={recordGAEvent}
-        showPDFInfoVersionTwo={showPDFInfoVersionTwo}
       />
       <div className="vads-u-margin-y--1 vsa-from-last-updated">
         <span className="vads-u-font-weight--bold">Form last updated:</span>{' '}
@@ -210,35 +201,6 @@ const SearchResult = ({
           </a>
         </div>
       ) : null}
-      {showPDFInfoVersionOne && (
-        <div className="find-forms-alert-message vads-u-margin-bottom--2 vads-u-background-color--primary-alt-lightest vads-u-display--flex vads-u-padding-y--4 vads-u-padding-right--7 vads-u-padding-left--3 vads-u-width--full">
-          <i aria-hidden="true" role="img" />
-          <span className="sr-only">Alert: </span>
-          <div>
-            <p className="vads-u-margin-top--0">
-              We recommend that you download PDF forms and open them in Adobe
-              Acrobat Reader
-            </p>
-            <a href="https://www.va.gov/resources/how-to-download-and-open-a-vagov-pdf-form/">
-              Get instructions for opening the form in Acrobat Reader
-            </a>
-          </div>
-        </div>
-      )}
-      {showPDFInfoVersionThree && (
-        <div className="vads-u-margin-bottom--1 vads-u-margin-top--6">
-          <span className="vads-u-margin-top--0 vads-u-margin-right--0p5 vads-u-color--gray-medium">
-            You’ll need to download this form and open it in Adobe Acrobat
-            Reader.
-          </span>
-          <a
-            className="vads-u-display--inline "
-            href="https://www.va.gov/resources/how-to-download-and-open-a-vagov-pdf-form/"
-          >
-            Read More
-          </a>
-        </div>
-      )}
       <div className="vads-u-margin-bottom--5">
         <a
           className="find-forms-max-content vads-u-text-decoration--none"
@@ -265,12 +227,9 @@ const SearchResult = ({
 };
 
 SearchResult.propTypes = {
-  currentPosition: PropTypes.number,
   form: customPropTypes.Form.isRequired,
   formMetaInfo: customPropTypes.FormMetaInfo,
   showPDFInfoVersionOne: PropTypes.bool,
-  showPDFInfoVersionTwo: PropTypes.bool,
-  showPDFInfoVersionThree: PropTypes.bool,
 };
 
 export default SearchResult;

--- a/src/applications/find-forms/components/SearchResult.jsx
+++ b/src/applications/find-forms/components/SearchResult.jsx
@@ -121,7 +121,12 @@ const deriveRelatedTo = ({
   return null;
 };
 
-const SearchResult = ({ form, formMetaInfo, showPDFInfoVersionThree }) => {
+const SearchResult = ({
+  form,
+  formMetaInfo,
+  showPDFInfoVersionOne,
+  toggleModalState,
+}) => {
   // Escape early if we don't have the necessary form attributes.
   if (!form?.attributes) {
     return null;
@@ -175,11 +180,7 @@ const SearchResult = ({ form, formMetaInfo, showPDFInfoVersionThree }) => {
 
       {relatedTo}
       {formToolUrl ? (
-        <div
-          className={
-            showPDFInfoVersionThree ? null : 'vads-u-margin-bottom--2p5'
-          }
-        >
+        <div className="vads-u-margin-bottom--2p5">
           <a
             className="find-forms-max-content vads-u-display--flex vads-u-align-items--center vads-u-text-decoration--none"
             href={formToolUrl}
@@ -204,11 +205,12 @@ const SearchResult = ({ form, formMetaInfo, showPDFInfoVersionThree }) => {
       <div className="vads-u-margin-bottom--5">
         <a
           className="find-forms-max-content vads-u-text-decoration--none"
-          href={url}
           rel="noreferrer noopener"
-          onClick={() =>
-            recordGAEvent(`Download VA form ${id} ${pdfLabel}`, url, 'pdf')
-          }
+          href={!showPDFInfoVersionOne ? url : null}
+          onClick={() => {
+            recordGAEvent(`Download VA form ${id} ${pdfLabel}`, url, 'pdf');
+            if (showPDFInfoVersionOne) toggleModalState(id, url);
+          }}
           {...linkProps}
         >
           <i
@@ -230,6 +232,7 @@ SearchResult.propTypes = {
   form: customPropTypes.Form.isRequired,
   formMetaInfo: customPropTypes.FormMetaInfo,
   showPDFInfoVersionOne: PropTypes.bool,
+  toggleModalState: PropTypes.func,
 };
 
 export default SearchResult;

--- a/src/applications/find-forms/components/SearchResult.jsx
+++ b/src/applications/find-forms/components/SearchResult.jsx
@@ -206,7 +206,7 @@ const SearchResult = ({
         <a
           className="find-forms-max-content vads-u-text-decoration--none"
           rel="noreferrer noopener"
-          href={!showPDFInfoVersionOne ? url : null}
+          href={showPDFInfoVersionOne ? null : url}
           onClick={() => {
             recordGAEvent(`Download VA form ${id} ${pdfLabel}`, url, 'pdf');
             if (showPDFInfoVersionOne) toggleModalState(id, url);

--- a/src/applications/find-forms/containers/SearchResults.jsx
+++ b/src/applications/find-forms/containers/SearchResults.jsx
@@ -229,6 +229,7 @@ export const SearchResults = ({
 
       {/*  */}
       <div
+        className="pdf-alert-modal"
         style={{
           height: '500px',
         }}

--- a/src/applications/find-forms/containers/SearchResults.jsx
+++ b/src/applications/find-forms/containers/SearchResults.jsx
@@ -251,15 +251,16 @@ export const SearchResults = ({
                 All PDF forms do not function fully in a web browser or other
                 PDF viewer. Please download the form and use Adobe Acrobat
                 Reader DC to fill out. For specific instructions about working
-                with PDF’s
+                with PDFs
               </span>{' '}
               <a href="https://www.va.gov/resources/how-to-download-and-open-a-vagov-pdf-form">
                 please read out Resources and Support Article
               </a>
             </p>
             <a
-              href="https://get.adobe.com/reader/"
               className="vads-u-display--block vads-u-margin-bottom--1p5"
+              href="https://get.adobe.com/reader/"
+              rel="noopener noreferrer"
             >
               <span>Get Acrobat Reader DC</span>
             </a>

--- a/src/applications/find-forms/tests/components/SearchResult.unit.spec.jsx
+++ b/src/applications/find-forms/tests/components/SearchResult.unit.spec.jsx
@@ -92,37 +92,6 @@ describe('Find VA Forms <SearchResult />', () => {
     tree.unmount();
   });
 
-  it('should have have a Alert Box PDF information (version one) for download trouble', () => {
-    const tree = mount(
-      <SearchResult
-        formMetaInfo={formMetaInfo}
-        form={form}
-        showPDFInfoVersionOne
-      />,
-    );
-    expect(tree.html()).to.include('<div class="find-forms-alert-message');
-    expect(tree.html()).to.include(
-      'href="https://www.va.gov/resources/how-to-download-and-open-a-vagov-pdf-form/"',
-    );
-    tree.unmount();
-  });
-
-  it('should have have a Alert Box PDF information (version two)for download trouble', () => {
-    const tree = mount(
-      <SearchResult
-        formMetaInfo={formMetaInfo}
-        form={form}
-        showPDFInfoVersionTwo
-        currentPosition={1}
-      />,
-    );
-    expect(tree.html()).to.include('<va-alert status="info">');
-    expect(tree.html()).to.include(
-      'href="https://www.va.gov/resources/how-to-download-and-open-a-vagov-pdf-form/"',
-    );
-    tree.unmount();
-  });
-
   it('should have "Fill out VA Form" link', () => {
     const tree = mount(
       <SearchResult formMetaInfo={formMetaInfo} form={form} />,

--- a/src/applications/find-forms/tests/containers/SearchResults.unit.spec.jsx
+++ b/src/applications/find-forms/tests/containers/SearchResults.unit.spec.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import times from 'lodash/times';
 // Relative imports.
 import { INITIAL_SORT_STATE } from '../../constants';
@@ -12,6 +12,16 @@ import {
 } from '../../containers/SearchResults';
 
 describe('Find VA Forms <SearchResults>', () => {
+  const results = times(MAX_PAGE_LIST_LENGTH + 1, () => ({
+    id: 'VA10192',
+    attributes: {
+      formName: 'VA10192',
+      title: 'Information for Pre-Complaint Processing',
+      url: 'https://www.va.gov/vaforms/va/pdf/VA10192.pdf',
+      lastRevisionOn: '2020-12-22',
+    },
+  }));
+
   it('renders a loading indicator', () => {
     const tree = shallow(<SearchResults fetching />);
 
@@ -46,17 +56,21 @@ describe('Find VA Forms <SearchResults>', () => {
     tree.unmount();
   });
 
-  it('renders a table and pagination', () => {
-    const results = times(MAX_PAGE_LIST_LENGTH + 1, () => ({
-      id: 'VA10192',
-      attributes: {
-        formName: 'VA10192',
-        title: 'Information for Pre-Complaint Processing',
-        url: 'https://www.va.gov/vaforms/va/pdf/VA10192.pdf',
-        lastRevisionOn: '2020-12-22',
-      },
-    }));
+  it('should have a Modal detailing PDF information for download trouble', () => {
+    const tree = mount(
+      <SearchResults
+        startIndex={0}
+        results={results}
+        updateSortByPropertyName={sinon.stub()}
+        showPDFInfoVersionOne
+        sortByPropertyName={INITIAL_SORT_STATE}
+      />,
+    );
+    expect(tree.html()).to.include('<div class="pdf-alert-modal');
+    tree.unmount();
+  });
 
+  it('renders a table and pagination', () => {
     const tree = shallow(
       <SearchResults
         startIndex={0}


### PR DESCRIPTION
## Description
Adding a modal after our user research session showed the other 3 during testing failed.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#29706


## Testing done
Ran and updated unit tests, ran e2e tests, ran the feature locally

## Screenshots
![Screen Shot 2021-09-28 at 2 58 10 PM](https://user-images.githubusercontent.com/26075258/135149106-708a6aea-a7d3-4e84-b850-43efcf7ba6af.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
