### PR TITLE
style: add margin and update padding for breadcrumbs

### DIFF
--- a/src/platform/site-wide/sass/shame.scss
+++ b/src/platform/site-wide/sass/shame.scss
@@ -139,12 +139,11 @@ $medium-phone-screen: 375px;
   }
 
   .va-nav-breadcrumbs-list {
-    padding-left: 0;
+    padding: 1em 0 0 0;
 
     li {
       list-style: none;
-      padding-bottom: 1em;
-      padding-top: 1em;
+      margin: 0 0 1.375em 0;
     }
   }
 


### PR DESCRIPTION
## Description


## Original issue(s)
[department-of-veterans-affairs/va.gov-team/issues/13717](https://github.com/department-of-veterans-affairs/va.gov-team/issues/13717)


## Testing done

Visual

## Screenshots

<img width="911" alt="breadcrumbs-after" src="https://user-images.githubusercontent.com/36863582/141324820-79cb8115-24f2-4f57-913b-3fe86b35117f.png">

## Acceptance criteria
- [ ] 22px vertical space between breadcrumbs

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
