### PR TITLE
Create script to map frontend apps to owners in json

### DIFF
--- a/script/mapAppToOwners.js
+++ b/script/mapAppToOwners.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const path = require('path');
+
+const codeOwners = fs.readFileSync(
+  path.join(__dirname, '../.github/CODEOWNERS'),
+  'utf-8',
+);
+
+const mappedLines = codeOwners
+  .split(/\n/)
+  .map(line => {
+    const match = /(?<directory>\S*)\s@department-of-veterans-affairs\/(?<owner>.\S*).*$/g.exec(
+      line,
+    );
+
+    if (match?.groups?.directory && match.groups.owner) {
+      return { directory: match.groups.directory, owner: match.groups.owner };
+    }
+
+    return undefined;
+  })
+  .filter(line => !!line);
+
+const appOwnerMap = mappedLines
+  .map(app => {
+    try {
+      const files = fs.readdirSync(`${app.directory}`);
+
+      if (files.includes('manifest.json')) {
+        const file = JSON.parse(
+          fs.readFileSync(`${app.directory}/manifest.json`),
+        );
+
+        return { owner: app.owner, appName: file.entryName };
+      }
+
+      return app;
+    } catch (err) {
+      return app;
+    }
+  })
+  .filter(app => !!app.appName);
+
+process.stdout.write(JSON.stringify(appOwnerMap));

--- a/script/mapAppToOwners.js
+++ b/script/mapAppToOwners.js
@@ -10,12 +10,21 @@ const codeOwners = fs.readFileSync(
 const mappedLines = codeOwners
   .split(/\n/)
   .map(line => {
-    const match = /(?<directory>\S*)\s@department-of-veterans-affairs\/(?<owner>.\S*).*$/g.exec(
+    const directory = /(?<directory>\S*)\s@department-of-veterans-affairs\/\S.*$/g.exec(
       line,
-    );
+    )?.groups?.directory;
 
-    if (match?.groups?.directory && match.groups.owner) {
-      return { directory: match.groups.directory, owner: match.groups.owner };
+    const regex = /\S*\s@department-of-veterans-affairs\/(\S*)/g;
+    const matches = [];
+    let match = regex.exec(line);
+
+    while (match != null) {
+      matches.push(match[1]);
+      match = regex.exec(line);
+    }
+
+    if (directory && matches.length) {
+      return { directory, owner: matches };
     }
 
     return undefined;


### PR DESCRIPTION
## Description
As part of our discovery for the Integration Experience Team we want an automated way of seeing which teams own which frontend apps.

Currently this writes to stdout as I'm not sure where we'd want this to live.

Current output:
```json
[{"owner":"vsp-identity","appName":"auth"},{"owner":"vsp-identity","appName":"login-page"},{"owner":"vsa-bam-1-frontend","appName":"letters"},{"owner":"vsa-bam-1-frontend","appName":"claims-status"},{"owner":"vsa-bam-1-frontend","appName":"pre-need"},{"owner":"vsa-debt-frontend","appName":"order-form-2346"},{"owner":"vsa-debt-frontend","appName":"your-debt"},{"owner":"vsa-debt-frontend","appName":"burials"},{"owner":"vsa-debt-frontend","appName":"request-debt-help-form-5655"},{"owner":"vsa-debt-frontend","appName":"medical-copays"},{"owner":"vsa-public-websites-frontend","appName":"proxy-rewrite"},{"owner":"vsa-public-websites-frontend","appName":"static-pages"},{"owner":"vsa-public-websites-frontend","appName":"yellow-ribbon"},{"owner":"vsa-public-websites-frontend","appName":"discharge-upgrade-instructions"},{"owner":"vsa-public-websites-frontend","appName":"search"},{"owner":"vsa-public-websites-frontend","appName":"resources-and-support"},{"owner":"vsa-facilities-frontend","appName":"facilities"},{"owner":"vsa-caregiver-frontend","appName":"1010cg-application-caregiver-assistance"},{"owner":"vsa-caregiver-frontend","appName":"hca"},{"owner":"vsa-healthcare-experience","appName":"check-in"},{"owner":"afs-code-reviewers","appName":"gi"},{"owner":"afs-code-reviewers","appName":"gi-sandbox"},{"owner":"va-cto-health-products","appName":"coronavirus-research"},{"owner":"va-cto-health-products","appName":"covid19screen"},{"owner":"va-cto-health-products","appName":"coronavirus-vaccination"},{"owner":"va-cto-health-products","appName":"covid-vaccine"},{"owner":"my-education-benefits","appName":"1990ez-edu-benefits"},{"owner":"orchid","appName":"ask-a-question"},{"owner":"orchid","appName":"messages"},{"owner":"orchid","appName":"virtual-agent"},{"owner":"vfs-vaos-fe","appName":"vaos"}]
```

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/31775


## Testing done
local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
