### PR TITLE
Search Rep no results display

### DIFF
--- a/src/applications/personalization/search-representative/config/search/searchRepresentativeWidget.jsx
+++ b/src/applications/personalization/search-representative/config/search/searchRepresentativeWidget.jsx
@@ -81,13 +81,16 @@ const SearchRepresentativeWidget = props => {
           page={currentPage}
           pages={pages}
         />
-        <h2>If you don’t see the representative you want</h2>
-        <p>You can go back to make changes and search again.</p>
+        <h2>If the accredited representative you want isn’t listed here</h2>
+        <p>
+          You can go back to try your search again. Try entering a different
+          kind of representative or a different location.
+        </p>
         <a
           className="vads-c-action-link--green"
           href="/view-change-representative/search/representative-type"
         >
-          Go back and search again
+          Go back to search again
         </a>
         <h2>If you found the representative you want</h2>
         <p>
@@ -154,7 +157,21 @@ const SearchRepresentativeWidget = props => {
       </div>
     );
   } else {
-    return <div>No results</div>;
+    return (
+      <>
+        <h2>We didn’t find a match</h2>
+        <p>
+          You can go back to try your search again. Try entering a different
+          kind of representative or a different location.
+        </p>
+        <a
+          className="vads-c-action-link--green"
+          href="/view-change-representative/search/representative-type"
+        >
+          Go back to search again
+        </a>
+      </>
+    );
   }
 };
 

--- a/src/applications/personalization/search-representative/reducers/index.js
+++ b/src/applications/personalization/search-representative/reducers/index.js
@@ -9,7 +9,7 @@ import {
 const initialState = {
   loading: true, // app starts in loading state
   error: null,
-  representativeSearchResults: null,
+  representativeSearchResults: [],
 };
 
 function allSearchResults(state = initialState, action) {


### PR DESCRIPTION
## Description
Adds code for displaying message and action link when a representative search returns no results

## Original issue(s)
department-of-veterans-affairs/va.gov-team#32857

## Screenshots
<img width="870" alt="Screen Shot 2021-11-16 at 1 41 07 PM" src="https://user-images.githubusercontent.com/13838621/142054332-68ccf67e-4fed-40dc-a34d-5586514002b2.png">

## Acceptance criteria
- [x] When there are no search results, user sees a message and action link directing them to search again

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
