### PR TITLE
31944: [FSR] currency vals should be greater than 0

### DIFF
--- a/src/applications/financial-status-report/utils/validations.js
+++ b/src/applications/financial-status-report/utils/validations.js
@@ -72,7 +72,7 @@ export const validateMilitaryState = (
 export const validateCurrency = (errors, currencyAmount) => {
   const regex = /(?=.*?\d)^\$?(([1-9]\d{0,2}(,\d{3})*)|\d+)?(\.\d{1,2})?$/;
 
-  if (!regex.test(currencyAmount)) {
+  if (!regex.test(currencyAmount) || Number(currencyAmount) < 0) {
     errors.addError('Please enter a valid dollar amount.');
   }
 };


### PR DESCRIPTION
## Description
update validation to ensure currency vals are greater than 0 to prevent users from inputting negative dollar amounts

## Original issue(s)
department-of-veterans-affairs/va.gov-team#31944

## Screenshots
![Financial Status Report  Veterans Affairs 2021-11-04 11-29-47](https://user-images.githubusercontent.com/7518899/140355695-0d18ef25-00d3-4cf4-a1b7-64ae6e6c384d.png)


## Acceptance criteria
- [x] users should not be able to enter negative dollar amounts

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
