### PR TITLE
Remove disability benefits imports

### DIFF
--- a/src/applications/disability-benefits/686c-674/tests/config/childAdditionalInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/686c-674/tests/config/childAdditionalInformation.unit.spec.jsx
@@ -8,7 +8,7 @@ import {
 } from 'platform/testing/unit/schemaform-utils.jsx';
 
 import formConfig from '../../config/form';
-import { changeDropdown } from '../helpers';
+import { changeDropdown } from 'platform/testing/unit/helpers';
 
 describe('686 add child - child additional information', () => {
   const {

--- a/src/applications/disability-benefits/686c-674/tests/config/childInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/686c-674/tests/config/childInformation.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
-import { changeDropdown } from '../helpers/index.js';
+import { changeDropdown } from 'platform/testing/unit/helpers';
 import {
   DefinitionTester,
   fillData,

--- a/src/applications/disability-benefits/686c-674/tests/config/childPlaceOfBirth.unit.spec.jsx
+++ b/src/applications/disability-benefits/686c-674/tests/config/childPlaceOfBirth.unit.spec.jsx
@@ -8,7 +8,7 @@ import {
   selectCheckbox,
   selectRadio,
 } from 'platform/testing/unit/schemaform-utils.jsx';
-import { changeDropdown } from '../helpers/index';
+import { changeDropdown } from 'platform/testing/unit/helpers';
 
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/686c-674/tests/config/currentMarriageInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/686c-674/tests/config/currentMarriageInformation.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
-import { changeDropdown } from '../helpers/index.js';
+import { changeDropdown } from 'platform/testing/unit/helpers';
 import {
   DefinitionTester,
   fillData,

--- a/src/applications/disability-benefits/686c-674/tests/config/currentSpouseInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/686c-674/tests/config/currentSpouseInformation.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
-import { changeDropdown } from '../helpers/index.js';
+import { changeDropdown } from 'platform/testing/unit/helpers';
 import {
   DefinitionTester,
   fillData,

--- a/src/applications/disability-benefits/686c-674/tests/config/doesLiveWithSpouse.unit.spec.jsx
+++ b/src/applications/disability-benefits/686c-674/tests/config/doesLiveWithSpouse.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
-import { changeDropdown } from '../helpers/index.js';
+import { changeDropdown } from 'platform/testing/unit/helpers';
 import {
   DefinitionTester,
   fillData,

--- a/src/applications/disability-benefits/686c-674/tests/config/reportChildStoppedAttendingSchool.unit.spec.jsx
+++ b/src/applications/disability-benefits/686c-674/tests/config/reportChildStoppedAttendingSchool.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   fillData,
 } from 'platform/testing/unit/schemaform-utils.jsx';
-import { changeDropdown } from '../helpers/index.js';
+import { changeDropdown } from 'platform/testing/unit/helpers';
 import formConfig from '../../config/form';
 
 describe('686 report a child has stopped attending school', () => {

--- a/src/applications/disability-benefits/686c-674/tests/config/reportDeath.unit.spec.jsx
+++ b/src/applications/disability-benefits/686c-674/tests/config/reportDeath.unit.spec.jsx
@@ -9,7 +9,7 @@ import {
   selectCheckbox,
   selectRadio,
 } from 'platform/testing/unit/schemaform-utils.jsx';
-import { changeDropdown } from '../helpers/index.js';
+import { changeDropdown } from 'platform/testing/unit/helpers';
 import formConfig from '../../config/form';
 
 describe('686 report dependent death', () => {

--- a/src/applications/disability-benefits/686c-674/tests/config/reportDeathAdditionalInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/686c-674/tests/config/reportDeathAdditionalInformation.unit.spec.jsx
@@ -8,7 +8,7 @@ import {
   fillData,
   selectCheckbox,
 } from 'platform/testing/unit/schemaform-utils.jsx';
-import { changeDropdown } from '../helpers/index';
+import { changeDropdown } from 'platform/testing/unit/helpers';
 import formConfig from '../../config/form';
 
 describe('686 report dependent death additional information', () => {

--- a/src/applications/disability-benefits/686c-674/tests/config/reportDivorce.unit.spec.jsx
+++ b/src/applications/disability-benefits/686c-674/tests/config/reportDivorce.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
-import { changeDropdown } from '../helpers/index.js';
+import { changeDropdown } from 'platform/testing/unit/helpers';
 
 import {
   DefinitionTester,

--- a/src/applications/disability-benefits/686c-674/tests/config/reportMarriageOfChild.unit.spec.jsx
+++ b/src/applications/disability-benefits/686c-674/tests/config/reportMarriageOfChild.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
-import { changeDropdown } from '../helpers/index.js';
+import { changeDropdown } from 'platform/testing/unit/helpers';
 import {
   DefinitionTester,
   fillData,

--- a/src/applications/disability-benefits/686c-674/tests/config/spouseMarriageHistoryDetails.unit.spec.jsx
+++ b/src/applications/disability-benefits/686c-674/tests/config/spouseMarriageHistoryDetails.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
-import { changeDropdown } from '../helpers/index.js';
+import { changeDropdown } from 'platform/testing/unit/helpers';
 import {
   DefinitionTester,
   fillData,

--- a/src/applications/disability-benefits/686c-674/tests/config/stepchildInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/686c-674/tests/config/stepchildInformation.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
-import { changeDropdown } from '../helpers/index.js';
+import { changeDropdown } from 'platform/testing/unit/helpers';
 import {
   DefinitionTester,
   fillData,

--- a/src/applications/disability-benefits/686c-674/tests/config/stepchildren.unit.spec.jsx
+++ b/src/applications/disability-benefits/686c-674/tests/config/stepchildren.unit.spec.jsx
@@ -6,7 +6,7 @@ import {
   DefinitionTester,
   fillData,
 } from 'platform/testing/unit/schemaform-utils.jsx';
-import { changeDropdown } from '../helpers/index.js';
+import { changeDropdown } from 'platform/testing/unit/helpers';
 import formConfig from '../../config/form.js';
 
 describe('686 stepchildren', () => {

--- a/src/applications/disability-benefits/686c-674/tests/config/studentAddressMarriageTuition.unit.spec.jsx
+++ b/src/applications/disability-benefits/686c-674/tests/config/studentAddressMarriageTuition.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
-import { changeDropdown } from '../helpers/index.js';
+import { changeDropdown } from 'platform/testing/unit/helpers';
 import {
   DefinitionTester,
   fillData,

--- a/src/applications/disability-benefits/686c-674/tests/config/studentLastTermInfo.unit.spec.jsx
+++ b/src/applications/disability-benefits/686c-674/tests/config/studentLastTermInfo.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
-import { changeDropdown } from '../helpers/index.js';
+import { changeDropdown } from 'platform/testing/unit/helpers';
 import {
   DefinitionTester,
   fillData,

--- a/src/applications/disability-benefits/686c-674/tests/config/studentNameSSN674.unit.spec.jsx
+++ b/src/applications/disability-benefits/686c-674/tests/config/studentNameSSN674.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
-import { changeDropdown } from '../helpers/index.js';
+import { changeDropdown } from 'platform/testing/unit/helpers';
 import {
   DefinitionTester,
   fillData,

--- a/src/applications/disability-benefits/686c-674/tests/config/studentSchoolAddress.unit.spec.jsx
+++ b/src/applications/disability-benefits/686c-674/tests/config/studentSchoolAddress.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
-import { changeDropdown } from '../helpers/index.js';
+import { changeDropdown } from 'platform/testing/unit/helpers';
 import {
   DefinitionTester,
   fillData,

--- a/src/applications/disability-benefits/686c-674/tests/config/studentTermDates.unit.spec.jsx
+++ b/src/applications/disability-benefits/686c-674/tests/config/studentTermDates.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
-import { changeDropdown } from '../helpers/index.js';
+import { changeDropdown } from 'platform/testing/unit/helpers';
 import {
   DefinitionTester,
   fillData,

--- a/src/applications/disability-benefits/686c-674/tests/config/veteranMarriageHistoryDetails.unit.spec.jsx
+++ b/src/applications/disability-benefits/686c-674/tests/config/veteranMarriageHistoryDetails.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
-import { changeDropdown } from '../helpers/index.js';
+import { changeDropdown } from 'platform/testing/unit/helpers';
 import {
   DefinitionTester,
   fillData,

--- a/src/applications/disability-benefits/686c-674/tests/helpers/index.js
+++ b/src/applications/disability-benefits/686c-674/tests/helpers/index.js
@@ -1,7 +1,0 @@
-// Helper function to allow the user to change a dropdown input to the value provided
-export function changeDropdown(form, selector, value) {
-  const field = form.find(selector);
-  field.simulate('change', {
-    target: { value },
-  });
-}

--- a/src/applications/lgy/coe/tests/helpers.js
+++ b/src/applications/lgy/coe/tests/helpers.js
@@ -1,7 +1,0 @@
-// Helper function to allow the user to change a dropdown input to the value provided
-export function changeDropdown(form, selector, value) {
-  const field = form.find(selector);
-  field.simulate('change', {
-    target: { value },
-  });
-}

--- a/src/applications/vre/28-1900/tests/config/additionalInformation.unit.spec.jsx
+++ b/src/applications/vre/28-1900/tests/config/additionalInformation.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
-import { changeDropdown } from '../../../../disability-benefits/686c-674/tests/helpers';
+import { changeDropdown } from 'platform/testing/unit/helpers';
 
 import {
   DefinitionTester,

--- a/src/applications/vre/28-1900/tests/config/veteranContactInformation.unit.spec.js
+++ b/src/applications/vre/28-1900/tests/config/veteranContactInformation.unit.spec.js
@@ -6,7 +6,7 @@ import {
   DefinitionTester,
   fillData,
 } from 'platform/testing/unit/schemaform-utils.jsx';
-import { changeDropdown } from '../helpers';
+import { changeDropdown } from 'platform/testing/unit/helpers';
 
 import formConfig from '../../config/form';
 

--- a/src/applications/vre/28-1900/tests/config/veteranInformation.unit.spec.js
+++ b/src/applications/vre/28-1900/tests/config/veteranInformation.unit.spec.js
@@ -6,7 +6,7 @@ import {
   DefinitionTester,
   fillData,
 } from 'platform/testing/unit/schemaform-utils.jsx';
-import { changeDropdown } from '../helpers';
+import { changeDropdown } from 'platform/testing/unit/helpers';
 
 import formConfig from '../../config/form';
 

--- a/src/applications/vre/28-1900/tests/helpers.js
+++ b/src/applications/vre/28-1900/tests/helpers.js
@@ -1,7 +1,0 @@
-// Helper function to allow the user to change a dropdown input to the value provided
-export function changeDropdown(form, selector, value) {
-  const field = form.find(selector);
-  field.simulate('change', {
-    target: { value },
-  });
-}

--- a/src/applications/vre/28-8832/tests/config/claimant-information/claimant-address.unit.spec.jsx
+++ b/src/applications/vre/28-8832/tests/config/claimant-information/claimant-address.unit.spec.jsx
@@ -6,7 +6,7 @@ import {
   DefinitionTester,
   fillData,
 } from 'platform/testing/unit/schemaform-utils.jsx';
-import { changeDropdown } from '../../helpers';
+import { changeDropdown } from 'platform/testing/unit/helpers';
 import formConfig from '../../../config/form';
 
 describe('Chapter 36 Claimant Address', () => {

--- a/src/applications/vre/28-8832/tests/config/claimant-information/claimant-information.unit.spec.jsx
+++ b/src/applications/vre/28-8832/tests/config/claimant-information/claimant-information.unit.spec.jsx
@@ -6,7 +6,7 @@ import {
   DefinitionTester,
   fillData,
 } from 'platform/testing/unit/schemaform-utils.jsx';
-import { changeDropdown } from '../../helpers';
+import { changeDropdown } from 'platform/testing/unit/helpers';
 
 import formConfig from '../../../config/form';
 

--- a/src/applications/vre/28-8832/tests/helpers.js
+++ b/src/applications/vre/28-8832/tests/helpers.js
@@ -1,7 +1,0 @@
-// Helper function to allow the user to change a dropdown input to the value provided
-export function changeDropdown(form, selector, value) {
-  const field = form.find(selector);
-  field.simulate('change', {
-    target: { value },
-  });
-}

--- a/src/platform/testing/unit/helpers.js
+++ b/src/platform/testing/unit/helpers.js
@@ -84,6 +84,20 @@ function fillDate(formDOM, partialId, dateString) {
 }
 
 /**
+ * Allows the user to change a dropdown input to the value provided
+ *
+ * @param {object} form
+ * @param {string} selector
+ * @param {string} value
+ */
+export function changeDropdown(form, selector, value) {
+  const field = form.find(selector);
+  field.simulate('change', {
+    target: { value },
+  });
+}
+
+/**
  * A function to mock the global fetch function and return
  * the value provided in returnVal.
  *


### PR DESCRIPTION
## Description
The `changeDropdown` unit test helper function was being referenced across a few apps. This PR adds it to the platform unit test helpers so that apps are using it from that file.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#30304


## Testing done
Tested locally and in CI.

## Screenshots


## Acceptance criteria
- [x] `changeDropdown` is only reference from the platform unit test helpers file.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
