### PR TITLE
Focus on CTA after contact info update

### DIFF
--- a/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
+++ b/src/applications/personalization/profile/components/personal-information/ContactInformationField.jsx
@@ -139,8 +139,11 @@ class ContactInformationField extends React.Component {
       clearTimeout(this.closeModalTimeoutID);
       if (this.props.transaction) {
         focusElement(`div#${fieldName}-transaction-status`);
+      } else if (this.props.showUpdateSuccessAlert) {
+        focusElement('[data-testid=update-success-alert]');
+      } else {
+        focusElement(`#${getEditButtonId(fieldName)}`);
       }
-      focusElement(`#${getEditButtonId(fieldName)}`);
     }
   }
 
@@ -306,7 +309,9 @@ class ContactInformationField extends React.Component {
         />
 
         {this.props.showUpdateSuccessAlert ? (
-          <UpdateSuccessAlert fieldName={fieldName} />
+          <div data-testid="update-success-alert">
+            <UpdateSuccessAlert fieldName={fieldName} />
+          </div>
         ) : null}
 
         <div className="vads-u-width--full">

--- a/src/applications/personalization/profile/tests/e2e/address-validation/bad-unit.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/bad-unit.cypress.spec.js
@@ -46,9 +46,9 @@ describe('Personal and contact information', () => {
         .should('contain', '225 irving st, Unit A')
         .and('contain', 'San Francisco, CA 94122');
 
-      cy.findByRole('button', { name: /edit mailing address/i }).should(
-        'be.focused',
-      );
+      cy.focused()
+        .invoke('text')
+        .should('match', /update saved/i);
     });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/confirm-address.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/confirm-address.cypress.spec.js
@@ -38,9 +38,9 @@ describe('Personal and contact information', () => {
         .should('contain', '36310 Coronado Dr')
         .and('contain', 'Fremont, CA 94536');
 
-      cy.findByRole('button', { name: /edit mailing address/i }).should(
-        'be.focused',
-      );
+      cy.focused()
+        .invoke('text')
+        .should('match', /update saved/i);
     });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/edit-after-validation.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/edit-after-validation.cypress.spec.js
@@ -69,9 +69,9 @@ describe('Personal and contact information', () => {
         .should('contain', '225 irving st, Unit A')
         .and('contain', 'San Francisco, CA 94122');
 
-      cy.findByRole('button', { name: /edit mailing address/i }).should(
-        'be.focused',
-      );
+      cy.focused()
+        .invoke('text')
+        .should('match', /update saved/i);
     });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/international-address.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/international-address.cypress.spec.js
@@ -29,9 +29,9 @@ describe('Personal and contact information', () => {
         .and('contain', 'Amsterdam, Noord-Holland, 1012 JS')
         .and('contain', 'Netherlands');
 
-      cy.findByRole('button', { name: /edit mailing address/i }).should(
-        'be.focused',
-      );
+      cy.focused()
+        .invoke('text')
+        .should('match', /update saved/i);
     });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/low-confidence.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/low-confidence.cypress.spec.js
@@ -41,9 +41,9 @@ describe('Personal and contact information', () => {
         .should('contain', '36320 Coronado Dr')
         .and('contain', 'Fremont, CA 94536');
 
-      cy.findByRole('button', { name: /edit mailing address/i }).should(
-        'be.focused',
-      );
+      cy.focused()
+        .invoke('text')
+        .should('match', /update saved/i);
     });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/military-address.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/military-address.cypress.spec.js
@@ -30,9 +30,9 @@ describe('Personal and contact information', () => {
         .should('contain', 'PSC 808 Box 37')
         .and('contain', 'FPO, Armed Forces Europe');
 
-      cy.findByRole('button', { name: /edit mailing address/i }).should(
-        'be.focused',
-      );
+      cy.focused()
+        .invoke('text')
+        .should('match', /update saved/i);
     });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/missing-unit.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/missing-unit.cypress.spec.js
@@ -35,9 +35,9 @@ describe('Personal and contact information', () => {
         .should('contain', '225 irving st')
         .and('contain', 'San Francisco, CA 94122');
 
-      cy.findByRole('button', { name: /edit mailing address/i }).should(
-        'be.focused',
-      );
+      cy.focused()
+        .invoke('text')
+        .should('match', /update saved/i);
     });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/one-suggestion.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/one-suggestion.cypress.spec.js
@@ -36,9 +36,9 @@ describe('Personal and contact information', () => {
         .should('contain', '400 NW 65th St')
         .and('contain', 'Seattle, WA 98117');
 
-      cy.findByRole('button', { name: /edit mailing address/i }).should(
-        'be.focused',
-      );
+      cy.focused()
+        .invoke('text')
+        .should('match', /update saved/i);
     });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/setup.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/setup.js
@@ -19,32 +19,27 @@ export const setUp = type => {
     force: true,
   });
 
-  cy.server();
-  cy.route({
-    method: 'POST',
-    url: '/v0/profile/address_validation',
-    status: 200,
-    response: createAddressValidationResponse(type),
-  }).as('validateAddress');
+  cy.intercept('POST', '/v0/profile/address_validation', {
+    statusCode: 200,
+    body: createAddressValidationResponse(type),
+  });
 
-  cy.route({
-    method: 'PUT',
-    url: '/v0/profile/addresses',
-    status: 200,
-    response: type === 'no-change' ? noChangesTransaction : receivedTransaction,
-  }).as('saveAddress');
+  cy.intercept('PUT', '/v0/profile/addresses', {
+    statusCode: 200,
+    body: type === 'no-change' ? noChangesTransaction : receivedTransaction,
+  });
 
-  cy.route({
-    method: 'GET',
-    url: '/v0/profile/status/bfedd909-9dc4-4b27-abc2-a6cccaece35d',
-    status: 200,
-    response: finishedTransaction,
-  }).as('finishedTransaction');
+  cy.intercept(
+    'GET',
+    '/v0/profile/status/bfedd909-9dc4-4b27-abc2-a6cccaece35d',
+    {
+      statusCode: 200,
+      body: finishedTransaction,
+    },
+  );
 
-  cy.route({
-    method: 'GET',
-    url: '/v0/user?*',
-    status: 200,
-    response: createUserResponse(type),
-  }).as('getUser');
+  cy.intercept('GET', '/v0/user?*', {
+    statusCode: 200,
+    body: createUserResponse(type),
+  });
 };

--- a/src/applications/personalization/profile/tests/e2e/address-validation/two-suggestions.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/two-suggestions.cypress.spec.js
@@ -40,9 +40,9 @@ describe('Personal and contact information', () => {
         .should('contain', '575 20th St')
         .and('contain', 'San Francisco, CA 94107');
 
-      cy.findByRole('button', { name: /edit mailing address/i }).should(
-        'be.focused',
-      );
+      cy.focused()
+        .invoke('text')
+        .should('match', /update saved/i);
     });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/valid-address.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/valid-address.cypress.spec.js
@@ -24,15 +24,13 @@ describe('Personal and contact information', () => {
           force: true,
         });
 
-        cy.wait('@getUser');
-
         cy.findByTestId('mailingAddress')
           .should('contain', '36320 Coronado Dr')
           .and('contain', 'Fremont, CA 94536');
 
-        cy.findByRole('button', { name: /edit mailing address/i }).should(
-          'be.focused',
-        );
+        cy.focused()
+          .invoke('text')
+          .should('match', /update saved/i);
       });
     });
   });

--- a/src/applications/personalization/profile/tests/e2e/post-add-mobile-phone-cta.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/post-add-mobile-phone-cta.cypress.spec.js
@@ -55,6 +55,12 @@ describe('Return to Notification Settings CTA', () => {
     cy.injectAxeThenAxeCheck();
 
     cy.findByText(/update saved/i).should('exist');
+
+    cy.focused()
+      .invoke('text')
+      .should('match', /manage text notifications/i)
+      .should('match', /update saved/i);
+
     cy.injectAxeThenAxeCheck();
     cy.findByRole('link', { name: /manage text notifications/i }).click();
 


### PR DESCRIPTION
## Description
Improve focus handling after updating contact info. Focus will now be on the "update saved" alert. This will improve the experience for screen reader users and also allow users to hit `tab` once to focus on the CTA link that will redirect them back to the Notification Settings page.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs