### PR TITLE
Update Cypress configuration for v9.0.0

### DIFF
--- a/config/cypress.json
+++ b/config/cypress.json
@@ -4,7 +4,6 @@
   "viewportHeight": 960,
   "integrationFolder": "src",
   "modifyObstructiveCode": false,
-  "nodeVersion": "system",
   "pluginsFile": "src/platform/testing/e2e/cypress/plugins/index.js",
   "supportFile": "src/platform/testing/e2e/cypress/support/index.js",
   "testFiles": "**/tests/**/*.cypress.spec.js?(x)",


### PR DESCRIPTION
## Description
`nodeVersion` is set to `system` by default in Cypress 9.0.0, so this configuration setting can be removed. This line is generating deprecation warnings on CI.

## Acceptance criteria
- [ ] CI passes.