### PR TITLE
Fail unit test report generation step on GitHub Actions when results file does not exist

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -131,12 +131,14 @@ jobs:
 
       - name: Publish test results
         if: ${{ always() }}
+        continue-on-error: true
         uses: mikepenz/action-junit-report@v2.6.0
         with:
           check_name: 'Unit Tests Summary'
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: 'test-results/unit-tests.xml'
           summary: ${{ steps.code-coverage.outputs.MARKDOWN }}
+          fail_on_failure: 'true'
 
   contract-tests:
     name: Contract Tests


### PR DESCRIPTION
## Description
On GitHub Actions, the `test-results/unit-tests.xml` file for unit tests is not generated sometimes when there's a unit test failure. Currently the step to upload the report only shows a warning when this file does not exist. This PR modifies this step so that there's an error when the file does not exist.

## Acceptance criteria
- [ ] CI passes.