### PR TITLE
30380 add about covid vax pages

### DIFF
--- a/src/applications/static-pages/i18Select/utilities/urls.js
+++ b/src/applications/static-pages/i18Select/utilities/urls.js
@@ -1,3 +1,6 @@
+// glossary of 'pages' that are translated
+// each page has english, spanish, and tagalog urls
+// when adding a page, make sure that all the translation urls for the new page are live before updating this file
 export default {
   faq: {
     en: '/coronavirus-veteran-frequently-asked-questions',

--- a/src/applications/static-pages/i18Select/utilities/urls.js
+++ b/src/applications/static-pages/i18Select/utilities/urls.js
@@ -1,24 +1,29 @@
 export default {
   faq: {
-    en: '/coronavirus-veteran-frequently-asked-questions/',
-    es: '/coronavirus-veteran-frequently-asked-questions-esp/',
-    tl: '/coronavirus-veteran-frequently-asked-questions-tag/',
+    en: '/coronavirus-veteran-frequently-asked-questions',
+    es: '/coronavirus-veteran-frequently-asked-questions-esp',
+    tl: '/coronavirus-veteran-frequently-asked-questions-tag',
   },
   vaccine: {
-    en: '/health-care/covid-19-vaccine/',
-    es: '/health-care/covid-19-vaccine-esp/',
-    tl: '/health-care/covid-19-vaccine-tag/',
+    en: '/health-care/covid-19-vaccine',
+    es: '/health-care/covid-19-vaccine-esp',
+    tl: '/health-care/covid-19-vaccine-tag',
   },
   booster: {
-    en: '/health-care/covid-19-vaccine/booster-shots-and-additional-doses/',
+    en: '/health-care/covid-19-vaccine/booster-shots-and-additional-doses',
     es:
-      '/health-care/covid-19-vaccine-esp/booster-shots-and-additional-doses-esp/',
+      '/health-care/covid-19-vaccine-esp/booster-shots-and-additional-doses-esp',
     tl:
-      '/health-care/covid-19-vaccine-tag/booster-shots-and-additional-doses-tag/',
+      '/health-care/covid-19-vaccine-tag/booster-shots-and-additional-doses-tag',
   },
   vaccineRecord: {
     en: '/health-care/covid-19-vaccine/vaccine-record',
     es: '/health-care/covid-19-vaccine-esp/vaccine-record-esp',
     tl: '/health-care/covid-19-vaccine-tag/vaccine-record-tag',
+  },
+  about: {
+    en: '/health-care/covid-19-vaccine/about-covid-19-vaccine',
+    es: '/health-care/covid-19-vaccine/about-covid-19-vaccine-esp',
+    tl: '/health-care/covid-19-vaccine/about-covid-19-vaccine-tag',
   },
 };


### PR DESCRIPTION
## Description
Adds 'About covid vaccine' pages to list of translated urls.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/30380


## Testing done
Tested all translated urls locally and on review instance

## Screenshot
![Screen Shot 2021-10-11 at 12 15 00 PM](https://user-images.githubusercontent.com/8332986/136835913-d55c5ab3-60fe-4461-9756-78b02595562f.png)
es

## Acceptance criteria
- [x] Language selector react widget appears on new page urls

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
