### PR TITLE
526: Show dependents info on confirmation

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ConfirmationPoll.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationPoll.jsx
@@ -10,6 +10,7 @@ import ConfirmationPage from '../containers/ConfirmationPage';
 import { pendingMessage } from '../content/confirmation-poll';
 
 import { submissionStatuses, terminalStatuses } from '../constants';
+import { isBDD } from '../utils';
 
 export class ConfirmationPoll extends React.Component {
   // Using it as a prop for easy testing
@@ -103,7 +104,13 @@ export class ConfirmationPoll extends React.Component {
       return pendingMessage(this.state.longWait);
     }
 
-    const { fullName, disabilities, submittedAt, jobId } = this.props;
+    const {
+      fullName,
+      disabilities,
+      submittedAt,
+      jobId,
+      isSubmittingBDD,
+    } = this.props;
 
     setTimeout(() => focusElement('h2'));
     return (
@@ -114,6 +121,7 @@ export class ConfirmationPoll extends React.Component {
         fullName={fullName}
         disabilities={disabilities}
         submittedAt={submittedAt}
+        isSubmittingBDD={isSubmittingBDD}
       />
     );
   }
@@ -135,6 +143,7 @@ function mapStateToProps(state) {
     disabilities: selectAllDisabilityNames(state),
     submittedAt: state.form.submission.timestamp,
     jobId: state.form.submission.response?.attributes?.jobId,
+    isSubmittingBDD: isBDD(state.form.data) || true,
   };
 }
 

--- a/src/applications/disability-benefits/all-claims/components/DownloadPDF.js
+++ b/src/applications/disability-benefits/all-claims/components/DownloadPDF.js
@@ -1,0 +1,29 @@
+import React from 'react';
+
+// See github.com/department-of-veterans-affairs/va.gov-team/issues/11852
+// Updated with lang="en" span from the Find a form download links
+const DownloadPDF = ({ formNumber = '', fileName = '', size = '' }) => (
+  <a
+    href={`https://www.vba.va.gov/pubs/forms/${fileName}.pdf`}
+    download={`${fileName}.pdf`}
+    type="application/pdf"
+    target="_blank"
+    rel="noopener noreferrer"
+    className="vads-u-text-decoration--none"
+  >
+    <i
+      aria-hidden="true"
+      className="fas fa-download fa-lg vads-u-padding-right--1"
+      role="img"
+    />
+    <span lang="en" className="vads-u-text-decoration--underline">
+      Download VA Form {formNumber}{' '}
+      <dfn>
+        <abbr title="Portable Document Format">PDF</abbr> ({size}
+        <abbr title="Megabytes">MB</abbr>)
+      </dfn>
+    </span>
+  </a>
+);
+
+export default DownloadPDF;

--- a/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
+++ b/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
@@ -149,11 +149,14 @@ const template = (props, title, content, submissionMessage, messageType) => {
         </h2>
         <p className="confirmation-guidance-message">
           <strong>If you have a spouse or child</strong>, you may be entitled to
-          additional payments.{' '}
-          <a href="https://www.va.gov/view-change-dependents/">
-            Apply online to add a dependent
-          </a>
+          additional payments.
         </p>
+        <a
+          className="vads-c-action-link--blue"
+          href="https://www.va.gov/view-change-dependents/"
+        >
+          Apply online to add a dependent
+        </a>
         <p>
           Or you can fill out and submit an Application Request to Add and/or
           Remove Dependents (VA Form 21-686c)

--- a/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
+++ b/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
@@ -4,6 +4,7 @@ import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/component-library/Telephone';
 
+import DownloadPDF from '../components/DownloadPDF';
 import { capitalizeEachWord, formatDate } from '../utils';
 import {
   successMessage,
@@ -141,6 +142,61 @@ const template = (props, title, content, submissionMessage, messageType) => {
         </p>
         <p>
           <a href="/track-claims">Check the status of your claim</a>
+        </p>
+
+        <h2 className="confirmation-guidance-heading vads-u-font-size--h4">
+          What should I do next?
+        </h2>
+        <p className="confirmation-guidance-message">
+          <strong>If you have a spouse or child</strong>, you may be entitled to
+          additional payments.{' '}
+          <a href="https://www.va.gov/view-change-dependents/">
+            Apply online to add a dependent
+          </a>
+        </p>
+        <p>
+          Or you can fill out and submit an Application Request to Add and/or
+          Remove Dependents (VA Form 21-686c)
+        </p>
+        <p>
+          <DownloadPDF
+            formNumber="21-686c"
+            fileName="VBA-21-686c-ARE"
+            size="2.7"
+          />
+        </p>
+        <p>
+          <strong>Note:</strong> If you’re claiming your child who became
+          permanently disabled before they turned 18, you’ll need to submit all
+          military and private medical records relating to the child’s
+          disabilities with your application.
+        </p>
+        <p>
+          <strong>
+            If you’re claiming a child who’s between 18 and 23 years old and
+            attending school full time
+          </strong>
+          , you’ll need to fill out and submit a Request for Approval of School
+          Attendance (VA Form 21-674) so we can verify their attendance.
+        </p>
+        <p>
+          <DownloadPDF
+            formNumber="21-674"
+            fileName="VBA-21-674-ARE"
+            size="1.3"
+          />
+        </p>
+        <p>
+          <strong>If you have dependent parents</strong>, you may be entitled to
+          additional payments. Fill out and submit a Statement of Dependency of
+          Parent(s) (VA Form 21P-509).
+        </p>
+        <p>
+          <DownloadPDF
+            formNumber="21P-509"
+            fileName="VBA-21P-509-ARE"
+            size="1"
+          />
         </p>
 
         <h2 className="confirmation-guidance-heading vads-u-font-size--h4">

--- a/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
+++ b/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
@@ -15,7 +15,7 @@ import {
 import { NULL_CONDITION_STRING } from '../constants';
 
 const template = (props, title, content, submissionMessage, messageType) => {
-  const { fullName, disabilities, submittedAt } = props;
+  const { fullName, disabilities, submittedAt, isSubmittingBDD } = props;
   const { first, last, middle, suffix } = fullName;
 
   // This is easier than passing down props and checking if the form type
@@ -144,63 +144,68 @@ const template = (props, title, content, submissionMessage, messageType) => {
           <a href="/track-claims">Check the status of your claim</a>
         </p>
 
-        <h2 className="confirmation-guidance-heading vads-u-font-size--h4">
-          What should I do next?
-        </h2>
-        <p className="confirmation-guidance-message">
-          <strong>If you have a spouse or child</strong>, you may be entitled to
-          additional payments.
-        </p>
-        <a
-          className="vads-c-action-link--blue"
-          href="https://www.va.gov/view-change-dependents/"
-        >
-          Apply online to add a dependent
-        </a>
-        <p>
-          Or you can fill out and submit an Application Request to Add and/or
-          Remove Dependents (VA Form 21-686c)
-        </p>
-        <p>
-          <DownloadPDF
-            formNumber="21-686c"
-            fileName="VBA-21-686c-ARE"
-            size="2.7"
-          />
-        </p>
-        <p>
-          <strong>Note:</strong> If you’re claiming your child who became
-          permanently disabled before they turned 18, you’ll need to submit all
-          military and private medical records relating to the child’s
-          disabilities with your application.
-        </p>
-        <p>
-          <strong>
-            If you’re claiming a child who’s between 18 and 23 years old and
-            attending school full time
-          </strong>
-          , you’ll need to fill out and submit a Request for Approval of School
-          Attendance (VA Form 21-674) so we can verify their attendance.
-        </p>
-        <p>
-          <DownloadPDF
-            formNumber="21-674"
-            fileName="VBA-21-674-ARE"
-            size="1.3"
-          />
-        </p>
-        <p>
-          <strong>If you have dependent parents</strong>, you may be entitled to
-          additional payments. Fill out and submit a Statement of Dependency of
-          Parent(s) (VA Form 21P-509).
-        </p>
-        <p>
-          <DownloadPDF
-            formNumber="21P-509"
-            fileName="VBA-21P-509-ARE"
-            size="1"
-          />
-        </p>
+        {!isSubmittingBDD && (
+          <>
+            <h2 className="confirmation-guidance-heading vads-u-font-size--h4">
+              What should I do next?
+            </h2>
+            <p className="confirmation-guidance-message">
+              <strong>If you have a spouse or child</strong>, you may be
+              entitled to additional payments.
+            </p>
+            <a
+              className="vads-c-action-link--blue"
+              href="https://www.va.gov/view-change-dependents/"
+            >
+              Apply online to add a dependent
+            </a>
+            <p>
+              Or you can fill out and submit an Application Request to Add
+              and/or Remove Dependents (VA Form 21-686c)
+            </p>
+            <p>
+              <DownloadPDF
+                formNumber="21-686c"
+                fileName="VBA-21-686c-ARE"
+                size="2.7"
+              />
+            </p>
+            <p>
+              <strong>Note:</strong> If you’re claiming your child who became
+              permanently disabled before they turned 18, you’ll need to submit
+              all military and private medical records relating to the child’s
+              disabilities with your application.
+            </p>
+            <p>
+              <strong>
+                If you’re claiming a child who’s between 18 and 23 years old and
+                attending school full time
+              </strong>
+              , you’ll need to fill out and submit a Request for Approval of
+              School Attendance (VA Form 21-674) so we can verify their
+              attendance.
+            </p>
+            <p>
+              <DownloadPDF
+                formNumber="21-674"
+                fileName="VBA-21-674-ARE"
+                size="1.3"
+              />
+            </p>
+            <p>
+              <strong>If you have dependent parents</strong>, you may be
+              entitled to additional payments. Fill out and submit a Statement
+              of Dependency of Parent(s) (VA Form 21P-509).
+            </p>
+            <p>
+              <DownloadPDF
+                formNumber="21P-509"
+                fileName="VBA-21P-509-ARE"
+                size="1"
+              />
+            </p>
+          </>
+        )}
 
         <h2 className="confirmation-guidance-heading vads-u-font-size--h4">
           What happens after I file a claim for disability compensation?

--- a/src/applications/disability-benefits/all-claims/tests/components/ConfirmationPoll.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/ConfirmationPoll.unit.spec.jsx
@@ -67,6 +67,7 @@ describe('ConfirmationPoll', () => {
     fullName: { first: 'asdf', last: 'fdsa' },
     disabilities: [],
     submittedAt: Date.now(),
+    isSubmittingBDD: false,
   };
 
   it('should make an api call after mounting', () => {
@@ -108,6 +109,7 @@ describe('ConfirmationPoll', () => {
         fullName: defaultProps.fullName,
         disabilities: defaultProps.disabilities,
         submittedAt: defaultProps.submittedAt,
+        isSubmittingBDD: defaultProps.isSubmittingBDD,
       });
       tree.unmount();
       done();


### PR DESCRIPTION
## Description

For 526 claims, the Veteran may need to fill out additional form to add dependents. For this, we add a block of information on the confirmation page. This work is non BDD-specific - opposite of the original ticket - because this would be useful information for a Veteran filling an already established claim. Form 686c is only available to Veterans who have a disability rating over 30%, and disability ratings only get finalized after a service member retires from active duty.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/27782

## Testing done

N/A - only content changes

## Screenshots

![what should I do next section: add a dependent](https://user-images.githubusercontent.com/136959/139115605-7e87d459-04d8-4d7b-8580-9ff271f1ea96.png)

## Acceptance criteria
- [x] Include a new section on the confirmation page indicating the next steps specific to adding a dependent

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
