### PR TITLE
Add `legend` to NotificationRadioButton `fieldset`

### DIFF
--- a/src/applications/personalization/profile/components/notification-settings/NotificationRadioButtons.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationRadioButtons.jsx
@@ -215,10 +215,14 @@ const NotificationRadioButtons = ({
 
   return (
     <fieldset className={fieldsetClasses} disabled={disabled} id={id}>
-      <h3 className={legendClasses}>
-        {label}
-        {requiredSpan}
-      </h3>
+      <div className="clearfix">
+        <legend className="rb-legend vads-u-padding--0">
+          <h3 className={legendClasses}>
+            {label}
+            {requiredSpan}
+          </h3>
+        </legend>
+      </div>
       {description ? (
         <p className="vads-u-margin-y--0p5 vads-u-color--gray-medium">
           {description}


### PR DESCRIPTION
## Description
We previously used a `legend` with the radio button `fieldset`. An a11y review requested that we use headings (`h3`s) instead for easier navigation using assistive tech. [Yet another a11y review requested that we use both](https://github.com/department-of-veterans-affairs/va.gov-team/issues/30341#issuecomment-932399872) 😆  So this PR wraps the existing `h3` in a `legend` element.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#31225


## Testing done


## Screenshots
Still looks good!

<img width="1177" alt="Screen Shot 2021-10-07 at 11 35 36 AM" src="https://user-images.githubusercontent.com/20728956/136443817-d3838fcf-7c67-4859-91dc-5ccb7bbdcd7a.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs