### PR TITLE
Handle no unit tests in app folder

### DIFF
--- a/script/run-unit-test.js
+++ b/script/run-unit-test.js
@@ -1,6 +1,8 @@
+/* eslint-disable no-console */
 const printUnitTestHelp = require('./run-unit-test-help.js');
 const commandLineArgs = require('command-line-args');
 const { runCommand } = require('./utils');
+const glob = require('glob');
 
 // For usage instructions see https://github.com/department-of-veterans-affairs/vets-website#unit-tests
 
@@ -33,6 +35,13 @@ if (
     '/src/',
     `/src/applications/${options['app-folder']}/`,
   );
+
+  const unitTestList = glob.sync(options.path[0]);
+  if (!unitTestList.length) {
+    console.log('There are no unit tests in the app folder.');
+    process.exit(0);
+  }
+
   coverageInclude = `--include 'src/applications/${options['app-folder']}/**'`;
 }
 


### PR DESCRIPTION
## Description
This PR adds behavior to handle when there are no unit tests in an app folder when using the `app-folder` option. Currently, `yarn test:unit --app-folder` fails when no tests are found.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots

<img width="706" alt="Screen Shot 2021-09-30 at 7 09 51 PM" src="https://user-images.githubusercontent.com/9042882/135554823-652d3c27-b0e0-48c5-a0a4-5e93a3e67b6b.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
