### PR TITLE
Adding null check for a possible missing home address

### DIFF
--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelect.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelect.jsx
@@ -20,6 +20,16 @@ export default function SelectedProvider({
   );
   const [showRemoveProviderModal, setShowRemoveProviderModal] = useState(false);
 
+  const srSortMethod = () => {
+    if (sortMethod === FACILITY_SORT_METHODS.distanceFromCurrentLocation) {
+      return 'from your current location';
+    } else if (sortMethod === FACILITY_SORT_METHODS.distanceFromResidential) {
+      return 'from your home address';
+    } else {
+      return 'from closest VA facility';
+    }
+  };
+
   return (
     <div className="vads-u-background-color--gray-lightest vads-u-padding--2 medium-screen:vads-u-padding--3">
       {!providerSelected && (
@@ -57,11 +67,7 @@ export default function SelectedProvider({
           </span>
           <span className="vads-u-display--block vads-u-font-size--sm">
             {formData[sortMethod]} miles{' '}
-            <span className="sr-only">
-              {sortMethod === FACILITY_SORT_METHODS.distanceFromCurrentLocation
-                ? 'from your current location'
-                : 'from your home address'}
-            </span>
+            <span className="sr-only">{srSortMethod()}</span>
           </span>
           <div className="vads-u-display--flex vads-u-margin-top--1">
             <button
@@ -91,6 +97,7 @@ export default function SelectedProvider({
         <RemoveProviderModal
           provider={formData}
           address={address}
+          distanceInMiles={formData[sortMethod]}
           onClose={response => {
             setShowRemoveProviderModal(false);
             if (response === true) {

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/RemoveProviderModal.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/RemoveProviderModal.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import Modal from '@department-of-veterans-affairs/component-library/Modal';
-import { distanceBetween } from '../../../utils/address';
 
-export default function RemoveProviderModal({ onClose, provider, address }) {
+export default function RemoveProviderModal({
+  onClose,
+  provider,
+  distanceInMiles = null,
+}) {
   const title = 'Are you sure you want to remove this provider?';
   const content = (
     <>
@@ -14,15 +17,11 @@ export default function RemoveProviderModal({ onClose, provider, address }) {
         {provider.address?.city}, {provider.address?.state}{' '}
         {provider.address?.postalCode}
       </span>
-      <span className="vads-u-display--block vads-u-font-size--sm vads-u-font-weight--bold vads-u-margin-bottom--2">
-        {distanceBetween(
-          provider.position?.latitude,
-          provider.position?.longitude,
-          address.latitude,
-          address.longitude,
-        )}{' '}
-        miles
-      </span>
+      {distanceInMiles && (
+        <span className="vads-u-display--block vads-u-font-size--sm vads-u-font-weight--bold vads-u-margin-bottom--2">
+          {distanceInMiles} miles
+        </span>
+      )}
       <button type="button" onClick={() => onClose(true)}>
         Yes, remove provider
       </button>

--- a/src/applications/vaos/new-appointment/redux/reducer.js
+++ b/src/applications/vaos/new-appointment/redux/reducer.js
@@ -740,7 +740,7 @@ export default function formReducer(state = initialState, action) {
         : FACILITY_SORT_METHODS.distanceFromFacility;
 
       const selectedCCFacility =
-        !hasResidentialCoordinates && state.ccEnabledSystems.length > 1
+        !hasResidentialCoordinates && state.ccEnabledSystems?.length > 1
           ? state.ccEnabledSystems.find(
               system => system.id === state.data?.communityCareSystemId,
             )

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.jsx
@@ -3,7 +3,6 @@ import { expect } from 'chai';
 import userEvent from '@testing-library/user-event';
 import { waitFor } from '@testing-library/dom';
 import { cleanup } from '@testing-library/react';
-
 import { mockFetch } from 'platform/testing/unit/helpers';
 
 import {
@@ -299,6 +298,276 @@ describe('VAOS <CommunityCareProviderSelectionPage>', () => {
     expect(await screen.findByText(/Choose a provider/i));
     expect(screen.baseElement).not.to.contain.text(
       'AJADI, ADEDIWURA700 CONSTITUTION AVE NEWASHINGTON, DC 20002-6599',
+    );
+  });
+
+  it('should display choose provider when remove provider clicked', async () => {
+    const testState = {
+      ...initialState,
+      newAppointment: {
+        pages: {},
+        data: {
+          communityCareProvider: {
+            id: '1952935777',
+            identifier: [
+              {
+                system: 'PPMS',
+                value: '1952935777',
+              },
+            ],
+            resourceType: 'Location',
+            address: {
+              line: ['7700 LITTLE RIVER TPKE STE 102'],
+              city: 'ANNANDALE',
+              state: 'VA',
+              postalCode: '22003-2400',
+            },
+            name: 'OH, JANICE',
+            position: {
+              longitude: -77.211165,
+              latitude: 38.833571,
+            },
+            telecom: [
+              {
+                system: 'phone',
+                value: '703-752-4623',
+              },
+            ],
+            distanceFromResidentialAddress: 2409,
+          },
+          communityCareSystemId: '983',
+          facilityType: 'communityCare',
+          typeOfCareId: '323',
+          selectedDates: ['2021-12-08T00:00:00.000'],
+        },
+        facilities: {},
+        facilityDetails: {},
+        clinics: {},
+        eligibility: {},
+        parentFacilities: [
+          {
+            resourceType: 'Location',
+            id: '983',
+            vistaId: '983',
+            name: 'Cheyenne VA Medical Center',
+            identifier: [
+              {
+                system: 'http://med.va.gov/fhir/urn',
+                value: 'urn:va:division:983:983',
+              },
+              {
+                system: 'urn:oid:2.16.840.1.113883.6.233',
+                value: '983',
+              },
+            ],
+            telecom: [
+              {
+                system: 'phone',
+                value: '307-778-7550',
+              },
+            ],
+            position: {
+              longitude: -104.786159,
+              latitude: 41.148179,
+            },
+            address: {
+              line: ['2360 East Pershing Boulevard'],
+              city: 'Cheyenne',
+              state: 'WY',
+              postalCode: '82001-5356',
+            },
+          },
+          {
+            resourceType: 'Location',
+            id: '984',
+            vistaId: '984',
+            name: 'Dayton VA Medical Center',
+            identifier: [
+              {
+                system: 'http://med.va.gov/fhir/urn',
+                value: 'urn:va:division:984:984',
+              },
+              {
+                system: 'urn:oid:2.16.840.1.113883.6.233',
+                value: '984',
+              },
+            ],
+            telecom: [
+              {
+                system: 'phone',
+                value: '937-268-6511',
+              },
+            ],
+            position: {
+              longitude: '-84.2651895',
+              latitude: '39.7424427',
+            },
+            address: {
+              line: ['4100 West Third Street'],
+              city: 'Dayton',
+              state: 'OH',
+              postalCode: '45428-9000',
+            },
+          },
+        ],
+        ccEnabledSystems: [
+          {
+            resourceType: 'Location',
+            id: '983',
+            vistaId: '983',
+            name: 'Cheyenne VA Medical Center',
+            identifier: [
+              {
+                system: 'http://med.va.gov/fhir/urn',
+                value: 'urn:va:division:983:983',
+              },
+              {
+                system: 'urn:oid:2.16.840.1.113883.6.233',
+                value: '983',
+              },
+            ],
+            telecom: [
+              {
+                system: 'phone',
+                value: '307-778-7550',
+              },
+            ],
+            position: {
+              longitude: -104.786159,
+              latitude: 41.148179,
+            },
+            address: {
+              line: ['2360 East Pershing Boulevard'],
+              city: 'Cheyenne',
+              state: 'WY',
+              postalCode: '82001-5356',
+            },
+          },
+          {
+            resourceType: 'Location',
+            id: '984',
+            vistaId: '984',
+            name: 'Dayton VA Medical Center',
+            identifier: [
+              {
+                system: 'http://med.va.gov/fhir/urn',
+                value: 'urn:va:division:984:984',
+              },
+              {
+                system: 'urn:oid:2.16.840.1.113883.6.233',
+                value: '984',
+              },
+            ],
+            telecom: [
+              {
+                system: 'phone',
+                value: '937-268-6511',
+              },
+            ],
+            position: {
+              longitude: '-84.2651895',
+              latitude: '39.7424427',
+            },
+            address: {
+              line: ['4100 West Third Street'],
+              city: 'Dayton',
+              state: 'OH',
+              postalCode: '45428-9000',
+            },
+          },
+        ],
+        pageChangeInProgress: false,
+        previousPages: {
+          typeOfCare: 'home',
+          typeOfFacility: 'typeOfCare',
+          requestDateTime: 'typeOfFacility',
+          ccClosestCity: 'requestDateTime',
+          ccPreferences: 'ccClosestCity',
+        },
+        childFacilitiesStatus: 'notStarted',
+        parentFacilitiesStatus: 'succeeded',
+        eligibilityStatus: 'notStarted',
+        facilityDetailsStatus: 'notStarted',
+        pastAppointments: null,
+        appointmentSlotsStatus: 'notStarted',
+        availableSlots: null,
+        fetchedAppointmentSlotMonths: [],
+        submitStatus: 'notStarted',
+        isCCEligible: true,
+        hideUpdateAddressAlert: false,
+        requestLocationStatus: 'notStarted',
+        communityCareProviders: {},
+        requestStatus: 'notStarted',
+        currentLocation: {},
+        ccProviderPageSortMethod: 'distanceFromResidentialAddress',
+        facilityPageSortMethod: null,
+        flowType: 'request',
+        selectedCCFacility: {
+          resourceType: 'Location',
+          id: '983',
+          vistaId: '983',
+          name: 'Cheyenne VA Medical Center',
+          identifier: [
+            {
+              system: 'http://med.va.gov/fhir/urn',
+              value: 'urn:va:division:983:983',
+            },
+            {
+              system: 'urn:oid:2.16.840.1.113883.6.233',
+              value: '983',
+            },
+          ],
+          telecom: [
+            {
+              system: 'phone',
+              value: '307-778-7550',
+            },
+          ],
+          position: {
+            longitude: -104.786159,
+            latitude: 41.148179,
+          },
+          address: {
+            line: ['2360 East Pershing Boulevard'],
+            city: 'Cheyenne',
+            state: 'WY',
+            postalCode: '82001-5356',
+          },
+        },
+      },
+
+      user: {
+        profile: {
+          facilities: [...initialState.user.profile.facilities],
+          vapContactInfo: {
+            residentialAddress: null,
+          },
+        },
+      },
+    };
+
+    const store = createTestStore(testState);
+
+    const screen = renderWithStoreAndRouter(
+      <CommunityCareProviderSelectionPage />,
+      {
+        store,
+      },
+    );
+
+    // Remove Provider
+    userEvent.click(await screen.findByRole('button', { name: /remove/i }));
+    userEvent.click(
+      await screen.findByText(
+        /Are you sure you want to remove this provider\?/i,
+      ),
+    );
+    userEvent.click(
+      await screen.findByRole('button', { name: /Yes, remove provider/i }),
+    );
+    expect(await screen.findByText(/Choose a provider/i));
+    expect(screen.baseElement).not.to.contain.text(
+      'OH, JANICE7700 LITTLE RIVER TPKE STE 102',
     );
   });
 


### PR DESCRIPTION
## Description
This PR is adding functionality that passes in the distance calculated in the provider selector to the provider removal modal. This is to cover scenarios where the home address is null for a patient.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#32686


## Testing done
Manual and unit

## Screenshots
![image](https://user-images.githubusercontent.com/3951775/144291273-36176aa8-712f-48d8-9faa-dea8da29779c.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
