### PR TITLE
Fix Current or Past Date Error Message for Years < Min

### DIFF
--- a/src/platform/forms-system/src/js/validation.js
+++ b/src/platform/forms-system/src/js/validation.js
@@ -1,4 +1,3 @@
-import moment from 'moment';
 import find from 'lodash/find';
 import get from '../../../utilities/data/get';
 import omit from '../../../utilities/data/omit';
@@ -384,7 +383,7 @@ export function validateCurrentOrPastDate(
   const {
     futureDate = 'Please provide a valid current or past date',
   } = errorMessages;
-  validateDate(errors, dateString, minYear, moment().year());
+  validateDate(errors, dateString, minYear, new Date().getFullYear());
   const { day, month, year } = parseISODate(dateString);
   if (!isValidCurrentOrPastDate(day, month, year)) {
     errors.addError(futureDate);

--- a/src/platform/forms-system/src/js/validation.js
+++ b/src/platform/forms-system/src/js/validation.js
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import find from 'lodash/find';
 import get from '../../../utilities/data/get';
 import omit from '../../../utilities/data/omit';
@@ -345,10 +346,17 @@ export function validateSSN(errors, ssn) {
   }
 }
 
-export function validateDate(errors, dateString) {
+export function validateDate(
+  errors,
+  dateString,
+  customMinYear = minYear,
+  customMaxYear = maxYear,
+) {
   const { day, month, year } = parseISODate(dateString);
   if (year?.length >= 4 && !isValidYear(year)) {
-    errors.addError(`Please enter a year between ${minYear} and ${maxYear}`);
+    errors.addError(
+      `Please enter a year between ${customMinYear} and ${customMaxYear}`,
+    );
   } else if (!isValidPartialDate(day, month, year)) {
     errors.addError('Please provide a valid date');
   }
@@ -376,7 +384,7 @@ export function validateCurrentOrPastDate(
   const {
     futureDate = 'Please provide a valid current or past date',
   } = errorMessages;
-  validateDate(errors, dateString);
+  validateDate(errors, dateString, minYear, moment().year());
   const { day, month, year } = parseISODate(dateString);
   if (!isValidCurrentOrPastDate(day, month, year)) {
     errors.addError(futureDate);

--- a/src/platform/forms-system/test/js/validation.unit.spec.js
+++ b/src/platform/forms-system/test/js/validation.unit.spec.js
@@ -281,11 +281,12 @@ describe('Schemaform validations', () => {
     it('should set message if invalid', () => {
       const errors = { addError: sinon.spy() };
       const pastDate = `${minYear - 1}-01-01`;
+      const currentYear = new Date().getFullYear();
       validateCurrentOrPastDate(errors, pastDate);
 
       expect(errors.addError.callCount).to.equal(1);
       expect(errors.addError.firstCall.args[0]).to.equal(
-        `Please enter a year between ${minYear} and ${maxYear}`,
+        `Please enter a year between ${minYear} and ${currentYear}`,
       );
     });
     it('should use custom message', () => {


### PR DESCRIPTION
## Description
There is an issue with the error message displayed for current or past dates (specifically with the validateCurrentOrPastDate function) when the year is less than the minimum year (currently 1900). The error message that gets displayed is "Please enter a year between 1900 and 2121", but the actual validation requires a year less than or equal to the current year and not less than current year + 100 years, obviously. The error message for future dates is fine: "Please provide a valid current or past date".

There are multiple ways to fix this error message, but I updated the error message to simply use the current year, rather than the maxYear, in the error message.

## Screenshots
<img width="354" alt="Birthday Min Year Error Message" src="https://user-images.githubusercontent.com/112403/141513762-74e7893e-5c9c-4b15-9ec2-2a8fda42175e.png">


