### PR TITLE
Readd always to run on testing reports

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -435,7 +435,7 @@ jobs:
     name: Testing Reports
     runs-on: ubuntu-latest
     needs: [cypress-tests-prep, cypress-tests]
-    if: ${{ needs.cypress-tests-prep.outputs.num_containers > 0 && (needs.cypress-tests.result == 'success' || needs.cypress-tests.result == 'failure') }}
+    if: ${{ always() && needs.cypress-tests-prep.outputs.num_containers > 0 && (needs.cypress-tests.result == 'success' || needs.cypress-tests.result == 'failure') }}
     continue-on-error: true
     steps:
       - name: Checkout


### PR DESCRIPTION
## Description
This will ensure that testing-reports is never skipped when Cypress fails.

