### PR TITLE
[HOLD] update notification settings GA events

### DIFF
--- a/src/applications/personalization/profile/components/notification-settings/NotificationChannel.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationChannel.jsx
@@ -110,10 +110,9 @@ const NotificationChannel = ({
           recordEvent({
             event: 'int-radio-button-option-click',
             'radio-button-label': itemName,
-            'radio-button-optionLabel': `${
-              channelTypes[channelType]
-            } - ${newValue}`,
-            'radio-button-required': false,
+            'radio-button-optionLabel': `${channelTypes[channelType]} - ${
+              newValue ? 'opted in' : 'opted out'
+            }`,
           });
 
           saveSetting(channelId, model.getApiCallObject());


### PR DESCRIPTION
## Description
As discussed here https://dsva.slack.com/archives/C909ZG2BB/p1635554888259400

This PR changes what will show up in GA from `Radio Button - Board of Veterans' Appeals hearing reminder - text - false - false ` to `Radio Button - Board of Veterans' Appeals hearing reminder - text - opted out `

This is on hold until we get confirmation that removing the `radio-button-required` won't have unintended side effects.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs