### PR TITLE
Add force edit mode & callbacks to ContactInformationField

### DIFF
--- a/src/platform/user/profile/vap-svc/tests/components/ContactInformationField.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/components/ContactInformationField.unit.spec.jsx
@@ -70,6 +70,17 @@ describe('<ContactInformationField/>', () => {
 
     component.unmount();
   });
+  it('renders the ContactInformationEditView when forceEditView is set', () => {
+    props.forceEditView = true;
+    component = enzyme.shallow(<ContactInformationField {...props} />);
+
+    expect(
+      component.find('Connect(ContactInformationEditView)'),
+      'the ContactInformationEditView was rendered',
+    ).to.have.lengthOf(1);
+
+    component.unmount();
+  });
 
   it('renders the ContactInformationView', () => {
     component = enzyme.shallow(<ContactInformationField {...props} />);
@@ -91,6 +102,80 @@ describe('<ContactInformationField/>', () => {
       component.find('.usa-button-secondary'),
       'the remove button was not rendered',
     ).to.have.lengthOf(0);
+
+    component.unmount();
+  });
+
+  it('calls the cancelCallback', () => {
+    const cancelCallbackSpy = sinon.spy();
+    props.forceEditView = true;
+    component = enzyme.shallow(
+      <ContactInformationField {...props} cancelCallback={cancelCallbackSpy} />,
+    );
+
+    expect(
+      component.find('Connect(ContactInformationEditView)'),
+      'the ContactInformationEditView was rendered',
+    ).to.have.lengthOf(1);
+
+    component
+      .find('Connect(ContactInformationEditView)')
+      .props()
+      .onCancel();
+
+    expect(cancelCallbackSpy.calledOnce, 'cancelCallback called').to.be.true;
+
+    component.unmount();
+  });
+  it('calls the successCallback (non-address changes)', () => {
+    const successCallbackSpy = sinon.spy();
+    const data = {
+      ...props,
+      forceEditView: true,
+      transactionRequest: {},
+      successCallback: successCallbackSpy,
+    };
+    component = enzyme.shallow(<ContactInformationField {...data} />);
+
+    expect(
+      component.find('Connect(ContactInformationEditView)'),
+      'the ContactInformationEditView was rendered',
+    ).to.have.lengthOf(1);
+
+    data.transactionRequest = null; // non-address success
+    component.setProps(data);
+
+    expect(successCallbackSpy.calledOnce, 'successCallback called').to.be.true;
+
+    component.unmount();
+  });
+  it('calls the successCallback (address changes)', () => {
+    const successCallbackSpy = sinon.spy();
+    const data = {
+      ...props,
+      showEditView: true,
+      forceEditView: true,
+      fieldName: FIELD_NAMES.MAILING_ADDRESS,
+      transaction: { data: { attributes: { transactionStatus: '' } } },
+      successCallback: successCallbackSpy,
+    };
+    component = enzyme.shallow(<ContactInformationField {...data} />);
+
+    expect(
+      component.find('Connect(ContactInformationEditView)'),
+      'the ContactInformationEditView was rendered',
+    ).to.have.lengthOf(1);
+
+    const newData = {
+      ...data,
+      showEditView: false, // justClosedModal check
+      transaction: null,
+      showUpdateSuccessAlert: true, // success check
+    };
+    // Address success callback
+    component.setProps(newData);
+
+    expect(successCallbackSpy.calledOnce, 'successCallback called').to.be.true;
 
     component.unmount();
   });


### PR DESCRIPTION
## Description

We were asked to implement an in-form contact info editing pattern where clicking "edit" would take the Veteran to a new form page, and return them back to the contact info page when complete.

```
    ┌──────────────────────────◄─────┐
    ▼                                │
Contact info ──────► Edit address ──►┤
    │    │ └──► Edit phone ─────────►┤
    │    └──► Edit email ───────────►┘
    │ Continue
    ▼ 
```

In this PR, the following properties were added to the profile `ContactInformationField` component:

- `forceEditView` - Changes the view to the editor to show the prefill form elements instead of the information + edit button
- `cancelCallback` - A function that is called when the "cancel" button is pressed to change the form route back to the contact information page
- `successCallback` - A function that is called once the "update" button is clicked for non-address changes. When the address is edited a confirmation view is shown, and once that "update" button is clicked, the `successCallback` is executed.

## Original issue(s)

- Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/31700
- `FormPage` changes: https://github.com/department-of-veterans-affairs/vets-website/pull/19315
- `FormPage` doc updates: https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/706

## Testing done

Added unit tests

## Screenshots

<details><summary>Update phone number flow (cancel & submit)</summary>

<!-- leave a blank line above -->
![editing phone number flow](https://user-images.githubusercontent.com/136959/140820609-a13cf4ef-4781-44e4-be49-4c52457a919c.gif)</details>

<details><summary>Update address flow (cancel & submit)</summary>

<!-- leave a blank line above -->
![editing address flow](https://user-images.githubusercontent.com/136959/140820596-a3a12545-496d-4b7a-8c22-9f122dc3b00a.gif)</details>

**NOTE** the contact info doesn't actually update in these screenshots because they were made in a local environment which uses mock data

## Acceptance criteria
- [x] `forceEditView` reveals the field in edit mode
- [x] `cancelCallback` function executed when the changes are cancelled
- [x] `successCallback` function executed when the changes have been successfully made
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
