### PR TITLE
[Check in] Add instructions for sharing envs with Codespaces

### DIFF
--- a/src/applications/check-in/README.md
+++ b/src/applications/check-in/README.md
@@ -8,6 +8,7 @@
   - [Good to knows](#good-to-knows)
     - [Project URLS](#project-urls)
     - [How to run locally](#how-to-run-locally)
+    - [How to run with Codespaces](#how-to-run-with-codespaces)
     - [Where is the data coming from?](#where-is-the-data-coming-from)
     - [Why is this not a VA forms app (formation)](#why-is-this-not-a-va-forms-app-formation)
     - [What API(s) does this use?](#what-apis-does-this-use)

--- a/src/applications/check-in/README.md
+++ b/src/applications/check-in/README.md
@@ -56,7 +56,24 @@ Currently, we are using the `v2` of the API, with `v1` behind a feature flip. Th
 
 ### How to run locally
 
-Follow the standard directions to run the app. The API needs to be running in order to run the app locally. Currently I would use the mock api in `src/applications/check-in/api/local-mock-api` using the directions in the [README](https://github.com/department-of-veterans-affairs/vets-website/blob/master/README.md#running-a-mock-api-for-local-development). This will make developer easier since creating a valid token is tedious.
+Follow the standard directions to run the app. The API needs to be running in order to run the app locally. Currently I would use the mock api in `src/applications/check-in/api/local-mock-api` using the directions in the [README](https://github.com/department-of-veterans-affairs/vets-website/blob/master/README.md#running-a-mock-api-for-local-development). This makes development easier since creating a valid token is tedious.
+
+### How to run with Codespaces
+
+#### Setup
+
+[Codespaces](https://docs.github.com/en/codespaces) is available for VA project development, and provides a convenient way to create a functional environment for testing a branch or collaborative review. To set up a codespace, follow the [instructions here](https://depo-platform-documentation.scrollhelp.site/developer-docs/Using-GitHub-Codespaces.1909063762.html). (Note that you can lower the setup time to ~6-7 minutes by creating a setting on your Github account to skip the content build) You may then run the app locally using Codespace's default port forwarding setup.
+
+#### Public sharing
+
+To share an app instance using the mock API running on Codespaces publicly, use these steps:
+
+- Create the codespace as above and wait for it to build
+- Start the mock API in a Codespace terminal: `yarn mock-api --responses src/applications/check-in/api/local-mock-api/phase.3.js`
+- Start the app in another Codespace terminal: `yarn watch --env.api="https://${CODESPACE_NAME}-3000.githubpreview.dev" --env.entry check-in`
+- Go to the "Ports" tab and make both port 3000 and 3001 public by right-clicking and selecting Privacy -> Public:
+  <img width="999" alt="Screen Shot 2021-10-13 at 2 35 24 PM" src="https://user-images.githubusercontent.com/101649/137209007-c38ea216-1450-47f5-8d4a-7873f5cf82e1.png">
+- Hover over the "Local Address" on the line for port 3001 and click the globe icon to open the public URL in your browser.
 
 ### Where is the data coming from?
 


### PR DESCRIPTION
## Description

Add instructions for publicly sharing review environments with Codespaces using the mock API.