### PR TITLE
Refactor address validation Cypress tests with page objects

### DIFF
--- a/src/applications/personalization/profile/tests/e2e/address-validation/additional-address-lines.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/additional-address-lines.cypress.spec.js
@@ -1,34 +1,20 @@
-import { setUp } from '@@profile/tests/e2e/address-validation/setup';
+import AddressPage from './page-objects/AddressPage';
 
 describe('Personal and contact information', () => {
   context('when entering info on line two', () => {
     it('show show the address validation screen', () => {
-      setUp('valid-address');
-
-      cy.findByLabelText(/^street address \(/i)
-        .clear()
-        .type('36320 Coronado Dr');
-      cy.findByLabelText(/^street address line 2/i)
-        .clear()
-        .type('care of Care Taker');
-      cy.findByLabelText(/^street address line 3/i).clear();
-
-      cy.findByLabelText(/City/i)
-        .clear()
-        .type('Fremont');
-      cy.findByLabelText(/^State/).select('MD');
-      cy.findByLabelText(/Zip code/i)
-        .clear()
-        .type('94536');
-
-      cy.findByTestId('save-edit-button').click({
-        force: true,
-      });
-
-      cy.findByTestId('mailingAddress').should(
-        'contain',
-        'Please confirm your address',
-      );
+      const formFields = {
+        address: '36320 Coronado Dr',
+        address2: 'care of Care Taker',
+        city: 'Fremont',
+        state: 'CA',
+        zipCode: '94536',
+      };
+      const addressPage = new AddressPage();
+      addressPage.loadPage('valid-address');
+      addressPage.fillAddressForm(formFields);
+      addressPage.saveForm();
+      addressPage.confirmAddress(formFields);
     });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/additional-address-lines.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/additional-address-lines.cypress.spec.js
@@ -18,3 +18,4 @@ describe('Personal and contact information', () => {
     });
   });
 });
+

--- a/src/applications/personalization/profile/tests/e2e/address-validation/additional-address-lines.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/additional-address-lines.cypress.spec.js
@@ -18,4 +18,3 @@ describe('Personal and contact information', () => {
     });
   });
 });
-

--- a/src/applications/personalization/profile/tests/e2e/address-validation/bad-unit.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/bad-unit.cypress.spec.js
@@ -1,54 +1,26 @@
-import { setUp } from '@@profile/tests/e2e/address-validation/setup';
+import AddressPage from './page-objects/AddressPage';
 
 describe('Personal and contact information', () => {
   describe('when entering an address with a bad unit', () => {
     it('should successfully update on Desktop', () => {
-      setUp('bad-unit');
-      cy.axeCheck();
-
-      cy.findByLabelText(/^street address \(/i)
-        .clear()
-        .type('225 irving st');
-      cy.findByLabelText(/^street address line 2/i)
-        .clear()
-        .type('Unit A');
-
-      cy.findByLabelText(/^street address line 3/i).clear();
-
-      cy.findByLabelText(/City/i)
-        .clear()
-        .type('San Francisco');
-      cy.findByLabelText(/^State/).select('CA');
-      cy.findByLabelText(/Zip code/i)
-        .clear()
-        .type('94122');
-
-      cy.findByTestId('save-edit-button').click({
-        force: true,
-      });
-
-      cy.axeCheck();
-
-      cy.findByText('Please update or confirm your unit number').should(
-        'exist',
+      const formFields = {
+        address: '225 irving st',
+        address2: 'Unit A',
+        city: 'San Francisco',
+        state: 'CA',
+        zipCode: '94122',
+      };
+      const addressPage = new AddressPage();
+      addressPage.loadPage('bad-unit');
+      addressPage.fillAddressForm(formFields);
+      addressPage.saveForm();
+      addressPage.validateSavedForm(
+        formFields,
+        false,
+        'Please update or confirm your unit number',
       );
-
-      cy.findByTestId('mailingAddress').should(
-        'contain',
-        '225 irving st, Unit A',
-      );
-
-      cy.findByTestId('confirm-address-button').click({
-        force: true,
-      });
-
-      cy.findByTestId('mailingAddress')
-        .should('contain', '225 irving st, Unit A')
-        .and('contain', 'San Francisco, CA 94122');
-
-      cy.focused()
-        .invoke('text')
-        .should('match', /update saved/i);
+      addressPage.saveForm(true);
+      addressPage.confirmAddress(formFields, [], true);
     });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/confirm-address.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/confirm-address.cypress.spec.js
@@ -12,9 +12,6 @@ describe('Personal and contact information', () => {
       const addressPage = new AddressPage();
       addressPage.loadPage('confirm-address');
       addressPage.fillAddressForm(formFields);
-      cy.findByTestId('save-edit-button').click({
-        force: true,
-      });
       addressPage.saveForm();
       addressPage.confirmAddress(formFields);
       addressPage.validateSavedForm(formFields);

--- a/src/applications/personalization/profile/tests/e2e/address-validation/confirm-address.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/confirm-address.cypress.spec.js
@@ -16,18 +16,8 @@ describe('Personal and contact information', () => {
         force: true,
       });
       addressPage.saveForm();
-      addressPage.confirmAddressMessage(formFields);
-      cy.findByTestId('confirm-address-button').click({
-        force: true,
-      });
-
-      cy.findByTestId('mailingAddress')
-        .should('contain', '36310 Coronado Dr')
-        .and('contain', 'Fremont, CA 94536');
-
-      cy.focused()
-        .invoke('text')
-        .should('match', /update saved/i);
+      addressPage.confirmAddress(formFields);
+      addressPage.validateSavedForm(formFields);
     });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/confirm-address.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/confirm-address.cypress.spec.js
@@ -1,35 +1,22 @@
-import { setUp } from '@@profile/tests/e2e/address-validation/setup';
+import AddressPage from './page-objects/AddressPage';
 
 describe('Personal and contact information', () => {
   describe('when entering a valid address that needs confirmation', () => {
     it('should successfully update on Desktop', () => {
-      setUp('confirm-address');
-
-      cy.findByLabelText(/^street address \(/i)
-        .clear()
-        .type('36310 Coronado Dr');
-
-      cy.findByLabelText(/^street address line 2/i).clear();
-      cy.findByLabelText(/^street address line 3/i).clear();
-
-      cy.findByLabelText(/City/i)
-        .clear()
-        .type('Fremont');
-
-      cy.findByLabelText(/^State/).select('CA');
-
-      cy.findByLabelText(/Zip code/i)
-        .clear()
-        .type('94536');
-
+      const formFields = {
+        address: '36310 Coronado Dr',
+        city: 'Fremont',
+        state: 'CA',
+        zipCode: '94536',
+      };
+      const addressPage = new AddressPage();
+      addressPage.loadPage('confirm-address');
+      addressPage.fillAddressForm(formFields);
       cy.findByTestId('save-edit-button').click({
         force: true,
       });
-
-      cy.findByTestId('mailingAddress')
-        .should('contain', '36310 Coronado Dr')
-        .and('contain', 'Please confirm your address');
-
+      addressPage.saveForm();
+      addressPage.confirmAddressMessage(formFields);
       cy.findByTestId('confirm-address-button').click({
         force: true,
       });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/confirm-state-diff.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/confirm-state-diff.cypress.spec.js
@@ -1,24 +1,25 @@
-import { setUp } from 'applications/personalization/profile/tests/e2e/address-validation/setup';
+import AddressPage from './page-objects/AddressPage';
 
 describe('Personal and contact information', () => {
   describe('when user-input state does not match suggested address state', () => {
     it('should ask the user to confirm their address', () => {
       // This will return a single confirmed, high confidence address from the
       // validation API with a stateCode of 'CA'...
-      setUp('valid-address');
-
+      const formFields = {
+        address: '36320 Coronado Dr',
+        address2: 'care of Care Taker',
+        city: 'Fremont',
+        state: 'CA',
+        zipCode: '94536',
+      };
+      const addressPage = new AddressPage();
+      addressPage.loadPage('valid-address');
+      addressPage.fillAddressForm(formFields);
       // ...so we'll set our address's state as 'CO'...
-      cy.findByLabelText(/^State/).select('CO');
-
-      cy.findByTestId('save-edit-button').click({
-        force: true,
-      });
-
+      addressPage.fillAddressForm({ state: 'CO' });
+      addressPage.saveForm();
       // ...and expect to be asked to confirm our address
-      cy.findByTestId('mailingAddress').should(
-        'contain',
-        'Please confirm your address',
-      );
+      addressPage.confirmAddress(formFields);
     });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/edit-after-validation.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/edit-after-validation.cypress.spec.js
@@ -1,48 +1,28 @@
-import { setUp } from '@@profile/tests/e2e/address-validation/setup';
+import AddressPage from './page-objects/AddressPage';
 
 describe('Personal and contact information', () => {
   describe('when returning to the address edit form from the validation screen', () => {
     it('should prefill the address edit form with the address they had just entered, _not_ the address currently on file', () => {
-      const addressLine1 = '225 irving st';
-      const addressLine2 = 'Unit A';
-
-      setUp('bad-unit');
-      cy.axeCheck();
-
-      cy.findByRole('button', { name: /^Update$/i }).should(
-        'not.have.attr',
-        'disabled',
-      );
-
-      cy.findByLabelText(/^street address \(/i)
-        .clear()
-        .type(addressLine1);
-      cy.findAllByLabelText(/^street address line 2/i)
-        .clear()
-        .type(addressLine2);
-      cy.findAllByLabelText(/^street address line 3/i).clear();
-
-      cy.findByLabelText(/City/i)
-        .clear()
-        .type('San Francisco');
-      cy.findByLabelText(/^State/).select('CA');
-      cy.findByLabelText(/Zip code/i)
-        .clear()
-        .type('94122');
-
-      cy.axeCheck();
-
-      cy.findByRole('button', { name: /^Update$/i }).click({ force: true });
-
-      cy.axeCheck();
-
-      cy.findByText('Please update or confirm your unit number').should(
-        'exist',
+      const formFields = {
+        address: '225 irving st',
+        address2: 'Unit A',
+        city: 'San Francisco',
+        state: 'CA',
+        zipCode: '94122',
+      };
+      const addressPage = new AddressPage();
+      addressPage.loadPage('bad-unit');
+      addressPage.fillAddressForm(formFields);
+      addressPage.saveForm();
+      addressPage.validateSavedForm(
+        formFields,
+        false,
+        'Please update or confirm your unit number',
       );
 
       cy.findByTestId('mailingAddress').should(
         'contain',
-        `${addressLine1}, ${addressLine2}`,
+        `${formFields.address}, ${formFields.address2}`,
       );
 
       // click the edit address button to return to the edit view
@@ -51,11 +31,11 @@ describe('Personal and contact information', () => {
       // confirm the address we just entered is in the form
       cy.findByLabelText(/^street address \(/i).should(
         'have.value',
-        addressLine1,
+        formFields.address,
       );
       cy.findAllByLabelText(/^street address line 2/i).should(
         'have.value',
-        addressLine2,
+        formFields.address2,
       );
 
       // then click the update button to return to the validation screen

--- a/src/applications/personalization/profile/tests/e2e/address-validation/edit-after-validation.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/edit-after-validation.cypress.spec.js
@@ -19,39 +19,11 @@ describe('Personal and contact information', () => {
         false,
         'Please update or confirm your unit number',
       );
-
-      cy.findByTestId('mailingAddress').should(
-        'contain',
-        `${formFields.address}, ${formFields.address2}`,
+      addressPage.editAddress(
+        [/^street address \(/i, /^street address line 2/i],
+        [formFields.address, formFields.address2],
       );
-
-      // click the edit address button to return to the edit view
-      cy.findByRole('button', { name: /edit your address/i }).click();
-
-      // confirm the address we just entered is in the form
-      cy.findByLabelText(/^street address \(/i).should(
-        'have.value',
-        formFields.address,
-      );
-      cy.findAllByLabelText(/^street address line 2/i).should(
-        'have.value',
-        formFields.address2,
-      );
-
-      // then click the update button to return to the validation screen
-      cy.findByRole('button', { name: /^Update$/i }).click({ force: true });
-
-      cy.findByRole('button', { name: /^use this address$/i }).click({
-        force: true,
-      });
-
-      cy.findByTestId('mailingAddress')
-        .should('contain', '225 irving st, Unit A')
-        .and('contain', 'San Francisco, CA 94122');
-
-      cy.focused()
-        .invoke('text')
-        .should('match', /update saved/i);
+      addressPage.validateSavedForm(formFields);
     });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/international-address.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/international-address.cypress.spec.js
@@ -1,37 +1,22 @@
-import { setUp } from '@@profile/tests/e2e/address-validation/setup';
+import AddressPage from './page-objects/AddressPage';
 
 describe('Personal and contact information', () => {
   describe('when entering an international address', () => {
     it('should successfully update on Desktop', () => {
-      setUp('international');
-
-      cy.findByLabelText(/Country/i).select('NLD');
-
-      cy.findByLabelText(/^street address \(/i)
-        .clear()
-        .type('Dam 1');
-      cy.findByLabelText(/^street address line 2/i).clear();
-      cy.findByLabelText(/^street address line 3/i).clear();
-
-      cy.findByLabelText(/City/i)
-        .clear()
-        .type('Amsterdam');
-      cy.findByLabelText(/International postal code/i)
-        .clear()
-        .type('1012 JS');
-
-      cy.findByTestId('save-edit-button').click({
-        force: true,
-      });
-
-      cy.findByTestId('mailingAddress')
-        .should('contain', 'Dam 1')
-        .and('contain', 'Amsterdam, Noord-Holland, 1012 JS')
-        .and('contain', 'Netherlands');
-
-      cy.focused()
-        .invoke('text')
-        .should('match', /update saved/i);
+      const formFields = {
+        country: 'NLD',
+        address: 'Dam 1',
+        city: 'Amsterdam',
+        zipCodeInt: '1012 JS',
+      };
+      const addressPage = new AddressPage();
+      addressPage.loadPage('international');
+      addressPage.fillAddressForm(formFields);
+      addressPage.saveForm();
+      addressPage.validateSavedForm(formFields, true, null, [
+        'Noord-Holland',
+        'Netherlands',
+      ]);
     });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/low-confidence.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/low-confidence.cypress.spec.js
@@ -1,30 +1,22 @@
-import { setUp } from '@@profile/tests/e2e/address-validation/setup';
+import AddressPage from './page-objects/AddressPage';
 
 describe('Personal and contact information', () => {
   describe('when getting a single suggestion with a confidence score <90', () => {
     it('should show the validation view and successfully update', () => {
-      setUp('low-confidence');
-
-      cy.findByLabelText(/^street address \(/i)
-        .clear()
-        .type('36320 Coronado Dr');
-
-      cy.findByLabelText(/^street address line 2/i).clear();
-      cy.findByLabelText(/^street address line 3/i).clear();
-
-      cy.findByLabelText(/City/i)
-        .clear()
-        .type('Fremont');
-
-      cy.findByLabelText(/^State/).select('CA');
-
-      cy.findByLabelText(/Zip code/i)
-        .clear()
-        .type('94530');
-
-      cy.findByTestId('save-edit-button').click({
-        force: true,
-      });
+      const formFields = {
+        address: '36320 Coronado Dr',
+        city: 'Fremont',
+        state: 'CA',
+        zipCode: '94530',
+      };
+      const addressPage = new AddressPage();
+      addressPage.loadPage('low-confidence');
+      addressPage.fillAddressForm(formFields);
+      addressPage.saveForm();
+      addressPage.validateSavedForm(formFields, true, null, [
+        'Fremont, CA 94536',
+      ]);
+      // addressPage.confirmAddress(formFields);
 
       cy.findByTestId('mailingAddress')
         .should('contain', '36320 Coronado Dr')

--- a/src/applications/personalization/profile/tests/e2e/address-validation/low-confidence.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/low-confidence.cypress.spec.js
@@ -13,29 +13,10 @@ describe('Personal and contact information', () => {
       addressPage.loadPage('low-confidence');
       addressPage.fillAddressForm(formFields);
       addressPage.saveForm();
-      addressPage.validateSavedForm(formFields, true, null, [
+      addressPage.validateSavedForm(formFields, false, null, [
         'Fremont, CA 94536',
       ]);
-      // addressPage.confirmAddress(formFields);
-
-      cy.findByTestId('mailingAddress')
-        .should('contain', '36320 Coronado Dr')
-        .should('contain', 'Fremont, CA 94530')
-        .should('contain', '36320 Coronado Dr')
-        .should('contain', 'Fremont, CA 94536')
-        .and('contain', 'Please confirm your address');
-
-      cy.findByTestId('confirm-address-button').click({
-        force: true,
-      });
-
-      cy.findByTestId('mailingAddress')
-        .should('contain', '36320 Coronado Dr')
-        .and('contain', 'Fremont, CA 94536');
-
-      cy.focused()
-        .invoke('text')
-        .should('match', /update saved/i);
+      addressPage.confirmAddress(formFields);
     });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/military-address.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/military-address.cypress.spec.js
@@ -1,38 +1,19 @@
-import { setUp } from '@@profile/tests/e2e/address-validation/setup';
+import AddressPage from './page-objects/AddressPage';
 
 describe('Personal and contact information', () => {
   describe('when entering a military address', () => {
     it('should successfully update on Desktop', () => {
-      setUp('military');
-
-      cy.findByRole('checkbox', {
-        name: /I live on a.*military base/i,
-      }).check();
-
-      cy.findByLabelText(/^street address \(/i)
-        .clear()
-        .type('PSC 808 Box 37');
-      cy.findByLabelText(/^street address line 2/i).clear();
-      cy.findByLabelText(/^street address line 3/i).clear();
-
-      cy.get('#root_city').select('FPO');
-
-      cy.findByLabelText(/^State/).select('AE');
-      cy.findByLabelText(/Zip code/i)
-        .clear()
-        .type('09618');
-
-      cy.findByTestId('save-edit-button').click({
-        force: true,
-      });
-
-      cy.findByTestId('mailingAddress')
-        .should('contain', 'PSC 808 Box 37')
-        .and('contain', 'FPO, Armed Forces Europe');
-
-      cy.focused()
-        .invoke('text')
-        .should('match', /update saved/i);
+      const formFields = {
+        address: 'PSC 808 Box 37',
+        state: 'AE',
+        zipCode: '09618',
+        military: true,
+        postOffice: 'FPO',
+      };
+      const addressPage = new AddressPage();
+      addressPage.loadPage('military');
+      addressPage.fillAddressForm(formFields);
+      addressPage.saveForm();
     });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/missing-unit.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/missing-unit.cypress.spec.js
@@ -1,43 +1,20 @@
-import { setUp } from '@@profile/tests/e2e/address-validation/setup';
+import AddressPage from './page-objects/AddressPage';
 
 describe('Personal and contact information', () => {
   describe('when entering a home address with a missing unit', () => {
     it('should successfully update on Desktop', () => {
-      setUp('missing-unit');
-
-      cy.findByLabelText(/^street address \(/i)
-        .clear()
-        .type('225 irving st');
-      cy.findByLabelText(/^street address line 2/i).clear();
-      cy.findByLabelText(/^street address line 3/i).clear();
-
-      cy.findByLabelText(/City/i)
-        .clear()
-        .type('San Francisco');
-      cy.findByLabelText(/^State/).select('CA');
-      cy.findByLabelText(/Zip code/i)
-        .clear()
-        .type('94122');
-
-      cy.findByTestId('save-edit-button').click({
-        force: true,
-      });
-
-      cy.findByTestId('mailingAddress')
-        .should('contain', 'Please add a unit number')
-        .and('contain', '225 irving st');
-
-      cy.findByTestId('confirm-address-button').click({
-        force: true,
-      });
-
-      cy.findByTestId('mailingAddress')
-        .should('contain', '225 irving st')
-        .and('contain', 'San Francisco, CA 94122');
-
-      cy.focused()
-        .invoke('text')
-        .should('match', /update saved/i);
+      const formFields = {
+        address: '225 irving st',
+        city: 'San Francisco',
+        state: 'CA',
+        zipCode: '94122',
+      };
+      const addressPage = new AddressPage();
+      addressPage.loadPage('missing-unit');
+      addressPage.fillAddressForm(formFields);
+      addressPage.saveForm();
+      addressPage.confirmAddress(formFields, [], true, true);
+      addressPage.validateSavedForm(formFields);
     });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/no-changes-made.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/no-changes-made.cypress.spec.js
@@ -1,31 +1,22 @@
-import { setUp } from '@@profile/tests/e2e/address-validation/setup';
+import AddressPage from './page-objects/AddressPage';
 
 describe('Personal and contact information', () => {
   describe('when updating their address without actually making a change', () => {
     it('should quickly exit edit view', () => {
-      setUp('no-change');
-
-      // hit save without making any changes on the form
-      cy.findByRole('button', { name: /^update$/i }).should(
-        'not.have.attr',
-        'disabled',
-      );
-      cy.findByRole('button', { name: /^update$/i }).click({
-        force: true,
+      const formFields = {
+        address: '123 Test Street',
+        city: 'Waldorf',
+        state: 'MD',
+        zipCode: '20603',
+      };
+      const addressPage = new AddressPage();
+      addressPage.loadPage('no-change');
+      addressPage.updateWithoutChanges();
+      addressPage.validateSavedForm(formFields, false);
+      addressPage.validateFocusedElement({
+        tag: 'button',
+        name: /edit mailing address/i,
       });
-
-      // Use a short timeout to make sure that the edit view is exited quickly
-      // and not just because the logic that auto-exits the edit view took
-      // effect
-      cy.findByRole('button', { name: /^update$/i, timeout: 10 }).should(
-        'not.exist',
-      );
-
-      cy.findByTestId('mailingAddress').should('contain', '123 Test Street');
-
-      cy.findByRole('button', { name: /edit mailing address/i }).should(
-        'be.focused',
-      );
     });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/one-suggestion.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/one-suggestion.cypress.spec.js
@@ -1,44 +1,24 @@
-import { setUp } from '@@profile/tests/e2e/address-validation/setup';
+import AddressPage from './page-objects/AddressPage';
 
 describe('Personal and contact information', () => {
   describe('when entering a home address that has one suggestion', () => {
     it('should successfully update on Desktop', () => {
-      setUp('one-suggestion');
-
-      cy.findByLabelText(/^street address \(/i)
-        .clear()
-        .type('400 65th st');
-      cy.findByLabelText(/^street address line 2/i).clear();
-      cy.findByLabelText(/^street address line 3/i).clear();
-
-      cy.findByLabelText(/City/i)
-        .clear()
-        .type('Seattle');
-      cy.findByLabelText(/^State/).select('WA');
-      cy.findByLabelText(/Zip code/i)
-        .clear()
-        .type('12345');
-
-      cy.findByTestId('save-edit-button').click({
-        force: true,
+      const formFields = {
+        address: '400 65th st',
+        city: 'Seattle',
+        state: 'WA',
+        zipCode: '12345',
+      };
+      const addressPage = new AddressPage();
+      addressPage.loadPage('one-suggestion');
+      addressPage.fillAddressForm(formFields);
+      addressPage.saveForm();
+      addressPage.confirmAddress(formFields, ['400 NW 65th St']);
+      addressPage.validateSavedForm({
+        ...formFields,
+        address: '400 NW 65th St',
+        zipCode: 12345,
       });
-
-      cy.findByTestId('mailingAddress')
-        .should('contain', 'Please confirm your address')
-        .and('contain', '400 65th st')
-        .and('contain', '400 NW 65th St');
-
-      cy.findByTestId('confirm-address-button').click({
-        force: true,
-      });
-
-      cy.findByTestId('mailingAddress')
-        .should('contain', '400 NW 65th St')
-        .and('contain', 'Seattle, WA 98117');
-
-      cy.focused()
-        .invoke('text')
-        .should('match', /update saved/i);
     });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/page-objects/AddressPage.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/page-objects/AddressPage.js
@@ -7,6 +7,7 @@ class AddressPage {
   }
 
   fillAddressForm(fields) {
+    fields.country && cy.findByLabelText(/Country/i).select(fields.country);
     fields.military &&
       cy
         .findByRole('checkbox', {
@@ -40,6 +41,11 @@ class AddressPage {
         .findByLabelText(/Zip code/i)
         .clear()
         .type(fields.zipCode);
+    fields.zipCodeInt &&
+      cy
+        .findByLabelText(/International postal code/i)
+        .clear()
+        .type(fields.zipCodeInt);
   }
 
   saveForm(confirm = false) {
@@ -54,10 +60,25 @@ class AddressPage {
     }
   }
 
-  validateSavedForm(fields, saved = true, altText = null) {
-    cy.findByTestId('mailingAddress')
-      .should('contain', `${fields.address}`)
-      .and('contain', `${fields.city}, ${fields.state} ${fields.zipCode}`);
+  validateSavedForm(
+    fields,
+    saved = true,
+    altText = null,
+    additionalFields = [],
+  ) {
+    !fields.country &&
+      cy
+        .findByTestId('mailingAddress')
+        .should('contain', `${fields.address}`)
+        .and('contain', `${fields.city}, ${fields.state} ${fields.zipCode}`);
+    fields.country &&
+      cy
+        .findByTestId('mailingAddress')
+        .should('contain', `${fields.address}`)
+        .and('contain', `${fields.zipCodeInt}`);
+    additionalFields.forEach(field => {
+      cy.findByTestId('mailingAddress').should('contain', field);
+    });
     fields.military &&
       cy.findByTestId('mailingAddress').should('contain', 'FPO');
     saved &&
@@ -82,9 +103,20 @@ class AddressPage {
     });
   }
 
-  editAddress(fields) {
+  confirmAddressFields(labels, fields) {
+    labels.forEach((label, i) => {
+      cy.findByLabelText(label).should('have.value', fields[i]);
+      cy.findAllByLabelText(label).should('have.value', fields[i]);
+    });
+  }
+
+  editAddress(labels, fields) {
     cy.findByRole('button', { name: /edit your address/i }).click();
-    this.fillAddressForm(fields);
+    this.confirmAddressFields(labels, fields);
+    cy.findByRole('button', { name: /^Update$/i }).click({ force: true });
+    cy.findByRole('button', { name: /^use this address$/i }).click({
+      force: true,
+    });
   }
 }
 

--- a/src/applications/personalization/profile/tests/e2e/address-validation/page-objects/AddressPage.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/page-objects/AddressPage.js
@@ -1,3 +1,4 @@
+/* eslint no-unused-expressions: "off" */
 import { setUp } from '@@profile/tests/e2e/address-validation/setup';
 
 class AddressPage {
@@ -6,33 +7,34 @@ class AddressPage {
   }
 
   fillAddressForm(fields) {
-    // eslint-disable-next-line no-unused-expressions
+    fields.military &&
+      cy
+        .findByRole('checkbox', {
+          name: /I live on a.*military base/i,
+        })
+        .check();
+    fields.military && cy.get('#root_city').select('FPO');
     fields.address &&
       cy
         .findByLabelText(/^street address \(/i)
         .clear()
         .type(fields.address);
-    // eslint-disable-next-line no-unused-expressions
     fields.address2 &&
       cy
         .findByLabelText(/^street address line 2/i)
         .clear()
         .type(fields.address2);
-    // eslint-disable-next-line no-unused-expressions
     fields.address3 &&
       cy
         .findByLabelText(/^street address line 3/i)
         .clear()
         .type(fields.address3);
-    // eslint-disable-next-line no-unused-expressions
     fields.city &&
       cy
         .findByLabelText(/City/i)
         .clear()
         .type(fields.city);
-    // eslint-disable-next-line no-unused-expressions
     fields.state && cy.findByLabelText(/^State/).select(fields.state);
-    // eslint-disable-next-line no-unused-expressions
     fields.zipCode &&
       cy
         .findByLabelText(/Zip code/i)
@@ -50,15 +52,20 @@ class AddressPage {
     cy.findByTestId('mailingAddress')
       .should('contain', `${fields.address}`)
       .and('contain', `${fields.city}, ${fields.state} ${fields.zipCode}`);
+    fields.military &&
+      cy.findByTestId('mailingAddress').should('contain', 'FPO');
     cy.focused()
       .invoke('text')
       .should('match', /update saved/i);
   }
 
-  confirmAddress(fields) {
+  confirmAddress(fields, alternateSuggestions = []) {
     cy.findByTestId('mailingAddress')
       .should('contain', `${fields.address}`)
       .and('contain', 'Please confirm your address');
+    alternateSuggestions.forEach(field =>
+      cy.findByTestId('mailingAddress').should('contain', field),
+    );
     cy.findByTestId('confirm-address-button').click({
       force: true,
     });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/page-objects/AddressPage.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/page-objects/AddressPage.js
@@ -42,27 +42,38 @@ class AddressPage {
         .type(fields.zipCode);
   }
 
-  saveForm() {
-    cy.findByTestId('save-edit-button').click({
-      force: true,
-    });
+  saveForm(confirm = false) {
+    if (confirm) {
+      cy.findByTestId('confirm-address-button').click({
+        force: true,
+      });
+    } else {
+      cy.findByTestId('save-edit-button').click({
+        force: true,
+      });
+    }
   }
 
-  validateSavedForm(fields) {
+  validateSavedForm(fields, saved = true, altText = null) {
     cy.findByTestId('mailingAddress')
       .should('contain', `${fields.address}`)
       .and('contain', `${fields.city}, ${fields.state} ${fields.zipCode}`);
     fields.military &&
       cy.findByTestId('mailingAddress').should('contain', 'FPO');
-    cy.focused()
-      .invoke('text')
-      .should('match', /update saved/i);
+    saved &&
+      cy
+        .focused()
+        .invoke('text')
+        .should('match', /update saved/i);
+    altText && cy.findByText(altText).should('exist');
   }
 
-  confirmAddress(fields, alternateSuggestions = []) {
-    cy.findByTestId('mailingAddress')
-      .should('contain', `${fields.address}`)
-      .and('contain', 'Please confirm your address');
+  confirmAddress(fields, alternateSuggestions = [], secondSave = false) {
+    cy.findByTestId('mailingAddress').should('contain', `${fields.address}`);
+    !secondSave &&
+      cy
+        .findByTestId('mailingAddress')
+        .should('contain', 'Please confirm your address');
     alternateSuggestions.forEach(field =>
       cy.findByTestId('mailingAddress').should('contain', field),
     );

--- a/src/applications/personalization/profile/tests/e2e/address-validation/page-objects/AddressPage.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/page-objects/AddressPage.js
@@ -89,7 +89,12 @@ class AddressPage {
     altText && cy.findByText(altText).should('exist');
   }
 
-  confirmAddress(fields, alternateSuggestions = [], secondSave = false) {
+  confirmAddress(
+    fields,
+    alternateSuggestions = [],
+    secondSave = false,
+    missingUnit = false,
+  ) {
     cy.findByTestId('mailingAddress').should('contain', `${fields.address}`);
     !secondSave &&
       cy
@@ -98,6 +103,10 @@ class AddressPage {
     alternateSuggestions.forEach(field =>
       cy.findByTestId('mailingAddress').should('contain', field),
     );
+    missingUnit &&
+      cy
+        .findByTestId('mailingAddress')
+        .should('contain', 'Please add a unit number');
     cy.findByTestId('confirm-address-button').click({
       force: true,
     });
@@ -117,6 +126,23 @@ class AddressPage {
     cy.findByRole('button', { name: /^use this address$/i }).click({
       force: true,
     });
+  }
+
+  updateWithoutChanges() {
+    cy.findByRole('button', { name: /^update$/i }).should(
+      'not.have.attr',
+      'disabled',
+    );
+    cy.findByRole('button', { name: /^update$/i }).click({
+      force: true,
+    });
+    cy.findByRole('button', { name: /^update$/i, timeout: 10 }).should(
+      'not.exist',
+    );
+  }
+
+  validateFocusedElement(element) {
+    cy.findByRole(element.tag, { name: element.name }).should('be.focused');
   }
 }
 

--- a/src/applications/personalization/profile/tests/e2e/address-validation/page-objects/AddressPage.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/page-objects/AddressPage.js
@@ -6,19 +6,38 @@ class AddressPage {
   }
 
   fillAddressForm(fields) {
-    cy.findByLabelText(/^street address \(/i)
-      .clear()
-      .type(fields.address);
-    cy.findByLabelText(/^street address line 2/i).clear();
-    cy.findByLabelText(/^street address line 3/i).clear();
-
-    cy.findByLabelText(/City/i)
-      .clear()
-      .type(fields.city);
-    cy.findByLabelText(/^State/).select(fields.state);
-    cy.findByLabelText(/Zip code/i)
-      .clear()
-      .type(fields.zipCode);
+    // eslint-disable-next-line no-unused-expressions
+    fields.address &&
+      cy
+        .findByLabelText(/^street address \(/i)
+        .clear()
+        .type(fields.address);
+    // eslint-disable-next-line no-unused-expressions
+    fields.address2 &&
+      cy
+        .findByLabelText(/^street address line 2/i)
+        .clear()
+        .type(fields.address2);
+    // eslint-disable-next-line no-unused-expressions
+    fields.address3 &&
+      cy
+        .findByLabelText(/^street address line 3/i)
+        .clear()
+        .type(fields.address3);
+    // eslint-disable-next-line no-unused-expressions
+    fields.city &&
+      cy
+        .findByLabelText(/City/i)
+        .clear()
+        .type(fields.city);
+    // eslint-disable-next-line no-unused-expressions
+    fields.state && cy.findByLabelText(/^State/).select(fields.state);
+    // eslint-disable-next-line no-unused-expressions
+    fields.zipCode &&
+      cy
+        .findByLabelText(/Zip code/i)
+        .clear()
+        .type(fields.zipCode);
   }
 
   saveForm() {
@@ -36,10 +55,13 @@ class AddressPage {
       .should('match', /update saved/i);
   }
 
-  confirmAddressMessage(fields) {
+  confirmAddress(fields) {
     cy.findByTestId('mailingAddress')
       .should('contain', `${fields.address}`)
       .and('contain', 'Please confirm your address');
+    cy.findByTestId('confirm-address-button').click({
+      force: true,
+    });
   }
 }
 

--- a/src/applications/personalization/profile/tests/e2e/address-validation/page-objects/AddressPage.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/page-objects/AddressPage.js
@@ -1,0 +1,46 @@
+import { setUp } from '@@profile/tests/e2e/address-validation/setup';
+
+class AddressPage {
+  loadPage(config) {
+    setUp(config);
+  }
+
+  fillAddressForm(fields) {
+    cy.findByLabelText(/^street address \(/i)
+      .clear()
+      .type(fields.address);
+    cy.findByLabelText(/^street address line 2/i).clear();
+    cy.findByLabelText(/^street address line 3/i).clear();
+
+    cy.findByLabelText(/City/i)
+      .clear()
+      .type(fields.city);
+    cy.findByLabelText(/^State/).select(fields.state);
+    cy.findByLabelText(/Zip code/i)
+      .clear()
+      .type(fields.zipCode);
+  }
+
+  saveForm() {
+    cy.findByTestId('save-edit-button').click({
+      force: true,
+    });
+  }
+
+  validateSavedForm(fields) {
+    cy.findByTestId('mailingAddress')
+      .should('contain', `${fields.address}`)
+      .and('contain', `${fields.city}, ${fields.state} ${fields.zipCode}`);
+    cy.focused()
+      .invoke('text')
+      .should('match', /update saved/i);
+  }
+
+  confirmAddressMessage(fields) {
+    cy.findByTestId('mailingAddress')
+      .should('contain', `${fields.address}`)
+      .and('contain', 'Please confirm your address');
+  }
+}
+
+export default AddressPage;

--- a/src/applications/personalization/profile/tests/e2e/address-validation/page-objects/AddressPage.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/page-objects/AddressPage.js
@@ -81,6 +81,11 @@ class AddressPage {
       force: true,
     });
   }
+
+  editAddress(fields) {
+    cy.findByRole('button', { name: /edit your address/i }).click();
+    this.fillAddressForm(fields);
+  }
 }
 
 export default AddressPage;

--- a/src/applications/personalization/profile/tests/e2e/address-validation/two-suggestions.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/two-suggestions.cypress.spec.js
@@ -1,48 +1,24 @@
-import { setUp } from '@@profile/tests/e2e/address-validation/setup';
+import AddressPage from './page-objects/AddressPage';
 
 describe('Personal and contact information', () => {
   describe('when entering a home address that has two suggestions', () => {
     it('should successfully update on Desktop', () => {
-      setUp('two-suggestions');
-
-      cy.findByLabelText(/^street address \(/i)
-        .clear()
-        .type('575 20th');
-      cy.findByLabelText(/^street address line 2/i).clear();
-      cy.findByLabelText(/^street address line 3/i).clear();
-
-      cy.findByLabelText(/City/i)
-        .clear()
-        .type('San Francisco');
-      cy.findByLabelText(/^State/).select('CA');
-      cy.findByLabelText(/Zip code/i)
-        .clear()
-        .type('12345');
-
-      cy.findByTestId('save-edit-button').click({
-        force: true,
+      const formFields = {
+        address: '575 20th',
+        city: 'San Francisco',
+        state: 'CA',
+        zipCode: '12345',
+      };
+      const addressPage = new AddressPage();
+      addressPage.loadPage('two-suggestions');
+      addressPage.fillAddressForm(formFields);
+      addressPage.saveForm();
+      addressPage.confirmAddress(formFields, ['575 20th Ave', '575 20th St']);
+      addressPage.validateSavedForm({
+        ...formFields,
+        address: '575 20th St',
+        zipCode: 94107,
       });
-
-      cy.findByText('Please confirm your address').should('exist');
-
-      cy.findByTestId('mailingAddress')
-        .should('contain', 'Please confirm your address')
-        .and('contain', '575 20th')
-        .and('contain', '575 20th Ave')
-        .and('contain', '575 20th St');
-
-      // Confirm we choose the first option (default)
-      cy.findByTestId('confirm-address-button').click({
-        force: true,
-      });
-
-      cy.findByTestId('mailingAddress')
-        .should('contain', '575 20th St')
-        .and('contain', 'San Francisco, CA 94107');
-
-      cy.focused()
-        .invoke('text')
-        .should('match', /update saved/i);
     });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/address-validation/valid-address.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/address-validation/valid-address.cypress.spec.js
@@ -1,36 +1,20 @@
-import { setUp } from '@@profile/tests/e2e/address-validation/setup';
+import AddressPage from './page-objects/AddressPage';
 
 describe('Personal and contact information', () => {
   describe('should successfully update on Desktop', () => {
     describe('when entering a valid home address', () => {
       it('should update successfully without showing the validation screen', () => {
-        setUp('valid-address');
-
-        cy.findByLabelText(/^street address \(/i)
-          .clear()
-          .type('36320 Coronado Dr');
-        cy.findByLabelText(/^street address line 2/i).clear();
-        cy.findByLabelText(/^street address line 3/i).clear();
-
-        cy.findByLabelText(/City/i)
-          .clear()
-          .type('Fremont');
-        cy.findByLabelText(/^State/).select('MD');
-        cy.findByLabelText(/Zip code/i)
-          .clear()
-          .type('94536');
-
-        cy.findByTestId('save-edit-button').click({
-          force: true,
-        });
-
-        cy.findByTestId('mailingAddress')
-          .should('contain', '36320 Coronado Dr')
-          .and('contain', 'Fremont, CA 94536');
-
-        cy.focused()
-          .invoke('text')
-          .should('match', /update saved/i);
+        const formFields = {
+          address: '36320 Coronado Dr',
+          city: 'Fremont',
+          state: 'MD',
+          zipCode: '94536',
+        };
+        const addressPage = new AddressPage();
+        addressPage.loadPage('valid-address');
+        addressPage.fillAddressForm(formFields);
+        addressPage.saveForm();
+        addressPage.validateSavedForm({ ...formFields, state: 'CA' });
       });
     });
   });


### PR DESCRIPTION
## Description
This PR refactors Cypress tests for address validation to use page objects. This was done as a proof of concept to show that tests can be shortened and made easier to read with page objects.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/30424

## Testing done
- Local testing.

## Acceptance criteria
- [ ] CI passes.