### PR TITLE
Fix named exports from JSON modules for Webpack 5 upgrade

### DIFF
--- a/src/platform/forms-system/src/js/definitions/profileAddress.js
+++ b/src/platform/forms-system/src/js/definitions/profileAddress.js
@@ -5,12 +5,7 @@
 
 import React from 'react';
 import get from 'platform/utilities/data/get';
-import {
-  countries,
-  states,
-  militaryCities,
-  militaryStates,
-} from 'vets-json-schema/dist/constants.json';
+import constants from 'vets-json-schema/dist/constants.json';
 
 /**
  * PATTERNS
@@ -20,7 +15,7 @@ import {
 const STREET_PATTERN = '^.*\\S.*';
 const US_POSTAL_CODE_PATTERN = '^\\d{5}$';
 // filtered States that include US territories
-const filteredStates = states.USA.filter(
+const filteredStates = constants.states.USA.filter(
   state => !['AA', 'AE', 'AP'].includes(state.value),
 );
 
@@ -38,8 +33,8 @@ const filteredStates = states.USA.filter(
       },
       country: {
         type: 'string',
-        enum: countries.map(country => country.value),
-        enumNames: countries.map(country => country.label),
+        enum: constants.countries.map(country => country.value),
+        enumNames: constants.countries.map(country => country.label),
       },
       street: {
         type: 'string',
@@ -163,8 +158,8 @@ export default function addressUiSchema(
           countryUI['ui:disabled'] = false;
           return {
             type: 'string',
-            enum: countries.map(country => country.value),
-            enumNames: countries.map(country => country.label),
+            enum: constants.countries.map(country => country.value),
+            enumNames: constants.countries.map(country => country.label),
           };
         },
       },
@@ -209,8 +204,8 @@ export default function addressUiSchema(
             return {
               type: 'string',
               title: 'APO/FPO/DPO',
-              enum: militaryCities.map(city => city.value),
-              enumNames: militaryCities.map(city => city.label),
+              enum: constants.militaryCities.map(city => city.value),
+              enumNames: constants.militaryCities.map(city => city.label),
             };
           }
           return {
@@ -253,8 +248,8 @@ export default function addressUiSchema(
             return {
               type: 'string',
               title: 'State',
-              enum: militaryStates.map(state => state.value),
-              enumNames: militaryStates.map(state => state.label),
+              enum: constants.militaryStates.map(state => state.value),
+              enumNames: constants.militaryStates.map(state => state.label),
             };
           } else if (!isMilitary && country === 'USA') {
             return {

--- a/src/platform/forms-system/test/js/definitions/address.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/definitions/address.unit.spec.jsx
@@ -7,8 +7,9 @@ import {
   fillData,
 } from 'platform/testing/unit/schemaform-utils.jsx';
 import { schema, uiSchema } from '../../../src/js/definitions/address';
-import { address } from 'vets-json-schema/dist/definitions.json';
+import definitions from 'vets-json-schema/dist/definitions.json';
 
+const { address } = definitions;
 const addressSchema = {
   definitions: {
     address,

--- a/src/platform/forms-system/test/js/definitions/bankAccount.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/definitions/bankAccount.unit.spec.jsx
@@ -6,12 +6,12 @@ import Form from '@department-of-veterans-affairs/react-jsonschema-form';
 
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import uiSchema from '../../../src/js/definitions/bankAccount';
-import { bankAccount } from 'vets-json-schema/dist/definitions.json';
+import definitions from 'vets-json-schema/dist/definitions.json';
 
 describe('Schemaform definition bankAccount', () => {
   it('should render bankAccount', () => {
     const form = ReactTestUtils.renderIntoDocument(
-      <DefinitionTester schema={bankAccount} uiSchema={uiSchema} />,
+      <DefinitionTester schema={definitions.bankAccount} uiSchema={uiSchema} />,
     );
 
     const formDOM = findDOMNode(form);
@@ -27,7 +27,7 @@ describe('Schemaform definition bankAccount', () => {
   });
   it('should render bankAccount with routing number error', () => {
     const form = ReactTestUtils.renderIntoDocument(
-      <DefinitionTester schema={bankAccount} uiSchema={uiSchema} />,
+      <DefinitionTester schema={definitions.bankAccount} uiSchema={uiSchema} />,
     );
 
     const formDOM = findDOMNode(form);

--- a/src/platform/forms-system/test/js/definitions/date.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/definitions/date.unit.spec.jsx
@@ -6,12 +6,12 @@ import Form from '@department-of-veterans-affairs/react-jsonschema-form';
 
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import uiSchema from '../../../src/js/definitions/date';
-import { date as schema } from 'vets-json-schema/dist/definitions.json';
+import definitions from 'vets-json-schema/dist/definitions.json';
 
 describe('Schemaform definition date', () => {
   it('should render date', () => {
     const form = ReactTestUtils.renderIntoDocument(
-      <DefinitionTester schema={schema} uiSchema={uiSchema()} />,
+      <DefinitionTester schema={definitions.date} uiSchema={uiSchema()} />,
     );
 
     const formDOM = findDOMNode(form);
@@ -24,7 +24,7 @@ describe('Schemaform definition date', () => {
   it('should render invalid date error', () => {
     const dateUISchema = uiSchema();
     const form = ReactTestUtils.renderIntoDocument(
-      <DefinitionTester schema={schema} uiSchema={dateUISchema} />,
+      <DefinitionTester schema={definitions.date} uiSchema={dateUISchema} />,
     );
 
     const formDOM = findDOMNode(form);
@@ -44,7 +44,10 @@ describe('Schemaform definition date', () => {
   });
   it('should render date title', () => {
     const form = ReactTestUtils.renderIntoDocument(
-      <DefinitionTester schema={schema} uiSchema={uiSchema('My date')} />,
+      <DefinitionTester
+        schema={definitions.date}
+        uiSchema={uiSchema('My date')}
+      />,
     );
 
     const formDOM = findDOMNode(form);

--- a/src/platform/forms-system/test/js/definitions/dateRange.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/definitions/dateRange.unit.spec.jsx
@@ -6,10 +6,9 @@ import Form from '@department-of-veterans-affairs/react-jsonschema-form';
 
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import uiSchema from '../../../src/js/definitions/dateRange';
-import {
-  dateRange as schema,
-  date,
-} from 'vets-json-schema/dist/definitions.json';
+import definitions from 'vets-json-schema/dist/definitions.json';
+
+const { dateRange: schema, date } = definitions;
 
 function fillDate(find, toFrom, day, month, year) {
   ReactTestUtils.Simulate.change(find(`#root_${toFrom}Day`), {

--- a/src/platform/forms-system/test/js/definitions/fullName.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/definitions/fullName.unit.spec.jsx
@@ -5,12 +5,12 @@ import ReactTestUtils from 'react-dom/test-utils';
 
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import uiSchema from '../../../src/js/definitions/fullName';
-import { fullName as schema } from 'vets-json-schema/dist/definitions.json';
+import definitions from 'vets-json-schema/dist/definitions.json';
 
 describe('Schemaform definition fullName', () => {
   it('should render fullName', () => {
     const form = ReactTestUtils.renderIntoDocument(
-      <DefinitionTester schema={schema} uiSchema={uiSchema} />,
+      <DefinitionTester schema={definitions.fullName} uiSchema={uiSchema} />,
     );
 
     const formDOM = findDOMNode(form);

--- a/src/platform/forms-system/test/js/definitions/phone.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/definitions/phone.unit.spec.jsx
@@ -6,13 +6,13 @@ import Form from '@department-of-veterans-affairs/react-jsonschema-form';
 
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import uiSchema from '../../../src/js/definitions/phone';
-import { phone as schema } from 'vets-json-schema/dist/definitions.json';
+import definitions from 'vets-json-schema/dist/definitions.json';
 
 describe('Schemaform definition phone', () => {
   it('should render phone', () => {
     const phoneUiSchema = uiSchema();
     const form = ReactTestUtils.renderIntoDocument(
-      <DefinitionTester schema={schema} uiSchema={phoneUiSchema} />,
+      <DefinitionTester schema={definitions.phone} uiSchema={phoneUiSchema} />,
     );
 
     const formDOM = findDOMNode(form);
@@ -28,7 +28,10 @@ describe('Schemaform definition phone', () => {
   });
   it('should render phone title', () => {
     const form = ReactTestUtils.renderIntoDocument(
-      <DefinitionTester schema={schema} uiSchema={uiSchema('My phone')} />,
+      <DefinitionTester
+        schema={definitions.phone}
+        uiSchema={uiSchema('My phone')}
+      />,
     );
 
     const formDOM = findDOMNode(form);
@@ -37,7 +40,7 @@ describe('Schemaform definition phone', () => {
   });
   it('should render minLength phone error', () => {
     const form = ReactTestUtils.renderIntoDocument(
-      <DefinitionTester schema={schema} uiSchema={uiSchema()} />,
+      <DefinitionTester schema={definitions.phone} uiSchema={uiSchema()} />,
     );
 
     const formDOM = findDOMNode(form);

--- a/src/platform/forms-system/test/js/definitions/ssn.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/definitions/ssn.unit.spec.jsx
@@ -5,12 +5,12 @@ import ReactTestUtils from 'react-dom/test-utils';
 
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import uiSchema from '../../../src/js/definitions/ssn';
-import { ssn as schema } from 'vets-json-schema/dist/definitions.json';
+import definitions from 'vets-json-schema/dist/definitions.json';
 
 describe('Schemaform definition ssn', () => {
   it('should render ssn with error', () => {
     const form = ReactTestUtils.renderIntoDocument(
-      <DefinitionTester schema={schema} uiSchema={uiSchema} />,
+      <DefinitionTester schema={definitions.ssn} uiSchema={uiSchema} />,
     );
 
     const formDOM = findDOMNode(form);
@@ -37,7 +37,7 @@ describe('Schemaform definition ssn', () => {
     const form = ReactTestUtils.renderIntoDocument(
       <DefinitionTester
         reviewMode
-        schema={schema}
+        schema={definitions.ssn}
         uiSchema={uiSchema}
         data="123456789"
       />,

--- a/src/platform/forms/address/data/index.js
+++ b/src/platform/forms/address/data/index.js
@@ -1,8 +1,8 @@
-import { states as statesList } from 'vets-json-schema/dist/constants.json';
+import constants from 'vets-json-schema/dist/constants.json';
 
 // create an object of states using this pattern - {abbreviation}: {full name}
 // e.g. "DC": "District of Columnbia"
-const states = statesList.USA.reduce(
+const states = constants.states.USA.reduce(
   (stateList, { value, label }) => ({
     ...stateList,
     [value]: label,

--- a/src/platform/forms/address/data/labels.js
+++ b/src/platform/forms/address/data/labels.js
@@ -1,7 +1,4 @@
-import {
-  states as STATES,
-  countries,
-} from 'vets-json-schema/dist/constants.json';
+import constants from 'vets-json-schema/dist/constants.json';
 
 export const branchCodeLabels = {
   A: 'Army',
@@ -11,11 +8,11 @@ export const branchCodeLabels = {
   M: 'Marine Corps',
 };
 
-export const countryValues = countries.map(country => country.value);
-export const countryLabels = countries.map(country => country.label);
+export const countryValues = constants.countries.map(country => country.value);
+export const countryLabels = constants.countries.map(country => country.label);
 
 const { CAN, MEX, USA } = ['USA', 'MEX', 'CAN'].reduce((acc, country) => {
-  acc[country] = STATES[country].map(state => state.label);
+  acc[country] = constants.states[country].map(state => state.label);
   return acc;
 }, {});
 

--- a/src/platform/forms/address/index.js
+++ b/src/platform/forms/address/index.js
@@ -1,10 +1,10 @@
-import { states, countries } from 'vets-json-schema/dist/constants.json';
+import constants from 'vets-json-schema/dist/constants.json';
 
 // states.USA_OTHER = states.USA.concat([{ label: 'Other', value: 'Other' }]).sort(
 //   (a, b) => a.label.localeCompare(b.label),
 // );
 
-export { countries, states };
+export const { countries, states } = constants;
 
 export function isValidUSZipCode(value) {
   return /(^\d{5}$)|(^\d{5}[ -]{0,1}\d{4}$)/.test(value);

--- a/src/platform/forms/tests/definitions/address.unit.spec.jsx
+++ b/src/platform/forms/tests/definitions/address.unit.spec.jsx
@@ -13,8 +13,9 @@ import {
   requireStateWithCountry,
   requireStateWithData,
 } from '../../definitions/address';
-import { address } from 'vets-json-schema/dist/definitions.json';
+import definitions from 'vets-json-schema/dist/definitions.json';
 
+const { address } = definitions;
 const addressSchema = {
   definitions: {
     address,

--- a/src/platform/forms/tests/definitions/bankAccount.unit.spec.jsx
+++ b/src/platform/forms/tests/definitions/bankAccount.unit.spec.jsx
@@ -6,12 +6,12 @@ import Form from '@department-of-veterans-affairs/react-jsonschema-form';
 
 import { DefinitionTester } from '../../../testing/unit/schemaform-utils.jsx';
 import uiSchema from '../../definitions/bankAccount';
-import { bankAccount } from 'vets-json-schema/dist/definitions.json';
+import definitions from 'vets-json-schema/dist/definitions.json';
 
 describe('Schemaform definition bankAccount', () => {
   it('should render bankAccount', () => {
     const form = ReactTestUtils.renderIntoDocument(
-      <DefinitionTester schema={bankAccount} uiSchema={uiSchema} />,
+      <DefinitionTester schema={definitions.bankAccount} uiSchema={uiSchema} />,
     );
 
     const formDOM = findDOMNode(form);
@@ -27,7 +27,7 @@ describe('Schemaform definition bankAccount', () => {
   });
   it('should render bankAccount with routing number error', () => {
     const form = ReactTestUtils.renderIntoDocument(
-      <DefinitionTester schema={bankAccount} uiSchema={uiSchema} />,
+      <DefinitionTester schema={definitions.bankAccount} uiSchema={uiSchema} />,
     );
 
     const formDOM = findDOMNode(form);

--- a/src/platform/forms/tests/definitions/fullName.unit.spec.jsx
+++ b/src/platform/forms/tests/definitions/fullName.unit.spec.jsx
@@ -5,12 +5,12 @@ import ReactTestUtils from 'react-dom/test-utils';
 
 import { DefinitionTester } from '../../../testing/unit/schemaform-utils.jsx';
 import uiSchema from '../../definitions/fullName';
-import { fullName as schema } from 'vets-json-schema/dist/definitions.json';
+import definitions from 'vets-json-schema/dist/definitions.json';
 
 describe('Schemaform definition fullName', () => {
   it('should render fullName', () => {
     const form = ReactTestUtils.renderIntoDocument(
-      <DefinitionTester schema={schema} uiSchema={uiSchema} />,
+      <DefinitionTester schema={definitions.fullName} uiSchema={uiSchema} />,
     );
 
     const formDOM = findDOMNode(form);

--- a/src/platform/user/profile/vap-svc/constants/index.js
+++ b/src/platform/user/profile/vap-svc/constants/index.js
@@ -1,4 +1,4 @@
-import { states } from 'vets-json-schema/dist/constants.json';
+import constants from 'vets-json-schema/dist/constants.json';
 import countries from './countries.json';
 
 import ADDRESS_DATA from 'platform/forms/address/data';
@@ -6,7 +6,7 @@ import ADDRESS_DATA from 'platform/forms/address/data';
 export const MILITARY_STATES = new Set(ADDRESS_DATA.militaryStates);
 
 export const ADDRESS_FORM_VALUES = {
-  STATES: states.USA.map(state => state.value),
+  STATES: constants.states.USA.map(state => state.value),
   COUNTRIES: countries.map(country => country.countryName),
   COUNTRY_ISO3_CODES: countries.map(country => country.countryCodeISO3),
   MILITARY_STATES,


### PR DESCRIPTION
## Description
In preparation to upgrade `Webpack` to version 5. There is a breaking change that needs to be fixed before it can be done.

Based on the `Webpack` [migration guide](https://webpack.js.org/migrate/5/), it is important to fix all [named exports from JSON modules](https://webpack.js.org/migrate/5/#using-named-exports-from-json-modules) because it's no longer supported

By using:
```
rg "import .*\} from '.*\.json'" --files-with-matches
```

We get this list:

![Screen Shot 2021-10-20 at 1 09 43 PM](https://user-images.githubusercontent.com/55560129/138141153-6ed142d5-0a92-42e6-8955-db6b7c693366.png)


This PR will only fixed the files under `src/platform/`

## Original issue(s)
department-of-veterans-affairs/va.gov-team#11510


## Testing done
Locally

After fixing all issues

![Screen Shot 2021-10-20 at 1 23 32 PM](https://user-images.githubusercontent.com/55560129/138141351-efb85fbf-6c52-404e-9e3d-1f9e9c6a5466.png)

## Acceptance criteria
- [ ] Remove all instances of named exports from JSON modules

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
