### PR TITLE
Fix width for banner alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -305,7 +305,7 @@
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
     "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#3a0946727d9013ff2771af37bfca0c4c0ff0a1d5",
-    "web-components": "https://github.com/department-of-veterans-affairs/component-library/releases/download/wc-v0.11.0/web-components-v0.10.0.tgz",
+    "web-components": "https://github.com/department-of-veterans-affairs/component-library/releases/download/wc-v0.11.1/web-components-v0.11.1.tgz",
     "whatwg-fetch": "^3.6.2"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19181,9 +19181,9 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-"web-components@https://github.com/department-of-veterans-affairs/component-library/releases/download/wc-v0.11.0/web-components-v0.10.0.tgz":
-  version "0.10.0"
-  resolved "https://github.com/department-of-veterans-affairs/component-library/releases/download/wc-v0.11.0/web-components-v0.10.0.tgz#c14b6c5786b35cd44402be6fcec57c3990c2d08c"
+"web-components@https://github.com/department-of-veterans-affairs/component-library/releases/download/wc-v0.11.1/web-components-v0.11.1.tgz":
+  version "0.11.1"
+  resolved "https://github.com/department-of-veterans-affairs/component-library/releases/download/wc-v0.11.1/web-components-v0.11.1.tgz#8ffbb75d64610eb401ce0ab4f5e628d29981ae3c"
   dependencies:
     "@stencil/core" "^2.0.1"
     "@stencil/postcss" "^2.0.0"


### PR DESCRIPTION
## Description

Bring the changes from https://github.com/department-of-veterans-affairs/component-library/pull/186#pullrequestreview-767303009 into `vets-website`

## Testing done

Storybook :eyes: and `content-build` :eyes: 

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/2008881/135484888-ea312439-fb3a-45cb-a6f2-640bbe12abf0.png)


### After

![image](https://user-images.githubusercontent.com/2008881/135484678-25e7ca96-6508-4097-82e1-a717fe7755b9.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
