### PR TITLE
Github Actions (dd) -- Update token for schedule deploy

### DIFF
--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -100,10 +100,24 @@ jobs:
     runs-on: ubuntu-latest
     needs: [set-env, notify-start, validate-build-status]
     steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+
+      - name: Get bot token from Parameter Store
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
 
       - name: Waiting to release
         run: |


### PR DESCRIPTION
## Description

Ops just confirmed and verified that `va_vsp_bot_github_token` has workflow permission. Adding it for if we do deploy in a previous commit, it won't error out

## Original issue(s)
department-of-veterans-affairs/va.gov-team#0000


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
