### PR TITLE
Change style to remove bottom border on active search tab

### DIFF
--- a/src/applications/gi-sandbox/sass/partials/_gi-search-form.scss
+++ b/src/applications/gi-sandbox/sass/partials/_gi-search-form.scss
@@ -51,6 +51,7 @@
 
   .active-search-tab {
     border-top: 4px solid $color-primary;
+    border-bottom: none;
     border-radius: 0%;
     height: 2.8em;
     margin-bottom: -1px;
@@ -58,13 +59,13 @@
 
   .inactive-search-tab {
     border-top: 2px solid $color-gray-light;
+    border-bottom: 2px solid $color-gray-light;
     border-radius: 0%;
     margin-bottom: -1px;
   }
 
   .search-tab {
     font-size: 25px;
-    border-bottom: 2px solid $color-gray-light;
     border-radius: 0px;
     margin-top: 0px;
     margin-bottom: 0px;


### PR DESCRIPTION
Changed the state of the bottom border in the active and inactive search-tab classes instead of search-tab

## Description
Design components or patterns don't align with Design System guidelines. (In the redesigned comparison tool) On the tabs, there is a gray bottom border between search by name and the text box. This makes the text box seem like it is not connected to the tab title
![](https://user-images.githubusercontent.com/85580424/139130633-e8dddc21-4cf1-453c-93e1-4da36b187eb7.png)

## Original issue(s)
[department-of-veterans-affairs/va.gov-team#0000](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/29371)
https://github.com/department-of-veterans-affairs/vets-website/pull/19488


## Testing done
Visual Confirmation that the changes holds (screenshots below)

## Screenshots
<img width="1068" alt="Screen Shot 2021-11-19 at 1 30 54 PM" src="https://user-images.githubusercontent.com/86262790/142681685-b48388b4-51fe-4e84-9283-7bc8b3b13001.png">
<img width="1060" alt="Screen Shot 2021-11-19 at 1 31 04 PM" src="https://user-images.githubusercontent.com/86262790/142681688-282bde9e-2a95-4b3a-8267-22eb18b06b18.png">


## Acceptance criteria
- [ ] There is no border underneath the active search tab on the comparison tool search element

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
