### PR TITLE
Rebalance Cypress parallelization on GitHub Actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -390,7 +390,7 @@ jobs:
     name: Cypress E2E Tests
     runs-on: self-hosted
     needs: [build, cypress-tests-prep]
-    if: ${{ needs.cypress-tests-prep.outputs.num_containers > 0 }}
+    if: ${{ needs.contract-tests.result == 'success' }}
     container:
       image: public.ecr.aws/cypress-io/cypress/browsers:node14.16.0-chrome90-ff88
       options: -u 1001:1001 -v /usr/local/share:/share
@@ -399,7 +399,7 @@ jobs:
       fail-fast: false
       max-parallel: 8
       matrix:
-        ci_node_index: ${{ fromJson(needs.cypress-tests-prep.outputs.ci_node_index) }}
+        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7]
 
     env:
       CHROMEDRIVER_FILEPATH: /share/chrome_driver/chromedriver
@@ -445,7 +445,6 @@ jobs:
         env:
           CYPRESS_CI: true
           STEP: ${{ matrix.ci_node_index }}
-          NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
           TESTS: ${{ needs.cypress-tests-prep.outputs.tests }}
 
       - name: Archive test videos

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -409,8 +409,7 @@ jobs:
 
     steps:
       - name: Test
-        run: |
-          curl ${{ fromJson(needs.cypress-tests-prep.outputs.selected) }}
+        run: curl ${{ needs.cypress-tests-prep.outputs.selected }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -392,8 +392,7 @@ jobs:
     needs: [build, cypress-tests-prep]
     if: |
       needs.build.result == 'success' &&
-      needs.cypress-tests-prep.result == 'success' &&
-      fromJson(needs.cypress-tests-prep.outputs.selected) != '' 
+      needs.cypress-tests-prep.result == 'success'
     container:
       image: public.ecr.aws/cypress-io/cypress/browsers:node14.16.0-chrome90-ff88
       options: -u 1001:1001 -v /usr/local/share:/share
@@ -409,6 +408,10 @@ jobs:
       NODE_EXTRA_CA_CERTS: /share/ca-certificates/VA-Internal-S2-RCA1-v1.cer.crt
 
     steps:
+      - name: Run Pact verify
+        run: |
+          test ${{ fromJson(needs.cypress-tests-prep.outputs.selected) }}'
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -409,7 +409,8 @@ jobs:
 
     steps:
       - name: Test
-        run: curl ${{ needs.cypress-tests-prep.outputs.selected }} ${{ needs.cypress-tests-prep.outputs..selected != '' }}
+        run: |
+          curl ${{ needs.cypress-tests-prep.outputs.selected }} ${{ needs.cypress-tests-prep.outputs..selected != '' }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -390,10 +390,10 @@ jobs:
     name: Cypress E2E Tests
     runs-on: self-hosted
     needs: [build, cypress-tests-prep]
-    if: ${{ needs.build.result == 'success' }}
     if: |
       needs.build.result == 'success' &&
       needs.cypress-tests-prep.result == 'success' &&
+      fromJson(needs.cypress-tests-prep.outputs.selected != '') 
     container:
       image: public.ecr.aws/cypress-io/cypress/browsers:node14.16.0-chrome90-ff88
       options: -u 1001:1001 -v /usr/local/share:/share

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -410,7 +410,7 @@ jobs:
     steps:
       - name: Test
         run: |
-          curl ${{ fromJson(needs.cypress-tests-prep.outputs.selected) }}'
+          curl ${{ fromJson(needs.cypress-tests-prep.outputs.selected) }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -408,7 +408,7 @@ jobs:
 
     steps:
       - name: Test
-        run: curl ${{ needs.cypress-tests-prep.outputs.tests }} ${{ needs.cypress-tests-prep.outputs.tests != "['']" }}
+        run: curl ${{ needs.cypress-tests-prep.outputs.tests }} ${{ needs.cypress-tests-prep.outputs.tests != '[\'\']' }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -390,7 +390,10 @@ jobs:
     name: Cypress E2E Tests
     runs-on: self-hosted
     needs: [build, cypress-tests-prep]
-    if: ${{ needs.contract-tests.result == 'success' }}
+    if: ${{ needs.build.result == 'success' }}
+    if: |
+      needs.build.result == 'success' &&
+      needs.cypress-tests-prep.result == 'success' &&
     container:
       image: public.ecr.aws/cypress-io/cypress/browsers:node14.16.0-chrome90-ff88
       options: -u 1001:1001 -v /usr/local/share:/share

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -408,7 +408,7 @@ jobs:
 
     steps:
       - name: Test
-        run: curl ${{ needs.cypress-tests-prep.outputs.tests }} ${{ needs.cypress-tests-prep.outputs.tests != '' }}
+        run: curl ${{ needs.cypress-tests-prep.outputs.tests }} ${{ needs.cypress-tests-prep.outputs.tests != '[]' }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -391,7 +391,6 @@ jobs:
     runs-on: self-hosted
     needs: [cypress-tests-prep]
     if: |
-      needs.build.result == 'success' &&
       needs.cypress-tests-prep.result == 'success'
     container:
       image: public.ecr.aws/cypress-io/cypress/browsers:node14.16.0-chrome90-ff88

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -408,7 +408,7 @@ jobs:
 
     steps:
       - name: Test
-        run: curl ${{ needs.cypress-tests-prep.outputs.tests }} ${{ needs.cypress-tests-prep.outputs.tests != [''] }}
+        run: curl ${{ needs.cypress-tests-prep.outputs.tests }} ${{ needs.cypress-tests-prep.outputs.tests != "['']" }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -408,7 +408,7 @@ jobs:
 
     steps:
       - name: Test
-        run: curl ${{ needs.cypress-tests-prep.outputs.tests }} ${{ needs.cypress-tests-prep.outputs.tests != '[\'\']' }}
+        run: curl ${{ needs.cypress-tests-prep.outputs.tests }} ${{ needs.cypress-tests-prep.outputs.tests != '' }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -409,7 +409,7 @@ jobs:
 
     steps:
       - name: Test
-        run: curl ${{ needs.cypress-tests-prep.outputs.selected }}
+        run: curl ${{ needs.cypress-tests-prep.outputs }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -391,7 +391,7 @@ jobs:
     runs-on: self-hosted
     needs: [build, cypress-tests-prep]
     if: |
-      needs.build.result = 'success' &&
+      needs.build.result == 'success' &&
       needs.cypress-tests-prep.result == 'success' &&
       needs.cypress-tests-prep.outputs.tests != '[]'
     container:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -409,7 +409,7 @@ jobs:
 
     steps:
       - name: Test
-        run: curl ${{ needs.cypress-tests-prep.outputs.selected }} ${{ needs.cypress-tests-prep.outputs..selected != '' }}
+        run: curl ${{ needs.cypress-tests-prep.outputs.selected }} ${{ needs.cypress-tests-prep.outputs.selected != '' }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -389,9 +389,11 @@ jobs:
   cypress-tests:
     name: Cypress E2E Tests
     runs-on: self-hosted
-    needs: [cypress-tests-prep]
+    needs: [build, cypress-tests-prep]
     if: |
-      needs.cypress-tests-prep.result == 'success'
+      needs.build.result = 'success' &&
+      needs.cypress-tests-prep.result == 'success' &&
+      needs.cypress-tests-prep.outputs.tests != '[]'
     container:
       image: public.ecr.aws/cypress-io/cypress/browsers:node14.16.0-chrome90-ff88
       options: -u 1001:1001 -v /usr/local/share:/share
@@ -407,9 +409,6 @@ jobs:
       NODE_EXTRA_CA_CERTS: /share/ca-certificates/VA-Internal-S2-RCA1-v1.cer.crt
 
     steps:
-      - name: Test
-        run: curl ${{ needs.cypress-tests-prep.outputs.tests }} ${{ needs.cypress-tests-prep.outputs.tests != '[]' }}
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -393,7 +393,7 @@ jobs:
     if: |
       needs.build.result == 'success' &&
       needs.cypress-tests-prep.result == 'success' &&
-      fromJson(needs.cypress-tests-prep.outputs.selected != '') 
+      fromJson(needs.cypress-tests-prep.outputs.selected) != '' 
     container:
       image: public.ecr.aws/cypress-io/cypress/browsers:node14.16.0-chrome90-ff88
       options: -u 1001:1001 -v /usr/local/share:/share

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -408,9 +408,9 @@ jobs:
       NODE_EXTRA_CA_CERTS: /share/ca-certificates/VA-Internal-S2-RCA1-v1.cer.crt
 
     steps:
-      - name: Run Pact verify
+      - name: Test
         run: |
-          test ${{ fromJson(needs.cypress-tests-prep.outputs.selected) }}'
+          curl ${{ fromJson(needs.cypress-tests-prep.outputs.selected) }}'
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -409,8 +409,7 @@ jobs:
 
     steps:
       - name: Test
-        run: |
-          curl ${{ needs.cypress-tests-prep.outputs.selected }} ${{ needs.cypress-tests-prep.outputs..selected != '' }}
+        run: curl ${{ needs.cypress-tests-prep.outputs.selected }} ${{ needs.cypress-tests-prep.outputs..selected != '' }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -408,7 +408,7 @@ jobs:
 
     steps:
       - name: Test
-        run: curl ${{ needs.cypress-tests-prep.outputs.tests }} ${{ needs.cypress-tests-prep.outputs.tests != '' }}
+        run: curl ${{ needs.cypress-tests-prep.outputs.tests }} ${{ needs.cypress-tests-prep.outputs.tests != [''] }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -409,7 +409,7 @@ jobs:
 
     steps:
       - name: Test
-        run: curl ${{ needs.cypress-tests-prep.outputs }}
+        run: curl ${{ needs.cypress-tests-prep.outputs.selected }} ${{ needs.cypress-tests-prep.outputs..selected != '' }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -389,7 +389,7 @@ jobs:
   cypress-tests:
     name: Cypress E2E Tests
     runs-on: self-hosted
-    needs: [build, cypress-tests-prep]
+    needs: [cypress-tests-prep]
     if: |
       needs.build.result == 'success' &&
       needs.cypress-tests-prep.result == 'success'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -589,7 +589,7 @@ jobs:
         run: yarn contract-mochawesome-to-bigquery
         working-directory: testing-tools-team-dashboard-data
         env:
-          NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
+          NUM_CONTAINERS: 8
           TEST_EXECUTIONS_TABLE_NAME: vets_website_contract_test_suite_executions
           TEST_RESULTS_TABLE_NAME: vets_website_contract_test_results
           TEST_REPORTS_FOLDER_NAME: vets-website-contract-test-reports
@@ -614,7 +614,7 @@ jobs:
     name: Testing Reports - Cypress E2E Tests
     runs-on: ubuntu-latest
     needs: [testing-reports-prep, cypress-tests-prep, cypress-tests]
-    if: ${{ always() && needs.cypress-tests-prep.outputs.num_containers > 0 && (needs.cypress-tests.result == 'success' || needs.cypress-tests.result == 'failure') }}
+    if: ${{ always() && needs.cypress-tests-prep.outputs.tests != '[]' && (needs.cypress-tests.result == 'success' || needs.cypress-tests.result == 'failure') }}
     env:
       APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
     continue-on-error: true
@@ -729,7 +729,7 @@ jobs:
         working-directory: testing-tools-team-dashboard-data
         env:
           IS_MASTER_BUILD: ${{ needs.cypress-tests-prep.outputs.is_master_build }}
-          NUM_CONTAINERS: ${{ needs.cypress-tests-prep.outputs.num_containers }}
+          NUM_CONTAINERS: 8
           TEST_EXECUTIONS_TABLE_NAME: cypress_test_suite_executions
           TEST_RESULTS_TABLE_NAME: cypress_test_results
           TEST_REPORTS_FOLDER_NAME: vets-website-cypress-reports

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -366,7 +366,7 @@ jobs:
         id: changed-files
         run: echo ::set-output name=all_changed_files::$(git diff --name-only origin/master...)
 
-      - name: Set TESTS variables
+      - name: Set TESTS variable
         run: node script/github-actions/select-cypress-tests.js
         env:
           IS_MASTER_BUILD: ${{ env.IS_MASTER_BUILD }}
@@ -589,7 +589,7 @@ jobs:
         run: yarn contract-mochawesome-to-bigquery
         working-directory: testing-tools-team-dashboard-data
         env:
-          NUM_CONTAINERS: 8
+          NUM_CONTAINERS: '8'
           TEST_EXECUTIONS_TABLE_NAME: vets_website_contract_test_suite_executions
           TEST_RESULTS_TABLE_NAME: vets_website_contract_test_results
           TEST_REPORTS_FOLDER_NAME: vets-website-contract-test-reports
@@ -729,7 +729,7 @@ jobs:
         working-directory: testing-tools-team-dashboard-data
         env:
           IS_MASTER_BUILD: ${{ needs.cypress-tests-prep.outputs.is_master_build }}
-          NUM_CONTAINERS: 8
+          NUM_CONTAINERS: '8'
           TEST_EXECUTIONS_TABLE_NAME: cypress_test_suite_executions
           TEST_RESULTS_TABLE_NAME: cypress_test_results
           TEST_REPORTS_FOLDER_NAME: vets-website-cypress-reports

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -409,7 +409,7 @@ jobs:
 
     steps:
       - name: Test
-        run: curl ${{ needs.cypress-tests-prep.outputs.selected }} ${{ needs.cypress-tests-prep.outputs.selected != '' }}
+        run: curl ${{ needs.cypress-tests-prep.outputs.tests }} ${{ needs.cypress-tests-prep.outputs.tests != '' }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -336,8 +336,6 @@ jobs:
     name: Prep for Cypress Tests
     runs-on: ubuntu-latest
     outputs:
-      num_containers: ${{ steps.containers.outputs.num }}
-      ci_node_index: ${{ steps.matrix.outputs.ci_node_index }}
       tests: ${{ steps.tests.outputs.selected }}
       is_master_build: ${{ env.IS_MASTER_BUILD }}
 
@@ -368,19 +366,11 @@ jobs:
         id: changed-files
         run: echo ::set-output name=all_changed_files::$(git diff --name-only origin/master...)
 
-      - name: Set NUM_CONTAINERS, CI_NODE_INDEX, TESTS variables
+      - name: Set TESTS variables
         run: node script/github-actions/select-cypress-tests.js
         env:
           IS_MASTER_BUILD: ${{ env.IS_MASTER_BUILD }}
           CHANGED_FILE_PATHS: ${{ steps.changed-files.outputs.all_changed_files }}
-
-      - name: Set output of NUM_CONTAINERS
-        id: containers
-        run: echo ::set-output name=num::$NUM_CONTAINERS
-
-      - name: Set output of CI_NODE_INDEX
-        id: matrix
-        run: echo ::set-output name=ci_node_index::$CI_NODE_INDEX
 
       - name: Set output of TESTS
         id: tests

--- a/script/github-actions/run-cypress-tests.js
+++ b/script/github-actions/run-cypress-tests.js
@@ -1,16 +1,19 @@
 const { runCommandSync } = require('../utils');
 
 const tests = JSON.parse(process.env.TESTS);
-const step = Number(process.env.STEP);
-const divider = Math.ceil(tests.length / Number(process.env.NUM_CONTAINERS));
+const step = JSON.parse(process.env.STEP);
+const divider = Math.ceil(tests.length / 8);
 
 const batch = tests
   .map(test => test.replace('/home/runner/work', '/__w'))
   .slice(step * divider, (step + 1) * divider)
   .join(',');
 
-const status = runCommandSync(
-  `yarn cy:run --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.json" --spec '${batch}'`,
-);
-
-process.exit(status);
+if (batch !== '') {
+  const status = runCommandSync(
+    `yarn cy:run --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.json" --spec '${batch}'`,
+  );
+  process.exit(status);
+} else {
+  process.exit(0);
+}

--- a/script/github-actions/run-cypress-tests.js
+++ b/script/github-actions/run-cypress-tests.js
@@ -1,7 +1,7 @@
 const { runCommandSync } = require('../utils');
 
 const tests = JSON.parse(process.env.TESTS);
-const step = JSON.parse(process.env.STEP);
+const step = Number(process.env.STEP);
 const divider = Math.ceil(tests.length / 8);
 
 const batch = tests

--- a/script/github-actions/select-cypress-tests.js
+++ b/script/github-actions/select-cypress-tests.js
@@ -197,9 +197,7 @@ function selectTests(graph, pathsOfChangedFiles) {
 }
 
 function exportVariables(tests) {
-  // eslint-disable-next-line no-console
-  console.log(tests);
-  core.exportVariable('TESTS', []);
+  core.exportVariable('TESTS', tests);
 }
 
 function run() {

--- a/script/github-actions/select-cypress-tests.js
+++ b/script/github-actions/select-cypress-tests.js
@@ -197,38 +197,7 @@ function selectTests(graph, pathsOfChangedFiles) {
 }
 
 function exportVariables(tests) {
-  const numTests = tests.length;
-
-  // core.exportVariable() exports variable to GitHub Actions workflow
-  if (numTests === 0) {
-    core.exportVariable('NUM_CONTAINERS', 0);
-  } else if (numTests <= 20) {
-    core.exportVariable('NUM_CONTAINERS', 1);
-    core.exportVariable('CI_NODE_INDEX', [0]);
-  } else if (numTests <= 40) {
-    core.exportVariable('NUM_CONTAINERS', 2);
-    core.exportVariable('CI_NODE_INDEX', [0, 1]);
-  } else if (numTests <= 60) {
-    core.exportVariable('NUM_CONTAINERS', 3);
-    core.exportVariable('CI_NODE_INDEX', [0, 1, 2]);
-  } else if (numTests <= 80) {
-    core.exportVariable('NUM_CONTAINERS', 4);
-    core.exportVariable('CI_NODE_INDEX', [0, 1, 2, 3]);
-  } else if (numTests <= 100) {
-    core.exportVariable('NUM_CONTAINERS', 5);
-    core.exportVariable('CI_NODE_INDEX', [0, 1, 2, 3, 4]);
-  } else if (numTests <= 120) {
-    core.exportVariable('NUM_CONTAINERS', 6);
-    core.exportVariable('CI_NODE_INDEX', [0, 1, 2, 3, 4, 5]);
-  } else if (numTests <= 140) {
-    core.exportVariable('NUM_CONTAINERS', 7);
-    core.exportVariable('CI_NODE_INDEX', [0, 1, 2, 3, 4, 5, 6]);
-  } else {
-    core.exportVariable('NUM_CONTAINERS', 8);
-    core.exportVariable('CI_NODE_INDEX', [0, 1, 2, 3, 4, 5, 6, 7]);
-  }
-
-  if (numTests > 0) core.exportVariable('TESTS', tests);
+  core.exportVariable('TESTS', tests);
 }
 
 function run() {

--- a/script/github-actions/select-cypress-tests.js
+++ b/script/github-actions/select-cypress-tests.js
@@ -197,7 +197,9 @@ function selectTests(graph, pathsOfChangedFiles) {
 }
 
 function exportVariables(tests) {
-  core.exportVariable('TESTS', tests);
+  // eslint-disable-next-line no-console
+  console.log(tests);
+  core.exportVariable('TESTS', []);
 }
 
 function run() {


### PR DESCRIPTION
## Description
This PR modifies parallelization of Cypress tests on GitHub Actions so that tests are always distributed among eight Docker containers instead of a variable amount in order to reduce CI times.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/32647

## Acceptance criteria
- [ ] CI passes.