### PR TITLE
Implement app list generation in CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -262,6 +262,8 @@ jobs:
   testing-reports-prep:
     name: Testing Reports Prep
     runs-on: ubuntu-latest
+    outputs:
+      app_list: ${{ env.APPLICATION_LIST }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -618,8 +620,10 @@ jobs:
   testing-reports-cypress:
     name: Testing Reports - Cypress E2E Tests
     runs-on: ubuntu-latest
-    needs: [cypress-tests-prep, cypress-tests]
+    needs: [testing-reports-prep, cypress-tests-prep, cypress-tests]
     if: ${{ always() && needs.cypress-tests-prep.outputs.num_containers > 0 && (needs.cypress-tests.result == 'success' || needs.cypress-tests.result == 'failure') }}
+    env:
+      APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
     continue-on-error: true
     steps:
       - name: Checkout

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -262,6 +262,18 @@ jobs:
     name: Testing Reports Prep
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        uses: ./.github/workflows/install
+        with:
+          key: ${{ hashFiles('yarn.lock') }}
+          yarn_cache_folder: .cache/yarn
+          path: |
+            .cache/yarn
+            node_modules
+
       - name: Generate new application list
         run: yarn generate-app-list
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -258,7 +258,15 @@ jobs:
       - name: Annotate Stylelint results
         if: ${{ always() }}
         run: node ./script/github-actions/stylelint-annotation-format.js
+  testing-reports-prep:
+    name: Testing Reports Prep
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate new application list
+        run: yarn generate-app-list
 
+      - name: Output application list
+        run: ${{ env.APPLICATION_LIST }}
   cypress-tests-prep:
     name: Prep for Cypress Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -302,6 +302,7 @@ jobs:
 
       - name: Upload app list to BigQuery
         run: yarn generate-app-list
+        working-directory: department-of-veterans-affairs/testing-tools-team-dashboard-data
 
   cypress-tests-prep:
     name: Prep for Cypress Tests

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -591,6 +591,7 @@ jobs:
           repository: department-of-veterans-affairs/testing-tools-team-dashboard-data
           token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
           path: testing-tools-team-dashboard-data
+          ref: test-naming-apps
 
         # TODO: Set .nvmrc in testing-tools-team-dashboard-data.
         # - name: Get Node version

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -311,6 +311,19 @@ jobs:
           YARN_CACHE_FOLDER: .cache/yarn
         working-directory: testing-tools-team-dashboard-data
 
+      - name: Get BigQuery service credentials
+        uses: marvinpinto/action-inject-ssm-secrets@latest
+        with:
+          ssm_parameter: /dsva-vagov/testing-team/bigquery_service_credentials
+          env_variable_name: BIGQUERY_SERVICE_CREDENTIALS
+
+      - name: Setup Cloud SDK
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: vsp-analytics-and-insights
+          service_account_key: ${{ env.BIGQUERY_SERVICE_CREDENTIALS }}
+          export_default_credentials: true
+
       - name: Upload app list to BigQuery
         run: yarn generate-app-list
         working-directory: testing-tools-team-dashboard-data

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -258,6 +258,7 @@ jobs:
       - name: Annotate Stylelint results
         if: ${{ always() }}
         run: node ./script/github-actions/stylelint-annotation-format.js
+
   testing-reports-prep:
     name: Testing Reports Prep
     runs-on: ubuntu-latest
@@ -276,9 +277,32 @@ jobs:
 
       - name: Generate new application list
         run: yarn generate-app-list
+      # exports app list and assigns to environmental variable at this step
 
-      - name: Output application list
-        run: ${{ env.APPLICATION_LIST }}
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Get va-vsp-bot token
+        uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
+      - name: Checkout Testing Tools Team Dashboard Data repo
+        uses: actions/checkout@v2
+        with:
+          repository: department-of-veterans-affairs/testing-tools-team-dashboard-data
+          token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
+          path: testing-tools-team-dashboard-data
+          ref: test-naming-apps
+
+      - name: Upload app list to BigQuery
+        run: yarn generate-app-list
+
   cypress-tests-prep:
     name: Prep for Cypress Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -300,6 +300,17 @@ jobs:
           path: testing-tools-team-dashboard-data
           ref: test-naming-apps
 
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14 # ${{ steps.get-node-version.outputs.NODE_VERSION }}
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --prefer-offline --production=false
+        env:
+          YARN_CACHE_FOLDER: .cache/yarn
+        working-directory: testing-tools-team-dashboard-data
+
       - name: Upload app list to BigQuery
         run: yarn generate-app-list
         working-directory: department-of-veterans-affairs/testing-tools-team-dashboard-data

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -313,7 +313,7 @@ jobs:
 
       - name: Upload app list to BigQuery
         run: yarn generate-app-list
-        working-directory: department-of-veterans-affairs/testing-tools-team-dashboard-data
+        working-directory: testing-tools-team-dashboard-data
 
   cypress-tests-prep:
     name: Prep for Cypress Tests

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -505,7 +505,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-        # ------------------------
+      # ------------------------
       # | Upload BigQuery Data |
       # ------------------------
 
@@ -664,7 +664,6 @@ jobs:
           repository: department-of-veterans-affairs/testing-tools-team-dashboard-data
           token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
           path: testing-tools-team-dashboard-data
-          ref: test-naming-apps
 
         # TODO: Set .nvmrc in testing-tools-team-dashboard-data.
         # - name: Get Node version

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "cy:testrail-run": "cypress run --config-file config/cypress-testrail.json --reporter-options host=https://dsvavsp.testrail.io/,username=$TR_USER,password=$TR_API_KEY,projectId=$TR_PROJECTID,suiteId=$TR_SUITEID,runName=$TR_RUN_NAME,includeAllInTestRun=$TR_INCLUDE_ALL,groupId=$TR_GROUPID,filter=$TR_FILTER",
     "cy:my-testrail-helper": "node ./script/cypress-testrail-helper",
     "cy:my-testrail-run": "cypress run --config-file config/my-cypress-testrail.json",
+    "generate-app-list": "node script/github-actions/generate-app-list.js",
     "heroku-serve": "http-server",
     "jsdoc": "jsdoc",
     "prebuild": "node script/prebuild.js",

--- a/script/github-actions/generate-app-list.js
+++ b/script/github-actions/generate-app-list.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const glob = require('glob');
+const core = require('@actions/core');
+
+function findAllManifests() {
+  const applicationList = [];
+  glob('src/applications/**/manifest.json', function(err, files) {
+    files.forEach(file => {
+      const manifestData = JSON.parse(fs.readFileSync(file));
+      applicationList.push({
+        name: manifestData.appName,
+        slug: manifestData.entryName,
+      });
+    });
+    core.exportVariable('APPLICATION_LIST', applicationList);
+  });
+}
+
+findAllManifests();

--- a/script/github-actions/generate-app-list.js
+++ b/script/github-actions/generate-app-list.js
@@ -1,19 +1,15 @@
-const fs = require('fs');
-const glob = require('glob');
 const core = require('@actions/core');
 
-function findAllManifests() {
-  const applicationList = [];
-  glob('src/applications/**/manifest.json', function(err, files) {
-    files.forEach(file => {
-      const manifestData = JSON.parse(fs.readFileSync(file));
-      applicationList.push({
-        name: manifestData.appName,
-        slug: manifestData.entryName,
-      });
-    });
-    core.exportVariable('APPLICATION_LIST', applicationList);
+const { getAppManifests } = require('../../config/manifest-helpers');
+
+function exportAppList() {
+  const applicationList = getAppManifests().map(app => {
+    return {
+      name: app.appName,
+      slug: app.entryName,
+    };
   });
+  core.exportVariable('APPLICATION_LIST', applicationList);
 }
 
-findAllManifests();
+exportAppList();


### PR DESCRIPTION
## Description
This PR adds the app list generation to vets website. This script runs a scan for all the `manifest.json` files in the different applications and generates a list correlating directories to application names. This is then uploaded to BigQuery so it can be used as a reference point for any queries.

## Original issue(s)
https://app.zenhub.com/workspaces/sprint-board-testing-tools-team-613a3f47e06ba00013d05eed/issues/department-of-veterans-affairs/va.gov-team/31952

## Testing done
Ran many times in CI and data made it to BQ in the proper format.


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
