### PR TITLE
Replace named exports from JSON modules

### DIFF
--- a/src/applications/static-pages/cta-widget/ctaWidgets.js
+++ b/src/applications/static-pages/cta-widget/ctaWidgets.js
@@ -2,11 +2,11 @@
 import backendServices from 'platform/user/profile/constants/backendServices';
 import { MHV_ACCOUNT_TYPES } from './constants';
 import { mhvUrl } from 'platform/site-wide/mhv/utilities';
-import { rootUrl as addRemoveDependentsUrl } from 'applications/disability-benefits/686c-674/manifest.json';
-import { rootUrl as hearingAidSuppliesUrl } from 'applications/disability-benefits/2346/manifest.json';
-import { rootUrl as higherLevelReviewUrl } from 'applications/disability-benefits/996/manifest.json';
-import { rootUrl as viewDependentsUrl } from 'applications/personalization/view-dependents/manifest.json';
-import { rootUrl as viewPaymentHistoryUrl } from 'applications/disability-benefits/view-payments/manifest.json';
+import constants686c from 'applications/disability-benefits/686c-674/manifest.json';
+import constants236 from 'applications/disability-benefits/2346/manifest.json';
+import constants996 from 'applications/disability-benefits/996/manifest.json';
+import constantsViewDependents from 'applications/personalization/view-dependents/manifest.json';
+import constantsViewPayments from 'applications/disability-benefits/view-payments/manifest.json';
 
 export const CTA_WIDGET_TYPES = {
   ADD_REMOVE_DEPENDENTS: 'add-remove-dependents',
@@ -37,7 +37,7 @@ export const ctaWidgetsLookup = {
   [CTA_WIDGET_TYPES.ADD_REMOVE_DEPENDENTS]: {
     id: CTA_WIDGET_TYPES.ADD_REMOVE_DEPENDENTS,
     deriveToolUrlDetails: () => ({
-      url: addRemoveDependentsUrl,
+      url: constants686c.rootUrl,
       redirect: false,
     }),
     hasRequiredMhvAccount: () => false,
@@ -134,7 +134,7 @@ export const ctaWidgetsLookup = {
   [CTA_WIDGET_TYPES.HEARING_AID_SUPPLIES]: {
     id: CTA_WIDGET_TYPES.HEARING_AID_SUPPLIES,
     deriveToolUrlDetails: () => ({
-      url: hearingAidSuppliesUrl,
+      url: constants236.rootUrl,
       redirect: false,
     }),
     hasRequiredMhvAccount: () => false,
@@ -146,7 +146,7 @@ export const ctaWidgetsLookup = {
   [CTA_WIDGET_TYPES.HIGHER_LEVEL_REVIEW]: {
     id: CTA_WIDGET_TYPES.HIGHER_LEVEL_REVIEW,
     deriveToolUrlDetails: () => ({
-      url: higherLevelReviewUrl,
+      url: constants996.rootUrl,
       redirect: false,
     }),
     isHealthTool: false,
@@ -270,7 +270,10 @@ export const ctaWidgetsLookup = {
   },
   [CTA_WIDGET_TYPES.VIEW_DEPENDENTS]: {
     id: CTA_WIDGET_TYPES.VIEW_DEPENDENTS,
-    deriveToolUrlDetails: () => ({ url: viewDependentsUrl, redirect: false }),
+    deriveToolUrlDetails: () => ({
+      url: constantsViewDependents.rootUrl,
+      redirect: false,
+    }),
     hasRequiredMhvAccount: () => false,
     isHealthTool: false,
     mhvToolName: null,
@@ -280,7 +283,7 @@ export const ctaWidgetsLookup = {
   [CTA_WIDGET_TYPES.VIEW_PAYMENT_HISTORY]: {
     id: CTA_WIDGET_TYPES.VIEW_PAYMENT_HISTORY,
     deriveToolUrlDetails: () => ({
-      url: viewPaymentHistoryUrl,
+      url: constantsViewPayments.rootUrl,
       redirect: false,
     }),
     hasRequiredMhvAccount: () => false,

--- a/src/applications/static-pages/widget-creators/createMyVALoginWidget.js
+++ b/src/applications/static-pages/widget-creators/createMyVALoginWidget.js
@@ -1,5 +1,5 @@
 import { isLoggedIn } from 'platform/user/selectors';
-import { rootUrl } from 'applications/personalization/dashboard/manifest.json';
+import constants from 'applications/personalization/dashboard/manifest.json';
 
 export default function createMyVALoginWidget(store) {
   const root = document.getElementById('myva-login');
@@ -7,7 +7,7 @@ export default function createMyVALoginWidget(store) {
   const homePageStoreListener = () => {
     if (root && isLoggedIn(store.getState())) {
       root.innerHTML =
-        `<a href="${rootUrl}" class="homepage-button">` +
+        `<a href="${constants.rootUrl}" class="homepage-button">` +
         '<div class="icon-wrapper">' +
         '<i class="fas fa-user-circle homepage-button-icon"></i>' +
         '</div>' +


### PR DESCRIPTION
## Description
In preparation to upgrade Webpack to version 5. There is a breaking change that needs to be fixed before it can be done.
Based on the Webpack migration guide, it is important to fix all named exports from JSON modules because it’s no longer supported.

https://dsva.slack.com/archives/C5HP4GN3F/p1635428396065100

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/32131


## Testing done
local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
