### PR TITLE
HLR: Update link to other benefit addresses

### DIFF
--- a/src/applications/disability-benefits/996/constants.js
+++ b/src/applications/disability-benefits/996/constants.js
@@ -22,7 +22,7 @@ export const LEGACY_APPEALS_URL = '/decision-reviews/legacy-appeals/';
 
 // 8622 is the ID of the <li> wrapping the "Find addresses for other benefit
 // types" accordion
-export const BENEFIT_OFFICES_URL = `${HLR_INFO_URL}#find-addresses-for-other-benef-8622`;
+export const BENEFIT_OFFICES_URL = `${HLR_INFO_URL}#find-addresses`;
 
 export const CONTESTABLE_ISSUES_API =
   '/higher_level_reviews/contestable_issues/';


### PR DESCRIPTION
## Description

The Higher-Level Review wizard content shown to the Veteran if they choose "A claim other than disability compensation" points to `/decision-reviews/higher-level-review` page, but the hash (anchor id) no longer targets & expands the accordion.

This PR is made in anticipation of merging in https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/702. Once updated, the following link will target, expand and focus on the desired accordion:

https://staging.va.gov/decision-reviews/higher-level-review/#find-addresses

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/28658

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] Updated anchor for "other benefit types" accordion

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
