### PR TITLE
Check in/feat/32780/pre check in error page

### DIFF
--- a/src/applications/check-in/components/ErrorMessage.jsx
+++ b/src/applications/check-in/components/ErrorMessage.jsx
@@ -1,0 +1,21 @@
+import React, { useEffect } from 'react';
+import { focusElement } from 'platform/utilities/ui';
+
+const ErrorMessage = () => {
+  useEffect(() => {
+    focusElement('h1');
+  }, []);
+  return (
+    <va-alert status="error">
+      <h1 tabIndex="-1" slot="headline">
+        We couldn’t check you in
+      </h1>
+      <p data-testid="error-message">
+        We’re sorry. Something went wrong on our end. Check in with a staff
+        member.
+      </p>
+    </va-alert>
+  );
+};
+
+export default ErrorMessage;

--- a/src/applications/check-in/components/tests/ErrorMessage.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/ErrorMessage.unit.spec.jsx
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react';
 
 import ErrorMessage from '../ErrorMessage';
 
-describe('Pre check in', () => {
+describe('check-in', () => {
   describe('ErrorMessage', () => {
     it('Renders error message', () => {
       const component = render(<ErrorMessage />);

--- a/src/applications/check-in/components/tests/ErrorMessage.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/ErrorMessage.unit.spec.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+
+import ErrorMessage from '../ErrorMessage';
+
+describe('Pre check in', () => {
+  describe('ErrorMessage', () => {
+    it('Renders error message', () => {
+      const component = render(<ErrorMessage />);
+      expect(component.getByText('We couldn’t check you in')).to.exist;
+
+      expect(component.getByTestId('error-message')).to.exist;
+      expect(component.getByTestId('error-message')).to.have.text(
+        'We’re sorry. Something went wrong on our end. Check in with a staff member.',
+      );
+    });
+  });
+});

--- a/src/applications/check-in/day-of/pages/Error.jsx
+++ b/src/applications/check-in/day-of/pages/Error.jsx
@@ -1,24 +1,13 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
+import ErrorMessage from '../../components/ErrorMessage';
 import BackToHome from '../components/BackToHome';
 import Footer from '../components/Footer';
-import { focusElement } from 'platform/utilities/ui';
 
 const Error = () => {
-  useEffect(() => {
-    focusElement('h1');
-  }, []);
   return (
     <div className="vads-l-grid-container vads-u-padding-y--5 ">
-      <va-alert status="error">
-        <h1 tabIndex="-1" slot="headline">
-          We couldn’t check you in
-        </h1>
-        <p data-testid="error-message">
-          We’re sorry. Something went wrong on our end. Check in with a staff
-          member.
-        </p>
-      </va-alert>
+      <ErrorMessage />
       <Footer />
       <BackToHome />
     </div>

--- a/src/applications/check-in/pre-check-in/pages/Error/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Error/index.jsx
@@ -1,5 +1,16 @@
 import React from 'react';
+import ErrorMessage from '../../../components/ErrorMessage';
+import BackToHome from '../../components/BackToHome';
+import Footer from '../../components/Footer';
 
-export default function index() {
-  return <div>Error</div>;
-}
+const Error = () => {
+  return (
+    <div className="vads-l-grid-container vads-u-padding-y--5 ">
+      <ErrorMessage />
+      <Footer />
+      <BackToHome />
+    </div>
+  );
+};
+
+export default Error;

--- a/src/applications/check-in/pre-check-in/pages/tests/Error.unit.spec.jsx
+++ b/src/applications/check-in/pre-check-in/pages/tests/Error.unit.spec.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { axeCheck } from 'platform/forms-system/test/config/helpers';
+import Error from '../Error';
+
+describe('check-in', () => {
+  describe('Pre-check-in Error page', () => {
+    it('renders error page', () => {
+      const component = render(<Error />);
+      expect(component.getByTestId('error-message')).to.exist;
+    });
+    it('Passes AxeCheck', () => {
+      axeCheck(<Error />);
+    });
+  });
+});

--- a/src/applications/check-in/pre-check-in/tests/e2e/pages/Error.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/pages/Error.js
@@ -1,0 +1,17 @@
+import Timeouts from 'platform/testing/e2e/timeouts';
+
+class Error {
+  validatePageLoaded() {
+    cy.get('h1', { timeout: Timeouts.slow })
+      .should('be.visible')
+      .and('have.text', 'We couldn’t check you in');
+    cy.get('div[data-testid="error-message"]')
+      .should('be.visible')
+      .and(
+        'have.text',
+        'We’re sorry. Something went wrong on our end. Check in with a staff member.',
+      );
+  }
+}
+
+export default new Error();


### PR DESCRIPTION
## Description
Add pre-check-in error page. Move error message out to a shared component used by day-of check in  and pre-check-in.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#32780


## Testing done
Unit

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
