### PR TITLE
Enable changed apps builds for staging

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Get app entries for changed files
         id: get-changed-apps
-        if: ${{ github.ref != 'refs/heads/master' && matrix.buildtype == 'vagovdev' }}
+        if: ${{ github.ref != 'refs/heads/master' && matrix.buildtype != 'vagovprod' }}
         run: echo ::set-output name=app_entries::$(node script/github-actions/get-changed-apps.js)
         env:
           CHANGED_FILE_PATHS: ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
## Description
Now that we've confirmed changed apps builds are working properly for dev builds ([Slack thread](https://dsva.slack.com/archives/CQH357ZTP/p1637086748086000)), we can enable them for staging builds.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#29141


## Testing done
Tested in CI, the `Get app entries for changed files` step doesn't run for the prod build. ([GHA run](https://github.com/department-of-veterans-affairs/vets-website/actions/runs/1474852506))

## Screenshots


## Acceptance criteria
- [x] Changed apps builds only run for `vagovdev` and `vagovstaging` builds.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
