### PR TITLE
Fixes clickedEvent auto-login

### DIFF
--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -121,7 +121,8 @@ export function redirect(redirectUrl, clickedEvent) {
 
   if (
     !loginAppUrlRE.test(window.location.pathname) &&
-    clickedEvent === 'login-link-clicked-modal'
+    (clickedEvent === 'login-link-clicked-modal' ||
+      clickedEvent === 'sso-automatic-login')
   ) {
     setLoginAttempted();
   }


### PR DESCRIPTION
## Description
This PR ensures the setLoginAttempted method is called when either the AutoSSO (sso-automatic-login) or the Modal (login-link-clicked-modal) events are called which prevents an auto login loop from occuring.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done
Unit testing

## Screenshots


## Acceptance criteria
- [ ] setLoginAttempted is only called on Inbound or Outbound

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
