### PR TITLE
Restore community care pagination

### DIFF
--- a/src/applications/facility-locator/components/PaginationWrapper.jsx
+++ b/src/applications/facility-locator/components/PaginationWrapper.jsx
@@ -2,6 +2,7 @@ import Pagination from '@department-of-veterans-affairs/component-library/Pagina
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { LocationType } from '../constants';
+import { facilityLocatorRestoreCommunityCarePagination } from '../utils/featureFlagSelectors';
 
 export class PaginationWrapper extends Component {
   shouldComponentUpdate = nextProps =>
@@ -38,6 +39,17 @@ export class PaginationWrapper extends Component {
 
 const mapStateToProps = state => {
   let isCommunityProviderSearch = false;
+
+  if (
+    [
+      LocationType.CC_PROVIDER,
+      LocationType.URGENT_CARE_PHARMACIES,
+      LocationType.EMERGENCY_CARE,
+    ].includes(state.searchQuery.facilityType) &&
+    !facilityLocatorRestoreCommunityCarePagination(state)
+  ) {
+    isCommunityProviderSearch = true;
+  }
 
   if (
     state.searchQuery.facilityType === LocationType.URGENT_CARE &&

--- a/src/applications/facility-locator/components/PaginationWrapper.jsx
+++ b/src/applications/facility-locator/components/PaginationWrapper.jsx
@@ -38,7 +38,7 @@ export class PaginationWrapper extends Component {
 }
 
 const mapStateToProps = state => {
-  let shouldHide = false;
+  let shouldHidePagination = false;
 
   if (
     [
@@ -48,7 +48,7 @@ const mapStateToProps = state => {
     ].includes(state.searchQuery.facilityType) &&
     !facilityLocatorRestoreCommunityCarePagination(state)
   ) {
-    shouldHide = true;
+    shouldHidePagination = true;
   }
 
   // pagination not yet supported for PPMS urgent care
@@ -59,11 +59,11 @@ const mapStateToProps = state => {
         state.searchQuery.serviceType,
       ))
   ) {
-    shouldHide = true;
+    shouldHidePagination = true;
   }
 
   return {
-    shouldRender: !shouldHide,
+    shouldRender: !shouldHidePagination,
   };
 };
 

--- a/src/applications/facility-locator/components/PaginationWrapper.jsx
+++ b/src/applications/facility-locator/components/PaginationWrapper.jsx
@@ -38,7 +38,7 @@ export class PaginationWrapper extends Component {
 }
 
 const mapStateToProps = state => {
-  let isCommunityProviderSearch = false;
+  let shouldHide = false;
 
   if (
     [
@@ -48,9 +48,10 @@ const mapStateToProps = state => {
     ].includes(state.searchQuery.facilityType) &&
     !facilityLocatorRestoreCommunityCarePagination(state)
   ) {
-    isCommunityProviderSearch = true;
+    shouldHide = true;
   }
 
+  // pagination not yet supported for PPMS urgent care
   if (
     state.searchQuery.facilityType === LocationType.URGENT_CARE &&
     (!state.searchQuery.serviceType ||
@@ -58,11 +59,11 @@ const mapStateToProps = state => {
         state.searchQuery.serviceType,
       ))
   ) {
-    isCommunityProviderSearch = true;
+    shouldHide = true;
   }
 
   return {
-    shouldRender: !isCommunityProviderSearch,
+    shouldRender: !shouldHide,
   };
 };
 

--- a/src/applications/facility-locator/components/PaginationWrapper.jsx
+++ b/src/applications/facility-locator/components/PaginationWrapper.jsx
@@ -40,16 +40,6 @@ const mapStateToProps = state => {
   let isCommunityProviderSearch = false;
 
   if (
-    [
-      LocationType.CC_PROVIDER,
-      LocationType.URGENT_CARE_PHARMACIES,
-      LocationType.EMERGENCY_CARE,
-    ].includes(state.searchQuery.facilityType)
-  ) {
-    isCommunityProviderSearch = true;
-  }
-
-  if (
     state.searchQuery.facilityType === LocationType.URGENT_CARE &&
     (!state.searchQuery.serviceType ||
       ['AllUrgentCare', 'NonVAUrgentCare'].includes(

--- a/src/applications/facility-locator/utils/featureFlagSelectors.js
+++ b/src/applications/facility-locator/utils/featureFlagSelectors.js
@@ -30,3 +30,8 @@ export const covidVaccineSchedulingFrontend = state =>
 
 export const facilityLocatorLatLongOnly = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.facilityLocatorLatLongOnly];
+
+export const facilityLocatorRestoreCommunityCarePagination = state =>
+  toggleValues(state)[
+    FEATURE_FLAG_NAMES.facilityLocatorRestoreCommunityCarePagination
+  ];

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -36,6 +36,7 @@ export default Object.freeze({
   facilityLocatorPredictiveLocationSearch:
     'facility_locator_predictive_location_search',
   facilityLocatorRailsEngine: 'facility_locator_rails_engine',
+  facilityLocatorRestoreCommunityCarePagination: 'facility_locator_restore_community_care_pagination',
   facilityLocatorShowCommunityCares: 'facility_locator_show_community_cares', // Facilities team has deprecated this flag for the frontEnd logic, there is still backend support though.
   facilityLocatorShowOperationalHoursSpecialInstructions:
     'facility_locator_show_operational_hours_special_instructions',


### PR DESCRIPTION
## Description
Resolves - https://github.com/department-of-veterans-affairs/va.gov-team/issues/29546

Restores pagination for community care providers, emergency care, and pharmacies. 
Does not restore pagination for PPMS urgent care, urgent care mashup or emergency care mashup.
