### PR TITLE
Letters: Fix timezone offset subtracting a day

### DIFF
--- a/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -9,6 +9,7 @@ import {
   characterOfServiceContent,
   optionsToAlwaysDisplay,
   getBenefitOptionText,
+  stripOffTime,
 } from '../utils/helpers.jsx';
 import { formatDateShort } from 'platform/utilities/date';
 import CallVBACenter from 'platform/static-data/CallVBACenter';
@@ -48,8 +49,8 @@ export class VeteranBenefitSummaryLetter extends React.Component {
             ]
           }
         </td>
-        <td>{formatDateShort(service.enteredDate)}</td>
-        <td>{formatDateShort(service.releasedDate)}</td>
+        <td>{formatDateShort(stripOffTime(service.enteredDate))}</td>
+        <td>{formatDateShort(stripOffTime(service.releasedDate))}</td>
       </tr>
     ));
 

--- a/src/applications/letters/tests/containers/VeteranBenefitSummaryLetter.unit.spec.jsx
+++ b/src/applications/letters/tests/containers/VeteranBenefitSummaryLetter.unit.spec.jsx
@@ -96,7 +96,12 @@ describe('<VeteranBenefitSummaryLetter>', () => {
       .dive(['#militaryServiceTable', 'tbody'])
       .everySubTree('tr');
 
+    const text = tree.text();
     expect(serviceRows.length).to.equal(doubleService.length);
+    expect(text).to.include('01/01/1965');
+    expect(text).to.include('10/01/1972');
+    expect(text).to.include('01/01/1974');
+    expect(text).to.include('10/01/1976');
   });
 
   it('handles check and uncheck events', () => {

--- a/src/applications/letters/tests/utils/helpers.unit.spec.jsx
+++ b/src/applications/letters/tests/utils/helpers.unit.spec.jsx
@@ -7,6 +7,7 @@ import {
   getBenefitOptionText,
   resetDisallowedAddressFields,
   isAddressEmpty,
+  stripOffTime,
 } from '../../utils/helpers';
 
 const address = {
@@ -142,5 +143,25 @@ describe('Letters helpers: ', () => {
     // type & countryName are ignored
     expect(isAddressEmpty({ type: 'foo', countryName: 'bar' })).to.be.true;
     expect(isAddressEmpty({ foo: 'bar' })).to.be.false;
+  });
+
+  // reset time to midnight
+  describe('stripOffTime', () => {
+    it('should return an empty string', () => {
+      expect(stripOffTime()).to.equal('');
+      expect(stripOffTime('')).to.equal('');
+      expect(stripOffTime(null)).to.equal('');
+    });
+    it('should replace time offsets with all zeros', () => {
+      expect(stripOffTime('2017-12-01T06:00:00.000+00:00')).to.equal(
+        '2017-12-01',
+      );
+      expect(stripOffTime('1965-01-01T06:00:00.000+00:00')).to.equal(
+        '1965-01-01',
+      );
+      expect(stripOffTime('1972-10-01T05:00:00.000+00:00')).to.equal(
+        '1972-10-01',
+      );
+    });
   });
 });

--- a/src/applications/letters/utils/helpers.jsx
+++ b/src/applications/letters/utils/helpers.jsx
@@ -311,6 +311,19 @@ const benefitOptionText = {
   },
 };
 
+/**
+ * EVSS sets dates to central time (T06:00:00.000+00:00), but adds the timezone
+ * offset after the "T" instead of after the "+". So we're going to strip off
+ * the time completely, see
+ * https://github.com/department-of-veterans-affairs/va.gov-team/issues/29762#issuecomment-920225928
+ * @param {String} date - ISO 8601 date format
+ * @returns {String} - ISO 8601 date format
+ */
+export function stripOffTime(date) {
+  const [ymd] = (date || '').split('T');
+  return ymd || '';
+}
+
 export function getBenefitOptionText(
   option,
   value,
@@ -345,7 +358,7 @@ export function getBenefitOptionText(
         </div>
         <div>
           The effective date of the last change to your current award was{' '}
-          <strong>{formatDateShort(awardEffectiveDate)}</strong>.
+          <strong>{formatDateShort(stripOffTime(awardEffectiveDate))}</strong>.
         </div>
       </div>
     );


### PR DESCRIPTION
## Description

In the letters app, the timezone is set to central time, when the date is processed in a different time zone, the resulting date may be one day off. This PR strips off the time and timezone portions of the ISO 8601 date so that momentJS parses the appropriate date for display.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/29762

## Testing done

Added unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Prevent letters app time zone differences from showing a date one day off
- [x] All tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
