### PR TITLE
26931 Vista based upcoming CC appts when canceled display “Add to Calendar” in VAOS appointment detail card

### DIFF
--- a/src/applications/vaos/appointment-list/components/CommunityCareAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/CommunityCareAppointmentDetailsPage.jsx
@@ -5,7 +5,7 @@ import LoadingIndicator from '@department-of-veterans-affairs/component-library/
 
 import moment from '../../lib/moment-tz';
 
-import { FETCH_STATUS } from '../../utils/constants';
+import { APPOINTMENT_STATUS, FETCH_STATUS } from '../../utils/constants';
 import { scrollAndFocus } from '../../utils/scrollAndFocus';
 import { fetchConfirmedAppointmentDetails } from '../redux/actions';
 import AppointmentDateTime from './AppointmentDateTime';
@@ -82,6 +82,7 @@ export default function CommunityCareAppointmentDetailsPage() {
     appointment,
   });
   const isPastAppointment = appointment.vaos.isPastAppointment;
+  const isCanceled = appointment.status === APPOINTMENT_STATUS.cancelled;
 
   return (
     <PageLayout>
@@ -131,25 +132,26 @@ export default function CommunityCareAppointmentDetailsPage() {
         )}
       </div>
 
-      {!isPastAppointment && (
-        <div className="vads-u-margin-top--3 vaos-appts__block-label vaos-hide-for-print">
-          <i
-            aria-hidden="true"
-            className="far fa-calendar vads-u-margin-right--1 vads-u-color--link-default"
-          />
-          <AddToCalendar
-            summary={calendarData.summary}
-            description={{
-              text: calendarData.text,
-              phone: calendarData.phone,
-              additionalText: calendarData.additionalText,
-            }}
-            location={calendarData.location}
-            duration={appointment.minutesDuration}
-            startDateTime={moment.parseZone(appointment.start)}
-          />
-        </div>
-      )}
+      {!isPastAppointment &&
+        !isCanceled && (
+          <div className="vads-u-margin-top--3 vaos-appts__block-label vaos-hide-for-print">
+            <i
+              aria-hidden="true"
+              className="far fa-calendar vads-u-margin-right--1 vads-u-color--link-default"
+            />
+            <AddToCalendar
+              summary={calendarData.summary}
+              description={{
+                text: calendarData.text,
+                phone: calendarData.phone,
+                additionalText: calendarData.additionalText,
+              }}
+              location={calendarData.location}
+              duration={appointment.minutesDuration}
+              startDateTime={moment.parseZone(appointment.start)}
+            />
+          </div>
+        )}
 
       <div className="vads-u-margin-top--2 vaos-appts__block-label vaos-hide-for-print">
         <i

--- a/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
@@ -713,4 +713,62 @@ describe('VAOS <CommunityCareAppointmentDetailsPage> with VAOS service', () => {
     expect(screen.getByText(/Community care/)).to.be.ok;
     expect(screen.getByText(/Atlantic Medical Care/)).to.be.ok;
   });
+
+  it('should not show "Add to Calendar" for canceled appointments', async () => {
+    // Given a user with a canceled CC appointment
+    const url = '/cc/01aa456cc';
+    const appointmentTime = moment().add(1, 'days');
+
+    const data = {
+      id: '01aa456cc',
+      kind: 'cc',
+      practitioners: [
+        {
+          identifier: { system: null, value: '123' },
+        },
+      ],
+      description: 'community care appointment',
+      comment: 'test comment',
+      start: appointmentTime,
+      communityCareProvider: {
+        practiceName: 'Atlantic Medical Care',
+      },
+      status: 'cancelled',
+    };
+
+    const appointment = createMockAppointmentByVersion({
+      version: 2,
+      ...data,
+    });
+
+    mockSingleVAOSAppointmentFetch({
+      appointment,
+    });
+
+    // When the page displays
+    const screen = renderWithStoreAndRouter(<AppointmentList />, {
+      initialState: {
+        featureToggles: {
+          ...initialState.featureToggles,
+          vaOnlineSchedulingVAOSServiceVAAppointments: true,
+          vaOnlineSchedulingVAOSServiceCCAppointments: true,
+        },
+      },
+      path: url,
+    });
+
+    // Verify page content...
+    expect(
+      await screen.findByRole('heading', {
+        level: 1,
+        name: new RegExp(
+          appointmentTime.format('dddd, MMMM D, YYYY [at] h:mm a'),
+          'i',
+        ),
+      }),
+    ).to.be.ok;
+
+    // Then the 'Add to calendar' link should not be displayed
+    expect(screen.queryByText(/Add to calendar/)).not.to.exist;
+  });
 });


### PR DESCRIPTION
## Description
Given the user has a canceled CC appointment, when the Community Care detail page displays the 'Add to calendar' link should not be displayed


## Original issue(s)
department-of-veterans-affairs/va.gov-team#26931


## Testing done
Unit testing

## Screenshots


## Acceptance criteria
- [ ] All test should pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
