### PR TITLE
Created commands to minimize repeated cypress code.

### DIFF
--- a/src/applications/check-in/api/local-mock-api/mocks/v2/patient.check.in.responses.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/patient.check.in.responses.js
@@ -1,6 +1,8 @@
+const defaultUUID = '46bebc0a-b99c-464f-a5c5-560bc9eae287';
+
 const createMockSuccessResponse = (data, hasBeenValidated) => {
   const rv = {
-    id: data.id || '46bebc0a-b99c-464f-a5c5-560bc9eae287',
+    id: data.id || defaultUUID,
     payload: {
       demographics: {
         mailingAddress: {
@@ -79,7 +81,7 @@ const createMultipleAppointments = (
   numberOfCheckInAbledAppointments = 2,
 ) => {
   const rv = {
-    id: token || '46bebc0a-b99c-464f-a5c5-560bc9eae287',
+    id: token || defaultUUID,
     payload: {
       demographics: {
         nextOfKin1: {
@@ -162,4 +164,5 @@ module.exports = {
   createMockFailedResponse,
   createMultipleAppointments,
   createAppointment,
+  defaultUUID,
 };

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/already-validated-user/returning.user.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/already-validated-user/returning.user.cypress.spec.js
@@ -1,24 +1,14 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
 
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 3 -- ', () => {
     beforeEach(function() {
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        req.reply(mockPatientCheckIns.createMultipleAppointments());
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
-      });
+      cy.alreadyAuthenticated();
+      cy.getAppointments();
+      cy.successfulCheckin();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/already-validated-user/returning.user.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/already-validated-user/returning.user.cypress.spec.js
@@ -23,9 +23,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('Returning user', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('have.text', 'Your appointments');

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/app-enabled/disabled.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/app-enabled/disabled.cypress.spec.js
@@ -1,4 +1,5 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
+import '../../support/commands';
 
 describe('Check In Experience -- ', () => {
   beforeEach(function() {
@@ -16,9 +17,7 @@ describe('Check In Experience -- ', () => {
     });
   });
   it('C5740 - Feature is disabled', () => {
-    const featureRoute =
-      '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-    cy.visit(featureRoute);
+    cy.visitWithUUID();
     cy.url().should('not.match', /check-in/);
   });
 });

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/app-enabled/enabled.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/app-enabled/enabled.cypress.spec.js
@@ -19,9 +19,7 @@ describe('Check In Experience -- ', () => {
     });
   });
   it('C5742 - Feature is enabled', () => {
-    const featureRoute =
-      '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-    cy.visit(featureRoute);
+    cy.visitWithUUID();
     cy.get('h1', { timeout: Timeouts.slow })
       .should('be.visible')
       .and('have.text', 'Check in at VA');

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/app-enabled/enabled.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/app-enabled/enabled.cypress.spec.js
@@ -1,5 +1,5 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
@@ -11,11 +11,7 @@ describe('Check In Experience -- ', () => {
         checkInExperienceUpdateInformationPageEnabled: false,
       }),
     );
-    cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-      req.reply(
-        mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-      );
-    });
+    cy.authenticate();
   });
   afterEach(() => {
     cy.window().then(window => {

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/appointment-status-types/appointment.bad.status.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/appointment-status-types/appointment.bad.status.cypress.spec.js
@@ -1,36 +1,14 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 3 -- ', () => {
     beforeEach(function() {
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        const badStatus = mockPatientCheckIns.createAppointment();
-        badStatus.eligibility = 'INELIGIBLE_BAD_STATUS';
-        const response = {
-          payload: {
-            appointments: [badStatus],
-          },
-        };
-        req.reply(response);
-      });
-      cy.intercept(
-        'GET',
-        '/v0/feature_toggles*',
-        generateFeatureToggles(true, true, true, false),
-      );
+      cy.authenticate();
+      const appointments = [{ eligibility: 'INELIGIBLE_BAD_STATUS' }];
+      cy.getAppointments(appointments);
+      cy.intercept('GET', '/v0/feature_toggles*', generateFeatureToggles({}));
     });
     afterEach(() => {
       cy.window().then(window => {
@@ -44,15 +22,7 @@ describe('Check In Experience -- ', () => {
       cy.get('h1').contains('Check in at VA');
       cy.injectAxe();
       cy.axeCheck();
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
       cy.get('.appointment-list > li p', { timeout: Timeouts.slow }).should(
         'contain',
         'Online check-in isn’t available for this appointment. Check in with a staff member.',

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/appointment-status-types/appointment.bad.status.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/appointment-status-types/appointment.bad.status.cypress.spec.js
@@ -16,9 +16,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('Appointment shows bad status', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
       cy.get('h1').contains('Check in at VA');
       cy.injectAxe();
       cy.axeCheck();

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/appointment-status-types/appointment.eligible.status.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/appointment-status-types/appointment.eligible.status.cypress.spec.js
@@ -1,36 +1,14 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 3 -- ', () => {
     beforeEach(function() {
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        const eligibleStatus = mockPatientCheckIns.createAppointment();
-        eligibleStatus.eligibility = 'ELIGIBLE';
-        const response = {
-          payload: {
-            appointments: [eligibleStatus],
-          },
-        };
-        req.reply(response);
-      });
-      cy.intercept(
-        'GET',
-        '/v0/feature_toggles*',
-        generateFeatureToggles(true, true, true, false),
-      );
+      cy.authenticate();
+      const appointments = [{ eligibility: 'ELIGIBLE' }];
+      cy.getAppointments(appointments);
+      cy.intercept('GET', '/v0/feature_toggles*', generateFeatureToggles({}));
     });
     afterEach(() => {
       cy.window().then(window => {
@@ -44,15 +22,7 @@ describe('Check In Experience -- ', () => {
       cy.get('h1').contains('Check in at VA');
       cy.injectAxe();
       cy.axeCheck();
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
       cy.get('.appointment-list > li > button', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('contain', 'Check in now');

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/appointment-status-types/appointment.eligible.status.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/appointment-status-types/appointment.eligible.status.cypress.spec.js
@@ -16,9 +16,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('Appointment is eligible for checkin and button is present.', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
       cy.get('h1').contains('Check in at VA');
       cy.injectAxe();
       cy.axeCheck();

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/appointment-status-types/appointment.too.early.status.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/appointment-status-types/appointment.too.early.status.cypress.spec.js
@@ -1,42 +1,25 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 3 -- ', () => {
     beforeEach(function() {
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        const earlyStatusWithStart = mockPatientCheckIns.createAppointment();
-        earlyStatusWithStart.eligibility = 'INELIGIBLE_TOO_EARLY';
-        earlyStatusWithStart.startTime = '2021-08-19T12:00:00';
-        earlyStatusWithStart.checkInWindowStart = '2021-08-19T11:00:00';
-        const earlyStatusWithoutStart = mockPatientCheckIns.createAppointment();
-        earlyStatusWithoutStart.eligibility = 'INELIGIBLE_TOO_EARLY';
-        earlyStatusWithoutStart.startTime = '2021-08-19T14:00:00';
-        earlyStatusWithoutStart.checkInWindowStart = undefined;
-        const response = {
-          payload: {
-            appointments: [earlyStatusWithStart, earlyStatusWithoutStart],
-          },
-        };
-        req.reply(response);
-      });
-      cy.intercept(
-        'GET',
-        '/v0/feature_toggles*',
-        generateFeatureToggles(true, true, true, false),
-      );
+      cy.authenticate();
+      const appointments = [
+        {
+          eligibility: 'INELIGIBLE_TOO_EARLY',
+          startTime: '2021-08-19T12:00:00',
+          checkInWindowStart: '2021-08-19T11:00:00',
+        },
+        {
+          eligibility: 'INELIGIBLE_TOO_EARLY',
+          startTime: '2021-08-19T14:00:00',
+          checkInWindowStart: undefined,
+        },
+      ];
+      cy.getAppointments(appointments);
+      cy.intercept('GET', '/v0/feature_toggles*', generateFeatureToggles({}));
     });
     afterEach(() => {
       cy.window().then(window => {
@@ -50,15 +33,7 @@ describe('Check In Experience -- ', () => {
       cy.get('h1').contains('Check in at VA');
       cy.injectAxe();
       cy.axeCheck();
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
       cy.get('.appointment-list > li p', { timeout: Timeouts.slow }).should(
         'contain',
         'You can check in starting at this time: 11:00 a.m.',

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/appointment-status-types/appointment.too.early.status.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/appointment-status-types/appointment.too.early.status.cypress.spec.js
@@ -27,9 +27,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('Appointment shows early status with time and without', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
       cy.get('h1').contains('Check in at VA');
       cy.injectAxe();
       cy.axeCheck();

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/appointment-status-types/appointment.too.late.status.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/appointment-status-types/appointment.too.late.status.cypress.spec.js
@@ -16,9 +16,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('Appointment shows late status', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
       cy.get('h1').contains('Check in at VA');
       cy.injectAxe();
       cy.axeCheck();

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/appointment-status-types/appointment.too.late.status.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/appointment-status-types/appointment.too.late.status.cypress.spec.js
@@ -1,36 +1,14 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 3 -- ', () => {
     beforeEach(function() {
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        const lateStatus = mockPatientCheckIns.createAppointment();
-        lateStatus.eligibility = 'INELIGIBLE_TOO_LATE';
-        const response = {
-          payload: {
-            appointments: [lateStatus],
-          },
-        };
-        req.reply(response);
-      });
-      cy.intercept(
-        'GET',
-        '/v0/feature_toggles*',
-        generateFeatureToggles(true, true, true, false),
-      );
+      cy.authenticate();
+      const appointments = [{ eligibility: 'INELIGIBLE_TOO_LATE' }];
+      cy.getAppointments(appointments);
+      cy.intercept('GET', '/v0/feature_toggles*', generateFeatureToggles({}));
     });
     afterEach(() => {
       cy.window().then(window => {
@@ -44,15 +22,7 @@ describe('Check In Experience -- ', () => {
       cy.get('h1').contains('Check in at VA');
       cy.injectAxe();
       cy.axeCheck();
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
       cy.get('.appointment-list > li p', { timeout: Timeouts.slow }).should(
         'contain',
         'Your appointment started more than 10 minutes ago. We can’t check you in online. Ask a staff member for help.',

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/appointment-status-types/appointment.unknown.reason.status.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/appointment-status-types/appointment.unknown.reason.status.cypress.spec.js
@@ -1,36 +1,14 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 3 -- ', () => {
     beforeEach(function() {
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        const unknownStatus = mockPatientCheckIns.createAppointment();
-        unknownStatus.eligibility = 'INELIGIBLE_UNKNOWN_REASON';
-        const response = {
-          payload: {
-            appointments: [unknownStatus],
-          },
-        };
-        req.reply(response);
-      });
-      cy.intercept(
-        'GET',
-        '/v0/feature_toggles*',
-        generateFeatureToggles(true, true, true, false),
-      );
+      cy.authenticate();
+      const appointments = [{ eligibility: 'INELIGIBLE_UNKNOWN_REASON' }];
+      cy.getAppointments(appointments);
+      cy.intercept('GET', '/v0/feature_toggles*', generateFeatureToggles({}));
     });
     afterEach(() => {
       cy.window().then(window => {
@@ -44,15 +22,7 @@ describe('Check In Experience -- ', () => {
       cy.get('h1').contains('Check in at VA');
       cy.injectAxe();
       cy.axeCheck();
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
       cy.get('.appointment-list > li p', { timeout: Timeouts.slow }).should(
         'contain',
         'Online check-in isn’t available for this appointment. Check in with a staff member.',

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/appointment-status-types/appointment.unknown.reason.status.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/appointment-status-types/appointment.unknown.reason.status.cypress.spec.js
@@ -16,9 +16,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('Appointment shows unknown reason status', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
       cy.get('h1').contains('Check in at VA');
       cy.injectAxe();
       cy.axeCheck();

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/confirm-page/back-button.does.not.shows.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/confirm-page/back-button.does.not.shows.cypress.spec.js
@@ -22,9 +22,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('confirm page toggles -- on', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('have.text', 'Check in at VA');

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/confirm-page/back-button.does.not.shows.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/confirm-page/back-button.does.not.shows.cypress.spec.js
@@ -1,29 +1,13 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 3 -- ', () => {
     beforeEach(function() {
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        req.reply(mockPatientCheckIns.createMultipleAppointments({}, 1));
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
-      });
+      cy.authenticate();
+      cy.getSingleAppointment();
+      cy.successfulCheckin();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',
@@ -46,15 +30,7 @@ describe('Check In Experience -- ', () => {
         .and('have.text', 'Check in at VA');
       cy.injectAxe();
       cy.axeCheck();
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('have.text', 'Your appointments');

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/confirm-page/back-button.shows.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/confirm-page/back-button.shows.cypress.spec.js
@@ -1,29 +1,13 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 3 -- ', () => {
     beforeEach(function() {
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        req.reply(mockPatientCheckIns.createMultipleAppointments({}));
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
-      });
+      cy.authenticate();
+      cy.getAppointments();
+      cy.successfulCheckin();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',
@@ -46,15 +30,7 @@ describe('Check In Experience -- ', () => {
         .and('have.text', 'Check in at VA');
       cy.injectAxe();
       cy.axeCheck();
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('have.text', 'Your appointments');

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/confirm-page/back-button.shows.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/confirm-page/back-button.shows.cypress.spec.js
@@ -22,9 +22,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('confirm page toggles -- on', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('have.text', 'Check in at VA');

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/confirm-page/feature.is.toggled.on.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/confirm-page/feature.is.toggled.on.cypress.spec.js
@@ -1,33 +1,13 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 3 -- ', () => {
     beforeEach(function() {
-      let hasValidated = false;
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        hasValidated = true;
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        req.reply(
-          mockPatientCheckIns.createMockSuccessResponse({}, hasValidated),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
-      });
+      cy.authenticate();
+      cy.getAppointments({}, [], 1);
+      cy.successfulCheckin();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',
@@ -50,15 +30,7 @@ describe('Check In Experience -- ', () => {
         .and('have.text', 'Check in at VA');
       cy.injectAxe();
       cy.axeCheck();
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('have.text', 'Your appointments');

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/confirm-page/feature.is.toggled.on.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/confirm-page/feature.is.toggled.on.cypress.spec.js
@@ -22,9 +22,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('confirm page toggles -- on', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('have.text', 'Check in at VA');

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/errors/check-in-failed.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/errors/check-in-failed.cypress.spec.js
@@ -1,31 +1,12 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   beforeEach(function() {
-    let hasValidated = false;
-    cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-      req.reply(
-        mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-      );
-    });
-    cy.intercept('POST', '/check_in/v2/sessions', req => {
-      hasValidated = true;
-      req.reply(
-        mockSession.createMockSuccessResponse('some-token', 'read.full'),
-      );
-    });
-    cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-      req.reply(
-        mockPatientCheckIns.createMockSuccessResponse({}, hasValidated),
-      );
-    });
-    cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-      req.reply(mockCheckIn.createMockFailedResponse({}));
-    });
+    cy.authenticate();
+    cy.getSingleAppointment();
+    cy.failedCheckin();
     cy.intercept(
       'GET',
       '/v0/feature_toggles*',
@@ -48,15 +29,7 @@ describe('Check In Experience -- ', () => {
       .and('have.text', 'Check in at VA');
     cy.injectAxe();
     cy.axeCheck();
-    cy.get('[label="Your last name"]')
-      .shadow()
-      .find('input')
-      .type('Smith');
-    cy.get('[label="Last 4 digits of your Social Security number"]')
-      .shadow()
-      .find('input')
-      .type('4837');
-    cy.get('[data-testid=check-in-button]').click();
+    cy.signIn();
     cy.get('h1', { timeout: Timeouts.slow })
       .should('be.visible')
       .and('have.text', 'Your appointments');

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/errors/check-in-failed.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/errors/check-in-failed.cypress.spec.js
@@ -21,9 +21,7 @@ describe('Check In Experience -- ', () => {
     });
   });
   it('C5722 - Check in failed with a 200 and error message in the body', () => {
-    const featureRoute =
-      '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-    cy.visit(featureRoute);
+    cy.visitWithUUID();
     cy.get('h1', { timeout: Timeouts.slow })
       .should('be.visible')
       .and('have.text', 'Check in at VA');

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/errors/malformed.token.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/errors/malformed.token.cypress.spec.js
@@ -1,4 +1,5 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
+import '../../support/commands';
 
 describe('Check In Experience -- ', () => {
   beforeEach(function() {
@@ -10,9 +11,7 @@ describe('Check In Experience -- ', () => {
     });
   });
   it('C5724 - Token is not valid', () => {
-    const featureRoute =
-      '/health-care/appointment-check-in/?id=MALFORMED_TOKEN';
-    cy.visit(featureRoute);
+    cy.visitWithUUID('MALFORMED_TOKEN');
     cy.get('h1').contains('We couldn’t check you in');
   });
 });

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/errors/server.403.on.check-in.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/errors/server.403.on.check-in.cypress.spec.js
@@ -1,5 +1,6 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
 import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
+import '../../support/commands';
 
 describe('Check In Experience -- ', () => {
   beforeEach(function() {
@@ -18,9 +19,7 @@ describe('Check In Experience -- ', () => {
     });
   });
   it('C5728 - Check in - 404 api error', () => {
-    const featureRoute =
-      '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-    cy.visit(featureRoute);
+    cy.visitWithUUID();
 
     cy.url().should('match', /error/);
     cy.get('h1').contains('We couldn’t check you in');

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/errors/server.404.on.check-in.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/errors/server.404.on.check-in.cypress.spec.js
@@ -1,29 +1,12 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
 import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   beforeEach(function() {
-    let hasValidated = false;
-    cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-      req.reply(
-        mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-      );
-    });
-    cy.intercept('POST', '/check_in/v2/sessions', req => {
-      hasValidated = true;
-      req.reply(
-        mockSession.createMockSuccessResponse('some-token', 'read.full'),
-      );
-    });
-    cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-      req.reply(
-        mockPatientCheckIns.createMockSuccessResponse({}, hasValidated),
-      );
-    });
+    cy.authenticate();
+    cy.getSingleAppointment();
     cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
       req.reply(404, mockCheckIn.createMockFailedResponse({}));
     });
@@ -52,15 +35,7 @@ describe('Check In Experience -- ', () => {
       .and('have.text', 'Check in at VA');
     cy.injectAxe();
     cy.axeCheck();
-    cy.get('[label="Your last name"]')
-      .shadow()
-      .find('input')
-      .type('Smith');
-    cy.get('[label="Last 4 digits of your Social Security number"]')
-      .shadow()
-      .find('input')
-      .type('4837');
-    cy.get('[data-testid=check-in-button]').click();
+    cy.signIn();
     cy.get('h1', { timeout: Timeouts.slow })
       .should('be.visible')
       .and('have.text', 'Your appointments');

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/errors/server.404.on.check-in.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/errors/server.404.on.check-in.cypress.spec.js
@@ -27,9 +27,7 @@ describe('Check In Experience -- ', () => {
     });
   });
   it('C5730 - Check in - 404 api error', () => {
-    const featureRoute =
-      '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-    cy.visit(featureRoute);
+    cy.visitWithUUID();
     cy.get('h1', { timeout: Timeouts.slow })
       .should('be.visible')
       .and('have.text', 'Check in at VA');

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/errors/server.404.on.validate.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/errors/server.404.on.validate.cypress.spec.js
@@ -1,5 +1,6 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
 import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
+import '../../support/commands';
 
 describe('Check In Experience -- ', () => {
   beforeEach(function() {
@@ -28,9 +29,7 @@ describe('Check In Experience -- ', () => {
     });
   });
   it('C5732 - Validate - 404 error', () => {
-    const featureRoute =
-      '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-    cy.visit(featureRoute);
+    cy.visitWithUUID();
     cy.url().should('match', /error/);
     cy.get('h1').contains('We couldn’t check you in');
   });

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/errors/server.500.on.check-in.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/errors/server.500.on.check-in.cypress.spec.js
@@ -25,9 +25,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('500 error on check in', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
       cy.get('h1').contains('Check in at VA');
       cy.injectAxe();
       cy.axeCheck();

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/errors/server.500.on.check-in.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/errors/server.500.on.check-in.cypress.spec.js
@@ -1,31 +1,13 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
 import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
-
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 3 -- ', () => {
     beforeEach(function() {
-      let hasValidated = false;
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        hasValidated = true;
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        req.reply(
-          mockPatientCheckIns.createMockSuccessResponse({}, hasValidated),
-        );
-      });
+      cy.authenticate();
+      cy.getSingleAppointment();
       cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
         req.reply(500, mockCheckIn.createMockFailedResponse({}));
       });
@@ -49,15 +31,7 @@ describe('Check In Experience -- ', () => {
       cy.get('h1').contains('Check in at VA');
       cy.injectAxe();
       cy.axeCheck();
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('contain', 'Your appointments');

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/errors/server.500.on.validate.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/errors/server.500.on.validate.cypress.spec.js
@@ -1,5 +1,6 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
 import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
+import '../../support/commands';
 
 describe('Check In Experience -- ', () => {
   beforeEach(function() {
@@ -24,9 +25,7 @@ describe('Check In Experience -- ', () => {
     });
   });
   it('C5736 - Validate - 500 api error', () => {
-    const featureRoute =
-      '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-    cy.visit(featureRoute);
+    cy.visitWithUUID();
     cy.url().should('match', /error/);
     cy.get('h1').contains('We couldn’t check you in');
   });

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/errors/token.is.not.valid.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/errors/token.is.not.valid.cypress.spec.js
@@ -1,5 +1,6 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
 import mockSessions from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
+import '../../support/commands';
 
 describe('Check In Experience -- ', () => {
   beforeEach(function() {
@@ -18,9 +19,7 @@ describe('Check In Experience -- ', () => {
     });
   });
   it('C5738 - Token is not valid', () => {
-    const featureRoute =
-      '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-    cy.visit(featureRoute);
+    cy.visitWithUUID();
     cy.get('h1').contains('We couldn’t check you in');
   });
 });

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/extra-validation/autocorrect.is.disabled.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/extra-validation/autocorrect.is.disabled.cypress.spec.js
@@ -19,9 +19,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('validation failed', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
       cy.get('h1').contains('Check in at VA');
       cy.get('[label="Your last name"]')
         .should('have.attr', 'autocorrect', 'false')

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/extra-validation/autocorrect.is.disabled.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/extra-validation/autocorrect.is.disabled.cypress.spec.js
@@ -1,23 +1,10 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
+import '../../support/commands';
 
 describe('Check In Experience -- ', () => {
   describe('phase 3 -- ', () => {
     beforeEach(function() {
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        req.reply(mockPatientCheckIns.createMockSuccessResponse({}, false));
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
-      });
+      cy.authenticate();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/extra-validation/extra.spaces.are.trimmed.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/extra-validation/extra.spaces.are.trimmed.cypress.spec.js
@@ -31,9 +31,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('validation trims white space before posting', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
       cy.get('h1').contains('Check in at VA');
       cy.get('[label="Your last name"]')
         .shadow()

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/extra-validation/extra.spaces.are.trimmed.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/extra-validation/extra.spaces.are.trimmed.cypress.spec.js
@@ -1,19 +1,12 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
 import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
-
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 3 -- ', () => {
     beforeEach(function() {
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
+      cy.authenticate();
       cy.intercept('POST', '/check_in/v2/sessions', req => {
         expect(req.body.session.lastName).to.equal('Smith');
         expect(req.body.session.last4).to.equal('4837');
@@ -22,12 +15,8 @@ describe('Check In Experience -- ', () => {
           mockSession.createMockSuccessResponse('some-token', 'read.full'),
         );
       });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        req.reply(mockPatientCheckIns.createMultipleAppointments());
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
-      });
+      cy.getAppointments();
+      cy.successfulCheckin();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/extra-validation/fields.are.required.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/extra-validation/fields.are.required.cypress.spec.js
@@ -20,9 +20,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('validation failed shows error messages', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
       cy.get('h1').contains('Check in at VA');
       cy.injectAxe();
       cy.axeCheck();

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/extra-validation/fields.are.required.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/extra-validation/fields.are.required.cypress.spec.js
@@ -1,28 +1,11 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 
 describe('Check In Experience -- ', () => {
   describe('phase 3 -- ', () => {
     beforeEach(function() {
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        req.reply(mockPatientCheckIns.createMockSuccessResponse({}, false));
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
-      });
+      cy.authenticate();
+      cy.getAppointments();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/extra-validation/last4.field.is.limited.to.4.characters.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/extra-validation/last4.field.is.limited.to.4.characters.cypress.spec.js
@@ -1,23 +1,11 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
+import '../../support/commands';
 
 describe('Check In Experience -- ', () => {
   describe('phase 3 -- ', () => {
     beforeEach(function() {
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        req.reply(mockPatientCheckIns.createMockSuccessResponse({}, false));
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
-      });
+      cy.authenticate();
+      cy.getAppointments();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/extra-validation/last4.field.is.limited.to.4.characters.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/extra-validation/last4.field.is.limited.to.4.characters.cypress.spec.js
@@ -20,9 +20,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('only allows typing 4 characters', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
       cy.get('h1').contains('Check in at VA');
       cy.get('[label="Last 4 digits of your Social Security number"]')
         .shadow()

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/extra-validation/last4.shows.number.keypad.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/extra-validation/last4.shows.number.keypad.cypress.spec.js
@@ -1,23 +1,10 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
+import '../../support/commands';
 
 describe('Check In Experience -- ', () => {
   describe('phase 3 -- ', () => {
     beforeEach(function() {
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        req.reply(mockPatientCheckIns.createMockSuccessResponse({}, false));
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
-      });
+      cy.authenticate();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/extra-validation/last4.shows.number.keypad.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/extra-validation/last4.shows.number.keypad.cypress.spec.js
@@ -19,9 +19,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('shows the numeric keypad on mobile devices', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
       cy.get('h1').contains('Check in at VA');
       cy.get('[label="Last 4 digits of your Social Security number"]').should(
         'have.attr',

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/extra-validation/validation.failed.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/extra-validation/validation.failed.cypress.spec.js
@@ -1,6 +1,7 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
 import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
 import Timeouts from 'platform/testing/e2e/timeouts';
+import '../../support/commands';
 
 describe('Check In Experience -- ', () => {
   describe('phase 3 -- ', () => {
@@ -27,9 +28,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('validation failed with failed response from server', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
       cy.get('h1').contains('Check in at VA');
       cy.injectAxe();
       cy.axeCheck();

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/extra-validation/validation.failed.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/extra-validation/validation.failed.cypress.spec.js
@@ -1,8 +1,5 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
 import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
@@ -15,12 +12,6 @@ describe('Check In Experience -- ', () => {
       });
       cy.intercept('POST', '/check_in/v2/sessions', req => {
         req.reply(400, mockSession.createMockFailedResponse());
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        req.reply(mockPatientCheckIns.createMockSuccessResponse({}, false));
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
       });
       cy.intercept(
         'GET',

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/happy-path/current.happy.path.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/happy-path/current.happy.path.cypress.spec.js
@@ -22,9 +22,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('phase 3 - happy path', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('have.text', 'Check in at VA');

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/happy-path/current.happy.path.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/happy-path/current.happy.path.cypress.spec.js
@@ -1,33 +1,13 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 3 -- ', () => {
     beforeEach(function() {
-      let hasValidated = false;
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        hasValidated = true;
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        req.reply(
-          mockPatientCheckIns.createMockSuccessResponse({}, hasValidated),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
-      });
+      cy.authenticate();
+      cy.getSingleAppointment();
+      cy.successfulCheckin();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',
@@ -50,15 +30,7 @@ describe('Check In Experience -- ', () => {
         .and('have.text', 'Check in at VA');
       cy.injectAxe();
       cy.axeCheck();
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('have.text', 'Your appointments');

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/happy-path/everything.happy.path.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/happy-path/everything.happy.path.cypress.spec.js
@@ -1,39 +1,13 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 3 -- ', () => {
     beforeEach(function() {
-      let hasValidated = false;
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        hasValidated = true;
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        req.reply(
-          mockPatientCheckIns.createMockSuccessResponse({}, hasValidated),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        const { uuid, appointmentIen, facilityId } =
-          req.body?.patientCheckIns || {};
-        expect(uuid).to.equal('46bebc0a-b99c-464f-a5c5-560bc9eae287');
-        expect(appointmentIen).to.equal('some-ien');
-        expect(facilityId).to.equal('ABC_123');
-
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
-      });
+      cy.authenticate();
+      cy.getSingleAppointment();
+      cy.successfulCheckin();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',
@@ -56,15 +30,7 @@ describe('Check In Experience -- ', () => {
         .and('have.text', 'Check in at VA');
       cy.injectAxe();
       cy.axeCheck();
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
       cy.get('legend > h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('have.text', 'Do you need to update any information?');

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/happy-path/everything.happy.path.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/happy-path/everything.happy.path.cypress.spec.js
@@ -22,9 +22,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('Everything Happy path', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('have.text', 'Check in at VA');

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/multiple-appointments/already.checked.in.appointment.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/multiple-appointments/already.checked.in.appointment.cypress.spec.js
@@ -32,9 +32,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('Appointments are displayed in a sorted manner', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
       cy.get('h1').contains('Check in at VA');
       cy.injectAxe();
       cy.axeCheck();

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/multiple-appointments/already.checked.in.appointment.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/multiple-appointments/already.checked.in.appointment.cypress.spec.js
@@ -1,38 +1,22 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
-
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 3 -- ', () => {
     beforeEach(function() {
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        const rv = mockPatientCheckIns.createMultipleAppointments();
-        const already = mockPatientCheckIns.createAppointment();
-        already.startTime = '2021-08-19T03:00:00';
-        already.eligibility = 'INELIGIBLE_ALREADY_CHECKED_IN';
-        const next = mockPatientCheckIns.createAppointment();
-        next.startTime = '2021-08-19T13:00:00';
-
-        rv.payload.appointments = [already, next];
-        req.reply(rv);
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
-      });
+      cy.authenticate();
+      const appointments = [
+        {
+          startTime: '2021-08-19T03:00:00',
+          eligibility: 'INELIGIBLE_ALREADY_CHECKED_IN',
+        },
+        {
+          startTime: '2021-08-19T13:00:00',
+        },
+      ];
+      cy.getAppointments(appointments);
+      cy.successfulCheckin();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',
@@ -54,15 +38,7 @@ describe('Check In Experience -- ', () => {
       cy.get('h1').contains('Check in at VA');
       cy.injectAxe();
       cy.axeCheck();
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('contain', 'Your appointments');

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/multiple-appointments/appointments.are.sorted.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/multiple-appointments/appointments.are.sorted.cypress.spec.js
@@ -27,9 +27,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('Appointments are displayed in a sorted manner', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
       cy.get('h1').contains('Check in at VA');
       cy.injectAxe();
       cy.axeCheck();

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/multiple-appointments/appointments.are.sorted.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/multiple-appointments/appointments.are.sorted.cypress.spec.js
@@ -1,44 +1,18 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
-
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 3 -- ', () => {
     beforeEach(function() {
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        const rv = mockPatientCheckIns.createMultipleAppointments();
-        const earliest = mockPatientCheckIns.createAppointment();
-        earliest.startTime = '2021-08-19T03:00:00';
-        const midday = mockPatientCheckIns.createAppointment();
-        midday.startTime = '2021-08-19T13:00:00';
-        const latest = mockPatientCheckIns.createAppointment();
-        latest.startTime = '2021-08-19T18:00:00';
-
-        rv.payload.appointments = [latest, earliest, midday];
-        req.reply(rv);
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        const { uuid, appointmentIen, facilityId } =
-          req.body?.patientCheckIns || {};
-        expect(uuid).to.equal('46bebc0a-b99c-464f-a5c5-560bc9eae287');
-        expect(appointmentIen).to.equal('some-ien-1');
-        expect(facilityId).to.equal('ABC_123');
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
-      });
+      cy.authenticate();
+      const appointments = [
+        { startTime: '2021-08-19T03:00:00' },
+        { startTime: '2021-08-19T13:00:00' },
+        { startTime: '2021-08-19T18:00:00' },
+      ];
+      cy.getAppointments(appointments);
+      cy.successfulCheckin();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',
@@ -59,15 +33,7 @@ describe('Check In Experience -- ', () => {
       cy.get('h1').contains('Check in at VA');
       cy.injectAxe();
       cy.axeCheck();
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('contain', 'Your appointments');

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/multiple-appointments/bad.formatted.datetime.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/multiple-appointments/bad.formatted.datetime.cypress.spec.js
@@ -33,9 +33,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('Appointments are displayed in a sorted manner', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
       cy.get('h1').contains('Check in at VA');
       cy.injectAxe();
       cy.axeCheck();

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/multiple-appointments/bad.formatted.datetime.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/multiple-appointments/bad.formatted.datetime.cypress.spec.js
@@ -1,38 +1,23 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
-
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 3 -- ', () => {
     beforeEach(function() {
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        const rv = mockPatientCheckIns.createMultipleAppointments();
-        const already = mockPatientCheckIns.createAppointment();
-        already.startTime = '2021-08-19T03:00:00';
-        already.checkedInTime = 'Invalid DateTime';
-        already.eligibility = 'INELIGIBLE_ALREADY_CHECKED_IN';
-        const next = mockPatientCheckIns.createAppointment();
-        next.startTime = '2021-08-19T13:00:00';
-        rv.payload.appointments = [already, next];
-        req.reply(rv);
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
-      });
+      cy.authenticate();
+      const appointments = [
+        {
+          startTime: '2021-08-19T03:00:00',
+          checkedInTime: 'Invalid DateTime',
+          eligibility: 'INELIGIBLE_ALREADY_CHECKED_IN',
+        },
+        {
+          startTime: '2021-08-19T13:00:00',
+        },
+      ];
+      cy.getAppointments(appointments);
+      cy.successfulCheckin();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',
@@ -54,15 +39,7 @@ describe('Check In Experience -- ', () => {
       cy.get('h1').contains('Check in at VA');
       cy.injectAxe();
       cy.axeCheck();
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('contain', 'Your appointments');

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/multiple-appointments/posting.appointment.data.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/multiple-appointments/posting.appointment.data.cypress.spec.js
@@ -1,35 +1,13 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
-
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 3 -- ', () => {
     beforeEach(function() {
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        req.reply(mockPatientCheckIns.createMultipleAppointments());
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        const { uuid, appointmentIen, facilityId } =
-          req.body?.patientCheckIns || {};
-        expect(uuid).to.equal('46bebc0a-b99c-464f-a5c5-560bc9eae287');
-        expect(appointmentIen).to.equal('some-ien-1');
-        expect(facilityId).to.equal('ABC_123');
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
-      });
+      cy.authenticate();
+      cy.getAppointments();
+      cy.successfulCheckin();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',
@@ -50,15 +28,7 @@ describe('Check In Experience -- ', () => {
       cy.get('h1').contains('Check in at VA');
       cy.injectAxe();
       cy.axeCheck();
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('contain', 'Your appointments');

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/multiple-appointments/posting.appointment.data.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/multiple-appointments/posting.appointment.data.cypress.spec.js
@@ -22,9 +22,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('The second appointment is selected', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
       cy.get('h1').contains('Check in at VA');
       cy.injectAxe();
       cy.axeCheck();

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/multiple-appointments/veterans.may.refresh.their.appointments.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/multiple-appointments/veterans.may.refresh.their.appointments.cypress.spec.js
@@ -1,26 +1,13 @@
 import format from 'date-fns/format';
-
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
 import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
-
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 3 -- ', () => {
     beforeEach(() => {
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-
+      cy.authenticate();
       const rv1 = mockPatientCheckIns.createMultipleAppointments();
       const earliest = mockPatientCheckIns.createAppointment();
       earliest.startTime = '2021-08-19T03:00:00';
@@ -67,15 +54,7 @@ describe('Check In Experience -- ', () => {
       cy.get('h1').contains('Check in at VA');
       cy.injectAxe();
       cy.axeCheck();
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
 
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/multiple-appointments/veterans.may.refresh.their.appointments.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/multiple-appointments/veterans.may.refresh.their.appointments.cypress.spec.js
@@ -48,9 +48,7 @@ describe('Check In Experience -- ', () => {
     });
     it('Veterans may refresh their appointments', () => {
       cy.viewport(550, 750);
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
       cy.get('h1').contains('Check in at VA');
       cy.injectAxe();
       cy.axeCheck();

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/session/no.data.in.redux.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/session/no.data.in.redux.cypress.spec.js
@@ -1,32 +1,10 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   beforeEach(function() {
-    let hasValidated = false;
-    cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-      req.reply(
-        mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-      );
-    });
-    cy.intercept('POST', '/check_in/v2/sessions', req => {
-      hasValidated = true;
-      req.reply(
-        mockSession.createMockSuccessResponse('some-token', 'read.full'),
-      );
-    });
-    cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-      req.reply(
-        mockPatientCheckIns.createMockSuccessResponse({}, hasValidated),
-      );
-    });
-    cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-      req.reply(mockCheckIn.createMockSuccessResponse({}));
-    });
+    cy.authenticate();
     cy.intercept(
       'GET',
       '/v0/feature_toggles*',

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/session/no.session.to.reload.on.refresh.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/session/no.session.to.reload.on.refresh.cypress.spec.js
@@ -1,32 +1,10 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   beforeEach(function() {
-    let hasValidated = false;
-    cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-      req.reply(
-        mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-      );
-    });
-    cy.intercept('POST', '/check_in/v2/sessions', req => {
-      hasValidated = true;
-      req.reply(
-        mockSession.createMockSuccessResponse('some-token', 'read.full'),
-      );
-    });
-    cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-      req.reply(
-        mockPatientCheckIns.createMockSuccessResponse({}, hasValidated),
-      );
-    });
-    cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-      req.reply(mockCheckIn.createMockSuccessResponse({}));
-    });
+    cy.authenticate();
     cy.intercept(
       'GET',
       '/v0/feature_toggles*',

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/session/session.is.saved.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/session/session.is.saved.cypress.spec.js
@@ -19,9 +19,7 @@ describe('Check In Experience -- ', () => {
     });
   });
   it('C5753 - Data is saved to session storage', () => {
-    const featureRoute =
-      '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-    cy.visit(featureRoute);
+    cy.visitWithUUID();
     cy.get('h1', { timeout: Timeouts.slow })
       .should('be.visible')
       .and('have.text', 'Check in at VA');

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/session/session.is.saved.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/session/session.is.saved.cypress.spec.js
@@ -1,32 +1,10 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   beforeEach(function() {
-    let hasValidated = false;
-    cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-      req.reply(
-        mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-      );
-    });
-    cy.intercept('POST', '/check_in/v2/sessions', req => {
-      hasValidated = true;
-      req.reply(
-        mockSession.createMockSuccessResponse('some-token', 'read.full'),
-      );
-    });
-    cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-      req.reply(
-        mockPatientCheckIns.createMockSuccessResponse({}, hasValidated),
-      );
-    });
-    cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-      req.reply(mockCheckIn.createMockSuccessResponse({}));
-    });
+    cy.authenticate();
     cy.intercept(
       'GET',
       '/v0/feature_toggles*',

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/session/session.reloads.on.refresh.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/session/session.reloads.on.refresh.cypress.spec.js
@@ -1,32 +1,10 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   beforeEach(function() {
-    let hasValidated = false;
-    cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-      req.reply(
-        mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-      );
-    });
-    cy.intercept('POST', '/check_in/v2/sessions', req => {
-      hasValidated = true;
-      req.reply(
-        mockSession.createMockSuccessResponse('some-token', 'read.full'),
-      );
-    });
-    cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-      req.reply(
-        mockPatientCheckIns.createMockSuccessResponse({}, hasValidated),
-      );
-    });
-    cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-      req.reply(mockCheckIn.createMockSuccessResponse({}));
-    });
+    cy.authenticate();
     cy.intercept(
       'GET',
       '/v0/feature_toggles*',

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/session/session.reloads.on.refresh.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/session/session.reloads.on.refresh.cypress.spec.js
@@ -19,9 +19,7 @@ describe('Check In Experience -- ', () => {
     });
   });
   it('C5755 - On page reload, the data should be pull from session storage and redirected to landing screen with data loaded', () => {
-    const featureRoute =
-      '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-    cy.visit(featureRoute);
+    cy.visitWithUUID();
     cy.get('h1', { timeout: Timeouts.slow })
       .should('be.visible')
       .and('have.text', 'Check in at VA');

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/session/url.is.priotized.over.session.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/session/url.is.priotized.over.session.cypress.spec.js
@@ -37,9 +37,7 @@ describe('Check In Experience -- ', () => {
       });
       expect(data).to.equal(sample);
     });
-    const featureRoute =
-      '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-    cy.visit(featureRoute);
+    cy.visitWithUUID();
     cy.get('h1', { timeout: Timeouts.slow })
       .should('be.visible')
       .and('have.text', 'Check in at VA');

--- a/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/session/url.is.priotized.over.session.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-3-multiple-appointments/session/url.is.priotized.over.session.cypress.spec.js
@@ -1,32 +1,10 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   beforeEach(function() {
-    let hasValidated = false;
-    cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-      req.reply(
-        mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-      );
-    });
-    cy.intercept('POST', '/check_in/v2/sessions', req => {
-      hasValidated = true;
-      req.reply(
-        mockSession.createMockSuccessResponse('some-token', 'read.full'),
-      );
-    });
-    cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-      req.reply(
-        mockPatientCheckIns.createMockSuccessResponse({}, hasValidated),
-      );
-    });
-    cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-      req.reply(mockCheckIn.createMockSuccessResponse({}));
-    });
+    cy.authenticate();
     cy.intercept(
       'GET',
       '/v0/feature_toggles*',

--- a/src/applications/check-in/tests/e2e/phase-4-demographics/demographics-page/demographics.display.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-4-demographics/demographics-page/demographics.display.cypress.spec.js
@@ -1,30 +1,13 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 4 -- ', () => {
     beforeEach(function() {
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        const rv = mockPatientCheckIns.createMultipleAppointments();
-        req.reply(rv);
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
-      });
+      cy.authenticate();
+      cy.getAppointments();
+      cy.successfulCheckin();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',
@@ -47,15 +30,7 @@ describe('Check In Experience -- ', () => {
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('have.text', 'Check in at VA');
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('have.text', 'Is this your current contact information?');

--- a/src/applications/check-in/tests/e2e/phase-4-demographics/demographics-page/demographics.display.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-4-demographics/demographics-page/demographics.display.cypress.spec.js
@@ -23,9 +23,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('demographics display', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
 
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')

--- a/src/applications/check-in/tests/e2e/phase-4-demographics/feature-toggle/demographics.disabled.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-4-demographics/feature-toggle/demographics.disabled.cypress.spec.js
@@ -1,33 +1,12 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 4 -- ', () => {
     beforeEach(function() {
-      let hasValidated = false;
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        hasValidated = true;
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        req.reply(
-          mockPatientCheckIns.createMockSuccessResponse({}, hasValidated),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
-      });
+      cy.authenticate();
+      cy.getSingleAppointment();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',
@@ -50,15 +29,7 @@ describe('Check In Experience -- ', () => {
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('have.text', 'Check in at VA');
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
 
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')

--- a/src/applications/check-in/tests/e2e/phase-4-demographics/feature-toggle/demographics.disabled.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-4-demographics/feature-toggle/demographics.disabled.cypress.spec.js
@@ -22,9 +22,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('demographics disabled ', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
 
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')

--- a/src/applications/check-in/tests/e2e/phase-4-demographics/feature-toggle/demographics.enabled.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-4-demographics/feature-toggle/demographics.enabled.cypress.spec.js
@@ -22,9 +22,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('demographics enabled', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
 
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')

--- a/src/applications/check-in/tests/e2e/phase-4-demographics/feature-toggle/demographics.enabled.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-4-demographics/feature-toggle/demographics.enabled.cypress.spec.js
@@ -1,33 +1,12 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 4 -- ', () => {
     beforeEach(function() {
-      let hasValidated = false;
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        hasValidated = true;
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        req.reply(
-          mockPatientCheckIns.createMockSuccessResponse({}, hasValidated),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
-      });
+      cy.authenticate();
+      cy.getAppointments();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',
@@ -50,15 +29,7 @@ describe('Check In Experience -- ', () => {
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('have.text', 'Check in at VA');
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
 
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')

--- a/src/applications/check-in/tests/e2e/phase-4-demographics/happy-path/current.happy.path.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-4-demographics/happy-path/current.happy.path.cypress.spec.js
@@ -22,9 +22,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('current happy path', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('have.text', 'Check in at VA');

--- a/src/applications/check-in/tests/e2e/phase-4-demographics/happy-path/current.happy.path.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-4-demographics/happy-path/current.happy.path.cypress.spec.js
@@ -1,33 +1,12 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 4 -- ', () => {
     beforeEach(function() {
-      let hasValidated = false;
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        hasValidated = true;
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        req.reply(
-          mockPatientCheckIns.createMockSuccessResponse({}, hasValidated),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
-      });
+      cy.authenticate();
+      cy.getSingleAppointment();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',
@@ -51,15 +30,7 @@ describe('Check In Experience -- ', () => {
         .and('have.text', 'Check in at VA');
       cy.injectAxe();
       cy.axeCheck();
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
 
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')

--- a/src/applications/check-in/tests/e2e/phase-4-demographics/happy-path/everything.happy.path.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-4-demographics/happy-path/everything.happy.path.cypress.spec.js
@@ -1,39 +1,12 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 4 -- ', () => {
     beforeEach(function() {
-      let hasValidated = false;
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        hasValidated = true;
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        req.reply(
-          mockPatientCheckIns.createMockSuccessResponse({}, hasValidated),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        const { uuid, appointmentIen, facilityId } =
-          req.body?.patientCheckIns || {};
-        expect(uuid).to.equal('46bebc0a-b99c-464f-a5c5-560bc9eae287');
-        expect(appointmentIen).to.equal('some-ien');
-        expect(facilityId).to.equal('ABC_123');
-
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
-      });
+      cy.authenticate();
+      cy.getSingleAppointment();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',
@@ -58,15 +31,7 @@ describe('Check In Experience -- ', () => {
         .and('have.text', 'Check in at VA');
       cy.injectAxe();
       cy.axeCheck();
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
 
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')

--- a/src/applications/check-in/tests/e2e/phase-4-demographics/happy-path/everything.happy.path.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-4-demographics/happy-path/everything.happy.path.cypress.spec.js
@@ -22,9 +22,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('everything Happy path', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
 
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')

--- a/src/applications/check-in/tests/e2e/phase-5-next-of-kin/SeeStaff-page/SeeStaff.back.link.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-5-next-of-kin/SeeStaff-page/SeeStaff.back.link.cypress.spec.js
@@ -1,30 +1,13 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 5 -- ', () => {
     beforeEach(function() {
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        const rv = mockPatientCheckIns.createMultipleAppointments();
-        req.reply(rv);
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
-      });
+      cy.authenticate();
+      cy.getAppointments();
+      cy.successfulCheckin();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',
@@ -41,22 +24,11 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('see staff display with demographics message', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
-
+      cy.visitWithUUID();
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('have.text', 'Check in at VA');
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
       cy.get('[data-testid=no-button]', { timeout: Timeouts.slow }).click();
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')

--- a/src/applications/check-in/tests/e2e/phase-5-next-of-kin/SeeStaff-page/SeeStaff.display.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-5-next-of-kin/SeeStaff-page/SeeStaff.display.cypress.spec.js
@@ -1,30 +1,12 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
+import '../../support/commands';
 
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 5 -- ', () => {
     beforeEach(function() {
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        const rv = mockPatientCheckIns.createMultipleAppointments();
-        req.reply(rv);
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
-      });
+      cy.authenticate();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',
@@ -48,19 +30,13 @@ describe('Check In Experience -- ', () => {
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('have.text', 'Check in at VA');
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
       cy.get('[data-testid=no-button]', { timeout: Timeouts.slow }).click();
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('have.text', 'Check in with a staff member');
+      cy.injectAxe();
+      cy.axeCheck();
       cy.get('h1')
         .next()
         .should('be.visible')

--- a/src/applications/check-in/tests/e2e/phase-5-next-of-kin/SeeStaff-page/SeeStaff.display.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-5-next-of-kin/SeeStaff-page/SeeStaff.display.cypress.spec.js
@@ -24,9 +24,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('see staff display with demographics message', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
 
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')

--- a/src/applications/check-in/tests/e2e/phase-5-next-of-kin/SeeStaff-page/SeeStaff.display.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-5-next-of-kin/SeeStaff-page/SeeStaff.display.cypress.spec.js
@@ -7,6 +7,7 @@ describe('Check In Experience -- ', () => {
   describe('phase 5 -- ', () => {
     beforeEach(function() {
       cy.authenticate();
+      cy.getAppointments();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',

--- a/src/applications/check-in/tests/e2e/phase-5-next-of-kin/feature-toggle/next-of-kin.disabled.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-5-next-of-kin/feature-toggle/next-of-kin.disabled.cypress.spec.js
@@ -24,9 +24,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('next of kin disabled ', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
 
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')

--- a/src/applications/check-in/tests/e2e/phase-5-next-of-kin/feature-toggle/next-of-kin.disabled.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-5-next-of-kin/feature-toggle/next-of-kin.disabled.cypress.spec.js
@@ -1,33 +1,13 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 5 -- ', () => {
     beforeEach(function() {
-      let hasValidated = false;
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        hasValidated = true;
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        req.reply(
-          mockPatientCheckIns.createMockSuccessResponse({}, hasValidated),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
-      });
+      cy.authenticate();
+      cy.getSingleAppointment();
+      cy.successfulCheckin();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',
@@ -51,15 +31,7 @@ describe('Check In Experience -- ', () => {
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('have.text', 'Check in at VA');
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
 
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')

--- a/src/applications/check-in/tests/e2e/phase-5-next-of-kin/feature-toggle/next-of-kin.enabled.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-5-next-of-kin/feature-toggle/next-of-kin.enabled.cypress.spec.js
@@ -23,9 +23,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('next of kin enabled', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
 
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')

--- a/src/applications/check-in/tests/e2e/phase-5-next-of-kin/feature-toggle/next-of-kin.enabled.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-5-next-of-kin/feature-toggle/next-of-kin.enabled.cypress.spec.js
@@ -1,33 +1,11 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 5 -- ', () => {
     beforeEach(function() {
-      let hasValidated = false;
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        hasValidated = true;
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        req.reply(
-          mockPatientCheckIns.createMockSuccessResponse({}, hasValidated),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
-      });
+      cy.authenticate();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',
@@ -51,15 +29,7 @@ describe('Check In Experience -- ', () => {
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('have.text', 'Check in at VA');
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
 
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')

--- a/src/applications/check-in/tests/e2e/phase-5-next-of-kin/feature-toggle/next-of-kin.enabled.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-5-next-of-kin/feature-toggle/next-of-kin.enabled.cypress.spec.js
@@ -6,6 +6,7 @@ describe('Check In Experience -- ', () => {
   describe('phase 5 -- ', () => {
     beforeEach(function() {
       cy.authenticate();
+      cy.getAppointments();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',

--- a/src/applications/check-in/tests/e2e/phase-5-next-of-kin/happy-path/current.happy.path.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-5-next-of-kin/happy-path/current.happy.path.cypress.spec.js
@@ -24,9 +24,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('current happy path', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('have.text', 'Check in at VA');

--- a/src/applications/check-in/tests/e2e/phase-5-next-of-kin/happy-path/current.happy.path.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-5-next-of-kin/happy-path/current.happy.path.cypress.spec.js
@@ -1,33 +1,13 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 5 -- ', () => {
     beforeEach(function() {
-      let hasValidated = false;
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        hasValidated = true;
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        req.reply(
-          mockPatientCheckIns.createMockSuccessResponse({}, hasValidated),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
-      });
+      cy.authenticate();
+      cy.getSingleAppointment();
+      cy.successfulCheckin();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',
@@ -52,15 +32,7 @@ describe('Check In Experience -- ', () => {
         .and('have.text', 'Check in at VA');
       cy.injectAxe();
       cy.axeCheck();
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
 
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')

--- a/src/applications/check-in/tests/e2e/phase-5-next-of-kin/happy-path/everything.happy.path.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-5-next-of-kin/happy-path/everything.happy.path.cypress.spec.js
@@ -1,39 +1,13 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 5 -- ', () => {
     beforeEach(function() {
-      let hasValidated = false;
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        hasValidated = true;
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        req.reply(
-          mockPatientCheckIns.createMockSuccessResponse({}, hasValidated),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        const { uuid, appointmentIen, facilityId } =
-          req.body?.patientCheckIns || {};
-        expect(uuid).to.equal('46bebc0a-b99c-464f-a5c5-560bc9eae287');
-        expect(appointmentIen).to.equal('some-ien');
-        expect(facilityId).to.equal('ABC_123');
-
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
-      });
+      cy.authenticate();
+      cy.getSingleAppointment();
+      cy.successfulCheckin();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',
@@ -59,15 +33,7 @@ describe('Check In Experience -- ', () => {
         .and('have.text', 'Check in at VA');
       cy.injectAxe();
       cy.axeCheck();
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
 
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')

--- a/src/applications/check-in/tests/e2e/phase-5-next-of-kin/happy-path/everything.happy.path.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-5-next-of-kin/happy-path/everything.happy.path.cypress.spec.js
@@ -24,9 +24,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('everything Happy path', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
 
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')

--- a/src/applications/check-in/tests/e2e/phase-5-next-of-kin/next-of-kin-page/next-of-kin.display.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-5-next-of-kin/next-of-kin-page/next-of-kin.display.cypress.spec.js
@@ -1,30 +1,11 @@
 import { generateFeatureToggles } from '../../../../api/local-mock-api/mocks/feature.toggles';
-
-import mockCheckIn from '../../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import '../../support/commands';
 import Timeouts from 'platform/testing/e2e/timeouts';
 
 describe('Check In Experience -- ', () => {
   describe('phase 5 -- ', () => {
     beforeEach(function() {
-      cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.basic'),
-        );
-      });
-      cy.intercept('POST', '/check_in/v2/sessions', req => {
-        req.reply(
-          mockSession.createMockSuccessResponse('some-token', 'read.full'),
-        );
-      });
-      cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-        const rv = mockPatientCheckIns.createMultipleAppointments();
-        req.reply(rv);
-      });
-      cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-        req.reply(mockCheckIn.createMockSuccessResponse({}));
-      });
+      cy.authenticate();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',
@@ -48,15 +29,7 @@ describe('Check In Experience -- ', () => {
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('have.text', 'Check in at VA');
-      cy.get('[label="Your last name"]')
-        .shadow()
-        .find('input')
-        .type('Smith');
-      cy.get('[label="Last 4 digits of your Social Security number"]')
-        .shadow()
-        .find('input')
-        .type('4837');
-      cy.get('[data-testid=check-in-button]').click();
+      cy.signIn();
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')
         .and('have.text', 'Is this your current contact information?');

--- a/src/applications/check-in/tests/e2e/phase-5-next-of-kin/next-of-kin-page/next-of-kin.display.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-5-next-of-kin/next-of-kin-page/next-of-kin.display.cypress.spec.js
@@ -23,9 +23,7 @@ describe('Check In Experience -- ', () => {
       });
     });
     it('next of kin display', () => {
-      const featureRoute =
-        '/health-care/appointment-check-in/?id=46bebc0a-b99c-464f-a5c5-560bc9eae287';
-      cy.visit(featureRoute);
+      cy.visitWithUUID();
 
       cy.get('h1', { timeout: Timeouts.slow })
         .should('be.visible')

--- a/src/applications/check-in/tests/e2e/phase-5-next-of-kin/next-of-kin-page/next-of-kin.display.cypress.spec.js
+++ b/src/applications/check-in/tests/e2e/phase-5-next-of-kin/next-of-kin-page/next-of-kin.display.cypress.spec.js
@@ -6,6 +6,7 @@ describe('Check In Experience -- ', () => {
   describe('phase 5 -- ', () => {
     beforeEach(function() {
       cy.authenticate();
+      cy.getAppointments();
       cy.intercept(
         'GET',
         '/v0/feature_toggles*',

--- a/src/applications/check-in/tests/e2e/support/commands.js
+++ b/src/applications/check-in/tests/e2e/support/commands.js
@@ -1,0 +1,74 @@
+import mockCheckIn from '../../../api/local-mock-api/mocks/v2/check.in.responses';
+import mockSession from '../../../api/local-mock-api/mocks/v2/sessions.responses';
+import mockPatientCheckIns from '../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+
+Cypress.Commands.add('authenticate', () => {
+  cy.intercept('GET', '/check_in/v2/sessions/*', req => {
+    req.reply(
+      mockSession.createMockSuccessResponse('some-token', 'read.basic'),
+    );
+  });
+  cy.intercept('POST', '/check_in/v2/sessions', req => {
+    req.reply(mockSession.createMockSuccessResponse('some-token', 'read.full'));
+  });
+});
+Cypress.Commands.add('alreadyAuthenticated', () => {
+  cy.intercept('GET', '/check_in/v2/sessions/*', req => {
+    req.reply(mockSession.createMockSuccessResponse('some-token', 'read.full'));
+  });
+});
+Cypress.Commands.add('successfulCheckin', () => {
+  cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
+    req.reply(mockCheckIn.createMockSuccessResponse());
+  });
+});
+Cypress.Commands.add('failedCheckin', () => {
+  cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
+    req.reply(mockCheckIn.createMockFailedResponse({}));
+  });
+});
+Cypress.Commands.add(
+  'getAppointments',
+  (appointments = null, token = null, numberOfCheckInAbledAppointments = 2) => {
+    cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
+      const rv = mockPatientCheckIns.createMultipleAppointments(
+        token,
+        numberOfCheckInAbledAppointments,
+      );
+      if (appointments && appointments.length) {
+        const customAppointments = [];
+        appointments.forEach(appointment => {
+          const createdAppointment = mockPatientCheckIns.createAppointment();
+          customAppointments.push(
+            Object.assign(createdAppointment, appointment),
+          );
+        });
+        rv.payload.appointments = customAppointments;
+      }
+      req.reply(rv);
+    });
+    cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
+      req.reply(mockCheckIn.createMockSuccessResponse({}));
+    });
+  },
+);
+Cypress.Commands.add('getSingleAppointment', () => {
+  cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
+    const rv = mockPatientCheckIns.createMultipleAppointments({}, 1);
+    req.reply(rv);
+  });
+  cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
+    req.reply(mockCheckIn.createMockSuccessResponse({}));
+  });
+});
+Cypress.Commands.add('signIn', () => {
+  cy.get('[label="Your last name"]')
+    .shadow()
+    .find('input')
+    .type('Smith');
+  cy.get('[label="Last 4 digits of your Social Security number"]')
+    .shadow()
+    .find('input')
+    .type('4837');
+  cy.get('[data-testid=check-in-button]').click();
+});

--- a/src/applications/check-in/tests/e2e/support/commands.js
+++ b/src/applications/check-in/tests/e2e/support/commands.js
@@ -12,6 +12,7 @@ const mockPatientCheckIns = {
   v2: mockPatientCheckInsV2,
 };
 const defaultAPIVersion = 'v2';
+const defaultUUID = '46bebc0a-b99c-464f-a5c5-560bc9eae287';
 
 Cypress.Commands.add('authenticate', (version = defaultAPIVersion) => {
   cy.intercept('GET', `/check_in/${version}/sessions/*`, req => {
@@ -96,4 +97,7 @@ Cypress.Commands.add('signIn', () => {
     .find('input')
     .type('4837');
   cy.get('[data-testid=check-in-button]').click();
+});
+Cypress.Commands.add('visitWithUUID', (uuid = defaultUUID) => {
+  cy.visit(`/health-care/appointment-check-in/?id=${uuid}`);
 });

--- a/src/applications/check-in/tests/e2e/support/commands.js
+++ b/src/applications/check-in/tests/e2e/support/commands.js
@@ -11,8 +11,9 @@ const mockSession = {
 const mockPatientCheckIns = {
   v2: mockPatientCheckInsV2,
 };
+
 const defaultAPIVersion = 'v2';
-const defaultUUID = '46bebc0a-b99c-464f-a5c5-560bc9eae287';
+const defaultUUID = mockPatientCheckIns[defaultAPIVersion].defaultUUID;
 
 Cypress.Commands.add('authenticate', (version = defaultAPIVersion) => {
   cy.intercept('GET', `/check_in/${version}/sessions/*`, req => {
@@ -50,7 +51,7 @@ Cypress.Commands.add(
   'getAppointments',
   (
     appointments = null,
-    token = null,
+    token = defaultUUID,
     numberOfCheckInAbledAppointments = 2,
     version = defaultAPIVersion,
   ) => {
@@ -80,7 +81,10 @@ Cypress.Commands.add(
 );
 Cypress.Commands.add('getSingleAppointment', (version = defaultAPIVersion) => {
   cy.intercept('GET', `/check_in/${version}/patient_check_ins/*`, req => {
-    const rv = mockPatientCheckIns[version].createMultipleAppointments({}, 1);
+    const rv = mockPatientCheckIns[version].createMultipleAppointments(
+      defaultUUID,
+      1,
+    );
     req.reply(rv);
   });
   cy.intercept('POST', `/check_in/${version}/patient_check_ins/`, req => {

--- a/src/applications/check-in/tests/e2e/support/commands.js
+++ b/src/applications/check-in/tests/e2e/support/commands.js
@@ -1,44 +1,69 @@
-import mockCheckIn from '../../../api/local-mock-api/mocks/v2/check.in.responses';
-import mockSession from '../../../api/local-mock-api/mocks/v2/sessions.responses';
-import mockPatientCheckIns from '../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
+import mockCheckInV2 from '../../../api/local-mock-api/mocks/v2/check.in.responses';
+import mockSessionV2 from '../../../api/local-mock-api/mocks/v2/sessions.responses';
+import mockPatientCheckInsV2 from '../../../api/local-mock-api/mocks/v2/patient.check.in.responses';
 
-Cypress.Commands.add('authenticate', () => {
-  cy.intercept('GET', '/check_in/v2/sessions/*', req => {
+const mockCheckIn = {
+  v2: mockCheckInV2,
+};
+const mockSession = {
+  v2: mockSessionV2,
+};
+const mockPatientCheckIns = {
+  v2: mockPatientCheckInsV2,
+};
+const defaultAPIVersion = 'v2';
+
+Cypress.Commands.add('authenticate', (version = defaultAPIVersion) => {
+  cy.intercept('GET', `/check_in/${version}/sessions/*`, req => {
     req.reply(
-      mockSession.createMockSuccessResponse('some-token', 'read.basic'),
+      mockSession[version].createMockSuccessResponse(
+        'some-token',
+        'read.basic',
+      ),
     );
   });
-  cy.intercept('POST', '/check_in/v2/sessions', req => {
-    req.reply(mockSession.createMockSuccessResponse('some-token', 'read.full'));
+  cy.intercept('POST', `/check_in/${version}/sessions`, req => {
+    req.reply(
+      mockSession[version].createMockSuccessResponse('some-token', 'read.full'),
+    );
   });
 });
-Cypress.Commands.add('alreadyAuthenticated', () => {
-  cy.intercept('GET', '/check_in/v2/sessions/*', req => {
-    req.reply(mockSession.createMockSuccessResponse('some-token', 'read.full'));
+Cypress.Commands.add('alreadyAuthenticated', (version = defaultAPIVersion) => {
+  cy.intercept('GET', `/check_in/${version}/sessions/*`, req => {
+    req.reply(
+      mockSession[version].createMockSuccessResponse('some-token', 'read.full'),
+    );
   });
 });
-Cypress.Commands.add('successfulCheckin', () => {
-  cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-    req.reply(mockCheckIn.createMockSuccessResponse());
+Cypress.Commands.add('successfulCheckin', (version = defaultAPIVersion) => {
+  cy.intercept('POST', `/check_in/${version}/patient_check_ins/`, req => {
+    req.reply(mockCheckIn[version].createMockSuccessResponse());
   });
 });
-Cypress.Commands.add('failedCheckin', () => {
-  cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-    req.reply(mockCheckIn.createMockFailedResponse({}));
+Cypress.Commands.add('failedCheckin', (version = defaultAPIVersion) => {
+  cy.intercept('POST', `/check_in/${version}/patient_check_ins/`, req => {
+    req.reply(mockCheckIn[version].createMockFailedResponse({}));
   });
 });
 Cypress.Commands.add(
   'getAppointments',
-  (appointments = null, token = null, numberOfCheckInAbledAppointments = 2) => {
-    cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-      const rv = mockPatientCheckIns.createMultipleAppointments(
+  (
+    appointments = null,
+    token = null,
+    numberOfCheckInAbledAppointments = 2,
+    version = defaultAPIVersion,
+  ) => {
+    cy.intercept('GET', `/check_in/${version}/patient_check_ins/*`, req => {
+      const rv = mockPatientCheckIns[version].createMultipleAppointments(
         token,
         numberOfCheckInAbledAppointments,
       );
       if (appointments && appointments.length) {
         const customAppointments = [];
         appointments.forEach(appointment => {
-          const createdAppointment = mockPatientCheckIns.createAppointment();
+          const createdAppointment = mockPatientCheckIns[
+            version
+          ].createAppointment();
           customAppointments.push(
             Object.assign(createdAppointment, appointment),
           );
@@ -47,18 +72,18 @@ Cypress.Commands.add(
       }
       req.reply(rv);
     });
-    cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-      req.reply(mockCheckIn.createMockSuccessResponse({}));
+    cy.intercept('POST', `/check_in/${version}/patient_check_ins/`, req => {
+      req.reply(mockCheckIn[version].createMockSuccessResponse({}));
     });
   },
 );
-Cypress.Commands.add('getSingleAppointment', () => {
-  cy.intercept('GET', '/check_in/v2/patient_check_ins/*', req => {
-    const rv = mockPatientCheckIns.createMultipleAppointments({}, 1);
+Cypress.Commands.add('getSingleAppointment', (version = defaultAPIVersion) => {
+  cy.intercept('GET', `/check_in/${version}/patient_check_ins/*`, req => {
+    const rv = mockPatientCheckIns[version].createMultipleAppointments({}, 1);
     req.reply(rv);
   });
-  cy.intercept('POST', '/check_in/v2/patient_check_ins/', req => {
-    req.reply(mockCheckIn.createMockSuccessResponse({}));
+  cy.intercept('POST', `/check_in/${version}/patient_check_ins/`, req => {
+    req.reply(mockCheckIn[version].createMockSuccessResponse({}));
   });
 });
 Cypress.Commands.add('signIn', () => {


### PR DESCRIPTION
## Description
Adds a commands file to the root of the check-in e2e tests. This follows a similar pattern to using a support directory at the root of cypress config. Since this is all localized to our application, I kept it contained in our directory structure. Which means that it doesn't get imported before tests like a the main commands file would be. So there is an added import for it in our tests. 

The commands replace a lot of the repeated data mocking / intercepts as well as the sign in process. The ticket suggested fixtures but I felt that a few commands were more useful since we already had functions setup for dynamically mocking data responses. 

## Original issue(s)
department-of-veterans-affairs/va.gov-team#31478
[department-of-veterans-affairs/va.gov-team#31476](https://github.com/department-of-veterans-affairs/va.gov-team/issues/31476)
## Testing done
Updates are to tests.


## Acceptance criteria
- [ ] Factors out dup code in testing layers

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
