### PR TITLE
Add medical copays CTA widget

### DIFF
--- a/src/applications/static-pages/medical-copays-cta/components/App/index.js
+++ b/src/applications/static-pages/medical-copays-cta/components/App/index.js
@@ -15,8 +15,8 @@ export const App = ({ loggedIn, show, toggleLoginModal }) => {
       {/* Title */}
       <h2 slot="headline" className="vads-u-font-size--h3">
         {loggedIn
-          ? 'View your VA copay balances'
-          : 'Please sign in to view your VA copay balances'}
+          ? 'Review your VA copay balances'
+          : 'Please sign in to review your VA copay balances'}
       </h2>
 
       {/* Explanation */}
@@ -31,7 +31,7 @@ export const App = ({ loggedIn, show, toggleLoginModal }) => {
         </p>
       )}
       <ul>
-        <li>View your balances for each of your medical facilities</li>
+        <li>Review your balances for each of your medical facilities</li>
         <li>Download your copay statements</li>
         <li>Find the right repayment option for you</li>
       </ul>
@@ -42,7 +42,7 @@ export const App = ({ loggedIn, show, toggleLoginModal }) => {
           className="vads-c-action-link--blue vads-u-margin-top--2"
           href="/health-care/pay-copay-bill/your-current-balances/"
         >
-          View your current copay balances
+          Review your current copay balances
         </a>
       ) : (
         <button

--- a/src/applications/static-pages/medical-copays-cta/components/App/index.js
+++ b/src/applications/static-pages/medical-copays-cta/components/App/index.js
@@ -1,0 +1,66 @@
+// Node modules.
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+// Relative imports.
+import { toggleLoginModal as toggleLoginModalAction } from 'platform/site-wide/user-nav/actions';
+
+export const App = ({ loggedIn, show, toggleLoginModal }) => {
+  if (!show) {
+    return null;
+  }
+
+  return (
+    <va-alert status="info">
+      {/* Title */}
+      <h2 slot="headline" className="vads-u-font-size--h3">
+        View your VA copay balances
+      </h2>
+
+      {/* Explanation */}
+      <p>With this tool, you can:</p>
+      <ul>
+        <li>View your balances for each of your medical facilities</li>
+        <li>See your copay charges and payments</li>
+        <li>Download your copay statements</li>
+        <li>Find the right repayment option for you</li>
+      </ul>
+
+      {/* Call to action button/link */}
+      {loggedIn ? (
+        <a
+          className="vads-c-action-link--blue vads-u-margin-top--2"
+          href="/health-care/pay-copay-bill/your-current-balances/"
+        >
+          View your current copay balances
+        </a>
+      ) : (
+        <button className="usa-button" onClick={() => toggleLoginModal(false)}>
+          Sign in or create an account
+        </button>
+      )}
+    </va-alert>
+  );
+};
+
+App.propTypes = {
+  // From mapStateToProps.
+  loggedIn: PropTypes.bool,
+  show: PropTypes.bool,
+  // From mapDispatchToProps.
+  toggleLoginModal: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = state => ({
+  loggedIn: state?.user?.login?.currentlyLoggedIn || false,
+  show: state?.featureToggles?.showMedicalCopays,
+});
+
+const mapDispatchToProps = dispatch => ({
+  toggleLoginModal: open => dispatch(toggleLoginModalAction(open)),
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(App);

--- a/src/applications/static-pages/medical-copays-cta/components/App/index.js
+++ b/src/applications/static-pages/medical-copays-cta/components/App/index.js
@@ -47,7 +47,7 @@ export const App = ({ loggedIn, show, toggleLoginModal }) => {
       ) : (
         <button
           className="va-button-primary"
-          onClick={() => toggleLoginModal(false)}
+          onClick={() => toggleLoginModal(true)}
         >
           Sign in or create an account
         </button>

--- a/src/applications/static-pages/medical-copays-cta/components/App/index.js
+++ b/src/applications/static-pages/medical-copays-cta/components/App/index.js
@@ -11,17 +11,21 @@ export const App = ({ loggedIn, show, toggleLoginModal }) => {
   }
 
   return (
-    <va-alert status="info">
+    <va-alert status="continue">
       {/* Title */}
       <h2 slot="headline" className="vads-u-font-size--h3">
-        View your VA copay balances
+        Please sign in to view your VA copay balances
       </h2>
 
       {/* Explanation */}
-      <p>With this tool, you can:</p>
+      <p>
+        Try signing in with your <strong>DS Logon</strong>,{' '}
+        <strong>My HealtheVet</strong>, or <strong>ID.me</strong> account. If
+        you don’t have any of those accounts, you can create one now. When you
+        sign in or create an account, you’ll be able to:
+      </p>
       <ul>
         <li>View your balances for each of your medical facilities</li>
-        <li>See your copay charges and payments</li>
         <li>Download your copay statements</li>
         <li>Find the right repayment option for you</li>
       </ul>
@@ -35,7 +39,10 @@ export const App = ({ loggedIn, show, toggleLoginModal }) => {
           View your current copay balances
         </a>
       ) : (
-        <button className="usa-button" onClick={() => toggleLoginModal(false)}>
+        <button
+          className="va-button-primary"
+          onClick={() => toggleLoginModal(false)}
+        >
           Sign in or create an account
         </button>
       )}

--- a/src/applications/static-pages/medical-copays-cta/components/App/index.js
+++ b/src/applications/static-pages/medical-copays-cta/components/App/index.js
@@ -11,19 +11,25 @@ export const App = ({ loggedIn, show, toggleLoginModal }) => {
   }
 
   return (
-    <va-alert status="continue">
+    <va-alert status={loggedIn ? 'info' : 'continue'}>
       {/* Title */}
       <h2 slot="headline" className="vads-u-font-size--h3">
-        Please sign in to view your VA copay balances
+        {loggedIn
+          ? 'View your VA copay balances'
+          : 'Please sign in to view your VA copay balances'}
       </h2>
 
       {/* Explanation */}
-      <p>
-        Try signing in with your <strong>DS Logon</strong>,{' '}
-        <strong>My HealtheVet</strong>, or <strong>ID.me</strong> account. If
-        you don’t have any of those accounts, you can create one now. When you
-        sign in or create an account, you’ll be able to:
-      </p>
+      {loggedIn ? (
+        <p>With this tool, you can:</p>
+      ) : (
+        <p>
+          Try signing in with your <strong>DS Logon</strong>,{' '}
+          <strong>My HealtheVet</strong>, or <strong>ID.me</strong> account. If
+          you don’t have any of those accounts, you can create one now. When you
+          sign in or create an account, you’ll be able to:
+        </p>
+      )}
       <ul>
         <li>View your balances for each of your medical facilities</li>
         <li>Download your copay statements</li>

--- a/src/applications/static-pages/medical-copays-cta/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/medical-copays-cta/components/App/index.unit.spec.js
@@ -1,0 +1,46 @@
+// Dependencies.
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+// Relative imports.
+import { App } from '.';
+
+describe('Medical Copays CTA <App>', () => {
+  it('does not render when feature toggle is falsey', () => {
+    const wrapper = shallow(<App show={false} />);
+    expect(wrapper.type()).to.equal(null);
+    wrapper.unmount();
+  });
+
+  it('renders what we expect when unauthenticated', () => {
+    const wrapper = shallow(<App loggedIn={false} show />);
+    expect(wrapper.type()).to.not.equal(null);
+    expect(wrapper.text()).includes('View your VA copay balances');
+    expect(wrapper.text()).includes('With this tool, you can:');
+    expect(wrapper.text()).includes(
+      'View your balances for each of your medical facilities',
+    );
+    expect(wrapper.text()).includes('See your copay charges and payments');
+    expect(wrapper.text()).includes('Download your copay statements');
+    expect(wrapper.text()).includes('Find the right repayment option for you');
+    expect(wrapper.find('a.vads-c-action-link--blue')).to.have.lengthOf(0);
+    expect(wrapper.find('button.usa-button')).to.have.lengthOf(1);
+    wrapper.unmount();
+  });
+
+  it('renders what we expect when authenticated', () => {
+    const wrapper = shallow(<App loggedIn show />);
+    expect(wrapper.type()).to.not.equal(null);
+    expect(wrapper.text()).includes('View your VA copay balances');
+    expect(wrapper.text()).includes('With this tool, you can:');
+    expect(wrapper.text()).includes(
+      'View your balances for each of your medical facilities',
+    );
+    expect(wrapper.text()).includes('See your copay charges and payments');
+    expect(wrapper.text()).includes('Download your copay statements');
+    expect(wrapper.text()).includes('Find the right repayment option for you');
+    expect(wrapper.find('a.vads-c-action-link--blue')).to.have.lengthOf(1);
+    expect(wrapper.find('button.usa-button')).to.have.lengthOf(0);
+    wrapper.unmount();
+  });
+});

--- a/src/applications/static-pages/medical-copays-cta/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/medical-copays-cta/components/App/index.unit.spec.js
@@ -15,12 +15,15 @@ describe('Medical Copays CTA <App>', () => {
   it('renders what we expect when unauthenticated', () => {
     const wrapper = shallow(<App loggedIn={false} show />);
     expect(wrapper.type()).to.not.equal(null);
-    expect(wrapper.text()).includes('View your VA copay balances');
-    expect(wrapper.text()).includes('With this tool, you can:');
+    expect(wrapper.text()).includes(
+      'Please sign in to view your VA copay balances',
+    );
+    expect(wrapper.text()).includes(
+      'If you don’t have any of those accounts, you can create one now. When you sign in or create an account, you’ll be able to:',
+    );
     expect(wrapper.text()).includes(
       'View your balances for each of your medical facilities',
     );
-    expect(wrapper.text()).includes('See your copay charges and payments');
     expect(wrapper.text()).includes('Download your copay statements');
     expect(wrapper.text()).includes('Find the right repayment option for you');
     expect(wrapper.find('a.vads-c-action-link--blue')).to.have.lengthOf(0);
@@ -31,12 +34,15 @@ describe('Medical Copays CTA <App>', () => {
   it('renders what we expect when authenticated', () => {
     const wrapper = shallow(<App loggedIn show />);
     expect(wrapper.type()).to.not.equal(null);
-    expect(wrapper.text()).includes('View your VA copay balances');
-    expect(wrapper.text()).includes('With this tool, you can:');
+    expect(wrapper.text()).includes(
+      'Please sign in to view your VA copay balances',
+    );
+    expect(wrapper.text()).includes(
+      'If you don’t have any of those accounts, you can create one now. When you sign in or create an account, you’ll be able to:',
+    );
     expect(wrapper.text()).includes(
       'View your balances for each of your medical facilities',
     );
-    expect(wrapper.text()).includes('See your copay charges and payments');
     expect(wrapper.text()).includes('Download your copay statements');
     expect(wrapper.text()).includes('Find the right repayment option for you');
     expect(wrapper.find('a.vads-c-action-link--blue')).to.have.lengthOf(1);

--- a/src/applications/static-pages/medical-copays-cta/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/medical-copays-cta/components/App/index.unit.spec.js
@@ -16,15 +16,15 @@ describe('Medical Copays CTA <App>', () => {
     const wrapper = shallow(<App loggedIn={false} show />);
     expect(wrapper.type()).to.not.equal(null);
     expect(wrapper.text()).includes(
-      'Please sign in to view your VA copay balances',
+      'Please sign in to review your VA copay balances',
     );
-    expect(wrapper.text()).not.includes('View your VA copay balances');
+    expect(wrapper.text()).not.includes('Review your VA copay balances');
     expect(wrapper.text()).includes(
       'If you don’t have any of those accounts, you can create one now. When you sign in or create an account, you’ll be able to:',
     );
     expect(wrapper.text()).not.includes('With this tool, you can:');
     expect(wrapper.text()).includes(
-      'View your balances for each of your medical facilities',
+      'Review your balances for each of your medical facilities',
     );
     expect(wrapper.text()).includes('Download your copay statements');
     expect(wrapper.text()).includes('Find the right repayment option for you');
@@ -36,16 +36,16 @@ describe('Medical Copays CTA <App>', () => {
   it('renders what we expect when authenticated', () => {
     const wrapper = shallow(<App loggedIn show />);
     expect(wrapper.type()).to.not.equal(null);
-    expect(wrapper.text()).includes('View your VA copay balances');
+    expect(wrapper.text()).includes('Review your VA copay balances');
     expect(wrapper.text()).includes('With this tool, you can:');
     expect(wrapper.text()).not.includes(
-      'Please sign in to view your VA copay balances',
+      'Please sign in to review your VA copay balances',
     );
     expect(wrapper.text()).not.includes(
       'If you don’t have any of those accounts, you can create one now. When you sign in or create an account, you’ll be able to:',
     );
     expect(wrapper.text()).includes(
-      'View your balances for each of your medical facilities',
+      'Review your balances for each of your medical facilities',
     );
     expect(wrapper.text()).includes('Download your copay statements');
     expect(wrapper.text()).includes('Find the right repayment option for you');

--- a/src/applications/static-pages/medical-copays-cta/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/medical-copays-cta/components/App/index.unit.spec.js
@@ -18,26 +18,30 @@ describe('Medical Copays CTA <App>', () => {
     expect(wrapper.text()).includes(
       'Please sign in to view your VA copay balances',
     );
+    expect(wrapper.text()).not.includes('View your VA copay balances');
     expect(wrapper.text()).includes(
       'If you don’t have any of those accounts, you can create one now. When you sign in or create an account, you’ll be able to:',
     );
+    expect(wrapper.text()).not.includes('With this tool, you can:');
     expect(wrapper.text()).includes(
       'View your balances for each of your medical facilities',
     );
     expect(wrapper.text()).includes('Download your copay statements');
     expect(wrapper.text()).includes('Find the right repayment option for you');
     expect(wrapper.find('a.vads-c-action-link--blue')).to.have.lengthOf(0);
-    expect(wrapper.find('button.usa-button')).to.have.lengthOf(1);
+    expect(wrapper.find('button.va-button-primary')).to.have.lengthOf(1);
     wrapper.unmount();
   });
 
   it('renders what we expect when authenticated', () => {
     const wrapper = shallow(<App loggedIn show />);
     expect(wrapper.type()).to.not.equal(null);
-    expect(wrapper.text()).includes(
+    expect(wrapper.text()).includes('View your VA copay balances');
+    expect(wrapper.text()).includes('With this tool, you can:');
+    expect(wrapper.text()).not.includes(
       'Please sign in to view your VA copay balances',
     );
-    expect(wrapper.text()).includes(
+    expect(wrapper.text()).not.includes(
       'If you don’t have any of those accounts, you can create one now. When you sign in or create an account, you’ll be able to:',
     );
     expect(wrapper.text()).includes(
@@ -46,7 +50,7 @@ describe('Medical Copays CTA <App>', () => {
     expect(wrapper.text()).includes('Download your copay statements');
     expect(wrapper.text()).includes('Find the right repayment option for you');
     expect(wrapper.find('a.vads-c-action-link--blue')).to.have.lengthOf(1);
-    expect(wrapper.find('button.usa-button')).to.have.lengthOf(0);
+    expect(wrapper.find('button.va-button-primary')).to.have.lengthOf(0);
     wrapper.unmount();
   });
 });

--- a/src/applications/static-pages/medical-copays-cta/index.js
+++ b/src/applications/static-pages/medical-copays-cta/index.js
@@ -1,0 +1,21 @@
+// Node modules.
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+
+export default (store, widgetType) => {
+  const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
+
+  if (root) {
+    import(/* webpackChunkName: "medical-copays-cta" */
+    './components/App').then(module => {
+      const App = module.default;
+      ReactDOM.render(
+        <Provider store={store}>
+          <App />
+        </Provider>,
+        root,
+      );
+    });
+  }
+};

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -50,6 +50,7 @@ import createFindVaForms, {
 import createFindVaFormsPDFDownloadHelper from '../find-forms/widgets/createFindVaFormsPDFDownloadHelper';
 import createHigherLevelReviewApplicationStatus from 'applications/disability-benefits/996/components/createHLRApplicationStatus';
 import createManageVADebtCTA from './manage-va-debt/createManageVADebtCTA';
+import createMedicalCopaysCTA from './medical-copays-cta';
 import createMyVALoginWidget from './widget-creators/createMyVALoginWidget';
 import createNearByVetCenters from './facilities/vet-center/createNearByVetCenters';
 import createOptOutApplicationStatus from '../edu-benefits/components/createOptOutApplicationStatus';
@@ -159,6 +160,7 @@ createCovidVaccineUpdatesWidget(store, widgetTypes.COVID_VACCINE_UPDATES_CTA);
 createViewDependentsCTA(store, widgetTypes.VIEW_DEPENDENTS_CTA);
 form686CTA(store, widgetTypes.FORM_686_CTA);
 createAskVAWidget(store, widgetTypes.ASK_VA);
+createMedicalCopaysCTA(store, widgetTypes.MEDICAL_COPAYS_CTA);
 createGetMedicalRecordsPage(store, widgetTypes.GET_MEDICAL_RECORDS_PAGE);
 createRefillTrackPrescriptionsPage(
   store,

--- a/src/applications/static-pages/widgetTypes.js
+++ b/src/applications/static-pages/widgetTypes.js
@@ -30,6 +30,7 @@ export default {
   I_18_SELECT: 'i18-select',
   MAINTENANCE_BANNER: 'maintenance-banner',
   MANAGE_VA_DEBT_CTA: 'manage-va-debt-cta',
+  MEDICAL_COPAYS_CTA: 'medical-copays-cta',
   OPT_OUT_APP_STATUS: 'opt-out-app-status',
   OTHER_FACILITY_LOCATIONS_LIST: 'other-facility-locations-list',
   PENSION_APP_STATUS: 'pension-app-status',


### PR DESCRIPTION
## Description

This PR adds the medical copays CTA widget. It renders `null` when the `show_medical_copay` feature toggle is disabled. If the user is authenticated, it will show the blue action link. If the user is unauthenticated, it will show a sign in button.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/32117


## Testing done
✅ Unit tests

## Screenshots

### Unauthenticated

![image](https://user-images.githubusercontent.com/12773166/140983586-897d053a-f947-45c4-a1ab-6e733070cb23.png)

### Authenticated

![image](https://user-images.githubusercontent.com/12773166/140983602-22b8fdb2-8312-4e72-93fd-1b1d0ba46ea3.png)

## Acceptance criteria
- [x] Create medical copays CTA

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
