### PR TITLE
when exiting DD page and edit mode is opened, close the edit mode

### DIFF
--- a/src/applications/personalization/profile/actions/paymentInformation.js
+++ b/src/applications/personalization/profile/actions/paymentInformation.js
@@ -169,8 +169,8 @@ export function saveCNPPaymentInformation(
   };
 }
 
-export function editCNPPaymentInformationToggled() {
-  return { type: CNP_PAYMENT_INFORMATION_EDIT_TOGGLED };
+export function editCNPPaymentInformationToggled(open) {
+  return { type: CNP_PAYMENT_INFORMATION_EDIT_TOGGLED, open };
 }
 
 export function fetchEDUPaymentInformation(recordEvent = recordAnalyticsEvent) {
@@ -261,6 +261,6 @@ export function saveEDUPaymentInformation(
   };
 }
 
-export function editEDUPaymentInformationToggled() {
-  return { type: EDU_PAYMENT_INFORMATION_EDIT_TOGGLED };
+export function editEDUPaymentInformationToggled(open) {
+  return { type: EDU_PAYMENT_INFORMATION_EDIT_TOGGLED, open };
 }

--- a/src/applications/personalization/profile/components/direct-deposit/BankInfo.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfo.jsx
@@ -89,6 +89,17 @@ export const BankInfo = ({
     [isEmptyForm],
   );
 
+  useEffect(
+    () => {
+      return () => {
+        if (isEditingBankInfo) {
+          toggleEditState(false);
+        }
+      };
+    },
+    [isEditingBankInfo],
+  );
+
   // when we enter and exit edit mode...
   useEffect(
     () => {

--- a/src/applications/personalization/profile/reducers/vaProfile.js
+++ b/src/applications/personalization/profile/reducers/vaProfile.js
@@ -66,7 +66,7 @@ function vaProfile(state = initialState, action) {
     case CNP_PAYMENT_INFORMATION_EDIT_TOGGLED: {
       const newState = set(
         'cnpPaymentInformationUiState.isEditing',
-        !state.cnpPaymentInformationUiState.isEditing,
+        action.open ?? !state.cnpPaymentInformationUiState.isEditing,
         state,
       );
 
@@ -113,7 +113,7 @@ function vaProfile(state = initialState, action) {
     case EDU_PAYMENT_INFORMATION_EDIT_TOGGLED: {
       const newState = set(
         'eduPaymentInformationUiState.isEditing',
-        !state.eduPaymentInformationUiState.isEditing,
+        action.open ?? !state.eduPaymentInformationUiState.isEditing,
         state,
       );
 

--- a/src/applications/personalization/profile/tests/e2e/direct-deposit/update-flow.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/direct-deposit/update-flow.cypress.spec.js
@@ -189,4 +189,32 @@ describe('Direct Deposit', () => {
       cy.axeCheck();
     });
   });
+  describe('when moving to other profile sections', () => {
+    it('should exit edit mode if opened', () => {
+      cy.findByRole('button', {
+        name: /edit.*disability.*bank information/i,
+      }).click({
+        // using force: true since there are times when the click does not
+        // register and the bank info form does not open
+        force: true,
+      });
+      cy.findByRole('link', {
+        name: /military information/i,
+      }).click({
+        // using force: true since there are times when the click does not
+        // register and the bank info form does not open
+        force: true,
+      });
+      cy.findByRole('link', {
+        name: /direct deposit information/i,
+      }).click({
+        // using force: true since there are times when the click does not
+        // register and the bank info form does not open
+        force: true,
+      });
+      cy.findByRole('button', {
+        name: /edit.*disability.*bank info/i,
+      }).should('exist');
+    });
+  });
 });


### PR DESCRIPTION
## Description
When exiting DD page for another page in profile edit mode needs to be exited upon unmount of the component

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done
Wrote Test and tested manually

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
