### PR TITLE
Reverts new Modal work

### DIFF
--- a/src/applications/login/components/FedWarning.jsx
+++ b/src/applications/login/components/FedWarning.jsx
@@ -1,9 +1,15 @@
 import React from 'react';
 
-export default function FedWarning() {
+export default function FedWarning({ loginGovEnabled }) {
   return (
-    <div className="vads-u-padding-bottom--2p5">
-      <h2 className="vads-u-margin-top--0">Terms of use</h2>
+    <div
+      className={`${
+        loginGovEnabled ? 'vads-u-padding-bottom--2p5' : 'fed-warning'
+      }`}
+    >
+      {loginGovEnabled && (
+        <h2 className="vads-u-margin-top--0">Terms of use</h2>
+      )}
       <p>
         When you sign in to VA.gov, you’re using a United States federal
         government information system.

--- a/src/applications/login/components/SignInButtons.jsx
+++ b/src/applications/login/components/SignInButtons.jsx
@@ -12,73 +12,146 @@ function loginHandler(loginType) {
   login(loginType, 'v1');
 }
 
+const LoginGovButtons = ({ isDisabled }) => (
+  <>
+    <button
+      disabled={isDisabled}
+      type="button"
+      aria-label="Sign in with Login.gov"
+      className="usa-button usa-button-big logingov-button vads-u-margin-y--1p5"
+      onClick={() => loginHandler('logingov')}
+    >
+      <LoginGovSVG />
+    </button>
+    <button
+      disabled={isDisabled}
+      type="button"
+      aria-label="Sign in with ID.me"
+      className="usa-button usa-button-big idme-button vads-u-margin-y--1p5"
+      onClick={() => loginHandler('idme')}
+    >
+      <img
+        alt="Sign in with ID.me"
+        src={`${vaGovFullDomain}/img/signin/idme-icon-white.svg`}
+      />
+    </button>
+    <button
+      disabled={isDisabled}
+      type="button"
+      aria-label="Sign in with DS Logon"
+      className="usa-button usa-button-big dslogon-button vads-u-margin-y--1p5"
+      onClick={() => loginHandler('dslogon')}
+    >
+      DS Logon
+    </button>
+    <button
+      disabled={isDisabled}
+      type="button"
+      aria-label="Sign in with My HealtheVet"
+      className="usa-button usa-button-big mhv-button vads-u-margin-y--1p5"
+      onClick={() => loginHandler('mhv')}
+    >
+      My HealtheVet
+    </button>
+    <div id="create-account">
+      <h2 className="vads-u-margin-top--3">Or create an account</h2>
+      <div className="vads-u-display--flex vads-u-flex-direction--column">
+        <button
+          type="button"
+          aria-label="Create an account with Login.gov"
+          disabled={isDisabled}
+          onClick={() => signup({ csp: 'logingov' })}
+        >
+          Create an account with Login.gov
+        </button>
+        <button
+          type="button"
+          aria-label="Create an account with ID.me"
+          disabled={isDisabled}
+          onClick={() => signup({ csp: 'idme' })}
+        >
+          Create an account with ID.me
+        </button>
+      </div>
+    </div>
+  </>
+);
+
+const OriginalButtons = ({ isDisabled }) => (
+  <>
+    <button
+      disabled={isDisabled}
+      className="dslogon"
+      onClick={() => loginHandler('dslogon')}
+    >
+      <img
+        aria-hidden="true"
+        role="presentation"
+        alt="DS Logon"
+        src={`${vaGovFullDomain}/img/signin/dslogon-icon.svg`}
+      />
+      <strong> Sign in with DS Logon</strong>
+    </button>
+    <button
+      disabled={isDisabled}
+      className="mhv"
+      onClick={() => loginHandler('mhv')}
+    >
+      <img
+        aria-hidden="true"
+        role="presentation"
+        alt="My HealtheVet"
+        src={`${vaGovFullDomain}/img/signin/mhv-icon.svg`}
+      />
+      <strong> Sign in with My HealtheVet</strong>
+    </button>
+    <button
+      disabled={isDisabled}
+      className="usa-button-primary va-button-primary"
+      onClick={() => loginHandler('idme')}
+    >
+      <img
+        aria-hidden="true"
+        role="presentation"
+        alt="ID.me"
+        src={`${vaGovFullDomain}/img/signin/idme-icon-white.svg`}
+      />
+      <strong> Sign in with ID.me</strong>
+    </button>
+    <span className="sidelines">OR</span>
+    <div className="alternate-signin">
+      <h2 className="vads-u-font-size--sm vads-u-margin-top--0">
+        Don’t have those accounts?
+      </h2>
+      <button
+        disabled={isDisabled}
+        className="idme-create usa-button usa-button-secondary"
+        onClick={() => signup('v1')}
+      >
+        <img
+          aria-hidden="true"
+          role="presentation"
+          alt="ID.me"
+          src={`${vaGovFullDomain}/img/signin/idme-icon-dark.svg`}
+        />
+        <strong> Create an ID.me account</strong>
+      </button>
+      <p>Use your email, Google, or Facebook</p>
+    </div>
+  </>
+);
+
 export default function SignInButtons({ isDisabled, loginGovEnabled }) {
   return (
     <div>
-      {loginGovEnabled && (
-        <button
-          disabled={isDisabled}
-          type="button"
-          aria-label="Sign in with Login.gov"
-          className="usa-button usa-button-big logingov-button vads-u-margin-y--1p5"
-          onClick={() => loginHandler('logingov')}
-        >
-          <LoginGovSVG />
-        </button>
-      )}
-      <button
-        disabled={isDisabled}
-        type="button"
-        aria-label="Sign in with ID.me"
-        className="usa-button usa-button-big idme-button vads-u-margin-y--1p5"
-        onClick={() => loginHandler('idme')}
-      >
-        <img
-          alt="Sign in with ID.me"
-          src={`${vaGovFullDomain}/img/signin/idme-icon-white.svg`}
+      {!loginGovEnabled ? (
+        <OriginalButtons isDisabled={isDisabled} />
+      ) : (
+        <LoginGovButtons
+          isDisabled={isDisabled}
+          loginGovEnabled={loginGovEnabled}
         />
-      </button>
-      <button
-        disabled={isDisabled}
-        type="button"
-        aria-label="Sign in with DS Logon"
-        className="usa-button usa-button-big dslogon-button vads-u-margin-y--1p5"
-        onClick={() => loginHandler('dslogon')}
-      >
-        DS Logon
-      </button>
-      <button
-        disabled={isDisabled}
-        type="button"
-        aria-label="Sign in with My HealtheVet"
-        className="usa-button usa-button-big mhv-button vads-u-margin-y--1p5"
-        onClick={() => loginHandler('mhv')}
-      >
-        My HealtheVet
-      </button>
-      <div id="create-account">
-        <h2 className="vads-u-margin-top--3">Or create an account</h2>
-        <div className="vads-u-display--flex vads-u-flex-direction--column">
-          {loginGovEnabled && (
-            <button
-              type="button"
-              aria-label="Create an account with Login.gov"
-              disabled={isDisabled}
-              onClick={() => signup({ csp: 'logingov' })}
-            >
-              Create an account with Login.gov
-            </button>
-          )}
-          <button
-            type="button"
-            aria-label="Create an account with ID.me"
-            disabled={isDisabled}
-            onClick={() => signup({ csp: 'idme' })}
-          >
-            Create an account with ID.me
-          </button>
-        </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/src/applications/login/containers/SignInApp.jsx
+++ b/src/applications/login/containers/SignInApp.jsx
@@ -5,11 +5,13 @@ import 'url-search-params-polyfill';
 
 import AutoSSO from 'platform/site-wide/user-nav/containers/AutoSSO';
 import SignInButtons from '../components/SignInButtons';
+import SignInDescription from '../components/SignInDescription';
 import FedWarning from '../components/FedWarning';
 import LogoutAlert from '../components/LogoutAlert';
 
 import ExternalServicesError from 'platform/monitoring/external-services/ExternalServicesError';
 import SubmitSignInForm from 'platform/static-data/SubmitSignInForm';
+import environment from 'platform/utilities/environment';
 import {
   isAuthenticatedWithSSOe,
   loginGov,
@@ -17,6 +19,8 @@ import {
 import { selectProfile, isProfileLoading } from 'platform/user/selectors';
 
 import downtimeBanners from '../utilities/downtimeBanners';
+
+const vaGovFullDomain = environment.BASE_URL;
 
 class SignInPage extends React.Component {
   state = {
@@ -76,26 +80,81 @@ class SignInPage extends React.Component {
         <div className="row">
           {loggedOut && <LogoutAlert />}
           <div className="columns small-12">
-            <h1 className="vads-u-margin-top--2 medium-screen:vads-u-margin-bottom--2">
+            <h1
+              className={`${
+                loginGovEnabled
+                  ? 'vads-u-margin-top--2 medium-screen:vads-u-margin-bottom--2'
+                  : 'medium-screen:vads-u-margin-top--1 medium-screen:vads-u-margin-bottom--5'
+              }`}
+            >
               Sign in
             </h1>
           </div>
         </div>
+        {!loginGovEnabled && (
+          <div className="row medium-screen:vads-u-display--none mobile-explanation">
+            <div className="columns small-12">
+              <h2 className="vads-u-margin-top--0">
+                One sign in. A lifetime of benefits and services at your
+                fingertips.
+              </h2>
+            </div>
+          </div>
+        )}
         {downtimeBanners.map((props, index) =>
           this.downtimeBanner(props, globalDowntime, index),
         )}
         <div className="row">
-          <div className="columns small-12 medium-6">
-            <SignInButtons
-              isDisabled={globalDowntime}
-              loginGovEnabled={loginGovEnabled}
-            />
-          </div>
+          {!loginGovEnabled ? (
+            <>
+              <div className="usa-width-one-half">
+                <div className="signin-actions-container">
+                  <div className="top-banner">
+                    <div>
+                      <img
+                        aria-hidden="true"
+                        role="presentation"
+                        alt="ID.me"
+                        src={`${vaGovFullDomain}/img/signin/lock-icon.svg`}
+                      />{' '}
+                      Secured & powered by{' '}
+                      <img
+                        aria-hidden="true"
+                        role="presentation"
+                        alt="ID.me"
+                        src={`${vaGovFullDomain}/img/signin/idme-icon-dark.svg`}
+                      />
+                    </div>
+                  </div>
+                  <div className="signin-actions">
+                    <h2 className="vads-u-font-size--sm vads-u-margin-top--0">
+                      Sign in with an existing account
+                    </h2>
+                    <SignInButtons isDisabled={globalDowntime} />
+                  </div>
+                </div>
+              </div>
+              <SignInDescription />
+            </>
+          ) : (
+            <div className="columns small-12 medium-6">
+              <SignInButtons
+                isDisabled={globalDowntime}
+                loginGovEnabled={loginGovEnabled}
+              />
+            </div>
+          )}
         </div>
         <div className="row">
           <div className="columns small-12">
             <div className="help-info">
-              <h2 className="vads-u-margin-top--0">
+              <h2
+                className={`${
+                  loginGovEnabled
+                    ? 'vads-u-margin-top--0'
+                    : 'vads-u-font-size--md'
+                }`}
+              >
                 Having trouble signing in?
               </h2>
               <p>
@@ -113,9 +172,11 @@ class SignInPage extends React.Component {
                 .
               </p>
               <p>
-                <SubmitSignInForm startSentence /> We're here 24/7.
+                <SubmitSignInForm startSentence />{' '}
+                {loginGovEnabled && `We're here 24/7.`}
               </p>
             </div>
+            {!loginGovEnabled && <hr />}
             <FedWarning />
           </div>
         </div>

--- a/src/platform/site-wide/user-nav/sass/user-nav.scss
+++ b/src/platform/site-wide/user-nav/sass/user-nav.scss
@@ -1,6 +1,38 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 
+span.sidelines {
+  position: relative;
+  z-index: 1;
+  overflow: hidden;
+  text-align: center;
+  width: 100%;
+  display: inline-block;
+
+  font-size: 1.15em;
+  font-weight: bold;
+
+  &:before,
+  &:after {
+    position: absolute;
+    top: 51%;
+    overflow: hidden;
+    width: 50%;
+    height: 2px;
+    content: "\a0";
+    background-color: $color-gray-light-alt;
+  }
+
+  &:before {
+    margin-left: -52%;
+    text-align: right;
+  }
+
+  &:after {
+    margin-left: 2%;
+  }
+}
+
 #signin-signup-modal {
   .va-modal-body {
     // Overwrite white header color.
@@ -12,6 +44,23 @@
   .va-modal-inner {
     max-width: 62.5em;
     width: 95vw;
+  }
+
+  .login {
+    .explanation-content {
+      @include media($medium-large-screen) {
+        margin-left: 2em;
+      }
+
+      ul {
+        list-style: square;
+        padding-left: 1.5em;
+      }
+
+      p {
+        margin: 1em 0;
+      }
+    }
   }
 }
 
@@ -42,6 +91,25 @@
 
       &:hover {
         background: $color-primary-darkest;
+      }
+    }
+
+    &.dslogon {
+      background: $color-primary-darker;
+
+      &:hover {
+        background: $color-primary-darkest;
+      }
+    }
+
+    &.idme-create {
+      box-shadow: inset 0 0 0 2px $color-green;
+      color: $color-green;
+      margin-bottom: 0;
+
+      &:hover {
+        box-shadow: inset 0 0 0 2px $color-green-darker;
+        color: $color-green-darker;
       }
     }
 
@@ -78,6 +146,7 @@
 
   .container {
     color: $color-base;
+    padding: 2em 0;
   }
 
   .logo {
@@ -119,6 +188,80 @@
 
 .login {
   background: $color-white;
+
+  hr {
+    border-color: $color-gray-lighter;
+  }
+
+  .mobile-explanation {
+    padding: 1em 0;
+
+    p {
+      margin-top: 0;
+    }
+  }
+
+  .fed-warning {
+    font-size: 0.9em;
+    margin-bottom: 2em;
+
+    p {
+      margin: 0.5em 0;
+    }
+  }
+
+  .signin-actions-container {
+    text-align: center;
+
+    @include media-maxwidth($small-screen) {
+      margin-right: 0;
+    }
+
+    div:first-child {
+      background: $color-gray-light-alt;
+    }
+
+    border: solid 2px $color-gray-light-alt;
+
+    .top-banner {
+      text-align: center;
+      display: flex;
+      align-items: center;
+      padding: 0.25em 0;
+      font-style: italic;
+
+      div:first-child {
+        margin: 0 auto;
+      }
+
+      img {
+        height: inherit;
+        vertical-align: baseline;
+        padding: 0 0.25em;
+      }
+    }
+
+    .signin-actions {
+      padding: 2em 2em 1em;
+
+      h5 {
+        margin-top: 0;
+      }
+
+      @include media-maxwidth($small-screen) {
+        padding: 2em 1em 1em;
+      }
+
+      .alternate-signin {
+        padding-top: 1em;
+
+        p:first-of-type {
+          margin-top: 0.5em;
+          color: $color-gray-dark;
+        }
+      }
+    }
+  }
 }
 
 .sign-in-nav {
@@ -163,4 +306,40 @@
 
 #help-menu {
   width: 21rem;
+}
+
+#create-account button {
+  display: block;
+  text-align: left;
+  border-radius: 0;
+  margin: 0;
+  background-color: transparent;
+  text-decoration: underline;
+  font-weight: 700;
+  padding: 1.16em 0 1.6em;
+  color: $color-link-default;
+  border-top: 1px solid $color-gray-light;
+  border-bottom: 1px solid $color-gray-light;
+
+  &:before {
+    color: $color-link-default;
+    content: "\F138";
+    display: inline-block;
+    font-family: "Font Awesome 5 Free";
+    font-size: 175%;
+    font-weight: 900;
+    height: 0;
+    padding-right: 1rem;
+    transform: translateY(5px);
+    text-decoration: none;
+  }
+
+  &:hover {
+    color: $color-black;
+    background-color: $color-gray-lightest;
+  }
+
+  &:last-of-type {
+    border-top: none;
+  }
 }

--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -245,7 +245,7 @@ export class SignInModal extends React.Component {
               className={`${this.props.loginGovEnabled &&
                 'vads-u-margin-top--2 medium-screen:vads-u-margin-top--1 medium-screen:vads-u-margin-bottom--2'}`}
             >
-              Sign in to VA.gov
+              Sign in
             </h1>
           </div>
         </div>

--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -7,12 +7,14 @@ import Modal from '@department-of-veterans-affairs/component-library/Modal';
 import FedWarning from 'applications/login/components/FedWarning';
 import SignInButtons from 'applications/login/components/SignInButtons';
 import SubmitSignInForm from 'platform/static-data/SubmitSignInForm';
+import SignInDescription from 'applications/login/components/SignInDescription';
 
 // import { getCurrentGlobalDowntime } from 'platform/monitoring/DowntimeNotification/util/helpers';
 import ExternalServicesError from 'platform/monitoring/external-services/ExternalServicesError';
 import { EXTERNAL_SERVICES } from 'platform/monitoring/external-services/config';
 import recordEvent from 'platform/monitoring/record-event';
 import { ssoe, loginGov } from 'platform/user/authentication/selectors';
+import { login, signup } from 'platform/user/authentication/utilities';
 import { formatDowntime } from 'platform/utilities/date';
 import environment from 'platform/utilities/environment';
 
@@ -30,6 +32,15 @@ export class SignInModal extends React.Component {
   }
   */
 
+  loginHandler = loginType => () => {
+    recordEvent({ event: `login-attempted-${loginType}` });
+    login(loginType, 'v1');
+  };
+
+  signupHandler = () => {
+    signup();
+  };
+
   componentDidUpdate(prevProps) {
     if (!prevProps.visible && this.props.visible) {
       recordEvent({ event: 'login-modal-opened' });
@@ -37,6 +48,101 @@ export class SignInModal extends React.Component {
       recordEvent({ event: 'login-modal-closed' });
     }
   }
+
+  original = ({ globalDowntime }) => {
+    return (
+      <div>
+        <div className="usa-width-one-half">
+          <div className="signin-actions-container">
+            <div className="top-banner">
+              <div>
+                <img
+                  aria-hidden="true"
+                  role="presentation"
+                  alt="ID.me"
+                  src={`${vaGovFullDomain}/img/signin/lock-icon.svg`}
+                />{' '}
+                Secured & powered by{' '}
+                <img
+                  aria-hidden="true"
+                  role="presentation"
+                  alt="ID.me"
+                  src={`${vaGovFullDomain}/img/signin/idme-icon-dark.svg`}
+                />
+              </div>
+            </div>
+            <div className="signin-actions">
+              <h2 className="vads-u-font-size--sm vads-u-margin-top--0">
+                Sign in with an existing account
+              </h2>
+              <div>
+                <button
+                  disabled={globalDowntime}
+                  className="dslogon"
+                  onClick={this.loginHandler('dslogon')}
+                >
+                  <img
+                    aria-hidden="true"
+                    role="presentation"
+                    alt="DS Logon"
+                    src={`${vaGovFullDomain}/img/signin/dslogon-icon.svg`}
+                  />
+                  <strong> Sign in with DS Logon</strong>
+                </button>
+                <button
+                  disabled={globalDowntime}
+                  className="mhv"
+                  onClick={this.loginHandler('mhv')}
+                >
+                  <img
+                    aria-hidden="true"
+                    role="presentation"
+                    alt="My HealtheVet"
+                    src={`${vaGovFullDomain}/img/signin/mhv-icon.svg`}
+                  />
+                  <strong> Sign in with My HealtheVet</strong>
+                </button>
+                <button
+                  disabled={globalDowntime}
+                  className="usa-button-primary va-button-primary"
+                  onClick={this.loginHandler('idme')}
+                >
+                  <img
+                    aria-hidden="true"
+                    role="presentation"
+                    alt="ID.me"
+                    src={`${vaGovFullDomain}/img/signin/idme-icon-white.svg`}
+                  />
+                  <strong> Sign in with ID.me</strong>
+                </button>
+                <span className="sidelines">OR</span>
+                <div className="alternate-signin">
+                  <h2 className="vads-u-font-size--sm vads-u-margin-top--0">
+                    Don't have those accounts?
+                  </h2>
+                  <button
+                    disabled={globalDowntime}
+                    className="idme-create usa-button usa-button-secondary"
+                    onClick={this.signupHandler}
+                  >
+                    <img
+                      aria-hidden="true"
+                      role="presentation"
+                      alt="ID.me"
+                      src={`${vaGovFullDomain}/img/signin/idme-icon-dark.svg`}
+                    />
+                    <strong> Create an ID.me account</strong>
+                  </button>
+                  <p>Use your email, Google, or Facebook</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <SignInDescription />
+      </div>
+    );
+  };
 
   downtimeBanner = (dependencies, headline, status, message, onRender) => (
     <ExternalServicesError dependencies={dependencies} onRender={onRender}>
@@ -135,24 +241,49 @@ export class SignInModal extends React.Component {
       <div className="container">
         <div className="row">
           <div className="columns small-12">
-            <h1 className="vads-u-margin-top--2 medium-screen:vads-u-margin-top--1 medium-screen:vads-u-margin-bottom--2">
-              Sign in
+            <h1
+              className={`${this.props.loginGovEnabled &&
+                'vads-u-margin-top--2 medium-screen:vads-u-margin-top--1 medium-screen:vads-u-margin-bottom--2'}`}
+            >
+              Sign in to VA.gov
             </h1>
           </div>
         </div>
-        {this.renderDowntimeBanners()}
-        <div className="row">
-          <div className="columns small-12 medium-6">
-            <SignInButtons
-              loginGovEnabled={this.props.loginGovEnabled}
-              isDisabled={globalDowntime}
-            />
+        {!this.props.loginGovEnabled ? (
+          <div className="row medium-screen:vads-u-display--none mobile-explanation">
+            <div className="columns small-12">
+              <h2>
+                One site. A lifetime of benefits and services at your
+                fingertips.
+              </h2>
+            </div>
           </div>
-        </div>
+        ) : null}
+        {this.renderDowntimeBanners()}
+        {!this.props.loginGovEnabled ? (
+          this.original({
+            globalDowntime,
+          })
+        ) : (
+          <div className="row">
+            <div className="columns small-12 medium-6">
+              <SignInButtons
+                loginGovEnabled={this.props.loginGovEnabled}
+                isDisabled={globalDowntime}
+              />
+            </div>
+          </div>
+        )}
         <div className="row">
           <div className="columns small-12">
             <div className="help-info">
-              <h2 className="vads-u-margin-top--0">
+              <h2
+                className={`${
+                  this.props.loginGovEnabled
+                    ? 'vads-u-margin-top--0'
+                    : 'vads-u-font-size--md'
+                }`}
+              >
                 Having trouble signing in?
               </h2>
               <p>
@@ -175,7 +306,8 @@ export class SignInModal extends React.Component {
                 .
               </p>
               <p>
-                <SubmitSignInForm startSentence /> We're here 24/7.
+                <SubmitSignInForm startSentence />{' '}
+                {this.props.loginGovEnabled && ` We're here 24/7.`}
               </p>
             </div>
             <FedWarning />

--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -49,7 +49,7 @@ export class SignInModal extends React.Component {
     }
   }
 
-  original = ({ globalDowntime }) => {
+  renderOriginalModal = ({ globalDowntime }) => {
     return (
       <div>
         <div className="usa-width-one-half">
@@ -261,7 +261,7 @@ export class SignInModal extends React.Component {
         ) : null}
         {this.renderDowntimeBanners()}
         {!this.props.loginGovEnabled ? (
-          this.original({
+          this.renderOriginalModal({
             globalDowntime,
           })
         ) : (

--- a/src/platform/user/tests/unauthed-flows.cypress.spec.js
+++ b/src/platform/user/tests/unauthed-flows.cypress.spec.js
@@ -11,7 +11,7 @@ describe('Unauthed User Flow Test', () => {
       cy.visit(path);
       cy.get('body').should('be.visible');
       cy.get('.login').should('be.visible');
-      cy.get('h1').should('contain', 'Sign in to VA.gov');
+      cy.get('h1').should('contain', 'Sign in');
     });
   });
 });

--- a/src/platform/user/tests/unauthed-flows.cypress.spec.js
+++ b/src/platform/user/tests/unauthed-flows.cypress.spec.js
@@ -11,7 +11,7 @@ describe('Unauthed User Flow Test', () => {
       cy.visit(path);
       cy.get('body').should('be.visible');
       cy.get('.login').should('be.visible');
-      cy.get('h1').should('contain', 'Sign in');
+      cy.get('h1').should('contain', 'Sign in to VA.gov');
     });
   });
 });


### PR DESCRIPTION
## Description
This PR reverts the new modal work (with the addition of Login.gov) and locks the entire new design behind a feature flag until ready to go live. Once approved we will rip out the "dead code" of the original Sign in Modal & /sign-in page.

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#32704


## Testing done
Unit testing, visual testing,

## Screenshots
**Original (`loginGov` feature flag IS NOT enabled)**
![Screen Shot 2021-11-10 at 10 53 40 AM](https://user-images.githubusercontent.com/67602137/141146748-b1270692-52d1-44c6-9c7c-4d41637f5de0.png)


**Proposed (`loginGov` feature flag IS enabled)**
![Screen Shot 2021-11-10 at 10 59 57 AM](https://user-images.githubusercontent.com/67602137/141147856-507f4fa4-7bd1-4a28-a2da-4a7e962d271a.png)


## Acceptance criteria
- [ ] I can see the Login.gov modal on the Dev environment
- [ ] I can NOT see the Login.gov modal on any other environment

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
