### PR TITLE
In runCommand(), only exit when child exits abnormally

### DIFF
--- a/script/utils.js
+++ b/script/utils.js
@@ -1,9 +1,13 @@
 const { spawn, spawnSync } = require('child_process');
 
-const runCommand = (cmd, forcedExitCode = null) => {
+const runCommand = cmd => {
   const child = spawn(cmd, [], { shell: true, stdio: 'inherit' });
+
+  // If the child process exits abnormally, exit parent with the same code
   child.on('exit', code => {
-    process.exit(forcedExitCode === null ? code : forcedExitCode);
+    if (code) {
+      process.exit(code);
+    }
   });
 
   // When we ^C out of the parent Node script, also interrupt the child

--- a/src/applications/personalization/dashboard/tests/e2e/claims-and-appeals.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/claims-and-appeals.cypress.spec.js
@@ -60,9 +60,9 @@ describe('The My VA Dashboard Claims and Appeals section', () => {
 
         // make sure that the Claims and Appeals section and CTA is shown
         cy.findByTestId('dashboard-section-claims-and-appeals').should('exist');
-        cy.findByRole('link', { name: /your claim or appeal/i }).should(
-          'exist',
-        );
+        cy.findByRole('link', {
+          name: /yr claim or appeal/i,
+        }).should('exist');
         cy.findByText(
           /You have no claims or appeals updates in the last 30 days/i,
         ).should('exist');

--- a/src/applications/personalization/dashboard/tests/e2e/claims-and-appeals.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/claims-and-appeals.cypress.spec.js
@@ -60,9 +60,9 @@ describe('The My VA Dashboard Claims and Appeals section', () => {
 
         // make sure that the Claims and Appeals section and CTA is shown
         cy.findByTestId('dashboard-section-claims-and-appeals').should('exist');
-        cy.findByRole('link', {
-          name: /yr claim or appeal/i,
-        }).should('exist');
+        cy.findByRole('link', { name: /your claim or appeal/i }).should(
+          'exist',
+        );
         cy.findByText(
           /You have no claims or appeals updates in the last 30 days/i,
         ).should('exist');


### PR DESCRIPTION
## Description
In its current implementation, `runCommand()` always causes the parent process to exit when the child process completes, regardless of exit code. This led to [an issue](https://dsva.slack.com/archives/CBU0KDSB1/p1633549113067800) where the parent process was forced to exit even though its own async task was still running.

This PR modifies `runCommand()` so it only causes the parent process to exit if the child process exits with an abnormal (non-zero) return code. The second parameter, `forcedExitCode`, is also removed since it was unused.

An [equivalent PR](https://github.com/department-of-veterans-affairs/content-build/pull/631) was already merged in `content-build`.

## Testing done
- Local testing of build and unit tests (successful and failing)
- Successful CI run, and test of Cypress failure on CI

## Acceptance criteria
- [x] Parent process only exits if child exits with nonzero return code

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
