### PR TITLE
29366 - Update styling on comparison tool result cards

### DIFF
--- a/src/applications/gi-sandbox/containers/search/ResultCard.jsx
+++ b/src/applications/gi-sandbox/containers/search/ResultCard.jsx
@@ -187,7 +187,7 @@ export function ResultCard({
   const tuitionAndEligibility = (
     <>
       <p>
-        <strong>You may be eligible for up to smirf:</strong>
+        <strong>You may be eligible for up to:</strong>
       </p>
       <div className="vads-u-display--flex vads-u-margin-top--0 vads-u-margin-bottom--2">
         <div className="vads-u-flex--1">

--- a/src/applications/gi-sandbox/containers/search/ResultCard.jsx
+++ b/src/applications/gi-sandbox/containers/search/ResultCard.jsx
@@ -187,15 +187,15 @@ export function ResultCard({
   const tuitionAndEligibility = (
     <>
       <p>
-        <strong>You may be eligible for up to:</strong>
+        <strong>You may be eligible for up to smirf:</strong>
       </p>
       <div className="vads-u-display--flex vads-u-margin-top--0 vads-u-margin-bottom--2">
         <div className="vads-u-flex--1">
-          <p className="secondary-info-label">Tuition benefit:</p>
+          <p className="secondary-info-label-large">Tuition benefit:</p>
           <p className="vads-u-margin-y--0">{tuition}</p>
         </div>
         <div className="vads-u-flex--1">
-          <p className="secondary-info-label">Housing benefit:</p>
+          <p className="secondary-info-label-large">Housing benefit:</p>
           <p className="vads-u-margin-y--0">
             {housing} /mo
             {employerProvider && '*'}
@@ -214,7 +214,7 @@ export function ResultCard({
   const schoolEmployerInstitutionDetails = (
     <>
       <div className="vads-u-flex--1">
-        <p className="secondary-info-label">
+        <p className="secondary-info-label-large">
           <strong>Accreditation:</strong>
         </p>
         <p className="vads-u-margin-top--1 vads-u-margin-bottom--2p5">
@@ -225,7 +225,7 @@ export function ResultCard({
         </p>
       </div>
       <div className="vads-u-flex--1">
-        <p className="secondary-info-label">
+        <p className="secondary-info-label-large">
           <strong>GI Bill students:</strong>
         </p>
         <p className="vads-u-margin-top--1 vads-u-margin-bottom--2p5">
@@ -249,7 +249,7 @@ export function ResultCard({
   const vettecInstitutionDetails = (
     <>
       <div className="vads-u-flex--1">
-        <p className="secondary-info-label">
+        <p className="secondary-info-label-large">
           <strong>Approved programs:</strong>
         </p>
         <p className="vads-u-margin-top--1 vads-u-margin-bottom--2p5">
@@ -257,7 +257,7 @@ export function ResultCard({
         </p>
       </div>
       <div className="vads-u-flex--1">
-        <p className="secondary-info-label">
+        <p className="secondary-info-label-large">
           <strong>Program length:</strong>
         </p>
         <p className="vads-u-margin-top--1 vads-u-margin-bottom--2p5">

--- a/src/applications/gi-sandbox/sass/partials/_gi-search-page.scss
+++ b/src/applications/gi-sandbox/sass/partials/_gi-search-page.scss
@@ -416,6 +416,12 @@
     margin-bottom: 0;
   }
 
+  .secondary-info-label-large {
+    font-size: 15px;
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
   @include media-maxwidth($small-screen) {
     width: 75%;
   }


### PR DESCRIPTION
## Update styling on comparison tool result cards


## Original issue(s)
[] Update font size on label result cards to 15px
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/29366


## Testing done


## Screenshots


<img width="354" alt="Screen Shot 2021-11-17 at 6 27 39 PM" src="https://user-images.githubusercontent.com/3818397/142340346-497b6965-32f0-49ce-b6c6-08073961f6ea.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
