### PR TITLE
Bump component-library to get loading indicator

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,6 +52,11 @@ module.exports = {
         name: '@department-of-veterans-affairs/component-library/AlertBox',
         use: '<va-alert>',
       },
+      {
+        name:
+          '@department-of-veterans-affairs/component-library/LoadingIndicator',
+        use: '<va-loading-indicator>',
+      },
     ],
 
     // "func-names": 2,

--- a/package.json
+++ b/package.json
@@ -249,7 +249,7 @@
   },
   "private": true,
   "dependencies": {
-    "@department-of-veterans-affairs/component-library": "^3.6.0",
+    "@department-of-veterans-affairs/component-library": "^3.7.0",
     "@department-of-veterans-affairs/formation": "6.17.3",
     "@department-of-veterans-affairs/formulate": "0.0.1",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1988,13 +1988,13 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@department-of-veterans-affairs/component-library@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-3.6.0.tgz#7398b4eb644eb460fa40eeb0f15346a3a9715813"
-  integrity sha512-vNzR1hXcnE76dnAP8wA9bi5IpLvD07fSd7qTuQSC3aJ6dgApLKrO9RAS01/0tO713gNj5h1BXFfzQ4ehp5odGw==
+"@department-of-veterans-affairs/component-library@^3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-3.7.0.tgz#67c24ef44855aabccccdaf18e1f27d20fe36d371"
+  integrity sha512-j8h3PMGuo9C5X29J+wEtmlSHXPdnfqtqzgXlw+/+NWxBO+jut2GXHqXzLYPOqvCxfwp6ctNtO/uQKd8yEbT9Eg==
   dependencies:
     "@department-of-veterans-affairs/react-components" "3.3.0"
-    "@department-of-veterans-affairs/web-components" "0.15.0"
+    "@department-of-veterans-affairs/web-components" "0.16.0"
     date-fns-tz "^1.1.1"
     react-focus-on "^3.5.1"
     react-scroll "^1.7.16"
@@ -2056,12 +2056,12 @@
     react-is "^17.0.1"
     setimmediate "^1.0.5"
 
-"@department-of-veterans-affairs/web-components@0.15.0":
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-0.15.0.tgz#6002b2f83f18bd7bfbdc8a9bb760e959d3f41ab5"
-  integrity sha512-2C+vr/8HuvSwiqyt4IpT310XHv+eOTKdH1B/pm6Ua592nTwLqlXhIKbPHBwxNN2LmFQeaJvpiK2WDA4Hk4eAUA==
+"@department-of-veterans-affairs/web-components@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-0.16.0.tgz#014359735167b947206713dab157214efbd6835a"
+  integrity sha512-7NynHy6lyf0X1UZYpgtn86g0tc/j781OV6Qn4ONT4jZxjfr3mwyCztxZeQuvcktKU5e+0h+cLZJH72yYecrKuQ==
   dependencies:
-    "@stencil/core" "^2.8.1"
+    "@stencil/core" "^2.10.0"
     "@stencil/postcss" "^2.0.0"
     classnames "^2.3.1"
     intersection-observer "^0.12.0"
@@ -2823,10 +2823,10 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-2.1.1.tgz#ceff6a28a5b4867c2dd4a1ba513de278ccbe8bb1"
   integrity sha512-/aPsuoj/1Dw/kzhkgz+ES6TxG0zfTMGLwuK2ZG00k/iJzYHTLCE8mVU8EPqEOp/lmxPoq1C1C9RYToRKb2KEfg==
 
-"@stencil/core@^2.8.1":
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.8.1.tgz#21b15c115d9a5e2f56379774fcbd9bc947bf336f"
-  integrity sha512-iv9J6oLO/lv7/aO45M05yw3pp1J7olY400vlOZgdMVs3s5zHfalY1ZPYM0KyqU4+7DZuadKYbd0aQZ/g2PInZw==
+"@stencil/core@^2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.10.0.tgz#acf44b9ae6578a20f0d09bf94296e833beadc885"
+  integrity sha512-15rWMTPQ/sp0lSV82HVCXkIya3QLN+uBl7pqK4JnTrp4HiLrzLmNbWjbvgCs55gw0lULbCIGbRIEsFz+Pe/Q+A==
 
 "@stencil/postcss@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
## Description

Once `<va-loading-indicator>` is available in `vets-website`, we will be able to merge the PR that migrates the older component to use it: https://github.com/department-of-veterans-affairs/vets-website/pull/19295

Release notes: https://github.com/department-of-veterans-affairs/component-library/releases/tag/v3.7.0


## Original issue(s)


## Testing done
None

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
