### PR TITLE
31499 Remove unused v1 flag from readme

### DIFF
--- a/src/applications/check-in/README.md
+++ b/src/applications/check-in/README.md
@@ -105,8 +105,6 @@ We are currently using an HOC located at `src/applications/check-in/containers/w
   - when to sunset: never;
 - `check_in_experience_demographics_page_enabled`: Enables or disabled the demographics page
   - when to sunset: when the demographics page is deployed in production;
-- `check_in_experience_low_authentication_enabled` : Enables or disabled the low authentication flow
-  - when to sunset: Sprint 59
 - `check_in_experience_update_information_page_enabled` : Enables or disabled the update information page
   - when to sunset: when we expand to multiple facilities and address the edge cases around it
 - `check_in_experience_next_of_kin_enabled` : Enables or disabled the next of kin page


### PR DESCRIPTION
## Description
We have deprecated check-in v1 api so removing it from readme.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#31499


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
