### PR TITLE
Remove vaos test store

### DIFF
--- a/src/applications/virtual-agent/tests/Chatbox.unit.spec.js
+++ b/src/applications/virtual-agent/tests/Chatbox.unit.spec.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { createStore, combineReducers, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
 import { expect } from 'chai';
 import { waitFor, screen, fireEvent, act } from '@testing-library/react';
 import sinon from 'sinon';
@@ -7,11 +9,11 @@ import * as Sentry from '@sentry/browser';
 
 import Chatbox from '../components/chatbox/Chatbox';
 import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
+import { commonReducer } from 'platform/startup/store';
 import {
   mockApiRequest,
   mockMultipleApiRequests,
 } from 'platform/testing/unit/helpers';
-import { createTestStore } from '../../vaos/tests/mocks/setup';
 import { FETCH_TOGGLE_VALUES_SUCCEEDED } from 'platform/site-wide/feature-toggles/actionTypes';
 import Main from 'platform/site-wide/user-nav/containers/Main';
 import GreetUser from '../components/webchat/makeBotGreetUser';
@@ -36,6 +38,16 @@ describe('App', () => {
         },
       },
     });
+  }
+
+  function createTestStore(initialState) {
+    return createStore(
+      combineReducers({
+        ...commonReducer,
+      }),
+      initialState,
+      applyMiddleware(thunk),
+    );
   }
 
   beforeEach(() => {


### PR DESCRIPTION
## Description
As part of removing cross app imports from the repo, this PR removes importing the `vaos` test store since the `vaos` reducers aren't needed in the `virtual-agent` Chatbox test.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#30299


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
