### PR TITLE
Fix --app-folder option with multiple default spec dirs

### DIFF
--- a/script/run-unit-test.js
+++ b/script/run-unit-test.js
@@ -6,7 +6,8 @@ const glob = require('glob');
 
 // For usage instructions see https://github.com/department-of-veterans-affairs/vets-website#unit-tests
 
-const defaultPath = './{src,script}/**/*.unit.spec.js?(x)';
+const specDirs = '{src,script}';
+const defaultPath = `./${specDirs}/**/*.unit.spec.js?(x)`;
 
 const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'log-level', type: String, defaultValue: 'debug' },
@@ -33,7 +34,7 @@ if (
   options.path.length === 1
 ) {
   options.path[0] = options.path[0].replace(
-    '/src/',
+    `/${specDirs}/`,
     `/src/applications/${options['app-folder']}/`,
   );
 


### PR DESCRIPTION
## Description
We updated the the unit tests to look for spec files not just in `src` but also in `script`. However, the `--app-folder` option stopped functioning correctly after the change. This PR updates the app-folder option so it works when multiple default spec directories are present. We can add more spec directories in the future with a single change, without breaking the app-folder option.

## Testing done
- Local testing of `--app-folder`

## Screenshots

## Acceptance criteria
- [x] Tests run with and without `--app-folder` option

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
