### PR TITLE
Fixed background color on playbook header

### DIFF
--- a/src/applications/static-pages/sass/layouts/_l-playbook.scss
+++ b/src/applications/static-pages/sass/layouts/_l-playbook.scss
@@ -21,11 +21,6 @@
 
 // Blog / Playbook
 .page-playbook {
-  background-color: $color-white;
-
-  .header {
-    background-color: inherit;
-  }
 
   .vets-logo {
     path, rect {


### PR DESCRIPTION
## Description
Playbook header was set to white, this fixed it to blue. View error: https://www.va.gov/playbook/

**Current**
<img width="1054" alt="Screen Shot 2021-11-19 at 11 30 22 AM" src="https://user-images.githubusercontent.com/459581/142657785-166cefb1-dc2b-428d-9d4d-13edd2d8e575.png">

**Fixed**
<img width="1112" alt="Screen Shot 2021-11-19 at 11 30 39 AM" src="https://user-images.githubusercontent.com/459581/142657819-fe7d350c-a2d2-4bff-83fd-8d67150cff11.png">


