### PR TITLE
Add aria-attributes to intro pages

### DIFF
--- a/src/applications/appeals/10182/containers/IntroductionPage.jsx
+++ b/src/applications/appeals/10182/containers/IntroductionPage.jsx
@@ -42,13 +42,14 @@ class IntroductionPage extends React.Component {
         // don't need to pass the entire formConfig
         customText,
       },
+      ariaDescribedby: 'main-content',
     };
 
     return (
       <div className="schemaform-intro">
         <FormTitle title={formConfig.title} subTitle={formConfig.subTitle} />
         <SaveInProgressIntro {...sipOptions} />
-        <h2 className="vads-u-font-size--h3">
+        <h2 id="main-content" className="vads-u-font-size--h3">
           Follow these steps to request a Board Appeal
         </h2>
         <AdditionalInfo triggerText="Find out about opting in if you have an older claim">

--- a/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
@@ -120,6 +120,7 @@ export class IntroductionPage extends React.Component {
           pageList={route.pageList}
           startText="Start the Request for a Higher-Level Review"
           gaStartEventName="decision-reviews-va20-0996-start-form"
+          ariaDescribedby="main-content"
         />
       );
     }
@@ -181,10 +182,16 @@ export class IntroductionPage extends React.Component {
       <article className="schemaform-intro">
         <FormTitle title={pageTitle} />
         <p>Equal to VA Form 20-0996 (Higher-Level Review).</p>
-        <CallToActionWidget appId="higher-level-review" headerLevel={2}>
+        <CallToActionWidget
+          appId="higher-level-review"
+          headerLevel={2}
+          ariaDescribedby="main-content"
+        >
           {callToActionContent}
         </CallToActionWidget>
-        <h2 className="vads-u-font-size--h3">What’s a Higher-Level Review?</h2>
+        <h2 id="main-content" className="vads-u-font-size--h3">
+          What’s a Higher-Level Review?
+        </h2>
         <p>
           If you or your representative disagree with VA’s decision on your
           claim, you can request a Higher-Level Review. With a Higher-Level
@@ -283,7 +290,11 @@ export class IntroductionPage extends React.Component {
             </li>
           </ol>
         </div>
-        <CallToActionWidget appId="higher-level-review" headerLevel={2}>
+        <CallToActionWidget
+          appId="higher-level-review"
+          headerLevel={2}
+          ariaDescribedby="main-content"
+        >
           {callToActionContent}
         </CallToActionWidget>
         <div className="omb-info--container vads-u-padding-left--0">

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -80,9 +80,12 @@ class IntroductionPage extends React.Component {
           startText={startText}
           retentionPeriod="1 year"
           downtime={formConfig.downtime}
+          ariaDescribedby="main-content"
         />
         {itfNotice}
-        <h2 className="vads-u-font-size--h4">{subwayTitle}</h2>
+        <h2 id="main-content" className="vads-u-font-size--h4">
+          {subwayTitle}
+        </h2>
         <div className="process schemaform-process">
           {loggedIn && (
             <p id="restart-wizard" className="vads-u-margin-top--0">


### PR DESCRIPTION
## Description

This work adds descriptive labels to the forms our teams supports. Originally it was an accessibility evaluation for the Higher-Level Review form, but needs to be extended to all form introduction pages. This PR applies the `aria-describedby` to the Higher-Level Review (Form 0996), Notice of Disagreement (Form 10182) and Disability Compensation (Form 526) forms.

It has not be throughly tested as the work in the related pull requests need to be applied before this work can be evaluated.

Related to:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/16182
- https://github.com/department-of-veterans-affairs/vets-website/pull/19000
- https://github.com/department-of-veterans-affairs/component-library/pull/193

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/16182

## Testing done

Manual testing, but it will need to be re-evaluated using a screenreader once the component-library work has been merged & updated in vets-website

## Screenshots

Pending

## Acceptance criteria

- [ ] Form 526 - an `aria-describedby` attribute is added to the call to action button
- [ ] Form 996 - an `aria-describedby` attribute is added to the call to action button
- [ ] Form 10182 - an `aria-describedby` attribute is added to the call to action button
- [ ] Screen reader evaluation reads content below the call to action

## Definition of done

- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
