### PR TITLE
Profile Contact information accoutning for null/ undefined/ falsey

### DIFF
--- a/src/applications/personalization/profile/util/contact-information/formValues.js
+++ b/src/applications/personalization/profile/util/contact-information/formValues.js
@@ -49,11 +49,13 @@ export const getInitialFormValues = options => {
 
     if (data) {
       const { extension, areaCode, phoneNumber } = data;
+      const inputPhoneNumber =
+        areaCode && phoneNumber ? `${areaCode}${phoneNumber}` : phoneNumber;
 
       initialFormValues = {
         ...data,
         extension: extension || '',
-        inputPhoneNumber: `${areaCode}${phoneNumber}`,
+        inputPhoneNumber,
       };
     }
 

--- a/src/applications/personalization/profile/util/contact-information/formValues.js
+++ b/src/applications/personalization/profile/util/contact-information/formValues.js
@@ -50,7 +50,9 @@ export const getInitialFormValues = options => {
     if (data) {
       const { extension, areaCode, phoneNumber } = data;
       const inputPhoneNumber =
-        areaCode && phoneNumber ? `${areaCode}${phoneNumber}` : phoneNumber;
+        areaCode && phoneNumber
+          ? `${areaCode}${phoneNumber}`
+          : `${phoneNumber}`;
 
       initialFormValues = {
         ...data,


### PR DESCRIPTION
## Description
Null area code is showing up on Profile users if the areaCode values given are null.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#22312


## Testing done
Ran e2e to show error and update it accordingly. 

## Screenshots
 Updated Mock user to show area code is null for TDD.
![Screen Shot 2021-10-26 at 2 27 51 PM](https://user-images.githubusercontent.com/26075258/138939076-831cf474-1ca4-4120-aa1a-9e2bd498a9b8.png)

modals.cypress.spec e2e
![Screen Shot 2021-10-26 at 2 28 02 PM](https://user-images.githubusercontent.com/26075258/138939082-d1d07e01-5992-49ad-8888-2a546563a012.png)

All Unit tests passing
<img width="1101" alt="Screen Shot 2021-10-26 at 2 39 23 PM" src="https://user-images.githubusercontent.com/26075258/138940720-e7f4737e-a963-4569-b666-4f2c9ba21392.png">
## Acceptance criteria
- [x] if Area Code is null, don't show null. Show it has it is in read mode.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
