### PR TITLE
remove checks for languageSupport feature toggle in Footer

### DIFF
--- a/src/platform/site-wide/va-footer/components/Footer.jsx
+++ b/src/platform/site-wide/va-footer/components/Footer.jsx
@@ -7,8 +7,6 @@ import LanguageSupport from './LanguageSupport';
 import { createLinkGroups } from '../helpers';
 import { replaceWithStagingDomain } from '../../../utilities/environment/stagingDomains';
 import { connect } from 'react-redux';
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import { langSelectedAction } from 'applications/static-pages/i18Select/actions';
 
 class Footer extends React.Component {
@@ -45,14 +43,12 @@ class Footer extends React.Component {
             visible={this.state.isMobile}
             links={this.linkObj}
             langConfig={{
-              showLangSupport: this.props.showLangSupport,
               dispatchLanguageSelection: this.props.dispatchLanguageSelection,
               languageCode: this.props.languageCode,
             }}
           />
           {!this.state.isMobile && (
             <LanguageSupport
-              showLangSupport={this.props.showLangSupport}
               isDesktop
               dispatchLanguageSelection={this.props.dispatchLanguageSelection}
               languageCode={this.props.languageCode}
@@ -79,13 +75,10 @@ class Footer extends React.Component {
   }
 }
 const mapDispatchToProps = dispatch => ({
-  dispatchLanguageSelection: lang => {
-    return dispatch(langSelectedAction(lang));
-  },
+  dispatchLanguageSelection: lang => dispatch(langSelectedAction(lang)),
 });
 
 const mapStateToProps = state => ({
-  showLangSupport: toggleValues(state)[FEATURE_FLAG_NAMES.languageSupport],
   languageCode: state.i18State.lang,
 });
 

--- a/src/platform/site-wide/va-footer/components/Footer.jsx
+++ b/src/platform/site-wide/va-footer/components/Footer.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { debounce } from 'lodash';
 import { isWideScreen } from '../../../utilities/accessibility/index';
 import CrisisPanel from './CrisisPanel';
 import DesktopLinks from './DesktopLinks';
@@ -18,16 +19,15 @@ class Footer extends React.Component {
     };
   }
   componentDidMount() {
-    // TODO: debounce
     window.addEventListener(
       'resize',
-      () => {
+      debounce(() => {
         if (this.state.isMobile !== !isWideScreen()) {
           this.setState({
             isMobile: !isWideScreen(),
           });
         }
-      },
+      }, 250),
       false,
     );
     if (this.props.handleFooterDidMount) {

--- a/src/platform/site-wide/va-footer/components/LanguageSupport.jsx
+++ b/src/platform/site-wide/va-footer/components/LanguageSupport.jsx
@@ -56,7 +56,6 @@ function LanguagesListTemplate({ dispatchLanguageSelection }) {
 }
 export default function LanguageSupport({
   isDesktop,
-  showLangSupport,
   dispatchLanguageSelection,
   languageCode,
 }) {
@@ -75,8 +74,6 @@ export default function LanguageSupport({
     },
     [dispatchLanguageSelection, languageCode],
   );
-
-  if (showLangSupport !== true) return null;
 
   if (isDesktop) {
     return (

--- a/src/platform/site-wide/va-footer/components/MobileLinks.jsx
+++ b/src/platform/site-wide/va-footer/components/MobileLinks.jsx
@@ -82,7 +82,6 @@ export default function MobileLinks({ links, visible, langConfig }) {
           </div>
         </li>
         <LanguageSupport
-          showLangSupport={langConfig.showLangSupport}
           dispatchLanguageSelection={langConfig.dispatchLanguageSelection}
           languageCode={langConfig.languageCode}
         />


### PR DESCRIPTION
## Description
No longer checking for the `languageSupport` feature toggle to determine whether to show the LanguageSupport component in the footer.

The `languageSupport` toggle can now be deprecated because the component should show globally. 

Currently there are sub-domains that are use the shared header and footer code, but are NOT showing the LanguageSupport component because the Redux feature toggles are not being set and resulting in undefined. One such sub-domain is https://benefits.va.gov

This PR will allow the LanguageSupport component to show on these sub-domains.

Also added a debounce on the window resize event listener as that was a minor todo that I noticed within the footer component.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/29996


## Testing done
Tested on review instance and locally

## Screenshots

Api request on benefits subdomain failing
![Screen Shot 2021-09-27 at 1 04 24 PM](https://user-images.githubusercontent.com/8332986/134969371-5e927ae0-1127-44e1-8458-3e79f23051fb.png)




## Acceptance criteria
- [x] LanguageSupport component continues to show on footer globally

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
