### PR TITLE
CST: Hide mobile alert in prod

### DIFF
--- a/src/applications/claims-status/components/MobileAppMessage.jsx
+++ b/src/applications/claims-status/components/MobileAppMessage.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import environment from 'platform/utilities/environment';
 
 const appleStoreUrl =
   'https://apps.apple.com/app/apple-store/id1559609596?pt=545860&ct=gov.va.claimstatus&mt=8';
@@ -22,6 +23,11 @@ export default function MobileAppMessage({ mockUserAgent }) {
   const [isHidden, setIsHidden] = useState(
     (sessionStorage.getItem(STORAGE_KEY) || '') !== '',
   );
+
+  // Hide in production until content review is complete
+  if (environment.isProduction()) {
+    return null;
+  }
 
   const userAgent =
     mockUserAgent || navigator.userAgent || navigator.vendor || window.opera;


### PR DESCRIPTION
## Description

Hide the claim status tool mobile app alert in production until after content review has been completed

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/30252

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] Hide mobile app announcement in production

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
