### PR TITLE
FIX: Verify signInMethod logic

### DIFF
--- a/src/applications/verify/containers/VerifyApp.jsx
+++ b/src/applications/verify/containers/VerifyApp.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import URLSearchParams from 'url-search-params';
 
-import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import LoginGovSVG from 'applications/login/components/LoginGov';
 import LoadingIndicator from '@department-of-veterans-affairs/component-library/LoadingIndicator';
 import recordEvent from 'platform/monitoring/record-event';
@@ -96,11 +95,9 @@ export class VerifyApp extends React.Component {
             <div className="columns small-12">
               <div>
                 <h1>Verify your identity</h1>
-                <AlertBox
-                  content={`You signed in with ${signInMethod}`}
-                  isVisible
-                  status="success"
-                />
+                <va-alert visible status="success">
+                  You signed in with {signInMethod}
+                </va-alert>
                 <p>
                   We'll need to verify your identity so that you can securely
                   access and manage your benefits.

--- a/src/applications/verify/containers/VerifyApp.jsx
+++ b/src/applications/verify/containers/VerifyApp.jsx
@@ -16,17 +16,14 @@ import { focusElement } from '~/platform/utilities/ui';
 export class VerifyApp extends React.Component {
   constructor(props) {
     super(props);
-    const { profile } = this.props;
-    const serviceName = (profile.signIn || {}).serviceName;
 
-    const signinMethodLabels = {
+    this.signinMethodLabels = {
       dslogon: 'DS Logon',
       myhealthevet: 'My HealtheVet',
       logingov: 'Login.gov',
     };
-
-    this.signInMethod = signinMethodLabels[serviceName] || 'ID.me';
   }
+
   componentDidMount() {
     if (!hasSession()) {
       window.location.replace('/');
@@ -85,6 +82,8 @@ export class VerifyApp extends React.Component {
 
   render() {
     const { profile } = this.props;
+    const signInMethod =
+      this.signinMethodLabels[(profile?.signIn?.serviceName)] || 'ID.me';
 
     if (profile.loading) {
       return <LoadingIndicator message="Loading the application..." />;
@@ -98,7 +97,7 @@ export class VerifyApp extends React.Component {
               <div>
                 <h1>Verify your identity</h1>
                 <AlertBox
-                  content={`You signed in with ${this.signInMethod}`}
+                  content={`You signed in with ${signInMethod}`}
                   isVisible
                   status="success"
                 />

--- a/src/applications/verify/containers/VerifyApp.jsx
+++ b/src/applications/verify/containers/VerifyApp.jsx
@@ -50,11 +50,13 @@ export class VerifyApp extends React.Component {
     }
   }
 
-  renderVerifyButton() {
-    const { loginGovEnabled } = this.props;
+  renderVerifyButton(signInMethod) {
+    const verifyWithLoginGov =
+      this.signinMethodLabels.logingov === signInMethod;
+
     const renderOpts = {
-      copy: loginGovEnabled ? 'Login.gov' : 'ID.me',
-      renderImage: loginGovEnabled ? (
+      copy: verifyWithLoginGov ? 'Login.gov' : 'ID.me',
+      renderImage: verifyWithLoginGov ? (
         <LoginGovSVG />
       ) : (
         <img
@@ -65,7 +67,7 @@ export class VerifyApp extends React.Component {
         />
       ),
       className: `usa-button ${
-        loginGovEnabled ? 'logingov-button' : 'idme-button'
+        verifyWithLoginGov ? 'logingov-button' : 'idme-button'
       }`,
     };
 
@@ -113,7 +115,7 @@ export class VerifyApp extends React.Component {
                   This one-time process will take{' '}
                   <strong>5 - 10 minutes</strong> to complete.
                 </p>
-                {this.renderVerifyButton()}
+                {this.renderVerifyButton(signInMethod)}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Description
`signInMethod` was always resolving as `ID.me` since the constructor did not `re-construct` after initialization. Therefore it never re-evaluated after receiving props.

Removes feature flag dependency, and changes style based on the login method used.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#28760


## Testing done


## Screenshots
<img width="1048" alt="Screen Shot 2021-11-16 at 3 53 57 PM" src="https://user-images.githubusercontent.com/13320944/142072314-c1bf3826-2fa9-4553-b1be-d462720bff78.png">
<img width="1032" alt="Screen Shot 2021-11-16 at 3 55 04 PM" src="https://user-images.githubusercontent.com/13320944/142072315-1ffa8621-08e4-4977-a160-d07989c1e8a9.png">


## Acceptance criteria
- [ ] Verify page `signInAttempted` resolves correctly based on `profile` prop

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
