### PR TITLE
Fix to move info under page title

### DIFF
--- a/src/applications/hca/config/chapters/vaBenefits/pensionInformation.js
+++ b/src/applications/hca/config/chapters/vaBenefits/pensionInformation.js
@@ -6,40 +6,35 @@ import CustomReviewField from '../../../components/CustomReviewField';
 
 const { vaPensionType } = fullSchemaHca.properties;
 
-const PensionInfo = props => (
-  <>
-    <PrefillMessage {...props} />
-
-    <div className="vads-u-margin-top--2 vads-u-margin-bottom--5">
-      <AdditionalInfo triggerText="Why we ask for this information">
-        <p>We use this information to help us decide these 3 things:</p>
-        <ul>
-          <li className="vads-u-margin-left--3 vads-u-margin-bottom--2 bullet-disc">
-            What types of VA health care benefits you’re eligible for,
-            <strong className="vads-u-margin-left--0p5">and</strong>
-          </li>
-          <li className="vads-u-margin-left--3 vads-u-margin-bottom--2 bullet-disc">
-            How soon we enroll you in a VA health care, <strong>and</strong>
-          </li>
-          <li className="vads-u-margin-left--3 bullet-disc">
-            How much (if anything) you’ll have to pay toward the cost of your
-            care
-          </li>
-        </ul>
-        <p>
-          If you have a Veterans Pension, you may pay a lower copay, or no
-          copay, for certain types of care and services.
-        </p>
-      </AdditionalInfo>
-    </div>
-  </>
+const PensionInfo = () => (
+  <div className="vads-u-margin-top--2 vads-u-margin-bottom--5">
+    <AdditionalInfo triggerText="Why we ask for this information">
+      <p>We use this information to help us decide these 3 things:</p>
+      <ul>
+        <li className="vads-u-margin-left--3 vads-u-margin-bottom--2 bullet-disc">
+          What types of VA health care benefits you’re eligible for,
+          <strong className="vads-u-margin-left--0p5">and</strong>
+        </li>
+        <li className="vads-u-margin-left--3 vads-u-margin-bottom--2 bullet-disc">
+          How soon we enroll you in a VA health care, <strong>and</strong>
+        </li>
+        <li className="vads-u-margin-left--3 bullet-disc">
+          How much (if anything) you’ll have to pay toward the cost of your care
+        </li>
+      </ul>
+      <p>
+        If you have a Veterans Pension, you may pay a lower copay, or no copay,
+        for certain types of care and services.
+      </p>
+    </AdditionalInfo>
+  </div>
 );
 
 export default {
   uiSchema: {
-    'ui:description': PensionInfo,
+    'ui:title': 'Current compensation',
+    'ui:description': PrefillMessage,
     'view:compDesc': {
-      'ui:title': 'Current compensation from VA',
       'ui:description':
         'Our Veterans Pension program provides monthly payments to certain wartime Veterans. To get a Veterans Pension, you must meet certain age or disability requirements and have income and net worth certain limits.',
       'ui:options': {
@@ -48,6 +43,7 @@ export default {
     },
     vaPensionType: {
       'ui:title': 'Do you receive a Veterans pension from the VA?',
+      'ui:description': PensionInfo,
       'ui:reviewField': CustomReviewField,
       'ui:required': () => true,
       'ui:widget': 'radio',


### PR DESCRIPTION
## Description

When refactoring SaveInProgress messages accidentally move the info box above the page title, moving it down to below the page title


## Original issue(s)
[issue](https://app.zenhub.com/workspaces/vsa---caregiver-5fff0cfd1462b6000e320fc7/issues/department-of-veterans-affairs/va.gov-team/33087)


## Testing done
- Manual testing

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/23741323/142459637-aa173a48-067d-493e-a985-5a062fa8ea03.png)


### After
![image](https://user-images.githubusercontent.com/23741323/142459717-0ca15227-5d04-4157-ac88-cf3a6e570767.png)


## Acceptance criteria
- [x] Info box is below page title

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
