### PR TITLE
removed border classes from accordion button

### DIFF
--- a/src/applications/gi-sandbox/components/AccordionItem.jsx
+++ b/src/applications/gi-sandbox/components/AccordionItem.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import classNames from 'classnames';
 import recordEvent from 'platform/monitoring/record-event';
 import { createId } from '../utils/helpers';
+import environment from 'platform/utilities/environment';
 
 export default function AccordionItem({
   button,
@@ -38,7 +39,11 @@ export default function AccordionItem({
           aria-expanded={displayExpanded}
           aria-controls={id}
           onClick={toggle}
-          className="usa-accordion-button vads-u-border--2px vads-u-border-style--solid vads-u-border-color--gray-light vads-u-margin--0"
+          className={
+            environment.isProduction()
+              ? 'usa-accordion-button vads-u-border--2px vads-u-border-style--solid vads-u-border-color--gray-light vads-u-margin--0'
+              : 'usa-accordion-button vads-u-margin--0'
+          }
         >
           <span className="section-button-span">{button}</span>
         </button>


### PR DESCRIPTION
## Description
On the school details page, the accordions do not have the correct styling applied.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/29370


## Testing done
local environment

## Screenshots

<img width="1066" alt="Screen Shot 2021-11-01 at 11 41 05 AM" src="https://user-images.githubusercontent.com/18352271/139944146-7c914afb-9854-44a7-9937-8ec077a7e72d.png">

## Acceptance criteria
- [ ] Accordion is styled according to https://design.va.gov/components/accordions

## Definition of done
- [ ] Acceptance criteria is met
- [ ] Production flags are used
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
