### PR TITLE
Refactor Claims E2E tests to use page objects

### DIFF
--- a/src/applications/claims-status/tests/e2e/00.claims-list-breadcrumb.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/00.claims-list-breadcrumb.cypress.spec.js
@@ -1,50 +1,11 @@
-const Timeouts = require('platform/testing/e2e/timeouts.js');
-
+import TrackClaimsPage from './page-objects/TrackClaimsPage';
 import claimsList from './fixtures/mocks/claims-list.json';
 
 describe('Breadcrumb Test', () => {
   it('Verifies breadcrumb functionality', () => {
-    cy.intercept('GET', '/v0/evss_claims_async', claimsList);
-    cy.login();
-    cy.visit('/track-claims');
-    cy.title().should('eq', 'Track Claims: VA.gov');
-    cy.get('.claim-list-item-container', { timeout: Timeouts.slow }).should(
-      'be.visible',
-    );
-    cy.get('.va-nav-breadcrumbs').should('be.visible');
-    cy.get('.va-nav-breadcrumbs-list').should('be.visible');
-    cy.get('a[aria-current="page"').should('be.visible');
-    cy.injectAxeThenAxeCheck();
-
-    cy.get(
-      '.va-nav-breadcrumbs-list li:nth-of-type(2) a[aria-current="page"]',
-    ).should('exist');
-    cy.get(
-      '.va-nav-breadcrumbs-list li:nth-of-type(2) a[aria-current="page"]',
-    ).should('contain', 'Check your claims and appeals');
-    cy.get(
-      '.va-nav-breadcrumbs-list li:nth-of-type(2) a[aria-current="page"]',
-    ).should('have.css', 'pointer-events', 'none');
-
-    cy.viewportPreset('va-top-mobile-1');
-
-    cy.get('.va-nav-breadcrumbs-list').should('be.visible');
-
-    cy.get('.va-nav-breadcrumbs-list li:not(:nth-last-child(2))').should(
-      'have.css',
-      'display',
-      'none',
-    );
-    cy.get('.va-nav-breadcrumbs-list li:nth-last-child(2)').should(
-      'contain',
-      'Home',
-    );
-    cy.get('.va-nav-breadcrumbs-list li:nth-last-child(2)').should(
-      'have.css',
-      'display',
-      'inline-block',
-    );
-
-    cy.viewport(1024, 768);
+    const trackClaimsPage = new TrackClaimsPage();
+    trackClaimsPage.loadPage(claimsList);
+    trackClaimsPage.checkBreadcrumbs();
+    trackClaimsPage.checkBreadcrumbsMobile();
   });
 });

--- a/src/applications/claims-status/tests/e2e/00.claims-list-empty.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/00.claims-list-empty.cypress.spec.js
@@ -1,20 +1,10 @@
-const Timeouts = require('platform/testing/e2e/timeouts.js');
-
 import claimsListEmpty from './fixtures/mocks/claims-list-empty.json';
+import TrackClaimsPage from './page-objects/TrackClaimsPage';
 
 describe('Breadcrumb Test Empty List', () => {
   it('Verifies functionality with an empty list', () => {
-    cy.intercept('GET', '/v0/evss_claims_async', claimsListEmpty);
-    cy.login();
-    cy.visit('/track-claims');
-    cy.get('.claims-container-title', { timeout: Timeouts.slow }).should(
-      'be.visible',
-    );
-    // });
-    cy.get('.claims-alert').should(
-      'contain',
-      'You do not have any submitted claims',
-    );
-    cy.injectAxeThenAxeCheck();
+    const trackClaimsPage = new TrackClaimsPage();
+    trackClaimsPage.loadPage(claimsListEmpty);
+    trackClaimsPage.verifyNoClaims();
   });
 });

--- a/src/applications/claims-status/tests/e2e/00.claims-list.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/00.claims-list.cypress.spec.js
@@ -1,43 +1,11 @@
+import TrackClaimsPage from './page-objects/TrackClaimsPage';
 import claimsList from './fixtures/mocks/claims-list.json';
 
 describe('Claimst List Test', () => {
   it('Tests consolidated claim functionality', () => {
-    cy.intercept('GET', '/v0/evss_claims_async', claimsList);
-    cy.login();
-
-    // Claim is visible
-    cy.visit('/track-claims');
-
-    // Combined claim link
-    cy.get('button.claims-combined').click();
-    cy.get('.claims-status-upload-header').should('be.visible');
-
-    // check modal
-    cy.injectAxeThenAxeCheck();
-
-    cy.get('.claims-status-upload-header').should(
-      'contain',
-      'A note about consolidated claims',
-    );
-    cy.get('.va-modal-close')
-      .first()
-      .click();
-    cy.get('.claims-status.upload-header').should('not.exist');
-    cy.axeCheck();
-
-    // Verify text on page
-    cy.get('.claims-container-title').should(
-      'contain',
-      'Check your claim or appeal status',
-    );
-    cy.get('.claim-list-item-header-v2')
-      .first()
-      .should('contain', `Claim for disability compensation`)
-      .and('contain', 'updated on October 31, 2016');
-    cy.get('.claim-list-item-container:first-child a.vads-c-action-link--blue')
-      .click()
-      .then(() => {
-        cy.url().should('contain', '/your-claims/11/status');
-      });
+    const trackClaimsPage = new TrackClaimsPage();
+    trackClaimsPage.loadPage(claimsList);
+    trackClaimsPage.checkConsolidatedClaimsModal();
+    trackClaimsPage.checkClaimsContent();
   });
 });

--- a/src/applications/claims-status/tests/e2e/01.claim-status-decision.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-decision.cypress.spec.js
@@ -1,5 +1,4 @@
-const Timeouts = require('platform/testing/e2e/timeouts.js');
-
+import TrackClaimsPage from './page-objects/TrackClaimsPage';
 import claimsList from './fixtures/mocks/claims-list.json';
 
 let mockDetails = {};
@@ -12,33 +11,8 @@ beforeEach(() => {
 
 describe('Claim Status Decision', () => {
   it('Checks that a decision is ready', () => {
-    cy.intercept('GET', `/v0/evss_claims_async/11`, mockDetails).as(
-      'detailRequest',
-    );
-    cy.intercept('GET', `/v0/evss_claims_async`, claimsList).as('claim');
-    cy.login();
-
-    cy.visit('/track-claims');
-    cy.get('.claim-list-item-container', { timeout: Timeouts.slow }).should(
-      'be.visible',
-    );
-
-    cy.get('.claim-list-item-container:first-child a.vads-c-action-link--blue')
-      .click()
-      .then(() => {
-        cy.get('body').should('be.visible');
-        // Currently does not load data after button click, React prop error, rest of test fails
-
-        cy.get('.claim-title', { timeout: Timeouts.slow }).should('be.visible');
-        cy.injectAxeThenAxeCheck();
-      });
-
-    cy.get('.main .usa-alert')
-      .should('be.visible')
-      .then(alertElem => {
-        cy.wrap(alertElem).should('contain', 'Your claim decision is ready');
-      });
-
-    cy.get('.disability-benefits-timeline').should('not.exist');
+    const trackClaimsPage = new TrackClaimsPage();
+    trackClaimsPage.loadPage(claimsList, mockDetails);
+    trackClaimsPage.verifyReadyClaim();
   });
 });

--- a/src/applications/claims-status/tests/e2e/01.claim-status-est-current.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-est-current.cypress.spec.js
@@ -1,7 +1,6 @@
+import TrackClaimsPage from './page-objects/TrackClaimsPage';
 import moment from 'moment';
 import claimsList from './fixtures/mocks/claims-list.json';
-
-const Timeouts = require('platform/testing/e2e/timeouts.js');
 
 let mockDetails = {};
 
@@ -21,29 +20,8 @@ beforeEach(() => {
 
 describe('Claims status est current test', () => {
   it('Shows the correct status for the claim', () => {
-    cy.intercept('GET', `/v0/evss_claims_async/11`, mockDetails).as(
-      'detailRequest',
-    );
-    cy.intercept('GET', `/v0/evss_claims_async`, claimsList).as('claim');
-    cy.login();
-
-    cy.visit('/track-claims');
-    cy.get('.claim-list-item-container', { timeout: Timeouts.slow }).should(
-      'be.visible',
-    );
-
-    cy.get('.claim-list-item-container:first-child a.vads-c-action-link--blue')
-      .click()
-      .then(() => {
-        cy.get('body').should('be.visible');
-        // Currently does not load data after button click, React prop error, rest of test fails
-
-        cy.get('.claim-title', { timeout: Timeouts.slow }).should('be.visible');
-        cy.injectAxeThenAxeCheck();
-      });
-
-    cy.url().should('contain', '/your-claims/11/status');
-
-    cy.get('va-alert').should('contain', 'COVID-19 has had on');
+    const trackClaimsPage = new TrackClaimsPage();
+    trackClaimsPage.loadPage(claimsList, mockDetails);
+    trackClaimsPage.verifyInProgressClaim();
   });
 });

--- a/src/applications/claims-status/tests/e2e/01.claim-status-est-past.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-est-past.cypress.spec.js
@@ -1,7 +1,6 @@
+import TrackClaimsPage from './page-objects/TrackClaimsPage';
 import moment from 'moment';
 import claimsList from './fixtures/mocks/claims-list.json';
-
-const Timeouts = require('platform/testing/e2e/timeouts.js');
 
 let mockDetails = {};
 
@@ -21,31 +20,8 @@ beforeEach(() => {
 
 describe('Claims status est current test', () => {
   it('Shows the correct status for the claim', () => {
-    cy.intercept('GET', `/v0/evss_claims_async/11`, mockDetails).as(
-      'detailRequest',
-    );
-    cy.intercept('GET', `/v0/evss_claims_async`, claimsList).as('claim');
-    cy.login();
-
-    cy.visit('/track-claims');
-
-    cy.get('.claim-list-item-container', { timeout: Timeouts.slow }).should(
-      'be.visible',
-    );
-    cy.get('.claim-list-item-container:first-child a.vads-c-action-link--blue')
-      .click()
-      .then(() => {
-        cy.get('body').should('be.visible');
-        // Currently does not load data after button click, React prop error, rest of test fails
-
-        cy.get('.claim-title', { timeout: Timeouts.slow }).should('be.visible');
-        cy.injectAxeThenAxeCheck();
-      });
-
-    cy.url().should('contain', '/your-claims/11/status');
-
-    // Disabled until COVID-19 message removed
-    // cy.get('.claim-completion-desc').should('contain', 'We estimated your claim would be completed by now');
-    cy.get('va-alert').should('contain', 'COVID-19 has had on');
+    const trackClaimsPage = new TrackClaimsPage();
+    trackClaimsPage.loadPage(claimsList, mockDetails);
+    trackClaimsPage.verifyInProgressClaim();
   });
 });

--- a/src/applications/claims-status/tests/e2e/01.claim-status-est.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-est.cypress.spec.js
@@ -1,7 +1,6 @@
+import TrackClaimsPage from './page-objects/TrackClaimsPage';
 import moment from 'moment';
 import claimsList from './fixtures/mocks/claims-list.json';
-
-const Timeouts = require('platform/testing/e2e/timeouts.js');
 
 let mockDetails = {};
 
@@ -21,29 +20,8 @@ beforeEach(() => {
 
 describe('Claims status est current test', () => {
   it('Shows the correct status for the claim', () => {
-    cy.intercept('GET', `/v0/evss_claims_async/11`, mockDetails).as(
-      'detailRequest',
-    );
-    cy.intercept('GET', `/v0/evss_claims_async`, claimsList).as('claim');
-    cy.login();
-
-    cy.visit('/track-claims');
-    cy.get('.claim-list-item-container', { timeout: Timeouts.slow }).should(
-      'be.visible',
-    );
-
-    cy.get('.claim-list-item-container:first-child a.vads-c-action-link--blue')
-      .click()
-      .then(() => {
-        cy.get('body').should('be.visible');
-        // Currently does not load data after button click, React prop error, rest of test fails
-
-        cy.get('.claim-title', { timeout: Timeouts.slow }).should('be.visible');
-        cy.injectAxeThenAxeCheck();
-      });
-
-    cy.url().should('contain', '/your-claims/11/status');
-
-    cy.get('va-alert').should('contain', 'COVID-19 has had on');
+    const trackClaimsPage = new TrackClaimsPage();
+    trackClaimsPage.loadPage(claimsList, mockDetails);
+    trackClaimsPage.verifyInProgressClaim();
   });
 });

--- a/src/applications/claims-status/tests/e2e/01.claim-status.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status.cypress.spec.js
@@ -1,3 +1,4 @@
+import TrackClaimsPage from './page-objects/TrackClaimsPage';
 import claimsList from './fixtures/mocks/claims-list.json';
 
 const Timeouts = require('platform/testing/e2e/timeouts.js');
@@ -12,16 +13,8 @@ beforeEach(() => {
 
 describe('Claims status test', () => {
   it('Shows the correct status for the claim', () => {
-    cy.intercept('GET', `/v0/evss_claims_async/11`, mockDetails).as(
-      'detailRequest',
-    );
-    cy.intercept('GET', `/v0/evss_claims_async`, claimsList).as('claim');
-    cy.login();
-
-    cy.visit('/track-claims');
-    cy.get('.claim-list-item-container', { timeout: Timeouts.slow }).should(
-      'be.visible',
-    );
+    const trackClaimsPage = new TrackClaimsPage();
+    trackClaimsPage.loadPage(claimsList, mockDetails);
 
     cy.get('.claim-list-item-container:first-child a.vads-c-action-link--blue')
       .click()

--- a/src/applications/claims-status/tests/e2e/01.claim-status.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status.cypress.spec.js
@@ -14,11 +14,7 @@ describe('Claims status test', () => {
     const trackClaimsPage = new TrackClaimsPage();
     trackClaimsPage.loadPage(claimsList, mockDetails);
     trackClaimsPage.verifyInProgressClaim(false);
-    trackClaimsPage.verifyClaimedConditions([
-      'Hearing Loss (New)',
-      'skin condition (New)',
-      'jungle rot (New)',
-    ]);
+    trackClaimsPage.verifyClaimedConditions(['Hearing Loss (New)']);
     trackClaimsPage.verifyCompletedSteps(5);
     trackClaimsPage.verifyClosedClaim();
     trackClaimsPage.axeCheckClaimDetails();

--- a/src/applications/claims-status/tests/e2e/01.claim-status.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status.cypress.spec.js
@@ -1,8 +1,6 @@
 import TrackClaimsPage from './page-objects/TrackClaimsPage';
 import claimsList from './fixtures/mocks/claims-list.json';
 
-const Timeouts = require('platform/testing/e2e/timeouts.js');
-
 let mockDetails = {};
 
 beforeEach(() => {
@@ -15,62 +13,15 @@ describe('Claims status test', () => {
   it('Shows the correct status for the claim', () => {
     const trackClaimsPage = new TrackClaimsPage();
     trackClaimsPage.loadPage(claimsList, mockDetails);
-
-    cy.get('.claim-list-item-container:first-child a.vads-c-action-link--blue')
-      .click()
-      .then(() => {
-        cy.get('body').should('be.visible');
-        // Currently does not load data after button click, React prop error, rest of test fails
-
-        cy.get('.claim-title', { timeout: Timeouts.slow }).should('be.visible');
-        cy.injectAxeThenAxeCheck();
-      });
-
-    // redirect to status tab
-    cy.url().should('contain', '/your-claims/11/status');
-
-    // status tab highlighted
-    cy.get('a.va-tab-trigger.va-tab-trigger--current').should(
-      'contain',
-      'Status',
-    );
-
-    // conditions list
-    cy.get('.claim-contentions > span').should(
-      'contain',
-      'Hearing Loss (New), skin condition (New), jungle rot (New)',
-    );
-
-    // timeline
-    cy.get('.list-five.section-current').should('exist');
-    cy.get('.list-one.section-complete').should('exist');
-    cy.get('.list-two.section-complete').should('exist');
-    cy.get('.list-three.section-complete').should('exist');
-    cy.get('.list-four.section-complete').should('exist');
-
-    // timeline expand
-    cy.get('li.list-one')
-      .click()
-      .then(() => {
-        cy.get('li.list-one .claims-evidence', {
-          timeout: Timeouts.slow,
-        }).should('be.visible');
-        cy.get('.claims-evidence:nth-child(3) .claims-evidence-item').should(
-          'contain',
-          'Your claim is closed',
-        );
-        cy.get('.claim-older-updates').should('exist');
-      });
-    // Nightwatch original test had an extra click on li.list-one here, however, this was collapsing the accordion causing the next step to fail.  Removed it to test the rest of the items.
-    cy.get('li.list-one .claims-evidence', {
-      timeout: Timeouts.slow,
-    }).should('be.visible');
-    // });
-    cy.get('main button[aria-expanded="false"]').each(element => {
-      cy.wrap(element).click();
-      cy.axeCheck();
-    });
-
-    cy.get('.usa-alert-body h2').should('contain', 'your attention');
+    trackClaimsPage.verifyInProgressClaim(false);
+    trackClaimsPage.verifyClaimedConditions([
+      'Hearing Loss (New)',
+      'skin condition (New)',
+      'jungle rot (New)',
+    ]);
+    trackClaimsPage.verifyCompletedSteps(5);
+    trackClaimsPage.verifyClosedClaim();
+    trackClaimsPage.axeCheckClaimDetails();
+    trackClaimsPage.verifyItemsNeedAttention(2);
   });
 });

--- a/src/applications/claims-status/tests/e2e/02.claim-files.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/02.claim-files.cypress.spec.js
@@ -1,6 +1,5 @@
+import TrackClaimsPage from './page-objects/TrackClaimsPage';
 import claimsList from './fixtures/mocks/claims-list.json';
-
-const Timeouts = require('platform/testing/e2e/timeouts.js');
 
 let mockDetails = {};
 
@@ -12,57 +11,11 @@ beforeEach(() => {
 
 describe('Claim Files Test', () => {
   it('Gets files properly', () => {
-    cy.intercept('GET', `/v0/evss_claims_async/11`, mockDetails).as(
-      'detailRequest',
-    );
-    cy.intercept('GET', `/v0/evss_claims_async`, claimsList).as('claim');
-    cy.login();
-
-    cy.visit('/track-claims');
-    cy.get('.claim-list-item-container', { timeout: Timeouts.slow }).should(
-      'be.visible',
-    );
-
-    cy.get('.claim-list-item-container:first-child a.vads-c-action-link--blue')
-      .click()
-      .then(() => {
-        cy.get('.claim-title', { timeout: Timeouts.slow }).should('be.visible');
-      });
-
-    // go to files taba
-    cy.get('.va-tabs li:nth-child(2) > a')
-      .click()
-      .then(() => {
-        cy.get('.file-request-list-item').should('be.visible');
-        cy.injectAxeThenAxeCheck();
-      });
-
-    cy.url().should('contain', '/your-claims/11/files');
-
-    cy.get('a.va-tab-trigger.va-tab-trigger--current').should(
-      'contain',
-      'Files',
-    );
-
-    // should show two files requested
-    cy.get('.file-request-list-item').should('have.length', 3);
-
-    // should show four files received
-    cy.get('.submitted-file-list-item').should('have.length', 3);
-
-    // should show additional evidence box
-    cy.get('.submit-additional-evidence .usa-alert').should('be.visible');
-
-    // should show a submitted date message
-    cy.get('.submitted-file-list-item:last-child .submission-status').should(
-      'contain',
-      'Submitted',
-    );
-
-    // should show a reviewed date message
-    cy.get('.submitted-file-list-item .submission-status').should(
-      'contain',
-      'Reviewed by VA',
-    );
+    const trackClaimsPage = new TrackClaimsPage();
+    trackClaimsPage.loadPage(claimsList, mockDetails);
+    trackClaimsPage.verifyInProgressClaim(false);
+    trackClaimsPage.verifyNumberOfFiles(3);
+    trackClaimsPage.verifyClaimEvidence(2, 'Reviewed by VA');
+    trackClaimsPage.verifyClaimEvidence(4, 'Submitted');
   });
 });

--- a/src/applications/claims-status/tests/e2e/03.claim-details.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/03.claim-details.cypress.spec.js
@@ -1,5 +1,4 @@
-const Timeouts = require('platform/testing/e2e/timeouts.js');
-
+import TrackClaimsPage from './page-objects/TrackClaimsPage';
 import claimsList from './fixtures/mocks/claims-list.json';
 
 let mockDetails = {};
@@ -12,52 +11,10 @@ beforeEach(() => {
 
 describe('Claim Details Test', () => {
   it('Shows the correct details', () => {
-    cy.intercept('GET', `/v0/evss_claims_async/11`, mockDetails).as(
-      'detailRequest',
-    );
-    cy.intercept('GET', `/v0/evss_claims_async`, claimsList).as('claim');
-    cy.login();
-
-    cy.visit('/track-claims');
-    cy.get('.claim-list-item-container', { timeout: Timeouts.slow }).should(
-      'be.visible',
-    );
-
-    cy.get('.claim-list-item-container:first-child a.vads-c-action-link--blue')
-      .click()
-      .then(() => {
-        cy.get('.claim-title', { timeout: Timeouts.slow }).should('be.visible');
-      });
-
-    // go to details tab
-    cy.get('.va-tabs li:nth-child(3) > a')
-      .click()
-      .then(() => {
-        cy.get('.claim-details').should('be.visible');
-        cy.injectAxeThenAxeCheck();
-      });
-
-    cy.url().should('contain', '/your-claims/11/details');
-
-    cy.get('a.va-tab-trigger.va-tab-trigger--current').should(
-      'contain',
-      'Details',
-    );
-    cy.get('.claim-detail-label:nth-of-type(1)').should(
-      'contain',
-      'Claim type',
-    );
-    cy.get('.claim-detail-label:nth-of-type(2)').should(
-      'contain',
-      'What you’ve claimed',
-    );
-    cy.get('.claim-detail-label:nth-of-type(3)').should(
-      'contain',
-      'Date received',
-    );
-    cy.get('.claim-detail-label:nth-of-type(4)').should(
-      'contain',
-      'Your representative for VA claims',
-    );
+    const trackClaimsPage = new TrackClaimsPage();
+    trackClaimsPage.loadPage(claimsList, mockDetails);
+    trackClaimsPage.checkClaimsContent();
+    trackClaimsPage.claimDetailsTab();
+    trackClaimsPage.verifyClaimDetails();
   });
 });

--- a/src/applications/claims-status/tests/e2e/04.claim-ask-va.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/04.claim-ask-va.cypress.spec.js
@@ -1,6 +1,5 @@
+import TrackClaimsPage from './page-objects/TrackClaimsPage';
 import claimsList from './fixtures/mocks/claims-list.json';
-
-const Timeouts = require('platform/testing/e2e/timeouts.js');
 
 let mockDetails = {};
 
@@ -12,68 +11,10 @@ beforeEach(() => {
 
 describe('Ask VA Claim Test', () => {
   it('Submits the form', () => {
-    cy.intercept('POST', `/v0/evss_claims/11/request_decision`, {
-      body: {},
-    }).as('askVA');
-    cy.intercept('GET', `/v0/evss_claims_async/11`, mockDetails).as(
-      'detailRequest',
-    );
-    cy.intercept('GET', `/v0/evss_claims_async`, claimsList).as('claim');
-    cy.login();
-
-    cy.visit('/track-claims');
-    cy.get('.claim-list-item-container', { timeout: Timeouts.slow }).should(
-      'be.visible',
-    );
-
-    cy.get('.claim-list-item-container:first-child a.vads-c-action-link--blue')
-      .click()
-      .then(() => {
-        cy.get('.claim-title', { timeout: Timeouts.slow }).should('be.visible');
-        cy.injectAxeThenAxeCheck();
-      });
-
-    // go to files taba
-    cy.get('.va-tabs li:nth-child(2) > a')
-      .click()
-      .then(() => {
-        cy.get('.file-request-list-item').should('be.visible');
-        cy.axeCheck();
-      });
-
-    // alert is visible
-    cy.get('.claims-alert-status')
-      .should('be.visible')
-      .then(status => {
-        cy.wrap(status).should('contain', 'Ask for your Claim Decision');
-      });
-
-    // click on link to page
-    cy.get('.claims-alert-status a')
-      .click()
-      .then(() => {
-        cy.get('.usa-button-secondary');
-        cy.axeCheck();
-      });
-
-    // click on disabled button
-    cy.get('.main .usa-button-primary').click({ force: true });
-
-    // should not have changed pages
-    cy.url().should('contain', 'ask-va-to-decide');
-
-    // click on checkbox, then submit, expect success message
-    cy.get('input[type=checkbox]')
-      .click()
-      .then(() => {
-        cy.get('.main .usa-button-primary').click();
-        cy.wait('@askVA');
-      });
-
-    // should have gone back to status page
-    cy.url().should('contain', 'status');
-
-    cy.get('.usa-alert-success').should('be.visible');
-    cy.axeCheck();
+    const trackClaimsPage = new TrackClaimsPage();
+    trackClaimsPage.loadPage(claimsList, mockDetails, true);
+    trackClaimsPage.verifyInProgressClaim(false);
+    trackClaimsPage.verifyNumberOfFiles(3);
+    trackClaimsPage.askForClaimDecision();
   });
 });

--- a/src/applications/claims-status/tests/e2e/05.claim-additional-evidence.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/05.claim-additional-evidence.cypress.spec.js
@@ -1,6 +1,5 @@
+import TrackClaimsPage from './page-objects/TrackClaimsPage';
 import claimsList from './fixtures/mocks/claims-list.json';
-
-const Timeouts = require('platform/testing/e2e/timeouts.js');
 
 let mockDetails = {};
 
@@ -12,45 +11,10 @@ beforeEach(() => {
 
 describe('Claim Additional Evidence Test', () => {
   it('Submits files', () => {
-    cy.intercept('GET', `/v0/evss_claims_async/11`, mockDetails).as(
-      'detailRequest',
-    );
-    cy.intercept('GET', `/v0/evss_claims_async`, claimsList).as('claim');
-    cy.login();
-
-    cy.visit('/track-claims');
-    cy.get('.claim-list-item-container', { timeout: Timeouts.slow }).should(
-      'be.visible',
-    );
-
-    cy.get('.claim-list-item-container:first-child a.vads-c-action-link--blue')
-      .click()
-      .then(() => {
-        cy.get('.claim-title', { timeout: Timeouts.slow }).should('be.visible');
-      });
-
-    // go to files taba
-    cy.get('.va-tabs li:nth-child(2) > a')
-      .click()
-      .then(() => {
-        cy.get('.file-request-list-item').should('be.visible');
-      });
-
-    cy.get('button.usa-button')
-      .click()
-      .then(() => {
-        cy.get('.usa-input-error');
-        cy.injectAxeThenAxeCheck;
-      });
-
-    cy.get('.usa-input-error-message').should(
-      'contain',
-      'Please select a file first',
-    );
-
-    // File uploads don't appear to work in Nightwatch/PhantomJS
-    // TODO: switch to something that does support uploads or figure out the problem
-
-    // The above comment lifted from the old Nightwatch test.  Cypress can test file uploads, however this would need to be written in a future effort after our conversion effort is complete.
+    const trackClaimsPage = new TrackClaimsPage();
+    trackClaimsPage.loadPage(claimsList, mockDetails);
+    trackClaimsPage.verifyInProgressClaim(false);
+    trackClaimsPage.verifyNumberOfFiles(3);
+    trackClaimsPage.submitFilesForReview();
   });
 });

--- a/src/applications/claims-status/tests/e2e/05.claim-document-request.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/05.claim-document-request.cypress.spec.js
@@ -1,6 +1,5 @@
+import TrackClaimsPage from './page-objects/TrackClaimsPage';
 import claimsList from './fixtures/mocks/claims-list.json';
-
-const Timeouts = require('platform/testing/e2e/timeouts.js');
 
 let mockDetails = {};
 
@@ -12,55 +11,10 @@ beforeEach(() => {
 
 describe('Claim Additional Evidence Test', () => {
   it('Submits documents', () => {
-    cy.intercept('GET', `/v0/evss_claims_async/11`, mockDetails).as(
-      'detailRequest',
-    );
-    cy.intercept('GET', `/v0/evss_claims_async`, claimsList).as('claim');
-    cy.login();
-
-    cy.visit('/track-claims');
-    cy.get('.claim-list-item-container', { timeout: Timeouts.slow }).should(
-      'be.visible',
-    );
-
-    cy.get('.claim-list-item-container:first-child a.vads-c-action-link--blue')
-      .click()
-      .then(() => {
-        cy.get('.claim-title', { timeout: Timeouts.slow }).should('be.visible');
-      });
-
-    // go to files taba
-    cy.get('.va-tabs li:nth-child(2) > a')
-      .click()
-      .then(() => {
-        cy.get('.file-request-list-item').should('be.visible');
-      });
-
-    // go to document request page
-    cy.get('.file-request-list-item .usa-button')
-      .first()
-      .click()
-      .then(() => {
-        cy.get('.file-requirements');
-        cy.injectAxeThenAxeCheck();
-      });
-
-    cy.get('button.usa-button').should('contain', 'Submit Files for Review');
-
-    cy.get('button.usa-button')
-      .click()
-      .then(() => {
-        cy.get('.usa-input-error').should('be.visible');
-      });
-
-    cy.get('.usa-input-error-message').should(
-      'contain',
-      'Please select a file first',
-    );
-
-    // File uploads don't appear to work in Nightwatch/PhantomJS
-    // TODO: switch to something that does support uploads or figure out the problem
-
-    // The above comment lifted from the old Nightwatch test.  Cypress can test file uploads, however this would need to be written in a future effort after our conversion effort is complete.
+    const trackClaimsPage = new TrackClaimsPage();
+    trackClaimsPage.loadPage(claimsList, mockDetails);
+    trackClaimsPage.verifyInProgressClaim(false);
+    trackClaimsPage.verifyNumberOfFiles(3);
+    trackClaimsPage.submitFilesForReview();
   });
 });

--- a/src/applications/claims-status/tests/e2e/06-claim-estimation-breadcrumb.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/06-claim-estimation-breadcrumb.cypress.spec.js
@@ -1,6 +1,5 @@
+import TrackClaimsPage from './page-objects/TrackClaimsPage';
 import claimsList from './fixtures/mocks/claims-list.json';
-
-const Timeouts = require('platform/testing/e2e/timeouts.js');
 
 let mockDetails = {};
 
@@ -12,28 +11,11 @@ beforeEach(() => {
 
 describe('Claim Estimation Breadcrumb Test', () => {
   it('Verifies the breadcrumb contents', () => {
-    cy.intercept('GET', `/v0/evss_claims_async/11`, mockDetails).as(
-      'detailRequest',
-    );
-    cy.intercept('GET', `/v0/evss_claims_async`, claimsList).as('claim');
-    cy.login();
-
-    cy.visit('/track-claims');
-    cy.get('.claim-list-item-container', { timeout: Timeouts.slow }).should(
-      'be.visible',
-    );
-
-    cy.get('.claim-list-item-container:first-child a.vads-c-action-link--blue')
-      .click()
-      .then(() => {
-        cy.get('.claim-title', { timeout: Timeouts.slow }).should('be.visible');
-        cy.injectAxeThenAxeCheck();
-      });
-
+    const trackClaimsPage = new TrackClaimsPage();
+    trackClaimsPage.loadPage(claimsList, mockDetails);
+    trackClaimsPage.verifyInProgressClaim();
     // Disabled until COVID-19 message removed
-
     // const selector = '.claim-estimate-link';
-
     // cy.pause(500);
     // cy.get(selector)
     //   .click()

--- a/src/applications/claims-status/tests/e2e/06.claim-estimation.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/06.claim-estimation.cypress.spec.js
@@ -1,6 +1,5 @@
+import TrackClaimsPage from './page-objects/TrackClaimsPage';
 import claimsList from './fixtures/mocks/claims-list.json';
-
-const Timeouts = require('platform/testing/e2e/timeouts.js');
 
 let mockDetails = {};
 
@@ -12,28 +11,11 @@ beforeEach(() => {
 
 describe('Claim Estimation Breadcrumb Test', () => {
   it('Verifies the breadcrumb contents', () => {
-    cy.intercept('GET', `/v0/evss_claims_async/11`, mockDetails).as(
-      'detailRequest',
-    );
-    cy.intercept('GET', `/v0/evss_claims_async`, claimsList).as('claim');
-    cy.login();
-
-    cy.visit('/track-claims');
-    cy.get('.claim-list-item-container', { timeout: Timeouts.slow }).should(
-      'be.visible',
-    );
-
-    cy.get('.claim-list-item-container:first-child a.vads-c-action-link--blue')
-      .click()
-      .then(() => {
-        cy.get('.claim-title', { timeout: Timeouts.slow }).should('be.visible');
-        cy.injectAxeThenAxeCheck();
-      });
-
+    const trackClaimsPage = new TrackClaimsPage();
+    trackClaimsPage.loadPage(claimsList, mockDetails);
+    trackClaimsPage.verifyInProgressClaim();
     // Disabled until COVID-19 message removed
-
     // const selector = '.claim-estimate-link';
-
     // cy.pause(500);
     // cy.get(selector)
     //   .click()

--- a/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
+++ b/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
@@ -191,6 +191,57 @@ class TrackClaimsPage {
       `${count} ${count > 1 ? 'items' : 'item'} need your attention`,
     );
   }
+
+  verifyNumberOfFiles(number) {
+    cy.get('.va-tabs li:nth-child(2) > a')
+      .click()
+      .then(() => {
+        cy.get('.file-request-list-item').should('be.visible');
+        cy.injectAxeThenAxeCheck();
+      });
+    cy.get('a.va-tab-trigger.va-tab-trigger--current').should(
+      'contain',
+      'Files',
+    );
+    cy.get('.file-request-list-item').should('have.length', number);
+    cy.get('.submitted-file-list-item').should('have.length', number);
+  }
+
+  verifyClaimEvidence(claimId, claimStatus) {
+    cy.get('.submit-additional-evidence .usa-alert').should('be.visible');
+    cy.get(
+      `.submitted-file-list-item:nth-child(${claimId}) .submission-status`,
+    ).should('contain', `${claimStatus}`);
+  }
+
+  claimDetailsTab() {
+    cy.get('.va-tabs li:nth-child(3) > a')
+      .click()
+      .then(() => {
+        cy.get('.claim-details').should('be.visible');
+        cy.injectAxeThenAxeCheck();
+      });
+    cy.url().should('contain', '/your-claims/11/details');
+  }
+
+  verifyClaimDetails() {
+    cy.get('a.va-tab-trigger.va-tab-trigger--current').should(
+      'contain',
+      'Details',
+    );
+    const details = [
+      'Claim type',
+      'What you’ve claimed',
+      'Date received',
+      'Your representative for VA claims',
+    ];
+    for (const id of [1, 2, 3, 4]) {
+      cy.get(`.claim-detail-label:nth-of-type(${id})`).should(
+        'contain',
+        `${details[id - 1]}`,
+      );
+    }
+  }
 }
 
 export default TrackClaimsPage;

--- a/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
+++ b/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
@@ -115,7 +115,7 @@ class TrackClaimsPage {
     cy.get('.disability-benefits-timeline').should('not.exist');
   }
 
-  verifyInProgressClaim() {
+  verifyInProgressClaim(inProgress = true) {
     cy.get('.claim-list-item-container:first-child a.vads-c-action-link--blue')
       .click()
       .then(() => {
@@ -130,7 +130,67 @@ class TrackClaimsPage {
 
     // Disabled until COVID-19 message removed
     // cy.get('.claim-completion-desc').should('contain', 'We estimated your claim would be completed by now');
-    cy.get('va-alert').should('contain', 'COVID-19 has had on');
+    if (inProgress) {
+      cy.get('va-alert').should('contain', 'COVID-19 has had on');
+    }
+  }
+
+  verifyClaimedConditions(conditions) {
+    cy.get('.claim-contentions > span').should(
+      'contain',
+      conditions.join(', '),
+    );
+  }
+
+  verifyCompletedSteps(step) {
+    cy.get(`.list-one.section-${step > 1 ? 'complete' : 'current'}`).should(
+      'exist',
+    );
+    cy.get(`.list-two.section-${step > 2 ? 'complete' : 'current'}`).should(
+      'exist',
+    );
+    cy.get(`.list-three.section-${step > 3 ? 'complete' : 'current'}`).should(
+      'exist',
+    );
+    cy.get(`.list-four.section-${step > 4 ? 'complete' : 'current'}`).should(
+      'exist',
+    );
+    cy.get(`.list-five.section-${step > 5 ? 'complete' : 'current'}`).should(
+      'exist',
+    );
+  }
+
+  verifyClosedClaim() {
+    cy.get('li.list-one')
+      .click()
+      .then(() => {
+        cy.get('li.list-one .claims-evidence', {
+          timeout: Timeouts.slow,
+        }).should('be.visible');
+        cy.get('.claims-evidence:nth-child(3) .claims-evidence-item').should(
+          'contain',
+          'Your claim is closed',
+        );
+        cy.get('.claim-older-updates').should('exist');
+      });
+    cy.get('li.list-one .claims-evidence', {
+      timeout: Timeouts.slow,
+    }).should('be.visible');
+  }
+
+  axeCheckClaimDetails() {
+    cy.get('main button[aria-expanded="false"]')
+      .each(el => {
+        el.click();
+      })
+      .axeCheck();
+  }
+
+  verifyItemsNeedAttention(count) {
+    cy.get('.usa-alert-body h2').should(
+      'contain',
+      `${count} ${count > 1 ? 'items' : 'item'} need your attention`,
+    );
   }
 }
 

--- a/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
+++ b/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
@@ -54,7 +54,6 @@ class TrackClaimsPage {
       'display',
       'inline-block',
     );
-    cy.viewport(1280, 960);
   }
 
   verifyNoClaims() {

--- a/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
+++ b/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
@@ -1,0 +1,96 @@
+const Timeouts = require('platform/testing/e2e/timeouts.js');
+
+class TrackClaimsPage {
+  loadPage(claimsList) {
+    cy.intercept('GET', '/v0/evss_claims_async', claimsList);
+    cy.login();
+    cy.visit('/track-claims');
+    cy.title().should('eq', 'Track Claims: VA.gov');
+    if (claimsList.data.length) {
+      cy.get('.claim-list-item-container', { timeout: Timeouts.slow }).should(
+        'be.visible',
+      );
+    } else {
+      cy.get('.claims-alert').should(
+        'contain',
+        'You do not have any submitted claims',
+      );
+    }
+    cy.get('.va-nav-breadcrumbs').should('be.visible');
+    cy.get('.va-nav-breadcrumbs-list').should('be.visible');
+    cy.get('a[aria-current="page"').should('be.visible');
+    cy.injectAxeThenAxeCheck();
+  }
+
+  checkBreadcrumbs() {
+    cy.get(
+      '.va-nav-breadcrumbs-list li:nth-of-type(2) a[aria-current="page"]',
+    ).should('exist');
+    cy.get(
+      '.va-nav-breadcrumbs-list li:nth-of-type(2) a[aria-current="page"]',
+    ).should('contain', 'Check your claims and appeals');
+    cy.get(
+      '.va-nav-breadcrumbs-list li:nth-of-type(2) a[aria-current="page"]',
+    ).should('have.css', 'pointer-events', 'none');
+  }
+
+  checkBreadcrumbsMobile() {
+    cy.viewportPreset('va-top-mobile-1');
+    cy.get('.va-nav-breadcrumbs-list').should('be.visible');
+    cy.get('.va-nav-breadcrumbs-list li:not(:nth-last-child(2))').should(
+      'have.css',
+      'display',
+      'none',
+    );
+    cy.get('.va-nav-breadcrumbs-list li:nth-last-child(2)').should(
+      'contain',
+      'Home',
+    );
+    cy.get('.va-nav-breadcrumbs-list li:nth-last-child(2)').should(
+      'have.css',
+      'display',
+      'inline-block',
+    );
+    cy.viewport(1280, 960);
+  }
+
+  verifyNoClaims() {
+    cy.get('.claims-alert').should(
+      'contain',
+      'You do not have any submitted claims',
+    );
+  }
+
+  checkConsolidatedClaimsModal() {
+    cy.get('button.claims-combined').click();
+    cy.get('.claims-status-upload-header').should('be.visible');
+    cy.injectAxeThenAxeCheck();
+    cy.get('.claims-status-upload-header').should(
+      'contain',
+      'A note about consolidated claims',
+    );
+    cy.get('.va-modal-close')
+      .first()
+      .click();
+    cy.get('.claims-status.upload-header').should('not.exist');
+    cy.axeCheck();
+  }
+
+  checkClaimsContent() {
+    cy.get('.claims-container-title').should(
+      'contain',
+      'Check your claim or appeal status',
+    );
+    cy.get('.claim-list-item-header-v2')
+      .first()
+      .should('contain', `Claim for disability compensation`)
+      .and('contain', 'updated on October 31, 2016');
+    cy.get('.claim-list-item-container:first-child a.vads-c-action-link--blue')
+      .click()
+      .then(() => {
+        cy.url().should('contain', '/your-claims/11/status');
+      });
+  }
+}
+
+export default TrackClaimsPage;


### PR DESCRIPTION
## Description
This PR refactors Cypress tests for the Claims Status feature to use page objects. This was done as a proof of concept to show that tests can be shortened and made easier to read with page objects.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/30424

## Acceptance criteria
- [ ] CI passes.