### PR TITLE
Bug: Fix invalid RegExp

### DIFF
--- a/src/platform/forms-system/src/js/fields/AutosuggestField.jsx
+++ b/src/platform/forms-system/src/js/fields/AutosuggestField.jsx
@@ -6,6 +6,7 @@ import classNames from 'classnames';
 
 import debounce from '../utilities/data/debounce';
 import sortListByFuzzyMatch from '../utilities/fuzzy-matching';
+import escapeRegExp from '../utilities/data/escapeRegExp';
 
 const ESCAPE_KEY = 27;
 
@@ -211,7 +212,7 @@ export default class AutosuggestField extends React.Component {
     // wrap matching text in a <span> element
     const highlightText = uiSchema['ui:options']?.highlightText ?? true;
     const value = this.state.input?.toLowerCase() || '';
-    const caseInsensitiveMatch = new RegExp(`(${value})`, 'i');
+    const caseInsensitiveMatch = new RegExp(`(${escapeRegExp(value)})`, 'i');
     const highLightMatchingText = query => {
       if (value.length > 2) {
         return query

--- a/src/platform/forms-system/src/js/utilities/data/escapeRegExp.js
+++ b/src/platform/forms-system/src/js/utilities/data/escapeRegExp.js
@@ -1,0 +1,3 @@
+const escapeRegExp = text => text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+export default escapeRegExp;

--- a/src/platform/forms-system/test/js/fields/AutosuggestField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/fields/AutosuggestField.unit.spec.jsx
@@ -550,4 +550,47 @@ describe('<AutosuggestField>', () => {
       done();
     });
   });
+  it('should not throw an error if the value includes regexp special characters', done => {
+    const onChange = sinon.spy();
+    const props = {
+      uiSchema: {
+        'ui:options': {
+          freeInput: true,
+          highlightText: true,
+          labels: {
+            AL: 'Label(1)',
+            BC: 'LABEL 2',
+          },
+        },
+      },
+      schema: {
+        type: 'string',
+        enum: ['AL', 'BC'],
+      },
+      formContext: { reviewMode: false },
+      idSchema: { $id: 'id' },
+      onChange,
+      onBlur: () => {},
+    };
+    const wrapper = mount(<AutosuggestField {...props} />);
+
+    // Input something not in options
+    const input = wrapper.find('input');
+    input.simulate('focus');
+    input.simulate('change', {
+      target: {
+        value: 'Bel(',
+      },
+    });
+
+    setTimeout(() => {
+      expect(wrapper.find('.autosuggest-list')).to.exist;
+      const firstItem = wrapper.find('.autosuggest-item').last();
+      const highlight = firstItem.find('.autosuggest-highlight').text();
+      expect(firstItem.text()).to.equal('Label(1)');
+      expect(highlight).to.equal('bel(');
+      wrapper.unmount();
+      done();
+    });
+  });
 });

--- a/src/platform/forms-system/test/js/utilities/escapeRegExp.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/escapeRegExp.unit.spec.js
@@ -5,13 +5,11 @@ import escapeRegExp from 'platform/forms-system/src/js/utilities/data/escapeRegE
 describe('escapeRegExp', () => {
   it('should escape regular expression special characters', () => {
     const raw = '[]{}()*+?.^$|';
-    // eslint-disable-next-line no-useless-escape
     const result = '\\[\\]\\{\\}\\(\\)\\*\\+\\?\\.\\^\\$\\|';
     expect(escapeRegExp(raw)).to.equal(result);
   });
   it('should escape regular expression escaped characters', () => {
     const raw = '\\s and \\';
-    // eslint-disable-next-line no-useless-escape
     const result = '\\\\s and \\\\';
     expect(escapeRegExp(raw)).to.equal(result);
   });

--- a/src/platform/forms-system/test/js/utilities/escapeRegExp.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/escapeRegExp.unit.spec.js
@@ -1,0 +1,18 @@
+import { expect } from 'chai';
+
+import escapeRegExp from 'platform/forms-system/src/js/utilities/data/escapeRegExp';
+
+describe('escapeRegExp', () => {
+  it('should escape regular expression special characters', () => {
+    const raw = '[]{}()*+?.^$|';
+    // eslint-disable-next-line no-useless-escape
+    const result = '\\[\\]\\{\\}\\(\\)\\*\\+\\?\\.\\^\\$\\|';
+    expect(escapeRegExp(raw)).to.equal(result);
+  });
+  it('should escape regular expression escaped characters', () => {
+    const raw = '\\s and \\';
+    // eslint-disable-next-line no-useless-escape
+    const result = '\\\\s and \\\\';
+    expect(escapeRegExp(raw)).to.equal(result);
+  });
+});

--- a/src/platform/forms-system/test/js/utilities/escapeRegExp.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/escapeRegExp.unit.spec.js
@@ -3,14 +3,24 @@ import { expect } from 'chai';
 import escapeRegExp from 'platform/forms-system/src/js/utilities/data/escapeRegExp';
 
 describe('escapeRegExp', () => {
+  const getRegExpString = raw =>
+    new RegExp(`(${escapeRegExp(raw)})`).toString();
+
+  it('should not escape characters that are not special characters', () => {
+    const raw = 'abcdefghijklmnopqrstuvwxyz1234567890!@#%_=:;<>~`';
+    expect(escapeRegExp(raw)).to.equal(raw);
+    expect(getRegExpString(raw)).to.eq(`/(${raw})/`);
+  });
   it('should escape regular expression special characters', () => {
-    const raw = '[]{}()*+?.^$|';
-    const result = '\\[\\]\\{\\}\\(\\)\\*\\+\\?\\.\\^\\$\\|';
+    const raw = '][}{)(*+?.^$|';
+    const result = '\\]\\[\\}\\{\\)\\(\\*\\+\\?\\.\\^\\$\\|';
     expect(escapeRegExp(raw)).to.equal(result);
+    expect(getRegExpString(raw)).to.eq(`/(${result})/`);
   });
   it('should escape regular expression escaped characters', () => {
     const raw = '\\s and \\';
     const result = '\\\\s and \\\\';
     expect(escapeRegExp(raw)).to.equal(result);
+    expect(getRegExpString(raw)).to.eq(`/(${result})/`);
   });
 });


### PR DESCRIPTION
## Description

The autocomplete highlighter uses the user input to build a regular expression. When a Veteran enters a special character that needs to be escaped, it causes a JS error - see http://sentry.vfs.va.gov/organizations/vsp/issues/54794/

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/32508

## Testing done

- Added unit test for new `escapeRegExp` utility
- Added unit test for AutosuggestField search with parenthesis

## Screenshots

N/A

## Acceptance criteria
- [x] Special RegExp characters are escaped before building a RegExp from user input
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
