### PR TITLE
Update cypress-testrail-helper specs-search scope

### DIFF
--- a/script/cypress-testrail-helper/lib/utils.js
+++ b/script/cypress-testrail-helper/lib/utils.js
@@ -43,7 +43,7 @@ module.exports = {
 
     return new Promise((myResolve, myReject) => {
       try {
-        specGlob = 'src/applications/**/' + filename + '.cypress.spec.js?(x)';
+        specGlob = 'src/**/tests/**/' + filename + '.cypress.spec.js?(x)';
         glob(specGlob, {}, (err, files) => {
           if (err) {
             throw new Error(err);


### PR DESCRIPTION
## Description
Update cypress-testrail-helper script to search both src/applications/... & src/platform/... for Cypress spec-files.  Previously, only src/applications/... tree was searched.

## Original issue(s)
n/a

## Testing done
- Does NOT impact app-functionalities.  Only a glob-pattern config-change.
- Ran src/platform/... specs locally with cy-tr-helper, and successfully pushed results to TestRail.

## Acceptance criteria
- [ ] Reviewers approved changes.

## Definition of done
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
