### PR TITLE
fix cerner-widget url

### DIFF
--- a/src/applications/personalization/dashboard/components/cerner-widgets.js
+++ b/src/applications/personalization/dashboard/components/cerner-widgets.js
@@ -2,7 +2,7 @@ import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 
 import { mhvUrl } from 'platform/site-wide/mhv/utilities';
-import { externalRedirects } from 'platform/user/authentication/utilities';
+import { getCernerURL } from 'platform/utilities/cerner';
 
 // Returns an AlertBox to present the user with info about working with the
 // Cerner facility they are enrolled at. Props allow you to edit a small amount
@@ -75,7 +75,7 @@ export const CernerWidget = ({ facilityNames, authenticatedWithSSOe }) => (
   <div data-testid="cerner-widget">
     <CernerAlertBox
       facilityNames={facilityNames}
-      primaryCtaButtonUrl={externalRedirects.myvahealth}
+      primaryCtaButtonUrl={getCernerURL('')}
       secondaryCtaButtonText="Use My HealtheVet"
       secondaryCtaButtonUrl={mhvUrl(authenticatedWithSSOe, 'home')}
       level={2}

--- a/src/applications/personalization/dashboard/tests/components/cerner-widgets.unit.spec.js
+++ b/src/applications/personalization/dashboard/tests/components/cerner-widgets.unit.spec.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { render } from '@testing-library/react';
 
 import { CernerWidget } from '../../components/cerner-widgets';
+import { getCernerURL } from 'platform/utilities/cerner';
 
 describe('General Widget', () => {
   const facilityNames = ['Facility Name'];
@@ -19,9 +20,8 @@ describe('General Widget', () => {
     const myVAHealthLink = view.getByRole('link', {
       name: /Use My VA Health/i,
     });
-    expect(myVAHealthLink.href).to.equal(
-      'https://staging-patientportal.myhealth.va.gov/',
-    );
+    const cernerURL = getCernerURL('');
+    expect(myVAHealthLink.href).to.equal(cernerURL);
   });
   it('renders the correct secondary CTA link', () => {
     const ctaLink = view.getByRole('link', {


### PR DESCRIPTION
## Description
Forcers the CernerWidget component to use the updated getCernerURL method.  This will help to ensure a terminated VA.gov session is accurately depicted on the Cerner site.

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#30732


## Testing done
Unit test

## Screenshots


## Acceptance criteria
- [x] The My VA Health link works as expected

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
