### PR TITLE
Record analytics events from Notification Settings

### DIFF
--- a/src/applications/personalization/profile/components/notification-settings/NotificationChannel.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationChannel.jsx
@@ -13,6 +13,7 @@ import { selectCommunicationPreferences } from '@@profile/reducers';
 
 import { getContactInfoSelectorByChannelType } from '@@profile/util/notification-settings';
 
+import recordEvent from '~/platform/monitoring/record-event';
 import { selectPatientFacilities } from '~/platform/user/selectors';
 
 import { LOADING_STATES } from '../../../common/constants';
@@ -106,6 +107,15 @@ const NotificationChannel = ({
             isAllowed: newValue === 'true',
             wasAllowed: currentValue,
           });
+          recordEvent({
+            event: 'int-radio-button-option-click',
+            'radio-button-label': itemName,
+            'radio-button-optionLabel': `${
+              channelTypes[channelType]
+            } - ${newValue}`,
+            'radio-button-required': false,
+          });
+
           saveSetting(channelId, model.getApiCallObject());
         }}
         warningMessage={


### PR DESCRIPTION
## Description
Sends Notification Settings events to Google Analytics:
- user interactions with the radio buttons
- API events for getting settings and making updates to the settings

## Original issue(s)
department-of-veterans-affairs/va.gov-team#31574

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs