### PR TITLE
Added placeholder for new nav, made use of feature flag

### DIFF
--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -42,6 +42,7 @@ import {
   eduDirectDepositInformation,
   eduDirectDepositIsSetUp,
   showNotificationSettings,
+  showProfileLGBTQEnhancements,
 } from '@@profile/selectors';
 import {
   fetchCNPPaymentInformation as fetchCNPPaymentInformationAction,
@@ -158,6 +159,8 @@ class Profile extends Component {
     const routesOptions = {
       removeDirectDeposit: !this.props.shouldShowDirectDeposit,
       removeNotificationSettings: !this.props.shouldShowNotificationSettings,
+      shouldShowProfileLGBTQEnhancements: this.props
+        .shouldShowProfileLGBTQEnhancements,
     };
 
     // We need to pass in a config to hide forbidden routes
@@ -265,6 +268,7 @@ Profile.propTypes = {
   fetchPersonalInformation: PropTypes.func.isRequired,
   fetchCNPPaymentInformation: PropTypes.func.isRequired,
   fetchEDUPaymentInformation: PropTypes.func.isRequired,
+  shouldShowProfileLGBTQEnhancements: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = state => {
@@ -365,6 +369,7 @@ const mapStateToProps = state => {
     isDowntimeWarningDismissed: state.scheduledDowntime?.dismissedDowntimeWarnings?.includes(
       'profile',
     ),
+    shouldShowProfileLGBTQEnhancements: showProfileLGBTQEnhancements(state),
   };
 };
 

--- a/src/applications/personalization/profile/components/contact-information/ContactInformation.jsx
+++ b/src/applications/personalization/profile/components/contact-information/ContactInformation.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const ContactInformation = () => {
+  return <div>GREETINGS HERE IS NEW CONTACT INFORMATION PLACE HOLDER</div>;
+};
+
+export default ContactInformation;

--- a/src/applications/personalization/profile/constants.js
+++ b/src/applications/personalization/profile/constants.js
@@ -35,6 +35,16 @@ export const PROFILE_PATH_NAMES = Object.freeze({
   ACCOUNT_SECURITY: 'Account security',
 });
 
+export const PROFILE_PATHS_LGBTQ_ENHANCEMENT = Object.freeze({
+  PERSONAL_INFORMATION: '/profile/personal-information',
+  CONTACT_INFORMATION: '/profile/contact-information',
+});
+
+export const PROFILE_PATH_NAMES_LGBTQ_ENHANCEMENT = Object.freeze({
+  PERSONAL_INFORMATION: 'Personal information',
+  CONTACT_INFORMATION: 'Contact information',
+});
+
 export const ACCOUNT_TYPES_OPTIONS = {
   checking: 'Checking',
   savings: 'Savings',

--- a/src/applications/personalization/profile/routes.js
+++ b/src/applications/personalization/profile/routes.js
@@ -1,10 +1,16 @@
 import AccountSecurity from './components/account-security/AccountSecurity';
+import ContactInformation from './components/contact-information/ContactInformation';
 import PersonalInformation from './components/personal-information/PersonalInformation';
 import MilitaryInformation from './components/military-information/MilitaryInformation';
 import DirectDeposit from './components/direct-deposit/DirectDeposit';
 import ConnectedApplications from './components/connected-apps/ConnectedApps';
 import NotificationSettings from './components/notification-settings/NotificationSettings';
-import { PROFILE_PATHS, PROFILE_PATH_NAMES } from './constants';
+import {
+  PROFILE_PATHS,
+  PROFILE_PATH_NAMES,
+  PROFILE_PATH_NAMES_LGBTQ_ENHANCEMENT,
+  PROFILE_PATHS_LGBTQ_ENHANCEMENT,
+} from './constants';
 
 const getRoutes = options => {
   let routes = [
@@ -62,6 +68,25 @@ const getRoutes = options => {
     routes = routes.filter(
       route => route.name !== PROFILE_PATH_NAMES.NOTIFICATION_SETTINGS,
     );
+  }
+
+  if (options.shouldShowProfileLGBTQEnhancements) {
+    const personalInformation = {
+      component: PersonalInformation,
+      name: PROFILE_PATH_NAMES_LGBTQ_ENHANCEMENT.PERSONAL_INFORMATION,
+      path: PROFILE_PATHS_LGBTQ_ENHANCEMENT.PERSONAL_INFORMATION,
+      requiresLOA3: true,
+      requiresMVI: true,
+    };
+    const contactInformation = {
+      component: ContactInformation,
+      name: PROFILE_PATH_NAMES_LGBTQ_ENHANCEMENT.CONTACT_INFORMATION,
+      path: PROFILE_PATHS_LGBTQ_ENHANCEMENT.CONTACT_INFORMATION,
+      requiresLOA3: true,
+      requiresMVI: true,
+    };
+    routes.splice(0, 1, personalInformation);
+    routes.splice(1, 0, contactInformation);
   }
 
   return routes;

--- a/src/applications/personalization/profile/selectors.js
+++ b/src/applications/personalization/profile/selectors.js
@@ -95,3 +95,6 @@ export const showNotificationSettings = state => {
   }
   return !!FFProfileNotificationSettings;
 };
+
+export const showProfileLGBTQEnhancements = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.profileEnhancements];

--- a/src/applications/personalization/profile/tests/components/Profile.unit.spec.js
+++ b/src/applications/personalization/profile/tests/components/Profile.unit.spec.js
@@ -287,6 +287,7 @@ describe('mapStateToProps', () => {
       'shouldShowDirectDeposit',
       'shouldShowNotificationSettings',
       'isDowntimeWarningDismissed',
+      'shouldShowProfileLGBTQEnhancements',
     ];
     expect(Object.keys(props)).to.deep.equal(expectedKeys);
   });


### PR DESCRIPTION
## Description
Added contact-information to the side nav for the profile.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#31662


## Testing done
Ran it locally, used Judy Morrison as test user.
Ran unit and integration tests.

## Screenshots
![Screen Shot 2021-11-15 at 1 53 43 PM](https://user-images.githubusercontent.com/26075258/141839359-c564be90-65a5-409c-bec9-1ddf9898d2af.png)

### **FEATURE FLAG OFF**
![Screen Shot 2021-11-15 at 1 53 13 PM](https://user-images.githubusercontent.com/26075258/141839361-03c85650-7dbd-4b8e-8a9b-e009110e8177.png)

### **FEATURE FLAG ON**
![Screen Shot 2021-11-15 at 1 52 32 PM](https://user-images.githubusercontent.com/26075258/141839363-611bcc8d-f999-4c64-8c2f-4ade3a16cab9.png)
![Screen Shot 2021-11-15 at 1 52 24 PM](https://user-images.githubusercontent.com/26075258/141839366-e306331e-cfb7-492f-b08d-5cdb01127bd1.png)

## Acceptance criteria
- [ ] Feature Flag toggled on changes side navigation to split personal and contact information

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
