### PR TITLE
[COE] Move h1 to avoid having 2 h1s when going through form process

### DIFF
--- a/src/applications/lgy/coe/actions/index.js
+++ b/src/applications/lgy/coe/actions/index.js
@@ -7,7 +7,7 @@ export const SKIP_AUTOMATIC_COE_CHECK = 'SKIP_AUTOMATIC_COE_CHECK';
 const mockApiCall = () => {
   return new Promise(resolve => {
     setTimeout(() => {
-      resolve({ status: 'success' });
+      resolve({ status: 'pending' });
     }, 2000);
   });
   //   return new Promise(reject => {

--- a/src/applications/lgy/coe/containers/App.jsx
+++ b/src/applications/lgy/coe/containers/App.jsx
@@ -10,7 +10,7 @@ import formConfig from '../config/form';
 import { generateCoe } from '../actions';
 
 function App(props) {
-  const { location, children } = props;
+  const { children, location } = props;
 
   useEffect(() => {
     props.generateCoe();
@@ -18,20 +18,16 @@ function App(props) {
 
   const content = (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
+      <FormTitle title="Request a VA home loan Certificate of Eligibility (COE)" />
+      <p className="vads-u-padding-bottom--3">
+        Request for a Certificate of Eligibility (VA Form 26-1880)
+      </p>
       {children}
     </RoutedSavableApp>
   );
 
   return (
     <>
-      <header className="row">
-        <div className="usa-width-two-thirds medium-12 columns">
-          <FormTitle title="Request a VA home loan Certificate of Eligibility (COE)" />
-          <p className="vads-u-padding-bottom--3">
-            Request for a Certificate of Eligibility (VA Form 26-1880)
-          </p>
-        </div>
-      </header>
       {content}
       <FormFooter formConfig={formConfig} />
     </>

--- a/src/applications/lgy/coe/containers/App.jsx
+++ b/src/applications/lgy/coe/containers/App.jsx
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 
 import FormFooter from 'platform/forms/components/FormFooter';
-import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 
 import formConfig from '../config/form';
@@ -18,10 +17,6 @@ function App(props) {
 
   const content = (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-      <FormTitle title="Request a VA home loan Certificate of Eligibility (COE)" />
-      <p className="vads-u-padding-bottom--3">
-        Request for a Certificate of Eligibility (VA Form 26-1880)
-      </p>
       {children}
     </RoutedSavableApp>
   );

--- a/src/applications/lgy/coe/containers/IntroductionPage.jsx
+++ b/src/applications/lgy/coe/containers/IntroductionPage.jsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { focusElement } from 'platform/utilities/ui';
 import { isLoggedIn } from 'platform/user/selectors';
+import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import { notLoggedInContent } from './introduction-content/notLoggedInContent.jsx';
 import COEIntroPageBox from './introduction-content/COEIntroPageBox';
 import LoggedInContent from './introduction-content/loggedInContent.jsx';
@@ -26,6 +27,10 @@ const IntroductionPage = props => {
   if (props.loggedIn && coeCallEnded.includes(props.status)) {
     content = (
       <div>
+        <FormTitle title="Request a VA home loan Certificate of Eligibility (COE)" />
+        <p className="vads-u-padding-bottom--3">
+          Request for a Certificate of Eligibility (VA Form 26-1880)
+        </p>
         <COEIntroPageBox coe={props.coe} status={props.status} />
         {props.coe.status !== COE_ELIGIBILITY_STATUS.denied && (
           <LoggedInContent parentProps={props} />


### PR DESCRIPTION
## Description
Moved the `FormTItle` for the form app so that it is removed from the DOM once the user enters the form

## Original issue(s)
department-of-veterans-affairs/va.gov-team#31223

## Acceptance criteria
- [x] h1 from introduction page is removed when user enters form

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
