### PR TITLE
Adding analytics to search results with cautionary warnings.

### DIFF
--- a/src/applications/gi-sandbox/containers/search/ResultCard.jsx
+++ b/src/applications/gi-sandbox/containers/search/ResultCard.jsx
@@ -107,6 +107,12 @@ export function ResultCard({
         <Link
           to={profileLink}
           aria-labelledby={`${facilityCode}-label ${facilityCode}-classification`}
+          onClick={() =>
+            cautionFlags.length > 0 &&
+            recordEvent({
+              event: `Cautionary Warnings: ${name} profile link clicked`,
+            })
+          }
         >
           <h3
             className={nameClasses}


### PR DESCRIPTION
## Description
Adds GA event logging to GIBCT search results with cautionary warnings.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#32627

## Testing done
Validated locally using ObservePoint chrome extension.

## Screenshots
* GA event triggered when user opens up warning panel to view more information for schools with cautionary warnings
<img width="383" alt="-sandboxinstitution14912446" src="https://user-images.githubusercontent.com/90346049/142217564-cb114373-f9a9-49f5-aa6c-727f9aab5e00.png">

* GA event triggered when user visits profile of school with cautionary warnings
<img width="372" alt="ool  Veterans Affairs" src="https://user-images.githubusercontent.com/90346049/142217595-49fe91ff-2285-44d2-8183-78b4b3647519.png">

## Acceptance criteria
- [x] GA event triggered when user opens up warning panel to view more information for schools with cautionary warnings
- [x] GA event triggered when user visits profile of school with cautionary warnings

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
