### PR TITLE
29631 compare additional info

### DIFF
--- a/src/applications/gi-sandbox/components/CompareGrid.jsx
+++ b/src/applications/gi-sandbox/components/CompareGrid.jsx
@@ -130,7 +130,7 @@ export function CompareGrid({
       <div
         role="table"
         aria-labelledby={sectionLabelId}
-        className={classNames('grid-data-parent', {
+        className={classNames('grid-data-parent', 'vads-u-margin-bottom--3', {
           'vads-l-row': !smallScreen,
         })}
       >

--- a/src/applications/gi-sandbox/components/content/additonal-info/Summary.jsx
+++ b/src/applications/gi-sandbox/components/content/additonal-info/Summary.jsx
@@ -1,7 +1,0 @@
-// Summary.jsx
-export {
-  default as AccreditationModalContent,
-} from '../modals/AccreditationModalContent';
-// export {
-//   default as GiBillStudentsModalContent,
-// } from '../modals/GiBillStudentsModalContent';

--- a/src/applications/gi-sandbox/components/content/additonal-info/Summary.jsx
+++ b/src/applications/gi-sandbox/components/content/additonal-info/Summary.jsx
@@ -1,0 +1,7 @@
+// Summary.jsx
+export {
+  default as AccreditationModalContent,
+} from '../modals/AccreditationModalContent';
+// export {
+//   default as GiBillStudentsModalContent,
+// } from '../modals/GiBillStudentsModalContent';

--- a/src/applications/gi-sandbox/components/content/modals/CautionFlagsModalContent.jsx
+++ b/src/applications/gi-sandbox/components/content/modals/CautionFlagsModalContent.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default function() {
+export default function CautionFlagsModalContent() {
   return (
     <>
       <p>

--- a/src/applications/gi-sandbox/components/content/modals/SpecializedMissionModalContent.jsx
+++ b/src/applications/gi-sandbox/components/content/modals/SpecializedMissionModalContent.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default function() {
+export default function SpecializedMissionModalContent() {
   return (
     <>
       <h3>Specialized mission</h3>

--- a/src/applications/gi-sandbox/components/content/modals/index.jsx
+++ b/src/applications/gi-sandbox/components/content/modals/index.jsx
@@ -2,3 +2,66 @@ export {
   default as AccreditationModalContent,
 } from './AccreditationModalContent';
 export { default as AllCampusesModalContent } from './AllCampusesModalContent';
+export {
+  default as BookStipendInfoModalContent,
+} from './BookStipendInfoModalContent';
+export {
+  default as CalcBeneficiaryLocationQuestionModalContent,
+} from './CalcBeneficiaryLocationQuestionModalContent';
+export {
+  default as CautionFlagsModalContent,
+} from './CautionFlagsModalContent';
+export { default as EightKeysModalContent } from './EightKeysModalContent';
+export {
+  default as FacilityCodeModalContent,
+} from './FacilityCodeModalContent';
+export {
+  default as HousingAllowanceOJTModalContent,
+} from './HousingAllowanceOJTModalContent';
+export {
+  default as GiBillStudentsModalContent,
+} from './GiBillStudentsModalContent';
+export {
+  default as HousingAllowanceSchoolModalContent,
+} from './HousingAllowanceSchoolModalContent';
+export {
+  default as IndependentStudyModalContent,
+} from './IndependentStudyModalContent';
+export { default as IpedsCodeModalContent } from './IpedsCodeModalContent';
+export {
+  default as MilitaryTrainingCreditModalContent,
+} from './MilitaryTrainingCreditModalContent';
+export {
+  default as MilitaryTuitionAssistanceModalContent,
+} from './MilitaryTuitionAssistanceModalContent';
+export { default as OpeCodeModalContent } from './OpeCodeModalContent';
+export {
+  default as PrinciplesOfExcellenceModalContent,
+} from './PrinciplesOfExcellenceModalContent';
+export {
+  default as PriorityEnrollmentModalContent,
+} from './PriorityEnrollmentModalContent';
+export {
+  default as SingleContactModalContent,
+} from './SingleContactModalContent';
+export {
+  default as SizeOfInstitutionsModalContent,
+} from './SizeOfInstitutionsModalContent';
+export {
+  default as SpecializedMissionModalContent,
+} from './SpecializedMissionModalContent';
+export {
+  default as StudentComplaintsModalContent,
+} from './StudentComplaintsModalContent';
+export {
+  default as StudentVeteranGroupModalContent,
+} from './StudentVeteranGroupModalContent';
+export {
+  default as TuitionAndFeesModalContent,
+} from './TuitionAndFeesModalContent';
+export {
+  default as VeteranSuccessModalContent,
+} from './VeteranSuccessModalContent';
+export {
+  default as YellowRibbonModalContent,
+} from './YellowRibbonModalContent';

--- a/src/applications/gi-sandbox/components/content/modals/index.jsx
+++ b/src/applications/gi-sandbox/components/content/modals/index.jsx
@@ -1,0 +1,4 @@
+export {
+  default as AccreditationModalContent,
+} from './AccreditationModalContent';
+export { default as AllCampusesModalContent } from './AllCampusesModalContent';

--- a/src/applications/gi-sandbox/containers/CompareLayout.jsx
+++ b/src/applications/gi-sandbox/containers/CompareLayout.jsx
@@ -18,7 +18,6 @@ import LearnMoreLabel from '../components/LearnMoreLabel';
 import { religiousAffiliations } from '../utils/data/religiousAffiliations';
 import recordEvent from 'platform/monitoring/record-event';
 import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
-import Summary from '../components/content/additonal-info/Summary';
 
 const CompareLayout = ({
   calculated,
@@ -95,39 +94,13 @@ const CompareLayout = ({
             },
           },
           {
-            label: (
-              <LearnMoreLabel
-                text="Accreditation"
-                onClick={() => {
-                  dispatchShowModal('accreditation');
-                  recordEvent({
-                    event: `Learn more click: ${
-                      ariaLabels.learnMore.accreditation
-                    }`,
-                  });
-                }}
-                ariaLabel={ariaLabels.learnMore.accreditation}
-              />
-            ),
+            label: 'Accreditation',
             className: 'capitalize-value',
             mapper: institution => naIfNull(institution.accreditationType),
           },
           {
-            label: (
-              <LearnMoreLabel
-                text="GI Bill students"
-                onClick={() => {
-                  dispatchShowModal('gibillstudents');
-                  recordEvent({
-                    event: `Learn more click: ${
-                      ariaLabels.learnMore.numberOfStudents
-                    }`,
-                  });
-                }}
-                ariaLabel={ariaLabels.learnMore.numberOfStudents}
-                buttonId="GI-Bill-students-compare"
-              />
-            ),
+            label: 'GI Bill students',
+            className: 'capitalize-value',
             mapper: institution => naIfNull(institution.studentCount),
           },
           {
@@ -160,37 +133,13 @@ const CompareLayout = ({
             mapper: institution => naIfNull(institution.localeType),
           },
           {
-            label: (
-              <LearnMoreLabel
-                text="Size of institution"
-                onClick={() => {
-                  dispatchShowModal('sizeOfInstitution');
-                  recordEvent({
-                    event: `Learn more click: ${
-                      ariaLabels.learnMore.sizeOfInstitution
-                    }`,
-                  });
-                }}
-                ariaLabel={ariaLabels.learnMore.sizeOfInstitution}
-              />
-            ),
+            label: 'Size of institution',
+            className: 'capitalize-value',
             mapper: institution => schoolSize(institution.undergradEnrollment),
           },
           {
-            label: (
-              <LearnMoreLabel
-                text="Specialized mission"
-                onClick={() => {
-                  dispatchShowModal('specializedMission');
-                  recordEvent({
-                    event: `Learn more click: ${
-                      ariaLabels.learnMore.specializedMission
-                    }`,
-                  });
-                }}
-                ariaLabel={ariaLabels.learnMore.specializedMission}
-              />
-            ),
+            label: 'Specialized mission',
+            className: 'capitalize-value',
             mapper: institution => {
               const specialMission = [];
               if (institution.hbcu) {
@@ -214,8 +163,8 @@ const CompareLayout = ({
           },
         ]}
       />
-      <AdditionalInfo triggerText="Additional information form comparison summary ">
-        <Summary />
+      <AdditionalInfo triggerText="Additional information on Comparison Summary ">
+        <></>
       </AdditionalInfo>
 
       <CompareGrid
@@ -264,6 +213,9 @@ const CompareLayout = ({
           },
         ]}
       />
+      <AdditionalInfo triggerText="Additional information on payments made to institution">
+        <></>
+      </AdditionalInfo>
 
       <CompareGrid
         subSectionLabel="Payments made to you"
@@ -309,7 +261,6 @@ const CompareLayout = ({
           },
         ]}
       />
-
       {gibctSchoolRatings &&
         hasRatings && (
           <>

--- a/src/applications/gi-sandbox/containers/CompareLayout.jsx
+++ b/src/applications/gi-sandbox/containers/CompareLayout.jsx
@@ -17,6 +17,8 @@ import { showModal } from '../actions';
 import LearnMoreLabel from '../components/LearnMoreLabel';
 import { religiousAffiliations } from '../utils/data/religiousAffiliations';
 import recordEvent from 'platform/monitoring/record-event';
+import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
+import Summary from '../components/content/additonal-info/Summary';
 
 const CompareLayout = ({
   calculated,
@@ -212,6 +214,9 @@ const CompareLayout = ({
           },
         ]}
       />
+      <AdditionalInfo triggerText="Additional information form comparison summary ">
+        <Summary />
+      </AdditionalInfo>
 
       <CompareGrid
         sectionLabel="Your estimated benefits"

--- a/src/applications/gi-sandbox/containers/CompareLayout.jsx
+++ b/src/applications/gi-sandbox/containers/CompareLayout.jsx
@@ -11,17 +11,32 @@ import {
   upperCaseFirstLetterOnly,
 } from '../utils/helpers';
 import _ from 'lodash';
-import { ariaLabels, MINIMUM_RATING_COUNT } from '../constants';
+import { MINIMUM_RATING_COUNT } from '../constants';
 import RatingsStars from '../components/RatingsStars';
 import { showModal } from '../actions';
-import LearnMoreLabel from '../components/LearnMoreLabel';
 import { religiousAffiliations } from '../utils/data/religiousAffiliations';
-import recordEvent from 'platform/monitoring/record-event';
 import AdditionalInfo from '@department-of-veterans-affairs/component-library/AdditionalInfo';
+import {
+  AccreditationModalContent,
+  GiBillStudentsModalContent,
+  SizeOfInstitutionsModalContent,
+  SpecializedMissionModalContent,
+  TuitionAndFeesModalContent,
+  HousingAllowanceSchoolModalContent,
+  BookStipendInfoModalContent,
+  CautionFlagsModalContent,
+  StudentComplaintsModalContent,
+  MilitaryTrainingCreditModalContent,
+  YellowRibbonModalContent,
+  StudentVeteranGroupModalContent,
+  PrinciplesOfExcellenceModalContent,
+  EightKeysModalContent,
+  MilitaryTuitionAssistanceModalContent,
+  PriorityEnrollmentModalContent,
+} from '../components/content/modals';
 
 const CompareLayout = ({
   calculated,
-  dispatchShowModal,
   estimated,
   hasRatings,
   institutions,
@@ -163,8 +178,11 @@ const CompareLayout = ({
           },
         ]}
       />
-      <AdditionalInfo triggerText="Additional information on Comparison Summary ">
-        <></>
+      <AdditionalInfo triggerText="Additional information on comparison summary fields">
+        <AccreditationModalContent />
+        <GiBillStudentsModalContent />
+        <SizeOfInstitutionsModalContent />
+        <SpecializedMissionModalContent />
       </AdditionalInfo>
 
       <CompareGrid
@@ -175,20 +193,7 @@ const CompareLayout = ({
         smallScreen={smallScreen}
         fieldData={[
           {
-            label: (
-              <LearnMoreLabel
-                text="Tuition and fees"
-                onClick={() => {
-                  dispatchShowModal('tuitionAndFeesSchool');
-                  recordEvent({
-                    event: `Learn more click: ${
-                      ariaLabels.learnMore.tuitionFees
-                    }`,
-                  });
-                }}
-                ariaLabel={ariaLabels.learnMore.tuitionFees}
-              />
-            ),
+            label: 'Tuition and fees',
             mapper: institution =>
               formatCurrency(
                 calculated[institution.facilityCode].outputs
@@ -213,8 +218,8 @@ const CompareLayout = ({
           },
         ]}
       />
-      <AdditionalInfo triggerText="Additional information on payments made to institution">
-        <></>
+      <AdditionalInfo triggerText="Additional information on payments made to institution fields">
+        <TuitionAndFeesModalContent />
       </AdditionalInfo>
 
       <CompareGrid
@@ -224,43 +229,21 @@ const CompareLayout = ({
         smallScreen={smallScreen}
         fieldData={[
           {
-            label: (
-              <LearnMoreLabel
-                text="Housing allowance"
-                onClick={() => {
-                  dispatchShowModal('housingAllowanceSchool');
-                  recordEvent({
-                    event: `Learn more click: ${
-                      ariaLabels.learnMore.housingAllowance
-                    }`,
-                  });
-                }}
-                ariaLabel={ariaLabels.learnMore.housingAllowance}
-              />
-            ),
+            label: 'Housing allowance',
             mapper: institution =>
               formatEstimate(estimated[institution.facilityCode].housing),
           },
           {
-            label: (
-              <LearnMoreLabel
-                text="Book stipend"
-                onClick={() => {
-                  dispatchShowModal('bookStipendInfo');
-                  recordEvent({
-                    event: `Learn more click: ${
-                      ariaLabels.learnMore.bookStipend
-                    }`,
-                  });
-                }}
-                ariaLabel={ariaLabels.learnMore.bookStipend}
-              />
-            ),
+            label: 'Book stipend',
             mapper: institution =>
               formatEstimate(estimated[institution.facilityCode].books),
           },
         ]}
       />
+      <AdditionalInfo triggerText="Additional information on payments made to you fields">
+        <HousingAllowanceSchoolModalContent />
+        <BookStipendInfoModalContent />
+      </AdditionalInfo>
       {gibctSchoolRatings &&
         hasRatings && (
           <>
@@ -318,7 +301,6 @@ const CompareLayout = ({
                 },
               ]}
             />
-
             <CompareGrid
               subSectionLabel="Education ratings"
               institutions={institutions}
@@ -380,20 +362,7 @@ const CompareLayout = ({
         smallScreen={smallScreen}
         fieldData={[
           {
-            label: (
-              <LearnMoreLabel
-                text="Caution flags"
-                onClick={() => {
-                  dispatchShowModal('cautionFlags');
-                  recordEvent({
-                    event: `Learn more click: ${
-                      ariaLabels.learnMore.cautionFlags
-                    }`,
-                  });
-                }}
-                ariaLabel={ariaLabels.learnMore.cautionFlags}
-              />
-            ),
+            label: 'Caution flags',
             className: institution =>
               classNames('caution-flag-display', {
                 none: institution.cautionFlags.length === 0,
@@ -446,24 +415,15 @@ const CompareLayout = ({
         smallScreen={smallScreen}
         fieldData={[
           {
-            label: (
-              <LearnMoreLabel
-                text="Student complaints"
-                onClick={() => {
-                  dispatchShowModal('studentComplaints');
-                  recordEvent({
-                    event: `Learn more click: ${
-                      ariaLabels.learnMore.allCampusComplaints
-                    }`,
-                  });
-                }}
-                ariaLabel={ariaLabels.learnMore.allCampusComplaints}
-              />
-            ),
+            label: 'Student complaints',
             mapper: institution => +institution.complaints.mainCampusRollUp,
           },
         ]}
       />
+      <AdditionalInfo triggerText="Additional information on cautionary information fields">
+        <CautionFlagsModalContent />
+        <StudentComplaintsModalContent />
+      </AdditionalInfo>
 
       <CompareGrid
         sectionLabel="Academics"
@@ -477,24 +437,14 @@ const CompareLayout = ({
               programHours(institution.programLengthInHours),
           },
           {
-            label: (
-              <LearnMoreLabel
-                text="Credit for military training"
-                onClick={() => {
-                  dispatchShowModal('militaryTrainingCredit');
-                  recordEvent({
-                    event: `Learn more click: ${
-                      ariaLabels.learnMore.militaryTrainingCredit
-                    }`,
-                  });
-                }}
-                ariaLabel={ariaLabels.learnMore.militaryTrainingCredit}
-              />
-            ),
+            label: 'Credit for military training',
             mapper: institution => boolYesNo(institution.creditForMilTraining),
           },
         ]}
       />
+      <AdditionalInfo triggerText="Additional information on academics fields">
+        <MilitaryTrainingCreditModalContent />
+      </AdditionalInfo>
 
       <CompareGrid
         sectionLabel="Veteran programs"
@@ -503,115 +453,39 @@ const CompareLayout = ({
         smallScreen={smallScreen}
         fieldData={[
           {
-            label: (
-              <LearnMoreLabel
-                text="Yellow Ribbon"
-                onClick={() => {
-                  dispatchShowModal('yribbon');
-                  recordEvent({
-                    event: `Learn more click: ${
-                      ariaLabels.learnMore.yellowRibbonProgram
-                    }`,
-                  });
-                }}
-                ariaLabel={ariaLabels.learnMore.yellowRibbonProgram}
-                buttonId="veteran-programs-yellow-ribbon"
-              />
-            ),
+            label: 'Yellow Ribbon',
             mapper: institution => boolYesNo(institution.yr),
           },
           {
-            label: (
-              <LearnMoreLabel
-                text="Student Veteran Group"
-                onClick={() => {
-                  dispatchShowModal('vetgroups');
-                  recordEvent({
-                    event: `Learn more click: ${
-                      ariaLabels.learnMore.studentVeteranGroup
-                    }`,
-                  });
-                }}
-                ariaLabel={ariaLabels.learnMore.studentVeteranGroup}
-                buttonId="student-veteran-group"
-              />
-            ),
+            label: 'Student Veteran Group',
             mapper: institution => boolYesNo(institution.studentVeteran),
           },
           {
-            label: (
-              <LearnMoreLabel
-                text="Principles of Excellence"
-                onClick={() => {
-                  dispatchShowModal('poe');
-                  recordEvent({
-                    event: `Learn more click: ${
-                      ariaLabels.learnMore.principlesOfExcellence
-                    }`,
-                  });
-                }}
-                ariaLabel={ariaLabels.learnMore.principlesOfExcellence}
-                buttonId="principles-of-excellence"
-              />
-            ),
+            label: 'Principles of Excellence',
             mapper: institution => boolYesNo(institution.poe),
           },
           {
-            label: (
-              <LearnMoreLabel
-                text="8 Keys to Veteran Success"
-                onClick={() => {
-                  dispatchShowModal('eightKeys');
-                  recordEvent({
-                    event: `Learn more click: ${
-                      ariaLabels.learnMore.eightKeys
-                    }`,
-                  });
-                }}
-                ariaLabel={ariaLabels.learnMore.eightKeys}
-                buttonId="eight-keys-to-veteran-success"
-              />
-            ),
+            label: '8 Keys to Veteran Success',
             mapper: institution => boolYesNo(institution.eightKeys),
           },
           {
-            label: (
-              <LearnMoreLabel
-                text="Military Tuition Assistance (TA)"
-                onClick={() => {
-                  dispatchShowModal('ta');
-                  recordEvent({
-                    event: `Learn more click: ${
-                      ariaLabels.learnMore.militaryTuitionAssistance
-                    }`,
-                  });
-                }}
-                ariaLabel={ariaLabels.learnMore.militaryTuitionAssistance}
-                buttonId="military-tuition-assistance"
-              />
-            ),
+            label: 'Military Tuition Assistance (TA)',
             mapper: institution => boolYesNo(institution.dodmou),
           },
           {
-            label: (
-              <LearnMoreLabel
-                text="Priority Enrollment"
-                onClick={() => {
-                  dispatchShowModal('priorityEnrollment');
-                  recordEvent({
-                    event: `Learn more click: ${
-                      ariaLabels.learnMore.priorityEnrollment
-                    }`,
-                  });
-                }}
-                ariaLabel={ariaLabels.learnMore.priorityEnrollment}
-                buttonId="priority-enrollments"
-              />
-            ),
+            label: 'Priority Enrollment',
             mapper: institution => boolYesNo(institution.priorityEnrollment),
           },
         ]}
       />
+      <AdditionalInfo triggerText="Additional information on veteran programs fields">
+        <YellowRibbonModalContent />
+        <StudentVeteranGroupModalContent />
+        <PrinciplesOfExcellenceModalContent />
+        <EightKeysModalContent />
+        <MilitaryTuitionAssistanceModalContent />
+        <PriorityEnrollmentModalContent />
+      </AdditionalInfo>
     </div>
   );
 };


### PR DESCRIPTION
## Description
### Platform Issue
Design components or patterns don't align with Design System guidelines.

### Issue Details
"Learn more" is a text link

### Platform Recommendation
All of the "Learn more" that open modals should be a button. A better option may be to make them an additional info component instead. Consider adding something like “Learn more about these definitions” in the additional info component per section. If they clicked the component it would expand and the title would be bold followed by a definition. You could put all words in this one expanded component per section.


## Original issue(s)
[https://github.com/department-of-veterans-affairs/va.gov-team/issues/29361)
](https://github.com/department-of-veterans-affairs/va.gov-team/issues/29361)

## Testing done
Local Environment

## Screenshots
<img width="1031" alt="Screen Shot 2021-11-29 at 12 17 10 PM" src="https://user-images.githubusercontent.com/18352271/143925678-5e8b6d96-f351-4294-8653-e81174530a75.png">
<img width="1080" alt="Screen Shot 2021-11-29 at 12 17 53 PM" src="https://user-images.githubusercontent.com/18352271/143925706-11327fb5-313e-4367-ae63-18a8fa18f4af.png">

## Acceptance criteria
- [ ] Additional Information component shows the old learn more modal content

## Definition of done
- [ ] Learn more buttons removed
- [ ] Additional information component added containing old modal content for the appropriate section. 
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
