### PR TITLE
Profile Page Analytics

### DIFF
--- a/src/applications/gi-sandbox/components/BackToTop.jsx
+++ b/src/applications/gi-sandbox/components/BackToTop.jsx
@@ -2,6 +2,8 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import classNames from 'classnames';
+import recordEvent from 'platform/monitoring/record-event';
+import environment from 'platform/utilities/environment';
 
 /**
  * This thing has a hack in it to make sure the when the element is floating at bottom of page it is on the right side
@@ -116,7 +118,18 @@ export default function BackToTop({
             <button
               type="button"
               className="usa-button va-top-button-transition-in"
-              onClick={() => scrollToTop()}
+              onClick={
+                environment.isProduction()
+                  ? () => scrollToTop()
+                  : () => {
+                      scrollToTop();
+                      recordEvent({
+                        event: 'button_click',
+                        'button-text': 'Back to top',
+                        'button-type': 'Default|Back to Top',
+                      });
+                    }
+              }
             >
               <span>
                 <i aria-hidden="true" className="fas fa-arrow-up" role="img" />

--- a/src/applications/gi-sandbox/components/BackToTop.jsx
+++ b/src/applications/gi-sandbox/components/BackToTop.jsx
@@ -3,7 +3,6 @@ import React, { useEffect, useRef, useState, useCallback } from 'react';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import classNames from 'classnames';
 import recordEvent from 'platform/monitoring/record-event';
-import environment from 'platform/utilities/environment';
 
 /**
  * This thing has a hack in it to make sure the when the element is floating at bottom of page it is on the right side
@@ -124,18 +123,14 @@ export default function BackToTop({
             <button
               type="button"
               className="usa-button va-top-button-transition-in"
-              onClick={
-                environment.isProduction()
-                  ? () => scrollToTop()
-                  : () => {
-                      scrollToTop();
-                      recordEvent({
-                        event: 'button_click',
-                        'button-text': 'Back to top',
-                        'button-type': 'Default|Back to Top',
-                      });
-                    }
-              }
+              onClick={() => {
+                scrollToTop();
+                recordEvent({
+                  event: 'button_click',
+                  'button-text': 'Back to top',
+                  'button-type': 'Default|Back to Top',
+                });
+              }}
             >
               <span>
                 <i aria-hidden="true" className="fas fa-arrow-up" role="img" />

--- a/src/applications/gi-sandbox/components/BackToTop.jsx
+++ b/src/applications/gi-sandbox/components/BackToTop.jsx
@@ -126,7 +126,7 @@ export default function BackToTop({
               onClick={() => {
                 scrollToTop();
                 recordEvent({
-                  event: 'button_click',
+                  event: 'button_click Back to top',
                   'button-text': 'Back to top',
                   'button-type': 'Default|Back to Top',
                 });

--- a/src/applications/gi-sandbox/components/BackToTop.jsx
+++ b/src/applications/gi-sandbox/components/BackToTop.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
 
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import classNames from 'classnames';
@@ -64,34 +64,40 @@ export default function BackToTop({
       }
       setCompareOpen(compare.open);
     },
-    [scrolled, smallScreen, compare.open],
+    [scrolled, smallScreen, compare.open, profilePageHeaderId, compareOpen],
   );
 
-  const resize = () => {
-    if (floating) {
-      const parentElement = document.getElementById(parentId);
-      if (parentElement) {
-        const parentX = parentElement.getBoundingClientRect().x;
-        setBackToTopContainerStyle({ right: parentX });
+  const resize = useCallback(
+    () => {
+      if (floating) {
+        const parentElement = document.getElementById(parentId);
+        if (parentElement) {
+          const parentX = parentElement.getBoundingClientRect().x;
+          setBackToTopContainerStyle({ right: parentX });
+        }
       }
-    }
-  };
+    },
+    [floating, parentId],
+  );
 
-  useEffect(() => {
-    window.addEventListener('scroll', handleScroll, true);
-    window.addEventListener('resize', resize);
+  useEffect(
+    () => {
+      window.addEventListener('scroll', handleScroll, true);
+      window.addEventListener('resize', resize);
 
-    return () => {
-      window.removeEventListener('scroll', handleScroll, true);
-      window.removeEventListener('scroll', resize, true);
-    };
-  }, []);
+      return () => {
+        window.removeEventListener('scroll', handleScroll, true);
+        window.removeEventListener('scroll', resize, true);
+      };
+    },
+    [resize],
+  );
 
   useEffect(
     () => {
       resize();
     },
-    [floating],
+    [floating, resize],
   );
 
   const backToTopClasses = classNames('back-to-top', {

--- a/src/applications/gi-sandbox/components/CautionFlagAdditionalInfo.jsx
+++ b/src/applications/gi-sandbox/components/CautionFlagAdditionalInfo.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import classNames from 'classnames';
 import JumpLink from './profile/JumpLink';
+import recordEvent from 'platform/monitoring/record-event';
+import environment from 'platform/utilities/environment';
 
 export const CautionFlagAdditionalInfo = ({
   cautionFlags,
@@ -21,7 +23,18 @@ export const CautionFlagAdditionalInfo = ({
       <div className="usa-alert-body ">
         <button
           className="caution-flag-toggle"
-          onClick={() => toggleExpansion(!expanded)}
+          onClick={
+            environment.isProduction()
+              ? () => toggleExpansion(!expanded)
+              : () => {
+                  toggleExpansion(!expanded);
+                  recordEvent(
+                    !expanded
+                      ? { event: 'caution-flag-additional-info-expand' }
+                      : { event: 'caution-flag-additional-info-collapsed' },
+                  );
+                }
+          }
         >
           <div className="vads-u-display--flex">
             <div>

--- a/src/applications/gi-sandbox/components/CautionFlagAdditionalInfo.jsx
+++ b/src/applications/gi-sandbox/components/CautionFlagAdditionalInfo.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import classNames from 'classnames';
 import JumpLink from './profile/JumpLink';
 import recordEvent from 'platform/monitoring/record-event';
-import environment from 'platform/utilities/environment';
 
 export const CautionFlagAdditionalInfo = ({
   cautionFlags,
@@ -23,18 +22,14 @@ export const CautionFlagAdditionalInfo = ({
       <div className="usa-alert-body ">
         <button
           className="caution-flag-toggle"
-          onClick={
-            environment.isProduction()
-              ? () => toggleExpansion(!expanded)
-              : () => {
-                  toggleExpansion(!expanded);
-                  recordEvent(
-                    !expanded
-                      ? { event: 'caution-flag-additional-info-expand' }
-                      : { event: 'caution-flag-additional-info-collapsed' },
-                  );
-                }
-          }
+          onClick={() => {
+            toggleExpansion(!expanded);
+            recordEvent(
+              !expanded
+                ? { event: 'caution-flag-additional-info-expand' }
+                : { event: 'caution-flag-additional-info-collapsed' },
+            );
+          }}
         >
           <div className="vads-u-display--flex">
             <div>

--- a/src/applications/gi-sandbox/components/LearnMoreLabel.jsx
+++ b/src/applications/gi-sandbox/components/LearnMoreLabel.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { focusElement } from 'platform/utilities/ui';
 import classNames from 'classnames';
+import recordEvent from 'platform/monitoring/record-event';
 
 export default function LearnMoreLabel({
   ariaLabel,
@@ -33,7 +34,12 @@ export default function LearnMoreLabel({
           'vads-u-font-weight--bold': bold,
         },
       )}
-      onClick={focusElement(labelFor)}
+      onClick={() => {
+        focusElement(labelFor);
+        recordEvent({
+          event: `Learn more clicked for ${labelFor}`,
+        });
+      }}
     >
       {bold ? <strong>{displayText}</strong> : displayText}
       <span

--- a/src/applications/gi-sandbox/components/profile/CalculateYourBenefitsForm.jsx
+++ b/src/applications/gi-sandbox/components/profile/CalculateYourBenefitsForm.jsx
@@ -25,6 +25,7 @@ import AccordionItem from '../AccordionItem';
 import BenefitsForm from './BenefitsForm';
 import LearnMoreLabel from '../LearnMoreLabel';
 import scrollTo from 'platform/utilities/ui/scrollTo';
+import environment from 'platform/utilities/environment';
 
 function CalculateYourBenefitsForm({
   calculatorInputChange,
@@ -124,6 +125,22 @@ function CalculateYourBenefitsForm({
           'gibct-form-value': 'other location',
         });
       }
+    }
+    if (environment.isProduction()) {
+      return;
+    }
+    if (
+      field === 'buyUp' ||
+      field === 'inState' ||
+      field === 'kickerEligible' ||
+      field === 'yellowRibbonRecipient' ||
+      field === 'giBillBenefit'
+    ) {
+      recordEvent({
+        event: 'int-radio-button-option-click',
+        'radio-button-label': field,
+        'radio-button-optionLabel': value,
+      });
     }
   };
 

--- a/src/applications/gi-sandbox/components/profile/CalculateYourBenefitsForm.jsx
+++ b/src/applications/gi-sandbox/components/profile/CalculateYourBenefitsForm.jsx
@@ -25,7 +25,6 @@ import AccordionItem from '../AccordionItem';
 import BenefitsForm from './BenefitsForm';
 import LearnMoreLabel from '../LearnMoreLabel';
 import scrollTo from 'platform/utilities/ui/scrollTo';
-import environment from 'platform/utilities/environment';
 
 function CalculateYourBenefitsForm({
   calculatorInputChange,
@@ -125,9 +124,6 @@ function CalculateYourBenefitsForm({
           'gibct-form-value': 'other location',
         });
       }
-    }
-    if (environment.isProduction()) {
-      return;
     }
     if (
       field === 'buyUp' ||

--- a/src/applications/gi-sandbox/components/profile/SchoolLocations.jsx
+++ b/src/applications/gi-sandbox/components/profile/SchoolLocations.jsx
@@ -4,7 +4,6 @@ import { locationInfo, upperCaseFirstLetterOnly } from '../../utils/helpers';
 import ResponsiveTable from '../ResponsiveTable';
 import { Link } from 'react-router-dom';
 import recordEvent from 'platform/monitoring/record-event';
-import environment from 'platform/utilities/environment';
 
 export default function SchoolLocations({
   calculator,
@@ -73,17 +72,13 @@ export default function SchoolLocations({
     setViewableRowCount(totalRowCount);
     setViewAll(true);
     setFocusedElementIndex(previousRowCount);
-    if (!environment.isProduction()) {
-      recordEvent({ event: 'view-all-locations-click' });
-    }
+    recordEvent({ event: 'view-all-locations-click' });
   };
 
   const handleViewLessClicked = () => {
     if (onViewLess) {
       onViewLess();
-      if (!environment.isProduction()) {
-        recordEvent({ event: 'view-less-locations-click' });
-      }
+      recordEvent({ event: 'view-less-locations-click' });
     }
 
     setViewableRowCount(initialRowCount);
@@ -101,9 +96,7 @@ export default function SchoolLocations({
 
     setViewableRowCount(newViewableRowCount);
     setFocusedElementIndex(previousRowCount);
-    if (!environment.isProduction()) {
-      recordEvent({ event: 'view-more-locations-click' });
-    }
+    recordEvent({ event: 'view-more-locations-click' });
   };
 
   const schoolLocationTableInfo = (

--- a/src/applications/gi-sandbox/components/profile/SchoolLocations.jsx
+++ b/src/applications/gi-sandbox/components/profile/SchoolLocations.jsx
@@ -3,6 +3,8 @@ import { getCalculatedBenefits } from '../../selectors/calculator';
 import { locationInfo, upperCaseFirstLetterOnly } from '../../utils/helpers';
 import ResponsiveTable from '../ResponsiveTable';
 import { Link } from 'react-router-dom';
+import recordEvent from 'platform/monitoring/record-event';
+import environment from 'platform/utilities/environment';
 
 export default function SchoolLocations({
   calculator,
@@ -71,11 +73,17 @@ export default function SchoolLocations({
     setViewableRowCount(totalRowCount);
     setViewAll(true);
     setFocusedElementIndex(previousRowCount);
+    if (!environment.isProduction()) {
+      recordEvent({ event: 'view-all-locations-click' });
+    }
   };
 
   const handleViewLessClicked = () => {
     if (onViewLess) {
       onViewLess();
+      if (!environment.isProduction()) {
+        recordEvent({ event: 'view-less-locations-click' });
+      }
     }
 
     setViewableRowCount(initialRowCount);
@@ -93,6 +101,9 @@ export default function SchoolLocations({
 
     setViewableRowCount(newViewableRowCount);
     setFocusedElementIndex(previousRowCount);
+    if (!environment.isProduction()) {
+      recordEvent({ event: 'view-more-locations-click' });
+    }
   };
 
   const schoolLocationTableInfo = (


### PR DESCRIPTION
added analytics to back to top button, caution flag additional info, school location view buttons and calculate benefits radio buttons.

## Description
OCTO reported the GIBCT Redesign is missing critical Google Analytics. After conducting thorough analysis and collaboration with the OCTO team it was determined by OCTO GIBCT Redesign cannot be released to production without Google Analytics

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/32631


## Testing done
Trigger events via UI, validated using ObservePoint TagDebugger chrome extension


## Screenshots
Caution Flags
<img width="273" alt="Screen Shot 2021-11-10 at 8 55 56 AM" src="https://user-images.githubusercontent.com/18352271/141136690-a9906404-ad01-412c-a86c-c3b99f797646.png">
<img width="277" alt="Screen Shot 2021-11-10 at 8 55 41 AM" src="https://user-images.githubusercontent.com/18352271/141136691-92500b7f-7f81-4236-9c24-16d962cd9934.png">

Jump Links
<img width="273" alt="Screen Shot 2021-11-10 at 8 59 25 AM" src="https://user-images.githubusercontent.com/18352271/141136993-2c627f3a-2171-402d-b642-9f5031b81fde.png">

Learn More
<img width="281" alt="Screen Shot 2021-11-10 at 9 09 57 AM" src="https://user-images.githubusercontent.com/18352271/141138905-e6147c50-e2b2-47e8-ab6f-c5354e51318c.png">

School's Website
<img width="284" alt="Screen Shot 2021-11-10 at 9 11 44 AM" src="https://user-images.githubusercontent.com/18352271/141139240-66608fb2-ddeb-4667-9496-27593258cf4b.png">

VetTech program selection radio buttons
<img width="280" alt="Screen Shot 2021-11-10 at 9 15 09 AM" src="https://user-images.githubusercontent.com/18352271/141139773-18b0f808-94ec-4a7d-9c1f-d2b08798f84b.png">

Calculate benefits
   benefit
<img width="288" alt="Screen Shot 2021-11-10 at 9 16 58 AM" src="https://user-images.githubusercontent.com/18352271/141140332-c8c75d13-51fd-413d-b3b2-3f7a8b6dce91.png">
    adjustment
    <img width="279" alt="Screen Shot 2021-11-10 at 9 17 19 AM" src="https://user-images.githubusercontent.com/18352271/141140432-91343313-dd47-4fa3-9607-ad7eea7b5198.png">

Apply for benefits
<img width="287" alt="Screen Shot 2021-11-10 at 9 34 41 AM" src="https://user-images.githubusercontent.com/18352271/141143207-d104edf9-995f-4e5e-95d6-63936f43a9a8.png">

Submit a compliant through our Feedback System
<img width="282" alt="Screen Shot 2021-11-10 at 9 37 42 AM" src="https://user-images.githubusercontent.com/18352271/141143700-7d850b16-bf37-4114-bfb6-e96718ab2114.png">

School Location buttons
view more
<img width="277" alt="Screen Shot 2021-11-10 at 9 43 03 AM" src="https://user-images.githubusercontent.com/18352271/141144783-11ca722a-8cbd-4f95-8f74-059fc98a3453.png">

view all
<img width="278" alt="Screen Shot 2021-11-10 at 9 43 14 AM" src="https://user-images.githubusercontent.com/18352271/141144820-c7ca6dd3-96fb-47fe-9034-59f0b99904ad.png">

view less
<img width="266" alt="Screen Shot 2021-11-10 at 9 43 27 AM" src="https://user-images.githubusercontent.com/18352271/141144875-f6bfa57c-5927-49e6-ad29-a909b20c4799.png">

Back to Top
<img width="275" alt="Screen Shot 2021-11-10 at 9 48 20 AM" src="https://user-images.githubusercontent.com/18352271/141145687-dd247314-ae1e-4c10-95b2-5bbd93c8d612.png">

Exit about This Tool
<img width="281" alt="Screen Shot 2021-11-10 at 9 49 26 AM" src="https://user-images.githubusercontent.com/18352271/141145842-5e0ba128-929f-44f1-acee-e4db72d65163.png">

Download School Data
<img width="279" alt="Screen Shot 2021-11-10 at 9 50 11 AM" src="https://user-images.githubusercontent.com/18352271/141146005-7fc7254a-87e4-46d7-b8d1-25545cfeef2a.png">

## Acceptance criteria
- [ ] Add GA analytics calls to various points on profile page to trigger necessary events

## Definition of done
- [ ] GA analytics reporting if users open warning panel to view more information for schools with cautionary warnings.
- [ ]  GA analytics reporting if users visit profiles for schools with cautionary warning.
- [ ] GA analytics reportingUser engages with "On this page" jumplinks
- [ ] GA analytics reporting which"Learn more" links were selected.
- [ ] GA analytics reporting if user clicks school's website
- [ ] GA analytics reporting if user engages with program selection radio buttons (VET TEC PROFILE ONLY)
- [ ] GA analytics reporting if user engages with Calculate your benefits accordions
     - [ ] Which benefits?
     - [ ] Which adjustments?
- [ ] GA analytics reporting if user engages with content links in Apply for benefits section
- [ ] GA analytics reporting if user engages with "Submit a compliant through our Feedback System"
- [ ] GA analytics reporting if user engages with links to other schools in School locations section
- [ ] GA analytics reporting if user engages with "Back to top" element
- [ ] GA analytics reporting if user exits to About this tool page
- [ ] GA analytics reporting if user downloads data on all schools (Excel download)
