### PR TITLE
HLR: Add edit contact info page loop

### DIFF
--- a/src/applications/disability-benefits/996/components/EditContactInfo.jsx
+++ b/src/applications/disability-benefits/996/components/EditContactInfo.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import InitializeVAPServiceID from '@@vap-svc/containers/InitializeVAPServiceID';
+import ContactInformationField from '@@vap-svc/components/ContactInformationField';
+import { FIELD_NAMES } from '@@vap-svc/constants';
+
+const buildPage = ({ title, field, goToPath }) => (
+  <div
+    className="va-profile-wrapper"
+    onSubmit={event => {
+      // This prevents this nested form submit event from passing to the
+      // outer form and causing a page advance
+      event.stopPropagation();
+    }}
+  >
+    <InitializeVAPServiceID>
+      <h3>{title}</h3>
+      <ContactInformationField
+        forceEditView
+        fieldName={FIELD_NAMES[field]}
+        isDeleteDisabled
+        cancelCallback={() => {
+          goToPath('/contact-information');
+        }}
+        successCallback={() => {
+          goToPath('/contact-information');
+        }}
+      />
+    </InitializeVAPServiceID>
+  </div>
+);
+
+export const EditPhone = ({ title, goToPath }) =>
+  buildPage({ title, goToPath, field: 'MOBILE_PHONE' });
+
+export const EditEmail = ({ title, goToPath }) =>
+  buildPage({ title, goToPath, field: 'EMAIL' });
+
+export const EditAddress = ({ title, goToPath }) =>
+  buildPage({ title, goToPath, field: 'MAILING_ADDRESS' });

--- a/src/applications/disability-benefits/996/config/form.js
+++ b/src/applications/disability-benefits/996/config/form.js
@@ -13,6 +13,11 @@ import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import GetFormHelp from '../content/GetFormHelp';
 import ReviewDescription from '../components/ReviewDescription';
+import {
+  EditPhone,
+  EditEmail,
+  EditAddress,
+} from '../components/EditContactInfo';
 
 // Pages
 import veteranInformation from '../pages/veteranInformation';
@@ -120,6 +125,33 @@ const formConfig = {
           path: 'contact-information',
           uiSchema: contactInfo.uiSchema,
           schema: contactInfo.schema,
+        },
+        editMobilePhone: {
+          title: 'Edit mobile phone',
+          path: 'edit-mobile-phone',
+          CustomPage: EditPhone,
+          CustomPageReview: EditPhone,
+          depends: () => false, // accessed from contact info page
+          uiSchema: {},
+          schema: { type: 'object', properties: {} },
+        },
+        editEmailAddress: {
+          title: 'Edit email address',
+          path: 'edit-email-address',
+          CustomPage: EditEmail,
+          CustomPageReview: EditEmail,
+          depends: () => false, // accessed from contact info page
+          uiSchema: {},
+          schema: { type: 'object', properties: {} },
+        },
+        editMailingAddress: {
+          title: 'Edit mailing address',
+          path: 'edit-mailing-address',
+          CustomPage: EditAddress,
+          CustomPageReview: EditAddress,
+          depends: () => false, // accessed from contact info page
+          uiSchema: {},
+          schema: { type: 'object', properties: {} },
         },
       },
     },

--- a/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
+++ b/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
@@ -183,6 +183,12 @@ dl.review .additional-issue.review-row {
   word-break: break-word;
 }
 
+@media screen and (min-width: 481px) {
+  .va-profile-wrapper button {
+    width: auto;
+  }
+}
+
 /* IE11 hack to fix edit button placement, see
  * https://github.com/department-of-veterans-affairs/va.gov-team/issues/25108
  */

--- a/src/applications/disability-benefits/996/tests/components/ContactInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/components/ContactInformation.unit.spec.jsx
@@ -10,6 +10,7 @@ const getData = ({
   address = true,
   submitted = false,
   homeless = false,
+  loopPages = false,
 } = {}) => {
   const data = {};
   if (email) {
@@ -40,17 +41,32 @@ const getData = ({
     formContext: { submitted },
     profile: { vapContactInfo: data },
     homeless,
+    loopPages,
   };
 };
 
 describe('Veteran information review content', () => {
-  it('should render contact information', () => {
+  it('should render inline contact information', () => {
     const data = getData();
     const tree = shallow(<ContactInfoDescription {...data} />);
 
     expect(tree.find('PhoneField')).to.exist;
     expect(tree.find('EmailField')).to.exist;
     expect(tree.find('MailingAddress')).to.exist;
+    tree.unmount();
+  });
+
+  it('should render contact information main loop', () => {
+    const data = getData({ loopPages: true });
+    const tree = shallow(<ContactInfoDescription {...data} />);
+
+    expect(tree.find('Telephone')).to.exist;
+    expect(tree.find('AddressView')).to.exist;
+    expect(tree.find('Link').length).to.eq(3);
+
+    expect(tree.find('PhoneField').length).to.eq(0);
+    expect(tree.find('EmailField').length).to.eq(0);
+    expect(tree.find('MailingAddress').length).to.eq(0);
     tree.unmount();
   });
 

--- a/src/applications/disability-benefits/996/tests/fixtures/mocks/telephone-update-success.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/mocks/telephone-update-success.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "id": "",
+    "type": "async_transaction_va_profile_telephone_transactions",
+    "attributes": {
+      "transactionId": "c049d895-ecdf-40a4-ac0f-7947a06ea0c2",
+      "transactionStatus": "COMPLETED_SUCCESS",
+      "type": "AsyncTransaction::VAProfile::TelephoneTransaction",
+      "metadata": []
+    }
+  }
+}

--- a/src/applications/disability-benefits/996/tests/fixtures/mocks/telephone-update.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/mocks/telephone-update.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "attributes": {
+      "transaction_status": "RECEIVED",
+      "transaction_id": "c049d895-ecdf-40a4-ac0f-7947a06ea0c2",
+      "type": "AsyncTransaction::VAProfile::TelephoneTransaction",
+      "metadata": []
+    }
+  }
+}

--- a/src/applications/disability-benefits/996/tests/fixtures/mocks/user.json
+++ b/src/applications/disability-benefits/996/tests/fixtures/mocks/user.json
@@ -18,7 +18,9 @@
         "identity-proofed",
         "vet360",
         "evss_common_client",
-        "claim_increase"
+        "claim_increase",
+        "user-profile",
+        "vet360"
       ],
       "account": { "accountUuid": "c049d895-ecdf-40a4-ac0f-7947a06ea0c2" },
       "profile": {

--- a/src/applications/disability-benefits/996/tests/hlr-contact-loop.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr-contact-loop.cypress.spec.js
@@ -1,0 +1,140 @@
+import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
+
+import { BASE_URL, WIZARD_STATUS, CONTESTABLE_ISSUES_API } from '../constants';
+
+import mockUser from './fixtures/mocks/user.json';
+import mockStatus from './fixtures/mocks/profile-status.json';
+import mockV2Data from './fixtures/data/maximal-test-v2.json';
+import { mockContestableIssues } from './hlr.cypress.helpers';
+
+// Telephone specific responses
+import mockTelephoneUpdate from './fixtures/mocks/telephone-update.json';
+import mockTelephoneUpdateSuccess from './fixtures/mocks/telephone-update-success.json';
+
+const checkOpt = {
+  waitForAnimations: true,
+};
+
+describe('HLR contact info loop', () => {
+  beforeEach(() => {
+    window.dataLayer = [];
+    cy.intercept('GET', '/v0/feature_toggles?*', {
+      data: {
+        type: 'feature_toggles',
+        features: [
+          { name: 'loop_pages', value: true },
+          { name: 'hlrV2', value: true },
+        ],
+      },
+    });
+
+    cy.intercept(
+      'GET',
+      `/v0${CONTESTABLE_ISSUES_API}compensation`,
+      mockContestableIssues,
+    );
+    cy.intercept(
+      'GET',
+      `/v1${CONTESTABLE_ISSUES_API}compensation`,
+      mockContestableIssues,
+    );
+    cy.intercept('GET', '/v0/in_progress_forms/20-0996', mockV2Data);
+    cy.intercept('PUT', '/v0/in_progress_forms/20-0996', mockV2Data);
+
+    // telephone
+    cy.intercept('PUT', '/v0/profile/telephones', mockTelephoneUpdate);
+    cy.intercept('GET', '/v0/profile/status/*', mockTelephoneUpdateSuccess);
+
+    sessionStorage.setItem(WIZARD_STATUS, WIZARD_STATUS_COMPLETE);
+
+    cy.login(mockUser);
+    cy.intercept('GET', '/v0/profile/status', mockStatus);
+
+    cy.visit(BASE_URL);
+    cy.injectAxe();
+  });
+
+  const getToContactPage = () => {
+    // start form
+    cy.findAllByText(/start the request/i, { selector: 'a' })
+      .first()
+      .click();
+
+    // Veteran info (DOB, SSN, etc)
+    cy.location('pathname').should('eq', `${BASE_URL}/veteran-information`);
+    cy.findAllByText(/continue/i, { selector: 'button' })
+      .first()
+      .click();
+
+    // Homeless question
+    cy.location('pathname').should('eq', `${BASE_URL}/homeless`);
+    cy.get('[type="radio"][value="N"]').check(checkOpt);
+    cy.findAllByText(/continue/i, { selector: 'button' })
+      .first()
+      .click();
+  };
+
+  it('should edit info on a new page & cancel returns to contact info page', () => {
+    getToContactPage();
+
+    // Contact info
+    cy.location('pathname').should('eq', `${BASE_URL}/contact-information`);
+    cy.injectAxe();
+    cy.axeCheck();
+
+    // Mobile phone
+    cy.get('a[href$="phone"]').click();
+    cy.location('pathname').should('eq', `${BASE_URL}/edit-mobile-phone`);
+    cy.injectAxe();
+    cy.axeCheck();
+
+    cy.findByText(/cancel/i, { selector: 'button' }).click();
+    cy.location('pathname').should('eq', `${BASE_URL}/contact-information`);
+
+    // Email
+    cy.get('a[href$="email-address"]').click();
+    cy.location('pathname').should('eq', `${BASE_URL}/edit-email-address`);
+    cy.injectAxe();
+    cy.axeCheck();
+
+    cy.findByText(/cancel/i, { selector: 'button' }).click();
+    cy.location('pathname').should('eq', `${BASE_URL}/contact-information`);
+
+    // Mailing address
+    cy.get('a[href$="mailing-address"]').click();
+    cy.location('pathname').should('eq', `${BASE_URL}/edit-mailing-address`);
+    cy.injectAxe();
+    cy.axeCheck();
+
+    cy.findByText(/cancel/i, { selector: 'button' }).click();
+    cy.location('pathname').should('eq', `${BASE_URL}/contact-information`);
+  });
+
+  /*
+   * Skipping for now because clicking "update" should return to the contact
+   * info page, but this isn't working... I think I'm missing an intermediate
+   * step here?
+
+  it.skip('should edit info on a new page, update & return to contact info page', () => {
+    getToContactPage();
+
+    // Contact info
+    cy.location('pathname').should('eq', `${BASE_URL}/contact-information`);
+
+    // Mobile phone
+    cy.get('a[href$="phone"]').click();
+    cy.location('pathname').should('eq', `${BASE_URL}/edit-mobile-phone`);
+
+    cy.findByLabelText(/mobile phone/i)
+      .clear()
+      .type('8885551212');
+    cy.findByLabelText(/extension/i)
+      .clear()
+      .type('12345');
+    cy.findAllByText(/update/i, { selector: 'button' })
+      .first()
+      .click();
+    // Not returning to the contact info page :(
+  });
+  */
+});

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -49,6 +49,7 @@ export default Object.freeze({
   gibctSchoolRatings: 'gibct_school_ratings',
   hlrv2: 'hlr_v2',
   loginGov: 'login_gov',
+  loopPages: 'loop_pages',
   manageDependents: 'dependents_management',
   megaMenuMobileV2: 'mega_menu_mobile_v2',
   preEntryCovid19Screener: 'pre_entry_covid19_screener',


### PR DESCRIPTION
## Description

Testing a new contact info editing loop behind a feature flag. This new method shows the contact info with edit buttons on one page, and clicking on the "Edit" link takes you to a separate page to edit the field.

```
    ┌────────────────────────◄─────┐
    ▼                              │
Contact info ───► Edit address ───►┤
    │    │ └────► Edit phone ─────►┤
    │    └──────► Edit email ─────►┘
    │ Continue
    ▼
Next page after contact info
```

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/31700

## Testing done

Added unit tests & e2e tests for the cancel buttons. Will need to coordinate with the auth-experience team about tests for updating.

## Screenshots

<details><summary>Editing mobile phone flow</summary>

<!-- leave a blank line above -->
![editing phone flow](https://user-images.githubusercontent.com/136959/141170504-75262c82-6f87-479c-8e8e-1caea08b1c96.gif)</details>

<details><summary>Editing address flow with validation</summary>

<!-- leave a blank line above -->
![editing address flow with address validation view](https://user-images.githubusercontent.com/136959/141170499-661c1409-e19b-40e4-baca-6ef76041d0ce.gif)</details>

## Acceptance criteria
- [x] Add contact info editing page loop behind a feature flag
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
