### PR TITLE
Bump component-library for styling fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -249,7 +249,7 @@
   },
   "private": true,
   "dependencies": {
-    "@department-of-veterans-affairs/component-library": "^3.7.0",
+    "@department-of-veterans-affairs/component-library": "^3.7.1",
     "@department-of-veterans-affairs/formation": "6.17.3",
     "@department-of-veterans-affairs/formulate": "0.0.1",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1988,13 +1988,13 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@department-of-veterans-affairs/component-library@^3.7.0":
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-3.7.0.tgz#67c24ef44855aabccccdaf18e1f27d20fe36d371"
-  integrity sha512-j8h3PMGuo9C5X29J+wEtmlSHXPdnfqtqzgXlw+/+NWxBO+jut2GXHqXzLYPOqvCxfwp6ctNtO/uQKd8yEbT9Eg==
+"@department-of-veterans-affairs/component-library@^3.7.1":
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-3.7.1.tgz#f11a23d4406d292ead63859bb1577fbeb7eee34d"
+  integrity sha512-YsbsZR/lUcZmeKzJAbgZuoNwcTd4m7AQ2Lu6gG/K2BoL1mY3ykWlz6Omi3KqRM3XP5Ba5ESB6cSjwkbMIHMSNA==
   dependencies:
     "@department-of-veterans-affairs/react-components" "3.3.0"
-    "@department-of-veterans-affairs/web-components" "0.16.0"
+    "@department-of-veterans-affairs/web-components" "0.16.1"
     date-fns-tz "^1.1.1"
     react-focus-on "^3.5.1"
     react-scroll "^1.7.16"
@@ -2056,10 +2056,10 @@
     react-is "^17.0.1"
     setimmediate "^1.0.5"
 
-"@department-of-veterans-affairs/web-components@0.16.0":
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-0.16.0.tgz#014359735167b947206713dab157214efbd6835a"
-  integrity sha512-7NynHy6lyf0X1UZYpgtn86g0tc/j781OV6Qn4ONT4jZxjfr3mwyCztxZeQuvcktKU5e+0h+cLZJH72yYecrKuQ==
+"@department-of-veterans-affairs/web-components@0.16.1":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-0.16.1.tgz#a6466595597f96b765b0dc1dbe46a9d65eeb0ef8"
+  integrity sha512-gCTtT7JSG8E+DWWA/JxQAS1ba0mXxexuvqgFPyuLYiZ81IMmy9RPuS0EVzbp3PlqDDgMlZZgfp1Ly0PJC6U5iQ==
   dependencies:
     "@stencil/core" "^2.10.0"
     "@stencil/postcss" "^2.0.0"


### PR DESCRIPTION
## Description

This is so that the fix from [version 3.7.1](https://github.com/department-of-veterans-affairs/component-library/releases/tag/v3.7.1) gets into `vets-website`, so that it will make a difference when migrating to `<va-back-to-top>` in the `content-build`: https://github.com/department-of-veterans-affairs/content-build/pull/759

The fix is for a styling change in `<va-back-to-top>` to prevent an override from `uswds` styles.


## Testing done
N/A

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
