### PR TITLE
32579 select request then change to direct schedule ends up as a request

### DIFF
--- a/src/applications/vaos/new-appointment/newAppointmentFlow.js
+++ b/src/applications/vaos/new-appointment/newAppointmentFlow.js
@@ -242,6 +242,7 @@ export default {
       }
 
       // fetch appointment slots
+      dispatch(startDirectScheduleFlow());
       return 'preferredDate';
     },
   },

--- a/src/applications/vaos/tests/new-appointment/newAppointmentFlow.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/newAppointmentFlow.unit.spec.js
@@ -430,10 +430,12 @@ describe('VAOS newAppointmentFlow', () => {
             },
           },
         };
+        const dispatch = sinon.spy();
 
-        const nextState = newAppointmentFlow.clinicChoice.next(state);
+        const nextState = newAppointmentFlow.clinicChoice.next(state, dispatch);
 
         expect(nextState).to.equal('preferredDate');
+        expect(dispatch.called).to.be.true;
       });
 
       it('should be requestDateTime if user chose that they need a different clinic', () => {

--- a/src/applications/vaos/tests/new-appointment/newAppointmentFlow.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/newAppointmentFlow.unit.spec.js
@@ -435,7 +435,6 @@ describe('VAOS newAppointmentFlow', () => {
         const nextState = newAppointmentFlow.clinicChoice.next(state, dispatch);
 
         expect(nextState).to.equal('preferredDate');
-        expect(dispatch.called).to.be.true;
       });
 
       it('should be requestDateTime if user chose that they need a different clinic', () => {


### PR DESCRIPTION
## Description
This PR fixes issue with direct schedule ending up as appointment request by updating the direct scheduling state when clicking next on the clinics page.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#32579


## Testing done
Unit testing

## Screenshots
N/A

## Acceptance criteria
- [ ] All test should pass
- [ ] See #32579 for expected response

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
