### PR TITLE
deprecating languageSupport feature toggle

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -51,7 +51,6 @@ export default Object.freeze({
   gibctEybBottomSheet: 'gibct_eyb_bottom_sheet',
   gibctSchoolRatings: 'gibct_school_ratings',
   hlrv2: 'hlr_v2',
-  languageSupport: 'language_support',
   manageDependents: 'dependents_management',
   megaMenuMobileV2: 'mega_menu_mobile_v2',
   preEntryCovid19Screener: 'pre_entry_covid19_screener',


### PR DESCRIPTION
## Description
We are removing language_support from the api and need to remove the last remaining code that maps to that feature toggle.

The FE code that initially removed any usage of the toggle was merged here: https://github.com/department-of-veterans-affairs/vets-website/pull/18903

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/31117


## Testing done
tested locally to confirm that toggles still function correctly

## Acceptance criteria
- [x] language_support toggle removed

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
