### PR TITLE
update link refs

### DIFF
--- a/src/applications/static-pages/ask-va/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/ask-va/components/App/index.unit.spec.js
@@ -9,8 +9,8 @@ import { App } from '.';
 describe('Ask VA <App>', () => {
   it('renders ask va link when not authenticated', () => {
     const expectedHref = environment.isProduction()
-      ? 'https://ava.va.gov/'
-      : 'https://ask-staging.va.gov';
+      ? 'https://ask.va.gov'
+      : 'https://dvagov-veft-qa.dynamics365portals.us/';
     const wrapper = shallow(<App loa={undefined} />);
     expect(wrapper.find(`a[href="${expectedHref}"]`)).be.have.lengthOf(1);
     expect(wrapper.find(`a[href="${expectedHref}"]`).text()).to.equal(
@@ -21,8 +21,8 @@ describe('Ask VA <App>', () => {
 
   it('renders what we expect when user is LOA1', () => {
     const expectedHref = environment.isProduction()
-      ? 'https://ava.va.gov/Unauthenticated'
-      : 'https://ask-staging.va.gov/Unauthenticated';
+      ? 'https://ask.va.gov/unauthenticated'
+      : 'https://dvagov-veft-qa.dynamics365portals.us/unauthenticated';
     const wrapper = shallow(<App loa={1} />);
     expect(wrapper.find(`a[href="${expectedHref}"]`)).be.have.lengthOf(1);
     expect(wrapper.find(`a[href="${expectedHref}"]`).text()).to.equal(
@@ -34,7 +34,7 @@ describe('Ask VA <App>', () => {
   it('renders what we expect when user is LOA2', () => {
     const expectedHref = environment.isProduction()
       ? 'https://eauth.va.gov/isam/sps/saml20idp/saml20/logininitial?PartnerId=https://prod-va-gov-sso.portals.va.gov/ava/SSO/Metadata/'
-      : 'https://preprod.eauth.va.gov/isam/sps/saml20idp/saml20/logininitial?PartnerId=https://preprod-va-gov-sso.portals.va.gov/ava/SSO/Metadata/';
+      : 'https://sqa.eauth.va.gov/isam/sps/saml20idp/saml20/logininitial?PartnerId=https://iam-ssoe-sqa1-veis.devtest.vaec.va.gov/ava/SSO/Metadata/';
     const wrapper = shallow(<App loa={2} />);
     expect(wrapper.find(`a[href="${expectedHref}"]`)).be.have.lengthOf(1);
     expect(wrapper.find(`a[href="${expectedHref}"]`).text()).to.equal(
@@ -46,7 +46,7 @@ describe('Ask VA <App>', () => {
   it('renders what we expect when user is LOA2+', () => {
     const expectedHref = environment.isProduction()
       ? 'https://eauth.va.gov/isam/sps/saml20idp/saml20/logininitial?PartnerId=https://prod-va-gov-sso.portals.va.gov/ava/SSO/Metadata/'
-      : 'https://preprod.eauth.va.gov/isam/sps/saml20idp/saml20/logininitial?PartnerId=https://preprod-va-gov-sso.portals.va.gov/ava/SSO/Metadata/';
+      : 'https://sqa.eauth.va.gov/isam/sps/saml20idp/saml20/logininitial?PartnerId=https://iam-ssoe-sqa1-veis.devtest.vaec.va.gov/ava/SSO/Metadata/';
     const wrapper = shallow(<App loa={3} />);
     expect(wrapper.find(`a[href="${expectedHref}"]`)).be.have.lengthOf(1);
     expect(wrapper.find(`a[href="${expectedHref}"]`).text()).to.equal(

--- a/src/applications/static-pages/ask-va/helpers/index.js
+++ b/src/applications/static-pages/ask-va/helpers/index.js
@@ -4,21 +4,21 @@ import environment from 'platform/utilities/environment';
 export const deriveDefaultURL = () => {
   // Production environments.
   if (environment.isProduction()) {
-    return 'https://ava.va.gov/';
+    return 'https://ask.va.gov';
   }
 
   // Non-production environments.
-  return 'https://ask-staging.va.gov';
+  return 'https://dvagov-veft-qa.dynamics365portals.us/';
 };
 
 export const deriveLOA1URL = () => {
   // Production environments.
   if (environment.isProduction()) {
-    return 'https://ava.va.gov/Unauthenticated';
+    return 'https://ask.va.gov/unauthenticated';
   }
 
   // Non-production environments.
-  return 'https://ask-staging.va.gov/Unauthenticated';
+  return 'https://dvagov-veft-qa.dynamics365portals.us/unauthenticated';
 };
 
 export const deriveLOA2PlusURL = () => {
@@ -28,5 +28,5 @@ export const deriveLOA2PlusURL = () => {
   }
 
   // Non-production environments.
-  return 'https://preprod.eauth.va.gov/isam/sps/saml20idp/saml20/logininitial?PartnerId=https://preprod-va-gov-sso.portals.va.gov/ava/SSO/Metadata/';
+  return 'https://sqa.eauth.va.gov/isam/sps/saml20idp/saml20/logininitial?PartnerId=https://iam-ssoe-sqa1-veis.devtest.vaec.va.gov/ava/SSO/Metadata/';
 };


### PR DESCRIPTION
## Description
This PR updates the links to the following values as per the email chain with the following message

Hi all,
I had a quick chat with Brian and Sam and we confirmed that staging.va.gov uses Access VA’s SQA environment. Therefore, we will need to test using the Ask VA QA environment which is also linked to Access VA’s SQA environment. So the URLs will need to be as follows:
 
Unauthenticated
Production: ~~'https://ava.va.gov/'~~   https://ask.va.gov
Non-Production: ~~'https://ask-staging.va.gov'~~  https://dvagov-veft-qa.dynamics365portals.us/
 
Level 1
Production: ~~'https://ava.va.gov/Unauthenticated'~~   https://ask.va.gov/unauthenticated
Non-Production: ~~'https://ask-staging.va.gov/Unauthenticated'~~   https://dvagov-veft-qa.dynamics365portals.us/unauthenticated
 
Level 2
Production: 'https://eauth.va.gov/isam/sps/saml20idp/saml20/logininitial?PartnerId=https://prod-va-gov-sso.portals.va.gov/ava/SSO/Metadata/'
Non-Production: ~~'https://preprod.eauth.va.gov/isam/sps/saml20idp/saml20/logininitial?PartnerId=https://preprod-va-gov-sso.portals.va.gov/ava/SSO/Metadata/'~~ https://sqa.eauth.va.gov/isam/sps/saml20idp/saml20/logininitial?PartnerId=https://iam-ssoe-sqa1-veis.devtest.vaec.va.gov/ava/SSO/Metadata/
 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#288488

