### PR TITLE
Github Actions (CI) & Jenkins -- Remove dup of ENV

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -719,9 +719,10 @@ jobs:
     name: Archive
     runs-on: ubuntu-latest
 
+    # TODO: Add vagovprod when ready
     strategy:
       matrix:
-        buildtype: [vagovdev, vagovstaging, vagovprod]
+        buildtype: [vagovdev, vagovstaging]
 
     needs: [cypress-tests, unit-tests, contract-tests, security-audit, linting]
 

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -115,11 +115,11 @@ def archive(dockerContainer, String ref, String envName) {
     withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'vetsgov-website-builds-s3-upload',
                      usernameVariable: 'AWS_ACCESS_KEY', passwordVariable: 'AWS_SECRET_KEY']]) {
       sh "echo \"${buildDetails}\" > /application/build/${envName}/BUILD.txt"
-      if(envName == 'vagovstaging') {
-        sh "tar -C /application/build/${envName} -cf /application/build/apps.${envName}.tar.bz2 ."
-        sh "aws s3 cp /application/build/apps.${envName}.tar.bz2 s3://vetsgov-website-builds-s3-upload/application-build/${ref}/${envName}.tar.bz2 --acl public-read --region us-gov-west-1 --quiet"
-      }
-      if(envName == 'vagovstaging' || envName == 'vagovprod') {
+      // if(envName == 'vagovstaging') {
+      //   sh "tar -C /application/build/${envName} -cf /application/build/apps.${envName}.tar.bz2 ."
+      //   sh "aws s3 cp /application/build/apps.${envName}.tar.bz2 s3://vetsgov-website-builds-s3-upload/application-build/${ref}/${envName}.tar.bz2 --acl public-read --region us-gov-west-1 --quiet"
+      // }
+      if(envName == 'vagovprod') {
         sh "tar -C /application/build/${envName} -cf /application/build/${envName}.tar.bz2 ."
         sh "aws s3 cp /application/build/${envName}.tar.bz2 s3://vetsgov-website-builds-s3-upload/${ref}/${envName}.tar.bz2 --acl public-read --region us-gov-west-1 --quiet"
       }


### PR DESCRIPTION
## Description

With Jenkins only handling `vagovprod` and GHA handling `vagovstaging`, we want to ensure there are no dups when uploading `archive`. Fixing so no race-condition


## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
