### PR TITLE
put focus on h1

### DIFF
--- a/src/applications/personalization/dashboard/tests/e2e/loa1.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/loa1.cypress.spec.js
@@ -111,3 +111,14 @@ describe('The My VA Dashboard', () => {
     loa1DashboardTest(true, stubs);
   });
 });
+
+describe('When clicking on the verify your identity link', () => {
+  it('should focus on the h1 element', () => {
+    cy.login(loa1User);
+    cy.visit(manifest.rootUrl);
+    cy.findByRole('link', { name: /verify your identity/i })
+      .should('exist')
+      .click();
+    cy.get('h1').should('be.focused');
+  });
+});

--- a/src/applications/verify/containers/VerifyApp.jsx
+++ b/src/applications/verify/containers/VerifyApp.jsx
@@ -65,7 +65,7 @@ export class VerifyApp extends React.Component {
           <div className="row">
             <div className="columns small-12">
               <div>
-                <h1>Verify your identity</h1>
+                <h1 tabIndex="-1">Verify your identity</h1>
                 <AlertBox
                   content={`You signed in with ${this.signInMethod}`}
                   isVisible

--- a/src/applications/verify/containers/VerifyApp.jsx
+++ b/src/applications/verify/containers/VerifyApp.jsx
@@ -13,6 +13,7 @@ import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors'
 import { verify } from 'platform/user/authentication/utilities';
 import { hasSession } from 'platform/user/profile/utilities';
 import SubmitSignInForm from 'platform/static-data/SubmitSignInForm';
+import { focusElement } from '~/platform/utilities/ui';
 
 export class VerifyApp extends React.Component {
   constructor(props) {
@@ -41,6 +42,9 @@ export class VerifyApp extends React.Component {
     if (shouldCheckAccount) {
       this.checkAccountAccess();
     }
+    if (!this.props.profile.loading && prevProps.profile.loading) {
+      focusElement('h1');
+    }
   }
 
   checkAccountAccess() {
@@ -65,7 +69,7 @@ export class VerifyApp extends React.Component {
           <div className="row">
             <div className="columns small-12">
               <div>
-                <h1 tabIndex="-1">Verify your identity</h1>
+                <h1>Verify your identity</h1>
                 <AlertBox
                   content={`You signed in with ${this.signInMethod}`}
                   isVisible


### PR DESCRIPTION
## Description
Focus should go to the `h1` Verify your identity when the LOA user uses the "Verify your identity" link


## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done
Cypress test written and passes plus manual testing using a screen reader

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
