### PR TITLE
29364 - School result content card incorrect overlap

### DIFF
--- a/src/applications/gi-sandbox/containers/search/ResultCard.jsx
+++ b/src/applications/gi-sandbox/containers/search/ResultCard.jsx
@@ -187,7 +187,7 @@ export function ResultCard({
   const tuitionAndEligibility = (
     <>
       <p>
-        <strong>You may be eligible for up to smirf:</strong>
+        <strong>You may be eligible for up to:</strong>
       </p>
       <div className="vads-u-display--flex vads-u-margin-top--0 vads-u-margin-bottom--2">
         <div className="vads-u-flex--1">

--- a/src/applications/gi-sandbox/containers/search/ResultCard.jsx
+++ b/src/applications/gi-sandbox/containers/search/ResultCard.jsx
@@ -297,7 +297,7 @@ export function ResultCard({
               />
             </div>
           )}
-          {expanded && (
+          {
             <>
               <div
                 className={classNames(
@@ -318,7 +318,7 @@ export function ResultCard({
                 </div>
               </div>
             </>
-          )}
+          }
 
           <div
             className={classNames(

--- a/src/applications/gi-sandbox/containers/search/ResultCard.jsx
+++ b/src/applications/gi-sandbox/containers/search/ResultCard.jsx
@@ -297,7 +297,7 @@ export function ResultCard({
               />
             </div>
           )}
-          {!expanded && (
+          {expanded && (
             <>
               <div
                 className={classNames(

--- a/src/applications/gi-sandbox/containers/search/ResultCard.jsx
+++ b/src/applications/gi-sandbox/containers/search/ResultCard.jsx
@@ -187,7 +187,7 @@ export function ResultCard({
   const tuitionAndEligibility = (
     <>
       <p>
-        <strong>You may be eligible for up to:</strong>
+        <strong>You may be eligible for up to smirf:</strong>
       </p>
       <div className="vads-u-display--flex vads-u-margin-top--0 vads-u-margin-bottom--2">
         <div className="vads-u-flex--1">


### PR DESCRIPTION
## School result content card incorrect overlap


## Original issue(s)
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/29364

## Testing done


## Screenshots

Before and after behavior, when clicking on expand arrow:
<img width="1016" alt="Screen Shot 2021-11-29 at 9 17 18 AM" src="https://user-images.githubusercontent.com/3818397/143914374-6d248a34-b37e-4efd-a465-89b365e4d842.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
