### PR TITLE
[12617] fix email address wrapping

### DIFF
--- a/src/applications/edu-benefits/10203/sass/10203_stem.scss
+++ b/src/applications/edu-benefits/10203/sass/10203_stem.scss
@@ -19,6 +19,11 @@
     }
   }
 }
+
+dd > span {
+  overflow-wrap: break-word;
+}
+
 .form-checkbox > input[type="checkbox"] + .schemaform-label {
   // TODO: add > to .schemaform-first-field .schemaform-label, .schemaform-first-field > .usa-input-error in us-forms-system
   margin-top: 10px;


### PR DESCRIPTION
## Description

This fixes the issue where email addresses do not wrap once the input has been entered.

## Original issue(s)

department-of-veterans-affairs/va-website#12617

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/12617

## Testing done


## Screenshots

![ce0963ab-a3a9-4dc9-bed2-30a142152f45](https://user-images.githubusercontent.com/3201/143060888-bf93491b-2151-4a00-b522-528d23198668.png)


## Acceptance criteria
- [ ] The email address now wraps properly in the display

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
