### PR TITLE
Remove breadcrumbs from Profile and My VA

### DIFF
--- a/src/applications/personalization/dashboard/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard/components/Dashboard.jsx
@@ -4,7 +4,6 @@ import isEmpty from 'lodash/isEmpty';
 
 import '../sass/dashboard.scss';
 
-import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
 import AlertBox, {
   ALERT_TYPE,
 } from '@department-of-veterans-affairs/component-library/AlertBox';
@@ -76,7 +75,7 @@ const DashboardHeader = () => {
         id="dashboard-title"
         data-testid="dashboard-title"
         tabIndex="-1"
-        className="vads-u-margin--0"
+        className="vads-u-margin--0 vads-u-margin-top--2 medium-screen:vads-u-margin-top--3"
       >
         My VA
       </h1>
@@ -178,13 +177,6 @@ const Dashboard = ({
               </div>
             )}
             <div className="vads-l-grid-container vads-u-padding-x--1 vads-u-padding-bottom--3 medium-screen:vads-u-padding-x--2 medium-screen:vads-u-padding-bottom--4">
-              <Breadcrumbs className="vads-u-padding-x--0 vads-u-padding-y--1p5 medium-screen:vads-u-padding-y--0">
-                <a href="/" key="home">
-                  Home
-                </a>
-                <a href="/my-va">My VA</a>
-              </Breadcrumbs>
-
               <DashboardHeader />
 
               {showMPIConnectionError ? (

--- a/src/applications/personalization/profile/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile/components/ProfileWrapper.jsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { useLocation } from 'react-router-dom';
 import { isEmpty } from 'lodash';
 import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
-import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
 
 import { selectProfile } from '~/platform/user/selectors';
 
@@ -48,16 +46,6 @@ const ProfileWrapper = ({
   totalDisabilityRatingServerError,
   showNameTag,
 }) => {
-  const location = useLocation();
-  const createBreadCrumbAttributes = () => {
-    const activeLocation = location?.pathname;
-    const activeRoute = routes.find(route => route.path === activeLocation);
-
-    return { activeLocation, activeRouteName: activeRoute?.name };
-  };
-
-  const { activeLocation, activeRouteName } = createBreadCrumbAttributes();
-
   return (
     <>
       {showNameTag && (
@@ -66,17 +54,6 @@ const ProfileWrapper = ({
           totalDisabilityRatingServerError={totalDisabilityRatingServerError}
         />
       )}
-
-      {/* Breadcrumbs */}
-      <div
-        data-testid="breadcrumbs"
-        className="vads-l-grid-container vads-u-padding-x--0"
-      >
-        <Breadcrumbs className="vads-u-padding-x--1 vads-u-padding-y--1p5 medium-screen:vads-u-padding-y--0 medium-screen:vads-u-padding-x--2">
-          <a href="/">Home</a>
-          <a href={activeLocation}>{`Profile: ${activeRouteName}`}</a>
-        </Breadcrumbs>
-      </div>
 
       <div className="medium-screen:vads-u-display--none">
         <ProfileMobileSubNav

--- a/src/applications/personalization/profile/tests/components/ProfileWrapper.unit.spec.js
+++ b/src/applications/personalization/profile/tests/components/ProfileWrapper.unit.spec.js
@@ -16,23 +16,6 @@ describe('ProfileWrapper', () => {
     </MemoryRouter>
   );
 
-  it('should render the correct breadcrumb (Personal and contact Information)', () => {
-    const initialState = {
-      vaProfile: {
-        hero: {
-          userFullName: {
-            first: 'Test',
-            last: 'Test',
-          },
-        },
-      },
-    };
-    const { getByTestId } = render(uiLOA3, { initialState });
-    const breadcrumbs = getByTestId('breadcrumbs');
-    expect(breadcrumbs.textContent.match(/Personal and contact information/i))
-      .not.to.be.null;
-  });
-
   it('should render NameTag when the full name of the user was fetched)', () => {
     const initialState = {
       vaProfile: {


### PR DESCRIPTION
## Description


## Original issue(s)
department-of-veterans-affairs/va.gov-team#31229
department-of-veterans-affairs/va.gov-team#31231

## Testing done
Local + existing tests

## Screenshots
Breadcrumbs have been removed, and the vertical spacing where the crumbs used to be looks decent IMO.

![my-va](https://user-images.githubusercontent.com/20728956/142454848-92b18759-ef46-4f4f-8669-cd5fd5d9ea28.gif)
![profile](https://user-images.githubusercontent.com/20728956/142454941-626e7cd9-e452-4d70-adb1-63880c5afb5b.gif)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs