### PR TITLE
Update vets-json-schema to latest version that includes Legacy Appeals

### DIFF
--- a/package.json
+++ b/package.json
@@ -313,7 +313,7 @@
     "url-search-params-polyfill": "^8.1.1",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#4e052b3bfea310e581dc11d332b051bb87581271",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#097045b553829a5aa122dbf1c19de6a59cd14619",
     "whatwg-fetch": "^3.6.2"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19533,9 +19533,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#4e052b3bfea310e581dc11d332b051bb87581271":
-  version "20.14.3"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#4e052b3bfea310e581dc11d332b051bb87581271"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#097045b553829a5aa122dbf1c19de6a59cd14619":
+  version "20.14.4"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#097045b553829a5aa122dbf1c19de6a59cd14619"
 
 vfile-message@^2.0.0:
   version "2.0.4"


### PR DESCRIPTION
## Description
Update Json Schema to include new Legacy Appeals Schema


## Original issue(s)
department-of-veterans-affairs/va.gov-team#31149


## Testing done
Currently, this new schema is hidden behind the HLR_2 feature flag and is dark.  Testing will be done as part of the HLR V2 work

## Screenshots


## Acceptance criteria
- [x] vets-website configured to use 20.14.4 of vets-json-schema

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
