### PR TITLE
Updates eAuth keepalive to add Login.gov

### DIFF
--- a/src/platform/utilities/sso/index.js
+++ b/src/platform/utilities/sso/index.js
@@ -38,6 +38,12 @@ export async function ssoKeepAliveSession() {
   return { ttl, transactionid, authn };
 }
 
+/**
+ *
+ * @param {*} loggedIn checks if user is loggedIn
+ * @param {*} ssoeTransactionId transactionId received from eAuth
+ * @param {*} profile profile of current user (for verified)
+ */
 export async function checkAutoSession(
   loggedIn,
   ssoeTransactionId,
@@ -45,21 +51,27 @@ export async function checkAutoSession(
 ) {
   const { ttl, transactionid, authn } = await ssoKeepAliveSession();
 
+  /**
+   * Ensure user is authenticated with SSOe by verifying
+   * loggedIn status and transaction ID
+   */
   if (loggedIn && ssoeTransactionId) {
-    // being logged in is not enough, we also need to make sure that the user
-    // has been authenticated with SSOe, otherwise we don't want to perform any
-    // auto login/logout operations.
     if (ttl === 0) {
-      // explicitly check to see if the TTL for the SSOe session is 0, as it
-      // could also be undefined if we failed to get a response from the SSOe server,
-      // in which case we don't want to logout the user, because we don't know
-      // their SSOe status.
-      logout('v1', AUTH_EVENTS.SSO_LOGOUT, { 'auto-logout': 'true' });
+      /**
+       * Check if TTL is 0
+       * TTL: 0 = Session invalid
+       * TTL: > 0 and < 900 = Session valid
+       * TTL: undefined, can't verify SSOe status
+       */
+      logout('v1', AUTH_EVENTS.SSO_LOGOUT, {
+        'auto-logout': 'true',
+      });
     } else if (transactionid && transactionid !== ssoeTransactionId) {
-      // compare the transaction id from the keepalive endpoint with the existing
-      // transaction id. If they don't match, it means we might have a different
-      // user logged in. Thus, we should perform an auto login, which will
-      // effectively logout the user then log them back in.
+      /**
+       * Compare transaction ID with ssoeTransactionID
+       * transactionID (eAuth) !== ssoeTransaction: Different user logged in
+       * and perform an auto-login with the new session. (Auto logout and re-logins)
+       */
       login({
         policy: 'custom',
         queryParams: { authn },
@@ -70,17 +82,21 @@ export async function checkAutoSession(
       ttl > 0 &&
       profile.verified
     ) {
-      // the user is in the login app, but already logged in with SSOe
-      // and verified, redirect them back to their return url
+      /**
+       * Unified Sign-in page
+       * If user has an SSOe session & is verified, redirect them
+       * to the specified return url
+       */
       window.location = standaloneRedirect() || window.location.origin;
     }
   } else if (!loggedIn && ttl > 0 && !getLoginAttempted() && authn) {
-    // only attempt an auto login if the user is
-    // a) does not have a VA.gov session
-    // b) has an SSOe session
-    // c) has not previously tried to login (if the last attempt to login failed
-    //    don't keep retrying)
-    // d) we have a non empty type value from the keepalive call to login with
+    /**
+     * Create an auto-login when the following are true
+     * 1. No active VA.gov session
+     * 2. Active SSOe session
+     * 3. No previously attempted to login (sessionStorage `setLoginAttempted` is false)
+     * 4. Have a non-empty type value from eAuth keepalive endpoint
+     */
     login({
       policy: 'custom',
       queryParams: { authn },

--- a/src/platform/utilities/sso/keepAliveSSO.js
+++ b/src/platform/utilities/sso/keepAliveSSO.js
@@ -69,17 +69,18 @@ export default async function keepAlive() {
     await resp.text();
     const alive = resp.headers.get('session-alive');
 
+    /**
+     * Use mapped authncontext for DS Logon and MHV
+     * Use `authncontextclassref` lookup for ID.me and Login.gov
+     */
+
     return {
       ttl: alive === 'true' ? Number(resp.headers.get('session-timeout')) : 0,
       transactionid: resp.headers.get('va_eauth_transactionid'),
-      /* for DSLogon or mhv, use a mapped authn context value, however for
-      * idme, we need to use the provided authncontextclassref as it could be
-      * for LOA1 or LOA3.  Any other csid values should be ignored, and we
-      * should return undefined
-      */
       authn: {
         DSLogon: 'dslogon',
         mhv: 'myhealthevet',
+        LOGINGOV: resp.headers.get('va_eauth_authncontextclassref'),
         idme: resp.headers.get('va_eauth_authncontextclassref'),
       }[resp.headers.get('va_eauth_csid')],
     };

--- a/src/platform/utilities/tests/sso.unit.spec.js
+++ b/src/platform/utilities/tests/sso.unit.spec.js
@@ -21,7 +21,7 @@ function setKeepAliveResponse(stub, sessionTimeout = 0, csid = null) {
     {
       DSLogon: 'NOT_FOUND ',
       mhv: 'NOT_FOUND ',
-      LOGINGOV: 'NOT_FOUND',
+      LOGINGOV: 'http://idmanagement.gov/ns/assurance/ial/2',
       idme: 'http://idmanagement.gov/ns/assurance/loa/3',
     }[csid],
   );
@@ -438,12 +438,18 @@ describe.skip('keepAlive', () => {
         'session-timeout': '900',
         va_eauth_transactionid: 'X',
         va_eauth_csid: 'LOGINGOV',
+        va_eauth_authncontextclassref:
+          'http://idmanagement.gov/ns/assurance/ial/2',
       },
     });
     /* eslint-enable camelcase */
     stubFetch.resolves(resp);
     return keepAlive().then(res => {
-      expect(res).to.eql({ ttl: 900, transactionid: 'X', authn: 'logingov' });
+      expect(res).to.eql({
+        ttl: 900,
+        transactionid: 'X',
+        authn: 'http://idmanagement.gov/ns/assurance/ial/2',
+      });
     });
   });
 });

--- a/src/platform/utilities/tests/sso.unit.spec.js
+++ b/src/platform/utilities/tests/sso.unit.spec.js
@@ -21,6 +21,7 @@ function setKeepAliveResponse(stub, sessionTimeout = 0, csid = null) {
     {
       DSLogon: 'NOT_FOUND ',
       mhv: 'NOT_FOUND ',
+      LOGINGOV: 'NOT_FOUND',
       idme: 'http://idmanagement.gov/ns/assurance/loa/3',
     }[csid],
   );
@@ -426,6 +427,23 @@ describe.skip('keepAlive', () => {
         transactionid: 'X',
         authn: '/loa1',
       });
+    });
+  });
+
+  it('should return active logingov session', () => {
+    /* eslint-disable camelcase */
+    const resp = new Response('{}', {
+      headers: {
+        'session-alive': 'true',
+        'session-timeout': '900',
+        va_eauth_transactionid: 'X',
+        va_eauth_csid: 'LOGINGOV',
+      },
+    });
+    /* eslint-enable camelcase */
+    stubFetch.resolves(resp);
+    return keepAlive().then(res => {
+      expect(res).to.eql({ ttl: 900, transactionid: 'X', authn: 'logingov' });
     });
   });
 });


### PR DESCRIPTION
## Description
This PR adds the Login.gov key/value lookup on the `/keepalive` endpoint to allow proper session management and AutoSSO capability.

## Original issue(s)
Closes department-of-veterans-affairs/va.gov-team#30235

## Testing done
Unit testing / visual

## Screenshots
n/a

## Acceptance criteria
- [x] When logging in using the Login.gov service provider, calls to the keepalive endpoint do not automatically log a user out
- [x] When logging into Login.gov (Sandbox) and navigating to VA.gov (staging), a user is automatically logged in.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
