### PR TITLE
standalone sign in to work when no ?application

### DIFF
--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -110,17 +110,22 @@ export function standaloneRedirect() {
 }
 
 export function redirect(redirectUrl, clickedEvent) {
+  const { application: app } = getQueryParams();
+  const isStandaloneAndValidExternal =
+    loginAppUrlRE.test(window.location.pathname) &&
+    Object.keys(externalRedirects).includes(app);
+
   let rUrl = redirectUrl;
   // Keep track of the URL to return to after auth operation.
   // If the user is coming via the standalone sign-in, redirect to the home page.
-  const returnUrl = loginAppUrlRE.test(window.location.pathname)
-    ? standaloneRedirect() || window.location.origin
-    : window.location;
+  const returnUrl = isStandaloneAndValidExternal
+    ? standaloneRedirect()
+    : window.location.origin;
   sessionStorage.setItem(authnSettings.RETURN_URL, returnUrl);
   recordEvent({ event: clickedEvent });
 
   if (
-    !loginAppUrlRE.test(window.location.pathname) &&
+    !isStandaloneAndValidExternal &&
     (clickedEvent === 'login-link-clicked-modal' ||
       clickedEvent === 'sso-automatic-login')
   ) {
@@ -128,8 +133,7 @@ export function redirect(redirectUrl, clickedEvent) {
   }
 
   // Generates the redirect for /sign-in page and tracks event
-  if (loginAppUrlRE.test(window.location.pathname)) {
-    const { application: app } = getQueryParams();
+  if (isStandaloneAndValidExternal) {
     rUrl = {
       mhv: `${redirectUrl}?skip_dupe=mhv&redirect=${returnUrl}&postLogin=true`,
       myvahealth: `${redirectUrl}`,

--- a/src/platform/user/tests/authentication/utilities.unit.spec.js
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.js
@@ -116,6 +116,19 @@ describe('authentication URL helpers', () => {
     login('idme', 'v1');
     expect(global.window.location).to.include('/v1/sessions/idme/new');
   });
+
+  it('should mimick modal behavior when sign-in page lacks appliction param', () => {
+    global.window.location.pathname = '/sign-in/';
+    login('idme', 'v1');
+    expect(global.window.location).to.include('/v1/sessions/idme/new');
+  });
+
+  it('should mimick modal behavior when sign-in page has invalid application param', () => {
+    global.window.location.pathname = '/sign-in/';
+    global.window.location.search = '?application=foobar';
+    login('idme', 'v1');
+    expect(global.window.location).to.include('/v1/sessions/idme/new');
+  });
 });
 
 describe('standaloneRedirect', () => {


### PR DESCRIPTION
## Description
Standalone sign page would redirect to `/sign-in/undefined` when param `?application=mhv || ?application=myvahealth` was absent. 

This PR aims to treat the `/sign-in` page the same as the modal when an application to redirect to is missing. Thus any logic specific to the standalone page is now locked behind 2 checks:
- Are we on the `sign-in` page
- Is an `application` param present and is it valid

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#32134


## Testing done
Unit testing

## Screenshots
Original Issue
https://user-images.githubusercontent.com/13320944/139331551-ee31f85f-3596-488a-8533-878f14a68eb9.mov

New Behavior
https://user-images.githubusercontent.com/13320944/139331989-d42597b3-7f30-4862-bc58-9714821cd3a6.mov


## Acceptance criteria
 - [x] On the /sign-in page I can log into VA.gov when no application is specified
 - [x] If no param is specified in the app, we default to vagov.
 - [x] if the param is vagov (or whatever you want to name it) we default to vagov
 -- **Note:** My approach does not add a new valid param but rather uses base logic on the lack of a valid param
 - [x] if the param is garbage/not in our explicit list of apps, we default to vagov
 - [x] security requirement: as we parse the param we need to ensure its sanitized and do not execute or store any params directly via input from the URL, all logic redirect must be explicitly created by our parser after sanitization and verification checks.
 -- **Note:** As there is not a newly implemented param, I think we can clear the security requirement as it's using previously implemented logic

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
