### PR TITLE
Modify Unified Sign-in page based on MHV requirements

### DIFF
--- a/src/platform/site-wide/mega-menu/containers/Main.jsx
+++ b/src/platform/site-wide/mega-menu/containers/Main.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 // Relative imports.
 import MY_VA_LINK from '../constants/MY_VA_LINK';
 import MegaMenu from '../components/MegaMenu';
-import authenticatedUserLinkData from '../mega-menu-link-data-for-authenticated-users.json';
+import authenticatedUserLinkData from '../mega-menu-link-data-for-authenticated-users';
 import recordEvent from '../../../monitoring/record-event';
 import { isLoggedIn } from '../../../user/selectors';
 import { replaceDomainsInData } from '../../../utilities/environment/stagingDomains';

--- a/src/platform/site-wide/mega-menu/mega-menu-link-data-for-authenticated-users.js
+++ b/src/platform/site-wide/mega-menu/mega-menu-link-data-for-authenticated-users.js
@@ -1,0 +1,8 @@
+import { mhvUrl } from 'platform/site-wide/mhv/utilities';
+
+export default [
+  {
+    href: mhvUrl(true, 'home'),
+    title: 'My Health',
+  },
+];

--- a/src/platform/site-wide/mega-menu/mega-menu-link-data-for-authenticated-users.json
+++ b/src/platform/site-wide/mega-menu/mega-menu-link-data-for-authenticated-users.json
@@ -1,6 +1,0 @@
-[
-  {
-    "href": "/health-care/my-health-account-validation/",
-    "title": "My Health"
-  }
-]

--- a/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
+++ b/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 
 import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
 import { logout } from 'platform/user/authentication/utilities';
+import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 import recordEvent from 'platform/monitoring/record-event';
 
 const recordNavUserEvent = section => () => {
@@ -31,10 +32,7 @@ export class PersonalizationDropdown extends React.Component {
           </a>
         </li>
         <li>
-          <a
-            href="/health-care/my-health-account-validation/"
-            onClick={recordMyHealthEvent}
-          >
+          <a href={mhvUrl(true, 'home')} onClick={recordMyHealthEvent}>
             My Health
           </a>
         </li>

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -39,17 +39,6 @@ export const externalRedirects = {
   }eauth.va.gov/mhv-portal-web/eauth`,
 };
 
-const mhvRedirects = {
-  '?deeplinking=download_my_data': 'download_my_data',
-  '?deeplinking=prescription_refill': 'prescription_refill',
-  '?deeplinking=secure_messaging': 'secure_messaging',
-  '?deeplinking=appointments': 'appointments',
-  '?deeplinking=home': 'home',
-  '?deeplinking=labs_and_tests': 'home',
-  '?deeplinking=null': 'home',
-  home: 'home',
-};
-
 export const ssoKeepAliveEndpoint = () => {
   const envPrefix = eauthEnvironmentPrefixes[environment.BUILDTYPE];
   return `https://${envPrefix}eauth.va.gov/keepalive`;
@@ -120,28 +109,6 @@ export function standaloneRedirect() {
   return url;
 }
 
-export function generateLookup(returnUrl) {
-  // Grabs the `app` & `to` queries, generates the path and does
-  // a reverse lookup to create mapping
-  const { application: app, to } = getQueryParams();
-  const link = !to ? '' : generatePath(app, to);
-
-  const toRedirect = {
-    ...(app === 'mhv' && { ...mhvRedirects }),
-  }[link || 'home'];
-
-  const externalRedirectLookup = {
-    ...(app === 'mhv' && {
-      [`${externalRedirects.mhv}${link}`]: `mhv_${toRedirect}`,
-    }),
-  };
-
-  return {
-    redirectsTo: externalRedirectLookup[`${returnUrl}`],
-    app,
-  };
-}
-
 export function redirect(redirectUrl, clickedEvent) {
   let rUrl = redirectUrl;
   // Keep track of the URL to return to after auth operation.
@@ -152,11 +119,15 @@ export function redirect(redirectUrl, clickedEvent) {
   sessionStorage.setItem(authnSettings.RETURN_URL, returnUrl);
   recordEvent({ event: clickedEvent });
 
+  if (!loginAppUrlRE.test(window.location.pathname)) {
+    setLoginAttempted();
+  }
+
   // Generates the redirect for /sign-in page and tracks event
   if (loginAppUrlRE.test(window.location.pathname)) {
-    const { redirectsTo, app } = generateLookup(returnUrl);
+    const { application: app } = getQueryParams();
     rUrl = {
-      mhv: `${redirectUrl}?redirect=${redirectsTo}`,
+      mhv: `${redirectUrl}?redirect=${returnUrl}`,
       myvahealth: `${redirectUrl}`,
     }[app];
     recordEvent({ event: `${authnSettings.REDIRECT_EVENT}-${app}-inbound` });
@@ -176,7 +147,6 @@ export function login(
   clickedEvent = 'login-link-clicked-modal',
 ) {
   const url = sessionTypeUrl({ type: policy, version, queryParams });
-  setLoginAttempted();
   return redirect(url, clickedEvent);
 }
 

--- a/src/platform/user/tests/authentication/utilities.unit.spec.js
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.js
@@ -92,7 +92,7 @@ describe('authentication URL helpers', () => {
     global.window.location.search = '?application=mhv';
     login('idme', 'v1');
     expect(global.window.location).to.include(
-      '/v1/sessions/idme/new?redirect=mhv_home',
+      `/v1/sessions/idme/new?redirect=${externalRedirects.mhv}`,
     );
   });
 
@@ -102,7 +102,9 @@ describe('authentication URL helpers', () => {
 
     login('idme', 'v1');
     expect(global.window.location).to.include(
-      '/v1/sessions/idme/new?redirect=mhv_secure_messaging',
+      `/v1/sessions/idme/new?redirect=${
+        externalRedirects.mhv
+      }?deeplinking=secure_messaging`,
     );
   });
 


### PR DESCRIPTION
## Description
After a discussion with the My HealtheVet team we have clarified a few miscommunications on my part.  The `to` query parameter on the Unified Sign-in page should be allowed to redirect to any MHV link instead of using predefined lookups as previously thought.  Additionally, the authenticated user mega menu will now point directly to the MHV site regardless of users patient or MHV status (the ValidateMHVAccount application logic will be ripped out).

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done
- Unit testing / manual

## Screenshots
n/a

## Acceptance criteria
- [x] Unified Sign In allows AutoSSO
- [x] MHV deep-linking is fixed to allow any property in the `to` query parameter
- [x] Change all 'My Health' links (authenticated-user.json => .js & PersonalizationDropdown component) to use mhvUrl function to redirect to MHV.

## Definition of done
- [x] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
