### PR TITLE
Run unit tests in the script directory

### DIFF
--- a/script/run-unit-test.js
+++ b/script/run-unit-test.js
@@ -6,7 +6,7 @@ const glob = require('glob');
 
 // For usage instructions see https://github.com/department-of-veterans-affairs/vets-website#unit-tests
 
-const defaultPath = './src/**/*.unit.spec.js?(x)';
+const defaultPath = './{src,script}/**/*.unit.spec.js?(x)';
 
 const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'log-level', type: String, defaultValue: 'debug' },

--- a/script/temp.unit.spec.js
+++ b/script/temp.unit.spec.js
@@ -1,7 +1,0 @@
-import { expect } from 'chai';
-
-describe('TEMP TEST', () => {
-  it('should run', () => {
-    expect(true).to.equal(true);
-  });
-});

--- a/script/temp.unit.spec.js
+++ b/script/temp.unit.spec.js
@@ -1,0 +1,7 @@
+import { expect } from 'chai';
+
+describe('TEMP TEST', () => {
+  it('should run', () => {
+    expect(true).to.equal(true);
+  });
+});

--- a/script/watch-tests.js
+++ b/script/watch-tests.js
@@ -15,7 +15,7 @@ let busy = false;
 let pendingTests = [];
 
 // all unit test files
-const allUnitTests = glob.sync('{src,test}/**/*.unit.spec.js?(x)');
+const allUnitTests = glob.sync('{src,script,test}/**/*.unit.spec.js?(x)');
 
 function runMochaTests(tests) {
   // fork mocha into a separate process


### PR DESCRIPTION
## Description
Currently unit tests must be inside the `src` directory to run. However we need to also run spec files in the `script` directory in order to properly test our scripts. This PR modifies the type glob passed to mocha to include script files.

I benchmarked this change locally and it only increases total unit test execution time by 0.2 seconds.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#31142

## Testing done
- Run unit tests both `src` and `script` directories
- Successful CI run

## Acceptance criteria
- [x] Unit tests run in the `script` directory

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
