### PR TITLE
526: Update treatment start date validations

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-test.json
@@ -246,7 +246,7 @@
       },
       "servicePeriods": [
         {
-          "serviceBranch": "Air Force Reserve",
+          "serviceBranch": "Air Force",
           "dateRange": {
             "from": "2001-03-21",
             "to": "2014-07-21"

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/secondary-new-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/secondary-new-test.json
@@ -192,7 +192,7 @@
       },
       "servicePeriods": [
         {
-          "serviceBranch": "Air Force Reserve",
+          "serviceBranch": "Air Force",
           "dateRange": {
             "from": "2001-03-21",
             "to": "2014-07-21"

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/maximal-test.json
@@ -98,7 +98,7 @@
       },
       "servicePeriods": [
         {
-          "serviceBranch": "Air Force Reserve",
+          "serviceBranch": "Air Force",
           "dateRange": { "from": "2001-03-21", "to": "2014-07-21" }
         },
         {

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/secondary-new-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/secondary-new-test.json
@@ -78,7 +78,7 @@
       },
       "servicePeriods": [
         {
-          "serviceBranch": "Air Force Reserve",
+          "serviceBranch": "Air Force",
           "dateRange": { "from": "2001-03-21", "to": "2014-07-21" }
         },
         {

--- a/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
@@ -134,8 +134,8 @@ describe('VA Medical Records', () => {
           ],
           serviceInformation: {
             servicePeriods: [
-              { dateRange: { from: '2012-01-12' } },
-              { dateRange: { from: '2001-05-30' } },
+              { dateRange: { from: '2012-01-12' }, serviceBranch: 'Army' },
+              { dateRange: { from: '2001-05-30' }, serviceBranch: 'Army' },
             ],
           },
         }}

--- a/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
@@ -109,15 +109,20 @@ describe('526 All Claims validations', () => {
   });
 
   describe('startedAfterServicePeriod', () => {
-    it('should add error if treatment start date is before earliest service start date', () => {
+    it('should add error if treatment start date is before earliest active service start date', () => {
       const err = { addError: sinon.spy() };
 
       const formData = {
         serviceInformation: {
           servicePeriods: [
-            { dateRange: { from: '2003-03-12' } },
-            { dateRange: { from: '2000-01-14' } },
-            { dateRange: { from: '2011-12-25' } },
+            { dateRange: { from: '2003-03-12' }, serviceBranch: 'Army' },
+            { dateRange: { from: '2000-01-14' }, serviceBranch: 'Army' },
+            { dateRange: { from: '2011-12-25' }, serviceBranch: 'Army' },
+            // ignored
+            {
+              dateRange: { from: '1990-10-11' },
+              serviceBranch: 'Army Reserve',
+            },
           ],
         },
       };
@@ -126,15 +131,20 @@ describe('526 All Claims validations', () => {
       expect(err.addError.calledOnce).to.be.true;
     });
 
-    it('should not add error if treatment start date monthYear is the same as earliest service start date', () => {
+    it('should not add error if treatment start date monthYear is the same as earliest active service start date', () => {
       const err = { addError: sinon.spy() };
 
       const formData = {
         serviceInformation: {
           servicePeriods: [
-            { dateRange: { from: '2003-03-12' } },
-            { dateRange: { from: '2000-01-14' } },
-            { dateRange: { from: '2011-12-25' } },
+            { dateRange: { from: '2003-03-12' }, serviceBranch: 'Army' },
+            { dateRange: { from: '2000-01-14' }, serviceBranch: 'Army' },
+            { dateRange: { from: '2011-12-25' }, serviceBranch: 'Coast Guard' },
+            // ignored
+            {
+              dateRange: { from: '1990-10-11' },
+              serviceBranch: 'Coast Guard Reserve',
+            },
           ],
         },
       };
@@ -143,15 +153,20 @@ describe('526 All Claims validations', () => {
       expect(err.addError.called).to.be.false;
     });
 
-    it('should not add error if treatment start date is after earliest service start date', () => {
+    it('should not add error if treatment start date is after earliest active service start date', () => {
       const err = { addError: sinon.spy() };
 
       const formData = {
         serviceInformation: {
           servicePeriods: [
-            { dateRange: { from: '2003-03-12' } },
-            { dateRange: { from: '2000-01-14' } },
-            { dateRange: { from: '2011-12-25' } },
+            { dateRange: { from: '2003-03-12' }, serviceBranch: 'Army' },
+            { dateRange: { from: '2000-01-14' }, serviceBranch: 'Army' },
+            { dateRange: { from: '2011-12-25' }, serviceBranch: 'Army' },
+            // ignored
+            {
+              dateRange: { from: '1990-10-11' },
+              serviceBranch: 'Army National Guard',
+            },
           ],
         },
       };

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -19,6 +19,7 @@ import {
   MILITARY_STATE_VALUES,
   LOWERED_DISABILITY_DESCRIPTIONS,
   NULL_CONDITION_STRING,
+  RESERVE_GUARD_TYPES,
 } from './constants';
 
 export const hasMilitaryRetiredPay = data =>
@@ -223,24 +224,31 @@ export function startedAfterServicePeriod(err, fieldData, formData) {
   if (!_.get('servicePeriods.length', formData.serviceInformation, false)) {
     return;
   }
+  const { nationalGuard, reserve } = RESERVE_GUARD_TYPES;
 
+  // only check active duty periods
   const earliestServiceStartDate = formData.serviceInformation.servicePeriods
-    .map(period => new Date(period.dateRange.from))
-    .reduce((earliestDate, current) => {
-      if (current < earliestDate) {
-        return current;
-      }
-
-      return earliestDate;
-    });
+    .filter(
+      ({ serviceBranch = '' } = {}) =>
+        serviceBranch &&
+        !(
+          serviceBranch.includes(nationalGuard) ||
+          serviceBranch.includes(reserve)
+        ),
+    )
+    .map(period => moment(period.dateRange.from, 'YYYY-MM-DD'))
+    .reduce(
+      (earliestDate, current) =>
+        current.isBefore(earliestDate) ? current : earliestDate,
+      moment(),
+    );
 
   const treatmentStartDate = moment(fieldData, 'YYYY-MM');
-  const firstServiceStartDate = moment(earliestServiceStartDate);
   // If the moment is earlier than the moment passed to moment.diff(),
   // the return value will be negative.
-  if (treatmentStartDate.diff(firstServiceStartDate, 'month') < 0) {
+  if (treatmentStartDate.diff(earliestServiceStartDate, 'month') < 0) {
     err.addError(
-      'Your first treatment date needs to be after the start of your earliest service period.',
+      'Your first treatment date needs to be after the start of your earliest active duty service period.',
     );
   }
 }


### PR DESCRIPTION
## Description

This PR updates a validation rule based on this EVSS error:

> `form526.treatments.TreatmentPastActiveDutyDate` The start date for a treatment record cannot be prior to the earliest period of service

The frontend currently validates against the earliest period of service, which includes Reserve and National Guard service periods. This PR ignores non-active duty service periods.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/30659

## Testing done

- Updated mock data (for e2e testing)
- Updated unit tests

## Screenshots

<details><summary>Error shown in Treatment center entry</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-09-29 at 11 16 36 AM](https://user-images.githubusercontent.com/136959/135312174-0b0331c2-eaaf-4e02-9af6-e8b4cf952486.png)</details>

## Acceptance criteria
- [x] Update validation to exclude non-active duty service periods
- [x] All unit & e2e tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
