### PR TITLE
Tweak styling and focus behavior

### DIFF
--- a/src/platform/site-wide/header/components/MenuItemLevel1/index.js
+++ b/src/platform/site-wide/header/components/MenuItemLevel1/index.js
@@ -1,5 +1,5 @@
 // Node modules.
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 // Relative imports.
@@ -17,16 +17,6 @@ export const MenuItemLevel1 = ({
 
   // Derive if we the menu item is expanded.
   const isExpanded = menuItemID === expandedMenuID;
-
-  // Focus item if expanded when coming from SubMenu.
-  useEffect(
-    () => {
-      if (isExpanded) {
-        document.getElementById(menuItemID)?.focus?.();
-      }
-    },
-    [isExpanded, menuItemID],
-  );
 
   // Do not render if we are missing necessary menu item data.
   if (!item?.menuSections && !item?.href && !item?.title) {

--- a/src/platform/site-wide/header/components/MenuItemLevel2/index.js
+++ b/src/platform/site-wide/header/components/MenuItemLevel2/index.js
@@ -1,25 +1,47 @@
 // Node modules.
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 // Relative imports.
 import { deriveMenuItemID, formatMenuItems } from '../../helpers';
 import { updateSubMenuAction } from '../../containers/Menu/actions';
 
-export const MenuItemLevel2 = ({ item, updateSubMenu }) => {
+export const MenuItemLevel2 = ({ item, lastClickedMenuID, updateSubMenu }) => {
+  // Derive the menu item's ID.
+  const menuItemID = deriveMenuItemID(item, '2');
+
+  // Derive if we the menu item is expanded.
+  const shouldFocus = menuItemID === lastClickedMenuID;
+
+  // Focus item if last clicked when coming back from SubMenu.
+  useEffect(
+    () => {
+      if (shouldFocus) {
+        document.getElementById(menuItemID)?.focus?.();
+      }
+    },
+    [shouldFocus, menuItemID],
+  );
+
   // Do not render if we are missing necessary menu item data.
   if (!item?.links && !item?.href && !item?.title) {
     return null;
   }
-
-  // Derive the menu item's ID.
-  const menuItemID = deriveMenuItemID(item, '2');
 
   const toggleShowItems = () => {
     updateSubMenu({
       id: menuItemID,
       menuSections: formatMenuItems(item?.links),
     });
+  };
+
+  const onButtonKeyDown = event => {
+    const isEnterKey = event.keyCode === 13;
+    const isSpaceKey = event.keyCode === 32;
+
+    if (isEnterKey || isSpaceKey) {
+      toggleShowItems();
+    }
   };
 
   return (
@@ -48,7 +70,7 @@ export const MenuItemLevel2 = ({ item, updateSubMenu }) => {
         <button
           className="header-menu-item-button vads-u-background-color--gray-lightest vads-u-display--flex vads-u-justify-content--space-between vads-u-width--full vads-u-text-decoration--none vads-u-margin--0 vads-u-padding--2 vads-u-color--link-default"
           id={menuItemID}
-          onKeyDown={event => event.keyCode === 13 && toggleShowItems()}
+          onKeyDown={onButtonKeyDown}
           onMouseUp={toggleShowItems}
           type="button"
         >
@@ -145,15 +167,21 @@ MenuItemLevel2.propTypes = {
       }),
     }),
   ]),
+  // From mapStateToProps.
+  lastClickedMenuID: PropTypes.string,
   // From mapDispatchToProps.
   updateSubMenu: PropTypes.func.isRequired,
 };
+
+const mapStateToProps = state => ({
+  lastClickedMenuID: state.headerMenuReducer.lastClickedMenuID,
+});
 
 const mapDispatchToProps = dispatch => ({
   updateSubMenu: subMenu => dispatch(updateSubMenuAction(subMenu)),
 });
 
 export default connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps,
 )(MenuItemLevel2);

--- a/src/platform/site-wide/header/containers/Menu/index.js
+++ b/src/platform/site-wide/header/containers/Menu/index.js
@@ -32,22 +32,19 @@ export const Menu = ({ isMenuOpen, megaMenuData, showMegaMenu, subMenu }) => {
   return (
     <div className="vads-u-background-color--gray-lightest vads-u-display--flex vads-u-flex-direction--column vads-u-margin--0 vads-u-padding--0 vads-u-width--full">
       {/* Search */}
-      <p className="vads-u-padding-x--2 vads-u-color--gray-dark vads-u-margin-bottom--1">
+      <label className="vads-u-padding-x--1p5 vads-u-color--gray-dark vads-u-margin--0 vads-u-margin-top--2">
         Search
-      </p>
+      </label>
       <SearchDropdownComponent
+        buttonClassName="vads-u-padding--0"
         buttonText=""
         canSubmit
-        id="header-search-dropdown"
-        componentClassName="vads-u-margin-bottom--2"
-        containerClassName="vads-u-max-width--none vads-u-margin-left--2 vads-u-padding--0"
-        buttonClassName="vads-u-padding--0 vads-u-margin-right--2"
-        inputClassName="vads-u-max-width--none vads-u-margin--0 "
-        suggestionsListClassName=""
-        suggestionClassName=""
+        componentClassName="header-search vads-u-padding-right--1p5 vads-u-padding-bottom--2"
+        containerClassName="vads-u-padding-left--1p5"
         fetchSuggestions={fetchSearchSuggestions}
         formatSuggestions
         fullWidthSuggestions
+        id="header-search-dropdown"
         onInputSubmit={onSearch}
         onSuggestionSubmit={onSuggestionSubmit}
         startingValue=""

--- a/src/platform/site-wide/header/containers/Menu/index.unit.spec.js
+++ b/src/platform/site-wide/header/containers/Menu/index.unit.spec.js
@@ -37,7 +37,7 @@ describe('Header <Menu>', () => {
     expect(
       wrapper.find('div.vads-u-background-color--gray-lightest'),
     ).to.have.length(1);
-    expect(wrapper.find('p').text()).to.equal('Search');
+    expect(wrapper.find('label').text()).to.equal('Search');
     expect(wrapper.find('SearchDropdownComponent')).to.have.length(1);
     expect(wrapper.find('ul')).to.have.length(0);
 
@@ -54,7 +54,7 @@ describe('Header <Menu>', () => {
     expect(
       wrapper.find('div.vads-u-background-color--gray-lightest'),
     ).to.have.length(1);
-    expect(wrapper.find('p').text()).to.equal('Search');
+    expect(wrapper.find('label').text()).to.equal('Search');
     expect(wrapper.find('SearchDropdownComponent')).to.have.length(1);
     expect(wrapper.find('ul')).to.have.length(1);
     expect(wrapper.find('Connect(MenuItemLevel1)')).to.have.length(1);
@@ -80,7 +80,7 @@ describe('Header <Menu>', () => {
     expect(
       wrapper.find('div.vads-u-background-color--gray-lightest'),
     ).to.have.length(1);
-    expect(wrapper.find('p').text()).to.equal('Search');
+    expect(wrapper.find('label').text()).to.equal('Search');
     expect(wrapper.find('SearchDropdownComponent')).to.have.length(1);
     expect(wrapper.find('ul')).to.have.length(1);
     expect(wrapper.find('Connect(MenuItemLevel1)')).to.have.length(2);

--- a/src/platform/site-wide/header/containers/Menu/reducer.js
+++ b/src/platform/site-wide/header/containers/Menu/reducer.js
@@ -3,6 +3,7 @@ import { UPDATE_EXPANDED_MENU_ID, UPDATE_SUB_MENU } from './constants';
 
 export const initialState = {
   expandedMenuID: undefined,
+  lastClickedMenuID: undefined,
   subMenu: undefined,
 };
 
@@ -11,12 +12,14 @@ export default (state = initialState, action = {}) => {
     return {
       ...state,
       expandedMenuID: action.expandedMenuID,
+      lastClickedMenuID: undefined,
     };
   }
 
   if (action.type === UPDATE_SUB_MENU) {
     return {
       ...state,
+      lastClickedMenuID: action.subMenu?.id || state.lastClickedMenuID,
       subMenu: action.subMenu,
     };
   }

--- a/src/platform/site-wide/header/containers/Menu/reducer.unit.spec.js
+++ b/src/platform/site-wide/header/containers/Menu/reducer.unit.spec.js
@@ -9,6 +9,7 @@ describe('Menu reducer', () => {
     // Assertions.
     expect(initialState).to.deep.equal({
       expandedMenuID: undefined,
+      lastClickedMenuID: undefined,
       subMenu: undefined,
     });
   });
@@ -25,18 +26,20 @@ describe('Menu reducer', () => {
     // Assertions.
     expect(headerMenuReducer(initialState, action)).to.deep.equal({
       expandedMenuID: 'test',
+      lastClickedMenuID: undefined,
       subMenu: undefined,
     });
   });
 
   it('headerMenuReducer handles UPDATE_SUB_MENU case', () => {
     // Set up.
-    const action = { subMenu: 'test', type: UPDATE_SUB_MENU };
+    const action = { subMenu: { id: 'test' }, type: UPDATE_SUB_MENU };
 
     // Assertions.
     expect(headerMenuReducer(initialState, action)).to.deep.equal({
       expandedMenuID: undefined,
-      subMenu: 'test',
+      lastClickedMenuID: 'test',
+      subMenu: { id: 'test' },
     });
   });
 });

--- a/src/platform/site-wide/header/containers/Menu/styles.scss
+++ b/src/platform/site-wide/header/containers/Menu/styles.scss
@@ -2,8 +2,15 @@
   border-radius: 0;
 }
 
-#header-search-dropdown-submit-button {
-  border-bottom-left-radius: 0;
-  border-top-left-radius: 0;
-  width: 55px;
+.header-search {
+  .search-dropdown-container.full-width-suggestions {
+    max-width: unset;
+  }
+
+  .search-dropdown-submit-button {
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0;
+    margin-right: 0 !important;
+    width: 45px;
+  }
 }


### PR DESCRIPTION
## Description
This PR implements some a11y fixes and design tweaks for header v2.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/32806

## Testing done
Locally

## Screenshots

### Design spec:

![image](https://user-images.githubusercontent.com/12773166/141864649-c0bc33b4-293b-4f28-ac36-2cb741f76647.png)

https://user-images.githubusercontent.com/12773166/141864445-a098792b-e354-4545-8c46-511b395f7b2a.mov

## Acceptance criteria
- [x] Focus should be circular, in other words, when going backwards, focus should return to the button that originally triggered it. For example, Health Care > should go to Back to menu which should return back to Health Care > (and not the parent VA Benefits and Health Care
- [x] Search should be a label , not a p element.
- [x] space should work for the child nav buttons too, not just enter

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
