### PR TITLE
508: [COGNITIION, SCREEN READER] Add aria-attributes to sign in button

### DIFF
--- a/src/applications/static-pages/cta-widget/components/CallToActionAlert.jsx
+++ b/src/applications/static-pages/cta-widget/components/CallToActionAlert.jsx
@@ -11,6 +11,8 @@ export default function CallToActionAlert({
   secondaryButtonText,
   secondaryButtonHandler,
   status,
+  ariaLabel = null,
+  ariaDescribedby = null,
 }) {
   const buttonClass =
     status === 'continue' ? 'va-button-primary' : 'usa-button-primary';
@@ -22,7 +24,12 @@ export default function CallToActionAlert({
       <div>
         {alertText}
         {primaryButtonText && (
-          <button className={buttonClass} onClick={primaryButtonHandler}>
+          <button
+            className={buttonClass}
+            onClick={primaryButtonHandler}
+            aria-label={ariaLabel}
+            aria-describedby={ariaDescribedby}
+          >
             {primaryButtonText}
           </button>
         )}

--- a/src/applications/static-pages/cta-widget/components/messages/SignIn.jsx
+++ b/src/applications/static-pages/cta-widget/components/messages/SignIn.jsx
@@ -2,20 +2,28 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import CallToActionAlert from '../CallToActionAlert';
 
-const SignIn = ({ serviceDescription, primaryButtonHandler, headerLevel }) => {
+const SignIn = ({
+  serviceDescription,
+  primaryButtonHandler,
+  headerLevel,
+  ariaLabel = null,
+  ariaDescribedby = null,
+}) => {
   const content = {
     heading: `Please sign in to ${serviceDescription}`,
     headerLevel,
     alertText: (
       <p>
-        Try signing in with your <b>DS Logon</b>, <b>My HealtheVet</b>, or{' '}
-        <b>ID.me</b> account. If you don’t have any of those accounts, you can
-        create one now.
+        Try signing in with your <strong>DS Logon</strong>,
+        <strong>My HealtheVet</strong>, or <strong>ID.me</strong> account. If
+        you don’t have any of those accounts, you can create one now.
       </p>
     ),
     primaryButtonText: 'Sign in or create an account',
     primaryButtonHandler,
     status: 'continue',
+    ariaLabel,
+    ariaDescribedby,
   };
 
   return <CallToActionAlert {...content} />;
@@ -25,6 +33,8 @@ SignIn.propTypes = {
   serviceDescription: PropTypes.string.isRequired,
   primaryButtonHandler: PropTypes.func.isRequired,
   headerLevel: PropTypes.number,
+  ariaLabel: PropTypes.string,
+  ariaDescribedby: PropTypes.string,
 };
 
 export default SignIn;

--- a/src/applications/static-pages/cta-widget/index.js
+++ b/src/applications/static-pages/cta-widget/index.js
@@ -62,6 +62,8 @@ export class CallToActionWidget extends Component {
     fetchMHVAccount: PropTypes.func.isRequired,
     toggleLoginModal: PropTypes.func.isRequired,
     upgradeMHVAccount: PropTypes.func.isRequired,
+    ariaLabel: PropTypes.string,
+    ariaDescribedby: PropTypes.string,
   };
 
   static defaultProps = {
@@ -140,6 +142,8 @@ export class CallToActionWidget extends Component {
           serviceDescription={this._serviceDescription}
           primaryButtonHandler={this.openLoginModal}
           headerLevel={this.props.headerLevel}
+          ariaLabel={this.props.ariaLabel}
+          ariaDescribedby={this.props.ariaDescribedby}
         />
       );
     }

--- a/src/applications/static-pages/cta-widget/tests/index.unit.spec.js
+++ b/src/applications/static-pages/cta-widget/tests/index.unit.spec.js
@@ -65,11 +65,16 @@ describe('<CallToActionWidget>', () => {
         featureToggles={{
           loading: false,
         }}
+        ariaLabel="test aria-label"
+        ariaDescribedby="test-id"
       />,
     );
 
+    const signIn = tree.find('SignIn');
     expect(tree.find('LoadingIndicator').exists()).to.be.false;
-    expect(tree.find('SignIn').exists()).to.be.true;
+    expect(signIn.exists()).to.be.true;
+    expect(signIn.prop('ariaLabel')).to.eq('test aria-label');
+    expect(signIn.prop('ariaDescribedby')).to.eq('test-id');
     tree.unmount();
   });
   it('should show verify link', () => {

--- a/src/platform/forms/save-in-progress/FormStartControls.jsx
+++ b/src/platform/forms/save-in-progress/FormStartControls.jsx
@@ -88,6 +88,7 @@ class FormStartControls extends React.Component {
       continueAppButtonText = CONTINUE_APP_DEFAULT_MESSAGE,
       startNewAppButtonText = START_NEW_APP_DEFAULT_MESSAGE,
     } = formConfig?.customText || {};
+    const { ariaLabel = null, ariaDescribedby = null } = this.props;
 
     if (this.props.formSaved) {
       return (
@@ -97,8 +98,8 @@ class FormStartControls extends React.Component {
               onButtonClick={this.handleLoadForm}
               buttonText={continueAppButtonText}
               buttonClass="usa-button-primary no-text-transform"
-              ariaLabel={this.props.ariaLabel}
-              ariaDescribedby={this.props.ariaDescribedby}
+              ariaLabel={ariaLabel}
+              ariaDescribedby={ariaDescribedby}
             />
           )}
           {!this.props.resumeOnly && (
@@ -110,8 +111,8 @@ class FormStartControls extends React.Component {
                   ? 'usa-button-primary'
                   : 'usa-button-secondary'
               }
-              ariaLabel={this.props.ariaLabel}
-              ariaDescribedby={this.props.ariaDescribedby}
+              ariaLabel={ariaLabel}
+              ariaDescribedby={ariaDescribedby}
             />
           )}
           <Modal
@@ -146,8 +147,8 @@ class FormStartControls extends React.Component {
           event.preventDefault();
           this.handleLoadPrefill();
         }}
-        ariaLabel={this.props.ariaLabel}
-        ariaDescribedby={this.props.ariaDescribedby}
+        aria-label={ariaLabel}
+        aria-describedby={ariaDescribedby}
       >
         {startText}
       </a>
@@ -158,8 +159,8 @@ class FormStartControls extends React.Component {
           buttonText={startText}
           buttonClass="usa-button-primary va-button-primary schemaform-start-button"
           afterText="»"
-          ariaLabel={this.props.ariaLabel}
-          ariaDescribedby={this.props.ariaDescribedby}
+          ariaLabel={ariaLabel}
+          ariaDescribedby={ariaDescribedby}
         />
       </div>
     );

--- a/src/platform/forms/save-in-progress/FormStartControls.jsx
+++ b/src/platform/forms/save-in-progress/FormStartControls.jsx
@@ -202,6 +202,8 @@ FormStartControls.defaultProps = {
       continueAppButtonText: '',
     },
   },
+  ariaLabel: null,
+  ariaDescribedby: null,
 };
 
 export default withRouter(FormStartControls);

--- a/src/platform/forms/save-in-progress/FormStartControls.jsx
+++ b/src/platform/forms/save-in-progress/FormStartControls.jsx
@@ -97,6 +97,8 @@ class FormStartControls extends React.Component {
               onButtonClick={this.handleLoadForm}
               buttonText={continueAppButtonText}
               buttonClass="usa-button-primary no-text-transform"
+              ariaLabel={this.props.ariaLabel}
+              ariaDescribedby={this.props.ariaDescribedby}
             />
           )}
           {!this.props.resumeOnly && (
@@ -108,6 +110,8 @@ class FormStartControls extends React.Component {
                   ? 'usa-button-primary'
                   : 'usa-button-secondary'
               }
+              ariaLabel={this.props.ariaLabel}
+              ariaDescribedby={this.props.ariaDescribedby}
             />
           )}
           <Modal
@@ -142,6 +146,8 @@ class FormStartControls extends React.Component {
           event.preventDefault();
           this.handleLoadPrefill();
         }}
+        ariaLabel={this.props.ariaLabel}
+        ariaDescribedby={this.props.ariaDescribedby}
       >
         {startText}
       </a>
@@ -152,6 +158,8 @@ class FormStartControls extends React.Component {
           buttonText={startText}
           buttonClass="usa-button-primary va-button-primary schemaform-start-button"
           afterText="»"
+          ariaLabel={this.props.ariaLabel}
+          ariaDescribedby={this.props.ariaDescribedby}
         />
       </div>
     );
@@ -179,6 +187,8 @@ FormStartControls.propTypes = {
       continueAppButtonText: PropTypes.string,
     }),
   }),
+  ariaLabel: PropTypes.string,
+  ariaDescribedby: PropTypes.string,
 };
 
 FormStartControls.defaultProps = {

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -54,6 +54,8 @@ class SaveInProgressIntro extends React.Component {
         prefillAvailable={prefillAvailable}
         formSaved={!!savedForm}
         gaStartEventName={this.props.gaStartEventName}
+        ariaLabel={this.props.ariaLabel}
+        ariaDescribedby={this.props.ariaDescribedby}
       />
     );
   };
@@ -176,7 +178,12 @@ class SaveInProgressIntro extends React.Component {
       const H = `h${this.props.headingLevel}`;
       const { buttonOnly, retentionPeriod, unauthStartText } = this.props;
       const unauthStartButton = (
-        <button className="usa-button-primary" onClick={this.openLoginModal}>
+        <button
+          className="usa-button-primary"
+          onClick={this.openLoginModal}
+          ariaLabel={this.props.ariaLabel || null}
+          ariaDescribedby={this.props.ariaDescribedby || null}
+        >
           {unauthStartText || UNAUTH_SIGN_IN_DEFAULT_MESSAGE}
         </button>
       );
@@ -188,6 +195,8 @@ class SaveInProgressIntro extends React.Component {
               <button
                 className="va-button-link schemaform-start-button"
                 onClick={this.goToBeginning}
+                ariaLabel={this.props.ariaLabel || null}
+                ariaDescribedby={this.props.ariaDescribedby || null}
               >
                 Start your {appType} without signing in
               </button>
@@ -227,6 +236,8 @@ class SaveInProgressIntro extends React.Component {
                   <button
                     className="va-button-link schemaform-start-button"
                     onClick={this.goToBeginning}
+                    ariaLabel={this.props.ariaLabel || null}
+                    ariaDescribedby={this.props.ariaDescribedby || null}
                   >
                     Start your {appType} without signing in
                   </button>
@@ -246,7 +257,12 @@ class SaveInProgressIntro extends React.Component {
               You can save this {appType} in progress, and come back later to
               finish filling it out.
               <br />
-              <button className="va-button-link" onClick={this.openLoginModal}>
+              <button
+                className="va-button-link"
+                onClick={this.openLoginModal}
+                ariaLabel={this.props.ariaLabel || null}
+                ariaDescribedby={this.props.ariaDescribedby || null}
+              >
                 Sign in to your account.
               </button>
             </div>
@@ -388,6 +404,8 @@ SaveInProgressIntro.propTypes = {
     }),
   }),
   headingLevel: PropTypes.number,
+  ariaLabel: PropTypes.string,
+  ariaDescribedby: PropTypes.string,
 };
 
 SaveInProgressIntro.defaultProps = {

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -420,6 +420,8 @@ SaveInProgressIntro.defaultProps = {
     },
   },
   headingLevel: 3,
+  ariaLabel: null,
+  ariaDescribedby: null,
 };
 
 function mapStateToProps(state) {

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -71,6 +71,8 @@ class SaveInProgressIntro extends React.Component {
       verifiedPrefillAlert,
       unverifiedPrefillAlert,
       formConfig,
+      ariaLabel = null,
+      ariaDescribedby = null,
     } = this.props;
     const { profile, login } = this.props.user;
     const prefillAvailable = !!(
@@ -181,8 +183,8 @@ class SaveInProgressIntro extends React.Component {
         <button
           className="usa-button-primary"
           onClick={this.openLoginModal}
-          ariaLabel={this.props.ariaLabel || null}
-          ariaDescribedby={this.props.ariaDescribedby || null}
+          aria-label={ariaLabel}
+          aria-describedby={ariaDescribedby}
         >
           {unauthStartText || UNAUTH_SIGN_IN_DEFAULT_MESSAGE}
         </button>
@@ -195,8 +197,8 @@ class SaveInProgressIntro extends React.Component {
               <button
                 className="va-button-link schemaform-start-button"
                 onClick={this.goToBeginning}
-                ariaLabel={this.props.ariaLabel || null}
-                ariaDescribedby={this.props.ariaDescribedby || null}
+                aria-label={ariaLabel}
+                aria-describedby={ariaDescribedby}
               >
                 Start your {appType} without signing in
               </button>
@@ -236,8 +238,8 @@ class SaveInProgressIntro extends React.Component {
                   <button
                     className="va-button-link schemaform-start-button"
                     onClick={this.goToBeginning}
-                    ariaLabel={this.props.ariaLabel || null}
-                    ariaDescribedby={this.props.ariaDescribedby || null}
+                    aria-label={ariaLabel}
+                    aria-describedby={ariaDescribedby}
                   >
                     Start your {appType} without signing in
                   </button>
@@ -260,8 +262,8 @@ class SaveInProgressIntro extends React.Component {
               <button
                 className="va-button-link"
                 onClick={this.openLoginModal}
-                ariaLabel={this.props.ariaLabel || null}
-                ariaDescribedby={this.props.ariaDescribedby || null}
+                aria-label={ariaLabel}
+                aria-describedby={ariaDescribedby}
               >
                 Sign in to your account.
               </button>

--- a/src/platform/forms/tests/save-in-progress/FormStartControls.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/FormStartControls.unit.spec.jsx
@@ -366,12 +366,16 @@ describe('Schemaform <FormStartControls>', () => {
         fetchInProgressForm={fetchSpy}
         prefillAvailable
         routes={[{}, { formConfig: { wizardStorageKey } }]}
+        ariaLabel="test aria-label"
+        ariaDescribedby="test-id"
       />,
     );
     const formDOM = getFormDOM(tree);
 
     expect(formDOM.className).to.contain('vads-c-action-link--green');
     expect(formDOM.textContent).to.eq('Get Started');
+    expect(formDOM.getAttribute('aria-label')).to.eq('test aria-label');
+    expect(formDOM.getAttribute('aria-describedby')).to.eq('test-id');
   });
 
   it('should display the startNewAppButtonText', () => {
@@ -439,5 +443,58 @@ describe('Schemaform <FormStartControls>', () => {
     expect(
       tree.dive(['ProgressButton', '.usa-button-primary']).text(),
     ).to.include('A custom continue app message');
+  });
+
+  it('should include aria-label & aria-describedby on sign in button', () => {
+    const routerSpy = {
+      push: sinon.spy(),
+    };
+    const fetchSpy = sinon.spy();
+    const tree = SkinDeep.shallowRender(
+      <FormStartControls
+        formId="1010ez"
+        migrations={[]}
+        formSaved={false}
+        startPage={startPage}
+        router={routerSpy}
+        fetchInProgressForm={fetchSpy}
+        routes={defaultRoutes}
+        ariaLabel="test aria-label"
+        ariaDescribedby="test-id"
+      />,
+    );
+
+    const button = tree.everySubTree('ProgressButton');
+    expect(button.length).to.equal(1);
+    expect(button[0].props.ariaLabel).to.eq('test aria-label');
+    expect(button[0].props.ariaDescribedby).to.eq('test-id');
+  });
+  it('should include aria-label & aria-describedby on all buttons when logged in with a saved form', () => {
+    const routerSpy = {
+      push: sinon.spy(),
+    };
+    const fetchSpy = sinon.spy();
+    const tree = SkinDeep.shallowRender(
+      <FormStartControls
+        formId="1010ez"
+        migrations={[]}
+        formSaved
+        startPage={startPage}
+        router={routerSpy}
+        fetchInProgressForm={fetchSpy}
+        routes={defaultRoutes}
+        ariaLabel="test aria-label"
+        ariaDescribedby="test-id"
+      />,
+    );
+
+    const buttons = tree.everySubTree('ProgressButton');
+    expect(buttons.length).to.equal(4);
+
+    // Modal buttons = last 2, do not include these aria-attributes
+    expect(buttons[0].props.ariaLabel).to.eq('test aria-label');
+    expect(buttons[0].props.ariaDescribedby).to.eq('test-id');
+    expect(buttons[1].props.ariaLabel).to.eq('test aria-label');
+    expect(buttons[1].props.ariaDescribedby).to.eq('test-id');
   });
 });

--- a/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
@@ -149,11 +149,15 @@ describe('Schemaform <SaveInProgressIntro>', () => {
         removeInProgressForm={removeInProgressForm}
         toggleLoginModal={toggleLoginModal}
         formConfig={formConfig}
+        ariaLabel="test aria-label"
+        ariaDescribedby="test-id"
       />,
     );
 
-    expect(tree.find('withRouter(FormStartControls)').props().prefillAvailable)
-      .to.be.true;
+    const formControlProps = tree.find('withRouter(FormStartControls)').props();
+    expect(formControlProps.prefillAvailable).to.be.true;
+    expect(formControlProps.ariaLabel).to.eq('test aria-label');
+    expect(formControlProps.ariaDescribedby).to.eq('test-id');
     tree.unmount();
   });
   it('should render sign in message', () => {
@@ -185,12 +189,15 @@ describe('Schemaform <SaveInProgressIntro>', () => {
         removeInProgressForm={removeInProgressForm}
         toggleLoginModal={toggleLoginModal}
         formConfig={formConfig}
+        ariaLabel="test aria-label"
+        ariaDescribedby="test-id"
       />,
     );
 
-    expect(tree.find('.va-button-link').text()).to.contain(
-      'Sign in to your account.',
-    );
+    const link = tree.find('.va-button-link');
+    expect(link.text()).to.contain('Sign in to your account.');
+    expect(link.prop('aria-label')).to.eq('test aria-label');
+    expect(link.prop('aria-describedby')).to.eq('test-id');
     expect(tree.find('withRouter(FormStartControls)').exists()).to.be.false;
     tree.unmount();
   });


### PR DESCRIPTION
## Description

The form `cta-widget` (call to action widget) and `SaveInProgressIntro` components render a button to either prompt the Veteran to sign in or start the form. All content below the button may be ignored by a screen reader user. To fix this, the a11y experts recommended adding an `aria-describedby` to the button (or action link) to inform screen reader users that there is more content. See option 1 in https://github.com/department-of-veterans-affairs/va.gov-team/issues/16182.

The aforementioned components may also render the `ProgressButton` component from the component-library. This is updated in https://github.com/department-of-veterans-affairs/component-library/pull/193.

Note: `aria-label` was also included as part of a separate set of a11y issues - see https://github.com/department-of-veterans-affairs/va.gov-team/issues/18923

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/16182

## Testing done

Added unit tests

## Screenshots

<details><summary>a11y recommendation</summary>

<!-- leave a blank line above -->
![Intro page screenshot with added text showing the sign in button with aria-describedby and matching ID on the header below the call to action](https://user-images.githubusercontent.com/57469/99128924-25128100-25da-11eb-994f-38d0f5aa1fb2.png)</details>

## Acceptance criteria
- [x] `aria-label` and `aria-describedby` added to call to action widget buttons
- [x] `aria-label` and `aria-describedby` added to save in progress intro buttons
- [x] All tests passing
- [x] Passes axe tests

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
