### PR TITLE
Add new header component

### DIFF
--- a/src/applications/proxy-rewrite/README.md
+++ b/src/applications/proxy-rewrite/README.md
@@ -25,6 +25,7 @@ http://localhost:3001/?target=https://www.va.gov/health/
 
 ## Charles Proxy
 You can also use an application called Charles Proxy to map the `proxy-rewrite` bundles of TeamSite pages to your local machine. This way you can navigate directly to `https://www.va.gov/health/` and when the request for the production bundle of `proxy-rewrite` is sent, Charles will have overridden that file to instead be served locally. Instructions to set this up are located here, https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Work%20Practices/Engineering/Teamsite.md.
+
 ## What To Do When The Test Fails
 - If needed, run `npm run vrt` locally
 - The test log will show a

--- a/src/applications/proxy-rewrite/partials/header.js
+++ b/src/applications/proxy-rewrite/partials/header.js
@@ -1,92 +1,102 @@
 import { replaceWithStagingDomain } from 'platform/utilities/environment/stagingDomains';
 
 export default `
-<header class="header merger">
-  <div class="incompatible-browser-warning">
-    <div class="row full">
-      <div class="small-12">
-        Your browser is out of date. To use this website, please <a href="https://browsehappy.com/">update your browser</a> or use a different device.
+  <!-- Header -->
+  <div
+    data-widget-type="header"
+    data-show="{{ !noHeader }}"
+    data-show-nav-login="{{ !noNavOrLogin }}"
+    data-show-mega-menu="{{ !noMegamenu }}"
+    id="header-v2"
+  ></div>
+
+  <!-- Legacy Header -->
+  <header class="header merger" id="legacy-header">
+    <div class="incompatible-browser-warning">
+      <div class="row full">
+        <div class="small-12">
+          Your browser is out of date. To use this website, please <a href="https://browsehappy.com/">update your browser</a> or use a different device.
+        </div>
       </div>
     </div>
-  </div>
 
-  <div id="preview-site-alert"></div>
+    <div id="preview-site-alert"></div>
 
-  <div class="va-notice--banner">
-    <div class="va-notice--banner-inner">
-      <!-- /va-gov/includes/usa-website-header.html -->
-      <div class="usa-banner">
-        <div class="usa-accordion">
-          <div class="usa-banner-header">
-            <div class="usa-grid usa-banner-inner">
-            <img src="${replaceWithStagingDomain(
-              'https://www.va.gov/img/tiny-usa-flag.png',
-            )}" alt="U.S. flag">
-            <p>An official website of the United States government</p>
-            <button id="usa-banner-toggle" class="usa-accordion-button usa-banner-button" aria-expanded="false" aria-controls="gov-banner">
-              <span class="usa-banner-button-text">Here&rsquo;s how you know</span>
-            </button>
-            </div>
-          </div>
-          <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner" aria-hidden="true">
-            <div class="usa-banner-guidance-gov usa-width-one-half">
-              <img class="usa-banner-icon usa-media_block-img" src="${replaceWithStagingDomain(
-                'https://www.va.gov/img/icon-dot-gov.svg',
-              )}" alt="Dot gov">
-              <div class="usa-media_block-body">
-                <p>
-                  <strong>The .gov means it&rsquo;s official.</strong>
-                  <br>
-                  Federal government websites often end in .gov or .mil. Before sharing sensitive information, make sure you're on a federal government site.
-                </p>
+    <div class="va-notice--banner">
+      <div class="va-notice--banner-inner">
+        <!-- /va-gov/includes/usa-website-header.html -->
+        <div class="usa-banner">
+          <div class="usa-accordion">
+            <div class="usa-banner-header">
+              <div class="usa-grid usa-banner-inner">
+              <img src="${replaceWithStagingDomain(
+                'https://www.va.gov/img/tiny-usa-flag.png',
+              )}" alt="U.S. flag">
+              <p>An official website of the United States government</p>
+              <button id="usa-banner-toggle" class="usa-accordion-button usa-banner-button" aria-expanded="false" aria-controls="gov-banner">
+                <span class="usa-banner-button-text">Here&rsquo;s how you know</span>
+              </button>
               </div>
             </div>
-            <div class="usa-banner-guidance-ssl usa-width-one-half">
-              <img class="usa-banner-icon usa-media_block-img" src="${replaceWithStagingDomain(
-                'https://www.va.gov/img/icon-https.svg',
-              )}" alt="SSL">
-              <div class="usa-media_block-body">
-                <p>
-                  <strong>The site is secure.</strong>
-                  <br> The <strong>https://</strong> ensures that you're connecting to the official website and that any information you provide is encrypted and sent securely.
-                </p>
+            <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner" aria-hidden="true">
+              <div class="usa-banner-guidance-gov usa-width-one-half">
+                <img class="usa-banner-icon usa-media_block-img" src="${replaceWithStagingDomain(
+                  'https://www.va.gov/img/icon-dot-gov.svg',
+                )}" alt="Dot gov">
+                <div class="usa-media_block-body">
+                  <p>
+                    <strong>The .gov means it&rsquo;s official.</strong>
+                    <br>
+                    Federal government websites often end in .gov or .mil. Before sharing sensitive information, make sure you're on a federal government site.
+                  </p>
+                </div>
+              </div>
+              <div class="usa-banner-guidance-ssl usa-width-one-half">
+                <img class="usa-banner-icon usa-media_block-img" src="${replaceWithStagingDomain(
+                  'https://www.va.gov/img/icon-https.svg',
+                )}" alt="SSL">
+                <div class="usa-media_block-body">
+                  <p>
+                    <strong>The site is secure.</strong>
+                    <br> The <strong>https://</strong> ensures that you're connecting to the official website and that any information you provide is encrypted and sent securely.
+                  </p>
+                </div>
               </div>
             </div>
           </div>
         </div>
+        <!-- /va-gov/includes/usa-website-header.html -->
       </div>
-      <!-- /va-gov/includes/usa-website-header.html -->
+      <div class="va-crisis-line-container">
+        <button data-show="#modal-crisisline" class="va-crisis-line va-overlay-trigger">
+          <div class="va-crisis-line-inner">
+            <span class="va-crisis-line-icon" aria-hidden="true"></span>
+            <span class="va-crisis-line-text">Talk to the <strong>Veterans Crisis Line</strong> now</span>
+            <img class="va-crisis-line-arrow" src="${replaceWithStagingDomain(
+              'https://www.va.gov/img/arrow-right-white.svg',
+            )}" aria-hidden="true"></img>
+          </div>
+        </button>
+      </div>
     </div>
-    <div class="va-crisis-line-container">
-      <button data-show="#modal-crisisline" class="va-crisis-line va-overlay-trigger">
-        <div class="va-crisis-line-inner">
-          <span class="va-crisis-line-icon" aria-hidden="true"></span>
-          <span class="va-crisis-line-text">Talk to the <strong>Veterans Crisis Line</strong> now</span>
-          <img class="va-crisis-line-arrow" src="${replaceWithStagingDomain(
-            'https://www.va.gov/img/arrow-right-white.svg',
-          )}" aria-hidden="true"></img>
-        </div>
-      </button>
-    </div>
-  </div>
-  <!-- /header alert box -->
+    <!-- /header alert box -->
 
-  <div class="row va-flex usa-grid" id="va-header-logo-menu">
-    <div class="va-header-logo-wrapper">
-      <a href="${replaceWithStagingDomain(
-        'https://www.va.gov',
-      )}" class="va-header-logo">
-      <img src="${replaceWithStagingDomain(
-        'https://www.va.gov/img/header-logo.png',
-      )}" alt="Go to VA.gov"/>
-      </a>
+    <div class="row va-flex usa-grid" id="va-header-logo-menu">
+      <div class="va-header-logo-wrapper">
+        <a href="${replaceWithStagingDomain(
+          'https://www.va.gov',
+        )}" class="va-header-logo">
+        <img src="${replaceWithStagingDomain(
+          'https://www.va.gov/img/header-logo.png',
+        )}" alt="Go to VA.gov"/>
+        </a>
+      </div>
+      <div id="va-nav-controls"></div>
+      <div id="login-root" class="vet-toolbar"></div>
     </div>
-    <div id="va-nav-controls"></div>
-    <div id="login-root" class="vet-toolbar"></div>
-  </div>
-  <div class="usa-grid usa-grid-full">
-    <div class="menu-rule usa-one-whole"></div>
-    <div id="mega-menu"></div>
-  </div>
-</header>
+    <div class="usa-grid usa-grid-full">
+      <div class="menu-rule usa-one-whole"></div>
+      <div id="mega-menu"></div>
+    </div>
+  </header>
 `;

--- a/src/applications/proxy-rewrite/proxy-rewrite-entry.jsx
+++ b/src/applications/proxy-rewrite/proxy-rewrite-entry.jsx
@@ -1,25 +1,21 @@
+// Node modules.
 import 'platform/polyfills';
 import cookie from 'cookie';
-
+// Relative imports.
+import addFocusBehaviorToCrisisLineModal from 'platform/site-wide/accessible-VCL-modal';
 import buckets from 'site/constants/buckets';
 import bucketsContent from 'site/constants/buckets-content';
-import environments from 'site/constants/environments';
-
 import createCommonStore from 'platform/startup/store';
 import environment from 'platform/utilities/environment';
-
-import headerPartial from './partials/header';
+import environments from 'site/constants/environments';
 import footerPartial from './partials/footer';
-
-import startUserNavWidget from 'platform/site-wide/user-nav';
+import headerPartial from './partials/header';
+import redirectIfNecessary from './redirects';
+import startHeader from 'platform/site-wide/header';
 import startMegaMenuWidget from 'platform/site-wide/mega-menu';
 import startMobileMenuButton from 'platform/site-wide/mobile-menu-button';
-
-// import startLRNHealthCarWidget from 'platform/site-wide/left-rail-navs/health-care';
-// import startAnnouncementWidget from 'platform/site-wide/announcements';
+import startUserNavWidget from 'platform/site-wide/user-nav';
 import startVAFooter, { footerElemementId } from 'platform/site-wide/va-footer';
-import redirectIfNecessary from './redirects';
-import addFocusBehaviorToCrisisLineModal from 'platform/site-wide/accessible-VCL-modal';
 import { addOverlayTriggers } from 'platform/site-wide/legacy/menu';
 import { proxyRewriteWhitelist } from './proxy-rewrite-whitelist.json';
 
@@ -123,9 +119,8 @@ function mountReactComponents(headerFooterData, commonStore) {
   startUserNavWidget(commonStore);
   startMegaMenuWidget(headerFooterData.megaMenuData, commonStore);
   startMobileMenuButton(commonStore);
-  // startLRNHealthCarWidget(commonStore);
-  // startAnnouncementWidget(commonStore);
   renderFooter(headerFooterData.footerData, commonStore);
+  startHeader(commonStore, headerFooterData.megaMenuData);
 }
 
 function getContentHostName() {

--- a/src/platform/landing-pages/dev-template.ejs
+++ b/src/platform/landing-pages/dev-template.ejs
@@ -59,7 +59,17 @@
   <body class="merger">
     <a class="show-on-focus" href="#content" onclick="focusContent(event)">Skip to Content</a>
 
-    <header class="header">
+    <!-- Header -->
+    <div
+      data-widget-type="header"
+      data-show="{{ !noHeader }}"
+      data-show-nav-login="{{ !noNavOrLogin }}"
+      data-show-mega-menu="{{ !noMegamenu }}"
+      id="header-v2"
+    ></div>
+
+    <!-- Legacy Header -->
+    <header class="header" id="legacy-header">
       <div class="incompatible-browser-warning">
         <div class="row full">
           <div class="small-12">

--- a/src/platform/site-wide/header/components/App/index.js
+++ b/src/platform/site-wide/header/components/App/index.js
@@ -1,0 +1,72 @@
+// Node modules.
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+// Relative imports.
+import Header from '../Header';
+import { hideLegacyHeader, showLegacyHeader } from '../../helpers';
+
+const MOBILE_BREAKPOINT_PX = 768;
+
+export const App = ({
+  megaMenuData,
+  show,
+  showHeaderV2,
+  showMegaMenu,
+  showNavLogin,
+}) => {
+  // Derive if we are on desktop.
+  const [isDesktop, setIsDesktop] = useState(
+    window.innerWidth >= MOBILE_BREAKPOINT_PX,
+  );
+
+  // Derive if we are on desktop and set isDesktop state.
+  const deriveIsDesktop = () =>
+    setIsDesktop(window.innerWidth >= MOBILE_BREAKPOINT_PX);
+
+  useEffect(() => {
+    // Set screen size listener.
+    window.addEventListener('resize', deriveIsDesktop);
+
+    // Clear listener.
+    return () => window.removeEventListener('resize', deriveIsDesktop);
+  }, []);
+
+  // Do not render if prop show is falsey.
+  if (!show) {
+    return null;
+  }
+
+  // Render the legacy header if the feature toggle is NOT enabled OR if we are on desktop.
+  if (!showHeaderV2 || isDesktop) {
+    showLegacyHeader();
+    return null;
+  }
+
+  hideLegacyHeader();
+  return (
+    <Header
+      megaMenuData={megaMenuData}
+      showMegaMenu={showMegaMenu}
+      showNavLogin={showNavLogin}
+    />
+  );
+};
+
+App.propTypes = {
+  megaMenuData: PropTypes.arrayOf(PropTypes.object).isRequired,
+  show: PropTypes.bool.isRequired,
+  showMegaMenu: PropTypes.bool.isRequired,
+  showNavLogin: PropTypes.bool.isRequired,
+  // From mapStateToProps.
+  showHeaderV2: PropTypes.bool,
+};
+
+const mapStateToProps = state => ({
+  showHeaderV2: state?.featureToggles?.showHeaderV2,
+});
+
+export default connect(
+  mapStateToProps,
+  null,
+)(App);

--- a/src/platform/site-wide/header/components/App/index.unit.spec.js
+++ b/src/platform/site-wide/header/components/App/index.unit.spec.js
@@ -1,0 +1,28 @@
+// Node modules.
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+// Relative imports.
+import { App } from '.';
+
+describe('Header <App>', () => {
+  it('renders legacy header when showHeaderV2 is falsey', () => {
+    const wrapper = shallow(<App show />);
+    expect(wrapper.find(`Header`)).be.have.lengthOf(0);
+    wrapper.unmount();
+  });
+
+  it('renders legacy header when showHeaderV2 is truthy and our width is more than 768px', () => {
+    window.innerWidth = 768;
+    const wrapper = shallow(<App show showHeaderV2 />);
+    expect(wrapper.find(`Header`)).be.have.lengthOf(0);
+    wrapper.unmount();
+  });
+
+  it('renders header v2 when showHeaderV2 is truthy and our width is less than 768px', () => {
+    window.innerWidth = 767;
+    const wrapper = shallow(<App show showHeaderV2 />);
+    expect(wrapper.find(`Header`)).be.have.lengthOf(1);
+    wrapper.unmount();
+  });
+});

--- a/src/platform/site-wide/header/components/App/index.unit.spec.js
+++ b/src/platform/site-wide/header/components/App/index.unit.spec.js
@@ -8,21 +8,21 @@ import { App } from '.';
 describe('Header <App>', () => {
   it('renders legacy header when showHeaderV2 is falsey', () => {
     const wrapper = shallow(<App show />);
-    expect(wrapper.find(`Header`)).be.have.lengthOf(0);
+    expect(wrapper.find(`Header`)).to.have.lengthOf(0);
     wrapper.unmount();
   });
 
   it('renders legacy header when showHeaderV2 is truthy and our width is more than 768px', () => {
     window.innerWidth = 768;
     const wrapper = shallow(<App show showHeaderV2 />);
-    expect(wrapper.find(`Header`)).be.have.lengthOf(0);
+    expect(wrapper.find(`Header`)).to.have.lengthOf(0);
     wrapper.unmount();
   });
 
   it('renders header v2 when showHeaderV2 is truthy and our width is less than 768px', () => {
     window.innerWidth = 767;
     const wrapper = shallow(<App show showHeaderV2 />);
-    expect(wrapper.find(`Header`)).be.have.lengthOf(1);
+    expect(wrapper.find(`Header`)).to.have.lengthOf(1);
     wrapper.unmount();
   });
 });

--- a/src/platform/site-wide/header/components/Header/index.js
+++ b/src/platform/site-wide/header/components/Header/index.js
@@ -1,0 +1,16 @@
+// Node modules.
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// This is the Header v2 component, it will be built out in a follow-up PR.
+export const Header = () => {
+  return <header className="header">New header</header>;
+};
+
+Header.propTypes = {
+  megaMenuData: PropTypes.arrayOf(PropTypes.object).isRequired,
+  showMegaMenu: PropTypes.bool.isRequired,
+  showNavLogin: PropTypes.bool.isRequired,
+};
+
+export default Header;

--- a/src/platform/site-wide/header/components/Header/index.unit.spec.js
+++ b/src/platform/site-wide/header/components/Header/index.unit.spec.js
@@ -1,0 +1,14 @@
+// Node modules.
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+// Relative imports.
+import { Header } from '.';
+
+describe('Header <Header>', () => {
+  it('renders content', () => {
+    const wrapper = shallow(<Header showMegaMenu showNavLogin />);
+    expect(wrapper.text()).to.include('New header');
+    wrapper.unmount();
+  });
+});

--- a/src/platform/site-wide/header/constants/index.js
+++ b/src/platform/site-wide/header/constants/index.js
@@ -1,0 +1,1 @@
+export const MIN_SCREEN_SIZE_PX = 767;

--- a/src/platform/site-wide/header/helpers/index.js
+++ b/src/platform/site-wide/header/helpers/index.js
@@ -1,0 +1,29 @@
+export const hideLegacyHeader = () => {
+  // Derive the legacy header.
+  const legacyHeader = document.getElementById('legacy-header');
+
+  // Escape early if the legacy header doesn't exist.
+  if (!legacyHeader) {
+    return;
+  }
+
+  // Add `vads-u-display--none` to the legacy header if it doesn't already have it.
+  if (!legacyHeader.classList.contains('vads-u-display--none')) {
+    legacyHeader.classList.add('vads-u-display--none');
+  }
+};
+
+export const showLegacyHeader = () => {
+  // Derive the legacy header.
+  const legacyHeader = document.getElementById('legacy-header');
+
+  // Escape early if the legacy header doesn't exist.
+  if (!legacyHeader) {
+    return;
+  }
+
+  // Add `vads-u-display--none` to the legacy header if it doesn't already have it.
+  if (legacyHeader.classList.contains('vads-u-display--none')) {
+    legacyHeader.classList.remove('vads-u-display--none');
+  }
+};

--- a/src/platform/site-wide/header/index.js
+++ b/src/platform/site-wide/header/index.js
@@ -1,0 +1,31 @@
+// Node modules.
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+// Relative imports.
+import App from './components/App';
+import { connectFeatureToggle } from 'platform/utilities/feature-toggles';
+
+export default (store, megaMenuData) => {
+  // Derive the widget and its data properties for props.
+  const root = document.querySelector(`[data-widget-type="header"]`);
+  const props = root?.dataset;
+
+  // Connect feature toggles.
+  connectFeatureToggle(store.dispatch);
+
+  // Render the widget.
+  if (root) {
+    ReactDOM.render(
+      <Provider store={store}>
+        <App
+          megaMenuData={megaMenuData}
+          show={props.show !== 'false'}
+          showMegaMenu={props.showMegaMenu !== 'false'}
+          showNavLogin={props.showNavLogin !== 'false'}
+        />
+      </Provider>,
+      root,
+    );
+  }
+};

--- a/src/platform/site-wide/index.js
+++ b/src/platform/site-wide/index.js
@@ -1,24 +1,22 @@
-/**
- * Module for site wide components
- * @module platform/site-wide
- */
+// Node modules.
+import '@department-of-veterans-affairs/formation/dist/formation';
+// Relative imports.
 import '../monitoring/sentry.js';
-import './legacy/menu'; // Used in the footer.
+import './legacy/menu';
 import './medallia-feedback-button';
 import './moment-setup';
 import './popups';
 import './wysiwyg-analytics-setup';
 import './component-library-analytics-setup';
-import startUserNavWidget from './user-nav';
-import startMegaMenuWidget from './mega-menu';
-import startSideNav from './side-nav';
-import startBanners from './banners';
-import startMobileMenuButton from './mobile-menu-button';
-import startAnnouncementWidget from './announcements';
-import startVAFooter from './va-footer';
 import addFocusBehaviorToCrisisLineModal from './accessible-VCL-modal';
-
-import '@department-of-veterans-affairs/formation/dist/formation';
+import startAnnouncementWidget from './announcements';
+import startBanners from './banners';
+import startHeader from './header';
+import startMegaMenuWidget from './mega-menu';
+import startMobileMenuButton from './mobile-menu-button';
+import startSideNav from './side-nav';
+import startUserNavWidget from './user-nav';
+import startVAFooter from './va-footer';
 
 /**
  * Start up the site-wide components that live on every page, like
@@ -45,6 +43,7 @@ export default function startSitewideComponents(commonStore) {
     }
   });
 
+  // Start site-wide widgets.
   startUserNavWidget(commonStore);
   startAnnouncementWidget(commonStore);
   startMegaMenuWidget(window.VetsGov.headerFooter.megaMenuData, commonStore);
@@ -56,4 +55,5 @@ export default function startSitewideComponents(commonStore) {
     addFocusBehaviorToCrisisLineModal,
     commonStore,
   );
+  startHeader(commonStore, window.VetsGov.headerFooter.headerData);
 }

--- a/src/platform/site-wide/index.js
+++ b/src/platform/site-wide/index.js
@@ -55,5 +55,5 @@ export default function startSitewideComponents(commonStore) {
     addFocusBehaviorToCrisisLineModal,
     commonStore,
   );
-  startHeader(commonStore, window.VetsGov.headerFooter.headerData);
+  startHeader(commonStore, window.VetsGov.headerFooter.megaMenuData);
 }

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -68,6 +68,7 @@ export default Object.freeze({
   showEduBenefits5495Wizard: 'show_edu_benefits_5495_wizard',
   showFinancialStatusReport: 'show_financial_status_report',
   showFinancialStatusReportWizard: 'show_financial_status_report_wizard',
+  showHeaderV2: 'show_header_v2',
   showMebMockEndpoints: 'show_meb_mock_endpoints',
   showMedicalCopays: 'show_medical_copays',
   showHealthcareExperienceQuestionnaire:


### PR DESCRIPTION
## Description

**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/31145

This PR adds the `header` react widget to use for the new header.

## Testing

Added unit tests and tested locally with the related content-build PR: https://github.com/department-of-veterans-affairs/content-build/pull/699

## Screenshots

### New header with feature toggle `show_header_v2` on and on mobile

<img width="765" alt="Screen Shot 2021-10-27 at 8 56 37 AM" src="https://user-images.githubusercontent.com/12773166/139093944-f9454189-4da7-403f-ae9c-607b72b9d4cc.png">

### Legacy header used when feature toggle is disabled OR we are on desktop

![image](https://user-images.githubusercontent.com/12773166/138750916-de887586-1f57-4c72-a47d-22640505afce.png)

## Acceptance Criteria

- [x] Create main header App component
- [x] Create header v2 component
- [x] Test to see if it will work on subdomains
