### PR TITLE
Bump formation to 6.17.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -237,7 +237,7 @@
   "private": true,
   "dependencies": {
     "@department-of-veterans-affairs/component-library": "^3.1.1",
-    "@department-of-veterans-affairs/formation": "6.17.2",
+    "@department-of-veterans-affairs/formation": "6.17.3",
     "@department-of-veterans-affairs/formulate": "0.0.1",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "@formatjs/intl-datetimeformat": "^4.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1998,10 +1998,10 @@
     react-transition-group "1"
     recast "^0.14.4"
 
-"@department-of-veterans-affairs/formation@6.17.2":
-  version "6.17.2"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-6.17.2.tgz#4daef23cbf01edfc3aff0b5b1750556bc641cf99"
-  integrity sha512-nhOecnMZfFQTgECSvTKe5DxQk7GXZ8Qaqh67aLyb0AkWTTA6/nffbEgehjIeoWlgkhJCV4WstqtrMRSIEvNhCA==
+"@department-of-veterans-affairs/formation@6.17.3":
+  version "6.17.3"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation/-/formation-6.17.3.tgz#204a1e86d041eec30c6ed8a16c8f74f94498dc21"
+  integrity sha512-JS103tNPG4oHYAL3PZoeEWpUdkZVNqAqkegM82Sv5L4hkf5hpPZdrmulIi7xFXE3tmfWc1rHLXL2uMf8auOKYg==
   dependencies:
     "@fortawesome/fontawesome-free" "^5.6.3"
     domready "^1.0.8"


### PR DESCRIPTION
## Description
Removes the focus outline for the in-page link headers

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/15244


## Testing done
local

## Screenshots
https://user-images.githubusercontent.com/3144003/135161419-2b385ac9-ba9c-462c-b932-ea7f04438c75.mov


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
