### PR TITLE
Add PDF-modal test to Find Forms Cypress spec

### DIFF
--- a/src/applications/find-forms/components/SearchResult.jsx
+++ b/src/applications/find-forms/components/SearchResult.jsx
@@ -240,6 +240,7 @@ const SearchResult = ({
       <div className="vads-u-margin-bottom--5">
         <a
           className="find-forms-max-content vads-u-text-decoration--none"
+          data-testid={`pdf-link-${id}`}
           rel="noreferrer noopener"
           href={showPDFInfoVersionOne && !doesCookieExist ? null : url}
           onClick={() => pdfDownloadHandler()}

--- a/src/applications/find-forms/tests/e2e/find-forms-required.cypress.spec.js
+++ b/src/applications/find-forms/tests/e2e/find-forms-required.cypress.spec.js
@@ -33,20 +33,30 @@ function axeTestPage() {
 }
 
 describe('functionality of Find Forms', () => {
-  it('search the form and expect dom to have elements - C3994', () => {
+  beforeEach(() => {
     cy.intercept('GET', '/v0/feature_toggles*', {
       data: {
         type: 'feature_toggles',
         features: [
           {
+            name: 'find_forms_first_flag',
+            value: true,
+          },
+          {
             name: 'find_forms_second_flag',
+            value: true,
+          },
+          {
+            name: 'find_forms_third_flag',
             value: true,
           },
         ],
       },
     });
     cy.intercept('GET', '/v0/forms?query=health', stub).as('getFindAForm');
+  });
 
+  it('search the form and expect dom to have elements - C3994', () => {
     // navigate to find-forms and make axe check on browser
     cy.visit('/find-forms/');
     axeTestPage();
@@ -72,7 +82,7 @@ describe('functionality of Find Forms', () => {
 
     pages.forEach((page, pageNumber) => {
       page.forEach(form => {
-        cy.get(`a[href="${form.attributes.url}"]`);
+        cy.get(`a[data-testid="pdf-link-${form.id}"]`).should('exist');
       });
 
       const nextPage = pageNumber + 1;
@@ -94,5 +104,19 @@ describe('functionality of Find Forms', () => {
     cy.get(`${SELECTORS.SORT_SELECT_WIDGET} option:first`)
       .should('be.selected')
       .should('contain', FAF_SORT_OPTIONS[0]);
+  });
+
+  it('opens PDF modal - C12431', () => {
+    cy.clearCookie('findForms');
+    cy.visit('/find-forms/?q=health');
+    cy.get('a[data-testid^="pdf-link"]').then($links => {
+      const randomIndex = Math.floor(Math.random() * $links.length);
+
+      cy.wrap($links)
+        .eq(randomIndex)
+        .scrollIntoView()
+        .click();
+    });
+    cy.get('#va-modal-title').should('contain.text', 'PDF');
   });
 });


### PR DESCRIPTION
## Description
Add test for new PDF download-instructions modal to existing Find a VA Form Cypress E2E spec.

## Testing done
- Does NOT impact any app-functionalities.
- Ran updated spec locally, and all tests passed as expected, incl. [results pushed to TestRail](https://dsvavsp.testrail.io/index.php?/runs/overview/30) [see Wednesday, November 24, 2021].

## Screenshots
![2021-11-24_12-33-09](https://user-images.githubusercontent.com/587583/143302564-e89bdbd0-94d0-4778-8b9b-376732a21151.png)


## Acceptance criteria
- [x] Reviewers approved changes.

## Definition of done
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
