### PR TITLE
Add `eslint-plugin` npm keywords

### DIFF
--- a/script/eslint-plugin-va/package.json
+++ b/script/eslint-plugin-va/package.json
@@ -7,5 +7,10 @@
   },
   "engines": {
     "node": ">=0.10.0"
-  }
+  },
+  "keywords": [
+    "eslint",
+    "eslint-plugin",
+    "eslintplugin"
+  ]
 }


### PR DESCRIPTION

## Description

These are the keywords typically used by eslint plugins to make them easier to find / search for. Even if this plugin is internal-only / not published, it's still good practice to give it the appropriate package description and keywords.

https://eslint.org/docs/developer-guide/working-with-plugins#share-plugins

Other examples showing this:

* https://github.com/eslint/generator-eslint/blob/e435549283d310b23c297ade3fc9b9283ecb146d/plugin/templates/_package.json#L5
* https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/57d4b5e0aec2d7b3767546227c7d78f22958c13c/package.json#L19

## Original issue(s)

N/A

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
