### PR TITLE
CST: Add link to mobile app store

### DIFF
--- a/src/applications/claims-status/components/MobileAppMessage.jsx
+++ b/src/applications/claims-status/components/MobileAppMessage.jsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+
+const appleStoreUrl =
+  'https://apps.apple.com/app/apple-store/id1559609596?pt=545860&ct=gov.va.claimstatus&mt=8';
+const googlePlayUrl =
+  'https://play.google.com/store/apps/details?id=gov.va.mobileapp&referrer=utm_source%3Dgov.va.claimstatus%26utm_medium%3Dbanner';
+
+export const STORAGE_KEY = 'cst-mobile-app-message';
+
+const createLink = (href, name, label) => (
+  <a
+    href={href}
+    target="_blank"
+    rel="noopener noreferrer"
+    aria-label={`download the VA health and benefits app from ${label || name}`}
+  >
+    {name}
+  </a>
+);
+
+export default function MobileAppMessage({ mockUserAgent }) {
+  const [isHidden, setIsHidden] = useState(
+    (sessionStorage.getItem(STORAGE_KEY) || '') !== '',
+  );
+
+  const userAgent =
+    mockUserAgent || navigator.userAgent || navigator.vendor || window.opera;
+  const devices = {
+    ios: {
+      detect: /iPad|iPhone|iPod/.test(userAgent) && !window.MSStream,
+      link: <>the {createLink(appleStoreUrl, 'App Store', 'the app store')}</>,
+    },
+    android: {
+      // https://stackoverflow.com/a/21742107
+      detect: /android/i.test(userAgent),
+      link: createLink(googlePlayUrl, 'Google Play'),
+    },
+  };
+
+  const detectedDevice = Object.keys(devices).filter(os => devices[os].detect);
+  const storeLinks =
+    detectedDevice.length !== 0
+      ? devices[detectedDevice].link
+      : [devices.ios.link, ' or on ', devices.android.link];
+
+  return isHidden ? null : (
+    <va-alert
+      status="info"
+      closeable
+      onClose={() => {
+        setIsHidden(true);
+        sessionStorage.setItem(STORAGE_KEY, 'hidden');
+      }}
+    >
+      <h2 slot="headline">Check your status with our new mobile app</h2>
+      <p>
+        Get updates on your claims or appeals right at your fingertips using our
+        new mobile app. Download it on {storeLinks}.
+      </p>
+    </va-alert>
+  );
+}

--- a/src/applications/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/applications/claims-status/containers/YourClaimsPageV2.jsx
@@ -38,6 +38,7 @@ import { setUpPage, setPageFocus } from '../utils/page';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import ClaimsBreadcrumbs from '../components/ClaimsBreadcrumbs';
 import StemClaimListItem from '../components/StemClaimListItem';
+import MobileAppMessage from '../components/MobileAppMessage';
 
 class YourClaimsPageV2 extends React.Component {
   constructor(props) {
@@ -207,6 +208,7 @@ class YourClaimsPageV2 extends React.Component {
               <h1 className="claims-container-title">
                 Check your claim or appeal status
               </h1>
+              <MobileAppMessage />
               <div>{this.renderErrorMessages()}</div>
               <p>
                 <button

--- a/src/applications/claims-status/tests/components/MobileAppMessage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/MobileAppMessage.unit.spec.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import MobileAppMessage, {
+  STORAGE_KEY,
+} from '../../components/MobileAppMessage';
+
+describe('<MobileAppMessage>', () => {
+  beforeEach(() => {
+    sessionStorage.removeItem(STORAGE_KEY);
+  });
+
+  it('should render', () => {
+    const wrapper = shallow(<MobileAppMessage mockUserAgent={'blah'} />);
+    expect(wrapper.length).to.equal(1);
+    expect(wrapper.props().status).to.equal('info');
+    expect(wrapper.text()).to.include(
+      'Download it on the App Store or on Google Play.',
+    );
+    expect(wrapper.find('a[aria-label]').length).to.equal(2);
+    wrapper.unmount();
+  });
+  it('should hide the alert initially', () => {
+    sessionStorage.setItem(STORAGE_KEY, 'hidden');
+    const wrapper = shallow(<MobileAppMessage />);
+    expect(wrapper).to.be.empty;
+    wrapper.unmount();
+  });
+  it('should hide the alert', () => {
+    const wrapper = shallow(<MobileAppMessage />);
+    expect(wrapper.length).to.equal(1);
+
+    wrapper.props().onClose();
+    expect(wrapper).to.be.empty;
+    expect(sessionStorage.getItem(STORAGE_KEY)).to.equal('hidden');
+    wrapper.unmount();
+  });
+
+  it('should show app store link for iOS device', () => {
+    const wrapper = shallow(<MobileAppMessage mockUserAgent={'iPhone'} />);
+    const link = wrapper.find('a[aria-label]');
+    expect(wrapper.text()).to.include('Download it on the App Store.');
+    expect(link.length).to.equal(1);
+    expect(link.props()['aria-label']).to.include('app store');
+    wrapper.unmount();
+  });
+  it('should show Google play store link for android device', () => {
+    const wrapper = shallow(<MobileAppMessage mockUserAgent={'android'} />);
+    const link = wrapper.find('a[aria-label]');
+    expect(wrapper.text()).to.include('Download it on Google Play.');
+    expect(link.length).to.equal(1);
+    expect(link.props()['aria-label']).to.include('Google Play');
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
## Description

Adding an alert at the top of the Claim Status Tool page promoting the mobile VA Health and Benefits app.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/30252

## Testing done

Added unit tests

## Screenshots

<details><summary>Design</summary>

<!-- leave a blank line above -->
![](https://camo.githubusercontent.com/f7287e233706f93fbd8b69ec2426133a02211198f4251f51019f50bd5df9493f/68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3566666361316363386566373630653364623838313932372f62393931653363362d626239622d346162392d383465342d343963633734396161306365)</details>

<details><summary>Non-mobile (2 links)</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-10-08 at 1 37 53 PM](https://user-images.githubusercontent.com/136959/136610467-d9f78427-6de5-4f0f-ab6b-54d7c529d679.png)</details>

<details><summary>iOS (Apple store link only)</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-10-08 at 1 38 37 PM](https://user-images.githubusercontent.com/136959/136610463-8f38a97b-9bd2-4661-9a5b-e7ef224f192c.png)</details>

<details><summary>Android (Google Play link only)</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-10-08 at 1 39 02 PM](https://user-images.githubusercontent.com/136959/136610460-5a67e054-03b6-46f4-9e58-55aae8127e00.png)</details>

## Acceptance criteria
- [x] Add alert promoting mobile app to top of CST
- [x] Change app link based on device OS
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
