### PR TITLE
Revert 3.2.0 to 3.1.2 for component-library

### DIFF
--- a/package.json
+++ b/package.json
@@ -236,7 +236,7 @@
   },
   "private": true,
   "dependencies": {
-    "@department-of-veterans-affairs/component-library": "3.2.0",
+    "@department-of-veterans-affairs/component-library": "3.1.2",
     "@department-of-veterans-affairs/formation": "6.17.3",
     "@department-of-veterans-affairs/formulate": "0.0.1",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1980,10 +1980,10 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@department-of-veterans-affairs/component-library@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-3.2.0.tgz#690ce52632e2a03e0ace5e8725255cf572ccbfa1"
-  integrity sha512-hReCj/1VNSpEj+0h81wxmxclRyu2pAtsjlLIdzFfAVsd6dDxWmsXdjcBURWMmMJKbubD8MJfqEzr9R6BrssLbg==
+"@department-of-veterans-affairs/component-library@3.1.2":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-3.1.2.tgz#6c3c11ec8eac91762b9d192d8cbd1117bb81ed9e"
+  integrity sha512-9y8HBE/nAjU3hu8NrSqYJMdaUYncd8uHZKR6tswZ7HIv9w/3hil85rbaR6cIAGrBV60dOiiyy5IpYdD28tFXbQ==
   dependencies:
     classnames "^2.2.6"
     core-js "^3.9.0"


### PR DESCRIPTION
## Description

[This PR](https://github.com/department-of-veterans-affairs/component-library/pull/180/files) accidentally made the banners 100% width for the homepage, which it should not be. This will be resolved [likely later today](https://dsva.slack.com/archives/C52CL1PKQ/p1632927866027400?thread_ts=1632926162.017600&cid=C52CL1PKQ) but in the meantime we need to make sure we don't bump the component-library until it's resolved.

## Original issue(s)
https://dsva.slack.com/archives/C52CL1PKQ/p1632926162017600


## Testing done

Locally

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/12773166/135298026-bd2fff8e-0612-471e-8099-5b71b1957b50.png)

### After

![image](https://user-images.githubusercontent.com/12773166/135298117-8a9f7610-4870-4290-a140-78b98491a324.png)

## Acceptance criteria
- [x] Fix new homepage banner styling

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
