### PR TITLE
Allow skipping content build on codespace creation

### DIFF
--- a/.devcontainer/codespaces-create.sh
+++ b/.devcontainer/codespaces-create.sh
@@ -15,7 +15,7 @@ printf "\n\n##### Installing vets-website #####\n"
 set -e
 cd ../vets-website && yarn install --production=false --prefer-offline && yarn build -- --buildtype=localhost --api=https://staging-api.va.gov --host="${CODESPACE_NAME}-3001.githubpreview.dev/" --port=3001
 
-if [[ "${VETS_WEBSITE_BUILD_CONTENT}" !== "NO" ]]
+if [[ "${VETS_WEBSITE_BUILD_CONTENT}" != "NO" ]]
 then
   # Build content-build and serve site
   printf "\n\n##### Installing content-build #####\n"

--- a/.devcontainer/codespaces-create.sh
+++ b/.devcontainer/codespaces-create.sh
@@ -14,5 +14,11 @@ yarn install-repos
 set -e
 cd ../vets-website && yarn install --production=false --prefer-offline && yarn build -- --buildtype=localhost --api=https://staging-api.va.gov --host="${CODESPACE_NAME}-3001.githubpreview.dev/" --port=3001
 
-# Build content-build and serve site
-cd ../content-build && yarn install --production=false --prefer-offline && yarn fetch-drupal-cache && yarn build -- --buildtype=localhost --api=https://staging-api.va.gov --host="${CODESPACE_NAME}-3002.githubpreview.dev/" --port=3002 --apps-directory-name=vets-website
+if [[ $VETS_WEBSITE_BUILD_CONTENT == 'NO' ]]
+then
+  # Build content-build and serve site
+  cd ../content-build && yarn install --production=false --prefer-offline && yarn fetch-drupal-cache && yarn build -- --buildtype=localhost --api=https://staging-api.va.gov --host="${CODESPACE_NAME}-3002.githubpreview.dev/" --port=3002 --apps-directory-name=vets-website
+else
+  # Skip content build
+  cd ../vets-website && yarn watch
+fi

--- a/.devcontainer/codespaces-create.sh
+++ b/.devcontainer/codespaces-create.sh
@@ -1,24 +1,25 @@
 #!/bin/bash
 
-# configure NVM
+# Configure NVM
 printf "\n\n#####" Configuring Node, NPM, and Yarn #####\n""
 source $NVM_DIR/nvm.sh
 nvm install || true # ignore exit code due to npm prefix
 nvm use --delete-prefix
 
-# download content repo
+# Download content repo
 printf "\n\n##### Downloading content repo #####\n"
 yarn install-repos
 
 # Build vets-website
+printf "\n\n##### Installing vets-website #####\n"
 set -e
 cd ../vets-website && yarn install --production=false --prefer-offline && yarn build -- --buildtype=localhost --api=https://staging-api.va.gov --host="${CODESPACE_NAME}-3001.githubpreview.dev/" --port=3001
 
-if [[ $VETS_WEBSITE_BUILD_CONTENT == 'NO' ]]
+if [[ "${VETS_WEBSITE_BUILD_CONTENT}" !== "NO" ]]
 then
-  # Skip content build
-  cd ../vets-website && yarn watch
-else
   # Build content-build and serve site
+  printf "\n\n##### Installing content-build #####\n"
   cd ../content-build && yarn install --production=false --prefer-offline && yarn fetch-drupal-cache && yarn build -- --buildtype=localhost --api=https://staging-api.va.gov --host="${CODESPACE_NAME}-3002.githubpreview.dev/" --port=3002 --apps-directory-name=vets-website
 fi
+
+printf "\n\n##### Your codespace has been created! #####\n"

--- a/.devcontainer/codespaces-create.sh
+++ b/.devcontainer/codespaces-create.sh
@@ -16,9 +16,9 @@ cd ../vets-website && yarn install --production=false --prefer-offline && yarn b
 
 if [[ $VETS_WEBSITE_BUILD_CONTENT == 'NO' ]]
 then
-  # Build content-build and serve site
-  cd ../content-build && yarn install --production=false --prefer-offline && yarn fetch-drupal-cache && yarn build -- --buildtype=localhost --api=https://staging-api.va.gov --host="${CODESPACE_NAME}-3002.githubpreview.dev/" --port=3002 --apps-directory-name=vets-website
-else
   # Skip content build
   cd ../vets-website && yarn watch
+else
+  # Build content-build and serve site
+  cd ../content-build && yarn install --production=false --prefer-offline && yarn fetch-drupal-cache && yarn build -- --buildtype=localhost --api=https://staging-api.va.gov --host="${CODESPACE_NAME}-3002.githubpreview.dev/" --port=3002 --apps-directory-name=vets-website
 fi


### PR DESCRIPTION
## Description

This PR allows skipping the content build process for app developers who are interested in quickly creating a codespace for development or collaborative review. To do so, a developer may [add an encrypted secret](https://docs.github.com/en/codespaces/managing-your-codespaces/managing-encrypted-secrets-for-your-codespaces) with name `VETS_WEBSITE_BUILD_CONTENT` and value `NO` and make it accessible by `vets-website`. If the secret is not present or has any other value, the content build process will proceed as usual.

## Testing done

Tested with and without secret present and with values other than `NO`.

## Screenshots

<img width="767" alt="Screen Shot 2021-10-13 at 9 26 23 AM" src="https://user-images.githubusercontent.com/101649/137164601-09a236e7-e548-40e9-826b-d6f6227c7536.png">

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
