### PR TITLE
Fix styling of header logo on safari

### DIFF
--- a/src/platform/site-wide/header/components/LogoRow/styles.scss
+++ b/src/platform/site-wide/header/components/LogoRow/styles.scss
@@ -1,5 +1,7 @@
 .header-logo {
-  width: 40px;
+  svg {
+    width: 40px;
+  }
 }
 
 .header-sign-in-button {


### PR DESCRIPTION
## Description
This PR fixes the styling of header v2 on Safari.

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#0000](https://github.com/department-of-veterans-affairs/va.gov-team/issues/32821)

## Testing done
N/A

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/12773166/141857538-2d0e1d06-885d-4008-9c54-c89359c534f5.png)

### After

![image](https://user-images.githubusercontent.com/12773166/141857460-ae53af92-56bb-4ba8-9565-0c81a088b3c9.png)

## Acceptance criteria
- [x] Fix header v2 logo on Safari.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
