### PR TITLE
Replaced a tag with save in progress

### DIFF
--- a/src/applications/lgy/coe/containers/IntroductionPage.jsx
+++ b/src/applications/lgy/coe/containers/IntroductionPage.jsx
@@ -8,7 +8,7 @@ import LoggedInContent from './introduction-content/loggedInContent.jsx';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import { CALLSTATUS, COE_ELIGIBILITY_STATUS } from '../constants';
 
-function IntroductionPage(props) {
+const IntroductionPage = props => {
   let content;
 
   useEffect(() => {
@@ -28,14 +28,14 @@ function IntroductionPage(props) {
       <div>
         <COEIntroPageBox coe={props.coe} status={props.status} />
         {props.coe.status !== COE_ELIGIBILITY_STATUS.denied && (
-          <LoggedInContent />
+          <LoggedInContent parentProps={props} />
         )}
       </div>
     );
   }
 
   return <div>{content}</div>;
-}
+};
 
 const mapStateToProps = state => ({
   status: state.certificateOfEligibility.generateAutoCoeStatus,

--- a/src/applications/lgy/coe/containers/introduction-content/loggedInContent.jsx
+++ b/src/applications/lgy/coe/containers/introduction-content/loggedInContent.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
 import OMBInfo from '@department-of-veterans-affairs/component-library/OMBInfo';
+import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 
-const LoggedInContent = () => (
+const LoggedInContent = props => (
   <>
     <div className="process schemaform-process">
       <ol>
@@ -91,12 +92,19 @@ const LoggedInContent = () => (
           </AdditionalInfo>
         </li>
       </ol>
-      <a
-        className="vads-c-action-link--green vads-u-margin-bottom--3 vads-u-display--block"
-        href="/housing-assistance/home-loans/apply-for-coe-form-26-1880/applicant-information-summary"
-      >
-        Apply for a Certificate of Eligibility
-      </a>
+      <div className="vads-u-margin-bottom--4">
+        <SaveInProgressIntro
+          buttonOnly
+          testActionLink
+          prefillEnabled={props.parentProps.route.formConfig.prefillEnabled}
+          messages={props.parentProps.route.formConfig.savedFormMessages}
+          formConfig={props.parentProps.route.formConfig}
+          pageList={props.parentProps.route.pageList}
+          downtime={props.parentProps.route.formConfig.downtime}
+          startText="Apply for a Certificate of Eligibility"
+          headingLevel={2}
+        />
+      </div>
       <OMBInfo expDate="11/30/2022" ombNumber="2900-0086" resBurden={15} />
     </div>
   </>


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/30911)

It was discovered during testing that the link tag we added on the introduction page of the COE form did not work because it was not passing specific props to the form. To fix this we have changed the link tag to be the save in progress intro component so that the correct props will be passed in.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done
Tested on local


## Acceptance criteria
- [x] above solution has been implemented
- [x] PR has been created and merged

