### PR TITLE
Redoing sandbox implementation of tab titles from test-ready master

### DIFF
--- a/src/applications/gi-sandbox/containers/GiBillApp.jsx
+++ b/src/applications/gi-sandbox/containers/GiBillApp.jsx
@@ -38,6 +38,7 @@ export function GiBillApp({
   const location = useLocation();
 
   useEffect(() => {
+    document.title = 'GI Bill® Comparison Tool | Veterans Affairs';
     document.addEventListener('focus', scrollToFocusedElement, true);
 
     return () => {
@@ -91,7 +92,7 @@ export function GiBillApp({
           {constants.inProgress && <LoadingIndicator message="Loading..." />}
           {constants.error && <ServiceError />}
           {!(constants.error || constants.inProgress) && (
-            <DowntimeNotification appTitle={'GI Bill Comparison Tool'}>
+            <DowntimeNotification appTitle={'GI Bill® Comparison Tool'}>
               {children}
             </DowntimeNotification>
           )}

--- a/src/applications/gi-sandbox/containers/ProfilePage.jsx
+++ b/src/applications/gi-sandbox/containers/ProfilePage.jsx
@@ -21,7 +21,6 @@ export function ProfilePage({
   profile,
   calculator,
   dispatchFetchProfile,
-  dispatchSetPageTitle,
   dispatchShowModal,
   dispatchHideModal,
   eligibility,
@@ -51,7 +50,7 @@ export function ProfilePage({
   useEffect(
     () => {
       if (institutionName) {
-        dispatchSetPageTitle(`${institutionName} - GI Bill® Comparison Tool`);
+        document.title = `${institutionName} - GI Bill® Comparison Tool`;
       }
     },
     [institutionName],

--- a/src/applications/gi/containers/GiBillApp.jsx
+++ b/src/applications/gi/containers/GiBillApp.jsx
@@ -57,7 +57,7 @@ export function GiBillApp({
           {constants.inProgress && <LoadingIndicator message="Loading..." />}
           {constants.error && <ServiceError />}
           {!(constants.error || constants.inProgress) && (
-            <DowntimeNotification appTitle={'GI Bill Comparison Tool'}>
+            <DowntimeNotification appTitle={'GI Bill® Comparison Tool'}>
               {children}
             </DowntimeNotification>
           )}


### PR DESCRIPTION
Making sure to not implement redundant/unnecessary changes identified in previous implementation.

## Description


## Original issue(s)
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/29346


## Testing done
Visual confirmation of sandbox tab title changes

## Screenshots
<img width="568" alt="Search-Page-Sandbox" src="https://user-images.githubusercontent.com/86262790/141193128-788e200b-eb85-4130-8c1f-a6077bdf857a.png">

<img width="612" alt="Comparison-Tool-Sandbox" src="https://user-images.githubusercontent.com/86262790/141193131-59289af4-c07b-451f-b26e-8f8d99377765.png">

<img width="548" alt="Profile-Page-Sandbox" src="https://user-images.githubusercontent.com/86262790/141193133-2be9f1db-b983-401d-9523-917616cb201e.png">


## Acceptance criteria
- [x] Tab title changes seen on sandbox pages

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
