### PR TITLE
Kelsonic 32940 search header v2

### DIFF
--- a/src/platform/site-wide/header/components/LogoRow/index.js
+++ b/src/platform/site-wide/header/components/LogoRow/index.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 // Relative imports.
 import Logo from '../Logo';
 import UserNav from '../../../user-nav/containers/Main';
+import { onEnterOrSpaceHandler } from '../../helpers';
 import { updateExpandedMenuIDAction } from '../../containers/Menu/actions';
 
 export const LogoRow = ({
@@ -37,8 +38,8 @@ export const LogoRow = ({
           aria-controls="header-nav-items"
           aria-expanded={isMenuOpen ? 'true' : 'false'}
           className="header-menu-button usa-button vads-u-background-color--gray-lightest vads-u-color--link-default vads-u-padding-y--1 vads-u-padding-x--1p5 vads-u-margin--0 vads-u-margin-left--2 vads-u-position--relative"
+          onKeyDown={onEnterOrSpaceHandler(onMenuToggle)}
           onMouseUp={onMenuToggle}
-          onKeyDown={event => event.keyCode === 13 && onMenuToggle()}
           type="button"
         >
           {/* Menu | Close */}

--- a/src/platform/site-wide/header/components/LogoRow/index.js
+++ b/src/platform/site-wide/header/components/LogoRow/index.js
@@ -5,7 +5,6 @@ import { connect } from 'react-redux';
 // Relative imports.
 import Logo from '../Logo';
 import UserNav from '../../../user-nav/containers/Main';
-import { onEnterOrSpaceHandler } from '../../helpers';
 import { updateExpandedMenuIDAction } from '../../containers/Menu/actions';
 
 export const LogoRow = ({
@@ -38,8 +37,7 @@ export const LogoRow = ({
           aria-controls="header-nav-items"
           aria-expanded={isMenuOpen ? 'true' : 'false'}
           className="header-menu-button usa-button vads-u-background-color--gray-lightest vads-u-color--link-default vads-u-padding-y--1 vads-u-padding-x--1p5 vads-u-margin--0 vads-u-margin-left--2 vads-u-position--relative"
-          onKeyDown={onEnterOrSpaceHandler(onMenuToggle)}
-          onMouseUp={onMenuToggle}
+          onClick={onMenuToggle}
           type="button"
         >
           {/* Menu | Close */}

--- a/src/platform/site-wide/header/components/LogoRow/index.unit.spec.js
+++ b/src/platform/site-wide/header/components/LogoRow/index.unit.spec.js
@@ -54,7 +54,7 @@ describe('Header <LogoRow>', () => {
         setIsMenuOpen={setIsMenuOpen}
       />,
     );
-    wrapper.find('.header-menu-button').simulate('mouseup');
+    wrapper.find('.header-menu-button').simulate('click');
 
     // Assertions.
     expect(updateExpandedMenuID.called).to.be.true;

--- a/src/platform/site-wide/header/components/MenuItemLevel1/index.js
+++ b/src/platform/site-wide/header/components/MenuItemLevel1/index.js
@@ -4,11 +4,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 // Relative imports.
 import MenuItemLevel2 from '../MenuItemLevel2';
-import {
-  deriveMenuItemID,
-  formatMenuItems,
-  onEnterOrSpaceHandler,
-} from '../../helpers';
+import { deriveMenuItemID, formatMenuItems } from '../../helpers';
 import { updateExpandedMenuIDAction } from '../../containers/Menu/actions';
 
 export const MenuItemLevel1 = ({
@@ -73,8 +69,7 @@ export const MenuItemLevel1 = ({
             aria-expanded={isExpanded ? 'true' : 'false'}
             className="header-menu-item-button vads-u-background-color--primary-darker vads-u-display--flex vads-u-justify-content--space-between vads-u-width--full vads-u-text-decoration--none vads-u-margin--0 vads-u-padding--2 vads-u-color--white"
             id={menuItemID}
-            onKeyDown={onEnterOrSpaceHandler(toggleShowItems)}
-            onMouseUp={toggleShowItems}
+            onClick={toggleShowItems}
             type="button"
           >
             {item?.title}

--- a/src/platform/site-wide/header/components/MenuItemLevel1/index.js
+++ b/src/platform/site-wide/header/components/MenuItemLevel1/index.js
@@ -4,7 +4,11 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 // Relative imports.
 import MenuItemLevel2 from '../MenuItemLevel2';
-import { deriveMenuItemID, formatMenuItems } from '../../helpers';
+import {
+  deriveMenuItemID,
+  formatMenuItems,
+  onEnterOrSpaceHandler,
+} from '../../helpers';
 import { updateExpandedMenuIDAction } from '../../containers/Menu/actions';
 
 export const MenuItemLevel1 = ({
@@ -41,15 +45,6 @@ export const MenuItemLevel1 = ({
     }
   };
 
-  const onButtonKeyDown = event => {
-    const isEnterKey = event.keyCode === 13;
-    const isSpaceKey = event.keyCode === 32;
-
-    if (isEnterKey || isSpaceKey) {
-      toggleShowItems();
-    }
-  };
-
   return (
     <li className="vads-u-background-color--primary-darker vads-u-margin--0 vads-u-margin-bottom--0p5 vads-u-width--full vads-u-font-weight--bold">
       {/* Raw title */}
@@ -78,7 +73,7 @@ export const MenuItemLevel1 = ({
             aria-expanded={isExpanded ? 'true' : 'false'}
             className="header-menu-item-button vads-u-background-color--primary-darker vads-u-display--flex vads-u-justify-content--space-between vads-u-width--full vads-u-text-decoration--none vads-u-margin--0 vads-u-padding--2 vads-u-color--white"
             id={menuItemID}
-            onKeyDown={onButtonKeyDown}
+            onKeyDown={onEnterOrSpaceHandler(toggleShowItems)}
             onMouseUp={toggleShowItems}
             type="button"
           >

--- a/src/platform/site-wide/header/components/MenuItemLevel1/index.unit.spec.js
+++ b/src/platform/site-wide/header/components/MenuItemLevel1/index.unit.spec.js
@@ -25,7 +25,7 @@ describe('Header <MenuItemLevel1>', () => {
     wrapper.unmount();
   });
 
-  it('renders an expanded item with children and collapses it on mouseup', () => {
+  it('renders an expanded item with children and collapses it on click', () => {
     // Set up.
     const updateExpandedMenuID = sinon.spy();
     const item = {
@@ -52,7 +52,7 @@ describe('Header <MenuItemLevel1>', () => {
     expect(wrapper.find('ul')).to.have.length(1);
 
     // Set up.
-    wrapper.find('.header-menu-item-button').simulate('mouseup');
+    wrapper.find('.header-menu-item-button').simulate('click');
 
     // Assertions.
     expect(updateExpandedMenuID.firstCall.args[0]).to.equal(undefined);
@@ -61,7 +61,7 @@ describe('Header <MenuItemLevel1>', () => {
     wrapper.unmount();
   });
 
-  it('renders a collapsed item with children and expands it on mouseup', () => {
+  it('renders a collapsed item with children and expands it on click', () => {
     // Set up.
     const updateExpandedMenuID = sinon.spy();
     const item = {
@@ -88,7 +88,7 @@ describe('Header <MenuItemLevel1>', () => {
     expect(wrapper.find('ul')).to.have.length(0);
 
     // Set up.
-    wrapper.find('.header-menu-item-button').simulate('mouseup');
+    wrapper.find('.header-menu-item-button').simulate('click');
 
     // Assertions.
     expect(updateExpandedMenuID.firstCall.args[0]).to.equal('example--1');

--- a/src/platform/site-wide/header/components/MenuItemLevel2/index.js
+++ b/src/platform/site-wide/header/components/MenuItemLevel2/index.js
@@ -3,7 +3,11 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 // Relative imports.
-import { deriveMenuItemID, formatMenuItems } from '../../helpers';
+import {
+  deriveMenuItemID,
+  formatMenuItems,
+  onEnterOrSpaceHandler,
+} from '../../helpers';
 import { updateSubMenuAction } from '../../containers/Menu/actions';
 
 export const MenuItemLevel2 = ({ item, lastClickedMenuID, updateSubMenu }) => {
@@ -35,15 +39,6 @@ export const MenuItemLevel2 = ({ item, lastClickedMenuID, updateSubMenu }) => {
     });
   };
 
-  const onButtonKeyDown = event => {
-    const isEnterKey = event.keyCode === 13;
-    const isSpaceKey = event.keyCode === 32;
-
-    if (isEnterKey || isSpaceKey) {
-      toggleShowItems();
-    }
-  };
-
   return (
     <li className="vads-u-background-color--gray-lightest vads-u-margin--0 vads-u-margin-bottom--0p5 vads-u-width--full vads-u-font-weight--bold">
       {/* Raw title */}
@@ -70,7 +65,7 @@ export const MenuItemLevel2 = ({ item, lastClickedMenuID, updateSubMenu }) => {
         <button
           className="header-menu-item-button vads-u-background-color--gray-lightest vads-u-display--flex vads-u-justify-content--space-between vads-u-width--full vads-u-text-decoration--none vads-u-margin--0 vads-u-padding--2 vads-u-color--link-default"
           id={menuItemID}
-          onKeyDown={onButtonKeyDown}
+          onKeyDown={onEnterOrSpaceHandler(toggleShowItems)}
           onMouseUp={toggleShowItems}
           type="button"
         >

--- a/src/platform/site-wide/header/components/MenuItemLevel2/index.js
+++ b/src/platform/site-wide/header/components/MenuItemLevel2/index.js
@@ -3,11 +3,7 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 // Relative imports.
-import {
-  deriveMenuItemID,
-  formatMenuItems,
-  onEnterOrSpaceHandler,
-} from '../../helpers';
+import { deriveMenuItemID, formatMenuItems } from '../../helpers';
 import { updateSubMenuAction } from '../../containers/Menu/actions';
 
 export const MenuItemLevel2 = ({ item, lastClickedMenuID, updateSubMenu }) => {
@@ -65,8 +61,7 @@ export const MenuItemLevel2 = ({ item, lastClickedMenuID, updateSubMenu }) => {
         <button
           className="header-menu-item-button vads-u-background-color--gray-lightest vads-u-display--flex vads-u-justify-content--space-between vads-u-width--full vads-u-text-decoration--none vads-u-margin--0 vads-u-padding--2 vads-u-color--link-default"
           id={menuItemID}
-          onKeyDown={onEnterOrSpaceHandler(toggleShowItems)}
-          onMouseUp={toggleShowItems}
+          onClick={toggleShowItems}
           type="button"
         >
           {item?.title}

--- a/src/platform/site-wide/header/components/MenuItemLevel2/index.unit.spec.js
+++ b/src/platform/site-wide/header/components/MenuItemLevel2/index.unit.spec.js
@@ -25,7 +25,7 @@ describe('Header <MenuItemLevel2>', () => {
     wrapper.unmount();
   });
 
-  it('renders an item and updates the sub menu on mouseup', () => {
+  it('renders an item and updates the sub menu on click', () => {
     // Set up.
     const updateSubMenu = sinon.spy();
     const item = {
@@ -46,7 +46,7 @@ describe('Header <MenuItemLevel2>', () => {
     expect(wrapper.find('i.fa.fa-chevron-right')).to.have.length(1);
 
     // Set up.
-    wrapper.find('.header-menu-item-button').simulate('mouseup');
+    wrapper.find('.header-menu-item-button').simulate('click');
 
     // Assertions.
     expect(updateSubMenu.firstCall.args[0]).to.deep.equal({

--- a/src/platform/site-wide/header/components/OfficialGovtWebsite/index.js
+++ b/src/platform/site-wide/header/components/OfficialGovtWebsite/index.js
@@ -1,8 +1,14 @@
 // Node modules.
 import React, { useState } from 'react';
+// Relative imports.
+import { onEnterOrSpaceHandler } from '../../helpers';
 
 export const OfficialGovtWebsite = () => {
   const [expanded, setExpanded] = useState(false);
+
+  const onToggle = () => {
+    setExpanded(!expanded);
+  };
 
   return (
     <div className="vads-u-display--flex vads-u-flex-direction--column">
@@ -17,8 +23,8 @@ export const OfficialGovtWebsite = () => {
           aria-controls="official-govt-site-explanation"
           aria-expanded={expanded ? 'true' : 'false'}
           className="expand-official-govt-explanation va-button-link vads-u-text-decoration--none"
-          onKeyDown={event => event.keyCode === 13 && setExpanded(!expanded)}
-          onMouseUp={() => setExpanded(!expanded)}
+          onKeyDown={onEnterOrSpaceHandler(onToggle)}
+          onMouseUp={onToggle}
         >
           An official website of the United States government.
           <i
@@ -32,7 +38,7 @@ export const OfficialGovtWebsite = () => {
       {expanded && (
         <div
           aria-hidden={expanded ? 'false' : 'true'}
-          className="vads-u-background-color--gray-lightest vads-u-display--flex vads-u-flex-direction--column vads-u-padding--0p5 vads-u-padding-y--2"
+          className="vads-u-background-color--gray-lightest vads-u-display--flex vads-u-flex-direction--column vads-u-padding--1p5 vads-u-padding-y--2"
           id="official-govt-site-explanation"
         >
           <div className="vads-u-display--flex vads-u-flex-direction--row vads-u-align-items--flex-start">

--- a/src/platform/site-wide/header/components/OfficialGovtWebsite/index.js
+++ b/src/platform/site-wide/header/components/OfficialGovtWebsite/index.js
@@ -1,7 +1,5 @@
 // Node modules.
 import React, { useState } from 'react';
-// Relative imports.
-import { onEnterOrSpaceHandler } from '../../helpers';
 
 export const OfficialGovtWebsite = () => {
   const [expanded, setExpanded] = useState(false);
@@ -23,8 +21,7 @@ export const OfficialGovtWebsite = () => {
           aria-controls="official-govt-site-explanation"
           aria-expanded={expanded ? 'true' : 'false'}
           className="expand-official-govt-explanation va-button-link vads-u-text-decoration--none"
-          onKeyDown={onEnterOrSpaceHandler(onToggle)}
-          onMouseUp={onToggle}
+          onClick={onToggle}
         >
           An official website of the United States government.
           <i

--- a/src/platform/site-wide/header/components/OfficialGovtWebsite/index.unit.spec.js
+++ b/src/platform/site-wide/header/components/OfficialGovtWebsite/index.unit.spec.js
@@ -23,7 +23,7 @@ describe('Header <OfficialGovtWebsite>', () => {
     expect(wrapper.text()).not.includes('The site is secure.');
 
     // Set up.
-    wrapper.find('.expand-official-govt-explanation').simulate('mouseup');
+    wrapper.find('.expand-official-govt-explanation').simulate('click');
 
     // Assertions.
     expect(wrapper.find('#official-govt-site-explanation')).to.have.length(1);

--- a/src/platform/site-wide/header/components/Search/index.js
+++ b/src/platform/site-wide/header/components/Search/index.js
@@ -1,0 +1,67 @@
+// Node modules.
+import React, { useState } from 'react';
+// Relative imports.
+import IconSearch from '@department-of-veterans-affairs/component-library/IconSearch';
+import recordEvent from 'platform/monitoring/record-event';
+
+export const Search = () => {
+  const [term, setTerm] = useState('');
+
+  const onFormSubmit = event => {
+    event.preventDefault();
+
+    // Derive the search results page.
+    const searchResultsPage = `https://www.va.gov/search/?query=${term}&t=false`;
+
+    // Record the analytic event.
+    recordEvent({
+      event: 'view_search_results',
+      'search-page-path': searchResultsPage,
+      'search-query': term,
+      'search-results-total-count': null,
+      'search-results-total-pages': null,
+      'search-selection': 'All VA.gov',
+      'search-typeahead-enabled': false,
+      'search-location': 'Search Results Page',
+      'sitewide-search-app-used': false,
+      'type-ahead-option-keyword-selected': null,
+      'type-ahead-option-position': null,
+      'type-ahead-options-list': null,
+      'type-ahead-options-count': null,
+    });
+
+    // Redirect to the search results page.
+    window.location.push(searchResultsPage);
+  };
+
+  return (
+    <form
+      className="header-search vads-u-display--flex vads-u-flex-direction--column vads-u-padding-x--1p5"
+      onSubmit={onFormSubmit}
+    >
+      <label
+        className="vads-u-color--gray-dark vads-u-margin--0 vads-u-margin-top--2"
+        htmlFor="header-search"
+      >
+        Search
+      </label>
+
+      <div className="vads-u-display--flex vads-u-flex-direction--row vads-u-align-items--center">
+        <input
+          aria-label="Enter a keyword"
+          className="vads-u-width--full"
+          id="header-search"
+          name="query"
+          onChange={event => setTerm(event.target.value)}
+          type="text"
+          value={term}
+        />
+        <button className="vads-u-margin--0 vads-u-padding--0" type="submit">
+          <IconSearch color="#fff" />
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default Search;

--- a/src/platform/site-wide/header/components/Search/index.js
+++ b/src/platform/site-wide/header/components/Search/index.js
@@ -31,7 +31,7 @@ export const Search = () => {
     });
 
     // Redirect to the search results page.
-    window.location.push(searchResultsPage);
+    window.location.href = searchResultsPage;
   };
 
   return (

--- a/src/platform/site-wide/header/components/Search/index.unit.spec.js
+++ b/src/platform/site-wide/header/components/Search/index.unit.spec.js
@@ -1,0 +1,22 @@
+// Node modules.
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+// Relative imports.
+import { Search } from '.';
+
+describe('Header <Search>', () => {
+  it('renders correct content with no props', () => {
+    // Set up.
+    const wrapper = shallow(<Search />);
+
+    // Assertions.
+    expect(wrapper.find('form')).to.have.length(1);
+    expect(wrapper.find('label')).to.have.length(1);
+    expect(wrapper.find('input[type="text"]')).to.have.length(1);
+    expect(wrapper.find('button[type="submit"]')).to.have.length(1);
+
+    // Clean up.
+    wrapper.unmount();
+  });
+});

--- a/src/platform/site-wide/header/components/Search/styles.scss
+++ b/src/platform/site-wide/header/components/Search/styles.scss
@@ -1,0 +1,12 @@
+.header-search {
+  input {
+    max-width: unset;
+  }
+
+  button {
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0;
+    height: 42px;
+    width: 45px;
+  }
+}

--- a/src/platform/site-wide/header/components/SubMenu/index.js
+++ b/src/platform/site-wide/header/components/SubMenu/index.js
@@ -3,11 +3,7 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 // Relative imports.
-import {
-  deriveMenuItemID,
-  formatSubMenuSections,
-  onEnterOrSpaceHandler,
-} from '../../helpers';
+import { deriveMenuItemID, formatSubMenuSections } from '../../helpers';
 import { updateSubMenuAction } from '../../containers/Menu/actions';
 
 export const SubMenu = ({ subMenu, updateSubMenu }) => {
@@ -33,8 +29,7 @@ export const SubMenu = ({ subMenu, updateSubMenu }) => {
           <button
             className="header-menu-item-button vads-u-background-color--gray-lightest vads-u-display--flex vads-u-width--full vads-u-text-decoration--none vads-u-margin--0 vads-u-padding--2 vads-u-color--link-default vads-u-align-items--center"
             id="header-back-to-menu"
-            onKeyDown={onEnterOrSpaceHandler(onBack)}
-            onMouseUp={onBack}
+            onClick={onBack}
             type="button"
           >
             <i

--- a/src/platform/site-wide/header/components/SubMenu/index.js
+++ b/src/platform/site-wide/header/components/SubMenu/index.js
@@ -3,7 +3,11 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 // Relative imports.
-import { deriveMenuItemID, formatSubMenuSections } from '../../helpers';
+import {
+  deriveMenuItemID,
+  formatSubMenuSections,
+  onEnterOrSpaceHandler,
+} from '../../helpers';
 import { updateSubMenuAction } from '../../containers/Menu/actions';
 
 export const SubMenu = ({ subMenu, updateSubMenu }) => {
@@ -29,7 +33,7 @@ export const SubMenu = ({ subMenu, updateSubMenu }) => {
           <button
             className="header-menu-item-button vads-u-background-color--gray-lightest vads-u-display--flex vads-u-width--full vads-u-text-decoration--none vads-u-margin--0 vads-u-padding--2 vads-u-color--link-default vads-u-align-items--center"
             id="header-back-to-menu"
-            onKeyDown={event => event.keyCode === 13 && onBack()}
+            onKeyDown={onEnterOrSpaceHandler(onBack)}
             onMouseUp={onBack}
             type="button"
           >

--- a/src/platform/site-wide/header/components/SubMenu/index.unit.spec.js
+++ b/src/platform/site-wide/header/components/SubMenu/index.unit.spec.js
@@ -47,7 +47,7 @@ describe('Header <SubMenu>', () => {
     ).to.have.length(7);
 
     // Set up.
-    wrapper.find('.header-menu-item-button').simulate('mouseup');
+    wrapper.find('.header-menu-item-button').simulate('click');
 
     // Assertions.
     expect(updateSubMenu.calledOnce).to.be.true;

--- a/src/platform/site-wide/header/containers/Menu/index.js
+++ b/src/platform/site-wide/header/containers/Menu/index.js
@@ -4,14 +4,9 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 // Relative imports.
 import MenuItemLevel1 from '../../components/MenuItemLevel1';
-import SearchDropdownComponent from 'applications/search/components/SearchDropdown/SearchDropdownComponent';
+import Search from '../../components/Search';
 import SubMenu from '../../components/SubMenu';
-import {
-  deriveMenuItemID,
-  fetchSearchSuggestions,
-  onSearch,
-  onSuggestionSubmit,
-} from '../../helpers';
+import { deriveMenuItemID } from '../../helpers';
 
 export const Menu = ({ isMenuOpen, megaMenuData, showMegaMenu, subMenu }) => {
   // Do not render if the menu is closed.
@@ -32,25 +27,7 @@ export const Menu = ({ isMenuOpen, megaMenuData, showMegaMenu, subMenu }) => {
   return (
     <div className="vads-u-background-color--gray-lightest vads-u-display--flex vads-u-flex-direction--column vads-u-margin--0 vads-u-padding--0 vads-u-width--full">
       {/* Search */}
-      <label className="vads-u-padding-x--1p5 vads-u-color--gray-dark vads-u-margin--0 vads-u-margin-top--2">
-        Search
-      </label>
-      <SearchDropdownComponent
-        buttonClassName="vads-u-padding--0"
-        buttonText=""
-        canSubmit
-        componentClassName="header-search vads-u-padding-right--1p5 vads-u-padding-bottom--2"
-        containerClassName="vads-u-padding-left--1p5"
-        fetchSuggestions={fetchSearchSuggestions}
-        formatSuggestions
-        fullWidthSuggestions
-        id="header-search-dropdown"
-        onInputSubmit={onSearch}
-        onSuggestionSubmit={onSuggestionSubmit}
-        startingValue=""
-        submitOnClick
-        submitOnEnter
-      />
+      <Search />
 
       {/* Menu items */}
       {showMegaMenu && (

--- a/src/platform/site-wide/header/containers/Menu/index.unit.spec.js
+++ b/src/platform/site-wide/header/containers/Menu/index.unit.spec.js
@@ -37,8 +37,7 @@ describe('Header <Menu>', () => {
     expect(
       wrapper.find('div.vads-u-background-color--gray-lightest'),
     ).to.have.length(1);
-    expect(wrapper.find('label').text()).to.equal('Search');
-    expect(wrapper.find('SearchDropdownComponent')).to.have.length(1);
+    expect(wrapper.find('Search')).to.have.length(1);
     expect(wrapper.find('ul')).to.have.length(0);
 
     // Clean up.
@@ -54,8 +53,7 @@ describe('Header <Menu>', () => {
     expect(
       wrapper.find('div.vads-u-background-color--gray-lightest'),
     ).to.have.length(1);
-    expect(wrapper.find('label').text()).to.equal('Search');
-    expect(wrapper.find('SearchDropdownComponent')).to.have.length(1);
+    expect(wrapper.find('Search')).to.have.length(1);
     expect(wrapper.find('ul')).to.have.length(1);
     expect(wrapper.find('Connect(MenuItemLevel1)')).to.have.length(1);
 
@@ -80,8 +78,7 @@ describe('Header <Menu>', () => {
     expect(
       wrapper.find('div.vads-u-background-color--gray-lightest'),
     ).to.have.length(1);
-    expect(wrapper.find('label').text()).to.equal('Search');
-    expect(wrapper.find('SearchDropdownComponent')).to.have.length(1);
+    expect(wrapper.find('Search')).to.have.length(1);
     expect(wrapper.find('ul')).to.have.length(1);
     expect(wrapper.find('Connect(MenuItemLevel1)')).to.have.length(2);
 

--- a/src/platform/site-wide/header/containers/Menu/styles.scss
+++ b/src/platform/site-wide/header/containers/Menu/styles.scss
@@ -1,20 +1,3 @@
 .header-menu-item-button {
   border-radius: 0;
 }
-
-.header-search {
-  .search-dropdown-container.full-width-suggestions {
-    max-width: unset;
-  }
-
-  input {
-    max-width: unset;
-  }
-
-  .search-dropdown-submit-button {
-    border-bottom-left-radius: 0;
-    border-top-left-radius: 0;
-    margin-right: 0 !important;
-    width: 45px;
-  }
-}

--- a/src/platform/site-wide/header/helpers/index.js
+++ b/src/platform/site-wide/header/helpers/index.js
@@ -208,3 +208,13 @@ export const deriveMenuItemID = (item, level) => {
   const formattedLevel = level || '';
   return `${formattedTitle}-${formattedHref}-${formattedLevel}`;
 };
+
+export const onEnterOrSpaceHandler = onEnterOrSpace => event => {
+  const isEnterKey = event.keyCode === 13;
+  const isSpaceKey = event.keyCode === 32;
+
+  if (isEnterKey || isSpaceKey) {
+    event.preventDefault();
+    onEnterOrSpace?.();
+  }
+};

--- a/src/platform/site-wide/header/helpers/index.js
+++ b/src/platform/site-wide/header/helpers/index.js
@@ -208,13 +208,3 @@ export const deriveMenuItemID = (item, level) => {
   const formattedLevel = level || '';
   return `${formattedTitle}-${formattedHref}-${formattedLevel}`;
 };
-
-export const onEnterOrSpaceHandler = onEnterOrSpace => event => {
-  const isEnterKey = event.keyCode === 13;
-  const isSpaceKey = event.keyCode === 32;
-
-  if (isEnterKey || isSpaceKey) {
-    event.preventDefault();
-    onEnterOrSpace?.();
-  }
-};

--- a/src/platform/site-wide/header/index.js
+++ b/src/platform/site-wide/header/index.js
@@ -5,6 +5,7 @@ import { Provider } from 'react-redux';
 // Relative imports.
 import './components/LogoRow/styles.scss';
 import './components/OfficialGovtWebsite/styles.scss';
+import './components/Search/styles.scss';
 import './containers/Menu/styles.scss';
 import App from './components/App';
 import { connectFeatureToggle } from 'platform/utilities/feature-toggles';


### PR DESCRIPTION
## Description

This PR does some a11y and design tweaks to header v2. It also replaces the common Search component (it's not ready for prod yet) with a custom Search component without typeahead.

## Testing done
Added unit tests.

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/142056899-b91b27ea-24ad-42f6-a832-61f6a830d32b.png)

## Acceptance criteria
- [x] some a11y and design tweaks to header v2
- [x] replaces the common Search component (it's not ready for prod yet) with a custom Search component without typeahead

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
