### PR TITLE
31841: [Debt Portal] Create alert for PDF downloads

### DIFF
--- a/src/applications/debt-letters/components/DebtLettersDownload.jsx
+++ b/src/applications/debt-letters/components/DebtLettersDownload.jsx
@@ -75,6 +75,21 @@ const NoDebtLinks = () => (
   </div>
 );
 
+const DownloadLettersAlert = () => (
+  <va-alert
+    class="vads-u-margin-top--4 vads-u-margin-bottom--4"
+    status="warning"
+  >
+    <h3 slot="headline">Downloadable letters may have incorrect information</h3>
+    <p className="vads-u-font-size--base vads-u-font-family--sans">
+      We’re sorry. The letters available here for download may have incorrect
+      information about your repayment terms. Use the letters you get in the
+      mail for the correct information. We’ll post an update here when we’ve
+      fixed this problem.
+    </p>
+  </va-alert>
+);
+
 const DebtLettersDownload = ({
   debtLinks,
   isError,
@@ -124,6 +139,9 @@ const DebtLettersDownload = ({
           Download your debt letters, learn your payment options, or find out
           how to get help with your VA debts.
         </p>
+
+        <DownloadLettersAlert />
+
         <h2>Your debt letters</h2>
         <DebtLetters />
         <div className="vads-u-margin-bottom--6 vads-u-margin-top--5">


### PR DESCRIPTION
## Description
Alert informing users of incorrect information about their debts

## Original issue(s)
department-of-veterans-affairs/va.gov-team#31817
department-of-veterans-affairs/va.gov-team#31841


## Screenshots
![Your VA Debt  Veterans Affairs 2021-10-21 09-37-24](https://user-images.githubusercontent.com/7518899/138289136-fae35453-c91b-4e8b-9cc9-368f1a39d171.png)

## Acceptance criteria
- [x] alert should render on the download debt letters page

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs