### PR TITLE
Accept multiple output types

### DIFF
--- a/script/github-actions/get-changed-apps.js
+++ b/script/github-actions/get-changed-apps.js
@@ -39,26 +39,29 @@ const getAllowedApp = (file, allowList, outputType = 'entry') => {
   const entryName = manifest?.entryName;
 
   if (allowList.includes(entryName)) {
-    // Return the app path, entry name, or root URL depending on the output type
-    if (outputType === 'folder') {
+    // Return the entry name, folder path, or root URL depending on the output type
+    if (outputType === 'entry') {
+      return entryName;
+    } else if (outputType === 'folder') {
       const appFolderName = file.split('/')[2];
       return `src/applications/${appFolderName}`;
-    } else if (outputType === 'url') return manifest?.rootUrl;
-    return entryName;
+    } else if (outputType === 'url') {
+      return manifest?.rootUrl;
+    } else throw new Error('Invalid output type specified.');
   }
 
   return null;
 };
 
 /**
- * Checks if an only changed apps build is possible by confirming that all
- * files are from apps on an allow list. If so, returns a comma-delimited
- * list of app entry names or relative paths. If not, returns an empty string.
+ * Checks if a changed apps build is possible by confirming that all
+ * files are from apps on an allow list. If so, returns a comma-delimited list
+ * of app entry names, relative paths, or URLs. If not, returns an empty string.
  *
  * @param {string[]} files - An array of relative file paths.
  * @param {Object} config - The changed apps build config.
- * @param {string} outputType - Determines whether app paths or entries should be returned.
- * @returns {string} A comma-delimited string of either app entry names or relative paths.
+ * @param {string} outputType - Determines what app information should be returned.
+ * @returns {string} A comma-delimited string of app entry names, relative paths or URLs.
  */
 const getChangedAppsString = (files, config, outputType = 'entry') => {
   const allowedApps = [];

--- a/script/github-actions/get-changed-apps.js
+++ b/script/github-actions/get-changed-apps.js
@@ -76,7 +76,10 @@ const getChangedAppsString = (files, config, outputType = 'entry') => {
 };
 
 if (process.env.CHANGED_FILE_PATHS) {
-  const changedFiles = process.env.CHANGED_FILE_PATHS.split(' ');
+  // Filter changed files for testing
+  const changedFiles = process.env.CHANGED_FILE_PATHS.split(' ').filter(
+    filePath => filePath.startsWith('src/applications'),
+  );
 
   const options = commandLineArgs([
     // Use the --output-type option to specify one of the following outputs:

--- a/script/github-actions/get-changed-apps.js
+++ b/script/github-actions/get-changed-apps.js
@@ -39,7 +39,7 @@ const getAllowedApp = (file, allowList, outputType = 'entry') => {
   const entryName = manifest?.entryName;
 
   if (allowList.includes(entryName)) {
-    // Return either the app path, entry name, or root URL depending on the output type
+    // Return the app path, entry name, or root URL depending on the output type
     if (outputType === 'folder') {
       const appFolderName = file.split('/')[2];
       return `src/applications/${appFolderName}`;
@@ -76,10 +76,7 @@ const getChangedAppsString = (files, config, outputType = 'entry') => {
 };
 
 if (process.env.CHANGED_FILE_PATHS) {
-  // Filter changed files for testing
-  const changedFiles = process.env.CHANGED_FILE_PATHS.split(' ').filter(
-    filePath => filePath.startsWith('src/applications'),
-  );
+  const changedFiles = process.env.CHANGED_FILE_PATHS.split(' ');
 
   const options = commandLineArgs([
     // Use the --output-type option to specify one of the following outputs:

--- a/script/github-actions/get-changed-apps.js
+++ b/script/github-actions/get-changed-apps.js
@@ -7,21 +7,19 @@ const commandLineArgs = require('command-line-args');
 const changedAppsConfig = require('../../config/single-app-build.json');
 
 /**
- * Gets the entry name of the app that a file belongs to.
+ * Gets the manifest object of the app that a file belongs to.
  *
  * @param {string} filePath - Relative file path.
  * @returns {string} The entry name of an app.
  */
-const getEntryName = filePath => {
+const getManifest = filePath => {
   const root = path.join(__dirname, '../..');
   const appDirectory = filePath.split('/')[2];
   const fullPath = path.join(root, `./src/applications/${appDirectory}`);
 
-  const manifestFile = find
+  return find
     .fileSync(/manifest\.(json|js)$/, fullPath)
     .map(file => JSON.parse(fs.readFileSync(file)))[0];
-
-  return manifestFile?.entryName;
 };
 
 /**
@@ -37,14 +35,15 @@ const getEntryName = filePath => {
 const getAllowedApp = (file, allowList, outputType = 'entry') => {
   if (!file.startsWith('src/applications')) return null;
 
-  const entryName = getEntryName(file);
+  const manifest = getManifest(file);
+  const entryName = manifest?.entryName;
 
   if (allowList.includes(entryName)) {
-    // Return app path when 'app-folders' option is used
+    // Return either the app path, entry name, or root URL depending on the output type
     if (outputType === 'folder') {
       const appFolderName = file.split('/')[2];
       return `src/applications/${appFolderName}`;
-    }
+    } else if (outputType === 'url') return manifest?.rootUrl;
     return entryName;
   }
 
@@ -80,10 +79,13 @@ if (process.env.CHANGED_FILE_PATHS) {
   const changedFiles = process.env.CHANGED_FILE_PATHS.split(' ');
 
   const options = commandLineArgs([
-    // Use the --get-folders option to get app folder paths. Entry names are the default.
-    { name: 'get-folders', type: Boolean, defaultValue: false },
+    // Use the --output-type option to specify one of the following outputs:
+    // 'entry': The entry names of the changed apps.
+    // 'folder': The relative path of the changed apps root folders.
+    // 'url': The root URLs of the changed apps.
+    { name: 'output-type', type: String, defaultValue: 'entry' },
   ]);
-  const outputType = options['get-folders'] ? 'folder' : 'entry';
+  const outputType = options['output-type'];
 
   const changedAppsString = getChangedAppsString(
     changedFiles,

--- a/script/github-actions/get-changed-apps.js
+++ b/script/github-actions/get-changed-apps.js
@@ -10,7 +10,7 @@ const changedAppsConfig = require('../../config/single-app-build.json');
  * Gets the manifest object of the app that a file belongs to.
  *
  * @param {string} filePath - Relative file path.
- * @returns {string} The entry name of an app.
+ * @returns {Object} Application manifest.
  */
 const getManifest = filePath => {
   const root = path.join(__dirname, '../..');
@@ -23,14 +23,13 @@ const getManifest = filePath => {
 };
 
 /**
- * Gets either the entry name or relative path of the app
- * that a file belongs to. The app must be in the given allow list,
- * otherwise returns null.
+ * Gets the entry name, relative path, or URL of the app that a file belongs to.
+ * The app must be in the given allow list, otherwise returns null.
  *
  * @param {string} file - Relative file path.
  * @param {string[]} allowList - A list of application entry names.
- * @param {string} outputType - Determines whether the app's path or entry name should be returned.
- * @returns {string|null} Either the entry name or relative path app of an app. Otherwise null.
+ * @param {string} outputType - Determines what app information should be returned.
+ * @returns {string|null} The app information specified in the output type. Otherwise null.
  */
 const getAllowedApp = (file, allowList, outputType = 'entry') => {
   if (!file.startsWith('src/applications')) return null;

--- a/script/github-actions/get-changed-apps.unit.spec.js
+++ b/script/github-actions/get-changed-apps.unit.spec.js
@@ -111,5 +111,14 @@ describe('getChangedAppsString', () => {
     expect(appString).to.equal('app1');
   });
 
+  it('should throw an error when an unknown output type is specified', () => {
+    const config = { allow: ['app1', 'app2'] };
+    const changedFiles = ['src/applications/app1', 'src/applications/app2'];
+
+    expect(() => {
+      getChangedAppsString(changedFiles, config, 'unknown');
+    }).to.throw('Invalid output type specified.');
+  });
+
   after(() => mockFs.restore());
 });

--- a/script/github-actions/get-changed-apps.unit.spec.js
+++ b/script/github-actions/get-changed-apps.unit.spec.js
@@ -92,6 +92,14 @@ describe('getChangedAppsString', () => {
     expect(appString).to.equal('src/applications/app1,src/applications/app2');
   });
 
+  it('should return a comma-delimited string of app URLs when the url output type is specified', () => {
+    const config = { allow: ['app1', 'app2'] };
+    const changedFiles = ['src/applications/app1', 'src/applications/app2'];
+
+    const appString = getChangedAppsString(changedFiles, config, 'url');
+    expect(appString).to.equal('/app1,/app2');
+  });
+
   it('should not duplicate entry names when multiple files in an app are modified', () => {
     const config = { allow: ['app1'] };
     const changedFiles = [

--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItem.jsx
@@ -9,6 +9,7 @@ import { APPOINTMENT_STATUS, VIDEO_TYPES } from '../../../utils/constants';
 import { Link, useHistory } from 'react-router-dom';
 import { focusElement } from 'platform/utilities/ui';
 
+// Test changed apps build
 function VideoAppointmentDescription({ appointment }) {
   const isAtlas = appointment.videoData.isAtlas;
   const videoKind = appointment.videoData.kind;

--- a/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPageV2/AppointmentListItem.jsx
@@ -9,7 +9,6 @@ import { APPOINTMENT_STATUS, VIDEO_TYPES } from '../../../utils/constants';
 import { Link, useHistory } from 'react-router-dom';
 import { focusElement } from 'platform/utilities/ui';
 
-// Test changed apps build
 function VideoAppointmentDescription({ appointment }) {
   const isAtlas = appointment.videoData.isAtlas;
   const videoKind = appointment.videoData.kind;


### PR DESCRIPTION
## Description
This PR updates the `get-changed-apps` script to support multiple output types by adding the `output-type` option. Supported output types are `entry`, `folder`, and `url`. 

This update is needed so that we can get the root URL of changed apps for the mega menu Cypress test in only changed app builds. A proof of concept was done in this PR: https://github.com/department-of-veterans-affairs/vets-website/pull/19479.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#33183


## Testing done
Tested in added unit test, locally, and in CI ([GHA run](https://github.com/department-of-veterans-affairs/vets-website/actions/runs/1496743275) from POC PR).

## Screenshots


## Acceptance criteria
- [x] The get-changed-apps.js script can accept multiple options as the output type.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
