### PR TITLE
Github Actions (CI) -- Remove slack notification for build only

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -45,30 +45,6 @@ jobs:
         run: yarn build --verbose --buildtype=${{ matrix.buildtype }}
         timeout-minutes: 30
 
-      # ----------------------------
-      # | Notify Slack of failures |
-      # ---------------------------
-
-      - name: Notify Slack about build failures
-        if: ${{ failure() }}
-        uses: ./.github/workflows/slack-notify
-        continue-on-error: true
-        env:
-          SSL_CERT_DIR: /etc/ssl/certs
-        with:
-          attachments: '[{"mrkdwn_in": ["text"], "color": "danger", "text": "At least one build step in `vets-website` has failed, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}]'
-          channel_id: C02AG8UF95M # gha-build-status
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      - name: Cancel other parallel steps
-        if: ${{ failure() }}
-        uses: andymckay/cancel-action@0.2
-
-      # ----------------
-      # | End Notify Slack |
-      # ----------------
-
       - name: Generate build details
         run: |
           cat > build/${{ matrix.buildtype }}/BUILD.txt << EOF


### PR DESCRIPTION
## Description

See [Slack](https://dsva.slack.com/archives/C01CHAY3ULR/p1635185996010700) for more details

Removing notification on build as we only need to worry about those in `master`

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
