### PR TITLE
29484 - Update preferred providers label (IA Feedback - Staging Review - VET TEC Filters)

### DIFF
--- a/src/applications/gi-sandbox/containers/FilterYourResults.jsx
+++ b/src/applications/gi-sandbox/containers/FilterYourResults.jsx
@@ -325,7 +325,7 @@ export function FilterYourResults({
             <Checkbox
               checked={preferredProvider}
               name="preferredProvider"
-              label="Preferred providers"
+              label="Preferred providers only"
               onChange={handlePreferredProviderChange}
               labelAriaLabel="VET TEC Preferred providers"
               inputAriaLabelledBy={legendId}

--- a/src/applications/gi-sandbox/containers/FilterYourResults.jsx
+++ b/src/applications/gi-sandbox/containers/FilterYourResults.jsx
@@ -1,3 +1,4 @@
+import environment from 'platform/utilities/environment';
 import React, { useState, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import SearchAccordion from '../components/SearchAccordion';
@@ -322,14 +323,25 @@ export function FilterYourResults({
             inputAriaLabelledBy={legendId}
           />
           <div className="expanding-group-children">
-            <Checkbox
-              checked={preferredProvider}
-              name="preferredProvider"
-              label="Preferred providers only"
-              onChange={handlePreferredProviderChange}
-              labelAriaLabel="VET TEC Preferred providers"
-              inputAriaLabelledBy={legendId}
-            />
+            {environment.isProduction() ? (
+              <Checkbox
+                checked={preferredProvider}
+                name="preferredProvider"
+                label="Preferred providers"
+                onChange={handlePreferredProviderChange}
+                labelAriaLabel="VET TEC Preferred providers"
+                inputAriaLabelledBy={legendId}
+              />
+            ) : (
+              <Checkbox
+                checked={preferredProvider}
+                name="preferredProvider"
+                label="Preferred providers only"
+                onChange={handlePreferredProviderChange}
+                labelAriaLabel="VET TEC Preferred providers"
+                inputAriaLabelledBy={legendId}
+              />
+            )}
           </div>
         </ExpandingGroup>
       </>


### PR DESCRIPTION
## IA Feedback - Staging Review - VET TEC Filters

## Original issue(s)
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/29484

## Testing done
Confirmed on Local and by QA (screenshot)

## Screenshots
<img width="1776" alt="screen_shot_2021-10-12_at_1 36 59_pm" src="https://user-images.githubusercontent.com/3818397/137773873-72de3008-5240-4f53-b221-22230b827fb3.png">

## Acceptance criteria
The "Preferred providers" filter label is replaced with "Preferred providers only".

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
