### PR TITLE
31950: [FSR] List Loop renders no data when cancel is clicked

### DIFF
--- a/src/applications/financial-status-report/components/CardDetailsView.jsx
+++ b/src/applications/financial-status-report/components/CardDetailsView.jsx
@@ -4,7 +4,7 @@ import toLower from 'lodash/toLower';
 import moment from 'moment';
 import { currency } from '../utils/helpers';
 
-const CardDetailsView = ({ formData, onEdit, index, title }) => {
+const CardDetailsView = ({ formData, onEdit, title }) => {
   if (!formData) return <div>no data</div>;
 
   const keys = Object.keys(formData);
@@ -115,8 +115,9 @@ const CardDetailsView = ({ formData, onEdit, index, title }) => {
         <div className="edit-item-container">
           <button
             className="usa-button-secondary vads-u-flex--auto"
-            onClick={e => onEdit(e, index)}
+            onClick={() => onEdit()}
             aria-label={`Edit ${title}`}
+            type="button"
           >
             Edit
           </button>

--- a/src/applications/financial-status-report/components/ItemLoop.jsx
+++ b/src/applications/financial-status-report/components/ItemLoop.jsx
@@ -125,8 +125,9 @@ const InputSection = ({
           <div className="row small-collapse">
             <div className="small-4 left columns button-group">
               <button
+                type="button"
                 className="float-left"
-                onClick={e => handleSave(e, index)}
+                onClick={() => handleSave(index)}
                 aria-label={`${buttonText} ${title}`}
               >
                 {buttonText}
@@ -152,15 +153,15 @@ const InputSection = ({
 };
 
 const AddAnotherButton = ({ uiOptions, handleAdd, collapsed }) => {
-  const linkClassNames = classNames('add-item-link-section', {
+  const linkClassNames = classNames('add-item-link', {
     disabled: !collapsed,
   });
 
   return (
     <div className="add-item-container" name="table_root_">
-      <div className={linkClassNames}>
-        <i className="fas fa-plus plus-icon" />
-        <a className="add-item-link" onClick={handleAdd}>
+      <div className="add-item-link-section">
+        <a className={linkClassNames} onClick={handleAdd}>
+          <i className="fas fa-plus plus-icon" />
           {uiOptions.itemName ? `Add ${uiOptions.itemName}` : 'Add another'}
         </a>
       </div>
@@ -236,7 +237,7 @@ const ItemLoop = ({
     handleScroll(`table_${idSchema.$id}_${index}`, 0);
   };
 
-  const handleSave = (e, index) => {
+  const handleSave = index => {
     if (errorSchemaIsValid(errorSchema[index])) {
       const editData = editing.map(() => false);
       setEditing(editData);

--- a/src/applications/financial-status-report/components/ItemLoop.jsx
+++ b/src/applications/financial-status-report/components/ItemLoop.jsx
@@ -10,6 +10,7 @@ import {
   getDefaultFormState,
 } from '@department-of-veterans-affairs/react-jsonschema-form/lib/utils';
 import { isReactComponent } from 'platform/utilities/ui';
+import { allEqual } from '../utils/helpers';
 
 const ScrollElement = Scroll.Element;
 const scroller = Scroll.scroller;
@@ -62,8 +63,6 @@ const InputSection = ({
   item,
   onBlur,
   registry,
-  disabled,
-  readonly,
   idSchema,
   editing,
   handleChange,
@@ -121,8 +120,6 @@ const InputSection = ({
             formData={item}
             onBlur={onBlur}
             registry={registry}
-            disabled={disabled}
-            readonly={readonly}
             onChange={value => handleChange(index, value)}
             required={false}
           />
@@ -155,31 +152,23 @@ const InputSection = ({
   );
 };
 
-const AddAnotherButton = ({
-  items,
-  addAnotherDisabled,
-  uiOptions,
-  handleAdd,
-}) => (
-  <div>
+const AddAnotherButton = ({ uiOptions, handleAdd, editing }) => {
+  const isClosed = allEqual(editing) && editing.includes(false);
+  const linkClassNames = classNames('add-item-link-section', {
+    disabled: !isClosed,
+  });
+
+  return (
     <div className="add-item-container" name="table_root_">
-      <div className="add-item-link-section">
+      <div className={linkClassNames}>
         <i className="fas fa-plus plus-icon" />
-        <a
-          className="add-item-link"
-          disabled={!items || addAnotherDisabled}
-          onClick={handleAdd}
-        >
+        <a className="add-item-link" onClick={handleAdd}>
           {uiOptions.itemName ? `Add ${uiOptions.itemName}` : 'Add another'}
         </a>
       </div>
     </div>
-    <p>
-      {addAnotherDisabled &&
-        `You’ve entered the maximum number of items allowed.`}
-    </p>
-  </div>
-);
+  );
+};
 
 const ItemLoop = ({
   uiSchema,
@@ -190,8 +179,6 @@ const ItemLoop = ({
   formData,
   errorSchema,
   formContext,
-  disabled,
-  readonly,
   onBlur,
 }) => {
   const uiOptions = uiSchema['ui:options'] || {};
@@ -213,7 +200,6 @@ const ItemLoop = ({
   const items = formData?.length
     ? formData
     : [getDefaultFormState(schema, undefined, registry.definitions)];
-  const addAnotherDisabled = items.length >= (schema.maxItems || Infinity);
 
   // Throw an error if there’s no viewField (should be React component)
   if (!isReactComponent(uiSchema['ui:options'].viewField)) {
@@ -393,8 +379,6 @@ const ItemLoop = ({
                         idSchema={idSchema}
                         onBlur={onBlur}
                         registry={registry}
-                        disabled={disabled}
-                        readonly={readonly}
                         errorSchema={errorSchema}
                         editing={editing}
                         handleChange={handleChange}
@@ -432,8 +416,6 @@ const ItemLoop = ({
                 idSchema={idSchema}
                 onBlur={onBlur}
                 registry={registry}
-                disabled={disabled}
-                readonly={readonly}
                 errorSchema={errorSchema}
                 editing={editing}
                 handleChange={handleChange}
@@ -452,11 +434,9 @@ const ItemLoop = ({
             );
           })
         )}
-
         <AddAnotherButton
-          items={items}
-          addAnotherDisabled={addAnotherDisabled}
           uiOptions={uiOptions}
+          editing={editing}
           handleAdd={handleAdd}
         />
       </div>
@@ -475,8 +455,6 @@ ItemLoop.propTypes = {
   onChange: PropTypes.func.isRequired,
   onBlur: PropTypes.func,
   formData: PropTypes.array,
-  disabled: PropTypes.bool,
-  readonly: PropTypes.bool,
   registry: PropTypes.shape({
     widgets: PropTypes.objectOf(
       PropTypes.oneOfType([PropTypes.func, PropTypes.object]),

--- a/src/applications/financial-status-report/components/ItemLoop.jsx
+++ b/src/applications/financial-status-report/components/ItemLoop.jsx
@@ -253,40 +253,29 @@ const ItemLoop = ({
 
   const handleAdd = () => {
     const lastIndex = items?.length - 1;
-    if (errorSchemaIsValid(errorSchema[lastIndex])) {
-      const defaultData = getDefaultFormState(
-        schema.additionalItems,
-        undefined,
-        registry.definitions,
-      );
-      const newFormData = [...items, defaultData];
-      setCache(items);
-      onChange(newFormData);
-      setEditing([...editing, 'add']);
-      handleScroll(`table_${idSchema.$id}_${lastIndex + 1}`, 0);
-    } else {
-      const touched = setArrayRecordTouched(idSchema.$id, lastIndex);
-      formContext.setTouched(touched, () => {
-        scrollToFirstError();
-      });
-    }
+    const defaultData = getDefaultFormState(
+      schema.additionalItems,
+      undefined,
+      registry.definitions,
+    );
+    const newFormData = [...items, defaultData];
+    setCache(items);
+    onChange(newFormData);
+    setEditing(prevState => [...prevState, 'add']);
+    handleScroll(`table_${idSchema.$id}_${lastIndex + 1}`, 0);
   };
 
   const handleCancel = index => {
     const lastIndex = items.length - 1;
     const isAdding = editing.includes('add');
-    if (isAdding && lastIndex === index) {
+    if (isAdding && index === lastIndex) {
       const editData = editing.filter(item => item !== 'add');
-      const filtered = items.filter(item => {
-        return Object.values(item).includes(undefined) ? null : item;
-      });
       setEditing(editData);
-      onChange(filtered);
     } else {
       const editData = editing.map(() => false);
       setEditing(editData);
-      onChange(cache);
     }
+    onChange(cache);
   };
 
   const handleRemove = index => {

--- a/src/applications/financial-status-report/components/ItemLoop.jsx
+++ b/src/applications/financial-status-report/components/ItemLoop.jsx
@@ -158,12 +158,14 @@ const AddAnotherButton = ({ uiOptions, handleAdd, collapsed }) => {
   });
 
   return (
-    <div className="add-item-container" name="table_root_">
-      <div className="add-item-link-section">
-        <a className={linkClassNames} onClick={handleAdd}>
-          <i className="fas fa-plus plus-icon" />
-          {uiOptions.itemName ? `Add ${uiOptions.itemName}` : 'Add another'}
-        </a>
+    <div>
+      <div className="add-item-container" name="table_root_">
+        <div className="add-item-link-section">
+          <a className={linkClassNames} onClick={handleAdd}>
+            <i className="fas fa-plus plus-icon" />
+            {uiOptions.itemName ? `Add ${uiOptions.itemName}` : 'Add another'}
+          </a>
+        </div>
       </div>
     </div>
   );

--- a/src/applications/financial-status-report/components/ItemLoop.jsx
+++ b/src/applications/financial-status-report/components/ItemLoop.jsx
@@ -226,6 +226,7 @@ const ItemLoop = ({
   };
 
   const handleEdit = index => {
+    if (!isCollapsed) return;
     const editData = editing.map((item, i) => index === i);
     if (editing.length === 1) {
       setShowTable(false);

--- a/src/applications/financial-status-report/components/TableDetailsView.jsx
+++ b/src/applications/financial-status-report/components/TableDetailsView.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { currency } from '../utils/helpers';
 
-const TableDetailsView = ({ formData, onEdit, index }) => {
+const TableDetailsView = ({ formData, onEdit }) => {
   const values = formData && Object.values(formData);
   const keys = formData && Object.keys(formData);
 
@@ -25,11 +25,7 @@ const TableDetailsView = ({ formData, onEdit, index }) => {
     <tr className="vads-u-border-bottom--1px">
       {renderDetails(keys)}
       <td className="vads-u-border--0">
-        <a
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={e => onEdit(e, index)}
-        >
+        <a target="_blank" rel="noopener noreferrer" onClick={() => onEdit()}>
           <span aria-hidden="true">Edit</span>
         </a>
       </td>

--- a/src/applications/financial-status-report/pages/assets/other/records.js
+++ b/src/applications/financial-status-report/pages/assets/other/records.js
@@ -41,7 +41,6 @@ export const uiSchema = {
         viewType: 'table',
         viewField: TableDetailsView,
         doNotScroll: true,
-        showSave: true,
         itemName: 'asset',
         keepInPageOnReview: true,
       },

--- a/src/applications/financial-status-report/pages/assets/realEstate/records.js
+++ b/src/applications/financial-status-report/pages/assets/realEstate/records.js
@@ -16,7 +16,6 @@ export const uiSchema = {
     'ui:options': {
       viewField: CardDetailsView,
       doNotScroll: true,
-      showSave: true,
       itemName: 'real estate',
       keepInPageOnReview: true,
     },

--- a/src/applications/financial-status-report/pages/assets/recreationalVehicles/records.js
+++ b/src/applications/financial-status-report/pages/assets/recreationalVehicles/records.js
@@ -40,7 +40,6 @@ export const uiSchema = {
       'ui:options': {
         viewField: CardDetailsView,
         doNotScroll: true,
-        showSave: true,
         itemName: 'trailer, camper, or boat',
         keepInPageOnReview: true,
       },

--- a/src/applications/financial-status-report/pages/assets/vehicles/records.js
+++ b/src/applications/financial-status-report/pages/assets/vehicles/records.js
@@ -26,7 +26,6 @@ export const uiSchema = {
       'ui:options': {
         viewField: CardDetailsView,
         doNotScroll: true,
-        showSave: true,
         itemName: 'vehicle',
         keepInPageOnReview: true,
       },

--- a/src/applications/financial-status-report/pages/expenses/other/records.js
+++ b/src/applications/financial-status-report/pages/expenses/other/records.js
@@ -28,7 +28,6 @@ export const uiSchema = {
       viewType: 'table',
       viewField: TableDetailsView,
       doNotScroll: true,
-      showSave: true,
       itemName: 'an expense',
       keepInPageOnReview: true,
     },

--- a/src/applications/financial-status-report/pages/expenses/repayments/records.js
+++ b/src/applications/financial-status-report/pages/expenses/repayments/records.js
@@ -18,7 +18,6 @@ export const uiSchema = {
     'ui:options': {
       viewField: CardDetailsView,
       doNotScroll: true,
-      showSave: true,
       itemName: 'installment or other debt',
       keepInPageOnReview: true,
     },

--- a/src/applications/financial-status-report/pages/expenses/utilities/records.js
+++ b/src/applications/financial-status-report/pages/expenses/utilities/records.js
@@ -18,7 +18,6 @@ export const uiSchema = {
       viewType: 'table',
       viewField: TableDetailsView,
       doNotScroll: true,
-      showSave: true,
       itemName: 'utility',
       keepInPageOnReview: true,
     },

--- a/src/applications/financial-status-report/pages/income/additionalIncome/records.js
+++ b/src/applications/financial-status-report/pages/income/additionalIncome/records.js
@@ -25,7 +25,6 @@ export const uiSchema = {
         viewType: 'table',
         viewField: TableDetailsView,
         doNotScroll: true,
-        showSave: true,
         itemName: 'income',
         keepInPageOnReview: true,
       },

--- a/src/applications/financial-status-report/pages/income/currentIncome/index.js
+++ b/src/applications/financial-status-report/pages/income/currentIncome/index.js
@@ -43,7 +43,6 @@ export const uiSchema = {
           viewType: 'table',
           viewField: TableDetailsView,
           doNotScroll: true,
-          showSave: true,
           itemName: 'payroll deduction',
           keepInPageOnReview: true,
         },

--- a/src/applications/financial-status-report/pages/income/dependents/records.js
+++ b/src/applications/financial-status-report/pages/income/dependents/records.js
@@ -17,7 +17,6 @@ export const uiSchema = {
       'ui:options': {
         viewField: CardDetailsView,
         doNotScroll: true,
-        showSave: true,
         itemName: 'a dependent',
         keepInPageOnReview: true,
       },

--- a/src/applications/financial-status-report/pages/income/employment/records.js
+++ b/src/applications/financial-status-report/pages/income/employment/records.js
@@ -22,7 +22,6 @@ export const uiSchema = {
           'ui:options': {
             viewField: CardDetailsView,
             doNotScroll: true,
-            showSave: true,
             itemName: 'job',
             keepInPageOnReview: true,
           },

--- a/src/applications/financial-status-report/pages/income/spouse/additionalIncome/records.js
+++ b/src/applications/financial-status-report/pages/income/spouse/additionalIncome/records.js
@@ -28,7 +28,6 @@ export const uiSchema = {
           viewType: 'table',
           viewField: TableDetailsView,
           doNotScroll: true,
-          showSave: true,
           itemName: 'income',
           keepInPageOnReview: true,
         },

--- a/src/applications/financial-status-report/pages/income/spouse/currentIncome/index.js
+++ b/src/applications/financial-status-report/pages/income/spouse/currentIncome/index.js
@@ -43,7 +43,6 @@ export const uiSchema = {
           viewType: 'table',
           viewField: TableDetailsView,
           doNotScroll: true,
-          showSave: true,
           itemName: 'payroll deduction',
           keepInPageOnReview: true,
         },

--- a/src/applications/financial-status-report/pages/income/spouse/employment/records.js
+++ b/src/applications/financial-status-report/pages/income/spouse/employment/records.js
@@ -24,7 +24,6 @@ export const uiSchema = {
           'ui:options': {
             viewField: CardDetailsView,
             doNotScroll: true,
-            showSave: true,
             itemName: 'job',
             keepInPageOnReview: true,
           },

--- a/src/applications/financial-status-report/sass/financial-status-report.scss
+++ b/src/applications/financial-status-report/sass/financial-status-report.scss
@@ -115,6 +115,9 @@
         margin-right: 5px;
       }
     }
+    .disabled {
+      pointer-events: none;
+    }
   }
   .card-details-view {
     padding: 10px 30px;

--- a/src/applications/financial-status-report/sass/financial-status-report.scss
+++ b/src/applications/financial-status-report/sass/financial-status-report.scss
@@ -110,6 +110,8 @@
     padding: 20px 30px 20px;
     margin-top: 20px;
     .add-item-link-section {
+      cursor: pointer;
+      width: fit-content;
       .plus-icon {
         color: $color-light-blue;
         margin-right: 5px;

--- a/src/applications/financial-status-report/utils/helpers.js
+++ b/src/applications/financial-status-report/utils/helpers.js
@@ -12,6 +12,8 @@ export const fsrFeatureToggle = state => {
   return toggleValues(state)[FEATURE_FLAG_NAMES.showFinancialStatusReport];
 };
 
+export const allEqual = arr => arr.every(val => val === arr[0]);
+
 export const dateFormatter = date => {
   if (!date) return undefined;
   const formatDate = date?.slice(0, -3);


### PR DESCRIPTION
## Description
Fix for clicking cancel on newly added item which results in no data. Also removes unused props from list loop component

## Original issue(s)
department-of-veterans-affairs/va.gov-team#31950

## Screenshots
![screencast 2021-11-01 12-14-36](https://user-images.githubusercontent.com/7518899/139704244-5278d6c1-0177-4880-bf0f-b152777e5923.gif)


## Acceptance criteria
- [x] users should now be able to click cancel on new items

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs