### PR TITLE
Use `.nvmrc` file for Node version in testing report prep job on GitHub Actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -319,10 +319,15 @@ jobs:
           token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
           path: testing-tools-team-dashboard-data
 
+      - name: Get Node version
+        id: get-node-version
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+        working-directory: testing-tools-team-dashboard-data
+
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: 14 # ${{ steps.get-node-version.outputs.NODE_VERSION }}
+          node-version: ${{ steps.get-node-version.outputs.NODE_VERSION }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline --production=false


### PR DESCRIPTION
## Description
Uncommenting and updating a line in the CI workflow to use the. `.nvmrc` file to set the Node version in a job. A `.nvmrc` file was added recently to the repo being cloned here.

## Acceptance criteria
- [ ] CI passes.