### PR TITLE
update alert message heading

### DIFF
--- a/src/applications/vaos/new-appointment/components/TypeOfCarePage/TypeOfCareAlert.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfCarePage/TypeOfCareAlert.jsx
@@ -5,7 +5,7 @@ import NewTabAnchor from '../../../components/NewTabAnchor';
 import InfoAlert from '../../../components/InfoAlert';
 
 export default function TypeOfCareAlert() {
-  const headline = 'Not seeing the type of care you need?';
+  const headline = 'Is the type of care you need not listed here?';
   return (
     <PostFormFieldContent>
       <InfoAlert
@@ -23,7 +23,8 @@ export default function TypeOfCareAlert() {
               recordEvent({
                 event: 'nav-alert-box-link-click',
                 'alert-box-type': 'informational',
-                'alert-box-heading': 'Not seeing the type of care you need',
+                'alert-box-heading':
+                  'Is the type of care you need not listed here',
                 'alert-box-subheading': undefined,
                 'alert-box-click-label': 'Find a VA location',
               })

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfCarePage.unit.spec.jsx
@@ -59,7 +59,7 @@ describe('VAOS <TypeOfCarePage>', () => {
     // Verify alert is shown
     expect(
       screen.getByRole('heading', {
-        name: /not seeing the type of care you need\?/i,
+        name: /Is the type of care you need not listed here\?/i,
       }),
     ).to.exist;
     expect(
@@ -72,7 +72,7 @@ describe('VAOS <TypeOfCarePage>', () => {
 
     expect(global.window.dataLayer[0]).to.eql({
       'alert-box-click-label': 'Find a VA location',
-      'alert-box-heading': 'Not seeing the type of care you need',
+      'alert-box-heading': 'Is the type of care you need not listed here',
       'alert-box-subheading': undefined,
       'alert-box-type': 'informational',
       event: 'nav-alert-box-link-click',


### PR DESCRIPTION
## Description
Update the alert message on the Type of Care page

## Original issue(s)
department-of-veterans-affairs/va.gov-team#30905


## Testing done
unit and local test

## Screenshots
![image](https://user-images.githubusercontent.com/54327023/140768039-6082cef9-97ee-496b-8c32-88c2b008d53b.png)


## Acceptance criteria
- [ ] change heading of alert message to say "Is the type of care you need not listed here?"

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
