### PR TITLE
 26995 - Add 'submit-application' aria and id tag for proper accessibility screen reader operation

### DIFF
--- a/src/applications/edu-benefits/0994/config/form.js
+++ b/src/applications/edu-benefits/0994/config/form.js
@@ -31,9 +31,7 @@ import {
 } from '../pages';
 
 const formConfig = {
-  ariaDescribedBy: {
-    submitSection: '22-0994-submit-application',
-  },
+  ariaDescribedBySubmit: '22-0994-submit-application',
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
   submitUrl: `${environment.API_URL}/v0/education_benefits_claims/0994`,

--- a/src/applications/edu-benefits/0994/config/form.js
+++ b/src/applications/edu-benefits/0994/config/form.js
@@ -31,6 +31,9 @@ import {
 } from '../pages';
 
 const formConfig = {
+  ariaDescribedBy: {
+    submitSection: '22-0994-submit-application',
+  },
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
   submitUrl: `${environment.API_URL}/v0/education_benefits_claims/0994`,

--- a/src/applications/edu-benefits/0994/containers/PreSubmitInfo.jsx
+++ b/src/applications/edu-benefits/0994/containers/PreSubmitInfo.jsx
@@ -10,8 +10,8 @@ function PreSubmitNotice({
   setPreSubmit,
 }) {
   let ariaDescribedBy = null;
-  if (formConfig.ariaDescribedBySubmit !== null) {
-    ariaDescribedBy = formConfig.ariaDescribedBySubmit;
+  if (formConfig?.ariaDescribedBySubmit !== null) {
+    ariaDescribedBy = formConfig?.ariaDescribedBySubmit;
   } else {
     ariaDescribedBy = null;
   }

--- a/src/applications/edu-benefits/0994/containers/PreSubmitInfo.jsx
+++ b/src/applications/edu-benefits/0994/containers/PreSubmitInfo.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PreSubmitInfo from '../../containers/PreSubmitInfo';
+import environment from 'platform/utilities/environment';
 
 function PreSubmitNotice({
   formData,
@@ -8,7 +9,10 @@ function PreSubmitNotice({
   setPreSubmit,
 }) {
   const activeDutyNote = (
-    <div className="vads-u-margin-bottom--3">
+    <div
+      className="vads-u-margin-bottom--3"
+      id={!environment.isProduction() && 'submit-application'}
+    >
       {formData.activeDuty ? (
         <div>
           <strong>By submitting this form</strong> you certify that:

--- a/src/applications/edu-benefits/0994/containers/PreSubmitInfo.jsx
+++ b/src/applications/edu-benefits/0994/containers/PreSubmitInfo.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PreSubmitInfo from '../../containers/PreSubmitInfo';
 import environment from 'platform/utilities/environment';
+import formConfig from '../config/form';
 
 function PreSubmitNotice({
   formData,
@@ -11,7 +12,9 @@ function PreSubmitNotice({
   const activeDutyNote = (
     <div
       className="vads-u-margin-bottom--3"
-      id={!environment.isProduction() && 'submit-application'}
+      id={
+        !environment.isProduction() && formConfig.ariaDescribedBy.submitSection
+      }
     >
       {formData.activeDuty ? (
         <div>

--- a/src/applications/edu-benefits/0994/containers/PreSubmitInfo.jsx
+++ b/src/applications/edu-benefits/0994/containers/PreSubmitInfo.jsx
@@ -9,12 +9,17 @@ function PreSubmitNotice({
   onSectionComplete,
   setPreSubmit,
 }) {
+  let ariaDescribedBy = null;
+  if (formConfig.ariaDescribedBySubmit !== null) {
+    ariaDescribedBy = formConfig.ariaDescribedBySubmit;
+  } else {
+    ariaDescribedBy = null;
+  }
+
   const activeDutyNote = (
     <div
       className="vads-u-margin-bottom--3"
-      id={
-        !environment.isProduction() && formConfig.ariaDescribedBy.submitSection
-      }
+      id={!environment.isProduction() && ariaDescribedBy}
     >
       {formData.activeDuty ? (
         <div>

--- a/src/applications/edu-benefits/0994/tests/containers/PreSubmitInfo.unit.spec.jsx
+++ b/src/applications/edu-benefits/0994/tests/containers/PreSubmitInfo.unit.spec.jsx
@@ -28,7 +28,6 @@ describe('<PreSubmitInfo>', () => {
     expect(tree).to.not.be.undefined;
     expect(tree.text()).to.contain('By submitting this form you certify');
     expect(tree.text()).to.contain('privacy policy');
-    // TODO: expect(tree.find('[aria-describedby]')).to.contain('22-0994-submit-application');
     tree.unmount();
   });
 });

--- a/src/applications/edu-benefits/0994/tests/containers/PreSubmitInfo.unit.spec.jsx
+++ b/src/applications/edu-benefits/0994/tests/containers/PreSubmitInfo.unit.spec.jsx
@@ -28,7 +28,7 @@ describe('<PreSubmitInfo>', () => {
     expect(tree).to.not.be.undefined;
     expect(tree.text()).to.contain('By submitting this form you certify');
     expect(tree.text()).to.contain('privacy policy');
-
+    // TODO: expect(tree.find('[aria-describedby]')).to.contain('22-0994-submit-application');
     tree.unmount();
   });
 });

--- a/src/platform/forms-system/src/js/components/ProgressButton.jsx
+++ b/src/platform/forms-system/src/js/components/ProgressButton.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import uniqueId from 'lodash/uniqueId';
+import environment from 'platform/utilities/environment';
 
 /**
  * A component for the continue button to navigate through panels of questions.
@@ -31,6 +32,8 @@ class ProgressButton extends React.Component {
     );
 
     return (
+      // aria-describedby tag invoked explicitly to match
+      // "By submitting this form" text for proper screen reader operation
       <button
         type={this.props.submitButton ? 'submit' : 'button'}
         disabled={this.props.disabled}
@@ -40,6 +43,12 @@ class ProgressButton extends React.Component {
         id={`${this.id}-continueButton`}
         onClick={this.props.onButtonClick}
         aria-label={this.props.ariaLabel || null}
+        aria-describedby={
+          this.props.buttonText === 'Submit application' &&
+          !environment.isProduction()
+            ? 'submit-application'
+            : null
+        }
       >
         {beforeText}
         {this.props.buttonText}

--- a/src/platform/forms-system/src/js/components/ProgressButton.jsx
+++ b/src/platform/forms-system/src/js/components/ProgressButton.jsx
@@ -32,8 +32,8 @@ class ProgressButton extends React.Component {
     );
 
     return (
-      // aria-describedby tag invoked explicitly to match
-      // "By submitting this form" text for proper screen reader operation
+      // aria-describedby tag to match "By submitting this form"
+      // text for proper screen reader operation
       <button
         type={this.props.submitButton ? 'submit' : 'button'}
         disabled={this.props.disabled}
@@ -44,10 +44,7 @@ class ProgressButton extends React.Component {
         onClick={this.props.onButtonClick}
         aria-label={this.props.ariaLabel || null}
         aria-describedby={
-          this.props.buttonText === 'Submit application' &&
-          !environment.isProduction()
-            ? 'submit-application'
-            : null
+          !environment.isProduction() && this.props.ariaDescribedBy
         }
       >
         {beforeText}

--- a/src/platform/forms-system/src/js/review/submit-states/ClientError.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/ClientError.jsx
@@ -11,11 +11,18 @@ import scrollTo from 'platform/utilities/ui/scrollTo';
 
 export default function ClientError(props) {
   const { buttonText, formConfig, onBack, onSubmit, testId } = props;
-  const ariaDescribedBy = formConfig.ariaDescribedBy.submitSection;
   const Element = Scroll.Element;
   const scrollToError = () => {
     scrollTo('errorScrollElement', getScrollOptions());
   };
+  let ariaDescribedBy = null;
+  // If no ariaDescribedBy is passed down from form.js,
+  // a null value will properly not render the aria label.
+  if (formConfig.ariaDescribedBySubmit !== null) {
+    ariaDescribedBy = formConfig.ariaDescribedBySubmit;
+  } else {
+    ariaDescribedBy = null;
+  }
 
   useEffect(() => {
     focusElement('.schemaform-failure-alert');

--- a/src/platform/forms-system/src/js/review/submit-states/ClientError.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/ClientError.jsx
@@ -11,6 +11,7 @@ import scrollTo from 'platform/utilities/ui/scrollTo';
 
 export default function ClientError(props) {
   const { buttonText, formConfig, onBack, onSubmit, testId } = props;
+  const ariaDescribedBy = formConfig.ariaDescribedBy.submitSection;
   const Element = Scroll.Element;
   const scrollToError = () => {
     scrollTo('errorScrollElement', getScrollOptions());
@@ -40,6 +41,7 @@ export default function ClientError(props) {
         </Column>
         <Column classNames="small-6 medium-5">
           <ProgressButton
+            ariaDescribedBy={ariaDescribedBy}
             onButtonClick={onSubmit}
             buttonText={buttonText}
             buttonClass="usa-button-primary"

--- a/src/platform/forms-system/src/js/review/submit-states/ClientError.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/ClientError.jsx
@@ -18,8 +18,8 @@ export default function ClientError(props) {
   let ariaDescribedBy = null;
   // If no ariaDescribedBy is passed down from form.js,
   // a null value will properly not render the aria label.
-  if (formConfig.ariaDescribedBySubmit !== null) {
-    ariaDescribedBy = formConfig.ariaDescribedBySubmit;
+  if (formConfig?.ariaDescribedBySubmit !== null) {
+    ariaDescribedBy = formConfig?.ariaDescribedBySubmit;
   } else {
     ariaDescribedBy = null;
   }

--- a/src/platform/forms-system/src/js/review/submit-states/Default.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/Default.jsx
@@ -7,7 +7,15 @@ import PreSubmitSection from 'platform/forms/components/review/PreSubmitSection'
 
 export default function Default(props) {
   const { buttonText, formConfig, onBack, onSubmit } = props;
-  const ariaDescribedBy = formConfig.ariaDescribedBy.submitSection;
+  let ariaDescribedBy = null;
+  // If no ariaDescribedBy is passed down from form.js,
+  // a null value will properly not render the aria label.
+  if (formConfig.ariaDescribedBySubmit !== null) {
+    ariaDescribedBy = formConfig.ariaDescribedBySubmit;
+  } else {
+    ariaDescribedBy = null;
+  }
+
   return (
     <>
       <PreSubmitSection formConfig={formConfig} />

--- a/src/platform/forms-system/src/js/review/submit-states/Default.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/Default.jsx
@@ -7,6 +7,7 @@ import PreSubmitSection from 'platform/forms/components/review/PreSubmitSection'
 
 export default function Default(props) {
   const { buttonText, formConfig, onBack, onSubmit } = props;
+  const ariaDescribedBy = formConfig.ariaDescribedBy.submitSection;
   return (
     <>
       <PreSubmitSection formConfig={formConfig} />
@@ -16,6 +17,7 @@ export default function Default(props) {
         </Column>
         <Column classNames={`vads-u-flex--1`}>
           <ProgressButton
+            ariaDescribedBy={ariaDescribedBy}
             onButtonClick={onSubmit}
             buttonText={buttonText}
             buttonClass="usa-button-primary"

--- a/src/platform/forms-system/src/js/review/submit-states/Default.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/Default.jsx
@@ -10,8 +10,8 @@ export default function Default(props) {
   let ariaDescribedBy = null;
   // If no ariaDescribedBy is passed down from form.js,
   // a null value will properly not render the aria label.
-  if (formConfig.ariaDescribedBySubmit !== null) {
-    ariaDescribedBy = formConfig.ariaDescribedBySubmit;
+  if (formConfig?.ariaDescribedBySubmit !== null) {
+    ariaDescribedBy = formConfig?.ariaDescribedBySubmit;
   } else {
     ariaDescribedBy = null;
   }

--- a/src/platform/forms-system/src/js/review/submit-states/Pending.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/Pending.jsx
@@ -7,7 +7,14 @@ import PreSubmitSection from 'platform/forms/components/review/PreSubmitSection'
 
 export default function Pending(props) {
   const { formConfig, onBack, onSubmit } = props;
-  const ariaDescribedBy = formConfig.ariaDescribedBy.submitSection;
+  let ariaDescribedBy = null;
+  // If no ariaDescribedBy is passed down from form.js,
+  // a null value will properly not render the aria label.
+  if (formConfig.ariaDescribedBySubmit !== null) {
+    ariaDescribedBy = formConfig.ariaDescribedBySubmit;
+  } else {
+    ariaDescribedBy = null;
+  }
 
   return (
     <>

--- a/src/platform/forms-system/src/js/review/submit-states/Pending.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/Pending.jsx
@@ -7,6 +7,7 @@ import PreSubmitSection from 'platform/forms/components/review/PreSubmitSection'
 
 export default function Pending(props) {
   const { formConfig, onBack, onSubmit } = props;
+  const ariaDescribedBy = formConfig.ariaDescribedBy.submitSection;
 
   return (
     <>
@@ -17,6 +18,7 @@ export default function Pending(props) {
         </Column>
         <Column classNames="small-6 medium-5">
           <ProgressButton
+            ariaDescribedBy={ariaDescribedBy}
             onButtonClick={onSubmit}
             buttonText="Sending..."
             disabled

--- a/src/platform/forms-system/src/js/review/submit-states/Pending.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/Pending.jsx
@@ -10,8 +10,8 @@ export default function Pending(props) {
   let ariaDescribedBy = null;
   // If no ariaDescribedBy is passed down from form.js,
   // a null value will properly not render the aria label.
-  if (formConfig.ariaDescribedBySubmit !== null) {
-    ariaDescribedBy = formConfig.ariaDescribedBySubmit;
+  if (formConfig?.ariaDescribedBySubmit !== null) {
+    ariaDescribedBy = formConfig?.ariaDescribedBySubmit;
   } else {
     ariaDescribedBy = null;
   }

--- a/src/platform/forms-system/src/js/review/submit-states/Submitted.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/Submitted.jsx
@@ -7,7 +7,14 @@ import PreSubmitSection from 'platform/forms/components/review/PreSubmitSection'
 
 export default function Submitted(props) {
   const { formConfig, onBack, onSubmit } = props;
-  const ariaDescribedBy = formConfig.ariaDescribedBy.submitSection;
+  let ariaDescribedBy = null;
+  // If no ariaDescribedBy is passed down from form.js,
+  // a null value will properly not render the aria label.
+  if (formConfig.ariaDescribedBySubmit !== null) {
+    ariaDescribedBy = formConfig.ariaDescribedBySubmit;
+  } else {
+    ariaDescribedBy = null;
+  }
 
   return (
     <>

--- a/src/platform/forms-system/src/js/review/submit-states/Submitted.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/Submitted.jsx
@@ -10,8 +10,8 @@ export default function Submitted(props) {
   let ariaDescribedBy = null;
   // If no ariaDescribedBy is passed down from form.js,
   // a null value will properly not render the aria label.
-  if (formConfig.ariaDescribedBySubmit !== null) {
-    ariaDescribedBy = formConfig.ariaDescribedBySubmit;
+  if (formConfig?.ariaDescribedBySubmit !== null) {
+    ariaDescribedBy = formConfig?.ariaDescribedBySubmit;
   } else {
     ariaDescribedBy = null;
   }

--- a/src/platform/forms-system/src/js/review/submit-states/Submitted.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/Submitted.jsx
@@ -7,6 +7,7 @@ import PreSubmitSection from 'platform/forms/components/review/PreSubmitSection'
 
 export default function Submitted(props) {
   const { formConfig, onBack, onSubmit } = props;
+  const ariaDescribedBy = formConfig.ariaDescribedBy.submitSection;
 
   return (
     <>
@@ -17,6 +18,7 @@ export default function Submitted(props) {
         </Column>
         <Column classNames="small-6 medium-5">
           <ProgressButton
+            ariaDescribedBy={ariaDescribedBy}
             onButtonClick={onSubmit}
             buttonText="Submitted"
             disabled

--- a/src/platform/forms-system/src/js/review/submit-states/ThrottledError.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/ThrottledError.jsx
@@ -11,7 +11,14 @@ import PreSubmitSection from 'platform/forms/components/review/PreSubmitSection'
 
 export default function ThrottledError(props) {
   const { buttonText, when, formConfig, onBack, onSubmit, testId } = props;
-  const ariaDescribedBy = formConfig.ariaDescribedBy.submitSection;
+  let ariaDescribedBy = null;
+  // If no ariaDescribedBy is passed down from form.js,
+  // a null value will properly not render the aria label.
+  if (formConfig.ariaDescribedBySubmit !== null) {
+    ariaDescribedBy = formConfig.ariaDescribedBySubmit;
+  } else {
+    ariaDescribedBy = null;
+  }
 
   return (
     <>

--- a/src/platform/forms-system/src/js/review/submit-states/ThrottledError.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/ThrottledError.jsx
@@ -11,6 +11,7 @@ import PreSubmitSection from 'platform/forms/components/review/PreSubmitSection'
 
 export default function ThrottledError(props) {
   const { buttonText, when, formConfig, onBack, onSubmit, testId } = props;
+  const ariaDescribedBy = formConfig.ariaDescribedBy.submitSection;
 
   return (
     <>
@@ -33,6 +34,7 @@ export default function ThrottledError(props) {
         </Column>
         <Column classNames="small-6 medium-5">
           <ProgressButton
+            ariaDescribedBy={ariaDescribedBy}
             onButtonClick={onSubmit}
             buttonText={buttonText}
             buttonClass="usa-button-primary"

--- a/src/platform/forms-system/src/js/review/submit-states/ThrottledError.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/ThrottledError.jsx
@@ -14,8 +14,8 @@ export default function ThrottledError(props) {
   let ariaDescribedBy = null;
   // If no ariaDescribedBy is passed down from form.js,
   // a null value will properly not render the aria label.
-  if (formConfig.ariaDescribedBySubmit !== null) {
-    ariaDescribedBy = formConfig.ariaDescribedBySubmit;
+  if (formConfig?.ariaDescribedBySubmit !== null) {
+    ariaDescribedBy = formConfig?.ariaDescribedBySubmit;
   } else {
     ariaDescribedBy = null;
   }

--- a/src/platform/forms-system/src/js/review/submit-states/ValidationError.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/ValidationError.jsx
@@ -10,6 +10,7 @@ import ErrorLinks from './ErrorLinks';
 
 function ValidationError(props) {
   const { appType, buttonText, formConfig, onBack, onSubmit, testId } = props;
+  const ariaDescribedBy = formConfig.ariaDescribedBy.submitSection;
 
   const alert = formConfig.showReviewErrors ? (
     <ErrorLinks appType={appType} testId={testId} />
@@ -39,6 +40,7 @@ function ValidationError(props) {
         </Column>
         <Column classNames="small-6 medium-5">
           <ProgressButton
+            ariaDescribedBy={ariaDescribedBy}
             onButtonClick={onSubmit}
             buttonText={buttonText}
             buttonClass="usa-button-primary"

--- a/src/platform/forms-system/src/js/review/submit-states/ValidationError.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/ValidationError.jsx
@@ -10,7 +10,14 @@ import ErrorLinks from './ErrorLinks';
 
 function ValidationError(props) {
   const { appType, buttonText, formConfig, onBack, onSubmit, testId } = props;
-  const ariaDescribedBy = formConfig.ariaDescribedBy.submitSection;
+  let ariaDescribedBy = null;
+  // If no ariaDescribedBy is passed down from form.js,
+  // a null value will properly not render the aria label.
+  if (formConfig.ariaDescribedBySubmit !== null) {
+    ariaDescribedBy = formConfig.ariaDescribedBySubmit;
+  } else {
+    ariaDescribedBy = null;
+  }
 
   const alert = formConfig.showReviewErrors ? (
     <ErrorLinks appType={appType} testId={testId} />

--- a/src/platform/forms-system/src/js/review/submit-states/ValidationError.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/ValidationError.jsx
@@ -13,8 +13,8 @@ function ValidationError(props) {
   let ariaDescribedBy = null;
   // If no ariaDescribedBy is passed down from form.js,
   // a null value will properly not render the aria label.
-  if (formConfig.ariaDescribedBySubmit !== null) {
-    ariaDescribedBy = formConfig.ariaDescribedBySubmit;
+  if (formConfig?.ariaDescribedBySubmit !== null) {
+    ariaDescribedBy = formConfig?.ariaDescribedBySubmit;
   } else {
     ariaDescribedBy = null;
   }

--- a/src/platform/forms-system/test/js/review/SubmitController.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/SubmitController.unit.spec.jsx
@@ -24,9 +24,7 @@ const createformReducer = (options = {}) =>
 // Return fresh objects from templates for use with individual tests
 // Default setup: Valid (but empty) form, privacy agreement not set
 const createFormConfig = options => ({
-  ariaDescribedBy: {
-    submitSection: '22-0994-submit-application',
-  },
+  ariaDescribedBySubmit: '22-0994-submit-application',
   urlPrefix: '/',
   trackingPrefix: 'test-',
   prefillEnabled: true,

--- a/src/platform/forms-system/test/js/review/SubmitController.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/SubmitController.unit.spec.jsx
@@ -24,6 +24,9 @@ const createformReducer = (options = {}) =>
 // Return fresh objects from templates for use with individual tests
 // Default setup: Valid (but empty) form, privacy agreement not set
 const createFormConfig = options => ({
+  ariaDescribedBy: {
+    submitSection: '22-0994-submit-application',
+  },
   urlPrefix: '/',
   trackingPrefix: 'test-',
   prefillEnabled: true,

--- a/src/platform/forms-system/test/js/review/submit-states/ClientError.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/submit-states/ClientError.unit.spec.jsx
@@ -46,9 +46,7 @@ const createformReducer = (options = {}) =>
   );
 
 const getFormConfig = (options = {}) => ({
-  ariaDescribedBy: {
-    submitSection: '22-0994-submit-application',
-  },
+  ariaDescribedBySubmit: '22-0994-submit-application',
   preSubmitInfo: {
     required: true,
     field: 'privacyAgreementAccepted',

--- a/src/platform/forms-system/test/js/review/submit-states/ClientError.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/submit-states/ClientError.unit.spec.jsx
@@ -46,6 +46,9 @@ const createformReducer = (options = {}) =>
   );
 
 const getFormConfig = (options = {}) => ({
+  ariaDescribedBy: {
+    submitSection: '22-0994-submit-application',
+  },
   preSubmitInfo: {
     required: true,
     field: 'privacyAgreementAccepted',

--- a/src/platform/forms-system/test/js/review/submit-states/Default.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/submit-states/Default.unit.spec.jsx
@@ -46,9 +46,7 @@ const createformReducer = (options = {}) =>
   );
 
 const getFormConfig = (options = {}) => ({
-  ariaDescribedBy: {
-    submitSection: '22-0994-submit-application',
-  },
+  ariaDescribedBySubmit: '22-0994-submit-application',
   preSubmitInfo: {
     required: true,
     field: 'privacyAgreementAccepted',

--- a/src/platform/forms-system/test/js/review/submit-states/Default.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/submit-states/Default.unit.spec.jsx
@@ -46,6 +46,9 @@ const createformReducer = (options = {}) =>
   );
 
 const getFormConfig = (options = {}) => ({
+  ariaDescribedBy: {
+    submitSection: '22-0994-submit-application',
+  },
   preSubmitInfo: {
     required: true,
     field: 'privacyAgreementAccepted',

--- a/src/platform/forms-system/test/js/review/submit-states/GenericError.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/submit-states/GenericError.unit.spec.jsx
@@ -46,9 +46,7 @@ const createformReducer = (options = {}) =>
   );
 
 const getFormConfig = (options = {}) => ({
-  ariaDescribedBy: {
-    submitSection: '22-0994-submit-application',
-  },
+  ariaDescribedBySubmit: '22-0994-submit-application',
   preSubmitInfo: {
     required: true,
     field: 'privacyAgreementAccepted',

--- a/src/platform/forms-system/test/js/review/submit-states/GenericError.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/submit-states/GenericError.unit.spec.jsx
@@ -46,6 +46,9 @@ const createformReducer = (options = {}) =>
   );
 
 const getFormConfig = (options = {}) => ({
+  ariaDescribedBy: {
+    submitSection: '22-0994-submit-application',
+  },
   preSubmitInfo: {
     required: true,
     field: 'privacyAgreementAccepted',

--- a/src/platform/forms-system/test/js/review/submit-states/Pending.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/submit-states/Pending.unit.spec.jsx
@@ -46,9 +46,7 @@ const createformReducer = (options = {}) =>
   );
 
 const getFormConfig = (options = {}) => ({
-  ariaDescribedBy: {
-    submitSection: '22-0994-submit-application',
-  },
+  ariaDescribedBySubmit: '22-0994-submit-application',
   preSubmitInfo: {
     required: true,
     field: 'privacyAgreementAccepted',

--- a/src/platform/forms-system/test/js/review/submit-states/Pending.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/submit-states/Pending.unit.spec.jsx
@@ -46,6 +46,9 @@ const createformReducer = (options = {}) =>
   );
 
 const getFormConfig = (options = {}) => ({
+  ariaDescribedBy: {
+    submitSection: '22-0994-submit-application',
+  },
   preSubmitInfo: {
     required: true,
     field: 'privacyAgreementAccepted',

--- a/src/platform/forms-system/test/js/review/submit-states/Submitted.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/submit-states/Submitted.unit.spec.jsx
@@ -45,6 +45,9 @@ const createformReducer = (options = {}) =>
   );
 
 const getFormConfig = (options = {}) => ({
+  ariaDescribedBy: {
+    submitSection: '22-0994-submit-application',
+  },
   preSubmitInfo: {
     required: true,
     field: 'privacyAgreementAccepted',

--- a/src/platform/forms-system/test/js/review/submit-states/Submitted.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/submit-states/Submitted.unit.spec.jsx
@@ -45,9 +45,7 @@ const createformReducer = (options = {}) =>
   );
 
 const getFormConfig = (options = {}) => ({
-  ariaDescribedBy: {
-    submitSection: '22-0994-submit-application',
-  },
+  ariaDescribedBySubmit: '22-0994-submit-application',
   preSubmitInfo: {
     required: true,
     field: 'privacyAgreementAccepted',

--- a/src/platform/forms-system/test/js/review/submit-states/ThrottledError.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/submit-states/ThrottledError.unit.spec.jsx
@@ -46,9 +46,7 @@ const createformReducer = (options = {}) =>
   );
 
 const getFormConfig = (options = {}) => ({
-  ariaDescribedBy: {
-    submitSection: '22-0994-submit-application',
-  },
+  ariaDescribedBySubmit: '22-0994-submit-application',
   preSubmitInfo: {
     required: true,
     field: 'privacyAgreementAccepted',

--- a/src/platform/forms-system/test/js/review/submit-states/ThrottledError.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/submit-states/ThrottledError.unit.spec.jsx
@@ -46,6 +46,9 @@ const createformReducer = (options = {}) =>
   );
 
 const getFormConfig = (options = {}) => ({
+  ariaDescribedBy: {
+    submitSection: '22-0994-submit-application',
+  },
   preSubmitInfo: {
     required: true,
     field: 'privacyAgreementAccepted',

--- a/src/platform/forms-system/test/js/review/submit-states/ValidationError.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/submit-states/ValidationError.unit.spec.jsx
@@ -46,9 +46,7 @@ const createformReducer = (options = {}) =>
   );
 
 const getFormConfig = (options = {}) => ({
-  ariaDescribedBy: {
-    submitSection: '22-0994-submit-application',
-  },
+  ariaDescribedBySubmit: '22-0994-submit-application',
   preSubmitInfo: {
     required: true,
     field: 'privacyAgreementAccepted',

--- a/src/platform/forms-system/test/js/review/submit-states/ValidationError.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/submit-states/ValidationError.unit.spec.jsx
@@ -46,6 +46,9 @@ const createformReducer = (options = {}) =>
   );
 
 const getFormConfig = (options = {}) => ({
+  ariaDescribedBy: {
+    submitSection: '22-0994-submit-application',
+  },
   preSubmitInfo: {
     required: true,
     field: 'privacyAgreementAccepted',

--- a/src/platform/forms/tests/forms.unit.spec.js
+++ b/src/platform/forms/tests/forms.unit.spec.js
@@ -25,7 +25,7 @@ const missingFromVetsJsonSchema = [
 const root = path.join(__dirname, '../../../');
 
 const formConfigKeys = [
-  'ariaDescribedBy',
+  'ariaDescribedBySubmit',
   'rootUrl',
   'formId',
   'version',
@@ -284,7 +284,7 @@ describe('form:', () => {
       return expect(
         // Dynamically import the module and perform tests on its default export
         import(configFilePath).then(({ default: formConfig }) => {
-          validStringProperty(formConfig, 'ariaDescribedBy', false);
+          validStringProperty(formConfig, 'ariaDescribedBySubmit', false);
           validFormConfigKeys(formConfig);
           validFormId(formConfig);
           validStringProperty(formConfig, 'rootUrl', true);

--- a/src/platform/forms/tests/forms.unit.spec.js
+++ b/src/platform/forms/tests/forms.unit.spec.js
@@ -25,6 +25,7 @@ const missingFromVetsJsonSchema = [
 const root = path.join(__dirname, '../../../');
 
 const formConfigKeys = [
+  'ariaDescribedBy',
   'rootUrl',
   'formId',
   'version',
@@ -283,6 +284,7 @@ describe('form:', () => {
       return expect(
         // Dynamically import the module and perform tests on its default export
         import(configFilePath).then(({ default: formConfig }) => {
+          validStringProperty(formConfig, 'ariaDescribedBy', false);
           validFormConfigKeys(formConfig);
           validFormId(formConfig);
           validStringProperty(formConfig, 'rootUrl', true);


### PR DESCRIPTION
## Add 'submit-application' aria and id tag for proper accessibility screen reader operation


## Original issue(s)
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/26995

## Testing done

## Screenshots
<img width="1437" alt="Screen Shot 2021-11-04 at 9 03 36 AM" src="https://user-images.githubusercontent.com/3818397/140563560-319b046c-7a33-4d9b-a8e2-c9bce12da9e5.png">


## Acceptance criteria
- [ ] See thread: https://dsva.slack.com/archives/CBU0KDSB1/p1635964442241300

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
