### PR TITLE
HLR v2: Fix time content

### DIFF
--- a/src/applications/disability-benefits/996/constants.js
+++ b/src/applications/disability-benefits/996/constants.js
@@ -110,11 +110,11 @@ export const CONFERENCE_TIMES_V1 = {
 
 export const CONFERENCE_TIMES_V2 = {
   time0800to1200: {
-    label: '8:00 a.m. to 12:00 p.m. ET',
+    label: '8:00 a.m. to noon ET',
     submit: '800-1200 ET',
   },
   time1200to1630: {
-    label: '12:00 p.m. to 4:30 p.m. ET',
+    label: 'noon to 4:30 p.m. ET',
     submit: '1200-1630 ET',
   },
 };

--- a/src/applications/disability-benefits/996/constants.js
+++ b/src/applications/disability-benefits/996/constants.js
@@ -114,7 +114,7 @@ export const CONFERENCE_TIMES_V2 = {
     submit: '800-1200 ET',
   },
   time1200to1630: {
-    label: 'noon to 4:30 p.m. ET',
+    label: 'Noon to 4:30 p.m. ET',
     submit: '1200-1630 ET',
   },
 };


### PR DESCRIPTION
## Description

Changing "12:00 p.m." in the conference time text to "noon" to match the content recommendations - https://design.va.gov/content-style-guide/dates-and-numbers#times-and-time-zones

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/31701

## Testing done

N/A

## Screenshots

![Screen Shot 2021-10-22 at 1 41 31 PM](https://user-images.githubusercontent.com/136959/138506756-1da2581e-7682-4ab6-8a0e-49a4b6a50690.png)

## Acceptance criteria
- [x] Fix informal conference time content

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
