### PR TITLE
Fix URL for representative type page

### DIFF
--- a/src/applications/personalization/search-representative/config/form.js
+++ b/src/applications/personalization/search-representative/config/form.js
@@ -33,7 +33,7 @@ const formConfig = {
       title: '',
       pages: {
         representativeType: {
-          path: 'representstive-type',
+          path: 'representative-type',
           uiSchema: basicInformation.uiSchema,
           schema: basicInformation.schema,
         },

--- a/src/applications/personalization/search-representative/containers/IntroductionPage.jsx
+++ b/src/applications/personalization/search-representative/containers/IntroductionPage.jsx
@@ -25,7 +25,7 @@ class IntroductionPage extends React.Component {
         </p>
         <a
           className="vads-c-action-link--green"
-          href={`${manifest.rootUrl}/representstive-type`}
+          href={`${manifest.rootUrl}/representative-type`}
         >
           Search for a representative
         </a>


### PR DESCRIPTION
## Description
Fix URL for representative search - representative type page

## Original issue(s)
department-of-veterans-affairs/va.gov-team#32368

## Acceptance criteria
- [x] URL for representative search should be `/view-change-representative/search/representative-type`

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
