### PR TITLE
Run Archive steps on GitHub Actions when Cypress tests are skipped

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -706,7 +706,7 @@ jobs:
     # or else they will also be skipped when linting is skipped.
     if: |
       always() &&
-      needs.cypress-tests.result == 'success' &&
+      (needs.cypress-tests.result == 'success' || needs.cypress-tests.result == 'skipped') &&
       needs.unit-tests.result == 'success' &&
       needs.contract-tests.result == 'success' &&
       needs.security-audit.result == 'success' &&

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -707,6 +707,7 @@ jobs:
     if: |
       always() &&
       (needs.cypress-tests.result == 'success' || needs.cypress-tests.result == 'skipped') &&
+      needs.build.result == 'success' &&
       needs.unit-tests.result == 'success' &&
       needs.contract-tests.result == 'success' &&
       needs.security-audit.result == 'success' &&


### PR DESCRIPTION
## Description
This PR modifies the GitHub Actions workflow so that the `archive` jobs still run when no Cypress tests run.

## Acceptance criteria
- [ ] CI passes.