### PR TITLE
Fix typo in dependency verification status confirmation alert

### DIFF
--- a/src/applications/personalization/view-dependents/components/ViewDependentsHeader/ViewDependentsHeader.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsHeader/ViewDependentsHeader.jsx
@@ -29,7 +29,7 @@ function ViewDependentsHeader(props) {
             <p className="vads-u-font-size--base">
               We’ll make a note that our records are correct and an updated VA
               Form 21-0538 will go into your e-folder. If we need you to give us
-              more information or documents, we’ll contact you be mail.
+              more information or documents, we’ll contact you by mail.
             </p>
           </>
         ),


### PR DESCRIPTION
## Description
Fixes issue with typo in dependency verfication status confirmation alert copy

## Original issue(s)
department-of-veterans-affairs/va.gov-team#32129

## Screenshots
<img width="661" alt="Screen Shot 2021-10-28 at 1 59 21 PM" src="https://user-images.githubusercontent.com/13838621/139318712-4d739d14-ae51-40c2-8f3a-800b6d5d632a.png">

## Acceptance criteria
- [x] Update the copy on the confirmation page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
