### PR TITLE
Fix named exports from JSON modules v2

### DIFF
--- a/src/applications/coronavirus-vaccination-expansion/config/address/addressSchema.js
+++ b/src/applications/coronavirus-vaccination-expansion/config/address/addressSchema.js
@@ -25,11 +25,7 @@ import AdditionalInfo from '@department-of-veterans-affairs/component-library/Ad
 import ADDRESS_DATA from 'platform/forms/address/data';
 import cloneDeep from 'platform/utilities/data/cloneDeep';
 import get from 'platform/utilities/data/get';
-import {
-  countries,
-  states50AndDC,
-  militaryCities,
-} from 'vets-json-schema/dist/constants.json';
+import constants from 'vets-json-schema/dist/constants.json';
 
 /**
  * CONSTANTS:
@@ -148,8 +144,8 @@ export const addressUISchema = (
             countryUI['ui:disabled'] = false;
             return {
               type: 'string',
-              enum: countries.map(country => country.value),
-              enumNames: countries.map(country => country.label),
+              enum: constants.countries.map(country => country.value),
+              enumNames: constants.countries.map(country => country.label),
             };
           },
         },
@@ -188,8 +184,8 @@ export const addressUISchema = (
               return {
                 type: 'string',
                 title: 'APO/FPO/DPO',
-                enum: militaryCities.map(city => city.value),
-                enumNames: militaryCities.map(city => city.label),
+                enum: constants.militaryCities.map(city => city.value),
+                enumNames: constants.militaryCities.map(city => city.label),
               };
             }
             return {
@@ -255,8 +251,8 @@ export const addressUISchema = (
               };
             }
             return {
-              enum: states50AndDC.map(state => state.value),
-              enumNames: states50AndDC.map(state => state.label),
+              enum: constants.states50AndDC.map(state => state.value),
+              enumNames: constants.states50AndDC.map(state => state.label),
             };
           },
         },

--- a/src/applications/disability-benefits/686c-674/config/address-schema.js
+++ b/src/applications/disability-benefits/686c-674/config/address-schema.js
@@ -25,11 +25,7 @@ import AdditionalInfo from '@department-of-veterans-affairs/component-library/Ad
 import ADDRESS_DATA from 'platform/forms/address/data';
 import cloneDeep from 'platform/utilities/data/cloneDeep';
 import get from 'platform/utilities/data/get';
-import {
-  countries,
-  states,
-  militaryCities,
-} from 'vets-json-schema/dist/constants.json';
+import constants from 'vets-json-schema/dist/constants.json';
 
 /**
  * CONSTANTS:
@@ -40,7 +36,7 @@ import {
  */
 
 // filtered States that include US territories
-const filteredStates = states.USA.filter(
+const filteredStates = constants.states.USA.filter(
   state => !['AA', 'AE', 'AP'].includes(state.value),
 );
 
@@ -155,8 +151,8 @@ export const addressUISchema = (
             countryUI['ui:disabled'] = false;
             return {
               type: 'string',
-              enum: countries.map(country => country.value),
-              enumNames: countries.map(country => country.label),
+              enum: constants.countries.map(country => country.value),
+              enumNames: constants.countries.map(country => country.label),
             };
           },
         },
@@ -201,8 +197,8 @@ export const addressUISchema = (
               return {
                 type: 'string',
                 title: 'APO/FPO/DPO',
-                enum: militaryCities.map(city => city.value),
-                enumNames: militaryCities.map(city => city.label),
+                enum: constants.militaryCities.map(city => city.value),
+                enumNames: constants.militaryCities.map(city => city.label),
               };
             }
             return {

--- a/src/applications/edu-benefits/tests/definitions/educationProgram.unit.spec.jsx
+++ b/src/applications/edu-benefits/tests/definitions/educationProgram.unit.spec.jsx
@@ -5,12 +5,9 @@ import ReactTestUtils from 'react-dom/test-utils';
 
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import * as formConfig from '../../definitions/educationProgram';
-import {
-  address,
-  educationProgram,
-  educationType,
-  date,
-} from 'vets-json-schema/dist/definitions.json';
+import definitionsJson from 'vets-json-schema/dist/definitions.json';
+
+const { address, educationProgram, educationType, date } = definitionsJson;
 
 const schemaWithEdu = {
   definitions: {


### PR DESCRIPTION
## Description
In preparation to upgrade `Webpack` to version 5. There is a breaking change that needs to be fixed before it can be done.

Based on the `Webpack` [migration guide](https://webpack.js.org/migrate/5/), it is important to fix all [named exports from JSON modules](https://webpack.js.org/migrate/5/#using-named-exports-from-json-modules) because it's no longer supported

* **Missed previously because the `import` contains multiple lines**

## Original issue(s)
department-of-veterans-affairs/va.gov-team#11510


## Testing done
Locally
