### PR TITLE
Github Actions (CI) -- continue-on-error for reporting prep

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -262,6 +262,7 @@ jobs:
   testing-reports-prep:
     name: Testing Reports Prep
     runs-on: ubuntu-latest
+    continue-on-error: true
     outputs:
       app_list: ${{ env.APPLICATION_LIST }}
     steps:


### PR DESCRIPTION
## Description

Overlooked testing-report prep job and being treated as a failure. Report is being hashed out by TT, but should not be a CI blocker.


## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
