### PR TITLE
26995 - Remove production exclusion flags

### DIFF
--- a/src/applications/edu-benefits/0994/containers/PreSubmitInfo.jsx
+++ b/src/applications/edu-benefits/0994/containers/PreSubmitInfo.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PreSubmitInfo from '../../containers/PreSubmitInfo';
-import environment from 'platform/utilities/environment';
 import formConfig from '../config/form';
 
 function PreSubmitNotice({
@@ -17,10 +16,7 @@ function PreSubmitNotice({
   }
 
   const activeDutyNote = (
-    <div
-      className="vads-u-margin-bottom--3"
-      id={!environment.isProduction() && ariaDescribedBy}
-    >
+    <div className="vads-u-margin-bottom--3" id={ariaDescribedBy}>
       {formData.activeDuty ? (
         <div>
           <strong>By submitting this form</strong> you certify that:

--- a/src/platform/forms-system/src/js/components/ProgressButton.jsx
+++ b/src/platform/forms-system/src/js/components/ProgressButton.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import uniqueId from 'lodash/uniqueId';
-import environment from 'platform/utilities/environment';
 
 /**
  * A component for the continue button to navigate through panels of questions.
@@ -43,9 +42,7 @@ class ProgressButton extends React.Component {
         id={`${this.id}-continueButton`}
         onClick={this.props.onButtonClick}
         aria-label={this.props.ariaLabel || null}
-        aria-describedby={
-          !environment.isProduction() && this.props.ariaDescribedBy
-        }
+        aria-describedby={this.props.ariaDescribedBy}
       >
         {beforeText}
         {this.props.buttonText}


### PR DESCRIPTION
## Remove production exclusion flags

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#0000](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/26995)


## Testing done


## Screenshots

<img width="1024" alt="0994-aria" src="https://user-images.githubusercontent.com/3818397/141869886-6576bf2f-f4c2-4a77-b4f3-66b4affccc58.png">

## Acceptance criteria
- [ ] Submit button `aria-describedby` label must match "By submitting this form" `id` tag above on the page for proper screen reader operation.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
