### PR TITLE
526: Prevent event propogation on icons (Sentry)

### DIFF
--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -29,6 +29,10 @@
   clear: both;
 }
 
+.button-icon {
+  pointer-events: none;
+}
+
 ul.original-disability-list {
   li {
     margin-bottom: 0;


### PR DESCRIPTION
## Description

We're still seeing a `TypeError: undefined is not an object (evaluating 'e.type')` Sentry event.

From looking at the breadcrumbs in http://sentry.vfs.va.gov/organizations/vsp/issues/52403/, it appears that the icon was clicked, the page still navigated, then the error occurred.

<details><summary>click on button-icon</summary>

<!-- leave a blank line above -->
<img width="916" alt="Screen Shot 2021-10-12 at 1 53 44 PM" src="https://user-images.githubusercontent.com/136959/137013271-bcc6c2f9-f630-4cd7-8052-bf4ad8fcd04c.png"></details>

I'm not 100% sure that the icon was the cause of the problem, but I've seen this same pattern enough to want to hide the icon using CSS.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/30151

## Testing done

N/A

## Screenshots

See Description

## Acceptance criteria
- [x] button icon clicks are ignored. They are captured by the parent element (button)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
