### PR TITLE
Profile - Adjusting Contact Inofrmation alerts

### DIFF
--- a/src/applications/personalization/profile/components/contact-information/ContactInformationEditView.jsx
+++ b/src/applications/personalization/profile/components/contact-information/ContactInformationEditView.jsx
@@ -290,7 +290,7 @@ export class ContactInformationEditView extends Component {
               {error && (
                 <div
                   role="alert"
-                  className="vads-u-margin-bottom--2 vads-u-margin-top--4"
+                  className="vads-u-margin-bottom--2 vads-u-margin-top--2"
                   data-testid="edit-error-alert"
                 >
                   <VAPServiceEditModalErrorMessage error={error} />

--- a/src/applications/personalization/profile/components/contact-information/ContactInformationEditView.jsx
+++ b/src/applications/personalization/profile/components/contact-information/ContactInformationEditView.jsx
@@ -79,11 +79,6 @@ export class ContactInformationEditView extends Component {
     }
   }
 
-  clearErrorsAndShiftFocus(fieldName) {
-    this.props.clearTransactionRequest(fieldName);
-    this.focusOnFirstFormElement();
-  }
-
   componentDidMount() {
     const { getInitialFormValues } = this.props;
     this.onChangeFormDataAndSchemas(
@@ -266,20 +261,6 @@ export class ContactInformationEditView extends Component {
 
     return (
       <>
-        {error && (
-          <div
-            role="alert"
-            className="vads-u-margin-bottom--2"
-            data-testid="edit-error-alert"
-          >
-            <VAPServiceEditModalErrorMessage
-              title={title}
-              error={error}
-              clearErrors={() => this.clearErrorsAndShiftFocus(fieldName)}
-            />
-          </div>
-        )}
-
         {!!field && (
           <div
             ref={el => {
@@ -306,6 +287,15 @@ export class ContactInformationEditView extends Component {
               }
               onSubmit={onSubmit}
             >
+              {error && (
+                <div
+                  role="alert"
+                  className="vads-u-margin-bottom--2 vads-u-margin-top--4"
+                  data-testid="edit-error-alert"
+                >
+                  <VAPServiceEditModalErrorMessage error={error} />
+                </div>
+              )}
               <ContactInformationActionButtons
                 onCancel={onCancel}
                 title={title}

--- a/src/applications/personalization/profile/components/contact-information/ContactInformationEditView.jsx
+++ b/src/applications/personalization/profile/components/contact-information/ContactInformationEditView.jsx
@@ -290,7 +290,7 @@ export class ContactInformationEditView extends Component {
               {error && (
                 <div
                   role="alert"
-                  className="vads-u-margin-bottom--2 vads-u-margin-top--2"
+                  className="vads-u-margin-y--2"
                   data-testid="edit-error-alert"
                 >
                   <VAPServiceEditModalErrorMessage error={error} />

--- a/src/applications/personalization/profile/sass/profile.scss
+++ b/src/applications/personalization/profile/sass/profile.scss
@@ -62,3 +62,20 @@
 .overflow-auto {
   overflow: auto;
 }
+
+.va-profile-alert {
+  i {
+    font-family: "Font Awesome 5 Free";
+    font-style: normal;
+    font-weight: 900;
+  }
+  i::before {
+    content: "\f05a";
+    display: flex;
+    margin-right: 1.6rem;
+    font-size: 2rem;
+  }
+  p {
+    margin: 0;
+  }
+}

--- a/src/applications/personalization/profile/sass/profile.scss
+++ b/src/applications/personalization/profile/sass/profile.scss
@@ -63,21 +63,6 @@
   overflow: auto;
 }
 
-.va-profile-alert.usa-alert-error::before {
-  content: "\f05a";
-}
-.va-profile-alert.usa-alert-error::before {
-  background: none;
-  display: block;
-  color: 000;
-  font-family: "Font Awesome 5 Free";
-  font-style: normal;
-  font-size: 2rem;
-  font-weight: 900;
-  margin-right: 4px;
-  position: static;
-  width: auto;
-}
 .va-profile-alert {
   p {
     margin: 0;

--- a/src/applications/personalization/profile/sass/profile.scss
+++ b/src/applications/personalization/profile/sass/profile.scss
@@ -63,18 +63,22 @@
   overflow: auto;
 }
 
+.va-profile-alert.usa-alert-error::before {
+  content: "\f05a";
+}
+.va-profile-alert.usa-alert-error::before {
+  background: none;
+  display: block;
+  color: 000;
+  font-family: "Font Awesome 5 Free";
+  font-style: normal;
+  font-size: 2rem;
+  font-weight: 900;
+  margin-right: 4px;
+  position: static;
+  width: auto;
+}
 .va-profile-alert {
-  i {
-    font-family: "Font Awesome 5 Free";
-    font-style: normal;
-    font-weight: 900;
-  }
-  i::before {
-    content: "\f05a";
-    display: flex;
-    margin-right: 1.6rem;
-    font-size: 2rem;
-  }
   p {
     margin: 0;
   }

--- a/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.delete-address.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.delete-address.unit.spec.jsx
@@ -22,6 +22,7 @@ const ui = (
 );
 let view;
 let server;
+const errorText = `We're sorry. We can't update your information right now. We're working to fix this problem. Please check back later.`;
 
 function getEditButton(addressName) {
   // Need to use `queryByRole` since the visible label is simply `Edit`, but
@@ -116,10 +117,8 @@ async function testTransactionCreationFails(addressName) {
 
   // expect an error to be shown
   const alert = await view.findByTestId('delete-error-alert');
-  expect(alert).to.have.descendant('div.usa-alert-error');
-  expect(alert).to.contain.text(
-    `We’re sorry. We can’t save your ${addressName.toLowerCase()} at this time. We’re working to fix this problem. Please try again or check back soon.`,
-  );
+  expect(alert).to.have.descendant('div.va-profile-alert');
+  expect(alert).to.contain.text(errorText);
 
   // make sure that delete modal is not automatically exited
   await wait(75);
@@ -136,10 +135,8 @@ async function testQuickFailure(addressName) {
 
   // expect an error to be shown
   const alert = await view.findByTestId('delete-error-alert');
-  expect(alert).to.have.descendant('div.usa-alert-error');
-  expect(alert).to.contain.text(
-    `We’re sorry. We can’t save your ${addressName.toLowerCase()} at this time. We’re working to fix this problem. Please try again or check back soon.`,
-  );
+  expect(alert).to.have.descendant('div.va-profile-alert');
+  expect(alert).to.contain.text(errorText);
 
   // waiting to make sure it doesn't auto exit
   await wait(75);

--- a/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.delete-address.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.delete-address.unit.spec.jsx
@@ -22,7 +22,7 @@ const ui = (
 );
 let view;
 let server;
-const errorText = `We're sorry. We can't update your information right now. We're working to fix this problem. Please check back later.`;
+const errorText = `We’re sorry. We can’t update your information right now. We’re working to fix this problem. Please check back later.`;
 
 function getEditButton(addressName) {
   // Need to use `queryByRole` since the visible label is simply `Edit`, but

--- a/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.delete-email-address.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.delete-email-address.unit.spec.jsx
@@ -20,6 +20,7 @@ const ui = (
 );
 let view;
 let server;
+const errorText = `We’re sorry. We can’t update your information right now. We’re working to fix this problem. Please check back later.`;
 
 function getEditButton() {
   let editButton = view.queryByText(/add.*email address/i, {
@@ -139,9 +140,7 @@ describe('Deleting email address', () => {
     // expect an error to be shown
     const alert = await view.findByTestId('delete-error-alert');
     expect(alert).to.have.descendant('div.va-profile-alert');
-    expect(alert).to.contain.text(
-      `We're sorry. We can't update your information right now. We're working to fix this problem. Please check back later.`,
-    );
+    expect(alert).to.contain.text(errorText);
   });
   it('should show an error if the deletion fails quickly', async () => {
     server.use(...mocks.transactionPending);
@@ -164,9 +163,7 @@ describe('Deleting email address', () => {
     // expect an error to be shown
     const alert = await view.findByTestId('delete-error-alert');
     expect(alert).to.have.descendant('div.va-profile-alert');
-    expect(alert).to.contain.text(
-      `We're sorry. We can't update your information right now. We're working to fix this problem. Please check back later.`,
-    );
+    expect(alert).to.contain.text(errorText);
 
     // waiting to make sure it doesn't auto exit
     await wait(75);

--- a/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.delete-email-address.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.delete-email-address.unit.spec.jsx
@@ -138,9 +138,9 @@ describe('Deleting email address', () => {
 
     // expect an error to be shown
     const alert = await view.findByTestId('delete-error-alert');
-    expect(alert).to.have.descendant('div.usa-alert-error');
+    expect(alert).to.have.descendant('div.va-profile-alert');
     expect(alert).to.contain.text(
-      `We’re sorry. We can’t save your contact email address at this time. We’re working to fix this problem. Please try again or check back soon.`,
+      `We're sorry. We can't update your information right now. We're working to fix this problem. Please check back later.`,
     );
   });
   it('should show an error if the deletion fails quickly', async () => {
@@ -163,9 +163,9 @@ describe('Deleting email address', () => {
 
     // expect an error to be shown
     const alert = await view.findByTestId('delete-error-alert');
-    expect(alert).to.have.descendant('div.usa-alert-error');
+    expect(alert).to.have.descendant('div.va-profile-alert');
     expect(alert).to.contain.text(
-      `We’re sorry. We can’t save your contact email address at this time. We’re working to fix this problem. Please try again or check back soon.`,
+      `We're sorry. We can't update your information right now. We're working to fix this problem. Please check back later.`,
     );
 
     // waiting to make sure it doesn't auto exit

--- a/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.delete-telephone.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.delete-telephone.unit.spec.jsx
@@ -22,7 +22,7 @@ const ui = (
 );
 let view;
 let server;
-const errorText = `We're sorry. We can't update your information right now. We're working to fix this problem. Please check back later.`;
+const errorText = `We’re sorry. We can’t update your information right now. We’re working to fix this problem. Please check back later.`;
 
 function getEditButton(numberName) {
   let editButton = view.queryByText(new RegExp(`add.*${numberName}`, 'i'), {

--- a/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.delete-telephone.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.delete-telephone.unit.spec.jsx
@@ -22,6 +22,7 @@ const ui = (
 );
 let view;
 let server;
+const errorText = `We're sorry. We can't update your information right now. We're working to fix this problem. Please check back later.`;
 
 function getEditButton(numberName) {
   let editButton = view.queryByText(new RegExp(`add.*${numberName}`, 'i'), {
@@ -120,10 +121,8 @@ async function testTransactionCreationFails(numberName) {
 
   // expect an error to be shown
   const alert = await view.findByTestId('delete-error-alert');
-  expect(alert).to.have.descendant('div.usa-alert-error');
-  expect(alert).to.contain.text(
-    `We’re sorry. We can’t save your ${numberName.toLowerCase()} at this time. We’re working to fix this problem. Please try again or check back soon.`,
-  );
+  expect(alert).to.have.descendant('div.va-profile-alert');
+  expect(alert).to.contain.text(errorText);
 
   // make sure that Delete Modal is not automatically exited
   await wait(75);
@@ -153,10 +152,8 @@ async function testQuickFailure(numberName) {
 
   // expect an error to be shown
   const alert = await view.findByTestId('delete-error-alert');
-  expect(alert).to.have.descendant('div.usa-alert-error');
-  expect(alert).to.contain.text(
-    `We’re sorry. We can’t save your ${numberName.toLowerCase()} at this time. We’re working to fix this problem. Please try again or check back soon.`,
-  );
+  expect(alert).to.have.descendant('div.va-profile-alert');
+  expect(alert).to.contain.text(errorText);
 
   // waiting to make sure it doesn't auto exit
   await wait(75);

--- a/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.edit-email-address.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.edit-email-address.unit.spec.jsx
@@ -15,7 +15,7 @@ import {
 } from '../../unit-test-helpers';
 import { beforeEach } from 'mocha';
 
-const errorText = `We're sorry. We can't update your information right now. We're working to fix this problem. Please check back later.`;
+const errorText = `We’re sorry. We can’t update your information right now. We’re working to fix this problem. Please check back later.`;
 const newUserName = 'newemailaddress';
 const newUserNameRegex = new RegExp(newUserName);
 const newEmailAddress = `${newUserName}@domain.com`;

--- a/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.edit-email-address.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.edit-email-address.unit.spec.jsx
@@ -15,7 +15,7 @@ import {
 } from '../../unit-test-helpers';
 import { beforeEach } from 'mocha';
 
-const errorText = `We’re sorry. We can’t save your contact email address at this time. We’re working to fix this problem. Please try again or check back soon.`;
+const errorText = `We're sorry. We can't update your information right now. We're working to fix this problem. Please check back later.`;
 const newUserName = 'newemailaddress';
 const newUserNameRegex = new RegExp(newUserName);
 const newEmailAddress = `${newUserName}@domain.com`;

--- a/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.edit-telephone.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.edit-telephone.unit.spec.jsx
@@ -16,6 +16,7 @@ import {
 } from '../../unit-test-helpers';
 import { beforeEach } from 'mocha';
 
+const errorText = `We're sorry. We can't update your information right now. We're working to fix this problem. Please check back later.`;
 const newAreaCode = '415';
 const newPhoneNumber = '555-0055';
 const ui = (
@@ -135,11 +136,9 @@ async function testTransactionCreationFails(numberName) {
 
   // expect an error to be shown
   const alert = await view.findByTestId('edit-error-alert');
-  expect(alert).to.have.descendant('div.usa-alert-error');
+  expect(alert).to.have.descendant('div.va-profile-alert');
   // TODO: would be nice to be able to check the contents against a RegExp
-  expect(alert).to.contain.text(
-    `We’re sorry. We can’t save your ${numberName.toLowerCase()} at this time. We’re working to fix this problem. Please try again or check back soon.`,
-  );
+  expect(alert).to.contain.text(errorText);
 
   // make sure that edit mode is not automatically exited
   await wait(75);
@@ -156,11 +155,9 @@ async function testQuickFailure(numberName) {
 
   // expect an error to be shown
   const alert = await view.findByTestId('edit-error-alert');
-  expect(alert).to.have.descendant('div.usa-alert-error');
+  expect(alert).to.have.descendant('div.va-profile-alert');
   // TODO: would be nice to be able to check the contents against a RegExp
-  expect(alert).to.contain.text(
-    `We’re sorry. We can’t save your ${numberName.toLowerCase()} at this time. We’re working to fix this problem. Please try again or check back soon.`,
-  );
+  expect(alert).to.contain.text(errorText);
 
   // make sure that edit mode is not automatically exited
   await wait(75);

--- a/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.edit-telephone.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.edit-telephone.unit.spec.jsx
@@ -16,7 +16,7 @@ import {
 } from '../../unit-test-helpers';
 import { beforeEach } from 'mocha';
 
-const errorText = `We're sorry. We can't update your information right now. We're working to fix this problem. Please check back later.`;
+const errorText = `We’re sorry. We can’t update your information right now. We’re working to fix this problem. Please check back later.`;
 const newAreaCode = '415';
 const newPhoneNumber = '555-0055';
 const ui = (

--- a/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.update-address.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.update-address.unit.spec.jsx
@@ -23,7 +23,7 @@ const ui = (
 );
 let view;
 let server;
-const errorText = `We're sorry. We can't update your information right now. We're working to fix this problem. Please check back later.`;
+const errorText = `We’re sorry. We can’t update your information right now. We’re working to fix this problem. Please check back later.`;
 
 function getEditButton(addressName) {
   let editButton = view.queryByText(new RegExp(`add.*${addressName}`, 'i'), {

--- a/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.update-address.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/contact-information/PersonalInformation.update-address.unit.spec.jsx
@@ -23,6 +23,7 @@ const ui = (
 );
 let view;
 let server;
+const errorText = `We're sorry. We can't update your information right now. We're working to fix this problem. Please check back later.`;
 
 function getEditButton(addressName) {
   let editButton = view.queryByText(new RegExp(`add.*${addressName}`, 'i'), {
@@ -135,10 +136,8 @@ async function testAddressValidation500(addressName) {
 
   // expect an error to be shown
   const alert = await view.findByTestId('edit-error-alert');
-  expect(alert).to.have.descendant('div.usa-alert-error');
-  expect(alert).to.contain.text(
-    `We’re sorry. We can’t save your ${addressName.toLowerCase()} at this time. We’re working to fix this problem. Please try again or check back soon.`,
-  );
+  expect(alert).to.have.descendant('div.va-profile-alert');
+  expect(alert).to.contain.text(errorText);
 
   // make sure that edit mode is not automatically exited
   await wait(75);
@@ -155,10 +154,8 @@ async function testTransactionCreationFails(addressName) {
 
   // expect an error to be shown
   const alert = await view.findByTestId('edit-error-alert');
-  expect(alert).to.have.descendant('div.usa-alert-error');
-  expect(alert).to.contain.text(
-    `We’re sorry. We can’t save your ${addressName.toLowerCase()} at this time. We’re working to fix this problem. Please try again or check back soon.`,
-  );
+  expect(alert).to.have.descendant('div.va-profile-alert');
+  expect(alert).to.contain.text(errorText);
 
   // make sure that edit mode is not automatically exited
   await wait(75);
@@ -175,10 +172,8 @@ async function testQuickFailure(addressName) {
 
   // expect an error to be shown
   const alert = await view.findByTestId('edit-error-alert');
-  expect(alert).to.have.descendant('div.usa-alert-error');
-  expect(alert).to.contain.text(
-    `We’re sorry. We can’t save your ${addressName.toLowerCase()} at this time. We’re working to fix this problem. Please try again or check back soon.`,
-  );
+  expect(alert).to.have.descendant('div.va-profile-alert');
+  expect(alert).to.contain.text(errorText);
 
   // make sure that edit mode is not automatically exited
   await wait(75);

--- a/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/modals.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-and-contact-info/modals.cypress.spec.js
@@ -221,7 +221,7 @@ describe('when moving to other profile sections', () => {
 });
 
 describe('Modals on the personal information and content page when they error', () => {
-  it('should focus on the close notification and the save button when the error is closed', () => {
+  it('should exist', () => {
     setup();
 
     const sectionName = 'contact email address';
@@ -242,13 +242,5 @@ describe('Modals on the personal information and content page when they error', 
 
     // expect an error to be shown
     cy.findByTestId('edit-error-alert').should('exist');
-
-    // check for error modal and check that the close is focused then click it
-    cy.findByRole('button', { name: /close notification/i })
-      .should('be.focused')
-      .click();
-
-    // check if first form element is focused
-    cy.findByLabelText(/email address/i).should('be.focused');
   });
 });

--- a/src/platform/user/profile/vap-svc/components/ContactInformationFieldInfo/ConfirmRemoveModal.jsx
+++ b/src/platform/user/profile/vap-svc/components/ContactInformationFieldInfo/ConfirmRemoveModal.jsx
@@ -61,7 +61,7 @@ const ConfirmRemoveModal = ({
           className="vads-u-margin-bottom--2"
           data-testid="delete-error-alert"
         >
-          <VAPServiceEditModalErrorMessage title={title} error={error} />
+          <VAPServiceEditModalErrorMessage error={error} />
         </div>
       )}
       <div>

--- a/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModal.jsx
+++ b/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModal.jsx
@@ -64,7 +64,6 @@ export default class VAPServiceEditModal extends React.Component {
         isEmpty,
         onCancel,
         title,
-        clearErrors,
         render,
         onDelete,
         transaction,
@@ -108,11 +107,7 @@ export default class VAPServiceEditModal extends React.Component {
         <h3>Edit {title.toLowerCase()}</h3>
         {error && (
           <div className="vads-u-margin-bottom--1">
-            <VAPServiceEditModalErrorMessage
-              title={title}
-              error={error}
-              clearErrors={clearErrors}
-            />
+            <VAPServiceEditModalErrorMessage error={error} />
           </div>
         )}
         {isFormReady && render(actionButtons, onSubmit)}

--- a/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage.jsx
+++ b/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import facilityLocator from '~/applications/facility-locator/manifest.json';
 
 import {
@@ -63,20 +64,19 @@ export default function VAPServiceEditModalErrorMessage({
     default:
       content = (
         <p>
-          We're sorry. We can't update your information right now. We're working
+          We’re sorry. We can’t update your information right now. We’re working
           to fix this problem. Please check back later.
         </p>
       );
   }
 
   return (
-    <div
-      className="va-profile-alert vads-u-margin-bottom--2 
-    vads-u-background-color--secondary-lightest vads-u-display--flex vads-u-padding-y--4 vads-u-padding-right--7 vads-u-padding-left--3 vads-u-width--full"
-    >
-      <i aria-hidden="true" role="img" />
-      <span className="sr-only">Alert: </span>
-      <div>{content}</div>
-    </div>
+    <AlertBox
+      className="va-profile-alert vads-u-margin-top--0"
+      backgroundOnly
+      content={<div className="columns">{content}</div>}
+      isVisible
+      status="error"
+    />
   );
 }

--- a/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage.jsx
+++ b/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import facilityLocator from '~/applications/facility-locator/manifest.json';
 
 import {
@@ -70,17 +71,22 @@ export default function VAPServiceEditModalErrorMessage({
   }
 
   return (
-    <div
-      className="va-profile-alert vads-u-margin-bottom--2 vads-u-margin-top--0
-  vads-u-background-color--secondary-lightest vads-u-display--flex vads-u-padding-y--4 vads-u-padding-right--7 vads-u-padding-left--3 vads-u-width--full"
+    <AlertBox
+      backgroundOnly
+      status="error"
+      className="va-profile-alert vads-u-margin-y--1"
     >
-      <i
-        className="fas fa-info-circle vads-u-font-size--md vads-u-color--black vads-u-margin-right--2 vads-u-padding-top--0p5"
-        aria-hidden="true"
-        role="img"
-      />
-      <span className="sr-only">Alert: </span>
-      <div>{content}</div>
-    </div>
+      <div className="vads-u-display--flex">
+        <i
+          className="fas fa-info-circle vads-u-font-size--md vads-u-color--black vads-u-margin-right--2 vads-u-padding-top--0p5"
+          aria-hidden="true"
+          role="img"
+        />
+        <span className="sr-only">Alert: </span>
+        <div role="alert" aria-live="polite">
+          {content}
+        </div>
+      </div>
+    </AlertBox>
   );
 }

--- a/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage.jsx
+++ b/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage.jsx
@@ -1,7 +1,4 @@
 import React from 'react';
-import AlertBox, {
-  ALERT_TYPE,
-} from '@department-of-veterans-affairs/component-library/AlertBox';
 import facilityLocator from '~/applications/facility-locator/manifest.json';
 
 import {
@@ -17,8 +14,6 @@ function hasError(codes, errors) {
 
 export default function VAPServiceEditModalErrorMessage({
   error: { errors = [] },
-  clearErrors,
-  title,
 }) {
   let content = null;
 
@@ -68,21 +63,20 @@ export default function VAPServiceEditModalErrorMessage({
     default:
       content = (
         <p>
-          We’re sorry. We can’t save your {title.toLowerCase()} at this time.
-          We’re working to fix this problem. Please try again or check back
-          soon.
+          We're sorry. We can't update your information right now. We're working
+          to fix this problem. Please check back later.
         </p>
       );
   }
 
   return (
-    <AlertBox
-      className="vads-u-margin-top--0"
-      content={<div className="columns">{content}</div>}
-      isVisible
-      onCloseAlert={clearErrors}
-      scrollOnShow
-      status={ALERT_TYPE.ERROR}
-    />
+    <div
+      className="va-profile-alert vads-u-margin-bottom--2 
+    vads-u-background-color--secondary-lightest vads-u-display--flex vads-u-padding-y--4 vads-u-padding-right--7 vads-u-padding-left--3 vads-u-width--full"
+    >
+      <i aria-hidden="true" role="img" />
+      <span className="sr-only">Alert: </span>
+      <div>{content}</div>
+    </div>
   );
 }

--- a/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage.jsx
+++ b/src/platform/user/profile/vap-svc/components/base/VAPServiceEditModalErrorMessage.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import AlertBox from '@department-of-veterans-affairs/component-library/AlertBox';
 import facilityLocator from '~/applications/facility-locator/manifest.json';
 
 import {
@@ -71,12 +70,17 @@ export default function VAPServiceEditModalErrorMessage({
   }
 
   return (
-    <AlertBox
-      className="va-profile-alert vads-u-margin-top--0"
-      backgroundOnly
-      content={<div className="columns">{content}</div>}
-      isVisible
-      status="error"
-    />
+    <div
+      className="va-profile-alert vads-u-margin-bottom--2 vads-u-margin-top--0
+  vads-u-background-color--secondary-lightest vads-u-display--flex vads-u-padding-y--4 vads-u-padding-right--7 vads-u-padding-left--3 vads-u-width--full"
+    >
+      <i
+        className="fas fa-info-circle vads-u-font-size--md vads-u-color--black vads-u-margin-right--2 vads-u-padding-top--0p5"
+        aria-hidden="true"
+        role="img"
+      />
+      <span className="sr-only">Alert: </span>
+      <div>{content}</div>
+    </div>
   );
 }

--- a/src/platform/user/profile/vap-svc/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vap-svc/containers/AddressValidationModal.jsx
@@ -199,8 +199,6 @@ class AddressValidationModal extends React.Component {
       confirmedSuggestions,
       transaction,
       transactionRequest,
-      title,
-      clearErrors,
     } = this.props;
 
     const resetDataAndCloseModal = () => {
@@ -237,11 +235,7 @@ class AddressValidationModal extends React.Component {
       >
         {error && (
           <div className="vads-u-margin-bottom--1">
-            <VAPServiceEditModalErrorMessage
-              title={title}
-              error={error}
-              clearErrors={clearErrors}
-            />
+            <VAPServiceEditModalErrorMessage error={error} />
           </div>
         )}
         <AlertBox

--- a/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
+++ b/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
@@ -219,11 +219,9 @@ class AddressValidationView extends React.Component {
     const {
       addressFromUser,
       addressValidationError,
-      clearErrors,
       confirmedSuggestions,
       resetAddressValidation,
       suggestedAddresses,
-      title,
       transaction,
       transactionRequest,
       validationKey,
@@ -255,11 +253,7 @@ class AddressValidationView extends React.Component {
       <>
         {error && (
           <div className="vads-u-margin-bottom--1" role="alert">
-            <VAPServiceEditModalErrorMessage
-              title={title}
-              error={error}
-              clearErrors={clearErrors}
-            />
+            <VAPServiceEditModalErrorMessage error={error} />
           </div>
         )}
         <div role="alert">

--- a/src/platform/user/profile/vap-svc/tests/components/VAPServiceEditModalErrorMessage.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/components/VAPServiceEditModalErrorMessage.unit.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { expect } from 'chai';
 import VAPServiceEditModalErrorMessage from '../../components/base/VAPServiceEditModalErrorMessage';
 
@@ -17,13 +17,11 @@ describe('<VAPServiceEditModalErrorMessage />', () => {
         },
       ],
     };
-    const wrapper = shallow(
-      <VAPServiceEditModalErrorMessage error={invalidEmailError} title="" />,
+    const wrapper = mount(
+      <VAPServiceEditModalErrorMessage error={invalidEmailError} />,
     );
-    const alert = wrapper.find('AlertBox');
-    const alertContentText = alert?.prop('content')?.props?.children?.props
-      ?.children;
-    expect(alertContentText).to.include(
+    expect(wrapper.find('div.va-profile-alert')).to.have.lengthOf(1);
+    expect(wrapper.html()).to.include(
       'It looks like the email you entered isn’t valid. Please enter your email address again.',
     );
     wrapper.unmount();
@@ -40,13 +38,11 @@ describe('<VAPServiceEditModalErrorMessage />', () => {
         },
       ],
     };
-    const wrapper = shallow(
-      <VAPServiceEditModalErrorMessage error={invalidPhoneError} title="" />,
+    const wrapper = mount(
+      <VAPServiceEditModalErrorMessage error={invalidPhoneError} />,
     );
-    const alert = wrapper.find('AlertBox');
-    const alertContentText = alert.prop('content').props.children.props
-      .children;
-    expect(alertContentText).to.include(
+    expect(wrapper.find('div.va-profile-alert')).to.have.lengthOf(1);
+    expect(wrapper.html()).to.include(
       'currently only support U.S. area codes. Please provide a U.S.-based',
     );
     wrapper.unmount();


### PR DESCRIPTION
## Description
Changing the alerts within the contact information section.
See => https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/identity-personalization/profile/maintenance/front-end/alert-updates-Sept-2021.md#4-failure-to-update-contact-information-in-profile-31405

## Original issue(s)
department-of-veterans-affairs/va.gov-team#31405


## Testing done
Ran unit tests, e2e tests, updated them.

## Screenshots
![Screen Shot 2021-11-30 at 3 27 01 PM](https://user-images.githubusercontent.com/26075258/144123845-f773ad0c-c55e-45aa-98fd-bcbde7a5524c.png)
![Screen Shot 2021-11-29 at 4 48 27 PM](https://user-images.githubusercontent.com/26075258/144123847-65491756-94cc-4d94-a7f9-361a91545321.png)
![Screen Shot 2021-11-29 at 4 45 22 PM](https://user-images.githubusercontent.com/26075258/144123848-8b38071f-aef9-4f4f-aeeb-5433fcc0d8f2.png)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
