### PR TITLE
Optimize webpack preprocessing in Cypress tests

### DIFF
--- a/src/applications/facility-locator/tests/e2e/accessibility.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/accessibility.cypress.spec.js
@@ -1,5 +1,3 @@
-import { facilityTypesOptions } from '../../config';
-import { LocationType } from '../../constants';
 import mockFacilityData from '../../constants/mock-facility-data.json';
 import mockGeocodingData from '../../constants/mock-geocoding-data.json';
 
@@ -32,9 +30,7 @@ describe('Accessibility', () => {
     cy.get('#facility-type-dropdown').focused();
 
     // Select facility option
-    cy.get('#facility-type-dropdown').select(
-      facilityTypesOptions[LocationType.HEALTH],
-    );
+    cy.get('#facility-type-dropdown').select('VA health');
 
     // Tab
     cy.get('#facility-type-dropdown').tab();

--- a/src/applications/facility-locator/tests/e2e/accessibility.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/accessibility.cypress.spec.js
@@ -1,6 +1,8 @@
 import mockFacilityData from '../../constants/mock-facility-data.json';
 import mockGeocodingData from '../../constants/mock-geocoding-data.json';
 
+const LOCAATION_TYPE_HEALTH = 'VA health';
+
 describe('Accessibility', () => {
   beforeEach(() => {
     cy.viewport(1200, 700);
@@ -30,7 +32,7 @@ describe('Accessibility', () => {
     cy.get('#facility-type-dropdown').focused();
 
     // Select facility option
-    cy.get('#facility-type-dropdown').select('VA health');
+    cy.get('#facility-type-dropdown').select(LOCAATION_TYPE_HEALTH);
 
     // Tab
     cy.get('#facility-type-dropdown').tab();

--- a/src/applications/facility-locator/tests/e2e/accessibility.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/accessibility.cypress.spec.js
@@ -1,7 +1,7 @@
 import mockFacilityData from '../../constants/mock-facility-data.json';
 import mockGeocodingData from '../../constants/mock-geocoding-data.json';
 
-const LOCAATION_TYPE_HEALTH = 'VA health';
+const LOCATION_TYPE_HEALTH = 'VA health';
 
 describe('Accessibility', () => {
   beforeEach(() => {
@@ -32,7 +32,7 @@ describe('Accessibility', () => {
     cy.get('#facility-type-dropdown').focused();
 
     // Select facility option
-    cy.get('#facility-type-dropdown').select(LOCAATION_TYPE_HEALTH);
+    cy.get('#facility-type-dropdown').select(LOCATION_TYPE_HEALTH);
 
     // Tab
     cy.get('#facility-type-dropdown').tab();

--- a/src/applications/facility-locator/tests/e2e/ccpDisabled.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/ccpDisabled.cypress.spec.js
@@ -1,6 +1,4 @@
 import mockFeatureTogglesDisabled from '../fixtures/toggle-ccp-disabled.json';
-import { LocationType } from '../../constants/index';
-import { facilityTypesOptions } from '../../config';
 import mockFacilityData from '../../constants/mock-facility-data.json';
 import mockGeocodingData from '../../constants/mock-geocoding-data.json';
 
@@ -21,7 +19,7 @@ describe('Facility Search - CCP (community care providers) disabled', () => {
     cy.get('#facility-type-dropdown option').then(options => {
       const optionsWithoutCCP = [...options].map(o => o.text);
       expect(optionsWithoutCCP).to.not.include(
-        facilityTypesOptions[LocationType.CC_PROVIDER],
+        'Community providers (in VA’s network)',
       );
     });
   });

--- a/src/applications/facility-locator/tests/e2e/ccpDisabled.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/ccpDisabled.cypress.spec.js
@@ -2,6 +2,8 @@ import mockFeatureTogglesDisabled from '../fixtures/toggle-ccp-disabled.json';
 import mockFacilityData from '../../constants/mock-facility-data.json';
 import mockGeocodingData from '../../constants/mock-geocoding-data.json';
 
+const CC_PROVIDER = 'Community providers (in VA’s network)';
+
 describe('Facility Search - CCP (community care providers) disabled', () => {
   beforeEach(() => {
     cy.intercept('GET', '/v0/feature_toggles*', mockFeatureTogglesDisabled);
@@ -18,9 +20,7 @@ describe('Facility Search - CCP (community care providers) disabled', () => {
 
     cy.get('#facility-type-dropdown option').then(options => {
       const optionsWithoutCCP = [...options].map(o => o.text);
-      expect(optionsWithoutCCP).to.not.include(
-        'Community providers (in VA’s network)',
-      );
+      expect(optionsWithoutCCP).to.not.include(CC_PROVIDER);
     });
   });
 });

--- a/src/applications/facility-locator/tests/e2e/ccpEnabled.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/ccpEnabled.cypress.spec.js
@@ -1,8 +1,8 @@
 import mockFeatureTogglesEnabled from '../fixtures/toggle-ccp-enabled.json';
-import { facilityTypesOptions } from '../../config';
-import { LocationType } from '../../constants';
 import mockFacilityData from '../../constants/mock-facility-data.json';
 import mockGeocodingData from '../../constants/mock-geocoding-data.json';
+
+const CC_PROVIDER = 'Community providers (in VA’s network)';
 
 describe('Facility Search - CCP (community care providers) enabled', () => {
   beforeEach(() => {
@@ -19,13 +19,11 @@ describe('Facility Search - CCP (community care providers) enabled', () => {
     cy.injectAxe();
     cy.axeCheck();
     cy.get('#facility-type-dropdown')
-      .select(facilityTypesOptions[LocationType.CC_PROVIDER])
+      .select(CC_PROVIDER)
       .should('exist');
     cy.get('#facility-type-dropdown option').then(options => {
       const optionsWithoutCCP = [...options].map(o => o.text);
-      expect(optionsWithoutCCP).to.include(
-        facilityTypesOptions[LocationType.CC_PROVIDER],
-      );
+      expect(optionsWithoutCCP).to.include(CC_PROVIDER);
     });
   });
 
@@ -36,13 +34,11 @@ describe('Facility Search - CCP (community care providers) enabled', () => {
     cy.injectAxe();
     cy.axeCheck();
     cy.get('#facility-type-dropdown')
-      .select(facilityTypesOptions[LocationType.CC_PROVIDER])
+      .select(CC_PROVIDER)
       .should('exist');
     cy.get('#facility-type-dropdown option').then(options => {
       const optionsWithoutCCP = [...options].map(o => o.text);
-      expect(optionsWithoutCCP).to.include(
-        facilityTypesOptions[LocationType.CC_PROVIDER],
-      );
+      expect(optionsWithoutCCP).to.include(CC_PROVIDER);
     });
   });
 });

--- a/src/applications/facility-locator/tests/e2e/facilitySearch.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/facilitySearch.cypress.spec.js
@@ -31,7 +31,6 @@ Cypress.Commands.add('verifyOptions', () => {
   // Va facilities have services available
   cy.get('#facility-type-dropdown').select('VA health');
   cy.get('#service-type-dropdown').should('not.have.attr', 'disabled');
-  delete 'COVID-19 vaccines';
   const hServices = Object.keys(healthServices);
 
   for (let i = 0; i < hServices.length; i++) {

--- a/src/applications/facility-locator/tests/e2e/facilitySearch.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/facilitySearch.cypress.spec.js
@@ -9,7 +9,6 @@ const healthServices = {
   All: 'All VA health services',
   PrimaryCare: 'Primary care',
   MentalHealthCare: 'Mental health care',
-  Covid19Vaccine: 'COVID-19 vaccines',
   DentalServices: 'Dental services',
   UrgentCare: 'Urgent care',
   EmergencyCare: 'Emergency care',

--- a/src/applications/facility-locator/tests/e2e/facilitySearch.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/facilitySearch.cypress.spec.js
@@ -2,16 +2,37 @@ import mockFacilitiesSearchResultsV1 from '../../constants/mock-facility-data-v1
 import mockFacilityDataV1 from '../../constants/mock-facility-v1.json';
 import mockGeocodingData from '../../constants/mock-geocoding-data.json';
 import mockLaLocation from '../../constants/mock-la-location.json';
-import { healthServices } from '../../config';
 import mockServices from '../../constants/mock-provider-services.json';
 
 const CC_PROVIDER = 'Community providers (in VA’s network)';
+const healthServices = {
+  All: 'All VA health services',
+  PrimaryCare: 'Primary care',
+  MentalHealthCare: 'Mental health care',
+  Covid19Vaccine: 'COVID-19 vaccines',
+  DentalServices: 'Dental services',
+  UrgentCare: 'Urgent care',
+  EmergencyCare: 'Emergency care',
+  Audiology: 'Audiology',
+  Cardiology: 'Cardiology',
+  Dermatology: 'Dermatology',
+  Gastroenterology: 'Gastroenterology',
+  Gynecology: 'Gynecology',
+  Ophthalmology: 'Ophthalmology',
+  Optometry: 'Optometry',
+  Orthopedics: 'Orthopedics',
+  Urology: 'Urology',
+  WomensHealth: "Women's health",
+  Podiatry: 'Podiatry',
+  Nutrition: 'Nutrition',
+  CaregiverSupport: 'Caregiver support',
+};
 
 Cypress.Commands.add('verifyOptions', () => {
   // Va facilities have services available
   cy.get('#facility-type-dropdown').select('VA health');
   cy.get('#service-type-dropdown').should('not.have.attr', 'disabled');
-  delete healthServices.Covid19Vaccine;
+  delete 'COVID-19 vaccines';
   const hServices = Object.keys(healthServices);
 
   for (let i = 0; i < hServices.length; i++) {

--- a/src/applications/facility-locator/tests/e2e/facilitySearch.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/facilitySearch.cypress.spec.js
@@ -2,9 +2,10 @@ import mockFacilitiesSearchResultsV1 from '../../constants/mock-facility-data-v1
 import mockFacilityDataV1 from '../../constants/mock-facility-v1.json';
 import mockGeocodingData from '../../constants/mock-geocoding-data.json';
 import mockLaLocation from '../../constants/mock-la-location.json';
-import { healthServices, facilityTypesOptions } from '../../config';
-import { LocationType } from '../../constants';
+import { healthServices } from '../../config';
 import mockServices from '../../constants/mock-provider-services.json';
+
+const CC_PROVIDER = 'Community providers (in VA’s network)';
 
 Cypress.Commands.add('verifyOptions', () => {
   // Va facilities have services available
@@ -158,9 +159,7 @@ describe('Facility VA search', () => {
     );
 
     cy.get('#street-city-state-zip').type('27606');
-    cy.get('#facility-type-dropdown').select(
-      facilityTypesOptions[LocationType.CC_PROVIDER],
-    );
+    cy.get('#facility-type-dropdown').select(CC_PROVIDER);
     cy.get('#service-type-ahead-input').type('General');
     cy.get('#downshift-1-item-0').click({ waitForAnimations: true });
 

--- a/src/applications/facility-locator/tests/e2e/providerSearch.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/providerSearch.cypress.spec.js
@@ -1,10 +1,11 @@
-import { facilityTypes, urgentCareServices } from '../../config.js';
-import { LocationType } from '../../constants';
 import mockGeocodingData from '../../constants/mock-geocoding-data.json';
 import mockFacilitiesSearchResultsV1 from '../../constants/mock-facility-data-v1.json';
 import mockUrgentCareSearchResults from '../../constants/mock-urgent-care-mashup-data.json';
 import mockEmergencyCareSearchResults from '../../constants/mock-emergency-care-mashup-data.json';
 import mockServices from '../../constants/mock-provider-services.json';
+
+const CC_PROVIDER = 'Community providers (in VA’s network)';
+const NON_VA_URGENT_CARE = 'In-network community urgent care';
 
 describe('Provider search', () => {
   beforeEach(() => {
@@ -76,17 +77,13 @@ describe('Provider search', () => {
     cy.injectAxe();
 
     cy.get('#street-city-state-zip').type('Austin, TX');
-    cy.get('#facility-type-dropdown').select(
-      facilityTypes[LocationType.CC_PROVIDER],
-    );
+    cy.get('#facility-type-dropdown').select(CC_PROVIDER);
     cy.get('#service-type-ahead-input').type('Dentist');
     cy.get('#downshift-1-item-0').click({ waitForAnimations: true });
 
     cy.get('#facility-search').click({ waitForAnimations: true });
     cy.get('#search-results-subheader').contains(
-      `Results for "${
-        facilityTypes[LocationType.CC_PROVIDER]
-      }", "Dentist - Orofacial Pain" near "Austin, Texas"`,
+      `Results for "${CC_PROVIDER}", "Dentist - Orofacial Pain" near "Austin, Texas"`,
     );
     cy.get('#other-tools').should('exist');
 
@@ -102,17 +99,13 @@ describe('Provider search', () => {
     cy.injectAxe();
 
     cy.get('#street-city-state-zip').type('Austin, TX');
-    cy.get('#facility-type-dropdown').select(
-      facilityTypes[LocationType.CC_PROVIDER],
-    );
+    cy.get('#facility-type-dropdown').select(CC_PROVIDER);
     cy.get('#service-type-ahead-input').type('Clinic/Center - Urgent Care');
     cy.get('#downshift-1-item-0').click({ waitForAnimations: true });
 
     cy.get('#facility-search').click({ waitForAnimations: true });
     cy.get('#search-results-subheader').contains(
-      `Results for "${
-        facilityTypes[LocationType.CC_PROVIDER]
-      }", "Clinic/Center - Urgent Care" near "Austin, Texas"`,
+      `Results for "${CC_PROVIDER}", "Clinic/Center - Urgent Care" near "Austin, Texas"`,
     );
     cy.get('#other-tools').should('exist');
 
@@ -127,12 +120,10 @@ describe('Provider search', () => {
 
     cy.get('#street-city-state-zip').type('Austin, TX');
     cy.get('#facility-type-dropdown').select('Urgent care');
-    cy.get('#service-type-dropdown').select(urgentCareServices.NonVAUrgentCare);
+    cy.get('#service-type-dropdown').select(NON_VA_URGENT_CARE);
     cy.get('#facility-search').click({ waitForAnimations: true });
     cy.get('#search-results-subheader').contains(
-      `Results for "Urgent care", "${
-        urgentCareServices.NonVAUrgentCare
-      }" near "Austin, Texas"`,
+      `Results for "Urgent care", "${NON_VA_URGENT_CARE}" near "Austin, Texas"`,
     );
     cy.get('#other-tools').should('exist');
 

--- a/src/platform/testing/e2e/cypress/plugins/index.js
+++ b/src/platform/testing/e2e/cypress/plugins/index.js
@@ -18,6 +18,7 @@ module.exports = on => {
       const options = {
         webpackOptions: {
           ...webpackConfig,
+          plugins: [],
 
           // Expose some Node globals.
           node: {

--- a/src/platform/testing/e2e/cypress/plugins/index.js
+++ b/src/platform/testing/e2e/cypress/plugins/index.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const webpackPreprocessor = require('@cypress/webpack-preprocessor');
 const table = require('table').table;
+const DefinePlugin = require('webpack').DefinePlugin;
 
 const tableConfig = {
   columns: {
@@ -18,7 +19,12 @@ module.exports = on => {
       const options = {
         webpackOptions: {
           ...webpackConfig,
-          plugins: [],
+          plugins: [
+            new DefinePlugin({
+              __BUILDTYPE__: JSON.stringify(ENV),
+              __API__: JSON.stringify(''),
+            }),
+          ],
 
           // Expose some Node globals.
           node: {


### PR DESCRIPTION
## Description
PR to optimize the webpack preprocessing step for Cypress tests, which should speed up CI times by 30-60 seconds.

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/33109

## Testing done
Local testing.

## Acceptance criteria
- [ ] CI passes.