### PR TITLE
30747: [FSR] Update typeahead options

### DIFF
--- a/src/applications/financial-status-report/constants/typeaheadOptions.js
+++ b/src/applications/financial-status-report/constants/typeaheadOptions.js
@@ -1,5 +1,5 @@
 export const formatOptions = options => {
-  return options.map(item => ({
+  return options.sort((a, b) => (a > b ? 1 : -1)).map(item => ({
     label: item,
   }));
 };
@@ -57,7 +57,7 @@ export const incomeTypes = [
   'Substitute teaching',
   'Postmates service',
   'DoorDash service',
-  'Waitr service',
+  'Waiter service',
   'InstaCart service',
   'AirBnB service',
   'GetAround service',


### PR DESCRIPTION
## Description
Fixed typo for the term 'waiter' in the 'Other income' section and sorted typeahead options

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/30747

## Screenshots


## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs