### PR TITLE
Pre-check-in Mock API: GET and POST endpoints

### DIFF
--- a/src/applications/check-in/pre-check-in/api/local-mock-api/mocks/v2/patient.pre.check.in.responses.js
+++ b/src/applications/check-in/pre-check-in/api/local-mock-api/mocks/v2/patient.pre.check.in.responses.js
@@ -1,0 +1,88 @@
+const defaultUUID = '46bebc0a-b99c-464f-a5c5-560bc9eae287';
+
+const createMockSuccessResponse = token => {
+  const mockTime = new Date();
+  return {
+    id: token || defaultUUID,
+    payload: {
+      demographics: {
+        nextOfKin1: {
+          name: 'VETERAN,JONAH',
+          relationship: 'BROTHER',
+          phone: '1112223333',
+          workPhone: '4445556666',
+          address: {
+            street1: '123 Main St',
+            street2: 'Ste 234',
+            street3: '',
+            city: 'Los Angeles',
+            county: 'Los Angeles',
+            state: 'CA',
+            zip: '90089',
+            zip4: '',
+            country: 'USA',
+          },
+        },
+        mailingAddress: {
+          street1: '123 Turtle Trail',
+          street2: '',
+          street3: '',
+          city: 'Treetopper',
+          state: 'Tennessee',
+          zip: '101010',
+        },
+        homeAddress: {
+          street1: '445 Fine Finch Fairway',
+          street2: 'Apt 201',
+          city: 'Fairfence',
+          state: 'Florida',
+          zip: '445545',
+        },
+        homePhone: '5552223333',
+        mobilePhone: '5553334444',
+        workPhone: '5554445555',
+        emailAddress: 'kermit.frog@sesameenterprises.us',
+      },
+      appointments: [
+        {
+          facility: 'LOMA LINDA VA CLINIC',
+          clinicPhoneNumber: '5551234567',
+          clinicFriendlyName: 'TEST CLINIC',
+          clinicName: 'LOM ACC CLINIC TEST',
+          appointmentIen: 'some-ien',
+          startTime: mockTime,
+          eligibility: 'ELIGIBLE',
+          facilityId: 'some-facility',
+          checkInWindowStart: mockTime,
+          checkInWindowEnd: mockTime,
+          checkedInTime: '',
+        },
+        {
+          facility: 'LOMA LINDA VA CLINIC',
+          clinicPhoneNumber: '5551234567',
+          clinicFriendlyName: 'TEST CLINIC',
+          clinicName: 'LOM ACC CLINIC TEST',
+          appointmentIen: 'some-other-ien',
+          startTime: mockTime,
+          eligibility: 'ELIGIBLE',
+          facilityId: 'some-facility',
+          checkInWindowStart: mockTime,
+          checkInWindowEnd: mockTime,
+          checkedInTime: '',
+        },
+      ],
+    },
+  };
+};
+
+const createMockFailedResponse = _data => {
+  return {
+    error: true,
+  };
+};
+
+module.exports = {
+  createMockSuccessResponse,
+  createMockFailedResponse,
+  defaultUUID,
+};

--- a/src/applications/check-in/pre-check-in/api/local-mock-api/mocks/v2/pre.check.in.responses.js
+++ b/src/applications/check-in/pre-check-in/api/local-mock-api/mocks/v2/pre.check.in.responses.js
@@ -1,0 +1,9 @@
+const createMockSuccessResponse = _data => {
+  return { data: 'Pre Check In successful', status: 200 };
+};
+
+const createMockFailedResponse = _data => {
+  return { data: { error: true } };
+};
+
+module.exports = { createMockSuccessResponse, createMockFailedResponse };

--- a/src/applications/check-in/pre-check-in/api/local-mock-api/phase.1.js
+++ b/src/applications/check-in/pre-check-in/api/local-mock-api/phase.1.js
@@ -2,6 +2,8 @@
 
 const commonResponses = require('../../../../../platform/testing/local-dev-mock-api/common');
 const mockSessions = require('./mocks/v2/sessions.responses');
+const mockPatientPreCheckIns = require('./mocks/v2/patient.pre.check.in.responses');
+const mockPreCheckIns = require('./mocks/v2/pre.check.in.responses');
 
 const featureToggles = require('./mocks/feature.toggles');
 const delay = require('mocker-api/lib/delay');
@@ -21,6 +23,19 @@ const responses = {
       return res.status(400).json(mockSessions.createMockFailedResponse());
     }
     return res.json(mockSessions.mocks.post(req.body));
+  },
+  'GET /check_in/v2/pre_check_ins/:uuid': (req, res) => {
+    // TODO??: add check for queryString "/pre_check_ins/<uuid>?checkInType=preCheckIn"
+    const { uuid } = req.params;
+    return res.json(mockPatientPreCheckIns.createMockSuccessResponse(uuid));
+  },
+  'POST /check_in/v2/pre_check_ins/': (req, res) => {
+    const { uuid, checkInType } = req.body?.preCheckIn || {};
+    if (!uuid || checkInType !== 'preCheckIn') {
+      return res.status(500).json(mockPreCheckIns.createMockFailedResponse());
+    } else {
+      return res.json(mockPreCheckIns.createMockSuccessResponse({}));
+    }
   },
 };
 

--- a/src/applications/check-in/pre-check-in/api/versions/v2.js
+++ b/src/applications/check-in/pre-check-in/api/versions/v2.js
@@ -41,6 +41,50 @@ const v2 = {
       ...json,
     };
   },
+  getPreCheckInData: async token => {
+    const url = '/check_in/v2/pre_check_ins/';
+    const json = await makeApiCall(
+      apiRequest(`${environment.API_URL}${url}${token}?checkInType=preCheckIn`),
+      'get-lorota-data',
+      token,
+    );
+    return {
+      ...json,
+    };
+  },
+  postPreCheckInData: async ({
+    uuid,
+    demographicsUpToDate,
+    nextOfKinUpToDate,
+    checkInType,
+  }) => {
+    const url = '/check_in/v2/pre_check_ins/';
+    const headers = { 'Content-Type': 'application/json' };
+    const data = {
+      preCheckIn: {
+        uuid,
+        demographicsUpToDate,
+        nextOfKinUpToDate,
+        checkInType,
+      },
+    };
+    const body = JSON.stringify(data);
+    const settings = {
+      headers,
+      body,
+      method: 'POST',
+      mode: 'cors',
+    };
+
+    const json = await makeApiCall(
+      apiRequest(`${environment.API_URL}${url}`, settings),
+      'pre-check-in-user',
+      uuid,
+    );
+    return {
+      ...json,
+    };
+  },
 };
 
 export { v2 };


### PR DESCRIPTION
## Description
Adds mock GET call for fetching demographics and appointment data. Adds mock POST call for submitting user pre-check-in responses.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#32770


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
