### PR TITLE
Re-adds postLogin query

### DIFF
--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -127,7 +127,7 @@ export function redirect(redirectUrl, clickedEvent) {
   if (loginAppUrlRE.test(window.location.pathname)) {
     const { application: app } = getQueryParams();
     rUrl = {
-      mhv: `${redirectUrl}?skip_dupe=mhv&redirect=${returnUrl}`,
+      mhv: `${redirectUrl}?skip_dupe=mhv&redirect=${returnUrl}&postLogin=true`,
       myvahealth: `${redirectUrl}`,
     }[app];
     recordEvent({ event: `${authnSettings.REDIRECT_EVENT}-${app}-inbound` });

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -119,7 +119,10 @@ export function redirect(redirectUrl, clickedEvent) {
   sessionStorage.setItem(authnSettings.RETURN_URL, returnUrl);
   recordEvent({ event: clickedEvent });
 
-  if (!loginAppUrlRE.test(window.location.pathname)) {
+  if (
+    !loginAppUrlRE.test(window.location.pathname) &&
+    clickedEvent === 'login-link-clicked-modal'
+  ) {
     setLoginAttempted();
   }
 

--- a/src/platform/user/tests/authentication/utilities.unit.spec.js
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.js
@@ -92,7 +92,9 @@ describe('authentication URL helpers', () => {
     global.window.location.search = '?application=mhv';
     login('idme', 'v1');
     expect(global.window.location).to.include(
-      `/v1/sessions/idme/new?skip_dupe=mhv&redirect=${externalRedirects.mhv}`,
+      `/v1/sessions/idme/new?skip_dupe=mhv&redirect=${
+        externalRedirects.mhv
+      }&postLogin=true`,
     );
   });
 
@@ -104,7 +106,7 @@ describe('authentication URL helpers', () => {
     expect(global.window.location).to.include(
       `/v1/sessions/idme/new?skip_dupe=mhv&redirect=${
         externalRedirects.mhv
-      }?deeplinking=secure_messaging`,
+      }?deeplinking=secure_messaging&postLogin=true`,
     );
   });
 


### PR DESCRIPTION
## Description
This PR does two things:
- Ensures the `postLogin=true` parameter is appended to the `redirect` URL we send to vets-api (This will allow MHV to verify the logged in status).
- Fixes a bug by adding extra logic to ensure we only call setLoginAttempted when a login is performed.

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#30522


## Testing done
Unit testing / manual

## Screenshots
n/a

## Acceptance criteria
- [x] All unit tests pass
- [x] Using the Unified Sign-in page I see the redirect URL has an appended query of `postLogin=true`
- [x] The `loginAttempted` local storage is only called on login (not logout).

## Definition of done
- [x] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
