### PR TITLE
Fixed named JSON exports (vsa-ebenefits)

### DIFF
--- a/src/applications/static-pages/dependency-verification/tests/dependency-verification.cypress.spec.js
+++ b/src/applications/static-pages/dependency-verification/tests/dependency-verification.cypress.spec.js
@@ -1,4 +1,4 @@
-import { rootUrl } from 'applications/personalization/view-dependents/manifest.json';
+import manifest from 'applications/personalization/view-dependents/manifest.json';
 import mockDependents from 'applications/personalization/view-dependents/tests/e2e/fixtures/mock-dependents.json';
 import mockDiaries from './fixtures/diaries.json';
 
@@ -34,7 +34,7 @@ describe('Dependency Verification', () => {
     cy.intercept('GET', '/v0/dependents_verifications', mockDiaries).as(
       'mockDiaries',
     );
-    cy.visit(rootUrl);
+    cy.visit(manifest.rootUrl);
     cy.findByRole('heading', {
       name: /Dependents on your VA benefits/i,
     }).should('exist');
@@ -53,7 +53,7 @@ describe('Dependency Verification', () => {
       statusCode: 200,
       body: { updateDiaries: 'true' },
     });
-    cy.visit(rootUrl);
+    cy.visit(manifest.rootUrl);
     cy.findByRole('heading', {
       name: /Please make sure your dependents are correct/i,
     }).should('exist');
@@ -77,7 +77,7 @@ describe('Dependency Verification', () => {
       statusCode: 500,
       body: { updateDiaries: 'true' },
     });
-    cy.visit(rootUrl);
+    cy.visit(manifest.rootUrl);
     cy.findByRole('heading', {
       name: /Dependents on your VA benefits/i,
     }).should('exist');

--- a/src/applications/static-pages/vre-chapter36/Chapter36CTA.js
+++ b/src/applications/static-pages/vre-chapter36/Chapter36CTA.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { rootUrl as chapter36Url } from 'applications/vre/28-8832/manifest.json';
+import manifest from 'applications/vre/28-8832/manifest.json';
 
 const EDUCATION_CAREER_COUNSELING_PATH = 'education-and-career-counseling';
 
@@ -14,7 +14,7 @@ const Chapter36CTA = () => {
       <a
         className="usa-button-primary va-button-primary"
         target="_self"
-        href={chapter36Url}
+        href={manifest.rootUrl}
       >
         Apply for career counseling
       </a>


### PR DESCRIPTION
## Description
In preparation to upgrade Webpack to version 5. There is a breaking change that needs to be fixed before it can be done. Based on the [Webpack migration guide](https://webpack.js.org/migrate/5/), it is important to fix all [named exports from JSON modules](https://webpack.js.org/migrate/5/#using-named-exports-from-json-modules) because it’s no longer supported. This is a [PR](https://github.com/department-of-veterans-affairs/vets-website/pull/19142) sample of the changes

slack: https://dsva.slack.com/archives/CLY6Q69RV/p1635427903022400

## Original issue(s)
department-of-veterans-affairs/va.gov-team#32177

## Tasks
Files that need to be updated:
- [x] src/applications/static-pages/vre-chapter36/Chapter36CTA.js
- [x] src/applications/static-pages/dependency-verification/tests/dependency-verification.cypress.spec.js

## Acceptance Criteria
- [x] all named exports from JSON modules should be updated
