### PR TITLE
NOD: Fix issue card margins

### DIFF
--- a/src/applications/appeals/10182/sass/10182-nod.scss
+++ b/src/applications/appeals/10182/sass/10182-nod.scss
@@ -75,7 +75,7 @@ dl.review {
   }
 
   dd.widget-content {
-    margin-inline-start: 0; /* override user agent */
+    margin-inline-start: 5rem; /* override user agent */
     text-align: left;
     margin: 3rem 3.5rem 0 5rem;
   }


### PR DESCRIPTION
## Description

Fix issue card left margin by setting the `margin-inline-start` to `5rem` (same as the `margin`). IE11 ignores that property

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/32372

## Testing done

Visual testing in Chrome & IE11

## Screenshots

<details><summary>Before</summary>

<!-- leave a blank line above -->
![issue card with no left margin or padding](https://user-images.githubusercontent.com/136959/140096585-22a125c8-21e5-4397-b67a-f133fe1c9a27.png)</details>

<details><summary>After</summary>

<!-- leave a blank line above -->
![issue card with content left aligned with header](https://user-images.githubusercontent.com/136959/140102993-2f03810e-9c44-4975-a4ee-58f21968be68.png)</details>

## Acceptance criteria
- [x] Issue card text is left-aligned
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
