### PR TITLE
Adding analytics for various events on GIBCT Location search page.

### DIFF
--- a/src/applications/gi-sandbox/containers/SearchPage.jsx
+++ b/src/applications/gi-sandbox/containers/SearchPage.jsx
@@ -14,6 +14,8 @@ import AccordionItem from '../components/AccordionItem';
 import { getSearchQueryChanged, updateUrlParams } from '../selectors/search';
 import classNames from 'classnames';
 import GIBillHeaderInfo from '../components/GIBillHeaderInfo';
+import environment from 'platform/utilities/environment';
+import recordEvent from 'platform/monitoring/record-event';
 
 export function SearchPage({
   dispatchChangeSearchTab,
@@ -58,6 +60,9 @@ export function SearchPage({
   };
 
   const tabChange = selectedTab => {
+    recordEvent({
+      event: `Search By ${selectedTab} tab clicked`,
+    });
     dispatchChangeSearchTab(selectedTab);
     queryParams.set('search', selectedTab);
     history.push({ pathname: '/', search: queryParams.toString() });
@@ -112,16 +117,24 @@ export function SearchPage({
                   <AccordionItem
                     button="Search by name"
                     expanded={accordions[TABS.name]}
-                    onClick={expanded => accordionChange(TABS.name, expanded)}
+                    onClick={expanded => {
+                      accordionChange(TABS.name, expanded);
+                      recordEvent({
+                        event: `Search By Name tab clicked`,
+                      });
+                    }}
                   >
                     <NameSearchForm smallScreen />
                   </AccordionItem>
                   <AccordionItem
                     button="Search by location"
                     expanded={accordions[TABS.location]}
-                    onClick={expanded =>
-                      accordionChange(TABS.location, expanded)
-                    }
+                    onClick={expanded => {
+                      recordEvent({
+                        event: `Search By Location tab clicked`,
+                      });
+                      accordionChange(TABS.location, expanded);
+                    }}
                   >
                     <LocationSearchForm smallScreen />
                   </AccordionItem>

--- a/src/applications/gi-sandbox/containers/SearchPage.jsx
+++ b/src/applications/gi-sandbox/containers/SearchPage.jsx
@@ -14,7 +14,6 @@ import AccordionItem from '../components/AccordionItem';
 import { getSearchQueryChanged, updateUrlParams } from '../selectors/search';
 import classNames from 'classnames';
 import GIBillHeaderInfo from '../components/GIBillHeaderInfo';
-import environment from 'platform/utilities/environment';
 import recordEvent from 'platform/monitoring/record-event';
 
 export function SearchPage({

--- a/src/applications/gi-sandbox/containers/search/LocationSearchForm.jsx
+++ b/src/applications/gi-sandbox/containers/search/LocationSearchForm.jsx
@@ -17,6 +17,7 @@ import { useHistory } from 'react-router-dom';
 import { updateUrlParams } from '../../selectors/search';
 import { TABS } from '../../constants';
 import { INITIAL_STATE } from '../../reducers/search';
+import recordEvent from 'platform/monitoring/record-event';
 
 export function LocationSearchForm({
   autocomplete,
@@ -77,6 +78,12 @@ export function LocationSearchForm({
     }
     let paramLocation = location;
     dispatchMapChanged({ changed: false, distance: null });
+
+    recordEvent({
+      event: 'gibct-form-change',
+      'gibct-form-field': 'locationSearch',
+      'gibct-form-value': location,
+    });
 
     if (autocompleteSelection?.coords) {
       paramLocation = autocompleteSelection.label;
@@ -203,7 +210,12 @@ export function LocationSearchForm({
                     </div>
                   ) : (
                     <button
-                      onClick={dispatchGeolocateUser}
+                      onClick={() => {
+                        recordEvent({
+                          event: 'use-my-location-clicked',
+                        });
+                        dispatchGeolocateUser();
+                      }}
                       className="use-my-location-link"
                     >
                       <i
@@ -238,7 +250,14 @@ export function LocationSearchForm({
                 value={distance}
                 alt="distance"
                 visible
-                onChange={e => setDistance(e.target.value)}
+                onChange={e => {
+                  recordEvent({
+                    event: 'gibct-form-change',
+                    'gibct-form-field': 'locationRadius',
+                    'gibct-form-value': e.target.value,
+                  });
+                  setDistance(e.target.value);
+                }}
               />
               <button
                 type="submit"


### PR DESCRIPTION
## Description
OCTO reported the GIBCT Redesign is missing critical Google Analytics. After conducting thorough analysis and collaboration with the OCTO team it was determined by OCTO GIBCT Redesign cannot be released to production without Google Analytics.

This story is to add Analytics to the Search Location Page.

![image](https://user-images.githubusercontent.com/90346049/142056396-8d62db1d-ff2e-4b30-9936-8f8ae852ce82.png)Location Search tab selection
* Location search executed
* Location Search terms
* User selects from autocomplete results listing
* Location search returns 0 results
* User engages with "Use my current location" to search
* User adjusts radius option
* User engages with map to search
* User engages with markers on map
* "Tuition housing & estimates" Accordion
  * Accordion opens
  * Update selections inside accordion - which selections
  * "Learn more" selected - which ones?
* "Filter your search" accordion
  * Accordion opens
  * Update selections inside accordion - which selections
  * "Learn more" selected - which ones?

## Original issue(s)
department-of-veterans-affairs/va.gov-team#32626


## Testing done
Trigger events via UI, validated using ObservePoint TagDebugger chrome extension

## Screenshots
* Location Search tab selection
![image](https://user-images.githubusercontent.com/90346049/142054096-4693fcd0-65b9-45d8-ba48-a3ef7db024ed.png)

* Location search executed and terms
![image](https://user-images.githubusercontent.com/90346049/142054415-9549f7c0-bb87-4b07-80a4-2506fed87396.png)

* User selects from autocomplete results listing
![image](https://user-images.githubusercontent.com/90346049/142054593-e0c73522-cdee-4665-ae4d-2dd5903f4a1e.png)

* Location search returns results (cm41 = number of results, cm42 = pages)
![image](https://user-images.githubusercontent.com/90346049/142054481-1c977e49-fa99-486e-9145-395aa44a0218.png)

* User engages with "Use my current location" to search
![image](https://user-images.githubusercontent.com/90346049/142054272-67b80e81-5ab6-4b5f-81d4-8ceb54cba648.png)

* User adjusts radius option
![image](https://user-images.githubusercontent.com/90346049/142054668-7cae1552-bc00-4f23-a6f5-ed3b7af40dce.png)

* User engages with map to search 
![image](https://user-images.githubusercontent.com/90346049/142056396-8d62db1d-ff2e-4b30-9936-8f8ae852ce82.png)

* User engages with markers on map
![image](https://user-images.githubusercontent.com/90346049/142056076-7e73a0f9-6bbc-4c99-9589-a850d864cf91.png)

* "Tuition housing & estimates" Accordion
  * Accordion opens  
![image](https://user-images.githubusercontent.com/90346049/142054717-58ff683b-fbaf-4ca5-80f1-0267273ca2f0.png)

  * Update selections inside accordion - which selections
![image](https://user-images.githubusercontent.com/90346049/142056133-cff5b3a8-5446-4781-abbb-903e688f8c8a.png)

  * "Learn more" selected - which ones?
![image](https://user-images.githubusercontent.com/90346049/142054830-be7921b7-65e0-4bd7-8536-9ec6cea372cb.png)

* "Filter your search" accordion
  * Accordion opens
![image](https://user-images.githubusercontent.com/90346049/142056196-32682d82-117a-4c1a-b172-13309ac68b07.png)

  * Update selections inside accordion - which selections
![image](https://user-images.githubusercontent.com/90346049/142056250-c008ecfa-0422-4db3-824d-0083c1624c28.png)

  * "Learn more" selected - which ones?
![image](https://user-images.githubusercontent.com/90346049/142056341-ff8c6886-4fff-4f43-a805-ed97d8e16fb7.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
