### PR TITLE
feature/edu-benefits-dynamic-isInternational-checkbox

### DIFF
--- a/src/applications/my-education-benefits/config/form.js
+++ b/src/applications/my-education-benefits/config/form.js
@@ -200,6 +200,18 @@ function phoneUISchema(category) {
     isInternational: {
       'ui:title': `This ${category} phone number is international`,
       'ui:reviewField': YesNoReviewField,
+      'ui:options': {
+        hideIf: formData => {
+          if (category === 'mobile') {
+            if (!formData['view:phoneNumbers'].mobilePhoneNumber.phone) {
+              return true;
+            }
+          } else if (!formData['view:phoneNumbers'].phoneNumber.phone) {
+            return true;
+          }
+          return false;
+        },
+      },
     },
   };
 }


### PR DESCRIPTION
## Description
WHEN the applicant is on the contact information page

AND a mobile phone number is provided, then a check box should appear with label "This mobile phone number is international"
IF a mobile phone number is not provided, then a check box should not appear with label "This mobile phone number is international"
WHEN the applicant is on the contact information page

AND a home phone number is provided, then a check box should appear with label "This home phone number is international"
If a home phone number is not provided, then a check box should not appear with label "This home phone number is international"
 

## Testing Notes
remove a checkbox IF NO phone (home or mobile) is loaded from the database.

If a user begins to input a phone THEN show a checkbox(international)

if a user leaves it alone, then it should be by default with no checkbox.

## Testing
- [x] Not started
- [ ] In progress
- [ ] Done


## Definition of done
- [X] Events are logged appropriately
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
