### PR TITLE
NOD: Add inline contact info editing

### DIFF
--- a/src/applications/appeals/10182/components/ContactInformation.jsx
+++ b/src/applications/appeals/10182/components/ContactInformation.jsx
@@ -96,7 +96,11 @@ export const ContactInfoDescription = ({ formContext, profile, homeless }) => {
       )}
       <div
         className="va-profile-wrapper blue-bar-block vads-u-margin-y--4"
-        onSubmit={event => event.stopPropagation()}
+        onSubmit={event => {
+          // This prevents this nested form submit event from passing to the
+          // outer form and causing a page advance
+          event.stopPropagation();
+        }}
       >
         <InitializeVAPServiceID>
           <h3>Mobile phone number</h3>

--- a/src/applications/appeals/10182/components/ContactInformation.jsx
+++ b/src/applications/appeals/10182/components/ContactInformation.jsx
@@ -3,11 +3,8 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import InitializeVAPServiceID from '@@vap-svc/containers/InitializeVAPServiceID';
-import VAPServicePendingTransactionCategory from '@@vap-svc/containers/VAPServicePendingTransactionCategory';
-import PhoneField from '@@vap-svc/components/PhoneField/PhoneField';
-import EmailField from '@@vap-svc/components/EmailField/EmailField';
-import AddressField from '@@vap-svc/components/AddressField/AddressField';
-import { TRANSACTION_CATEGORY_TYPES, FIELD_NAMES } from '@@vap-svc/constants';
+import ContactInformationField from '@@vap-svc/components/ContactInformationField';
+import { FIELD_NAMES } from '@@vap-svc/constants';
 
 import { selectProfile } from '~/platform/user/selectors';
 
@@ -97,42 +94,27 @@ export const ContactInfoDescription = ({ formContext, profile, homeless }) => {
           </div>
         </>
       )}
-      <div className="blue-bar-block vads-u-margin-top--4">
-        <div
-          className="va-profile-wrapper"
-          onSubmit={event => event.stopPropagation()}
-        >
-          <InitializeVAPServiceID>
-            <VAPServicePendingTransactionCategory
-              categoryType={TRANSACTION_CATEGORY_TYPES.PHONE}
-            >
-              <PhoneField
-                title="Mobile phone number"
-                fieldName={FIELD_NAMES.MOBILE_PHONE}
-                deleteDisabled
-                alertClosingDisabled
-              />
-            </VAPServicePendingTransactionCategory>
-            <VAPServicePendingTransactionCategory
-              categoryType={TRANSACTION_CATEGORY_TYPES.EMAIL}
-            >
-              <EmailField
-                title="Email address"
-                fieldName={FIELD_NAMES.EMAIL}
-                deleteDisabled
-              />
-            </VAPServicePendingTransactionCategory>
-            <VAPServicePendingTransactionCategory
-              categoryType={TRANSACTION_CATEGORY_TYPES.ADDRESS}
-            >
-              <AddressField
-                title="Mailing address"
-                fieldName={FIELD_NAMES.MAILING_ADDRESS}
-                deleteDisabled
-              />
-            </VAPServicePendingTransactionCategory>
-          </InitializeVAPServiceID>
-        </div>
+      <div
+        className="va-profile-wrapper blue-bar-block vads-u-margin-y--4"
+        onSubmit={event => event.stopPropagation()}
+      >
+        <InitializeVAPServiceID>
+          <h3>Mobile phone number</h3>
+          <ContactInformationField
+            fieldName={FIELD_NAMES.MOBILE_PHONE}
+            isDeleteDisabled
+          />
+          <h3>Email address</h3>
+          <ContactInformationField
+            fieldName={FIELD_NAMES.EMAIL}
+            isDeleteDisabled
+          />
+          <h3>Mailing address</h3>
+          <ContactInformationField
+            fieldName={FIELD_NAMES.MAILING_ADDRESS}
+            isDeleteDisabled
+          />
+        </InitializeVAPServiceID>
       </div>
     </>
   );

--- a/src/applications/appeals/10182/sass/10182-nod.scss
+++ b/src/applications/appeals/10182/sass/10182-nod.scss
@@ -118,6 +118,12 @@ dl.review {
   }
 }
 
+@media screen and (min-width: 481px) {
+  .va-profile-wrapper button {
+    width: auto;
+  }
+}
+
 /* IE11 hack to fix edit button placement, see
  * https://github.com/department-of-veterans-affairs/va.gov-team/issues/25108
  */

--- a/src/applications/appeals/10182/tests/components/ContactInformation.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/ContactInformation.unit.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
+import { Provider } from 'react-redux';
 
 import { ContactInfoDescription } from '../../components/ContactInformation';
 
@@ -26,6 +27,7 @@ const getData = ({
   }
   if (address) {
     data.mailingAddress = {
+      addressType: 'DOMESTIC',
       countryName: 'United States',
       countryCodeIso3: 'USA',
       addressLine1: '123 Main Blvd',
@@ -46,11 +48,34 @@ const getData = ({
 describe('Veteran information review content', () => {
   it('should render contact information', () => {
     const data = getData();
-    const tree = shallow(<ContactInfoDescription {...data} />);
+    const mockStore = {
+      getState: () => ({
+        user: {
+          profile: data.profile,
+        },
+        vapService: {
+          fieldTransactionMap: {},
+          modal: '',
+          modalData: null,
+          addressValidation: {},
+        },
+      }),
+      subscribe: () => {},
+      dispatch: () => {},
+    };
+    const tree = shallow(
+      <Provider store={mockStore}>
+        <ContactInfoDescription {...data} />
+      </Provider>,
+    );
 
-    expect(tree.find('PhoneField')).to.exist;
-    expect(tree.find('EmailField')).to.exist;
-    expect(tree.find('MailingAddress')).to.exist;
+    const html = tree.html();
+    expect(html).to.contain('555-800-1212, ext. 1234');
+    expect(html).to.contain(
+      'someone<span class="email-address-symbol">@</span>famous<span class="email-address-symbol">.</span>com',
+    );
+    expect(html).to.contain('123 Main Blvd, Floor 33, Suite 55');
+    expect(html).to.contain('Hollywood, CA 90210');
     tree.unmount();
   });
 


### PR DESCRIPTION
## Description

Add inline-contact info editing for testing in staging. The ticket is to implement this in the Higher-Level Review (HLR) form, but it's live in production, so we're going to test it in the Notice of Disagreement (NOD) form which is not live. If this change is acceptable, the code for NOD will remain, and copied over to HLR.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/31700

## Testing done

Updated unit tests

## Screenshots

<details><summary>Contact Info page (not editing)</summary>

<!-- leave a blank line above -->
![Veteran contact info with edit buttons](https://user-images.githubusercontent.com/136959/138931297-ddd36200-1e5f-4cb1-be4f-a7f3f942d157.png)</details>

<details><summary>Editing contact info inline (one at a time)</summary>

<!-- leave a blank line above -->
![Editing contact info](https://user-images.githubusercontent.com/136959/138931430-fe7a6ebf-b460-429d-ae5e-d79f7b43c08d.gif)</details>

<details><summary>Attempt to edit multiple (alert shown)</summary>

<!-- leave a blank line above -->
![alert shown when attempted to edit multiple fields](https://user-images.githubusercontent.com/136959/138931562-1860c565-bfbf-420e-9b9c-f1b7bd6fc56e.gif)</details>

## Acceptance criteria
- [x] Implement editing of contact info inline
- [x] All test passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
