### PR TITLE
Update selectSeeStaffMessage hook and tests

### DIFF
--- a/src/applications/check-in/hooks/selectors/index.js
+++ b/src/applications/check-in/hooks/selectors/index.js
@@ -59,12 +59,14 @@ const selectContext = createSelector(
 
 const makeSelectContext = () => selectContext;
 
-const selectSeeStaffMessage = () =>
-  createSelector(state => {
+const selectSeeStaffMessage = createSelector(
+  state => {
     return {
       message: state?.checkInData?.seeStaffMessage,
     };
-  });
+  },
+  message => message,
+);
 
 const makeSelectSeeStaffMessage = () => selectSeeStaffMessage;
 

--- a/src/applications/check-in/hooks/selectors/selector.unit.spec.js
+++ b/src/applications/check-in/hooks/selectors/selector.unit.spec.js
@@ -154,7 +154,7 @@ describe('check-in', () => {
     describe('makeSelectSeeStaffMessage', () => {
       it('returns see staff message', () => {
         const selectSeeStaffMessage = makeSelectSeeStaffMessage();
-        expect(selectSeeStaffMessage().resultFunc(state)).to.eql({
+        expect(selectSeeStaffMessage(state)).to.eql({
           message: 'Test message',
         });
       });


### PR DESCRIPTION
## Description
This change updates the selector hook for selectSeeStaffMessage used on the SeeStaff page. Currently, that page is displaying the default see staff message even if a message is set in the redux store

## Original issue(s)
department-of-veterans-affairs/va.gov-team#31557


## Testing done
Updated unit test

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
