### PR TITLE
Adds skip_dupe

### DIFF
--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -127,7 +127,7 @@ export function redirect(redirectUrl, clickedEvent) {
   if (loginAppUrlRE.test(window.location.pathname)) {
     const { application: app } = getQueryParams();
     rUrl = {
-      mhv: `${redirectUrl}?redirect=${returnUrl}&skip_dupe=mhv`,
+      mhv: `${redirectUrl}?skip_dupe=mhv&redirect=${returnUrl}`,
       myvahealth: `${redirectUrl}`,
     }[app];
     recordEvent({ event: `${authnSettings.REDIRECT_EVENT}-${app}-inbound` });

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -127,7 +127,7 @@ export function redirect(redirectUrl, clickedEvent) {
   if (loginAppUrlRE.test(window.location.pathname)) {
     const { application: app } = getQueryParams();
     rUrl = {
-      mhv: `${redirectUrl}?redirect=${returnUrl}`,
+      mhv: `${redirectUrl}?redirect=${returnUrl}&skip_dupe=mhv`,
       myvahealth: `${redirectUrl}`,
     }[app];
     recordEvent({ event: `${authnSettings.REDIRECT_EVENT}-${app}-inbound` });

--- a/src/platform/user/tests/authentication/utilities.unit.spec.js
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.js
@@ -92,7 +92,7 @@ describe('authentication URL helpers', () => {
     global.window.location.search = '?application=mhv';
     login('idme', 'v1');
     expect(global.window.location).to.include(
-      `/v1/sessions/idme/new?redirect=${externalRedirects.mhv}`,
+      `/v1/sessions/idme/new?skip_dupe=mhv&redirect=${externalRedirects.mhv}`,
     );
   });
 
@@ -102,7 +102,7 @@ describe('authentication URL helpers', () => {
 
     login('idme', 'v1');
     expect(global.window.location).to.include(
-      `/v1/sessions/idme/new?redirect=${
+      `/v1/sessions/idme/new?skip_dupe=mhv&redirect=${
         externalRedirects.mhv
       }?deeplinking=secure_messaging`,
     );


### PR DESCRIPTION
## Description
This PR adds `skip_dupe=mhv` query parameter to the return URL to allow vets-api to allow Multiple MHV Correlation IDs to pass through only on the Unified Sign-in page `/sign-in/?application=mhv`

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done
Unit testing / Manual

## Screenshots


## Acceptance criteria
- [x] The `skip_dupe=mhv` property is present on 

## Definition of done
- [x] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
