### PR TITLE
CST: Update mobile app callout content

### DIFF
--- a/src/applications/claims-status/components/MobileAppMessage.jsx
+++ b/src/applications/claims-status/components/MobileAppMessage.jsx
@@ -8,15 +8,12 @@ const googlePlayUrl =
 
 export const STORAGE_KEY = 'cst-mobile-app-message';
 
-const createLink = (href, name, label) => (
-  <a
-    href={href}
-    target="_blank"
-    rel="noopener noreferrer"
-    aria-label={`download the VA health and benefits app from ${label || name}`}
-  >
-    {name}
-  </a>
+const createLink = (href, name) => (
+  <p className="vads-u-margin-bottom--0">
+    <a href={href} target="_blank" rel="noopener noreferrer">
+      Download the app from {name}
+    </a>
+  </p>
 );
 
 export default function MobileAppMessage({ mockUserAgent }) {
@@ -34,7 +31,7 @@ export default function MobileAppMessage({ mockUserAgent }) {
   const devices = {
     ios: {
       detect: /iPad|iPhone|iPod/.test(userAgent) && !window.MSStream,
-      link: <>the {createLink(appleStoreUrl, 'App Store', 'the app store')}</>,
+      link: createLink(appleStoreUrl, 'the App Store'),
     },
     android: {
       // https://stackoverflow.com/a/21742107
@@ -45,9 +42,14 @@ export default function MobileAppMessage({ mockUserAgent }) {
 
   const detectedDevice = Object.keys(devices).filter(os => devices[os].detect);
   const storeLinks =
-    detectedDevice.length !== 0
-      ? devices[detectedDevice].link
-      : [devices.ios.link, ' or on ', devices.android.link];
+    detectedDevice.length !== 0 ? (
+      devices[detectedDevice].link
+    ) : (
+      <>
+        {devices.ios.link}
+        {devices.android.link}
+      </>
+    );
 
   return isHidden ? null : (
     <va-alert
@@ -58,11 +60,13 @@ export default function MobileAppMessage({ mockUserAgent }) {
         sessionStorage.setItem(STORAGE_KEY, 'hidden');
       }}
     >
-      <h2 slot="headline">Check your status with our new mobile app</h2>
+      <h2 slot="headline">Track your claim or appeal on your mobile device</h2>
       <p>
-        Get updates on your claims or appeals right at your fingertips using our
-        new mobile app. Download it on {storeLinks}.
+        You can use our new mobile app to check the status of your claims or
+        appeals on your mobile device. Download the{' '}
+        <strong>VA: Health and Benefits</strong> mobile app to get started.
       </p>
+      {storeLinks}
     </va-alert>
   );
 }

--- a/src/applications/claims-status/tests/components/MobileAppMessage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/MobileAppMessage.unit.spec.jsx
@@ -14,10 +14,10 @@ describe('<MobileAppMessage>', () => {
     const wrapper = shallow(<MobileAppMessage mockUserAgent={'blah'} />);
     expect(wrapper.length).to.equal(1);
     expect(wrapper.props().status).to.equal('info');
-    expect(wrapper.text()).to.include(
-      'Download it on the App Store or on Google Play.',
-    );
-    expect(wrapper.find('a[aria-label]').length).to.equal(2);
+    const links = wrapper.find('a[target="_blank"]');
+    expect(links.length).to.equal(2);
+    expect(links.first().text()).to.eq('Download the app from the App Store');
+    expect(links.last().text()).to.eq('Download the app from Google Play');
     wrapper.unmount();
   });
   it('should hide the alert initially', () => {
@@ -38,18 +38,16 @@ describe('<MobileAppMessage>', () => {
 
   it('should show app store link for iOS device', () => {
     const wrapper = shallow(<MobileAppMessage mockUserAgent={'iPhone'} />);
-    const link = wrapper.find('a[aria-label]');
-    expect(wrapper.text()).to.include('Download it on the App Store.');
+    const link = wrapper.find('a[target="_blank"]');
     expect(link.length).to.equal(1);
-    expect(link.props()['aria-label']).to.include('app store');
+    expect(link.text()).to.eq('Download the app from the App Store');
     wrapper.unmount();
   });
   it('should show Google play store link for android device', () => {
     const wrapper = shallow(<MobileAppMessage mockUserAgent={'android'} />);
-    const link = wrapper.find('a[aria-label]');
-    expect(wrapper.text()).to.include('Download it on Google Play.');
+    const link = wrapper.find('a[target="_blank"]');
     expect(link.length).to.equal(1);
-    expect(link.props()['aria-label']).to.include('Google Play');
+    expect(link.text()).to.eq('Download the app from Google Play');
     wrapper.unmount();
   });
 });


### PR DESCRIPTION
## Description

Updating the mobile app callout content in the Claim Status Tool

## Original issue(s)

- Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/30252
- Content review: https://github.com/department-of-veterans-affairs/va.gov-team/issues/31497

## Testing done

N/A - content update only

## Screenshots

<details><summary>Desktop</summary>

<!-- leave a blank line above -->

![Screen Shot 2021-10-28 at 9 53 57 AM](https://user-images.githubusercontent.com/136959/139283334-3743b838-f215-4251-b803-f117a03d1a69.png)</details>

<details><summary>Android detected</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-10-28 at 9 53 27 AM](https://user-images.githubusercontent.com/136959/139283340-c0c2328f-bb5b-4acd-b5dd-a7aa34fee43c.png)</details>

<details><summary>iOS detected</summary>

<!-- leave a blank line above -->
![Screen Shot 2021-10-28 at 9 52 54 AM](https://user-images.githubusercontent.com/136959/139283342-ef180a6f-63bb-4e60-9c51-6f74618917dc.png)</details>


## Acceptance criteria
- [x] Update content of Mobile app callout

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
