### PR TITLE
update urls for translated 'about covid-19 vaccines' pages

### DIFF
--- a/src/applications/static-pages/i18Select/utilities/urls.js
+++ b/src/applications/static-pages/i18Select/utilities/urls.js
@@ -26,7 +26,7 @@ export default {
   },
   about: {
     en: '/health-care/covid-19-vaccine/about-covid-19-vaccine',
-    es: '/health-care/covid-19-vaccine/about-covid-19-vaccine-esp',
-    tl: '/health-care/covid-19-vaccine/about-covid-19-vaccine-tag',
+    es: '/health-care/covid-19-vaccine-esp/about-covid-19-vaccine-esp',
+    tl: '/health-care/covid-19-vaccine-tag/about-covid-19-vaccine-tag',
   },
 };


### PR DESCRIPTION
## Description
Really small hotfix to fix some url changes that are being made to a couple pages.

The incorrect url structure was published for the 'about covid' pages for just the spanish and tagalog versions. The code needs to be updated for the new urls.

Current urls:
https://www.va.gov/health-care/covid-19-vaccine/about-covid-19-vaccine-esp
https://www.va.gov/health-care/covid-19-vaccine/about-covid-19-vaccine-tag

New correct urls:
https://www.va.gov/health-care/covid-19-vaccine-esp/about-covid-19-vaccine-esp
https://www.va.gov/health-care/covid-19-vaccine-tag/about-covid-19-vaccine-tag

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/31459



