### PR TITLE
31627: [MCP] Configure Sentry for failed endpoint calls

### DIFF
--- a/src/applications/medical-copays/actions/index.js
+++ b/src/applications/medical-copays/actions/index.js
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/browser';
 import { apiRequest } from 'platform/utilities/api';
 import { transform } from '../utils/helpers';
 
@@ -15,7 +16,11 @@ export const getStatements = () => {
           response: transform(data),
         });
       })
-      .catch(errors => {
+      .catch(({ errors }) => {
+        Sentry.withScope(scope => {
+          Sentry.captureMessage('medical_copays getStatements failed');
+          scope.setExtra('errors', errors);
+        });
         return dispatch({
           type: MCP_STATEMENTS_FETCH_FAILURE,
           errors,


### PR DESCRIPTION
## Description
Endpoint failures should be captured and logged in Sentry under the following capture message

`medical_copays getStatements failed`

## Original issue(s)
department-of-veterans-affairs/va.gov-team#31627


## Acceptance criteria
- [x] failed endpoint calls to `/v0/medical_copays` should now log to Sentry

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs