### PR TITLE
HLR: move wizard to `/start` in production

### DIFF
--- a/src/applications/disability-benefits/996/constants.js
+++ b/src/applications/disability-benefits/996/constants.js
@@ -1,5 +1,4 @@
 import constants from 'vets-json-schema/dist/constants.json';
-import environment from 'platform/utilities/environment';
 
 // *** URLS ***
 export const HLR_INFO_URL = '/decision-reviews/higher-level-review/';
@@ -86,8 +85,6 @@ export const SUPPORTED_BENEFIT_TYPES = constants.benefitTypes.map(type => ({
   ...type,
   isSupported: supportedBenefitTypes.includes(type.value),
 }));
-
-export const IS_PRODUCTION = environment.isProduction();
 
 export const CONFERENCE_TIMES_V1 = {
   time0800to1000: {

--- a/src/applications/disability-benefits/996/containers/Form0996App.jsx
+++ b/src/applications/disability-benefits/996/containers/Form0996App.jsx
@@ -14,7 +14,7 @@ import {
 } from '../actions';
 
 import formConfig from '../config/form';
-import { IS_PRODUCTION, SAVED_CLAIM_TYPE } from '../constants';
+import { SAVED_CLAIM_TYPE } from '../constants';
 import { getHlrWizardStatus, shouldShowWizard } from '../wizard/utils';
 import {
   issuesNeedUpdating,
@@ -115,7 +115,7 @@ export const Form0996App = ({
     </RoutedSavableApp>
   );
 
-  if (!IS_PRODUCTION && shouldShowWizard(formConfig.formId, savedForms)) {
+  if (shouldShowWizard(formConfig.formId, savedForms)) {
     router.push('/start');
     content = (
       <h1 className="vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal">
@@ -123,7 +123,6 @@ export const Form0996App = ({
       </h1>
     );
   } else if (
-    !IS_PRODUCTION &&
     loggedIn &&
     ((contestableIssues?.status || '') === '' ||
       contestableIssues?.status === FETCH_CONTESTABLE_ISSUES_INIT)

--- a/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
@@ -15,10 +15,7 @@ import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
 import { isEmptyAddress } from 'platform/forms/address/helpers';
 import { selectVAPContactInfoField } from '@@vap-svc/selectors';
 import { FIELD_NAMES } from '@@vap-svc/constants';
-import {
-  WIZARD_STATUS_NOT_STARTED,
-  WIZARD_STATUS_COMPLETE,
-} from 'platform/site-wide/wizard';
+import { WIZARD_STATUS_NOT_STARTED } from 'platform/site-wide/wizard';
 
 import {
   getContestableIssues as getContestableIssuesAction,
@@ -38,39 +35,12 @@ import {
   showContestableIssueError,
   showHasEmptyAddress,
 } from '../content/contestableIssueAlerts';
-import { getHlrWizardStatus, shouldShowWizard } from '../wizard/utils';
 
 export class IntroductionPage extends React.Component {
-  state = {
-    status: getHlrWizardStatus() || WIZARD_STATUS_NOT_STARTED,
-  };
-
   componentDidMount() {
-    this.setPageFocus();
-  }
-
-  componentDidUpdate(prevProps, prevState) {
-    if (
-      this.state.status === WIZARD_STATUS_COMPLETE &&
-      prevState.status !== WIZARD_STATUS_COMPLETE
-    ) {
-      // set focus on h1 only after wizard completes (wizard on /introduction)
-      setTimeout(() => {
-        this.setPageFocus();
-      }, 100);
-    }
-  }
-
-  setPageFocus = () => {
-    // focus on h1 if wizard has completed
-    // focus on breadcrumb nav when wizard is visible
-    const focusTarget =
-      this.state.status === WIZARD_STATUS_COMPLETE
-        ? 'h1'
-        : '.va-nav-breadcrumbs-list';
-    focusElement(focusTarget);
+    focusElement('h1');
     scrollToTop();
-  };
+  }
 
   getCallToActionContent = ({ last } = {}) => {
     const { loggedIn, route, contestableIssues, delay = 250 } = this.props;
@@ -126,15 +96,8 @@ export class IntroductionPage extends React.Component {
   };
 
   render() {
-    const { loggedIn, savedForms, hasEmptyAddress, route } = this.props;
-
-    const showWizard = shouldShowWizard(route.formConfig.formId, savedForms);
-
-    // Change page title once wizard has closed to provide a Veteran using a
-    // screenreader some indication that the content has changed
-    const pageTitle = `Request a Higher-Level Review${
-      showWizard ? '' : ' with VA Form 20-0996'
-    }`;
+    const { loggedIn, hasEmptyAddress } = this.props;
+    const pageTitle = 'Request a Higher-Level Review with VA Form 20-0996';
     const subTitle = 'Equal to VA Form 20-0996 (Higher-Level Review)';
 
     // check if user has address
@@ -181,7 +144,6 @@ export class IntroductionPage extends React.Component {
               className="va-button-link"
               onClick={() => {
                 this.setWizardStatus(WIZARD_STATUS_NOT_STARTED);
-                this.setPageFocus();
                 recordEvent({ event: 'howToWizard-start-over' });
               }}
             >

--- a/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/containers/IntroductionPage.jsx
@@ -29,23 +29,16 @@ import { isLoggedIn, selectProfile } from 'platform/user/selectors';
 
 import {
   BASE_URL,
-  SAVED_CLAIM_TYPE,
   SUPPLEMENTAL_CLAIM_URL,
   FACILITY_LOCATOR_URL,
   GET_HELP_REVIEW_REQUEST_URL,
-  IS_PRODUCTION,
 } from '../constants';
 import {
   noContestableIssuesFound,
   showContestableIssueError,
   showHasEmptyAddress,
 } from '../content/contestableIssueAlerts';
-import WizardContainer from '../wizard/WizardContainer';
-import {
-  getHlrWizardStatus,
-  setHlrWizardStatus,
-  shouldShowWizard,
-} from '../wizard/utils';
+import { getHlrWizardStatus, shouldShowWizard } from '../wizard/utils';
 
 export class IntroductionPage extends React.Component {
   state = {
@@ -57,27 +50,7 @@ export class IntroductionPage extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    if (IS_PRODUCTION || this.props.isProduction) {
-      const {
-        contestableIssues = {},
-        getContestableIssues,
-        hlrV2,
-      } = this.props;
-      const wizardComplete = this.state.status === WIZARD_STATUS_COMPLETE;
-      if (wizardComplete && this.props.loggedIn) {
-        const benefitType = sessionStorage.getItem(SAVED_CLAIM_TYPE);
-        if (!contestableIssues?.status) {
-          getContestableIssues({ benefitType, hlrV2 });
-        }
-        // set focus on h1 only after wizard completes
-        if (prevState.status !== WIZARD_STATUS_COMPLETE) {
-          setTimeout(() => {
-            scrollToTop();
-            focusElement('h1');
-          }, 100);
-        }
-      }
-    } else if (
+    if (
       this.state.status === WIZARD_STATUS_COMPLETE &&
       prevState.status !== WIZARD_STATUS_COMPLETE
     ) {
@@ -107,7 +80,6 @@ export class IntroductionPage extends React.Component {
     }
 
     if (
-      (IS_PRODUCTION || this.props.isProduction) &&
       loggedIn &&
       ((contestableIssues?.status || '') === '' ||
         contestableIssues?.status === FETCH_CONTESTABLE_ISSUES_INIT)
@@ -153,20 +125,8 @@ export class IntroductionPage extends React.Component {
     return noContestableIssuesFound;
   };
 
-  // Used for production only
-  setWizardStatus = value => {
-    setHlrWizardStatus(value);
-    this.setState({ status: value });
-  };
-
   render() {
-    const {
-      loggedIn,
-      savedForms,
-      hasEmptyAddress,
-      route,
-      isProduction = IS_PRODUCTION, // for unit tests
-    } = this.props;
+    const { loggedIn, savedForms, hasEmptyAddress, route } = this.props;
 
     const showWizard = shouldShowWizard(route.formConfig.formId, savedForms);
 
@@ -185,10 +145,6 @@ export class IntroductionPage extends React.Component {
           {showHasEmptyAddress}
         </article>
       );
-    }
-
-    if (showWizard && isProduction) {
-      return <WizardContainer setWizardStatus={this.setWizardStatus} />;
     }
 
     return (
@@ -221,13 +177,9 @@ export class IntroductionPage extends React.Component {
           <p className="vads-u-margin-top--2">
             if you don’t think this is the right form for you,{' '}
             <a
-              href={`${BASE_URL}${isProduction ? '' : '/start'}`}
+              href={`${BASE_URL}/start`}
               className="va-button-link"
-              onClick={event => {
-                // prevent reload, but allow opening a new tab
-                if (isProduction) {
-                  event.preventDefault();
-                }
+              onClick={() => {
                 this.setWizardStatus(WIZARD_STATUS_NOT_STARTED);
                 this.setPageFocus();
                 recordEvent({ event: 'howToWizard-start-over' });

--- a/src/applications/disability-benefits/996/routes.jsx
+++ b/src/applications/disability-benefits/996/routes.jsx
@@ -3,30 +3,21 @@ import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
 
 import Form0996App from './containers/Form0996App';
 import WizardContainer from './wizard/WizardContainer';
-import { IS_PRODUCTION } from './constants';
 import formConfig from './config/form';
 import { getHlrWizardStatus } from './wizard/utils';
 
-const start = IS_PRODUCTION
-  ? []
-  : [
-      {
-        path: '/start',
-        component: WizardContainer,
-      },
-    ];
-
-const onEnter = IS_PRODUCTION
-  ? (nextState, replace) => replace('/introduction')
-  : (nextState, replace) =>
-      replace(
-        getHlrWizardStatus() === WIZARD_STATUS_COMPLETE
-          ? '/introduction'
-          : '/start',
-      );
+const onEnter = (nextState, replace) =>
+  replace(
+    getHlrWizardStatus() === WIZARD_STATUS_COMPLETE
+      ? '/introduction'
+      : '/start',
+  );
 
 const routes = [
-  ...start,
+  {
+    path: '/start',
+    component: WizardContainer,
+  },
   {
     path: '/',
     component: Form0996App,

--- a/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
@@ -177,7 +177,6 @@ describe('IntroductionPage', () => {
     setHlrWizardStatus(WIZARD_STATUS_COMPLETE);
     const props = {
       ...defaultProps,
-      isProduction: true,
       loggedIn: true,
       contestableIssues: {
         issues: [{}],
@@ -191,27 +190,6 @@ describe('IntroductionPage', () => {
     expect(loading.props().message).to.contain(
       'Loading your previous decisions',
     );
-    tree.unmount();
-  });
-
-  // Wizard
-  it('should render wizard', () => {
-    removeHlrWizardStatus();
-    const props = {
-      ...defaultProps,
-      isProduction: true,
-      contestableIssues: {
-        issues: [{}],
-        status: 'done',
-        error: '',
-      },
-    };
-
-    const tree = shallow(<IntroductionPage {...props} />);
-    expect(tree.find('Connect(WizardContainer)')).to.have.lengthOf(1);
-    expect(
-      tree.find('withRouter(Connect(SaveInProgressIntro))'),
-    ).to.have.lengthOf(0);
     tree.unmount();
   });
 });

--- a/src/applications/disability-benefits/996/tests/hlr-wizard.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr-wizard.cypress.spec.js
@@ -75,7 +75,7 @@ describe('HLR wizard', () => {
   });
 
   // legacy appeals flow
-  it('should show legacy appeals question & alert', () => {
+  it('should show legacy appeals question, yes & alert', () => {
     cy.get('[type="radio"][value="compensation"]').check(checkOpt);
     cy.get(`a[href*="${LEGACY_APPEALS_URL}"]`).should('exist');
     cy.checkFormChange({
@@ -96,8 +96,7 @@ describe('HLR wizard', () => {
     cy.axeCheck();
   });
 
-  // start form flow; skip until wizard is on /start in prod
-  it.skip('should show legacy appeals question & alert', () => {
+  it('should show legacy appeals question, no & form start', () => {
     const h1Text = 'Request a Higher-Level Review';
     // starts with focus on breadcrumb
     cy.focused().should('have.attr', 'id', 'va-breadcrumbs-list');
@@ -139,8 +138,7 @@ describe('HLR wizard', () => {
     cy.axeCheck();
   });
 
-  // v2 skip legacy appeals question; skip until wizard is on /start in prod
-  it.skip('should show skip legacy appeals question & show form start for HLR v2', () => {
+  it('should show skip legacy appeals question & show form start for HLR v2', () => {
     cy.intercept('GET', '/v0/feature_toggles?*', {
       data: {
         type: 'feature_toggles',

--- a/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
@@ -43,7 +43,7 @@ const testConfig = createTestConfig(
       introduction: ({ afterHook }) => {
         afterHook(() => {
           // Hit the start button
-          cy.findAllByText(/start/i, { selector: 'a' })
+          cy.findAllByText(/start the request/i, { selector: 'a' })
             .first()
             .click();
         });
@@ -105,14 +105,14 @@ const testConfig = createTestConfig(
         mockContestableIssues,
       );
 
-      cy.intercept('PUT', 'v0/in_progress_forms/20-0996', mockInProgress);
+      cy.intercept('PUT', '/v0/in_progress_forms/20-0996', mockInProgress);
 
       cy.intercept('POST', '/v0/higher_level_reviews', mockSubmit);
       cy.intercept('POST', '/v1/higher_level_reviews', mockSubmit);
 
       cy.get('@testData').then(testData => {
         cy.intercept('GET', '/v0/in_progress_forms/20-0996', testData);
-        cy.intercept('PUT', 'v0/in_progress_forms/20-0996', testData);
+        cy.intercept('PUT', '/v0/in_progress_forms/20-0996', testData);
 
         const features = testData.hlrV2 ? [{ name: 'hlrV2', value: true }] : [];
         cy.intercept('GET', '/v0/feature_toggles?*', { data: { features } });

--- a/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
@@ -42,16 +42,6 @@ const testConfig = createTestConfig(
 
       introduction: ({ afterHook }) => {
         afterHook(() => {
-          if (Cypress.env('CI')) {
-            cy.get('@testData').then(testData => {
-              cy.get('[type="radio"][value="compensation"]').click();
-              if (!testData.hlrV2) {
-                cy.get('[type="radio"][value="legacy-no"]').click();
-              }
-              cy.axeCheck();
-              cy.findByText(/review online/i, { selector: 'a' }).click();
-            });
-          }
           // Hit the start button
           cy.findAllByText(/start/i, { selector: 'a' })
             .first()
@@ -128,10 +118,6 @@ const testConfig = createTestConfig(
         cy.intercept('GET', '/v0/feature_toggles?*', { data: { features } });
       });
     },
-    // Skip tests in CI until the wizard has been moved to the /start page.
-    // We're using an env production flag to adjust the route since I haven't
-    // found a way to check/get a feature flag in the router
-    skip: Cypress.env('CI'),
   },
   manifest,
   formConfig,

--- a/src/applications/disability-benefits/996/wizard/WizardContainer.jsx
+++ b/src/applications/disability-benefits/996/wizard/WizardContainer.jsx
@@ -12,7 +12,7 @@ import Wizard from 'applications/static-pages/wizard';
 
 import pages from './pages';
 import formConfig from '../config/form';
-import { SAVED_CLAIM_TYPE, IS_PRODUCTION } from '../constants';
+import { SAVED_CLAIM_TYPE } from '../constants';
 import {
   getHlrWizardStatus,
   removeHlrWizardStatus,
@@ -58,9 +58,7 @@ export const WizardContainer = ({ setWizardStatus, hlrV2 }) => {
     </>
   );
 
-  return IS_PRODUCTION ? (
-    wizard
-  ) : (
+  return (
     <article className="row">
       <div className="usa-width-two-thirds medium-8 columns vads-u-margin-bottom--2">
         {wizard}

--- a/src/applications/disability-benefits/996/wizard/pages/legacyNo.jsx
+++ b/src/applications/disability-benefits/996/wizard/pages/legacyNo.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import recordEvent from 'platform/monitoring/record-event';
 import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
 
-import { HLR_INFO_URL, BASE_URL, IS_PRODUCTION } from '../../constants';
+import { HLR_INFO_URL, BASE_URL } from '../../constants';
 import pageNames from './pageNames';
 
 // Does not have a legacy appeal
@@ -26,10 +26,7 @@ const LegacyNo = ({ setWizardStatus }) => {
       </p>
       <a
         href={`${BASE_URL}/introduction`}
-        onClick={event => {
-          if (IS_PRODUCTION) {
-            event.preventDefault();
-          }
+        onClick={() => {
           recordEvent({
             event: 'howToWizard-hidden',
             'reason-for-hidden-wizard': 'wizard completed, starting form',


### PR DESCRIPTION
## Description

The wizard for the Higher-Level Review form has successfully completed its colla cycle review and with this PR will be visible in production on the `/start` page.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/32269

## Testing done

Updated unit & e2e tests

## Screenshots

N/A - the appearance is the same, only the URL has changed

## Acceptance criteria
- [x] HLR wizard moved to the form `/start` page
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
