### PR TITLE
Add TestRail Case IDs to Notification-Settings Cypress tests.

### DIFF
--- a/src/applications/personalization/profile/tests/e2e/notification-settings/feature-gating.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/feature-gating.cypress.spec.js
@@ -9,7 +9,7 @@ describe('Notification Settings', () => {
     mockNotificationSettingsAPIs();
   });
   context('when the feature flag is turned on', () => {
-    it('is available in the side nav and the section loads', () => {
+    it('is available in the side nav and the section loads - C8542', () => {
       cy.intercept('GET', '/v0/feature_toggles?*', mockFeatureToggles);
       // go to the root of the Profile
       cy.visit(PROFILE_PATHS.PROFILE_ROOT);
@@ -29,7 +29,7 @@ describe('Notification Settings', () => {
     });
   });
   context('when the feature flag is turned off', () => {
-    it('is not available in the side nav and the path redirects to the personal info section', () => {
+    it('is not available in the side nav and the path redirects to the personal info section - C8543', () => {
       // go to the root of the Profile
       cy.visit(PROFILE_PATHS.PROFILE_ROOT);
       // this assertion is only here to make sure the following "not.exist" does

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/happy-editing-path.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/happy-editing-path.cypress.spec.js
@@ -34,7 +34,7 @@ describe('Updating Notification Settings', () => {
     });
   });
   context('when the API behaves', () => {
-    it('should allow opting into getting notifications for the first time', () => {
+    it('should allow opting into getting notifications for the first time - C8544', () => {
       cy.login(mockPatient);
       cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
 
@@ -72,7 +72,7 @@ describe('Updating Notification Settings', () => {
       cy.findByTestId('select-options-alert').should('not.exist');
     });
 
-    it('should allow opting out of getting notifications', () => {
+    it('should allow opting out of getting notifications - C8545', () => {
       cy.login(mockPatient);
       cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
 

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/happy-loading-path.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/happy-loading-path.cypress.spec.js
@@ -24,7 +24,7 @@ describe('Notification Settings', () => {
   context(
     'when user is a VA patient at at least one facility that supports Rx tracking',
     () => {
-      it('should show the Health Care group first and show the Rx tracking item along with the radio button hint text', () => {
+      it('should show the Health Care group first and show the Rx tracking item along with the radio button hint text - C9477', () => {
         cy.login(
           makeUserObject({
             isPatient: true,
@@ -65,7 +65,7 @@ describe('Notification Settings', () => {
   context(
     'when user is a VA patient and is only associated with facilities that supports Rx tracking',
     () => {
-      it('should show the Health Care group first and show the Rx tracking item but hide the radio button hint text', () => {
+      it('should show the Health Care group first and show the Rx tracking item but hide the radio button hint text - C9478', () => {
         cy.login(
           makeUserObject({
             isPatient: true,
@@ -103,7 +103,7 @@ describe('Notification Settings', () => {
   context(
     'when user is a VA patient at a facility that does not support Rx tracking',
     () => {
-      it('should show the Health Care group first but not show the Rx tracking item', () => {
+      it('should show the Health Care group first but not show the Rx tracking item - C9479', () => {
         cy.login(
           makeUserObject({
             isPatient: true,
@@ -138,7 +138,7 @@ describe('Notification Settings', () => {
     },
   );
   context('when user is not a VA patient', () => {
-    it('should not show the Health Care notification group', () => {
+    it('should not show the Health Care notification group - C9480', () => {
       cy.login(makeUserObject({ isPatient: false }));
       cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
       cy.findByRole('heading', {

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/loading-errors.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/loading-errors.cypress.spec.js
@@ -19,7 +19,7 @@ describe('Notification Settings - Load Errors', () => {
     cy.intercept('/v0/feature_toggles?*', mockFeatureToggles);
   });
   context('when VA Profile contact info is not available', () => {
-    it('should show an error message and not even try to fetch current notification preferences', () => {
+    it('should show an error message and not even try to fetch current notification preferences - C9491', () => {
       const getCommPrefsStub = cy.stub();
       cy.intercept('GET', 'v0/profile/communication_preferences', () => {
         getCommPrefsStub();
@@ -42,7 +42,7 @@ describe('Notification Settings - Load Errors', () => {
     });
   });
   context('when we cannot fetch current notification preferences', () => {
-    it('should show an error message', () => {
+    it('should show an error message - C9492', () => {
       cy.intercept('GET', 'v0/profile/communication_preferences', {
         statusCode: 500,
         data: error500,

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/missing-contact-info.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/missing-contact-info.cypress.spec.js
@@ -33,7 +33,7 @@ describe('Notification Settings', () => {
     'when both mobile phone and email are supported communication channels',
     () => {
       context('when user is missing mobile phone', () => {
-        it('should show the correct messages', () => {
+        it('should show the correct messages - C9503', () => {
           const user = makeMockUser();
           user.data.attributes.vet360ContactInformation.mobilePhone = null;
           cy.login(user);
@@ -69,7 +69,7 @@ describe('Notification Settings', () => {
         });
       });
       context('when user is missing email address', () => {
-        it('should show the correct messages', () => {
+        it('should show the correct messages - C9504', () => {
           const user = makeMockUser();
           user.data.attributes.vet360ContactInformation.email = null;
           cy.login(user);
@@ -103,7 +103,7 @@ describe('Notification Settings', () => {
       context(
         'when user is missing both email address and mobile phone',
         () => {
-          it('should show the correct message, not attempt to fetch notification prefs, and hide all notification groups', () => {
+          it('should show the correct message, not attempt to fetch notification prefs, and hide all notification groups - C9505', () => {
             const user = makeMockUser();
             user.data.attributes.vet360ContactInformation.email = null;
             user.data.attributes.vet360ContactInformation.mobilePhone = null;
@@ -146,7 +146,7 @@ describe('Notification Settings', () => {
     'when only mobile phone is the only supported communication channel',
     () => {
       context('when user is missing mobile phone', () => {
-        it('should show the correct message, not attempt to fetch notification prefs, and hide all notification groups', () => {
+        it('should show the correct message, not attempt to fetch notification prefs, and hide all notification groups - C9506', () => {
           const user = makeMockUser();
           user.data.attributes.vet360ContactInformation.mobilePhone = null;
           cy.login(user);
@@ -177,7 +177,7 @@ describe('Notification Settings', () => {
         });
       });
       context('when user is missing email address', () => {
-        it('should not show an alert', () => {
+        it('should not show an alert - C9507', () => {
           const user = makeMockUser();
           user.data.attributes.vet360ContactInformation.email = null;
           cy.login(user);

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/sad-editing-path.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/sad-editing-path.cypress.spec.js
@@ -34,7 +34,7 @@ describe('Updating Notification Settings', () => {
     });
   });
   context('when there is an API error', () => {
-    it('should handle 401 errors when opting into getting notifications for the first time', () => {
+    it('should handle 401 errors when opting into getting notifications for the first time - C9518', () => {
       cy.login(mockPatient);
       cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
 
@@ -63,7 +63,7 @@ describe('Updating Notification Settings', () => {
         .should('not.be.disabled');
     });
 
-    it('should handle 500 error when opting out of getting notifications', () => {
+    it('should handle 500 error when opting out of getting notifications - C9519', () => {
       cy.login(mockPatient);
       cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
 

--- a/src/applications/personalization/profile/tests/e2e/notification-settings/select-options-alert.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/notification-settings/select-options-alert.cypress.spec.js
@@ -26,7 +26,7 @@ describe('Notification Settings', () => {
     context(
       'and is a VA patient, has an email address, and a mobile phone number',
       () => {
-        it('should show the "select options" alert and the jump link should work', () => {
+        it('should show the "select options" alert and the jump link should work - C9530', () => {
           const patientWithAllContactInfoOnFile = makeMockUser();
           cy.login(patientWithAllContactInfoOnFile);
           cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
@@ -46,7 +46,7 @@ describe('Notification Settings', () => {
     context(
       'and is a VA patient, has an email address, and a mobile phone number',
       () => {
-        it('should not show the "select options" alert', () => {
+        it('should not show the "select options" alert - C9531', () => {
           cy.intercept('GET', '/v0/profile/communication_preferences', {
             statusCode: 200,
             body: mockCommPrefsAllSelectionsMade,


### PR DESCRIPTION
## Description
Insert TestRail Case IDs into test-description strings in all Notification Preferences Cypress tests.

## Original issue(s)
\[N/A &mdash; Ongoing Cypress-TestRail integration.\] 


## Testing done
\[N/A &mdash; Only updated static strings.\]

## Definition of done
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
