### PR TITLE
Pre check in 32770 mock api - User Session Responses

### DIFF
--- a/src/applications/check-in/day-of/utils/session/session.test.unit.spec.js
+++ b/src/applications/check-in/day-of/utils/session/session.test.unit.spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { setCurrentToken, clearCurrentSession, getCurrentToken } from './index';
 
-describe('check in', () => {
+describe('Pre check in', () => {
   describe('session utils', () => {
     describe('save token to session storage', () => {
       it('saves data to name spaced key', () => {

--- a/src/applications/check-in/day-of/utils/session/session.test.unit.spec.js
+++ b/src/applications/check-in/day-of/utils/session/session.test.unit.spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { setCurrentToken, clearCurrentSession, getCurrentToken } from './index';
 
-describe('Pre check in', () => {
+describe('check in', () => {
   describe('session utils', () => {
     describe('save token to session storage', () => {
       it('saves data to name spaced key', () => {

--- a/src/applications/check-in/pre-check-in/api/index.js
+++ b/src/applications/check-in/pre-check-in/api/index.js
@@ -1,0 +1,7 @@
+import { v2 } from './versions/v2';
+
+const api = {
+  v2,
+};
+
+export { api };

--- a/src/applications/check-in/pre-check-in/api/local-mock-api/mocks/v2/sessions.responses.js
+++ b/src/applications/check-in/pre-check-in/api/local-mock-api/mocks/v2/sessions.responses.js
@@ -1,0 +1,34 @@
+const createMockSuccessResponse = (uuid, permissions) => {
+  return {
+    permissions,
+    status: 'success',
+    error: undefined,
+    uuid,
+  };
+};
+
+const createMockFailedResponse = () => {
+  return {
+    errors: [
+      {
+        title: 'Operation failed',
+        detail: 'Operation failed',
+        code: 'VA900',
+        status: '400',
+      },
+    ],
+  };
+};
+
+const mocks = {
+  get: params => {
+    const { uuid } = params;
+    return createMockSuccessResponse(uuid, 'read.none');
+  },
+  post: body => {
+    const { id } = body;
+    return createMockSuccessResponse(id, 'read.full');
+  },
+};
+
+module.exports = { createMockSuccessResponse, createMockFailedResponse, mocks };

--- a/src/applications/check-in/pre-check-in/api/versions/v2.js
+++ b/src/applications/check-in/pre-check-in/api/versions/v2.js
@@ -1,0 +1,46 @@
+import { apiRequest } from 'platform/utilities/api';
+import environment from 'platform/utilities/environment';
+import { makeApiCall } from '../../utils/api';
+
+const v2 = {
+  getSession: async token => {
+    const url = '/check_in/v2/sessions/';
+    const json = await makeApiCall(
+      apiRequest(`${environment.API_URL}${url}${token}`),
+      'get-current-session',
+      token,
+    );
+    return {
+      ...json,
+    };
+  },
+  postSession: async ({ lastName, last4, token }) => {
+    const url = '/check_in/v2/sessions/';
+    const headers = { 'Content-Type': 'application/json' };
+    const data = {
+      session: {
+        uuid: token,
+        last4: last4.trim(),
+        lastName: lastName.trim(),
+      },
+    };
+    const body = JSON.stringify(data);
+    const settings = {
+      headers,
+      body,
+      method: 'POST',
+      mode: 'cors',
+    };
+
+    const json = await makeApiCall(
+      apiRequest(`${environment.API_URL}${url}`, settings),
+      'validating-user',
+      token,
+    );
+    return {
+      ...json,
+    };
+  },
+};
+
+export { v2 };

--- a/src/applications/check-in/pre-check-in/utils/analytics/analytics.test.unit.spec.js
+++ b/src/applications/check-in/pre-check-in/utils/analytics/analytics.test.unit.spec.js
@@ -1,0 +1,85 @@
+import { expect } from 'chai';
+
+import { createAnalyticsSlug, createApiEvent } from './index';
+
+describe('check in', () => {
+  describe('analytics utils', () => {
+    describe('createAnalyticsSlug', () => {
+      it('returns a created slug  with undefined', () => {
+        const slug = undefined;
+        const result = createAnalyticsSlug(slug);
+        expect(result).to.equal('check-in-undefined');
+      });
+      it('returns a created slug  with value', () => {
+        const slug = 'testing';
+        const result = createAnalyticsSlug(slug);
+        expect(result).to.equal('check-in-testing');
+      });
+    });
+    describe('createApiEvent', () => {
+      it('no parameters are provided and it stuff creates and objects', () => {
+        const result = createApiEvent();
+        expect(result).to.deep.equal({
+          'api-status': undefined,
+          event: 'api_call',
+          'api-name': undefined,
+        });
+      });
+      it('name and status are provided', () => {
+        const name = 'hello-there';
+        const status = 'success';
+        const result = createApiEvent(name, status);
+        expect(result).to.deep.equal({
+          'api-status': status,
+          event: 'api_call',
+          'api-name': name,
+        });
+      });
+      it('time is added', () => {
+        const name = 'hello-there';
+        const status = 'success';
+        const time = 1234;
+        const result = createApiEvent(name, status, time);
+        expect(result).to.deep.equal({
+          'api-status': status,
+          event: 'api_call',
+          'api-name': name,
+          // eslint-disable-next-line camelcase
+          api_latency_ms: time,
+        });
+      });
+      it('token is added', () => {
+        const name = 'hello-there';
+        const status = 'success';
+        const time = 1234;
+        const token = 'UUID';
+        const result = createApiEvent(name, status, time, token);
+        expect(result).to.deep.equal({
+          'api-status': status,
+          event: 'api_call',
+          'api-name': name,
+          // eslint-disable-next-line camelcase
+          api_latency_ms: time,
+          'api-request-id': token,
+        });
+      });
+      it('has an error', () => {
+        const name = 'hello-there';
+        const status = 'success';
+        const time = 1234;
+        const token = 'UUID';
+        const error = 'something went wrong';
+        const result = createApiEvent(name, status, time, token, error);
+        expect(result).to.deep.equal({
+          'api-status': status,
+          event: 'api_call',
+          'api-name': name,
+          // eslint-disable-next-line camelcase
+          api_latency_ms: time,
+          'error-key': error,
+          'api-request-id': token,
+        });
+      });
+    });
+  });
+});

--- a/src/applications/check-in/pre-check-in/utils/analytics/analytics.test.unit.spec.js
+++ b/src/applications/check-in/pre-check-in/utils/analytics/analytics.test.unit.spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import { createAnalyticsSlug, createApiEvent } from './index';
 
-describe('check in', () => {
+describe('Pre check in', () => {
   describe('analytics utils', () => {
     describe('createAnalyticsSlug', () => {
       it('returns a created slug  with undefined', () => {

--- a/src/applications/check-in/pre-check-in/utils/analytics/index.js
+++ b/src/applications/check-in/pre-check-in/utils/analytics/index.js
@@ -1,0 +1,44 @@
+/**
+ * @param {string} slug
+ */
+const createAnalyticsSlug = slug => {
+  return `check-in-${slug}`;
+};
+
+/**
+ * @typedef {Object} CreateApiEventResponse
+ * @property {string} event
+ * @property {string} api-name
+ * @property {string} api-status
+ * @property {number} [api_latency_ms]
+ * @property {string} [api-request-id]
+ * @property {string} [error-key]
+ */
+
+/**
+ * @param {string} [name]
+ * @param {string} [status]
+ * @param {number} [time]
+ * @param {string} [token]
+ * @param {string} [error]
+ * @returns {CreateApiEventResponse}
+ */
+const createApiEvent = (name, status, time, token, error) => {
+  const rv = {
+    event: 'api_call',
+    'api-name': name,
+    'api-status': status,
+  };
+  if (time) {
+    // eslint-disable-next-line camelcase
+    rv.api_latency_ms = time;
+  }
+  if (token) {
+    rv['api-request-id'] = token;
+  }
+  if (error) {
+    rv['error-key'] = error;
+  }
+  return rv;
+};
+export { createAnalyticsSlug, createApiEvent };

--- a/src/applications/check-in/pre-check-in/utils/api/api.utils.unit.spec.js
+++ b/src/applications/check-in/pre-check-in/utils/api/api.utils.unit.spec.js
@@ -1,0 +1,34 @@
+import { expect } from 'chai';
+
+import { makeApiCall } from './index';
+
+describe('check in', () => {
+  describe('api utils', () => {
+    describe('makeApiCall', () => {
+      it('makeApiCall invokes promise', async () => {
+        const testPromise = new Promise(resolve => {
+          const sample = { data: { hello: 'world' } };
+          resolve(sample);
+        });
+        const result = await makeApiCall(testPromise);
+        expect(result).to.deep.equal({ data: { hello: 'world' } });
+      });
+      it('makeApiCall invokes promise with error', async () => {
+        const testPromise = new Promise(resolve => {
+          const sample = { data: { hello: 'world', error: 'no error' } };
+          resolve(sample);
+        });
+        const result = await makeApiCall(testPromise);
+        expect(result).to.deep.equal({
+          data: { hello: 'world', error: 'no error' },
+        });
+      });
+      it('failed api call is caught', async () => {
+        const testPromise = new Promise((resolve, reject) => {
+          reject(new Error('failed'));
+        });
+        await expect(makeApiCall(testPromise)).to.be.rejectedWith('failed');
+      });
+    });
+  });
+});

--- a/src/applications/check-in/pre-check-in/utils/api/api.utils.unit.spec.js
+++ b/src/applications/check-in/pre-check-in/utils/api/api.utils.unit.spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import { makeApiCall } from './index';
 
-describe('check in', () => {
+describe('Pre check in', () => {
   describe('api utils', () => {
     describe('makeApiCall', () => {
       it('makeApiCall invokes promise', async () => {

--- a/src/applications/check-in/pre-check-in/utils/api/index.js
+++ b/src/applications/check-in/pre-check-in/utils/api/index.js
@@ -1,0 +1,34 @@
+import { createApiEvent } from '../analytics';
+import recordEvent from 'platform/monitoring/record-event';
+
+/**
+ * @param {Promise} request
+ * @param {string} [eventName]
+ * @param {string} [token]
+ */
+const makeApiCall = async (request, eventName, token) => {
+  // log call started
+  recordEvent(createApiEvent(eventName, 'started'));
+  // start the timer
+  const startTime = new Date();
+  // do the call
+
+  try {
+    const json = await request;
+    const endTime = new Date();
+    const timeDiff = endTime.getTime() - startTime.getTime();
+
+    const { data } = json;
+    const error = data?.error || data?.errors;
+    const status = error ? 'failed' : 'success';
+    const event = createApiEvent(eventName, status, timeDiff, token, error);
+    recordEvent(event);
+    return json;
+  } catch (error) {
+    const event = createApiEvent(eventName, status, null, token, error);
+    recordEvent(event);
+    throw error;
+  }
+};
+
+export { makeApiCall };

--- a/src/applications/check-in/pre-check-in/utils/session/index.js
+++ b/src/applications/check-in/pre-check-in/utils/session/index.js
@@ -1,0 +1,45 @@
+const sessionNameSpace = 'health.care.check-in.';
+
+const SESSION_STORAGE_KEYS = Object.freeze({
+  CURRENT_UUID: `${sessionNameSpace}current.uuid`,
+});
+
+/**
+ * @param {Window} window
+ */
+const clearCurrentSession = window => {
+  const { sessionStorage } = window;
+  const { CURRENT_UUID } = SESSION_STORAGE_KEYS;
+  sessionStorage.removeItem(CURRENT_UUID);
+};
+
+/**
+ * @param {Window} window
+ * @param {string} token
+ */
+const setCurrentToken = (window, token) => {
+  const { sessionStorage } = window;
+  const { CURRENT_UUID } = SESSION_STORAGE_KEYS;
+  const key = CURRENT_UUID;
+  const data = { token };
+  sessionStorage.setItem(key, JSON.stringify(data));
+};
+
+/**
+ * @param {Window} window
+ */
+const getCurrentToken = window => {
+  if (!window) return null;
+  const { sessionStorage } = window;
+  const { CURRENT_UUID } = SESSION_STORAGE_KEYS;
+
+  const key = CURRENT_UUID;
+
+  const data = sessionStorage.getItem(key);
+  if (data) {
+    return JSON.parse(data);
+  } else {
+    return null;
+  }
+};
+export { clearCurrentSession, getCurrentToken, setCurrentToken };

--- a/src/applications/check-in/pre-check-in/utils/session/session.test.unit.spec.js
+++ b/src/applications/check-in/pre-check-in/utils/session/session.test.unit.spec.js
@@ -1,0 +1,80 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { setCurrentToken, clearCurrentSession, getCurrentToken } from './index';
+
+describe('check in', () => {
+  describe('session utils', () => {
+    describe('save token to session storage', () => {
+      it('saves data to name spaced key', () => {
+        const setItem = sinon.spy();
+        const window = {
+          sessionStorage: {
+            setItem,
+          },
+        };
+        const testToken = 'testToken';
+        setCurrentToken(window, testToken);
+        expect(setItem.called).to.be.true;
+        expect(
+          setItem.calledWith(
+            'health.care.check-in.current.uuid',
+            JSON.stringify({ token: testToken }),
+          ),
+        ).to.be.true;
+      });
+    });
+    describe('clears current session', () => {
+      it('name-spaced session should be empty', () => {
+        const removeItem = sinon.spy();
+        const window = {
+          sessionStorage: {
+            removeItem,
+          },
+        };
+        clearCurrentSession(window);
+        expect(removeItem.called).to.be.true;
+        expect(removeItem.calledWith('health.care.check-in.current.uuid')).to.be
+          .true;
+      });
+    });
+    describe('get token from session storage', () => {
+      it('window is null', () => {
+        const window = null;
+        const result = getCurrentToken(window);
+        expect(result).to.be.null;
+      });
+      it('calls getItem', () => {
+        const getItem = sinon.spy();
+
+        const window = {
+          sessionStorage: {
+            getItem,
+          },
+        };
+        const result = getCurrentToken(window);
+        expect(getItem.called).to.be.true;
+        expect(getItem.calledWith('health.care.check-in.current.uuid')).to.be
+          .true;
+        expect(result).to.be.null;
+      });
+      it('key is not', () => {
+        const window = {
+          sessionStorage: {
+            getItem: () => null,
+          },
+        };
+        const result = getCurrentToken(window);
+        expect(result).to.be.null;
+      });
+      it('key is found', () => {
+        const window = {
+          sessionStorage: {
+            getItem: () => JSON.stringify({ token: 'some-token' }),
+          },
+        };
+        const result = getCurrentToken(window);
+        expect(result).to.have.property('token', 'some-token');
+      });
+    });
+  });
+});

--- a/src/applications/check-in/pre-check-in/utils/session/session.test.unit.spec.js
+++ b/src/applications/check-in/pre-check-in/utils/session/session.test.unit.spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { setCurrentToken, clearCurrentSession, getCurrentToken } from './index';
 
-describe('check in', () => {
+describe('Pre check in', () => {
   describe('session utils', () => {
     describe('save token to session storage', () => {
       it('saves data to name spaced key', () => {


### PR DESCRIPTION
## Description
This is the first batch of changes for the mock API for pre check in. It includes the API base setup and the session mock responses from day-of check in. It also includes the util files for api, analytics and session.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#32770


## Testing done
Includes unit tests

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
