### PR TITLE
HLR v2: Add area of disagreement page

### DIFF
--- a/src/applications/disability-benefits/996/config/form.js
+++ b/src/applications/disability-benefits/996/config/form.js
@@ -21,14 +21,15 @@ import homeless from '../pages/homeless';
 import contestedIssuesPage from '../pages/contestedIssues';
 import additionalIssuesIntro from '../pages/additionalIssuesIntro';
 import additionalIssues from '../pages/additionalIssues';
+import areaOfDisagreementFollowUp from '../pages/areaOfDisagreement';
+import optIn from '../pages/optIn';
+import issueSummary from '../pages/issueSummary';
+import sameOffice from '../pages/sameOffice';
 import informalConference from '../pages/informalConference';
 import informalConferenceRep from '../pages/informalConferenceRep';
 import informalConferenceRepV2 from '../pages/informalConferenceRepV2';
 import informalConferenceTimes from '../pages/informalConferenceTimes';
 import informalConferenceTime from '../pages/informalConferenceTimeV2';
-import optIn from '../pages/optIn';
-import issueSummary from '../pages/issueSummary';
-import sameOffice from '../pages/sameOffice';
 
 import { errorMessages, WIZARD_STATUS } from '../constants';
 import {
@@ -37,6 +38,7 @@ import {
   appStateSelector,
   showAddIssueQuestion,
   showAddIssuesPage,
+  getIssueName,
 } from '../utils/helpers';
 // import initialData from '../tests/schema/initialData';
 
@@ -147,6 +149,16 @@ const formConfig = {
             showAddIssuesPage(formData) && apiVersion2(formData),
           uiSchema: additionalIssues.uiSchema,
           schema: additionalIssues.schema,
+          appStateSelector,
+        },
+        areaOfDisagreementFollowUp: {
+          title: getIssueName,
+          path: 'area-of-disagreement/:index',
+          depends: apiVersion2,
+          showPagePerItem: true,
+          arrayPath: 'areaOfDisagreement',
+          uiSchema: areaOfDisagreementFollowUp.uiSchema,
+          schema: areaOfDisagreementFollowUp.schema,
           appStateSelector,
         },
         optIn: {

--- a/src/applications/disability-benefits/996/config/submit-transformer.js
+++ b/src/applications/disability-benefits/996/config/submit-transformer.js
@@ -5,6 +5,7 @@ import {
   getConferenceTimes,
   getConferenceTime, // v2
   addIncludedIssues,
+  addAreaOfDisagreement,
   getContact,
   getAddress,
   getPhone,
@@ -15,6 +16,7 @@ import { apiVersion1 } from '../utils/helpers';
 export function transform(formConfig, form) {
   // https://dev-developer.va.gov/explore/appeals/docs/decision_reviews?version=current
   const mainTransform = formData => {
+    let included;
     const version1 = apiVersion1(formData);
     const informalConference = formData.informalConference !== 'no';
     const attributes = {
@@ -32,12 +34,14 @@ export function transform(formConfig, form) {
 
     if (version1) {
       attributes.sameOffice = formData.sameOffice || false;
+      included = addIncludedIssues(formData);
     }
     if (!version1) {
       attributes.veteran.homeless = formData.homeless;
       attributes.veteran.phone = getPhone(formData);
       attributes.veteran.email = formData.veteran?.email || '';
       attributes.socOptIn = formData.socOptIn;
+      included = addAreaOfDisagreement(addIncludedIssues(formData), formData);
     }
 
     // Add informal conference data
@@ -60,7 +64,7 @@ export function transform(formConfig, form) {
         type: 'higherLevelReview',
         attributes,
       },
-      included: addIncludedIssues(formData),
+      included,
     };
   };
 

--- a/src/applications/disability-benefits/996/constants.js
+++ b/src/applications/disability-benefits/996/constants.js
@@ -118,3 +118,17 @@ export const CONFERENCE_TIMES_V2 = {
     submit: '1200-1630 ET',
   },
 };
+
+// Values from Lighthouse maintained schema
+// see https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/appeals_api/config/schemas/v2/200996.json
+export const MAX_ISSUE_NAME_LENGTH = 140;
+export const MAX_DISAGREEMENT_REASON_LENGTH = 90;
+
+// Using MAX_DISAGREEMENT_REASON_LENGTH (90) and with all checkboxes selected,
+// this string is submitted - the numbers constitute the "other" typed in value
+// "service connection,effective date,disability evaluation,1234567890123456789012345678901234"
+export const SUBMITTED_DISAGREEMENTS = {
+  serviceConnection: 'service connection',
+  effectiveDate: 'effective date',
+  evaluation: 'disability evaluation',
+};

--- a/src/applications/disability-benefits/996/containers/Form0996App.jsx
+++ b/src/applications/disability-benefits/996/containers/Form0996App.jsx
@@ -77,7 +77,7 @@ export const Form0996App = ({
             ),
           });
         } else if (
-          hlrV2 &&
+          formData.hlrV2 && // easier to test formData.hlrV2 with SiP menu
           (areaOfDisagreement?.length !== formData.areaOfDisagreement?.length ||
             !areaOfDisagreement.every(
               (entry, index) =>

--- a/src/applications/disability-benefits/996/containers/Form0996App.jsx
+++ b/src/applications/disability-benefits/996/containers/Form0996App.jsx
@@ -16,7 +16,13 @@ import {
 import formConfig from '../config/form';
 import { IS_PRODUCTION, SAVED_CLAIM_TYPE } from '../constants';
 import { getHlrWizardStatus, shouldShowWizard } from '../wizard/utils';
-import { issuesNeedUpdating, processContestableIssues } from '../utils/helpers';
+import {
+  issuesNeedUpdating,
+  getSelected,
+  getIssueNameAndDate,
+  processContestableIssues,
+} from '../utils/helpers';
+import { copyAreaOfDisagreementOptions } from '../utils/disagreement';
 
 export const Form0996App = ({
   loggedIn,
@@ -38,6 +44,7 @@ export const Form0996App = ({
     () => {
       if (loggedIn && getHlrWizardStatus() === WIZARD_STATUS_COMPLETE) {
         const { veteran = {} } = formData || {};
+        const areaOfDisagreement = getSelected(formData);
         if (!contestableIssues?.status) {
           const benefitType =
             sessionStorage.getItem(SAVED_CLAIM_TYPE) || formData.benefitType;
@@ -67,6 +74,23 @@ export const Form0996App = ({
             benefitType: contestableIssues?.benefitType || formData.benefitType,
             contestedIssues: processContestableIssues(
               contestableIssues?.issues,
+            ),
+          });
+        } else if (
+          hlrV2 &&
+          (areaOfDisagreement?.length !== formData.areaOfDisagreement?.length ||
+            !areaOfDisagreement.every(
+              (entry, index) =>
+                getIssueNameAndDate(entry) ===
+                getIssueNameAndDate(formData.areaOfDisagreement[index]),
+            ))
+        ) {
+          setFormData({
+            ...formData,
+            // save existing settings
+            areaOfDisagreement: copyAreaOfDisagreementOptions(
+              areaOfDisagreement,
+              formData.areaOfDisagreement,
             ),
           });
         }

--- a/src/applications/disability-benefits/996/content/areaOfDisagreement.jsx
+++ b/src/applications/disability-benefits/996/content/areaOfDisagreement.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import moment from 'moment';
+
+import { getIssueName, getIssueDate } from '../utils/helpers';
+import { FORMAT_YMD, FORMAT_READABLE } from '../constants';
+
+export const missingAreaOfDisagreementErrorMessage =
+  'Please choose an area of disagreement';
+export const missingAreaOfDisagreementOtherErrorMessage =
+  'Please enter a reason for disagreement';
+
+// formContext.pagePerItemIndex is undefined here? Use index added to data :(
+export const issueName = ({ formData, formContext } = {}) => {
+  const index = formContext.pagePerItemIndex || formData.index;
+  // https://github.com/department-of-veterans-affairs/va.gov-team/issues/27096
+  const Header = formContext.onReviewPage ? 'h4' : 'h3';
+  const date = moment(getIssueDate(formData), FORMAT_YMD).format(
+    FORMAT_READABLE,
+  );
+  const title = `${getIssueName(formData)}${date ? ` (${date})` : ''}`;
+  return (
+    <legend
+      className="schemaform-block-title schemaform-title-underline"
+      aria-describedby={`area-of-disagreement-label-${index}`}
+    >
+      <Header className="vads-u-margin-top--0">{title}</Header>
+    </legend>
+  );
+};
+
+// Error revealed through CSS (need to verify this works for screenreaders)
+// "hidden" class uses an !important flag, so we're using "hide" here
+export const issusDescription = ({ formContext }) => {
+  const { pagePerItemIndex, submitted } = formContext;
+  // adding data-submitted attribute; updating the class name outside of React
+  // breaks the areaOfDisagreementWorkAround
+  return (
+    <div
+      key={pagePerItemIndex}
+      id={`area-of-disagreement-label-${pagePerItemIndex}`}
+      className="area-of-disagreement-label vads-u-font-size--base vads-u-font-weight--normal"
+      data-submitted={submitted}
+    >
+      Tell us what you disagree with. You can choose more than one.
+      <span className="vads-u-font-weight--normal schemaform-required-span">
+        (*Required)
+      </span>
+      <p>I disagree with this:</p>
+      <span
+        className="usa-input-error-message"
+        role="alert"
+        id={`error-message-${pagePerItemIndex}`}
+      >
+        <span className="sr-only">Error</span>
+        {missingAreaOfDisagreementErrorMessage}
+      </span>
+    </div>
+  );
+};
+
+const titles = {
+  serviceConnection: 'The service connection',
+  effectiveDate: 'The effective date of award',
+  evaluation: 'Your evaluation of my condition',
+  other: 'Something else',
+};
+
+export const serviceConnection = titles.serviceConnection;
+export const effectiveDate = titles.effectiveDate;
+export const evaluation = titles.evaluation;
+export const other = titles.other;
+export const otherLabel = 'Tell us what you disagree with:';
+// Includes _{index} which is appended by the TextWidget
+export const otherDescription = ({ index }) => (
+  <div
+    id={`other_hint_text_${index}`}
+    className="vads-u-color--gray hide-on-review"
+  >
+    Please explain in a few words
+  </div>
+);
+
+// Only show set values (ignore false & undefined)
+export const AreaOfDisagreementReviewField = ({ children }) =>
+  children?.props.formData ? (
+    <div className="review-row">
+      <dt>{titles[children.props.name]}</dt>
+      <dd>{children}</dd>
+    </div>
+  ) : null;

--- a/src/applications/disability-benefits/996/pages/areaOfDisagreement.js
+++ b/src/applications/disability-benefits/996/pages/areaOfDisagreement.js
@@ -1,0 +1,118 @@
+import {
+  issueName,
+  issusDescription,
+  serviceConnection,
+  effectiveDate,
+  evaluation,
+  other,
+  AreaOfDisagreementReviewField,
+  otherLabel,
+  otherDescription,
+  missingAreaOfDisagreementErrorMessage,
+  missingAreaOfDisagreementOtherErrorMessage,
+} from '../content/areaOfDisagreement';
+
+import { areaOfDisagreementRequired } from '../validations/issues';
+import {
+  otherTypeSelected,
+  calculateOtherMaxLength,
+} from '../utils/disagreement';
+import { getIssueName } from '../utils/helpers';
+
+export default {
+  uiSchema: {
+    areaOfDisagreement: {
+      items: {
+        'ui:title': issueName,
+        'ui:description': issusDescription,
+        'ui:required': () => true,
+        'ui:validations': [areaOfDisagreementRequired],
+        'ui:errorMessages': {
+          required: missingAreaOfDisagreementErrorMessage,
+        },
+        'ui:options': {
+          // Edit added issue button & specific area of disagreement edit button
+          // had duplicate aria-labels. This makes them unique
+          itemAriaLabel: data => `${getIssueName(data)} disagreement reasons`,
+          // this will show error messages, but breaks the title (no formData)
+          // see https://dsva.slack.com/archives/CBU0KDSB1/p1620840904269500
+          // showFieldLabel: true,
+        },
+        disagreementOptions: {
+          serviceConnection: {
+            'ui:title': serviceConnection,
+            'ui:reviewField': AreaOfDisagreementReviewField,
+          },
+          effectiveDate: {
+            'ui:title': effectiveDate,
+            'ui:reviewField': AreaOfDisagreementReviewField,
+          },
+          evaluation: {
+            'ui:title': evaluation,
+            'ui:reviewField': AreaOfDisagreementReviewField,
+          },
+          other: {
+            'ui:title': other,
+            'ui:reviewField': AreaOfDisagreementReviewField,
+          },
+        },
+        otherEntry: {
+          'ui:title': otherLabel,
+          'ui:description': otherDescription,
+          'ui:required': otherTypeSelected,
+          'ui:options': {
+            hideIf: (formData, index) => !otherTypeSelected(formData, index),
+            updateSchema: (formData, _schema, uiSchema, index) => ({
+              type: 'string',
+              maxLength: calculateOtherMaxLength(
+                formData.areaOfDisagreement[index],
+              ),
+            }),
+            // index is appended to this ID in the TextWidget
+            ariaDescribedby: 'other_hint_text',
+          },
+          'ui:errorMessages': {
+            required: missingAreaOfDisagreementOtherErrorMessage,
+          },
+        },
+      },
+    },
+  },
+
+  schema: {
+    type: 'object',
+    properties: {
+      areaOfDisagreement: {
+        type: 'array',
+        minItems: 1,
+        items: {
+          type: 'object',
+          properties: {
+            disagreementOptions: {
+              type: 'object',
+              properties: {
+                serviceConnection: {
+                  type: 'boolean',
+                },
+                effectiveDate: {
+                  type: 'boolean',
+                },
+                evaluation: {
+                  type: 'boolean',
+                },
+                other: {
+                  type: 'boolean',
+                },
+              },
+            },
+            otherEntry: {
+              type: 'string',
+              // disagreementArea limited to 90 chars max
+              maxLength: 34,
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
+++ b/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
@@ -223,6 +223,29 @@ article[data-location="additional-issues"] {
   }
 }
 
+/* Area of disagreement */
+.area-of-disagreement-label {
+  margin-top: 0;
+
+  .usa-input-error-message {
+    display: none;
+  }
+}
+.area-of-disagreement-label[data-submitted="true"].usa-input-error {
+  .usa-input-error-message {
+    display: block;
+  }
+  .input-section {
+    margin-bottom: 0;
+  }
+}
+.area-of-disagreement-label:not(.usa-input-error) {
+  margin: 2rem 0;
+}
+label[for^="root_disagreementOptions"] {
+  margin-top: 3rem;
+}
+
 /* Step 3 */
 /* Informal conference */
 /* global */
@@ -243,6 +266,14 @@ article[data-location="additional-issues"] {
 /* page specific */
 article[data-contact-choice] .contact-choice {
   display: none;
+}
+
+article[data-location^="area-of-disagreement"] {
+  .schemaform-block-header,
+  .schemaform-block-header + .usa-input-error {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
 }
 
 article[data-contact-choice="rep"] .contact-choice.selected-rep,

--- a/src/applications/disability-benefits/996/tests/fixtures/data/maximal-test-v2.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/data/maximal-test-v2.json
@@ -86,6 +86,40 @@
         "decisionDate": "2021-06-06",
         "view:selected": true
       }
+    ],
+    "areaOfDisagreement": [
+      {
+        "type": "contestableIssue",
+        "attributes": {
+          "ratingIssueSubjectText": "Headaches"
+        },
+        "disagreementOptions": {
+          "serviceConnection": true,
+          "effectiveDate": true,
+          "evaluation": true,
+          "other": true
+        },
+        "otherEntry": "this is an other entry"
+      },
+      {
+        "type": "contestableIssue",
+        "attributes": {
+          "ratingIssueSubjectText": "Being green"
+        },
+        "disagreementOptions": {
+          "serviceConnection": false,
+          "effectiveDate": true
+        },
+        "otherEntry": ""
+      },
+      {
+        "issue": "right shoulder",
+        "disagreementOptions": {
+          "evaluation": true,
+          "other": true
+        },
+        "otherEntry": "this is another other entry"
+      }
     ]
   }
 }

--- a/src/applications/disability-benefits/996/tests/fixtures/data/transformed/maximal-test-v2.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/data/transformed/maximal-test-v2.json
@@ -48,7 +48,8 @@
         "issue": "Headaches - 20% - Acute chronic head pain",
         "decisionDate": "2021-06-10",
         "decisionIssueId": 44,
-        "ratingIssueReferenceId": "66"
+        "ratingIssueReferenceId": "66",
+        "disagreementArea": "service connection,effective date,disability evaluation,this is an other entry"
       }
     },
     {
@@ -58,14 +59,16 @@
         "decisionDate": "2021-06-01",
         "decisionIssueId": 42,
         "ratingIssueReferenceId": "52",
-        "ratingDecisionReferenceId": "999"
+        "ratingDecisionReferenceId": "999",
+        "disagreementArea": "effective date"
       }
     },
     {
       "type": "contestableIssue",
       "attributes": {
         "issue": "right shoulder",
-        "decisionDate": "2021-06-06"
+        "decisionDate": "2021-06-06",
+        "disagreementArea": "disability evaluation,this is another other entry"
       }
     }
   ]

--- a/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
@@ -53,7 +53,7 @@ const testConfig = createTestConfig(
             });
           }
           // Hit the start button
-          cy.findAllByText(/start/i, { selector: 'button' })
+          cy.findAllByText(/start/i, { selector: 'a' })
             .first()
             .click();
         });

--- a/src/applications/disability-benefits/996/tests/pages/areaOfDisagreement.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/pages/areaOfDisagreement.unit.spec.jsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import sinon from 'sinon';
+
+import {
+  DefinitionTester,
+  selectCheckbox,
+  fillData,
+} from 'platform/testing/unit/schemaform-utils.jsx';
+
+import formConfig from '../../config/form';
+
+describe('area of disagreement page', () => {
+  const {
+    schema,
+    uiSchema,
+    arrayPath,
+  } = formConfig.chapters.conditions.pages.areaOfDisagreementFollowUp;
+
+  const data = {
+    areaOfDisagreement: [
+      {
+        attributes: {
+          ratingIssueSubjectText: 'Tinnitus',
+          approxDecisionDate: '2021-01-01',
+        },
+      },
+    ],
+  };
+
+  it('should render', () => {
+    const form = mount(
+      <DefinitionTester
+        definitions={{}}
+        arrayPath={arrayPath}
+        pagePerItemIndex={0}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={data}
+      />,
+    );
+
+    expect(form.find('input[type="checkbox"]').length).to.equal(4);
+    expect(form.find('h3').text()).to.equal('Tinnitus (January 1, 2021)');
+    form.unmount();
+  });
+
+  it('should not allow submit when nothing is checked', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={{}}
+        arrayPath={arrayPath}
+        pagePerItemIndex={0}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={data}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+    expect(onSubmit.called).to.be.false;
+    form.unmount();
+  });
+  it('should not allow submit when other is checked with no additional text', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={{}}
+        arrayPath={arrayPath}
+        pagePerItemIndex={0}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={data}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    selectCheckbox(form, 'root_disagreementOptions_other', true);
+    form.find('form').simulate('submit');
+    expect(onSubmit.called).to.be.false;
+    form.unmount();
+  });
+  it('should allow submit when an area (not other) is checked', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={{}}
+        arrayPath={arrayPath}
+        pagePerItemIndex={0}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={data}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    selectCheckbox(form, 'root_disagreementOptions_serviceConnection', true);
+    form.find('form').simulate('submit');
+    expect(onSubmit.called).to.be.true;
+    form.unmount();
+  });
+  it('should allow submit when other is checked with additional text', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={{}}
+        arrayPath={arrayPath}
+        pagePerItemIndex={0}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={data}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    selectCheckbox(form, 'root_disagreementOptions_other', true);
+    fillData(form, '[name="root_otherEntry"]', 'foo');
+    form.find('form').simulate('submit');
+    expect(onSubmit.called).to.be.true;
+    form.unmount();
+  });
+});

--- a/src/applications/disability-benefits/996/tests/utils/disagreement.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/utils/disagreement.unit.spec.js
@@ -1,0 +1,105 @@
+import { expect } from 'chai';
+
+import {
+  MAX_DISAGREEMENT_REASON_LENGTH,
+  SUBMITTED_DISAGREEMENTS,
+} from '../../constants';
+import {
+  copyAreaOfDisagreementOptions,
+  calculateOtherMaxLength,
+} from '../../utils/disagreement';
+
+describe('copyAreaOfDisagreementOptions', () => {
+  it('should return original issues only', () => {
+    const result = [
+      { issue: 'test' },
+      { attributes: { ratingIssueSubjectText: 'test2' } },
+    ];
+    expect(copyAreaOfDisagreementOptions(result, [])).to.deep.equal(result);
+  });
+  it('should return additional issue with included options', () => {
+    const newIssues = [
+      { issue: 'test' },
+      { attributes: { ratingIssueSubjectText: 'test2' } },
+    ];
+    const existingIssues = [
+      { issue: 'test', disagreementOptions: { test: true } },
+    ];
+    const result = [
+      { issue: 'test', disagreementOptions: { test: true }, otherEntry: '' },
+      { attributes: { ratingIssueSubjectText: 'test2' } },
+    ];
+    expect(
+      copyAreaOfDisagreementOptions(newIssues, existingIssues),
+    ).to.deep.equal(result);
+  });
+  it('should return eligible issues with included options', () => {
+    const newIssues = [
+      { issue: 'test' },
+      { attributes: { ratingIssueSubjectText: 'test2' } },
+    ];
+    const existingIssues = [
+      {
+        attributes: { ratingIssueSubjectText: 'test2' },
+        disagreementOptions: { test: true },
+        otherEntry: 'ok',
+      },
+    ];
+    expect(
+      copyAreaOfDisagreementOptions(newIssues, existingIssues),
+    ).to.deep.equal([newIssues[0], existingIssues[0]]);
+  });
+
+  it('should return disagreement options & other entry', () => {
+    const result = [
+      { issue: 'test', disagreementOptions: { test: true }, otherEntry: 'ok' },
+    ];
+    expect(
+      copyAreaOfDisagreementOptions([{ issue: 'test' }], result),
+    ).to.deep.equal(result);
+  });
+});
+
+describe('calculateOtherMaxLength', () => {
+  const keys = Object.keys(SUBMITTED_DISAGREEMENTS);
+  const values = Object.values(SUBMITTED_DISAGREEMENTS);
+  const getData = settings => {
+    const disagreementOptions = keys.reduce((finalOptions, key, index) => {
+      if (settings[index]) {
+        return { ...finalOptions, [key]: true };
+      }
+      return finalOptions;
+    }, {});
+    return { disagreementOptions };
+  };
+  const calcLength = settings => {
+    const string = values.filter((value, index) => settings[index]).join(',');
+    // add 1 to string length for the final comma
+    return MAX_DISAGREEMENT_REASON_LENGTH - (string.length + 1);
+  };
+  it('should return max length when nothing is selected', () => {
+    expect(calculateOtherMaxLength(getData([]))).to.eq(
+      MAX_DISAGREEMENT_REASON_LENGTH,
+    );
+  });
+  it('should return appropriate length with 1 selection', () => {
+    const data = [true];
+    const length = calcLength(data);
+    expect(calculateOtherMaxLength(getData(data))).to.eq(length);
+  });
+  it('should return appropriate length with 2 selections', () => {
+    const data = [true, false, true];
+    const length = calcLength(data);
+    expect(calculateOtherMaxLength(getData(data))).to.eq(length);
+  });
+  it('should return appropriate length with 2 different selections', () => {
+    const data = [false, true, true];
+    const length = calcLength(data);
+    expect(calculateOtherMaxLength(getData(data))).to.eq(length);
+  });
+  it('should return appropriate length with 3 selections', () => {
+    const data = [true, true, true];
+    const length = calcLength(data);
+    expect(calculateOtherMaxLength(getData(data))).to.eq(length);
+  });
+});

--- a/src/applications/disability-benefits/996/tests/utils/helpers.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/utils/helpers.unit.spec.js
@@ -14,6 +14,7 @@ import {
   getSelected,
   getSelectedCount,
   getIssueName,
+  getIssueDate,
   getIssueNameAndDate,
   hasDuplicates,
   showAddIssuesPage,
@@ -217,6 +218,20 @@ describe('getIssueName', () => {
   });
   it('should return an added issue name', () => {
     expect(getIssueName({ issue: 'test2' })).to.eq('test2');
+  });
+});
+
+describe('getIssueDate', () => {
+  it('should return undefined', () => {
+    expect(getIssueDate()).to.eq('');
+  });
+  it('should return a contestable issue date', () => {
+    expect(
+      getIssueDate({ attributes: { approxDecisionDate: '2021-01-01' } }),
+    ).to.eq('2021-01-01');
+  });
+  it('should return an added issue name', () => {
+    expect(getIssueDate({ decisionDate: '2021-02-01' })).to.eq('2021-02-01');
   });
 });
 

--- a/src/applications/disability-benefits/996/tests/utils/submit.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/utils/submit.unit.spec.js
@@ -5,6 +5,7 @@ import { getDate } from '../../utils/dates';
 import {
   createIssueName,
   getContestedIssues,
+  addAreaOfDisagreement,
   getConferenceTimes,
   getConferenceTime,
   removeEmptyEntries,
@@ -101,6 +102,73 @@ describe('getContestedIssues', () => {
       ],
     };
     expect(getContestedIssues(formData)).to.deep.equal([issue2.result]);
+  });
+});
+
+describe('addAreaOfDisagreement', () => {
+  it('should process a single choice', () => {
+    const formData = {
+      areaOfDisagreement: [
+        {
+          disagreementOptions: {
+            serviceConnection: true,
+            effectiveDate: false,
+          },
+        },
+        {
+          disagreementOptions: {
+            effectiveDate: true,
+            other: false,
+          },
+          otherEntry: 'test',
+        },
+      ],
+    };
+    const result = addAreaOfDisagreement(
+      [issue1.result, issue2.result],
+      formData,
+    );
+    expect(result[0].attributes.disagreementArea).to.equal(
+      'service connection',
+    );
+    expect(result[1].attributes.disagreementArea).to.equal('effective date');
+  });
+  it('should process multiple choices', () => {
+    const formData = {
+      areaOfDisagreement: [
+        {
+          disagreementOptions: {
+            serviceConnection: true,
+            effectiveDate: true,
+            evaluation: true,
+          },
+          otherEntry: 'test',
+        },
+      ],
+    };
+    const result = addAreaOfDisagreement([issue1.result], formData);
+    expect(result[0].attributes.disagreementArea).to.equal(
+      'service connection,effective date,disability evaluation',
+    );
+  });
+  it('should process other choice', () => {
+    const formData = {
+      areaOfDisagreement: [
+        {
+          disagreementOptions: {
+            serviceConnection: true,
+            effectiveDate: true,
+            evaluation: true,
+            other: true,
+          },
+          otherEntry: 'this is an other entry',
+        },
+      ],
+    };
+    const result = addAreaOfDisagreement([issue1.result], formData);
+    expect(result[0].attributes.disagreementArea).to.equal(
+      'service connection,effective date,disability evaluation,this is an other entry',
+    );
   });
 });
 

--- a/src/applications/disability-benefits/996/tests/validations/issues.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/validations/issues.unit.spec.js
@@ -4,7 +4,11 @@ import sinon from 'sinon';
 import { getDate } from '../../utils/dates';
 import { SELECTED, MAX_SELECTIONS } from '../../constants';
 
-import { uniqueIssue, maxIssues } from '../../validations/issues';
+import {
+  uniqueIssue,
+  maxIssues,
+  areaOfDisagreementRequired,
+} from '../../validations/issues';
 
 describe('uniqueIssue', () => {
   const _ = null;
@@ -76,5 +80,33 @@ describe('maxIssues', () => {
       contestedIssues: new Array(MAX_SELECTIONS + 1).fill(template),
     });
     expect(errors.addError.called).to.be.true;
+  });
+});
+
+describe('areaOfDisagreementRequired', () => {
+  it('should show an error with no selections', () => {
+    const errors = { addError: sinon.spy() };
+    areaOfDisagreementRequired(errors);
+    expect(errors.addError.called).to.be.true;
+  });
+  it('should show an error with other selected, but no entry text', () => {
+    const errors = { addError: sinon.spy() };
+    areaOfDisagreementRequired(errors, {
+      disagreementOptions: { other: true },
+    });
+    expect(errors.addError.called).to.be.true;
+  });
+  it('should not show an error with a single selection', () => {
+    const errors = { addError: sinon.spy() };
+    areaOfDisagreementRequired(errors, { disagreementOptions: { foo: true } });
+    expect(errors.addError.called).to.be.false;
+  });
+  it('should not show an error with other selected with entry text', () => {
+    const errors = { addError: sinon.spy() };
+    areaOfDisagreementRequired(errors, {
+      disagreementOptions: { other: true },
+      otherEntry: 'foo',
+    });
+    expect(errors.addError.called).to.be.false;
   });
 });

--- a/src/applications/disability-benefits/996/utils/disagreement.js
+++ b/src/applications/disability-benefits/996/utils/disagreement.js
@@ -1,0 +1,73 @@
+import {
+  MAX_DISAGREEMENT_REASON_LENGTH,
+  SUBMITTED_DISAGREEMENTS,
+} from '../constants';
+import { getIssueName } from './helpers';
+
+/**
+ * @typedef AreaOfDisagreement~Options
+ * @type {object}
+ * @property {boolean} serviceConnection
+ * @property {boolean} effectiveDate
+ * @property {boolean} evaluation
+ * @property {boolean} other
+ */
+/**
+ * @typedef AreaOfDisagreement~Page
+ * @type {object}
+ * @property {object} attributes - Attributes of issue
+ * @property {AreaOfDisagreement~Options} disagreementOptions
+ * @property {string} otherEntry - Free text entered when "other" is selected
+ */
+/**
+ * @typedef FormData~AreaOfDisagreement
+ * @type {AreaOfDisagreement~Page[]}
+ */
+
+export const otherTypeSelected = ({ areaOfDisagreement } = {}, index) =>
+  areaOfDisagreement?.[index]?.disagreementOptions?.other;
+
+/**
+ * Compare currently selected issues with previously selected issues and copy
+ * over the area of disagreement selections if the issue persists
+ * @param {array} newIssues - currently selected issues
+ * @param {array} existingIssues - previously selected issues
+ * @returns {FormData~AreaOfDisagreement}
+ */
+export const copyAreaOfDisagreementOptions = (newIssues, existingIssues) => {
+  return newIssues.map(issue => {
+    const foundIssue = (existingIssues || []).find(
+      entry => getIssueName(entry) === getIssueName(issue),
+    );
+    if (foundIssue) {
+      const { disagreementOptions = {}, otherEntry = '' } = foundIssue;
+      return {
+        ...issue,
+        disagreementOptions,
+        otherEntry,
+      };
+    }
+    return issue;
+  });
+};
+
+/**
+ * Calculate schema max length of area of disagreement "other" free text input
+ * for a specific page
+ * @param {AreaOfDisagreement~Page} formData
+ * @returns {number}
+ */
+export const calculateOtherMaxLength = formData => {
+  // Schema has a max length of 90 characters for the areaOfDisagreement value
+  // We include fixed text for each selected option with the left over for the
+  // free-text "other reason" input to use up the remaining characters
+  const options = formData?.disagreementOptions || {};
+  const stringLength = Object.keys(options).reduce((totalLength, key) => {
+    if (key !== 'other' && options[key]) {
+      // add one for the comma
+      return totalLength + SUBMITTED_DISAGREEMENTS[key].length + 1;
+    }
+    return totalLength;
+  }, 0);
+  return MAX_DISAGREEMENT_REASON_LENGTH - stringLength;
+};

--- a/src/applications/disability-benefits/996/utils/helpers.js
+++ b/src/applications/disability-benefits/996/utils/helpers.js
@@ -93,6 +93,9 @@ export const getEligibleContestableIssues = issues => {
 export const getIssueName = (entry = {}) =>
   entry.issue || entry.attributes?.ratingIssueSubjectText;
 
+export const getIssueDate = (entry = {}) =>
+  entry.decisionDate || entry.attributes?.approxDecisionDate || '';
+
 export const getIssueNameAndDate = (entry = {}) =>
   `${(getIssueName(entry) || '').toLowerCase()}${entry.decisionDate ||
     entry.attributes?.approxDecisionDate ||

--- a/src/applications/disability-benefits/996/utils/ui.js
+++ b/src/applications/disability-benefits/996/utils/ui.js
@@ -27,3 +27,19 @@ export const scrollAndFocus = ({ selector, offset = 50, timer }) => {
     scrollAndFocusFunctions(selector, offset);
   }
 };
+
+// work-around for error message not showing :(
+export const areaOfDisagreementWorkAround = (hasSelection, index) => {
+  // we can't target the fieldset because it doesn't get re-rendered on other
+  // pages by React
+  // see https://dsva.slack.com/archives/CBU0KDSB1/p1620840904269500
+  const label = $(`#area-of-disagreement-label-${index}`);
+  if (label) {
+    const showError = label.dataset.submitted === 'true' && !hasSelection;
+    label.classList.toggle('usa-input-error', showError);
+    label.parentElement.nextElementSibling.classList.toggle(
+      'usa-input-error',
+      showError,
+    );
+  }
+};

--- a/src/applications/disability-benefits/996/validations/issues.js
+++ b/src/applications/disability-benefits/996/validations/issues.js
@@ -6,13 +6,17 @@ import {
   isValidPartialDate,
 } from 'platform/forms-system/src/js/utilities/validations';
 
-import { $ } from '../utils/ui';
+import { $, areaOfDisagreementWorkAround } from '../utils/ui';
 import { getSelected, hasSomeSelected, hasDuplicates } from '../utils/helpers';
 import {
   missingIssuesErrorMessageText,
   uniqueIssueErrorMessage,
   maxSelected,
 } from '../content/additionalIssues';
+import {
+  missingAreaOfDisagreementErrorMessage,
+  missingAreaOfDisagreementOtherErrorMessage,
+} from '../content/areaOfDisagreement';
 import { MAX_SELECTIONS } from '../constants';
 
 export const requireIssue = (
@@ -127,4 +131,26 @@ export const maxIssues = (error, data) => {
   if (getSelected(data).length > MAX_SELECTIONS) {
     error.addError(maxSelected);
   }
+};
+
+export const areaOfDisagreementRequired = (
+  errors,
+  // added index to get around arrayIndex being null
+  { disagreementOptions, otherEntry, index } = {},
+  formData,
+  _schema,
+  _uiSchema,
+  arrayIndex, // always null?!
+) => {
+  const keys = Object.keys(disagreementOptions || {});
+  const hasSelection = keys.some(key => disagreementOptions[key]);
+
+  if (!hasSelection) {
+    errors.addError(missingAreaOfDisagreementErrorMessage);
+  } else if (disagreementOptions.other && !otherEntry) {
+    errors.addError(missingAreaOfDisagreementOtherErrorMessage);
+  }
+
+  // work-around for error message not showing :(
+  areaOfDisagreementWorkAround(hasSelection, arrayIndex || index);
 };


### PR DESCRIPTION
## Description

Adding area of disagreement choices to the Higher-Level Review v2 form

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/30900

## Testing done

- Updated & added unit tests
- Updated mock data
- Verified e2e test passing locally

## Screenshots

<details><summary>Are of disagreement page</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-10-22 at 10 37 19 AM](https://user-images.githubusercontent.com/136959/138483531-aa74fd8f-590d-471b-8073-5e7c424bcb1c.png)</details>

<details><summary>All choices made</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-10-22 at 10 37 59 AM](https://user-images.githubusercontent.com/136959/138483526-abfb889d-31e7-4569-8956-bfdd95d62a57.png)</details>

<details><summary>Character limit error</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-10-22 at 11 05 13 AM](https://user-images.githubusercontent.com/136959/138487326-117e2257-0fbf-4ce4-9388-2ebe9357dedc.png)</details>


## Acceptance criteria
- [x] Add area of disagreement page
- [x] Add dynamic character limits to input
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
