### PR TITLE
32951: [MCP] add cta widget to pay copay bill page

### DIFF
--- a/src/applications/registry.scaffold.json
+++ b/src/applications/registry.scaffold.json
@@ -65,6 +65,11 @@
     "widgetType": "manage-va-debt-cta"
   },
   {
+    "appName": "Pay Your VA Copay Bill",
+    "rootUrl": "/health-care/pay-copay-bill",
+    "widgetType": "medical-copays-cta"
+  },
+  {
     "appName": "Post-9/11 GI Bill Statement Of Benefits",
     "rootUrl": "/education/gi-bill/post-9-11/ch-33-benefit",
     "widgetType": "post-9-11-gi-bill-status"


### PR DESCRIPTION
## Description
adds the Medical Copays CTA widget to /health-care/pay-copay-bill/

## Original issue(s)
department-of-veterans-affairs/va.gov-team#32951


## Screenshots
![Pay your VA copay bill  Veterans Affairs 2021-11-29 16-01-57](https://user-images.githubusercontent.com/7518899/144069415-2a6d7b0f-8f32-431d-b607-2777161e7151.png)

## Acceptance criteria
- [x] copay widget should render on localhost instead of a blank content page

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
