### PR TITLE
32125: Fix all named exports from JSON modules

### DIFF
--- a/src/applications/static-pages/manage-va-debt/MangeVADebtCTA.jsx
+++ b/src/applications/static-pages/manage-va-debt/MangeVADebtCTA.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { rootUrl as yourDebt } from '../../debt-letters/manifest.json';
-import { rootUrl as requestHelp } from '../../financial-status-report/manifest.json';
+import debtLettersManifest from '../../debt-letters/manifest.json';
+import fsrManifest from '../../financial-status-report/manifest.json';
 import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
 
 const ManageVADebtCTA = () => {
@@ -14,13 +14,13 @@ const ManageVADebtCTA = () => {
       <p>
         Check the status of debt related to VA disability compensation,
         non-service-connected pension, or education benefits. And make payments
-        or request help now if you'd like.
+        or request help now if you’d like.
       </p>
       <h3>Check the status of your VA benefit debt</h3>
       <a
         className="usa-button-primary va-button-primary"
         target="_self"
-        href={yourDebt}
+        href={debtLettersManifest.rootUrl}
       >
         Manage your VA debt
       </a>
@@ -29,7 +29,7 @@ const ManageVADebtCTA = () => {
       <a
         className="usa-button-primary va-button-primary"
         target="_self"
-        href={requestHelp}
+        href={fsrManifest.rootUrl}
       >
         Request help with VA debt
       </a>

--- a/src/applications/static-pages/manage-va-debt/MangeVADebtCTA.jsx
+++ b/src/applications/static-pages/manage-va-debt/MangeVADebtCTA.jsx
@@ -3,38 +3,36 @@ import debtLettersManifest from '../../debt-letters/manifest.json';
 import fsrManifest from '../../financial-status-report/manifest.json';
 import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
 
-const ManageVADebtCTA = () => {
-  return (
-    <>
-      <Breadcrumbs>
-        <a href="/">Home</a>
-        <a href="/manage-va-debt">Manage your VA debt</a>
-      </Breadcrumbs>
-      <h1>Manage your VA debt</h1>
-      <p>
-        Check the status of debt related to VA disability compensation,
-        non-service-connected pension, or education benefits. And make payments
-        or request help now if you’d like.
-      </p>
-      <h3>Check the status of your VA benefit debt</h3>
-      <a
-        className="usa-button-primary va-button-primary"
-        target="_self"
-        href={debtLettersManifest.rootUrl}
-      >
-        Manage your VA debt
-      </a>
-      <hr />
-      <h3>Request help with VA debt (VA Form 5655)</h3>
-      <a
-        className="usa-button-primary va-button-primary"
-        target="_self"
-        href={fsrManifest.rootUrl}
-      >
-        Request help with VA debt
-      </a>
-    </>
-  );
-};
+const ManageVADebtCTA = () => (
+  <>
+    <Breadcrumbs>
+      <a href="/">Home</a>
+      <a href="/manage-va-debt">Manage your VA debt</a>
+    </Breadcrumbs>
+    <h1>Manage your VA debt</h1>
+    <p>
+      Check the status of debt related to VA disability compensation,
+      non-service-connected pension, or education benefits. And make payments or
+      request help now if you’d like.
+    </p>
+    <h3>Check the status of your VA benefit debt</h3>
+    <a
+      className="usa-button-primary va-button-primary"
+      target="_self"
+      href={debtLettersManifest.rootUrl}
+    >
+      Manage your VA debt
+    </a>
+    <hr />
+    <h3>Request help with VA debt (VA Form 5655)</h3>
+    <a
+      className="usa-button-primary va-button-primary"
+      target="_self"
+      href={fsrManifest.rootUrl}
+    >
+      Request help with VA debt
+    </a>
+  </>
+);
 
 export default ManageVADebtCTA;


### PR DESCRIPTION
## Description
updated to remove named JSON exports from the following file:

`src/applications/static-pages/manage-va-debt/MangeVADebtCTA.jsx
`

## Original issue(s)
department-of-veterans-affairs/va.gov-team#32125

## Screenshots


## Acceptance criteria
- [x] should not be using named JSON exports 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs