### PR TITLE
Add asset bucket to deploy

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -859,11 +859,9 @@ jobs:
           - environment: vagovdev
             deploy-bucket: dev.va.gov
             asset-bucket: dev-va-gov-assets
-            apps-bucket: apps.dev.va.gov
           - environment: vagovstaging
             deploy-bucket: staging.va.gov
             asset-bucket: staging-va-gov-assets
-            apps-bucket: apps.staging.va.gov
 
     steps:
       - name: Checkout
@@ -898,14 +896,6 @@ jobs:
           SRC: s3://vetsgov-website-builds-s3-upload/${{ github.sha }}/${{ matrix.environment }}.tar.bz2
           DEST: s3://${{ matrix.deploy-bucket }}
           ASSET_DEST: s3://${{ matrix.asset-bucket }}
-
-      # TODO: Revisit revproxy
-      - name: Deploy to ${{ matrix.apps-bucket }}
-        run: ./script/github-actions/deploy.sh -s $SRC -d $DEST -a $ASSET_DEST -v
-        env:
-          SRC: s3://vetsgov-website-builds-s3-upload/${{ github.sha }}/${{ matrix.environment }}.tar.bz2
-          DEST: s3://${{ matrix.deploy-bucket }}
-          ASSET_DEST: s3://${{ matrix.apps-bucket }}
 
   # jenkins:
   #   name: Run Jenkins CI

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -857,10 +857,12 @@ jobs:
       matrix:
         include:
           - environment: vagovdev
-            bucket: dev-va-gov-assets
+            deploy-bucket: dev.va.gov
+            asset-bucket: dev-va-gov-assets
             apps-bucket: apps.dev.va.gov
           - environment: vagovstaging
-            bucket: staging-va-gov-assets
+            deploy-bucket: staging.va.gov
+            asset-bucket: staging-va-gov-assets
             apps-bucket: apps.staging.va.gov
 
     steps:
@@ -891,17 +893,19 @@ jobs:
           role-session-name: vsp-frontendteam-githubaction
 
       - name: Deploy
-        run: ./script/github-actions/deploy.sh -s $SRC -d $DEST -v
+        run: ./script/github-actions/deploy.sh -s $SRC -d $DEST -a $ASSET_DEST -v
         env:
           SRC: s3://vetsgov-website-builds-s3-upload/${{ github.sha }}/${{ matrix.environment }}.tar.bz2
-          DEST: s3://${{ matrix.bucket }}
+          DEST: s3://${{ matrix.deploy-bucket }}
+          ASSET_DEST: s3://${{ matrix.asset-bucket }}
 
       # TODO: Revisit revproxy
       - name: Deploy to ${{ matrix.apps-bucket }}
-        run: ./script/github-actions/deploy.sh -s $SRC -d $DEST -v
+        run: ./script/github-actions/deploy.sh -s $SRC -d $DEST -a $ASSET_DEST -v
         env:
           SRC: s3://vetsgov-website-builds-s3-upload/${{ github.sha }}/${{ matrix.environment }}.tar.bz2
-          DEST: s3://${{ matrix.apps-bucket }}
+          DEST: s3://${{ matrix.deploy-bucket }}
+          ASSET_DEST: s3://${{ matrix.apps-bucket }}
 
   # jenkins:
   #   name: Run Jenkins CI


### PR DESCRIPTION
## Description
Currently assets in the S3 asset buckets aren't being compressed, which will affect performance. This PR updates the dev/staging deploy job to use the asset buckets (`dev-va-gov-assets`, `staging-va-gov-assets`) as the `ASSET_DEST` variable in the deploy script.

Also, now that we [removed](https://github.com/department-of-veterans-affairs/devops/pull/10252) the apps buckets from the nginx config, we can remove the S3 upload to `apps.dev.va.gov` and `apps.staging.va.gov`.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
