### PR TITLE
Add more details to aXe failure messages

### DIFF
--- a/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
+++ b/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
@@ -11,14 +11,19 @@ const processAxeCheckResults = violations => {
   } detected`;
 
   // Pluck specific keys to keep the table readable.
-  const violationData = violations.map(({ id, impact, description, nodes }) => [
-    ['id', id],
-    ['impact', impact],
-    ['description', description],
-    ['target', nodes.map(node => node.target).join('\n\n')],
-    ['html', nodes.map(node => node.html).join('\n\n')],
-    ['nodes', nodes.length],
-  ]);
+  const violationData = violations.map(
+    ({ id, impact, description, nodes, help, helpUrl }) => [
+      ['id', id],
+      ['impact', impact],
+      ['description', description],
+      ['help', help],
+      ['help URL', helpUrl],
+      ['target', nodes.map(node => node.target).join('\n\n')],
+      ['html', nodes.map(node => node.html).join('\n\n')],
+      ['failure summary', nodes.map(node => node.failureSummary).join('\n\n')],
+      ['nodes', nodes.length],
+    ],
+  );
 
   cy.task('log', violationMessage);
   violationData.forEach(violation => cy.task('table', violation));


### PR DESCRIPTION
## Description
This PR adds more detail to the table printed out when an aXe failure is detected so that it is easier to determine what the exact issue is.

## Screenshots
New failure message:

<img width="757" alt="Screen Shot 2021-10-29 at 3 11 48 PM" src="https://user-images.githubusercontent.com/3535749/139496368-7306deb9-425e-4bd7-884e-eca0a44eb9de.png">


## Acceptance criteria
- [ ] CI passes.