### PR TITLE
Hide Claimant ID on Review; Fix Text Capitalization

### DIFF
--- a/src/applications/my-education-benefits/config/form.js
+++ b/src/applications/my-education-benefits/config/form.js
@@ -400,6 +400,9 @@ const formConfig = {
             claimantId: {
               'ui:title': 'Claimant ID',
               'ui:disabled': true,
+              'ui:options': {
+                hideOnReview: true,
+              },
             },
             'view:userFullName': {
               'ui:description': (

--- a/src/applications/my-education-benefits/helpers.js
+++ b/src/applications/my-education-benefits/helpers.js
@@ -75,7 +75,7 @@ export const unsureDescription = (
 
 export const post911GiBillNote = (
   <div className="usa-alert background-color-only">
-    <h3>You’re applying for the Post-9/11 GI BIll®</h3>
+    <h3>You’re applying for the Post-9/11 GI Bill®</h3>
     <p>
       At this time, you can only apply for the Post-9/11 GI Bill (Chapter 33)
       benefits through this application. Doing so will require that you give up


### PR DESCRIPTION
## Description
Two small fixes: hide the claimant ID on the review page (hidden form field) and fix the capitalization of GI Bill on one page.