### PR TITLE
updated scroll

### DIFF
--- a/src/applications/vre/28-1900/orientation/OrientationApp.jsx
+++ b/src/applications/vre/28-1900/orientation/OrientationApp.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 
-import scrollToTop from 'platform/utilities/ui/scrollToTop';
+import scrollTo from 'platform/utilities/ui/scrollTo';
 import { focusElement } from 'platform/utilities/ui';
 import StepComponent from './StepComponent';
 import { orientationSteps } from './utils';
@@ -17,7 +17,7 @@ const OrientationApp = props => {
         setIsFirstRender(false);
       } else {
         focusElement('#StepTitle');
-        scrollToTop('topScrollElement');
+        scrollTo(document.getElementById('StepTitle'));
       }
     },
     [step],


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/30714)

It was discovered during testing that when a Veteran is progressing through the orientation app and they click the button to move to the next step we set the step heading to have focus but are scrolling to the top of the page instead of scrolling to the step heading. This PR changes it so that we scroll to the step heading.

## Testing done
Tested locally

## Acceptance criteria
- [x] scrolling has been fixed
- [x] PR has been submitted
