### PR TITLE
CST: Show mobile alert in production

### DIFF
--- a/src/applications/claims-status/components/MobileAppMessage.jsx
+++ b/src/applications/claims-status/components/MobileAppMessage.jsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import environment from 'platform/utilities/environment';
 
 const appleStoreUrl =
   'https://apps.apple.com/app/apple-store/id1559609596?pt=545860&ct=gov.va.claimstatus&mt=8';
@@ -20,11 +19,6 @@ export default function MobileAppMessage({ mockUserAgent }) {
   const [isHidden, setIsHidden] = useState(
     (sessionStorage.getItem(STORAGE_KEY) || '') !== '',
   );
-
-  // Hide in production until content review is complete
-  if (environment.isProduction()) {
-    return null;
-  }
 
   const userAgent =
     mockUserAgent || navigator.userAgent || navigator.vendor || window.opera;


### PR DESCRIPTION
## Description

Show Claim Status Tool mobile app alert in production

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/30252

## Testing done

N/A, removing a production check

## Screenshots

![get VA Health and Benefits app for mobile alert](https://user-images.githubusercontent.com/136959/139283334-3743b838-f215-4251-b803-f117a03d1a69.png)

## Acceptance criteria
- [x] Mobile alert is visible in the Claim Status Tool in production
- [x] All test passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
