### PR TITLE
PW - Fix named exports from JSON modules

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-entry.jsx
+++ b/src/applications/proxy-rewrite/proxy-rewrite-entry.jsx
@@ -17,7 +17,7 @@ import startMobileMenuButton from 'platform/site-wide/mobile-menu-button';
 import startUserNavWidget from 'platform/site-wide/user-nav';
 import startVAFooter, { footerElemementId } from 'platform/site-wide/va-footer';
 import { addOverlayTriggers } from 'platform/site-wide/legacy/menu';
-import { proxyRewriteWhitelist } from './proxy-rewrite-whitelist.json';
+import proxyWhitelist from './proxy-rewrite-whitelist.json';
 
 function createMutationObserverCallback() {
   // Find native header, footer, etc based on page path
@@ -179,7 +179,9 @@ function getProxyRewriteCookieValue(
   return parseCookie(cookies).proxyRewrite;
 }
 
-function getMatchedWhitelistItem(whitelist = proxyRewriteWhitelist) {
+function getMatchedWhitelistItem(
+  whitelist = proxyWhitelist.proxyRewriteWhitelist,
+) {
   const { hostname, pathname } = window.location;
 
   return whitelist.find(

--- a/src/applications/yellow-ribbon/containers/SearchForm/index.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchForm/index.jsx
@@ -8,7 +8,7 @@ import classNames from 'classnames';
 import { connect } from 'react-redux';
 // Relative imports.
 import recordEvent from 'platform/monitoring/record-event';
-import { states as STATES } from 'vets-json-schema/dist/constants.json';
+import constants from 'vets-json-schema/dist/constants.json';
 import { TOOL_TIP_CONTENT, TOOL_TIP_LABEL } from '../../constants';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { fetchResultsThunk } from '../../actions';
@@ -192,7 +192,7 @@ export class SearchForm extends Component {
               value={state}
             >
               <option value="">- Select -</option>
-              {STATES.USA.map(provincialState => (
+              {constants.states.USA.map(provincialState => (
                 <option
                   key={provincialState?.value}
                   value={provincialState?.value}


### PR DESCRIPTION
## Description
In preparation to upgrade `Webpack` to version 5. There is a breaking change that needs to be fixed before it can be done.

Based on the `Webpack` [migration guide](https://webpack.js.org/migrate/5/), it is important to fix all [named exports from JSON modules](https://webpack.js.org/migrate/5/#using-named-exports-from-json-modules) because it's no longer supported

## Original issue(s)
department-of-veterans-affairs/va.gov-team#11510


## Testing done
Locally
