### PR TITLE
Refactor COVID Stay Informed Cypress tests to use page objects

### DIFF
--- a/src/applications/coronavirus-vaccination/tests/e2e/hideauth.cypress.spec.js
+++ b/src/applications/coronavirus-vaccination/tests/e2e/hideauth.cypress.spec.js
@@ -1,4 +1,5 @@
 import featureTogglesEnabled from './fixtures/toggle-covid-feature-hide-auth.json';
+import StayInformedPage from './page-objects/StayInformedPage';
 
 describe('COVID-19 Vaccination Preparation Form', () => {
   describe('when entering app with auth turned off', () => {
@@ -6,94 +7,32 @@ describe('COVID-19 Vaccination Preparation Form', () => {
       cy.intercept('GET', '/v0/feature_toggles*', featureTogglesEnabled).as(
         'feature',
       );
-      cy.visit('health-care/covid-19-vaccine/stay-informed/');
-      cy.wait('@feature');
-      cy.injectAxe();
     });
 
     it('should launch app from the continue button', () => {
+      const stayInformedPage = new StayInformedPage();
+
       // Intro page
-      cy.axeCheck();
-      cy.get('.vads-l-row').contains('What you should know about signing up');
+      stayInformedPage.loadPage();
+      stayInformedPage.continueWithoutSigningIn();
 
-      cy.get('.usa-button').contains('Sign up now');
+      // Fill out form
+      stayInformedPage.sameZipCode(true);
+      stayInformedPage.vaccineInterest(true);
+      stayInformedPage.checkForHelpInfo();
+      stayInformedPage.fillForm([
+        { field: /First Name/i, value: 'Testing', clear: true },
+        { field: /Last name/i, value: 'Veteran', clear: true },
+        { field: /Month/i, value: 'June', clear: false },
+        { field: /Day/i, value: '30', clear: false },
+        { field: /Year/i, value: '1950', clear: true },
+        { field: /Email address/i, value: 'test@example.com', clear: true },
+        { field: /Phone/i, value: '8005551234', clear: true },
+        { field: /Zip code/i, value: '10001', clear: true },
+      ]);
 
-      cy.findByText('Sign up now', { selector: 'a' }).click();
-
-      // Form page
-      cy.url().should(
-        'include',
-        '/health-care/covid-19-vaccine/stay-informed/form',
-      );
-      cy.injectAxe();
-      cy.axeCheck();
-      cy.get('#covid-vaccination-heading-form').contains(
-        'Sign up for vaccine updates',
-      );
-
-      cy.findByLabelText(/First name/i)
-        .clear()
-        .type('Testing');
-
-      cy.findByLabelText(/Last name/i)
-        .clear()
-        .type('Veteran');
-
-      cy.findByLabelText(/^Month/).select('June');
-
-      cy.findByLabelText(/^Day/).select('30');
-
-      cy.findByLabelText(/Year/i)
-        .clear()
-        .type('1950');
-
-      cy.findByLabelText(/Email address/i)
-        .clear()
-        .type('test@example.com');
-
-      cy.findByLabelText(/Phone/i)
-        .clear()
-        .type('8005551234');
-
-      cy.findByLabelText(/Zip code/i)
-        .clear()
-        .type('10001');
-
-      cy.get('#root_locationDetails-label').contains(
-        'Will you be in this zip code for the next 6 to 12 months?',
-      );
-      cy.get('#root_locationDetails_0').check();
-
-      cy.get('#root_vaccineInterest-label').contains(
-        'Do you plan to get a COVID-19 vaccine when one is available to you?',
-      );
-      cy.get('#root_vaccineInterest_0').check();
-
-      cy.axeCheck();
-      cy.intercept('POST', '**/covid_vaccine/v0/registration', {
-        status: 200,
-      }).as('response');
-
-      cy.get('.usa-button').contains('Submit form');
-      cy.get('.usa-button').click();
-      cy.wait('@response');
-
-      // Confirmation page
-      cy.url().should(
-        'include',
-        '/health-care/covid-19-vaccine/stay-informed/confirmation',
-      );
-      cy.axeCheck();
-      cy.get('#covid-vaccination-heading-confirmation').contains(
-        "We've received your information",
-      );
-
-      cy.get('.vads-l-row').contains(
-        'Thank you for signing up to stay informed about COVID-19 vaccines at VA',
-      );
-      cy.get('.vads-l-row').contains(
-        'Your local VA health facility may contact you by phone, email, or text message.',
-      );
+      stayInformedPage.submitForm();
+      stayInformedPage.validateSubmission();
     });
   });
 });

--- a/src/applications/coronavirus-vaccination/tests/e2e/page-objects/StayInformedPage.js
+++ b/src/applications/coronavirus-vaccination/tests/e2e/page-objects/StayInformedPage.js
@@ -1,0 +1,106 @@
+class StayInformedPage {
+  constructor() {
+    // this.header = new Header();
+  }
+
+  loadPage() {
+    cy.visit('health-care/covid-19-vaccine/stay-informed/');
+    cy.wait('@feature');
+    cy.get('.vads-l-row').contains('What you should know about signing up');
+    cy.injectAxe();
+    cy.axeCheck();
+  }
+
+  checkAccordions(accordionBody) {
+    cy.get('va-accordion-item')
+      .next()
+      .get('button')
+      .first()
+      .type('{shift}');
+    cy.get('div').contains(accordionBody);
+  }
+
+  continueWithoutSigningIn(auth = false) {
+    if (auth) {
+      cy.get('.usa-button').contains('Sign in');
+      cy.findByText('Continue without signing in', { selector: 'a' }).click();
+    } else {
+      cy.get('.usa-button').contains('Sign up now');
+      cy.findByText('Sign up now', { selector: 'a' }).click();
+    }
+    cy.url().should(
+      'include',
+      '/health-care/covid-19-vaccine/stay-informed/form',
+    );
+    cy.get('#covid-vaccination-heading-form').contains(
+      'Sign up for vaccine updates',
+    );
+  }
+
+  sameZipCode(sameZipCode) {
+    cy.get('#root_locationDetails-label').contains(
+      'Will you be in this zip code for the next 6 to 12 months?',
+    );
+    // eslint-disable-next-line no-unused-expressions
+    sameZipCode
+      ? cy.get(`#root_locationDetails_0`).check()
+      : cy.get(`#root_locationDetails_1`).check();
+  }
+
+  vaccineInterest(interestedInVaccine) {
+    cy.get('#root_vaccineInterest-label').contains(
+      'Do you plan to get a COVID-19 vaccine when one is available to you?',
+    );
+    // eslint-disable-next-line no-unused-expressions
+    interestedInVaccine
+      ? cy.get('#root_vaccineInterest_0').check()
+      : cy.get('#root_vaccineInterest_1').check();
+  }
+
+  fillForm(fields) {
+    fields.forEach(field => {
+      cy.findByLabelText(field.field);
+      // eslint-disable-next-line no-unused-expressions
+      field.clear
+        ? cy
+            .findByLabelText(field.field)
+            .clear()
+            .type(field.value)
+        : cy.findByLabelText(field.field).select(field.value);
+    });
+  }
+
+  submitForm() {
+    cy.intercept('POST', '**/covid_vaccine/v0/registration', {
+      status: 200,
+    }).as('response');
+
+    cy.get('.usa-button').contains('Submit form');
+    cy.get('.usa-button').click();
+    cy.wait('@response');
+
+    // Confirmation page
+    cy.url().should(
+      'include',
+      '/health-care/covid-19-vaccine/stay-informed/confirmation',
+    );
+
+    cy.get('#covid-vaccination-heading-confirmation').contains(
+      "We've received your information",
+    );
+  }
+
+  validateSubmission() {
+    cy.get('.vads-l-row').contains(
+      'Thank you for signing up to stay informed about COVID-19 vaccines at VA',
+    );
+  }
+
+  checkForHelpInfo() {
+    cy.get('.help-talk').contains(
+      'If you have questions or need help filling out this form, call our MyVA411 main information line at 800-698-2411 (TTY: 711).',
+    );
+  }
+}
+
+export default StayInformedPage;

--- a/src/applications/coronavirus-vaccination/tests/e2e/page-objects/StayInformedPage.js
+++ b/src/applications/coronavirus-vaccination/tests/e2e/page-objects/StayInformedPage.js
@@ -1,8 +1,4 @@
 class StayInformedPage {
-  constructor() {
-    // this.header = new Header();
-  }
-
   loadPage() {
     cy.visit('health-care/covid-19-vaccine/stay-informed/');
     cy.wait('@feature');
@@ -11,13 +7,15 @@ class StayInformedPage {
     cy.axeCheck();
   }
 
-  checkAccordions(accordionBody) {
-    cy.get('va-accordion-item')
-      .next()
-      .get('button')
-      .first()
-      .type('{shift}');
-    cy.get('div').contains(accordionBody);
+  checkAccordions(accordionBodies) {
+    accordionBodies.forEach(accordionBody => {
+      cy.get('va-accordion-item')
+        .next()
+        .get('button')
+        .first()
+        .type('{shift}');
+      cy.get('div').contains(accordionBody);
+    });
   }
 
   continueWithoutSigningIn(auth = false) {
@@ -59,7 +57,6 @@ class StayInformedPage {
 
   fillForm(fields) {
     fields.forEach(field => {
-      cy.findByLabelText(field.field);
       // eslint-disable-next-line no-unused-expressions
       field.clear
         ? cy

--- a/src/applications/coronavirus-vaccination/tests/e2e/page-objects/UnsubscribePage.js
+++ b/src/applications/coronavirus-vaccination/tests/e2e/page-objects/UnsubscribePage.js
@@ -1,0 +1,33 @@
+import featureTogglesEnabled from '../fixtures/toggle-covid-feature.json';
+
+class UnsubscribePage {
+  loadPage(status, pageId) {
+    cy.server();
+    let optOutRoute;
+    if (status === 200) optOutRoute = '**';
+    cy.route('PUT', `**/covid_vaccine/v0/registration/opt_out${optOutRoute}`, {
+      status,
+    });
+    cy.route('GET', '/v0/feature_toggles*', featureTogglesEnabled).as(
+      'feature',
+    );
+    cy.visit(
+      `health-care/covid-19-vaccine/stay-informed/unsubscribe?sid=${pageId}`,
+    );
+    cy.get('#covid-vaccination-heading-unsubscribe').contains('Unsubscribe');
+  }
+
+  confirmUnsubscription(status) {
+    if (status === 'failed') {
+        cy.get('.va-introtext').contains(
+            "We're sorry. We couldn't unsubscribe you from COVID-19 vaccine updates at this time. Please try again later.",
+          );
+    } else {
+        cy.get('.va-introtext').contains(
+            "You've unsubscribed from COVID-19 vaccine updates. We won't send you any more emails.",
+          );
+    }
+  }
+}
+
+export default UnsubscribePage;

--- a/src/applications/coronavirus-vaccination/tests/e2e/page-objects/UnsubscribePage.js
+++ b/src/applications/coronavirus-vaccination/tests/e2e/page-objects/UnsubscribePage.js
@@ -19,13 +19,13 @@ class UnsubscribePage {
 
   confirmUnsubscription(status) {
     if (status === 'failed') {
-        cy.get('.va-introtext').contains(
-            "We're sorry. We couldn't unsubscribe you from COVID-19 vaccine updates at this time. Please try again later.",
-          );
+      cy.get('.va-introtext').contains(
+        "We're sorry. We couldn't unsubscribe you from COVID-19 vaccine updates at this time. Please try again later.",
+      );
     } else {
-        cy.get('.va-introtext').contains(
-            "You've unsubscribed from COVID-19 vaccine updates. We won't send you any more emails.",
-          );
+      cy.get('.va-introtext').contains(
+        "You've unsubscribed from COVID-19 vaccine updates. We won't send you any more emails.",
+      );
     }
   }
 }

--- a/src/applications/coronavirus-vaccination/tests/e2e/signup.cypress.spec.js
+++ b/src/applications/coronavirus-vaccination/tests/e2e/signup.cypress.spec.js
@@ -16,24 +16,13 @@ describe('COVID-19 Vaccination Preparation Form', () => {
       stayInformedPage.loadPage();
 
       // Expand all accordions with keyboard and test for A11y
-      stayInformedPage.checkAccordions(
+      stayInformedPage.checkAccordions([
         'Contacting Veterans who we know plan to get a vaccine helps us do the most good with our limited supply.',
-      );
-      stayInformedPage.checkAccordions(
         'If you want to learn more before you decide your plans:',
-      );
-      stayInformedPage.checkAccordions(
         'you don’t have to provide your Social Security number. ',
-      );
-      stayInformedPage.checkAccordions(
         'Your local VA health facility may contact you by phone, email, or text message. If you’re eligible and want to get a vaccine, we encourage you to respond.',
-      );
-      cy.get('.help-talk').contains(
         'If you have questions or need help filling out this form, call our MyVA411 main information line at 800-698-2411 (TTY: 711).',
-      );
-
-      // aXe check expanded accordions
-      cy.axeCheck();
+      ]);
 
       stayInformedPage.continueWithoutSigningIn(true);
 
@@ -51,11 +40,9 @@ describe('COVID-19 Vaccination Preparation Form', () => {
         { field: /Phone/i, value: '8005551234', clear: true },
         { field: /Zip code/i, value: '10001', clear: true },
       ]);
-      cy.axeCheck();
 
       stayInformedPage.submitForm();
       stayInformedPage.validateSubmission();
-      cy.axeCheck();
     });
   });
 });

--- a/src/applications/coronavirus-vaccination/tests/e2e/unsubscribe.cypress.spec.js
+++ b/src/applications/coronavirus-vaccination/tests/e2e/unsubscribe.cypress.spec.js
@@ -1,23 +1,9 @@
-import featureTogglesEnabled from './fixtures/toggle-covid-feature.json';
+import UnsubscribePage from './page-objects/UnsubscribePage';
 
 describe('COVID-19 Vaccination Preparation Form', () => {
   it('should successfully unsubscribe the user', () => {
-    cy.server();
-    cy.route('PUT', '**/covid_vaccine/v0/registration/opt_out**', {
-      status: 200,
-    });
-    cy.route('GET', '/v0/feature_toggles*', featureTogglesEnabled).as(
-      'feature',
-    );
-    cy.visit(
-      'health-care/covid-19-vaccine/stay-informed/unsubscribe?sid=12345',
-    );
-    cy.injectAxe();
-
-    cy.get('#covid-vaccination-heading-unsubscribe').contains('Unsubscribe');
-    cy.get('.va-introtext').contains(
-      "You've unsubscribed from COVID-19 vaccine updates. We won't send you any more emails.",
-    );
-    cy.server({ enable: false });
+    const unsubscribePage = new UnsubscribePage();
+    unsubscribePage.loadPage(200, 12345);
+    unsubscribePage.confirmUnsubscription();
   });
 });

--- a/src/applications/coronavirus-vaccination/tests/e2e/unsubscribeFail.cypress.spec.js
+++ b/src/applications/coronavirus-vaccination/tests/e2e/unsubscribeFail.cypress.spec.js
@@ -1,4 +1,3 @@
-import featureTogglesEnabled from './fixtures/toggle-covid-feature.json';
 import UnsubscribePage from './page-objects/UnsubscribePage';
 
 describe('COVID-19 Vaccination Preparation Form', () => {

--- a/src/applications/coronavirus-vaccination/tests/e2e/unsubscribeFail.cypress.spec.js
+++ b/src/applications/coronavirus-vaccination/tests/e2e/unsubscribeFail.cypress.spec.js
@@ -1,25 +1,10 @@
 import featureTogglesEnabled from './fixtures/toggle-covid-feature.json';
+import UnsubscribePage from './page-objects/UnsubscribePage';
 
 describe('COVID-19 Vaccination Preparation Form', () => {
   it('should fail to unsubscribe the user', () => {
-    cy.server();
-    cy.route({
-      method: 'PUT',
-      url: '**/covid_vaccine/v0/registration/opt_out',
-      status: 404,
-    });
-    cy.route('GET', '/v0/feature_toggles*', featureTogglesEnabled).as(
-      'feature',
-    );
-    cy.visit(
-      'health-care/covid-19-vaccine/stay-informed/unsubscribe?sid=00000',
-    );
-    cy.injectAxe();
-
-    cy.get('#covid-vaccination-heading-unsubscribe').contains('Unsubscribe');
-    cy.get('.va-introtext').contains(
-      "We're sorry. We couldn't unsubscribe you from COVID-19 vaccine updates at this time. Please try again later.",
-    );
-    cy.server({ enable: false });
+    const unsubscribePage = new UnsubscribePage();
+    unsubscribePage.loadPage(404, '00000');
+    unsubscribePage.confirmUnsubscription('failed');
   });
 });


### PR DESCRIPTION
## Description
This PR refactors Cypress tests for the COVID vaccine Stay Informed tool to use page objects. This was done as a proof of concept to show that tests can be shortened and made easier to read with page objects.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/30434

## Acceptance criteria
- [ ] CI passes.