### PR TITLE
Add top & bottom margin to the fieldset

### DIFF
--- a/src/platform/forms-system/src/js/fields/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/fields/ObjectField.jsx
@@ -201,6 +201,10 @@ class ObjectField extends React.Component {
       'schemaform-block': title && !isRoot,
     });
 
+    const newFieldsetClassNames = classNames(fieldsetClassNames, {
+      'vads-u-margin-bottom--2': !environment.isProduction(),
+    });
+
     const pageIndex = formContext?.pagePerItemIndex;
     // Fix array nested ids (one-level deep)
     const processIds = (originalIds = {}) =>
@@ -378,14 +382,14 @@ class ObjectField extends React.Component {
 
     if (title && !forceDivWrapper) {
       return (
-        <fieldset className={fieldsetClassNames}>
+        <fieldset className={newFieldsetClassNames}>
           {environment.isProduction() ? fieldContent : accessibleFieldContent}
         </fieldset>
       );
     }
 
     return (
-      <div className={fieldsetClassNames}>
+      <div className={newFieldsetClassNames}>
         {environment.isProduction() ? fieldContent : accessibleFieldContent}
       </div>
     );

--- a/src/platform/forms-system/src/js/fields/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/fields/ObjectField.jsx
@@ -181,7 +181,7 @@ class ObjectField extends React.Component {
     // description and title setup
     const showFieldLabel = uiOptions.showFieldLabel;
     const fieldsetClassNames = classNames(uiOptions.classNames, {
-      'vads-u-margin-bottom--2': !environment.isProduction(),
+      'vads-u-margin-y--2': !environment.isProduction(),
     });
 
     const forceDivWrapper = !!uiOptions.forceDivWrapper;

--- a/src/platform/forms-system/src/js/fields/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/fields/ObjectField.jsx
@@ -180,7 +180,10 @@ class ObjectField extends React.Component {
 
     // description and title setup
     const showFieldLabel = uiOptions.showFieldLabel;
-    const fieldsetClassNames = uiOptions.classNames;
+    const fieldsetClassNames = classNames(uiOptions.classNames, {
+      'vads-u-margin-bottom--2': !environment.isProduction(),
+    });
+
     const forceDivWrapper = !!uiOptions.forceDivWrapper;
     const title = uiSchema['ui:title'] || schema.title;
     const CustomTitleField = isReactComponent(title) ? title : null;
@@ -199,10 +202,6 @@ class ObjectField extends React.Component {
       'input-section': isRoot,
       'schemaform-field-container': true,
       'schemaform-block': title && !isRoot,
-    });
-
-    const newFieldsetClassNames = classNames(fieldsetClassNames, {
-      'vads-u-margin-bottom--2': !environment.isProduction(),
     });
 
     const pageIndex = formContext?.pagePerItemIndex;
@@ -382,14 +381,14 @@ class ObjectField extends React.Component {
 
     if (title && !forceDivWrapper) {
       return (
-        <fieldset className={newFieldsetClassNames}>
+        <fieldset className={fieldsetClassNames}>
           {environment.isProduction() ? fieldContent : accessibleFieldContent}
         </fieldset>
       );
     }
 
     return (
-      <div className={newFieldsetClassNames}>
+      <div className={fieldsetClassNames}>
         {environment.isProduction() ? fieldContent : accessibleFieldContent}
       </div>
     );


### PR DESCRIPTION
## Description

This is to fix a dev/staging styling issue that was introduced with https://github.com/department-of-veterans-affairs/vets-website/pull/13321. Inner wrapping divs were removed for accessibility reasons, and their styles along with them. 

- One of those styles was [`.input-section`](https://github.com/department-of-veterans-affairs/vets-website/blob/e05f44309e62b09996f95977befd841e0c667220/src/platform/forms-system/src/js/fields/ObjectField.jsx#L199), which was [adding bottom margin](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/39eafcbbc698faae521cf3d6078ea84ab495130e/packages/formation/sass/_shame.scss#L77-L78).
- Another was [`.schemaform-block`](https://github.com/department-of-veterans-affairs/vets-website/blob/28f3a7411d81d2f1cbf84753f67026c11d2169e7/src/platform/forms/sass/_m-schemaform.scss#L153-L155), which was adding top margin.

This PR adds that styling back, applying it to an outer wrapper instead.


## Original issue(s)
https://dsva.slack.com/archives/C909ZG2BB/p1638208546363200?thread_ts=1638201101.349400&cid=C909ZG2BB


## Testing done

Local browser :eyes: 

## Screenshots

![image](https://user-images.githubusercontent.com/2008881/144101337-472e536c-0e3d-4f51-83b8-32aebbf23be0.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
