### PR TITLE
Made tab title changes in 4 places in CT

### DIFF
--- a/src/applications/gi-sandbox/containers/ComparePage.jsx
+++ b/src/applications/gi-sandbox/containers/ComparePage.jsx
@@ -34,14 +34,12 @@ import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import CompareHeader from '../components/CompareHeader';
 import CompareLayout from './CompareLayout';
 import { isSmallScreen } from '../utils/helpers';
-import environment from 'yeoman-environment';
 
 export function ComparePage({
   allLoaded,
   compare,
   dispatchFetchCompareDetails,
   dispatchRemoveCompareInstitution,
-  dispatchSetPageTitle,
   estimated,
   filters,
   gibctSchoolRatings,
@@ -72,16 +70,6 @@ export function ComparePage({
       }
     },
     [allLoaded, dispatchFetchCompareDetails, filters, selected, version],
-  );
-
-  useEffect(
-    () => {
-      if (environment.isProduction())
-        dispatchSetPageTitle(
-          'Compare institutions: GI Bill(R) Comparison Tool | Veterans Affairs',
-        );
-    },
-    [dispatchSetPageTitle],
   );
 
   useEffect(
@@ -335,7 +323,7 @@ const mapDispatchToProps = {
   dispatchFetchCompareDetails: fetchCompareDetails,
   dispatchFetchProfile: fetchProfile,
   dispatchRemoveCompareInstitution: removeCompareInstitution,
-  dispatchSetPageTitle: setPageTitle,
+  setPageTitle,
   dispatchShowModal: showModal,
   dispatchHideModal: hideModal,
 };

--- a/src/applications/gi-sandbox/containers/ComparePage.jsx
+++ b/src/applications/gi-sandbox/containers/ComparePage.jsx
@@ -34,12 +34,14 @@ import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import CompareHeader from '../components/CompareHeader';
 import CompareLayout from './CompareLayout';
 import { isSmallScreen } from '../utils/helpers';
+import environment from 'yeoman-environment';
 
 export function ComparePage({
   allLoaded,
   compare,
   dispatchFetchCompareDetails,
   dispatchRemoveCompareInstitution,
+  dispatchSetPageTitle,
   estimated,
   filters,
   gibctSchoolRatings,
@@ -71,6 +73,13 @@ export function ComparePage({
     },
     [allLoaded, dispatchFetchCompareDetails, filters, selected, version],
   );
+
+  useEffect(() => {
+    if (environment.isProduction())
+      dispatchSetPageTitle(
+        'Compare institutions: GI Bill(R) Comparison Tool | Veterans Affairs',
+      );
+  }, []);
 
   useEffect(
     () => {

--- a/src/applications/gi-sandbox/containers/ComparePage.jsx
+++ b/src/applications/gi-sandbox/containers/ComparePage.jsx
@@ -74,12 +74,15 @@ export function ComparePage({
     [allLoaded, dispatchFetchCompareDetails, filters, selected, version],
   );
 
-  useEffect(() => {
-    if (environment.isProduction())
-      dispatchSetPageTitle(
-        'Compare institutions: GI Bill(R) Comparison Tool | Veterans Affairs',
-      );
-  }, []);
+  useEffect(
+    () => {
+      if (environment.isProduction())
+        dispatchSetPageTitle(
+          'Compare institutions: GI Bill(R) Comparison Tool | Veterans Affairs',
+        );
+    },
+    [dispatchSetPageTitle],
+  );
 
   useEffect(
     () => {

--- a/src/applications/gi-sandbox/containers/SearchPage.jsx
+++ b/src/applications/gi-sandbox/containers/SearchPage.jsx
@@ -14,6 +14,7 @@ import AccordionItem from '../components/AccordionItem';
 import { getSearchQueryChanged, updateUrlParams } from '../selectors/search';
 import classNames from 'classnames';
 import GIBillHeaderInfo from '../components/GIBillHeaderInfo';
+import environment from 'platform/utilities/environment';
 
 export function SearchPage({
   dispatchChangeSearchTab,
@@ -34,7 +35,11 @@ export function SearchPage({
 
   useEffect(
     () => {
-      dispatchSetPageTitle(`${PAGE_TITLE}: VA.gov`);
+      document.title = `${
+        environment.isProduction()
+          ? `${PAGE_TITLE}: VA.gov`
+          : 'Compare institutions: GI Bill(R) Comparison Tool | Veterans Affairs'
+      }`;
     },
     [dispatchSetPageTitle],
   );

--- a/src/applications/gi-sandbox/containers/SearchPage.jsx
+++ b/src/applications/gi-sandbox/containers/SearchPage.jsx
@@ -38,7 +38,7 @@ export function SearchPage({
       document.title = `${
         environment.isProduction()
           ? `${PAGE_TITLE}: VA.gov`
-          : 'Compare institutions: GI Bill(R) Comparison Tool | Veterans Affairs'
+          : 'Compare institutions: GI Bill® Comparison Tool | Veterans Affairs'
       }`;
     },
     [dispatchSetPageTitle],

--- a/src/applications/gi/containers/LandingPage.jsx
+++ b/src/applications/gi/containers/LandingPage.jsx
@@ -37,15 +37,18 @@ export function LandingPage({
   eligibility,
   filters,
 }) {
-  useEffect(() => {
-    dispatchSetPageTitle(
-      `${
-        environment.isProduction()
-          ? 'GI Bill® Comparison Tool: VA.gov'
-          : 'GI Bill(R) Comparison Tool | Veterans Affairs'
-      }`,
-    );
-  }, []);
+  useEffect(
+    () => {
+      dispatchSetPageTitle(
+        `${
+          environment.isProduction()
+            ? 'GI Bill® Comparison Tool: VA.gov'
+            : 'GI Bill(R) Comparison Tool | Veterans Affairs'
+        }`,
+      );
+    },
+    [dispatchSetPageTitle],
+  );
 
   const location = useLocation();
   const history = useHistory();

--- a/src/applications/gi/containers/LandingPage.jsx
+++ b/src/applications/gi/containers/LandingPage.jsx
@@ -43,7 +43,7 @@ export function LandingPage({
         `${
           environment.isProduction()
             ? 'GI Bill® Comparison Tool: VA.gov'
-            : 'GI Bill(R) Comparison Tool | Veterans Affairs'
+            : 'GI Bill® Comparison Tool | Veterans Affairs'
         }`,
       );
     },

--- a/src/applications/gi/containers/LandingPage.jsx
+++ b/src/applications/gi/containers/LandingPage.jsx
@@ -22,6 +22,7 @@ import { calculateFilters } from '../selectors/search';
 import { isVetTecSelected, useQueryParams } from '../utils/helpers';
 import recordEvent from 'platform/monitoring/record-event';
 import BenefitsForm from '../components/profile/BenefitsForm';
+import environment from 'platform/utilities/environment';
 
 export function LandingPage({
   autocomplete,
@@ -37,7 +38,13 @@ export function LandingPage({
   filters,
 }) {
   useEffect(() => {
-    dispatchSetPageTitle(`GI Bill® Comparison Tool: VA.gov`);
+    dispatchSetPageTitle(
+      `${
+        environment.isProduction()
+          ? 'GI Bill® Comparison Tool: VA.gov'
+          : 'GI Bill(R) Comparison Tool | Veterans Affairs'
+      }`,
+    );
   }, []);
 
   const location = useLocation();

--- a/src/applications/gi/containers/ProfilePage.jsx
+++ b/src/applications/gi/containers/ProfilePage.jsx
@@ -13,6 +13,7 @@ import InstitutionProfile from '../components/profile/InstitutionProfile';
 import ServiceError from '../components/ServiceError';
 import { useQueryParams } from '../utils/helpers';
 import scrollTo from 'platform/utilities/ui/scrollTo';
+import environment from 'platform/utilities/environment';
 
 const { Element: ScrollElement } = Scroll;
 
@@ -43,7 +44,12 @@ export function ProfilePage({
   useEffect(
     () => {
       if (institutionName) {
-        dispatchSetPageTitle(`${institutionName} - GI Bill® Comparison Tool`);
+        if (environment.isProduction())
+          dispatchSetPageTitle(`${institutionName} - GI Bill® Comparison Tool`);
+        else
+          dispatchSetPageTitle(
+            `${institutionName}: GI Bill(R) Comparison Tool | Veterans Affairs`,
+          );
       }
     },
     [institutionName],

--- a/src/applications/gi/containers/ProfilePage.jsx
+++ b/src/applications/gi/containers/ProfilePage.jsx
@@ -48,7 +48,7 @@ export function ProfilePage({
           dispatchSetPageTitle(`${institutionName} - GI Bill® Comparison Tool`);
         else
           dispatchSetPageTitle(
-            `${institutionName}: GI Bill(R) Comparison Tool | Veterans Affairs`,
+            `${institutionName}: GI Bill® Comparison Tool | Veterans Affairs`,
           );
       }
     },

--- a/src/applications/gi/containers/ProfilePage.jsx
+++ b/src/applications/gi/containers/ProfilePage.jsx
@@ -52,7 +52,7 @@ export function ProfilePage({
           );
       }
     },
-    [institutionName],
+    [dispatchSetPageTitle, institutionName],
   );
 
   useEffect(

--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -63,7 +63,7 @@ export function SearchPage({
   const legacyTitle = searchTerm
     ? `SearchResults - ${searchTerm}`
     : 'Search Results';
-  const newTitle = `Search results: GI Bill(R) Comparison Tool | Veterans Affairs`;
+  const newTitle = `Search results: GI Bill® Comparison Tool | Veterans Affairs`;
 
   useEffect(
     () => {

--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -64,7 +64,7 @@ export function SearchPage({
     () => {
       dispatchSetPageTitle(environment.isProduction() ? title : newTitle);
     },
-    [title],
+    [dispatchSetPageTitle, newTitle, title],
   );
 
   useEffect(

--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -56,15 +56,33 @@ export function SearchPage({
   const history = useHistory();
   const queryParams = useQueryParams();
 
-  const searchTerm = autocomplete.term;
-  const title = searchTerm ? `SearchResults - ${searchTerm}` : 'Search Results';
-  const newTitle = `Search results: GI Bill(R) Comparison Tool | Veterans Affairs`;
+  // const searchTerm = autocomplete.term;
+  // const title = searchTerm ? `SearchResults - ${searchTerm}` : 'Search Results';
+  // const newTitle = `Search results: GI Bill(R) Comparison Tool | Veterans Affairs`;
+
+  // useEffect(
+  //   () => {
+  //     if (searchTerm)
+  //       // document.title = environment.isProduction() ? title : newTitle;
+  //       dispatchSetPageTitle(environment.isProduction() ? title : newTitle);
+  //   },
+  //   [dispatchSetPageTitle, newTitle, searchTerm, title],
+  // );
+
+  const searchTerm = environment.isProduction()
+    ? autocomplete.term
+    : autocomplete.searchTerm;
+
+  const title = searchTerm
+    ? `${searchTerm} Search results: GI Bill(R) Comparison Tool | Veterans Affairs`
+    : 'Search Results';
 
   useEffect(
     () => {
-      dispatchSetPageTitle(environment.isProduction() ? title : newTitle);
+      dispatchSetPageTitle(title);
     },
-    [dispatchSetPageTitle, newTitle, title],
+
+    [title],
   );
 
   useEffect(

--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -56,33 +56,23 @@ export function SearchPage({
   const history = useHistory();
   const queryParams = useQueryParams();
 
-  // const searchTerm = autocomplete.term;
-  // const title = searchTerm ? `SearchResults - ${searchTerm}` : 'Search Results';
-  // const newTitle = `Search results: GI Bill(R) Comparison Tool | Veterans Affairs`;
-
-  // useEffect(
-  //   () => {
-  //     if (searchTerm)
-  //       // document.title = environment.isProduction() ? title : newTitle;
-  //       dispatchSetPageTitle(environment.isProduction() ? title : newTitle);
-  //   },
-  //   [dispatchSetPageTitle, newTitle, searchTerm, title],
-  // );
-
-  const searchTerm = environment.isProduction()
+  const searchTerm = autocomplete.term
     ? autocomplete.term
     : autocomplete.searchTerm;
 
-  const title = searchTerm
-    ? `${searchTerm} Search results: GI Bill(R) Comparison Tool | Veterans Affairs`
+  const legacyTitle = searchTerm
+    ? `SearchResults - ${searchTerm}`
     : 'Search Results';
+  const newTitle = `Search results: GI Bill(R) Comparison Tool | Veterans Affairs`;
 
   useEffect(
     () => {
-      dispatchSetPageTitle(title);
+      dispatchSetPageTitle(
+        `${environment.isProduction() ? legacyTitle : newTitle}`,
+      );
     },
 
-    [title],
+    [dispatchSetPageTitle, legacyTitle, newTitle],
   );
 
   useEffect(

--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -31,6 +31,7 @@ import { renderSearchResultsHeader } from '../utils/render';
 import { isMobileView, useQueryParams } from '../utils/helpers';
 import { searchWithFilters } from '../utils/search';
 import scrollTo from 'platform/utilities/ui/scrollTo';
+import environment from 'platform/utilities/environment';
 
 const { Element: ScrollElement } = Scroll;
 
@@ -57,10 +58,11 @@ export function SearchPage({
 
   const searchTerm = autocomplete.term;
   const title = searchTerm ? `SearchResults - ${searchTerm}` : 'Search Results';
+  const newTitle = `Search results: GI Bill(R) Comparison Tool | Veterans Affairs`;
 
   useEffect(
     () => {
-      dispatchSetPageTitle(title);
+      dispatchSetPageTitle(environment.isProduction() ? title : newTitle);
     },
     [title],
   );


### PR DESCRIPTION
Landing page, Search results, Compare page, & Profile page

## Description
Change the following pages to their new accompanied titles

Landing page: GI Bill(R) Comparison Tool | Veterans Affairs
Search results: Search results: GI Bill(R) Comparison Tool | Veterans Affairs
Compare page: Compare institutions: GI Bill(R) Comparison Tool | Veterans Affairs
Profile page: {Name of institution}: GI Bill(R) Comparison Tool | Veterans Affairs

## Testing done
- [x] Visual confirmation on all 4 pages

## Screenshots
Landing page -> GI Bill(R) Comparison Tool | Veterans Affairs
<img width="407" alt="Landing Page" src="https://user-images.githubusercontent.com/86262790/138510883-e243cace-634d-48fa-948a-52d149896fc6.png">


Search results -> Search results: GI Bill(R) Comparison Tool | Veterans Affairs
<img width="461" alt="Search Results" src="https://user-images.githubusercontent.com/86262790/138769253-4648efcd-fd49-4b7c-a0ac-5d7f790c26d3.png">


Compare page -> Compare institutions: GI Bill(R) Comparison Tool | Veterans Affairs
<img width="477" alt="Compare Page" src="https://user-images.githubusercontent.com/86262790/138769248-e72c8dad-7143-4c48-af12-034f7b781310.png">


Profile page -> {Name of institution}: GI Bill(R) Comparison Tool | Veterans Affairs
<img width="563" alt="Profile Page" src="https://user-images.githubusercontent.com/86262790/138769252-ca349a9c-8b1b-4b3d-92d4-8328dfe6a87c.png">


## Original issue(s)
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/29346

## Acceptance criteria
- [x] Landing Page tab title changed to "GI Bill(R) Comparison Tool | Veterans Affairs"
- [x] Search results tab title changed to "Search results: GI Bill(R) Comparison Tool | Veterans Affairs"
- [x] Compare page tab title changed to "Compare institutions: GI Bill(R) Comparison Tool | Veterans Affairs"
- [x] Profile Page tab tile changed to "Profile page: {Name of institution}: GI Bill(R) Comparison Tool | Veterans Affairs"

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
