### PR TITLE
turn off user agent autocomplete for input field

### DIFF
--- a/src/applications/search/components/SearchDropdown/SearchDropdownComponent.js
+++ b/src/applications/search/components/SearchDropdown/SearchDropdownComponent.js
@@ -642,6 +642,7 @@ class SearchDropdownComponent extends React.Component {
             aria-expanded={isOpen}
             aria-haspopup="listbox"
             aria-label={'Search'}
+            autoComplete="off"
             className={`vads-u-width--full search-dropdown-input-field ${
               fullWidthSuggestions
                 ? 'vads-u-margin--0 vads-u-display--block'


### PR DESCRIPTION
## Description
This PR fixes a minor bug that was previously allowing google autofill and other user agents to add their own dropdown on top of our dropdown.
