### PR TITLE
Normalizing timefields in reducer.

### DIFF
--- a/src/applications/check-in/reducers/index.js
+++ b/src/applications/check-in/reducers/index.js
@@ -31,8 +31,35 @@ const checkInReducer = (state = initialState, action) => {
         ...state,
         context: { ...state.context, ...action.payload.context },
       };
-    case RECEIVED_APPOINTMENT_DETAILS:
-      return { ...state, ...action.payload };
+    case RECEIVED_APPOINTMENT_DETAILS: {
+      // Grabing the appointment payload and stripping out timezone here.
+      // Chip should be handling this but currently isn't, this code may be refactored out.
+      const updatedPayload = JSON.parse(JSON.stringify(action.payload));
+      // These fields have a potential to include a time stamp.
+      const timeFields = [
+        'checkInWindowEnd',
+        'checkInWindowStart',
+        'checkedInTime',
+        'startTime',
+      ];
+
+      const updatedAppointments = updatedPayload.appointments.map(
+        appointment => {
+          const updatedAppointment = { ...appointment };
+          // If field exists in object we will replace the TZ part of the string.
+          timeFields.forEach(field => {
+            if (field in updatedAppointment) {
+              updatedAppointment[field] = updatedAppointment[field].replace(
+                /(?=\.).*/,
+                '',
+              );
+            }
+          });
+          return updatedAppointment;
+        },
+      );
+      return { ...state, appointments: updatedAppointments };
+    }
     case RECEIVED_DEMOGRAPHICS_DATA:
       return { ...state, ...action.payload };
 

--- a/src/applications/check-in/reducers/index.js
+++ b/src/applications/check-in/reducers/index.js
@@ -1,3 +1,5 @@
+import { removeTimeZone } from '../utils/appointment';
+
 const initialState = {
   appointments: [],
   context: {},
@@ -32,33 +34,11 @@ const checkInReducer = (state = initialState, action) => {
         context: { ...state.context, ...action.payload.context },
       };
     case RECEIVED_APPOINTMENT_DETAILS: {
-      // Grabing the appointment payload and stripping out timezone here.
-      // Chip should be handling this but currently isn't, this code may be refactored out.
-      const updatedPayload = JSON.parse(JSON.stringify(action.payload));
-      // These fields have a potential to include a time stamp.
-      const timeFields = [
-        'checkInWindowEnd',
-        'checkInWindowStart',
-        'checkedInTime',
-        'startTime',
-      ];
-
-      const updatedAppointments = updatedPayload.appointments.map(
-        appointment => {
-          const updatedAppointment = { ...appointment };
-          // If field exists in object we will replace the TZ part of the string.
-          timeFields.forEach(field => {
-            if (field in updatedAppointment) {
-              updatedAppointment[field] = updatedAppointment[field].replace(
-                /(?=\.).*/,
-                '',
-              );
-            }
-          });
-          return updatedAppointment;
-        },
-      );
-      return { ...state, appointments: updatedAppointments };
+      let payload = JSON.parse(JSON.stringify(action.payload));
+      if ('appointments' in payload) {
+        payload = removeTimeZone(payload);
+      }
+      return { ...state, ...payload };
     }
     case RECEIVED_DEMOGRAPHICS_DATA:
       return { ...state, ...action.payload };

--- a/src/applications/check-in/reducers/reducer.unit.spec.js
+++ b/src/applications/check-in/reducers/reducer.unit.spec.js
@@ -60,7 +60,7 @@ describe('check-in', () => {
 
       it('should set appointment', () => {
         const data = {
-          startTime: '2021-08-19T13:56:31',
+          startTime: '2021-08-19T13:56:31.000-07:00',
           facility: 'LOMA LINDA VA CLINIC',
           clinicPhoneNumber: '5551234567',
           clinicFriendlyName: 'TEST CLINIC',
@@ -72,6 +72,7 @@ describe('check-in', () => {
         expect(state.appointments).to.be.an('array');
 
         expect(state.appointments[0]).haveOwnProperty('startTime');
+        expect(state.appointments[0].startTime).to.equal('2021-08-19T13:56:31');
         expect(state.appointments[0]).haveOwnProperty('facility');
         expect(state.appointments[0]).haveOwnProperty('clinicPhoneNumber');
         expect(state.appointments[0]).haveOwnProperty('clinicFriendlyName');

--- a/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.js
+++ b/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.js
@@ -139,7 +139,7 @@ describe('check in', () => {
     });
     describe('removeTimeZone', () => {
       it('removes timezone from date strings', () => {
-        const payload = {
+        const payloadWithTZ = {
           appointments: [
             {
               checkInWindowEnd: '2018-01-01T00:00:00.070Z',
@@ -149,17 +149,40 @@ describe('check in', () => {
             },
           ],
         };
-        const updatedPayload = removeTimeZone(payload);
-        expect(updatedPayload.appointments[0].checkInWindowEnd).to.equal(
+        const payloadWithoutTZ = {
+          appointments: [
+            {
+              checkInWindowEnd: '2018-01-01T00:00:00',
+              checkInWindowStart: '2018-01-01T00:00:00',
+              checkedInTime: '2018-01-01T00:00:00',
+              startTime: '2018-01-01T00:00:00',
+            },
+          ],
+        };
+        const updatedPayloadWithTZ = removeTimeZone(payloadWithTZ);
+        const updatedPayloadWithoutTZ = removeTimeZone(payloadWithoutTZ);
+        expect(updatedPayloadWithTZ.appointments[0].checkInWindowEnd).to.equal(
           '2018-01-01T00:00:00',
         );
-        expect(updatedPayload.appointments[0].checkInWindowStart).to.equal(
+        expect(
+          updatedPayloadWithTZ.appointments[0].checkInWindowStart,
+        ).to.equal('2018-01-01T00:00:00');
+        expect(updatedPayloadWithTZ.appointments[0].checkedInTime).to.equal(
           '2018-01-01T00:00:00',
         );
-        expect(updatedPayload.appointments[0].checkedInTime).to.equal(
+        expect(updatedPayloadWithTZ.appointments[0].startTime).to.equal(
           '2018-01-01T00:00:00',
         );
-        expect(updatedPayload.appointments[0].startTime).to.equal(
+        expect(
+          updatedPayloadWithoutTZ.appointments[0].checkInWindowEnd,
+        ).to.equal('2018-01-01T00:00:00');
+        expect(
+          updatedPayloadWithoutTZ.appointments[0].checkInWindowStart,
+        ).to.equal('2018-01-01T00:00:00');
+        expect(updatedPayloadWithoutTZ.appointments[0].checkedInTime).to.equal(
+          '2018-01-01T00:00:00',
+        );
+        expect(updatedPayloadWithoutTZ.appointments[0].startTime).to.equal(
           '2018-01-01T00:00:00',
         );
       });

--- a/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.js
+++ b/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import {
   hasMoreAppointmentsToCheckInto,
   sortAppointmentsByStartTime,
+  removeTimeZone,
 } from './index';
 import { createAppointment } from '../../api/local-mock-api/mocks/v2/patient.check.in.responses';
 
@@ -133,6 +134,33 @@ describe('check in', () => {
         const sortedAppointments = [earliest, midday, latest];
         expect(sortAppointmentsByStartTime(appointments)).to.deep.equal(
           sortedAppointments,
+        );
+      });
+    });
+    describe('removeTimeZone', () => {
+      it('removes timezone from date strings', () => {
+        const payload = {
+          appointments: [
+            {
+              checkInWindowEnd: '2018-01-01T00:00:00.070Z',
+              checkInWindowStart: '2018-01-01T00:00:00.070Z',
+              checkedInTime: '2018-01-01T00:00:00.070Z',
+              startTime: '2018-01-01T00:00:00.070Z',
+            },
+          ],
+        };
+        const updatedPayload = removeTimeZone(payload);
+        expect(updatedPayload.appointments[0].checkInWindowEnd).to.equal(
+          '2018-01-01T00:00:00',
+        );
+        expect(updatedPayload.appointments[0].checkInWindowStart).to.equal(
+          '2018-01-01T00:00:00',
+        );
+        expect(updatedPayload.appointments[0].checkedInTime).to.equal(
+          '2018-01-01T00:00:00',
+        );
+        expect(updatedPayload.appointments[0].startTime).to.equal(
+          '2018-01-01T00:00:00',
         );
       });
     });

--- a/src/applications/check-in/utils/appointment/index.js
+++ b/src/applications/check-in/utils/appointment/index.js
@@ -19,4 +19,39 @@ const sortAppointmentsByStartTime = appointments => {
       ]
     : [];
 };
-export { hasMoreAppointmentsToCheckInto, sortAppointmentsByStartTime };
+
+const removeTimeZone = payload => {
+  // Grabing the appointment payload and stripping out timezone here.
+  // Chip should be handling this but currently isn't, this code may be refactored out.
+  const updatedPayload = { ...payload };
+  // These fields have a potential to include a time stamp.
+  const timeFields = [
+    'checkInWindowEnd',
+    'checkInWindowStart',
+    'checkedInTime',
+    'startTime',
+  ];
+
+  const updatedAppointments = updatedPayload.appointments.map(appointment => {
+    const updatedAppointment = { ...appointment };
+    // If field exists in object we will replace the TZ part of the string.
+    timeFields.forEach(field => {
+      if (field in updatedAppointment) {
+        updatedAppointment[field] = updatedAppointment[field].replace(
+          /(?=\.).*/,
+          '',
+        );
+      }
+    });
+    return updatedAppointment;
+  });
+
+  updatedPayload.appointments = updatedAppointments;
+
+  return updatedPayload;
+};
+export {
+  hasMoreAppointmentsToCheckInto,
+  sortAppointmentsByStartTime,
+  removeTimeZone,
+};


### PR DESCRIPTION
## Description
CHIP should be sending the timestamp already converted for timezone. Some fields still of TZ values in the string. For now, we are striping the TZ part out to avoid any conversions. 

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#31247](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/31247)

## Testing done
Updated unit test for reducer

## Acceptance criteria
- [ ] Passes Accessibility checks using axe
- [ ] Deployed to staging.
- [ ]  Designer has signed off on the feature
- [ ]  Product team has signed off on the feature

## Definition of done
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
