### PR TITLE
Add auth-exp as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,7 +32,7 @@ config/cypress.json @department-of-veterans-affairs/vsp-testing
 src/applications/personalization @department-of-veterans-affairs/vsa-authd-exp-frontend @department-of-veterans-affairs/vsa-ebenefits-frontend
 src/platform/user/profile/vap-svc @department-of-veterans-affairs/vsa-authd-exp-frontend
 
-# Benefits and Memorials
+# Claims & appeals (Benefits and Memorials 1)
 src/applications/letters @department-of-veterans-affairs/vsa-bam-1-frontend @department-of-veterans-affairs/vsa-authd-exp-frontend
 src/applications/disability-benefits @department-of-veterans-affairs/vsa-bam-1-frontend @department-of-veterans-affairs/vsa-ebenefits-frontend @department-of-veterans-affairs/vsa-authd-exp-frontend
 src/applications/claims-status @department-of-veterans-affairs/vsa-bam-1-frontend @department-of-veterans-affairs/vsa-debt-frontend

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,9 +34,9 @@ src/platform/user/profile/vap-svc @department-of-veterans-affairs/vsa-authd-exp-
 
 # Benefits and Memorials
 src/applications/letters @department-of-veterans-affairs/vsa-bam-1-frontend @department-of-veterans-affairs/vsa-authd-exp-frontend
-src/applications/disability-benefits @department-of-veterans-affairs/vsa-bam-1-frontend @department-of-veterans-affairs/vsa-ebenefits-frontend
+src/applications/disability-benefits @department-of-veterans-affairs/vsa-bam-1-frontend @department-of-veterans-affairs/vsa-ebenefits-frontend @department-of-veterans-affairs/vsa-authd-exp-frontend
 src/applications/claims-status @department-of-veterans-affairs/vsa-bam-1-frontend @department-of-veterans-affairs/vsa-debt-frontend
-src/applications/appeals @department-of-veterans-affairs/vsa-bam-1-frontend @department-of-veterans-affairs/vsa-debt-frontend @department-of-veterans-affairs/vsa-ebenefits-frontend
+src/applications/appeals @department-of-veterans-affairs/vsa-bam-1-frontend @department-of-veterans-affairs/vsa-debt-frontend @department-of-veterans-affairs/vsa-ebenefits-frontend @department-of-veterans-affairs/vsa-authd-exp-frontend
 src/applications/pre-need @department-of-veterans-affairs/vsa-bam-1-frontend @department-of-veterans-affairs/vsa-debt-frontend @department-of-veterans-affairs/vsa-ebenefits-frontend
 
 # VSA Debt


### PR DESCRIPTION
## Description

Adding the authenticated experience team as backup codeowners for our team's main forms until we more FE devs on our team and the eBenefits team

## Acceptance criteria
- [x] Add more code owners

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
