### PR TITLE
Rewording covid second dose page description to new requirements

### DIFF
--- a/src/applications/vaos/covid-19-vaccine/components/SecondDosePage.jsx
+++ b/src/applications/vaos/covid-19-vaccine/components/SecondDosePage.jsx
@@ -11,10 +11,10 @@ import {
 } from '../redux/actions';
 
 const pageKey = 'secondDosePage';
-const pageTitle = 'When to expect a second dose';
+const pageTitle = 'When to plan for a second dose';
 
 export default function SecondDosePage() {
-  const { data, facility } = useSelector(
+  const { data } = useSelector(
     state => getReviewPage(state, pageKey),
     shallowEqual,
   );
@@ -33,14 +33,9 @@ export default function SecondDosePage() {
       <h1>{pageTitle}</h1>
       <div className="vads-u-margin-bottom--4">
         <p>
-          If you need a second dose, you may need to return to the{' '}
-          {facility.name} after the dates below, depending on which vaccine you
-          receive:
-        </p>
-        <p>
-          If you receive your first dose on{' '}
-          <strong>{moment(date1[0]).format('dddd, MMMM DD, YYYY')}</strong> and
-          receive:
+          If you get your first dose of a 2-dose vaccine on{' '}
+          <strong>{moment(date1[0]).format('dddd, MMMM DD, YYYY')}</strong>,
+          here’s when to plan to come back for your second dose.
         </p>
         <h2 className="vads-u-font-size--h3 vads-u-margin-bottom--0">
           Moderna

--- a/src/applications/vaos/tests/covid-19-vaccine/components/SecondDosePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/SecondDosePage.unit.spec.jsx
@@ -52,19 +52,25 @@ describe('VAOS vaccine flow <SecondDosePage>', () => {
     });
 
     expect(
-      await screen.getByText(/When to expect a second dose/i),
+      await screen.getByText(/When to plan for a second dose/i),
     ).to.have.tagName('h1');
+
     expect(
       screen.getByText(
-        /If you need a second dose, you may need to return to the Cheyenne VA Medical Center after the dates below, depending on which vaccine you receive:/i,
+        new RegExp(`If you get your first dose of a 2-dose vaccine on`, 'i'),
       ),
-    ).to.be.ok;
-    expect(
-      screen.getByText(new RegExp(`If you receive your first dose on`, 'i')),
     ).to.be.ok;
     expect(
       screen.getByText(
         new RegExp(`${start.clone().format('dddd, MMMM DD, YYYY')}`, 'i'),
+      ),
+    ).to.be.ok;
+    expect(
+      screen.getByText(
+        new RegExp(
+          `, here’s when to plan to come back for your second dose`,
+          'i',
+        ),
       ),
     ).to.be.ok;
     expect(screen.getByText('Moderna')).to.have.tagName('h2');
@@ -92,14 +98,6 @@ describe('VAOS vaccine flow <SecondDosePage>', () => {
         ),
       ),
     ).to.be.ok;
-  });
-
-  xit('should show additional message after user clicks the expand link', async () => {
-    const screen = renderWithStoreAndRouter(<SecondDosePage />, {
-      store,
-    });
-    userEvent.click(screen.getByText(/Can I choose which vaccine I will get/i));
-    expect(await screen.getByText(/Not at this time/i)).to.be.ok;
   });
 
   it('should continue to the correct page once continue to clicked', async () => {


### PR DESCRIPTION
## Description
This PR is for the re-wording of the page description in the covid vaccine second dose page.

## Original issue(s)
department-of-veterans-affairs/va.gov-team#32193


## Testing done
Manual and Unit

## Screenshots
<img width="918" alt="32193" src="https://user-images.githubusercontent.com/3951775/144082613-34bb4025-3fb3-4c15-aea4-89cb5683bd6e.PNG">


## Acceptance criteria
- [ ] Given the COVID-19 new appointment workflow,
When the user enters the vaccine second dose page,
Then the page description matches the copy doc

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
