### PR TITLE
Simplify Cypress Docker container count on GitHub Actions CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -440,6 +440,7 @@ jobs:
           CYPRESS_CI: true
           STEP: ${{ matrix.ci_node_index }}
           TESTS: ${{ needs.cypress-tests-prep.outputs.tests }}
+          NUM_CONTAINERS: ${{ env.NUM_CYPRESS_CONTAINERS }}
 
       - name: Archive test videos
         uses: actions/upload-artifact@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,6 +10,7 @@ on:
 env:
   DEVOPS_CHANNEL_ID: C37M86Y8G #devops-deploys
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
+  NUM_CYPRESS_CONTAINERS: '8'
 
 concurrency:
   group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha }}
@@ -390,7 +391,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 8
+      max-parallel: ${{ env.NUM_CYPRESS_CONTAINERS }}
       matrix:
         ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7]
 
@@ -589,7 +590,7 @@ jobs:
         run: yarn contract-mochawesome-to-bigquery
         working-directory: testing-tools-team-dashboard-data
         env:
-          NUM_CONTAINERS: '8'
+          NUM_CONTAINERS: ${{ env.NUM_CYPRESS_CONTAINERS }}
           TEST_EXECUTIONS_TABLE_NAME: vets_website_contract_test_suite_executions
           TEST_RESULTS_TABLE_NAME: vets_website_contract_test_results
           TEST_REPORTS_FOLDER_NAME: vets-website-contract-test-reports
@@ -729,7 +730,7 @@ jobs:
         working-directory: testing-tools-team-dashboard-data
         env:
           IS_MASTER_BUILD: ${{ needs.cypress-tests-prep.outputs.is_master_build }}
-          NUM_CONTAINERS: '8'
+          NUM_CONTAINERS: ${{ env.NUM_CYPRESS_CONTAINERS }}
           TEST_EXECUTIONS_TABLE_NAME: cypress_test_suite_executions
           TEST_RESULTS_TABLE_NAME: cypress_test_results
           TEST_REPORTS_FOLDER_NAME: vets-website-cypress-reports

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -391,7 +391,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: ${{ env.NUM_CYPRESS_CONTAINERS }}
+      max-parallel: 8
       matrix:
         ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7]
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,7 +10,7 @@ on:
 env:
   DEVOPS_CHANNEL_ID: C37M86Y8G #devops-deploys
   CHROMEDRIVER_FILEPATH: /usr/local/share/chrome_driver/chromedriver
-  NUM_CYPRESS_CONTAINERS: '8'
+  NUM_CONTAINERS: '8'
 
 concurrency:
   group: ${{ github.ref != 'refs/heads/master' && github.ref || github.sha }}
@@ -440,7 +440,6 @@ jobs:
           CYPRESS_CI: true
           STEP: ${{ matrix.ci_node_index }}
           TESTS: ${{ needs.cypress-tests-prep.outputs.tests }}
-          NUM_CONTAINERS: ${{ env.NUM_CYPRESS_CONTAINERS }}
 
       - name: Archive test videos
         uses: actions/upload-artifact@v2
@@ -591,7 +590,6 @@ jobs:
         run: yarn contract-mochawesome-to-bigquery
         working-directory: testing-tools-team-dashboard-data
         env:
-          NUM_CONTAINERS: ${{ env.NUM_CYPRESS_CONTAINERS }}
           TEST_EXECUTIONS_TABLE_NAME: vets_website_contract_test_suite_executions
           TEST_RESULTS_TABLE_NAME: vets_website_contract_test_results
           TEST_REPORTS_FOLDER_NAME: vets-website-contract-test-reports
@@ -731,7 +729,6 @@ jobs:
         working-directory: testing-tools-team-dashboard-data
         env:
           IS_MASTER_BUILD: ${{ needs.cypress-tests-prep.outputs.is_master_build }}
-          NUM_CONTAINERS: ${{ env.NUM_CYPRESS_CONTAINERS }}
           TEST_EXECUTIONS_TABLE_NAME: cypress_test_suite_executions
           TEST_RESULTS_TABLE_NAME: cypress_test_results
           TEST_REPORTS_FOLDER_NAME: vets-website-cypress-reports

--- a/script/github-actions/run-cypress-tests.js
+++ b/script/github-actions/run-cypress-tests.js
@@ -2,7 +2,7 @@ const { runCommandSync } = require('../utils');
 
 const tests = JSON.parse(process.env.TESTS);
 const step = Number(process.env.STEP);
-const numContainers = Number(process.env.MUM_CYPRESS_CONTAINERS);
+const numContainers = Number(process.env.MUM_CONTAINERS);
 const divider = Math.ceil(tests.length / numContainers);
 
 const batch = tests

--- a/script/github-actions/run-cypress-tests.js
+++ b/script/github-actions/run-cypress-tests.js
@@ -2,7 +2,8 @@ const { runCommandSync } = require('../utils');
 
 const tests = JSON.parse(process.env.TESTS);
 const step = Number(process.env.STEP);
-const divider = Math.ceil(tests.length / 8);
+const numContainers = Number(process.env.MUM_CYPRESS_CONTAINERS);
+const divider = Math.ceil(tests.length / numContainers);
 
 const batch = tests
   .map(test => test.replace('/home/runner/work', '/__w'))

--- a/script/github-actions/run-cypress-tests.js
+++ b/script/github-actions/run-cypress-tests.js
@@ -2,7 +2,7 @@ const { runCommandSync } = require('../utils');
 
 const tests = JSON.parse(process.env.TESTS);
 const step = Number(process.env.STEP);
-const numContainers = Number(process.env.MUM_CONTAINERS);
+const numContainers = Number(process.env.NUM_CONTAINERS);
 const divider = Math.ceil(tests.length / numContainers);
 
 const batch = tests


### PR DESCRIPTION
## Description
PR to refactor the GitHub Actions CI workflow so that the Docker container count for Cypress tests can be changed in only one line rather than in multiple spots.

## Acceptance criteria
- [ ] CI passes.