### PR TITLE
Update VEText shortcode in KMI pages

### DIFF
--- a/src/applications/coronavirus-vaccination-expansion/containers/ConfirmationPage.jsx
+++ b/src/applications/coronavirus-vaccination-expansion/containers/ConfirmationPage.jsx
@@ -59,7 +59,7 @@ export class ConfirmationPage extends React.Component {
         </p>
         <ul>
           <li>
-            Text messages will always come from <strong>53079</strong>.
+            Text messages will always come from <strong>80728</strong>.
           </li>
           <li>
             Emails will always come from a <strong>va.gov</strong> email

--- a/src/applications/coronavirus-vaccination/components/VerbiageHelper.jsx
+++ b/src/applications/coronavirus-vaccination/components/VerbiageHelper.jsx
@@ -143,7 +143,7 @@ export const ContactRules = () => {
         be sure the call, email, or text is really from VA.
         <ul>
           <li>
-            Text messages will always come from <strong>53079</strong>.
+            Text messages will always come from <strong>80728</strong>.
           </li>
           <li>
             Emails will always come from a <strong>va.gov</strong> email


### PR DESCRIPTION
## Description
Updates VEText short code from which Veterans should expect messages about COVID-19 vaccines.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/30667

## Testing done
👀 

## Screenshots


## Acceptance criteria
- [ ] Number changed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
