### PR TITLE
DRAFT: Limit Validation Retries

### DIFF
--- a/src/applications/check-in/api/local-mock-api/mocks/v2/sessions.responses.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/sessions.responses.js
@@ -20,6 +20,23 @@ const createMockFailedResponse = () => {
   };
 };
 
+const createMockFailedLoginResponse = (current = 0, max = 3) => {
+  const messageDetail =
+    current < max
+      ? `Login attempts: ${current}, The max number of login attempts is: ${max}`
+      : 'Max number of login attempts reached';
+  return {
+    retries: { current, max },
+    errors: [
+      {
+        title: 'Login failed',
+        detail: messageDetail,
+        status: '400',
+      },
+    ],
+  };
+};
+
 const mocks = {
   get: params => {
     const { uuid } = params;
@@ -31,4 +48,9 @@ const mocks = {
   },
 };
 
-module.exports = { createMockSuccessResponse, createMockFailedResponse, mocks };
+module.exports = {
+  createMockSuccessResponse,
+  createMockFailedResponse,
+  createMockFailedLoginResponse,
+  mocks,
+};

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/sessions.responses.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/sessions.responses.js
@@ -26,14 +26,13 @@ const createMockFailedLoginResponse = (current = 0, max = 3) => {
       ? `Login attempts: ${current}, The max number of login attempts is: ${max}`
       : 'Max number of login attempts reached';
   return {
-    retries: { current, max },
-    errors: [
-      {
-        title: 'Login failed',
-        detail: messageDetail,
-        status: '400',
-      },
-    ],
+    status: 'error',
+    error: {
+      title: 'Login failed',
+      detail: messageDetail,
+      status: '401',
+    },
+    maxValidateLimit: current >= max,
   };
 };
 

--- a/src/applications/check-in/api/local-mock-api/phase.3.js
+++ b/src/applications/check-in/api/local-mock-api/phase.3.js
@@ -10,7 +10,7 @@ const delay = require('mocker-api/lib/delay');
 
 let hasBeenValidated = false;
 const retries = { current: 0, max: 3 };
-const mockUser = { last4: '5555', lastName: 'lastName' };
+const mockUser = { last4: '4837', lastName: 'Smith' };
 
 const responses = {
   ...commonResponses,
@@ -30,7 +30,7 @@ const responses = {
     if (last4 !== mockUser.last4 || lastName !== mockUser.lastName) {
       retries.current++;
       return res
-        .status(400)
+        .status(401)
         .json(mockSessions.createMockFailedLoginResponse(retries.current));
     }
     hasBeenValidated = true;

--- a/src/applications/check-in/api/local-mock-api/phase.3.js
+++ b/src/applications/check-in/api/local-mock-api/phase.3.js
@@ -9,6 +9,8 @@ const featureToggles = require('./mocks/feature.toggles');
 const delay = require('mocker-api/lib/delay');
 
 let hasBeenValidated = false;
+const retries = { current: 0, max: 3 };
+const mockUser = { last4: '5555', lastName: 'lastName' };
 
 const responses = {
   ...commonResponses,
@@ -24,6 +26,12 @@ const responses = {
     const { last4, lastName } = req.body?.session || {};
     if (!last4 || !lastName) {
       return res.status(400).json(mockSessions.createMockFailedResponse());
+    }
+    if (last4 !== mockUser.last4 || lastName !== mockUser.lastName) {
+      retries.current++;
+      return res
+        .status(400)
+        .json(mockSessions.createMockFailedLoginResponse(retries.current));
     }
     hasBeenValidated = true;
     return res.json(mockSessions.mocks.post(req.body));

--- a/src/applications/check-in/pages/Error.jsx
+++ b/src/applications/check-in/pages/Error.jsx
@@ -5,11 +5,14 @@ import BackToHome from '../components/BackToHome';
 import Footer from '../components/Footer';
 import { focusElement } from 'platform/utilities/ui';
 
+import { getMaxValidateLimit } from '../utils/session';
+
 import Telephone from '@department-of-veterans-affairs/component-library/Telephone';
 
 const Error = props => {
   const { appointment } = props;
   const { clinicPhoneNumber } = appointment || {};
+  const { maxValidateLimit } = getMaxValidateLimit(window) || false;
   useEffect(() => {
     focusElement('h1');
   }, []);
@@ -19,19 +22,26 @@ const Error = props => {
         <h1 tabIndex="-1" slot="headline">
           We couldn’t check you in
         </h1>
-        <p data-testid="error-message">
-          We’re sorry. Something went wrong on our end. Check in with a staff
-          member
-          {clinicPhoneNumber ? (
-            <>
-              {' '}
-              or call us at <Telephone contact={clinicPhoneNumber} />
-            </>
-          ) : (
-            ''
-          )}
-          .
-        </p>
+        {maxValidateLimit ? (
+          <p data-testid="error-message">
+            We’re sorry. We couldn’t verify your identity with the information
+            you provided. Ask a staff member for help.
+          </p>
+        ) : (
+          <p data-testid="error-message">
+            We’re sorry. Something went wrong on our end. Check in with a staff
+            member
+            {clinicPhoneNumber ? (
+              <>
+                {' '}
+                or call us at <Telephone contact={clinicPhoneNumber} />
+              </>
+            ) : (
+              ''
+            )}
+            .
+          </p>
+        )}
       </va-alert>
       <Footer />
       <BackToHome />

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/errors/server.401.on.max-validate-limit.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/errors/server.401.on.max-validate-limit.cypress.spec.js
@@ -1,0 +1,112 @@
+import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
+
+import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
+import Timeouts from 'platform/testing/e2e/timeouts';
+
+describe('Check In Experience -- ', () => {
+  describe('phase 3 -- ', () => {
+    beforeEach(function() {
+      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
+        req.reply(
+          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
+        );
+      });
+      cy.intercept('POST', '/check_in/v2/sessions', req => {
+        req.reply(401, mockSession.createMockFailedLoginResponse(3));
+      });
+      cy.intercept(
+        'GET',
+        '/v0/feature_toggles*',
+        generateFeatureToggles({
+          checkInExperienceMultipleAppointmentSupport: true,
+          checkInExperienceUpdateInformationPageEnabled: false,
+        }),
+      );
+    });
+    afterEach(() => {
+      cy.window().then(window => {
+        window.sessionStorage.clear();
+      });
+    });
+    it('Failed login with retry - 401 api error', () => {
+      cy.intercept('POST', '/check_in/v2/sessions', req => {
+        // hasValidated = false;
+        req.reply(401, mockSession.createMockFailedLoginResponse(1));
+      });
+      const featureRoute =
+        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
+      cy.visit(featureRoute);
+      cy.get('h1', { timeout: Timeouts.slow })
+        .should('be.visible')
+        .and('have.text', 'Check in at VA');
+      cy.get('.vads-l-grid-container').within(() => {
+        cy.findByText(
+          /We need some information to verify your identity to check you in./i,
+        ).should('exist');
+      });
+      cy.injectAxe();
+      cy.axeCheck();
+      cy.get('[label="Your last name"]')
+        .shadow()
+        .find('input')
+        .type('Smith');
+      cy.get('[label="Last 4 digits of your Social Security number"]')
+        .shadow()
+        .find('input')
+        .type('4837');
+      cy.get('[data-testid=check-in-button]').click();
+      cy.url().should('match', /verify/);
+      cy.get('h1').contains(/Check in at VA/i);
+      cy.get('.vads-l-grid-container').within(() => {
+        cy.findByText(
+          /We need some information to verify your identity to check you in./i,
+        ).should('not.exist');
+      });
+      cy.get('[data-testid=error-message]').contains(
+        /We’re sorry. We couldn’t verify your identity with the information you provided/i,
+      );
+      cy.get('[label="Your last name"]').should('have.value', 'Smith');
+      cy.get('[label="Last 4 digits of your Social Security number"]').should(
+        'have.value',
+        '4837',
+      );
+      cy.get('[data-testid=check-in-button]').contains(/continue/i);
+      cy.injectAxe();
+      cy.axeCheck();
+    });
+    it('Max validate limit error page - 401 api error', () => {
+      cy.intercept('POST', '/check_in/v2/sessions', req => {
+        req.reply(401, mockSession.createMockFailedLoginResponse(3));
+      });
+      const featureRoute =
+        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
+      cy.visit(featureRoute);
+      cy.get('h1', { timeout: Timeouts.slow })
+        .should('be.visible')
+        .and('have.text', 'Check in at VA');
+      cy.get('.vads-l-grid-container').within(() => {
+        cy.findByText(
+          /We need some information to verify your identity to check you in./i,
+        ).should('exist');
+      });
+      cy.injectAxe();
+      cy.axeCheck();
+      cy.get('[label="Your last name"]')
+        .shadow()
+        .find('input')
+        .type('Smith');
+      cy.get('[label="Last 4 digits of your Social Security number"]')
+        .shadow()
+        .find('input')
+        .type('4837');
+      cy.get('[data-testid=check-in-button]').click();
+      cy.url().should('match', /error/);
+      cy.get('h1').contains('We couldn’t check you in');
+      cy.get('[data-testid=error-message]').contains(
+        /We’re sorry. We couldn’t verify your identity with the information you provided/i,
+      );
+      cy.injectAxe();
+      cy.axeCheck();
+    });
+  });
+});

--- a/src/applications/check-in/utils/session/index.jsx
+++ b/src/applications/check-in/utils/session/index.jsx
@@ -2,12 +2,14 @@ const sessionNameSpace = 'health.care.check-in.';
 
 const SESSION_STORAGE_KEYS = Object.freeze({
   CURRENT_UUID: `${sessionNameSpace}current.uuid`,
+  MAX_VALIDATE_LIMIT: `${sessionNameSpace}max.validate.limit`,
 });
 
 const clearCurrentSession = window => {
   const { sessionStorage } = window;
-  const { CURRENT_UUID } = SESSION_STORAGE_KEYS;
+  const { CURRENT_UUID, MAX_VALIDATE_LIMIT } = SESSION_STORAGE_KEYS;
   sessionStorage.removeItem(CURRENT_UUID);
+  sessionStorage.removeItem(MAX_VALIDATE_LIMIT);
 };
 
 const setCurrentToken = (window, token) => {
@@ -15,6 +17,14 @@ const setCurrentToken = (window, token) => {
   const { CURRENT_UUID } = SESSION_STORAGE_KEYS;
   const key = CURRENT_UUID;
   const data = { token };
+  sessionStorage.setItem(key, JSON.stringify(data));
+};
+
+const setMaxValidateLimit = (window, maxValidateLimit) => {
+  const { sessionStorage } = window;
+  const { MAX_VALIDATE_LIMIT } = SESSION_STORAGE_KEYS;
+  const key = MAX_VALIDATE_LIMIT;
+  const data = { maxValidateLimit };
   sessionStorage.setItem(key, JSON.stringify(data));
 };
 
@@ -32,4 +42,22 @@ const getCurrentToken = window => {
     return null;
   }
 };
-export { clearCurrentSession, getCurrentToken, setCurrentToken };
+
+const getMaxValidateLimit = window => {
+  if (!window) return null;
+  const { sessionStorage } = window;
+  const { MAX_VALIDATE_LIMIT } = SESSION_STORAGE_KEYS;
+
+  const key = MAX_VALIDATE_LIMIT;
+
+  const data = sessionStorage.getItem(key);
+  return data ? JSON.parse(data) : null;
+};
+
+export {
+  clearCurrentSession,
+  getCurrentToken,
+  getMaxValidateLimit,
+  setCurrentToken,
+  setMaxValidateLimit,
+};

--- a/src/applications/check-in/utils/session/session.test.unit.spec.js
+++ b/src/applications/check-in/utils/session/session.test.unit.spec.js
@@ -1,6 +1,12 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { setCurrentToken, clearCurrentSession, getCurrentToken } from './index';
+import {
+  setCurrentToken,
+  setMaxValidateLimit,
+  clearCurrentSession,
+  getCurrentToken,
+  getMaxValidateLimit,
+} from './index';
 
 describe('check in', () => {
   describe('session utils', () => {
@@ -23,6 +29,21 @@ describe('check in', () => {
         ).to.be.true;
       });
     });
+    describe('save max validate limit to session storage', () => {
+      it('saves data to name spaced key', () => {
+        const setItem = sinon.spy();
+        const window = { sessionStorage: { setItem } };
+        const testMaxValidateLimit = true;
+        setMaxValidateLimit(window, testMaxValidateLimit);
+        expect(setItem.called).to.be.true;
+        expect(
+          setItem.calledWith(
+            'health.care.check-in.max.validate.limit',
+            JSON.stringify({ maxValidateLimit: testMaxValidateLimit }),
+          ),
+        ).to.be.true;
+      });
+    });
     describe('clears current session', () => {
       it('name-spaced session should be empty', () => {
         const removeItem = sinon.spy();
@@ -35,6 +56,8 @@ describe('check in', () => {
         expect(removeItem.called).to.be.true;
         expect(removeItem.calledWith('health.care.check-in.current.uuid')).to.be
           .true;
+        expect(removeItem.calledWith('health.care.check-in.max.validate.limit'))
+          .to.be.true;
       });
     });
     describe('get token from session storage', () => {
@@ -74,6 +97,37 @@ describe('check in', () => {
         };
         const result = getCurrentToken(window);
         expect(result).to.have.property('token', 'some-token');
+      });
+    });
+    describe('get max validate limit from session storage', () => {
+      it('window is null', () => {
+        const window = null;
+        const result = getMaxValidateLimit(window);
+        expect(result).to.be.null;
+      });
+      it('calls getItem', () => {
+        const getItem = sinon.spy();
+
+        const window = { sessionStorage: { getItem } };
+        const result = getMaxValidateLimit(window);
+        expect(getItem.called).to.be.true;
+        expect(getItem.calledWith('health.care.check-in.max.validate.limit')).to
+          .be.true;
+        expect(result).to.be.null;
+      });
+      it('key is not', () => {
+        const window = { sessionStorage: { getItem: () => null } };
+        const result = getMaxValidateLimit(window);
+        expect(result).to.be.null;
+      });
+      it('key is found', () => {
+        const window = {
+          sessionStorage: {
+            getItem: () => JSON.stringify({ maxValidateLimit: true }),
+          },
+        };
+        const result = getMaxValidateLimit(window);
+        expect(result).to.have.property('maxValidateLimit', true);
       });
     });
   });


### PR DESCRIPTION
## Description
WIP. Here is a rough draft of the Mock API code to support limiting the number of retries authenticating

This PR adds mock user data to the process, checks if `lastName` and `last4` values in the session match the values stored for the mock user, and keeps track of the number of failed login attempts.

This does not block login if the max number of attempts has been reached yet. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#29983


## Testing done


## Screenshots

![Screen Shot 2021-10-04 at 2 42 58 PM](https://user-images.githubusercontent.com/4554388/135906616-3f03a492-0387-49dc-9151-0c3b88f63824.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
