### PR TITLE
Add versioned facility mock

### DIFF
--- a/src/applications/vaos/tests/appointment-list/components/CanceledAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/CanceledAppointmentsList.unit.spec.jsx
@@ -5,13 +5,15 @@ import moment from 'moment';
 import environment from 'platform/utilities/environment';
 import { mockFetch, setFetchJSONFailure } from 'platform/testing/unit/helpers';
 import reducers from '../../../redux/reducer';
-import { getVAAppointmentMock, getVAFacilityMock } from '../../mocks/v0';
+import { getVAAppointmentMock } from '../../mocks/v0';
 import { mockAppointmentInfo, mockFacilitiesFetch } from '../../mocks/helpers';
 import {
   renderWithStoreAndRouter,
   getTimezoneTestDate,
 } from '../../mocks/setup';
 import CanceledAppointmentsList from '../../../appointment-list/components/CanceledAppointmentsList';
+import { mockFacilitiesFetchByVersion } from '../../mocks/fetch';
+import { createMockFacilityByVersion } from '../../mocks/data';
 
 const initialState = {
   featureToggles: {
@@ -77,26 +79,23 @@ describe('VAOS <CanceledAppointmentsList>', () => {
       'CANCELLED BY CLINIC';
     mockAppointmentInfo({ va: [appointment] });
 
-    const facility = {
-      id: 'vha_442GC',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '442GC',
-        name: 'Cheyenne VA Medical Center',
-        address: {
-          physical: {
-            zip: '82001-5356',
+    mockFacilitiesFetchByVersion({
+      facilities: [
+        createMockFacilityByVersion({
+          id: '442GC',
+          name: 'Cheyenne VA Medical Center',
+          address: {
+            postalCode: '82001-5356',
             city: 'Cheyenne',
             state: 'WY',
-            address1: '2360 East Pershing Boulevard',
+            line: ['2360 East Pershing Boulevard'],
           },
-        },
-        phone: {
-          main: '307-778-7550',
-        },
-      },
-    };
-    mockFacilitiesFetch('vha_442GC', [facility]);
+          phone: '307-778-7550',
+          version: 0,
+        }),
+      ],
+      version: 0,
+    });
 
     const screen = renderWithStoreAndRouter(<CanceledAppointmentsList />, {
       initialState,

--- a/src/applications/vaos/tests/appointment-list/components/CanceledAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/CanceledAppointmentsList.unit.spec.jsx
@@ -6,7 +6,7 @@ import environment from 'platform/utilities/environment';
 import { mockFetch, setFetchJSONFailure } from 'platform/testing/unit/helpers';
 import reducers from '../../../redux/reducer';
 import { getVAAppointmentMock } from '../../mocks/v0';
-import { mockAppointmentInfo, mockFacilitiesFetch } from '../../mocks/helpers';
+import { mockAppointmentInfo } from '../../mocks/helpers';
 import {
   renderWithStoreAndRouter,
   getTimezoneTestDate,
@@ -25,7 +25,7 @@ describe('VAOS <CanceledAppointmentsList>', () => {
   beforeEach(() => {
     mockFetch();
     MockDate.set(getTimezoneTestDate());
-    mockFacilitiesFetch();
+    mockFacilitiesFetchByVersion({ version: 0 });
   });
   afterEach(() => {
     MockDate.reset();
@@ -257,7 +257,7 @@ describe('VAOS <CanceledAppointmentsList>', () => {
     };
 
     mockAppointmentInfo({ va: [appointment] });
-    mockFacilitiesFetch('vha_442', []);
+    mockFacilitiesFetchByVersion({ ids: ['442'], version: 0 });
     const screen = renderWithStoreAndRouter(<CanceledAppointmentsList />, {
       initialState,
       reducers,
@@ -374,7 +374,7 @@ describe('VAOS <CanceledAppointmentsList>', () => {
       'CANCELLED BY CLINIC';
 
     mockAppointmentInfo({ va: [appointment] });
-    mockFacilitiesFetch('vha_442GC', []);
+    mockFacilitiesFetchByVersion({ ids: ['442GC'], version: 0 });
     const screen = renderWithStoreAndRouter(<CanceledAppointmentsList />, {
       initialState,
       reducers,
@@ -406,7 +406,7 @@ describe('VAOS <CanceledAppointmentsList>', () => {
     appointment.attributes.vdsAppointments[0].bookingNote = 'Some random note';
 
     mockAppointmentInfo({ va: [appointment] });
-    mockFacilitiesFetch('vha_442GC', []);
+    mockFacilitiesFetchByVersion({ ids: ['442GC'], version: 0 });
     const screen = renderWithStoreAndRouter(<CanceledAppointmentsList />, {
       initialState,
       reducers,
@@ -445,7 +445,7 @@ describe('VAOS <CanceledAppointmentsList>', () => {
     appointment.attributes.vdsAppointments[0].bookingNote = 'Some random note';
 
     mockAppointmentInfo({ va: [appointment] });
-    mockFacilitiesFetch('vha_442GC', []);
+    mockFacilitiesFetchByVersion({ ids: ['442GC'], version: 0 });
     const screen = renderWithStoreAndRouter(<CanceledAppointmentsList />, {
       initialState,
       reducers,
@@ -484,7 +484,7 @@ describe('VAOS <CanceledAppointmentsList>', () => {
     appointment.attributes.vdsAppointments[0].bookingNote = 'Some random note';
 
     mockAppointmentInfo({ va: [appointment] });
-    mockFacilitiesFetch('vha_442GC', []);
+    mockFacilitiesFetchByVersion({ ids: ['442GC'], version: 0 });
     const screen = renderWithStoreAndRouter(<CanceledAppointmentsList />, {
       initialState,
       reducers,
@@ -512,7 +512,7 @@ describe('VAOS <CanceledAppointmentsList>', () => {
     appointment.attributes.vdsAppointments[0].bookingNote = 'Some random note';
 
     mockAppointmentInfo({ va: [appointment] });
-    mockFacilitiesFetch('vha_442GC', []);
+    mockFacilitiesFetchByVersion({ ids: ['442GC'], version: 0 });
     const screen = renderWithStoreAndRouter(<CanceledAppointmentsList />, {
       initialState,
       reducers,

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
@@ -3,15 +3,10 @@ import MockDate from 'mockdate';
 import { expect } from 'chai';
 import moment from 'moment';
 import { mockFetch } from 'platform/testing/unit/helpers';
-import {
-  getVAAppointmentMock,
-  getVAFacilityMock,
-  getCancelReasonMock,
-} from '../../../mocks/v0';
+import { getVAAppointmentMock, getCancelReasonMock } from '../../../mocks/v0';
 import {
   mockAppointmentInfo,
   mockFacilitiesFetch,
-  mockFacilityFetch,
   mockSingleAppointmentFetch,
   mockVACancelFetches,
 } from '../../../mocks/helpers';
@@ -25,12 +20,13 @@ import { AppointmentList } from '../../../../appointment-list';
 import sinon from 'sinon';
 import { fireEvent, waitFor } from '@testing-library/react';
 import { getICSTokens } from '../../../../utils/calendar';
+import { mockSingleVAOSAppointmentFetch } from '../../../mocks/helpers.v2';
+import { getVAOSAppointmentMock } from '../../../mocks/v2';
 import {
-  mockSingleVAOSAppointmentFetch,
-  mockV2FacilityFetch,
-} from '../../../mocks/helpers.v2';
-import { getV2FacilityMock, getVAOSAppointmentMock } from '../../../mocks/v2';
-import { mockSingleClinicFetchByVersion } from '../../../mocks/fetch';
+  mockFacilityFetchByVersion,
+  mockSingleClinicFetchByVersion,
+} from '../../../mocks/fetch';
+import { createMockFacilityByVersion } from '../../../mocks/data';
 
 const initialState = {
   featureToggles: {
@@ -79,19 +75,15 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       appointment,
     });
 
-    const facility = {
-      id: 'vha_442GC',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '442GC',
+    mockFacilityFetchByVersion({
+      facility: createMockFacilityByVersion({
+        id: '442GC',
         name: 'Fort Collins VA Clinic',
-        phone: {
-          main: '970-224-1550',
-        },
-      },
-    };
-
-    mockFacilityFetch('vha_442GC', facility);
+        phone: '970-224-1550',
+        version: 0,
+      }),
+      version: 0,
+    });
     const screen = renderWithStoreAndRouter(<AppointmentList />, {
       initialState,
       path: url,
@@ -253,19 +245,15 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       appointment,
     });
 
-    const facility = {
-      id: 'vha_442GC',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '442GC',
+    mockFacilityFetchByVersion({
+      facility: createMockFacilityByVersion({
+        id: '442GC',
         name: 'Fort Collins VA Clinic',
-        phone: {
-          main: '970-224-1550',
-        },
-      },
-    };
-
-    mockFacilityFetch('vha_442GC', facility);
+        phone: '970-224-1550',
+        version: 0,
+      }),
+      version: 0,
+    });
     const screen = renderWithStoreAndRouter(<AppointmentList />, {
       initialState,
       path: url,
@@ -350,16 +338,14 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       va: [appointment],
     });
 
-    const facility = {
-      id: 'vha_442GC',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '442GC',
+    mockFacilityFetchByVersion({
+      facility: createMockFacilityByVersion({
+        id: '442GC',
         name: 'Fort Collins VA Clinic',
-      },
-    };
-
-    mockFacilitiesFetch('vha_442GC', [facility]);
+        version: 0,
+      }),
+      version: 0,
+    });
 
     const cancelReason = getCancelReasonMock();
     cancelReason.attributes = {
@@ -450,16 +436,14 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       appointment,
     });
 
-    const facility = {
-      id: 'vha_442GC',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '442GC',
+    mockFacilityFetchByVersion({
+      facility: createMockFacilityByVersion({
+        id: '442GC',
         name: 'Fort Collins VA Clinic',
-      },
-    };
-
-    mockFacilityFetch('vha_442GC', facility);
+        version: 0,
+      }),
+      version: 0,
+    });
 
     const screen = renderWithStoreAndRouter(<AppointmentList />, {
       initialState,
@@ -500,16 +484,14 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       appointment,
     });
 
-    const facility = {
-      id: 'vha_442GC',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '442GC',
+    mockFacilityFetchByVersion({
+      facility: createMockFacilityByVersion({
+        id: '442GC',
         name: 'Fort Collins VA Clinic',
-      },
-    };
-
-    mockFacilityFetch('vha_442GC', facility);
+        version: 0,
+      }),
+      version: 0,
+    });
 
     const screen = renderWithStoreAndRouter(<AppointmentList />, {
       initialState,
@@ -550,16 +532,14 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       appointment,
     });
 
-    const facility = {
-      id: 'vha_442GC',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '442GC',
+    mockFacilityFetchByVersion({
+      facility: createMockFacilityByVersion({
+        id: '442GC',
         name: 'Fort Collins VA Clinic',
-      },
-    };
-
-    mockFacilityFetch('vha_442GC', facility);
+        version: 0,
+      }),
+      version: 0,
+    });
 
     const screen = renderWithStoreAndRouter(<AppointmentList />, {
       initialState,
@@ -604,16 +584,14 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       appointment,
     });
 
-    const facility = {
-      id: 'vha_442GC',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '442GC',
+    mockFacilityFetchByVersion({
+      facility: createMockFacilityByVersion({
+        id: '442GC',
         name: 'Fort Collins VA Clinic',
-      },
-    };
-
-    mockFacilityFetch('vha_442GC', facility);
+        version: 0,
+      }),
+      version: 0,
+    });
 
     const screen = renderWithStoreAndRouter(<AppointmentList />, {
       initialState,
@@ -695,16 +673,14 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
 
     mockSingleAppointmentFetch({ appointment });
 
-    const facility = {
-      id: 'vha_442GC',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '442GC',
+    mockFacilityFetchByVersion({
+      facility: createMockFacilityByVersion({
+        id: '442GC',
         name: 'Fort Collins VA Clinic',
-      },
-    };
-
-    mockFacilityFetch('vha_442GC', facility);
+        version: 0,
+      }),
+      version: 0,
+    });
 
     const screen = renderWithStoreAndRouter(<AppointmentList />, {
       initialState,
@@ -744,16 +720,14 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       va: [appointment],
     });
 
-    const facility = {
-      id: 'vha_442GC',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '442GC',
+    mockFacilityFetchByVersion({
+      facility: createMockFacilityByVersion({
+        id: '442GC',
         name: 'Fort Collins VA Clinic',
-      },
-    };
-
-    mockFacilityFetch('vha_442GC', facility);
+        version: 0,
+      }),
+      version: 0,
+    });
 
     const screen = renderWithStoreAndRouter(<AppointmentList />, {
       initialState,
@@ -795,19 +769,15 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       appointment,
     });
 
-    const facility = {
-      id: 'vha_442GC',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '442GC',
+    mockFacilityFetchByVersion({
+      facility: createMockFacilityByVersion({
+        id: '442GC',
         name: 'Fort Collins VA Clinic',
-        phone: {
-          main: '970-224-1550',
-        },
-      },
-    };
-
-    mockFacilityFetch('vha_442GC', facility);
+        phone: '970-224-1550',
+        version: 0,
+      }),
+      version: 0,
+    });
 
     const screen = renderWithStoreAndRouter(<AppointmentList />, {
       initialState,
@@ -914,19 +884,15 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       appointment,
     });
 
-    const facility = {
-      id: 'vha_442GC',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '442GC',
+    mockFacilityFetchByVersion({
+      facility: createMockFacilityByVersion({
+        id: '442GC',
         name: 'Cheyenne VA Medical Center',
-        phone: {
-          main: '970-224-1550',
-        },
-      },
-    };
-
-    mockFacilityFetch('vha_442GC', facility);
+        phone: '970-224-1550',
+        version: 0,
+      }),
+      version: 0,
+    });
 
     const screen = renderWithStoreAndRouter(<AppointmentList />, {
       initialState,
@@ -1029,16 +995,14 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       appointment,
     });
 
-    mockFacilityFetch('vha_437GJ', {
-      id: 'vha_437GJ',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '437GJ',
+    mockFacilityFetchByVersion({
+      facility: createMockFacilityByVersion({
+        id: '437GJ',
         name: 'Facility in Denver time',
-        phone: {
-          main: '970-224-1550',
-        },
-      },
+        phone: '970-224-1550',
+        version: 0,
+      }),
+      version: 0,
     });
 
     const screen = renderWithStoreAndRouter(<AppointmentList />, {
@@ -1115,24 +1079,21 @@ describe('VAOS <ConfirmedAppointmentDetailsPage> with VAOS service', () => {
     });
     mockSingleVAOSAppointmentFetch({ appointment });
 
-    const facility = getVAFacilityMock();
-    facility.attributes = {
-      ...facility.attributes,
-      id: 'vha_442GC',
-      uniqueId: '442GC',
-      name: 'Cheyenne VA Medical Center',
-      address: {
-        physical: {
-          zip: '82001-5356',
+    mockFacilityFetchByVersion({
+      facility: createMockFacilityByVersion({
+        id: '442GC',
+        name: 'Cheyenne VA Medical Center',
+        phone: '970-224-1550',
+        address: {
+          postalCode: '82001-5356',
           city: 'Cheyenne',
           state: 'WY',
-          address1: '2360 East Pershing Boulevard',
+          line: ['2360 East Pershing Boulevard'],
         },
-      },
-      phone: { main: '970-224-1550' },
-    };
-
-    mockFacilityFetch('vha_442GC', facility);
+        version: 0,
+      }),
+      version: 0,
+    });
 
     const screen = renderWithStoreAndRouter(<AppointmentList />, {
       initialState: myInitialState,
@@ -1213,24 +1174,21 @@ describe('VAOS <ConfirmedAppointmentDetailsPage> with VAOS service', () => {
 
     mockSingleVAOSAppointmentFetch({ appointment });
 
-    const facility = getVAFacilityMock();
-    facility.attributes = {
-      ...facility.attributes,
-      id: 'vha_442GC',
-      uniqueId: '442GC',
-      name: 'Cheyenne VA Medical Center',
-      address: {
-        physical: {
-          zip: '82001-5356',
+    mockFacilityFetchByVersion({
+      facility: createMockFacilityByVersion({
+        id: '442GC',
+        name: 'Cheyenne VA Medical Center',
+        phone: '970-224-1550',
+        address: {
+          postalCode: '82001-5356',
           city: 'Cheyenne',
           state: 'WY',
-          address1: '2360 East Pershing Boulevard',
+          line: ['2360 East Pershing Boulevard'],
         },
-      },
-      phone: { main: '970-224-1550' },
-    };
-
-    mockFacilityFetch('vha_442GC', facility);
+        version: 0,
+      }),
+      version: 0,
+    });
 
     const screen = renderWithStoreAndRouter(<AppointmentList />, {
       initialState: myInitialState,
@@ -1291,8 +1249,8 @@ describe('VAOS <ConfirmedAppointmentDetailsPage> with VAOS service', () => {
     });
     mockSingleVAOSAppointmentFetch({ appointment });
 
-    mockV2FacilityFetch(
-      getV2FacilityMock({
+    mockFacilityFetchByVersion({
+      facility: createMockFacilityByVersion({
         id: '983GC',
         name: 'Cheyenne VA Medical Center',
         address: {
@@ -1303,7 +1261,7 @@ describe('VAOS <ConfirmedAppointmentDetailsPage> with VAOS service', () => {
         },
         phone: '970-224-1550',
       }),
-    );
+    });
 
     const screen = renderWithStoreAndRouter(<AppointmentList />, {
       initialState: myInitialState,

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.video.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.video.unit.spec.jsx
@@ -19,11 +19,10 @@ import { mockFetch } from 'platform/testing/unit/helpers';
 import { AppointmentList } from '../../../../appointment-list';
 import sinon from 'sinon';
 import { getICSTokens } from '../../../../utils/calendar';
-import { getV2FacilityMock, getVAOSAppointmentMock } from '../../../mocks/v2';
-import {
-  mockSingleVAOSAppointmentFetch,
-  mockV2FacilityFetch,
-} from '../../../mocks/helpers.v2';
+import { getVAOSAppointmentMock } from '../../../mocks/v2';
+import { mockSingleVAOSAppointmentFetch } from '../../../mocks/helpers.v2';
+import { mockFacilityFetchByVersion } from '../../../mocks/fetch';
+import { createMockFacilityByVersion } from '../../../mocks/data';
 
 const initialState = {
   featureToggles: {
@@ -1459,20 +1458,19 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
 
       mockSingleVAOSAppointmentFetch({ appointment });
 
-      // And the appointment has associated facility information
-      const facility = getV2FacilityMock({
-        id: '983',
-        name: 'Cheyenne VA Medical Center',
-        address: {
-          postalCode: '82001-5356',
-          city: 'Cheyenne',
-          state: 'WY',
-          line: ['2360 East Pershing Boulevard'],
-        },
-        phone: '970-224-1550',
+      mockFacilityFetchByVersion({
+        facility: createMockFacilityByVersion({
+          id: '983',
+          name: 'Cheyenne VA Medical Center',
+          address: {
+            postalCode: '82001-5356',
+            city: 'Cheyenne',
+            state: 'WY',
+            line: ['2360 East Pershing Boulevard'],
+          },
+          phone: '970-224-1550',
+        }),
       });
-
-      mockV2FacilityFetch(facility);
 
       // When the page is displayed
       const screen = renderWithStoreAndRouter(<AppointmentList />, {

--- a/src/applications/vaos/tests/appointment-list/components/UpcomingAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/UpcomingAppointmentsList.unit.spec.jsx
@@ -5,7 +5,7 @@ import moment from 'moment';
 import { mockFetch } from 'platform/testing/unit/helpers';
 import reducers from '../../../redux/reducer';
 import { getCCAppointmentMock, getVAAppointmentMock } from '../../mocks/v0';
-import { mockAppointmentInfo, mockFacilitiesFetch } from '../../mocks/helpers';
+import { mockAppointmentInfo } from '../../mocks/helpers';
 import {
   getTimezoneTestDate,
   renderWithStoreAndRouter,
@@ -134,7 +134,7 @@ describe('VAOS <UpcomingAppointmentsList>', () => {
     appointment.attributes.vdsAppointments[0].currentStatus =
       'CANCELLED BY CLINIC';
     mockAppointmentInfo({ va: [appointment] });
-    mockFacilitiesFetch();
+    mockFacilitiesFetchByVersion({ version: 0 });
 
     const screen = renderWithStoreAndRouter(<UpcomingAppointmentsList />, {
       initialState,
@@ -230,7 +230,7 @@ describe('VAOS <UpcomingAppointmentsList>', () => {
     };
 
     mockAppointmentInfo({ va: [appointment] });
-    mockFacilitiesFetch();
+    mockFacilitiesFetchByVersion({ version: 0 });
     const screen = renderWithStoreAndRouter(<UpcomingAppointmentsList />, {
       initialState,
       reducers,
@@ -283,7 +283,7 @@ describe('VAOS <UpcomingAppointmentsList>', () => {
     };
 
     mockAppointmentInfo({ va: [appointment] });
-    mockFacilitiesFetch();
+    mockFacilitiesFetchByVersion({ version: 0 });
     const screen = renderWithStoreAndRouter(<UpcomingAppointmentsList />, {
       initialState,
       reducers,
@@ -323,7 +323,7 @@ describe('VAOS <UpcomingAppointmentsList>', () => {
     };
 
     mockAppointmentInfo({ va: [appointment] });
-    mockFacilitiesFetch();
+    mockFacilitiesFetchByVersion({ version: 0 });
     const screen = renderWithStoreAndRouter(<UpcomingAppointmentsList />, {
       initialState,
       reducers,
@@ -534,7 +534,7 @@ describe('VAOS <UpcomingAppointmentsList>', () => {
     appointment.attributes.vdsAppointments[0].currentStatus = 'FUTURE';
 
     mockAppointmentInfo({ va: [appointment] });
-    mockFacilitiesFetch();
+    mockFacilitiesFetchByVersion({ version: 0 });
     const screen = renderWithStoreAndRouter(<UpcomingAppointmentsList />, {
       initialState,
       reducers,
@@ -605,7 +605,7 @@ describe('VAOS <UpcomingAppointmentsList> V2 api', () => {
       statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
     });
 
-    mockFacilitiesFetch();
+    mockFacilitiesFetchByVersion({ version: 0 });
     const screen = renderWithStoreAndRouter(<UpcomingAppointmentsList />, {
       initialState: myInitialState,
       reducers,
@@ -644,7 +644,7 @@ describe('VAOS <UpcomingAppointmentsList> V2 api', () => {
       statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
     });
 
-    mockFacilitiesFetch();
+    mockFacilitiesFetchByVersion({ version: 0 });
     const screen = renderWithStoreAndRouter(<UpcomingAppointmentsList />, {
       initialState: myInitialState,
       reducers,
@@ -683,7 +683,7 @@ describe('VAOS <UpcomingAppointmentsList> V2 api', () => {
       statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
     });
 
-    mockFacilitiesFetch();
+    mockFacilitiesFetchByVersion({ version: 0 });
     const screen = renderWithStoreAndRouter(<UpcomingAppointmentsList />, {
       initialState: myInitialState,
       reducers,
@@ -722,7 +722,7 @@ describe('VAOS <UpcomingAppointmentsList> V2 api', () => {
       statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
     });
 
-    mockFacilitiesFetch();
+    mockFacilitiesFetchByVersion({ version: 0 });
     const screen = renderWithStoreAndRouter(<UpcomingAppointmentsList />, {
       initialState: myInitialState,
       reducers,
@@ -761,7 +761,7 @@ describe('VAOS <UpcomingAppointmentsList> V2 api', () => {
       statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
     });
 
-    mockFacilitiesFetch();
+    mockFacilitiesFetchByVersion({ version: 0 });
     const screen = renderWithStoreAndRouter(<UpcomingAppointmentsList />, {
       initialState: myInitialState,
       reducers,

--- a/src/applications/vaos/tests/appointment-list/components/UpcomingAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/UpcomingAppointmentsList.unit.spec.jsx
@@ -4,11 +4,7 @@ import { expect } from 'chai';
 import moment from 'moment';
 import { mockFetch } from 'platform/testing/unit/helpers';
 import reducers from '../../../redux/reducer';
-import {
-  getCCAppointmentMock,
-  getVAAppointmentMock,
-  getVAFacilityMock,
-} from '../../mocks/v0';
+import { getCCAppointmentMock, getVAAppointmentMock } from '../../mocks/v0';
 import { mockAppointmentInfo, mockFacilitiesFetch } from '../../mocks/helpers';
 import {
   getTimezoneTestDate,
@@ -17,6 +13,8 @@ import {
 import UpcomingAppointmentsList from '../../../appointment-list/components/UpcomingAppointmentsList';
 import { mockVAOSAppointmentsFetch } from '../../mocks/helpers.v2';
 import { getVAOSAppointmentMock } from '../../mocks/v2';
+import { createMockFacilityByVersion } from '../../mocks/data';
+import { mockFacilitiesFetchByVersion } from '../../mocks/fetch';
 
 const initialState = {
   featureToggles: {
@@ -79,26 +77,23 @@ describe('VAOS <UpcomingAppointmentsList>', () => {
     appointment.attributes.vdsAppointments[0].currentStatus = 'FUTURE';
     mockAppointmentInfo({ va: [appointment] });
 
-    const facility = {
-      id: 'vha_442GC',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '442GC',
-        name: 'Cheyenne VA Medical Center',
-        address: {
-          physical: {
-            zip: '82001-5356',
+    mockFacilitiesFetchByVersion({
+      facilities: [
+        createMockFacilityByVersion({
+          id: '442GC',
+          name: 'Cheyenne VA Medical Center',
+          address: {
+            postalCode: '82001-5356',
             city: 'Cheyenne',
             state: 'WY',
-            address1: '2360 East Pershing Boulevard',
+            line: ['2360 East Pershing Boulevard'],
           },
-        },
-        phone: {
-          main: '307-778-7550',
-        },
-      },
-    };
-    mockFacilitiesFetch('vha_442GC', [facility]);
+          phone: '307-778-7550',
+          version: 0,
+        }),
+      ],
+      version: 0,
+    });
 
     const screen = renderWithStoreAndRouter(<UpcomingAppointmentsList />, {
       initialState,

--- a/src/applications/vaos/tests/mocks/data.js
+++ b/src/applications/vaos/tests/mocks/data.js
@@ -321,6 +321,22 @@ export function createMockClinicByVersion({
   throw new Error('Missing version specified');
 }
 
+/**
+ * Creates a mock VA facility object, for the specified version
+ *
+ * @export
+ * @param {Object} params
+ * @param {string} params.id The facility id
+ * @param {string} params.name The facility name
+ * @param {Address} params.address The facility address, in the FHIR format
+ * @param {string} params.phone The facility phone
+ * @param {number} params.lat The latitude of the facility
+ * @param {number} params.long The longitude of the facility
+ * @param {?boolean} params.isParent Is the facility is parent facility or not. Only relevent for version 2
+ * @param {number} [params.version = 2] The version of the facility object to create
+ *
+ * @returns {VAFacility|MFSFacility} The facility mock with specified data
+ */
 export function createMockFacilityByVersion({
   id,
   name,

--- a/src/applications/vaos/tests/mocks/data.js
+++ b/src/applications/vaos/tests/mocks/data.js
@@ -339,7 +339,7 @@ export function createMockClinicByVersion({
  */
 export function createMockFacilityByVersion({
   id,
-  name,
+  name = 'Fake',
   address,
   phone,
   lat,

--- a/src/applications/vaos/tests/mocks/data.js
+++ b/src/applications/vaos/tests/mocks/data.js
@@ -320,3 +320,61 @@ export function createMockClinicByVersion({
 
   throw new Error('Missing version specified');
 }
+
+export function createMockFacilityByVersion({
+  id,
+  name,
+  address,
+  phone,
+  lat,
+  long,
+  isParent = null,
+  version = 2,
+}) {
+  if (version === 2) {
+    return {
+      id,
+      type: 'facility',
+      attributes: {
+        id,
+        vistaSite: id.substring(0, 3),
+        vastParent: isParent ? id : id.substring(0, 3),
+        name,
+        lat,
+        long,
+        phone: { main: phone },
+        physicalAddress: address || {
+          line: [],
+          city: 'fake',
+          state: 'fake',
+          postalCode: 'fake',
+        },
+      },
+    };
+  }
+
+  return {
+    id: `vha_${id}`,
+    type: 'va_facilities',
+    attributes: {
+      uniqueId: id,
+      name,
+      address: {
+        physical: {
+          zip: address?.postalCode || 'fake zip',
+          city: address?.city || 'Fake city',
+          state: address?.state || 'FA',
+          address1: address?.line[0] || 'Fake street',
+          address2: null,
+          address3: null,
+        },
+      },
+      lat,
+      long,
+      phone: {
+        main: phone,
+      },
+      hours: {},
+    },
+  };
+}

--- a/src/applications/vaos/tests/mocks/fetch.js
+++ b/src/applications/vaos/tests/mocks/fetch.js
@@ -181,28 +181,27 @@ export function mockSingleClinicFetchByVersion({
  * @param {Object} params
  * @param {?Array<string>} params.ids An array of facility ids to use in the query params. Not necessary
  *   unless you are using the children param to return the child facilities of parents
- * @param {Array<MFSFacility|VAFacility>} params.facilities An array of facility objects to return from the fetch
+ * @param {Array<MFSFacility|VAFacility>} [params.facilities=[]] An array of facility objects to return from the fetch
  * @param {Boolean} [params.children=false] Sets the children query param, which is meant to include child
  *   facilities. Only relevant for version 2
  * @param {0|2} [params.version=2] The api version to use, defaulted to version 2,
  */
 export function mockFacilitiesFetchByVersion({
   ids = null,
-  facilities,
+  facilities = [],
   children = false,
   version = 2,
-}) {
+} = {}) {
+  const idList = ids || facilities.map(f => f.id);
+
   if (version !== 2) {
     setFetchJSONResponse(
       global.fetch.withArgs(
-        sinon.match(
-          `/v1/facilities/va?ids=${facilities.map(f => f.id).join(',')}`,
-        ),
+        sinon.match(`/v1/facilities/va?ids=${idList.join(',')}`),
       ),
       { data: facilities },
     );
   } else {
-    const idList = ids || facilities.map(f => f.id);
     setFetchJSONResponse(
       global.fetch.withArgs(
         `${
@@ -225,7 +224,7 @@ export function mockFacilitiesFetchByVersion({
  * @param {MFSFacility|VAFacility} params.facility The facility object to return from the fetch
  * @param {0|2} [params.version=2] The api version to use, defaulted to version 2,
  */
-export function mockFacilityFetchByVersion({ facility, version = 2 }) {
+export function mockFacilityFetchByVersion({ facility, version = 2 } = {}) {
   if (version !== 2) {
     setFetchJSONResponse(
       global.fetch.withArgs(sinon.match(`/v1/facilities/va/${facility.id}`)),

--- a/src/applications/vaos/tests/mocks/helpers.v2.js
+++ b/src/applications/vaos/tests/mocks/helpers.v2.js
@@ -208,39 +208,6 @@ export function mockSchedulingConfigurations(configs) {
 }
 
 /**
- * Mocks the api call to get facilities from the VAOS service.
- *
- * @export
- * @param {Array<string>} ids A list of VistA site ids to mock the request for
- * @param {Array<VARParentSite>} data The list of parent site data returned from the mock call
- */
-export function mockV2FacilitiesFetch(ids, data, children = false) {
-  setFetchJSONResponse(
-    global.fetch.withArgs(
-      `${environment.API_URL}/vaos/v2/facilities?children=${children}&${ids
-        .map(id => `ids[]=${id}`)
-        .join('&')}`,
-    ),
-    { data },
-  );
-}
-
-/**
- * Mocks the api call to get a facility from the VAOS service.
- *
- * @export
- * @param {Array<VAOSFacility>} data The facility to return
- */
-export function mockV2FacilityFetch(data) {
-  setFetchJSONResponse(
-    global.fetch.withArgs(
-      `${environment.API_URL}/vaos/v2/facilities/${data.id}`,
-    ),
-    { data },
-  );
-}
-
-/**
  * Mocks the api call that fetches a list of appointment slots for direct scheduling
  *
  * @export

--- a/src/applications/vaos/tests/mocks/setup.js
+++ b/src/applications/vaos/tests/mocks/setup.js
@@ -47,9 +47,9 @@ import {
   mockV2CommunityCareEligibility,
   mockVAOSParentSites,
 } from './helpers.v2';
-import { getV2FacilityMock } from './v2';
 import { TYPES_OF_CARE } from '../../utils/constants';
 import ClosestCityStatePage from '../../new-appointment/components/ClosestCityStatePage';
+import { createMockFacilityByVersion } from './data';
 
 /**
  * Creates a Redux store when the VAOS reducers loaded and the thunk middleware applied
@@ -491,7 +491,7 @@ export async function setPreferredDate(store, preferredDate) {
  * @param {Object} params
  * @param {Object} toggles Any feature toggles to set. CC toggle is set by default
  * @param {Array<Object>} parentSites List of parent sites and data, in the format used
- *  by the getV2FacilityMock params, so you can pass name, id, and address
+ *  by the createMockFacilityByVersion params, so you can pass name, id, and address
  * @param {?Array<string>} supportedSites List of site ids that support community care.
  *  Defaults to the parent site ids if not provided
  * @param {?Array<string>} registeredSites List of registered site ids. Will use ids
@@ -536,7 +536,9 @@ export async function setCommunityCareFlow({
   if (useV2) {
     mockVAOSParentSites(
       registered,
-      parentSites.map(data => getV2FacilityMock({ ...data, isParent: true })),
+      parentSites.map(data =>
+        createMockFacilityByVersion({ ...data, isParent: true }),
+      ),
       true,
     );
     mockV2CommunityCareEligibility({

--- a/src/applications/vaos/tests/mocks/v2.js
+++ b/src/applications/vaos/tests/mocks/v2.js
@@ -83,42 +83,6 @@ export function getVAOSAppointmentMock() {
     },
   };
 }
-/**
- * Returns a stubbed var-resources parent site object from the VAOS service.
- *
- * @export
- * @param {String} id id for the appointment
- * @returns {VARParentSite} var-resources parent site object
- */
-export function getV2FacilityMock({
-  id = 'Fake',
-  name = 'Fake',
-  isParent = false,
-  address = null,
-  lat = null,
-  long = null,
-  phone = null,
-}) {
-  return {
-    id,
-    type: 'facility',
-    attributes: {
-      id: 'fake',
-      vistaSite: id.substring(0, 3),
-      vastParent: isParent ? id : id.substring(0, 3),
-      name,
-      lat,
-      long,
-      phone: { main: phone },
-      physicalAddress: address || {
-        line: [],
-        city: 'fake',
-        state: 'fake',
-        postalCode: 'fake',
-      },
-    },
-  };
-}
 
 export function getSchedulingConfigurationMock({
   id = 'fake',

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfCarePage.unit.spec.jsx
@@ -9,7 +9,6 @@ import set from 'platform/utilities/data/set';
 import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
 
 import { getParentSiteMock } from '../../mocks/v0';
-import { getV2FacilityMock } from '../../mocks/v2';
 import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
 import {
   mockCommunityCareEligibility,
@@ -24,6 +23,7 @@ import TypeOfCarePage from '../../../new-appointment/components/TypeOfCarePage';
 import { NewAppointment } from '../../../new-appointment';
 import moment from 'moment';
 import environment from 'platform/utilities/environment';
+import { createMockFacilityByVersion } from '../../mocks/data';
 
 const initialState = {
   featureToggles: {
@@ -398,8 +398,8 @@ describe('VAOS <TypeOfCarePage>', () => {
       mockVAOSParentSites(
         ['983'],
         [
-          getV2FacilityMock({ id: '983', isParent: true }),
-          getV2FacilityMock({ id: '983GC', isParent: true }),
+          createMockFacilityByVersion({ id: '983', isParent: true }),
+          createMockFacilityByVersion({ id: '983GC', isParent: true }),
         ],
         true,
       );
@@ -430,8 +430,8 @@ describe('VAOS <TypeOfCarePage>', () => {
       mockVAOSParentSites(
         ['983'],
         [
-          getV2FacilityMock({ id: '983', isParent: true }),
-          getV2FacilityMock({ id: '983GC', isParent: true }),
+          createMockFacilityByVersion({ id: '983', isParent: true }),
+          createMockFacilityByVersion({ id: '983GC', isParent: true }),
         ],
         true,
       );

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.eligibility.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.eligibility.unit.spec.jsx
@@ -28,11 +28,11 @@ import {
   getV2ClinicMock,
   getV2FacilityMock,
 } from '../../../mocks/v2';
+import { mockSchedulingConfigurations } from '../../../mocks/helpers.v2';
 import {
-  mockSchedulingConfigurations,
-  mockV2FacilitiesFetch,
-} from '../../../mocks/helpers.v2';
-import { mockEligibilityFetchesByVersion } from '../../../mocks/fetch';
+  mockEligibilityFetchesByVersion,
+  mockFacilitiesFetchByVersion,
+} from '../../../mocks/fetch';
 
 const parentSite983 = {
   id: '983',
@@ -731,11 +731,10 @@ describe('VAOS <VAFacilityPage> eligibility check', () => {
             patientHistoryDuration: 365,
           }),
         ]);
-        mockV2FacilitiesFetch(
-          ['983', '984'],
-          facilities.filter(f => f.id === '983' || f.id === '984'),
-          true,
-        );
+        mockFacilitiesFetchByVersion({
+          facilities: facilities.filter(f => f.id === '983' || f.id === '984'),
+          children: true,
+        });
         mockEligibilityFetchesByVersion({
           facilityId: '983',
           typeOfCareId: 'socialWork',

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.eligibility.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.eligibility.unit.spec.jsx
@@ -26,13 +26,13 @@ import {
 import {
   getSchedulingConfigurationMock,
   getV2ClinicMock,
-  getV2FacilityMock,
 } from '../../../mocks/v2';
 import { mockSchedulingConfigurations } from '../../../mocks/helpers.v2';
 import {
   mockEligibilityFetchesByVersion,
   mockFacilitiesFetchByVersion,
 } from '../../../mocks/fetch';
+import { createMockFacilityByVersion } from '../../../mocks/data';
 
 const parentSite983 = {
   id: '983',
@@ -699,7 +699,7 @@ describe('VAOS <VAFacilityPage> eligibility check', () => {
 
       const facilityIds = ['983', '983GC', '983GB', '983HK', '983QA', '984'];
       const facilities = facilityIds.map((id, index) =>
-        getV2FacilityMock({
+        createMockFacilityByVersion({
           id,
           name: `Fake facility name ${index + 1}`,
           lat: Math.random() * 90,

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.unit.spec.jsx
@@ -28,15 +28,13 @@ import {
 } from '../../../mocks/helpers';
 import {
   mockSchedulingConfigurations,
-  mockV2FacilitiesFetch,
   mockVAOSParentSites,
 } from '../../../mocks/helpers.v2';
-import {
-  getSchedulingConfigurationMock,
-  getV2FacilityMock,
-} from '../../../mocks/v2';
+import { getSchedulingConfigurationMock } from '../../../mocks/v2';
 import { NewAppointment } from '../../../../new-appointment';
 import { FETCH_STATUS } from '../../../../utils/constants';
+import { createMockFacilityByVersion } from '../../../mocks/data';
+import { mockFacilitiesFetchByVersion } from '../../../mocks/fetch';
 
 describe('VAOS <VAFacilityPage>', () => {
   describe('when there are multiple facilities to choose from', () => {
@@ -1643,15 +1641,21 @@ describe('VAOS <VAFacilityPage>', () => {
           typeOfCareId: 'primaryCare',
         }),
       ]);
-      mockV2FacilitiesFetch(
-        ['983', '984'],
-        [
-          getV2FacilityMock({ id: '983', name: 'A facility name' }),
-          getV2FacilityMock({ id: '984', name: 'Another facility name' }),
-          getV2FacilityMock({ id: '984GC', name: 'Disabled facility name' }),
+      mockFacilitiesFetchByVersion({
+        ids: ['983', '984'],
+        facilities: [
+          createMockFacilityByVersion({ id: '983', name: 'A facility name' }),
+          createMockFacilityByVersion({
+            id: '984',
+            name: 'Another facility name',
+          }),
+          createMockFacilityByVersion({
+            id: '984GC',
+            name: 'Disabled facility name',
+          }),
         ],
-        true,
-      );
+        children: true,
+      });
       mockEligibilityFetches({
         siteId: '983',
         facilityId: '983',


### PR DESCRIPTION
## Description
This PR
- Adds new fetch and data helpers for facility data, which can be used for either version of the facilities calls we make
- Updates some uses of our existing facility helpers to use the new ones

## Original issue(s)
department-of-veterans-affairs/va.gov-team#29540

## Testing done
Unit testing

## Acceptance criteria
- [ ] Build passes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
