### PR TITLE
HLR: Replace CTA widget & show action links

### DIFF
--- a/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
@@ -85,6 +85,7 @@ export class IntroductionPage extends React.Component {
       return (
         <SaveInProgressIntro
           formId={formId}
+          headingLevel={2}
           prefillEnabled={prefillEnabled}
           messages={savedFormMessages}
           pageList={route.pageList}

--- a/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
@@ -9,7 +9,6 @@ import Telephone, {
 import recordEvent from 'platform/monitoring/record-event';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
-import CallToActionWidget from 'applications/static-pages/cta-widget';
 import { focusElement } from 'platform/utilities/ui';
 import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
 import { isEmptyAddress } from 'platform/forms/address/helpers';
@@ -19,8 +18,9 @@ import {
   WIZARD_STATUS_NOT_STARTED,
   WIZARD_STATUS_COMPLETE,
 } from 'platform/site-wide/wizard';
-
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
+import { isLoggedIn, selectProfile } from 'platform/user/selectors';
+
 import {
   BASE_URL,
   SUPPLEMENTAL_CLAIM_URL,
@@ -72,8 +72,8 @@ export class IntroductionPage extends React.Component {
     scrollToTop();
   };
 
-  getCallToActionContent = () => {
-    const { route, contestableIssues, delay = 250 } = this.props;
+  getCallToActionContent = ({ last } = {}) => {
+    const { loggedIn, route, contestableIssues, delay = 250 } = this.props;
 
     if (contestableIssues?.error) {
       return showContestableIssueError(contestableIssues, delay);
@@ -81,7 +81,7 @@ export class IntroductionPage extends React.Component {
 
     const { formId, prefillEnabled, savedFormMessages } = route.formConfig;
 
-    if (contestableIssues?.issues?.length > 0) {
+    if (!loggedIn || contestableIssues?.issues?.length > 0) {
       return (
         <SaveInProgressIntro
           formId={formId}
@@ -91,6 +91,9 @@ export class IntroductionPage extends React.Component {
           startText="Start the Request for a Higher-Level Review"
           gaStartEventName="decision-reviews-va20-0996-start-form"
           ariaDescribedby="main-content"
+          hideUnauthedStartLink
+          testActionLink
+          buttonOnly={last}
         />
       );
     }
@@ -116,16 +119,14 @@ export class IntroductionPage extends React.Component {
 
   render() {
     const {
-      user,
+      loggedIn,
+      savedForms,
       hasEmptyAddress,
       route,
       isProduction = IS_PRODUCTION, // for unit tests
     } = this.props;
-    const callToActionContent = this.getCallToActionContent();
-    const showWizard = shouldShowWizard(
-      route.formConfig.formId,
-      user.profile.savedForms,
-    );
+
+    const showWizard = shouldShowWizard(route.formConfig.formId, savedForms);
 
     // Change page title once wizard has closed to provide a Veteran using a
     // screenreader some indication that the content has changed
@@ -135,7 +136,7 @@ export class IntroductionPage extends React.Component {
     const subTitle = 'Equal to VA Form 20-0996 (Higher-Level Review)';
 
     // check if user has address
-    if (user?.login?.currentlyLoggedIn && hasEmptyAddress) {
+    if (loggedIn && hasEmptyAddress) {
       return (
         <article className="schemaform-intro">
           <FormTitle title={pageTitle} subTitle={subTitle} />
@@ -151,13 +152,8 @@ export class IntroductionPage extends React.Component {
     return (
       <article className="schemaform-intro">
         <FormTitle title={pageTitle} subTitle={subTitle} />
-        <CallToActionWidget
-          appId="higher-level-review"
-          headerLevel={2}
-          ariaDescribedby="main-content"
-        >
-          {callToActionContent}
-        </CallToActionWidget>
+        {this.getCallToActionContent()}
+
         <h2 id="main-content" className="vads-u-font-size--h3">
           What’s a Higher-Level Review?
         </h2>
@@ -259,13 +255,9 @@ export class IntroductionPage extends React.Component {
             </li>
           </ol>
         </div>
-        <CallToActionWidget
-          appId="higher-level-review"
-          headerLevel={2}
-          ariaDescribedby="main-content"
-        >
-          {callToActionContent}
-        </CallToActionWidget>
+
+        {this.getCallToActionContent({ last: true })}
+
         <div className="omb-info--container vads-u-padding-left--0">
           <OMBInfo resBurden={15} ombNumber="2900-0862" expDate="04/30/2024" />
         </div>
@@ -275,10 +267,11 @@ export class IntroductionPage extends React.Component {
 }
 
 function mapStateToProps(state) {
-  const { form, user, contestableIssues } = state;
+  const { form, contestableIssues } = state;
   return {
     form,
-    user,
+    loggedIn: isLoggedIn(state),
+    savedForms: selectProfile(state).savedForms,
     contestableIssues,
     hasEmptyAddress: isEmptyAddress(
       selectVAPContactInfoField(state, FIELD_NAMES.MAILING_ADDRESS),

--- a/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
@@ -62,15 +62,8 @@ describe('IntroductionPage', () => {
   });
 
   it('should show has empty address message', () => {
-    const user = {
-      ...defaultProps.user,
-      login: {
-        currentlyLoggedIn: true,
-      },
-    };
-
     const tree = shallow(
-      <IntroductionPage {...defaultProps} user={user} hasEmptyAddress />,
+      <IntroductionPage {...defaultProps} loggedIn hasEmptyAddress />,
     );
 
     const alert = tree.find('va-alert');
@@ -79,14 +72,16 @@ describe('IntroductionPage', () => {
     tree.unmount();
   });
 
-  it('should render CallToActionWidget', () => {
+  it('should render SaveInProgressIntro', () => {
     setHlrWizardStatus(WIZARD_STATUS_COMPLETE);
     const tree = shallow(<IntroductionPage {...defaultProps} />);
 
-    const callToActionWidget = tree.find('Connect(CallToActionWidget)');
-    expect(callToActionWidget.length).to.equal(2);
-    expect(callToActionWidget.first().props().appId).to.equal(
-      'higher-level-review',
+    const saveInProgressIntro = tree.find(
+      'withRouter(Connect(SaveInProgressIntro))',
+    );
+    expect(saveInProgressIntro.length).to.equal(2);
+    expect(saveInProgressIntro.first().props().startText).to.contain(
+      'Higher-Level Review',
     );
     tree.unmount();
   });
@@ -126,6 +121,7 @@ describe('IntroductionPage', () => {
         error: '',
       },
       delay: 0,
+      loggedIn: true,
     };
 
     const tree = shallow(<IntroductionPage {...props} />);
@@ -150,8 +146,8 @@ describe('IntroductionPage', () => {
 
     const tree = shallow(<IntroductionPage {...props} />);
 
-    const Intro = tree.find('Connect(CallToActionWidget)').first();
-    expect(Intro.props().children.props.startText).to.include(
+    const Intro = tree.find('withRouter(Connect(SaveInProgressIntro))').first();
+    expect(Intro.props().startText).to.include(
       'Start the Request for a Higher-Level Review',
     );
     tree.unmount();
@@ -168,9 +164,8 @@ describe('IntroductionPage', () => {
     };
 
     const tree = shallow(<IntroductionPage {...props} />);
-
-    const Intro = tree.find('Connect(CallToActionWidget)').first();
-    expect(Intro.props().children.props.gaStartEventName).to.equal(
+    const Intro = tree.find('withRouter(Connect(SaveInProgressIntro))').first();
+    expect(Intro.props().gaStartEventName).to.equal(
       `${formConfig.trackingPrefix}start-form`,
     );
     tree.unmount();
@@ -191,7 +186,9 @@ describe('IntroductionPage', () => {
 
     const tree = shallow(<IntroductionPage {...props} />);
     expect(tree.find('Connect(WizardContainer)')).to.have.lengthOf(1);
-    expect(tree.find('Connect(CallToActionWidget)')).to.have.lengthOf(0);
+    expect(
+      tree.find('withRouter(Connect(SaveInProgressIntro))'),
+    ).to.have.lengthOf(0);
     tree.unmount();
   });
 });


### PR DESCRIPTION
## Description

Switching the sign in notification from the call-to-action widget, which doesn't give information about the save-in-progress system, to the save in progress component. This changed the green sign in button to a blue sign in button. But once you're signed in, the green start the form button is changed to an action link in this PR.

Note: The wizard start form "button" is already an action link

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/31699

## Testing done

Updated unit tests

## Screenshots

<details><summary>CTA to Save in progress</summary>

<!-- leave a blank line above -->
<img width="1456" alt="Screen Shot 2021-10-20 at 11 10 13 AM" src="https://user-images.githubusercontent.com/136959/138153793-d7a3a7d3-68f9-4a1f-ae91-da938763fc4a.png"></details>

<details><summary>Start the form action link</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-10-20 at 2 15 35 PM](https://user-images.githubusercontent.com/136959/138157314-81728af9-1ffc-4c10-9230-dcb7030a0de6.png)</details>

## Acceptance criteria
- [x] Green buttons changed to action links
- [x] Use Save in progress component instead of the CTA widgett

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
