### PR TITLE
31860: [FSR] remove all named exports from JSON modules

### DIFF
--- a/src/applications/financial-status-report/constants/index.js
+++ b/src/applications/financial-status-report/constants/index.js
@@ -1,10 +1,10 @@
-import { pciuStates, countries } from 'vets-json-schema/dist/constants.json';
+import constants from 'vets-json-schema/dist/constants.json';
 
-export const COUNTRY_LABELS = countries.map(country => country.label);
-export const COUNTRY_VALUES = countries.map(country => country.value);
+export const COUNTRY_LABELS = constants.countries.map(country => country.label);
+export const COUNTRY_VALUES = constants.countries.map(country => country.value);
 
-export const STATE_LABELS = pciuStates.map(state => state.label);
-export const STATE_VALUES = pciuStates.map(state => state.value);
+export const STATE_LABELS = constants.pciuStates.map(state => state.label);
+export const STATE_VALUES = constants.pciuStates.map(state => state.value);
 
 export const MILITARY_CITY_CODES = ['APO', 'DPO', 'FPO'];
 export const MILITARY_STATE_CODES = ['AA', 'AE', 'AP'];

--- a/src/applications/financial-status-report/containers/IntroductionPage.jsx
+++ b/src/applications/financial-status-report/containers/IntroductionPage.jsx
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import OMBInfo from '@department-of-veterans-affairs/component-library/OMBInfo';
 import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
-
 import { focusElement } from 'platform/utilities/ui';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
@@ -11,7 +10,7 @@ import recordEvent from 'platform/monitoring/record-event';
 import formConfig from '../config/form';
 import UnverifiedPrefillAlert from '../components/UnverifiedPrefillAlert';
 import { WIZARD_STATUS } from '../wizard/constants';
-import { rootUrl } from '../manifest.json';
+import manifest from '../manifest.json';
 
 const IntroductionPage = props => {
   useEffect(() => {
@@ -44,7 +43,7 @@ const IntroductionPage = props => {
       <p>
         If you don’t think this is the right form for you,
         <a
-          href={rootUrl}
+          href={manifest.rootUrl}
           onClick={() => {
             sessionStorage.removeItem(WIZARD_STATUS);
             recordEvent({ event: 'howToWizard-start-over' });
@@ -60,13 +59,13 @@ const IntroductionPage = props => {
           <li className="process-step list-one">
             <h3 className="vads-u-font-size--h4">Prepare</h3>
             <p>
-              You'll need this information for you (and your spouse if you’re
+              You’ll need this information for you (and your spouse if you’re
               married):
             </p>
             <ul>
               <li>
                 <strong>Work history for the past 2 years. </strong>
-                You'll need the employer name, start and end dates, and monthly
+                You’ll need the employer name, start and end dates, and monthly
                 income for each job.
               </li>
               <li>
@@ -96,8 +95,8 @@ const IntroductionPage = props => {
                 care, or health care.
               </li>
               <li>
-                <strong>If you've ever declared bankruptcy, </strong>
-                you'll need any related documents.
+                <strong>If you’ve ever declared bankruptcy, </strong>
+                you’ll need any related documents.
               </li>
             </ul>
             <p>

--- a/src/applications/financial-status-report/tests/e2e/fsr-5655-wizard.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/fsr-5655-wizard.cypress.spec.js
@@ -1,6 +1,6 @@
 import { WIZARD_STATUS } from '../../wizard/constants';
 import { WIZARD_STATUS_NOT_STARTED } from 'applications/static-pages/wizard';
-import { rootUrl } from '../../manifest.json';
+import manifest from '../../manifest.json';
 
 Cypress.config('waitForAnimations', true);
 
@@ -21,14 +21,14 @@ describe('Financial Status Report (Wizard)', () => {
         ],
       },
     });
-    cy.visit(rootUrl);
+    cy.visit(manifest.rootUrl);
     cy.injectAxe();
   });
 
   it('should navigate the wizard and start the form', () => {
     const title = 'Request help with VA debt (VA Form 5655)';
     const heading = 'Is this the form I need?';
-    cy.url().should('include', rootUrl);
+    cy.url().should('include', manifest.rootUrl);
     cy.get('h1').should('have.text', title);
     cy.get('.wizard-heading').should('have.text', heading);
     cy.get('[type="radio"][value="request"]').click();

--- a/src/applications/financial-status-report/wizard/components/StartFormButton.jsx
+++ b/src/applications/financial-status-report/wizard/components/StartFormButton.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import recordEvent from 'platform/monitoring/record-event';
 import { WIZARD_STATUS_COMPLETE } from 'applications/static-pages/wizard';
-import { rootUrl } from '../../manifest.json';
+import manifest from '../../manifest.json';
 
 const StartFormButton = ({ setWizardStatus, label, ariaId }) => {
   useEffect(() => {
@@ -12,7 +12,7 @@ const StartFormButton = ({ setWizardStatus, label, ariaId }) => {
 
   return (
     <a
-      href={`${rootUrl}/introduction`}
+      href={`${manifest.rootUrl}/introduction`}
       className="usa-button-primary va-button-primary"
       onClick={event => {
         event.preventDefault();


### PR DESCRIPTION
## Description
Updates the following files to remove all named JSON exports

-  src/applications/financial-status-report/containers/IntroductionPage.jsx
-  src/applications/financial-status-report/wizard/components/StartFormButton.jsx
-  src/applications/financial-status-report/constants/index.js
-  src/applications/financial-status-report/tests/e2e/fsr-5655-wizard.cypress.spec.js

## Original issue(s)
department-of-veterans-affairs/va.gov-team#31860

## Screenshots

## Acceptance criteria
- [x] all named exports should be updated

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs