### PR TITLE
508 [SCREENREADER]: Hide progress button icons from screen-readers

### DIFF
--- a/src/platform/forms-system/src/js/components/ProgressButton.jsx
+++ b/src/platform/forms-system/src/js/components/ProgressButton.jsx
@@ -14,12 +14,18 @@ class ProgressButton extends React.Component {
 
   render() {
     const beforeText = this.props.beforeText ? (
-      <span className="button-icon">{this.props.beforeText} </span>
+      <span className="button-icon" aria-hidden="true">
+        {this.props.beforeText}
+        &nbsp;
+      </span>
     ) : (
       ''
     );
     const afterText = this.props.afterText ? (
-      <span className="button-icon"> {this.props.afterText}</span>
+      <span className="button-icon" aria-hidden="true">
+        &nbsp;
+        {this.props.afterText}
+      </span>
     ) : (
       ''
     );
@@ -28,8 +34,8 @@ class ProgressButton extends React.Component {
       <button
         type={this.props.submitButton ? 'submit' : 'button'}
         disabled={this.props.disabled}
-        className={`${this.props.buttonClass} ${
-          this.props.disabled ? 'usa-button-disabled' : null
+        className={`${this.props.buttonClass}${
+          this.props.disabled ? ' usa-button-disabled' : ''
         }`}
         id={`${this.id}-continueButton`}
         onClick={this.props.onButtonClick}

--- a/src/platform/forms-system/test/js/components/ProgressButton.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/ProgressButton.unit.spec.jsx
@@ -48,6 +48,24 @@ describe('<ProgressButton>', () => {
     return expect(updatePromise).to.eventually.eql(true);
   });
 
+  it('should add aria-hidden button icons', () => {
+    const tree = shallow(
+      <ProgressButton
+        buttonText="Button text"
+        buttonClass="usa-button-primary"
+        disabled={false}
+        beforeText={'«'}
+        afterText={'»'}
+      />,
+    );
+    expect(tree.text()).to.equal('«\u00a0Button text\u00a0»');
+    const spans = tree.find('span[aria-hidden="true"]');
+    expect(spans).to.have.length.of(2);
+    expect(spans.first().text()).to.equal('«\u00a0');
+    expect(spans.last().text()).to.equal('\u00a0»');
+    tree.unmount();
+  });
+
   it('should pass aXe check when enabled', () =>
     axeCheck(
       <ProgressButton


### PR DESCRIPTION
## Description

The form progress buttons used to navigate within a form include a span with a `button-icon` class. It may contain either a double back arrow icon or double forward arrow icon. The screen-reader will still include, but may not verbally read out, these icons. For optimal accessibility, these icons should be hidden from the screen-reader completely.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/30724

## Testing done

Added unit test

## Screenshots

<details><summary>Before: rendered progress buttons</summary>

<!-- leave a blank line above -->
![Rendered back and continue buttons in the upper half with developer window in the bottom half showing HTML spans with only a button-icon class](https://user-images.githubusercontent.com/136959/135339124-bac4ccbb-db6e-4f2d-a42c-4550af7c2e58.png)</details>

<details><summary>After: buttons with hidden icons</summary>

<!-- leave a blank line above -->
![Rendered back and continue buttons in the upper half with developer window in the bottom half showing HTML spans with an aria-hidden attribute](https://user-images.githubusercontent.com/136959/135343953-e38600f4-fd85-43be-9fa9-fdda82dfb16f.png)</details>

## Acceptance criteria
- [x] Progress button icons have an `aria-hidden` attribute
- [x] Unit tests added & all passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
