### PR TITLE
Skip failing Health Care Questionnaire Cypress tests

### DIFF
--- a/src/applications/health-care-questionnaire/list/tests/e2e/03.session.storage.is.clearing.cypress.spec.js
+++ b/src/applications/health-care-questionnaire/list/tests/e2e/03.session.storage.is.clearing.cypress.spec.js
@@ -4,7 +4,7 @@ import featureToggles from './fixtures/mocks/feature-toggles.enabled.json';
 
 import selectedAppointment from '../../../shared/api/mock-data/fhir/upcoming.appointment.in.progress.primary.care.questionnaire.json';
 
-describe('health care questionnaire list -- ', () => {
+describe.skip('health care questionnaire list -- ', () => {
   beforeEach(() => {
     cy.login(basicUser);
     cy.intercept('GET', '/v0/feature_toggles*', featureToggles);

--- a/src/applications/health-care-questionnaire/list/tests/e2e/03.session.storage.is.populated.cypress.spec.js
+++ b/src/applications/health-care-questionnaire/list/tests/e2e/03.session.storage.is.populated.cypress.spec.js
@@ -4,7 +4,7 @@ import featureToggles from './fixtures/mocks/feature-toggles.enabled.json';
 
 import selectedAppointment from '../../../shared/api/mock-data/fhir/upcoming.appointment.in.progress.primary.care.questionnaire.json';
 
-describe('health care questionnaire list -- ', () => {
+describe.skip('health care questionnaire list -- ', () => {
   beforeEach(() => {
     cy.login(basicUser);
     cy.intercept('GET', '/v0/feature_toggles*', featureToggles);


### PR DESCRIPTION
## Description
PR to skip two Cypress tests that are failing on `master`:
* https://github.com/department-of-veterans-affairs/vets-website/runs/4071458619?check_suite_focus=true
* https://github.com/department-of-veterans-affairs/vets-website/runs/4071313147?check_suite_focus=true

@mdewey are we fine with skipping these until they're fixed?

## Acceptance criteria
- [ ] CI passes.