### PR TITLE
Migrate from named imports from json module to support Webpack 5 upgrade

### DIFF
--- a/src/applications/edu-benefits/10203/pages/programDetails.js
+++ b/src/applications/edu-benefits/10203/pages/programDetails.js
@@ -1,6 +1,6 @@
 import fullSchema10203 from 'vets-json-schema/dist/22-10203-schema.json';
 import emailUI from 'platform/forms-system/src/js/definitions/email';
-import { countries } from 'vets-json-schema/dist/constants.json';
+import constants from 'vets-json-schema/dist/constants.json';
 import environment from 'platform/utilities/environment';
 
 import {
@@ -81,8 +81,8 @@ export const schema = {
     schoolCountry: {
       default: 'USA',
       type: 'string',
-      enum: countries.map(country => country.value),
-      enumNames: countries.map(country => country.label),
+      enum: constants.countries.map(country => country.value),
+      enumNames: constants.countries.map(country => country.label),
     },
     'view:field': {
       type: 'object',


### PR DESCRIPTION
## Description

As part of the Webpack 5 migration, named imports of JSON modules need to be removed as it is a breaking change. This PR does that for `src/applications/edu-benefits/10203/pages/programDetails.js`


## Original issue(s)
department-of-veterans-affairs/va.gov-team#31871


## Testing done
Before change:
![image](https://user-images.githubusercontent.com/90346049/138461738-7336b2dc-9614-4d08-8dca-e57dd11aed88.png)

After change:
![image](https://user-images.githubusercontent.com/90346049/138461768-29476727-a701-4fd2-a096-24910892e4a3.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
