### PR TITLE
31578: [Debt Letters] Add collection status

### DIFF
--- a/src/applications/debt-letters/components/DebtDetails.jsx
+++ b/src/applications/debt-letters/components/DebtDetails.jsx
@@ -81,38 +81,32 @@ const DebtDetails = ({ selectedDebt, debts }) => {
               </span>
             </p>
           )}
-          <div className="vads-u-display--flex vads-u-flex-direction--row">
-            <dl className="vads-u-display--flex vads-u-flex-direction--column">
-              {dateFirstNotice && (
-                <div className="vads-u-margin-y--1 vads-u-display--flex">
-                  <dt>
-                    <strong>Date of first notice: </strong>
-                  </dt>
-                  <dd className="vads-u-margin-left--1">
-                    {moment(dateFirstNotice, 'MM-DD-YYYY').format(
-                      'MMMM D, YYYY',
-                    )}
-                  </dd>
-                </div>
-              )}
-              <div className="vads-u-display--flex ">
-                <dt>
-                  <strong>Original debt amount: </strong>
-                </dt>
-                <dd className="vads-u-margin-left--1">
-                  {currency.format(parseFloat(currentDebt.originalAr))}
+          <dl className="details-table">
+            <div className="details-row">
+              <dt className="details-title">Amount owed:</dt>
+              <dd className="details-data">
+                {currency.format(parseFloat(currentDebt.currentAr))}
+              </dd>
+            </div>
+            <div className="details-row">
+              <dt className="details-title">Original amount:</dt>
+              <dd className="details-data">
+                {currency.format(parseFloat(currentDebt.originalAr))}
+              </dd>
+            </div>
+            {dateFirstNotice && (
+              <div className="details-row">
+                <dt className="details-title">Date of first notice:</dt>
+                <dd className="details-data">
+                  {moment(dateFirstNotice, 'MM-DD-YYYY').format('MMMM D, YYYY')}
                 </dd>
               </div>
-              <div className="vads-u-margin-y--1 vads-u-display--flex">
-                <dt>
-                  <strong>Current balance: </strong>
-                </dt>
-                <dd className="vads-u-margin-left--1">
-                  {currency.format(parseFloat(currentDebt.currentAr))}
-                </dd>
-              </div>
-            </dl>
-          </div>
+            )}
+            <div className="details-row">
+              <dt className="details-title">Collection status:</dt>
+              <dd className="details-data">{additionalInfo.status}</dd>
+            </div>
+          </dl>
           <va-alert
             status="info"
             class="vads-u-margin-bottom--4 vads-u-font-size--base"

--- a/src/applications/debt-letters/components/DebtLetterCard.jsx
+++ b/src/applications/debt-letters/components/DebtLetterCard.jsx
@@ -48,7 +48,10 @@ const DebtLetterCard = ({ debt, setActiveDebt }) => {
           className="vads-u-margin-y--2 vads-u-font-size--md vads-u-font-family--sans"
           data-testid="diary-codes-status"
         >
-          {additionalInfo.status}
+          <p className="vads-u-margin-bottom--0">
+            <strong>Status: </strong>
+            {additionalInfo.status}
+          </p>
         </div>
       )}
 

--- a/src/applications/debt-letters/const/diary-codes/index.js
+++ b/src/applications/debt-letters/const/diary-codes/index.js
@@ -28,12 +28,8 @@ export const renderAdditionalInfo = (diaryCode, dateOfLetter, benefitType) => {
   switch (diaryCode) {
     case '71':
       return {
-        status: (
-          <p className="vads-u-margin-bottom--0">
-            <strong>Status: </strong>
-            We need to verify your military status to update your account.
-          </p>
-        ),
+        status:
+          'We need to verify your military status to update your account.',
         nextStep: (
           <p>
             <strong>Next step: </strong>
@@ -52,12 +48,8 @@ export const renderAdditionalInfo = (diaryCode, dateOfLetter, benefitType) => {
       };
     case '109':
       return {
-        status: (
-          <p className="vads-u-margin-bottom--0">
-            <strong>Status: </strong>
-            Your payment is past due, and we’re adding interest to the amount.
-          </p>
-        ),
+        status:
+          'Your payment is past due, and we’re adding interest to the amount.',
         nextStep: (
           <>
             <p>
@@ -84,12 +76,7 @@ export const renderAdditionalInfo = (diaryCode, dateOfLetter, benefitType) => {
       };
     case '117':
       return {
-        status: (
-          <p className="vads-u-margin-bottom--0">
-            <strong>Status: </strong>
-            Your payment is past due.
-          </p>
-        ),
+        status: 'Your payment is past due.',
         nextStep: (
           <span data-testid="diary-code-117-next-step">
             <p>
@@ -124,12 +111,7 @@ export const renderAdditionalInfo = (diaryCode, dateOfLetter, benefitType) => {
       };
     case '123':
       return {
-        status: (
-          <p className="vads-u-margin-bottom--0">
-            <strong>Status: </strong>
-            Your payment is past due.
-          </p>
-        ),
+        status: 'Your payment is past due.',
         nextStep: (
           <span data-testid="diary-code-123-next-step">
             <p>
@@ -164,12 +146,7 @@ export const renderAdditionalInfo = (diaryCode, dateOfLetter, benefitType) => {
       };
     case '212':
       return {
-        status: (
-          <p className="vads-u-margin-bottom--0">
-            <strong>Status: </strong>
-            We need your address to update your account.
-          </p>
-        ),
+        status: 'We need your address to update your account.',
         nextStep: (
           <p>
             <strong>Next step: </strong>
@@ -188,12 +165,7 @@ export const renderAdditionalInfo = (diaryCode, dateOfLetter, benefitType) => {
       };
     case '815':
       return {
-        status: (
-          <p className="vads-u-margin-bottom--0">
-            <strong>Status: </strong>
-            We’ve accepted your compromise payment.
-          </p>
-        ),
+        status: 'We’ve accepted your compromise payment.',
         nextStep: (
           <p>
             <strong>Next step: </strong>
@@ -217,12 +189,7 @@ export const renderAdditionalInfo = (diaryCode, dateOfLetter, benefitType) => {
     case '448':
     case '453':
       return {
-        status: (
-          <p className="vads-u-margin-bottom--0">
-            <strong>Status: </strong>
-            We’ve paused collection on this debt as you requested.
-          </p>
-        ),
+        status: 'We’ve paused collection on this debt as you requested.',
         nextStep: (
           <p>
             We’ll let you know when we start collecting on this debt again. You
@@ -232,12 +199,7 @@ export const renderAdditionalInfo = (diaryCode, dateOfLetter, benefitType) => {
       };
     case '811':
       return {
-        status: (
-          <p className="vads-u-margin-bottom--0">
-            <strong>Status: </strong>
-            We’re reviewing your compromise offer.
-          </p>
-        ),
+        status: 'We’re reviewing your compromise offer.',
         nextStep: (
           <p>
             <strong>Next step: </strong>
@@ -254,12 +216,7 @@ export const renderAdditionalInfo = (diaryCode, dateOfLetter, benefitType) => {
       };
     case '816':
       return {
-        status: (
-          <p className="vads-u-margin-bottom--0">
-            <strong>Status: </strong>
-            We’ve received your compromise payment.
-          </p>
-        ),
+        status: 'We’ve received your compromise payment.',
         nextStep: (
           <p>
             Please check your debt balance again soon. If it isn’t adjusted to
@@ -274,12 +231,7 @@ export const renderAdditionalInfo = (diaryCode, dateOfLetter, benefitType) => {
     case '032':
     case '609':
       return {
-        status: (
-          <p className="vads-u-margin-bottom--0">
-            <strong>Status: </strong>
-            We’re updating your account.
-          </p>
-        ),
+        status: 'We’re updating your account.',
         nextStep: (
           <p data-testid="diary-code-002-next-step">
             Please check back in 1 week for updates. If your account shows the
@@ -297,12 +249,7 @@ export const renderAdditionalInfo = (diaryCode, dateOfLetter, benefitType) => {
     case '425':
     case '627':
       return {
-        status: (
-          <p className="vads-u-margin-bottom--0">
-            <strong>Status: </strong>
-            We’re updating your account.
-          </p>
-        ),
+        status: 'We’re updating your account.',
         nextStep: (
           <p>
             Please check back in 30 days for updates. If your account shows the
@@ -317,12 +264,7 @@ export const renderAdditionalInfo = (diaryCode, dateOfLetter, benefitType) => {
     case '483':
     case '484':
       return {
-        status: (
-          <p className="vads-u-margin-bottom--0">
-            <strong>Status: </strong>
-            We’re reviewing your account.
-          </p>
-        ),
+        status: 'We’re reviewing your account.',
         nextStep: (
           <p>
             <strong>Next step: </strong>
@@ -336,12 +278,7 @@ export const renderAdditionalInfo = (diaryCode, dateOfLetter, benefitType) => {
     case '860':
     case '855':
       return {
-        status: (
-          <p className="vads-u-margin-bottom--0">
-            <strong>Status: </strong>
-            We referred this debt to the U.S. Department of the Treasury.
-          </p>
-        ),
+        status: 'We referred this debt to the U.S. Department of the Treasury.',
         nextStep: (
           <p data-testid="diary-code-080-next-step">
             <strong>Next step: </strong>
@@ -361,12 +298,8 @@ export const renderAdditionalInfo = (diaryCode, dateOfLetter, benefitType) => {
     case '510':
     case '503':
       return {
-        status: (
-          <p className="vads-u-margin-bottom--0">
-            <strong>Status: </strong> We’re referring this debt to the U.S.
-            Department of the Treasury today.
-          </p>
-        ),
+        status:
+          'We’re referring this debt to the U.S. Department of the Treasury today.',
         nextStep: (
           <span data-testid="diary-code-500-next-step">
             <p>
@@ -391,12 +324,7 @@ export const renderAdditionalInfo = (diaryCode, dateOfLetter, benefitType) => {
     case '130':
     case '140':
       return {
-        status: (
-          <p className="vads-u-margin-bottom--0">
-            <strong>Status: </strong>
-            Your payment is due now.
-          </p>
-        ),
+        status: 'Your payment is due now.',
         nextStep: (
           <span data-testid="diary-code-100-next-step">
             <p>
@@ -436,11 +364,11 @@ export const renderAdditionalInfo = (diaryCode, dateOfLetter, benefitType) => {
       // we need to have debt type available within this switch
       return {
         status: (
-          <p className="vads-u-margin-bottom--0">
-            <strong>Status: </strong> We’re keeping part of your
+          <>
+            We’re keeping part of your
             <span className="vads-u-margin-x--0p5">{benefitType}</span>
             payments each month to pay your debt (called monthly offsets).
-          </p>
+          </>
         ),
         nextStep: (
           <p data-testid="diary-code-608-next-step">
@@ -458,12 +386,7 @@ export const renderAdditionalInfo = (diaryCode, dateOfLetter, benefitType) => {
     case '449':
     case '459':
       return {
-        status: (
-          <p className="vads-u-margin-bottom--0">
-            <strong>Status: </strong>
-            We’ve restarted collection on this debt.
-          </p>
-        ),
+        status: 'We’ve restarted collection on this debt.',
         nextStep: (
           <p>
             <strong>Next step: </strong>
@@ -483,12 +406,7 @@ export const renderAdditionalInfo = (diaryCode, dateOfLetter, benefitType) => {
     case '600':
     case '601':
       return {
-        status: (
-          <p className="vads-u-margin-bottom--0">
-            <strong>Status: </strong>
-            Your payment is due.
-          </p>
-        ),
+        status: 'Your payment is due.',
         nextStep: (
           <p data-testid="diary-code-600-next-step">
             <strong>Next step: </strong>
@@ -503,12 +421,7 @@ export const renderAdditionalInfo = (diaryCode, dateOfLetter, benefitType) => {
     case '603':
     case '613':
       return {
-        status: (
-          <p className="vads-u-margin-bottom--0">
-            <strong>Status: </strong>
-            Your payment is past due.
-          </p>
-        ),
+        status: 'Your payment is past due.',
         nextStep: (
           <p>
             <strong>Next step: </strong>
@@ -534,13 +447,8 @@ export const renderAdditionalInfo = (diaryCode, dateOfLetter, benefitType) => {
     case '655':
     case '817':
       return {
-        status: (
-          <p className="vads-u-margin-bottom--0">
-            <strong>Status: </strong>
-            We need your completed Financial Status Report to make a decision on
-            your request.
-          </p>
-        ),
+        status:
+          'We need your completed Financial Status Report to make a decision on your request.',
         nextStep: (
           <>
             <p>
@@ -573,12 +481,7 @@ export const renderAdditionalInfo = (diaryCode, dateOfLetter, benefitType) => {
     case '681':
     case '682':
       return {
-        status: (
-          <p className="vads-u-margin-bottom--0">
-            <strong>Status: </strong>
-            Your payment is due.
-          </p>
-        ),
+        status: 'Your payment is due.',
         nextStep: (
           <p>
             <strong>Next step: </strong>
@@ -611,11 +514,7 @@ export const renderAdditionalInfo = (diaryCode, dateOfLetter, benefitType) => {
     case '809':
     case '820':
       return {
-        status: (
-          <p className="vads-u-margin-bottom--0">
-            <strong>Status: </strong> We’re reviewing your waiver request.
-          </p>
-        ),
+        status: 'We’re reviewing your waiver request.',
         nextStep: (
           <p>
             <strong>Next step: </strong>
@@ -632,11 +531,7 @@ export const renderAdditionalInfo = (diaryCode, dateOfLetter, benefitType) => {
       };
     case '822':
       return {
-        status: (
-          <p className="vads-u-margin-bottom--0">
-            <strong>Status: </strong> We’re reviewing your debt dispute.
-          </p>
-        ),
+        status: 'We’re reviewing your debt dispute.',
         nextStep: (
           <p>
             <strong>Next step: </strong>
@@ -653,12 +548,7 @@ export const renderAdditionalInfo = (diaryCode, dateOfLetter, benefitType) => {
       };
     case '825':
       return {
-        status: (
-          <p className="vads-u-margin-bottom--0">
-            <strong>Status: </strong> We’re reviewing your request for a waiver
-            or hearing.
-          </p>
-        ),
+        status: 'We’re reviewing your request for a waiver or hearing.',
         nextStep: (
           <p>
             <strong>Next step: </strong>
@@ -675,12 +565,7 @@ export const renderAdditionalInfo = (diaryCode, dateOfLetter, benefitType) => {
       };
     case '821':
       return {
-        status: (
-          <p className="vads-u-margin-bottom--0">
-            <strong>Status: </strong> We’re reviewing your notice of
-            disagreement.
-          </p>
-        ),
+        status: 'We’re reviewing your notice of disagreement.',
         nextStep: (
           <p>
             <strong>Next step: </strong>
@@ -697,12 +582,7 @@ export const renderAdditionalInfo = (diaryCode, dateOfLetter, benefitType) => {
       };
     default:
       return {
-        status: (
-          <p className="vads-u-margin-bottom--0">
-            <strong>Status: </strong>
-            We’re updating your account.
-          </p>
-        ),
+        status: 'We’re updating your account.',
         nextStep: (
           <p data-testid="diary-code-default-next-step">
             <strong>Next step: </strong>

--- a/src/applications/debt-letters/sass/debt-letters.scss
+++ b/src/applications/debt-letters/sass/debt-letters.scss
@@ -44,16 +44,8 @@ a i {
   margin: 15px 0;
 }
 
-dl {
-  width: 50%;
-}
-
 h1:focus {
   outline: none !important;
-}
-
-dt {
-  width: 50%;
 }
 
 .chapter33-alert {
@@ -69,5 +61,23 @@ dt {
 
   i.fas.fa-angle-down {
     display: none;
+  }
+}
+
+// debt details table
+.details-table {
+  display: table;
+  margin: 0 0 32px 0;
+  .details-row {
+    display: table-row;
+    .details-title,
+    .details-data {
+      display: table-cell;
+      padding: 5px;
+    }
+    .details-title {
+      font-weight: bold;
+      width: 150px;
+    }
   }
 }


### PR DESCRIPTION
## Description
Added an additional line item for collection status to debt letter details table

## Original issue(s)
department-of-veterans-affairs/va.gov-team#31578

## Screenshots
![Your VA Debt  Veterans Affairs 2021-10-28 09-38-24](https://user-images.githubusercontent.com/7518899/139267278-7e2f54c9-cb6a-429f-849a-9a7a31600a8b.png)


## Acceptance criteria
- [x] An additional line item for collection status should render in debt details

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs