### PR TITLE
Replace getVAFacilityMock with versioned helper

### DIFF
--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.video.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.video.unit.spec.jsx
@@ -9,7 +9,7 @@ import {
   mockFacilityFetch,
   mockSingleAppointmentFetch,
 } from '../../../mocks/helpers';
-import { getVAFacilityMock, getVideoAppointmentMock } from '../../../mocks/v0';
+import { getVideoAppointmentMock } from '../../../mocks/v0';
 import {
   renderWithStoreAndRouter,
   getTimezoneTestDate,
@@ -22,7 +22,10 @@ import { getICSTokens } from '../../../../utils/calendar';
 import { getVAOSAppointmentMock } from '../../../mocks/v2';
 import { mockSingleVAOSAppointmentFetch } from '../../../mocks/helpers.v2';
 import { mockFacilityFetchByVersion } from '../../../mocks/fetch';
-import { createMockFacilityByVersion } from '../../../mocks/data';
+import {
+  createMockFacilityByVersion,
+  createMockCheyenneFacilityByVersion,
+} from '../../../mocks/data';
 
 const initialState = {
   featureToggles: {
@@ -44,7 +47,9 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       mockFacilitiesFetch();
       mockFacilityFetch(
         'vha_442',
-        getVAFacilityMock({ id: '442', name: 'Cheyenne VA medical center' }),
+        createMockCheyenneFacilityByVersion({
+          version: 0,
+        }),
       );
     });
     afterEach(() => {
@@ -92,25 +97,7 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
         cc: [],
         requests: [],
       });
-      const facility = {
-        id: 'vha_442',
-        attributes: {
-          ...getVAFacilityMock().attributes,
-          uniqueId: '442',
-          name: 'Cheyenne VA Medical Center',
-          address: {
-            physical: {
-              zip: '82001-5356',
-              city: 'Cheyenne',
-              state: 'WY',
-              address1: '2360 East Pershing Boulevard',
-            },
-          },
-          phone: {
-            main: '307-778-7550',
-          },
-        },
-      };
+      const facility = createMockCheyenneFacilityByVersion({ version: 0 });
       mockFacilitiesFetch('vha_442', [facility]);
       mockFacilityFetch('vha_442', facility);
 
@@ -469,7 +456,9 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       });
       mockFacilityFetch(
         'vha_442',
-        getVAFacilityMock({ id: '442', name: 'Cheyenne VA medical center' }),
+        createMockCheyenneFacilityByVersion({
+          version: 0,
+        }),
       );
 
       const screen = renderWithStoreAndRouter(<AppointmentList />, {
@@ -507,7 +496,7 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       expect(screen.baseElement).to.contain.text(
         'Contact this facility if you need to reschedule or cancel your appointment',
       );
-      expect(screen.baseElement).to.contain.text('Cheyenne VA medical center');
+      expect(screen.baseElement).to.contain.text('Cheyenne VA Medical Center');
     });
 
     it('should direct user to VA facility if we are missing facility details', async () => {
@@ -575,7 +564,11 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       });
       mockFacilityFetch(
         'vha_612A4',
-        getVAFacilityMock({ id: '612A4', name: 'Sacramento VA' }),
+        createMockFacilityByVersion({
+          id: '612A4',
+          name: 'Sacramento VA',
+          version: 0,
+        }),
       );
       mockSingleAppointmentFetch({
         appointment,
@@ -635,25 +628,18 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
         requests: [],
       });
 
-      const facility = {
-        id: 'vha_442GD',
-        attributes: {
-          ...getVAFacilityMock().attributes,
-          uniqueId: '442GD',
-          name: 'Cheyenne VA Medical Center',
-          address: {
-            physical: {
-              zip: '82001-5356',
-              city: 'Cheyenne',
-              state: 'WY',
-              address1: '2360 East Pershing Boulevard',
-            },
-          },
-          phone: {
-            main: '307-778-7550',
-          },
+      const facility = createMockFacilityByVersion({
+        id: '442GD',
+        name: 'Cheyenne VA Medical Center',
+        address: {
+          postalCode: '82001-5356',
+          city: 'Cheyenne',
+          state: 'WY',
+          line: ['2360 East Pershing Boulevard'],
         },
-      };
+        phone: '307-778-7550',
+        version: 0,
+      });
       mockFacilitiesFetch('vha_442GD', [facility]);
 
       const screen = renderWithStoreAndRouter(<AppointmentList />, {
@@ -733,25 +719,18 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
         requests: [],
       });
 
-      const facility = {
-        id: 'vha_442GD',
-        attributes: {
-          ...getVAFacilityMock().attributes,
-          uniqueId: '442GD',
-          name: 'Cheyenne VA Medical Center',
-          address: {
-            physical: {
-              zip: '82001-5356',
-              city: 'Cheyenne',
-              state: 'WY',
-              address1: '2360 East Pershing Boulevard',
-            },
-          },
-          phone: {
-            main: '307-778-7550',
-          },
+      const facility = createMockFacilityByVersion({
+        id: '442GD',
+        name: 'Cheyenne VA Medical Center',
+        address: {
+          postalCode: '82001-5356',
+          city: 'Cheyenne',
+          state: 'WY',
+          line: ['2360 East Pershing Boulevard'],
         },
-      };
+        phone: '307-778-7550',
+        version: 0,
+      });
       mockFacilitiesFetch('vha_442GD', [facility]);
 
       const screen = renderWithStoreAndRouter(<AppointmentList />, {
@@ -1083,25 +1062,7 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
         requests: [],
       });
 
-      const facility = {
-        id: 'vha_442',
-        attributes: {
-          ...getVAFacilityMock().attributes,
-          uniqueId: '442',
-          name: 'Cheyenne VA Medical Center',
-          address: {
-            physical: {
-              zip: '82001-5356',
-              city: 'Cheyenne',
-              state: 'WY',
-              address1: '2360 East Pershing Boulevard',
-            },
-          },
-          phone: {
-            main: '307-778-7550',
-          },
-        },
-      };
+      const facility = createMockCheyenneFacilityByVersion({ version: 0 });
       mockFacilitiesFetch('vha_442', [facility]);
       mockFacilityFetch('vha_442', facility);
 
@@ -1530,7 +1491,11 @@ describe('VAOS <ConfirmedAppointmentDetailsPage>', () => {
       mockFacilitiesFetch();
       mockFacilityFetch(
         'vha_442',
-        getVAFacilityMock({ id: '442', name: 'Cheyenne VA medical center' }),
+        createMockFacilityByVersion({
+          id: '442',
+          name: 'Cheyenne VA medical center',
+          version: 0,
+        }),
       );
     });
     it('should reveal video visit instructions', async () => {

--- a/src/applications/vaos/tests/appointment-list/components/PastAppointmentsListV2.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/PastAppointmentsListV2.unit.spec.jsx
@@ -5,11 +5,7 @@ import moment from 'moment';
 import { fireEvent } from '@testing-library/react';
 import { within, waitFor } from '@testing-library/dom';
 import { mockFetch } from 'platform/testing/unit/helpers';
-import {
-  getVAAppointmentMock,
-  getVAFacilityMock,
-  getVideoAppointmentMock,
-} from '../../mocks/v0';
+import { getVAAppointmentMock, getVideoAppointmentMock } from '../../mocks/v0';
 import {
   mockFacilitiesFetch,
   mockPastAppointmentInfo,
@@ -24,6 +20,7 @@ import PastAppointmentsListV2, {
 } from '../../../appointment-list/components/PastAppointmentsListV2';
 import { getVAOSAppointmentMock } from '../../mocks/v2';
 import { mockVAOSAppointmentsFetch } from '../../mocks/helpers.v2';
+import { createMockFacilityByVersion } from '../../mocks/data';
 
 const initialState = {
   featureToggles: {
@@ -142,25 +139,18 @@ describe('VAOS <PastAppointmentsListV2>', () => {
     appointment.attributes.vdsAppointments[0].currentStatus = 'CHECKED OUT';
     mockPastAppointmentInfo({ va: [appointment] });
 
-    const facility = {
-      id: 'vha_442GC',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '442GC',
-        name: 'Cheyenne VA Medical Center',
-        address: {
-          physical: {
-            zip: '82001-5356',
-            city: 'Cheyenne',
-            state: 'WY',
-            address1: '2360 East Pershing Boulevard',
-          },
-        },
-        phone: {
-          main: '307-778-7550',
-        },
+    const facility = createMockFacilityByVersion({
+      id: '442GC',
+      name: 'Cheyenne VA Medical Center',
+      address: {
+        postalCode: '82001-5356',
+        city: 'Cheyenne',
+        state: 'WY',
+        line: ['2360 East Pershing Boulevard'],
       },
-    };
+      phone: '307-778-7550',
+      version: 0,
+    });
     mockFacilitiesFetch('vha_442GC', [facility]);
 
     const screen = renderWithStoreAndRouter(<PastAppointmentsListV2 />, {

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.jsx
@@ -24,12 +24,12 @@ import {
   renderWithStoreAndRouter,
 } from '../../mocks/setup';
 import {
-  getVAFacilityMock,
   getVARequestMock,
   getCCRequestMock,
   getMessageMock,
 } from '../../mocks/v0';
 import { getVAOSRequestMock } from '../../mocks/v2';
+import { createMockFacilityByVersion } from '../../mocks/data';
 
 const testDate = getTimezoneTestDate();
 
@@ -49,7 +49,7 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
   beforeEach(() => {
     mockFetch();
     MockDate.set(testDate);
-    mockFacilityFetch('vha_fake', getVAFacilityMock());
+    mockFacilityFetch('vha_fake', createMockFacilityByVersion({ version: 0 }));
     mockMessagesFetch();
   });
 
@@ -89,24 +89,18 @@ describe('VAOS <RequestedAppointmentDetailsPage>', () => {
 
     mockSingleRequestFetch({ request: appointment });
 
-    const facility = getVAFacilityMock();
-    facility.attributes = {
-      ...facility.attributes,
-      id: 'vha_442GC',
-      uniqueId: '442GC',
+    const facility = createMockFacilityByVersion({
+      id: '442GC',
       name: 'Cheyenne VA Medical Center',
       address: {
-        physical: {
-          zip: '82001-5356',
-          city: 'Cheyenne',
-          state: 'WY',
-          address1: '2360 East Pershing Boulevard',
-        },
+        postalCode: '82001-5356',
+        city: 'Cheyenne',
+        state: 'WY',
+        line: ['2360 East Pershing Boulevard'],
       },
-      phone: {
-        main: '307-778-7550',
-      },
-    };
+      phone: '307-778-7550',
+      version: 0,
+    });
 
     mockFacilityFetch('vha_442GC', facility);
     const message = getMessageMock();
@@ -673,22 +667,18 @@ describe('VAOS <RequestedAppointmentDetailsPage> with VAOS service', () => {
 
     mockSingleVAOSRequestFetch({ request: appointment });
 
-    const facility = getVAFacilityMock();
-    facility.attributes = {
-      ...facility.attributes,
-      id: 'vha_442GC',
-      uniqueId: '442GC',
+    const facility = createMockFacilityByVersion({
+      id: '442GC',
       name: 'Cheyenne VA Medical Center',
       address: {
-        physical: {
-          zip: '82001-5356',
-          city: 'Cheyenne',
-          state: 'WY',
-          address1: '2360 East Pershing Boulevard',
-        },
+        postalCode: '82001-5356',
+        city: 'Cheyenne',
+        state: 'WY',
+        line: ['2360 East Pershing Boulevard'],
       },
-      phone: { main: '307-778-7550' },
-    };
+      phone: '307-778-7550',
+      version: 0,
+    });
 
     mockFacilityFetch('vha_442GC', facility);
 
@@ -898,7 +888,10 @@ describe('VAOS <RequestedAppointmentDetailsPage> with VAOS service', () => {
     };
 
     mockSingleVAOSRequestFetch({ request: appointment });
-    mockFacilityFetch('vha_442GC', getVAFacilityMock({ id: '442GC' }));
+    mockFacilityFetch(
+      'vha_442GC',
+      createMockFacilityByVersion({ id: '442GC', version: 0 }),
+    );
 
     const screen = renderWithStoreAndRouter(<AppointmentList />, {
       initialState: initialStateVAOSService,
@@ -968,7 +961,10 @@ describe('VAOS <RequestedAppointmentDetailsPage> with VAOS service', () => {
     };
 
     mockSingleVAOSRequestFetch({ request: appointment });
-    mockFacilityFetch('vha_442GC', getVAFacilityMock({ id: '442GC' }));
+    mockFacilityFetch(
+      'vha_442GC',
+      createMockFacilityByVersion({ id: '442GC', version: 0 }),
+    );
 
     const screen = renderWithStoreAndRouter(<AppointmentList />, {
       initialState: initialStateVAOSService,

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentsList.unit.spec.jsx
@@ -5,7 +5,7 @@ import moment from 'moment';
 import environment from 'platform/utilities/environment';
 import { mockFetch, setFetchJSONFailure } from 'platform/testing/unit/helpers';
 import reducers from '../../../redux/reducer';
-import { getVAFacilityMock, getVARequestMock } from '../../mocks/v0';
+import { getVARequestMock } from '../../mocks/v0';
 import { getVAOSRequestMock } from '../../mocks/v2';
 import { mockAppointmentInfo, mockFacilitiesFetch } from '../../mocks/helpers';
 import { mockVAOSAppointmentsFetch } from '../../mocks/helpers.v2';
@@ -13,6 +13,7 @@ import {
   renderWithStoreAndRouter,
   getTimezoneTestDate,
 } from '../../mocks/setup';
+import { createMockFacilityByVersion } from '../../mocks/data';
 import RequestedAppointmentsList from '../../../appointment-list/components/RequestedAppointmentsList';
 
 const initialState = {
@@ -62,25 +63,18 @@ describe('VAOS <RequestedAppointmentsList>', () => {
     appointment.id = '1234';
     mockAppointmentInfo({ requests: [appointment] });
 
-    const facility = {
-      id: 'vha_442GC',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '442GC',
-        name: 'Cheyenne VA Medical Center',
-        address: {
-          physical: {
-            zip: '82001-5356',
-            city: 'Cheyenne',
-            state: 'WY',
-            address1: '2360 East Pershing Boulevard',
-          },
-        },
-        phone: {
-          main: '307-778-7550',
-        },
+    const facility = createMockFacilityByVersion({
+      id: '442GC',
+      name: 'Cheyenne VA Medical Center',
+      address: {
+        postalCode: '82001-5356',
+        city: 'Cheyenne',
+        state: 'WY',
+        line: ['2360 East Pershing Boulevard'],
       },
-    };
+      phone: '307-778-7550',
+      version: 0,
+    });
     mockFacilitiesFetch('vha_442GC', [facility]);
 
     // When the veteran selects the Requested dropdown selection
@@ -298,25 +292,18 @@ describe('VAOS <RequestedAppointmentsList> with the VAOS service', () => {
       requests: [appointment],
     });
 
-    const facility = {
-      id: 'vha_442GC',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '442GC',
-        name: 'Cheyenne VA Medical Center',
-        address: {
-          physical: {
-            zip: '82001-5356',
-            city: 'Cheyenne',
-            state: 'WY',
-            address1: '2360 East Pershing Boulevard',
-          },
-        },
-        phone: {
-          main: '307-778-7550',
-        },
+    const facility = createMockFacilityByVersion({
+      id: '442GC',
+      name: 'Cheyenne VA Medical Center',
+      address: {
+        postalCode: '82001-5356',
+        city: 'Cheyenne',
+        state: 'WY',
+        line: ['2360 East Pershing Boulevard'],
       },
-    };
+      phone: '307-778-7550',
+      version: 0,
+    });
     mockFacilitiesFetch('vha_442GC', [facility]);
     // When veteran selects the Requested dropdown selection
     const screen = renderWithStoreAndRouter(<RequestedAppointmentsList />, {

--- a/src/applications/vaos/tests/covid-19-vaccine/components/ContactFacilitiesPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/ContactFacilitiesPage.unit.spec.jsx
@@ -4,7 +4,6 @@ import { expect } from 'chai';
 import { mockFetch } from 'platform/testing/unit/helpers';
 import ContactFacilitiesPage from '../../../covid-19-vaccine/components/ContactFacilitiesPage';
 import {
-  getVAFacilityMock,
   getRequestEligibilityCriteriaMock,
   getDirectBookingEligibilityCriteriaMock,
 } from '../../mocks/v0';
@@ -14,6 +13,10 @@ import {
   mockDirectBookingEligibilityCriteria,
   mockFacilitiesFetch,
 } from '../../mocks/helpers';
+import {
+  createMockAppointmentByVersion,
+  createMockFacilityByVersion,
+} from '../../mocks/data';
 
 const initialState = {
   featureToggles: {
@@ -85,63 +88,42 @@ describe('VAOS COVID-19 Vaccine: <ContactFacilitiesPage>', () => {
       }),
     ]);
     mockFacilitiesFetch('vha_442,vha_442GC,vha_552', [
-      {
+      createMockFacilityByVersion({
         id: '983',
-        attributes: {
-          ...getVAFacilityMock().attributes,
-          uniqueId: '983',
-          name: 'Facility that is enabled',
-          lat: 39.1362562,
-          long: -83.1804804,
-          address: {
-            physical: {
-              city: 'Bozeman',
-              state: 'MT',
-            },
-          },
-          phone: {
-            main: '5555555555x1234',
-          },
+        name: 'Facility that is enabled',
+        lat: 39.1362562,
+        long: -83.1804804,
+        address: {
+          city: 'Bozeman',
+          state: 'MT',
         },
-      },
-      {
+        phone: '5555555555x1234',
+        version: 0,
+      }),
+      createMockFacilityByVersion({
         id: '983GC',
-        attributes: {
-          ...getVAFacilityMock().attributes,
-          uniqueId: '983GC',
-          name: 'Facility that is also enabled',
-          lat: 39.1362562,
-          long: -83.0804804,
-          address: {
-            physical: {
-              city: 'Belgrade',
-              state: 'MT',
-            },
-          },
-          phone: {
-            main: '5555555556x1234',
-          },
+        name: 'Facility that is also enabled',
+        lat: 39.1362562,
+        long: -83.0804804,
+        address: {
+          city: 'Belgrade',
+          state: 'MT',
         },
-      },
-      {
+        phone: '5555555556x1234',
+        version: 0,
+      }),
+      createMockAppointmentByVersion({
         id: '984',
-        attributes: {
-          ...getVAFacilityMock().attributes,
-          uniqueId: '984',
-          name: 'Facility that is furthest away',
-          lat: 39.1362562,
-          long: -82.1804804,
-          address: {
-            physical: {
-              city: 'Bozeman',
-              state: 'MT',
-            },
-          },
-          phone: {
-            main: '5555555555x1234',
-          },
+        name: 'Facility that is furthest away',
+        lat: 39.1362562,
+        long: -82.1804804,
+        address: {
+          city: 'Bozeman',
+          state: 'MT',
         },
-      },
+        phone: '5555555555x1234',
+        version: 0,
+      }),
     ]);
     const store = createTestStore({
       ...initialState,
@@ -264,54 +246,36 @@ describe('VAOS COVID-19 Vaccine: <ContactFacilitiesPage>', () => {
     mockFacilitiesFetch(
       'vha_442,vha_442GC,vha_552,vha_552GC,vha_552GD,vha_552GA',
       [
-        {
+        createMockFacilityByVersion({
           id: '983',
-          attributes: {
-            ...getVAFacilityMock().attributes,
-            uniqueId: '983',
-            name: 'F facility',
-          },
-        },
-        {
+          name: 'F facility',
+          version: 0,
+        }),
+        createMockFacilityByVersion({
           id: '983GC',
-          attributes: {
-            ...getVAFacilityMock().attributes,
-            uniqueId: '983GC',
-            name: 'A facility',
-          },
-        },
-        {
+          name: 'A facility',
+          version: 0,
+        }),
+        createMockFacilityByVersion({
           id: '984',
-          attributes: {
-            ...getVAFacilityMock().attributes,
-            uniqueId: '984',
-            name: 'B facility',
-          },
-        },
-        {
+          name: 'B facility',
+          version: 0,
+        }),
+        createMockFacilityByVersion({
           id: '984GC',
-          attributes: {
-            ...getVAFacilityMock().attributes,
-            uniqueId: '984GC',
-            name: 'C facility',
-          },
-        },
-        {
+          name: 'C facility',
+          version: 0,
+        }),
+        createMockFacilityByVersion({
           id: '984GD',
-          attributes: {
-            ...getVAFacilityMock().attributes,
-            uniqueId: '984GD',
-            name: 'D facility',
-          },
-        },
-        {
+          name: 'D facility',
+          version: 0,
+        }),
+        createMockFacilityByVersion({
           id: '984GA',
-          attributes: {
-            ...getVAFacilityMock().attributes,
-            uniqueId: '984GA',
-            name: 'E facility',
-          },
-        },
+          name: 'E facility',
+          version: 0,
+        }),
       ],
     );
     const store = createTestStore(initialState);
@@ -363,16 +327,13 @@ describe('VAOS COVID-19 Vaccine: <ContactFacilitiesPage>', () => {
       }),
     ]);
     mockFacilitiesFetch('vha_442', [
-      {
+      createMockFacilityByVersion({
         id: '983',
-        attributes: {
-          ...getVAFacilityMock().attributes,
-          uniqueId: '983',
-          name: 'Facility that is enabled',
-          lat: 39.1362562,
-          long: -83.1804804,
-        },
-      },
+        name: 'Facility that is enabled',
+        lat: 39.1362562,
+        long: -83.1804804,
+        version: 0,
+      }),
     ]);
     const store = createTestStore({
       ...initialState,

--- a/src/applications/vaos/tests/covid-19-vaccine/components/NewBookingPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/NewBookingPage.unit.spec.jsx
@@ -5,16 +5,14 @@ import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
 import environment from 'platform/utilities/environment';
 import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
 import { NewBookingSection } from '../../../covid-19-vaccine';
-import {
-  getDirectBookingEligibilityCriteriaMock,
-  getVAFacilityMock,
-} from '../../../tests/mocks/v0';
+import { getDirectBookingEligibilityCriteriaMock } from '../../../tests/mocks/v0';
 import {
   mockDirectBookingEligibilityCriteria,
   mockFacilitiesFetch,
   mockRequestEligibilityCriteria,
 } from '../../../tests/mocks/helpers';
 import { TYPE_OF_CARE_ID } from '../../../covid-19-vaccine/utils';
+import { createMockFacilityByVersion } from '../../mocks/data';
 
 const initialState = {
   featureToggles: {
@@ -67,25 +65,18 @@ describe('VAOS vaccine flow', () => {
     });
 
     mockFacilitiesFetch('vha_442', [
-      {
+      createMockFacilityByVersion({
         id: '983',
-        attributes: {
-          ...getVAFacilityMock().attributes,
-          uniqueId: '983',
-          name: 'Facility that is enabled',
-          lat: 39.1362562,
-          long: -83.1804804,
-          address: {
-            physical: {
-              city: 'Bozeman',
-              state: 'MT',
-            },
-          },
-          phone: {
-            main: '5555555555x1234',
-          },
+        name: 'Facility that is enabled',
+        lat: 39.1362562,
+        long: -83.1804804,
+        address: {
+          city: 'Bozeman',
+          state: 'MT',
         },
-      },
+        phone: '5555555555x1234',
+        version: 0,
+      }),
     ]);
     mockRequestEligibilityCriteria(['983', '984'], []);
     mockDirectBookingEligibilityCriteria(

--- a/src/applications/vaos/tests/covid-19-vaccine/components/ReviewPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/ReviewPage.unit.spec.jsx
@@ -12,7 +12,7 @@ import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
 import ReviewPage from '../../../covid-19-vaccine/components/ReviewPage';
 import { onCalendarChange } from '../../../covid-19-vaccine/redux/actions';
 import { mockAppointmentSubmit, mockFacilityFetch } from '../../mocks/helpers';
-import { getVAFacilityMock } from '../../mocks/v0';
+import { createMockCheyenneFacilityByVersion } from '../../mocks/data';
 
 const initialState = {
   featureToggles: {
@@ -137,25 +137,10 @@ describe('VAOS vaccine flow <ReviewPage>', () => {
   });
 
   it('should show appropriate message on bad request submit error', async () => {
-    mockFacilityFetch('vha_442', {
-      id: 'vha_442',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '442',
-        name: 'Cheyenne VA Medical Center',
-        address: {
-          physical: {
-            zip: '82001-5356',
-            city: 'Cheyenne',
-            state: 'WY',
-            address1: '2360 East Pershing Boulevard',
-          },
-        },
-        phone: {
-          main: '307-778-7550',
-        },
-      },
-    });
+    mockFacilityFetch(
+      'vha_442',
+      createMockCheyenneFacilityByVersion({ version: 0 }),
+    );
     setFetchJSONFailure(
       global.fetch.withArgs(`${environment.API_URL}/vaos/v0/appointments`),
       {
@@ -190,25 +175,10 @@ describe('VAOS vaccine flow <ReviewPage>', () => {
   });
 
   it('should show appropriate message on regular submit error', async () => {
-    mockFacilityFetch('vha_442', {
-      id: 'vha_442',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '442',
-        name: 'Cheyenne VA Medical Center',
-        address: {
-          physical: {
-            zip: '82001-5356',
-            city: 'Cheyenne',
-            state: 'WY',
-            address1: '2360 East Pershing Boulevard',
-          },
-        },
-        phone: {
-          main: '307-778-7550',
-        },
-      },
-    });
+    mockFacilityFetch(
+      'vha_442',
+      createMockCheyenneFacilityByVersion({ version: 0 }),
+    );
     setFetchJSONFailure(
       global.fetch.withArgs(`${environment.API_URL}/vaos/v0/appointments`),
       {

--- a/src/applications/vaos/tests/covid-19-vaccine/components/VAFacilityPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/VAFacilityPage/index.unit.spec.jsx
@@ -7,7 +7,6 @@ import { fireEvent, waitFor, within } from '@testing-library/dom';
 import { cleanup } from '@testing-library/react';
 import VAFacilityPage from '../../../../covid-19-vaccine/components/VAFacilityPage';
 import {
-  getVAFacilityMock,
   getDirectBookingEligibilityCriteriaMock,
   getClinicMock,
 } from '../../../mocks/v0';
@@ -23,6 +22,7 @@ import {
   mockGetCurrentPosition,
 } from '../../../mocks/helpers';
 import { TYPE_OF_CARE_ID } from '../../../../covid-19-vaccine/utils';
+import { createMockFacilityByVersion } from '../../../mocks/data';
 
 const initialState = {
   user: {
@@ -50,22 +50,18 @@ const vhaIds = facilityIds.map(
   id => `vha_${id.replace('983', '442').replace('984', '552')}`,
 );
 
-const facilities = vhaIds.map((id, index) => ({
-  id,
-  attributes: {
-    ...getVAFacilityMock().attributes,
-    uniqueId: id.replace('vha_', ''),
+const facilities = vhaIds.map((id, index) =>
+  createMockFacilityByVersion({
+    id: id.replace('vha_', ''),
     name: `Fake facility name ${index + 1}`,
     lat: Math.random() * 90,
     long: Math.random() * 180,
     address: {
-      physical: {
-        ...getVAFacilityMock().attributes.address.physical,
-        city: `Fake city ${index + 1}`,
-      },
+      city: `Fake city ${index + 1}`,
     },
-  },
-}));
+    version: 0,
+  }),
+);
 
 const closestFacility = facilities[2];
 closestFacility.attributes.name = 'Closest facility';
@@ -434,11 +430,12 @@ describe('VAOS vaccine flow: <VAFacilityPage>', () => {
       typeOfCareId: TYPE_OF_CARE_ID,
       patientHistoryRequired: null,
     });
-    const facilityDetails = getVAFacilityMock({
+    const facilityDetails = createMockFacilityByVersion({
       id: '123',
       name: 'Bozeman VA medical center',
       lat: 39.1362562,
       long: -85.6804804,
+      version: 0,
     });
     facilityDetails.attributes.address = {
       physical: {
@@ -464,11 +461,12 @@ describe('VAOS vaccine flow: <VAFacilityPage>', () => {
     mockRequestEligibilityCriteria(parentSiteIds, []);
     mockFacilitiesFetch('vha_123,vha_124', [
       facilityDetails,
-      getVAFacilityMock({
+      createMockFacilityByVersion({
         id: '124',
         name: 'Facility 124',
         lat: 39.1362562,
         long: -85.6804804,
+        version: 0,
       }),
     ]);
 

--- a/src/applications/vaos/tests/mocks/data.js
+++ b/src/applications/vaos/tests/mocks/data.js
@@ -339,7 +339,7 @@ export function createMockClinicByVersion({
  */
 export function createMockFacilityByVersion({
   id = 'fake',
-  name = 'Fake',
+  name = 'Fake name',
   address,
   phone = 'fake',
   lat,

--- a/src/applications/vaos/tests/mocks/data.js
+++ b/src/applications/vaos/tests/mocks/data.js
@@ -338,7 +338,7 @@ export function createMockClinicByVersion({
  * @returns {VAFacility|MFSFacility} The facility mock with specified data
  */
 export function createMockFacilityByVersion({
-  id,
+  id = 'fake',
   name = 'Fake',
   address,
   phone,
@@ -346,7 +346,7 @@ export function createMockFacilityByVersion({
   long,
   isParent = null,
   version = 2,
-}) {
+} = {}) {
   if (version === 2) {
     return {
       id,
@@ -380,7 +380,7 @@ export function createMockFacilityByVersion({
           zip: address?.postalCode || 'fake zip',
           city: address?.city || 'Fake city',
           state: address?.state || 'FA',
-          address1: address?.line[0] || 'Fake street',
+          address1: address?.line?.[0] || 'Fake street',
           address2: null,
           address3: null,
         },
@@ -393,4 +393,19 @@ export function createMockFacilityByVersion({
       hours: {},
     },
   };
+}
+
+export function createMockCheyenneFacilityByVersion({ version = 2 } = {}) {
+  return createMockFacilityByVersion({
+    id: '442',
+    name: 'Cheyenne VA Medical Center',
+    address: {
+      postalCode: '82001-5356',
+      city: 'Cheyenne',
+      state: 'WY',
+      line: ['2360 East Pershing Boulevard'],
+    },
+    phone: '307-778-7550',
+    version,
+  });
 }

--- a/src/applications/vaos/tests/mocks/data.js
+++ b/src/applications/vaos/tests/mocks/data.js
@@ -341,7 +341,7 @@ export function createMockFacilityByVersion({
   id = 'fake',
   name = 'Fake',
   address,
-  phone,
+  phone = 'fake',
   lat,
   long,
   isParent = null,

--- a/src/applications/vaos/tests/mocks/helpers.js
+++ b/src/applications/vaos/tests/mocks/helpers.js
@@ -12,9 +12,9 @@ import {
   getExpressCareRequestCriteriaMock,
   getRequestEligibilityCriteriaMock,
   getDirectBookingEligibilityCriteriaMock,
-  getVAFacilityMock,
 } from '../mocks/v0';
 import sinon from 'sinon';
+import { createMockFacilityByVersion } from './data';
 
 /**
  * Mocks appointment-related api calls for the upcoming appointments page
@@ -811,20 +811,18 @@ export function mockFacilitiesPageFetches(
     id => `vha_${id.replace('983', '442').replace('984', '552')}`,
   );
 
-  const facilities = vhaIds.map((id, index) => ({
-    id,
-    attributes: {
-      ...getVAFacilityMock().attributes,
-      uniqueId: id.replace('vha_', ''),
+  const facilities = vhaIds.map((id, index) =>
+    createMockFacilityByVersion({
+      id: id.replace('vha_', ''),
       name: `Fake facility name ${index + 1}`,
+      lat: Math.random() * 90,
+      long: Math.random() * 180,
       address: {
-        physical: {
-          ...getVAFacilityMock().attributes.address.physical,
-          city: `Fake city ${index + 1}`,
-        },
+        city: `Fake city ${index + 1}`,
       },
-    },
-  }));
+      version: 0,
+    }),
+  );
 
   mockDirectBookingEligibilityCriteria(parentSiteIds, directFacilities);
   mockRequestEligibilityCriteria(parentSiteIds, requestFacilities);

--- a/src/applications/vaos/tests/mocks/setup.js
+++ b/src/applications/vaos/tests/mocks/setup.js
@@ -27,7 +27,6 @@ import {
   getDirectBookingEligibilityCriteriaMock,
   getParentSiteMock,
   getRequestEligibilityCriteriaMock,
-  getVAFacilityMock,
 } from './v0';
 import {
   mockCommunityCareEligibility,
@@ -323,13 +322,11 @@ export async function setVAFacility(
   const realFacilityID = facilityId.replace('983', '442').replace('984', '552');
 
   const facilities = [
-    facilityData || {
-      id: `vha_${realFacilityID}`,
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: realFacilityID,
-      },
-    },
+    facilityData ||
+      createMockFacilityByVersion({
+        id: realFacilityID,
+        version: 0,
+      }),
   ];
 
   mockParentSites([siteCode], [parentSite]);
@@ -372,14 +369,11 @@ export async function setVaccineFacility(store, facilityId, facilityData = {}) {
   const realFacilityID = facilityId.replace('983', '442').replace('984', '552');
 
   const facilities = [
-    {
-      id: `vha_${realFacilityID}`,
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: realFacilityID,
-        ...facilityData,
-      },
-    },
+    createMockFacilityByVersion({
+      id: realFacilityID,
+      version: 0,
+      ...facilityData,
+    }),
   ];
 
   mockDirectBookingEligibilityCriteria([siteCode], directFacilities);

--- a/src/applications/vaos/tests/mocks/v0.js
+++ b/src/applications/vaos/tests/mocks/v0.js
@@ -46,49 +46,6 @@ export function getVAAppointmentMock() {
 }
 
 /**
- * Returns a stubbed mock of a VA facility, from the VA facilities api
- *
- * @export
- * @param {Object} [facilityMockParams]
- * @param {string} [facilityMockParams.id=fake] Facility id
- * @param {string} [facilityMockParams.name=Fake name] Facility name
- * @param {number} [facilityMockParams.lat] Latitude of facility
- * @param {number} [facilityMockParams.long] Longitude of facility
- * @returns {VAFacility} VA facility object
- */
-export function getVAFacilityMock({
-  id = 'fake',
-  name = 'Fake name',
-  lat = null,
-  long = null,
-} = {}) {
-  return {
-    id: `vha_${id}`,
-    type: 'va_facilities',
-    attributes: {
-      uniqueId: id,
-      name,
-      address: {
-        physical: {
-          zip: 'fake zip',
-          city: 'Fake city',
-          state: 'FA',
-          address1: 'Fake street',
-          address2: null,
-          address3: null,
-        },
-      },
-      lat,
-      long,
-      phone: {
-        main: 'Fake phone',
-      },
-      hours: {},
-    },
-  };
-}
-
-/**
  * Return a MAS appointment object, with a video appointment stub (item in vvsAppointments)
  *
  * @export

--- a/src/applications/vaos/tests/new-appointment/components/ClinicChoicePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ClinicChoicePage.unit.spec.jsx
@@ -12,7 +12,11 @@ import userEvent from '@testing-library/user-event';
 
 import ClinicChoicePage from '../../../new-appointment/components/ClinicChoicePage';
 import { mockEligibilityFetches, mockFacilityFetch } from '../../mocks/helpers';
-import { getClinicMock, getVAFacilityMock } from '../../mocks/v0';
+import { getClinicMock } from '../../mocks/v0';
+import {
+  createMockCheyenneFacilityByVersion,
+  createMockFacilityByVersion,
+} from '../../mocks/data';
 import { mockFetch } from 'platform/testing/unit/helpers';
 
 const initialState = {
@@ -51,25 +55,7 @@ describe('VAOS <ClinicChoicePage>', () => {
         },
       },
     ];
-    const facilityData = {
-      id: 'vha_442',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '442',
-        name: 'Cheyenne VA Medical Center',
-        address: {
-          physical: {
-            zip: '82001-5356',
-            city: 'Cheyenne',
-            state: 'WY',
-            address1: '2360 East Pershing Boulevard',
-          },
-        },
-        phone: {
-          main: '307-778-7550',
-        },
-      },
-    };
+    const facilityData = createMockCheyenneFacilityByVersion({ version: 0 });
     mockEligibilityFetches({
       siteId: '983',
       facilityId: '983',
@@ -148,7 +134,10 @@ describe('VAOS <ClinicChoicePage>', () => {
       clinics,
       pastClinics: true,
     });
-    mockFacilityFetch('vha_442', getVAFacilityMock());
+    mockFacilityFetch(
+      'vha_442',
+      createMockFacilityByVersion({ id: '442', version: 0 }),
+    );
 
     const store = createTestStore(initialState);
 
@@ -228,7 +217,10 @@ describe('VAOS <ClinicChoicePage>', () => {
       clinics,
       pastClinics: true,
     });
-    mockFacilityFetch('vha_442', getVAFacilityMock());
+    mockFacilityFetch(
+      'vha_442',
+      createMockCheyenneFacilityByVersion({ version: 0 }),
+    );
 
     // And the page has loaded
     const store = createTestStore(initialState);
@@ -274,25 +266,7 @@ describe('VAOS <ClinicChoicePage>', () => {
         },
       },
     ];
-    const facilityData = {
-      id: 'vha_442',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '442',
-        name: 'Cheyenne VA Medical Center',
-        address: {
-          physical: {
-            zip: '82001-5356',
-            city: 'Cheyenne',
-            state: 'WY',
-            address1: '2360 East Pershing Boulevard',
-          },
-        },
-        phone: {
-          main: '307-778-7550',
-        },
-      },
-    };
+    const facilityData = createMockCheyenneFacilityByVersion({ version: 0 });
     mockEligibilityFetches({
       siteId: '983',
       facilityId: '983',
@@ -384,25 +358,7 @@ describe('VAOS <ClinicChoicePage>', () => {
         },
       },
     ];
-    const facilityData = {
-      id: 'vha_442',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '442',
-        name: 'Cheyenne VA Medical Center',
-        address: {
-          physical: {
-            zip: '82001-5356',
-            city: 'Cheyenne',
-            state: 'WY',
-            address1: '2360 East Pershing Boulevard',
-          },
-        },
-        phone: {
-          main: '307-778-7550',
-        },
-      },
-    };
+    const facilityData = createMockCheyenneFacilityByVersion({ version: 0 });
 
     // And the second clinic matches a past appointment
     mockEligibilityFetches({
@@ -472,7 +428,10 @@ describe('VAOS <ClinicChoicePage>', () => {
       clinics,
       pastClinics: true,
     });
-    mockFacilityFetch('vha_442', getVAFacilityMock());
+    mockFacilityFetch(
+      'vha_442',
+      createMockCheyenneFacilityByVersion({ version: 0 }),
+    );
 
     const store = createTestStore(initialState);
 

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSortVariant.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSortVariant.unit.spec.jsx
@@ -13,7 +13,7 @@ import {
   setTypeOfCare,
   setTypeOfFacility,
 } from '../../../mocks/setup';
-import { getParentSiteMock, getVAFacilityMock } from '../../../mocks/v0';
+import { getParentSiteMock } from '../../../mocks/v0';
 import {
   mockCCProviderFetch,
   mockCommunityCareEligibility,
@@ -26,6 +26,7 @@ import CommunityCareProviderSelectionPage from '../../../../new-appointment/comp
 import { calculateBoundingBox } from '../../../../utils/address';
 import { CC_PROVIDERS_DATA } from './cc_providers_data';
 import { FACILITY_SORT_METHODS } from '../../../../utils/constants';
+import { createMockFacilityByVersion } from '../../../mocks/data';
 
 const initialState = {
   featureToggles: {
@@ -105,7 +106,12 @@ describe('VAOS ProviderSortVariant on <CommunityCareProviderSelectionPage>', () 
     );
     mockFacilityFetch(
       'vha_442',
-      getVAFacilityMock({ id: '442', lat: 38.5615, long: 122.9988 }),
+      createMockFacilityByVersion({
+        id: '442',
+        lat: 38.5615,
+        long: 122.9988,
+        version: 0,
+      }),
     );
   });
 
@@ -436,16 +442,16 @@ describe('VAOS ProviderSortVariant on <CommunityCareProviderSelectionPage>', () 
       CC_PROVIDERS_DATA,
     );
 
-    mockFacilityFetch('vha_442GJ', {
-      id: '983',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '983',
+    mockFacilityFetch(
+      'vha_442GJ',
+      createMockFacilityByVersion({
+        id: '442GJ',
         name: 'Facility that is enabled',
         lat: 39.1362562,
         long: -83.1804804,
-      },
-    });
+        version: 0,
+      }),
+    );
 
     await setTypeOfCare(store, /primary care/i);
     await setTypeOfFacility(store, /Community Care/i);
@@ -519,16 +525,16 @@ describe('VAOS ProviderSortVariant on <CommunityCareProviderSelectionPage>', () 
       CC_PROVIDERS_DATA,
     );
 
-    mockFacilityFetch('vha_442GJ', {
-      id: '983',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '983',
+    mockFacilityFetch(
+      'vha_442GJ',
+      createMockFacilityByVersion({
+        id: '442GJ',
         name: 'Facility that is enabled',
         lat: 39.1362562,
         long: -83.1804804,
-      },
-    });
+        version: 0,
+      }),
+    );
 
     await setTypeOfCare(store, /primary care/i);
     await setTypeOfFacility(store, /Community Care/i);

--- a/src/applications/vaos/tests/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
@@ -23,8 +23,9 @@ import {
   mockAppointmentSlotFetch,
   mockFacilityFetch,
 } from '../../../mocks/helpers';
-import { getAppointmentSlotMock, getVAFacilityMock } from '../../../mocks/v0';
+import { getAppointmentSlotMock } from '../../../mocks/v0';
 import { setDateTimeSelectMockFetches } from './helpers';
+import { createMockCheyenneFacilityByVersion } from '../../../mocks/data';
 
 const initialState = {
   featureToggles: {
@@ -40,7 +41,10 @@ const initialState = {
 describe('VAOS <DateTimeSelectPage>', () => {
   beforeEach(() => {
     mockFetch();
-    mockFacilityFetch('vha_442', getVAFacilityMock());
+    mockFacilityFetch(
+      'vha_442',
+      createMockCheyenneFacilityByVersion({ version: 0 }),
+    );
     MockDate.set(moment('2020-01-26T14:00:00'));
   });
   afterEach(() => {

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.cc-request.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.cc-request.unit.spec.jsx
@@ -28,7 +28,7 @@ import {
 } from '../../../mocks/helpers';
 
 import { mockAppointmentSubmitV2 } from '../../../mocks/helpers.v2';
-import { getVAFacilityMock } from '../../../mocks/v0';
+import { createMockCheyenneFacilityByVersion } from '../../../mocks/data';
 
 const initialState = {
   featureToggles: {
@@ -186,25 +186,10 @@ describe('VAOS <ReviewPage> CC request', () => {
   });
 
   it('should show error message on failure', async () => {
-    mockFacilityFetch('vha_442', {
-      id: 'vha_442',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '442',
-        name: 'Cheyenne VA Medical Center',
-        address: {
-          physical: {
-            zip: '82001-5356',
-            city: 'Cheyenne',
-            state: 'WY',
-            address1: '2360 East Pershing Boulevard',
-          },
-        },
-        phone: {
-          main: '307-778-7550',
-        },
-      },
-    });
+    mockFacilityFetch(
+      'vha_442',
+      createMockCheyenneFacilityByVersion({ version: 0 }),
+    );
     setFetchJSONFailure(
       global.fetch.withArgs(
         `${environment.API_URL}/vaos/v0/appointment_requests?type=cc`,
@@ -436,25 +421,10 @@ describe('VAOS <ReviewPage> CC request with provider selection', () => {
   });
 
   it('should show error message on failure', async () => {
-    mockFacilityFetch('vha_442', {
-      id: 'vha_442',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '442',
-        name: 'Cheyenne VA Medical Center',
-        address: {
-          physical: {
-            zip: '82001-5356',
-            city: 'Cheyenne',
-            state: 'WY',
-            address1: '2360 East Pershing Boulevard',
-          },
-        },
-        phone: {
-          main: '307-778-7550',
-        },
-      },
-    });
+    mockFacilityFetch(
+      'vha_442',
+      createMockCheyenneFacilityByVersion({ version: 0 }),
+    );
     setFetchJSONFailure(
       global.fetch.withArgs(
         `${environment.API_URL}/vaos/v0/appointment_requests?type=cc`,
@@ -637,25 +607,10 @@ describe('VAOS <ReviewPage> CC request with VAOS service', () => {
   });
 
   it('should show error message on failure', async () => {
-    mockFacilityFetch('vha_442', {
-      id: 'vha_442',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '442',
-        name: 'Cheyenne VA Medical Center',
-        address: {
-          physical: {
-            zip: '82001-5356',
-            city: 'Cheyenne',
-            state: 'WY',
-            address1: '2360 East Pershing Boulevard',
-          },
-        },
-        phone: {
-          main: '307-778-7550',
-        },
-      },
-    });
+    mockFacilityFetch(
+      'vha_442',
+      createMockCheyenneFacilityByVersion({ version: 0 }),
+    );
     setFetchJSONFailure(
       global.fetch.withArgs(`${environment.API_URL}/vaos/v2/appointments`),
       {

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.direct.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.direct.unit.spec.jsx
@@ -24,7 +24,7 @@ import {
   mockPreferences,
 } from '../../../mocks/helpers';
 import { mockAppointmentSubmitV2 } from '../../../mocks/helpers.v2';
-import { getVAFacilityMock } from '../../../mocks/v0';
+import { createMockCheyenneFacilityByVersion } from '../../../mocks/data';
 
 const initialState = {
   featureToggles: {
@@ -195,25 +195,10 @@ describe('VAOS <ReviewPage> direct scheduling', () => {
   });
 
   it('should show appropriate message on bad request submit error', async () => {
-    mockFacilityFetch('vha_442', {
-      id: 'vha_442',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '442',
-        name: 'Cheyenne VA Medical Center',
-        address: {
-          physical: {
-            zip: '82001-5356',
-            city: 'Cheyenne',
-            state: 'WY',
-            address1: '2360 East Pershing Boulevard',
-          },
-        },
-        phone: {
-          main: '307-778-7550',
-        },
-      },
-    });
+    mockFacilityFetch(
+      'vha_442',
+      createMockCheyenneFacilityByVersion({ version: 0 }),
+    );
     setFetchJSONFailure(
       global.fetch.withArgs(`${environment.API_URL}/vaos/v0/appointments`),
       {
@@ -431,25 +416,7 @@ describe('VAOS <ReviewPage> direct scheduling with v2 api', () => {
   });
 
   it('should show error message on failure', async () => {
-    mockFacilityFetch('vha_983', {
-      id: 'vha_983',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '983',
-        name: 'Cheyenne VA Medical Center',
-        address: {
-          physical: {
-            zip: '82001-5356',
-            city: 'Cheyenne',
-            state: 'WY',
-            address1: '2360 East Pershing Boulevard',
-          },
-        },
-        phone: {
-          main: '307-778-7550',
-        },
-      },
-    });
+    mockFacilityFetch('vha_442', createMockCheyenneFacilityByVersion());
 
     setFetchJSONFailure(
       global.fetch.withArgs(`${environment.API_URL}/vaos/v2/appointments`),

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.va-request.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.va-request.unit.spec.jsx
@@ -27,7 +27,7 @@ import {
   mockFacilityFetch,
 } from '../../../mocks/helpers';
 import { mockAppointmentSubmitV2 } from '../../../mocks/helpers.v2';
-import { getVAFacilityMock } from '../../../mocks/v0';
+import { createMockCheyenneFacilityByVersion } from '../../../mocks/data';
 
 const initialState = {
   featureToggles: {
@@ -342,25 +342,7 @@ describe('VAOS <ReviewPage> VA request with VAOS service', () => {
   });
 
   it('should show error message on failure', async () => {
-    mockFacilityFetch('vha_442', {
-      id: 'vha_442',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '442',
-        name: 'Cheyenne VA Medical Center',
-        address: {
-          physical: {
-            zip: '82001-5356',
-            city: 'Cheyenne',
-            state: 'WY',
-            address1: '2360 East Pershing Boulevard',
-          },
-        },
-        phone: {
-          main: '307-778-7550',
-        },
-      },
-    });
+    mockFacilityFetch('vha_442', createMockCheyenneFacilityByVersion());
     setFetchJSONFailure(
       global.fetch.withArgs(`${environment.API_URL}/vaos/v2/appointments`),
       {

--- a/src/applications/vaos/tests/new-appointment/components/ScheduleCernerPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ScheduleCernerPage.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   setVAFacility,
 } from '../../mocks/setup';
 
-import { getVAFacilityMock } from '../../mocks/v0';
+import { createMockCheyenneFacilityByVersion } from '../../mocks/data';
 import { mockFetch } from 'platform/testing/unit/helpers';
 import ScheduleCernerPage from '../../../new-appointment/components/ScheduleCernerPage';
 
@@ -25,25 +25,7 @@ const initialState = {
 describe('VAOS <ScheduleCernerPage>', () => {
   beforeEach(() => mockFetch());
   it('should show Cerner facility information', async () => {
-    const facilityData = {
-      id: 'vha_442',
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: '442',
-        name: 'Cheyenne VA Medical Center',
-        address: {
-          physical: {
-            zip: '82001-5356',
-            city: 'Cheyenne',
-            state: 'WY',
-            address1: '2360 East Pershing Boulevard',
-          },
-        },
-        phone: {
-          main: '307-778-7550',
-        },
-      },
-    };
+    const facilityData = createMockCheyenneFacilityByVersion({ version: 0 });
 
     const store = createTestStore(initialState);
 

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.eligibility.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.eligibility.unit.spec.jsx
@@ -7,7 +7,6 @@ import VAFacilityPage from '../../../../new-appointment/components/VAFacilityPag
 import {
   getParentSiteMock,
   getClinicMock,
-  getVAFacilityMock,
   getRequestEligibilityCriteriaMock,
   getDirectBookingEligibilityCriteriaMock,
 } from '../../../mocks/v0';
@@ -88,25 +87,18 @@ describe('VAOS <VAFacilityPage> eligibility check', () => {
         }),
       ]);
       mockFacilitiesFetch('vha_442', [
-        {
-          id: 'vha_442',
-          attributes: {
-            ...getVAFacilityMock().attributes,
-            uniqueId: '442',
-            name: 'San Diego VA Medical Center',
-            address: {
-              physical: {
-                address1: '2360 East Pershing Boulevard',
-                city: 'San Diego',
-                state: 'CA',
-                zip: '92128',
-              },
-            },
-            phone: {
-              main: '858-779-0338',
-            },
+        createMockFacilityByVersion({
+          id: '442',
+          name: 'San Diego VA Medical Center',
+          address: {
+            line: ['2360 East Pershing Boulevard'],
+            city: 'San Diego',
+            state: 'CA',
+            postalCode: '92128',
           },
-        },
+          phone: '858-779-0338',
+          version: 0,
+        }),
       ]);
     });
 
@@ -241,22 +233,18 @@ describe('VAOS <VAFacilityPage> eligibility check', () => {
     const vhaIds = facilityIds.map(
       id => `vha_${id.replace('983', '442').replace('984', '552')}`,
     );
-    const facilities = vhaIds.map((id, index) => ({
-      id,
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: id.replace('vha_', ''),
+    const facilities = vhaIds.map((id, index) =>
+      createMockFacilityByVersion({
+        id: id.replace('vha_', ''),
         name: `Fake facility name ${index + 1}`,
         lat: Math.random() * 90,
         long: Math.random() * 180,
         address: {
-          physical: {
-            ...getVAFacilityMock().attributes.address.physical,
-            city: `Fake city ${index + 1}`,
-          },
+          city: `Fake city ${index + 1}`,
         },
-      },
-    }));
+        version: 0,
+      }),
+    );
 
     const requestFacilities = facilityIds.map(id =>
       getRequestEligibilityCriteriaMock({

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.unit.spec.jsx
@@ -8,7 +8,6 @@ import { cleanup } from '@testing-library/react';
 import VAFacilityPage from '../../../../new-appointment/components/VAFacilityPage/VAFacilityPageV2';
 import {
   getParentSiteMock,
-  getVAFacilityMock,
   getRequestEligibilityCriteriaMock,
   getDirectBookingEligibilityCriteriaMock,
 } from '../../../mocks/v0';
@@ -101,22 +100,18 @@ describe('VAOS <VAFacilityPage>', () => {
       id => `vha_${id.replace('983', '442').replace('984', '552')}`,
     );
 
-    const facilities = vhaIds.map((id, index) => ({
-      id,
-      attributes: {
-        ...getVAFacilityMock().attributes,
-        uniqueId: id.replace('vha_', ''),
+    const facilities = vhaIds.map((id, index) =>
+      createMockFacilityByVersion({
+        id: id.replace('vha_', ''),
         name: `Fake facility name ${index + 1}`,
         lat: Math.random() * 90,
         long: Math.random() * 180,
         address: {
-          physical: {
-            ...getVAFacilityMock().attributes.address.physical,
-            city: `Fake city ${index + 1}`,
-          },
+          city: `Fake city ${index + 1}`,
         },
-      },
-    }));
+        version: 0,
+      }),
+    );
 
     const closestFacility = facilities[2];
     closestFacility.attributes.name = 'Closest facility';
@@ -261,11 +256,12 @@ describe('VAOS <VAFacilityPage>', () => {
         typeOfCareId: '323',
         patientHistoryRequired: null,
       });
-      const facilityDetails = getVAFacilityMock({
+      const facilityDetails = createMockFacilityByVersion({
         id: '123',
         name: 'Bozeman VA medical center',
         lat: 39.1362562,
         long: -85.6804804,
+        version: 0,
       });
       facilityDetails.attributes.address = {
         physical: {
@@ -296,17 +292,19 @@ describe('VAOS <VAFacilityPage>', () => {
       mockRequestEligibilityCriteria(parentSiteIds, []);
       mockFacilitiesFetch('vha_123,vha_124,vha_125', [
         facilityDetails,
-        getVAFacilityMock({
+        createMockFacilityByVersion({
           id: '124',
           name: 'Facility 124',
           lat: 39.1362562,
           long: -85.6804804,
+          version: 0,
         }),
-        getVAFacilityMock({
+        createMockFacilityByVersion({
           id: '125',
           name: 'Facility 125',
           lat: 39.1362562,
           long: -86.6804804,
+          version: 0,
         }),
       ]);
 
@@ -355,9 +353,10 @@ describe('VAOS <VAFacilityPage>', () => {
         typeOfCareId: '323',
         patientHistoryRequired: null,
       });
-      const facilityDetails = getVAFacilityMock({
+      const facilityDetails = createMockFacilityByVersion({
         id: '123',
         name: 'Bozeman VA medical center',
+        version: 0,
       });
       facilityDetails.attributes.address = {
         physical: {
@@ -403,25 +402,30 @@ describe('VAOS <VAFacilityPage>', () => {
       mockRequestEligibilityCriteria(parentSiteIds, []);
       mockFacilitiesFetch('vha_123,vha_124,vha_125,vha_126,vha_127,vha_128', [
         facilityDetails,
-        getVAFacilityMock({
+        createMockFacilityByVersion({
           id: '124',
           name: 'Facility 124',
+          version: 0,
         }),
-        getVAFacilityMock({
+        createMockFacilityByVersion({
           id: '125',
           name: 'Facility 125',
+          version: 0,
         }),
-        getVAFacilityMock({
+        createMockFacilityByVersion({
           id: '126',
           name: 'Facility 126',
+          version: 0,
         }),
-        getVAFacilityMock({
+        createMockFacilityByVersion({
           id: '127',
           name: 'Facility 127',
+          version: 0,
         }),
-        getVAFacilityMock({
+        createMockFacilityByVersion({
           id: '128',
           name: 'Facility 128',
+          version: 0,
         }),
       ]);
 
@@ -503,53 +507,37 @@ describe('VAOS <VAFacilityPage>', () => {
         }),
       ]);
       mockFacilitiesFetch('vha_442,vha_442GC,vha_552,vha_552GC', [
-        {
+        createMockFacilityByVersion({
           id: '983',
-          attributes: {
-            ...getVAFacilityMock().attributes,
-            uniqueId: '983',
-            name: 'Facility that is enabled',
-          },
-        },
-        {
+          name: 'Facility that is enabled',
+          version: 0,
+        }),
+        createMockFacilityByVersion({
           id: '983GC',
-          attributes: {
-            ...getVAFacilityMock().attributes,
-            uniqueId: '983GC',
-            name: 'Facility that is also enabled',
-          },
-        },
-        {
+          name: 'Facility that is also enabled',
+          version: 0,
+        }),
+        createMockFacilityByVersion({
           id: '984',
-          attributes: {
-            ...getVAFacilityMock().attributes,
-            uniqueId: '984',
-            name: 'Facility that is disabled',
-            lat: 39.1362562,
-            // tweaked longitude to be around 80 miles away
-            long: -83.1804804,
-            address: {
-              physical: {
-                city: 'Bozeman',
-                state: 'MT',
-              },
-            },
-            phone: {
-              main: '5555555555x1234',
-            },
+          name: 'Facility that is disabled',
+          lat: 39.1362562,
+          // tweaked longitude to be around 80 miles away
+          long: -83.1804804,
+          address: {
+            city: 'Bozeman',
+            state: 'MT',
           },
-        },
-        {
+          phone: '5555555555x1234',
+          version: 0,
+        }),
+        createMockFacilityByVersion({
           id: '984GC',
-          attributes: {
-            ...getVAFacilityMock().attributes,
-            uniqueId: '984GC',
-            name: 'Facility that is over 100 miles away and disabled',
-            lat: 39.1362562,
-            // tweaked longitude to be over 100 miles away
-            long: -82.1804804,
-          },
-        },
+          name: 'Facility that is over 100 miles away and disabled',
+          lat: 39.1362562,
+          // tweaked longitude to be over 100 miles away
+          long: -82.1804804,
+          version: 0,
+        }),
       ]);
       const store = createTestStore({
         ...initialState,
@@ -634,42 +622,30 @@ describe('VAOS <VAFacilityPage>', () => {
         }),
       ]);
       mockFacilitiesFetch('vha_442,vha_442GC,vha_552,vha_552GC', [
-        {
+        createMockFacilityByVersion({
           id: '983',
-          attributes: {
-            ...getVAFacilityMock().attributes,
-            uniqueId: '983',
-            name: 'Facility that is enabled',
-          },
-        },
-        {
+          name: 'Facility that is enabled',
+          version: 0,
+        }),
+        createMockFacilityByVersion({
           id: '983GC',
-          attributes: {
-            ...getVAFacilityMock().attributes,
-            uniqueId: '983GC',
-            name: 'Facility that is also enabled',
-          },
-        },
-        {
+          name: 'Facility that is also enabled',
+          version: 0,
+        }),
+        createMockFacilityByVersion({
           id: '984',
-          attributes: {
-            ...getVAFacilityMock().attributes,
-            uniqueId: '984',
-            name: 'Disabled facility near residential address',
-            lat: 39.1362562,
-            long: -83.1804804,
-          },
-        },
-        {
+          name: 'Disabled facility near residential address',
+          lat: 39.1362562,
+          long: -83.1804804,
+          version: 0,
+        }),
+        createMockFacilityByVersion({
           id: '984GC',
-          attributes: {
-            ...getVAFacilityMock().attributes,
-            uniqueId: '984GC',
-            name: 'Disabled facility near current location',
-            lat: 53.2734,
-            long: -7.77832031,
-          },
-        },
+          name: 'Disabled facility near current location',
+          lat: 53.2734,
+          long: -7.77832031,
+          version: 0,
+        }),
       ]);
       mockGetCurrentPosition();
       const store = createTestStore({
@@ -825,36 +801,27 @@ describe('VAOS <VAFacilityPage>', () => {
         }),
       ]);
       mockFacilitiesFetch('vha_442,vha_442GC,vha_552', [
-        {
+        createMockFacilityByVersion({
           id: '983',
-          attributes: {
-            ...getVAFacilityMock().attributes,
-            uniqueId: '983',
-            name: 'First cerner facility',
-            lat: 39.1362562,
-            long: -83.1804804,
-          },
-        },
-        {
+          name: 'First cerner facility',
+          lat: 39.1362562,
+          long: -83.1804804,
+          version: 0,
+        }),
+        createMockFacilityByVersion({
           id: '983GC',
-          attributes: {
-            ...getVAFacilityMock().attributes,
-            uniqueId: '983GC',
-            name: 'Second cerner facility',
-            lat: 39.1362562,
-            long: -83.1804804,
-          },
-        },
-        {
+          name: 'Second cerner facility',
+          lat: 39.1362562,
+          long: -83.1804804,
+          version: 0,
+        }),
+        createMockFacilityByVersion({
           id: '984',
-          attributes: {
-            ...getVAFacilityMock().attributes,
-            uniqueId: '984',
-            name: 'Vista facility',
-            lat: 39.1362562,
-            long: -83.1804804,
-          },
-        },
+          name: 'Vista facility',
+          lat: 39.1362562,
+          long: -83.1804804,
+          version: 0,
+        }),
       ]);
       const store = createTestStore({
         ...initialState,
@@ -1285,25 +1252,18 @@ describe('VAOS <VAFacilityPage>', () => {
         }),
       ]);
       mockFacilitiesFetch('vha_442', [
-        {
-          id: 'vha_442',
-          attributes: {
-            ...getVAFacilityMock().attributes,
-            uniqueId: '442',
-            name: 'San Diego VA Medical Center',
-            address: {
-              physical: {
-                address1: '2360 East Pershing Boulevard',
-                city: 'San Diego',
-                state: 'CA',
-                zip: '92128',
-              },
-            },
-            phone: {
-              main: '858-779-0338',
-            },
+        createMockFacilityByVersion({
+          id: '442',
+          name: 'San Diego VA Medical Center',
+          address: {
+            line: ['2360 East Pershing Boulevard'],
+            city: 'San Diego',
+            state: 'CA',
+            postalCode: '92128',
           },
-        },
+          phone: '858-779-0338',
+          version: 0,
+        }),
       ]);
     });
     it('should show facility information without form', async () => {
@@ -1349,9 +1309,21 @@ describe('VAOS <VAFacilityPage>', () => {
         getRequestEligibilityCriteriaMock({ id: '983GD', typeOfCareId: '407' }),
       ]);
       mockFacilitiesFetch('vha_442,vha_442GC,vha_442GD', [
-        getVAFacilityMock({ id: '442', name: 'Facility 1' }),
-        getVAFacilityMock({ id: '442GC', name: 'Facility 2' }),
-        getVAFacilityMock({ id: '442GD', name: 'Facility 3' }),
+        createMockFacilityByVersion({
+          id: '442',
+          name: 'Facility 1',
+          version: 0,
+        }),
+        createMockFacilityByVersion({
+          id: '442GC',
+          name: 'Facility 2',
+          version: 0,
+        }),
+        createMockFacilityByVersion({
+          id: '442GD',
+          name: 'Facility 3',
+          version: 0,
+        }),
       ]);
       mockEligibilityFetches({
         siteId: '983',


### PR DESCRIPTION
## Description
This PR
- Replaces all uses of getVAFacilityMock with the ByVerison helper
- Created a new createMockCheyenneFacilityByVersion helper that creates a mock of the Cheyenne facility data that was use a lot

## Original issue(s)
department-of-veterans-affairs/va.gov-team#31087

## Testing done
Unit testing, only tests were changed

## Acceptance criteria
- [ ] Tests pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
