### PR TITLE
CST: Use Ask VA links

### DIFF
--- a/src/applications/claims-status/components/AskVAQuestions.jsx
+++ b/src/applications/claims-status/components/AskVAQuestions.jsx
@@ -13,7 +13,9 @@ function AskVAQuestions() {
       </p>
       <p>Monday through Friday, 8:00 a.m. to 9:00 p.m. ET</p>
       <p>
-        <a href="https://iris.custhelp.com/">Submit a question to VA</a>
+        <a href="https://www.va.gov/contact-us/">
+          Contact us online through Ask VA
+        </a>
       </p>
     </div>
   );

--- a/src/applications/claims-status/components/StemAskVAQuestions.jsx
+++ b/src/applications/claims-status/components/StemAskVAQuestions.jsx
@@ -22,10 +22,9 @@ function StemAskVAQuestions() {
         Ask a question
       </h3>
       <p className="vads-u-padding-top--1px">
-        <a href="https://gibill.custhelp.va.gov/app/" onClick={recordLinkClick}>
-          Ask a question online
-        </a>{' '}
-        (Include your full name and VA file number)
+        <a href="https://www.va.gov/contact-us/" onClick={recordLinkClick}>
+          Contact us online through Ask VA
+        </a>
       </p>
       <h3 className="vads-u-font-size--h4 vads-u-margin-bottom--0p5">
         Call us


### PR DESCRIPTION
## Description

In the claim status tool, replace IRIS & GI Bill Help Portal links with Ask VA links 

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/31723

## Testing done

N/A - content update

## Screenshots

![Screen Shot 2021-10-27 at 3 20 52 PM](https://user-images.githubusercontent.com/136959/139141221-5f06d93c-790b-49e0-947e-97494a6b911f.png)

## Acceptance criteria
- [x] Replace links to IRIS and GI Bill Help Portal with links to the Ask VA page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
