### PR TITLE
32928: Login.gov - FIX GA Success Event | Add Correct Verify Copy

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -58,6 +58,7 @@ class AuthMetrics {
       case 'mhv':
       case 'dslogon':
       case 'idme':
+      case 'logingov':
         recordEvent({ event: `login-success-${this.serviceName}` });
         this.compareLoginPolicy();
         break;

--- a/src/applications/verify/containers/VerifyApp.jsx
+++ b/src/applications/verify/containers/VerifyApp.jsx
@@ -22,6 +22,7 @@ export class VerifyApp extends React.Component {
     const signinMethodLabels = {
       dslogon: 'DS Logon',
       myhealthevet: 'My HealtheVet',
+      logingov: 'Login.gov',
     };
 
     this.signInMethod = signinMethodLabels[serviceName] || 'ID.me';


### PR DESCRIPTION
## Description
Fixes `login-success-logingov` event and adds proper copy for verify page

## Original issue(s)
department-of-veterans-affairs/va.gov-team#32928


## Acceptance criteria
- [x] `login-success-logingov` able to be triggered
- [x] Adds `Login.gov` to sign in copy for Verify Page

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
