### PR TITLE
Adding analytics for various events on GIBCT Name search page.

### DIFF
--- a/src/applications/gi-sandbox/components/MobileFilterControls.jsx
+++ b/src/applications/gi-sandbox/components/MobileFilterControls.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import classNames from 'classnames';
 import TuitionAndHousingEstimates from '../containers/TuitionAndHousingEstimates';
 import FilterYourResults from '../containers/FilterYourResults';
+import recordEvent from 'platform/monitoring/record-event';
 
 export default function MobileFilterControls({ className }) {
   const [filtersOpen, setFiltersOpen] = useState(false);
@@ -10,12 +11,18 @@ export default function MobileFilterControls({ className }) {
   const filterClick = () => {
     if (!filtersOpen) {
       document.body.classList.add('modal-open');
+      recordEvent({
+        event: 'int-accordion-expand',
+      });
     }
     setFiltersOpen(!filtersOpen);
   };
 
   const tuitionAndHousingEstimatesClick = () => {
     if (!tuitionAndHousingOpen) {
+      recordEvent({
+        event: 'int-accordion-expand',
+      });
       document.body.classList.add('modal-open');
     }
     setTuitionAndHousingOpen(!tuitionAndHousingOpen);

--- a/src/applications/gi-sandbox/components/SearchBenefits.jsx
+++ b/src/applications/gi-sandbox/components/SearchBenefits.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import EbenefitsLink from 'platform/site-wide/ebenefits/containers/EbenefitsLink';
 import Dropdown from './Dropdown';
 import LearnMoreLabel from './LearnMoreLabel';
+import recordEvent from 'platform/monitoring/record-event';
 
 const SearchBenefits = ({
   cumulativeService,
@@ -39,7 +40,15 @@ const SearchBenefits = ({
         value={militaryStatus}
         alt="What's your military status?"
         visible
-        onChange={e => setMilitaryStatus(e.target.value)}
+        onChange={e => {
+          recordEvent({
+            event: 'howToWizard-formChange',
+            'form-field-type': 'form-dropdown',
+            'form-field-label': `What's your military status?`,
+            'form-field-value': e.target.value,
+          });
+          setMilitaryStatus(e.target.value);
+        }}
       />
 
       <Dropdown
@@ -59,7 +68,14 @@ const SearchBenefits = ({
         label={
           <LearnMoreLabel
             text="Which GI Bill benefit do you want to use?"
-            onClick={() => dispatchShowModal('giBillChapter')}
+            onClick={() => {
+              recordEvent({
+                event: 'gibct-form-help-text-clicked',
+                'help-text-label':
+                  'Learn more about VA education and training programs',
+              });
+              dispatchShowModal('giBillChapter');
+            }}
             ariaLabel="Learn more about VA education and training programs"
           />
         }
@@ -88,7 +104,15 @@ const SearchBenefits = ({
         value={giBillChapter}
         alt="Which GI Bill benefit do you want to use?"
         visible
-        onChange={e => setGiBillChapter(e.target.value)}
+        onChange={e => {
+          recordEvent({
+            event: 'howToWizard-formChange',
+            'form-field-type': 'form-dropdown',
+            'form-field-label': 'Which GI Bill benefit do you want to use?',
+            'form-field-value': e.target.value,
+          });
+          setGiBillChapter(e.target.value);
+        }}
       />
 
       {militaryStatus === 'active duty' &&
@@ -125,7 +149,14 @@ const SearchBenefits = ({
         label={
           <LearnMoreLabel
             text="Cumulative Post-9/11 active-duty service"
-            onClick={() => dispatchShowModal('cumulativeService')}
+            onClick={() => {
+              recordEvent({
+                event: 'gibct-form-help-text-clicked',
+                'help-text-label':
+                  'Learn more about Cumulative Post-9/11 service',
+              });
+              dispatchShowModal('cumulativeService');
+            }}
             ariaLabel="Learn more about Cumulative Post-9/11 service"
           />
         }
@@ -153,7 +184,15 @@ const SearchBenefits = ({
         value={cumulativeService}
         alt="Cumulative Post-9/11 active-duty service"
         visible={chapter33Check}
-        onChange={e => setCumulativeService(e.target.value)}
+        onChange={e => {
+          recordEvent({
+            event: 'howToWizard-formChange',
+            'form-field-type': 'form-dropdown',
+            'form-field-label': 'Cumulative Post-9/11 active-duty service',
+            'form-field-value': e.target.value,
+          });
+          setCumulativeService(e.target.value);
+        }}
       />
       <Dropdown
         label={

--- a/src/applications/gi-sandbox/containers/FilterYourResults.jsx
+++ b/src/applications/gi-sandbox/containers/FilterYourResults.jsx
@@ -19,6 +19,7 @@ import { TABS, INSTITUTION_TYPES } from '../constants';
 import CheckboxGroup from '../components/CheckboxGroup';
 import _ from 'lodash';
 import { updateUrlParams } from '../selectors/search';
+import recordEvent from 'platform/monitoring/record-event';
 
 export function FilterYourResults({
   dispatchShowModal,
@@ -53,15 +54,37 @@ export function FilterYourResults({
   const [showAllSchoolTypes, setShowAllSchoolTypes] = useState(false);
   const SEE_LESS_SIZE = 4;
 
+  const recordCheckboxEvent = e => {
+    recordEvent({
+      event: 'howToWizard-formChange',
+      'form-field-type': 'form-checkbox',
+      'form-field-label': e.target.name,
+      'form-field-value': e.target.checked,
+    });
+  };
+
   const updateInstitutionFilters = (name, value) => {
     dispatchFilterChange({ ...filters, [name]: value });
   };
-  const onChangeCheckbox = e =>
+  const onChangeCheckbox = e => {
+    recordCheckboxEvent(e);
     updateInstitutionFilters(e.target.name, e.target.checked);
+  };
 
-  const onChange = e => updateInstitutionFilters(e.target.name, e.target.value);
+  const onChange = e => {
+    recordEvent({
+      event: 'howToWizard-formChange',
+      'form-field-type': 'form-dropdown',
+      'form-field-label': e.target.name,
+      'form-field-value': e.target.value,
+    });
+    updateInstitutionFilters(e.target.name, e.target.value);
+  };
 
   const onAccordionChange = value => {
+    recordEvent({
+      event: value ? 'int-accordion-expand' : 'int-accordion-collapse',
+    });
     updateInstitutionFilters('expanded', value);
   };
 
@@ -79,6 +102,7 @@ export function FilterYourResults({
         yellowRibbonScholarship: false,
         specialMission: 'ALL',
       });
+      recordCheckboxEvent(e);
     } else {
       onChangeCheckbox(e);
     }
@@ -88,6 +112,7 @@ export function FilterYourResults({
     const name = e.target.name;
     const checked = e.target.checked;
     const newExcluded = _.cloneDeep(excludedSchoolTypes);
+    recordCheckboxEvent(e);
     updateInstitutionFilters(
       'excludedSchoolTypes',
       checked
@@ -104,6 +129,7 @@ export function FilterYourResults({
         vettec: false,
         preferredProvider: false,
       });
+      recordCheckboxEvent(e);
     } else {
       onChangeCheckbox(e);
     }
@@ -115,8 +141,9 @@ export function FilterYourResults({
       dispatchFilterChange({
         ...filters,
         vettec: true,
-        preferredProvider: true,
+        preferredProvider: false,
       });
+      recordCheckboxEvent(e);
     } else {
       onChangeCheckbox(e);
     }
@@ -204,7 +231,14 @@ export function FilterYourResults({
         optionLabel: (
           <LearnMoreLabel
             text="Has no cautionary warnings"
-            onClick={() => dispatchShowModal('cautionaryWarnings')}
+            onClick={() => {
+              recordEvent({
+                event: 'gibct-form-help-text-clicked',
+                'help-text-label':
+                  'Learn more about cautionary warnings and school closures',
+              });
+              dispatchShowModal('cautionaryWarnings');
+            }}
             ariaLabel="Learn more about VA education and training programs"
           />
         ),
@@ -215,7 +249,13 @@ export function FilterYourResults({
         optionLabel: (
           <LearnMoreLabel
             text="Is accredited"
-            onClick={() => dispatchShowModal('accredited')}
+            onClick={() => {
+              recordEvent({
+                event: 'gibct-form-help-text-clicked',
+                'help-text-label': 'Learn more about accreditation',
+              });
+              dispatchShowModal('accredited');
+            }}
             ariaLabel="Learn more about VA education and training programs"
           />
         ),

--- a/src/applications/gi-sandbox/containers/TuitionAndHousingEstimates.jsx
+++ b/src/applications/gi-sandbox/containers/TuitionAndHousingEstimates.jsx
@@ -6,6 +6,7 @@ import LearnMoreLabel from '../components/LearnMoreLabel';
 import { showModal, eligibilityChange } from '../actions';
 import { connect } from 'react-redux';
 import { createId } from '../utils/helpers';
+import recordEvent from 'platform/monitoring/record-event';
 
 export function TuitionAndHousingEstimates({
   eligibility,
@@ -52,6 +53,9 @@ export function TuitionAndHousingEstimates({
   };
 
   const onExpand = value => {
+    recordEvent({
+      event: value ? 'int-accordion-expand' : 'int-accordion-collapse',
+    });
     dispatchEligibilityChange({ expanded: value });
   };
 
@@ -83,7 +87,13 @@ export function TuitionAndHousingEstimates({
         label={
           <LearnMoreLabel
             text="Will you be taking any classes in person?"
-            onClick={() => dispatchShowModal('onlineOnlyDistanceLearning')}
+            onClick={() => {
+              recordEvent({
+                event: 'gibct-form-help-text-clicked',
+                'help-text-label': 'Will you be taking any classes in person?',
+              });
+              dispatchShowModal('onlineOnlyDistanceLearning');
+            }}
             ariaLabel="Learn more about how we calculate your housing allowance based on where you take classes"
             butttonId="classes-in-person-learn-more"
           />
@@ -92,6 +102,12 @@ export function TuitionAndHousingEstimates({
         options={[{ value: 'no', label: 'Yes' }, { value: 'yes', label: 'No' }]}
         value={onlineClasses}
         onChange={e => {
+          recordEvent({
+            event: 'howToWizard-formChange',
+            'form-field-type': 'form-radio-buttons',
+            'form-field-label': 'Will you be taking any classes in person ?',
+            'form-field-value': e.target.value,
+          });
           setOnlineClasses(e.target.value);
         }}
       />

--- a/src/applications/gi-sandbox/containers/search/NameSearchForm.jsx
+++ b/src/applications/gi-sandbox/containers/search/NameSearchForm.jsx
@@ -9,6 +9,7 @@ import KeywordSearch from '../../components/search/KeywordSearch';
 import { updateUrlParams } from '../../selectors/search';
 import { useHistory } from 'react-router-dom';
 import { TABS } from '../../constants';
+import recordEvent from 'platform/monitoring/record-event';
 
 export function NameSearchForm({
   autocomplete,
@@ -78,6 +79,11 @@ export function NameSearchForm({
   const handleSubmit = event => {
     event.preventDefault();
     if (validateSearchTerm(name)) {
+      recordEvent({
+        event: 'gibct-form-change',
+        'gibct-form-field': 'nameSearch',
+        'gibct-form-value': name,
+      });
       doSearch(name);
     }
   };

--- a/src/applications/gi-sandbox/containers/search/NameSearchResults.jsx
+++ b/src/applications/gi-sandbox/containers/search/NameSearchResults.jsx
@@ -11,6 +11,7 @@ import { updateUrlParams } from '../../selectors/search';
 import { getFiltersChanged } from '../../selectors/filters';
 import MobileFilterControls from '../../components/MobileFilterControls';
 import { focusElement } from 'platform/utilities/ui';
+import recordEvent from 'platform/monitoring/record-event';
 
 export function NameSearchResults({
   dispatchFetchSearchByNameResults,
@@ -34,11 +35,26 @@ export function NameSearchResults({
     },
     [search.name.results],
   );
+
   useEffect(
     () => {
       focusElement('#name-search-results-count');
+
+      recordEvent({
+        event: 'onsite-search-results-change',
+        'search-page-path': '/?search=name',
+        'search-query': name,
+        'search-results-total-count': count,
+        'search-results-total-pages': totalPages,
+        'search-selection': 'Search By Name',
+        'sitewide-search-app-used': false,
+        'type-ahead-option-keyword-selected': undefined,
+        'type-ahead-option-position': undefined,
+        'type-ahead-options-list': undefined,
+        'type-ahead-options-count': undefined,
+      });
     },
-    [results],
+    [results, name, totalPages, count],
   );
   const fetchPage = page => {
     dispatchFetchSearchByNameResults(name, page, filters, version);


### PR DESCRIPTION
## Description
OCTO reported the GIBCT Redesign is missing critical Google Analytics.  After conducting thorough analysis and collaboration with the OCTO team it was determined by OCTO GIBCT Redesign cannot be released to production without Google Analytics.

This story is to add Analytics to the Search Name Page.

- Name search executed
- Name Search terms
- User selects from autocomplete results listing
- Name search returns 0 results
- "Tuition housing & estimates" Accordion
  - Accordion opens
  - Update selections inside accordion - which selections
  - "Learn more" selected - which ones?
- "Filter your search" accordion
  - Accordion opens
  - Update selections inside accordion - which selections
  - "Learn more" selected - which ones?

## Original issue(s)
department-of-veterans-affairs/va.gov-team#32625


## Testing done
Trigger events via UI, validated using ObservePoint TagDebugger chrome extension


## Screenshots

* Search Results (cm41 = number of results, cm42 = total number of pages)
![image](https://user-images.githubusercontent.com/90346049/140976724-c616bea2-79f8-4e6d-a8d2-8279091257ef.png)

* Search Executed and search term 
![image](https://user-images.githubusercontent.com/90346049/140976910-ae281afb-930a-43f6-949e-f9c457ef1dcb.png)

* Accordion Opened
![image](https://user-images.githubusercontent.com/90346049/140976966-710cfc9a-4ddc-4a9f-8343-0263b4a58091.png)

* Filter changed
![image](https://user-images.githubusercontent.com/90346049/140977036-5d277585-c10d-4cc2-9ca9-d031cd6e7b64.png)

* Learn More clicked
![image](https://user-images.githubusercontent.com/90346049/140977063-27f88ab0-c238-4955-bc5e-0b2151960037.png)

## Acceptance criteria
- [ ] GA event triggered when name search executed
- [ ] GA event triggered logging name search terms
- [ ] GA event triggered when user selects from autocomplete results listing
- [ ] GA event triggered showing number of results
- [ ] GA event triggered when "Tuition housing & estimates" accordion opened/closed
- [ ] GA event triggered when selection changed in "Tuition housing & estimates" accordion
- [ ] GA event triggered when learn more selected under "Tuition housing & estimates" accordion
- [ ] GA event triggered when "Filter your search" accordion opened/closed
- [ ] GA event triggered when selection changed in "Filter your search" accordion
- [ ] GA event triggered when learn more selected under "Filter your search" accordion


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
