### PR TITLE
Fix named exports from JSON modules

### DIFF
--- a/src/applications/disability-benefits/686c-674/containers/App.jsx
+++ b/src/applications/disability-benefits/686c-674/containers/App.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 
-import { rootUrl } from '../manifest.json';
+import manifest from '../manifest.json';
 import formConfig from '../config/form';
 
 function App({ location, children, isLoggedIn, isLoading, vaFileNumber }) {
@@ -30,7 +30,7 @@ function App({ location, children, isLoggedIn, isLoading, vaFileNumber }) {
     !isLoggedIn ||
     (isLoggedIn && !vaFileNumber?.hasVaFileNumber?.VALIDVAFILENUMBER)
   ) {
-    document.location.replace(`${rootUrl}`);
+    document.location.replace(`${manifest.rootUrl}`);
     return <LoadingIndicator message="Redirecting to introduction page..." />;
   }
 

--- a/src/applications/disability-benefits/686c-674/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/686c-674/containers/ConfirmationPage.jsx
@@ -5,7 +5,7 @@ import scrollToTop from 'platform/utilities/ui/scrollToTop';
 
 import { focusElement } from 'platform/utilities/ui';
 
-import { rootUrl } from '../manifest.json';
+import manifest from '../manifest.json';
 
 export class ConfirmationPage extends React.Component {
   componentDidMount() {
@@ -137,9 +137,9 @@ export class ConfirmationPage extends React.Component {
           </h2>
           <p className="vads-u-margin-bottom--6">
             If something changes in your family status let VA know. Return to
-            the <a href={rootUrl}>21-686c</a> form, select the option that
-            describes your family status change and complete the form. This will
-            update our records and your benefits pay will be adjusted
+            the <a href={manifest.rootUrl}>21-686c</a> form, select the option
+            that describes your family status change and complete the form. This
+            will update our records and your benefits pay will be adjusted
             accordingly.
           </p>
           <h2 className="vads-u-font-size--h3 vads-u-font-family--serif">

--- a/src/applications/disability-benefits/996/constants.js
+++ b/src/applications/disability-benefits/996/constants.js
@@ -1,4 +1,4 @@
-import { benefitTypes } from 'vets-json-schema/dist/constants.json';
+import constants from 'vets-json-schema/dist/constants.json';
 import environment from 'platform/utilities/environment';
 
 // *** URLS ***
@@ -82,7 +82,7 @@ const supportedBenefitTypes = [
   // 'nca',
 ];
 
-export const SUPPORTED_BENEFIT_TYPES = benefitTypes.map(type => ({
+export const SUPPORTED_BENEFIT_TYPES = constants.benefitTypes.map(type => ({
   ...type,
   isSupported: supportedBenefitTypes.includes(type.value),
 }));

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -1,5 +1,7 @@
-import { pciuStates as PCIU_STATES } from 'vets-json-schema/dist/constants.json';
+import constants from 'vets-json-schema/dist/constants.json';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
+
+const { pciuStates: PCIU_STATES } = constants;
 
 import {
   VA_FORM_IDS,

--- a/src/applications/personalization/view-dependents/components/ViewDependentsHeader/ViewDependentsHeader.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsHeader/ViewDependentsHeader.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import recordEvent from 'platform/monitoring/record-event';
-
-import { rootUrl as form686RootUrl } from 'applications/disability-benefits/686c-674/manifest.json';
+import manifest from 'applications/disability-benefits/686c-674/manifest.json';
 
 import { errorFragment } from '../../layouts/helpers';
+
+const { rootUrl: form686RootUrl } = manifest;
 
 const CALLSTATUS = {
   pending: 'pending',

--- a/src/applications/personalization/view-dependents/manage-dependents/schemas.js
+++ b/src/applications/personalization/view-dependents/manage-dependents/schemas.js
@@ -1,4 +1,4 @@
-import { countries, states } from 'vets-json-schema/dist/constants.json';
+import constants from 'vets-json-schema/dist/constants.json';
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
 import addressUiSchema from 'platform/forms-system/src/js/definitions/profileAddress';
 
@@ -17,7 +17,7 @@ const PATTERNS = {
 };
 
 // filtered states that include US territories
-const filteredStates = states.USA.filter(
+const filteredStates = constants.states.USA.filter(
   state => !['AA', 'AE', 'AP'].includes(state.value),
 );
 
@@ -56,10 +56,10 @@ const locationUiSchema = uiRequiredCallback => {
             return {
               type: 'string',
               title: 'Country where this happened',
-              enum: countries
+              enum: constants.countries
                 .filter(country => country.value !== 'USA')
                 .map(country => country.value),
-              enumNames: countries
+              enumNames: constants.countries
                 .filter(country => country.label !== 'United States')
                 .map(country => country.label),
             };
@@ -217,8 +217,8 @@ export const SCHEMAS = {
             },
             country: {
               type: 'string',
-              enum: countries.map(country => country.value),
-              enumNames: countries.map(country => country.label),
+              enum: constants.countries.map(country => country.value),
+              enumNames: constants.countries.map(country => country.label),
             },
             'view:militaryBaseDescription': {
               type: 'object',

--- a/src/applications/personalization/view-dependents/manage-dependents/tests/e2e/manage-dependents.cypress.spec.js
+++ b/src/applications/personalization/view-dependents/manage-dependents/tests/e2e/manage-dependents.cypress.spec.js
@@ -1,9 +1,9 @@
 import disableFTUXModals from '~/platform/user/tests/disableFTUXModals';
 import mockDependents from '../fixtures/mock-dependents.json';
 import mockUser from '../fixtures/mockUser.json';
-import { rootUrl } from '~/applications/personalization/view-dependents/manifest.json';
+import manifest from '~/applications/personalization/view-dependents/manifest.json';
 
-const VIEW_DEPENDENTS_PATH = rootUrl;
+const VIEW_DEPENDENTS_PATH = manifest.rootUrl;
 const VIEW_DEPENDENTS_ENDPOINT = '/v0/dependents_applications/show';
 const FORM_686_ENDPOINT = '/v0/dependents_applications';
 

--- a/src/applications/personalization/view-dependents/tests/e2e/view-dependents.cypress.spec.js
+++ b/src/applications/personalization/view-dependents/tests/e2e/view-dependents.cypress.spec.js
@@ -1,4 +1,4 @@
-import { rootUrl } from '../../manifest.json';
+import manifest from '../../manifest.json';
 import mockDependents from './fixtures/mock-dependents.json';
 import mockNoAwardDependents from './fixtures/mock-no-dependents-on-award.json';
 
@@ -11,7 +11,7 @@ const testAxe = () => {
 
 const testHappyPath = () => {
   cy.intercept('GET', DEPENDENTS_ENDPOINT, mockDependents).as('mockDependents');
-  cy.visit(rootUrl);
+  cy.visit(manifest.rootUrl);
   testAxe();
   cy.findByRole('heading', { name: /Your VA Dependents/i }).should('exist');
   cy.findAllByRole('term', { name: /relationship/ }).should('have.length', 4);
@@ -22,7 +22,7 @@ const testNoDependentsOnAward = () => {
   cy.intercept('GET', DEPENDENTS_ENDPOINT, mockNoAwardDependents).as(
     'mockNoAwardDependents',
   );
-  cy.visit(rootUrl);
+  cy.visit(manifest.rootUrl);
   cy.findByText(
     'There are no dependents associated with your VA benefits',
   ).should('exist');
@@ -40,7 +40,7 @@ const testEmptyResponse = () => {
       },
     },
   }).as('emptyResponse');
-  cy.visit(rootUrl);
+  cy.visit(manifest.rootUrl);
   cy.findByRole('heading', {
     name: /We don’t have dependents information on file for you/i,
   }).should('exist');
@@ -60,7 +60,7 @@ const testServerError = () => {
     },
     statusCode: 500,
   }).as('serverError');
-  cy.visit(rootUrl);
+  cy.visit(manifest.rootUrl);
   cy.findByRole('heading', {
     name: /We’re sorry. Something went wrong on our end/i,
   }).should('exist');

--- a/src/applications/pre-need/tests/definitions/address.unit.spec.jsx
+++ b/src/applications/pre-need/tests/definitions/address.unit.spec.jsx
@@ -7,8 +7,9 @@ import {
   fillData,
 } from 'platform/testing/unit/schemaform-utils.jsx';
 import { schema, uiSchema } from '../../definitions/address';
-import { address } from 'vets-json-schema/dist/definitions.json';
+import definitions from 'vets-json-schema/dist/definitions.json';
 
+const { address } = definitions;
 const addressSchema = {
   definitions: {
     address,


### PR DESCRIPTION
## Description
In preparation to upgrade `Webpack` to version 5. There is a breaking change that needs to be fixed before it can be done.

Based on the `Webpack` [migration guide](https://webpack.js.org/migrate/5/), it is important to fix all [named exports from JSON modules](https://webpack.js.org/migrate/5/#using-named-exports-from-json-modules) because it's no longer supported

## Original issue(s)
department-of-veterans-affairs/va.gov-team#11510


## Testing done
Locally
