### PR TITLE
Add analytic events

### DIFF
--- a/src/platform/site-wide/header/components/LogoRow/index.js
+++ b/src/platform/site-wide/header/components/LogoRow/index.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 // Relative imports.
 import Logo from '../Logo';
 import UserNav from '../../../user-nav/containers/Main';
+import recordEvent from 'platform/monitoring/record-event';
 import { updateExpandedMenuIDAction } from '../../containers/Menu/actions';
 
 export const LogoRow = ({
@@ -13,6 +14,10 @@ export const LogoRow = ({
   updateExpandedMenuID,
 }) => {
   const onMenuToggle = () => {
+    // Record the analytic event.
+    recordEvent({ event: 'nav-header-menu-expand' });
+
+    // Update the state.
     updateExpandedMenuID();
     setIsMenuOpen(!isMenuOpen);
   };
@@ -24,6 +29,7 @@ export const LogoRow = ({
         aria-label="VA logo"
         className="header-logo vads-u-display--flex vads-u-align-items--center vads-u-justify-content--center"
         href="/"
+        onClick={() => recordEvent({ event: 'nav-header-logo' })}
       >
         <Logo />
       </a>

--- a/src/platform/site-wide/header/components/SubMenu/index.js
+++ b/src/platform/site-wide/header/components/SubMenu/index.js
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 // Relative imports.
+import recordEvent from 'platform/monitoring/record-event';
 import { deriveMenuItemID, formatSubMenuSections } from '../../helpers';
 import { updateSubMenuAction } from '../../containers/Menu/actions';
 
@@ -16,6 +17,8 @@ export const SubMenu = ({ subMenu, updateSubMenu }) => {
   }, []);
 
   const onBack = () => {
+    // Record analytic event.
+    recordEvent({ event: 'nav-header-back-to-menu' });
     updateSubMenu();
   };
 


### PR DESCRIPTION
## Description

Add the following analytic events to header v2:

| Interaction | Dev Spec | 
| -- | -- |
| Clicking Logo | 'event': 'nav-header-logo' |
| Expanding/collapsing Menu | 'event': 'nav-header-menu-expand` |
| Clicking Back to menu button |  'event': 'nav-header-back-to-menu` |

## Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/33145


## Testing done


## Screenshots


## Acceptance criteria
- [x] Add analytic events

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
