### PR TITLE
add absolute urls for when footer is used on sub-domain

### DIFF
--- a/src/platform/site-wide/va-footer/components/LanguageSupport.jsx
+++ b/src/platform/site-wide/va-footer/components/LanguageSupport.jsx
@@ -21,28 +21,23 @@ function LanguagesListTemplate({ dispatchLanguageSelection }) {
         {
           label: 'Español',
           lang: 'es',
-          href: replaceWithStagingDomain(
-            'https://www.va.gov/asistencia-y-recursos-en-espanol',
-          ),
+          href: 'https://www.va.gov/asistencia-y-recursos-en-espanol',
         },
         {
           label: 'Tagalog',
           lang: 'tl',
-          href: replaceWithStagingDomain(
-            'https://www.va.gov/tagalog-wika-mapagkukunan-at-tulong',
-          ),
+          href: 'https://www.va.gov/tagalog-wika-mapagkukunan-at-tulong',
         },
         {
           label: 'Other languages',
           lang: 'en',
-          href: replaceWithStagingDomain(
+          href:
             'https://www.va.gov/resources/how-to-get-free-language-assistance-from-va/',
-          ),
         },
       ].map((link, i) => (
         <li key={i}>
           <a
-            href={link.href}
+            href={replaceWithStagingDomain(link.href)}
             lang={link.lang}
             hrefLang={link.lang}
             onClick={() => {

--- a/src/platform/site-wide/va-footer/components/LanguageSupport.jsx
+++ b/src/platform/site-wide/va-footer/components/LanguageSupport.jsx
@@ -6,6 +6,7 @@ import {
 import { FOOTER_EVENTS } from '../helpers';
 import recordEvent from '../../../monitoring/record-event';
 import { TRANSLATED_LANGUAGES } from 'applications/static-pages/i18Select/utilities/constants';
+import { replaceWithStagingDomain } from '../../../utilities/environment/stagingDomains';
 
 const langAssistanceLabel = 'Language assistance';
 
@@ -20,17 +21,23 @@ function LanguagesListTemplate({ dispatchLanguageSelection }) {
         {
           label: 'Español',
           lang: 'es',
-          href: '/asistencia-y-recursos-en-espanol',
+          href: replaceWithStagingDomain(
+            'https://www.va.gov/asistencia-y-recursos-en-espanol',
+          ),
         },
         {
           label: 'Tagalog',
           lang: 'tl',
-          href: '/tagalog-wika-mapagkukunan-at-tulong',
+          href: replaceWithStagingDomain(
+            'https://www.va.gov/tagalog-wika-mapagkukunan-at-tulong',
+          ),
         },
         {
           label: 'Other languages',
           lang: 'en',
-          href: '/resources/how-to-get-free-language-assistance-from-va/',
+          href: replaceWithStagingDomain(
+            'https://www.va.gov/resources/how-to-get-free-language-assistance-from-va/',
+          ),
         },
       ].map((link, i) => (
         <li key={i}>


### PR DESCRIPTION
## Description
A small hotfix to set the urls on the LanguageSupport component in the footer to absolute urls, and to also use the `replaceWithStagingDomain` helper method for the urls.

## Original issue(s)
hotfix


## Testing done
locally tested

## Screenshots


## Acceptance criteria
- [x] urls show up as absolute and vary depending on environment

