### PR TITLE
Update `README.md` for Cypress changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,10 +185,6 @@ yarn cy:run --spec "src/applications/a/tests/**/*,src/applications/b/tests/**/*"
 To **run Cypress tests from the command line on a specific browser**:
 
 ```sh
-yarn cy:run --headless --browser chrome
-yarn cy:run --headless --browser firefox
-
-# Without --headless, the test runner will open and run the test.
 yarn cy:run --browser chrome
 yarn cy:run --browser firefox
 ```


### PR DESCRIPTION
## Description
This PR updates the `README.md` to reflect changes to the Cypress CLI. Cypress v9 runs headless by default when specifying a browser, so there is no need to include `--headless` in the command.