### PR TITLE
Update "not in DEERS" error alert

### DIFF
--- a/src/applications/personalization/profile/components/military-information/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile/components/military-information/MilitaryInformation.jsx
@@ -68,28 +68,19 @@ const NotInDEERSAlert = () => {
         <div>
           <p>
             We’re sorry. We can’t find your Department of Defense (DoD) ID. We
-            need this to access your military service records. Please call us at{' '}
-            <a
-              href="tel:1-800-827-1000"
-              aria-label="800. 8 2 7. 1000."
-              title="Dial the telephone number 800-827-1000"
-              className="no-wrap"
-            >
-              800-827-1000
-            </a>
-            , or visit your nearest VA regional office and request to be added
-            to the Defense Enrollment Eligibility Reporting System (DEERS).
+            need this to access your military service records. If you need help
+            updating your information in DEERS, please call the Defense Manpower
+            Data Center (DMDC).
           </p>
+          <p>
+            To reach the DMDC, call <Telephone contact={CONTACTS.DS_LOGON} />.
+            This office is open Monday through Friday (except federal holidays),
+            8:00 a.m. to 8:00 p.m. ET. If you have hearing loss, call TTY:{' '}
+            <Telephone contact={CONTACTS.DS_LOGON_TTY} />.
+          </p>
+          <p>Or you can visit your nearest VA regional office for help.</p>
           <a href={facilityLocator.rootUrl}>
             Find your nearest VA regional office
-          </a>
-          .
-          <p>
-            You can also request to be added to DEERS through our online
-            customer help center.
-          </p>
-          <a href="https://iris.custhelp.va.gov/app/answers/detail/a_id/3036/~/not-registered-in-deers%2C-or-received-and-error-message-while-trying-to">
-            Get instructions from our help center
           </a>
           .
         </div>

--- a/src/applications/personalization/profile/tests/components/MilitaryInformation.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/MilitaryInformation.unit.spec.jsx
@@ -254,15 +254,14 @@ describe('MilitaryInformation', () => {
         initialState,
       });
 
-      expect(view.getByText(/We can’t access your military information/i)).to
-        .exist;
-      expect(
-        view.getByText(
-          /We’re sorry. We can’t find your Department of Defense \(DoD\) ID. We need this to access your military service records. Please call us at/i,
-        ),
-      ).to.exist;
-      expect(view.getByText(/Find your nearest VA regional office/i)).to.exist;
-      expect(view.getByText(/Get instructions from our help center/i)).to.exist;
+      view.getByText(/We can’t access your military information/i);
+      view.getByText(
+        /We’re sorry. We can’t find your Department of Defense \(DoD\) ID. We need this to access your military service records/i,
+      );
+      view.getByText('800-538-9552');
+      view.getByRole('link', {
+        name: /Find your nearest VA regional office/i,
+      });
     });
   });
   describe('when another error occurs', () => {


### PR DESCRIPTION
## Description
Update content of the alert we show when a user is not found in DEERS.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#31433


## Testing done


## Screenshots
<img width="927" alt="not in DEERS alert" src="https://user-images.githubusercontent.com/20728956/137531302-b9647e17-eca3-4492-81da-c9b4c31748a3.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs