### PR TITLE
32271: Verify page - Having trouble adjustments

### DIFF
--- a/src/applications/verify/containers/VerifyApp.jsx
+++ b/src/applications/verify/containers/VerifyApp.jsx
@@ -4,9 +4,6 @@ import URLSearchParams from 'url-search-params';
 
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
-import Telephone, {
-  CONTACTS,
-} from '@department-of-veterans-affairs/component-library/Telephone';
 import recordEvent from 'platform/monitoring/record-event';
 
 import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
@@ -110,13 +107,7 @@ export class VerifyApp extends React.Component {
                   </a>
                 </p>
                 <p>
-                  <SubmitSignInForm startSentence>
-                    Call the VA.gov Help Desk at{' '}
-                    <a href="tel:1-855-574-7286">855-574-7286</a>, TTY:{' '}
-                    <Telephone contact={CONTACTS.HELP_TTY} />
-                    <br />
-                    Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. ET
-                  </SubmitSignInForm>
+                  <SubmitSignInForm startSentence />
                 </p>
               </div>
             </div>

--- a/src/platform/static-data/SubmitSignInForm.jsx
+++ b/src/platform/static-data/SubmitSignInForm.jsx
@@ -9,8 +9,7 @@ export default function SubmitSignInForm({ startSentence }) {
   return (
     <span>
       {startSentence ? 'Call' : 'call'} our MyVA411 main information line for
-      help at
-      <Telephone contact={CONTACTS.HELP_DESK} />
+      help at <Telephone contact={CONTACTS.HELP_DESK} />
       (TTY: <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
       ).
     </span>


### PR DESCRIPTION
## Description
Verify page uses the `SubmitSignInForm` component which renders a phone number to call for assistance. The component does not render `{children}` despite it being provided.

- Removed un-used children code on verify page
- Added a space between copy and number

## Original issue(s)
department-of-veterans-affairs/va.gov-team#32271


## Testing done
- NOne

## Screenshots
![image](https://user-images.githubusercontent.com/13320944/139867385-083e52d7-c3c9-45d8-829a-933e9c137c30.png)


## Acceptance criteria
- [ ] Unused code removed from codebase
- [ ] Space added between copy and number

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
