### PR TITLE
Remove Node version TODO from GitHub Actions CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -657,16 +657,15 @@ jobs:
           token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
           path: testing-tools-team-dashboard-data
 
-        # TODO: Set .nvmrc in testing-tools-team-dashboard-data.
-        # - name: Get Node version
-        #   id: get-node-version
-        #   run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-        #   working-directory: testing-tools-team-dashboard-data
+      - name: Get Node version
+        id: get-node-version
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+        working-directory: testing-tools-team-dashboard-data
 
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: 14 # ${{ steps.get-node-version.outputs.NODE_VERSION }}
+          node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline --production=false

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -522,16 +522,15 @@ jobs:
           token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
           path: testing-tools-team-dashboard-data
 
-      # TODO: Set .nvmrc in testing-tools-team-dashboard-data.
-      # - name: Get Node version
-      #   id: get-node-version
-      #   run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
-      #   working-directory: testing-tools-team-dashboard-data
+      - name: Get Node version
+        id: get-node-version
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+        working-directory: testing-tools-team-dashboard-data
 
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: 14 # ${{ steps.get-node-version.outputs.NODE_VERSION }}
+          node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
       # TODO: Potentially use install composite
       - name: Install dependencies


### PR DESCRIPTION
## Description
This PR removes a `TODO` from the GHA CI workflow. An `.nvmrc` file has been added to the repo in the commented out lines, so these lines can be uncommented.

## Acceptance criteria
- [ ] CI passes.