### PR TITLE
Check in 31053 demographics feature toggle

### DIFF
--- a/src/applications/check-in/README.md
+++ b/src/applications/check-in/README.md
@@ -74,6 +74,19 @@ We are currently using the endpoints that are mocked in `src/applications/check-
 
 We are currently using an HOC located at `src/applications/check-in/containers/withFeatureFlip.jsx` to control the feature flips. The whole app is wrapped around one, and each new feature should have its own toggle.
 
+#### Current toggles
+
+- `check_in_experience_enabled` : Enables or disabled the whole app on va.gov
+  - when to sunset: never;
+- `check_in_experience_demographics_page_enabled`: Enables or disabled the demographics page
+  - when to sunset: when the demographics page is deployed in production;
+- `check_in_experience_low_authentication_enabled` : Enables or disabled the low authentication flow
+  - when to sunset: Sprint 59
+- `check_in_experience_update_information_page_enabled` : Enables or disabled the update information page
+  - when to sunset: when we expand to multiple facilities and address the edge cases around it
+- `check_in_experience_multiple_appointment_support` : Enables or disabled the multiple appointment support
+  - when to sunset: When phase-4 is complete
+
 ### How to test this?
 
 Each feature should have unit tests and e2e tests.

--- a/src/applications/check-in/api/local-mock-api/mocks/feature.toggles.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/feature.toggles.js
@@ -3,6 +3,7 @@ const generateFeatureToggles = (toggles = {}) => {
     checkInExperienceEnabled = true,
     checkInExperienceMultipleAppointmentSupport = true,
     checkInExperienceUpdateInformationPageEnabled = false,
+    checkInExperienceDemographicsPageEnabled = false,
   } = toggles;
 
   return {
@@ -20,6 +21,10 @@ const generateFeatureToggles = (toggles = {}) => {
         {
           name: 'check_in_experience_multiple_appointment_support',
           value: checkInExperienceMultipleAppointmentSupport,
+        },
+        {
+          name: 'check_in_experience_demographics_page_enabled',
+          value: checkInExperienceDemographicsPageEnabled,
         },
       ],
     },

--- a/src/applications/check-in/containers/withFeatureFlip.jsx
+++ b/src/applications/check-in/containers/withFeatureFlip.jsx
@@ -6,6 +6,7 @@ import LoadingIndicator from '@department-of-veterans-affairs/component-library/
 
 import {
   checkInExperienceEnabled,
+  checkInExperienceDemographicsPageEnabled,
   checkInExperienceMultipleAppointmentEnabled,
   checkInExperienceUpdateInformationPageEnabled,
   loadingFeatureFlags,
@@ -33,10 +34,12 @@ const withFeatureFlip = WrappedComponent => props => {
 };
 const mapStateToProps = state => ({
   isCheckInEnabled: checkInExperienceEnabled(state),
+  isDemographicsPageEnabled: checkInExperienceDemographicsPageEnabled(state),
   isLoadingFeatureFlags: loadingFeatureFlags(state),
   isMultipleAppointmentsEnabled: checkInExperienceMultipleAppointmentEnabled(
     state,
   ),
+
   isUpdatePageEnabled: checkInExperienceUpdateInformationPageEnabled(state),
 });
 

--- a/src/applications/check-in/containers/withFeatureFlip.jsx
+++ b/src/applications/check-in/containers/withFeatureFlip.jsx
@@ -39,7 +39,6 @@ const mapStateToProps = state => ({
   isMultipleAppointmentsEnabled: checkInExperienceMultipleAppointmentEnabled(
     state,
   ),
-
   isUpdatePageEnabled: checkInExperienceUpdateInformationPageEnabled(state),
 });
 

--- a/src/applications/check-in/selectors.js
+++ b/src/applications/check-in/selectors.js
@@ -14,4 +14,9 @@ export const checkInExperienceUpdateInformationPageEnabled = state =>
     FEATURE_FLAG_NAMES.checkInExperienceUpdateInformationPageEnabled
   ];
 
+export const checkInExperienceDemographicsPageEnabled = state =>
+  toggleValues(state)[
+    FEATURE_FLAG_NAMES.checkInExperienceDemographicsPageEnabled
+  ];
+
 export const loadingFeatureFlags = state => state?.featureToggles?.loading;

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -12,11 +12,13 @@ export default Object.freeze({
   cernerOverride692: 'cerner_override_692',
   cernerOverride757: 'cerner_override_757',
   checkInExperienceEnabled: 'check_in_experience_enabled',
+  checkInExperienceDemographicsPageEnabled: 'check_in_experience_demographics_page_enabled',
   checkInExperienceUpdateInformationPageEnabled: 'check_in_experience_update_information_page_enabled',
   checkInExperienceLowRiskAuthenicationEnabled:
     'check_in_experience_low_authentication_enabled',
   checkInExperienceMultipleAppointmentEnabled:
     'check_in_experience_multiple_appointment_support',
+  
   coeAccess: 'coe_access',
   covidVaccineSchedulingFrontend: 'covid_vaccine_scheduling_frontend',
   covidVaccineUpdatesCTA: 'covid_vaccine_registration_frontend_cta',

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -18,7 +18,6 @@ export default Object.freeze({
     'check_in_experience_low_authentication_enabled',
   checkInExperienceMultipleAppointmentEnabled:
     'check_in_experience_multiple_appointment_support',
-  
   coeAccess: 'coe_access',
   covidVaccineSchedulingFrontend: 'covid_vaccine_scheduling_frontend',
   covidVaccineUpdatesCTA: 'covid_vaccine_registration_frontend_cta',


### PR DESCRIPTION
## Description
- Added access to the new feature toggle for `check_in_experience_demographics_page_enabled`

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/31053

## Testing done
- None, nothing uses it yet. 
