### PR TITLE
Add analytics to GIBCT Compare schools

### DIFF
--- a/src/applications/gi-sandbox/components/CompareHeader.jsx
+++ b/src/applications/gi-sandbox/components/CompareHeader.jsx
@@ -49,10 +49,7 @@ export default function({
   const handleOnChange = e => {
     setShowDifferences(e.target.checked);
     recordEvent({
-      event: 'gibct-formChange',
-      'form-field-type': 'form-checkbox',
-      'form-field-label': e.target.name,
-      'form-field-value': e.target.checked,
+      event: `Radio checkbox clicked: Compare schools highlight differences`,
     });
   };
 

--- a/src/applications/gi-sandbox/containers/ProfilePageHeader.jsx
+++ b/src/applications/gi-sandbox/containers/ProfilePageHeader.jsx
@@ -66,15 +66,42 @@ const ProfilePageHeader = ({
   );
 
   const compareChecked = !!compare.search.institutions[facilityCode];
+  const compareLength = compare.search.loaded.length;
+
   const handleCompareUpdate = e => {
+    recordEvent({
+      event: `Checkbox Clicked: Added from profile page`,
+    });
+
+    if (compareLength < 3) {
+      recordEvent({
+        event: compareChecked
+          ? `Compare Checkbox click: ${compareLength - 1} in Comparison Drawer`
+          : `Compare Checkbox click: ${compareLength + 1} in Comparison Drawer`,
+      });
+    }
+
     if (e.target.checked && !compareChecked) {
       if (compare.search.loaded.length === 3) {
         dispatchShowModal('comparisonLimit');
+        recordEvent({
+          event: `Compare Checkbox click: Comparison Limit Reached. More than 3 schools selected.`,
+        });
       } else {
         dispatchAddCompareInstitution(institution);
+        recordEvent({
+          event: `Compare Checkbox click: Added ${
+            institution.name
+          } to comparison tray`,
+        });
       }
     } else {
       dispatchRemoveCompareInstitution(facilityCode);
+      recordEvent({
+        event: `Compare Checkbox click: Removed ${
+          institution.name
+        } from comparison try`,
+      });
     }
   };
 


### PR DESCRIPTION
## Issue Description
OCTO reported the GIBCT Redesign is missing critical Google Analytics. After conducting thorough analysis and collaboration with the OCTO team it was determined by OCTO GIBCT Redesign cannot be released to production without Google Analytics.

This story is to add Analytics to Compare functionality.

### COMPARE
- Compare selections from Name search
- Compare selections from Location search
- Does user select schools to compare
- How many schools are users selecting (1, 2, 3)
- Comparison limit modal displays (too many schools)
- Remove schools from Tray? Remove Schools from Comparison Page?
- User engages with "Highlight differences" checkbox

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/32629


## Testing done
Trigger events via UI, validated using ObservePoint TagDebugger chrome extension.


## Screenshots
Compare selections from Name search
<img width="241" alt="addedfromnamesearch" src="https://user-images.githubusercontent.com/18352271/142281354-16455d3c-8a5a-4632-946b-623800185b52.png">

compare selection from Location Search
<img width="247" alt="Screen Shot 2021-11-17 at 2 58 18 PM" src="https://user-images.githubusercontent.com/18352271/142281472-c9b984db-68cb-4baa-8b89-d84754e7159a.png">

users if user select schools to compare
<img width="241" alt="Screen Shot 2021-11-17 at 2 59 02 PM" src="https://user-images.githubusercontent.com/18352271/142281569-15f43a3b-0ffa-4856-a0f2-e14cfd184ab7.png">

Compare Drawer
1. <img width="235" alt="comparisondrawer1" src="https://user-images.githubusercontent.com/18352271/142281646-f4c79e69-c9e4-4b1e-b593-b24f156f3ade.png">
2. <img width="236" alt="Screen Shot 2021-11-17 at 3 01 13 PM" src="https://user-images.githubusercontent.com/18352271/142281793-1864298d-424f-4608-8ab3-ce73cbe1a3ec.png">
3. <img width="240" alt="Screen Shot 2021-11-17 at 3 01 58 PM" src="https://user-images.githubusercontent.com/18352271/142281946-9558053f-a316-453c-8a35-e4133b8e8f0b.png">

Too many schools
 <img width="242" alt="tomanyschools" src="https://user-images.githubusercontent.com/18352271/142282003-63c4d4b0-57ca-4a42-93dd-656dc1495a5a.png">

Remove Schools
- Tray <img width="240" alt="Screen Shot 2021-11-17 at 3 04 12 PM" src="https://user-images.githubusercontent.com/18352271/142282407-e53fc245-50b4-4ea3-967d-acafb360e3cf.png">
- Page <img width="238" alt="Screen Shot 2021-11-17 at 3 04 38 PM" src="https://user-images.githubusercontent.com/18352271/142282483-fb431a0f-9b00-4053-acfa-7ae06386c7c5.png">

Highlight differences
<img width="238" alt="Screen Shot 2021-11-17 at 3 04 38 PM" src="https://user-images.githubusercontent.com/18352271/142283509-c197a01f-a5f4-46ac-ad52-6a57662ce016.png">


## Tasks
 - [ ] Add GA analytics calls to various points in location search page to trigger necessary events
 
## Acceptance criteria
- [ ] GA analytics reporting compare selections from Name search
- [ ] GA analytics reporting if users compare selections from Location search
- [ ] GA analytics reporting if users if user select schools to compare
- [ ] GA analytics reporting how many schools users are selecting (1, 2, 3)
- [ ] GA analytics reporting if comparison limit modal displays (too many schools)
- [ ] GA analytics reporting if users remove schools from tray or remove schools from Comparison Page.
- [ ] GA analytics reporting if users engages with "Highlight differences" checkbox

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
