### PR TITLE
HLR: Fix other benefits anchor

### DIFF
--- a/src/applications/disability-benefits/996/constants.js
+++ b/src/applications/disability-benefits/996/constants.js
@@ -19,8 +19,8 @@ export const GET_HELP_REVIEW_REQUEST_URL =
 export const PROFILE_URL = '/profile';
 export const LEGACY_APPEALS_URL = '/decision-reviews/legacy-appeals/';
 
-// 8622 is the ID of the <li> wrapping the "Find addresses for other benefit
-// types" accordion
+// 8622 is the ID of the <va-accordion-item> with a header of the "Find
+// addresses for other benefit types"
 export const BENEFIT_OFFICES_URL = `${HLR_INFO_URL}#find-addresses-for-other-benef-8622`;
 
 export const CONTESTABLE_ISSUES_API =

--- a/src/applications/disability-benefits/996/constants.js
+++ b/src/applications/disability-benefits/996/constants.js
@@ -21,7 +21,7 @@ export const LEGACY_APPEALS_URL = '/decision-reviews/legacy-appeals/';
 
 // 8622 is the ID of the <li> wrapping the "Find addresses for other benefit
 // types" accordion
-export const BENEFIT_OFFICES_URL = `${HLR_INFO_URL}#find-addresses`;
+export const BENEFIT_OFFICES_URL = `${HLR_INFO_URL}#find-addresses-for-other-benef-8622`;
 
 export const CONTESTABLE_ISSUES_API =
   '/higher_level_reviews/contestable_issues/';


### PR DESCRIPTION
## Description

Updating the Higher-Level Review anchor for the "Find addresses for other benefit types" accordion on this page: https://staging.va.gov/decision-reviews/higher-level-review/#find-addresses-for-other-benef-8622 - this updated anchor will get the accordion to auto-expand.

## Original issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/28658

## Testing done

N/A

## Screenshots

<img width="984" alt="Screen Shot 2021-12-01 at 9 55 20 AM" src="https://user-images.githubusercontent.com/136959/144268116-37a3b549-b1a3-40a2-9631-3e560df13682.png">

## Acceptance criteria
- [x] Anchor is updated within the HLR wizard

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
