### PR TITLE
Remove unneeded `mkdir` step from GitHub Actions Cypress job

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -366,9 +366,6 @@ jobs:
       - name: Start server
         run: node src/platform/testing/e2e/test-server.js --buildtype vagovprod --port=3001 &
 
-      - name: Create test results directory
-        run: mkdir -p test-results
-
       - name: Run Cypress tests
         run: node script/github-actions/run-cypress-tests.js
         timeout-minutes: 30


### PR DESCRIPTION
## Description
This PR removes an unneeded `mkdir` from the Cypress job in GitHub Actions. The `test-results` directory is not used by Cypress.

## Acceptance criteria
- [x] CI passes.