### PR TITLE
Bug: fixes non va patient

### DIFF
--- a/src/applications/validate-mhv-account/containers/ValidateMHVAccount.jsx
+++ b/src/applications/validate-mhv-account/containers/ValidateMHVAccount.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
-import appendQuery from 'append-query';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 
 import { fetchMHVAccount } from 'platform/user/profile/actions';
@@ -10,11 +9,7 @@ import recordEvent from 'platform/monitoring/record-event';
 import { selectProfile } from 'platform/user/selectors';
 import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 import { mhvUrl } from 'platform/site-wide/mhv/utilities';
-import {
-  ACCOUNT_STATES,
-  ACCOUNT_STATES_SET,
-  MHV_ACCOUNT_LEVELS,
-} from './../constants';
+import { ACCOUNT_STATES } from './../constants';
 
 import { MVI_ERROR_STATES } from 'platform/monitoring/RequiresMVI/constants';
 
@@ -36,14 +31,8 @@ class ValidateMHVAccount extends React.Component {
   }
 
   redirectSSOe = () => {
-    const { profile, router, mhvAccountIdState, mviStatus } = this.props;
+    const { router, mhvAccountIdState, mviStatus } = this.props;
     const gaPrefix = 'register-mhv';
-
-    if (!profile.verified) {
-      recordEvent({ event: `${gaPrefix}-info-needs-identity-verification` });
-      router.replace('verify');
-      return;
-    }
 
     // MVI Checks
     const mviErrorStatesSet = new Set(Object.values(MVI_ERROR_STATES));
@@ -53,10 +42,7 @@ class ValidateMHVAccount extends React.Component {
       recordEvent({
         event: `${gaPrefix}-error-mvi-error-${hyphenatedMviStatus}`,
       });
-      if (mviStatus === MVI_ERROR_STATES.NOT_AUTHORIZED) {
-        router.replace('verify');
-        return;
-      }
+
       router.replace(`error/mvi-error-${hyphenatedMviStatus}`);
       return;
     }
@@ -70,15 +56,10 @@ class ValidateMHVAccount extends React.Component {
   };
 
   redirect = () => {
-    const { profile, mhvAccount, router, mviStatus } = this.props;
-    const { accountLevel, accountState } = mhvAccount;
+    const { mhvAccount, router, mviStatus } = this.props;
+    const { accountState } = mhvAccount;
     const hyphenatedAccountState = accountState.replace(/_/g, '-');
     const gaPrefix = 'register-mhv';
-    if (!profile.verified) {
-      recordEvent({ event: `${gaPrefix}-info-needs-identity-verification` });
-      router.replace('verify');
-      return;
-    }
 
     // MVI/MHV Checks
     const mviErrorStatesSet = new Set(Object.values(MVI_ERROR_STATES));
@@ -88,10 +69,7 @@ class ValidateMHVAccount extends React.Component {
       recordEvent({
         event: `${gaPrefix}-error-mvi-error-${hyphenatedMviStatus}`,
       });
-      if (mviStatus === MVI_ERROR_STATES.NOT_AUTHORIZED) {
-        router.replace('verify');
-        return;
-      }
+
       router.replace(`error/mvi-error-${hyphenatedMviStatus}`);
       return;
     } else if (mhvAccount.errors) {
@@ -100,59 +78,17 @@ class ValidateMHVAccount extends React.Component {
       return;
     }
 
-    // If valid account error state, record GA event
-    if (ACCOUNT_STATES_SET.has(accountState)) {
-      recordEvent({
-        event: `${gaPrefix}-${
-          accountState === ACCOUNT_STATES.NEEDS_VERIFICATION ||
-          accountState === ACCOUNT_STATES.NEEDS_TERMS_ACCEPTANCE
-            ? 'info'
-            : 'error'
-        }-${hyphenatedAccountState}`,
-      });
-    }
-
     switch (accountState) {
-      case ACCOUNT_STATES.NEEDS_VERIFICATION:
-        router.replace('verify');
-        return;
-      case ACCOUNT_STATES.NEEDS_TERMS_ACCEPTANCE:
-        this.redirectToTermsAndConditions();
-        return;
       case ACCOUNT_STATES.DEACTIVATED_MHV_IDS:
       case ACCOUNT_STATES.MULTIPLE_IDS:
       case ACCOUNT_STATES.NEEDS_SSN_RESOLUTION:
       case ACCOUNT_STATES.REGISTER_FAILED:
       case ACCOUNT_STATES.UPGRADE_FAILED:
         router.replace(`error/${hyphenatedAccountState}`);
-        return;
+        break;
       default:
         break;
     }
-
-    if (!accountLevel) {
-      router.replace('create-account');
-    } else if (
-      accountLevel === MHV_ACCOUNT_LEVELS.PREMIUM ||
-      accountLevel === MHV_ACCOUNT_LEVELS.ADVANCED
-    ) {
-      window.location = mhvUrl(false, 'home');
-    } else if (accountLevel === MHV_ACCOUNT_LEVELS.BASIC) {
-      router.replace('upgrade-account');
-    } else {
-      router.replace('error');
-    }
-  };
-
-  redirectToTermsAndConditions = () => {
-    const redirectQuery = {
-      tc_redirect: '/health-care/my-health-account-validation', // eslint-disable-line camelcase
-    };
-    const termsConditionsUrl = appendQuery(
-      '/health-care/medical-information-terms-conditions/',
-      redirectQuery,
-    );
-    window.location = termsConditionsUrl;
   };
 
   render() {


### PR DESCRIPTION
## Description
To allow LOA1/Basic user accounts to pass through the ValidateMHVAccount page onto the My HealtheVet website (where they will handle non-patients) regardless of if they are Inbound (Authenticated elsewhere coming into VA.gov) or Outbound (Unified Sign in page) we need to remove some of the gates on vets-website.

This PR removes the necessity of a verified profile (LOA2+) and additionally removes the MPI not authorized (as they will be sent over to MHV to verify).  Some of the items in the redirect method (non-SSO) have been removed.  Ultimately, a lot of the non-SSO can be removed.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done
Unit / manual

## Screenshots
n/a

## Acceptance criteria
- [x] As a non-patient user, I can log into VA.gov and click on the My Health button and redirect to MHV
- [x] As a VA patient, I can log into VA.gov and click the My Health button and redirect to MHV.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
