### PR TITLE
33043: [FSR] duplicate values for resolution type

### DIFF
--- a/src/applications/financial-status-report/tests/e2e/fixtures/data/maximal.json
+++ b/src/applications/financial-status-report/tests/e2e/fixtures/data/maximal.json
@@ -467,7 +467,7 @@
       "deductions": [
         {
           "name": "Federal tax",
-          "amount": "200.0254334"
+          "amount": "200.02"
         },
         {
           "name": "Allotment",
@@ -495,7 +495,7 @@
         },
         {
           "name": "Health insurance",
-          "amount": "250.344324"
+          "amount": "250.34"
         },
         {
           "name": "Garnishment",

--- a/src/applications/financial-status-report/utils/helpers.js
+++ b/src/applications/financial-status-report/utils/helpers.js
@@ -78,6 +78,13 @@ export const nameStr = (socialSecurity, compensation, education, addlInc) => {
   return otherIncNames?.map(item => item).join(', ') ?? '';
 };
 
+export const getFsrReason = debts => {
+  const reasons = debts.map(({ resolution }) => resolution.resolutionType);
+  const uniqReasons = [...new Set(reasons)];
+
+  return uniqReasons.join(', ');
+};
+
 export const getMonthlyIncome = ({
   additionalIncome: {
     addlIncRecords,

--- a/src/applications/financial-status-report/utils/transform.js
+++ b/src/applications/financial-status-report/utils/transform.js
@@ -2,6 +2,7 @@ import moment from 'moment';
 import {
   sumValues,
   dateFormatter,
+  getFsrReason,
   getMonthlyIncome,
   getMonthlyExpenses,
   getEmploymentHistory,
@@ -111,14 +112,13 @@ export const transform = (formConfig, form) => {
   const totMonthlyExpenses = getMonthlyExpenses(form.data);
   const employmentHistory = getEmploymentHistory(form.data);
   const totalAssets = getTotalAssets(form.data);
+  const fsrReason = getFsrReason(selectedDebts);
 
   const submissionObj = {
     personalIdentification: {
       ssn: personalIdentification.ssn,
       fileNumber: personalIdentification.fileNumber,
-      fsrReason: selectedDebts
-        .map(({ resolution }) => resolution.resolutionType)
-        .join(', '),
+      fsrReason,
     },
     personalData: {
       veteranFullName: {


### PR DESCRIPTION
## Description
Removes duplicate values when the same resolution type is selected for multiple debts

## Original issue(s)
department-of-veterans-affairs/va.gov-team#33043

## Screenshots

![thumbnail_image005](https://user-images.githubusercontent.com/7518899/142466743-cb68ff9f-0648-40ff-915d-68442e8a6ebf.png)

## Acceptance criteria
- [x] payload on submit should not transmit duplicate values for FSR reason

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs