### PR TITLE
Clean up script used for running Cypress tests on GHA

### DIFF
--- a/script/github-actions/run-cypress-tests.js
+++ b/script/github-actions/run-cypress-tests.js
@@ -6,7 +6,7 @@ const divider = Math.ceil(tests.length / Number(process.env.NUM_CONTAINERS));
 
 const batch = tests
   .map(test => test.replace('/home/runner/work', '/__w'))
-  .slice(Number(step) * divider, (Number(step) + 1) * divider)
+  .slice(step * divider, (step + 1) * divider)
   .join(',');
 
 const status = runCommandSync(


### PR DESCRIPTION
## Description
The `step` variable in this file is already a number, so there is no need to use `Number()` in this line.

## Acceptance criteria
- [ ] CI passes.