### PR TITLE
Fix registered mark and missing how to apply link

### DIFF
--- a/src/applications/my-education-benefits/components/HowToApplyPost911GiBill.jsx
+++ b/src/applications/my-education-benefits/components/HowToApplyPost911GiBill.jsx
@@ -6,14 +6,14 @@ export default function HowToApplyPost911GiBill() {
       <div className="usa-alert usa-alert-warning">
         <div className="usa-alert-body">
           <h3 className="usa-alert-heading">
-            This application is only for the Post-9/11 GI Bill
+            This application is only for the Post-9/11 GI Bill®
           </h3>
           <div className="usa-alert-text">
             <p>
               Currently, we are only providing Post-9/11 GI Bill (Chapter 33)
               benefits through this application. If you would like to apply for
-              other benefits, please go to our <a href="#">How To Apply</a>{' '}
-              page.
+              other benefits, please go to our{' '}
+              <a href="/education/how-to-apply/">How To Apply</a> page.
             </p>
           </div>
         </div>


### PR DESCRIPTION
- Added missing registration mark.
- How to Apply is self referencing the page, it should point to /education/how-to-apply/

## Description


## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
