### PR TITLE
Check in 31796 see staff page

### DIFF
--- a/src/applications/check-in/actions/actions.unit.spec.js
+++ b/src/applications/check-in/actions/actions.unit.spec.js
@@ -15,9 +15,11 @@ import {
   TRIGGER_REFRESH,
   receivedNextOfKinData,
   RECEIVED_NEXT_OF_KIN_DATA,
+  SEE_STAFF_MESSAGE_UPDATED,
+  seeStaffMessageUpdated,
 } from './index';
 
-describe('check inactions', () => {
+describe('check in actions', () => {
   describe('actions', () => {
     describe('receivedMultipleAppointmentDetails', () => {
       it('should return correct action', () => {
@@ -113,6 +115,16 @@ describe('check inactions', () => {
         });
         expect(action.payload).to.haveOwnProperty('nextOfKin');
         expect(action.payload.nextOfKin.relationship).to.equal('spouse');
+      });
+    });
+    describe('seeStaffMessageUpdated', () => {
+      it('should return correct action', () => {
+        const action = seeStaffMessageUpdated('test');
+        expect(action.type).to.equal(SEE_STAFF_MESSAGE_UPDATED);
+      });
+      it('should return correct structure', () => {
+        const action = seeStaffMessageUpdated('test');
+        expect(action.payload.seeStaffMessage).to.equal('test');
       });
     });
   });

--- a/src/applications/check-in/actions/index.js
+++ b/src/applications/check-in/actions/index.js
@@ -87,6 +87,6 @@ export const SEE_STAFF_MESSAGE_UPDATED = 'SEE_STAFF_MESSAGE_UPDATED';
 export const seeStaffMessageUpdated = message => {
   return {
     type: SEE_STAFF_MESSAGE_UPDATED,
-    payload: { message },
+    payload: { seeStaffMessage: message },
   };
 };

--- a/src/applications/check-in/actions/index.js
+++ b/src/applications/check-in/actions/index.js
@@ -81,3 +81,12 @@ export const tokenWasValidated = (payload, token, scope) => {
     },
   };
 };
+
+export const SEE_STAFF_MESSAGE_UPDATED = 'SEE_STAFF_MESSAGE_UPDATED';
+
+export const seeStaffMessageUpdated = message => {
+  return {
+    type: SEE_STAFF_MESSAGE_UPDATED,
+    payload: { message },
+  };
+};

--- a/src/applications/check-in/pages/Demographics.jsx
+++ b/src/applications/check-in/pages/Demographics.jsx
@@ -1,15 +1,16 @@
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
-
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import recordEvent from 'platform/monitoring/record-event';
 import { goToNextPage, URLS } from '../utils/navigation';
 import BackToHome from '../components/BackToHome';
 import Footer from '../components/Footer';
 import DemographicItem from '../components/DemographicItem';
+// import { seeStaffMessageUpdated } from '../actions';
 
 const Demographics = props => {
   const { demographics, isLoading, isUpdatePageEnabled, router } = props;
+  // const seeStaffMessage = 'test';
 
   const yesClick = useCallback(
     () => {
@@ -32,6 +33,7 @@ const Demographics = props => {
         event: 'cta-button-click',
         'button-click-label': 'no-to-demographic-information',
       });
+
       goToNextPage(router, URLS.SEE_STAFF);
     },
     [router],

--- a/src/applications/check-in/pages/Demographics.jsx
+++ b/src/applications/check-in/pages/Demographics.jsx
@@ -44,7 +44,7 @@ const Demographics = props => {
       updateSeeStaffMessage(seeStaffMessage);
       goToNextPage(router, URLS.SEE_STAFF);
     },
-    [router],
+    [router, updateSeeStaffMessage],
   );
 
   const demographicFields = [

--- a/src/applications/check-in/pages/Demographics.jsx
+++ b/src/applications/check-in/pages/Demographics.jsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import recordEvent from 'platform/monitoring/record-event';
@@ -6,11 +7,18 @@ import { goToNextPage, URLS } from '../utils/navigation';
 import BackToHome from '../components/BackToHome';
 import Footer from '../components/Footer';
 import DemographicItem from '../components/DemographicItem';
-// import { seeStaffMessageUpdated } from '../actions';
+import { seeStaffMessageUpdated } from '../actions';
 
 const Demographics = props => {
-  const { demographics, isLoading, isUpdatePageEnabled, router } = props;
-  // const seeStaffMessage = 'test';
+  const {
+    demographics,
+    isLoading,
+    isUpdatePageEnabled,
+    router,
+    updateSeeStaffMessage,
+  } = props;
+  const seeStaffMessage =
+    'If you don’t live at a fixed address right now, we’ll help you find the best way to stay connected with us.';
 
   const yesClick = useCallback(
     () => {
@@ -33,7 +41,7 @@ const Demographics = props => {
         event: 'cta-button-click',
         'button-click-label': 'no-to-demographic-information',
       });
-
+      updateSeeStaffMessage(seeStaffMessage);
       goToNextPage(router, URLS.SEE_STAFF);
     },
     [router],
@@ -102,11 +110,23 @@ const Demographics = props => {
   }
 };
 
+const mapDispatchToProps = dispatch => {
+  return {
+    updateSeeStaffMessage: seeStaffMessage => {
+      dispatch(seeStaffMessageUpdated(seeStaffMessage));
+    },
+  };
+};
+
 Demographics.propTypes = {
   demographics: PropTypes.object,
   isLoading: PropTypes.bool,
   isUpdatePageEnabled: PropTypes.bool,
   router: PropTypes.object,
+  updateSeeStaffMessage: PropTypes.func,
 };
 
-export default Demographics;
+export default connect(
+  null,
+  mapDispatchToProps,
+)(Demographics);

--- a/src/applications/check-in/pages/SeeStaff.jsx
+++ b/src/applications/check-in/pages/SeeStaff.jsx
@@ -5,8 +5,8 @@ import Footer from '../components/Footer';
 import { focusElement } from 'platform/utilities/ui';
 import BackButton from '../components/BackButton';
 
-const Failed = props => {
-  const { router } = props;
+const SeeStaff = props => {
+  const { router, message } = props;
   useEffect(() => {
     focusElement('h1');
   }, []);
@@ -18,6 +18,7 @@ const Failed = props => {
       </h1>
       <p>Our staff can help you update your contact information.</p>
       <p className="vads-u-margin-bottom--0">
+        {message}
         If you don’t live at a fixed address right now, we’ll help you find the
         best way to stay connected with us.
       </p>
@@ -27,8 +28,9 @@ const Failed = props => {
   );
 };
 
-Failed.propTypes = {
+SeeStaff.propTypes = {
   router: PropTypes.object,
+  message: PropTypes.string,
 };
 
-export default Failed;
+export default SeeStaff;

--- a/src/applications/check-in/pages/SeeStaff.jsx
+++ b/src/applications/check-in/pages/SeeStaff.jsx
@@ -18,7 +18,13 @@ const SeeStaff = props => {
         Check in with a staff member
       </h1>
       <p>Our staff can help you update your contact information.</p>
-      <p className="vads-u-margin-bottom--0">{message}</p>
+      {message ? (
+        <p className="vads-u-margin-bottom--0" data-testid="see-staff-message">
+          {message}
+        </p>
+      ) : (
+        ''
+      )}
       <Footer />
       <BackToHome />
     </div>

--- a/src/applications/check-in/pages/SeeStaff.jsx
+++ b/src/applications/check-in/pages/SeeStaff.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import BackToHome from '../components/BackToHome';
 import Footer from '../components/Footer';
@@ -17,11 +18,7 @@ const SeeStaff = props => {
         Check in with a staff member
       </h1>
       <p>Our staff can help you update your contact information.</p>
-      <p className="vads-u-margin-bottom--0">
-        {message}
-        If you don’t live at a fixed address right now, we’ll help you find the
-        best way to stay connected with us.
-      </p>
+      <p className="vads-u-margin-bottom--0">{message}</p>
       <Footer />
       <BackToHome />
     </div>
@@ -33,4 +30,10 @@ SeeStaff.propTypes = {
   message: PropTypes.string,
 };
 
-export default SeeStaff;
+const mapStateToProps = state => {
+  return {
+    message: state.checkInData.seeStaffMessage,
+  };
+};
+
+export default connect(mapStateToProps)(SeeStaff);

--- a/src/applications/check-in/pages/tests/SeeStaff-unit.spec.jsx
+++ b/src/applications/check-in/pages/tests/SeeStaff-unit.spec.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+
+import { axeCheck } from 'platform/forms-system/test/config/helpers';
+
+import SeeStaff from '../SeeStaff';
+
+describe('check in', () => {
+  describe('SeeStaff', () => {
+    let store;
+    beforeEach(() => {
+      const middleware = [];
+      const mockStore = configureStore(middleware);
+      const initState = {
+        checkInData: {
+          seeStaffMessage: 'message test',
+        },
+      };
+      store = mockStore(initState);
+    });
+    it('has a header', () => {
+      const component = render(
+        <Provider store={store}>
+          <SeeStaff />
+        </Provider>,
+      );
+
+      expect(component.getByText('message test')).to.exist;
+    });
+    it('passes axeCheck', () => {
+      axeCheck(
+        <Provider store={store}>
+          <SeeStaff />
+        </Provider>,
+      );
+    });
+  });
+});

--- a/src/applications/check-in/reducers/index.js
+++ b/src/applications/check-in/reducers/index.js
@@ -14,6 +14,7 @@ import {
   SET_TOKEN_CONTEXT,
   TOKEN_WAS_VALIDATED,
   TRIGGER_REFRESH,
+  SEE_STAFF_MESSAGE_UPDATED,
 } from '../actions';
 
 const checkInReducer = (state = initialState, action) => {
@@ -46,6 +47,9 @@ const checkInReducer = (state = initialState, action) => {
     case RECEIVED_NEXT_OF_KIN_DATA:
       return { ...state, ...action.payload };
     case TOKEN_WAS_VALIDATED:
+      return { ...state, ...action.payload };
+
+    case SEE_STAFF_MESSAGE_UPDATED:
       return { ...state, ...action.payload };
     default:
       return { ...state };

--- a/src/applications/check-in/reducers/reducer.unit.spec.js
+++ b/src/applications/check-in/reducers/reducer.unit.spec.js
@@ -10,6 +10,7 @@ import {
   tokenWasValidated,
   permissionsUpdated,
   triggerRefresh,
+  seeStaffMessageUpdated,
 } from '../actions';
 
 describe('check-in', () => {
@@ -167,6 +168,14 @@ describe('check-in', () => {
       expect(state).haveOwnProperty('appointments');
       const newState = reducer.checkInData(state, { type: 'none' });
       expect(newState).to.eql(state);
+    });
+    describe('seeStaffMessageUpdated', () => {
+      it('the see staff message should get updates', () => {
+        const action = seeStaffMessageUpdated('This is a message');
+        const state = reducer.checkInData(undefined, action);
+        expect(state).haveOwnProperty('seeStaffMessage');
+        expect(state.seeStaffMessage).to.equal('This is a message');
+      });
     });
   });
 });

--- a/src/applications/check-in/routes.jsx
+++ b/src/applications/check-in/routes.jsx
@@ -5,7 +5,7 @@ import CheckIn from './pages/CheckIn';
 import Confirmation from './pages/Confirmation';
 import Demographics from './pages/Demographics';
 import Error from './pages/Error';
-import Failed from './pages/Failed';
+import SeeStaff from './pages/SeeStaff';
 import Landing from './pages/Landing';
 import UpdateInformationQuestion from './pages/UpdateInformationQuestion';
 import ValidateVeteran from './pages/ValidateVeteran';
@@ -45,7 +45,7 @@ const createRoutesWithStore = () => {
       />
       <Route
         path={`/${URLS.SEE_STAFF}`}
-        component={withFeatureFlip(withAppointmentData(Failed))}
+        component={withFeatureFlip(withAppointmentData(SeeStaff))}
       />
       <Route path={`/${URLS.ERROR}`} component={withFeatureFlip(Error)} />
     </Switch>

--- a/src/applications/check-in/tests/e2e/phase-5-next-of-kin/SeeStaff-page/SeeStaff.display.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-5-next-of-kin/SeeStaff-page/SeeStaff.display.cypress.spec.js
@@ -1,0 +1,72 @@
+import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
+
+import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
+import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
+import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import Timeouts from 'platform/testing/e2e/timeouts';
+
+describe('Check In Experience -- ', () => {
+  describe('phase 5 -- ', () => {
+    beforeEach(function() {
+      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
+        req.reply(
+          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
+        );
+      });
+      cy.intercept('POST', '/check_in/v2/sessions', req => {
+        req.reply(
+          mockSession.createMockSuccessResponse('some-token', 'read.full'),
+        );
+      });
+      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
+        const rv = mockPatientCheckIns.createMultipleAppointments();
+        req.reply(rv);
+      });
+      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
+        req.reply(mockCheckIn.createMockSuccessResponse({}));
+      });
+      cy.intercept(
+        'GET',
+        '/v0/feature_toggles*',
+        generateFeatureToggles({
+          checkInExperienceMultipleAppointmentSupport: true,
+          checkInExperienceUpdateInformationPageEnabled: false,
+          checkInExperienceDemographicsPageEnabled: true,
+        }),
+      );
+    });
+    afterEach(() => {
+      cy.window().then(window => {
+        window.sessionStorage.clear();
+      });
+    });
+    it('see staff display with demographics message', () => {
+      const featureRoute =
+        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
+      cy.visit(featureRoute);
+
+      cy.get('h1', { timeout: Timeouts.slow })
+        .should('be.visible')
+        .and('have.text', 'Check in at VA');
+      cy.get('[label="Your last name"]')
+        .shadow()
+        .find('input')
+        .type('Smith');
+      cy.get('[label="Last 4 digits of your Social Security number"]')
+        .shadow()
+        .find('input')
+        .type('4837');
+      cy.get('[data-testid=check-in-button]').click();
+      cy.get('[data-testid=no-button]', { timeout: Timeouts.slow }).click();
+      cy.get('h1', { timeout: Timeouts.slow })
+        .should('be.visible')
+        .and('have.text', 'Check in with a staff member');
+      cy.get('[data-testid=see-staff-message]')
+        .should('be.visible')
+        .and(
+          'have.text',
+          'If you don’t live at a fixed address right now, we’ll help you find the best way to stay connected with us.',
+        );
+    });
+  });
+});


### PR DESCRIPTION
## Description
We need to update the See Staff page to accept property and display an error message appropriately.

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#31796](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/31796)


## Testing done
Added unit tests and cypress test.

## Acceptance criteria
 - [ ] Passes Accessibility checks using axe
 - [ ] Deployed to staging.
 - [ ] Designer has signed off on the feature
 - [ ] Product team has signed off on the feature

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
