### PR TITLE
DT Find Forms solve busted link handler issue

### DIFF
--- a/src/applications/find-forms/tests/widgets/createInvalidPdfAlert.unit.spec.js
+++ b/src/applications/find-forms/tests/widgets/createInvalidPdfAlert.unit.spec.js
@@ -58,7 +58,7 @@ describe('createInvalidPdfAlert', () => {
       preventDefault: sinon.stub(),
     };
 
-    await onDownloadLinkClick(reduxStore)(event);
+    await onDownloadLinkClick(event, reduxStore, sinon.stub());
 
     expect(link.click.called).to.be.false;
     expect(link.parentNode.insertBefore.called).to.be.true;
@@ -88,7 +88,7 @@ describe('createInvalidPdfAlert', () => {
       preventDefault: sinon.stub(),
     };
 
-    await onDownloadLinkClick(reduxStore)(event);
+    await onDownloadLinkClick(event, reduxStore, sinon.stub());
 
     expect(link.parentNode.removeChild.called).to.be.false;
     expect(link.removeEventListener.called).to.be.true;

--- a/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/DownloadPDFGuidance.js
+++ b/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/DownloadPDFGuidance.js
@@ -6,7 +6,6 @@ import { Provider } from 'react-redux';
 // relative imports
 import DownloadPDFModal from './DownloadPDFModal';
 import InvalidFormDownload from './InvalidFormAlert';
-// import { onDownloadLinkClick, sentryLogger } from './index';
 import { sentryLogger } from './index';
 import { showPDFModal } from '../../helpers/selectors';
 

--- a/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/DownloadPDFGuidance.js
+++ b/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/DownloadPDFGuidance.js
@@ -6,7 +6,8 @@ import { Provider } from 'react-redux';
 // relative imports
 import DownloadPDFModal from './DownloadPDFModal';
 import InvalidFormDownload from './InvalidFormAlert';
-import { onDownloadLinkClick, sentryLogger } from './index';
+// import { onDownloadLinkClick, sentryLogger } from './index';
+import { sentryLogger } from './index';
 import { showPDFModal } from '../../helpers/selectors';
 
 const removeReactRoot = () => {
@@ -22,8 +23,9 @@ const DownloadPDFGuidance = ({
   formPdfIsValid,
   formPdfUrlIsValid,
   link,
+  listenerFunction,
   netWorkRequestError,
-  store,
+  reduxStore,
 }) => {
   const div = document.createElement('div');
   div.className = 'faf-pdf-alert-modal-root';
@@ -31,9 +33,9 @@ const DownloadPDFGuidance = ({
 
   if (formPdfIsValid && formPdfUrlIsValid && !netWorkRequestError) {
     // feature flag
-    if (store?.getState && showPDFModal(store.getState())) {
+    if (reduxStore?.getState && showPDFModal(reduxStore.getState())) {
       ReactDOM.render(
-        <Provider store={store}>
+        <Provider store={reduxStore}>
           <DownloadPDFModal
             formNumber={formNumber}
             removeNode={removeReactRoot}
@@ -45,7 +47,7 @@ const DownloadPDFGuidance = ({
       parentEl.insertBefore(div, link);
     } else {
       // if the Feature Flag for the Modal is turned off
-      link.removeEventListener('click', onDownloadLinkClick);
+      link.removeEventListener('click', listenerFunction);
       link.click();
     }
   } else {


### PR DESCRIPTION
## Description
I made a right mess of the https://www.va.gov/find-forms/about-form-10-10ez/
1. Navigate there 
2. open network tab
3. click one of the download links (see the rep calls)

How I solved it => I found out that the event handler registered on the node was actually the return anonymous function on line [21](https://github.com/department-of-veterans-affairs/vets-website/compare/DT-FindForms-Solvebustedlinkhandlerissue?expand=1#diff-51f90be8c608d32071ff21b9544cc0b97e502ca0788eb5b4cbd93f0a20fbd5b0L21) which caused the [listener removal](https://github.com/department-of-veterans-affairs/vets-website/compare/DT-FindForms-Solvebustedlinkhandlerissue?expand=1#diff-189e00ec16b29665a0d89140c1676f4c75795c93934c6ced88da556b2e194c37L48) to not work. THUS the link was repeatedly clicked. 

## Testing done
Ran it locally, updated unit test

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
