### PR TITLE
added support for redirect for already `read.full` user

### DIFF
--- a/src/applications/check-in/api/local-mock-api/phase.3.already.validated.js
+++ b/src/applications/check-in/api/local-mock-api/phase.3.already.validated.js
@@ -1,0 +1,54 @@
+/* eslint-disable camelcase */
+
+const commonResponses = require('../../../../platform/testing/local-dev-mock-api/common');
+const mockCheckIns = require('./mocks/v2/check.in.responses');
+const mockPatientCheckIns = require('./mocks/v2/patient.check.in.responses');
+const mockSessions = require('./mocks/v2/sessions.responses');
+
+const featureToggles = require('./mocks/feature.toggles');
+const delay = require('mocker-api/lib/delay');
+
+let hasBeenValidated = false;
+
+const responses = {
+  ...commonResponses,
+  'GET /v0/feature_toggles': featureToggles.createFeatureToggles(
+    true,
+    true,
+    true,
+    false,
+  ),
+  // v2
+  'GET /check_in/v2/sessions/:uuid': (req, res) => {
+    return res
+      .status(200)
+      .json(mockSessions.createMockSuccessResponse('some-uuid', 'read.full'));
+  },
+  'POST /check_in/v2/sessions': (req, res) => {
+    const { last4, lastName } = req.body?.session || {};
+    if (!last4 || !lastName) {
+      return res.status(400).json(mockSessions.createMockFailedResponse());
+    }
+    hasBeenValidated = true;
+    return res.json(mockSessions.mocks.post(req.body));
+  },
+  'GET /check_in/v2/patient_check_ins/:uuid': (_req, res) => {
+    if (hasBeenValidated) {
+      hasBeenValidated = false;
+      return res.json(mockPatientCheckIns.createMultipleAppointments({}));
+    } else {
+      return res.json(mockPatientCheckIns.createMultipleAppointments({}));
+    }
+  },
+  'POST /check_in/v2/patient_check_ins/': (req, res) => {
+    const { uuid, appointmentIEN, facilityId } =
+      req.body?.patientCheckIns || {};
+    if (!uuid || !appointmentIEN || !facilityId) {
+      return res.status(500).json(mockCheckIns.createMockFailedResponse());
+    } else {
+      return res.json(mockCheckIns.createMockSuccessResponse({}));
+    }
+  },
+};
+
+module.exports = delay(responses, 2000);

--- a/src/applications/check-in/api/versions/v2.js
+++ b/src/applications/check-in/api/versions/v2.js
@@ -12,6 +12,7 @@ const v2 = {
     );
     return {
       data: json.data,
+      ...json,
     };
   },
   postSession: async ({ lastName, last4, token }) => {

--- a/src/applications/check-in/api/versions/v2.js
+++ b/src/applications/check-in/api/versions/v2.js
@@ -11,7 +11,6 @@ const v2 = {
       token,
     );
     return {
-      data: json.data,
       ...json,
     };
   },

--- a/src/applications/check-in/pages/Landing.jsx
+++ b/src/applications/check-in/pages/Landing.jsx
@@ -17,6 +17,7 @@ const Landing = props => {
     location,
     setAppointment,
     setToken,
+    setAuthenticatedSession,
     isLowAuthEnabled,
     isUpdatePageEnabled,
     isMultipleAppointmentsEnabled,
@@ -50,7 +51,8 @@ const Landing = props => {
               .then(session => {
                 // if session with read.full exists, go to check in page
                 setCurrentToken(window, token);
-                if (session.permission === 'read.full') {
+                if (session.permissions === SCOPES.READ_FULL) {
+                  setAuthenticatedSession(token);
                   goToNextPage(router, URLS.DETAILS);
                 } else {
                   setToken(token);
@@ -68,7 +70,7 @@ const Landing = props => {
                 // if session with read.full exists, go to check in page
                 setCurrentToken(window, token);
                 setLoadMessage('Loading your appointment');
-                if (session.permission === 'read.full') {
+                if (session.permissions === SCOPES.READ_FULL) {
                   goToNextPage(router, URLS.DETAILS);
                 } else {
                   // else get the data then go to validate page
@@ -141,6 +143,8 @@ const mapDispatchToProps = dispatch => {
       dispatch(tokenWasValidated(data, token, SCOPES.READ_BASIC)),
     setToken: token =>
       dispatch(tokenWasValidated(undefined, token, SCOPES.READ_BASIC)),
+    setAuthenticatedSession: token =>
+      dispatch(tokenWasValidated(undefined, token, SCOPES.READ_FULL)),
   };
 };
 

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/already-validated-user/returning.user.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/already-validated-user/returning.user.cypress.spec.js
@@ -1,0 +1,51 @@
+import { createFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
+
+import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
+import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
+import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import Timeouts from 'platform/testing/e2e/timeouts';
+
+describe('Check In Experience -- ', () => {
+  describe('phase 3 -- ', () => {
+    beforeEach(function() {
+      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
+        req.reply(
+          mockSession.createMockSuccessResponse('some-token', 'read.full'),
+        );
+      });
+      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
+        req.reply(mockPatientCheckIns.createMultipleAppointments());
+      });
+      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
+        req.reply(mockCheckIn.createMockSuccessResponse({}));
+      });
+      cy.intercept(
+        'GET',
+        '/v0/feature_toggles*',
+        createFeatureToggles(true, true, true, false),
+      );
+    });
+    afterEach(() => {
+      cy.window().then(window => {
+        window.sessionStorage.clear();
+      });
+    });
+    it('Returning user', () => {
+      const featureRoute =
+        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
+      cy.visit(featureRoute);
+      cy.get('h1', { timeout: Timeouts.slow })
+        .should('be.visible')
+        .and('have.text', 'Your appointments');
+      cy.get('.appointment-list').should('have.length', 1);
+      cy.injectAxe();
+      cy.axeCheck();
+      cy.get(':nth-child(3) > [data-testid=check-in-button]').click();
+      cy.get('va-alert > h1', { timeout: Timeouts.slow })
+        .should('be.visible')
+        .and('include.text', 'checked in');
+      cy.injectAxe();
+      cy.axeCheck();
+    });
+  });
+});


### PR DESCRIPTION
## Description
If the user has already authenticated and has a session with `read.full` permissions, we redirect them to the appointment list instead of the validation page. 

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/29995

## Testing done
- added e2e test
