### PR TITLE
Added number of results to header

### DIFF
--- a/src/applications/facility-locator/components/SearchResultsHeader.jsx
+++ b/src/applications/facility-locator/components/SearchResultsHeader.jsx
@@ -17,6 +17,7 @@ export const SearchResultsHeader = ({
   context,
   inProgress,
   specialtyMap,
+  totalEntries,
 }) => {
   const noResultsFound = !results || !results.length;
 
@@ -64,7 +65,16 @@ export const SearchResultsHeader = ({
 
   const formattedServiceType = formatServiceType(serviceType);
 
-  const messagePrefix = noResultsFound ? 'No results found' : 'Results';
+  // const messagePrefix = noResultsFound ? 'No results found' : 'Results';
+
+  const handleNumberOfResults = () => {
+    if (noResultsFound) return 'No resutls found';
+    else if (totalEntries === 1) {
+      return '1 result';
+    } else if (totalEntries < 10 && totalEntries > 1) {
+      return `Showing 1 - ${totalEntries} results`;
+    } else return 'Resultss';
+  };
 
   return (
     <div>
@@ -73,7 +83,7 @@ export const SearchResultsHeader = ({
         className="vads-u-font-family--sans vads-u-font-weight--normal vads-u-font-size--base vads-u-padding--0p5 vads-u-margin-y--1"
         tabIndex="-1"
       >
-        {messagePrefix} for &quot;
+        {handleNumberOfResults()} for &quot;
         <b>{facilityTypes[facilityType]}</b>
         &quot;
         {formattedServiceType && (

--- a/src/applications/facility-locator/components/SearchResultsHeader.jsx
+++ b/src/applications/facility-locator/components/SearchResultsHeader.jsx
@@ -17,7 +17,7 @@ export const SearchResultsHeader = ({
   context,
   inProgress,
   specialtyMap,
-  totalEntries,
+  pagination,
 }) => {
   const noResultsFound = !results || !results.length;
 
@@ -65,15 +65,26 @@ export const SearchResultsHeader = ({
 
   const formattedServiceType = formatServiceType(serviceType);
 
-  // const messagePrefix = noResultsFound ? 'No results found' : 'Results';
+  const messagePrefix = noResultsFound ? 'No results found' : 'Results';
 
   const handleNumberOfResults = () => {
-    if (noResultsFound) return 'No resutls found';
-    else if (totalEntries === 1) {
-      return '1 result';
-    } else if (totalEntries < 10 && totalEntries > 1) {
+    const { totalEntries, currentPage, totalPages } = pagination;
+    if (noResultsFound) {
+      return 'No results found';
+    } else if (totalEntries === 1) {
+      return 'Showing 1 result';
+    } else if (totalEntries < 11 && totalEntries > 1) {
       return `Showing 1 - ${totalEntries} results`;
-    } else return 'Resultss';
+    } else if (totalEntries > 10) {
+      const startResultNum = 10 * (currentPage - 1) + 1;
+      let endResultNum;
+
+      if (currentPage !== totalPages) {
+        endResultNum = 10 * currentPage;
+      } else endResultNum = totalEntries;
+
+      return `Showing ${startResultNum} - ${endResultNum} of ${totalEntries} results`;
+    } else return 'Results';
   };
 
   return (
@@ -83,7 +94,11 @@ export const SearchResultsHeader = ({
         className="vads-u-font-family--sans vads-u-font-weight--normal vads-u-font-size--base vads-u-padding--0p5 vads-u-margin-y--1"
         tabIndex="-1"
       >
-        {handleNumberOfResults()} for &quot;
+        {facilityType === LocationType.URGENT_CARE ||
+        facilityType === LocationType.EMERGENCY_CARE
+          ? messagePrefix
+          : handleNumberOfResults()}{' '}
+        for &quot;
         <b>{facilityTypes[facilityType]}</b>
         &quot;
         {formattedServiceType && (

--- a/src/applications/facility-locator/components/SearchResultsHeader.jsx
+++ b/src/applications/facility-locator/components/SearchResultsHeader.jsx
@@ -94,8 +94,12 @@ export const SearchResultsHeader = ({
         className="vads-u-font-family--sans vads-u-font-weight--normal vads-u-font-size--base vads-u-padding--0p5 vads-u-margin-y--1"
         tabIndex="-1"
       >
-        {facilityType === LocationType.URGENT_CARE ||
-        facilityType === LocationType.EMERGENCY_CARE
+        {[
+          LocationType.URGENT_CARE,
+          LocationType.EMERGENCY_CARE,
+          LocationType.URGENT_CARE_PHARMACIES,
+          LocationType.CC_PROVIDER,
+        ].includes(facilityType)
           ? messagePrefix
           : handleNumberOfResults()}{' '}
         for &quot;

--- a/src/applications/facility-locator/containers/FacilitiesMap.jsx
+++ b/src/applications/facility-locator/containers/FacilitiesMap.jsx
@@ -445,7 +445,7 @@ const FacilitiesMap = props => {
               context={queryContext}
               specialtyMap={props.specialties}
               inProgress={currentQuery.inProgress}
-              totalEntries={pagination.totalEntries}
+              pagination={pagination}
             />
           )}
           {searchError && <p />}

--- a/src/applications/facility-locator/containers/FacilitiesMap.jsx
+++ b/src/applications/facility-locator/containers/FacilitiesMap.jsx
@@ -445,6 +445,7 @@ const FacilitiesMap = props => {
               context={queryContext}
               specialtyMap={props.specialties}
               inProgress={currentQuery.inProgress}
+              totalEntries={pagination.totalEntries}
             />
           )}
           {searchError && <p />}

--- a/src/applications/facility-locator/tests/components/search-results/SearchResultsHeader.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-results/SearchResultsHeader.unit.spec.jsx
@@ -199,7 +199,7 @@ describe('SearchResultsHeader', () => {
     wrapper.unmount();
   });
 
-  it('should render header with LocationType.CC_PROVIDER, totalEntries = 1', () => {
+  it('should render header with LocationType.CC_PROVIDER', () => {
     const wrapper = shallow(
       <SearchResultsHeader
         results={[{}]}
@@ -207,48 +207,11 @@ describe('SearchResultsHeader', () => {
         serviceType="foo"
         context="new york"
         specialtyMap={{ foo: 'test' }}
-        pagination={{ totalEntries: 1 }}
       />,
     );
 
     expect(wrapper.find('h2').text()).to.match(
-      /Showing 1 result for "Community providers \(in VA’s network\)",\s+"test"\s+near\s+"new york"/,
-    );
-    wrapper.unmount();
-  });
-
-  it('should render header with LocationType.CC_PROVIDER, totalEntries = 5', () => {
-    const wrapper = shallow(
-      <SearchResultsHeader
-        results={[{}]}
-        facilityType={LocationType.CC_PROVIDER}
-        serviceType="foo"
-        context="new york"
-        specialtyMap={{ foo: 'test' }}
-        pagination={{ totalEntries: 5 }}
-      />,
-    );
-
-    expect(wrapper.find('h2').text()).to.match(
-      /Showing 1 - 5 results for "Community providers \(in VA’s network\)",\s+"test"\s+near\s+"new york"/,
-    );
-    wrapper.unmount();
-  });
-
-  it('should render header with LocationType.CC_PROVIDER, totalEntries = 15, currentPage = 2, totalPages =2', () => {
-    const wrapper = shallow(
-      <SearchResultsHeader
-        results={[{}]}
-        facilityType={LocationType.CC_PROVIDER}
-        serviceType="foo"
-        context="new york"
-        specialtyMap={{ foo: 'test' }}
-        pagination={{ totalEntries: 15, currentPage: 2, totalPages: 2 }}
-      />,
-    );
-
-    expect(wrapper.find('h2').text()).to.match(
-      /Showing 11 - 15 of 15 results for "Community providers \(in VA’s network\)",\s+"test"\s+near\s+"new york"/,
+      /Results for "Community providers \(in VA’s network\)",\s+"test"\s+near\s+"new york"/,
     );
     wrapper.unmount();
   });

--- a/src/applications/facility-locator/tests/components/search-results/SearchResultsHeader.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-results/SearchResultsHeader.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import { SearchResultsHeader } from '../../../components/SearchResultsHeader';
 import { LocationType } from '../../../constants';
-import { urgentCareServices } from '../../../config';
+import { urgentCareServices, emergencyCareServices } from '../../../config';
 
 describe('SearchResultsHeader', () => {
   it('should not render header if context is not provided', () => {
@@ -15,7 +15,11 @@ describe('SearchResultsHeader', () => {
 
   it('should render header if results are empty and context exists', () => {
     const wrapper = shallow(
-      <SearchResultsHeader results={[]} context="11111" />,
+      <SearchResultsHeader
+        results={[]}
+        context="11111"
+        pagination={{ totalEntries: 0 }}
+      />,
     );
 
     expect(
@@ -40,27 +44,63 @@ describe('SearchResultsHeader', () => {
         results={[{}]}
         facilityType={LocationType.HEALTH}
         context={'new york'}
+        pagination={{ totalEntries: 5 }}
       />,
     );
 
     expect(wrapper.find('h2').text()).to.match(
-      /Results for "VA health",\s+"All VA health services"\s+near\s+"new york"/,
+      /Showing 1 - 5 results for "VA health",\s+"All VA health services"\s+near\s+"new york"/,
     );
     wrapper.unmount();
   });
 
-  it('should render header with LocationType.HEALTH', () => {
+  it('should render header with LocationType.HEALTH, totalEntries = 1', () => {
     const wrapper = shallow(
       <SearchResultsHeader
         results={[{}]}
         facilityType={LocationType.HEALTH}
         serviceType="PrimaryCare"
         context="new york"
+        pagination={{ totalEntries: 1 }}
       />,
     );
 
     expect(wrapper.find('h2').text()).to.match(
-      /Results for "VA health",\s+"Primary care"\s+near\s+"new york"/,
+      /Showing 1 result for "VA health",\s+"Primary care"\s+near\s+"new york"/,
+    );
+    wrapper.unmount();
+  });
+
+  it('should render header with LocationType.HEALTH, totalEntries = 5', () => {
+    const wrapper = shallow(
+      <SearchResultsHeader
+        results={[{}]}
+        facilityType={LocationType.HEALTH}
+        serviceType="PrimaryCare"
+        context="new york"
+        pagination={{ totalEntries: 5 }}
+      />,
+    );
+
+    expect(wrapper.find('h2').text()).to.match(
+      /Showing 1 - 5 results for "VA health",\s+"Primary care"\s+near\s+"new york"/,
+    );
+    wrapper.unmount();
+  });
+
+  it('should render header with LocationType.HEALTH, totalEntries = 15, currentPage = 2, totalPages = 2', () => {
+    const wrapper = shallow(
+      <SearchResultsHeader
+        results={[{}]}
+        facilityType={LocationType.HEALTH}
+        serviceType="PrimaryCare"
+        context="new york"
+        pagination={{ totalEntries: 15, currentPage: 2, totalPages: 2 }}
+      />,
+    );
+
+    expect(wrapper.find('h2').text()).to.match(
+      /Showing 11 - 15 of 15 results for "VA health",\s+"Primary care"\s+near\s+"new york"/,
     );
     wrapper.unmount();
   });
@@ -71,11 +111,12 @@ describe('SearchResultsHeader', () => {
         results={[{}]}
         facilityType={LocationType.HEALTH}
         context="new york"
+        pagination={{ totalEntries: 5 }}
       />,
     );
 
     expect(wrapper.find('h2').text()).to.match(
-      /Results for "VA health",\s+"All VA health services"\s+near\s+"new york"/,
+      /Showing 1 - 5 results for "VA health",\s+"All VA health services"\s+near\s+"new york"/,
     );
     wrapper.unmount();
   });
@@ -119,7 +160,46 @@ describe('SearchResultsHeader', () => {
     wrapper.unmount();
   });
 
-  it('should render header with LocationType.CC_PROVIDER', () => {
+  it('should render header with LocationType.EMERGENCY_CARE', () => {
+    const wrapper = shallow(
+      <SearchResultsHeader
+        results={[{}]}
+        facilityType={LocationType.EMERGENCY_CARE}
+        serviceType="NonVAEmergencyCare"
+        context="new york"
+      />,
+    );
+
+    expect(wrapper.find('h2').text()).to.match(
+      new RegExp(
+        `Results for "Emergency Care",\\s+"${
+          emergencyCareServices.NonVAEmergencyCare
+        }"\\s+near\\s+"new york"`,
+      ),
+    );
+    wrapper.unmount();
+  });
+
+  it('LocationType.EMERGENCY_CARE, null serviceType', () => {
+    const wrapper = shallow(
+      <SearchResultsHeader
+        results={[{}]}
+        facilityType={LocationType.EMERGENCY_CARE}
+        context="new york"
+      />,
+    );
+
+    expect(wrapper.find('h2').text()).to.match(
+      new RegExp(
+        `Results for "Emergency Care",\\s+"${
+          emergencyCareServices.AllEmergencyCare
+        }"\\s+near\\s+"new york"`,
+      ),
+    );
+    wrapper.unmount();
+  });
+
+  it('should render header with LocationType.CC_PROVIDER, totalEntries = 1', () => {
     const wrapper = shallow(
       <SearchResultsHeader
         results={[{}]}
@@ -127,27 +207,99 @@ describe('SearchResultsHeader', () => {
         serviceType="foo"
         context="new york"
         specialtyMap={{ foo: 'test' }}
+        pagination={{ totalEntries: 1 }}
       />,
     );
 
     expect(wrapper.find('h2').text()).to.match(
-      /Results for "Community providers \(in VA’s network\)",\s+"test"\s+near\s+"new york"/,
+      /Showing 1 result for "Community providers \(in VA’s network\)",\s+"test"\s+near\s+"new york"/,
     );
     wrapper.unmount();
   });
 
-  it('should render header with LocationType.BENEFITS', () => {
+  it('should render header with LocationType.CC_PROVIDER, totalEntries = 5', () => {
+    const wrapper = shallow(
+      <SearchResultsHeader
+        results={[{}]}
+        facilityType={LocationType.CC_PROVIDER}
+        serviceType="foo"
+        context="new york"
+        specialtyMap={{ foo: 'test' }}
+        pagination={{ totalEntries: 5 }}
+      />,
+    );
+
+    expect(wrapper.find('h2').text()).to.match(
+      /Showing 1 - 5 results for "Community providers \(in VA’s network\)",\s+"test"\s+near\s+"new york"/,
+    );
+    wrapper.unmount();
+  });
+
+  it('should render header with LocationType.CC_PROVIDER, totalEntries = 15, currentPage = 2, totalPages =2', () => {
+    const wrapper = shallow(
+      <SearchResultsHeader
+        results={[{}]}
+        facilityType={LocationType.CC_PROVIDER}
+        serviceType="foo"
+        context="new york"
+        specialtyMap={{ foo: 'test' }}
+        pagination={{ totalEntries: 15, currentPage: 2, totalPages: 2 }}
+      />,
+    );
+
+    expect(wrapper.find('h2').text()).to.match(
+      /Showing 11 - 15 of 15 results for "Community providers \(in VA’s network\)",\s+"test"\s+near\s+"new york"/,
+    );
+    wrapper.unmount();
+  });
+
+  it('should render header with LocationType.BENEFITS, totalEntries = 1', () => {
     const wrapper = shallow(
       <SearchResultsHeader
         results={[{}]}
         facilityType={LocationType.BENEFITS}
         serviceType="ApplyingForBenefits"
         context="new york"
+        pagination={{ totalEntries: 1 }}
       />,
     );
 
     expect(wrapper.find('h2').text()).to.match(
-      /Results for "VA benefits",\s+"Applying for benefits"\s+near\s+"new york"/,
+      /Showing 1 result for "VA benefits",\s+"Applying for benefits"\s+near\s+"new york"/,
+    );
+    wrapper.unmount();
+  });
+
+  it('should render header with LocationType.BENEFITS, totalEntries = 5', () => {
+    const wrapper = shallow(
+      <SearchResultsHeader
+        results={[{}]}
+        facilityType={LocationType.BENEFITS}
+        serviceType="ApplyingForBenefits"
+        context="new york"
+        pagination={{ totalEntries: 5 }}
+      />,
+    );
+
+    expect(wrapper.find('h2').text()).to.match(
+      /Showing 1 - 5 results for "VA benefits",\s+"Applying for benefits"\s+near\s+"new york"/,
+    );
+    wrapper.unmount();
+  });
+
+  it('should render header with LocationType.BENEFITS, totalEntries = 15, currentPage = 2, totalPages = 2', () => {
+    const wrapper = shallow(
+      <SearchResultsHeader
+        results={[{}]}
+        facilityType={LocationType.BENEFITS}
+        serviceType="ApplyingForBenefits"
+        context="new york"
+        pagination={{ totalEntries: 15, currentPage: 2, totalPages: 2 }}
+      />,
+    );
+
+    expect(wrapper.find('h2').text()).to.match(
+      /Showing 11 - 15 of 15 results for "VA benefits",\s+"Applying for benefits"\s+near\s+"new york"/,
     );
     wrapper.unmount();
   });
@@ -158,26 +310,60 @@ describe('SearchResultsHeader', () => {
         results={[{}]}
         facilityType={LocationType.BENEFITS}
         context="new york"
+        pagination={{ totalEntries: 5 }}
       />,
     );
 
     expect(wrapper.find('h2').text()).to.match(
-      /Results for "VA benefits",\s+"All VA benefit services"\s+near\s+"new york"/,
+      /Showing 1 - 5 results for "VA benefits",\s+"All VA benefit services"\s+near\s+"new york"/,
     );
     wrapper.unmount();
   });
 
-  it('LocationType.CEMETARY', () => {
+  it('LocationType.CEMETARY, totalEntries = 1', () => {
     const wrapper = shallow(
       <SearchResultsHeader
         results={[{}]}
         facilityType={LocationType.CEMETARY}
         context="new york"
+        pagination={{ totalEntries: 1 }}
       />,
     );
 
     expect(wrapper.find('h2').text()).to.match(
-      /Results for "VA cemeteries"\s+near\s+"new york"/,
+      /Showing 1 result for "VA cemeteries"\s+near\s+"new york"/,
+    );
+    wrapper.unmount();
+  });
+
+  it('LocationType.CEMETARY, totalEntries = 5', () => {
+    const wrapper = shallow(
+      <SearchResultsHeader
+        results={[{}]}
+        facilityType={LocationType.CEMETARY}
+        context="new york"
+        pagination={{ totalEntries: 5 }}
+      />,
+    );
+
+    expect(wrapper.find('h2').text()).to.match(
+      /Showing 1 - 5 results for "VA cemeteries"\s+near\s+"new york"/,
+    );
+    wrapper.unmount();
+  });
+
+  it('LocationType.CEMETARY, totalEntries = 15, currentPage = 2, totalPages = 2', () => {
+    const wrapper = shallow(
+      <SearchResultsHeader
+        results={[{}]}
+        facilityType={LocationType.CEMETARY}
+        context="new york"
+        pagination={{ totalEntries: 15, currentPage: 2, totalPages: 2 }}
+      />,
+    );
+
+    expect(wrapper.find('h2').text()).to.match(
+      /Showing 11 - 15 of 15 results for "VA cemeteries"\s+near\s+"new york"/,
     );
     wrapper.unmount();
   });

--- a/src/applications/facility-locator/tests/e2e/facilitySearch.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/facilitySearch.cypress.spec.js
@@ -2,7 +2,6 @@ import mockFacilitiesSearchResultsV1 from '../../constants/mock-facility-data-v1
 import mockFacilityDataV1 from '../../constants/mock-facility-v1.json';
 import mockGeocodingData from '../../constants/mock-geocoding-data.json';
 import mockLaLocation from '../../constants/mock-la-location.json';
-
 import { healthServices, facilityTypesOptions } from '../../config';
 import { LocationType } from '../../constants';
 import mockServices from '../../constants/mock-provider-services.json';


### PR DESCRIPTION
## Description

Resolves - https://github.com/department-of-veterans-affairs/va.gov-team/issues/11149

Per Michelle, we will not show number of results for **urgent care**, **emergency care**, **community care providers** or **pharmacy searches**. 

## Screenshots

<details>
<summary>If we get back 1 result, should read as:</summary>


<img width="1037" alt="Screen Shot 2021-11-09 at 11 01 21 PM" src="https://user-images.githubusercontent.com/84030819/141202020-044c6b13-bd26-41bf-98b7-faaf957453ad.png">

</details>


<details>
<summary>If we get back less than or equal to 10 results, should read as:</summary>


![Screen Shot 2021-11-10 at 5 13 43 PM](https://user-images.githubusercontent.com/84030819/141202338-e4b15fa9-e4f2-46c7-b567-b7b254628ff6.png)
</details>

<details>
<summary>If we get back more than 10 results, should read as:</summary>

![Screen Shot 2021-11-10 at 5 12 14 PM](https://user-images.githubusercontent.com/84030819/141202156-da5e3f36-aa87-4262-85db-e66723d660ef.png)

</details>


