### PR TITLE
31627: [MCP] capture exception in sentry

### DIFF
--- a/src/applications/medical-copays/actions/index.js
+++ b/src/applications/medical-copays/actions/index.js
@@ -17,10 +17,8 @@ export const getStatements = () => {
         });
       })
       .catch(({ errors }) => {
-        Sentry.withScope(scope => {
-          Sentry.captureMessage('medical_copays getStatements failed');
-          scope.setExtra('errors', errors);
-        });
+        Sentry.captureException(errors);
+        Sentry.captureMessage('medical_copays getStatements failed');
         return dispatch({
           type: MCP_STATEMENTS_FETCH_FAILURE,
           errors,


### PR DESCRIPTION
## Description
update to use `captureException` method in Sentry

## Original issue(s)
department-of-veterans-affairs/va.gov-team#31627

## Acceptance criteria
- [x] failed calls should now be logging errors to Sentry

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
