### PR TITLE
Update vets-json-schema to latest version that includes RRD 526 Special Issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -314,7 +314,7 @@
     "url-search-params-polyfill": "^8.1.1",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#28b3ebc4236222c18760cfbd839c5d2e90e4c317",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#7c75ec66abb2266abd0366831b64da70bc233576",
     "whatwg-fetch": "^3.6.2"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19504,9 +19504,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#28b3ebc4236222c18760cfbd839c5d2e90e4c317":
-  version "20.17.0"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#28b3ebc4236222c18760cfbd839c5d2e90e4c317"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#7c75ec66abb2266abd0366831b64da70bc233576":
+  version "20.17.1"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#7c75ec66abb2266abd0366831b64da70bc233576"
 
 vfile-message@^2.0.0:
   version "2.0.4"


### PR DESCRIPTION
## Description
vets-json-schema updated with new RRD special issue code for 526 submissions


## Original issue(s)
department-of-veterans-affairs/va.gov-team#33334


## Testing done
New Special Issues Code is behind a feature flag and will be tested as part of the Hypertension Fast Track rollout.
I did test the new code locally against the vets-json-schema, it worked as expected(RDD special issues passed json validation steps)


## Screenshots


## Acceptance criteria
- [x] "RDD" special issues are now valid in a 526 claim

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
